### PR TITLE
Improvements to Elsevier Harvard styles

### DIFF
--- a/elsevier-harvard-without-titles.csl
+++ b/elsevier-harvard-without-titles.csl
@@ -91,9 +91,17 @@
   <macro name="access">
     <choose>
       <if type="webpage">
-        <group>
-          <text value="URL" suffix=" "/>
+        <group delimiter=" ">
+          <text value="URL"/>
           <text variable="URL"/>
+          <group prefix="(" suffix=").">
+            <text term="accessed" suffix=" "/>
+            <date variable="accessed">
+              <date-part name="month" form="numeric" suffix="."/>
+              <date-part name="day" suffix="."/>
+              <date-part name="year" form="short"/>
+            </date>
+          </group>
         </group>
       </if>
     </choose>
@@ -151,18 +159,6 @@
           <date-part name="year"/>
         </date>
       </if>
-      <else-if variable="accessed">
-        <choose>
-          <if type="webpage">
-            <date variable="accessed">
-              <date-part name="year"/>
-            </date>
-          </if>
-          <else>
-            <text term="no date" form="short"/>
-          </else>
-        </choose>
-      </else-if>
       <else>
         <text term="no date" form="short"/>
       </else>
@@ -209,7 +205,7 @@
       </else-if>
     </choose>
   </macro>
-  <citation et-al-min="3" et-al-use-first="1" et-al-subsequent-min="3" et-al-subsequent-use-first="1" disambiguate-add-year-suffix="true" disambiguate-add-names="true" collapse="year">
+  <citation et-al-min="3" et-al-use-first="1" et-al-subsequent-min="3" et-al-subsequent-use-first="1" disambiguate-add-year-suffix="true" collapse="year">
     <sort>
       <key macro="issued"/>
       <key macro="author"/>

--- a/elsevier-harvard.csl
+++ b/elsevier-harvard.csl
@@ -92,9 +92,17 @@
   <macro name="access">
     <choose>
       <if type="webpage">
-        <group>
-          <text value="URL" suffix=" "/>
+        <group delimiter=" ">
+          <text value="URL"/>
           <text variable="URL"/>
+          <group prefix="(" suffix=").">
+            <text term="accessed" suffix=" "/>
+            <date variable="accessed">
+              <date-part name="month" form="numeric" suffix="."/>
+              <date-part name="day" suffix="."/>
+              <date-part name="year" form="short"/>
+            </date>
+          </group>
         </group>
       </if>
     </choose>
@@ -152,18 +160,6 @@
           <date-part name="year"/>
         </date>
       </if>
-      <else-if variable="accessed">
-        <choose>
-          <if type="webpage">
-            <date variable="accessed">
-              <date-part name="year"/>
-            </date>
-          </if>
-          <else>
-            <text term="no date" form="short"/>
-          </else>
-        </choose>
-      </else-if>
       <else>
         <text term="no date" form="short"/>
       </else>
@@ -210,7 +206,11 @@
       </else-if>
     </choose>
   </macro>
-  <citation et-al-min="3" et-al-use-first="1" disambiguate-add-year-suffix="true" disambiguate-add-names="true" collapse="year" cite-group-delimiter=", ">
+  <!--
+    cite-group-delimiter will be available with csl 1.0.1, but is not valid csl 1.0 & it doesn't work reliably with the released zotero version
+    <citation et-al-min="3" et-al-use-first="1" disambiguate-add-year-suffix="true" collapse="year" cite-group-delimiter=", ">
+  -->
+  <citation et-al-min="3" et-al-use-first="1" disambiguate-add-year-suffix="true" collapse="year">
     <sort>
       <key macro="author"/>
       <key macro="issued" sort="descending"/>

--- a/elsevier-harvard2.csl
+++ b/elsevier-harvard2.csl
@@ -77,9 +77,17 @@
   <macro name="access">
     <choose>
       <if type="webpage">
-        <group>
-          <text value="URL" suffix=" "/>
+        <group delimiter=" ">
+          <text value="URL"/>
           <text variable="URL"/>
+          <group prefix="(" suffix=").">
+            <text term="accessed" suffix=" "/>
+            <date variable="accessed">
+              <date-part name="month" form="numeric" suffix="."/>
+              <date-part name="day" suffix="."/>
+              <date-part name="year" form="short"/>
+            </date>
+          </group>
         </group>
       </if>
     </choose>
@@ -137,19 +145,7 @@
           <date-part name="year"/>
         </date>
       </if>
-      <else-if variable="accessed">
-        <choose>
-          <if type="webpage">
-            <date variable="accessed">
-              <date-part name="year"/>
-            </date>
-          </if>
-          <else>
-            <text term="no date" form="short"/>
-          </else>
-        </choose>
-      </else-if>
-      <else>
+     <else>
         <text term="no date" form="short"/>
       </else>
     </choose>
@@ -195,7 +191,11 @@
       </else-if>
     </choose>
   </macro>
-  <citation et-al-min="3" et-al-use-first="1" disambiguate-add-year-suffix="true" disambiguate-add-names="true" collapse="year" cite-group-delimiter=", ">
+  <!--
+    cite-group-delimiter will be available with csl 1.0.1, but is not valid csl 1.0 & it doesn't work reliably with the released zotero version
+    <citation et-al-min="3" et-al-use-first="1" disambiguate-add-year-suffix="true" collapse="year" cite-group-delimiter=", ">
+  -->
+  <citation et-al-min="3" et-al-use-first="1" disambiguate-add-year-suffix="true" collapse="year">
     <sort>
       <key macro="author"/>
       <key macro="issued" sort="descending"/>


### PR DESCRIPTION
Remove disambiguate-add-names and add an explicit access date for all Elsevier Harvard Styles.  Comment out non-working (CSL 1.0.1) cite-group-delimiter for now.

Per https://forums.zotero.org/discussion/26306
