### PR TITLE
Update iso690-numeric-cs.csl

### DIFF
--- a/iso690-numeric-cs.csl
+++ b/iso690-numeric-cs.csl
@@ -516,16 +516,6 @@
           </group>
         </else>
       </choose>
-      <group display="right-inline">
-        <text macro="archive"/>
-        <text macro="archive_location"/>
-      </group>
-      <group display="right-inline">
-        <text macro="abstract"/>
-      </group>
-      <group display="right-inline">
-        <text macro="note"/>
-      </group>
     </layout>
   </bibliography>
 </style>


### PR DESCRIPTION
Deleted abstract, note and archive location from bibliography. These items are not defined in ISO690.
