### PR TITLE
Put a period at end of McGill bibliography entries.

### DIFF
--- a/mcgill-guide-v7.csl
+++ b/mcgill-guide-v7.csl
@@ -326,7 +326,7 @@
       <key macro="author-bib"/>
       <key variable="issued"/>
     </sort>
-    <layout>
+    <layout suffix=".">
       <choose>
         <if type="bill legal_case" match="any">
           <choose>


### PR DESCRIPTION
Following McGill user request citing sec. 1.1 of McGill Guide.
