### PR TITLE
Update inter-ro.csl

### DIFF
--- a/inter-ro.csl
+++ b/inter-ro.csl
@@ -241,8 +241,8 @@
                   </if>
                   <else>
                     <group prefix=" ">
-                      <text macro="editor-short"/>
-                      <text variable="container-title" font-style="italic" prefix=", "/>
+                      <text macro="editor-short" suffix=", "/>
+                      <text variable="container-title" font-style="italic"/>
                       <text macro="collection" prefix=" "/>
                       <text macro="volume" prefix=", "/>
                     </group>
@@ -327,8 +327,8 @@
               </if>
               <else>
                 <group prefix=" ">
-                  <text macro="editor-short"/>
-                  <text variable="container-title" font-style="italic" prefix=", "/>
+                  <text macro="editor-short" suffix=", "/>
+                  <text variable="container-title" font-style="italic"/>
                   <text macro="collection" prefix=" "/>
                   <text macro="volume" prefix=", "/>
                 </group>


### PR DESCRIPTION
Minor change: a comma that must be suffix, not prefix, in order to appear only if a container-author exists.
