### PR TITLE
[Cell Reports] Change parent to Cell

### DIFF
--- a/dependent/cell-reports.csl
+++ b/dependent/cell-reports.csl
@@ -5,10 +5,11 @@
     <title>Cell Reports</title>
     <id>http://www.zotero.org/styles/cell-reports</id>
     <link href="http://www.zotero.org/styles/cell-reports" rel="self"/>
-    <link href="http://www.zotero.org/styles/elsevier-harvard" rel="independent-parent"/>
+    <link href="http://www.zotero.org/styles/cell" rel="independent-parent"/>
+    <link href="http://www.cell.com/cell-reports/authors" rel="documentation"/>
     <category citation-format="author-date"/>
     <issn>2211-1247</issn>
-    <updated>2013-04-22T12:00:00+00:00</updated>
+    <updated>2013-07-26T01:30:00+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
 </style>


### PR DESCRIPTION
They don't explicitly say that the Cell style should be used, but the provided samples look identical to Cell style.

Sample open access publication: http://download.cell.com/cell-reports/pdf/PIIS221112471300315X.pdf

Not sure if other Cell Press journals also have incorrect parents.
