### PR TITLE
Update vancouver.csl

### DIFF
--- a/vancouver.csl
+++ b/vancouver.csl
@@ -27,7 +27,7 @@
   <locale xml:lang="en">
     <date form="text" delimiter=" ">
       <date-part name="year"/>
-      <date-part name="month" form="short" strip-periods="true"/>
+      <date-part name="month" prefix=" " form="short" strip-periods="true"/>
       <date-part name="day"/>
     </date>
     <terms>
@@ -38,7 +38,7 @@
   <locale xml:lang="fr">
     <date form="text" delimiter=" ">
       <date-part name="day"/>
-      <date-part name="month" form="short" strip-periods="true"/>
+      <date-part name="month" prefix=" " form="short" strip-periods="true"/>
       <date-part name="year"/>
     </date>
     <terms>


### PR DESCRIPTION
Corrected format by adding a space between year and month in the bibliography.
