### PR TITLE
Replacement for zookeys.csl

### DIFF
--- a/zookeys.csl
+++ b/zookeys.csl
@@ -1,68 +1,236 @@
 <?xml version="1.0" encoding="utf-8"?>
-<style xmlns="http://purl.org/net/xbiblio/csl" version="1.0" class="in-text" default-locale="en-US">
+<style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" demote-non-dropping-particle="sort-only" default-locale="en-US">
   <info>
     <title>ZooKeys</title>
     <id>http://www.zotero.org/styles/zookeys</id>
     <link href="http://www.zotero.org/styles/zookeys" rel="self"/>
+    <link href="http://www.zotero.org/styles/zootaxa" rel="template"/>
     <link href="http://www.pensoft.net/journals/zookeys/about/Author%20Guidelines" rel="documentation"/>
     <author>
-      <name>Carlos Pena</name>
-      <email>mycalesis@gmail.com</email>
+      <name>Brian Stucky</name>
+      <email>stuckyb@colorado.edu</email>
     </author>
-    <category citation-format="numeric"/>
+    <category citation-format="author-date"/>
+    <category field="biology"/>
     <issn>1313-2989</issn>
     <eissn>1313-2970</eissn>
-    <updated>2012-12-01T03:03:04+01:00</updated>
+    <summary>The ZooKeys style.</summary>
+    <updated>2013-09-12T00:00:00+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
-  <citation>
-    <layout>
-      <text variable="citation-number" prefix="[" suffix="] "/>
+  <locale xml:lang="en-US">
+    <date form="text">
+      <date-part name="month" suffix=" "/>
+      <date-part name="day" suffix=", "/>
+      <date-part name="year"/>
+    </date>
+  </locale>
+  <macro name="editor">
+    <names variable="editor" delimiter=", ">
+      <name initialize-with="" name-as-sort-order="all" sort-separator=" "/>
+      <label form="short" prefix=" (" text-case="capitalize-first" suffix=")" strip-periods="true"/>
+    </names>
+  </macro>
+  <macro name="anon">
+    <text term="anonymous" form="short" text-case="capitalize-first" strip-periods="true"/>
+  </macro>
+  <macro name="author">
+    <names variable="author">
+      <name delimiter-precedes-last="never" initialize-with="" name-as-sort-order="all" sort-separator=" "/>
+      <et-al font-style="italic"/>
+      <label form="short" prefix=" " suffix="." text-case="lowercase" strip-periods="true"/>
+      <substitute>
+        <names variable="editor"/>
+        <text macro="anon"/>
+      </substitute>
+    </names>
+  </macro>
+  <macro name="author-short">
+    <names variable="author">
+      <name form="short" delimiter=" " and="text" delimiter-precedes-last="never" et-al-min="3" et-al-use-first="1" initialize-with=". "/>
+      <et-al font-style="normal"/>
+      <substitute>
+        <names variable="editor"/>
+        <names variable="translator"/>
+        <text macro="anon"/>
+      </substitute>
+    </names>
+  </macro>
+  <macro name="access">
+    <choose>
+      <if type="legal_case" match="none">
+        <choose>
+          <if variable="DOI">
+            <group delimiter=" ">
+              <text variable="DOI" prefix="doi: "/>
+            </group>
+          </if>
+          <else-if variable="URL">
+            <group delimiter=" " suffix=".">
+              <text variable="URL" prefix="Available from: "/>
+              <group prefix="(" suffix=")">
+                <date variable="accessed" form="text"/>
+              </group>
+            </group>
+          </else-if>
+        </choose>
+      </if>
+    </choose>
+  </macro>
+  <macro name="title">
+    <choose>
+      <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
+        <text variable="title" font-style="normal"/>
+      </if>
+      <else>
+        <text variable="title" quotes="false"/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="legal_case">
+    <group prefix=" " delimiter=" ">
+      <text variable="volume"/>
+      <text variable="container-title"/>
+    </group>
+    <text variable="authority" prefix=" (" suffix=")"/>
+  </macro>
+  <macro name="publisher">
+    <choose>
+      <if type="thesis" match="none">
+        <group prefix="" suffix="" delimiter=", ">
+          <text variable="publisher" suffix=""/>
+          <text variable="publisher-place"/>
+        </group>
+        <text variable="genre" prefix=". "/>
+      </if>
+      <else>
+        <group delimiter=". ">
+          <text variable="genre"/>
+          <text variable="publisher"/>
+        </group>
+      </else>
+    </choose>
+  </macro>
+  <macro name="year-date">
+    <choose>
+      <if variable="issued">
+        <group>
+          <date variable="issued">
+            <date-part name="year"/>
+          </date>
+        </group>
+      </if>
+      <else>
+        <text term="no date" form="short"/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="edition">
+    <choose>
+      <if is-numeric="edition">
+        <group delimiter=" ">
+          <number variable="edition" form="ordinal"/>
+          <text term="edition" form="short" suffix="." strip-periods="true"/>
+        </group>
+      </if>
+      <else>
+        <text variable="edition" suffix="."/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="locator">
+    <choose>
+      <if locator="page">
+        <text variable="locator"/>
+      </if>
+      <else>
+        <group delimiter=" ">
+          <label variable="locator" form="short"/>
+          <text variable="locator"/>
+        </group>
+      </else>
+    </choose>
+  </macro>
+  <citation et-al-min="2" et-al-use-first="2" et-al-subsequent-min="2" et-al-subsequent-use-first="1" disambiguate-add-year-suffix="true" disambiguate-add-names="true" disambiguate-add-givenname="true" collapse="year" givenname-disambiguation-rule="primary-name">
+    <sort>
+      <key macro="year-date"/>
+      <key macro="author-short"/>
+    </sort>
+    <layout delimiter=", " prefix="(" suffix=")">
+      <group delimiter=", ">
+        <group delimiter=" ">
+          <text macro="author-short"/>
+          <text macro="year-date"/>
+        </group>
+        <text macro="locator"/>
+      </group>
     </layout>
   </citation>
