### PR TITLE
Fix [Cell] sorting

### DIFF
--- a/cell.csl
+++ b/cell.csl
@@ -13,17 +13,26 @@
       <name>Julian Onions</name>
       <email>julian.onions@gmail.com</email>
     </contributor>
+    <contributor>
+      <name>Aurimas Vinckevicius</name>
+      <email>aurimas.dev@gmail.com</email>
+    </contributor>
     <category citation-format="author-date"/>
     <category field="biology"/>
     <issn>0092-8674</issn>
     <eissn>1097-4172</eissn>
     <summary>The Cell journal style. Original by Julian Onions.</summary>
-    <updated>2012-09-27T22:06:38+00:00</updated>
+    <updated>2013-01-26T22:06:38+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <macro name="author-short">
     <names variable="author">
       <name form="short" and="text"/>
+    </names>
+  </macro>
+  <macro name="author-count">
+    <names variable="author">
+      <name form="count"/>
     </names>
   </macro>
   <macro name="author">
@@ -50,8 +59,11 @@
   </macro>
   <citation et-al-min="3" et-al-use-first="1" disambiguate-add-year-suffix="true" collapse="year">
     <sort>
+      <key macro="author-short" names-min="1" names-use-first="1"/>
+      <key macro="author-count" names-min="3" names-use-first="3"/>
+      <key macro="author" names-min="3" names-use-first="1"/>
       <key macro="issued"/>
-      <key macro="author"/>
+      <key variable="title"/>
     </sort>
     <layout prefix="(" suffix=")" delimiter="; ">
       <group delimiter=", ">
@@ -62,9 +74,10 @@
   </citation>
   <bibliography et-al-min="11" et-al-use-first="10">
     <sort>
-      <key macro="author"/>
+      <key macro="author-short" names-min="1" names-use-first="1"/>
+      <key macro="author-count" names-min="3" names-use-first="3"/>
+      <key macro="author" names-min="3" names-use-first="1"/>
       <key macro="issued"/>
-      <key variable="title"/>
     </sort>
     <layout suffix=".">
       <group delimiter=" ">
@@ -74,8 +87,10 @@
           <if type="article article-magazine article-newspaper article-journal review" match="any">
             <text variable="title" suffix="."/>
             <text variable="container-title" form="short" text-case="title"/>
-            <text variable="volume" font-style="italic" suffix=","/>
-            <text variable="page"/>
+            <group delimiter=", ">
+              <text variable="volume" font-style="italic"/>
+              <text variable="page"/>
+            </group>
           </if>
           <else-if type="chapter paper-conference" match="any">
             <text variable="title" suffix="."/>


### PR DESCRIPTION
See http://forums.zotero.org/discussion/27396/bibliography-order-issues/

Publications (RDF) for testing/verifying this can be found at https://gist.github.com/4640309

One very minor issue (this is not even clear or defined by Cell):

See Crow publications in the linked RDF.

When inserting two sources (say with more than 3 authors) that have the same first author, same year, the order in the bibliography and the disambiguation (i.e. year+letter) are determined by the order in the text. This works perfectly fine.

Now, if you insert these publications into the same citation, I'm not entirely sure how the disambiguation and bibliography sorting is determined. Trying out different ways of adding these two publications (changing the order in which I add and selecting or deselecting "keep sources sorted"), I think that disambiguation is determined before citations are "sorted". E.g. If you add "Mutations in the gene encoding..." and then you add "Mutations in genes encoding..." (sort them in that order in the dialog box, "keep sources sorted" is unchecked). Then you get `(Crow et al., 2006b, 2006a)`. I realize that this is manually sorted out of order (and is probably an almost unrealistic edge case), but, I still think the correct way would have been `(Crow et al., 2006a, 2006b)`

Anyway, just a tiny nit.
