### PR TITLE
Update university-of-south-australia-harvard-2011.csl

### DIFF
--- a/university-of-south-australia-harvard-2011.csl
+++ b/university-of-south-australia-harvard-2011.csl
@@ -274,8 +274,8 @@ TO DO
   </macro>
   <citation et-al-min="4" et-al-use-first="1" et-al-subsequent-min="4" et-al-subsequent-use-first="1" disambiguate-add-givenname="true" disambiguate-add-year-suffix="true" collapse="year">
     <sort>
-      <key macro="year-date"/>
       <key macro="author-short"/>
+      <key macro="year-date"/>
     </sort>
     <layout prefix="(" suffix=")" delimiter="; ">
       <group delimiter=", ">


### PR DESCRIPTION
Bug-fix: Sort order of in-text citations was reversed.
