### PR TITLE
Three fixes for mis-quarterly style

### DIFF
--- a/mis-quarterly.csl
+++ b/mis-quarterly.csl
@@ -176,8 +176,10 @@
         <choose>
           <if type="speech paper-conference" match="any">
             <text variable="publisher-place"/>
-            <date-part prefix=", " name="month"/>
-            <date-part prefix=" " name="day"/>
+			<date variable="issued">
+              <date-part prefix=", " name="month"/>
+              <date-part prefix=" " name="day"/>
+			</date>
           </if>
 	  	  <else>
 		     <group delimiter=": ">
@@ -348,7 +350,7 @@
           <text macro="event"/>
           <text macro="publisher"/>
         </group>
-        <group delimiter=" ">
+        <group delimiter=" " prefix=", ">
           <label variable="page" form="short"/>
           <text variable="page"/>           
         </group>


### PR DESCRIPTION
I've just gone a round with the copy editor at MIS Quarterly and adjusted the style file to work for their requirements for Book Section/Proceedings (lower case in), Dissertations and Working Papers.  I also got dates working for conference presentations (ie speech) and conference proceedings (ie paper-conference).  I don't have good guidelines to link to (all by email as an author); they describe their styles by referring you to recent papers ....  I also adjusted the position of some commas (see individual commits).

I was now able to submit using this style file, but still have to make these manual changes:
1. Dealing with journals without pages, but with Article or Paper numbers.  Asked about this here: https://forums.zotero.org/discussion/28951/journals-without-page-numbers-eg-article-7-or-paper-122/  My solution was to use is-numeric on pages but that always seems to return false.
2. Dealing with date ranges.  MIS Quarterly wants to see dates for conferences.  These are invariably ranges.  (e.g., May 4-8 or July 31-August 5). I'm not sure how to accomplish this. I'm using Zotero 4.0.4 standalone and the date field parsing seems to preclude date ranges.  OTOH the 1.0.1 spec discusses them but I don't understand how to achieve them in CSL, especially across months.
