### PR TITLE
edit in Wheaton College style to handle lower case ibid.

### DIFF
--- a/wheaton-college-phd-in-biblical-and-theological-studies.csl
+++ b/wheaton-college-phd-in-biblical-and-theological-studies.csl
@@ -739,12 +739,12 @@
       <choose>
         <if position="ibid-with-locator">
           <group delimiter=", ">
-            <text term="ibid" text-case="capitalize-first"/>
+            <text term="ibid"/>
             <text macro="point-locators-subsequent"/>
           </group>
         </if>
         <else-if position="ibid">
-          <text term="ibid" text-case="capitalize-first"/>
+          <text term="ibid"/>
         </else-if>
         <else-if position="subsequent">
           <group delimiter=", ">


### PR DESCRIPTION
Brings this style in line with CMS styles, which support lower case
ibid within a sentence.
