### PR TITLE
journal of evolutionary biology style changes

### DIFF
--- a/journal-of-evolutionary-biology.csl
+++ b/journal-of-evolutionary-biology.csl
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" demote-non-dropping-particle="sort-only" default-locale="en-US">
+<style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" demote-non-dropping-particle="never" default-locale="en-US">
   <info>
     <title>Journal of Evolutionary Biology</title>
     <id>http://www.zotero.org/styles/journal-of-evolutionary-biology</id>
@@ -77,7 +77,7 @@
         <date variable="issued">
           <date-part name="year"/>
         </date>
-        <text variable="year-suffix" font-style="italic"/>
+        <text variable="year-suffix"/>
       </if>
       <else>
         <text term="no date" form="short"/>
@@ -121,7 +121,7 @@
         <group delimiter=", ">
           <group delimiter=" ">
             <text term="in" text-case="capitalize-first" suffix=":"/>
-            <text variable="container-title"/>
+            <text variable="container-title" font-style="italic"/>
             <text macro="editor-translator"/>
           </group>
           <group delimiter=" ">
@@ -132,18 +132,7 @@
       </if>
     </choose>
   </macro>
-  <macro name="access">
-    <choose>
-      <if variable="URL">
-        <choose>
-          <if variable="DOI" match="none">
-            <text variable="URL" prefix="See "/>
-          </if>
-        </choose>
-      </if>
-    </choose>
-  </macro>
-  <macro name="publisher">
+    <macro name="publisher">
     <group delimiter=", ">
       <text variable="publisher"/>
       <text variable="publisher-place"/>
@@ -177,7 +166,6 @@
         <text macro="journal-location"/>
         <text macro="chapter-info"/>
         <text macro="publisher"/>
-        <text macro="access"/>
       </group>
     </layout>
   </bibliography>


### PR DESCRIPTION
I changed small things: demote-non-dropping-particle should be "never", the year suffix is not italized, the title of a book when we cite a book chapter should be in italic. And also I suppressed the macro access because it is not asked to provide url in the bibliography.
