### PR TITLE
Update archaeometry.csl

### DIFF
--- a/archaeometry.csl
+++ b/archaeometry.csl
@@ -300,7 +300,7 @@
   
   <bibliography hanging-indent="true">
     <sort>
-      <key macro="author" names-min="1" names-use-first="1"/>
+      <key macro="contributors" names-min="1" names-use-first="1"/>
       <key variable="issued"/>
       <key variable="title"/>
     </sort>


### PR DESCRIPTION
Minor code changes. Addition of showing both container-author and container-editor if present: "(names of authors; ed./eds. names of editors).
