### PR TITLE
Altered et-al and added by-cite disambiguation

### DIFF
--- a/misq.csl
+++ b/misq.csl
@@ -287,7 +287,7 @@
          </group>
       </layout>
    </citation>
-   <bibliography entry-spacing="0" hanging-indent="true">
+   <bibliography entry-spacing="1" line-spacing="1" hanging-indent="true">
       <sort>
          <key macro="author"/>
          <key macro="issued-year" sort="ascending"/>


### PR DESCRIPTION
Two commits: changing et al behavior so as not to have long author lists on first usage and minimizing givenname disambiguation using "by-cite".  Both based on my reading of MISQ articles.  Happy to discuss :)
