### PR TITLE
Clean up strip-periods and remove unneeded sort macro

### DIFF
--- a/harvard-university-of-birmingham.csl
+++ b/harvard-university-of-birmingham.csl
@@ -117,45 +117,6 @@
       </else>
     </choose>
   </macro>
-  <!-- as author but with no label. Used to sort references -->
-  <macro name="author-sort">
-    <choose>
-      <!--UoB requires title rather than author for videos, films and broadcasts -->
-      <if type="broadcast motion_picture" match="any">
-        <choose>
-          <if variable="container-title">
-            <text variable="container-title" font-weight="bold"/>
-          </if>
-          <else-if variable="title">
-            <text variable="title" font-weight="bold"/>
-          </else-if>
-        </choose>
-      </if>
-      <else-if type="bill legislation" match="any">
-        <text variable="title" font-weight="bold"/>
-      </else-if>
-      <else>
-        <names variable="author">
-          <name name-as-sort-order="all" and="text" sort-separator=", " initialize-with="." delimiter-precedes-last="never" delimiter=", "/>
-          <substitute>
-            <text macro="editor-sort"/>
-            <!-- for anonymous works, use title -->
-            <choose>
-              <if type="webpage">
-                <text variable="title" font-weight="bold"/>
-              </if>
-              <else-if variable="container-title">
-                <text variable="title" font-weight="normal"/>
-              </else-if>
-              <else>
-                <text variable="title" font-weight="bold"/>
-              </else>
-            </choose>
-          </substitute>
-        </names>
-      </else>
-    </choose>
-  </macro>
   <macro name="access">
     <group delimiter=". ">
       <group>
@@ -296,7 +257,7 @@
   </citation>
   <bibliography hanging-indent="false" et-al-min="3" et-al-use-first="3" et-al-subsequent-min="3" et-al-subsequent-use-first="3">
     <sort>
-      <key macro="author-sort"/>
+      <key macro="author"/>
       <key macro="year-date" sort="ascending"/>
       <key variable="title"/>
     </sort>


### PR DESCRIPTION
Following the update to 3.0.11 the author-sort macro is not longer needed.
