### PR TITLE
In AMA styles, put a div around citation number so it can be styled.

### DIFF
--- a/american-medical-association-alphabetical.csl
+++ b/american-medical-association-alphabetical.csl
@@ -5,11 +5,15 @@
     <title-short>AMA</title-short>
     <id>http://www.zotero.org/styles/american-medical-association-alphabetical</id>
     <link href="http://www.zotero.org/styles/american-medical-association-alphabetical" rel="self"/>
-    <link href="http://www.samford.edu/schools/pharmacy/dic/amaquickref07.pdf" rel="documentation"/>
+    <link href="http://westlibrary.txwes.edu/sites/default/files/pdf/ama_citation_style.pdf" rel="documentation"/>
     <author>
       <name>Julian Onions</name>
       <email>julian.onions@gmail.com</email>
     </author>
+    <contributor>
+      <name>Christian Pietsch</name>
+      <uri>http://purl.org/net/pietsch</uri>
+    </contributor>
     <category citation-format="numeric"/>
     <category field="medicine"/>
     <summary>The American Medical Association style with alphabetical sorting bibliography</summary>

--- a/american-medical-association-no-et-al.csl
+++ b/american-medical-association-no-et-al.csl
@@ -5,11 +5,15 @@
     <title-short>AMA</title-short>
     <id>http://www.zotero.org/styles/american-medical-association-no-et-al</id>
     <link href="http://www.zotero.org/styles/american-medical-association-no-et-al" rel="self"/>
-    <link href="http://www.samford.edu/schools/pharmacy/dic/amaquickref07.pdf" rel="documentation"/>
+    <link href="http://westlibrary.txwes.edu/sites/default/files/pdf/ama_citation_style.pdf" rel="documentation"/>
     <author>
       <name>Julian Onions</name>
       <email>julian.onions@gmail.com</email>
     </author>
+    <contributor>
+      <name>Christian Pietsch</name>
+      <uri>http://purl.org/net/pietsch</uri>
+    </contributor>
     <category citation-format="numeric"/>
     <category field="medicine"/>
     <summary>The American Medical Association style without et al</summary>

--- a/american-medical-association-no-url.csl
+++ b/american-medical-association-no-url.csl
@@ -5,11 +5,15 @@
     <title-short>AMA</title-short>
     <id>http://www.zotero.org/styles/american-medical-association-no-url</id>
     <link href="http://www.zotero.org/styles/american-medical-association-no-url" rel="self"/>
-    <link href="http://www.samford.edu/schools/pharmacy/dic/amaquickref07.pdf" rel="documentation"/>
+    <link href="http://westlibrary.txwes.edu/sites/default/files/pdf/ama_citation_style.pdf" rel="documentation"/>
     <author>
       <name>Julian Onions</name>
       <email>julian.onions@gmail.com</email>
     </author>
+    <contributor>
+      <name>Christian Pietsch</name>
+      <uri>http://purl.org/net/pietsch</uri>
+    </contributor>
     <category citation-format="numeric"/>
     <category field="medicine"/>
     <summary>The American Medical Association style as used in JAMA, without the URL.</summary>

--- a/american-medical-association.csl
+++ b/american-medical-association.csl
@@ -5,11 +5,15 @@
     <title-short>AMA</title-short>
     <id>http://www.zotero.org/styles/american-medical-association</id>
     <link href="http://www.zotero.org/styles/american-medical-association" rel="self"/>
-    <link href="http://www.samford.edu/schools/pharmacy/dic/amaquickref07.pdf" rel="documentation"/>
+    <link href="http://westlibrary.txwes.edu/sites/default/files/pdf/ama_citation_style.pdf" rel="documentation"/>
     <author>
       <name>Julian Onions</name>
       <email>julian.onions@gmail.com</email>
     </author>
+    <contributor>
+      <name>Christian Pietsch</name>
+      <uri>http://purl.org/net/pietsch</uri>
+    </contributor>
     <category citation-format="numeric"/>
     <category field="medicine"/>
     <summary>The American Medical Association style as used in JAMA.</summary>


### PR DESCRIPTION
I would like to style citation numbers with CSS (in order to make them disappear). Many numeric styles wrap them in a div class="csl-left-margin" for easy selection in CSS -- but not the AMA styles. This patch corrects this by adding second-field-align="flush" to the bibliography element.
