### PR TITLE
Update arthritis-and-rheumatism.csl

### DIFF
--- a/arthritis-and-rheumatism.csl
+++ b/arthritis-and-rheumatism.csl
@@ -118,7 +118,7 @@
     <sort>
       <key variable="citation-number"/>
     </sort>
-    <layout delimiter="," vertical-align="sup">
+    <layout delimiter="," prefix=" (" suffix=")">
       <text variable="citation-number"/>
       <group prefix="(" suffix=")">
         <label variable="locator" form="short" strip-periods="true"/>


### PR DESCRIPTION
According to the citation layout currently used by the journal "Arthritis and Rheumatism", the inlice citations are not superscript and  parenthesize.

The old style listed citations as ² , but it should be cited this way (2). This modification fixes it.
