### PR TITLE
APA: make container-title title cased for periodicals

### DIFF
--- a/apa.csl
+++ b/apa.csl
@@ -388,9 +388,12 @@
   </macro>
   <macro name="container-title">
     <choose>
-      <if type="bill legal_case legislation" match="none">
-        <text variable="container-title" font-style="italic"/>
+      <if type="article article-journal article-magazine article-newspaper" match="any">
+        <text variable="container-title" font-style="italic" text-case="title"/>
       </if>
+      <else-if type="bill legal_case legislation" match="none">
+        <text variable="container-title" font-style="italic"/>
+      </else-if>
       <else>
         <group delimiter=" " prefix=", ">
           <choose>


### PR DESCRIPTION
As discussed in https://github.com/citation-style-language/styles/issues/759, this commit adds a text-case="title" to periodical item types in the APA style.

I'm not certain that I covered all of the periodical types — someone more familiar with general usage of CSL types should raise a flag if something is missing there.