-  <bibliography>
-    <layout>
+  <bibliography hanging-indent="true">
+    <sort>
+      <key macro="author"/>
+      <key macro="year-date"/>
+      <key variable="title"/>
+    </sort>
+    <layout suffix=" ">
+      <text macro="author" suffix=" ("/>
+      <date variable="issued">
+        <date-part name="year" suffix=")"/>
+      </date>
       <choose>
-        <if type="chapter">
-          <names variable="author">
-            <name delimiter=", " name-as-sort-order="all" sort-separator=" " form="long" initialize-with=""/>
-          </names>
-          <date variable="issued" prefix="(" suffix=")">
-            <date-part name="year" form="long"/>
-          </date>
-          <text variable="title" suffix="."/>
-          <text variable="container-title" suffix=" "/>
-          <group delimiter=" " suffix=". ">
-            <group>
-              <text variable="volume"/>
-              <text variable="issue" prefix="(" suffix=") "/>
-            </group>
-            <text variable="page" prefix=" :" suffix="."/>
+        <if type="book" match="any">
+          <text macro="legal_case"/>
+          <group prefix=" " delimiter=" ">
+            <text macro="title" font-style="normal" suffix="."/>
+            <text macro="edition"/>
+            <text macro="editor" suffix="."/>
+          </group>
+          <group prefix=" " suffix="." delimiter=", ">
+            <text macro="publisher"/>
+            <text variable="number-of-pages" prefix=" " suffix=" pp"/>
           </group>
         </if>
-        <else>
-          <names variable="author" suffix=" ">
-            <name delimiter=", " name-as-sort-order="all" sort-separator=" " form="long" initialize-with=""/>
-          </names>
-          <date variable="issued" prefix="(" suffix=") ">
-            <date-part name="year" form="long"/>
-          </date>
-          <text variable="title" suffix=". "/>
-          <group suffix=". ">
-            <text variable="container-title" font-style="italic"/>
-            <group>
-              <text variable="volume" prefix=" "/>
-              <text variable="issue" prefix=" (" suffix=")"/>
-              <text variable="page" prefix=": " suffix="."/>
-              <choose>
-                <if variable="DOI">
-                  <text variable="DOI" prefix=" doi: "/>
-                </if>
-              </choose>
+        <else-if type="chapter paper-conference" match="any">
+          <text macro="title" prefix=" " suffix="."/>
+          <group prefix=" In: " delimiter=" ">
+            <text macro="editor" suffix=","/>
+            <text variable="container-title" font-style="normal" suffix="."/>
+            <text variable="collection-title" font-style="normal" suffix="."/>
+            <group suffix=".">
+              <text macro="publisher"/>
+              <group delimiter=" " prefix=", " suffix=".">
+                <text variable="page"/>
+              </group>
             </group>
+          </group>
+        </else-if>
+        <else-if type="bill graphic legal_case legislation manuscript motion_picture report song thesis" match="any">
+          <text macro="legal_case"/>
+          <group prefix=" " delimiter=" ">
+            <text macro="title" suffix="."/>
+            <text macro="edition"/>
+            <text macro="editor" suffix="."/>
+          </group>
+          <group prefix=" " suffix="" delimiter=", ">
+            <text macro="publisher"/>
+            <text variable="page" prefix=" " suffix="pp."/>
+          </group>
+        </else-if>
+        <else>
+          <group prefix=" " delimiter=" " suffix=".">
+            <text macro="title"/>
+            <text macro="editor"/>
+          </group>
+          <group prefix=" " suffix=".">
+            <text variable="container-title" font-style="normal"/>
+            <group prefix=" ">
+              <text variable="volume"/>
+            </group>
+            <text variable="page" prefix=": " suffix="."/>
           </group>
         </else>
       </choose>
+      <text macro="access" prefix=" "/>
     </layout>
   </bibliography>
 </style>


### PR DESCRIPTION
Hello,
This update is not actually an incremental edit of the existing zookeys.csl, but a completely new replacement.  The previous ZooKeys style was incorrect on several major points:  it used a numeric citation style (ZooKeys uses author/date), sources were arranged by order of appearance (they should be arranged alphabetically), and the citation formatting was wrong.  Given that there had been no significant updates to this file since early December of last year, I decided to start over and develop a new ZooKeys CSL style definition.  I have tested this with a variety of source types (journal article, book, book chapter, software, Web) to verify that it produces correct citations.
