### PR TITLE
Add style for Ergoscience

### DIFF
--- a/ergoscience.csl
+++ b/ergoscience.csl
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" demote-non-dropping-particle="sort-only">
+<style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" demote-non-dropping-particle="sort-only" default-locale="de-DE">
    <info>
       <title>Ergoscience</title>
       <id>http://www.zotero.org/styles/ergoscience</id>


### PR DESCRIPTION
This adds a unique style for the German journal "Ergoscience" as
published in Schulz-Kirchner Verlag. The style is heavily based on the
Acta Materialia one, but required a few tweaks that I could not find in
any existing unique style. Things like patent citation probably still
look out of place, but the rest should be quite OK.

Signed-off-by: Sebastian Spaeth Sebastian@SSpaeth.de
