### PR TITLE
Changes to Acta Mater style:

### DIFF
--- a/acta-materialia.csl
+++ b/acta-materialia.csl
@@ -9,10 +9,14 @@
       <email>karnesky+zotero@gmail.com</email>
       <uri>http://arc.nucapt.northwestern.edu/Richard_Karnesky</uri>
     </author>
+    <contributor>
+      <name>Eric Payton</name>
+      <email>eric.payton@rub.de</email>
+    </contributor>
     <category field="engineering"/>
     <!--<category term="materials science"/>-->
     <category citation-format="numeric"/>
-    <updated>2012-01-01T00:00:00+00:00</updated>
+    <updated>2012-02-17T16:51:04+00:00</updated>
     <summary>A style for Elsevier's journal "Acta Materialia"</summary>
     <issn>1359-6454</issn>
     <link href="http://www.elsevier.com/wps/find/journaldescription.cws_home/221/authorinstructions#Refs" rel="documentation"/>
@@ -20,25 +24,25 @@
   </info>
   <macro name="author">
     <names variable="author">
-      <name initialize-with="" delimiter=", " delimiter-precedes-last="always" name-as-sort-order="all" sort-separator=" "/>
-      <label form="long" prefix=", " text-case="lowercase" suffix="."/>
-      <substitute>
-        <names variable="editor"/>
-        <names variable="translator"/>
-      </substitute>
+    <name initialize-with="" delimiter=", " delimiter-precedes-last="always" name-as-sort-order="all" sort-separator=" "/>
+    <label form="long" prefix=", " text-case="lowercase" suffix="."/>
+    <substitute>
+      <names variable="editor"/>
+      <names variable="translator"/>
+    </substitute>
     </names>
   </macro>
   <macro name="editor">
     <names variable="editor">
-      <name initialize-with="" delimiter=", " delimiter-precedes-last="always" name-as-sort-order="all" sort-separator=" "/>
-      <label form="long" prefix=", " text-case="lowercase" suffix="."/>
+    <name initialize-with="" delimiter=", " delimiter-precedes-last="always" name-as-sort-order="all" sort-separator=" "/>
+    <label form="short" prefix=" (" text-case="title" suffix=")."/>
     </names>
   </macro>
   <macro name="year-date">
     <choose>
       <if variable="issued">
         <date variable="issued">
-          <date-part name="year"/>
+        <date-part name="year"/>
         </date>
       </if>
       <else>
@@ -48,8 +52,21 @@
   </macro>
   <macro name="publisher">
     <text variable="publisher-place" suffix=": " text-case="title"/>
-    <text variable="publisher" suffix=", "/>
+    <text variable="publisher" suffix="; " text-case="title"/>
     <text macro="year-date"/>
+  </macro>
+  <macro name="edition">
+    <choose>
+      <if is-numeric="edition">
+        <group delimiter=" ">
+          <number variable="edition" form="long-ordinal"/>
+          <text term="edition" form="short" suffix="." strip-periods="true"/>
+        </group>
+      </if>
+      <else>
+        <text variable="edition" suffix="."/>
+      </else>
+    </choose>
   </macro>
   <citation collapse="citation-number">
     <sort>
@@ -61,67 +78,76 @@
   </citation>
   <bibliography entry-spacing="0" second-field-align="flush">
     <layout suffix=".">
-      <text variable="citation-number" prefix="[" suffix="]"/>
-      <text macro="author" prefix=" " suffix=". "/>
-      <choose>
-        <if type="bill book graphic legal_case motion_picture report song" match="any">
-          <group delimiter=". ">
-            <group delimiter=", ">
-              <text variable="title" text-case="title"/>
-              <text variable="volume" prefix="vol. "/>
-            </group>
-            <text macro="publisher"/>
-          </group>
-        </if>
-        <else-if type="chapter paper-conference" match="any">
-          <group delimiter=". ">
-            <text variable="title" text-case="sentence"/>
-            <text term="in" text-case="sentence" suffix=":"/>
-            <text macro="editor"/>
-            <group delimiter=", ">
-              <text variable="container-title" form="short" text-case="title"/>
-              <text variable="volume" prefix="vol. "/>
-            </group>
-            <text macro="publisher"/>
-            <group delimiter=" ">
-              <label variable="page" form="short" suffix="." strip-periods="true"/>
-              <text variable="page"/>
-            </group>
-          </group>
-        </else-if>
-        <else-if type="patent">
+    <text variable="citation-number" prefix="[" suffix="]"/>
+    <text macro="author" suffix=". "/>
+    <choose>
+      <if type="bill book graphic legal_case motion_picture report song" match="any">
+        <group delimiter=". ">
           <group delimiter=", ">
