### PR TITLE
Update american-medical-association.csl to support DOIs.

### DIFF
--- a/american-medical-association.csl
+++ b/american-medical-association.csl
@@ -46,7 +46,11 @@
     <choose>
       <if type="article-newspaper" match="none">
         <choose>
-          <if variable="URL">
+          <if variable="DOI">
+            <text value="doi:"/>
+            <text variable="DOI"/>
+          </if>
+          <else-if variable="URL">
             <text value="Available at:" suffix=" "/>
             <group delimiter=". ">
               <text variable="URL"/>
@@ -59,7 +63,7 @@
                 </date>
               </group>
             </group>
-          </if>
+          </else-if>
         </choose>
       </if>
     </choose>


### PR DESCRIPTION
When a DOI is provided, AMA calls for using the DOI rather than the URL and date accessed.
