### PR TITLE
New style: Harvard - University of Birmingham

### DIFF
--- a/harvard-university-of-birmingham.csl
+++ b/harvard-university-of-birmingham.csl
@@ -6,13 +6,14 @@
     <link href="http://www.zotero.org/styles/harvard-university-of-birmingham" rel="self"/>
     <link href="https://intranet.birmingham.ac.uk/as/libraryservices/icite/referencing/harvard/index.aspx" rel="documentation"/>
     <link href="https://intranet.birmingham.ac.uk/as/libraryservices/library/documents/public/alcd-guides/sk04.pdf" rel="documentation"/>
+    <link href="http://www.oak-wood.co.uk/oss/birmingham-harvard-csl" rel="documentation"/>
     <author>
       <name>Chris Hastie</name>
       <uri>http://www.oak-wood.co.uk</uri>
     </author>
     <category citation-format="author-date"/>
     <category field="generic-base"/>
-    <summary>The Harvard author-date style - adapted for the University of Birmingham</summary>
+    <summary>The Harvard author-date style - adapted for the University of Birmingham. See usage notes at http://www.oak-wood.co.uk/oss/birmingham-harvard-csl</summary>
     <updated>2012-10-03T13:09:00+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
@@ -239,13 +240,6 @@
 
   <citation et-al-min="3" et-al-use-first="1" et-al-subsequent-min="3" et-al-subsequent-use-first="1" disambiguate-add-year-suffix="true" collapse="year">
     <layout prefix="(" suffix=")" delimiter="; ">
-      <group delimiter=", ">
-        <text variable="author-short"/>
-        <group>
-          <label variable="locator" suffix="." form="short" strip-periods="true"/>
-          <text variable="locator"/>
-        </group>
-      </group>
       <group delimiter=", ">
         <text macro="author-short"/>
         <choose>


### PR DESCRIPTION
I've written a style sheet for the University of Birmingham's Harvard style guide at https://intranet.birmingham.ac.uk/as/libraryservices/library/documents/public/alcd-guides/sk04.pdf.

Some usage notes:
## E-books

The UoB's style guide says that books from electronic libraries (eg MyiLibrary, ebrary) should have the name of the library as well as the URL in the 'Available from' part of the reference. To do this, place the name of the library in the Archive field in Zotero.
## British standards

Use the ‘Book’ type and put the standard number and date (eg BS5606:1990) in the ‘Extra’ field.
## Command Papers/Official Publications

Use the ‘Book’ type. Give author in the format Country. Committee. Eg “Great Britain. Department of Health”.
## Thesis

Use the ‘Thesis’ type. Use the ‘Type’ field to indicate the degree, eg 'PhD thesis'.
## Known issues
- Entries listed by title rather than author (eg films, broadcasts, anonymous works) do not ignore a 'the', 'a' or 'an' at the beginning when sorting.
- Conferences can not include the location of the publishing organisation. Zotero only allows one place field and it used for the location of the conference.
- Referencing a chapter in a book when the chapter author is the same as the book author does not work as per the style guide. The guide appears to suggest that only the book title, not the chapter title should be given. The closest match is probably to enter only the chapter authors in the database, not the book authors.  
- Dates of newspaper articles do not include the day of the week.
