### PR TITLE
Patch 2

### DIFF
--- a/hwr-berlin.csl
+++ b/hwr-berlin.csl
@@ -35,7 +35,7 @@
          </term>
       </terms>
    </locale><!-- 
-  macro definitions 
+   macro definitions 
 	author
 	editor
 	accessed
@@ -44,6 +44,7 @@
 	pages
 	point-locators
 	point-locators-subsequent
+        hasUrl
   -->
    <macro name="author">
       <names variable="author">
@@ -147,6 +148,16 @@
          <text variable="locator"/>
       </group>
    </macro>
+<macro name="hasUrl">
+               <choose>
+                  <if variable="URL" match="any">
+                     <text value="yes"/>
+                  </if>
+                  <else>
+                     <text value="no"/>
+                  </else>
+               </choose>
+</macro>
    <citation et-al-min="3" et-al-use-first="1" disambiguate-add-year-suffix="true">
       <layout delimiter="; " suffix=".">
          <choose>
@@ -171,6 +182,7 @@
    </citation>
    <bibliography et-al-min="3" et-al-use-first="1" hanging-indent="true">
       <sort>
+         <key macro="hasUrl"/>
          <key macro="author"/>
          <key macro="date"/>
       </sort>


### PR DESCRIPTION
I've done some improvements for article-magazine, article-newspaper and article-journal presentaion in the bibliography. For other item types than books, web-pages, documents, chapters and articles it still has to be done.

I simplified the code at some points. 

Finnaly I made a automatic sorting for entries with an URL and entries without an URL when creating the bibliography - the guidelines of our university require two separate literature directories, one with printed literature like books or documents, one with web or intranet pages, pdfs from the web and so on. This way you can easier create this two directories.
