### PR TITLE
Magyar Pedagogia Citation Style

### DIFF
--- a/magyar-pedagogia.csl
+++ b/magyar-pedagogia.csl
@@ -1,0 +1,495 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" demote-non-dropping-particle="never">
+  <!-- This style was edited with the Visual CSL Editor (http://steveridout.com/csl/visualEditor/) -->
+  <info>
+    <title>Magyar Pedagógia</title>
+    <id>http://www.zotero.org/styles/magyar-pedagogia</id>
+    <link href="http://www.zotero.org/styles/magyar-pedagogia" rel="self"/>
+    <link href="http://www.magyarpedagogia.hu/?pid=50#hivatkozas" rel="documentation"/>
+    <link href="http://www.zotero.org/styles/apa" rel="template"/>
+    <author>
+      <name>Laszlo Marak</name>
+      <email>ujoimro@gmail.com</email>
+      <uri>https://pinkhq.com</uri>
+    </author>
+    <category citation-format="author-date"/>
+    <category field="sociology"/>
+    <category field="generic-base"/>
+    <updated>2013-04-04T10:00:00+00:00</updated>
+    <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
+  </info>
+  <locale xml:lang="hu">
+    <terms>
+      <term name="editortranslator" form="short">
+        <single>szerk. és ford.</single>
+        <multiple>szerk. és ford.</multiple>
+      </term>
+      <term name="translator" form="short">
+        <single>ford.</single>
+        <multiple>ford.</multiple>
+      </term>
+      <term name="editor" form="short">
+        <single>szerk.</single>
+        <multiple>szerk.</multiple>
+      </term>
+      <term name="and"> és </term>
+      <term name="page" form="short">
+	<single></single>
+	<multiple></multiple>
+      </term>
+      <term name="et-al">és mtsai</term>
+    </terms>
+  </locale>
+  <macro name="container-contributors">
+    <choose>
+      <if type="chapter paper-conference" match="any">
+	<choose>
+	  <if variable="note">
+	    <names variable="editor translator" delimiter=", " suffix=": ">
+	      <name and="text" initialize-with=". " delimiter=", "/>
+	      <label form="short" prefix=" (" text-case="title" suffix=")"/>
+	    </names> 
+	  </if>
+	  <else>
+	    <names variable="editor translator" delimiter=", " suffix=": ">
+	      <name name-as-sort-order="all" and="text" sort-separator=" " initialize-with=". " delimiter=", " delimiter-precedes-last="always" initialize="false" />
+	      <label form="short" prefix=" (" text-case="lowercase" suffix=")"/> 
+	    </names>
+	  </else>
+	</choose>
+      </if>
+    </choose>
+  </macro>
+  <macro name="secondary-contributors">
+    <choose>
+      <if type="chapter paper-conference" match="none">
+        <names variable="translator editor" delimiter=", " prefix=" (" suffix=")">
+          <name and="text" initialize-with=". " delimiter=", "/>
+          <label form="short" prefix=", " text-case="lowercase" suffix=""/>
+        </names>
+      </if>
+    </choose>
+  </macro>
+  <macro name="author">
+    <choose>
+      <if variable="note">
+	<names variable="author">
+	  <name name-as-sort-order="all" and="text" sort-separator=" " initialize-with=". " delimiter=", " delimiter-precedes-last="always" initialize="true" />
+	  <substitute>
+	    <names variable="editor"/>
+	    <names variable="translator"/>
+	    <choose>
+	      <if type="report">
+		<text variable="publisher"/>
+		<text macro="title"/>
+	      </if>
+	      <else>
+		<text macro="title"/>
+	      </else>
+	    </choose>
+	  </substitute>
+	</names>
+      </if>
+      <else>
+	<names variable="author">
+	  <name name-as-sort-order="all" and="text" sort-separator=" " initialize-with=". " delimiter=", " delimiter-precedes-last="always" initialize="false" />
+	  <substitute>
+	    <names variable="editor"/>
+	    <names variable="translator"/>
+	    <choose>
+	      <if type="report">
+		<text variable="publisher"/>
+		<text macro="title"/>
+	      </if>
+	      <else>
+		<text macro="title"/>
+	      </else>
+	    </choose>
+	  </substitute>
+	</names>
+      </else>
+    </choose>
+  </macro>
+  <macro name="author-short">
+    <names variable="author">
+      <name form="short" and="text" delimiter=", " initialize-with=". "/>
+      <substitute>
+        <names variable="editor"/>
+        <names variable="translator"/>
+        <choose>
+          <if type="report">
+            <text variable="publisher"/>
+            <text variable="title" form="short" font-style="italic"/>
+          </if>
+          <else-if type="bill book graphic legal_case legislation motion_picture song" match="any">
+            <text variable="title" form="short" font-style="italic"/>
+          </else-if>
+          <else>
+            <text variable="title" form="short" quotes="true"/>
+          </else>
+        </choose>
+      </substitute>
+    </names>
+  </macro>
+  <macro name="access">
+    <choose>
+      <if variable="ISBN">
+	<text variable="ISBN" prefix=". ISBN: " />
+      </if>
+    </choose>
+    <choose>
+      <if variable="ISSN">
+	<text variable="ISSN" prefix=". ISSN: " />
+      </if>
+    </choose>
+    <choose>
+      <if type="thesis">
+        <choose>
+          <if variable="archive" match="any">
+            <group prefix=". ">
+              <text term="retrieved" text-case="capitalize-first" suffix=" "/>
+              <text term="from" suffix=" "/>
+              <text variable="archive" suffix="."/>
+              <text variable="archive_location" prefix=" (" suffix=")"/>
+            </group>
+          </if>
+          <else>
+            <group prefix=". ">
+              <text term="retrieved" text-case="capitalize-first" suffix=" "/>
+              <text term="from" suffix=" "/>
+              <text variable="URL"/>
+            </group>
+          </else>
+        </choose>
+      </if>
+      <else>
+        <choose>
+          <if variable="DOI">
+            <text variable="DOI" prefix=". doi:"/>
+          </if>
+          <else>
+            <choose>
+              <if type="webpage">
+                <group delimiter=" ">
+                  <text term="retrieved" text-case="capitalize-first" suffix=" "/>
+                  <group>
+                    <date variable="accessed" form="text" suffix=", "/>
+                  </group>
+                  <text term="from"/>
+                  <text variable="URL"/>
+                </group>
+              </if>
+              <else>
+                <group prefix=". ">
+                  <text term="retrieved" text-case="capitalize-first" suffix=" "/>
+                  <text term="from" suffix=" "/>
+                  <text variable="URL"/>
+                </group>
+              </else>
+            </choose>
+          </else>
+        </choose>
+      </else>
+    </choose>
+  </macro>
+  <macro name="title">
+    <choose>
+      <if type="report thesis" match="any">
+        <text variable="title" font-style="italic"/>
+        <group prefix=" (" suffix=")" delimiter=" ">
+          <text variable="genre"/>
+          <text variable="number" prefix="No. "/>
+        </group>
+      </if>
+      <else-if type="book graphic  motion_picture report song manuscript speech" match="any">
+        <text variable="title" font-style="italic"/>
+      </else-if>
+      <else>
+        <text variable="title"/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="publisher">
+    <choose>
+      <if type="report" match="any">
+        <group delimiter=". ">
+          <text variable="publisher"/>
+          <text variable="publisher-place"/>
+        </group>
+      </if>
+      <else-if type="thesis" match="any">
+        <group delimiter=", ">
+          <text variable="publisher"/>
+          <text variable="publisher-place"/>
+        </group>
+      </else-if>
+      <else>
+        <group delimiter=", ">
+          <choose>
+            <if variable="event" match="none">
+              <text variable="genre"/>
+            </if>
+          </choose>
+          <choose>
+            <if type="article-journal article-magazine" match="none">
+              <group delimiter=". ">
+                <text variable="publisher"/>
+                <text variable="publisher-place"/>
+              </group>
+            </if>
+          </choose>
+        </group>
+      </else>
+    </choose>
+  </macro>
+  <macro name="event">
+    <choose>
+      <if variable="event">
+        <choose>
+          <if variable="genre" match="none">
+            <text term="presented at" text-case="capitalize-first" suffix=" "/>
+            <text variable="event"/>
+          </if>
+          <else>
+            <group delimiter=" ">
+              <text variable="genre" text-case="capitalize-first"/>
+              <text term="presented at"/>
+              <text variable="event"/>
+            </group>
+          </else>
+        </choose>
+      </if>
+    </choose>
+  </macro>
+  <macro name="issued">
+    <choose>
+      <if type="bill legal_case legislation" match="none">
+        <choose>
+          <if variable="issued">
+            <group prefix=" (" suffix=")">
+              <date variable="issued">
+                <date-part name="year"/>
+              </date>
+              <text variable="year-suffix"/>
+              <choose>
+                <if type="article-journal bill book chapter graphic legal_case legislation motion_picture paper-conference report song" match="none">
+                  <date variable="issued">
+                    <date-part prefix=", " name="month"/>
+                    <date-part prefix=" " name="day"/>
+                  </date>
+                </if>
+              </choose>
+            </group>
+          </if>
+          <else>
+            <group prefix=" (" suffix=")">
+              <text term="no date" form="short"/>
+              <text variable="year-suffix" prefix="-"/>
+            </group>
+          </else>
+        </choose>
+      </if>
+    </choose>
+  </macro>
+  <macro name="issued-sort">
+    <choose>
+      <if type="article-journal bill book chapter graphic legal_case legislation motion_picture paper-conference report song" match="none">
+        <date variable="issued">
+          <date-part name="year"/>
+          <date-part name="month"/>
+          <date-part name="day"/>
+        </date>
+      </if>
+      <else>
+        <date variable="issued">
+          <date-part name="year"/>
+        </date>
+      </else>
+    </choose>
+  </macro>
+  <macro name="issued-year">
+    <choose>
+      <if variable="issued">
+        <date variable="issued">
+          <date-part name="year"/>
+        </date>
+        <text variable="year-suffix"/>
+      </if>
+      <else>
+        <text term="no date" form="short"/>
+        <text variable="year-suffix" prefix="-"/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="edition">
+    <choose>
+      <if is-numeric="edition">
+        <group delimiter=" ">
+          <number variable="edition" form="ordinal"/>
+          <text term="edition" form="short"/>
+        </group>
+      </if>
+      <else>
+        <text variable="edition" suffix=". "/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="locators">
+    <!-- <text value="LOCATE!!" />  -->
+    <choose>
+      <if type="article-journal article-magazine" match="any">
+        <group prefix="" delimiter=". ">
+          <group>
+            <text variable="volume" font-style="normal" font-weight="bold" />
+            <text variable="issue" prefix=". " suffix=". sz."/>
+          </group>
+          <text variable="page"/>
+        </group>
+      </if>
+      <else-if type="article-newspaper">
+        <group delimiter=" " prefix=", ">
+          <label variable="page" form="short"/>
+          <text variable="page"/>
+        </group>
+      </else-if>
+      <else-if type="book graphic motion_picture report song chapter paper-conference" match="any">
+        <group prefix=" " suffix=". " delimiter=" ">
+          <text macro="edition"/>
+          <group>
+            <text term="volume" form="short" plural="true" text-case="capitalize-first" suffix=" "/>
+            <number variable="number-of-volumes" form="numeric" prefix="1-"/>
+          </group>
+          <group>
+            <text term="volume" form="short" text-case="capitalize-first" suffix=" "/>
+            <number variable="volume" form="numeric"/>
+          </group>
+<!--          <group>
+            <label variable="page" form="short" suffix=" "/>
+            <text variable="page"/>
+          </group> -->
+        </group>
+      </else-if>
+      <else-if type="legal_case">
+        <group prefix=" (" suffix=")" delimiter=" ">
+          <text variable="authority"/>
+          <date variable="issued" form="text"/>
+        </group>
+      </else-if>
+      <else-if type="bill legislation" match="any">
+        <date variable="issued" prefix=" (" suffix=")">
+          <date-part name="year"/>
+        </date>
+      </else-if>
+    </choose>  
+  </macro>
+  <macro name="pages">
+    <!-- <text value="PAGESS!!" />  -->
+    <choose>
+      <if type="book graphic motion_picture report song chapter paper-conference" match="any">
+        <group prefix=" " suffix=". " delimiter=" ">
+    	  <label variable="page" form="short" suffix=" "/>
+    	  <text variable="page"/>
+        </group>
+      </if>
+    </choose>
+  </macro>
+  <macro name="citation-locator">
+    <group>
+      <choose>
+        <if locator="chapter">
+          <label variable="locator" form="long" text-case="capitalize-first"/>
+        </if>
+        <else>
+          <label variable="locator" form="short"/>
+        </else>
+      </choose>
+      <text variable="locator" prefix=" "/>
+    </group>
+  </macro>
+  <macro name="container">
+    <group>
+      <choose>
+        <if type="chapter paper-conference entry-encyclopedia" match="any">
+          <text term="in" text-case="capitalize-first" suffix=": "/>
+        </if>
+      </choose>
+      <text macro="container-contributors"/>
+      <text macro="secondary-contributors"/>
+      <text macro="container-title"/>
+    </group>
+  </macro>
+  <macro name="container-title">
+    <choose>
+      <if type="bill legal_case legislation" match="none">
+        <text variable="container-title" font-style="italic"/>
+      </if>
+      <else>
+        <group delimiter=" " prefix=", ">
+          <choose>
+            <if variable="container-title">
+              <text variable="volume"/>
+              <text variable="container-title"/>
+              <group delimiter=" ">
+                <!--change to label variable="section" as that becomes available -->
+                <text term="section" form="symbol"/>
+                <text variable="section"/>
+              </group>
+              <text variable="page"/>
+            </if>
+            <else>
+              <choose>
+                <if type="legal_case">
+                  <text variable="number" prefix="No. "/>
+                </if>
+                <else>
+                  <text variable="number" prefix="Pub. L. No. "/>
+                  <group delimiter=" ">
+                    <!--change to label variable="section" as that becomes available -->
+                    <text term="section" form="symbol"/>
+                    <text variable="section"/>
+                  </group>
+                </else>
+              </choose>
+            </else>
+          </choose>
+        </group>
+      </else>
+    </choose>
+  </macro>
+  <citation et-al-min="6" et-al-use-first="1" et-al-subsequent-min="3" et-al-subsequent-use-first="1" disambiguate-add-year-suffix="true" disambiguate-add-names="true" disambiguate-add-givenname="true" collapse="year" givenname-disambiguation-rule="primary-name">
+    <sort>
+      <key macro="author"/>
+      <key macro="issued-sort"/>
+    </sort>
+    <layout prefix="(" suffix=")" delimiter="; ">
+      <group delimiter=", ">
+        <text macro="author-short"  font-style="italic" />
+        <text macro="issued-year"/>
+        <text macro="citation-locator"/>
+      </group>
+    </layout>
+  </citation>
+  <bibliography hanging-indent="true" et-al-min="8" et-al-use-first="6" et-al-use-last="true" entry-spacing="0" line-spacing="2">
+    <sort>
+      <key macro="author"/>
+      <key macro="issued-sort" sort="ascending"/>
+    </sort>
+    <layout>
+      <group delimiter=" " suffix=": " > <!-- author name and year -->
+	<text macro="author"/>
+	<text macro="issued"/>
+      </group>
+      <group suffix=". " > <!-- title -->
+	<text macro="title"/>
+	<text macro="container" prefix=". "/>
+      </group>
+      <text macro="locators"/>
+      <group delimiter=". " prefix="" suffix="">
+      	<text macro="event"/> 
+      	<text macro="publisher"/>
+      	<text macro="pages" />
+      </group>
+      <text macro="access"/>
+    </layout>
+  </bibliography>
+</style>


### PR DESCRIPTION
This is the bibliography style for the Hungarian journal Magyar Pedagogia. Note: There are different name-styles mandated for Hungarian and non-Hungarian publications. To mark non-hungarian publications set the note/extra to the language of the foreign publication (e.g. EN, ES, FR, etc.)
