### PR TITLE
add DOI to Elsevier Harvar and Elsevier (with titles)

### DIFF
--- a/elsevier-harvard.csl
+++ b/elsevier-harvard.csl
@@ -91,7 +91,10 @@
   </macro>
   <macro name="access">
     <choose>
-      <if type="webpage">
+      <if variable="DOI">
+        <text variable="DOI" prefix="doi:"/>
+      </if>
+      <else-if type="webpage">
         <group delimiter=" ">
           <text value="URL"/>
           <text variable="URL"/>
@@ -104,7 +107,7 @@
             </date>
           </group>
         </group>
-      </if>
+      </else-if>
     </choose>
   </macro>
   <macro name="title">

--- a/elsevier-with-titles.csl
+++ b/elsevier-with-titles.csl
@@ -125,6 +125,7 @@
           </group>
         </else>
       </choose>
+      <text variable="DOI" prefix=". doi:"/>
     </layout>
   </bibliography>
 </style>


### PR DESCRIPTION
That's the two styles where the DOI is consistently encouraged in the instructions for authors. @rmzelle @cpina - could you take a quick look whether that's OK? This looks to be the format that the .bst style does this
