### PR TITLE
Remove prefixes

### DIFF
--- a/australian-guide-to-legal-citation.csl
+++ b/australian-guide-to-legal-citation.csl
@@ -186,7 +186,7 @@
         <text variable="title" text-case="title"/>
       </else-if>
       <else-if type="legal_case">
-        <text variable="title" font-style="italic" strip-periods="true"/>
+        <text variable="title" font-style="italic" strip-periods="true" form="short"/>
       </else-if>
       <else>
         <text variable="title" quotes="true" text-case="title"/>
@@ -455,7 +455,7 @@
               <!--don't use short form and above note for legal citations -->
               <group delimiter=", ">
                 <text macro="author-note"/>
-                <text macro="title"/>
+                <text variable="title-short"/>
               </group>
               <!-- we could work with title-short here-->
               <group delimiter=" " prefix=" ">
@@ -488,28 +488,34 @@
         </else-if>
         <else>
           <!--general whole citation -->
-          <group delimiter=", ">
-            <text macro="author-note"/>
-            <text macro="title"/>
-            <text macro="broadcast-container"/>
-          </group>
-          <group delimiter=" " prefix=" ">
-            <text macro="date-parenthesis"/>
-            <text macro="article-case-info"/>
-            <text macro="book-container"/>
-            <text macro="publisher"/>
-          </group>
-          <text macro="manuscript-catchall" prefix=", "/>
-          <text macro="date-news" prefix=", "/>
-          <group delimiter=", " prefix=" ">
-            <group delimiter=" ">
-              <text macro="volume-book"/>
-              <text macro="looseleaf"/>
+          <group delimiter=" ">
+            <group delimiter=", ">
+              <group delimiter=" ">
+                <group delimiter=", ">
+                  <text macro="author-note"/>
+                  <text macro="title"/>
+                  <text macro="broadcast-container"/>
+                </group>
+                <group delimiter=" ">
+                  <text macro="date-parenthesis"/>
+                  <text macro="article-case-info"/>
+                  <text macro="book-container"/>
+                  <text macro="publisher"/>
+                </group>
+              </group>
+              <text macro="manuscript-catchall"/>
+              <text macro="date-news"/>
             </group>
-            <text macro="page-first"/>
-            <text variable="locator"/>
+            <group delimiter=", ">
+              <group delimiter=" ">
+                <text macro="volume-book"/>
+                <text macro="looseleaf"/>
+              </group>
+              <text macro="page-first"/>
+              <text variable="locator"/>
+            </group>
+            <text macro="URL"/>
           </group>
-          <text macro="URL" prefix=" "/>
         </else>
       </choose>
     </layout>


### PR DESCRIPTION
Style was leaving stray spaces behind when merging parallel case citations.
