### PR TITLE
I added a space to the initialize-with= field. This changes the author fo

### DIFF
--- a/nature.csl
+++ b/nature.csl
@@ -26,7 +26,7 @@
    </macro>
    <macro name="author">
       <names variable="author">
-         <name sort-separator=", " delimiter=", " and="symbol" initialize-with="." delimiter-precedes-last="never" name-as-sort-order="all"/>
+         <name sort-separator=", " delimiter=", " and="symbol" initialize-with=". " delimiter-precedes-last="never" name-as-sort-order="all"/>
          <et-al font-style="italic"/>
       </names>
    </macro>


### PR DESCRIPTION
I added a space to the initialize-with= field. This changes the author format from "Hickstein, D.D." to "Hickstein, D. D" (just a space between the initials). Nature uses a space between these two initials. See: http://www.nature.com/nature/authors/gta/2d_End_notes.pdf

Thanks! 
Dan
