### PR TITLE
Create new style "harvard-durham-university-business-school.csl" based on "harvard-imperial-college-london.csl"

### DIFF
--- a/harvard-durham-university-business-school.csl
+++ b/harvard-durham-university-business-school.csl
@@ -4,6 +4,7 @@
     <title>Harvard - Durham University Business School</title>
     <id>http://www.zotero.org/styles/harvard-durham-university-business-school</id>
     <link href="http://www.zotero.org/styles/harvard-durham-university-business-school" rel="self"/>
+    <link href="http://www.zotero.org/styles/harvard-imperial-college-london" rel="template"/>
     <link href="http://www.dur.ac.uk/resources/library/teaching/writingyourbibliography.pdf" rel="documentation"/>
     <author>
       <name>Victor V. Terber</name>


### PR DESCRIPTION
The basic citation requirements of the Durham university are described in this document:

http://www.dur.ac.uk/resources/library/teaching/writingyourbibliography.pdf

This document describes various alternative styles, but the representatives of the business school clarified that the Harvard author-date referencing style would be the only acceptable one for the business school.

I'm aware that many variations of the Harvard style already exist in the Zotero style repository. But it seems to me that none of the styles precisely matches the requirements as described on page two and three of the relevant document.

I therefore picked "harvard-imperial-college-london.csl" as initial template, and changed two items to meet the look of the examples:
-   Changed the URL string from "Available from: " to "Available at: "
-   Changed the brackets around the Access date from square brackets to round brackets.
