### PR TITLE
Correction to ama-no-url

### DIFF
--- a/american-medical-association-no-url.csl
+++ b/american-medical-association-no-url.csl
@@ -193,7 +193,6 @@
           </group>
         </else>
       </choose>
-      <text prefix=" " macro="access" suffix="."/>
     </layout>
   </bibliography>
 </style>


### PR DESCRIPTION
I mistakenly forgot to remove the line that added a space and period after the access macro.
