### PR TITLE
Update universitat-bremen-institut-fur-politikwissenschaft.csl

### DIFF
--- a/universitat-bremen-institut-fur-politikwissenschaft.csl
+++ b/universitat-bremen-institut-fur-politikwissenschaft.csl
@@ -227,8 +227,8 @@
   <bibliography hanging-indent="false" et-al-min="10" et-al-use-first="10">
     <sort>
       <key macro="author"/>
-      <key variable="title"/>
       <key variable="issued"/>
+      <key variable="title"/>
     </sort>
     <layout>
       <group delimiter=" " suffix=".">


### PR DESCRIPTION
Changed sort order in bibliography from author-title-issued to author-issued-title after complaints from Universität Bremen
