### PR TITLE
Created a style for the American Journal of Human Genetics

### DIFF
--- a/american-journal-of-human-genetics.csl
+++ b/american-journal-of-human-genetics.csl
@@ -2,8 +2,8 @@
 <style xmlns="http://purl.org/net/xbiblio/csl" version="1.0" class="in-text" default-locale="en-US" demote-non-dropping-particle="sort-only" page-range-format="expanded">
   <info>
     <title>American Journal of Human Genetics</title>
-    <id>http://www.zotero.org/styles/ajhg</id>
-    <link href="http://www.zotero.org/styles/ajhg" rel="self"/>
+    <id>http://www.zotero.org/styles/american-journal-of-human-genetics</id>
+    <link href="http://www.zotero.org/styles/american-journal-of-human-genetics" rel="self"/>
     <link href="http://www.zotero.org/styles/cell" rel="template"/>
     <link href="http://www.cell.com/authors" rel="documentation"/>
     <contributor>


### PR DESCRIPTION
AJHG is published by Cell but uses a different in-text citation format (superscript numeric).

Modified from the Cell and Vancouver superscript styles.
