### PR TITLE
Update briefings-in-bioinformatics.csl

### DIFF
--- a/briefings-in-bioinformatics.csl
+++ b/briefings-in-bioinformatics.csl
@@ -18,7 +18,7 @@
   </info>
   <macro name="author">
     <names variable="author">
-      <name sort-separator=", " delimiter=", " initialize-with="" delimiter-precedes-last="never" name-as-sort-order="all"/>
+      <name sort-separator=" " delimiter=", " initialize-with="" delimiter-precedes-last="never" name-as-sort-order="all"/>
     </names>
   </macro>
   <citation collapse="citation-number">


### PR DESCRIPTION
The author sort-separator should not have the comma character.
Currently: Smith, JH, Andrews, LH
Should be: Smith JH, Andrews LH
