### PR TITLE
Create quaderni-avogadro-colloquia.csl

### DIFF
--- a/quaderni-avogadro-colloquia.csl
+++ b/quaderni-avogadro-colloquia.csl
@@ -2,7 +2,7 @@
 <style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" demote-non-dropping-particle="sort-only" default-locale="en-GB">
 <!-- This style was edited with the Visual CSL Editor (http://editor.citationstyles.org/visualEditor/) -->
   <info>
-    <title>Quaderni Avogadro Colloquia</title>
+    <title>Quaderni degli Avogadro Colloquia</title>
     <id>http://www.zotero.org/styles/quaderni-avogadro-colloquia</id>
     <link rel="self" href="http://www.zotero.org/styles/quaderni-avogadro-colloquia"/>
     <link href="http://www.soc.chim.it/avogadro_colloquia" rel="documentation"/>
@@ -12,7 +12,7 @@
     </author>
     <category citation-format="numeric"/>
     <category field="science"/>
-    <category field="generic-base"/>
+    <category field="chemistry"/>
     <summary>Proceedings of the Italian Chemical Society's Avogadro Colloquia</summary>
     <updated>2013-01-18T11:40:11+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>


### PR DESCRIPTION
New style file for Quaderni Avogadro Colloquia, a new proceeding from the Italian Chemical Society (Società Chimica Italiana).
