### PR TITLE
Improve "Harvard Durham University Business School" citation style to be...

### DIFF
--- a/harvard-durham-university-business-school.csl
+++ b/harvard-durham-university-business-school.csl
@@ -144,7 +144,7 @@
   </macro>
   <citation et-al-min="4" et-al-use-first="3" disambiguate-add-year-suffix="true" collapse="year">
     <layout prefix="(" suffix=")" delimiter="; ">
-      <group delimiter=", ">
+      <group delimiter=" ">
         <text macro="author-short"/>
         <text macro="year-date"/>
         <group>


### PR DESCRIPTION
...tter match the reference examples

Improve "Harvard Durham University Business School" citation style to better match the reference examples

Remove comma separator in citation (as seen in the reference document at http://www.dur.ac.uk/resources/library/teaching/writingyourbibliography.pdf)
