### PR TITLE
Update harvard-university-of-leeds.csl

### DIFF
--- a/harvard-university-of-leeds.csl
+++ b/harvard-university-of-leeds.csl
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" demote-non-dropping-particle="sort-only" default-locale="en-GB">
-  <!-- This style was edited with the Visual CSL Editor (http://editor.citationstyles.org/visualEditor/) -->
+<!-- This style was edited with the Visual CSL Editor (http://editor.citationstyles.org/visualEditor/) -->
   <info>
-    <title>Harvard - University of Leeds (OLD VERSION - pre August 2013)</title>
+    <title>Harvard - University of Leeds (New version- post August 2013)</title>
     <id>http://www.zotero.org/styles/harvard-university-of-leeds</id>
     <link href="http://www.zotero.org/styles/harvard-university-of-leeds" rel="self"/>
     <link href="http://library.leeds.ac.uk/skills-referencing" rel="documentation"/>
@@ -14,10 +14,14 @@
       <name>John Salter</name>
       <email>j.salter@leeds.ac.uk</email>
     </contributor>
+	<contributor>
+      <name>Paul Bramley</name>
+      <email>paul.e.bramley@googlemail.com</email>
+    </contributor>
     <category citation-format="author-date"/>
     <category field="generic-base"/>
     <summary>The Harvard author-date style</summary>
-    <updated>2014-01-21T16:13:00+00:00</updated>
+    <updated>2014-03-02T17:09:17+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <macro name="editor">
@@ -31,8 +35,8 @@
   </macro>
   <macro name="author">
     <names variable="author">
-      <name and="text" delimiter-precedes-last="never" initialize-with="." name-as-sort-order="first">
-        <name-part name="family" text-case="uppercase"/>
+      <name and="text" delimiter-precedes-last="never" et-al-min="3" initialize-with="." name-as-sort-order="all">
+        <name-part name="family" text-case="capitalize-first"/>
       </name>
       <label form="short" prefix=" (" suffix=")."/>
       <substitute>
@@ -43,7 +47,7 @@
   </macro>
   <macro name="author-short">
     <names variable="author">
-      <name form="short" and="symbol" delimiter=", " delimiter-precedes-last="never" initialize-with="."/>
+      <name form="short" and="symbol" delimiter-precedes-last="never" et-al-min="3" initialize-with="."/>
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>


### PR DESCRIPTION
Updated the style to reflect changes found here http://library.leeds.ac.uk/news/article/98/changes_to_referencing_styles

Changed name to reflect that it is the new version. Changed id and link tag to remove reference to 'Old Version' to file name.

Added self as contributor.
