### PR TITLE
Update environmental-microbiology.csl

### DIFF
--- a/environmental-microbiology.csl
+++ b/environmental-microbiology.csl
@@ -90,6 +90,9 @@
     </choose>
   </macro>
   <citation et-al-min="3" et-al-use-first="1" disambiguate-add-year-suffix="true" disambiguate-add-names="true" disambiguate-add-givenname="true" collapse="year">
+    <sort>
+      <key macro="year-date"/>
+    </sort>
     <layout prefix="(" suffix=")" delimiter="; ">
       <group delimiter=", ">
         <text macro="author-short"/>
@@ -97,9 +100,6 @@
         <text variable="locator"/>
       </group>
     </layout>
-    <sort>
-      <key macro="year-date"/>
-    </sort>
   </citation>
   <bibliography et-al-min="3" et-al-use-first="8" entry-spacing="0" hanging-indent="true">
     <sort>


### PR DESCRIPTION
Added sort by date order to inline citations.
Changed et al formatting in bibliography so that 
et-al-min and et-al-use-first are set to the 
values required by Environmental Microbiology
outlined at http://onlinelibrary.wiley.com/journal/10.1111/%28ISSN%291462-2920/homepage/ForAuthors.html
