### PR TITLE
Update iso690-author-date-cs.csl

### DIFF
--- a/iso690-author-date-cs.csl
+++ b/iso690-author-date-cs.csl
@@ -179,9 +179,12 @@
       </else>
     </choose>
     <choose>
-      <if variable="URL">
+      <if variable="DOI">
         <text term="online" prefix=" [" suffix="]"/>
       </if>
+      <else-if variable="URL">
+        <text term="online" prefix=" [" suffix="]"/>
+      </else-if>
     </choose>
   </macro>
   <macro name="number">
@@ -314,13 +317,20 @@
   </macro>
   <macro name="url">
     <choose>
-      <if variable="URL">
+      <if variable="DOI">
+        <group>
+          <text term="retrieved" suffix=" " text-case="capitalize-first"/>
+          <text term="from" suffix=": doi:"/>
+          <text variable="DOI"/>
+        </group>
+      </if>
+      <else-if variable="URL">
         <group>
           <text term="retrieved" suffix=" " text-case="capitalize-first"/>
           <text term="from" suffix=": "/>
           <text variable="URL"/>
         </group>
-      </if>
+      </else-if>
     </choose>
   </macro>
   <macro name="archive">
@@ -404,7 +414,7 @@
             <text macro="issue" suffix=". "/>
             <text macro="accessed" suffix=". "/>
             <text macro="issn" suffix=". "/>
-            <text macro="doi" suffix=". "/>
+            <!--text macro="doi" suffix=". "/-->
             <text macro="url"/>
           </group>
         </else-if>


### PR DESCRIPTION
redesigned macro URL: now if record has defined URL and DOI, than in bibliography is printed only DOI.
(Note: this functionality is not working for articles - it seems, that Zotero don´t read item URL for all three types of articles - mayby it is Zotero´s bug)
Macro "doi" is not used, but for yet I don´t delete them.
