### PR TITLE
Universite-libre-de-Bruxelles-histoire

### DIFF
--- a/universite-libre-de-bruxelles-histoire.csl
+++ b/universite-libre-de-bruxelles-histoire.csl
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <style xmlns="http://purl.org/net/xbiblio/csl" class="note" default-locale="fr-FR" version="1.0" demote-non-dropping-particle="never">
   <info>
-    <title>Université libre de Bruxelles (histoire)</title>
+    <title>Université libre de Bruxelles - Histoire (French)</title>
 	<title-short>ULB-Hist</title-short>
-    <id>http://www.zotero.org/styles/Universite-libre-de-Bruxelles-histoire</id>
-    <link href="http://www.zotero.org/styles/Universite-libre-de-Bruxelles-histoire" rel="self"/>
+    <id>http://www.zotero.org/styles/universite-libre-de-bruxelles-histoire</id>
+    <link href="http://www.zotero.org/styles/universite-libre-de-bruxelles-histoire" rel="self"/>
 	<link href="http://www.zotero.org/styles/infoclio-fr-smallcaps" rel="template"/>
 	<link href="https://www.dropbox.com/s/5p4jzir9ie0n54q/Guide_presentation_travail_histoire_2011-2012.pdf" rel="documentation"/>
     <author>


### PR DESCRIPTION
First release of Universite-libre-de-Bruxelles-histoire.

According to our Vade Mecum, I made this to fulfill the lack of csl for the students/historians in our University. Most of us don't use Zotero because of this.
