### PR TITLE
Change et al behavior to remove listing all authors on first cite.

### DIFF
--- a/misq.csl
+++ b/misq.csl
@@ -28,6 +28,11 @@
       <contributor>
          <name>Sebastian Karcher</name>
       </contributor>
+      <contributor>
+         <name>James Howison</name>
+	 <email>james@howison.name</email>
+         <uri>http://james.howison.name</uri>
+      </contributor>
       <category citation-format="author-date"/>
       <updated>2008-09-20T09:22:05+00:00</updated>
    </info>
@@ -269,7 +274,7 @@
          <text variable="locator" prefix=" "/>
       </group>
    </macro>
-   <citation et-al-min="6" et-al-use-first="1" et-al-subsequent-min="3" et-al-subsequent-use-first="1" disambiguate-add-year-suffix="true" disambiguate-add-names="true" disambiguate-add-givenname="true" collapse="year">
+   <citation et-al-min="3" disambiguate-add-year-suffix="true" disambiguate-add-names="true" disambiguate-add-givenname="true" collapse="year">
       <sort>
          <key macro="author"/>
          <key macro="issued-year"/>


### PR DESCRIPTION
Very glad to have this style file.  Using it I found that it gave all the authors names for the first use.  My own memory and reviewing MISQ papers shows that not to be standard in MISQ. So I changed the et-al-min to 3 and removed the first/subsequent. If there is a place people talk about this style file pls advise.
