### PR TITLE
in-text citation fix; reverted one previous change

### DIFF
--- a/american-antiquity.csl
+++ b/american-antiquity.csl
@@ -350,7 +350,7 @@
     <text macro="locators-article"/>
     <text macro="access" prefix=". "/>
   </macro>
-  <citation et-al-min="3" et-al-use-first="1" disambiguate-add-year-suffix="true" disambiguate-add-names="true" disambiguate-add-givenname="true">
+  <citation et-al-min="3" et-al-use-first="1" disambiguate-add-year-suffix="true" disambiguate-add-names="true" disambiguate-add-givenname="false">
     <layout prefix="(" suffix=")" delimiter="; ">
       <group delimiter=":">
         <group delimiter=" ">
@@ -361,7 +361,7 @@
       </group>
     </layout>
   </citation>
-  <bibliography hanging-indent="true" entry-spacing="0">
+  <bibliography hanging-indent="false" entry-spacing="0">
     <sort>
       <key macro="contributors"/>
       <key variable="issued"/>


### PR DESCRIPTION
In-text citations of "et al." papers will no longer provide the given name of the primary author if another author already in the bibliography shares that surname. 
changed to:
"disambiguate-add-givenname="false">"
however "disambiguate-add-year-suffix="true"" and "disambiguate-add-names="true"" remain the same, and work well.

also the hanging-indent for the bibliography has been changed back to false, as it only applies to authors and not the date/following lines. (this is a style change for the future....)
