### PR TITLE
Update circulation.csl

### DIFF
--- a/circulation.csl
+++ b/circulation.csl
@@ -76,7 +76,7 @@
     <choose>
       <if type="article-journal article-magazine" match="any">
         <group suffix=". ">
-          <text variable="container-title" form="short" font-style="italic"/>
+          <text variable="container-title" form="short" font-style="italic" strip-periods="true"/>
           <choose>
             <if variable="URL">
               <text term="internet" prefix=" [" suffix="]" text-case="capitalize-first"/>
@@ -152,7 +152,7 @@
             <text macro="accessed-date" prefix=" "/>
           </group>
           <group suffix=". ">
-            <text variable="volume" prefix=" "/>
+            <text variable="volume"/>
             <text variable="page" prefix=":"/>
           </group>
         </else>


### PR DESCRIPTION
Just submitted an article to the journal using this style, and was asked to correct two things by the editor:
1. no periods in journal abbreviations. 
Zotero seems to add these when automatically abbreviating titles (useful feature though!), so the code needs a strip-periods="true" for the journal title field on line 79
2. no space between date and volume 
- prefix=" " removed from line 155

Thanks for all your work on this excellent software!
