### PR TITLE
Changes to WHO Europe styles

### DIFF
--- a/who-europe-harvard.csl
+++ b/who-europe-harvard.csl
@@ -10,7 +10,7 @@
     </author>
     <category citation-format="author-date" />
     <category field="medicine" />
-    <updated>2012-06-07T10:00:00</updated>
+    <updated>2012-06-19T10:00:00</updated>
     <summary>The WHO Regional Office for Europe author year style</summary>
     <rights>This work is licensed under a Creative Commons
     Attribution-Share Alike 3.0 License:
@@ -18,10 +18,10 @@
   </info>
   <macro name="editor">
     <names variable="editor">
-      <name name-as-sort-order="all" sort-separator=""
-      initialize-with="" delimiter=","
+      <name name-as-sort-order="all" sort-separator=" "
+      initialize-with="" delimiter=", "
       delimiter-precedes-last="always" />
-      <label form="short" prefix="," text-case="lowercase"
+      <label form="short" prefix=", " text-case="lowercase"
       suffix="." strip-periods="true" />
     </names>
   </macro>
@@ -32,8 +32,8 @@
   <macro name="author">
     <group>
       <names variable="author">
-        <name name-as-sort-order="all" sort-separator=""
-        initialize-with="" delimiter=","
+        <name name-as-sort-order="all" sort-separator=" "
+        initialize-with="" delimiter=", "
         delimiter-precedes-last="always" />
         <label form="short" prefix="" suffix=""
         text-case="lowercase" strip-periods="true" />
@@ -46,25 +46,25 @@
   </macro>
   <macro name="author-short">
     <names variable="author">
-      <name form="short" and="symbol" delimiter=","
-      initialize-with="." />
+      <name form="short" and="symbol" delimiter=", "
+      initialize-with="." delimiter-precedes-last="never"/>
       <substitute>
         <names variable="editor" />
         <names variable="translator" />
-        <!--text macro="anon"/-->
+        <text macro="anon"/>
       </substitute>
     </names>
   </macro>
   <macro name="access">
     <choose>
       <if variable="URL">
-        <group delimiter=",">
+        <group delimiter=", ">
           <text variable="URL" />
           <group>
             <text value="accessed " suffix="" />
-            <date variable="accessed">
-              <date-part name="day" suffix="" />
-              <date-part name="month" suffix="" />
+            <date variable="accessed ">
+              <date-part name="day" suffix=" " />
+              <date-part name="month" suffix=" " />
               <date-part name="year" />
             </date>
           </group>
@@ -77,7 +77,7 @@
       <if variable="URL collection-title collection-number"
       match="any">
         <text value="(" suffix="" />
-        <group delimiter=";">
+        <group delimiter="; ">
           <text macro="series" />
           <text macro="access" />
         </group>
@@ -116,7 +116,7 @@
     </choose>
   </macro>
   <macro name="publisher">
-    <group delimiter=",">
+    <group delimiter=", ">
       <text variable="publisher-place" />
       <text variable="publisher" />
     </group>
@@ -138,9 +138,9 @@
   <macro name="edition">
     <choose>
       <if is-numeric="edition">
-        <group delimiter="">
+        <group delimiter=" " >
           <number variable="edition" form="ordinal" />
-          <text term="edition" form="short" suffix="."
+          <text term="edition" form="short" suffix="." 
           strip-periods="true" />
         </group>
       </if>
@@ -155,66 +155,68 @@
       match="any">
         <group>
           <text variable="collection-title" />
-          <text variable="collection-number" prefix=", No." />
+          <text variable="collection-number" prefix=", No. " />
         </group>
       </if>
     </choose>
   </macro>
-  <citation collapse="citation-number" et-al-min="4"
+  <citation collapse="year-suffix-ranged" et-al-min="4"
   et-al-use-first="1" disambiguate-add-year-suffix="true"
-  disambiguate-add-names="true" disambiguate-add-givenname="true">
-    <layout>
-      <text macro="author" />
-      <group prefix=" (" suffix=")">
+  disambiguate-add-names="true" disambiguate-add-givenname="true" year-suffix-delimiter="," >
+    <layout delimiter="; " prefix="(" suffix=")"  >
+	<group delimiter=", ">
+	  <text macro="author-short" suffix=""/>
+      <group prefix="" suffix="">
         <date variable="issued">
           <date-part name="year" />
         </date>
       </group>
+	  </group>
     </layout>
   </citation>
   <bibliography hanging-indent="false" et-al-min="4"
   et-al-use-first="1">
     <sort>
       <key macro="author" />
