### PR TITLE
Very small edits

### DIFF
--- a/american-antiquity.csl
+++ b/american-antiquity.csl
@@ -352,7 +352,7 @@
   </macro>
   <citation et-al-min="3" et-al-use-first="1" disambiguate-add-year-suffix="true" disambiguate-add-names="true" disambiguate-add-givenname="true">
     <layout prefix="(" suffix=")" delimiter="; ">
-      <group delimiter=", ">
+      <group delimiter=":">
         <group delimiter=" ">
           <text macro="contributors-short"/>
           <text macro="date1"/>
@@ -361,7 +361,7 @@
       </group>
     </layout>
   </citation>
-  <bibliography hanging-indent="false" entry-spacing="0">
+  <bibliography hanging-indent="true" entry-spacing="0">
     <sort>
       <key macro="contributors"/>
       <key variable="issued"/>
@@ -371,7 +371,7 @@
         <text macro="contributors"/>
       </group>
       <group display="indent">
-        <text macro="date1" suffix=" "/>
+        <text macro="date1" suffix="  "/>
         <text macro="rest-of-bib"/>
       </group>
     </layout>


### PR DESCRIPTION
in-text citation page number prefix is now correctly a colon and the date suffix in bibliography list is now correctly double-spaced. Also the hanging indent is now true. I don't however know how to make a double indentation for the third and subsequent lines.
