### PR TITLE
Fix editor name part order in style "Harvard Durham University Business ...

### DIFF
--- a/harvard-durham-university-business-school.csl
+++ b/harvard-durham-university-business-school.csl
@@ -29,7 +29,7 @@
       <name and="text" name-as-sort-order="all" sort-separator=", " initialize-with="." delimiter-precedes-last="never" delimiter=", "/>
       <label form="short" prefix=" "/>
       <substitute>
-        <text macro="editor"/>
+        <names variable="editor"/>
         <text macro="anon"/>
       </substitute>
     </names>


### PR DESCRIPTION
...School"

In the style "Harvard Durham University Business School" the editors were in the bibliography written as "Richard E. Nisbett" instead "Nisbett, R.E.". That did not affect the authors, but only editors.

This bug was copied over from the style "Harvard - Imperial College London", on which Durham style is based.
