### PR TITLE
Update american-journal-of-botany.csl

### DIFF
--- a/american-journal-of-botany.csl
+++ b/american-journal-of-botany.csl
@@ -5,16 +5,19 @@
     <id>http://www.zotero.org/styles/american-journal-of-botany</id>
     <link href="http://www.zotero.org/styles/american-journal-of-botany" rel="self"/>
     <link href="http://www.botany.org/ajb/ajb_Lit_Cited_Instructions.pdf" rel="documentation"/>
+    <link href="http://www.amjbot.org/site/misc/ifora.xhtml#65Lcited" rel="documentation"/>
     <author>
       <name>Eric Fuchs</name>
       <email>eric.fuchs@ucr.ac.cr</email>
     </author>
     <category citation-format="author-date"/>
     <category field="biology"/>
+    <category field="botany"/>
+    <category field="science"/>
     <issn>0002-9122</issn>
     <issn>1537-2197</issn>
     <summary>American Journal of Botany author-date style</summary>
-    <updated>2012-09-27T22:06:38+00:00</updated>
+    <updated>2013-03-15T17:29:38+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <macro name="editor">
@@ -126,7 +129,7 @@
       </group>
     </layout>
   </citation>
-  <bibliography hanging-indent="true" et-al-min="7" et-al-use-first="1">
+  <bibliography hanging-indent="true" et-al-min="9" et-al-use-first="7">
     <sort>
       <key macro="author"/>
       <key variable="title"/>
@@ -176,7 +179,6 @@
               <text variable="volume" suffix=": "/>
             </group>
             <group prefix="">
-              <label variable="locator" suffix="." form="short" strip-periods="true"/>
               <text variable="page"/>
             </group>
           </group>


### PR DESCRIPTION
Added another source for the style documentation.
Added two more categories: "botany" and "science".
Changed the bibliography to et-al-min="9" et-al-use-first="7"
Changed how page numbers are displayed so they are not preceded by "p."
(e.g. "100-110" instead of "p.100-110")
