### PR TITLE
Style file for Research Policy.

### DIFF
--- a/research-policy.csl
+++ b/research-policy.csl
@@ -1,0 +1,259 @@
+<?xml version="1.0" encoding="utf-8"?>
+<style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" demote-non-dropping-particle="sort-only" default-locale="en-US">
+   <info>
+      <title>Research Policy</title>
+      <id>http://www.zotero.org/styles/elsevier-harvard</id>
+      <link href="http://www.zotero.org/styles/research-policy" rel="self"/>
+      <link href="http://www.elsevier.com/wps/find/journaldescription.cws_home/505598/authorinstructions#56000" rel="documentation"/>
+      <link href="http://forums.zotero.org/discussion/13748/style-request-research-policy" rel="documentation"/>
+      <link href="http://www.zotero.org/styles/elsevier-harvar" rel="template"/>
+      <author>
+         <name>David Kaplan</name>
+         <email>david.kaplan@ird.fr</email>
+      </author>
+      <contributor>
+         <name>Simon Kornblith</name>
+         <email>simon@simonster.com</email>
+      </contributor>
+      <contributor>
+         <name>Bruce D'Arcus</name>
+      </contributor>
+      <contributor>
+         <name>Curtis M. Humphrey</name>
+      </contributor>
+      <contributor>
+         <name>Richard Karnesky</name>
+         <email>karnesky+zotero@gmail.com</email>
+         <uri>http://arc.nucapt.northwestern.edu/Richard_Karnesky</uri>
+      </contributor>
+      <contributor>
+         <name>Sebastian Karcher</name>
+      </contributor>
+      <contributor>
+         <name>James Howison</name>
+         <email>james@howison.name</email>
+         <uri>http://james.howison.name</uri>
+      </contributor>
+      <category field="social science"/>
+      <category field="generic-base"/>
+      <category citation-format="author-date"/>
+      <updated>2011-08-11T12:56:45-0500</updated>
+      <rights>This work is licensed under a Creative Commons Attribution-Share Alike 3.0 License: http://creativecommons.org/licenses/by-sa/3.0/</rights>
+   </info>
+   <macro name="container">
+      <choose>
+         <if type="chapter paper-conference" match="any">
+            <text term="in" text-case="lowercase" prefix=", " suffix=": "/>
+            <names variable="editor translator" delimiter=", " suffix=", ">
+               <name name-as-sort-order="all" sort-separator=", " initialize-with="." delimiter=", " delimiter-precedes-last="always"/>
+               <label form="short" text-case="capitalize-first" prefix=" (" suffix=")" strip-periods="true"/>
+            </names>
+            <group delimiter=", ">
+               <text variable="container-title" text-case="title"/>
+               <text variable="collection-title" text-case="title"/>
+            </group>
+         </if>
+         <else-if type="bill book graphic legal_case motion_picture report song article article-newspaper article-magazine article-journal" match="any">
+            <group prefix=" " delimiter=", ">
+               <text variable="container-title"/>
+               <text variable="collection-title"/>
+            </group>
+         </else-if>
+         <else>
+            <group prefix=". " delimiter=", ">
+               <text variable="container-title" form="short"/>
+               <text variable="collection-title"/>
+            </group>
+         </else>
+      </choose>
+   </macro>
+   <macro name="author">
+      <names variable="author">
+         <name name-as-sort-order="all" sort-separator=", " initialize-with="." delimiter=", " delimiter-precedes-last="always"/>
+         <label form="short" prefix=" (" suffix=".)" text-case="capitalize-first" strip-periods="true"/>
+         <substitute>
+            <names variable="editor"/>
+            <names variable="translator"/>
+            <text macro="title"/>
+         </substitute>
+      </names>
+   </macro>
+   <macro name="author-short">
+      <names variable="author">
+         <name form="short" and="text" delimiter=", " initialize-with="."/>
+         <substitute>
+            <names variable="editor"/>
+            <names variable="translator"/>
+            <choose>
+               <if type="bill book graphic legal_case motion_picture report song" match="any">
+                  <text variable="title" form="short" font-style="italic"/>
+               </if>
+               <else>
+                  <text variable="title" form="short" quotes="true"/>
+               </else>
+            </choose>
+         </substitute>
+      </names>
+   </macro>
+   <macro name="access">
+      <choose>
+         <if type="webpage">
+            <group>
+               <text value="URL" suffix=" "/>
+               <text variable="URL"/>
+            </group>
+         </if>
+      </choose>
+   </macro>
+   <macro name="title">
+      <choose>
+         <if type="report thesis" match="any">
+            <text variable="title"/>
+            <group prefix=" (" suffix=")">
+               <text variable="genre"/>
+               <text variable="number" prefix=" No. "/>
+            </group>
+         </if>
+         <else-if type="bill book graphic legal_case motion_picture report song speech" match="any">
+            <text variable="title"/>
+            <text macro="edition" prefix=", "/>
+         </else-if>
+         <else-if type="webpage">
+            <text variable="title"/>
+            <text value="WWW Document" prefix=" [" suffix="]"/>
+         </else-if>
+         <else-if type="article article-newspaper article-magazine article-journal" match="any">
+            <text variable="title" suffix="."/>
+         </else-if>
+         <else>
+            <text variable="title"/>
+         </else>
+      </choose>
+   </macro>
+   <macro name="publisher">
+      <choose>
+         <if type="report thesis" match="any">
+            <group delimiter=", ">
+               <text variable="publisher"/>
+               <text variable="publisher-place"/>
+            </group>
+         </if>
+         <else>
+            <group delimiter=", ">
+               <text variable="publisher"/>
+               <text variable="publisher-place"/>
+            </group>
+         </else>
+      </choose>
+   </macro>
+   <macro name="event">
+      <choose>
+         <if variable="event">
+            <text term="presented at" text-case="capitalize-first" suffix=" "/>
+            <text variable="event"/>
+         </if>
+      </choose>
+   </macro>
+   <macro name="issued">
+      <choose>
+         <if variable="issued">
+            <date variable="issued">
+               <date-part name="year"/>
+            </date>
+         </if>
+         <else-if variable="accessed">
+            <choose>
+               <if type="webpage">
+                  <date variable="accessed">
+                     <date-part name="year"/>
+                  </date>
+               </if>
+               <else>
+                  <text term="no date" form="short"/>
+               </else>
+            </choose>
+         </else-if>
+         <else>
+            <text term="no date" form="short"/>
+         </else>
+      </choose>
+   </macro>
+   <macro name="edition">
+      <group delimiter=" ">
+         <choose>
+            <if is-numeric="edition">
+               <number variable="edition" form="ordinal"/>
+            </if>
+            <else>
+               <text variable="edition" suffix="."/>
+            </else>
+         </choose>
+         <text value="ed"/>
+      </group>
+   </macro>
+   <macro name="locators">
+      <choose>
+         <if type="article-journal article-magazine article-newspaper" match="any">
+            <group prefix=" " delimiter=", ">
+               <group>
+                  <text variable="volume"/>
+               </group>
+               <text variable="page"/>
+            </group>
+         </if>
+         <else-if type="bill book graphic legal_case motion_picture report song" match="any">
+            <group delimiter=", " prefix=". ">
+               <text macro="event"/>
+               <text macro="publisher"/>
+            </group>
+         </else-if>
+         <else-if type="chapter paper-conference" match="any">
+            <group delimiter=", " prefix=". ">
+               <text macro="event"/>
+               <text macro="publisher"/>
+               <group>
+                  <label variable="page" form="short" suffix=" "/>
+                  <text variable="page"/>
+               </group>
+            </group>
+         </else-if>
+      </choose>
+   </macro>
+   <macro name="citation-locator">
+      <group>
+         <label variable="locator" form="short"/>
+         <text variable="locator" prefix=" "/>
+      </group>
+   </macro>
+   <citation et-al-min="3" et-al-use-first="1"  disambiguate-add-year-suffix="true" disambiguate-add-givenname="true" givenname-disambiguation-rule="by-cite" collapse="year">
+      <sort>
+         <key macro="issued"/>
+         <key macro="author"/>
+      </sort>
+      <layout prefix="(" suffix=")" delimiter="; ">
+         <group delimiter=", ">
+            <text macro="author-short"/>
+            <text macro="issued"/>
+            <text macro="citation-locator"/>
+         </group>
+      </layout>
+   </citation>
+   <bibliography hanging-indent="true" entry-spacing="0" line-spacing="1">
+      <sort>
+         <key macro="author"/>
+         <key macro="issued" sort="ascending"/>
+      </sort>
+      <layout>
+         <group suffix=".">
+            <text macro="author" suffix=","/>
+            <text macro="issued" prefix=" " suffix=". "/>
+            <group>
+               <text macro="title"/>
+               <text macro="container"/>
+            </group>
+            <text macro="locators"/>
+         </group>
+         <text macro="access" prefix=". "/>
+      </layout>
+   </bibliography>
+</style>


