### PR TITLE
NSF grant proposal csl file: Fix sequential references and space after references

### DIFF
--- a/national-science-foundation-grant-proposals.csl
+++ b/national-science-foundation-grant-proposals.csl
@@ -15,8 +15,8 @@
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <citation>
-    <layout>
-      <text variable="citation-number" prefix="[" suffix="] "/>
+    <layout prefix="[" suffix="]" delimiter=", ">
+        <text variable="citation-number"/>
     </layout>
   </citation>
   <bibliography>


### PR DESCRIPTION
multiple references are currently in the text as [1] [2] [3] [4], which is not as standard as [1, 2, 3, 4]. Also, it is impossible to end a sentence with a reference since the suffix is 
"] ". This pull fixes both.
"This is an example of the current csl file [1] [2] ." [note the space after [2] ]
"This is an example of the fixed file [1, 2]."
