### PR TITLE
Create Deutsche-Medizinische-Wochenschrift

### DIFF
--- a/deutsche-medizinische-wochenschrift.csl
+++ b/deutsche-medizinische-wochenschrift.csl
@@ -14,7 +14,7 @@
       <email>robert.wagner@med.uni-tuebingen.de</email>
     </author>
     <category citation-format="numeric"/>
-    <category field="generic-base"/>
+    <category field="medicine"/>
     <updated>2014-07-07T19:33:00+01:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>


### PR DESCRIPTION
citation style for DMW (Deutsche Medizinische Wochenschrift)
- originally created from annual-reviews-alphabetical
