### PR TITLE
Added style for CHI Extended Abstract Format

### DIFF
--- a/acm-sigchi-proceedings-extended-abstract-format.csl
+++ b/acm-sigchi-proceedings-extended-abstract-format.csl
@@ -3,8 +3,8 @@
   <info>
     <title>ACM SIGCHI Proceedings - Extended Abstract Format</title>
     <title-short>CHI Extended Abstract Format</title-short>
-    <id>http://www.zotero.org/styles/acm-sigchi-extabs</id>
-    <link href="http://www.zotero.org/styles/acm-sigchi-extabs" rel="self"/>
+    <id>http://www.zotero.org/styles/acm-sigchi-proceedings-extended-abstract-format</id>
+    <link href="http://www.zotero.org/styles/acm-sigchi-proceedings-extended-abstract-format" rel="self"/>
     <link href="http://chi2014.acm.org/authors/format#extendedformat" rel="documentation"/>
     <link href="http://www.zotero.org/styles/acm-sigchi-proceedings" rel="template"/>
     <author>


### PR DESCRIPTION
Added a style for the CHI Extended Abstract Format, based on acm-sigchi-proceedings.csl but modified to use square brackets for citation numbers.
