### PR TITLE
Update mcrj7.csl (major changes)

### DIFF
--- a/mcrj7.csl
+++ b/mcrj7.csl
@@ -2,11 +2,10 @@
 <style xmlns="http://purl.org/net/xbiblio/csl" class="note" version="1.0" default-locale="fr-FR">
   <info>
     <title>Manuel canadien de la référence juridique 7e éd (Guide McGill, French)</title>
-    <title-short>Guide McGill 7e éd (FR)</title-short>
+    <title-short>Guide McGill FR v7</title-short>
     <id>http://www.zotero.org/styles/mcrj7</id>
     <link href="http://www.zotero.org/styles/mcrj7" rel="self"/>
-    <link href="http://lawjournal.mcgill.ca/citeguide.php?locale=fr" rel="documentation"/>
-    <link href="http://tinyurl.com/mcrj7-csl-doc" rel="documentation"/>
+    <link href="http://f-mb.github.io/cslegal/" rel="documentation"/>
     <author>
       <name>Philippe Tousignant</name>
       <email>philippe.tousignant@gmail.com</email>
@@ -17,37 +16,37 @@
     <contributor>
       <name>Florian Martin-Bariteau</name>
       <email>f.martin-bariteau@umontreal.ca</email>
+      <uri>http://f-mb.github.io/cslegal/</uri>
     </contributor>
     <contributor>
       <name>Jean-Sebastien Sauve</name>
     </contributor>
     <category citation-format="note"/>
     <category field="law"/>
-    <updated>2013-05-22T15:35:33+00:00</updated>
+    <updated>2013-09-05T10:00:00+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale xml:lang="fr">
     <terms>
       <term name="page" form="short">
-        <single>à la p&#160;</single>
-        <multiple>aux pp&#160;</multiple>
+        <single>à la p</single>
+        <multiple>aux pp</multiple>
       </term>
-      <term name="paragraph" form="long">
-        <single>au para&#160;</single>
-        <multiple>aux para&#160;</multiple>
+      <term name="paragraph" form="short">
+        <single>au para</single>
+        <multiple>aux paras</multiple>
       </term>
-      <term name="chapter" form="short">ch&#160;</term>
+      <term name="chapter" form="short">ch</term>
       <term name="editor" form="verb-short">dir</term>
       <term name="editor" form="short">dir</term>
       <term name="editor" form="verb">dir</term>
-      <term name="translator" form="verb-short">traduit par</term>
+      <term name="translator" form="verb">traduit par</term>
       <term name="in">dans</term>
-      <term name="sub verbo" form="short">sub verbo&#160;</term>
     </terms>
   </locale>
   <macro name="contributors-note">
     <names variable="author">
-      <name and="text" sort-separator=", " delimiter=", "/>
+      <name and="text" sort-separator=", " delimiter=", " delimiter-precedes-last="never"/>
       <substitute>
         <text macro="editor-note"/>
         <text macro="translator-note"/>
@@ -57,31 +56,31 @@
   </macro>
   <macro name="editor-note">
     <names variable="editor">
-      <name and="text" sort-separator=", " delimiter=", "/>
+      <name and="text" sort-separator=", " delimiter=", " delimiter-precedes-last="never"/>
       <label form="short" prefix=", " strip-periods="true"/>
     </names>
   </macro>
   <macro name="translator-note">
     <names variable="translator">
-      <label form="verb-short" suffix=" " strip-periods="true"/>
-      <name and="text" sort-separator=", " delimiter=", "/>
+      <label form="verb" suffix=" " strip-periods="true"/>
+      <name and="text" sort-separator=", " delimiter=", " delimiter-precedes-last="never"/>
     </names>
   </macro>
   <macro name="recipient-note">
     <names variable="recipient" delimiter=", ">
       <label form="verb" prefix=" " text-case="lowercase" suffix=" "/>
-      <name and="text"/>
+      <name and="text" delimiter-precedes-last="never"/>
     </names>
   </macro>
   <macro name="interviewer-note">
     <names variable="interviewer" delimiter=", ">
       <label form="verb" prefix=" " text-case="lowercase" suffix=" "/>
-      <name and="text" delimiter=", "/>
+      <name and="text" delimiter=", " delimiter-precedes-last="never"/>
     </names>
   </macro>
   <macro name="contributors">
     <names variable="author">
-      <name name-as-sort-order="first" and="text" sort-separator=", " delimiter=", " delimiter-precedes-last="always"/>
+      <name name-as-sort-order="first" and="text" sort-separator=", " delimiter=", " delimiter-precedes-last="never"/>
       <substitute>
         <text macro="editor"/>
         <text macro="translator"/>
@@ -91,14 +90,14 @@
   </macro>
   <macro name="editor">
     <names variable="editor">
-      <name name-as-sort-order="first" and="text" sort-separator=", " delimiter=", " delimiter-precedes-last="always"/>
+      <name name-as-sort-order="first" and="text" sort-separator=", " delimiter=", " delimiter-precedes-last="never"/>
       <label form="short" prefix=", " strip-periods="true"/>
     </names>
   </macro>
   <macro name="translator">
     <names variable="translator">
       <label form="verb-short" suffix=" " strip-periods="true"/>
-      <name and="text" sort-separator=", " delimiter=", " delimiter-precedes-last="always"/>
+      <name and="text" sort-separator=", " delimiter=", " delimiter-precedes-last="never"/>
     </names>
   </macro>
   <macro name="recipient">
@@ -118,7 +117,7 @@
   </macro>
   <macro name="contributors-short">
     <names variable="author">
-      <name form="short" and="text" delimiter=", "/>
+      <name form="short" and="text" delimiter=", " delimiter-precedes-last="never"/>
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
@@ -129,18 +128,18 @@
   <macro name="recipient-short">
     <names variable="recipient">
       <label form="verb" prefix=" " text-case="lowercase" suffix=" "/>
-      <name form="short" and="text" delimiter=", "/>
+      <name form="short" and="text" delimiter=", " delimiter-precedes-last="never"/>
     </names>
   </macro>
   <macro name="interviewer">
     <names variable="interviewer" delimiter=", ">
       <label form="verb" prefix=" " text-case="capitalize-first" suffix=" "/>
-      <name and="text" delimiter=", "/>
+      <name and="text" delimiter=", " delimiter-precedes-last="never"/>
     </names>
   </macro>
   <macro name="contributors-sort">
     <names variable="author">
-      <name name-as-sort-order="all" and="text" sort-separator=", " delimiter=", " delimiter-precedes-last="always"/>
+      <name name-as-sort-order="all" and="text" sort-separator=", " delimiter=", " delimiter-precedes-last="never"/>
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
@@ -175,20 +174,30 @@
       </choose>
     </group>
   </macro>
