### PR TITLE
Update universite-de-liege-histoire.csl

### DIFF
--- a/universite-de-liege-histoire.csl
+++ b/universite-de-liege-histoire.csl
@@ -38,14 +38,14 @@
     <choose>
       <if variable="author">
         <names variable="author">
-          <name form="long" and="text" delimiter-precedes-last="never" sort-separator=" " font-style="normal">
+          <name initialize-with="." delimiter=", " form="long" and="text" delimiter-precedes-last="never" font-style="normal" name-as-sort-order="all" sort-separator=", ">
             <name-part name="family" font-variant="small-caps"/>
           </name>
         </names>
       </if>
       <else-if variable="editor">
         <names variable="editor">
-          <name form="long" and="text" delimiter-precedes-last="never" sort-separator=" " font-style="normal">
+          <name initialize-with="." delimiter=", " form="long" and="text" delimiter-precedes-last="never" font-style="normal" name-as-sort-order="all" sort-separator=", ">
             <name-part name="family" font-variant="small-caps"/>
           </name>
           <label form="short" prefix="&#160;(" suffix=".)"/>
@@ -57,15 +57,14 @@
     <choose>
       <if variable="author">
         <names variable="author">
-          <name name-as-sort-order="all" form="long" and="text" delimiter-precedes-last="never" sort-separator=" " font-style="normal">
+          <name initialize-with="." delimiter=", " form="long" and="text" delimiter-precedes-last="never" font-style="normal" name-as-sort-order="all" sort-separator=", ">
             <name-part name="family" font-variant="small-caps"/>
           </name>
         </names>
       </if>
       <else-if variable="editor">
         <names variable="editor">
-          <name name-as-sort-order="all" form="long" and="text" delimiter-precedes-last="never" sort-separator=" " font-style="normal">
-            <name-part name="family" font-variant="small-caps"/>
+            <name initialize-with="." delimiter=", " form="long" and="text" delimiter-precedes-last="never" font-style="normal" name-as-sort-order="all" sort-separator=", ">            <name-part name="family" font-variant="small-caps"/>
           </name>
           <label form="short" prefix="&#160;(" suffix=".)"/>
         </names>
@@ -74,7 +73,7 @@
   </macro>
   <macro name="editor">
     <names variable="editor">
-      <name form="long" and="text" delimiter-precedes-last="never" sort-separator=" " font-style="normal">
+      <name initialize-with="." delimiter=", " form="long" and="text" delimiter-precedes-last="never" font-style="normal" name-as-sort-order="all" sort-separator=", ">
         <name-part name="family" font-variant="small-caps"/>
       </name>
       <label form="short" prefix="&#160;(" suffix=".)"/>
@@ -82,7 +81,7 @@
   </macro>
   <macro name="translator">
     <names variable="translator">
-      <name form="long" and="text" delimiter-precedes-last="never" sort-separator=" " font-style="normal" prefix=" traduit par ">
+      <name initialize-with="." delimiter=", " form="long" and="text" delimiter-precedes-last="never" font-style="normal" name-as-sort-order="all" sort-separator=", " prefix=" traduit par ">
         <name-part name="family" font-variant="small-caps"/>
       </name>
     </names>


### PR DESCRIPTION
Authors: Family name comes first, then first name abbreviated (now complies with Dep. of History's referencing rules)
