### PR TITLE
Information Systems Research, citation-locator fix

### DIFF
--- a/information-systems-research.csl
+++ b/information-systems-research.csl
@@ -281,8 +281,8 @@
       <group delimiter=" ">
         <text macro="author-short"/>
         <text macro="issued-year"/>
-        <text macro="citation-locator"/>
       </group>
+      <text macro="citation-locator" prefix=", "/>
     </layout>
   </citation>
   <bibliography entry-spacing="1" line-spacing="1" hanging-indent="true">


### PR DESCRIPTION
After the fix c3c85924, the citation-locator is now appended with the
group delimiter " ", ie citations look like this: (2012 pp. 12-14)

Checking articles, they have to look like this: (2012, pp. 12-14).
This can be fixed by taking the citation-locator out of the group that
is delimited with " " and add the citation-locator with the ", " prefix.
