### PR TITLE
Update university-of-south-australia-harvard-2013.csl

### DIFF
--- a/university-of-south-australia-harvard-2013.csl
+++ b/university-of-south-australia-harvard-2013.csl
@@ -282,8 +282,8 @@ TO DO
   </macro>
   <citation et-al-min="4" et-al-use-first="1" et-al-subsequent-min="4" et-al-subsequent-use-first="1" disambiguate-add-givenname="true" disambiguate-add-year-suffix="true" collapse="year">
     <sort>
-      <key macro="year-date"/>
       <key macro="author-short"/>
+      <key macro="year-date"/>
     </sort>
     <layout prefix="(" suffix=")" delimiter="; ">
       <group delimiter=", ">


### PR DESCRIPTION
Bug-fix: In-text citation sort order should be by author first, then year.
