### PR TITLE
Update harvard-coventry-university.csl

### DIFF
--- a/harvard-coventry-university.csl
+++ b/harvard-coventry-university.csl
@@ -73,7 +73,7 @@
   </macro>
   <macro name="title">
     <choose>
-      <if type="book report paper-conference thesis" match="any">
+      <if type="book report paper-conference thesis webpage pamphlet" match="any">
         <text variable="title" font-style="italic" suffix="."/>
       </if>
       <else-if type="article-journal article-magazine chapter article article-newspaper paper-conference" match="any">


### PR DESCRIPTION
Updated with title for "pamphlet" and "webpage". These was not shown in italic as specified.
