### PR TITLE
Update endeavour-college-of-natural-health.csl

### DIFF
--- a/dependent/endeavour-college-of-natural-health.csl
+++ b/dependent/endeavour-college-of-natural-health.csl
@@ -1,13 +1,18 @@
 <?xml version="1.0" encoding="utf-8"?>
 <style xmlns="http://purl.org/net/xbiblio/csl" version="1.0" default-locale="en-GB">
-  <info>
-    <title>Endeavour College of Natural Health (UniSA Harvard)</title>
+<!-- Endeavour College of Natural Health style dependent on the University of South Australia (Harvard) style -->
+<info>
+    <title>Endeavour College of Natural Health</title>
     <id>http://www.zotero.org/styles/endeavour-college-of-natural-health</id>
     <link href="http://www.zotero.org/styles/endeavour-college-of-natural-health" rel="self"/>
     <link href="http://www.zotero.org/styles/university-of-south-australia-harvard-2013" rel="independent-parent"/>
     <link href="http://docs.endeavour.edu.au/Public_Documents/Library/Information_Literacy/Reference_Citation_Guide.pdf" rel="documentation"/>
+    <author>
+      <name>Lubos Vnuk</name>
+      <email>zothero@hotmail.com</email>
+    </author>
     <category citation-format="author-date"/>
-    <updated>2013-05-28T21:58:08+00:00</updated>
+    <updated>2013-05-29T21:58:08+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
 </style>


### PR DESCRIPTION
Removed the (UniSA Harvard) suffix from the title as suggested by admins.
