### PR TITLE
Refactoring of McGill Guide v7

### DIFF
--- a/mcgill-guide-v7.csl
+++ b/mcgill-guide-v7.csl
@@ -1,364 +1,350 @@
 <?xml version="1.0" encoding="utf-8"?>
 <style xmlns="http://purl.org/net/xbiblio/csl" version="1.0" class="note" default-locale="en">
-<info>
-    <title>Canadian Guide to Uniform Legal Citation, 7th ed. (McGill Guide)</title>
+  <info>
+	<title>Canadian Guide to Uniform Legal Citation, 7th ed. (McGill Guide)</title>
 	<id>http://www.zotero.org/styles/mcgill-guide-v7</id>
 	<link href="http://www.zotero.org/styles/mcgill-guide-v7" rel="self" />
 	<link href="http://lawjournal.mcgill.ca/citeguide.php" rel="documentation" />
-    <author>
-      <name>Liam McHugh-Russell</name>
-      <email>liam.mchugh.russell@gmail.com</email>
+	<author>
+	  <name>Liam McHugh-Russell</name>
+	  <email>liam.mchugh.russell@gmail.com</email>
 	</author>
+	<contributor>
+	  <name>Frank Bennett</name>
+	</contributor>
 	<updated>2008-10-29T21:01:24+00:00</updated>
-	 <rights>This work is licensed under a Creative Commons
-         Attribution-Share Alike 3.0 Unported License
-         http://creativecommons.org/licenses/by-sa/3.0/</rights>
-    <category field="law" />
-    <category citation-format="note" />
-</info> 
-<locale xml:lang="en">
-    <style-options punctuation-in-quote="false" />
+	<rights>This work is licensed under a Creative Commons
+	Attribution-Share Alike 3.0 Unported License
+	http://creativecommons.org/licenses/by-sa/3.0/</rights>
+	<category field="law" />
+	<category citation-format="note" />
+  </info> 
+  <locale xml:lang="en">
+	<style-options punctuation-in-quote="false" />
 	<terms>
-	 <term name="et-al" >et al</term>
+	  <term name="et-al" >et al</term>
+	  <term name="ordinal-01">st</term>
+	  <term name="ordinal-02">d</term>
+	  <term name="ordinal-03">d</term>
+	  <term name="ordinal-04">th</term>
 	</terms> 
-</locale>
- 
-  <macro name="citation-number">
-    <text variable="citation-number" />
-  </macro>
-  <macro name="title">
-        <text variable="title" />
-  </macro>
+  </locale>
   <macro name="editor">
 	<names variable="editor"  >
-        <name and="symbol" delimiter-precedes-last="never" />
-		<et-al term="et-al" /> 
-		<label form="short" prefix=", " />
+	  <name and="symbol" delimiter-precedes-last="never" />
+	  <et-al term="et-al" /> 
+	  <label form="short" prefix=", " />
 	</names>
   </macro>
   <macro name="translator">
-    <names variable="translator" >
-      <label form="verb" suffix=" " />
+	<names variable="translator" >
+	  <label form="verb" suffix=" " />
 	  <name and="symbol" />
-    </names>
-  </macro>
-  <macro name="publisher">
-	<text variable="publisher" />
-  </macro>
-  <macro name="publisher-place">
-    <text variable="publisher-place" />
-  </macro>
-  <macro name="issue">
-    <text variable="issue" />
-  </macro>
-  <macro name="URL">
-    <text variable="URL" />
-  </macro>
-  <macro name="DOI">
-    <text variable="DOI" />
-  </macro>
-  <macro name="collection-title">
-    <text variable="collection-title" />
-  </macro>
-  <macro name="volume">
-    <text variable="volume" />
-  </macro>
-  <macro name="page">
-    <text variable="page-first" />
+	</names>
   </macro>
   <macro name="container-title">
-    <text strip-periods="true" variable="container-title" form="short" />
+	<text strip-periods="true" variable="container-title" form="short" />
   </macro>
-  <macro name="author-stripped">
-	<!-- should really also check, though this macro shouldn't be called in that case, if 
-	position="ibid ibid-with-locator subsequent", match="any" -->
-	<choose>
-		<if position="first" > 
-			<names variable="author"  >
-				<name and="symbol" delimiter-precedes-last="never"  />
-				<et-al term="et-al" />
-				<substitute>
-					<text macro="editor"  />
-				</substitute>
-			</names>
-		</if>
-		<else>
-			<names variable="author"  >
-				<name name-as-sort-order="first"
-					and="symbol"
-					sort-separator=", "
-					delimiter-precedes-last="never" />
-				<substitute>
-					<names variable="editor" >
-						<name name-as-sort-order="first"
-						and="symbol"
-						sort-separator=", "
-						delimiter-precedes-last="never" />
-						<label form="short" prefix=", " />
-					</names>
-				</substitute>
-			</names>
-		</else>
-	</choose>
+  <macro name="author-note">
+	<names variable="author"  >
+	  <name and="symbol" delimiter-precedes-last="never"  />
+	  <et-al term="et-al" />
+	  <substitute>
+		<text macro="editor"  />
+	  </substitute>
+	</names>
   </macro>
