### PR TITLE
Replace `source :rubygems` with https url for rubygems.org in Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
-source :rubygems
+source 'https://rubygems.org'
 
 gem 'rake'
 gem 'rspec'


### PR DESCRIPTION
Builder 1.3.2 complained:
The source :rubygems is deprecated because HTTP requests are insecure.
Please change your source to 'https://rubygems.org' if possible, or 'http://rubygems.org' if not.

Caveat: I know nothing about Ruby; I simply followed the instructions, tested, and observed that `bunder install` no longer produces this warning.
