### PR TITLE
Updating molecular-psychiatry, removing month/day

### DIFF
--- a/molecular-psychiatry.csl
+++ b/molecular-psychiatry.csl
@@ -72,8 +72,6 @@
           <text term="cited" text-case="lowercase"/>
           <date variable="accessed" suffix="">
             <date-part name="year"/>
-            <date-part name="month" prefix=" " form="short" strip-periods="true"/>
-            <date-part name="day" prefix=" "/>
           </date>
         </group>
       </if>


### PR DESCRIPTION
The current style generates reference list entries that resemble:

Brocke B, Lesch K-P, Armbruster D, Moser DA, Müller A, Strobel A et al. Stathmin, a gene regulating neural plasticity, affects fear and anxiety processing in humans. Am J Med Genet B 2010 Jan 5; 153B: 243–51.

The month and date (Jan 5) are inserted after the publication year, but this is not allowed by the journal. Removed month/day from csl to fix this.
