### PR TITLE
Added SPIE-conf-paper.csl for 2014 bibliography

### DIFF
--- a/spie-proceedings.csl
+++ b/spie-proceedings.csl
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" default-locale="en-US" version="1.0" demote-non-dropping-particle="sort-only" page-range-format="expanded">
   <info>
-    <title>SPIE Conference Papers</title>
+    <title>SPIE Conference Proceedings</title>
     <id>http://www.zotero.org/styles/spie-proceedings</id>
     <link href="http://www.zotero.org/styles/spie-proceedings" rel="self"/>
     <link href="http://spie.org/x14101.xml" rel="documentation"/>


### PR DESCRIPTION
The bibliography format differs considerably from the usual SPIE journals to permit SPIE to automatically generate linked bibliography entries.