-      <key variable="title" />
+      <key variable="issued" />
     </sort>
     <layout>
-      <group suffix=".">
         <group suffix=".">
+		<group suffix=". ">
           <text macro="author" suffix="" />
-          <group prefix="(" suffix=")">
+          <group prefix=" (" suffix=")">
             <date variable="issued">
               <date-part name="year" />
             </date>
           </group>
-        </group>
+		  </group>
         <choose>
           <if type="bill book graphic legal_case motion_picture song report thesis"
           match="any">
             <group suffix=".">
               <text macro="title" prefix="" suffix="" />
-              <text macro="edition" prefix="," />
+              <text macro="edition" prefix=", " />
               <text macro="editor" prefix=" (" suffix=")" />
             </group>
-            <text prefix="" suffix="" macro="publisher" />
+            <text prefix=" " suffix="" macro="publisher" />
             <group prefix=",">
               <text variable="page" prefix=":" />
             </group>
           </if>
           <else-if type="chapter" match="any">
             <text macro="title" prefix="" suffix="." />
-            <group prefix="">
+            <group prefix=" ">
               <text term="in" text-case="capitalize-first"
-              suffix=":" />
+              suffix=": " />
               <text macro="editor" />
               <text variable="container-title" font-style="italic"
-              prefix="" suffix="." />
+              prefix=" " suffix="." />
               <text variable="volume" prefix="Vol" suffix="." />
               <text macro="edition" prefix="," />
               <text variable="collection-title" prefix=""
               suffix="." />
               <group suffix=".">
-                <text macro="publisher" prefix="" />
+                <text macro="publisher" prefix=" " />
                 <group suffix="." prefix=",">
                   <date variable="issued">
                     <date-part name="year" />
@@ -226,12 +228,12 @@
           </else-if>
           <else-if type="paper-conference" match="any">
             <text macro="title" prefix="" suffix="." />
-            <group prefix="">
+            <group prefix=" ">
               <choose>
                 <if variable="editor">
                   <text term="in" text-case="capitalize-first"
-                  suffix=":" />
-                  <text macro="editor" />
+                  suffix=": " prefix=" "/>
+                  <text macro="editor" suffix=" " />
                   <text variable="container-title"
                   font-style="italic" prefix="" suffix="." />
                   <text variable="volume" prefix="Vol"
@@ -240,21 +242,17 @@
                   <text variable="collection-title" prefix=""
                   suffix="." />
                   <group suffix="">
-                    <text macro="publisher" prefix="" />
-                    <group suffix="." prefix=",">
-                      <date variable="issued">
-                        <date-part name="year" />
-                      </date>
-                      <text variable="page" prefix=":" />
+                    <text macro="publisher" prefix=" " />
+                    <text variable="page" prefix=", " />
                     </group>
-                  </group>
+                  
                 </if>
                 <else>
                   <!-- no editor given -->
                   <text variable="event" prefix=""
                   font-style="italic" suffix="." />
                   <group suffix=",">
-                    <text macro="publisher" prefix="" />
+                    <text macro="publisher" prefix=" " />
                     <group suffix="." prefix=",">
                       <date variable="issued">
                         <date-part name="year" />
@@ -269,7 +267,7 @@
           </else-if>
           <else-if type="webpage" match="any">
             <text macro="title" prefix="" suffix="." />
-            <text variable="note" prefix="" />
+            <text variable="note" prefix=" " />
             <!--date variable="issued" prefix=", ">
                                         <date-part name="year"/>
                                         <date-part name="month"/>
@@ -279,20 +277,20 @@
           <else-if type="article-newspaper broadcast" match="any">
             <group suffix=".">
               <text macro="title" prefix="" suffix="." />
-              <group suffix=",">
-                <text variable="container-title" prefix=""
+              <group suffix=", ">
+                <text variable="container-title" prefix=" "
                 font-style="italic" />
                 <text variable="publisher-place" prefix=" ("
                 suffix=")" />
               </group>
               <group>
                 <date variable="issued">
-                  <date-part name="day" suffix="" />
-                  <date-part name="month" suffix="" />
+                  <date-part name="day" suffix=" " />
+                  <date-part name="month" suffix=" " />
                   <date-part name="year" />
                 </date>
               </group>
-              <text variable="section" prefix=", Section" />
+              <text variable="section" prefix=", Section " />
               <text variable="page" prefix=":" />
             </group>
           </else-if>
@@ -301,23 +299,18 @@
               <text macro="title" prefix="" />
               <text macro="editor" prefix="" />
             </group>
