### PR TITLE
Removed extraneous comma.

### DIFF
--- a/new-zealand-veterinary-journal.csl
+++ b/new-zealand-veterinary-journal.csl
@@ -146,7 +146,7 @@
     </sort>
     <layout prefix="(" suffix=")" delimiter="; ">
       <group delimiter=" ">
-        <group delimiter=", ">
+        <group delimiter=" ">
           <text macro="author-cit"/>
           <text macro="date"/>
         </group>


### PR DESCRIPTION
NZVJ does not use a comma between author name and date in citation format.  Removed comma.
