### PR TITLE
redesign of inline citations

### DIFF
--- a/sociology-of-health-and-illness.csl
+++ b/sociology-of-health-and-illness.csl
@@ -172,8 +172,8 @@
         <text variable="locator"/>
       </group>
     </layout>
-   </citation>
-  <bibliography initialize-with="." hanging-indent="true">
+  </citation>
+  <bibliography initialize-with="." hanging-indent="true" line-spacing="2">
     <sort>
       <key macro="author"/>
       <key variable="year-suffix"/>


### PR DESCRIPTION
In the previous version there were some differences to the preferred inline citation style by the journal. Locator pp is not needed, delimeter has been changed, and sorting for inline citations has been included
