### PR TITLE
Author Initials and Author name list changes to bring the style consistent with the most recently OU referencing guide

### DIFF
--- a/the-open-university-harvard.csl
+++ b/the-open-university-harvard.csl
@@ -149,7 +149,7 @@
       </group>
     </layout>
   </citation>
-  <bibliography hanging-indent="true" et-al-min="6" et-al-use-first="4">
+  <bibliography hanging-indent="true">
     <sort>
       <key macro="author"/>
       <key variable="title"/>


### PR DESCRIPTION
It was recently pointed out by my tutor that the "the-open-university-harvard" style is generating author names inconsistently, e.g. depending on whether the author name is given as published already initialized or not. The OU Harvard referencing guide consistently abbreviates first names to initials when displayed in bibliography format, so this commit adds the "initialize-with" to make that consistent as suggested in the OU examples.

The most recent OU Harvard referencing guide also specifies that in the bibliography the author's names should be given in full;
"... in the reference list or bibliography you would list each author in full as follows:
Jones, R., Andrew, T. and MacColl, J. (2006) The Institutional Repository, Oxford, Chandos Publishing."
http://www.open.ac.uk/libraryservices/documents/Harvard_citation_hlp.pdf
