### PR TITLE
Update pontifical-biblical-institute.csl

### DIFF
--- a/pontifical-biblical-institute.csl
+++ b/pontifical-biblical-institute.csl
@@ -28,7 +28,6 @@
         <single>ed.</single>
         <multiple>ed.</multiple>
       </term>
-      <term name="page-range-delimiter">-</term>
     </terms>
   </locale>
   <macro name="author">


### PR DESCRIPTION
Various corrections based on the official style guide for the Pontifical Biblical Institute, including: 
- Separates page numbers with a hyphen instead of the default en-dash
- Format author names in the bibliography section last name, first name
- Books which have an author and an editor now correctly present the editor(s) with the first name preceding the last name
- Dictionary and encyclopedia entries take the short form of the name when available
- Includes fix for the group suppression bug related to "ibid" and "locator" by rmzelle
