### PR TITLE
Change DOI prefix to "http://dx.doi.org/".

### DIFF
--- a/modern-humanities-research-association.csl
+++ b/modern-humanities-research-association.csl
@@ -374,7 +374,7 @@
     </group>
     <choose>
       <if variable="DOI">
-        <text variable="DOI" prefix=" &lt;doi:" suffix="&gt;"/>
+        <text variable="DOI" prefix=" &lt;http://dx.doi.org/" suffix="&gt;"/>
       </if>
       <else>
         <choose>


### PR DESCRIPTION
Per §11.2.12 in the MHRA Style Guide. A bit silly, yes, but it's what they ask for.