### PR DESCRIPTION
## New Style file for Research Policy journal

See also discussion in [Zotero Forum Thread](http://forums.zotero.org/discussion/13748/style-request-research-policy)

My read of the [Research Policy guidelines](http://www.elsevier.com/wps/find/journaldescription.cws_home/505598/authorinstructions#56000) (scroll down to References)

is that Research Policy is Elsevier Harvard but with a few changes:
- no abbreviated journal titles
- making use of the p. 45 style locator (which the Elsevier Harvard doesn't?)
- adjusting scope of name disambiguation.
- issue numbers only need to be given if each issue of that journal begins its numbering from page 1.)
- page-range-format
- punctuation in bibliography
### No abbreviated journal titles

Removed form="short" from container (in else group)
### Added page locator for in-text citation.
### Scope of name disambiguation

This is mentioned in the guide, but doesn't completely solve the question, "(family name only, although include initials if the paper refers to work by two different authors with the same family name)"

Looking at a few papers it seems to be handled pretty idiosyncratically.  For example this paper (by a C Freeman, citing many papers by C Freeman):

Freeman, C. and Soete, L. (2009). Developing science, technology and innovation indicators: What we can learn from the past. Research Policy, 38(4):583 – 589.

cites a publication by an R Freeman in text as Richard Freeman, but the C Freeman articles as just Freeman.  In other places the same author is sometimes given two initials in the bibliography, sometimes one but just the last name in the in-text citation.

My take is that this journal minimizes initials in citations. the rule above specifically says papers with two authors with same last name should have initials and therefore I think it should use  givenname-disambiguation-rule="by-cite" and while it asks for initials, if those match then full given names (as with the Richard Freeman above). disambiguate-add-givenname="true" givenname-disambiguation-rule="by-cite"
### Page range format.

One citation (Pavitt) in the guidelines seem to suggest collapsing repeated or chicago, but looking at actual articles this doesn't appear to be done.  Going to leave it off for now.
### Issue numbers

From guidelines "In addition, issue numbers only need to be given if each issue of that journal begins its numbering from page 1.)" Not sure if this can be done in any automated way.  Ignoring.
### Punctuation in bibliography.

Removed comma after title for journal articles.  Removed period after Eds.  Again this is how it is in the style guide, but most actual articles use the period.  Sigh.
