### PR TITLE
Update journal-of-comparative-physiology-a.csl

### DIFF
--- a/journal-of-comparative-physiology-a.csl
+++ b/journal-of-comparative-physiology-a.csl
@@ -1,218 +1,214 @@
 <?xml version="1.0" encoding="utf-8"?>
 <style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" demote-non-dropping-particle="sort-only" default-locale="en-GB">
-<info>
-<title>Journal of Comparative Physiology A</title>
-<id>
-http://www.zotero.org/styles/journal-of-comparative-physiology-a
-</id>
-<link href="http://www.zotero.org/styles/journal-of-comparative-physiology-a" rel="self"/>
-<link href="http://www.zotero.org/styles/genome-biology-and-evolution" rel="template"/>
-<link href="http://www.springer.com/life+sciences/animal+sciences/journal/359" rel="documentation"/>
-<author>
-<name>Nicola Plowes</name>
-<email>nicolaplowes@gmail.com</email>
-</author>
-<contributor>
-<name>Ronald Petie</name>
-<email>ronald.petie@gmail.com</email>
-</contributor>
-<category citation-format="author-date"/>
-<category field="biology"/>
-<issn>0340-7594</issn>
-<issn>1432-1351</issn>
-<updated>2013-01-28T10:22:44+00:00</updated>
-<rights license="http://creativecommons.org/licenses/by-sa/3.0/">
-This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
-</info>
-<macro name="editor">
-<names variable="editor">
-<name and="symbol" delimiter=", " name-as-sort-order="all" sort-separator=", " initialize-with="">
-<name-part name="family" text-case="capitalize-first"/>
-<name-part name="given" text-case="capitalize-first"/>
-</name>
-<label form="long" text-case="lowercase" prefix=", "/>
-</names>
-</macro>
-<macro name="series-editor">
-<names variable="original-author">
-<label form="short" text-case="capitalize-first" suffix=". " strip-periods="true"/>
-<name and="symbol" delimiter=", "/>
-</names>
-</macro>
-<macro name="author">
-<names variable="author">
-<name name-as-sort-order="all" sort-separator=" " delimiter=", " delimiter-precedes-last="always" initialize-with=""/>
-<label form="short" prefix=", " suffix="." text-case="lowercase" strip-periods="true"/>
-<substitute>
-<names variable="translator"/>
-</substitute>
-</names>
-</macro>
-<macro name="author-short">
-<names variable="author">
-<name form="short" and="text" delimiter=", " delimiter-precedes-last="always"/>
-<substitute>
-<names variable="editor"/>
-<names variable="translator"/>
-</substitute>
-</names>
-</macro>
-<macro name="editor-short">
-<names variable="editor">
-<name name-as-sort-order="all" sort-separator=" " delimiter=", " delimiter-precedes-last="always" initialize-with=""/>
-<label form="short" prefix=" (" suffix=") " text-case="lowercase" strip-periods="true"/>
-</names>
-</macro>
-<macro name="access">
-<choose>
-<if variable="DOI">
-<text variable="DOI" prefix="doi: "/>
-</if>
-<else>
-<choose>
-<if variable="URL">
-<text variable="URL"/>
-<group prefix=". " suffix="">
-<text term="accessed" text-case="capitalize-first" suffix=" "/>
-<date variable="accessed">
-<date-part name="day" suffix=" "/>
-<date-part name="month" suffix=" "/>
-<date-part name="year"/>
-</date>
-</group>
-</if>
-</choose>
-</else>
-</choose>
-</macro>
-<macro name="title">
-<choose>
-<if type="bill book graphic legal_case legislation motion_picture report song" match="any">
-<text variable="title"/>
-</if>
-<else>
-<text variable="title"/>
-</else>
-</choose>
-</macro>
-<macro name="publisher">
-<group delimiter=", ">
-<text variable="publisher"/>
-<text variable="publisher-place"/>
-</group>
-</macro>
-<macro name="year-date">
-<date variable="issued">
-<date-part name="year"/>
-</date>
-</macro>
-<macro name="day-month">
-<date variable="issued">
-<date-part name="month"/>
-<date-part name="day" prefix=" "/>
-</date>
-</macro>
-<macro name="page">
-<label variable="page" suffix=" " form="short" strip-periods="true"/>
-<text variable="page"/>
-</macro>
-<macro name="edition">
-<choose>
-<if is-numeric="edition">
-<group delimiter=" ">
-<number variable="edition" form="ordinal"/>
-<text term="edition" form="short" suffix="." strip-periods="true"/>
-</group>
-</if>
-<else>
-<text variable="edition" suffix="."/>
-</else>
-</choose>
-</macro>
-<citation et-al-min="3" et-al-use-first="1" et-al-subsequent-min="3" et-al-subsequent-use-first="1" disambiguate-add-year-suffix="true" disambiguate-add-names="false" disambiguate-add-givenname="false" collapse="year">
-<layout prefix="(" suffix=")" delimiter="; ">
-<group delimiter=", ">
-<group delimiter=" ">
-<text macro="author-short"/>
-<text macro="year-date"/>
-</group>
-<text variable="locator"/>
-</group>
-</layout>
-</citation>
-<bibliography hanging-indent="false" et-al-min="6" et-al-use-first="1">
-<sort>
-<key macro="author"/>
-<key variable="title"/>
-</sort>
-<layout suffix="">
-<group delimiter=" ">
-<text macro="author" suffix=""/>
-<text macro="year-date" prefix="(" suffix=")"/>
-</group>
-<choose>
-<if type="article-newspaper article-magazine" match="any">
-<group delimiter=" ">
-<text macro="title" prefix=" " suffix="."/>
-</group>
-<group prefix=" " delimiter=", ">
-<text variable="container-title"/>
-<text macro="day-month"/>
-<text variable="edition"/>
-</group>
-</if>
-<else-if type="thesis">
-<text macro="title" prefix=" " suffix="."/>
-<group prefix=" " delimiter=", ">
-<text macro="edition"/>
-<text macro="editor" suffix="."/>
-<text variable="genre"/>
-<text variable="publisher"/>
-</group>
-</else-if>
-<else-if type="bill book graphic legal_case legislation motion_picture report song" match="any">
-<group delimiter=" ">
-<text macro="title" prefix=" " suffix="."/>
-<text macro="edition"/>
-<text macro="publisher"/>
-</group>
-</else-if>
-<else-if type="chapter paper-conference" match="any">
-<group delimiter=" ">
-<text macro="title" prefix=" " suffix="."/>
-<group prefix="In: " suffix="">
-<text macro="editor-short"/>
-<text variable="container-title" suffix=","/>
-<group delimiter=" ">
-<text variable="collection-title"/>
-<text variable="volume" prefix=" vol " suffix="."/>
-</group>
-<text macro="publisher" prefix=" " suffix=", "/>
-<text macro="page" prefix=" "/>
-</group>
-</group>
-</else-if>
-<else>
-<group suffix=".">
-<text macro="title" prefix=" "/>
-<text macro="editor" prefix=" "/>
-</group>
-<group prefix=" " suffix="" delimiter=" ">
-<text variable="container-title" form="short" suffix="" strip-periods="true"/>
-<group delimiter=":">
-<text variable="volume"/>
-<text variable="page"/>
-</group>
-</group>
-</else>
-</choose>
-<choose>
-<if type="book chapter" >
-</if>
-<else>
-<text prefix=". " macro="access" suffix=""/>
-</else>
-</choose>
-</layout>
-</bibliography>
+  <info>
+    <title>Journal of Comparative Physiology A</title>
+    <id>http://www.zotero.org/styles/journal-of-comparative-physiology-a</id>
+    <link href="http://www.zotero.org/styles/journal-of-comparative-physiology-a" rel="self"/>
+    <link href="http://www.zotero.org/styles/genome-biology-and-evolution" rel="template"/>
+    <link href="http://www.springer.com/life+sciences/animal+sciences/journal/359" rel="documentation"/>
+    <author>
+      <name>Nicola Plowes</name>
+      <email>nicolaplowes@gmail.com</email>
+    </author>
+    <contributor>
+      <name>Ronald Petie</name>
+      <email>ronald.petie@gmail.com</email>
+    </contributor>
+    <category citation-format="author-date"/>
+    <category field="biology"/>
+    <issn>0340-7594</issn>
+    <issn>1432-1351</issn>
+    <updated>2013-02-01T08:24:24+00:00</updated>
+    <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
+  </info>
+  <macro name="editor">
+    <names variable="editor">
+      <name and="symbol" delimiter=", " name-as-sort-order="all" sort-separator=", " initialize-with="">
+        <name-part name="family" text-case="capitalize-first"/>
+        <name-part name="given" text-case="capitalize-first"/>
+      </name>
+      <label form="long" text-case="lowercase" prefix=", "/>
+    </names>
+  </macro>
+  <macro name="series-editor">
+    <names variable="original-author">
+      <label form="short" text-case="capitalize-first" suffix=". " strip-periods="true"/>
+      <name and="symbol" delimiter=", "/>
+    </names>
+  </macro>
+  <macro name="author">
+    <names variable="author">
+      <name vertical-align="baseline" delimiter-precedes-last="always" et-al-min="6" initialize-with="" name-as-sort-order="all" sort-separator=" "/>
+      <label form="short" text-case="lowercase" strip-periods="true" prefix=", " suffix="."/>
+      <substitute>
+        <names variable="translator"/>
+      </substitute>
+    </names>
+  </macro>
+  <macro name="author-short">
+    <names variable="author">
+      <name form="short" delimiter=" " and="text" delimiter-precedes-last="always"/>
+      <substitute>
+        <names variable="editor"/>
+        <names variable="translator"/>
+      </substitute>
+    </names>
+  </macro>
+  <macro name="book-editor">
+    <names variable="editor">
+      <name name-as-sort-order="all" sort-separator=" " delimiter=", " delimiter-precedes-last="always" initialize-with=""/>
+      <label form="short" prefix=" (" suffix=") " text-case="lowercase" strip-periods="true"/>
+    </names>
+  </macro>
+  <macro name="access">
+    <choose>
+      <if variable="DOI">
+        <text variable="DOI" prefix="doi: "/>
+      </if>
+      <else>
+        <choose>
+          <if variable="URL">
+            <text variable="URL"/>
+            <group prefix=". " suffix="">
+              <text term="accessed" text-case="capitalize-first" suffix=" "/>
+              <date variable="accessed">
+                <date-part name="day" suffix=" "/>
+                <date-part name="month" suffix=" "/>
+                <date-part name="year"/>
+              </date>
+            </group>
+          </if>
+        </choose>
+      </else>
+    </choose>
+  </macro>
+  <macro name="title">
+    <choose>
+      <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
+        <text variable="title"/>
+      </if>
+      <else>
+        <text variable="title"/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="publisher">
+    <group delimiter=", ">
+      <text variable="publisher"/>
+      <text variable="publisher-place"/>
+    </group>
+  </macro>
+  <macro name="year-date">
+    <date variable="issued">
+      <date-part name="year"/>
+    </date>
+  </macro>
+  <macro name="day-month">
+    <date variable="issued">
+      <date-part name="month"/>
+      <date-part name="day" prefix=" "/>
+    </date>
+  </macro>
+  <macro name="page">
+    <label variable="page" suffix=" " form="short" strip-periods="true"/>
+    <text variable="page"/>
+  </macro>
+  <macro name="edition">
+    <choose>
+      <if is-numeric="edition">
+        <group delimiter=" ">
+          <number variable="edition" form="ordinal"/>
+          <text term="edition" form="short" suffix="." strip-periods="true"/>
+        </group>
+      </if>
+      <else>
+        <text variable="edition" suffix="."/>
+      </else>
+    </choose>
+  </macro>
+  <citation et-al-min="3" et-al-use-first="1" et-al-subsequent-min="3" et-al-subsequent-use-first="1" disambiguate-add-year-suffix="true" disambiguate-add-names="false" disambiguate-add-givenname="false" collapse="year">
+    <layout prefix="(" suffix=")" delimiter="; ">
+      <group delimiter=", ">
+        <group delimiter=" ">
+          <text macro="author-short"/>
+          <text macro="year-date"/>
+        </group>
+        <text variable="locator"/>
+      </group>
+    </layout>
+  </citation>
+  <bibliography hanging-indent="false" et-al-min="6" et-al-use-first="1">
+    <sort>
+      <key macro="author"/>
+      <key variable="title"/>
+    </sort>
+    <layout suffix="">
+      <group delimiter=" ">
+        <text macro="author" strip-periods="true"/>
+        <text macro="year-date" prefix="(" suffix=")"/>
+      </group>
+      <choose>
+        <if type="article-newspaper article-magazine" match="any">
+          <group delimiter=" ">
+            <text macro="title" prefix=" " suffix="."/>
+          </group>
+          <group prefix=" " delimiter=", ">
+            <text variable="container-title"/>
+            <text macro="day-month"/>
+            <text variable="edition"/>
+          </group>
+        </if>
+        <else-if type="thesis">
+          <text macro="title" prefix=" " suffix="."/>
+          <group prefix=" " delimiter=", ">
+            <text macro="edition"/>
+            <text macro="editor" suffix="."/>
+            <text variable="genre"/>
+            <text variable="publisher"/>
+          </group>
+        </else-if>
+        <else-if type="bill book graphic legal_case legislation motion_picture report song" match="any">
+          <group delimiter=" ">
+            <text macro="title" prefix=" " suffix="."/>
+            <text macro="edition"/>
+            <text macro="publisher"/>
+          </group>
+        </else-if>
+        <else-if type="chapter paper-conference" match="any">
+          <group delimiter=" ">
+            <text macro="title" prefix=" " suffix="."/>
+            <group prefix="In: " suffix="">
+              <text macro="book-editor"/>
+              <text variable="container-title" suffix=","/>
+              <group delimiter=" ">
+                <text variable="collection-title"/>
+                <text variable="volume" prefix=" vol " suffix="."/>
+              </group>
+              <text macro="publisher" prefix=" " suffix=", "/>
+              <text macro="page" prefix=" "/>
+            </group>
+          </group>
+        </else-if>
+        <else>
+          <group suffix=".">
+            <text macro="title" prefix=" "/>
+            <text macro="editor" prefix=" "/>
+          </group>
+          <group prefix=" " suffix="" delimiter=" ">
+            <text variable="container-title" form="short" suffix="" strip-periods="true"/>
+            <group delimiter=":">
+              <text variable="volume"/>
+              <text variable="page"/>
+            </group>
+          </group>
+        </else>
+      </choose>
+      <choose>
+        <if type="book chapter"/>
+        <else>
+          <text prefix=". " macro="access" suffix=""/>
+        </else>
+      </choose>
+    </layout>
+  </bibliography>
 </style>


### PR DESCRIPTION
Updated this style to reflect the current citation style for JCPA. I've used the stile recently for a publication

These are the changes I made:
- removed periods from the end of all entries in the bibliography
- books and chapters are printed without url in the bibliography
- changed the layout for "edited book chapters" in the bibliography
- removed country from "disstertation" in the bibliography
- citations from one author in one year are denoted with a,b,c, etc in bibliography and ciations
- separator for citations changed from & to "and"

I didn't get the indentation to work in zotero's style editor, so unfortunately no indentation (yet)
