### PR TITLE
Update iso690-author-date-cs.csl

### DIFF
--- a/iso690-author-date-cs.csl
+++ b/iso690-author-date-cs.csl
@@ -571,18 +571,7 @@
           </group>
         </else>
       </choose>
-      <group display="block">
-        <group display="block">
-          <text macro="archive"/>
-          <text macro="archive_location"/>
-        </group>
-      </group>
-      <group display="block">
-        <text macro="abstract" display="block"/>
-      </group>
-      <group display="block">
-        <text macro="note" display="block"/>
-      </group>
+      
     </layout>
   </bibliography>
 </style>


### PR DESCRIPTION
Deleted abstract, note and archive location from bibliography. These items are not defined in ISO690 .
