### PR TITLE
Workaround bug in Travis?

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -67,14 +67,14 @@ end
 print "\nLoading dependent styles"
 
 Dependents = Hash[Dir[File.join(STYLE_ROOT, 'dependent', '*.csl')].each_with_index.map { |path, i|
-  print '.' if i % 100 == 0
+  print '.' if i % 500 == 0
   load_style(path)
 }]
 
 print "\nLoading independent styles"
 
 Independents = Hash[Dir[File.join(STYLE_ROOT, '*.csl')].each_with_index.map { |path, i|
-  print '.'  if i % 100 == 0
+  print '.'  if i % 500 == 0
   load_style(path)
 }]
 


### PR DESCRIPTION
Travis said "The log length has exceeded the limit of 4 Megabytes (this usually means that test suite is raising the same exception over and over)."
Watching the log I don't see 4 MB of data (https://travis-ci.org/citation-style-language/styles/builds/6688872)
Someone may contact Travis but this patch tries to print less "." just in case this fixes the problem for the time being.
