### PR TITLE
Update agu.csl

### DIFF
--- a/agu.csl
+++ b/agu.csl
@@ -175,7 +175,7 @@
             <text macro="year-date" prefix="(" suffix=")"/>
          </group>
          <choose>
-            <if type="bill book graphic legal_case motion_picture report song" match="any">
+            <if type="bill book graphic legal_case motion_picture report song map" match="any">
                <group delimiter=", " prefix=" " suffix=".">
                   <text macro="title"/>
                   <group delimiter=" ">


### PR DESCRIPTION
I'm attempting to get map citations to display correctly when using the AGU citation style. Currently only authors, the date, and the title show up. The correct style should display as:

Bentor, Y., and A. Vroman (1960), Arava Valley, with explanatory text, in The Geological Map of the Negev, rev. ed., sheet 19, scale 1:1,000,000, Isr. Geol. Surv., Jerusalem.
