### PR TITLE
Update economie-et-statistique.csl

### DIFF
--- a/economie-et-statistique.csl
+++ b/economie-et-statistique.csl
@@ -200,6 +200,11 @@
             <text variable="publisher-place"/>
             <text variable="publisher"/>
             <text variable="collection-title"/>
+            <text variable="medium"/>
+            <group delimiter=" ">
+              <text term="version"/>
+              <text variable="version"/>
+            </group>
             <text macro="number-of-pages"/>
           </group>
         </else-if>
@@ -231,8 +236,8 @@
               <text variable="publisher-place"/>
               <text variable="publisher"/>
               <text variable="collection-title"/>
-              <text macro="page"/>
             </group>
+            <text macro="page"/>
           </group>
         </else-if>
         <else-if type="speech">


### PR DESCRIPTION
- Fix double comma before page indication for chapters.
- Display software system (medium in CSL) and version if present.
