### PR TITLE
fix wrong space in citations when omitting authors ( year, ...)

### DIFF
--- a/harvard7de.csl
+++ b/harvard7de.csl
@@ -198,10 +198,10 @@
       <key variable="issued"/>
     </sort>
     <layout prefix="(" suffix=")" delimiter="; ">
-      <group>
-        <text macro="author-short"/>
-        <text macro="year-date" prefix=", "/>
-        <text macro="locator-citation" prefix=": "/>
+      <group delimiter=" ">
+        <text macro="author-short" suffix=","/>
+        <text macro="year-date" suffix=":"/>
+        <text macro="locator-citation"/>
       </group>
     </layout>
   </citation>


### PR DESCRIPTION
thanks for seeing this :-)
