### PR TITLE
Changed et-al-use-first="3"

### DIFF
--- a/the-astrophysical-journal.csl
+++ b/the-astrophysical-journal.csl
@@ -89,7 +89,7 @@
       <text variable="citation-number"/>
     </layout>
   </citation>
-  <bibliography et-al-min="6" et-al-use-first="1" second-field-align="flush" entry-spacing="0">
+  <bibliography et-al-min="6" et-al-use-first="3" second-field-align="flush" entry-spacing="0">
     <layout>
       <group delimiter=" ">
         <text macro="author" suffix="."/>


### PR DESCRIPTION
For ApJ journal, If there are more than 5 authors, then "et al." should be added after first three authors name.
See http://aas.org/authors/manuscript-preparation-aj-apj-author-instructions#references
