### PR TITLE
Update iso690-numeric-cs.csl

### DIFF
--- a/iso690-numeric-cs.csl
+++ b/iso690-numeric-cs.csl
@@ -5,10 +5,22 @@
     <id>http://www.zotero.org/styles/iso690-numeric-cs</id>
     <link href="http://www.zotero.org/styles/iso690-numeric-cs" rel="self"/>
     <link href="http://www.zotero.org/styles/iso690-numeric-en" rel="template"/>
-    <author>
+   <author>
+      <name>Laure Mellifluo</name>
+      <email>laure.mellifluo@hesge.ch</email>
+   </author>
+   <author>
+      <name>Raphael Grolimund</name> 
+      <email>raphael.grolimund@epfl.ch</email>
+   </author>
+   <author>
+      <name>Michel Hardegger</name>
+      <email>michel.hardegger@hesge.ch</email>
+   </author>    
+   <contributor>
       <name>Jiří Kratochvíl</name>
       <email>kratec@ukb.muni.cz</email>
-    </author>
+    </contributor>
     <category citation-format="numeric"/>
     <category field="generic-base"/>
     <updated>2011-11-01T13:00:00+01:00</updated>
@@ -218,9 +230,9 @@
   </macro>
   <macro name="issue">
     <group delimiter=", ">
-      <text variable="volume" prefix="ro�?.&#160;"/>
-      <text variable="issue" prefix="�?.&#160;"/>
-      <text variable="page" prefix="s.&#160;"/>
+      <text variable="volume" prefix="roč. "/>
+      <text variable="issue" prefix="č. "/>
+      <text variable="page" prefix="s. "/>
     </group>
   </macro>
   <macro name="publisher">
@@ -250,9 +262,9 @@
         <group prefix=" [" suffix="]">
           <text term="accessed"/>
           <date variable="accessed">
-            <date-part name="day" prefix="&#160;"/>
-            <date-part name="month" prefix=".&#160;"/>
-            <date-part name="year" prefix="&#160;"/>
+            <date-part name="day" prefix=" "/>
+            <date-part name="month" prefix=". "/>
+            <date-part name="year" prefix=" "/>
           </date>
         </group>
       </if>
@@ -267,21 +279,21 @@
   <macro name="page">
     <choose>
       <if type="book thesis manuscript" match="any">
-        <text variable="number-of-pages" suffix="&#160;p"/>
+        <text variable="number-of-pages" suffix=" "/>
       </if>
       <else-if type="chapter paper-conference article-newspaper" match="any">
-        <text variable="page" prefix="s.&#160;"/>
+        <text variable="page" prefix="s. "/>
       </else-if>
       <else-if type="report patent" match="any">
-        <text variable="page" suffix="&#160;p"/>
+        <text variable="page" suffix=" "/>
       </else-if>
     </choose>
   </macro>
   <macro name="isbn">
-    <text variable="ISBN" prefix="ISBN&#160;"/>
+    <text variable="ISBN" prefix="ISBN "/>
   </macro>
   <macro name="doi">
-    <text variable="DOI" prefix="DOI&#160;"/>
+    <text variable="DOI" prefix="doi "/>
   </macro>
   <macro name="url">
     <choose>
@@ -298,7 +310,7 @@
     <text variable="archive"/>
     <choose>
       <if variable="archive_location">
-        <text value=":&#160;"/>
+        <text value=": "/>
       </if>
     </choose>
   </macro>


### PR DESCRIPTION
I found a few mistakes in few words with Czech diacritics and I have corrected them. I also add names of authors, I am only contributor. Source code for Czech version of ISO 690 is based on source code for English version. I forget add it to ISO690-author-date-cs.csl as well, I will add it later after accepting the changes. I also must verify all actual corrections are right (when Rintze used my code with previous code at Zotero repository website (many thanks for help!:-)), Czech letters with diacritics were changed because of Rintze´s English keyboard, so that´s what I have corrected now.
Thank you for understanding.
