### PR TITLE
chicago-annotated-bibliography.csl: Discrete sort keys

### DIFF
--- a/chicago-annotated-bibliography.csl
+++ b/chicago-annotated-bibliography.csl
@@ -143,7 +143,6 @@
   <macro name="contributors-sort">
     <names variable="author">
       <name name-as-sort-order="all" and="text" sort-separator=", " delimiter=", " delimiter-precedes-last="always"/>
-      <label form="verb-short" prefix=", " suffix="." strip-periods="true"/>
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
@@ -455,11 +454,6 @@
       </choose>
     </group>
   </macro>
-  <macro name="sort-key">
-    <text macro="contributors-sort" suffix=" "/>
-    <text variable="title" suffix=" "/>
-    <text variable="genre"/>
-  </macro>
   <citation et-al-min="4" et-al-use-first="1" et-al-subsequent-min="4" et-al-subsequent-use-first="1" disambiguate-add-names="true">
     <layout prefix="" suffix="." delimiter="; ">
       <choose>
@@ -484,7 +478,9 @@
   </citation>
   <bibliography hanging-indent="true" et-al-min="11" et-al-use-first="7" subsequent-author-substitute="———" entry-spacing="0">
     <sort>
-      <key macro="sort-key"/>
+      <key macro="contributors-sort"/>
+      <key variable="title"/>
+      <key variable="genre"/>
       <key variable="issued"/>
     </sort>
     <layout suffix=".">


### PR DESCRIPTION
Following up on the sorting issue, a revised version of this style, again with the sort-key macro broken out into discrete elements.
