### PR TITLE
Update university-of-melbourne.csl

### DIFF
--- a/university-of-melbourne.csl
+++ b/university-of-melbourne.csl
@@ -77,6 +77,7 @@
       <label form="short" prefix=" (" suffix=".)" text-case="lowercase" strip-periods="true"/>
       <substitute>
         <names variable="editor"/>
+        <names variable="translator"/>
         <text macro="noauthor_title"/>
       </substitute>
     </names>


### PR DESCRIPTION
Updated based on style guide at http://www.lib.unimelb.edu.au/recite/index.html 

Updates include:
allowing locators other than 'page' in in-text citation
use of short form 'ch.' instead of 'chap.'
referencing title for items with no author (instead of using 'Anon.')
changing term 'et al' to 'et al.'
changed et al delimitation for citations to '4' and removed for bibliography
use of plural 'pp.'
removed conversion of titles to sentence case (which converted proper nouns to lowercase)