-            <group prefix="" suffix=".">
+            <group prefix=" " suffix=".">
               <text variable="container-title"
               font-style="italic" />
-              <group delimiter="," prefix="">
-                <date variable="issued">
-                  <date-part name="year" />
-                </date>
-                <group>
+                <group prefix=", ">
                   <text variable="volume" />
                   <text variable="issue" prefix="(" suffix=")" />
                 </group>
-              </group>
               <text variable="page" prefix=":" />
             </group>
           </else>
         </choose>
-        <text prefix="" macro="accessSeries" />
+        <text prefix=" " macro="accessSeries" />
       </group>
     </layout>
   </bibliography>

--- a/who-europe-numeric.csl
+++ b/who-europe-numeric.csl
@@ -10,16 +10,16 @@
     </author>
     <category citation-format="numeric" />
     <category field="medicine" />
-    <updated>2012-06-08T10:00:00</updated>
+    <updated>2012-06-19T10:00:00</updated>
     <summary>The WHO Regional Office for Europe numeric style</summary>
     <rights>This work is licensed under a Creative Commons Attribution-Share Alike 3.0 License: http://creativecommons.org/licenses/by-sa/3.0/</rights>
   </info>
   <macro name="editor">
     <names variable="editor">
-      <name name-as-sort-order="all" sort-separator=""
-      initialize-with="" delimiter=","
+      <name name-as-sort-order="all" sort-separator=" "
+      initialize-with="" delimiter=", "
       delimiter-precedes-last="always" />
-      <label form="short" prefix="," text-case="lowercase"
+      <label form="short" prefix=", " text-case="lowercase"
       suffix="." strip-periods="true" />
     </names>
   </macro>
@@ -31,8 +31,8 @@
       <if variable="call-number" match="none">
         <group suffix=".">
           <names variable="author">
-            <name name-as-sort-order="all" sort-separator=""
-            initialize-with="" delimiter=","
+            <name name-as-sort-order="all" sort-separator=" "
+            initialize-with="" delimiter=", "
             delimiter-precedes-last="always" />
             <label form="short" prefix="" suffix=""
             text-case="lowercase" strip-periods="true" />
@@ -59,13 +59,13 @@
   <macro name="access">
     <choose>
       <if variable="URL">
-        <group delimiter=",">
+        <group delimiter=", ">
           <text variable="URL" />
           <group>
             <text value="accessed " suffix="" />
             <date variable="accessed">
-              <date-part name="day" suffix="" />
-              <date-part name="month" suffix="" />
+              <date-part name="day" suffix=" " />
+              <date-part name="month" suffix=" " />
               <date-part name="year" />
             </date>
           </group>
@@ -78,7 +78,7 @@
       <if variable="URL collection-title collection-number"
       match="any">
         <text value="(" suffix="" />
-        <group delimiter=";">
+        <group delimiter="; ">
           <text macro="series" />
           <text macro="access" />
         </group>
@@ -117,7 +117,7 @@
     </choose>
   </macro>
   <macro name="publisher">
-    <group delimiter=",">
+    <group delimiter=", ">
       <text variable="publisher-place" />
       <text variable="publisher" />
     </group>
@@ -139,7 +139,7 @@
   <macro name="edition">
     <choose>
       <if is-numeric="edition">
-        <group delimiter="">
+        <group delimiter=" " >
           <number variable="edition" form="ordinal" />
           <text term="edition" form="short" suffix="."
           strip-periods="true" />
@@ -156,7 +156,7 @@
       match="any">
         <group>
           <text variable="collection-title" />
-          <text variable="collection-number" prefix=", No." />
+          <text variable="collection-number" prefix=", No. " />
         </group>
       </if>
     </choose>
@@ -173,19 +173,19 @@
   <bibliography hanging-indent="false" et-al-min="4"
   et-al-use-first="1">
     <layout>
-      <text variable="citation-number" prefix="" suffix="." />
-      <group suffix=".">
-        <text macro="author" suffix="" />
+      <text variable="citation-number" prefix="" suffix=". " />
+      <group prefix="" suffix=".">
+        <text macro="author" suffix=" " />
         <choose>
           <if type="bill book graphic legal_case motion_picture song report thesis"
           match="any">
             <group suffix=".">
               <text macro="title" prefix="" suffix="" />
-              <text macro="edition" prefix="," />
+              <text macro="edition" prefix=", " />
               <text macro="editor" prefix=" (" suffix=")" />
             </group>
-            <text prefix="" suffix="" macro="publisher" />
-            <group prefix=",">
+            <text prefix=" " suffix="" macro="publisher" />
+            <group prefix=", ">
               <date variable="issued">
                 <date-part name="year" />
               </date>
