### PR TITLE
evolution.csl 

### DIFF
--- a/evolution.csl
+++ b/evolution.csl
@@ -24,7 +24,7 @@
   </macro>
   <macro name="author">
     <names variable="author">
-      <name name-as-sort-order="first" and="text" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="never"/>
+      <name name-as-sort-order="first" and="text" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
       <label form="short" prefix=" (" suffix=")" strip-periods="true"/>
       <substitute>
         <names variable="editor"/>


### PR DESCRIPTION
Adding a small change for the list of authors in the list of references.

A comma is required after every author in the reference list (except by the last one, off course).

This new version fixes that as your version of evolution.csl does not include the commas.
