### PR TITLE
Update and rename vancouver.csl to vancouver_RSP_2014.csl

### DIFF
--- a/vancouver_RSP_2014.csl
+++ b/vancouver_RSP_2014.csl
@@ -258,7 +258,7 @@
     <sort>
       <key variable="citation-number"/>
     </sort>
-    <layout prefix="(" suffix=")" delimiter=",">
+    <layout vertical-align="sup" delimiter=",">
       <text variable="citation-number"/>
     </layout>
   </citation>


### PR DESCRIPTION
Citation to Revista de Saúde Pública da USP - Health Public Journal (USP)
