### PR TITLE
Remove colon after accessed

### DIFF
--- a/harvard-university-of-birmingham.csl
+++ b/harvard-university-of-birmingham.csl
@@ -130,7 +130,7 @@
         <text variable="URL" prefix="" suffix=""/>
       </group>
       <group prefix=" [" suffix="]">
-        <text term="accessed" text-case="capitalize-first" suffix=": "/>
+        <text term="accessed" text-case="capitalize-first" suffix=" "/>
         <date variable="accessed">
           <date-part name="day" suffix=" "/>
           <date-part name="month" suffix=" "/>


### PR DESCRIPTION
UoB style guide is not entirely consistent, but majority of examples do not have colon after Accessed
