### PR TITLE
Update to Infoclio's styles (for Swiss historians)

### DIFF
--- a/infoclio-de.csl
+++ b/infoclio-de.csl
@@ -25,7 +25,7 @@
     <category citation-format="note"/>
     <category field="history"/>
     <category field="social_science"/>
-    <updated>2013-10-28T20:00:35+01:00</updated>
+    <updated>2013-11-08T17:47:37+01:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale xml:lang="de">
@@ -299,6 +299,7 @@
       <if type="graphic">
         <group delimiter=", ">
           <text variable="medium"/>
+          <text variable="dimensions"/>
           <text variable="genre"/>
           <text variable="archive"/>
           <text variable="archive_location"/>

--- a/infoclio-fr-nocaps.csl
+++ b/infoclio-fr-nocaps.csl
@@ -25,7 +25,7 @@
     <category citation-format="note"/>
     <category field="history"/>
     <category field="social_science"/>
-    <updated>2013-10-28T20:28:33+01:00</updated>
+    <updated>2013-11-11T09:47:27+01:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale xml:lang="fr">
@@ -318,6 +318,7 @@
       <if type="graphic">
         <group delimiter=", ">
           <text variable="medium"/>
+          <text variable="dimensions"/>
           <text variable="genre"/>
           <text variable="archive"/>
           <text variable="archive_location"/>

--- a/infoclio-fr-smallcaps.csl
+++ b/infoclio-fr-smallcaps.csl
@@ -24,7 +24,7 @@
     <category citation-format="note"/>
     <category field="history"/>
     <category field="social_science"/>
-    <updated>2013-10-28T20:24:38+01:00</updated>
+    <updated>2013-11-08T17:47:45+01:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale xml:lang="fr">
@@ -325,6 +325,7 @@
       <if type="graphic">
         <group delimiter=", ">
           <text variable="medium"/>
+          <text variable="dimensions"/>
           <text variable="genre"/>
           <text variable="archive"/>
           <text variable="archive_location"/>


### PR DESCRIPTION
Small update to a style created for history students in Switzerland [1]:
- Bug fixes: number of volumes and volume number not separated (leading to "33" instead of "3 / 3"), reports lacking information, repeated suffix in the French styles
- Making use of new CSL 1.0.1 features: duration for films and audio, and dimensions for artworks

[1]: see https://github.com/citation-style-language/styles/pull/234
