### PR TITLE
added jats.csl style

### DIFF
--- a/jats.csl
+++ b/jats.csl
@@ -4,8 +4,8 @@
   <info>
     <title>Journal Article Tag Suite</title>
     <title-short>JATS</title-short>
-    <id>http://www.zotero.org/styles/jats</id>
-    <link href="http://www.zotero.org/styles/jats" rel="self"/>
+    <id>http://www.zotero.org/styles/journal-article-tag-suite</id>
+    <link href="http://www.zotero.org/styles/journal-article-tag-suite" rel="self"/>
     <link rel="documentation" href="http://jats.nlm.nih.gov/archiving/tag-library/1.0/index.html"/>
     <author>
       <name>Martin Fenner</name>
@@ -15,7 +15,7 @@
     <category field="medicine"/>
     <category field="biology"/>
     <summary>Use this style to generate bibliographic data in Journal Article Tagging Suite (JATS) 1.0 XML format</summary>
-    <updated>2013-12-26T14:01:31+00:00</updated>
+    <updated>2013-12-26T15:25:12+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale xml:lang="en">
@@ -50,25 +50,13 @@
   </macro>
   <macro name="title">
     <text variable="title"/>
-    <choose>
-      <if type="article-journal article-magazine chapter paper-conference article-newspaper" match="none">
-        <text macro="edition"/>
-      </if>
-    </choose>
-    <choose>
-      <if type="thesis">
-        <text variable="genre" prefix=" [" suffix="]"/>
-      </if>
-    </choose>
   </macro>
   <macro name="container-title">
     <text variable="container-title" form="short" prefix="&lt;source&gt;" suffix="&lt;/source&gt;"/>
   </macro>
   <macro name="publisher">
-    <group>
-      <text variable="publisher" prefix="&lt;publisher-name&gt;" suffix="&lt;/publisher-name&gt;"/>
-      <text variable="publisher-place" prefix="&lt;publisher-loc&gt;" suffix="&lt;/publisher-loc&gt;"/>
-    </group>
+    <text variable="publisher" prefix="&lt;publisher-name&gt;" suffix="&lt;/publisher-name&gt;"/>
+    <text variable="publisher-place" prefix="&lt;publisher-loc&gt;" suffix="&lt;/publisher-loc&gt;"/>
   </macro>
   <macro name="link">
     <choose>


### PR DESCRIPTION
Added new jats.csl style. This style generates XML in the JATS XML format, used by PubMed Central and many publishers. Citations are formatted as `<xref ref-type="bibr">`, the bibliography as nested `<ref>` and  `<element-citation>` elements.
