### PR TITLE
Information Systems Research bug

### DIFF
--- a/information-systems-research.csl
+++ b/information-systems-research.csl
@@ -279,8 +279,8 @@
     </sort>
     <layout prefix="(" suffix=")" delimiter="; ">
       <group delimiter="">
-        <text macro="author-short"/>
-        <text macro="issued-year" prefix=" "/>
+        <text macro="author-short" suffix=" "/>
+        <text macro="issued-year"/>
         <text macro="citation-locator"/>
       </group>
     </layout>


### PR DESCRIPTION
suppressing the author led to ( 2012) citations, as we always prefixed "
" before the date. Use a " " suffix after the author instead.

Not sure if this should be handled by setting the group separator or similar.
Please see discussion at http://forums.zotero.org/discussion/27534/informationsystems-review-bug/#Comment_145024 for details.

Signed-off-by: Sebastian Spaeth Sebastian@SSpaeth.de
