### PR TITLE
Updates to harvard-university-of-the-west-of-england.csl

### DIFF
--- a/harvard-university-of-the-west-of-england.csl
+++ b/harvard-university-of-the-west-of-england.csl
@@ -45,18 +45,32 @@
     </names>
   </macro>
   <macro name="access">
-    <group>
-      <text variable="URL" prefix="Available from: "/>
-      <text variable="DOI" prefix="doi:" suffix=""/>
-      <group prefix=" [" suffix="]">
-        <text term="accessed" text-case="capitalize-first" suffix=": "/>
-        <date variable="accessed">
-          <date-part name="day" suffix=" "/>
-          <date-part name="month" suffix=" "/>
-          <date-part name="year"/>
-        </date>
-      </group>
-    </group>
+    <choose>
+      <if type="article-journal book" match="none">
+        <group>
+          <text variable="URL" prefix="Available from: "/>
+          <text variable="DOI" prefix="doi:"/>
+          <group prefix=" [" suffix="]">
+            <text term="accessed" text-case="capitalize-first" suffix=" "/>
+            <date variable="accessed">
+              <date-part name="day" suffix=" "/>
+              <date-part name="month" suffix=" "/>
+              <date-part name="year"/>
+            </date>
+          </group>
+        </group>
+      </if>
+      <else>
+        <group prefix="[" suffix="]">
+          <text term="accessed" text-case="capitalize-first" suffix=" "/>
+          <date variable="accessed">
+            <date-part name="day" suffix=" "/>
+            <date-part name="month" suffix=" "/>
+            <date-part name="year"/>
+          </date>
+        </group>
+      </else>
+    </choose>
   </macro>
   <macro name="title">
     <choose>
@@ -101,7 +115,7 @@
     </choose>
   </macro>
   <macro name="pages">
-    <group>
+    <group prefix="pp. ">
       <text variable="page"/>
     </group>
   </macro>
@@ -173,7 +187,7 @@
           <group suffix=".">
             <text macro="title" prefix=" "/>
             <text macro="editor" prefix=" "/>
-            <text macro="online" prefix=" "/>
+            <text macro="online" prefix=" "/>            
           </group>
           <choose>
             <if variable="author" match="any">


### PR DESCRIPTION
- Changed the access macro so that the URL or DOI are not shown for
  electronic articles or books.
- Prefixed page numbers with pp.
- Removed the online macro for webpages.
- Other punctuation tweaks.

For examples see
http://www2.uwe.ac.uk/services/library/help/printable%20library%20guides
/9-uwe-harvard.pdf
