### PR TITLE
Code clean up

### DIFF
--- a/harvard-university-of-birmingham.csl
+++ b/harvard-university-of-birmingham.csl
@@ -17,6 +17,13 @@
     <updated>2012-10-18T22:38:43+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
+  <locale>
+    <terms>
+      <term name="open-quote">&#8220;</term>
+      <term name="close-quote">&#8221;</term>
+    </terms>
+    <style-options punctuation-in-quote="true"/>
+  </locale>
   <macro name="editor">
     <names variable="editor" delimiter=", ">
       <name name-as-sort-order="all" and="text" sort-separator=", " initialize-with="." delimiter-precedes-last="never" delimiter=", "/>
@@ -153,6 +160,9 @@
           </if>
           <else-if variable="container-title" match="none">
             <text variable="title" font-weight="bold"/>
+          </else-if>
+          <else-if type="chapter paper-conference" match="any">
+            <text variable="title" quotes="true"/>
           </else-if>
           <else>
             <text variable="title"/>
@@ -399,7 +409,7 @@
             </else-if>
             <else-if type="chapter" match="any">
               <group>
-                <text macro="title" prefix=" &#8220;" suffix=".&#8221;"/>
+                <text macro="title" prefix=" " suffix="."/>
                 <group prefix=" " delimiter=" ">
                   <text term="in" text-case="capitalize-first" suffix=" " text-decoration="underline"/>
                   <text macro="bookauthor"/>
@@ -426,7 +436,7 @@
             </else-if>
             <else-if type="paper-conference" match="any">
               <group>
-                <text macro="title" prefix=" &#8220;" suffix=".&#8221;"/>
+                <text macro="title" prefix=" " suffix="."/>
                 <group delimiter=". ">
                   <group prefix=" " delimiter=" ">
                     <text term="in" text-case="capitalize-first" suffix=" " text-decoration="underline"/>


### PR DESCRIPTION
Clean up following comments in http://forums.zotero.org/discussion/28314/api-error-and-no-preview-for-styles-that-otherwise-work/#Item_2

Smart quotes have been replaced with html entities, but I was unable to use 'quotes="true"' because punctuation-in-quote seemed to have no effect.
