### PR TITLE
Fix lingering space issue in Cell style w/suppress-author

### DIFF
--- a/cell.csl
+++ b/cell.csl
@@ -52,8 +52,10 @@
       <key macro="author"/>
     </sort>
     <layout prefix="(" suffix=")" delimiter="; ">
-      <text macro="author-short"/>
-      <text macro="issued" prefix=", "/>
+      <group delimiter=", ">
+        <text macro="author-short"/>
+        <text macro="issued"/>
+      </group>
     </layout>
   </citation>
   <bibliography et-al-min="11" et-al-use-first="10">


### PR DESCRIPTION
The Cell style currently uses a prefix on the year to join author and year in citations. The space lingers when the suppress-author option is used. Moving the join string to a delimiter fixes the issue.