-  <macro name="publisher">
-    <text variable="publisher"/>
-  </macro>
-  <macro name="publisher-place">
-    <text variable="publisher-place"/>
-  </macro>
-  <macro name="issue">
-    <text variable="issue"/>
-  </macro>
   <macro name="URL">
-    <text variable="URL"/>
-  </macro>
-  <macro name="DOI">
-    <text variable="DOI"/>
+    <choose>
+      <if variable="DOI">
+        <text value=", doi&#160;: " font-variant="small-caps"/>
+        <text variable="DOI"/>
+      </if>
+      <else-if variable="URL">
+        <text value=", en ligne&#160;: "/>
+        <choose>
+          <if variable="archive" match="any">
+            <text variable="archive" text-case="capitalize-first"/>
+          </if>
+          <else>
+            <text variable="container-title" text-case="capitalize-first"/>
+          </else>
+        </choose>
+        <text variable="URL" prefix=" &lt;" suffix="&gt;"/>
+        <date variable="accessed" prefix=" (consulté le " suffix=")">
+          <date-part name="day" suffix=" "/>
+          <date-part name="month" suffix=" "/>
+          <date-part name="year"/>
+        </date>
+      </else-if>
+    </choose>
   </macro>
   <macro name="collection-title">
     <text variable="collection-title" prefix="coll "/>
@@ -196,56 +205,22 @@
   <macro name="collection-number">
     <text variable="collection-number" prefix="n°"/>
   </macro>
-  <macro name="volume">
-    <text variable="volume"/>
-  </macro>
-  <macro name="number-of-volumes">
-    <text variable="number-of-volumes"/>
-  </macro>
-  <macro name="page">
-    <text variable="page"/>
-  </macro>
   <macro name="issued-year">
     <date variable="issued">
       <date-part name="year" form="long"/>
     </date>
   </macro>
-  <macro name="genre">
-    <text variable="genre"/>
-  </macro>
-  <macro name="title">
-    <text variable="title"/>
-  </macro>
-  <macro name="title-note">
-    <text variable="title"/>
-  </macro>
-  <macro name="references">
-    <text variable="references"/>
-  </macro>
-  <macro name="number">
-    <text variable="number"/>
-  </macro>
-  <macro name="note">
-    <text variable="note"/>
-  </macro>
-  <macro name="authority">
-    <text variable="authority"/>
-  </macro>
   <macro name="edition">
     <choose>
-      <if type="bill book chapter graphic legal_case legislation motion_picture paper-conference report song" match="any">
-        <choose>
-          <if is-numeric="edition">
-            <group delimiter=" ">
-              <number variable="edition" form="ordinal"/>
-              <text term="edition" form="short" strip-periods="true"/>
-            </group>
-          </if>
-          <else>
-            <text variable="edition" text-case="capitalize-first" suffix="."/>
-          </else>
-        </choose>
+      <if is-numeric="edition">
+        <group delimiter=" ">
+          <number variable="edition" form="ordinal"/>
+          <text term="edition" form="short" strip-periods="true"/>
+        </group>
       </if>
+      <else>
+        <text variable="edition" text-case="capitalize-first"/>
+      </else>
     </choose>
   </macro>
   <macro name="issued">
@@ -255,35 +230,12 @@
       <date-part name="year"/>
     </date>
   </macro>
-  <macro name="title-short">
-    <choose>
-      <if variable="title" match="none">
-        <choose>
-          <if type="interview">
-            <text term="interview" text-case="lowercase"/>
-          </if>
-          <else-if type="manuscript speech" match="any">
-            <text variable="genre" form="short"/>
-          </else-if>
-          <else-if type="personal_communication">
-            <text macro="issued"/>
-          </else-if>
-        </choose>
-      </if>
-      <else-if type="bill book graphic legal_case legislation motion_picture report song thesis" match="any">
-        <text variable="title" form="short" font-style="italic"/>
-      </else-if>
-      <else>
-        <text variable="title" form="short" quotes="true"/>
-      </else>
-    </choose>
-  </macro>
   <macro name="editor-translator">
     <group delimiter=", ">
       <choose>
         <if variable="author">
           <names variable="editor" delimiter=", ">
-            <name and="text" delimiter=", "/>
+            <name and="text" delimiter=", " delimiter-precedes-last="never"/>
             <label form="verb-short" text-case="lowercase" prefix=", " strip-periods="true"/>
           </names>
           <choose>
@@ -291,7 +243,7 @@
               <group>
                 <names variable="container-author">
                   <label form="verb-short" prefix=" " text-case="lowercase" suffix=" " strip-periods="true"/>
-                  <name and="text" delimiter=", "/>
+                  <name and="text" delimiter=", " delimiter-precedes-last="never"/>
                 </names>
               </group>
             </if>
@@ -302,7 +254,7 @@
         <if variable="author editor" match="any">
           <names variable="translator" delimiter=", ">
             <label form="verb-short" text-case="lowercase" suffix=" " strip-periods="true"/>
-            <name and="text" delimiter=", "/>
+            <name and="text" delimiter=", " delimiter-precedes-last="never"/>
           </names>
         </if>
       </choose>
@@ -330,7 +282,7 @@
             <if variable="author">
               <names variable="editor" delimiter=". ">
                 <label form="verb" text-case="capitalize-first" suffix=" "/>
-                <name and="text" delimiter=", "/>
+                <name and="text" delimiter=", " delimiter-precedes-last="never"/>
               </names>
             </if>
           </choose>
@@ -338,7 +290,7 @@
             <if variable="author editor" match="any">
               <names variable="translator" delimiter=". ">
                 <label form="verb" text-case="capitalize-first" suffix=" "/>
-                <name and="text" delimiter=", "/>
+                <name and="text" delimiter=", " delimiter-precedes-last="never"/>
               </names>
             </if>
           </choose>
@@ -353,7 +305,7 @@
           <choose>
             <if variable="author">
               <names variable="editor" delimiter=", ">
-                <name and="text" delimiter=", "/>
+                <name and="text" delimiter=", " delimiter-precedes-last="never"/>
                 <label form="verb" text-case="lowercase" prefix=", "/>
               </names>
               <choose>
@@ -361,7 +313,7 @@
                   <group>
                     <names variable="container-author">
                       <label form="verb-short" prefix=" " text-case="lowercase" suffix=" " strip-periods="true"/>
-                      <name and="text" delimiter=", "/>
+                      <name and="text" delimiter=", " delimiter-precedes-last="never"/>
                     </names>
                   </group>
                 </if>
@@ -372,7 +324,7 @@
             <if variable="author editor" match="any">
               <names variable="translator" delimiter=", ">
                 <label form="verb" text-case="lowercase" suffix=" "/>
