### PR TITLE
Create osap.csl

### DIFF
--- a/oxford-studies-in-ancient-philosophy.csl
+++ b/oxford-studies-in-ancient-philosophy.csl
@@ -2,8 +2,8 @@
 <style xmlns="http://purl.org/net/xbiblio/csl" class="note" version="1.0" demote-non-dropping-particle="sort-only" default-locale="en-GB">
   <info>
     <title>Oxford Studies in Ancient Philosophy</title>
-    <id>http://www.zotero.org/styles/osap</id>
-    <link href="http://www.zotero.org/styles/osap" rel="self"/>
+    <id>http://www.zotero.org/styles/oxford-studies-in-ancient-philosophy</id>
+    <link href="http://www.zotero.org/styles/oxford-studies-in-ancient-philosophy" rel="self"/>
     <link href="http://www.oup.co.uk/academic/authors/instruct/series/osap/" rel="documentation"/>
     <link href="http://www.zotero.org/styles/chicago-fullnote-bibliography-no-ibid" rel="template"/>
     <issn>0265-7651</issn>
@@ -785,6 +785,9 @@
         <text macro="issue-note"/>
       </else-if>
     </choose>
+  </macro>
+  <macro name="issue-note-join-with-period">
+            <text macro="issue-note"/>
   </macro>
   <macro name="issue-note">
     <choose>


### PR DESCRIPTION
Oxford Studies in Ancient Philosophy citation style.
This is based on the Chicago full note no-ibid style, with a few changes:
- single quotes rather than double quotes
- British locations for commas outside quotes
- Publication location only (not publisher)
- Publication details always in brackets
- Some changes to the order of elements for book chapter citations
- Abbreviated titles for subsequent citations (using the Short Title field where the record contains something in that field), and announcing these in square brackets in both the first citation of an article and in the bibliography (again only where the Short Title ('title-short') field contains data).
- some minor changes to punctuation to allow greater flexibility of use (e.g. citations in notes have no final punctuation), and to meet OSAP-specific requirements.
