### PR TITLE
Update american-antiquity.csl

### DIFF
--- a/american-antiquity.csl
+++ b/american-antiquity.csl
@@ -1,23 +1,21 @@
-<?xml version="1.0" encoding="utf-8"?>
-<style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" demote-non-dropping-particle="sort-only" default-locale="en-US">
+<?xml version="1.0" encoding="UTF-8"?>
+<style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" demote-non-dropping-particle="sort-only">
   <info>
-    <title>American Antiquity</title>
-    <id>http://www.zotero.org/styles/american-antiquity</id>
-    <link href="http://www.zotero.org/styles/american-antiquity" rel="self"/>
-    <link href="http://www.zotero.org/styles/american-anthropological-association" rel="template"/>
-    <link href="http://www.saa.org/AbouttheSociety/Publications/StyleGuide/tabid/984/Default.aspx" rel="documentation"/>
+    <title>American Antiquity Custom</title>
+    <id>http://www.zotero.org/styles/american-antiquity-custom</id>
+    <link href="http://www.zotero.org/styles/american-antiquity-custom" rel="self"/>
     <author>
-      <name>Michael Barton</name>
-      <email>michael.barton@asu.edu</email>
+      <name>Allison Grunwald, based on American Anthropologist style by Mark Dingemanse</name>
+      <email>agrunwa1@uwyo.edu</email>
     </author>
     <category citation-format="author-date"/>
     <category field="anthropology"/>
-    <issn>0002-7316</issn>
-    <summary>American Antiquity format, imperfect due to incomplete CSL/Zotero implementation. Requires word processor hanging indent of about 0.5-inch</summary>
-    <updated>2011-05-18T17:46:02+00:00</updated>
-    <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
+    <updated>2012-06-26T17:46:02+00:00</updated>
+    <summary>American Antiquity format altered from previously-uploaded version on Zotero, perfectly compatible with at least Mendeley Desktop</summary>
+    <link href="http://www.saa.org/AbouttheSociety/Publications/StyleGuide/tabid/984/Default.aspx" rel="documentation"/>
+    <rights>This work is licensed under a Creative Commons Attribution-Share Alike 3.0 License: http://creativecommons.org/licenses/by-sa/3.0/</rights>
   </info>
-  <macro name="secondary-contributors">
+<macro name="secondary-contributors">
     <choose>
       <if type="chapter paper-conference" match="none">
         <group delimiter=". ">
@@ -46,13 +44,13 @@
             <name and="text" delimiter=", "/>
           </names>
           <choose>
-            <if variable="author editor" match="any">
-              <names variable="translator">
-                <label form="verb" prefix=" " text-case="lowercase" suffix=" "/>
-                <name and="text" delimiter=", "/>
-              </names>
-            </if>
-          </choose>
+          <if variable="author editor" match="any">
+           <names variable="translator">
+              <label form="verb" prefix=" " text-case="lowercase" suffix=" "/>
+              <name and="text" delimiter=", "/>
+           </names>
+          </if>
+        </choose>
         </group>
       </if>
     </choose>
@@ -64,7 +62,7 @@
       </if>
     </choose>
   </macro>
-  <macro name="editor">
+    <macro name="editor">
     <names variable="editor">
       <name name-as-sort-order="first" and="text" sort-separator=", " delimiter=", " delimiter-precedes-last="always"/>
       <label form="long" prefix=" (" suffix=")."/>
@@ -81,7 +79,7 @@
       <if type="personal_communication">
         <choose>
           <if variable="genre">
-            <text variable="genre" text-case="capitalize-first"/>
+            <text variable="genre" />
           </if>
           <else>
             <text term="letter" text-case="capitalize-first"/>
@@ -96,12 +94,12 @@
   </macro>
   <macro name="contributors">
     <names variable="author">
-      <name and="text" name-as-sort-order="first" sort-separator=", " delimiter=", " delimiter-precedes-last="always"/>
-      <label form="verb-short" prefix=", " suffix="." text-case="lowercase" strip-periods="true"/>
-      <substitute>
+       <name and="text" name-as-sort-order="first" sort-separator=", " delimiter=", " delimiter-precedes-last="always"/>
+       <label form="verb-short" prefix=", " suffix="." text-case="lowercase" strip-periods="true"/>
+       <substitute>
         <text macro="editor"/>
         <text macro="translator"/>
-      </substitute>
+       </substitute>
     </names>
     <text macro="anon"/>
     <text macro="recipient"/>
@@ -135,45 +133,43 @@
         <if type="graphic report" match="any">
           <text macro="archive"/>
         </if>
-        <else-if type="article-journal article-magazine article-newspaper bill book chapter graphic legal_case legislation motion_picture paper-conference report song thesis" match="none">
+        <else-if type="bill book graphic legal_case motion_picture report song article-journal article-magazine article-newspaper thesis chapter paper-conference" match="none">
           <text macro="archive"/>
         </else-if>
       </choose>
-      <text variable="DOI" prefix="doi:"/>
-      <text variable="URL"/>
     </group>
   </macro>
   <macro name="title">
     <choose>
-      <if variable="title" match="none">
-        <choose>
-          <if type="personal_communication" match="none">
-            <text variable="genre" text-case="capitalize-first"/>
-          </if>
-        </choose>
-      </if>
-      <else-if type="bill book graphic legal_case legislation motion_picture report song" match="any">
-        <text variable="title" font-style="italic"/>
-      </else-if>
-      <else>
-        <text variable="title"/>
-      </else>
+    <if variable="title" match="none">
+      <choose>
+        <if type="personal_communication" match="none">
+            <text variable="genre" />
+        </if>
+      </choose>
+    </if>
+    <else-if type="bill book graphic legal_case motion_picture report song" match="any">
+      <text variable="title" font-style="italic"/>
+    </else-if>
+    <else>
+      <text variable="title"/>
+    </else>
     </choose>
   </macro>
   <macro name="edition">
     <choose>
