### PR TITLE
improvements and fixes according DGfP citation rules

### DIFF
--- a/deutsche-gesellschaft-fur-psychologie.csl
+++ b/deutsche-gesellschaft-fur-psychologie.csl
@@ -269,7 +269,7 @@ delimiter-precedes-last="never"/>
       </choose>
     </layout>
   </citation>
-  <bibliography hanging-indent="true" et-al-min="8" et-al-use-first="7" entry-spacing="0">
+  <bibliography hanging-indent="true" et-al-min="7" et-al-use-first="6" entry-spacing="0">
     <sort>
       <key macro="author"/>
       <key macro="issued-year" sort="ascending"/>


### PR DESCRIPTION
- no spaces between initials in names
- in articles no space between issue and volume
- no comma before '&'
- collection title in brackets
- no italicisation of titles in articles and book chapters
- ibid handling for subsequent citations
- better formatting for 'access' entries
- minor tweaks