-                <name and="text" delimiter=", "/>
+                <name and="text" delimiter=", " delimiter-precedes-last="never"/>
               </names>
             </if>
           </choose>
@@ -406,133 +358,266 @@
     </choose>
   </macro>
   <macro name="note-chapter">
-    <text macro="contributors-note" suffix=", "/>
+    <text macro="contributors-note" suffix=", " strip-periods="true"/>
     <text macro="title-chapter-special"/>
     <group delimiter=", ">
-      <text macro="secondary-contributors-note"/>
-      <text macro="container-contributors-note"/>
+      <text macro="secondary-contributors-note" strip-periods="true"/>
+      <text macro="container-contributors-note" strip-periods="true"/>
       <text variable="container-title" font-style="italic"/>
       <text macro="edition"/>
-      <text macro="publisher-place"/>
-      <text macro="publisher"/>
+      <text variable="publisher-place" strip-periods="true"/>
+      <text variable="publisher" strip-periods="true"/>
       <text macro="issued-year"/>
+      <text variable="page"/>
+      <text variable="note"/>
     </group>
     <text macro="point-locators"/>
+    <text macro="URL"/>
   </macro>
   <macro name="chapter">
-    <text macro="contributors" suffix=". "/>
+    <text macro="contributors" suffix=". " strip-periods="true"/>
     <text macro="title-chapter-special"/>
     <group delimiter=", ">
-      <text macro="secondary-contributors"/>
-      <text macro="container-contributors"/>
+      <text macro="secondary-contributors" strip-periods="true"/>
+      <text macro="container-contributors" strip-periods="true"/>
       <text variable="container-title" font-style="italic"/>
       <text macro="edition"/>
-      <text macro="publisher-place"/>
-      <text macro="publisher"/>
+      <text variable="publisher-place" strip-periods="true"/>
+      <text variable="publisher" strip-periods="true"/>
       <text macro="issued-year"/>
+      <text variable="page"/>
+      <text variable="note"/>
     </group>
     <text macro="point-locators"/>
+    <text macro="URL"/>
   </macro>
   <macro name="note-thesis">
     <group delimiter=", ">
-      <text macro="contributors-note"/>
-      <text macro="title" font-style="italic"/>
-      <text macro="genre"/>
-      <text macro="publisher"/>
+      <text macro="contributors-note" strip-periods="true"/>
+      <text variable="title" font-style="italic"/>
+      <text variable="genre"/>
+      <text variable="publisher" strip-periods="true"/>
       <text macro="issued-year"/>
     </group>
-    <text macro="point-locators" prefix=" "/>
+    <text variable="note" prefix=" "/>
+    <text macro="point-locators"/>
+    <text macro="URL"/>
   </macro>
   <macro name="thesis">
-    <text macro="contributors" suffix=". "/>
+    <text macro="contributors" suffix=". " strip-periods="true"/>
     <group delimiter=", ">
-      <text macro="title" font-style="italic"/>
-      <text macro="genre"/>
-      <text macro="publisher"/>
+      <text variable="title" font-style="italic"/>
+      <text variable="genre"/>
+      <text variable="publisher" strip-periods="true"/>
       <text macro="issued-year"/>
     </group>
+    <text variable="note" prefix=" "/>
+    <text macro="URL"/>
+  </macro>
+  <macro name="note-bill">
+    <group delimiter=", ">
+      <text macro="contributors-note"/>
+      <choose>
+        <if variable="volume chapter-number">
+          <text variable="number" prefix="PL "/>
+        </if>
+      </choose>
+      <text variable="title" font-style="italic"/>
+      <choose>
+        <if variable="volume chapter-number" match="none">
+          <text variable="number"/>
+        </if>
+      </choose>
+      <choose>
+        <if variable="chapter-number">
+          <text variable="chapter-number" strip-periods="true"/>
+          <text variable="authority" strip-periods="true"/>
+        </if>
+        <else>
+          <text variable="volume"/>
+          <text variable="container-title" strip-periods="true"/>
+        </else>
+      </choose>
+      <text variable="section" strip-periods="true"/>
+      <text macro="issued" strip-periods="true"/>
+      <text variable="note"/>
+    </group>
+    <text macro="point-locators"/>
+    <text variable="references" prefix=" (" suffix=")"/>
+    <text variable="title-short" prefix=" [" suffix="]" font-style="italic"/>
+    <text macro="URL"/>
   </macro>
   <macro name="bill">
     <group delimiter=", ">
-      <text macro="number" prefix="PL "/>
-      <text macro="title" font-style="italic"/>
-      <text macro="publisher"/>
-      <text macro="contributors"/>
-      <text macro="note"/>
-      <text macro="issued-year"/>
-      <text macro="point-locators"/>
+      <text macro="contributors" strip-periods="true"/>
+      <choose>
+        <if variable="volume chapter-number">
+          <text variable="number" prefix="PL "/>
+        </if>
+      </choose>
+      <text variable="title" font-style="italic"/>
+      <choose>
+        <if variable="volume chapter-number" match="none">
+          <text variable="number"/>
+        </if>
+      </choose>
+      <choose>
+        <if variable="chapter-number">
+          <text variable="chapter-number" strip-periods="true"/>
+          <text variable="authority" strip-periods="true"/>
+        </if>
+        <else>
+          <text variable="volume"/>
+          <text variable="container-title" strip-periods="true"/>
+        </else>
+      </choose>
+      <text variable="section" strip-periods="true"/>
+      <text macro="issued"/>
+      <text variable="note"/>
     </group>
+    <text macro="URL"/>
+  </macro>
+  <macro name="legislation-note">
+    <group delimiter=", ">
+      <text macro="contributors-note" strip-periods="true"/>
+      <text variable="title" font-style="italic"/>
+      <choose>
+        <if variable="page">
+          <group delimiter=" ">
+            <text macro="issued-year" prefix=" (" suffix=")"/>
+            <text variable="section" strip-periods="true"/>
+            <text variable="container-title" strip-periods="true"/>
+            <text variable="page" strip-periods="true"/>
+          </group>
+          <text variable="number" strip-periods="true"/>
+        </if>
+        <else>
+          <text variable="container-title" strip-periods="true"/>
+          <text variable="section" strip-periods="true"/>
+          <text variable="number" strip-periods="true"/>
+          <text macro="issued"/>
+        </else>
+      </choose>
+      <text variable="note"/>
+    </group>
+    <text macro="point-locators"/>
+    <text variable="references" prefix=" (" suffix=")"/>
+    <text variable="title-short" prefix=" [" suffix="]"/>
+    <text macro="URL"/>
+  </macro>
+  <macro name="legislation-bib">
+    <group delimiter=", ">
+      <text macro="contributors" strip-periods="true"/>
+      <text variable="title" font-style="italic"/>
+      <choose>
+        <if variable="page">
+          <group delimiter=" ">
+            <text macro="issued-year" prefix=" (" suffix=")"/>
+            <text variable="section" strip-periods="true"/>
+            <text variable="container-title" strip-periods="true"/>
+            <text variable="page" strip-periods="true"/>
+          </group>
+          <text variable="number" strip-periods="true"/>
+        </if>
+        <else>
+          <text variable="container-title" strip-periods="true"/>
+          <text variable="section" strip-periods="true"/>
+          <text variable="number" strip-periods="true"/>
+          <text macro="issued"/>
+        </else>
+      </choose>
+      <text variable="note"/>
+    </group>
+    <text macro="URL"/>
   </macro>
   <macro name="note-book">
     <group delimiter=", ">
