### PR TITLE
Update palaeontology.csl

### DIFF
--- a/palaeontology.csl
+++ b/palaeontology.csl
@@ -18,7 +18,7 @@
     <category citation-format="author-date"/>
     <category field="biology"/>
     <issn>1475-4983</issn>
-    <updated>2012-09-27T22:06:38+00:00</updated>
+    <updated>2013-01-09T14:49:38+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <macro name="author">
@@ -109,7 +109,7 @@
       <text variable="year-suffix" font-style="italic"/>
     </layout>
   </citation>
-  <bibliography entry-spacing="0" hanging-indent="true" subsequent-author-substitute="&#8212;&#8212;&#8212;">
+  <bibliography entry-spacing="0" hanging-indent="true" subsequent-author-substitute-rule="partial-each" subsequent-author-substitute="&#8212;&#8212;&#8212;">
     <sort>
       <key macro="author" names-min="1" names-use-first="1"/>
       <key macro="author-count"/>


### PR DESCRIPTION
Use subsequent-author-substitute-rule="partial-each" to meet reference example format:

STREEL, M. 2000. Global Famennian climates based on palynomorph quantitative analysis. 77–103. In RODRIGUES, M. A. C. and PEREIRA, E. (eds). Ordovician – Devonian palynostratigraphy in western Gondwana: Update, Problems and Perspectives,  178 pp.
— and MARSHALL, J. E. A. 2006. Devonian–Carboniferous boundary global correlations and their paleogeographic implications for the Assembly of Pangaea. 481–496. In WONG, T. E. (ed.). Proceedings of the XVth International Congress on Carboniferous and Permian Stratigraphy, Utrecht, the Netherlands, 10-16 August 2003. Royal Netherlands Academy of Arts and Sciences. Xxx pp.
— and THERON, J. N. 1999. The Devonian–Carboniferous boundary in South Africa and the age of the earliest episode of the Dwyka glaciation: New palynological result. Episodes, 22 (1), 41–44.
— CAPUTO, M. V., LOBOZIAK, S. and MELO, J. H. G. 2000a. Late Frasnian–Famennian climates based on palynomorph analyses and the question of the Late Devonian glaciations. Earth Science Reviews, 52, 121–173.
— — — — and THOREZ, J. 2000b. Palynology and sedimentology of laminites and tillites from the latest Famennian of the Parnaíba Basin, Brazil. Geologica Belgica, 3 (1-2), 87–96.
— — — 2011. What do latest Famennian and Viséan diamictites from Western Gondwana tell us? IGCP 596 Opening Meeting, Graz 19-24th September 2011. Berichte des Institutes für Erdwissenschaften der Karl-Franzens-Universität Graz, Band 16, 83–84.
