### PR TITLE
As Adam suggested remove default-locale and various other tweaks. It validates. Thanks.

### DIFF
--- a/ergoscience.csl
+++ b/ergoscience.csl
@@ -1,10 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
-<style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" demote-non-dropping-particle="sort-only" default-locale="de-DE">
+<style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" demote-non-dropping-particle="sort-only">
    <info>
       <title>Ergoscience</title>
       <id>http://www.zotero.org/styles/ergoscience</id>
       <link href="http://www.zotero.org/styles/ergoscience" rel="self"/>
       <link href="http://www.zotero.org/styles/acta-materialia" rel="template"/>
+      <issn>1861-6348</issn>
       <author>
          <name>Sebastian Spaeth</name>
          <email>Sebastian@SSpaeth.de</email>
@@ -15,6 +16,8 @@
       <updated>2011-05-18T17:46:02+00:00</updated>
       <summary>A style for Schulz-Kirchner's "Ergoscience"</summary>
       <link href="http://www.schulz-kirchner.de/filese/ergoscience_autorenhinweise_englisch.pdf" rel="documentation"/>
+      <!--I received a more up-to-date hardcopy of the style guide which
+          has a slightly deviating format from the linked one and followed mine.-->
       <rights>This work is licensed under a Creative Commons Attribution-Share Alike 3.0 United States License: http://creativecommons.org/licenses/by-sa/3.0/us/</rights>
    </info>
    <macro name="author">
@@ -48,9 +51,11 @@
       </choose>
    </macro>
    <macro name="publisher">
-      <text variable="publisher-place" suffix=": " text-case="title"/>
-      <text variable="publisher" suffix=", "/>
-      <text macro="year-date"/>
+      <group delimiter=" ">
+        <text variable="publisher-place" suffix=":" text-case="title"/>
+        <text variable="publisher"/>
+        <text macro="year-date"/>
+      </group>
    </macro>
    <citation collapse="citation-number">
       <sort>
@@ -64,49 +69,40 @@
    <bibliography entry-spacing="0" second-field-align="flush">
       <layout suffix=".">
          <text variable="citation-number" prefix="[" suffix="]"/>
-         <text macro="author" prefix=" " suffix=". "/>
-         <choose>
+         <group delimiter=". ">
+           <text macro="author"/>
+           <choose>
             <if type="bill book graphic legal_case motion_picture report song" match="any">
-               <group delimiter=". ">
                   <group delimiter=", ">
                      <text variable="title" text-case="title"/>
                      <text variable="volume" prefix="vol. "/>
                   </group>
                   <text macro="publisher"/>
-               </group>
             </if>
             <else-if type="chapter paper-conference" match="any">
-               <group delimiter=". ">
-                  <text variable="title" text-case="title"/>
-                  <text term="in" text-case="sentence" suffix=":"/>
-                  <text macro="editor"/>
-                  <group delimiter=", ">
-                     <text variable="container-title" form="short" text-case="title"/>
-                     <text variable="volume" prefix="vol. "/>
-                  </group>
-                  <group delimiter="; ">
-                     <text macro="publisher"/>
-                     <text variable="page"/>
-                  </group>
-               </group>
+              <text variable="title" text-case="title"/>
+              <text term="in" text-case="sentence" suffix=":"/>
+              <text macro="editor"/>
+              <group delimiter=", ">
+                <text variable="container-title" form="short" text-case="title"/>
+                <text variable="volume" prefix="vol. "/>
+              </group>
+              <group delimiter="; ">
+                <text macro="publisher"/>
+                <text variable="page"/>
+              </group>
             </else-if>
             <else-if type="patent">
-               <group delimiter=", ">
-                  <group delimiter=". ">
-                     <text variable="title" text-case="title"/>
-                     <text variable="number" prefix="U.S. Patent "/>
-                  </group>
-                  <text macro="year-date"/>
-               </group>
+               <text variable="title" text-case="title"/>
+               <text variable="number" prefix="U.S. Patent "/>
+               <text macro="year-date"/>
             </else-if>
             <else-if type="thesis">
-               <group delimiter=". ">
-                  <text variable="title" text-case="title"/>
-                  <text variable="genre"/>
-                  <group delimiter=", ">
-                     <text variable="publisher"/>
-                     <text macro="year-date"/>
-                  </group>
+               <text variable="title" text-case="title"/>
+               <text variable="genre"/>
+               <group delimiter=", ">
+                 <text variable="publisher"/>
+                 <text macro="year-date"/>
                </group>
             </else-if>
             <else>
@@ -120,12 +116,12 @@
                             <text variable="issue" prefix="(" suffix=")" />
                          </group>
                      </group>
-                  </group><!-- TODO: Change to page-first when Zotero supports it -->
-                  <text variable="page" form="short" prefix=" " />
+                  </group>
+                  <text variable="page"/>
                </group>
             </else>
-         </choose>
-
+           </choose>
+         </group>
       </layout>
    </bibliography>
 </style>


### PR DESCRIPTION
1) No comma between publisher and year. 2) Don't use short form for pages.
3) Remove default-locale value per discussion with Adam Smith.
4) add ISSN number to Ergoscience style

Save a few lines by adding a new top-level group element and remove it from
various "if" sections. Reformat the bibliography part accordingly
(minimizing changes).

Signed-off-by: Sebastian Spaeth Sebastian@SSpaeth.de
