### PR TITLE
Collapse  in  health-services-research.csl

### DIFF
--- a/health-services-research.csl
+++ b/health-services-research.csl
@@ -20,7 +20,7 @@
     <eissn>1475-6773</eissn>
     <summary>Style for submission to the Health Services Research. Unofficial version; please check style output carefully. (This is a modification of the 2012-09-28 version of the "Harvard Reference format 1" author-date style by Julian Onions, which is packaged with Zotero).</summary>
     <published>2011-03-15T00:00:00+00:00</published>
-    <updated>2013-04-13T00:00:00+00:00</updated>
+    <updated>2013-05-17T00:00:00+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <macro name="editor">


### PR DESCRIPTION
I added  collapse="year-suffix" into the citation call health-services-research.csl.  I forgot to update the date, so there are actually two commits.
