### PR TITLE
createa new style that bases on the apa-cv but omitts the author fields for some resume/cv purposes

### DIFF
--- a/apa-cv-omit-author.csl
+++ b/apa-cv-omit-author.csl
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" demote-non-dropping-particle="never">
   <info>
-    <title>American Psychological Association (CV - sort by descending date)</title>
+    <title>American Psychological Association (CV - sort by descending full date but without author- )</title>
     <id>http://www.zotero.org/styles/apa-cv-omit-author</id>
     <link href="http://www.zotero.org/styles/apa-cv-omit-author" rel="self"/>
     <link href="http://owl.english.purdue.edu/owl/resource/560/01/" rel="documentation"/>
@@ -30,10 +30,10 @@
     <category field="psychology"/>
     <category field="generic-base"/>
     <summary>APA style for CVs, sorting by date (descending), then title (Author field omitted)</summary>
-    <updated>2013-04-06T18:50:33+00:00</updated>
+    <updated>2013-04-17T18:50:33+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
-  <locale xml:lang="en">
+  <locale xml:lang="en-gb">
     <terms>
       <term name="editortranslator" form="short">
         <single>ed. &amp; trans.</single>
@@ -191,23 +191,16 @@
       <if type="bill legal_case legislation" match="none">
         <choose>
           <if variable="issued">
-            <group prefix=" (" suffix=")">
-              <date variable="issued">
-                <date-part name="year"/>
+            <group prefix=" " suffix="  ">
+              <date variable="issued" form="text" >
+                <date-part name="day" font-weight="bold"/>
+                <date-part name="month" font-weight="bold"/>
+                <date-part name="year" font-weight="bold"/>
               </date>
-              <text variable="year-suffix"/>
-              <choose>
-                <if type="article-journal bill book chapter graphic legal_case legislation motion_picture paper-conference report song" match="none">
-                  <date variable="issued">
-                    <date-part prefix=", " name="month"/>
-                    <date-part prefix=" " name="day"/>
-                  </date>
-                </if>
-              </choose>
             </group>
           </if>
           <else>
-            <group prefix=" (" suffix=")">
+            <group prefix=" " suffix="  ">
               <text term="no date" form="short"/>
               <text variable="year-suffix" prefix="-"/>
             </group>
@@ -387,8 +380,8 @@
     </sort>
     <layout>
       <group suffix=".">
-        <group delimiter=". ">
           <text macro="issued"/>
+        <group delimiter=". ">
           <text macro="title" prefix=" "/>
           <text macro="container"/>
         </group>


### PR DESCRIPTION
exactly the same with apa-cv but author fields are omitted for cv format.