-      <text macro="contributors-note"/>
-      <text macro="title" font-style="italic"/>
+      <text macro="contributors-note" strip-periods="true"/>
+      <text variable="title" font-style="italic"/>
       <text macro="edition"/>
-      <text macro="translator-note"/>
-      <text macro="volume"/>
-      <text macro="number-of-volumes"/>
-      <text macro="collection-title"/>
+      <text macro="translator-note" strip-periods="true"/>
+      <text variable="genre" strip-periods="true"/>
+      <text variable="number" strip-periods="true"/>
+      <text variable="volume" strip-periods="true"/>
+      <text macro="collection-title" strip-periods="true"/>
       <text macro="collection-number"/>
-      <text macro="publisher-place"/>
-      <text macro="publisher"/>
+      <text variable="publisher-place" strip-periods="true"/>
+      <text variable="publisher" strip-periods="true"/>
       <text macro="issued-year"/>
-      <text macro="page" prefix=" "/>
+      <text variable="note"/>
     </group>
-    <text macro="point-locators" prefix=" "/>
+    <text macro="point-locators"/>
+    <text macro="URL"/>
   </macro>
   <macro name="book">
-    <text macro="contributors" suffix=". "/>
+    <text macro="contributors" suffix=". " strip-periods="true"/>
     <group delimiter=", ">
-      <text macro="title" font-style="italic"/>
-      <text macro="edition"/>
-      <text macro="translator"/>
-      <text macro="volume"/>
-      <text macro="number-of-volumes"/>
-      <text macro="collection-title"/>
-      <text macro="collection-number"/>
-      <text macro="publisher-place"/>
-      <text macro="publisher"/>
+      <text variable="title" font-style="italic"/>
+      <text macro="edition" strip-periods="true"/>
+      <text macro="translator" strip-periods="true"/>
+      <text variable="genre" strip-periods="true"/>
+      <text variable="number" strip-periods="true"/>
+      <text variable="volume" strip-periods="true"/>
+      <text macro="collection-title" strip-periods="true"/>
+      <text macro="collection-number" strip-periods="true"/>
+      <text variable="publisher-place" strip-periods="true"/>
+      <text variable="publisher" strip-periods="true"/>
       <text macro="issued-year"/>
+      <text variable="note"/>
     </group>
-    <text macro="page" prefix=" "/>
-    <text macro="point-locators"/>
+    <text macro="URL"/>
   </macro>
   <macro name="note-article-newspaper">
     <group delimiter=", ">
-      <text macro="contributors-note"/>
-      <text macro="title" quotes="true"/>
-      <text variable="container-title" font-style="italic"/>
-      <text macro="publisher-place"/>
+      <text macro="contributors-note" strip-periods="true"/>
+      <text variable="title" quotes="true"/>
+      <choose>
+        <if type="webpage post post-weblog" match="none">
+          <text variable="container-title" font-style="italic"/>
+        </if>
+      </choose>
+      <group>
+        <text term="edition" form="short" suffix=" " strip-periods="true"/>
+        <text variable="edition" strip-periods="true"/>
+      </group>
+      <group>
+        <text term="section" form="short" suffix=" " strip-periods="true"/>
+        <text variable="section" strip-periods="true"/>
+      </group>
     </group>
     <text macro="issued" prefix=" (" suffix=")"/>
-    <text macro="point-locators" prefix=" "/>
-    <choose>
-      <if variable="URL">
-        <text variable="container-title" prefix=", en ligne&#160;: "/>
-        <text variable="URL" prefix=" &lt;" suffix="&gt;"/>
-      </if>
-    </choose>
+    <text variable="page" prefix=" "/>
+    <text variable="note" prefix=", "/>
+    <text macro="point-locators"/>
+    <text macro="URL"/>
   </macro>
   <macro name="article-newspaper">
-    <text macro="contributors" suffix=". "/>
+    <text macro="contributors" suffix=". " strip-periods="true"/>
     <group delimiter=", ">
-      <text macro="title" quotes="true"/>
-      <text variable="container-title" font-style="italic"/>
-      <text macro="publisher-place"/>
+      <text variable="title" quotes="true"/>
+      <choose>
+        <if type="webpage post post-weblog" match="none">
+          <text variable="container-title" font-style="italic"/>
+        </if>
+      </choose>
+      <group>
+        <text term="edition" form="short" suffix=" " strip-periods="true"/>
+        <text variable="edition" strip-periods="true"/>
+      </group>
+      <group>
+        <text term="section" form="short" suffix=" " strip-periods="true"/>
+        <text variable="section" strip-periods="true"/>
+      </group>
     </group>
     <text macro="issued" prefix=" (" suffix=")"/>
-    <text macro="point-locators"/>
-    <choose>
-      <if variable="URL">
-        <text variable="container-title" prefix=", en ligne&#160;: "/>
-        <text variable="URL" prefix=" &lt;" suffix="&gt;"/>
-      </if>
-    </choose>
+    <text variable="page" prefix=" "/>
+    <text variable="note"/>
+    <text macro="URL"/>
   </macro>
   <macro name="note-article-magazine">
     <group delimiter=" ">
-      <text macro="contributors-note" suffix=","/>
-      <text macro="title" quotes="true" suffix=","/>
+      <text macro="contributors-note" suffix="," strip-periods="true"/>
+      <text variable="title" quotes="true" suffix=","/>
       <text variable="container-title" font-style="italic"/>
       <choose>
         <if variable="volume" match="any">
@@ -542,24 +627,23 @@
           </group>
         </if>
         <else>
-          <text term="issue" form="short" prefix=" " plural="true" strip-periods="true"/>
-          <number variable="issue" prefix=" "/>
+          <group>
+            <text term="issue" form="short" strip-periods="true"/>
+            <number variable="issue"/>
+           </group>
         </else>
       </choose>
