### PR TITLE
Update energy-policy.csl

### DIFF
--- a/energy-policy.csl
+++ b/energy-policy.csl
@@ -177,6 +177,7 @@
         <group prefix=" " delimiter=", ">
           <group>
             <text variable="volume"/>
+            <text variable="issue" prefix="(" suffix=")"/>
           </group>
           <text variable="page"/>
         </group>


### PR DESCRIPTION
Fixed bug submitted by request below.

Dear Chenura,
as you are listed as author of the Energy Policy style
(energy-policy.csl) I kindly ask you to fix a bug.
In the current style, for a journal paper the style outputs the volume
but not the issue.
This can easily be fixed by inserting
`<text variable="issue" prefix="(" suffix=")"/>`
after line 182 which currently reads
`<text variable="volume"/>`

Regards
Wilfried Hennings
