### PR TITLE
Update american-meteorological-society.csl

### DIFF
--- a/american-meteorological-society.csl
+++ b/american-meteorological-society.csl
@@ -35,12 +35,12 @@
         <name-part name="family" text-case="capitalize-first"/>
         <name-part name="given" text-case="capitalize-first"/>
       </name>
-      <label form="short" text-case="capitalize-first" prefix=", " suffix="." strip-periods="true"/>
+      <label form="short" text-case="capitalize-first" prefix=", " />
     </names>
   </macro>
   <macro name="series-editor">
     <names variable="original-author">
-      <label form="short" text-case="capitalize-first" suffix=". " strip-periods="true"/>
+      <label form="short" text-case="capitalize-first" />
       <name and="text" delimiter=", "/>
     </names>
   </macro>
@@ -48,7 +48,7 @@
     <names variable="author">
       <name and="text" name-as-sort-order="first" sort-separator=", " delimiter=", " delimiter-precedes-last="always" initialize-with=". "/>
       <et-al term="and others"/>
-      <label form="short" prefix=", " suffix="." text-case="lowercase" strip-periods="true"/>
+      <label form="short" prefix=", " text-case="lowercase" />
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
@@ -119,7 +119,7 @@
     </date>
   </macro>
   <macro name="page">
-    <label variable="page" suffix=". " form="short" strip-periods="true"/>
+    <label variable="page" form="short" />
     <text variable="page"/>
   </macro>
   <macro name="edition">
@@ -127,7 +127,7 @@
       <if is-numeric="edition">
         <group delimiter=" ">
           <number variable="edition" form="ordinal"/>
-          <text term="edition" form="short" suffix="." strip-periods="true"/>
+          <text term="edition" form="short" />
         </group>
       </if>
       <else>
@@ -149,7 +149,7 @@
       </group>
     </layout>
   </citation>
-  <bibliography entry-spacing="1" line-spacing="1" hanging-indent="true" et-al-min="9" et-al-use-first="1">
+  <bibliography hanging-indent="true" et-al-min="9" et-al-use-first="1">
     <sort>
       <key macro="author" names-min="1" names-use-first="1"/>
       <key macro="author-count" names-min="3" names-use-first="3"/>


### PR DESCRIPTION
Ok, I cleaned up the strip-periods and the suffixes.

The bibliography currently skips a line between entries. Is there a way to suppress that behavior? Or is it preferred as a default?