-      <if type="bill book chapter graphic legal_case legislation motion_picture paper-conference report song" match="any">
+      <if type="bill book graphic legal_case motion_picture report song chapter paper-conference" match="any">
         <choose>
           <if is-numeric="edition">
             <group delimiter=" ">
               <number variable="edition" form="ordinal"/>
               <text term="edition" form="short" suffix="." strip-periods="true"/>
             </group>
-          </if>
-          <else>
-            <text variable="edition" suffix="."/>
-          </else>
-        </choose>
+            </if>
+            <else>
+              <text variable="edition" suffix="."/>
+            </else>
+          </choose>
       </if>
     </choose>
   </macro>
@@ -183,7 +179,7 @@
         <text variable="volume" prefix=" "/>
         <text variable="issue" prefix="(" suffix=")"/>
       </if>
-      <else-if type="bill book graphic legal_case legislation motion_picture report song" match="any">
+      <else-if type="bill book graphic legal_case motion_picture report song" match="any">
         <group prefix=". " delimiter=". ">
           <group>
             <text term="volume" form="short" text-case="capitalize-first" suffix=". " strip-periods="true"/>
@@ -202,7 +198,7 @@
       <if type="chapter paper-conference" match="any">
         <group prefix=", ">
           <text variable="volume" suffix=":"/>
-          <text variable="page"/>
+          <text variable="page" prefix="pp. "/>
         </group>
       </if>
     </choose>
@@ -233,7 +229,7 @@
           <label variable="locator" form="short" suffix=" "/>
         </if>
       </choose>
-      <text variable="locator"/>
+        <text variable="locator"/>
     </group>
   </macro>
   <macro name="container-prefix">
@@ -248,11 +244,21 @@
     <text variable="container-title" font-style="italic"/>
   </macro>
   <macro name="publisher">
-    <group delimiter=", ">
-      <text variable="publisher"/>
-      <text variable="publisher-place"/>
-    </group>
-  </macro>
+      <choose>
+         <if type="report thesis" match="any">
+            <group delimiter=", ">
+               <text variable="publisher"/>
+               <text variable="publisher-place"/>
+            </group>
+         </if>
+         <else>
+            <group delimiter=", ">
+               <text variable="publisher"/>
+               <text variable="publisher-place"/>
+            </group>
+         </else>
+      </choose>
+   </macro>
   <macro name="date1">
     <date variable="issued">
       <date-part name="year"/>
@@ -288,7 +294,7 @@
       <if variable="title" match="none"/>
       <else-if type="thesis"/>
       <else>
-        <text variable="genre" text-case="capitalize-first" prefix=". "/>
+            <text variable="genre" prefix="Unpublished "/>
       </else>
     </choose>
   </macro>
@@ -310,11 +316,11 @@
         <group prefix=". " delimiter=", ">
           <choose>
             <if type="thesis">
-              <text variable="genre" text-case="capitalize-first"/>
+            <text variable="genre" prefix="Unpublished "/>
             </if>
           </choose>
-          <text macro="publisher"/>
-          <text macro="day-month"/>
+            <text macro="publisher"/>
+            <text macro="day-month"/>
         </group>
       </else>
     </choose>
@@ -333,7 +339,12 @@
     <text macro="locators-article"/>
     <text macro="access" prefix=". "/>
   </macro>
-  <citation et-al-min="4" et-al-use-first="1" et-al-subsequent-min="4" et-al-subsequent-use-first="1" disambiguate-add-year-suffix="true" disambiguate-add-names="true" disambiguate-add-givenname="true">
+  <citation et-al-min="3" et-al-use-first="1" disambiguate-add-year-suffix="true" disambiguate-add-names="true" disambiguate-add-givenname="true">
+
+/* DELETED FROM PREVIOUS LINE
+et-al-subsequent-min="3" et-al-subsequent-use-first="1" 
+*/
+
     <layout prefix="(" suffix=")" delimiter="; ">
       <group delimiter=", ">
         <group delimiter=" ">
@@ -344,7 +355,12 @@
       </group>
     </layout>
   </citation>
-  <bibliography hanging-indent="false" et-al-min="6" et-al-use-first="3" subsequent-author-substitute=" " entry-spacing="0">
+  <bibliography hanging-indent="false" entry-spacing="0">
+
+/*  DELETED FROM PREVIOUS LINE
+et-al-min="6" et-al-use-first="3" subsequent-author-substitute=" "
+*/
+
     <sort>
       <key macro="contributors"/>
       <key variable="issued"/>
@@ -354,9 +370,9 @@
         <text macro="contributors"/>
       </group>
       <group display="indent">
-        <text macro="date1" suffix=" "/>
-        <text macro="rest-of-bib"/>
+        <text  macro="date1" suffix=" " />
+        <text  macro="rest-of-bib"/>
       </group>
     </layout>
-  </bibliography>
+  </bibliography>  
 </style>


### PR DESCRIPTION
Everything on the previous style that has been spread around the internet is completely wrong. No one puts URLs, for instance, in their publication reference lists. Keep or throw away my edits if you want, but either way, the correct version of American Antiquity citation style can always be found at: https://gist.github.com/2987631
