### PR TITLE
Update mcgill-guide-v7.csl

### DIFF
--- a/mcgill-guide-v7.csl
+++ b/mcgill-guide-v7.csl
@@ -258,7 +258,7 @@
         </names>
       </if>
       <else>
-        <text variable="title" form="short"/>
+        <text variable="title" font-style="italic" form="short"/>
       </else>
     </choose>
   </macro>


### PR DESCRIPTION
Fixed: subsequent mentions of bills, legislation, cases should appear in italics