-      <text macro="issued" prefix="(" suffix=") "/>
+      <text macro="issued" prefix="(" suffix=")"/>
+      <text variable="page"/>
     </group>
+    <text variable="note" prefix=", "/>
     <text macro="point-locators"/>
-    <choose>
-      <if variable="URL">
-        <text variable="container-title" prefix=", en ligne&#160;: "/>
-        <text variable="URL" prefix=" &lt;" suffix="&gt;"/>
-      </if>
-    </choose>
+    <text macro="URL"/>
   </macro>
   <macro name="article-magazine">
-    <text macro="contributors" suffix=". "/>
+    <text macro="contributors" suffix=". " strip-periods="true"/>
     <group delimiter=" ">
-      <text macro="title" quotes="true" suffix=","/>
+      <text variable="title" quotes="true" suffix=","/>
       <text variable="container-title" font-style="italic"/>
       <choose>
         <if variable="volume" match="any">
@@ -569,24 +653,22 @@
           </group>
         </if>
         <else>
-          <text term="issue" form="short" prefix=" " plural="true" strip-periods="true"/>
-          <number variable="issue" prefix=" "/>
+          <group>
+            <text term="issue" form="short" strip-periods="true"/>
+            <number variable="issue"/>
+           </group>
         </else>
       </choose>
-      <text macro="issued-year" prefix="(" suffix=")"/>
+      <text macro="issued" prefix="(" suffix=")"/>
+      <text variable="page"/>
     </group>
-    <text macro="point-locators"/>
-    <choose>
-      <if variable="URL">
-        <text variable="container-title" prefix=", en ligne&#160;: "/>
-        <text variable="URL" prefix=" &lt;" suffix="&gt;"/>
-      </if>
-    </choose>
+    <text variable="note" prefix=", "/>
+    <text macro="URL"/>
   </macro>
   <macro name="note-article-journal">
     <group delimiter=" ">
-      <text macro="contributors-note" suffix=","/>
-      <text macro="title" quotes="true"/>
+      <text macro="contributors-note" suffix="," strip-periods="true"/>
+      <text variable="title" quotes="true"/>
       <choose>
         <if variable="volume" match="none">
           <text macro="issued-year" prefix="[" suffix="]"/>
@@ -597,24 +679,20 @@
           <group delimiter=":">
             <text variable="volume"/>
             <number variable="issue"/>
-            <number variable="number-of-volumes" form="numeric"/>
           </group>
         </else>
       </choose>
       <text variable="container-title" form="short" strip-periods="true"/>
-      <text macro="point-locators"/>
+      <text variable="page"/>
     </group>
-    <choose>
-      <if variable="URL">
-        <text variable="container-title" prefix=", en ligne&#160;: "/>
-        <text variable="URL" prefix=" &lt;" suffix="&gt;"/>
-      </if>
-    </choose>
+    <text variable="note" prefix=", "/>
+    <text macro="point-locators"/>
+    <text macro="URL"/>
   </macro>
   <macro name="article-journal">
-    <text macro="contributors" suffix=". "/>
+    <text macro="contributors" suffix=". " strip-periods="true"/>
     <group delimiter=" ">
-      <text macro="title" quotes="true"/>
+      <text variable="title" quotes="true"/>
       <choose>
         <if variable="volume" match="none">
           <text macro="issued-year" prefix="[" suffix="]"/>
@@ -625,205 +703,197 @@
           <group delimiter=":">
             <text variable="volume"/>
             <number variable="issue"/>
-            <number variable="number-of-volumes" form="numeric"/>
           </group>
         </else>
       </choose>
       <text variable="container-title" form="short" strip-periods="true"/>
-      <text macro="point-locators"/>
+      <text variable="page"/>
     </group>
-    <choose>
-      <if variable="URL">
-        <text variable="container-title" prefix=", en ligne&#160;: "/>
-        <text variable="URL" prefix=" &lt;" suffix="&gt;"/>
-      </if>
-    </choose>
+    <text variable="note" prefix=", "/>
+    <text macro="URL"/>
   </macro>
-  <macro name="case">
-    <text macro="title" font-style="italic" suffix=", " strip-periods="true"/>
+  <macro name="note-case">
     <choose>
-      <if variable="container-title" match="none">
-        <text macro="issued" suffix=" "/>
-        <text macro="authority" suffix=" " strip-periods="true"/>
-        <text variable="page"/>
+      <if variable="author">
+        <group delimiter=", ">
+          <text variable="authority" strip-periods="true"/>
+          <text macro="issued"/>
+          <text variable="number"/>
+          <group delimiter=" ">
+          <text variable="title" font-style="italic" strip-periods="true"/>
+          <text variable="references" prefix="(" suffix=")"/>
+          </group>
+          <text variable="container-title" strip-periods="true" font-style="italic"/>
+          <text variable="volume"/>
+          <text variable="page"/>
+          <text variable="note"/>
+        </group>
       </if>
       <else>
-        <text macro="issued" prefix=" [" suffix="] "/>
-        <text macro="volume" suffix=" "/>
-        <text variable="container-title" suffix=" " strip-periods="true"/>
-        <text variable="page"/>
-        <text macro="authority" prefix=" (" suffix=")" strip-periods="true"/>
+        <text variable="title" font-style="italic" suffix=", " strip-periods="true"/>
+        <choose>
+          <if variable="container-title" match="none">
+            <group delimiter=" ">
+              <text macro="issued-year"/>
+              <text variable="authority" strip-periods="true"/>
+              <text variable="page"/>
+            </group>
+          </if>
+          <else>
+            <text macro="issued-year" prefix=" [" suffix="] "/>
+            <text variable="volume" suffix=" "/>
+            <text variable="container-title" suffix=" " strip-periods="true"/>
+            <text variable="page"/>
+            <text variable="authority" prefix=" (" suffix=")" strip-periods="true"/>
+          </else>
+        </choose>
+        <text variable="note" prefix=", "/>
+        <text variable="references" prefix=" (" suffix=")"/>
       </else>
     </choose>
-    <text variable="note" prefix=", "/>
-    <text macro="point-locators" prefix=" "/>
+    <text macro="point-locators"/>
     <text variable="title-short" prefix=" [" suffix="]" font-style="italic"/>
-    <text variable="URL" prefix=", en ligne&#160;: &lt;" suffix="&gt;"/>
+    <text macro="URL"/>
   </macro>
