### PR TITLE
Add a full stop (period) after et al to make et al.

### DIFF
--- a/harvard-limerick.csl
+++ b/harvard-limerick.csl
@@ -15,11 +15,6 @@
     <updated>2013-02-14T12:00:00+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
-  <locale xml:lang="en-GB">
-    <terms>
-      <term name="et-al">et al.</term>
-    </terms>
-  </locale>
   <macro name="container">
     <choose>
       <if type="chapter paper-conference" match="any">


### PR DESCRIPTION
See:
http://www3.ul.ie/referencing/Cite_it_Right_Nov_2005.pdf
