### PR TITLE
Update frontiers-medical-journals.csl

### DIFF
--- a/frontiers-medical-journals.csl
+++ b/frontiers-medical-journals.csl
@@ -1,21 +1,22 @@
 <?xml version="1.0" encoding="utf-8"?>
 <style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" demote-non-dropping-particle="sort-only" default-locale="en-US">
-  <!-- The 'Frontiers in...' series of medical journals use different citation and bibliography styles 
-       than the 'Frontiers in...' series of science and engineering journals. -->
+<!-- This style was edited with the Visual CSL Editor (http://editor.citationstyles.org/visualEditor/) -->
   <info>
     <title>Frontiers medical journals</title>
     <id>http://www.zotero.org/styles/frontiers-medical-journals</id>
+    <!-- The 'Frontiers in...' series of medical (now called "Health" journals use different citation and bibliography styles 
+         than the 'Frontiers in...' series of engineering and science (except Physics) journals. -->
     <link href="http://www.zotero.org/styles/frontiers-medical-journals" rel="self"/>
+    <link href="http://www.zotero.org/styles/frontiers" rel="template"/>
     <link href="http://www.frontiersin.org/about/AuthorGuidelines#References" rel="documentation"/>
     <author>
       <name>Chris Forden</name>
       <email>cforden@comcast.net</email>
     </author>
-    <link href="http://www.zotero.org/styles/frontiers" rel="template"/>
     <category citation-format="numeric"/>
     <category field="medicine"/>
     <summary>Style for the Open Access Frontiers in ... Journals</summary>
-    <updated>2014-03-11T04:32:07+00:00</updated>
+    <updated>2014-03-22T17:19:39+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <macro name="editor">
@@ -26,7 +27,7 @@
   </macro>
   <macro name="author">
     <names variable="author">
-      <name name-as-sort-order="all" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
+      <name delimiter-precedes-last="always" initialize-with="" name-as-sort-order="all" sort-separator=" "/>
       <label form="short" prefix=" "/>
       <substitute>
         <names variable="editor"/>
@@ -106,7 +107,7 @@
   <bibliography et-al-min="11" et-al-use-first="10" second-field-align="flush">
     <layout>
       <text variable="citation-number" suffix=". "/>
-      <text macro="author"/>
+      <text macro="author" suffix="."/>
       <choose>
         <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
           <group delimiter=" " prefix=" ">


### PR DESCRIPTION
This updates what should become the parent of a large number of dependent styles for 'Frontiers in' journals.  This now appears to match actual practice.  

The previous version of this .csl file kept periods after each initial for an author in the bibliography.  The frontiersin.org editorial staff graciously updated their Manuscript Guidelines for authors so that it now matches their actual practice for Health and Physics journals, and omits punctuation and space between initials of one author's name.  This update follows those standards.  While retesting this file I noticed bibliographies for books omit the (US) state, keeping only the city name, in actual practice and as formatted by this .csl version, although the published guide (http://www.frontiersin.org/Immunology/authorguidelines#Medicine) shows both the state (at least if in the USA) and city of a book's publisher.  I do not intend to bother the Frontiers staff about that minor discrepancy.

An historical note, passed along from the Frontiers staff: they now refer to their medical journals as "Heath and Physics" journals.  (Frontiers Heath and Physics journals use different citation and bibliography styles than do Frontiers Engineering and Science journals.)  

After first proposing reducing the number of .csl files by only maintaining them for Frontiers journals rather than sections within journals, I figured out that there is a good theoretical reason for maintaining one file per section; sections can be parts of several journals simultaneously.  It may come to pass that there will be some section that is part of a Health journal and also part of an Engineering journal.  In that case it would be convenient to specify style by section not journal.

I am about to start a new 6+ months programming contract Monday.  I will have to postpone writing an Excel macro to convert the Frontiers spreadsheet categorizing their journals, into a citation-style-language / utilities/ ... /_journals.tab spreadsheet, probably for many months.  At least there is this up-to-date file people can use in the interim, however; this file works for me without a child .csl file.
