### PR TITLE
Added citation style for In-text full note [used in book reviews for Ethics, U Chicago Press].

### DIFF
--- a/ethics-book-reviews.csl
+++ b/ethics-book-reviews.csl
@@ -1,32 +1,19 @@
 <?xml version="1.0" encoding="utf-8"?>
 <style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" demote-non-dropping-particle="sort-only">
   <info>
-    <title>In-text full note [used in book reviews for Ethics, U Chicago Press]</title>
-    <id>http://www.zotero.org/styles/In-text-full-note-for-Ethics-book-reviews</id>
-    <link href="http://www.zotero.org/styles/In-text-full-note-for-Ethics-book-reviews" rel="self"/>
+    <title>Book Reviews for Ethics [in text full note]</title>
+    <id>http://www.zotero.org/styles/ethics-book-reviews</id>
+    <link href="http://www.zotero.org/styles/ethics-book-reviews" rel="self"/>
+    <link href="http://www.zotero.org/styles/chicago-author-date" rel="template"/>
     <link href="http://dl.dropbox.com/u/23387469/StyleSheetForBookReviews.pdf" rel="documentation"/>
     <author>
-      <name>Julian Onions</name>
-      <email>julian.onions@gmail.com</email>
-    </author>
-    <contributor>
-      <name>Simon Kornblith</name>
-      <email>simon@simonster.com</email>
-    </contributor>
-    <contributor>
-      <name>Elena Razlogova</name>
-      <email>elena.razlogova@gmail.com</email>
-    </contributor>
-    <contributor>
-      <name>Sebastian Karcher</name>
-    </contributor>
-    <contributor>
       <name>Clint Hall</name>
       <email>bclinthall@gmail.com</email>
-    </contributor>
-    <summary>In-text full note [used in book reviews for Ethics, U Chicago Press ].  Variation on Chicago full note formate for in-text use. Modified from csl id = http://www.zotero.org/styles/chicago-fullnote-bibliography by Clint Hall, January 17, 2012.</summary>
+    </author>
+    <summary>In-text full note [used in book reviews for Ethics, issn = 00141704, U Chicago Press ].  Variation on Chicago full note formate for in-text use. Modified from csl id = http://www.zotero.org/styles/chicago-fullnote-bibliography by Clint Hall, January 17, 2012.</summary>
+    <issn>0014-1704</issn>
     <category field="philosophy"/>
-    <category citation-format="in-text full"/>
+    <category citation-format="author-date"/>
     <updated>2012-01-13T03:46:08+00:00</updated>
     <rights>This work is licensed under a Creative Commons Attribution-Share Alike 3.0 License: http://creativecommons.org/licenses/by-sa/3.0/</rights>
   </info>


### PR DESCRIPTION
Ethics, which is a journal published by the U Chicago Press, uses a
variation on the Chicago full note style for their book reviews.  The
whole note is included in-text in parentheses, and some of the
parentheses within the citation style are changed to brackets.  No
bibliography.

There are a few things I'm unsure of about my code.  

re: Lines 5-6: These urls I used in the id and the 'self' link don't exist yet.  So maybe something different should go on those lines.

re: Lines 8-26:  To make the new .csl, I just made a few small modifications to .csl for Chicago Manual of Style (Full Note with Bibliography).  I left the previous authors and contributors untouched and added myself as a contributor.  I'm not sure what your standard practice for this sort of thing is.

re: Line 29:  There didn't seem to be a good citation format to describe this sort of citation style, so I invented a new one: "in-text full"

Thanks,
Clint
