### PR TITLE
Create harvard-international-journal-of-geriatric-psychiatry.csl

### DIFF
--- a/international-journal-of-geriatric-psychiatry.csl
+++ b/international-journal-of-geriatric-psychiatry.csl
@@ -2,9 +2,10 @@
 <style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" demote-non-dropping-particle="sort-only" default-locale="en-GB">
 <!-- This style was edited with the Visual CSL Editor (http://editor.citationstyles.org/visualEditor/) -->
   <info>
-    <title>Harvard - International Journal of Geriatric Psychiatry</title>
-    <id>http://www.zotero.org/styles/harvard-international-journal-of-geriatric-psychiatry</id>
-    <link href="http://www.zotero.org/styles/harvard-international-journal-of-geriatric-psychiatry" rel="self"/>
+    <title>International Journal of Geriatric Psychiatry</title>
+    <id>http://www.zotero.org/styles/international-journal-of-geriatric-psychiatry</id>
+    <link href="http://www.zotero.org/styles/international-journal-of-geriatric-psychiatry" rel="self"/>
+    <link href="http://www.zotero.org/styles/harvard-university-of-wolverhampton" rel="template"/>
     <link href="http://onlinelibrary.wiley.com/journal/10.1002/%28ISSN%291099-1166/homepage/ForAuthors.html" rel="documentation"/>
     <author>
       <name>Amit Parekh</name>
@@ -15,7 +16,9 @@
       <email>vincent.demaurex@chuv.ch</email>
     </contributor>
     <category citation-format="author-date"/>
-    <category field="generic-base"/>
+    <category field="medicine"/>
+    <issn>0885-6230</issn>
+    <eissn>1099-1166</eissn>
     <summary>Harvard (author-date style) for International Journal of Geriatric Psychiatry</summary>
     <updated>2013-12-18T13:12:00+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>


### PR DESCRIPTION
Style based on the "Harvard - University of Wolverhampton" style. Modified to correspond to the author guidelines of "International Journal of Geriatric Psychiatry" (http://onlinelibrary.wiley.com/journal/10.1002/%28ISSN%291099-1166/homepage/ForAuthors.html).
