### PR TITLE
Create archiv-fur-geschichte-der-philosophie.csl

### DIFF
--- a/archiv-fur-geschichte-der-philosophie.csl
+++ b/archiv-fur-geschichte-der-philosophie.csl
@@ -3,7 +3,7 @@
   <info>
     <title>Archiv für Geschichte der Philosophie</title>
     <title-short>AGP</title-short>
-    <id>http://www.zotero.org/styles/</id>
+    <id>http://www.zotero.org/styles/archiv-fur-geschichte-der-philosophie</id>
     <link href="http://www.zotero.org/styles/archiv-fur-geschichte-der-philosophie" rel="self"/>
     <link href="http://www.zotero.org/styles/environment-and-planning" rel="template"/>
     <link href="www.degruyter.com/view/supplement/s16130650_Instructions_for_Authors_en.pdf" rel="documentation"/>


### PR DESCRIPTION
CSL for Archiv fur Geschichte der Philosophie - an ancient philosophy journal, modified from environment-and-planning.

Principal changes were no brackets around citations, and then lots of full stops in the bibliography references, along with various other typographical requirements specific to Archiv.
