### PR TITLE
Clinical Neurophysiology corrections

### DIFF
--- a/clinical-neurophysiology.csl
+++ b/clinical-neurophysiology.csl
@@ -16,11 +16,14 @@
     <contributor>
       <name>Sebastian Karcher</name>
     </contributor>
+    <contributor>
+      <name>Kenta Takagaki</name>
+    </contributor>
     <category citation-format="numeric"/>
     <category field="medicine"/>
     <issn>1388-2457</issn>
     <eissn>1872-8952</eissn>
-    <summary>Vancouver author date version for the Elsevier Journal Cliniral Neurophysiology.(Note that the examples in the style guide are unreliable. Check actual articles for citations.</summary>
+    <summary>Vancouver author date version for the Elsevier Journal Clinical Neurophysiology.(Note that the examples in the style guide are unreliable. Check actual articles for citations.</summary>
     <updated>2014-04-03T17:00:00+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>


### PR DESCRIPTION
- issue not needed
- "and" instead of ampersand
- ; after date instead of period.
