### PR TITLE
Update iso690-author-date-cs.csl

### DIFF
--- a/iso690-author-date-cs.csl
+++ b/iso690-author-date-cs.csl
@@ -288,6 +288,12 @@
       </if>
     </choose>
   </macro>
+  <macro name="scale">
+    <group delimiter=" ">
+      <text term="scale" text-case="capitalize-first"/>
+      <text variable="scale"/>
+    </group>
+  </macro>
   <macro name="edition">
     <choose>
       <if is-numeric="edition">


### PR DESCRIPTION
1. Deleted terms, which are the same as in locale-cs-CZ.xml (term "from" is also same as in locale file on GitHub, but still not in Zotero, in some future version it can be delete too)
2. add <bibliography> section for type Interview + add macro "interviewer".
3. add macro "secondary-responsability"
4. to macro "year-date" add condition for uncertain date (Zotero cannot use this functionality, but other application yes - maybe)
5. Changed bibliography for Report: title is writen font-style="italic" and number is not before title.
6. delimiter are defined by group not by affixes (in some types of document it must be done in near future - after testing correct functionality)
7. add macro date-day-month for rendering only date part day and month
8. to macro "edition" add condition for numeric or textual value.
9. latin abbreviation s.l. and s.n. was changet to Czech abbr.
10. macro "collection" is now used for type Report too.
11. macro "page" - for book, thesis and manuscript is behaind number of page rendered term "page" in short form.
12. in citation is last delimiter between author set-up to "and"
13. add separated part for type map (it must be a little bit optimalized in near future)
