### PR TITLE
Update economie-et-statistique.csl

### DIFF
--- a/economie-et-statistique.csl
+++ b/economie-et-statistique.csl
@@ -231,8 +231,8 @@
               <text variable="publisher-place"/>
               <text variable="publisher"/>
               <text variable="collection-title"/>
-              <text macro="page"/>
             </group>
+            <text macro="page"/>
           </group>
         </else-if>
         <else-if type="speech">
@@ -263,6 +263,7 @@
           </group>
         </else>
       </choose>
+      <text variable="note" prefix=", "/>
     </layout>
   </bibliography>
 </style>


### PR DESCRIPTION
- Fix double comma before page indication for chapters.
- Display note (Extra) if present.

See https://github.com/citation-style-language/styles/pull/847 about last point.
