### PR TITLE
ISO-690 (author-date, RCTA).csl

### DIFF
--- a/revista-ciencias-tecnicas-agropecuarias.csl
+++ b/revista-ciencias-tecnicas-agropecuarias.csl
@@ -558,6 +558,7 @@
           <group>
             <text macro="responsability" suffix=" "/>
             <text variable="title" font-style="italic" suffix=", "/>
+            <text macro="note" prefix=" [" suffix="], "/>
             <text macro="online" font-style="italic"/>
             <text macro="interviewer" prefix="entr. " suffix=", "/>
 	    <text macro="medium" suffix=", "/>


### PR DESCRIPTION
This style is based on the norm ISO 690: 2010 and it was created for the Journal  Ciencias Técnicas Agropecuarias of the Agrarian University of Havana (UNAH) in Cuba. It cite in the text according to the form author-year and it organizes the bibliography alphabetically. It presents as distinctive features that in the bibliography the authors are presented in the short form, after the authors two points are placed and the year always appears at the end. It is able to recognize, to organize and to fill a very wide quantity of articles correctly for what can be used by any user.
