### PR TITLE
Updated types.

### DIFF
--- a/cell.csl
+++ b/cell.csl
@@ -81,7 +81,7 @@
             <label variable="page" suffix="." form="short" strip-periods="true"/>
             <text variable="page"/>
           </else-if>
-          <else-if type="thesis phdthesis mastersthesis" match="any">
+          <else-if type="thesis">
             <text variable="title" suffix="."/>
             <text variable="genre" suffix="."/>
             <text variable="publisher"/>


### PR DESCRIPTION
NOTE: if referencing a thesis, use "thesis" type with the following fields:
genre = type of thesis (PhD thesis, MSc thesis, etc.)
publisher = university