-  <macro name="author">
-	<!-- because <cs-name> doesn't take strip-periods, need to use awkward 'stripped' macro -->
-	<text macro="author-stripped" strip-periods="true" />
-	<!-- could just use strip-periods on the macro call, except adding the comma or period here 
-	means that rendering macros work both for biblio and citation -->
-	<choose>
-		<if position="first" > 
-			<text value="," />
-		</if>
-		<else>
-			<text value="." />
-		</else>
-	</choose>
-  </macro>	
+  <macro name="author-bib">
+	<names variable="author"  >
+	  <name name-as-sort-order="first"
+			and="symbol"
+			sort-separator=", "
+			delimiter-precedes-last="never" />
+	  <et-al term="et-al" />
+	  <label form="short" prefix=", " />
+	  <substitute>
+		<names variable="editor"/>
+	  </substitute>
+	</names>
+  </macro>
   <macro name="internet-location" >
 	<choose> 
-		<if variable="URL" >  
-			<text term="online" prefix=", " suffix=": &lt;" />
-			<text variable="URL" suffix="&gt;" />
-		</if>
-  </choose>
-  </macro>
-  <macro name="issued-year">
-    <date variable="issued">
-      <date-part name="year" form="long" />
-    </date>
+	  <if variable="URL" >  
+		<text term="online" prefix=", " suffix=": &lt;" />
+		<text variable="URL" suffix="&gt;" />
+	  </if>
+	</choose>
   </macro>
   <macro name="genre">
-    <text variable="genre" />
+	<text variable="genre" />
   </macro>
   <macro name="issued-long">
-		<date variable="issued" >
-			<date-part name="day" suffix=" " />
-			<date-part name="month" form="long" suffix=" " />
-			<date-part name="year" form="long"  />
-		</date>
-   </macro>
-   <macro name="edition" >
+	<date variable="issued" >
+	  <date-part name="day" suffix=" " />
+	  <date-part name="month" form="long" suffix=" " />
+	  <date-part name="year" form="long"  />
+	</date>
+  </macro>
+  <macro name="edition" >
 	<number variable="edition" form="ordinal" text-case="lowercase" suffix=" " />
 	<text term="edition" form="short" strip-periods="true" />
-   </macro>
-   <macro name="references" >
-		<text variable="references" />
-   </macro>
-   <macro name="sort-by-type">
-		<choose>
-			<if type="bill">
-				<text value="1" />
-			</if>
-			<else-if type="legal_case">
-				<text value="2" />
-			</else-if>
-			<else-if type="book thesis" match="any" >
-				<text value="3" />
-			</else-if>
-			<else-if type="article-journal chapter article-newspaper" match="any" >
-				<text value="4" />
-			</else-if>
-			<else>
-				<text value="5" />
-			</else>
-		</choose>
   </macro>
-   <!-- the 'rendering' macros mostly check if called from w/i bibliography so that author gets printed 
-   right. Only actually need to check for 'first' because w/i cite, 
-   all the other tests should have been done... -->
+  <macro name="references" >
+	<text variable="references" />
+  </macro>
+  <macro name="sort-by-type">
+	<choose>
+	  <if type="bill">
+		<text value="1" />
+	  </if>
+	  <else-if type="legal_case">
+		<text value="2" />
+	  </else-if>
+	  <else-if type="book thesis" match="any" >
+		<text value="3" />
+	  </else-if>
+	  <else-if type="article-journal chapter article-newspaper" match="any" >
+		<text value="4" />
+	  </else-if>
+	  <else>
+		<text value="5" />
+	  </else>
+	</choose>
+  </macro>
+  <!-- the 'rendering' macros mostly check if called from w/i bibliography so that author gets printed 
+	   right. Only actually need to check for 'first' because w/i cite, 
+	   all the other tests should have been done... -->
+
   <macro name="render-chapter">
 	<group delimiter=" "> 
