### PR TITLE
Updated CSL for Geochimica journal

### DIFF
--- a/geochimica-et-cosmochimica-acta.csl
+++ b/geochimica-et-cosmochimica-acta.csl
@@ -84,7 +84,7 @@
   <macro name="year-date">
     <choose>
       <if variable="issued">
-        <date variable="issued" prefix="(" suffix=")">
+        <date variable="issued">
           <date-part name="year"/>
         </date>
       </if>
@@ -112,14 +112,14 @@
       <text variable="page"/>
     </group>
   </macro>
-  <citation and="text" disambiguate-add-year-suffix="true" disambiguate-add-names="true" disambiguate-add-givenname="true">
+  <citation and="text" et-al-min="3" et-al-use-first="1" disambiguate-add-year-suffix="true" disambiguate-add-names="true" disambiguate-add-givenname="true">
     <sort>
       <key variable="issued"/>
       <key macro="author-short"/>
     </sort>
-    <layout prefix="(" suffix=")" delimiter=", ">
+    <layout prefix="(" suffix=")" delimiter="; ">
       <group delimiter=", ">
-        <group delimiter=" ">
+        <group delimiter=", ">
           <text macro="author-short"/>
           <text macro="year-date"/>
         </group>
@@ -130,7 +130,10 @@
       </group>
     </layout>
   </citation>
-  <bibliography hanging-indent="true">
+  <!-- dirty hack to get all authors in bibliography - without
+       this et-al-min seems to carry over from citation, not
+       sure why -->
+  <bibliography et-al-min="1000" hanging-indent="true">
     <sort>
       <key macro="author"/>
       <key variable="title"/>


### PR DESCRIPTION
The citation style for the Geochimica journal did not match citations in
that publication - specifically et-al use was required for 3 or more
authors, while the full author list should be reserved for the
bibliography. However, the original contributor of the CSL could hardly
be blamed for this oversight as the Geochimica site at [1] provides
details of bibliography style while saying nothing about citation style.

The example Geochimica paper on which this updated style is based is
available from [2] - sorry, not open access.

Please note there is a horrible hack in the updated CSL: the et-al-min
setting specified in cs:citation seems to "leak" into cs:bibliography, at
least when using the CSL editor at citationstyles.org.

To counter this, a ridiculously large et-al-min setting has been
specified for the bibliography element. I'm not sure yet if this is a
bug, and if so where it might be (csl-editor or citeproc-js) but if I
can track it down I'll file a bug report with the appropriate project.

[1] http://www.elsevier.com/journals/geochimica-et-cosmochimica-acta/0016-7037/guide-for-authors#67000

[2] http://www.sciencedirect.com/science/article/pii/S0016703712006850
