### PR TITLE
Update mcrj7.csl

### DIFF
--- a/mcrj7.csl
+++ b/mcrj7.csl
@@ -6,6 +6,7 @@
     <id>http://www.zotero.org/styles/mcrj7</id>
     <link href="http://www.zotero.org/styles/mcrj7" rel="self"/>
     <link href="http://lawjournal.mcgill.ca/citeguide.php?locale=fr" rel="documentation"/>
+    <link href="http://tinyurl.com/mcrj7-csl-doc" rel="documentation"/>
     <author>
       <name>Philippe Tousignant</name>
       <email>philippe.tousignant@gmail.com</email>
@@ -19,7 +20,7 @@
     </contributor>
     <category citation-format="note"/>
     <category field="law"/>
-    <updated>2013-05-01T23:01:51+00:00</updated>
+    <updated>2013-05-04T18:49:36+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale xml:lang="fr">
@@ -38,6 +39,7 @@
       <term name="editor" form="verb">dir</term>
       <term name="translator" form="verb-short">traduit par</term>
       <term name="in">dans</term>
+    <term name="sub verbo" form="short">sub verbo&#160;</term>
     </terms>
   </locale>
   <macro name="contributors-note">
@@ -82,7 +84,7 @@
         <text macro="translator"/>
       </substitute>
     </names>
-    <text macro="recipient" prefix=". " suffix="dd"/>
+    <text macro="recipient" prefix=". "/>
   </macro>
   <macro name="editor">
     <names variable="editor">
@@ -186,10 +188,10 @@
     <text variable="DOI"/>
   </macro>
   <macro name="collection-title">
-    <text variable="collection-title"/>
+    <text variable="collection-title" prefix="coll "/>
   </macro>
   <macro name="collection-number">
-    <text variable="collection-number"/>
+    <text variable="collection-number" prefix="n°"/>
   </macro>
   <macro name="volume">
     <text variable="volume"/>
@@ -265,7 +267,7 @@
           </else-if>
         </choose>
       </if>
-      <else-if type="bill book graphic legal_case legislation motion_picture report song" match="any">
+      <else-if type="bill book graphic legal_case legislation motion_picture report song thesis" match="any">
         <text variable="title" form="short" font-style="italic"/>
       </else-if>
       <else>
@@ -378,7 +380,7 @@
   <macro name="title-chapter-special">
     <choose>
       <if variable="container-title" match="any">
-        <text variable="title" font-style="italic" quotes="true"/>
+        <text variable="title" quotes="true"/>
         <text term="in" text-case="lowercase" suffix=" " prefix=", "/>
       </if>
       <else>
@@ -412,7 +414,7 @@
       <text macro="publisher" suffix=""/>
       <text macro="issued-year" suffix=""/>
     </group>
-    <text macro="point-locators"/>
+    <text macro="point-locators" prefix=" "/>
   </macro>
   <macro name="chapter">
     <text macro="contributors" suffix=". "/>
@@ -436,7 +438,7 @@
       <text macro="publisher"/>
       <text macro="issued-year" suffix=""/>
     </group>
-    <text value="[non publiée]"/>
+	<text macro="point-locators" prefix=" "/>
   </macro>
   <macro name="thesis">
     <text macro="contributors" suffix=". "/>
@@ -446,11 +448,10 @@
       <text macro="publisher"/>
       <text macro="issued-year" suffix=""/>
     </group>
-    <text value=" [non publiée]"/>
   </macro>
   <macro name="bill">
     <group delimiter=", ">
-      <text macro="number" prefix="P.L. "/>
+      <text macro="number" prefix="PL "/>
       <text macro="title" font-style="italic"/>
       <text macro="publisher"/>
       <text macro="contributors"/>
@@ -522,7 +523,7 @@
       <text variable="container-title" prefix="" font-style="italic"/>
       <choose>
         <if variable="volume" match="any">
-          <group delimiter="&#160;:">
+          <group delimiter=":">
             <text variable="volume" prefix=""/>
             <number variable="issue" prefix=""/>
           </group>
@@ -544,7 +545,7 @@
       <text variable="container-title" prefix="" font-style="italic"/>
       <choose>
         <if variable="volume" match="any">
