### PR TITLE
Update harvard-anglia-ruskin-university.csl

### DIFF
--- a/harvard-anglia-ruskin-university.csl
+++ b/harvard-anglia-ruskin-university.csl
@@ -366,7 +366,7 @@
       </group>
     </layout>
   </citation>
-  <bibliography hanging-indent="false" et-al-min="5" et-al-use-first="1">
+  <bibliography hanging-indent="false">
     <sort>
       <key macro="cite-author"/>
       <key macro="year-date"/>


### PR DESCRIPTION
Update to style to align with Anglia Ruskin guidelines 2012 and 2013. The full list of authors is required for a bibliography listing (and should not be shortened to "et al").
