### PR TITLE
apa.csl: set sort key according to item type

### DIFF
--- a/apa.csl
+++ b/apa.csl
@@ -141,7 +141,6 @@
 					  <date-part name="day" suffix=", "/>
 					  <date-part name="year"/>
 					</date>
-					<text variable="year-suffix"/>
 				  </group>
 				  <text term="from"/>
 				  <text variable="URL"/>
@@ -249,6 +248,22 @@
 	  </else>
 	</choose>
   </macro>
+  <macro name="issued-sort">
+    <choose>
+      <if type="bill book graphic legal_case motion_picture report song article-journal chapter paper-conference" match="none">
+        <date variable="issued">
+          <date-part name="year"/>
+          <date-part prefix=", " name="month"/>
+          <date-part prefix=" " name="day"/>
+        </date>
+      </if>
+      <else>
+        <date variable="issued">
+          <date-part name="year"/>
+        </date>
+      </else>
+    </choose>
+  </macro>
   <macro name="issued-year">
 	<choose>
 	  <if variable="issued">
@@ -321,7 +336,7 @@
   <citation et-al-min="6" et-al-use-first="1" et-al-subsequent-min="3" et-al-subsequent-use-first="1" disambiguate-add-year-suffix="true" disambiguate-add-names="true" disambiguate-add-givenname="true" collapse="year" givenname-disambiguation-rule="primary-name">
 	<sort>
 	  <key macro="author"/>
-	  <key macro="issued-year"/>
+	  <key macro="issued-sort"/>
 	</sort>
 	<layout prefix="(" suffix=")" delimiter="; ">
 	  <group delimiter=", ">
@@ -334,7 +349,7 @@
   <bibliography hanging-indent="true" et-al-min="8" et-al-use-first="7" entry-spacing="0" line-spacing="2">
 	<sort>
 	  <key macro="author"/>
-	  <key macro="issued-year" sort="ascending"/>
+	  <key macro="issued-sort" sort="ascending"/>
 	</sort>
 	<layout>
 	  <group suffix=".">


### PR DESCRIPTION
For some item types, the sort key should include month and day. This introduces a separate sort key macro that enables that behavior -- the macro used for rendering won't work, since it divides the date across two separate cs:date objects, in order to insert the year-suffix.

This also removes a stray year-suffix on accessed dates that was my doing back in August, I think.
