### PR TITLE
Update frontiers-medical-journals.csl

### DIFF
--- a/frontiers-medical-journals.csl
+++ b/frontiers-medical-journals.csl
@@ -21,12 +21,12 @@
   <macro name="editor">
     <names variable="editor" delimiter=", ">
       <label form="short" prefix=", "/>
-      <name and="text" initialize-with=". " delimiter=", " prefix=" "/>
+      <name initialize-with=". " delimiter=", " prefix=" "/>
     </names>
   </macro>
   <macro name="author">
     <names variable="author">
-      <name name-as-sort-order="all" and="text" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
+      <name name-as-sort-order="all" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
       <label form="short" prefix=" "/>
       <substitute>
         <names variable="editor"/>
@@ -36,7 +36,7 @@
   </macro>
   <macro name="author-short">
     <names variable="author">
-      <name form="short" and="text" delimiter=", " initialize-with=". "/>
+      <name form="short" delimiter=", " initialize-with=". "/>
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
@@ -114,6 +114,9 @@
             <text macro="edition"/>
             <text macro="editor"/>
             <text macro="publisher"/>
+            <date variable="issued" prefix=" (" suffix=").">
+              <date-part name="year"/>
+            </date>
           </group>
         </if>
         <else-if type="chapter paper-conference" match="any">


### PR DESCRIPTION
Added Year to bibliographic entries for type Book (and many other types).  Removed "and" before last author or editor.

Concerning periods following author initials: note that real, published articles violate the official spec; author initials are specified by example as having trailing periods, but real articles published in these journals omit those periods.  This commit follows the official spec; I believe I should contact the editors, have them update their spec to match actual practice, and then update frontiers-medical-journals.csl, and maybe frontiers.csl.
