### PR TITLE
Université Laval, Département d'histoire (notes de bas de page longues)

### DIFF
--- a/Université Laval, Département d'histoire (citations longues)
+++ b/Université Laval, Département d'histoire (citations longues)
@@ -1,0 +1,210 @@
+<?xml version="1.0" encoding="utf-8"?>
+<style class="note" version="1.0" and="text" et-al-min="3" demote-non-dropping-particle="never" default-locale="fr-CA" xmlns="http://purl.org/net/xbiblio/csl">
+  <info>
+    <title>Université Laval, Département d'histoire (citations complètes)</title>
+    <title-short>ULaval, HST - citations complètes</title-short>
+    <id>http://www.zotero.org/styles/universite-laval-departement-dhistoire-citations-completes</id>
+    <link href="http://www.zotero.org/styles/universite-laval-departement-dhistoire-citations-completes" rel="self"/>
+    <link href="http://www.hst.ulaval.ca/services-et-ressources/guides-pedagogiques/regles-de-presentation-bibliographique/" rel="documentation"/>
+    <author>
+      <name>Marc-Antoine Larose</name>
+      <email>marcantoine.larose@gmail.com</email>
+    </author>
+    <category field="Histoire" citation-format="AUTEUR-titre"/>
+    <summary>Normes bibliographiques du département d'histoire de l'Université Laval. La fonction &quot;locator&quot; est utilisée afin d'insérer automatiquement la page de référence des ouvrages en utilisant le complément pour MS Office.</summary>
+    <updated>2013-04-13T05:11:51+00:00</updated>
+    <rights>This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
+  </info>
+  <macro name="container-contributors">
+    <choose>
+      <if type="chapter paper-conference" match="any">
+        <text term="in" suffix=" "/>
+        <names variable="editor translator" delimiter=", ">
+          <name and="text" initialize-with=". " delimiter=", "/>
+          <label form="long" prefix=", " suffix="."/>
+        </names>
+      </if>
+    </choose>
+  </macro>
+  <macro name="secondary-contributors">
+    <choose>
+      <if type="chapter paper-conference" match="none">
+        <names variable="editor" delimiter=", " prefix=" (" suffix=")">
+          <name and="text" initialize-with=". " delimiter=", "/>
+          <label form="short" prefix=", " text-case="capitalize-first" suffix="." strip-periods="true"/>
+        </names>
+      </if>
+    </choose>
+  </macro>
+  <macro name="Auteur">
+    <names variable="author" font-variant="normal" delimiter="," suffix=" ">
+      <name font-style="normal" font-variant="normal" delimiter=" " suffix=", " and="text" delimiter-precedes-et-al="always" delimiter-precedes-last="always" et-al-min="4" et-al-use-first="3" initialize="false" initialize-with=".">
+        <name-part name="family" text-case="capitalize-first" font-variant="normal"/>
+      </name>
+      <label form="short" text-case="capitalize-first" strip-periods="true" prefix=" (" suffix=".)"/>
+    </names>
+  </macro>
+  <macro name="Auteur-note">
+    <names variable="author">
+      <name form="short" delimiter="" et-al-min="1" et-al-use-last="true" initialize="false" name-as-sort-order="first" sort-separator=""/>
+    </names>
+  </macro>
+  <macro name="access">
+    <choose>
+      <if variable="URL">
+        <group>
+          <text term="retrieved" text-case="lowercase" suffix=" le "/>
+          <date form="text" variable="accessed" suffix=".">
+            <date-part name="month" range-delimiter=""/>
+            <date-part name="day" range-delimiter=""/>
+            <date-part name="year" range-delimiter=""/>
+          </date>
+        </group>
+      </if>
+    </choose>
+  </macro>
+  <macro name="publisher">
+    <text variable="genre" suffix=", "/>
+    <group>
+      <text variable="publisher" suffix=", "/>
+      <text variable="publisher-place" suffix=", "/>
+      <group>
+        <choose>
+          <if type="webpage" match="any">
+            <text variable="container-title" font-style="italic" suffix=", "/>
+            <date form="text" variable="issued" suffix=", ">
+              <date-part name="year"/>
+            </date>
+            <text variable="URL" text-decoration="none" suffix=", "/>
+          </if>
+          <else-if type="article article-journal" match="any">
+            <date form="text" variable="issued" prefix="(" suffix="), "/>
+          </else-if>
+          <else-if type="entry-encyclopedia entry-dictionary" match="any">
+            <date form="text" variable="issued" suffix=". "/>
+            <choose>
+              <if match="any" variable="URL">
+                <text variable="URL" suffix=", "/>
+              </if>
+            </choose>
+          </else-if>
+        </choose>
+      </group>
+      <text variable="locator" prefix="p. " suffix="."/>
+    </group>
+  </macro>
+  <macro name="event">
+    <text variable="event"/>
+    <text variable="event-place" prefix=", "/>
+  </macro>
+  <macro name="issued">
+    <choose>
+      <if variable="issued">
+        <group prefix=" ">
+          <choose>
+            <if type="webpage" match="any"/>
+          </choose>
+        </group>
+      </if>
+    </choose>
+  </macro>
+  <macro name="issued-year">
+    <choose>
+      <if variable="issued"/>
+      <else>
+        <text term="no date" form="short"/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="edition">
+    <choose>
+      <if type="bill book chapter graphic legal_case legislation motion_picture paper-conference report song article article-magazine article-newspaper review-book review" match="any">
+        <choose>
+          <if is-numeric="edition">
+            <text term="edition" prefix=" " suffix=". "/>
+          </if>
+        </choose>
+      </if>
+    </choose>
+  </macro>
+  <macro name="locators">
+    <choose>
+      <if type="article-journal article-magazine article-newspaper" match="any">
+        <text variable="container-title" font-style="italic" suffix=", "/>
+        <number suffix=", " variable="volume"/>
+        <number suffix=" " variable="issue"/>
+      </if>
+      <else-if type="book chapter graphic legal_case legislation motion_picture paper-conference report song" match="any"/>
+    </choose>
+  </macro>
+  <macro name="citation-locator">
+    <group>
+      <label variable="locator" form="short"/>
+      <text variable="locator" prefix=" "/>
+    </group>
+  </macro>
+  <macro name="director-collectif">
+    <names variable="editor" font-variant="normal" suffix=", dir. ">
+      <name font-variant="normal" initialize="false">
+        <name-part name="family" font-variant="small-caps"/>
+      </name>
+    </names>
+  </macro>
+  <citation et-al-min="3" et-al-use-first="1" sort-separator="" disambiguate-add-year-suffix="true" collapse="year">
+    <layout>
+      <text macro="Auteur" strip-periods="false" font-variant="normal"/>
+      <group>
+        <choose>
+          <if type="article-journal article-magazine article-newspaper article chapter webpage" match="any">
+            <text variable="title" prefix="« " suffix=" », "/>
+            <text macro="director-collectif"/>
+          </if>
+          <else-if type="book" match="any">
+            <text variable="title" font-style="italic" prefix=" " suffix=", "/>
+          </else-if>
+          <else-if type="entry-encyclopedia entry-dictionary" match="any">
+            <text variable="title" prefix="« " suffix=" », "/>
+            <text variable="container-title" font-style="italic" suffix=", "/>
+          </else-if>
+        </choose>
+        <choose>
+          <if type="book" match="all" variable="volume">
+            <text variable="edition" suffix=", "/>
+            <number text-case="uppercase" font-variant="normal" prefix=" Tome " suffix=" : " variable="volume" form="roman"/>
+            <text variable="title-short" font-style="italic" suffix=", "/>
+          </if>
+        </choose>
+        <choose>
+          <if type="article article-journal article-magazine article-newspaper bill book broadcast chapter dataset entry entry-dictionary entry-encyclopedia figure graphic interview legal_case legislation manuscript map motion_picture musical_score pamphlet paper-conference patent personal_communication post post-weblog report review review-book song speech thesis treaty webpage" match="any">
+            <number variable="number"/>
+          </if>
+          <else>
+            <number prefix=" " suffix=", " variable="volume"/>
+          </else>
+        </choose>
+        <choose>
+          <if type="thesis" match="any">
+            <text variable="title" prefix="« " suffix=" ». "/>
+          </if>
+        </choose>
+      </group>
+      <text macro="locators"/>
+      <group>
+        <text macro="publisher"/>
+        <text macro="access"/>
+        <text macro="issued" suffix=" "/>
+      </group>
+    </layout>
+    <sort>
+      <key variable="issued"/>
+      <key macro="author"/>
+    </sort>
+    <layout/>
+  </citation>
+  <bibliography hanging-indent="true" et-al-min="11" et-al-use-first="1" entry-spacing="0">
+    <sort>
+      <key macro="author"/>
+      <key variable="issued"/>
+    </sort>
+  </bibliography>
+</style>


### PR DESCRIPTION
Normes bibliographiques du département d'histoire de l'Université Laval. - NOTES DE BAS DE PAGE LONGUES - La fonction "locator" est utilisée afin d'insérer automatiquement la page de référence des ouvrages en utilisant le complément pour MS Office. Autrement, inscrire le numéro de la page manuellement.