@@ -194,19 +194,19 @@
           </if>
           <else-if type="chapter" match="any">
             <text macro="title" prefix="" suffix="." />
-            <group prefix="">
+            <group prefix=" ">
               <text term="in" text-case="capitalize-first"
-              suffix=":" />
+              suffix=": " />
               <text macro="editor" />
               <text variable="container-title" font-style="italic"
-              prefix="" suffix="." />
+              prefix=" " suffix="." />
               <text variable="volume" prefix="Vol" suffix="." />
               <text macro="edition" prefix="," />
               <text variable="collection-title" prefix=""
               suffix="." />
-              <group suffix=".">
+              <group suffix="." prefix=" ">
                 <text macro="publisher" prefix="" />
-                <group suffix="." prefix=",">
+                <group suffix="." prefix=", ">
                   <date variable="issued">
                     <date-part name="year" />
                   </date>
@@ -217,22 +217,22 @@
           </else-if>
           <else-if type="paper-conference" match="any">
             <text macro="title" prefix="" suffix="." />
-            <group prefix="">
+            <group prefix=" ">
               <choose>
                 <if variable="editor">
                   <text term="in" text-case="capitalize-first"
-                  suffix=":" />
-                  <text macro="editor" />
+                  suffix=": " prefix=" "/>
+                  <text macro="editor" suffix=" "/>
                   <text variable="container-title"
-                  font-style="italic" prefix="" suffix="." />
+                  font-style="italic" prefix=" " suffix="." />
                   <text variable="volume" prefix="Vol"
                   suffix="." />
-                  <text macro="edition" prefix="" />
+                  <text macro="edition" prefix=" " />
                   <text variable="collection-title" prefix=""
                   suffix="." />
                   <group suffix="">
-                    <text macro="publisher" prefix="" />
-                    <group suffix="." prefix=",">
+                    <text macro="publisher" prefix=" " />
+                    <group suffix="." prefix=", ">
                       <date variable="issued">
                         <date-part name="year" />
                       </date>
@@ -260,28 +260,28 @@
           </else-if>
           <else-if type="webpage" match="any">
             <text macro="title" prefix="" suffix="." />
-            <text variable="note" prefix="" />
-            <date variable="issued" prefix=",">
+            <text variable="note" prefix=" " />
+            <date variable="issued" prefix=", ">
               <date-part name="year" />
             </date>
           </else-if>
           <else-if type="article-newspaper broadcast" match="any">
             <group suffix=".">
               <text macro="title" prefix="" suffix="." />
-              <group suffix=",">
-                <text variable="container-title" prefix=""
+              <group suffix=", ">
+                <text variable="container-title" prefix=" "
                 font-style="italic" />
                 <text variable="publisher-place" prefix=" ("
                 suffix=")" />
               </group>
               <group>
                 <date variable="issued">
-                  <date-part name="day" suffix="" />
-                  <date-part name="month" suffix="" />
+                  <date-part name="day" suffix=" " />
+                  <date-part name="month" suffix=" " />
                   <date-part name="year" />
                 </date>
               </group>
-              <text variable="section" prefix=", Section" />
+              <text variable="section" prefix=", Section " />
               <text variable="page" prefix=":" />
             </group>
           </else-if>
@@ -290,14 +290,14 @@
               <text macro="title" prefix="" />
               <text macro="editor" prefix="" />
             </group>
-            <group prefix="" suffix=".">
+            <group prefix=" " suffix=".">
               <text variable="container-title"
               font-style="italic" />
-              <group delimiter="," prefix="">
+              <group prefix=", ">
                 <date variable="issued">
                   <date-part name="year" />
                 </date>
-                <group>
+                <group prefix=", ">
                   <text variable="volume" />
                   <text variable="issue" prefix="(" suffix=")" />
                 </group>
@@ -306,7 +306,7 @@
             </group>
           </else>
         </choose>
-        <text prefix="" macro="accessSeries" />
+        <text prefix=" " macro="accessSeries" />
       </group>
     </layout>
   </bibliography>


### PR DESCRIPTION
Dear Zotero team,

I have updated the WHO Europe styles (who-europe-numeric.csl and who-europe-harvard.csl). Changes are mostly bug fixes related to spacing between different citation parts (author, title, publisher etc.), which for unknown reason were omitted in the original citation. Additionally, in text citation layout was changed for who-europe-harvard.csl.

Could you please be so kind and change the two aforementioned files in the Zotero Style repository.

Many thanks,
Best regards
