### PR TITLE
Update iso690-author-date-fr.csl

### DIFF
--- a/iso690-author-date-fr.csl
+++ b/iso690-author-date-fr.csl
@@ -33,7 +33,7 @@
       <term name="from">à l'adresse</term>
       <term name="page" form="short">
         <single>p.</single>
-        <multiple>pp.</multiple>
+        <multiple>p.</multiple>
       </term>
     </terms>
   </locale>
@@ -245,7 +245,7 @@
     <group delimiter=", ">
       <text variable="volume" prefix="Vol.&#160;"/>
       <text variable="issue" prefix="n°&#160;"/>
-      <text variable="page" prefix="pp.&#160;"/>
+      <text variable="page" prefix="p.&#160;"/>
     </group>
   </macro>
   <macro name="publisher">
@@ -295,7 +295,7 @@
         <text variable="number-of-pages" suffix="&#160;p"/>
       </if>
       <else-if type="chapter paper-conference article-newspaper" match="any">
-        <text variable="page" prefix="pp.&#160;"/>
+        <text variable="page" prefix="p.&#160;"/>
       </else-if>
       <else-if type="report patent" match="any">
         <text variable="page" suffix="&#160;p"/>
@@ -343,10 +343,10 @@
   <macro name="note">
     <text variable="note"/>
   </macro>
-  <citation disambiguate-add-year-suffix="true" disambiguate-add-names="true" disambiguate-add-givenname="true" collapse="year" year-suffix-delimiter=", " after-collapse-delimiter="&#160;; ">
+  <citation et-al-min="3" et-al-use-first="1" disambiguate-add-year-suffix="true" disambiguate-add-names="true" disambiguate-add-givenname="true" collapse="year" year-suffix-delimiter=", " after-collapse-delimiter="&#160;; ">
     <layout prefix="(" suffix=")" delimiter="&#160;; ">
-      <group delimiter=", ">
-        <group delimiter=" ">
+      <group delimiter=", p.&#160;">
+        <group delimiter=", ">
           <text macro="author-citation"/>
           <text macro="year-date"/>
         </group>


### PR DESCRIPTION
Some modifications to improve compatibility with ISO690 :
- "pp." is now simply "p." (see the various examples given in the ISO specification).
- "p." added in the citation itself.
- et al. is now handled correctly
