### PR TITLE
Update iso690-author-date-cs.csl

### DIFF
--- a/iso690-author-date-cs.csl
+++ b/iso690-author-date-cs.csl
@@ -369,10 +369,10 @@
     <layout prefix="(" suffix=")" delimiter="; ">
       <group delimiter=" ">
         <group delimiter=" ">
-          <text macro="author-citation" suffix=", "/>
+          <text macro="author-citation" suffix=" "/>
           <text macro="year-date"/>
         </group>
-        <text variable="locator" prefix=" s. "/>
+        <text variable="locator" prefix=", s. "/>
       </group>
     </layout>
   </citation>


### PR DESCRIPTION
deleted komma in citation between autoher and year; added komma between year and locator.
Template: https://sites.google.com/site/novaiso690/metody-citovani
https://sites.google.com/site/novaiso690/metody-citovani/harvardsky-system-pravidla
