### PR TITLE
Create osteoarthritis-and-cartilage-ama.csl

### DIFF
--- a/dependent/osteoarthritis-and-cartilage-ama.csl
+++ b/dependent/osteoarthritis-and-cartilage-ama.csl
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0">
+  <info>
+    <title>Osteoarthritis and Cartilage (AMA)</title>
+    <id>http://www.zotero.org/styles/osteoarthritis-and-cartilage</id>
+    <link href="http://www.zotero.org/styles/american-medical-association" rel="independent-parent"/>
+    <link href="http://www.zotero.org/styles/osteoarthritis-and-cartilage-ama.csl" rel="self"/> 
+    <link href="http://www.elsevier.com/journals/osteoarthritis-and-cartilage/1063-4584/guide-for-authors" rel="documentation"/>
+        <author>
+      <name>Anna Tassinari</name>
+      <email>aniat@bu.edu</email>
+    </author>
+    <category citation-format="numeric"/>
+    <category field="medicine"/>
+    <updated>2013-07-19T08:00:08+00:00</updated>
+    <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
+  </info>
+</style>


### PR DESCRIPTION
I have created a style for the Osteoarthritis and Cartilage journal. Although this style already exists in the CSL repo (http://www.zotero.org/styles/osteoarthritis-and-cartilage), it erroneously references the Vancouver superscript style (http://www.zotero.org/styles/vancouver-superscript). According to the O&C Guide for Authors, the style used should be American Medical Association (AMA) (http://www.zotero.org/styles/american-medical-association). I added 'ama' to the name of the style to distinguish the two.