-          <group delimiter="&#160;:">
+          <group delimiter=":">
             <text variable="volume" prefix=""/>
             <number variable="issue" prefix=""/>
           </group>
@@ -563,12 +564,20 @@
     <group delimiter=" ">
       <text macro="contributors-note" suffix=","/>
       <text macro="title" quotes="true"/>
+<choose>
+<if variable="volume" match="none">
+<text macro="issued-year" prefix="[" suffix="]"/>
+<number variable="issue" prefix=""/>
+</if>
+<else>  
       <text macro="issued-year" prefix="(" suffix=")"/>
-      <group delimiter="&#160;: ">
-        <text variable="volume" prefix=""/>
+      <group delimiter=":">
+        <text variable="volume"/>
         <number variable="issue"/>
         <number variable="number-of-volumes" form="numeric"/>
       </group>
+</else>
+</choose>
       <text variable="container-title" form="short" prefix="" strip-periods="true"/>
       <text macro="point-locators"/>
     </group>
@@ -578,70 +587,48 @@
     <text macro="contributors" suffix=". "/>
     <group delimiter=" ">
       <text macro="title" quotes="true"/>
+<choose>
+<if variable="volume" match="none">
+<text macro="issued-year" prefix="[" suffix="]"/>
+<number variable="issue" prefix=""/>
+</if>
+<else>  
       <text macro="issued-year" prefix="(" suffix=")"/>
-      <group delimiter="&#160;: ">
-        <text variable="volume" prefix=""/>
+      <group delimiter=":">
+        <text variable="volume"/>
         <number variable="issue"/>
         <number variable="number-of-volumes" form="numeric"/>
       </group>
+</else>
+</choose>
       <text variable="container-title" form="short" prefix="" strip-periods="true"/>
       <text macro="point-locators"/>
     </group>
     <text variable="URL" prefix=", en ligne&#160;: &lt;" suffix="&gt;"/>
   </macro>
+  
   <macro name="case">
-    <text macro="title" font-style="italic"/>
-    <choose>
-      <if variable="references" match="none">
-        <text macro="issued" prefix=" (" suffix="), "/>
-      </if>
-      <else>
-        <text value=", "/>
+    <text macro="title" font-style="italic" suffix=", " strip-periods="true"/>
+
+<choose>
+<if variable="container-title" match="none">
         <text macro="issued" suffix=" "/>
-        <choose>
-          <if variable="issued" match="any">
-            <text macro="authority" suffix=" "/>
-          </if>
-          <else-if variable="issued" match="none"/>
-        </choose>
-      </else>
-    </choose>
-    <group delimiter=" ">
-      <choose>
-        <if variable="page" match="any">
-          <group delimiter=" ">
-            <text variable="number" suffix=""/>
-            <text variable="references" prefix="[" suffix="]"/>
-            <text macro="volume" suffix=""/>
-            <text macro="issue"/>
-            <text variable="container-title" suffix=""/>
-          </group>
-        </if>
-        <else-if variable="page" match="none">
-          <group delimiter=" ">
-            <text variable="references" prefix="[" suffix="]"/>
-            <text macro="volume" suffix=""/>
-            <text macro="issue"/>
-            <text variable="container-title" suffix=""/>
-            <text variable="number" suffix=""/>
-          </group>
-        </else-if>
-      </choose>
-      <text macro="page" prefix=""/>
-      <text macro="point-locators"/>
-      <text variable="note" prefix="(" suffix=")"/>
-      <text macro="contributors"/>
-      <text macro="title-short" prefix="[" suffix="]" font-style="italic"/>
-    </group>
-    <choose>
-      <if variable="URL" match="none"/>
-      <else-if variable="URL" match="any">
-        <text value=" en ligne&#160;:"/>
-        <text variable="authority" prefix=" "/>
-        <text variable="URL" prefix=" &lt;" suffix="&gt;"/>
-      </else-if>
-    </choose>
+	<text macro="authority" suffix=" " strip-periods="true"/>
+	<text variable="page"/>
+</if>
+<else>
+	<text macro="issued" prefix=" [" suffix="] "/>
+            <text macro="volume" suffix=" "/>
+            <text variable="container-title" suffix=" " strip-periods="true"/>
+	<text variable="page"/>
+</else>
+</choose>
+<text variable="note" prefix=", "/>
+<text variable="title-short" prefix=" [" suffix="]" font-style="italic"/>
+<text variable="URL" prefix=", en ligne&#160;: &lt;" suffix="&gt;"/>
   </macro>
