### PR TITLE
Added pom.xml to distribute the CSL styles via Maven

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,63 @@
+<project>
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>org.citationstyles</groupId>
+  <artifactId>styles</artifactId>
+  <packaging>jar</packaging>
+  <distributionManagement>
+    <repository>
+      <id>sonatype-nexus-staging</id>
+      <url>https://oss.sonatype.org/service/local/staging/deploy/maven2</url>
+    </repository>
+    <snapshotRepository>
+      <id>sonatype-nexus-snapshots</id>
+      <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+    </snapshotRepository>
+  </distributionManagement>
+  <name>Citation Style Language (CSL) citation styles</name>
+  <version>1.0.2-SNAPSHOT</version>
+  <description>Citation Style Language (CSL) citation styles packaged as a Maven artifact</description>
+  <url>http://citationstyles.org/</url>
+  <licenses>
+    <license>
+      <name>Creative Commons Attribution-ShareAlike 3.0 Unported license</name>
+      <url>http://creativecommons.org/licenses/by-sa/3.0/</url>
+      <distribution>repo</distribution>
+      <comments>
+        All the styles in this repository are released under the Creative
+        Commons Attribution-ShareAlike 3.0 Unported license. For attribution,
+        any software using CSL styles from this repository must include a clear
+        mention of the CSL project and a link to CitationStyles.org. When
+        distributing these styles, the listings of authors and contributors in
+        the style metadata must be kept as is.
+      </comments>
+    </license>
+  </licenses>
+  <scm>
+    <url>scm:git:git://github.com/citation-style-language/styles.git</url>
+    <connection>scm:git:git://github.com/citation-style-language/styles.git</connection>
+    <developerConnection>scm:git:git://github.com/citation-style-language/styles.git</developerConnection>
+  </scm>
+  <organization>
+    <name>CitationStyles.org</name>
+    <url>http://citationstyles.org/</url>
+  </organization>
+  <developers>
+    <developer>
+      <id>michel-kraemer</id>
+      <name>Michel Kraemer</name>
+      <email>michel@undercouch.de</email>
+      <url>http://www.michel-kraemer.com</url>
+    </developer>
+  </developers>
+  <build>
+    <resources>
+      <resource>
+        <directory>.</directory>
+        <includes>
+          <include>*.csl</include>
+          <include>dependent/*.csl</include>
+        </includes>
+      </resource>
+    </resources>
+  </build>
+</project>


### PR DESCRIPTION
Hi folks!

I'm currently working on a project called 'citeproc-java' which is a small wrapper around citeproc-js with some additional stuff (such as bibtex conversion). The GitHub repo will be published soon. I will announce this on the mailing list, probably later today.

Since I would like to publish citeproc-java via Maven it makes sense to also publish the styles there so they are directly available for Java applications. That's why I'm sending you this pull request.

Please have a look at the version number. Currently I chose 1.0.2-SNAPSHOT. You should verify that this is OK.

Apart from that, I put myself in the developer's section so I can upload the artifact to Maven central with my user id michel-kraemer. If you have your own user id for Maven central you may of course replace my name and id with yours. If not, I would kindly ask you to allow me to create the `org.citationstyles` group id on Maven Central on your behalf. Of course, we can add more developers/contributors to the pom file if necessary.

Cheers,
Michel
