### PR TITLE
chicago-note-bibliography.csl: discrete sort keys

### DIFF
--- a/chicago-note-bibliography.csl
+++ b/chicago-note-bibliography.csl
@@ -498,7 +498,7 @@
   </citation>
   <bibliography hanging-indent="true" et-al-min="11" et-al-use-first="7" subsequent-author-substitute="———" entry-spacing="0">
     <sort>
-      <key macro="contributors-sort" names-min="11" names-use-first="7"/>
+      <key macro="contributors-sort"/>
       <key variable="title"/>
       <key variable="genre"/>
       <key variable="issued"/>


### PR DESCRIPTION
This separates a string used for sorting into separate keys, addressing an issue raised by a user in this thread:

http://forums.zotero.org/discussion/23276/different-works-by-same-author-listed-without-dash-replacing-authors-name/