+  
+  
   <macro name="access-note">
     <group delimiter=", ">
       <choose>
@@ -714,6 +701,10 @@
       </else-if>
     </choose>
   </macro>
+<macro name="point-locators-sub">
+	<label variable="locator" suffix="" form="short" strip-periods="true"/>
+        <text variable="locator" prefix=""/>
+</macro>
   <macro name="point-locators">
     <choose>
       <if variable="locator" match="none">
@@ -749,7 +740,7 @@
     </choose>
   </macro>
   <macro name="locators-note">
-    <group delimiter="&#160;: ">
+    <group delimiter=":">
       <text variable="volume" prefix=" "/>
       <number variable="issue"/>
       <number variable="number-of-volumes" form="numeric"/>
@@ -757,7 +748,7 @@
   </macro>
   <macro name="locators">
     <text macro="issued" prefix="" suffix=""/>
-    <group delimiter="&#160;: ">
+    <group delimiter=":">
       <text variable="volume" prefix=" "/>
       <number variable="issue"/>
       <number variable="number-of-volumes" form="numeric"/>
@@ -814,7 +805,7 @@
       <else-if type="book thesis" match="any">
         <text value="3" font-weight="normal"/>
       </else-if>
-      <else-if type="article-journal chapter article-newspaper entry-encyclopedia review-book article review article-magazine paper-conference" match="any">
+      <else-if type="article-journal chapter entry-encyclopedia review-book article review article-magazine paper-conference" match="any">
         <text value="4"/>
       </else-if>
       <else>
@@ -828,7 +819,7 @@
         <if position="ibid-with-locator">
           <group delimiter=", ">
             <text term="ibid" font-style="italic" strip-periods="true" text-case="capitalize-first"/>
-            <text macro="point-locators"/>
+            <text macro="point-locators-sub"/>
           </group>
         </if>
         <else-if position="ibid">
@@ -843,7 +834,7 @@
           <group delimiter=" ">
             <text value="note"/>
             <text variable="first-reference-note-number"/>
-            <text macro="point-locators"/>
+            <text macro="point-locators-sub"/>
           </group>
         </else-if>
         <else-if type="bill legislation" match="any">
@@ -855,13 +846,13 @@
         <else-if type="thesis">
           <text macro="note-thesis"/>
         </else-if>
-        <else-if type="chapter paper-conference" match="any">
+        <else-if type="chapter paper-conference entry-encyclopedia" match="any">
           <text macro="note-chapter"/>
         </else-if>
         <else-if type="bill book graphic legal_case legislation motion_picture report song" match="any">
           <text macro="note-book"/>
         </else-if>
-        <else-if type="article-newspaper">
+        <else-if type="article-newspaper webpage post post-weblog" match="any">
           <text macro="note-article-newspaper"/>
         </else-if>
         <else-if type="article-magazine">
@@ -873,7 +864,7 @@
         <else>
           <group delimiter=" ">
             <text macro="contributors-note" suffix=","/>
-            <text macro="title-note"/>
+            <text macro="title-note" font-style="italic"/>
             <text macro="description-note"/>
             <text macro="secondary-contributors-note"/>
             <group delimiter="">
@@ -916,7 +907,7 @@
         <else-if type="bill book graphic legal_case legislation motion_picture report song" match="any">
           <text macro="book"/>
         </else-if>
-        <else-if type="article-newspaper">
+        <else-if type="article-newspaper webpage" match="any">
           <text macro="article-newspaper"/>
         </else-if>
         <else-if type="article-magazine">
@@ -928,7 +919,7 @@
         <else>
           <text macro="contributors" suffix=". "/>
           <group delimiter=", ">
-            <text macro="title"/>
+            <text macro="title" font-style="italic"/>
             <text macro="description"/>
             <text macro="secondary-contributors"/>
             <group delimiter="">


### PR DESCRIPTION
New update. Common doctrine, case and legislation seem now correctly cited (in note and bib). Checked with the Guide.

Add < link href="http://tinyurl.com/mcrj7-csl-doc" rel="documentation" />
Doc explaining the fields to use (specially for case law).