-  <macro name="access-note">
-    <group delimiter=", ">
-      <choose>
-        <if type="graphic report" match="any">
-          <text macro="archive-note"/>
-        </if>
-        <else-if type="article-journal article-magazine article-newspaper bill book chapter graphic legal_case legislation motion_picture paper-conference report song thesis" match="none">
-          <text macro="archive-note"/>
-        </else-if>
-      </choose>
-      <choose>
-        <if type="article-journal article-magazine article-newspaper broadcast interview manuscript map patent personal_communication song speech thesis webpage" match="any">
-          <text variable="URL" prefix="en ligne&#160;: "/>
-        </if>
-      </choose>
-    </group>
-  </macro>
-  <macro name="access">
-    <group delimiter=". ">
-      <choose>
-        <if type="graphic report" match="any">
-          <text macro="archive"/>
-        </if>
-        <else-if type="article-journal article-magazine article-newspaper bill book chapter graphic legal_case legislation motion_picture paper-conference report song thesis" match="none">
-          <text macro="archive"/>
-        </else-if>
-      </choose>
-      <choose>
-        <if type="article-journal article-magazine article-newspaper broadcast interview manuscript map patent personal_communication song speech thesis webpage" match="any">
-          <text variable="URL" prefix=", en ligne&#160;: &lt;" suffix="&gt;"/>
-        </if>
-      </choose>
-    </group>
-  </macro>
-  <macro name="point-locators-subsequent">
-    <group>
-      <choose>
-        <if locator="page" match="none">
-          <choose>
-            <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
-              <choose>
-                <if variable="volume">
-                  <group>
-                    <text term="volume" form="short" text-case="lowercase" suffix=" "/>
-                    <number variable="volume" form="numeric"/>
-                    <label variable="locator" form="short" prefix=", " suffix=" " strip-periods="true"/>
-                  </group>
-                </if>
-                <else>
-                  <label variable="locator" form="short" suffix=" " strip-periods="true"/>
-                </else>
-              </choose>
-            </if>
-          </choose>
-        </if>
-        <else-if type="bill book graphic legal_case legislation motion_picture report song" match="any">
-          <number variable="volume" form="numeric" suffix=":"/>
-        </else-if>
-      </choose>
-      <text variable="locator"/>
-    </group>
-  </macro>
-  <macro name="pages">
+  <macro name="case">
     <choose>
-      <if type="article-journal">
-        <text variable="page"/>
+      <if variable="author">
+        <group delimiter=", ">
+          <text variable="authority" strip-periods="true"/>
+          <text macro="issued"/>
+          <text variable="number"/>
+          <group delimiter=" ">
+          <text variable="title" font-style="italic" strip-periods="true"/>
+          <text variable="references" prefix="(" suffix=")"/>
+          </group>
+          <text variable="container-title" strip-periods="true" font-style="italic"/>
+          <text variable="volume"/>
+          <text variable="page"/>
+          <text variable="note"/>
+        </group>
       </if>
-      <else-if type="chapter paper-conference" match="any">
-        <text variable="page" prefix=", "/>
-      </else-if>
+      <else>
+        <text variable="title" font-style="italic" suffix=", " strip-periods="true"/>
+        <choose>
+          <if variable="container-title" match="none">
+            <text macro="issued-year" suffix=" "/>
+            <text variable="authority" suffix=" " strip-periods="true"/>
+            <text variable="page"/>
+          </if>
+          <else>
+            <text macro="issued-year" prefix=" [" suffix="] "/>
+            <text variable="volume" suffix=" "/>
+            <text variable="container-title" suffix=" " strip-periods="true"/>
+            <text variable="page"/>
+            <text variable="authority" prefix=" (" suffix=")" strip-periods="true"/>
+          </else>
+        </choose>
+        <text variable="note" prefix=", "/>
+        <text variable="references" prefix=" (" suffix=")"/>
+      </else>
     </choose>
+    <text macro="URL"/>
   </macro>
-  <macro name="point-locators-sub">
-    <label variable="locator" form="short" strip-periods="true"/>
-    <text variable="locator"/>
+  <macro name="entrydic-note">
+    <group delimiter=", ">
+      <text macro="contributors-note" strip-periods="true"/>
+      <text variable="container-title" font-style="italic"/>
+      <text macro="edition" strip-periods="true"/>
+      <text macro="translator-note" strip-periods="true"/>
+      <text variable="volume" strip-periods="true"/>
+      <text macro="collection-title" strip-periods="true"/>
+      <text macro="collection-number" strip-periods="true"/>
+      <text variable="publisher-place" strip-periods="true"/>
+      <text variable="publisher" strip-periods="true"/>
+      <text macro="issued-year"/>
+      <group delimiter=" ">
+        <text value="sub verbo" font-style="italic"/>
+        <text variable="title" quotes="true"/>
+      </group>
+      <text variable="note"/>
+    </group>
+    <text macro="point-locators"/>
+    <text macro="URL"/>
+  </macro>
+  <macro name="entrydic-bib">
+    <text macro="contributors" suffix=". " strip-periods="true"/>
+    <group delimiter=", ">
+      <text variable="container-title" font-style="italic"/>
+      <text macro="edition" strip-periods="true"/>
+      <text macro="translator" strip-periods="true"/>
+      <text variable="volume" strip-periods="true"/>
+      <text macro="collection-title" strip-periods="true"/>
+      <text macro="collection-number" strip-periods="true"/>
+      <text variable="publisher-place" strip-periods="true"/>
+      <text variable="publisher" strip-periods="true"/>
+      <text macro="issued-year"/>
+      <text variable="note"/>
+    </group>
+    <text macro="URL"/>
+  </macro>
+  <macro name="entryencyclo-note">
+    <group delimiter=", ">
+      <text variable="container-title" font-style="italic" strip-periods="true"/>
+      <text macro="edition" strip-periods="true"/>
+      <text macro="translator-note" strip-periods="true"/>
+      <text variable="volume" strip-periods="true"/>
+      <text macro="collection-title" strip-periods="true"/>
+      <text macro="collection-number" strip-periods="true"/>
+      <text variable="publisher-place" strip-periods="true"/>
+      <text variable="publisher" strip-periods="true"/>
+      <text macro="issued-year"/>
+      <group delimiter=" ">
+        <text variable="page" strip-periods="true"/>
+        <text variable="title" quotes="true"/>
+        <text macro="contributors-note" prefix="par "/>
+      </group>
+      <text variable="note"/>
+    </group>
+    <text macro="point-locators"/>
+    <text macro="URL"/>
+  </macro>
+  <macro name="entryencyclo-bib">
+    <text macro="contributors" suffix=". " strip-periods="true"/>
+    <group delimiter=", ">
+      <group delimiter=" ">
+        <text variable="page" strip-periods="true"/>
+        <text variable="title" quotes="true"/>
+      </group>
+      <text variable="container-title" font-style="italic"/>
+      <text macro="edition" strip-periods="true"/>
+      <text macro="translator" strip-periods="true"/>
+      <text variable="volume" strip-periods="true"/>
+      <text macro="collection-title" strip-periods="true"/>
+      <text macro="collection-number" strip-periods="true"/>
+      <text variable="publisher-place" strip-periods="true"/>
+      <text variable="publisher" strip-periods="true"/>
+      <text macro="issued-year"/>
+      <text variable="note"/>
+    </group>
+    <text macro="URL"/>
   </macro>
   <macro name="point-locators">
     <choose>
