### PR TITLE
Update to name reflecting age of style

### DIFF
--- a/harvard-university-of-leeds.csl
+++ b/harvard-university-of-leeds.csl
@@ -1,19 +1,23 @@
 <?xml version="1.0" encoding="utf-8"?>
 <style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" demote-non-dropping-particle="sort-only" default-locale="en-GB">
-  <!-- This style was edited with the Visual CSL Editor (http://steveridout.com/csl/visualEditor/) -->
+<!-- This style was edited with the Visual CSL Editor (http://editor.citationstyles.org/visualEditor/) -->
   <info>
-    <title>Harvard - University of Leeds</title>
+    <title>Harvard - University of Leeds (OLD VERSION - pre August 2013)</title>
     <id>http://www.zotero.org/styles/harvard-university-of-leeds</id>
     <link href="http://www.zotero.org/styles/harvard-university-of-leeds" rel="self"/>
-    <link href="http://library.leeds.ac.uk/info/311/referencing" rel="documentation"/>
+    <link href="http://library.leeds.ac.uk/skills-referencing" rel="documentation"/>
     <author>
       <name>Julian Onions</name>
       <email>julian.onions@gmail.com</email>
     </author>
+    <contributor>
+      <name>John Salter</name>
+      <email>j.salter@leeds.ac.uk</email>
+    </contributor>
     <category citation-format="author-date"/>
     <category field="generic-base"/>
     <summary>The Harvard author-date style</summary>
-    <updated>2012-09-10T23:03:13+00:00</updated>
+    <updated>2014-01-21T16:13:00+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <macro name="editor">


### PR DESCRIPTION
The University of Leeds has amended it's Harvard style. Students using this style via e.g. Mendeley need to be aware that the style is out of date.
Hopefully I'll get a chance to look at what we changed in August 2013 and add an up-to-date CSL at some point.
