### PR TITLE
Create endeavour-college-of-natural-health

### DIFF
--- a/dependent/endeavour-college-of-natural-health.csl
+++ b/dependent/endeavour-college-of-natural-health.csl
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<style xmlns="http://purl.org/net/xbiblio/csl" version="1.0" default-locale="en-US">
+<style xmlns="http://purl.org/net/xbiblio/csl" version="1.0" default-locale="en-GB">
   <info>
     <title>Endeavour College of Natural Health (UniSA Harvard)</title>
     <id>http://www.zotero.org/styles/endeavour-college-of-natural-health</id>


### PR DESCRIPTION
New dependent institutional style for the Endeavour College of Natural Health - http://www.endeavour.edu.au/ based on the University of South Australia style.
