### PR TITLE
fungal-ecology: remove author sort key.

### DIFF
--- a/fungal-ecology.csl
+++ b/fungal-ecology.csl
@@ -69,7 +69,6 @@
   </macro>
   <citation collapse="year-suffix" et-al-min="3" et-al-use-first="1" disambiguate-add-year-suffix="true" year-suffix-delimiter=", ">
     <sort>
-      <key variable="author"/>
       <key variable="issued"/>
     </sort>
     <layout prefix="(" suffix=")" delimiter="; ">


### PR DESCRIPTION
Style requires sorting of citations by year.
