### PR TITLE
Changed punctuation-in-quote to "false" to conform to the new revision (May 2011) of the UniSA style guide

### DIFF
--- a/unisa-harvard.csl
+++ b/unisa-harvard.csl
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
-<style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" default-locale="en-AU" version="1.0" demote-non-dropping-particle="sort-only"><!-- University of South Australia 2010 (Harvard-based author-date system)
+<style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" default-locale="en-AU" version="1.0" demote-non-dropping-particle="sort-only"><!-- University of South Australia 2011 (Harvard-based author-date system)
 NOTES
 
-- This style is based on the March 2010 version of the style guide. A major change that places commas inside quoted titles makes it incompatible with the June 2007 style guide.
+- This style is based on the May 2011 version of the style guide.
 
 - This style uses CSL1.0 and has been tested with Zotero 2.1.7
 
@@ -24,13 +24,13 @@ KNOWN CHALLENGES
 
 TO DO
 
-- Incorporate more exotic resource types from the 2010 style guide
+- Incorporate more exotic resource types from the 2011 style guide
 
 - Reduce explicit handling of types in conditions
 
 -->
    <info>
-      <title>University of South Australia 2010 (Harvard-based author-date system)</title>
+      <title>University of South Australia 2011 (Harvard-based author-date system)</title>
       <id>http://www.zotero.org/styles/unisa-harvard</id>
       <link href="http://www.zotero.org/styles/unisa-harvard" rel="self"/>
       <author>
@@ -44,7 +44,7 @@ TO DO
       <category citation-format="author-date"/>
       <category field="generic-base"/>
       <updated>2011-06-05T15:58:59+00:00</updated>
-      <summary>University of South Australia citation style based on the March 2010 version of the style guide titled The Harvard Author–Date Referencing System</summary>
+      <summary>University of South Australia citation style based on the May 2011 version of the style guide titled The Harvard Author–Date Referencing System</summary>
       <link href="http://www.unisa.edu.au/ltu/students/study/referencing/harvard.pdf" rel="documentation"/>
       <rights>This work is licensed under a Creative Commons Attribution-Share Alike 3.0 License: http://creativecommons.org/licenses/by-sa/3.0/</rights>
    </info>
@@ -66,7 +66,7 @@ TO DO
          <term name="open-inner-quote">“</term> 
          <term name="close-inner-quote">”</term> 
 </terms>
-<style-options punctuation-in-quote="true"/>
+<style-options punctuation-in-quote="false"/>
   </locale>
    <macro name="editor">
       <names variable="editor" delimiter=", ">


### PR DESCRIPTION
Changed punctuation-in-quote to "false" to conform to the new revision (May 2011) of the UniSA style guide.
