### PR TITLE
Update "Harvard Durham University Business School" style to better match...

### DIFF
--- a/harvard-durham-university-business-school.csl
+++ b/harvard-durham-university-business-school.csl
@@ -12,12 +12,12 @@
     <category citation-format="author-date"/>
     <category field="generic-base"/>
     <summary>Harvard author-date style edited for Durham University Business School</summary>
-    <updated>2013-03-18T21:27:00+00:00</updated>
+    <updated>2013-04-04T23:01:07+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <macro name="editor">
     <names variable="editor" delimiter=", ">
-      <name and="symbol" delimiter=", "/>
+      <name and="text" delimiter=", "/>
       <label form="short" prefix=" (" suffix=")"/>
     </names>
   </macro>
@@ -26,7 +26,7 @@
   </macro>
   <macro name="author">
     <names variable="author">
-      <name and="symbol" name-as-sort-order="all" sort-separator=", " initialize-with="." delimiter-precedes-last="never" delimiter=", "/>
+      <name and="text" name-as-sort-order="all" sort-separator=", " initialize-with="." delimiter-precedes-last="never" delimiter=", "/>
       <label form="short" prefix=" "/>
       <substitute>
         <text macro="editor"/>
@@ -154,7 +154,7 @@
       </group>
     </layout>
   </citation>
-  <bibliography hanging-indent="true" et-al-min="5" et-al-use-first="4">
+  <bibliography hanging-indent="false" et-al-min="5" et-al-use-first="4">
     <sort>
       <key macro="author"/>
       <key variable="title"/>


### PR DESCRIPTION
... the reference examples

Update "Harvard Durham University Business School" style to better match the reference examples on page three of reference document http://www.dur.ac.uk/resources/library/teaching/writingyourbibliography.pdf.
-  Avoid hanging indentation in the bibliography
-  Use text ("and") instead of a symbol ("&") as delimiter between the second to last and last name of the authors or editors