-            <group delimiter=". ">
-              <text variable="title" text-case="title"/>
-              <text variable="number" prefix="U.S. Patent "/>
-            </group>
-            <text macro="year-date"/>
+            <text variable="title" text-case="title"/>
+            <text variable="volume" prefix="vol. "/>
+            <text macro="edition"/>
           </group>
-        </else-if>
-        <else-if type="thesis">
+          <text macro="publisher"/>
+        </group>
+      </if>
+      <else-if type="chapter paper-conference" match="any">
+        <group delimiter=". ">
+          <text variable="title" text-case="title" suffix=", in:"/>
+          <text macro="editor"/>
+          <group delimiter=", ">
+            <text variable="container-title" form="short" text-case="title"/>
+            <text variable="volume" prefix="vol. "/>
+            <text macro="edition"/>
+          </group>
+          <text macro="publisher"/>
+        </group>
+      </else-if>
+      <else-if type="patent">
+        <group delimiter=", ">
           <group delimiter=". ">
             <text variable="title" text-case="title"/>
-            <text variable="genre"/>
-            <group delimiter=", ">
-              <text variable="publisher"/>
+            <text variable="number" prefix="U.S. Patent "/>
+          </group>
+          <text macro="year-date"/>
+        </group>
+      </else-if>
+      <else-if type="thesis">
+        <group delimiter=". ">
+          <text variable="title" text-case="title"/>
+          <text variable="genre"/>
+          <group delimiter=", ">
+            <text variable="publisher"/>
+            <text macro="year-date"/>
+          </group>
+        </group>
+      </else-if>
+      <else-if type="webpage">
+        <group delimiter=". ">
+          <group delimiter=", ">
+            <text variable="title" text-case="title"/>
+            <date variable="accessed">
+              <date-part name="day" suffix=" " prefix="accessed "/>
+              <date-part name="month" form="short" suffix=" "/>
+              <date-part name="year"/>
+            </date>
+          </group>
+          <text variable="URL" prefix="URL:&#160;"/>
+        </group>
+      </else-if>
+      <else>
+        <group delimiter=":">
+          <group delimiter=" ">
+            <text variable="container-title" form="short" strip-periods="true" />
+            <group delimiter=";">
               <text macro="year-date"/>
+              <text variable="volume"/>
             </group>
           </group>
-        </else-if>
-        <else>
-          <group delimiter=":">
-            <group delimiter=" ">
-              <text variable="container-title" form="short" text-case="sentence"/>
-              <group delimiter=";">
-                <text macro="year-date"/>
-                <text variable="volume"/>
-              </group>
-            </group>
-            <!-- TODO: Change to page-first when Zotero supports it -->
-            <text variable="page" form="short"/>
-          </group>
-        </else>
-      </choose>
+          <text variable="page-first"/>
+        </group>
+      </else>
+    </choose>
     </layout>
   </bibliography>
 </style>


### PR DESCRIPTION
- made journal names title case to better comply with Acta Mater specification
- implemented page first for journals only
- changed publisher and edited book title to title case
- added strip periods style to journal abbreviations to comply with Acta Mater specification
- added edition macro to handle long-ordinal numbers to comply with Acta Mater specification
- added web page citation style (note: Acta Mater spec only says that the URL and date accessed need to be provided. No further guidelines are given.)
- fixed editors field to comply with Acta Mater spec ("in: Surname F, Surname2 X (Eds.).")
- changed punctuation between publisher and year to semicolon to comply with Acta Mater spec
- removed page numbers for book chapters to comply with Acta Mater specification
- removed leading space in authors for better alignment of hanging indents.
- moved edited book title into the comma-delimited group to comply with Acta Mater specification
