### PR TITLE
Update mcgill-guide-v7.csl

### DIFF
--- a/mcgill-guide-v7.csl
+++ b/mcgill-guide-v7.csl
@@ -25,6 +25,10 @@
       <term name="ordinal-02">d</term>
       <term name="ordinal-03">d</term>
       <term name="ordinal-04">th</term>
+      <term name="paragraph" form="short"> 
+      	<single>para</single>
+     	<multiple>paras</multiple>
+      </term>
     </terms>
   </locale>
   <macro name="editor">
@@ -107,7 +111,7 @@
     </choose>
   </macro>
   <!-- the 'rendering' macros mostly check if called from w/i bibliography so that author gets printed
-	right. Only actually need to check for 'first' because w/i cite,
+    right. Only actually need to check for 'first' because w/i cite,
 	all the other tests should have been done... -->
   <macro name="render-chapter">
     <group delimiter=" ">


### PR DESCRIPTION
Added term definition for "paras" when citing multiple paragraphs.
