### PR TITLE
Update american-journal-of-archaeology.csl

### DIFF
--- a/american-journal-of-archaeology.csl
+++ b/american-journal-of-archaeology.csl
@@ -80,13 +80,13 @@
   </macro>
   <macro name="editor">
     <names variable="editor">
-      <name name-as-sort-order="first" and="text" sort-separator=", " delimiter=", " delimiter-precedes-last="always"/>
+      <name name-as-sort-order="first" and="text" sort-separator=", " delimiter=", " delimiter-precedes-last="always" initialize-with="."/>
       <label form="short" prefix=", " suffix="." strip-periods="true"/>
     </names>
   </macro>
   <macro name="translator">
     <names variable="translator">
-      <name name-as-sort-order="first" and="text" sort-separator=", " delimiter=", " delimiter-precedes-last="always"/>
+      <name name-as-sort-order="first" and="text" sort-separator=", " delimiter=", " delimiter-precedes-last="always" initialize-with="."/>
       <label form="verb-short" prefix=", " suffix="." strip-periods="true"/>
     </names>
   </macro>
@@ -110,7 +110,7 @@
   </macro>
   <macro name="contributors">
     <names variable="author">
-      <name and="text" name-as-sort-order="first" sort-separator=", " delimiter=", " delimiter-precedes-last="always"/>
+      <name and="text" name-as-sort-order="first" sort-separator=", " delimiter=", " delimiter-precedes-last="always" initialize-with="."/>
       <label form="verb-short" prefix=", " suffix="." text-case="lowercase" strip-periods="true"/>
       <substitute>
         <text macro="editor"/>


### PR DESCRIPTION
Added `initialize-with="."` for author, editor and translator `<name>` sections.  This is intended to make first names in the bibliography only show as initials (with no spaces between them), in line with section 4.6 of [the AJA submission guidlines](http://www.ajaonline.org/submissions/#4).
