### PR TITLE
remove secondary contributors from journal-article

### DIFF
--- a/apa-annotated-bibliography.csl
+++ b/apa-annotated-bibliography.csl
@@ -56,7 +56,7 @@
   </macro>
   <macro name="secondary-contributors">
     <choose>
-      <if type="chapter paper-conference" match="none">
+      <if type="article-journal chapter paper-conference" match="none">
         <names variable="translator editor" delimiter=", " prefix=" (" suffix=")">
           <name and="symbol" initialize-with=". " delimiter=", "/>
           <label form="short" prefix=", " text-case="title" suffix=""/>

--- a/apa-cv.csl
+++ b/apa-cv.csl
@@ -55,7 +55,7 @@
   </macro>
   <macro name="secondary-contributors">
     <choose>
-      <if type="chapter paper-conference" match="none">
+      <if type="article-journal chapter paper-conference" match="none">
         <names variable="translator editor" delimiter=", " prefix=" (" suffix=")">
           <name and="symbol" initialize-with=". " delimiter=", "/>
           <label form="short" prefix=", " text-case="title" suffix=""/>

--- a/apa-no-doi-no-issue.csl
+++ b/apa-no-doi-no-issue.csl
@@ -55,7 +55,7 @@
   </macro>
   <macro name="secondary-contributors">
     <choose>
-      <if type="chapter paper-conference" match="none">
+      <if type="article-journal chapter paper-conference" match="none">
         <names variable="translator editor" delimiter=", " prefix=" (" suffix=")">
           <name and="symbol" initialize-with=". " delimiter=", "/>
           <label form="short" prefix=", " text-case="title" suffix=""/>

--- a/apa.csl
+++ b/apa.csl
@@ -55,7 +55,7 @@
   </macro>
   <macro name="secondary-contributors">
     <choose>
-      <if type="chapter paper-conference" match="none">
+      <if type="article-journal chapter paper-conference" match="none">
         <names variable="translator editor" delimiter=", " prefix=" (" suffix=")">
           <name and="symbol" initialize-with=". " delimiter=", "/>
           <label form="short" prefix=", " text-case="title" suffix=""/>

--- a/associacao-nacional-de-pesquisa-e-ensino-em-transportes.csl
+++ b/associacao-nacional-de-pesquisa-e-ensino-em-transportes.csl
@@ -62,7 +62,7 @@
   </macro>
   <macro name="secondary-contributors">
     <choose>
-      <if type="chapter paper-conference" match="none">
+      <if type="article-journal chapter paper-conference" match="none">
         <names variable="translator editor" delimiter=", " prefix=" (" suffix=")">
           <name and="symbol" initialize-with=". " delimiter=", "/>
           <label form="short" prefix=", " text-case="title" suffix=""/>

--- a/decision-sciences.csl
+++ b/decision-sciences.csl
@@ -246,7 +246,7 @@
   </macro>
   <macro name="secondary-contributors">
     <choose>
-      <if type="chapter paper-conference" match="none">
+      <if type="article-journal chapter paper-conference" match="none">
         <names variable="translator editor" delimiter=", " prefix=" (" suffix=")">
           <name and="symbol" initialize-with=". " delimiter=", "/>
           <label form="short" prefix=", " text-case="title" suffix=""/>

--- a/journal-of-information-technology.csl
+++ b/journal-of-information-technology.csl
@@ -30,7 +30,7 @@
   </macro>
   <macro name="secondary-contributors">
     <choose>
-      <if type="chapter paper-conference" match="none">
+      <if type="article-journal chapter paper-conference" match="none">
         <names variable="translator editor" delimiter=", " prefix=" (" suffix=")">
           <name and="symbol" initialize-with=". " delimiter=", "/>
           <label form="short" prefix=", " text-case="title" suffix=""/>

--- a/springer-socpsych-author-date.csl
+++ b/springer-socpsych-author-date.csl
@@ -44,7 +44,7 @@
   </macro>
   <macro name="secondary-contributors">
     <choose>
-      <if type="chapter paper-conference" match="none">
+      <if type="article-journal chapter paper-conference" match="none">
         <names variable="translator editor" delimiter=", " prefix=" (" suffix=")">
           <name and="symbol" initialize-with=". " delimiter=", "/>
           <label form="short" prefix=", " text-case="title" suffix=""/>

--- a/springer-socpsych-brackets.csl
+++ b/springer-socpsych-brackets.csl
@@ -45,7 +45,7 @@
   </macro>
   <macro name="secondary-contributors">
     <choose>
-      <if type="chapter paper-conference" match="none">
+      <if type="article-journal chapter paper-conference" match="none">
         <names variable="translator editor" delimiter=", " prefix=" (" suffix=")">
           <name and="symbol" initialize-with=". " delimiter=", "/>
           <label form="short" prefix=", " text-case="title" suffix=""/>


### PR DESCRIPTION
do not show secondary contributors for journal-article, not just for chapter and conference-paper

this fixes #635
problems arising in various styles with PLoS journals (Ambra backend?) putting the action editor in the journal article metadata

I just searched & replaced the faulty macro wherever it appeared (I don't know the specifics of all styles, but am fairly certain that editors of articles are not cited ever, because they nearly never appear in the meta-data)
