### PR TITLE
Update springer-basic-author-date-no-et-al.csl

### DIFF
--- a/springer-basic-author-date-no-et-al.csl
+++ b/springer-basic-author-date-no-et-al.csl
@@ -96,7 +96,7 @@
       </group>
     </layout>
   </citation>
-  <bibliography et-al-min="5" et-al-use-first="3" hanging-indent="true">
+  <bibliography hanging-indent="true">
     <sort>
       <key macro="author"/>
       <key variable="author" sort="ascending"/>


### PR DESCRIPTION
"No et-al" modification needs to be implemented by removing `et-al-min` and `et-al-use-first` options in `<bibliography>`. If you find this is correct, please accept the change.
