### PR TITLE
Create theologie-philosophie.csl

### DIFF
--- a/theologie-und-philosophie.csl
+++ b/theologie-und-philosophie.csl
@@ -4,8 +4,8 @@
   <info>
     <title>Theologie und Philosophie</title>
     <title-short>ThPh</title-short>
-    <id>http://www.zotero.org/styles/theologie-philosophie.csl</id>
-    <link href="http://www.zotero.org/styles/theologie-philosophie.csl" rel="self"/>
+    <id>http://www.zotero.org/styles/theologie-und-philosophie</id>
+    <link href="http://www.zotero.org/styles/theologie-und-philosophie" rel="self"/>
     <link href="http://www.sankt-georgen.de/thph/" rel="documentation"/>
     <issn>0040-5655</issn>
     <summary>A simple German citation style according to the guidelines of "Theologie und Philosophie" journal. Einfacher deutschsprachiger Zitationsstil für Philosophie, Theologie und andere Geisteswissenschaften. In Anlehnung an die Formatierungsrichtlinien der Zeitschrift "Theologie und Philosophie". Erstes Zitat: volle Literaturangabe, weitere Zitate: Autor, Kurztitel.</summary>
@@ -16,7 +16,7 @@
     <category citation-format="note"/>
     <category field="theology"/>
     <category field="philosophy"/>
-    <updated>2013-03-27T16:52:00+01:00</updated>
+    <updated>2013-03-27T17:40:00+01:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
    </info>
  <!-- ====== DEUTSCHE FORMEN ======================= -->
@@ -33,10 +33,6 @@
    <macro name="author">
       <names variable="author">
          <name name-as-sort-order="all" sort-separator=", " delimiter=" &#8211; "/>
-         <substitute>
-            <names variable="editor"/>
-            <names variable="translator"/>
-         </substitute>
       </names>
     </macro>
    <macro name="author-init">


### PR DESCRIPTION
A simple German citation style according to the guidelines of "Theologie und Philosophie" journal.
Einfacher deutschsprachiger Zitationsstil für Philosophie, Theologie und andere Geisteswissenschaften. In Anlehnung an die Formatierungsrichtlinien der Zeitschrift "Theologie und Philosophie". Erstes Zitat: volle Literaturangabe, weitere Zitate: Autor, Kurztitel.
