### PR TITLE
Correct extraneous trailing periods and spaces

### DIFF
--- a/systematic-biology.csl
+++ b/systematic-biology.csl
@@ -69,23 +69,23 @@
       <choose>
         <if type="book">
           <text variable="publisher-place" suffix=": "/>
-          <text variable="publisher" suffix="."/>
+          <text variable="publisher"/>
         </if>
         <else-if type="chapter">
           <text macro="editor"/>
           <text variable="container-title" suffix=". "/>
           <text variable="publisher-place" suffix=": "/>
           <text variable="publisher" suffix="."/>
-          <text variable="page" prefix=" p. " suffix="."/>
+          <text variable="page" prefix=" p. "/>
         </else-if>
         <else-if type="webpage">
-          <text variable="URL" prefix="Available from " suffix="."/>
+          <text variable="URL" prefix="Available from "/>
         </else-if>
         <else>
           <group suffix=".">
             <text variable="container-title" suffix="." form="short"/>
             <text variable="volume" prefix=" "/>
-            <text variable="page" prefix=":" suffix="."/>
+            <text variable="page" prefix=":"/>
           </group>
         </else>
       </choose>


### PR DESCRIPTION
The `<layout/>` already specifies `suffix="."` and thus for the consecutive periods to get collapsed into one period the periods must not be followed by trailing spaces.
