### PR TITLE
Update mcgill-guide-v7.csl

### DIFF
--- a/mcgill-guide-v7.csl
+++ b/mcgill-guide-v7.csl
@@ -121,7 +121,7 @@
   </macro>
   <!-- the 'rendering' macros mostly check if called from w/i bibliography so that author gets printed
     right. Only actually need to check for 'first' because w/i cite,
-	all the other tests should have been done... -->
+all the other tests should have been done... -->
   <macro name="render-chapter">
     <group delimiter=" ">
       <text variable="title" quotes="true"/>
@@ -222,6 +222,7 @@
         <text macro="container-title"/>
         <text variable="number"/>
         <text variable="page-first"/>
+        <text variable="authority" prefix="(" suffix=")"/>
         <text variable="URL" prefix="(available on " suffix=")"/>
       </group>
     </group>
@@ -245,7 +246,7 @@
   </macro>
   <macro name="short-form">
     <!-- Hump to overcome: cannot check against existence of short title.
-		Not implemented: "cited to" for cases, construct short casenames, adding ref to article -->
+Not implemented: "cited to" for cases, construct short casenames, adding ref to article -->
     <choose>
       <if type="bill legal_case legislation" match="none">
         <names variable="author">
@@ -278,12 +279,12 @@
         <!-- Not implemented: ibid only needs capitalize-first if it's the first word in a footnote -->
         <if position="ibid-with-locator">
           <group>
-            <text term="ibid" font-style="italic" strip-periods="true" text-case="capitalize-first"/>
+            <text term="ibid" font-style="italic" strip-periods="true" />
             <text macro="pinpoint"/>
           </group>
         </if>
         <else-if position="ibid">
-          <text term="ibid" font-style="italic" strip-periods="true" text-case="capitalize-first"/>
+          <text term="ibid" font-style="italic" strip-periods="true"/>
         </else-if>
         <!-- For future versions? Cannot test for whether short form exists (Supra should be capitalized if no short form) -->
         <else-if position="subsequent">


### PR DESCRIPTION
fixed: ibid should only be capitalized at the beginning of a sentence
