### PR TITLE
Add style for Vaccine

### DIFF
--- a/dependent/vaccine.csl
+++ b/dependent/vaccine.csl
@@ -3,7 +3,6 @@
   <info>
     <title>Vaccine</title>
     <id>http://www.zotero.org/styles/vaccine</id>
-    <link href="http://www.zotero.org/styles/vaccine" rel="self"/>
     <link href="http://www.zotero.org/styles/elsevier-vancouver" rel="independent-parent"/>
     <link href="http://www.elsevier.com/journals/vaccine/0264-410X/guide-for-authors#78000" rel="documentation"/>
     <author>


### PR DESCRIPTION
Added style for Elsevier journal Vaccine, which is a dependent of Elsevier Vancouver - http://www.elsevier.com/journals/vaccine/0264-410X/guide-for-authors#78000
