### PR TITLE
Update hamburg-school-of-food-science.csl

### DIFF
--- a/hamburg-school-of-food-science.csl
+++ b/hamburg-school-of-food-science.csl
@@ -2,7 +2,6 @@
 <style class="in-text" version="1.0" name-as-sort-order="all" demote-non-dropping-particle="sort-only" default-locale="de" xmlns="http://purl.org/net/xbiblio/csl">
   <info>
     <title>Hamburg School of Food Science (diploma, German)</title>
-    <title-short>Diplom-LC-UHH</title-short>
     <id>http://www.zotero.org/styles/hamburg-school-of-food-science</id>
     <link rel="self" href="http://www.zotero.org/styles/hamburg-school-of-food-science"/>
     <link href="http://www.zotero.org/styles/australian-journal-of-grape-and-wine-research" rel="template"/>
@@ -13,8 +12,9 @@
     <category citation-format="author-date"/>
     <category field="chemistry"/>
     <summary>Guidelines by Prof. Dr. Markus Fischer</summary>
-    <updated>2012-08-30T17:04:14+00:00</updated>
+    <updated>2012-11-06T10:44:33+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
+    <title-short>Diplom-LC-UHH</title-short>
   </info>
   <locale xml:lang="de">
     <terms>
@@ -109,14 +109,14 @@
     <choose>
       <if type="report thesis" match="any">
         <group>
-          <text variable="publisher" suffix=", " />
-          <text variable="publisher-place" form="long" />
+          <text variable="publisher" suffix=", "/>
+          <text variable="publisher-place" form="long"/>
         </group>
       </if>
       <else>
         <group>
           <text variable="publisher" suffix=", "/>
-          <text variable="publisher-place" form="long" />
+          <text variable="publisher-place" form="long"/>
         </group>
       </else>
     </choose>
@@ -132,7 +132,7 @@
   <macro name="issued">
     <choose>
       <if variable="issued">
-        <date date-parts="year-month-day" form="numeric" variable="issued">
+        <date date-parts="year" form="numeric" variable="issued">
           <date-part name="year" form="long"/>
         </date>
       </if>


### PR DESCRIPTION
Don't display the whole date, just the year. This broke when I tried to make it standards compliant.
