### PR TITLE
Update iso690-numeric-cs.csl

### DIFF
--- a/iso690-numeric-cs.csl
+++ b/iso690-numeric-cs.csl
@@ -332,7 +332,7 @@
       <key variable="citation-number"/>
     </sort>
     <layout>
-      <text variable="citation-number" display="left-margin" suffix=". "/>
+      <text variable="citation-number" suffix=". "/>
       <choose>
         <if type="book map" match="any">
           <group display="right-inline">


### PR DESCRIPTION
I deleted a part of line 335 (display="left-margin) which made a large breake between citation number and reference (validation on http://simonster.github.com/csl-validator.js/ was successful)

What I would like to do in the future is making reference to be shown in a block which is separated from citation number (like http://citationstyles.org/downloads/specification.html#whitespace), but now I don´t know where to implement described commands to a source code iso690-numeric-cs.csl :-(
