### PR TITLE
Update iso690-numeric-fr.csl

### DIFF
--- a/iso690-numeric-fr.csl
+++ b/iso690-numeric-fr.csl
@@ -32,7 +32,7 @@
       <term name="from">à l'adresse</term>
       <term name="page" form="short">
         <single>p.</single>
-        <multiple>pp.</multiple>
+        <multiple>p.</multiple>
       </term>
     </terms>
   </locale>
@@ -222,7 +222,7 @@
     <group delimiter=", ">
       <text variable="volume" prefix="Vol.&#160;"/>
       <text variable="issue" prefix="n°&#160;"/>
-      <text variable="page" prefix="pp.&#160;"/>
+      <text variable="page" prefix="p.&#160;"/>
     </group>
   </macro>
   <macro name="publisher">
@@ -272,7 +272,7 @@
         <text variable="number-of-pages" suffix="&#160;p"/>
       </if>
       <else-if type="chapter paper-conference article-newspaper" match="any">
-        <text variable="page" prefix="pp.&#160;"/>
+        <text variable="page" prefix="p.&#160;"/>
       </else-if>
       <else-if type="report patent" match="any">
         <text variable="page" suffix="&#160;p"/>


### PR DESCRIPTION
A modification to improve compliancy with ISO690 : "pp." is now simply "p."
