### PR TITLE
Use plural abbreviation 'eds.' in CMoS author-date

### DIFF
--- a/chicago-author-date.csl
+++ b/chicago-author-date.csl
@@ -39,7 +39,7 @@
     <choose>
       <if type="chapter paper-conference" match="none">
         <names variable="editor translator" delimiter=". ">
-          <label form="verb" text-case="capitalize-first" suffix=" " plural="never"/>
+          <label form="verb" text-case="capitalize-first" suffix=" "/>
           <name and="text" delimiter=", "/>
         </names>
       </if>
@@ -50,11 +50,11 @@
       <if type="chapter paper-conference" match="any">
         <group prefix=", " delimiter=", ">
           <names variable="container-author" delimiter=", ">
-            <label form="verb" suffix=" " plural="never"/>
+            <label form="verb" suffix=" "/>
             <name and="text" delimiter=", "/>
           </names>
           <names variable="editor translator" delimiter=", ">
-            <label form="verb" suffix=" " plural="never"/>
+            <label form="verb" suffix=" "/>
             <name and="text" delimiter=", "/>
           </names>
         </group>
@@ -70,7 +70,7 @@
   <macro name="translator">
     <names variable="translator">
       <name name-as-sort-order="first" and="text" sort-separator=", " delimiter=", " delimiter-precedes-last="always"/>
-      <label form="short" prefix=", " plural="never"/>
+      <label form="short" prefix=", "/>
     </names>
   </macro>
   <macro name="recipient">
@@ -95,7 +95,7 @@
     <group delimiter=". ">
       <names variable="author">
         <name and="text" name-as-sort-order="first" sort-separator=", " delimiter=", " delimiter-precedes-last="always"/>
-        <label form="short" plural="never" prefix=", "/>
+        <label form="short" prefix=", "/>
         <substitute>
           <names variable="editor"/>
           <names variable="translator"/>


### PR DESCRIPTION
It is specified in section 15.9 that the abbreviation in author-date when there are multiple editors is 'eds.' Please let me know if there is some other function for this, but I haven't been able to find it.
