### PR TITLE
Update revue-francaise-de-sociologie.csl

### DIFF
--- a/revue-francaise-de-sociologie.csl
+++ b/revue-francaise-de-sociologie.csl
@@ -29,7 +29,7 @@
   </locale>
   <macro name="editor">
     <names variable="editor" delimiter=" ">
-      <name and="text" delimiter=", " delimiter-precedes-last="always"/>
+      <name name-as-sort-order="all" sort-separator=" " delimiter=", " delimiter-precedes-last="always" initialize-with="." font-variant="small-caps"/>
       <label form="short" prefix=" (" suffix=")" text-case="lowercase"/>
       <substitute>
         <names variable="editorial-director"/>
@@ -143,10 +143,6 @@
       </else>
     </choose>
   </macro>
-  <macro name="issue">
-    <text variable="volume" font-style="italic" suffix=", "/>
-    <text variable="issue"/>
-  </macro>
   <macro name="citation-locator">
     <group>
       <label variable="locator" form="short" suffix=".&#160;"/>
@@ -191,13 +187,14 @@
       </group>
       <choose>
         <if type="report">
-          <text variable="title" quotes="true" prefix=", "/>
-          <group prefix=", ">
+          <group delimiter=", ">
+            <text variable="title" quotes="true"/>
             <text variable="genre"/>
-            <text variable="collection-title" prefix=", "/>
-            <text variable="number" prefix=" n°"/>
+            <text variable="collection-title" font-style="italic"/>
+            <text variable="number"/>
+            <text variable="publisher-place"/>
+            <text variable="publisher"/>
           </group>
-          <text macro="publisher-collection"/>
         </if>
         <else-if type="book">
           <group delimiter=", ">
@@ -261,11 +258,13 @@
           </group>
           <group prefix=" " delimiter=", ">
             <text variable="container-title" font-style="italic"/>
-            <text macro="issue"/>
+            <text variable="volume" font-style="italic"/>
+            <text variable="issue"/>
             <text macro="page"/>
           </group>
         </else>
       </choose>
+      <text variable="note" prefix=", "/>
     </layout>
   </bibliography>
 </style>


### PR DESCRIPTION
- Fix editors names not using the same convention as authors names.
- Fix an issue with reports where collection title was duplicated.
- Display note (Extra) if present.

About the last point, I'm not sure that's the correct way of handling this. My goal is in particular to allow referencing R packages this way:
Bouchet-Valat M., 2012, logmult: Log-multiplicative models, including association models, R package version 0.5.
(with "R package version 0.5." being in the Extra field)
