### PR TITLE
I changed "first" to "none" in lines 43 and 52. Now order of editors´ an...

### DIFF
--- a/iso690-numeric-cs.csl
+++ b/iso690-numeric-cs.csl
@@ -40,7 +40,7 @@
   </macro>
   <macro name="editor">
     <names variable="editor">
-      <name and="text" name-as-sort-order="all" sort-separator=", " delimiter=", " delimiter-precedes-last="never">
+      <name and="text" name-as-sort-order="none" sort-separator=", " delimiter=", " delimiter-precedes-last="never">
         <name-part name="family" text-case="uppercase"/>
         <name-part name="given"/>
       </name>
@@ -49,7 +49,7 @@
   </macro>
   <macro name="translator">
     <names variable="translator">
-      <name and="text" name-as-sort-order="first" sort-separator=", " delimiter=", " delimiter-precedes-last="never">
+      <name and="text" name-as-sort-order="none" sort-separator=", " delimiter=", " delimiter-precedes-last="never">
         <name-part name="family" text-case="uppercase"/>
         <name-part name="given"/>
       </name>


### PR DESCRIPTION
...d translators´ will be correct - according present ISO 690 name of editors in references on conference papers and name of editors have to be in form Name SURNAME (e.g. George SMITH).