-      <if variable="locator" match="none">
-        <text macro="pages"/>
-      </if>
-      <else-if type="article-journal article-magazine article-newspaper broadcast interview manuscript map patent personal_communication song speech thesis webpage" match="any">
-        <text variable="page" suffix=" "/>
-        <label variable="locator" form="short" strip-periods="true"/>
-        <text variable="locator"/>
-      </else-if>
-      <else-if type="chapter paper-conference" match="any">
+      <if variable="locator" match="any">
         <choose>
-          <if locator="page" match="none">
-            <label variable="locator" prefix=", " suffix=" " form="long"/>
-            <text variable="locator" quotes="true"/>
-          </if>
-          <else-if locator="page" match="any">
-            <text variable="page" prefix=", " suffix=" "/>
-            <label variable="locator" form="short" strip-periods="true"/>
+          <if locator="page paragraph" match="any">
+            <label variable="locator" prefix=" " suffix="&#160;" form="short" strip-periods="true"/>
             <text variable="locator"/>
+          </if>
+          <else-if locator="sub-verbo" match="any">
+            <label variable="locator" prefix=", " suffix="&#160;" form="long" font-style="italic"/>
+            <text variable="locator" quotes="true"/>
           </else-if>
+          <else-if type="legislation bill" locator="section" match="all">
+            <text variable="locator" prefix=", art&#160;"/>
+          </else-if>
+          <else>
+            <label variable="locator" prefix=", " suffix="&#160;" form="short" strip-periods="true"/>
+            <text variable="locator"/>
+          </else>
         </choose>
-      </else-if>
-      <else>
-        <label variable="locator" form="short" strip-periods="true"/>
-        <text variable="locator"/>
-      </else>
-    </choose>
-    <choose>
-      <if type="bill legislation" match="any">
-        <text variable="references" prefix=" (" suffix=")"/>
       </if>
     </choose>
-  </macro>
-  <macro name="locators-note">
-    <group delimiter=":">
-      <text variable="volume" prefix=" "/>
-      <number variable="issue"/>
-      <number variable="number-of-volumes" form="numeric"/>
-    </group>
-  </macro>
-  <macro name="locators">
-    <text macro="issued"/>
-    <group delimiter=":">
-      <text variable="volume" prefix=" "/>
-      <number variable="issue"/>
-      <number variable="number-of-volumes" form="numeric"/>
-    </group>
-  </macro>
-  <macro name="locators-newspaper">
-    <choose>
-      <if type="article-newspaper">
-        <group delimiter=", ">
-          <group>
-            <text variable="edition" suffix=" "/>
-            <text term="edition" prefix=" "/>
-          </group>
-          <group>
-            <text term="section" form="short" suffix=" "/>
-            <text variable="section"/>
-          </group>
-        </group>
-      </if>
-    </choose>
-  </macro>
-  <macro name="locators-journal">
-    <choose>
-      <if type="article-journal">
-        <text variable="page" prefix=" "/>
-      </if>
-    </choose>
-  </macro>
-  <macro name="archive-note">
-    <group delimiter=", ">
-      <text variable="archive_location"/>
-      <text variable="archive"/>
-      <text variable="archive-place"/>
-    </group>
-  </macro>
-  <macro name="archive">
-    <group delimiter=". ">
-      <text variable="archive_location" text-case="capitalize-first"/>
-      <text variable="archive"/>
-      <text variable="archive-place"/>
-    </group>
-  </macro>
-  <macro name="issue-note">
-    <text macro="issued" prefix=" (" suffix=")"/>
   </macro>
   <macro name="sort-by-type">
     <choose>
@@ -833,10 +903,10 @@
       <else-if type="legal_case">
         <text value="2"/>
       </else-if>
-      <else-if type="book thesis" match="any">
+      <else-if type="book thesis entry-dictionary" match="any">
         <text value="3" font-weight="normal"/>
       </else-if>
-      <else-if type="article-journal chapter entry-encyclopedia review-book article review article-magazine paper-conference" match="any">
+      <else-if type="chapter article-journal entry-encyclopedia" match="any">
         <text value="4"/>
       </else-if>
       <else>
@@ -844,46 +914,69 @@
       </else>
     </choose>
   </macro>
-  <citation et-al-min="4" et-al-use-first="1" et-al-subsequent-min="4" et-al-subsequent-use-first="1" disambiguate-add-names="true">
+<citation et-al-min="4" et-al-use-first="1" et-al-subsequent-min="4" et-al-subsequent-use-first="1" disambiguate-add-names="true" delimiter-precedes-et-al="never">
     <layout suffix="." delimiter="; ">
       <choose>
         <if position="ibid-with-locator">
-          <group delimiter=", ">
-            <text term="ibid" font-style="italic" strip-periods="true" text-case="capitalize-first"/>
-            <text macro="point-locators-sub"/>
-          </group>
+          <text term="ibid" font-style="italic" strip-periods="true" text-case="capitalize-first"/>
+          <text macro="point-locators"/>
         </if>
         <else-if position="ibid">
           <text term="ibid" font-style="italic" strip-periods="true" text-case="capitalize-first"/>
         </else-if>
         <else-if position="subsequent">
           <group delimiter=", ">
-            <text macro="contributors-short"/>
-            <text macro="title-short"/>
+            <choose>
+              <if type="bill legal_case legislation entry-dictionary">
+                <choose>
+                  <if variable="author" type="legal_case" match="all">
+                    <text variable="authority" strip-periods="true"/>
+                    <text macro="issued"/>
+                  </if>
+                </choose>
+                <choose>
+                  <if variable="title-short" type="legislation bill entry-dictionary" match="all">
+                    <text variable="title-short"/>
+                  </if>
+                  <else-if variable="title-short" match="any">
+                    <text variable="title-short" font-style="italic"/>
+                  </else-if>
+                  <else>
+                    <text variable="title" form="short" font-style="italic"/>
+                  </else>
+                </choose>
+              </if>
+              <else>
+                <text macro="contributors-short" strip-periods="true"/>
+              </else>
+            </choose>
             <text value="supra" font-style="italic" suffix=" "/>
           </group>
           <group delimiter=" ">
             <text value="note"/>
             <text variable="first-reference-note-number"/>
