### PR TITLE
Updates to Coventry University Harvard

### DIFF
--- a/harvard-coventry-university.csl
+++ b/harvard-coventry-university.csl
@@ -24,6 +24,7 @@
     <terms>
       <term name="edition" form="short">edn.</term>
       <term name="page" form="short"/>
+      <term name="section" form="short">s.</term>
     </terms>
     <style-options punctuation-in-quote="false"/>
   </locale>
@@ -96,18 +97,11 @@
       </if>
       <else-if type="legislation">
         <choose>
-          <if variable="author">
-            <names variable="author">
-              <name name-as-sort-order="all" and="text" sort-separator=", " initialize-with="." delimiter=", "/>
-              <label form="short" prefix=" " strip-periods="false"/>
-              <substitute>
-                <text macro="editor"/>
-                <text macro="anon"/>
-              </substitute>
-            </names>
+          <if variable="container-title">
+            <text variable="title" text-case="title"/>
           </if>
           <else>
-            <text variable="title" font-style="italic" text-case="title" suffix="."/>
+            <text variable="title" font-style="italic" text-case="title"/>
           </else>
         </choose>
       </else-if>
@@ -136,21 +130,7 @@
         </choose>
       </if>
       <else-if type="legislation">
-        <choose>
-          <if variable="author">
-            <names variable="author">
-              <name name-as-sort-order="all" and="text" sort-separator=", " initialize-with="." delimiter=", "/>
-              <label form="short" prefix=" " strip-periods="false"/>
-              <substitute>
-                <text macro="cite-editor"/>
-                <text macro="anon"/>
-              </substitute>
-            </names>
-          </if>
-          <else>
-            <text variable="title" font-style="italic" text-case="title"/>
-          </else>
-        </choose>
+        <text variable="title" text-case="title"/>
       </else-if>
       <else>
         <names variable="author">
@@ -239,6 +219,21 @@
       </else>
     </choose>
   </macro>
+  <macro name="year-date-legislation">
+    <choose>
+      <if variable="issued">
+        <group delimiter=", ">
+          <date variable="issued">
+            <date-part name="year"/>
+          </date>
+          <text variable="container-title"/>
+        </group>
+      </if>
+      <else>
+        <text term="no date" form="short"/>
+      </else>
+    </choose>
+  </macro>
   <macro name="edition">
     <choose>
       <if is-numeric="edition">
@@ -293,16 +288,29 @@
   </macro>
   <citation et-al-min="3" et-al-use-first="1" et-al-subsequent-min="3" et-al-subsequent-use-first="1" disambiguate-add-year-suffix="true" disambiguate-add-givenname="true" givenname-disambiguation-rule="all-names" name-as-sort-order="all" collapse="year">
     <layout prefix="(" suffix=")" delimiter=", ">
-      <group delimiter=":&#160;">
-        <group delimiter=" ">
-          <text macro="author-short"/>
-          <text macro="year-date"/>
-        </group>
-        <group delimiter=" ">
-          <label variable="locator" form="short" strip-periods="false"/>
-          <text variable="locator"/>
-        </group>
-      </group>
+      <choose>
+        <if locator="page">
+          <group delimiter=":&#160;">
+            <group delimiter=" ">
+              <text macro="author-short"/>
+              <text macro="year-date"/>
+            </group>
+            <text variable="locator"/>
+          </group>
+        </if>
+        <else>
+          <group delimiter=",&#160;">
+            <group delimiter=" ">
+              <text macro="author-short"/>
+              <text macro="year-date"/>
+            </group>
+            <group delimiter="&#160;">
+              <label variable="locator" form="short" strip-periods="false"/>
+              <text variable="locator"/>
+            </group>
+          </group>
+        </else>
+      </choose>
     </layout>
   </citation>
   <bibliography hanging-indent="true">
@@ -314,28 +322,21 @@
     <layout>
       <group delimiter=" ">
         <text macro="author"/>
-        <text macro="year-date" prefix=" (" suffix=")"/>
+        <choose>
+          <if type="legislation" match="any">
+            <text macro="year-date-legislation" prefix=" (" suffix=")"/>
+          </if>
+          <else>
+            <text macro="year-date" prefix=" (" suffix=")"/>
+          </else>
+        </choose>
         <choose>
           <if type="bill legislation" match="any">
             <group delimiter=". ">
-              <group delimiter=" ">
-                <choose>
-                  <if type="legislation" match="any">
-                    <choose>
-                      <if variable="author">
-                        <text variable="title" font-style="italic" text-case="title"/>
-                        <text value="[Act of Parliament]"/>
-                      </if>
-                    </choose>
-                  </if>
-                  <else>
-                    <text variable="title" font-style="italic" text-case="title"/>
-                  </else>
-                </choose>
-              </group>
               <text macro="edition"/>
               <text variable="number"/>
               <text macro="transby"/>
+              <text variable="references"/>
               <text macro="online"/>
               <text macro="access"/>
             </group>


### PR DESCRIPTION
Partially deal with the fact that the 'note' used for several specific items has had to be removed because it conflicted with Mendeley's use of the note field. 

Updates to legislation to reflect previously unspotted changes introduced by version 3.0.2 of the style guide.
