### PR TITLE
Create universitat-bremen-institut-fur-politikwissenschaft.csl

### DIFF
--- a/universitat-bremen-institut-fur-politikwissenschaft.csl
+++ b/universitat-bremen-institut-fur-politikwissenschaft.csl
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" demote-non-dropping-particle="sort-only" default-locale="de-DE">
   <info>
-    <title>Universität Bremen Institut für Politikwissenschaft</title>
+    <title>Universität Bremen - Institut für Politikwissenschaft</title>
     <title-short>IfP Uni Bremen</title-short>
     <id>http://www.zotero.org/styles/universitat-bremen-institut-fur-politikwissenschaft</id>
     <link href="http://www.zotero.org/styles/universitat-bremen-institut-fur-politikwissenschaft" rel="self"/>
@@ -13,7 +13,6 @@
       <email>jkoepff@uni-bremen.de</email>
     </contributor>
     <category citation-format="author-date"/>
-    <category field="generic-base"/>
     <category field="political_science"/>
     <category field="social_science"/>
     <summary>Universität Bremen - Institut für Politikwissenschaft (German) - A Harvard author-date style variant as used for Political Science at University of Bremen, Germany. The in-text citation style is changed to [author year: page], avoiding the abbreviation for pages (S.) and changing the delimiters. Based on Harvard - Institut fuer Praxisforschung (Bahr &amp; Frackmann) style by Jonas Bahr and Malte Frackmann.</summary>
@@ -42,6 +41,9 @@
         </names>
       </else>
     </choose>
+  </macro>
+  <macro name="anon">
+    <text term="anonymous" form="short"/>
   </macro>
   <macro name="author">
     <names variable="author" delimiter="/">


### PR DESCRIPTION
I started from harvard-institut-fur-praxisforschung-de style by Jonas Bahr and Malte Frackmann and adapted it to the requirements of Institut für Politikwissenschaft (Institute for Political Science) at University of Bremen, Germany. Some of the changes are
- using text-case="title" for nearly all important types of documents
- changing delimiters between authors from ; to /
- discarding quotation marks for titles
- using full author names in bibliography
- setting container name in italic only for journals and newspapers
- adding spechial features for documents with URL like documents and speeches
- modifying the "access" macro in order to state the access more precisely
- avoiding apperance of doi, abbreviation of pages (S.) and name of series in the bibliography
