### PR TITLE
Czech localization improvements for ISO 690 styles

### DIFF
--- a/iso690-author-date-cs.csl
+++ b/iso690-author-date-cs.csl
@@ -20,9 +20,10 @@
     <updated>2012-09-27T22:06:38+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
-  <locale>
+  <locale xml:lang="cs">
     <terms>
       <term name="from">z</term>
+      <term name="et-al">a kol.</term>
     </terms>
   </locale>
   <macro name="author">

--- a/iso690-note-cs.csl
+++ b/iso690-note-cs.csl
@@ -19,9 +19,10 @@
     <updated>2013-06-06T17:20:00+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
-  <locale>
+  <locale xml:lang="cs">
     <terms>
       <term name="from">z</term>
+      <term name="et-al">a kol.</term>
     </terms>
   </locale>
   <macro name="author">

--- a/iso690-numeric-brackets-cs.csl
+++ b/iso690-numeric-brackets-cs.csl
@@ -20,9 +20,10 @@
     <updated>2013-04-15T18:07:00+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
-  <locale>
+  <locale xml:lang="cs">
     <terms>
       <term name="from">z</term>
+      <term name="et-al">a kol.</term>
     </terms>
   </locale>
   <macro name="author">

--- a/iso690-numeric-cs.csl
+++ b/iso690-numeric-cs.csl
@@ -20,9 +20,10 @@
     <updated>2012-12-05T15:44:38+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
-  <locale>
+  <locale xml:lang="cs">
     <terms>
       <term name="from">z</term>
+      <term name="et-al">a kol.</term>
     </terms>
   </locale>
   <macro name="author">


### PR DESCRIPTION
1.) Localization should be applied just for Czech language
2.) Adding Czech translation for "et al"
