### PR TITLE
Update le-tapuscrit-note.csl

### DIFF
--- a/le-tapuscrit-note.csl
+++ b/le-tapuscrit-note.csl
@@ -251,12 +251,8 @@
         <date variable="issued">
           <date-part name="day" suffix=" "/>
           <date-part name="month" form="short" suffix=" "/>
-          <date-part name="year"/>
+          <date-part name="year" suffix=", "/>
         </date>
-        <group delimiter=" " font-style="normal">
-          <label variable="page" form="short"/>
-          <text variable="page"/>
-        </group>
         <group delimiter=" " font-style="normal">
           <choose>
             <if variable="locator" match="any">
@@ -331,7 +327,7 @@
           <date variable="issued">
             <date-part name="day" suffix=" "/>
             <date-part name="month" form="short" suffix=" "/>
-            <date-part name="year"/>
+            <date-part name="year" suffix=", "/>
           </date>
           <label variable="page" form="short"/>
           <text variable="page"/>


### PR DESCRIPTION
Correction d'un problème avec les citations d'articles de journaux. La page cité n'était pas séparée de la date par une virgule et c'était les pages auxquelles se trouvent l'article qui apparaissaient. Il manquait aussi la virgule en bibliographie.
