### PR TITLE
Create university-of-south-australia-harvard-2013.csl

### DIFF
--- a/university-of-south-australia-harvard-2013.csl
+++ b/university-of-south-australia-harvard-2013.csl
@@ -12,6 +12,7 @@ NOTES
 KNOWN ISSUES AND WORKAROUNDS
 
 - In-text citation for an edited book with no authors will not include "ed." or "eds" (can be added as Prefix manually). This is a current CSL limitation.
+- For a thesis, the Type field will need to contain "PhD thesis", "MSc thesis", or similar.
 - Certain item types (source types) may exhibit minor differences from the style guide due to specific field limitations of your reference manager. Use alternative item types if required (e.g. Report). 
 
 TO DO
@@ -59,7 +60,6 @@ TO DO
       <term name="issue" form="short">no.</term>
       <term name="accessed" form="long">accessed</term>
       <term name="retrieved" form="long">viewed</term>
-      <term name="thesis" form="long">thesis</term>
       <!-- Unlike the en-US locale, inner and outer quotation marks are swapped here -->
       <term name="open-quote">‘</term>
       <term name="close-quote">’</term>
@@ -209,17 +209,6 @@ TO DO
       <if type="song motion_picture" match="any">
         <text variable="medium"/>
       </if>
-      <else-if type="thesis">
-        <choose>
-          <if variable="genre">
-            <text variable="genre"/>
-            <text term="thesis" prefix=" "/>
-          </if>
-          <else>
-            <text term="thesis"/>
-          </else>
-        </choose>
-      </else-if>
       <else>
         <text variable="genre"/>
       </else>


### PR DESCRIPTION
The 2013 revision of the UniSA style guide. Derived and revamped from the 2011 csl. A few notable changes:
- Subsequent author substitution by a dash in the bibliography listing.
- Director label for motion pictures.
- Online audio recordings use "accessed" instead of "viewed".
