### PR TITLE
Update inter-ro.csl

### DIFF
--- a/inter-ro.csl
+++ b/inter-ro.csl
@@ -198,14 +198,14 @@
               <text macro="author"/>
               <text macro="recipient"/>
             </group>
-            <group delimiter=", ">
-              <text macro="title-short"/>
-              <text macro="volume"/>
-            </group>
+            <text macro="title-short"/>
             <choose>
-              <if type="interview">
+	            <if type="book">
+		            <text macro="volume"/>
+	            </if>
+              <else-if type="interview">
                 <text term="interview" text-case="lowercase"/>
-              </if>
+              </else-if>
               <else-if variable="recipient">
                 <text macro="issued"/>
               </else-if>
@@ -264,7 +264,11 @@
                 </group>
               </group>
               <text macro="translator" prefix=", "/>
-              <text macro="editor" prefix=", "/>
+              <choose>
+            		<if variable="author">
+            		  <text macro="editor" prefix=", "/>
+            		</if>
+            	</choose>
               <text variable="edition" prefix=", "/>
               <text macro="publisher" prefix=", "/>
               <text macro="issued" prefix=", "/>
@@ -340,7 +344,11 @@
             </group>
           </group>
           <text macro="translator" prefix=", "/>
-          <text macro="editor" prefix=", "/>
+          <choose>
+	          <if variable="author">
+	            <text macro="editor" prefix=", "/>
+	          </if>
+	        </choose>
           <text variable="edition" prefix=", "/>
           <text macro="publisher" prefix=", "/>
           <text macro="issued" prefix=", "/>


### PR DESCRIPTION
1. For subsequent citation volume must appear only for books.
2. For citation and bibliography: for an edited book, editor appears on the first position, in place of author; for a book with author and editor, editor must appear on another position.