-		<text macro="author" />		
-		<text macro="title" quotes="true" />
-		<text term="in" form="short" />
-		<text macro="editor" strip-periods="true" suffix="," />
-		<text macro="container-title" font-style="italic" />
+	  <text variable="title" quotes="true" />
+	  <text term="in" form="short" />
+	  <text macro="editor" strip-periods="true" suffix="," />
+	  <text macro="container-title" font-style="italic" />
 	</group>
 	<text macro="edition" prefix=", " />	
-	<text macro="publisher-place" prefix=" (" suffix=": " />
-	<text macro="publisher" suffix=", " />
-	<text macro="issued-year" suffix=")" />
-	<text macro="page" prefix=" " />
+	<text macro="publisher-place-year"/>
+	<text variable="page-first" prefix=" " />
   </macro>  
   <macro name="render-article-journal">
 	<group delimiter=" "> 
-		<text macro="author" />
-		<text macro="title" quotes="true" />
-		<text macro="issued-year" prefix="(" suffix=")" />
-		<text macro="volume"  />
+	  <text variable="title" quotes="true" />
+	  <date form="text" variable="issued" date-parts="year" prefix="(" suffix=")"/>
+	  <text variable="volume"  />
 	</group>
-	<text macro="issue" prefix=":" />
+	<text variable="issue" prefix=":" />
 	<text macro="container-title" prefix=" " />
-	<text macro="page" prefix=" " />
+	<text variable="page-first" prefix=" " />
   </macro>
   <macro name="render-thesis" >
 	<group delimiter=" "> 
-		<text macro="author" />	
-		<text macro="title" font-style="italic" />
-		<text macro="genre" prefix="(" suffix="," />
-		<text macro="publisher" suffix="," />
-		<text macro="issued-year" suffix=") [unpublished]" />
+	  <text variable="title" font-style="italic" />
+	  <text macro="genre" prefix="(" suffix="," />
+	  <text variable="publisher" suffix="," />
+	  <date form="text" variable="issued" date-parts="year" suffix=") [unpublished]" />
 	</group>
   </macro>
   <macro name="render-article-newspaper" >
 	<group delimiter=" " >
-		<text macro="author" />	
-		<text macro="title" quotes="true" suffix="," />
-		<text macro="container-title" font-style="italic"  />
-		<text macro="issued-long" prefix="(" suffix=")" />
-		<text macro="page" />
-		<text variable="URL" prefix=", online: &lt;" suffix="&gt;" />
+	  <text variable="title" quotes="true" suffix="," />
+	  <text macro="container-title" font-style="italic"  />
+	  <text macro="issued-long" prefix="(" suffix=")" />
+	  <text variable="page-first" />
+	  <text variable="URL" prefix=", online: &lt;" suffix="&gt;" />
 	</group>
   </macro>
   <!-- cases and bills render the same for biblio and (first) cite -->
-  <macro name="render-bill" >				
-	<text macro="title"  font-style="italic" suffix=", " />
-	<text macro="author" suffix=", " />
-	<text macro="issued-long" suffix=", " />
-	<text macro="container-title" prefix=" " suffix=" " />
-	<text macro="references" suffix="(" prefix=")" />
-	<text variable="title" prefix="[" suffix="]" font-style="italic" form="short" />
-</macro>
-<macro name="render-case"> 
-	<text macro="title" font-style="italic" />
-	<text macro="issued-year" prefix="(" suffix=") " />
-	<text macro="volume" />
-	<text macro="issue" prefix=":" />
+  <macro name="render-bill" >
+	<group delimiter=" ">
+	  <group delimiter=", ">
+		<text variable="title"  font-style="italic"/>
+		<text macro="author-note" strip-periods="true"/>
+		<text macro="issued-long"/>
+		<text macro="container-title"/>
+	  </group>
+	  <text macro="references" prefix="(" suffix=")" />
+	  <text variable="title" prefix="[" suffix="]" font-style="italic" form="short" />
+	</group>
+  </macro>
+  <macro name="render-case"> 
+	<text variable="title" font-style="italic" />
+	<date form="text" variable="issued" date-parts="year" prefix="(" suffix=") "/>
+	<text variable="volume" />
+	<text variable="issue" prefix=":" />
 	<text macro="container-title" prefix=", " suffix=" " />
-	<text macro="page" />
+	<text variable="page-first" />
 	<text variable="URL" prefix="(available on " suffix=")"/>
