### PR TITLE
Update teologia-catalunya.csl

### DIFF
--- a/teologia-catalunya.csl
+++ b/teologia-catalunya.csl
@@ -378,7 +378,7 @@
               </group>
               <text macro="translator" prefix=", "/>
               <text macro="editor" prefix=", "/>
-              <group prefix=", ">
+              <group prefix=", " delimiter=" ">
                 <text macro="publisher"/>
                 <text macro="edition-issued"/>
               </group>
@@ -466,7 +466,7 @@
           </group>
           <text macro="translator" prefix=", "/>
           <text macro="editor" prefix=", "/>
-          <group prefix=", ">
+          <group prefix=", " delimiter=" ">
             <text macro="publisher"/>
             <text macro="edition-issued"/>
           </group>


### PR DESCRIPTION
Fixed an error: The year was attached to the Publisher, without space. Added delimiter=" " in the group to avoid this.

EDIT: I think the < updated > tag in the < info > section should be updated.
