### PR TITLE
Update universite-de-liege-histoire.csl

### DIFF
--- a/universite-de-liege-histoire.csl
+++ b/universite-de-liege-histoire.csl
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<style xmlns="http://purl.org/net/xbiblio/csl" class="note" default-locale="fr-FR" version="1.0" page-range-format="expanded">
+<style xmlns="http://purl.org/net/xbiblio/csl" class="note" default-locale="fr-FR" version="1.0" page-range-format="expanded" demote-non-dropping-particle="never">
   <info>
     <title>Université de Liège - Histoire (French)</title>
     <title-short>ULg</title-short>


### PR DESCRIPTION
Setting demote-non-dropping-particle="never", as required by Flemish Authors names sorting rules.
