### PR TITLE
Add style for Journal of Simulation

### DIFF
--- a/journal-of-simulation
+++ b/journal-of-simulation
@@ -1,0 +1,198 @@
+<?xml version="1.0" encoding="utf-8"?>
+<style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" demote-non-dropping-particle="sort-only" 
+
+default-locale="en-GB">
+  <info>
+  <title>Journal of Simulation</title>
+  <id>http://www.zotero.org/styles/journal-of-simulation</id>
+  <author>
+    <name>J Richard Snape</name>
+    <uri>http://twitter.com/snapey1979</uri>
+  </author>
+  <category citation-format="author-date"/>
+  <category field="generic-base"/>
+  <issn>1747-7778</issn>
+  <eissn>1747-7786</eissn>
+  <summary>The Harvard author-date style - adapted for Palgrave Macmillan Journal of Simulation</summary>
+  <updated>2013-09-28T02:06:38+00:00</updated>
+  <link href="http://www.palgrave-journals.com/jos/author_instructions.html#References" rel="documentation"/>
+  <link href="http://www.zotero.org/styles/harvard-leeds-metropolitan-university" rel="template"/>
+  <link href="http://www.zotero.org/styles/journal-of-simulation" rel="self"/>
+  <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons 
+
+Attribution-ShareAlike 3.0 License</rights>
+  </info>
+  <macro name="editor">
+  <names variable="editor" delimiter=", ">
+    <name and="symbol" initialize-with=". " delimiter=", "/>
+    <label form="short" prefix=" " text-case="lowercase" suffix="." strip-periods="true"/>
+  </names>
+  </macro>
+  <macro name="anon">
+  <text term="anonymous" form="short" text-case="capitalize-first" strip-periods="true"/>
+  </macro>
+  <macro name="author">
+  <names variable="author">
+    <name name-as-sort-order="all" and="symbol" sort-separator=", " initialize-with="." delimiter-precedes-last="never" 
+
+delimiter=", "/>
+    <label form="short" prefix=" " suffix="." text-case="lowercase" strip-periods="true"/>
+    <substitute>
+    <names variable="editor"/>
+    <text macro="anon"/>
+    </substitute>
+  </names>
+  </macro>
+  <macro name="author-short">
+  <names variable="author">
+    <name form="short" and="symbol" delimiter=", " delimiter-precedes-last="never" initialize-with=". "/>
+    <substitute>
+    <names variable="editor"/>
+    <names variable="translator"/>
+    <text macro="anon"/>
+    </substitute>
+  </names>
+  </macro>
+  <macro name="access">
+  <choose>
+    <if variable="URL">
+    <text variable="URL"/>
+    <group prefix=", " >
+      <text term="accessed" suffix=" "/>
+      <date variable="accessed">
+      <date-part name="day" suffix=" "/>
+      <date-part name="month" suffix=" "/>
+      <date-part name="year"/>
+      </date>
+    </group>
+    </if>
+  </choose>
+  </macro>
+  <macro name="title">
+  <choose>
+    <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
+    <text variable="title" font-style="italic"/>
+    </if>
+    <else>
+    <text variable="title"/>
+    </else>
+  </choose>
+  </macro>
+  <macro name="publisher">
+  <group delimiter=": ">
+    <text variable="publisher"/>
+    <text variable="publisher-place"/>
+  </group>
+  </macro>
+  <macro name="year-date">
+  <choose>
+    <if variable="issued">
+    <date variable="issued">
+      <date-part name="year"/>
+    </date>
+    </if>
+    <else>
+    <text term="no date" form="short"/>
+    </else>
+  </choose>
+  </macro>
+  <macro name="edition">
+  <choose>
+    <if is-numeric="edition">
+    <group delimiter=" ">
+      <number variable="edition" form="ordinal"/>
+      <text term="edition" form="short" suffix="." strip-periods="true"/>
+    </group>
+    </if>
+    <else>
+    <text variable="edition" suffix="."/>
+    </else>
+  </choose>
+  </macro>
+  <macro name="pages">
+  <group>
+    <label variable="page" form="short"/>
+    <text variable="page"/>
+  </group>
+  </macro>
+  <citation et-al-min="3" et-al-use-first="1" et-al-subsequent-min="3" et-al-subsequent-use-first="1" 
+
+disambiguate-add-year-suffix="true" disambiguate-add-names="true" disambiguate-add-givenname="true">
+  <layout prefix="(" suffix=")" delimiter="; ">
+    <group delimiter=", ">
+    <text macro="author-short"/>
+    <text macro="year-date"/>
+    <group>
+      <label variable="locator" suffix="." form="short" strip-periods="true"/>
+      <text variable="locator"/>
+    </group>
+    </group>
+  </layout>
+  </citation>
+  <bibliography hanging-indent="false">
+  <sort>
+    <key macro="author"/>
+    <key variable="title"/>
+  </sort>
+  <layout>
+    <text macro="author"/>
+    <date variable="issued" prefix=" (" suffix=")">
+    <date-part name="year"/>
+    </date>
+    <choose>
+    <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
+      <group prefix=" " delimiter=". " suffix=".">
+      <text macro="title"/>
+      <text macro="edition"/>
+      <text macro="editor"/>
+      <text macro="publisher"/>
+      </group>
+    </if>
+    <else-if type="chapter paper-conference" match="any">
+      <text macro="title" prefix=" " suffix="."/>
+      <group prefix=" " delimiter=" ">
+      <text term="in" text-case="capitalize-first" suffix=":"/>
+      <text macro="editor"/>
+      <text variable="container-title" font-style="italic" suffix="."/>
+      <text variable="collection-title" suffix="."/>
+      <group suffix="." delimiter=", ">
+        <text macro="publisher" prefix=" "/>
+        <text macro="pages"/>
+      </group>
+      </group>
+    </else-if>
+    <else-if type="thesis">
+      <group prefix=" " delimiter=". " suffix=".">
+      <text macro="title" font-style="italic"/>
+      <text macro="edition"/>
+      <text variable="genre"/>
+      <text macro="publisher"/>
+      </group>
+    </else-if>
+    <else-if type="webpage">
+      <group prefix=" " delimiter=", " suffix=".">
+      <text macro="title" suffix=" [Internet]"/>
+      <text macro="edition"/>
+      </group>
+    </else-if>
+    <else>
+      <group suffix=".">
+      <text macro="title" prefix=" "/>
+      <text macro="editor" prefix=" "/>
+      </group>
+      <group prefix=" " suffix=".">
+      <text variable="container-title" font-style="italic"/>
+      <group prefix=", ">
+        <text variable="volume" font-weight="bold"/>
+        <text variable="issue" prefix=" (" suffix=")"/>
+      </group>
+      <group prefix=": ">
+        <text variable="page"/>
+      </group>
+      </group>
+    </else>
+    </choose>
+    <text prefix=" " macro="access" suffix="."/>
+  </layout>
+  </bibliography>
+</style>


### PR DESCRIPTION
I have made small changes to the Harvard adapted for Leeds Metropolitan university style to make it comply with the author information for the Journal of Simulation (link given in the info header of the style).  Changes consist in change of italicisation for theses/reports and changing the typeface of journal volume number to bold
