### PR TITLE
Update advanced-materials.csl

### DIFF
--- a/advanced-materials.csl
+++ b/advanced-materials.csl
@@ -79,7 +79,7 @@
     <sort>
       <key variable="citation-number"/>
     </sort>
-    <layout prefix="[" suffix="]" delimiter=",">
+    <layout prefix="[" suffix="]" delimiter="," vertical-align="sup">
       <text variable="citation-number"/>
     </layout>
   </citation>


### PR DESCRIPTION
Advanced Materials requires citations as superscript in brackets
