### PR TITLE
Added style derived from OSCOLA without the plain text field "(n__)"

### DIFF
--- a/oscola.csl
+++ b/oscola.csl
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <style xmlns="http://purl.org/net/xbiblio/csl" version="1.0" class="note" default-locale="en-GB">
   <info>
-    <title>Oxford Standard for Citation of Legal Authorities (OSCOLA)</title>
-    <id>http://www.zotero.org/styles/oscola</id>
+    <title>Oxford Standard for Citation of Legal Authorities (OSCOLA), without "(n__)"</title>
+    <id>http://www.zotero.org/styles/oscola-no-notenumber</id>
     <link href="http://www.zotero.org/styles/oscola" rel="self"/>
     <link href="http://www.zotero.org/styles/chicago-fullnote-bibliography" rel="template"/>
     <author>
@@ -496,7 +496,6 @@
           <group>
             <text macro="contributors-short" suffix=", "/>
             <text macro="title-short" suffix=" "/>
-            <text value="__" prefix="(n " suffix=")"/>
             <text macro="point-locators-subsequent"/>
           </group>
         </else-if>


### PR DESCRIPTION
If writing with a bibliography, the "(n__)" text field is unnecessary, and thus separate style excluding this text field seems necessary.
