### PR TITLE
Update global-change-biology.csl

### DIFF
--- a/global-change-biology.csl
+++ b/global-change-biology.csl
@@ -74,7 +74,7 @@
       <key variable="author"/>
     </sort>
     <layout prefix="(" suffix=")" delimiter="; ">
-      <group delimiter=" ">
+      <group delimiter=", ">
         <text macro="author-short"/>
         <date variable="issued">
           <date-part name="year"/>


### PR DESCRIPTION
I added a comma in the citation field to get (Author et al., 2013) instead of (Author et al. 2013) in order to comply with Journal requirements. 
See following link for the detailed style requirement: 
http://www.google.co.in/url?sa=t&rct=j&q=&esrc=s&source=web&cd=4&ved=0CEsQFjAD&url=http%3A%2F%2Fnceas.ucsb.edu%2F~menge%2Fgcb_cover.pdf&ei=QEBpUau0BMSPrgechIGADw&usg=AFQjCNG1FiNeKdVbvggt4PapJ6xKEdiwSQ&bvm=bv.45175338,d.bmk&cad=rja 
