### PR TITLE
Create figure-numbers-and-figure-list

### DIFF
--- a/chicago-figures.csl
+++ b/chicago-figures.csl
@@ -5,7 +5,7 @@
     <title>Chicago Manual of Style (figures and illustrations)</title>
     <title-short>chicago-figures</title-short>
     <id>http://www.zotero.org/styles/chicago-figures</id>
-    <link rel="self" href="http://www.zotero.org/chicago-figures"/>
+    <link rel="self" href="http://www.zotero.org/styles/chicago-figures"/>
     <author>
       <name>Alex Watkins</name>
     </author>


### PR DESCRIPTION
This style allows users to create figure citations throughout a document using artworks they have in Zotero. It inserts (fig. #) in text, will always refer to the work as figure #. Instead of a bibliography it inserts a figure list. Will also support images cited as located in a book (plates, diagrams, etc) using the book part item type.