-            <text macro="point-locators-sub"/>
           </group>
+          <text macro="point-locators"/>
         </else-if>
-        <else-if type="bill legislation" match="any">
-          <text macro="bill"/>
+        <else-if type="legislation">
+          <text macro="legislation-note"/>
+        </else-if>
+        <else-if type="bill">
+          <text macro="note-bill"/>
         </else-if>
         <else-if type="legal_case">
-          <text macro="case"/>
+          <text macro="note-case"/>
         </else-if>
         <else-if type="thesis">
           <text macro="note-thesis"/>
         </else-if>
-        <else-if type="chapter paper-conference entry-encyclopedia" match="any">
+        <else-if type="chapter">
           <text macro="note-chapter"/>
         </else-if>
-        <else-if type="bill book graphic legal_case legislation motion_picture report song" match="any">
+        <else-if type="book report">
           <text macro="note-book"/>
         </else-if>
-        <else-if type="article-newspaper webpage post post-weblog" match="any">
+        <else-if type="article-newspaper webpage post post-weblog">
           <text macro="note-article-newspaper"/>
         </else-if>
         <else-if type="article-magazine">
@@ -892,53 +985,67 @@
         <else-if type="article-journal">
           <text macro="note-article-journal"/>
         </else-if>
+        <else-if type="entry-dictionary">
+          <text macro="entrydic-note"/>
+        </else-if>
+        <else-if type="entry-encyclopedia">
+          <text macro="entryencyclo-note"/>
+        </else-if>
         <else>
-          <group delimiter=" ">
-            <text macro="contributors-note" suffix=","/>
-            <text macro="title-note" font-style="italic"/>
+          <group delimiter=", ">
+            <text macro="contributors-note" strip-periods="true"/>
+            <text variable="title" font-style="italic"/>
             <text macro="description-note"/>
-            <text macro="secondary-contributors-note"/>
-            <group>
-              <text macro="container-contributors-note"/>
+            <text macro="secondary-contributors-note" strip-periods="true"/>
+            <group delimiter="">
+              <text macro="container-contributors-note" strip-periods="true"/>
               <text macro="container-title-note"/>
             </group>
+            <text macro="collection-title" strip-periods="true"/>
+            <text variable="genre" strip-periods="true"/>
+            <text variable="publisher-place" strip-periods="true"/>
+            <text variable="publisher" strip-periods="true"/>
+            <text variable="event" strip-periods="true"/>
+            <text variable="issue" prefix="n°"/>
+            <text variable="volume" strip-periods="true"/>
+            <text macro="issued"/>
+            <text variable="page"/>
+            <text variable="note"/>
           </group>
-          <text macro="locators-note"/>
-          <text macro="collection-title" prefix=", "/>
-          <text macro="issue-note"/>
-          <text macro="locators-newspaper" prefix=", "/>
           <text macro="point-locators"/>
-          <text macro="access-note" prefix=", "/>
+          <text macro="URL"/>
         </else>
       </choose>
     </layout>
   </citation>
-  <bibliography hanging-indent="true" et-al-min="4" et-al-use-first="4" subsequent-author-substitute="&#8212;&#8212;&#8212;" entry-spacing="0">
+  <bibliography hanging-indent="true" subsequent-author-substitute="&#8212;&#8212;&#8212;" entry-spacing="0">
     <sort>
       <key macro="sort-by-type"/>
       <key macro="contributors-sort"/>
-      <key variable="title"/>
-      <key variable="genre"/>
       <key variable="issued"/>
+      <key variable="title"/>
     </sort>
     <layout suffix=".">
       <choose>
-        <if type="bill legislation" match="any">
-          <text macro="bill"/>
+        <if type="legislation">
+          <text macro="legislation-bib"/>
         </if>
+        <else-if type="bill">
+          <text macro="bill"/>
+        </else-if>
         <else-if type="legal_case">
           <text macro="case"/>
         </else-if>
         <else-if type="thesis">
           <text macro="thesis"/>
         </else-if>
-        <else-if type="chapter paper-conference entry-encyclopedia" match="any">
+        <else-if type="chapter paper-conference">
           <text macro="chapter"/>
         </else-if>
-        <else-if type="bill book graphic legal_case legislation motion_picture report song" match="any">
+        <else-if type="book report" match="any">
           <text macro="book"/>
         </else-if>
-        <else-if type="article-newspaper webpage post post-weblog" match="any">
+        <else-if type="article-newspaper webpage post post-weblog">
           <text macro="article-newspaper"/>
         </else-if>
         <else-if type="article-magazine">
@@ -947,23 +1054,33 @@
         <else-if type="article-journal">
           <text macro="article-journal"/>
         </else-if>
+        <else-if type="entry-dictionary">
+          <text macro="entrydic-bib"/>
+        </else-if>
+        <else-if type="entry-encyclopedia">
+          <text macro="entryencyclo-bib"/>
+        </else-if>
         <else>
-          <text macro="contributors" suffix=". "/>
+          <text macro="contributors" suffix=". " strip-periods="true"/>
           <group delimiter=", ">
-            <text macro="title" font-style="italic"/>
+            <text variable="title" font-style="italic"/>
             <text macro="description"/>
-            <text macro="secondary-contributors"/>
+            <text macro="secondary-contributors" strip-periods="true"/>
             <group>
-              <text macro="container-contributors"/>
+              <text macro="container-contributors" strip-periods="true"/>
               <text macro="container-title"/>
             </group>
+            <text macro="collection-title" strip-periods="true"/>
+            <text variable="genre" strip-periods="true"/>
+            <text variable="publisher-place" strip-periods="true"/>
+            <text variable="publisher" strip-periods="true"/>
+            <text variable="event" strip-periods="true"/>
+            <text variable="issue" prefix="n°"/>
+            <text variable="volume" strip-periods="true"/>
+            <text macro="issued"/>
+            <text variable="page" strip-periods="true"/>
+            <text variable="note"/>
           </group>
-          <text macro="locators" prefix=", "/>
-          <text macro="collection-title" prefix=" "/>
-          <text macro="issue"/>
-          <text macro="locators-newspaper" prefix=", "/>
-          <text macro="locators-journal"/>
-          <text macro="access"/>
         </else>
       </choose>
     </layout>


### PR DESCRIPTION
New layout. New items. The mcrj7.csl is now (almost) fully compliant with the McGill French 7th ed.

http://lawjournal.mcgill.ca/citeguide.php?locale=fr is deleted because McGill LJ website changed. The new URL will be add when new website launch.

A complete doc for mcrj7.csl will be published on http://f-mb.github.io/cslegal after the pull merge.