-</macro>
-<macro name="pinpoint">
-    <!-- Not implemented: currently only works for "page"; needs implementation for para in cases, 
-	s and art in bills, etc., also: not clear if this is possible, but in some cases a second pinpoint 
-	is called for to identify not only page, but the footnote on that page -->
-	<choose>
-		<if variable="locator" >
-			<text term="at" />
-			<text variable="locator" prefix=" " />
-		</if>
-	</choose>
-</macro>
-<macro name="short-form">
-    <!-- Hump to overcome: cannot check against existence of short title. 
-	Not implemented: "cited to" for cases, construct short casenames, adding ref to article -->
-	<choose>
-		<if type="bill legal_case" match="none" >
-			<names variable="author"  >
-				<name and="symbol" form="short" delimiter-precedes-last="never"  />
-				<substitute>
-					<names variable="editor"  >
-						<name and="symbol" form="short"/>
-					</names>
-				</substitute>
-			</names>
+  </macro>
+  <macro name="pinpoint">
+	<group delimiter=" ">
+	  <choose>
+		<if locator="page">
+		  <choose>
+			<if variable="locator">
+			  <text term="at" prefix=" "/>
+			</if>
+		  </choose>
 		</if>
 		<else>
-			<text variable="title" form="short" />
+		  <label variable="locator" prefix=", "/>
 		</else>
+	  </choose>
+	  <text variable="locator"/>
+	</group>
+  </macro>
+  <macro name="short-form">
+	<!-- Hump to overcome: cannot check against existence of short title. 
+		 Not implemented: "cited to" for cases, construct short casenames, adding ref to article -->
+	<choose>
+	  <if type="bill legal_case" match="none" >
+		<names variable="author"  >
+		  <name and="symbol" form="short" delimiter-precedes-last="never"  />
+		  <substitute>
+			<names variable="editor"  >
+			  <name and="symbol" form="short"/>
+			</names>
+		  </substitute>
+		</names>
+	  </if>
+	  <else>
+		<text variable="title" form="short" />
+	  </else>
 	</choose>
-</macro>
-<citation et-al-min="4" et-al-use-first="1" >
-<!-- translator needs to be added for chapter, book, film etc. chapter? -->
-    <layout delimiter="; " suffix="." >
+  </macro>
+  <macro name="publisher-place-year">
+	<group delimiter=", " prefix=" (" suffix=")">
+	  <group delimiter=": ">
+		<text variable="publisher-place"/>
+		<text variable="publisher"/>
+	  </group>
+	  <date form="text" variable="issued" date-parts="year"/>
+	</group>
+  </macro>
+  <citation et-al-min="4" et-al-use-first="1" >
+	<!-- translator needs to be added for chapter, book, film etc. chapter? -->
+	<layout delimiter="; " suffix="." >
 	  <choose>
 		<!-- Not implemented: ibid only needs capitalize-first if it's the first word in a footnote -->
 		<if position="ibid-with-locator">
-			  <group delimiter=" ">
-					<text term="ibid" font-style="italic" strip-periods="true" text-case="capitalize-first" />
-					<text macro="pinpoint" />
-			  </group>
+		  <group>
+			<text term="ibid" font-style="italic" strip-periods="true" text-case="capitalize-first" />
+			<text macro="pinpoint"/>
+		  </group>
 		</if>
 		<else-if position="ibid">
-			<text term="ibid" font-style="italic" strip-periods="true" text-case="capitalize-first"  />
-        </else-if>
-		<!-- For future versions? No way of indicating footnote # of previous citation 
-			e.g. "supra note X"; X is not stored, or is not available -->
+		  <text term="ibid" font-style="italic" strip-periods="true" text-case="capitalize-first"  />
+		</else-if>
 		<!-- For future versions? Cannot test for whether short form exists 
-			(Supra should be capitalized if no short form) -->	
+			 (Supra should be capitalized if no short form) -->	
 		<else-if position="subsequent">
-			  <group delimiter=", ">
-					<text macro="short-form"/>
-					<text value="supra" font-style="italic" />
-			  </group>
-			  <text value="note ---" prefix=" "/>
-			  <text macro="pinpoint" prefix=" " />
-        </else-if>
-		<else>
+		  <group delimiter=", ">
+			<text macro="short-form"/>
+			<text value="supra" font-style="italic" />
+		  </group>
+		  <group>
 			<group delimiter=" ">
-				<choose>
+			  <text value="note"/>
+			  <text variable="first-reference-note-number"/>
+			</group>
+			<text macro="pinpoint"/>
+		  </group>
+		</else-if>
+		<else>
+		  <group>
+			<group delimiter=", ">
+			  <choose>
+				<if type="bill legal_case" match="any">
+				  <choose>
 					<if type="bill">
-						<text macro="render-bill" />
-					</if >
+					  <text macro="render-bill" />
+					</if>
 					<else-if type="legal_case">
-						<text macro="render-case" /> 
+					  <text macro="render-case" />
 					</else-if>
