### PR TITLE
Update human-mutation.csl

### DIFF
--- a/human-mutation.csl
+++ b/human-mutation.csl
@@ -5,7 +5,7 @@
     <link href="http://onlinelibrary.wiley.com/journal/10.1002/(ISSN)1098-1004/homepage/ForAuthors.html" rel="documentation"/>
     <id>http://www.zotero.org/styles/human-mutation</id>
     <link href="http://www.zotero.org/styles/human-mutation" rel="self"/>
-    <updated>2012-07-06T16:31:32+00:00</updated>
+    <updated>2012-07-25T00:46:02+00:00</updated>
     <author>
       <name>Matthew Shirley</name>
       <uri>http://www.mattshirley.com/</uri>
@@ -22,8 +22,7 @@
   </macro>
   <macro name="author">
     <names variable="author">
-      <name name-as-sort-order="all" sort-separator=" " delimiter="" initialize-with="" et-al-min="12" and="text"/>
-      <et-al term="and others"/>
+      <name name-as-sort-order="all" sort-separator=" " delimiter=", " initialize-with=""  et-al-use-first="12" et-al-min="12"/>
     </names>
   </macro>
   <macro name="editor">


### PR DESCRIPTION
Added comma's between authors in the reference list.
And will always list the first 12 authors in the reference list before adding "et al."
Changed the "and others" to "et al."
