### PR TITLE
Update iso690-author-date-cs.csl

### DIFF
--- a/iso690-author-date-cs.csl
+++ b/iso690-author-date-cs.csl
@@ -172,12 +172,12 @@
           </if>
         </choose>
         <choose>
+          <if variable="container-title">
           <choose>
             <if variable="event">
               <text variable="event" font-style="italic" suffix=": "/>
             </if>  
           </choose>
-          <if variable="container-title">
             <text variable="container-title" font-style="italic"/>
           </if>
           <else>


### PR DESCRIPTION
Some little improvements. Now it seems that iso690-author-date-cs is compatible with national ČSN ISO 690:2011 (which is implementation of international ISO 690:2010) in most important items - book, chapters, articles. In personal communication are some problems based on Zotero datastructure (missing items - it cannot be solved by CSL). Other items will be changed sometimes in the future.
