### PR TITLE
Create frontiers-medical-journals.csl

### DIFF
--- a/frontiers-medical-journals.csl
+++ b/frontiers-medical-journals.csl
@@ -1,0 +1,149 @@
+<?xml version="1.0" encoding="utf-8"?>
+<style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" demote-non-dropping-particle="sort-only" default-locale="en-US">
+  <!-- The 'Frontiers in...' series of medical journals use different citation and bibliography styles 
+       than the 'Frontiers in...' series of science and engineering journals. -->
+  <info>
+    <title>Frontiers medical journals</title>
+    <id>http://www.zotero.org/styles/frontiers-medical-journals</id>
+    <link href="http://www.zotero.org/styles/frontiers-medical-journals" rel="self"/>
+    <link href="http://www.frontiersin.org/about/AuthorGuidelines#References" rel="documentation"/>
+    <author>
+      <name>Chris Forden</name>
+      <email>cforden@comcast.net</email>
+    </author>
+    <link href="http://www.zotero.org/styles/frontiers" rel="template"/>
+    <category citation-format="numeric"/>
+    <category field="medicine"/>
+    <summary>Style for the Open Access Frontiers in ... Journals</summary>
+    <updated>2014-03-11T04:32:07+00:00</updated>
+    <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
+  </info>
+  <macro name="editor">
+    <names variable="editor" delimiter=", ">
+      <label form="short" prefix=", "/>
+      <name and="text" initialize-with=". " delimiter=", " prefix=" "/>
+    </names>
+  </macro>
+  <macro name="author">
+    <names variable="author">
+      <name name-as-sort-order="all" and="text" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
+      <label form="short" prefix=" "/>
+      <substitute>
+        <names variable="editor"/>
+        <text variable="title"/>
+      </substitute>
+    </names>
+  </macro>
+  <macro name="author-short">
+    <names variable="author">
+      <name form="short" and="text" delimiter=", " initialize-with=". "/>
+      <substitute>
+        <names variable="editor"/>
+        <names variable="translator"/>
+        <text variable="title"/>
+      </substitute>
+    </names>
+  </macro>
+  <macro name="access">
+    <choose>
+      <if variable="DOI">
+        <text variable="DOI" prefix="doi:"/>
+      </if>
+      <else-if variable="URL">
+        <text value="Available at:" suffix=" "/>
+        <text variable="URL"/>
+        <group prefix=" [" suffix="]">
+          <text term="accessed" text-case="capitalize-first" suffix=" "/>
+          <date variable="accessed">
+            <date-part name="month" suffix=" "/>
+            <date-part name="day" suffix=", "/>
+            <date-part name="year"/>
+          </date>
+        </group>
+      </else-if>
+    </choose>
+  </macro>
+  <macro name="title">
+    <choose>
+      <if type="book">
+        <text variable="title" font-style="italic" suffix="."/>
+      </if>
+      <else-if type="chapter">
+        <text variable="title" quotes="true" suffix=","/>
+      </else-if>
+      <else>
+        <text variable="title" suffix="."/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="publisher">
+    <group delimiter=": ">
+      <text variable="publisher-place"/>
+      <text variable="publisher"/>
+    </group>
+  </macro>
+  <macro name="edition">
+    <choose>
+      <if is-numeric="edition">
+        <group delimiter=" ">
+          <number variable="edition" form="ordinal"/>
+          <text term="edition" form="short"/>
+        </group>
+      </if>
+      <else>
+        <text variable="edition" suffix="."/>
+      </else>
+    </choose>
+  </macro>
+  <citation collapse="citation-number">
+    <sort>
+      <key variable="citation-number"/>
+    </sort>
+    <layout prefix="(" suffix=")" delimiter=",">
+      <text variable="citation-number"/>
+    </layout>
+  </citation>
+  <bibliography et-al-min="11" et-al-use-first="10" second-field-align="flush">
+    <layout>
+      <text variable="citation-number" suffix=". "/>
+      <text macro="author"/>
+      <choose>
+        <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
+          <group delimiter=" " prefix=" ">
+            <text macro="title"/>
+            <text macro="edition"/>
+            <text macro="editor"/>
+            <text macro="publisher"/>
+          </group>
+        </if>
+        <else-if type="chapter paper-conference" match="any">
+          <group delimiter=" " prefix=" ">
+            <text macro="title"/>
+            <text term="in"/>
+            <text variable="container-title" font-style="italic"/>
+            <text variable="collection-title" suffix="."/>
+          </group>
+          <text macro="editor"/>
+          <group suffix=".">
+            <text macro="publisher" prefix=" (" suffix=")"/>
+            <group prefix=", ">
+              <text variable="page"/>
+            </group>
+          </group>
+        </else-if>
+        <else>
+          <text macro="title" prefix=" " suffix="."/>
+          <group delimiter=" " prefix=" ">
+            <text variable="container-title" form="short" strip-periods="true" font-style="italic"/>
+            <date variable="issued" prefix=" (" suffix=")">
+              <date-part name="year"/>
+            </date>
+            <text variable="volume" font-weight="bold" suffix=":"/>
+          </group>
+          <text variable="page" suffix="."/>
+        </else>
+      </choose>
+      <text prefix=" " macro="access"/>
+    </layout>
+  </bibliography>
+</style>


### PR DESCRIPTION
The 'Frontiers in' series of journals has two different citation styles and two different bibliography styles.  One set of styles is for journals in the fields of science and engineering, the other set of styles is for journals in the field of medicine.  These two sets of styles are documented at http://www.frontiersin.org/about/AuthorGuidelines#References .

Previous contributors created .csl files for all the 'Frontiers in' series of journals, but they applied science and engineering rules to all of the journals, even the medical journals.  Since I want to publish in Frontiers in Immunology, I was disheartened to find that a new style needed to be created. 

I have created an appropriate .csl file, using http://www.zotero.org/styles/frontiers as my template.  My new file is frontiers-medical-journals.csl.  It is, like its template, designed to be used as a base for other styles.  For now I am using it as my selected style in my document; it seems to work well with Word and Zotero.  After you accept it, I recommend that someone change all the styles for all the 'Frontiers in' medical journals to use this new style as their base.  If you want, I will do that.  (Although if you preferred to have someone else do that, I would be more than happy to let you or someone else take care of that task.)

There remains an interesting design question about the inheritance tree for 'Frontiers in' journals.  In frontiers-medical-journals.csl, I have created a peer of frontiers.csl, that duplicates the old code by copy-and-paste.  Maybe there should be a base for all 'Frontiers in' journals, then two derived styles, frontiers.csl for science and engineering, and my new one for medicine.  This alternative approach would eliminate xml code duplication, but take more work, and add a layer to the hierarchy.  I don't even know if the csl language and infrastructure would allow an additional layer.

I don't know whether I can even test a frontiers-in-medicine.csl as a parent yet until you accept and post it so it, because frontiers-in-immunology would refer to a non-existent URL as a parent.  Therefore I have not tested frontiers-in-medicine.csl as a parent yet.

Note that there is no journal named Frontiers in Medicine; I deliberately chose an unused journal-name for this new parent file.

Chris Forden
cforden at-sigil comcast.net