-					<else-if type="article-journal">
-						<text macro="render-article-journal" />
-					</else-if>
+				  </choose>
+				</if>
+				<else>
+				  <text macro="author-note" strip-periods="true"/>	
+				  <choose>
+					<if type="article-journal">
+					  <text macro="render-article-journal" />
+					</if>
 					<else-if type="chapter">
-						<text macro="render-chapter" />
+					  <text macro="render-chapter" />
 					</else-if>
 					<else-if type="thesis">
-						<text macro="render-thesis" />
+					  <text macro="render-thesis" />
 					</else-if>
 					<else-if type="article-newspaper">
-						<text macro="render-article-newspaper" />
+					  <text macro="render-article-newspaper" />
 					</else-if>
 					<else>
-						<text macro="author"  />
-						<text macro="title" font-style="italic"/>
-						<text macro="translator" prefix=", " />
-						<text macro="edition" prefix=", " />
-						<text macro="publisher-place" prefix=" (" suffix=": " />
-						<text macro="publisher" suffix=", " />
-						<text macro="issued-year" suffix=")" />
+                      <group delimiter=" ">
+						<group delimiter=", ">
+						  <text variable="title" font-style="italic"/>
+						  <text macro="translator"/>
+						  <text macro="edition"/>
+						</group>
+						<text macro="publisher-place-year"/>
+                      </group>
 					</else>
-				</choose>
-				<text macro="pinpoint" />
+				  </choose>
+				</else>
+			  </choose>
 			</group>
+			<text macro="pinpoint" />
+		  </group>
 		</else>
 	  </choose>
-    </layout>
- </citation>
- <bibliography et-al-min="4" et-al-use-first="1" >
+	</layout>
+  </citation>
+  <bibliography et-al-min="4" et-al-use-first="1" >
 	<sort>
-		<key macro="sort-by-type" />
-		<key macro="author" />
-		<key macro="issued-year" />
+	  <key macro="sort-by-type" />
+	  <key macro="author-bib" />
+	  <key variable="issued" />
 	</sort>
-    <layout>
-		<choose>
+	<layout>
+	  <choose>
+		<if type="bill legal_case" match="any">
+		  <choose>
 			<if type="bill">
-				<text macro="render-bill" />
-			</if >
+			  <text macro="render-bill" />
+			</if>
 			<else-if type="legal_case">
-				<text macro="render-case" />
+			  <text macro="render-case" />
 			</else-if>
-			<else-if type="article-journal">
+		  </choose>
+		</if>
+        <else>
+		  <group delimiter=". ">
+			<text macro="author-bib" strip-periods="true"/>
+			<choose>
+			  <else-if type="article-journal">
 				<text macro="render-article-journal" />
-			</else-if>
-			<else-if type="chapter">
+			  </else-if>
+			  <else-if type="chapter">
 				<text macro="render-chapter" />
-			</else-if>
-			<else-if type="thesis">
+			  </else-if>
+			  <else-if type="thesis">
 				<text macro="render-thesis" />
-			</else-if>
-			<else-if type="article-newspaper">
+			  </else-if>
+			  <else-if type="article-newspaper">
 				<text macro="render-article-newspaper" />
-			</else-if>
-			<else>
-				<text macro="author" suffix=" " />
-				<text macro="title" font-style="italic" />
-				<text macro="edition" prefix=", " />
-				<text macro="translator" prefix=", " /> 
-				<text macro="editor" prefix=", " />
-				<text macro="publisher-place" prefix=" (" suffix=": " />
-				<text macro="publisher" suffix=", " />
-				<text macro="issued-year" suffix=")" />
-			</else> 
-		</choose>
-    </layout>
+			  </else-if>
+			  <else>
+				<group delimiter=", ">
+				  <text variable="title" font-style="italic" />
+				  <text macro="edition"/>
+				  <text macro="translator"/> 
+				  <text macro="editor"/>
+				</group>
+				<text macro="publisher-place-year"/>
+			  </else> 
+			</choose>
+		  </group>
+		</else>
+	  </choose>
+	</layout>
   </bibliography>
 </style>


### PR DESCRIPTION
With this changeset, the style uses delimiters rather than affixes for many inter-element joins, in order to avoid extraneous punctuation when elements of a citation are missing in the input data. The changeset also makes use of the CSL 1.0 first-reference-note-number variable for back-references, and applies the ordinal suffixes (2d rather than 2nd, 3d rather than 3rd) required by the style guide.

The refactored style has not been extensively tested, but the basic structure has not changed, and any errors should be relatively easy to work out. A librarian at McGill (megan.fitzgibbons on the Zotero forums) is in the loop for submitting tests to lock in cite forms that are found wanting.
