### PR TITLE
Update american-meteorological-society.csl

### DIFF
--- a/american-meteorological-society.csl
+++ b/american-meteorological-society.csl
@@ -14,7 +14,7 @@
     </contributor>
     <category field="geography"/>
     <category citation-format="author-date"/>
-    <updated>2010-04-06T20:52:25+00:00</updated>
+    <updated>2012-02-07T01:46:04+00:00</updated>
     <link href="http://www.ametsoc.org/pubs/journals/author_reference_guide.pdf" rel="documentation"/>
     <summary>A style for all journals by AMS, based on Cold Spring Harbor Laboratory Press</summary>
     <rights>This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License: http://creativecommons.org/licenses/by-sa/3.0/</rights>
@@ -31,11 +31,11 @@
   </locale>
   <macro name="editor">
     <names variable="editor">
-      <label form="short" text-case="capitalize-first" suffix=". " strip-periods="true"/>
       <name and="text" delimiter=", " initialize-with=".">
         <name-part name="family" text-case="capitalize-first"/>
         <name-part name="given" text-case="capitalize-first"/>
       </name>
+      <label form="short" text-case="capitalize-first" prefix=", " suffix="." strip-periods="true"/>
     </names>
   </macro>
   <macro name="series-editor">
@@ -149,7 +149,7 @@
       </group>
     </layout>
   </citation>
-  <bibliography entry-spacing="0" line-spacing="2" hanging-indent="true" et-al-min="9" et-al-use-first="1">
+  <bibliography entry-spacing="1" line-spacing="1" hanging-indent="true" et-al-min="9" et-al-use-first="1">
     <sort>
       <key macro="author" names-min="1" names-use-first="1"/>
       <key macro="author-count" names-min="3" names-use-first="3"/>
@@ -219,15 +219,14 @@
                 <text variable="collection-title" font-style="italic"/>
                 <text macro="series-editor"/>
               </group>
-              <text macro="page"/>
               <text macro="publisher" prefix=" "/>
+              <text macro="page"/>
             </group>
           </group>
         </else-if>
         <else>
           <group suffix=".">
             <text macro="title" prefix=" "/>
-            <text macro="editor" prefix=" "/>
           </group>
           <group prefix=" " suffix="." delimiter=" ">
             <text variable="container-title" form="short" font-style="italic" suffix=","/>


### PR DESCRIPTION
Fixed order of publisher and pages for book citations. Also put "Ed." or "Eds." after the names of the editors (not before).

I think I got it right this time. Let me know if you see anything funny.
