### PR TITLE
Fix et-al and citation number blocks for ecology-letters.csl

### DIFF
--- a/ecology-letters.csl
+++ b/ecology-letters.csl
@@ -208,9 +208,6 @@
       <key macro="issued" sort="ascending"/>
     </sort>
     <layout>
-      <group display="block">
-        <text variable="citation-number" suffix="."/>
-      </group>
       <group suffix=".">
         <text macro="author" suffix="."/>
         <text macro="issued" prefix=" (" suffix="). "/>


### PR DESCRIPTION
One commit fixes an issue where "et al." was appearing for all references in the bibliography regardless of the number of authors. The other commit removes the numbers associated with the references. Although the official guidelines specify alphabetical references that are numbered, the numbering needs to be alphabetical, not in the order they were cited and there needs to be line breaks. I suggest the user do this manually before submission unless there is a way to properly do it within CSL. I have included detailed comments in the two commits. 
