### PR TITLE
[NP 405] Don't force author name initialization.

### DIFF
--- a/norma-portuguesa-405.csl
+++ b/norma-portuguesa-405.csl
@@ -45,7 +45,7 @@
     <category citation-format="author-date"/>
     <category field="generic-base"/>
     <summary>The Portuguese standard style</summary>
-    <updated>2013-09-20T11:50:09+00:00</updated>
+    <updated>2013-10-03T11:50:09+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale xml:lang="pt-PT">
@@ -64,7 +64,7 @@
     <choose>
       <if type="chapter paper-conference">
         <names variable="container-author" delimiter=", ">
-          <name name-as-sort-order="all" sort-separator=", " initialize-with=". " delimiter="; " delimiter-precedes-last="always">
+          <name name-as-sort-order="all" sort-separator=", " initialize="false" initialize-with=". " delimiter="; " delimiter-precedes-last="always">
             <name-part name="family" text-case="uppercase"/>
             <name-part name="given" text-case="uppercase"/>
           </name>
@@ -78,7 +78,7 @@
       </if>
       <else-if type="patent">
         <names variable="container-author" delimiter=", ">
-          <name name-as-sort-order="all" sort-separator=", " initialize-with=". " delimiter="; " delimiter-precedes-last="always">
+          <name name-as-sort-order="all" sort-separator=", " initialize="false" initialize-with=". " delimiter="; " delimiter-precedes-last="always">
             <name-part name="family"/>
             <name-part name="given"/>
           </name>
@@ -95,7 +95,7 @@
     <choose>
       <if type="chapter paper-conference patent" match="none">
         <names variable="editor" delimiter=", " prefix=" (" suffix=")">
-          <name and="symbol" initialize-with=". " delimiter=", "/>
+          <name and="symbol" initialize="false" initialize-with=". " delimiter=", "/>
           <label form="short" prefix=", " text-case="capitalize-first" suffix="."/>
         </names>
       </if>
@@ -113,7 +113,7 @@
   </macro>
   <macro name="author">
     <names variable="author">
-      <name name-as-sort-order="all" sort-separator=", " initialize-with=". " delimiter="; " delimiter-precedes-last="always">
+      <name name-as-sort-order="all" sort-separator=", " initialize="false" initialize-with=". " delimiter="; " delimiter-precedes-last="always">
         <name-part name="family" text-case="uppercase"/>
         <name-part name="given" text-case="capitalize-all"/>
       </name>
@@ -128,7 +128,7 @@
   </macro>
   <macro name="author-short">
     <names variable="author">
-      <name form="short" name-as-sort-order="all" sort-separator=", " and="text" initialize-with=". " delimiter=", " delimiter-precedes-last="never"/>
+      <name form="short" name-as-sort-order="all" sort-separator=", " and="text" initialize="false" initialize-with=". " delimiter=", " delimiter-precedes-last="never"/>
       <et-al font-style="italic"/>
       <substitute>
         <names variable="editor"/>


### PR DESCRIPTION
Re https://forums.zotero.org/discussion/32288/np-405/

I did obtain the NP 405 manuals. @adam3smith has access to them. If someone else wants access, let me (or @adam3smith) know.

Oh, I should say that section 6.2 of NP 405-1 says

> Podem ser utilizadas abreviaturas nos seguintes casos:
> Nomes próprios de autores, editores literários, tradutores, etc., desde que fiquem
> inequivocamente identificados.
> Ex. PIAGET, J.

or as Google Translate would say...

> Abbreviations may be used in the following cases:
> Proper names of authors, literary editors, translators, etc.., Provided it
> unequivocally identified.
> Eg Piaget, J.
