### PR TITLE
Fixes style title so it uses normal characters instead of Greek characters (looks the same, affected some sortings)

### DIFF
--- a/byzantina-symmeikta.csl
+++ b/byzantina-symmeikta.csl
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" demote-non-dropping-particle="sort-only">
   <info>
-    <title>ΒΥΖΑΝΤΙΝΑ SΥΜΜΕΙΚΤΑ</title>
+    <title>BYZANTINA SYMMEIKTA</title>
     <id>http://www.zotero.org/styles/byzantina-symmeikta</id>
     <link href="http://www.zotero.org/styles/byzantina-symmeikta" rel="self"/>
     <link href="http://www.byzsym.org/index.php/bz/about/submissions#authorGuidelines" rel="documentation"/>


### PR DESCRIPTION
Previously the title was using UTF-8 characters using Greek characters. I don't think that this is needed in the Title and was showing this style at the bottom of some listings instead of under the B.

An example of the problem caused by this in http://www.mendeley.com/citationstyles/ (scroll to the bottom).
