### PR TITLE
Update mcrj7.csl

### DIFF
--- a/mcrj7.csl
+++ b/mcrj7.csl
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <style xmlns="http://purl.org/net/xbiblio/csl" class="note" version="1.0" default-locale="fr-FR">
   <info>
-    <title>Manuel canadien de la référence juridique 7e éd (Guide McGill)</title>
+    <title>Manuel canadien de la référence juridique 7e éd (Guide McGill, French)</title>
     <title-short>Guide McGill 7e éd (FR)</title-short>
     <id>http://www.zotero.org/styles/mcrj7</id>
     <link href="http://www.zotero.org/styles/mcrj7" rel="self"/>


### PR DESCRIPTION
- Mise à jour du titre (à l'image du guide et de la version CSL anglaise)
- Bibliographie
  - organisée par genre (selon le découpage et l'ordre du Guide McGill)
  - avec le point après le nom de l'auteur
  - affectation des grands types de doctrine juridique à une macro de style
- "dans" à la place de "in"
- "ch" à la place de "chap" ou "chapchap" (il y avait un doublon de code qui dupliquait le "chap")
- "éd" à la place de "éd."
- ajout d'espaces manquants
