### PR TITLE
title-short for APA styles

### DIFF
--- a/apa-5th-edition.csl
+++ b/apa-5th-edition.csl
@@ -24,10 +24,6 @@
     <contributor>
       <name>Sebastian Karcher</name>
     </contributor>
-    <contributor>
-      <name>Christian Pietsch</name>
-      <uri>http://purl.org/net/pietsch</uri>
-    </contributor>
     <category citation-format="author-date"/>
     <category field="psychology"/>
     <category field="generic-base"/>

--- a/apa-annotated-bibliography.csl
+++ b/apa-annotated-bibliography.csl
@@ -25,10 +25,6 @@
     <contributor>
       <name>Sebastian Karcher</name>
     </contributor>
-    <contributor>
-      <name>Christian Pietsch</name>
-      <uri>http://purl.org/net/pietsch</uri>
-    </contributor>
     <category citation-format="author-date"/>
     <category field="psychology"/>
     <category field="generic-base"/>

--- a/apa-cv.csl
+++ b/apa-cv.csl
@@ -24,10 +24,6 @@
     <contributor>
       <name>Sebastian Karcher</name>
     </contributor>
-    <contributor>
-      <name>Christian Pietsch</name>
-      <uri>http://purl.org/net/pietsch</uri>
-    </contributor>
     <category citation-format="author-date"/>
     <category field="psychology"/>
     <category field="generic-base"/>

--- a/apa-no-doi-no-issue.csl
+++ b/apa-no-doi-no-issue.csl
@@ -24,10 +24,6 @@
     <contributor>
       <name>Sebastian Karcher</name>
     </contributor>
-    <contributor>
-      <name>Christian Pietsch</name>
-      <uri>http://purl.org/net/pietsch</uri>
-    </contributor>
     <category citation-format="author-date"/>
     <category field="psychology"/>
     <category field="generic-base"/>

--- a/apa-tr.csl
+++ b/apa-tr.csl
@@ -12,10 +12,6 @@
       <email>kbinici@atauni.edu.tr</email>
       <uri>http://www.atauni.edu.tr/#personel=kasim-binici</uri>
     </contributor>
-    <contributor>
-      <name>Christian Pietsch</name>
-      <uri>http://purl.org/net/pietsch</uri>
-    </contributor>
     <category citation-format="author-date"/>
     <category field="psychology"/>
     <category field="generic-base"/>

--- a/apa.csl
+++ b/apa.csl
@@ -25,10 +25,6 @@
     <contributor>
       <name>Sebastian Karcher</name>
     </contributor>
-    <contributor>
-      <name>Christian Pietsch</name>
-      <uri>http://purl.org/net/pietsch</uri>
-    </contributor>
     <category citation-format="author-date"/>
     <category field="psychology"/>
     <category field="generic-base"/>


### PR DESCRIPTION
Everybody calls APA styles “APA styles”, so this should be searchable. Without this patch, you would have to search for “American Psychological Association”.
