### PR TITLE
Update studia-bas.csl

### DIFF
--- a/studia-bas.csl
+++ b/studia-bas.csl
@@ -3,8 +3,8 @@
 <!-- This style was edited with the Visual CSL Editor (http://editor.citationstyles.org/visualEditor/) -->
   <info>
     <title>Studia BAS (Polish)</title>
-    <id>http://www.zotero.org/styles/studia-bas-polish</id>
-    <link href="http://www.zotero.org/styles/studia-bas-polish" rel="self"/>
+    <id>http://www.zotero.org/styles/studia-bas</id>
+    <link href="http://www.zotero.org/styles/studia-bas" rel="self"/>
     <link href="http://www.zotero.org/styles/polish-legal" rel="template"/>
     <link href="http://orka.sejm.gov.pl/WydBAS.nsf/PDF/Studia-wsk/$File/StudiaBAS_wskazowki_dla_autorow.pdf" rel="documentation"/>
     <author>
@@ -16,7 +16,7 @@
     <category field="political_science"/>
     <issn>2080-2404</issn>
     <eissn>2082-0658</eissn>
-    <summary>A style for Bureau of Research &quot;Studia BAS&quot; journal citation</summary>
+    <summary>A style for Bureau of Research "Studia BAS" journal citation</summary>
     <updated>2014-02-14T06:55:13+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>


### PR DESCRIPTION
- bugfix: remove double displaying publisher (book category)
- change: no more displaying "nr" and "t." prefixes when missing number or volume fields (article-journal category)
- change: full date display when "number" field is missing and only year display when "number" field is present (article-journal category)
