### PR TITLE
Create frontiers-in-immunology.csl

### DIFF
--- a/frontiers-in-immunology.csl
+++ b/frontiers-in-immunology.csl
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<style xmlns="http://purl.org/net/xbiblio/csl" version="1.0" default-locale="en-US">
+  <!-- Generated with https://github.com/citation-style-language/utilities/tree/master/generate_dependent_styles -->
+  <info>
+    <!-- Specialty journal of the "parent" field journal 'Frontiers in Immunology' -->
+    <title>Frontiers in Immunology</title>
+    <id>http://www.zotero.org/styles/frontiers-in-immunology</id>
+    <link href="http://www.zotero.org/styles/frontiers-in-immunology" rel="self"/>
+    <link href="http://www.zotero.org/styles/frontiers-medical-journals" rel="independent-parent"/>
+    <link href="http://www.frontiersin.org/about/AuthorGuidelines" rel="documentation"/>
+    <category citation-format="author-date"/>
+    <category field="biology"/>
+    <category field="medicine"/>
+    <eissn>1664-3224</eissn>
+    <updated>2013-03-29T23:50:45+00:00</updated>
+    <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
+  </info>
+</style>


### PR DESCRIPTION
This is an update from the existing http://zotero.org/styles/frontiers-in-immunology ; I have switched the parent to the new frontiers-medical-journals.csl because this and many other 'Frontiers-in' journals take styles different from 'Frontiers-in' science and engineering journals.  I made this change manually, but after this is proven OK, I plan to use utilities/generate_dependent_styles/generate_styles_from_data.rb to create updates for the other medical journals in the 'Frontiers in' series.  That will seriously increase the number of files in https://github.com/citation-style-language/styles/ .  But that is the plan, right?
