### PR TITLE
improved book chapter and journal article style, added conference paper style

### DIFF
--- a/human-mutation.csl
+++ b/human-mutation.csl
@@ -2,8 +2,8 @@
 <style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" default-locale="en-US">
   <info>
     <title>Human Mutation</title>
--   <id>http://www.zotero.org/styles/human-mutation</id>
--   <link href="http://www.zotero.org/styles/human-mutation" rel="self"/>
+  	<id>http://www.zotero.org/styles/human-mutation</id>
+    <link href="http://www.zotero.org/styles/human-mutation" rel="self"/>
     <link href="http://onlinelibrary.wiley.com/journal/10.1002/(ISSN)1098-1004/homepage/ForAuthors.html" rel="documentation"/>
     <author>
       <name>Matthew Shirley</name>


### PR DESCRIPTION
Fixed a few bugs in the chapter bibliography style (like not showing the book title).
Fixed journal article style to show short form of journal names.
Human Mutation does specify the style for conference papers, so I kept it pretty basic, could be further improved (adding publisher etc).
This is my first try at Github and updating a CSL, hope its ok.
