### PR TITLE
Update mcgill-guide-v7.csl

### DIFF
--- a/mcgill-guide-v7.csl
+++ b/mcgill-guide-v7.csl
@@ -94,6 +94,12 @@
   <macro name="references">
     <text variable="references"/>
   </macro>
+  <macro name="series-info">
+     <group delimiter=" "> 
+         <text variable="collection-title" strip-periods="true"/>
+	 <text variable="collection-number"/>
+     </group>
+  </macro>
   <macro name="sort-by-type">
     <choose>
       <if type="bill legislation" match="any">
@@ -144,6 +150,7 @@
       <text macro="edition"/>
       <text macro="translator"/>
       <text macro="editor"/>
+      <text macro="series-info"/>
     </group>
     <text macro="publisher-place-year"/>
   </macro>
@@ -306,6 +313,9 @@
                     </else-if>
                     <else-if type="webpage">
                       <text macro="render-webpage"/>
+                    </else-if>
+                    <else-if type="book">
+                      <text macro="render-book"/>
                     </else-if>
                     <else>
                       <group delimiter=" ">


### PR DESCRIPTION
Added series information to book citations; citation section now correctly calls "render-book" rather than relying on else case.
