### PR TITLE
Diploma Hamburg School of Food Science

### DIFF
--- a/diploma-hamburg-school-of-food-science.csl
+++ b/diploma-hamburg-school-of-food-science.csl
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<style class="in-text" version="1.0" name-as-sort-order="all" demote-non-dropping-particle="sort-only" default-locale="de-DE" xmlns="http://purl.org/net/xbiblio/csl">
+<style class="in-text" version="1.0" name-as-sort-order="all" demote-non-dropping-particle="sort-only" default-locale="de" xmlns="http://purl.org/net/xbiblio/csl">
   <info>
     <title>Diploma Hamburg School of Food Science</title>
     <id>http://www.zotero.org/styles/diploma-hamburg-school-of-food-science</id>


### PR DESCRIPTION
This citation style is based on non-published internal guidelines for a diploma thesis at http://hsfs.org/ and the citation style for the Australian Journal of Grape and Wine Research. It might be easier for my fellow students if it is available via http://zotero.org/styles and not only via GitHub.
