### PR TITLE
Quick update to mcgill-guide-v7

### DIFF
--- a/mcgill-guide-v7.csl
+++ b/mcgill-guide-v7.csl
@@ -131,6 +131,7 @@ all the other tests should have been done... -->
     <text variable="issue" prefix=":"/>
     <text macro="container-title" prefix=" "/>
     <text variable="page-first" prefix=" "/>
+    <text macro="internet-location"/>	
   </macro>
   <macro name="render-book">
 		<group delimiter=", ">
@@ -155,7 +156,7 @@ all the other tests should have been done... -->
       <text macro="container-title" font-style="italic"/>
       <text macro="issued-long" prefix="(" suffix=")"/>
       <text variable="page-first"/>
-      <text variable="URL" prefix=", online: &lt;" suffix="&gt;"/>
+      <text macro="internet-location"/>
     </group>
   </macro>
   <!-- cases and bills render the same for biblio and (first) cite -->


### PR DESCRIPTION
Added URL for journal articles and newspapers, to accord with "Include URL" setting
