### PR TITLE
Create harvard-coventry-university.csl

### DIFF
--- a/harvard-coventry-university.csl
+++ b/harvard-coventry-university.csl
@@ -14,9 +14,9 @@
     <category citation-format="author-date"/>
     <category field="generic-base"/>
     <summary>The Harvard author-date style - adapted for Coventry University</summary>
-    <updated>2013-04-07T00:46:20+00:00</updated>
+    <updated>2013-04-07T01:03:24+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
-    <link href="http://www.zotero.org/styles/harvard-coventry-university" rel="harvard-university-of-leeds"/>
+    <link href="http://www.zotero.org/styles/harvard-university-of-leeds" rel="template"/>
   </info>
   <macro name="editor">
     <names variable="editor" delimiter=". ">
@@ -182,12 +182,12 @@
       <group delimiter=" ">
         <text macro="author-short"/>
         <text macro="year-date"/>
+        <choose>
+          <if type="article article-newspaper article-journal entry-encyclopedia chapter" match="any">
+            <text variable="page" prefix=": "/>
+          </if>
+        </choose>
       </group>
-      <choose>
-        <if type="article article-newspaper article-journal entry-encyclopedia chapter" match="any">
-          <text variable="page" prefix=": "/>
-        </if>
-      </choose>
     </layout>
   </citation>
   <bibliography hanging-indent="true">


### PR DESCRIPTION
Coventry University Harvard Reference Style - using version 3.0.1, September 2009.
In-line citation should be ok, however, there are still some reference missing updates in the Bibliography.
