### PR TITLE
chicago full note tr

### DIFF
--- a/chicago-fullnote-bibliography-tr.csl
+++ b/chicago-fullnote-bibliography-tr.csl
@@ -1,0 +1,1035 @@
+<?xml version="1.0" encoding="utf-8"?>
+<style xmlns="http://purl.org/net/xbiblio/csl" class="note" version="1.0" and="text" delimiter-precedes-last="after-inverted-name" sort-separator="," page-range-format="chicago" demote-non-dropping-particle="never" default-locale="tr-TR">
+<!-- This style was edited with the Visual CSL Editor (http://editor.citationstyles.org/visualEditor/) -->
+  <info>
+    <title>Chicago Manual of Style 16th edition (Turkish full note)</title>
+    <title-short>chicago-fullnote-bibliography-tr</title-short>
+    <id>http://www.zotero.org/styles/chicago-manual-of-style-16th-edition-turkish-full-note</id>
+    <link href="http://www.zotero.org/styles/chicago-manual-of-style-16th-edition-turkish-full-note" rel="self"/>
+    <link href="http://www.chicagomanualofstyle.org/tools_citationguide.html" rel="documentation"/>
+    <author>
+      <name>Julian Onions</name>
+      <email>julian.onions@gmail.com</email>
+    </author>
+    <contributor>
+      <name>Sebastian Karcher</name>
+      <email>karnesky+zotero@gmail</email>
+    </contributor>
+    <contributor>
+      <name>Gazi Ozdemir</name>
+      <email>gozdemir45@gmail.com</email>
+      <uri>https://github.com/gozdemir/gozdemir.git</uri>
+    </contributor>
+    <category citation-format="note"/>
+    <summary>Chicago Manual of Style 16th edition (Turkish full note), Chicago Manual of Style 16th edition (full note) biçim dosyası kaynaklık etmiştir. Julian Onions tarafından yazılan Chicago Manual of Style 16th edition (full note) csl uzantılı dosya https://www.zotero.org/styles adresindeki zotero sitil deposundan indirilerek üzerinde gerekli düzenlemeler yapılmıştır. Türkçe dil yapısına göre künye oluşturma gerekliliği şemayı gözden geçirmeyi zorunlu kılmıştır. İlk olarak Chicago Manual of Style 16th edition (full note) ’dan Türkçeleştirilen etiketler &lt;locale&gt; &lt;/locale&gt; alanında yapılmıştır. Sonraki aşamada şemada yer alan &lt;macro&gt; &lt;/macro&gt;, &lt;citation&gt; &lt;/citation&gt;, &lt;bibliography&gt; &lt;/bibliography&gt; etiketleri içinde ki kodlarda silme, ekleme ve düzenlemeler yapılmıştır.  Söz konusu yöntemin izlenmesinin nedeni yerelleştirme sonucunda Türkçe dilbilgisi kuralları ve bazı etiketlerin künye içerisindeki yerinin değiştirilmesinin zorunluluğun kaynaklanmıştır.</summary>
+    <updated>2014-05-06T13:40:02+00:00</updated>
+    <rights>&lt;a rel=&quot;license&quot; href=&quot;http://creativecommons.org/licenses/by/4.0/&quot;&gt;&lt;img alt=&quot;Creative Commons License&quot; style=&quot;border-width:0&quot; src=&quot;http://i.creativecommons.org/l/by/4.0/88x31.png&quot; /&gt;&lt;/a&gt;&lt;br /&gt;&lt;span xmlns:dct=&quot;http://purl.org/dc/terms/&quot; property=&quot;dct:title&quot;&gt;Chicago Manual of Style 16th edition (Turkish full note)&lt;/span&gt; is licensed under a &lt;a rel=&quot;license&quot; href=&quot;http://creativecommons.org/licenses/by/4.0/&quot;&gt;Creative Commons Attribution 4.0 International License&lt;/a&gt;.&lt;br /&gt;Based on a work at &lt;a xmlns:dct=&quot;http://purl.org/dc/terms/&quot; href=&quot;http://www.zotero.org/styles/chicago-manual-of-style-16th-edition-turkish-full-note&quot; rel=&quot;dct:source&quot;&gt;http://www.zotero.org/styles/chicago-manual-of-style-16th-edition-turkish-full-note&lt;/a&gt;.</rights>
+  </info>
+  <locale xml:lang="tr-TR">
+    <terms>
+      <term name="editor" form="verb-short">ed.</term>
+      <term name="translator" form="verb-short">çev.</term>
+      <term name="editortranslator" form="verb-short">
+        <single>ed. and trans.</single>
+        <multiple>ed. and trans.</multiple>
+      </term>
+      <term name="editortranslator" form="verb">
+        <single>Edited and translated by</single>
+        <multiple>Edited and translated by</multiple>
+      </term>
+      <term name="accessed" form="verb-short">tarihinde erişildi.</term>
+      <term name="ibid">Aynı yer</term>
+      <term name="no date">t.y.</term>
+      <term name="presented at"/>
+    </terms>
+  </locale>
+  <macro name="editor-translator">
+    <group delimiter=", ">
+      <choose>
+        <if variable="author">
+          <names variable="editor">
+            <name delimiter=" " and="text" delimiter-precedes-last="after-inverted-name" et-al-use-last="true"/>
+            <label form="verb-short" prefix="(" suffix=")"/>
+          </names>
+          <names variable="translator" delimiter="  ">
+            <label form="verb-short" text-case="lowercase" prefix="("/>
+            <name prefix=" " suffix=")" and="text"/>
+          </names>
+        </if>
+      </choose>
+    </group>
+  </macro>
+  <macro name="secondary-contributors-note">
+    <choose>
+      <if type="chapter paper-conference" match="none">
+        <text macro="editor-translator"/>
+      </if>
+    </choose>
+  </macro>
+  <macro name="container-contributors-note">
+    <choose>
+      <if type="chapter paper-conference" match="any">
+        <text macro="editor-translator"/>
+      </if>
+    </choose>
+  </macro>
+  <macro name="secondary-contributors">
+    <choose>
+      <if type="chapter paper-conference" match="none">
+        <group delimiter=", ">
+          <choose>
+            <if variable="author">
+              <names variable="editor" delimiter=". ">
+                <name and="text" delimiter=", "/>
+                <label form="verb-short" text-case="capitalize-first" prefix="(" suffix=")"/>
+              </names>
+              <names variable="translator" prefix="(">
+                <label form="verb-short" plural="never" suffix=" "/>
+                <name suffix=")"/>
+              </names>
+            </if>
+          </choose>
+        </group>
+      </if>
+    </choose>
+  </macro>
+  <macro name="container-contributors">
+    <choose>
+      <if type="chapter paper-conference" match="any">
+        <group delimiter=", ">
+          <choose>
+            <if variable="author">
+              <choose>
+                <if variable="container-author">
+                  <names variable="container-author">
+                    <label form="verb-short" text-case="lowercase" suffix=" "/>
+                    <name and="text" delimiter-precedes-last="after-inverted-name"/>
+                  </names>
+                </if>
+              </choose>
+              <choose>
+                <if variable="container-author author" match="all">
+                  <group delimiter=". ">
+                    <text variable="page"/>
+                    <names variable="editor translator" delimiter=", ">
+                      <label form="verb" suffix=" "/>
+                      <name and="text" delimiter=", "/>
+                    </names>
+                  </group>
+                </if>
+                <else>
+                  <names variable="editor translator" delimiter=", ">
+                    <name and="text" delimiter-precedes-last="after-inverted-name"/>
+                    <label form="verb-short" text-case="lowercase" prefix="(" suffix="),"/>
+                  </names>
+                </else>
+              </choose>
+            </if>
+          </choose>
+        </group>
+      </if>
+    </choose>
+  </macro>
+  <macro name="recipient-note">
+    <names variable="recipient" delimiter=", ">
+      <label form="verb-short" text-case="lowercase" suffix=" "/>
+      <name and="text" delimiter-precedes-last="after-inverted-name"/>
+    </names>
+  </macro>
+  <macro name="contributors-note">
+    <group>
+      <names variable="author" delimiter=", ">
+        <name delimiter=" " and="text" delimiter-precedes-et-al="after-inverted-name" delimiter-precedes-last="after-inverted-name" et-al-use-last="true" sort-separator=""/>
+        <label form="short" prefix="(" suffix=")"/>
+        <substitute>
+          <names variable="editor"/>
+          <names variable="translator"/>
+        </substitute>
+      </names>
+      <text macro="recipient-note"/>
+    </group>
+  </macro>
+  <macro name="editor">
+    <names variable="editor">
+      <name delimiter=",  " and="text" delimiter-precedes-last="after-inverted-name" name-as-sort-order="first" sort-separator=" "/>
+      <label form="short" prefix="( " suffix=")"/>
+    </names>
+  </macro>
+  <macro name="translator">
+    <names variable="translator">
+      <name and="text" delimiter-precedes-last="after-inverted-name" name-as-sort-order="first"/>
+      <label form="verb-short" prefix=" "/>
+    </names>
+  </macro>
+  <macro name="recipient">
+    <group delimiter=" ">
+      <choose>
+        <if type="personal_communication">
+          <choose>
+            <if variable="genre">
+              <text variable="genre" text-case="capitalize-first"/>
+            </if>
+            <else>
+              <text term="letter" text-case="capitalize-first"/>
+            </else>
+          </choose>
+        </if>
+      </choose>
+      <text macro="recipient-note"/>
+    </group>
+  </macro>
+  <macro name="contributors">
+    <group delimiter=" ">
+      <names variable="author">
+        <name delimiter=" " and="text" delimiter-precedes-last="after-inverted-name" name-as-sort-order="first"/>
+        <substitute>
+          <text macro="editor"/>
+          <text macro="translator"/>
+        </substitute>
+      </names>
+      <text macro="recipient"/>
+    </group>
+  </macro>
+  <macro name="recipient-short">
+    <names variable="recipient">
+      <label form="verb" text-case="lowercase" suffix=" "/>
+      <name form="short" and="text" delimiter=", "/>
+    </names>
+  </macro>
+  <macro name="contributors-short">
+    <group delimiter=" ">
+      <names variable="author">
+        <name form="short" and="text" delimiter=", "/>
+        <substitute>
+          <names variable="editor"/>
+          <names variable="translator"/>
+        </substitute>
+      </names>
+      <text macro="recipient-short"/>
+    </group>
+  </macro>
+  <macro name="contributors-sort">
+    <names variable="author">
+      <name name-as-sort-order="all" and="text" sort-separator=", " delimiter=", " delimiter-precedes-last="always"/>
+      <substitute>
+        <names variable="editor"/>
+        <names variable="translator"/>
+        <text macro="title"/>
+      </substitute>
+    </names>
+  </macro>
+  <macro name="interviewer-note">
+    <names variable="interviewer" delimiter=", ">
+      <label form="verb" text-case="lowercase" suffix=" "/>
+      <name and="text" delimiter=", "/>
+    </names>
+  </macro>
+  <macro name="interviewer">
+    <names variable="interviewer" delimiter=", ">
+      <label form="verb" text-case="capitalize-first" suffix=" "/>
+      <name and="text" delimiter=", "/>
+    </names>
+  </macro>
+  <macro name="title-note">
+    <choose>
+      <if variable="title" match="none">
+        <text variable="genre"/>
+      </if>
+      <else-if type="book graphic  legislation motion_picture report song bill" match="any">
+        <text variable="title" text-case="title" font-style="normal" font-weight="bold"/>
+        <group delimiter=", " prefix=" ">
+          <text term="version"/>
+          <text variable="version"/>
+        </group>
+      </else-if>
+      <else-if type="legal_case interview thesis" match="any">
+        <text variable="title" font-weight="bold"/>
+      </else-if>
+      <else>
+        <text variable="title" text-case="title" quotes="false" font-weight="normal" prefix="&quot;" suffix="&quot;"/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="title">
+    <choose>
+      <if variable="title" match="none">
+        <choose>
+          <if type="personal_communication" match="none">
+            <text variable="genre" text-case="capitalize-first"/>
+          </if>
+        </choose>
+      </if>
+      <else-if type="bill book graphic legislation motion_picture report thesis" match="any">
+        <text variable="title" text-case="title" font-style="normal" font-weight="bold" text-decoration="none"/>
+        <group prefix=" (" suffix=")" delimiter=" ">
+          <text term="version"/>
+          <text variable="version"/>
+        </group>
+      </else-if>
+      <else-if type="legal_case interview" match="any">
+        <text variable="title"/>
+      </else-if>
+      <else>
+        <text variable="title" text-case="title" quotes="false" prefix="&quot;" suffix="&quot;"/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="title-short">
+    <choose>
+      <if variable="title" match="none">
+        <choose>
+          <if type="interview">
+            <text term="interview"/>
+          </if>
+          <else-if type="manuscript speech" match="any">
+            <text variable="genre" form="short"/>
+          </else-if>
+          <else-if type="personal_communication">
+            <text macro="issued"/>
+          </else-if>
+        </choose>
+      </if>
+      <else-if type="bill book graphic legislation motion_picture report song" match="any">
+        <text variable="title" form="short" text-case="title" font-style="normal" font-weight="bold"/>
+      </else-if>
+      <else-if type="legal_case interview" match="any">
+        <text variable="title"/>
+      </else-if>
+      <else>
+        <text variable="title" form="short" text-case="title" quotes="false" prefix="&quot;" suffix="&quot;"/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="date-disambiguate">
+    <choose>
+      <if disambiguate="true">
+        <text macro="issued"/>
+      </if>
+    </choose>
+  </macro>
+  <macro name="description-note">
+    <group delimiter=", ">
+      <text macro="interviewer-note"/>
+      <text variable="medium"/>
+      <choose>
+        <if variable="title" match="none"/>
+        <else-if type="thesis speech" match="any"/>
+        <else>
+          <text variable="genre"/>
+        </else>
+      </choose>
+    </group>
+  </macro>
+  <macro name="description">
+    <group delimiter=" ">
+      <group delimiter=" ">
+        <text macro="interviewer"/>
+        <text variable="medium" text-case="capitalize-first"/>
+      </group>
+      <choose>
+        <if variable="title" match="none"/>
+        <else-if type="thesis speech" match="any"/>
+        <else>
+          <text variable="genre" text-case="capitalize-first"/>
+        </else>
+      </choose>
+    </group>
+  </macro>
+  <macro name="container-title-note">
+    <group delimiter=", ">
+      <choose>
+        <if type="legal_case" match="none">
+          <text variable="container-title" text-case="title" font-style="normal" font-weight="bold"/>
+        </if>
+      </choose>
+      <choose>
+        <if type="chapter paper-conference" match="any">
+          <text term="in" text-case="lowercase" font-style="italic"/>
+        </if>
+      </choose>
+    </group>
+  </macro>
+  <macro name="container-title">
+    <group delimiter=" " suffix=",">
+      <choose>
+        <if type="legal_case" match="none">
+          <text variable="container-title" text-case="title" font-style="normal" font-weight="bold"/>
+          <choose>
+            <if type="chapter paper-conference" match="any">
+              <text term="in" text-case="lowercase" font-style="italic"/>
+            </if>
+          </choose>
+        </if>
+      </choose>
+    </group>
+  </macro>
+  <macro name="collection-title">
+    <group delimiter=" ">
+      <text variable="collection-title" text-case="title"/>
+      <text variable="collection-number"/>
+    </group>
+  </macro>
+  <macro name="edition-note">
+    <choose>
+      <if type="bill book chapter graphic legal_case legislation motion_picture paper-conference report song" match="any">
+        <choose>
+          <if is-numeric="edition">
+            <group delimiter=" ">
+              <number variable="edition" form="ordinal"/>
+              <text term="edition"/>
+            </group>
+          </if>
+          <else>
+            <number variable="edition" suffix="."/>
+          </else>
+        </choose>
+      </if>
+    </choose>
+  </macro>
+  <macro name="edition">
+    <choose>
+      <if type="bill book chapter graphic legal_case legislation motion_picture paper-conference report song" match="any">
+        <choose>
+          <if is-numeric="edition">
+            <group delimiter=" ">
+              <number variable="edition" form="ordinal"/>
+              <text term="edition" form="verb-short"/>
+            </group>
+          </if>
+          <else>
+            <number variable="edition" text-case="capitalize-first" suffix="."/>
+          </else>
+        </choose>
+      </if>
+    </choose>
+  </macro>
+  <macro name="locators-note-join-with-space">
+    <choose>
+      <if type="article-journal">
+        <text macro="locators-note"/>
+      </if>
+    </choose>
+  </macro>
+  <macro name="locators-note-join-with-comma">
+    <choose>
+      <if type="article-journal" match="none">
+        <text macro="locators-note"/>
+      </if>
+    </choose>
+  </macro>
+  <macro name="locators-note">
+    <choose>
+      <if type="article-journal">
+        <group delimiter=" ">
+          <number variable="volume"/>
+          <number prefix="(" suffix=")" variable="issue"/>
+        </group>
+      </if>
+      <else-if type="legal_case">
+        <group delimiter=", ">
+          <group delimiter=", ">
+            <number variable="volume"/>
+            <text variable="container-title"/>
+            <text variable="page"/>
+          </group>
+          <text variable="locator"/>
+        </group>
+      </else-if>
+      <else-if type="bill book chapter graphic legal_case legislation motion_picture paper-conference report song" match="any">
+        <group delimiter=", ">
+          <group delimiter=" ">
+            <number variable="volume" form="numeric"/>
+          </group>
+          <choose>
+            <if variable="locator" match="none">
+              <group delimiter=" ">
+                <number variable="number-of-volumes" form="numeric"/>
+                <text term="volume" form="short" plural="true"/>
+              </group>
+            </if>
+          </choose>
+          <text macro="edition-note"/>
+        </group>
+      </else-if>
+    </choose>
+  </macro>
+  <macro name="locators-join-with-space">
+    <choose>
+      <if type="article-journal">
+        <text macro="locators"/>
+      </if>
+    </choose>
+  </macro>
+  <macro name="locators-join-with-comma">
+    <choose>
+      <if type="legal_case">
+        <text macro="locators"/>
+      </if>
+    </choose>
+  </macro>
+  <macro name="locators-join-with-period">
+    <choose>
+      <if type="legal_case article-journal" match="none">
+        <text macro="locators"/>
+      </if>
+    </choose>
+  </macro>
+  <macro name="locators">
+    <choose>
+      <if type="article-journal">
+        <group delimiter=" ">
+          <number variable="volume"/>
+          <group delimiter=" ">
+            <number prefix="(" suffix=")" variable="issue"/>
+          </group>
+        </group>
+      </if>
+      <else-if type="legal_case">
+        <group delimiter=" ">
+          <number variable="volume"/>
+          <text variable="container-title"/>
+          <text variable="page"/>
+        </group>
+      </else-if>
+      <else-if type="bill book graphic legal_case legislation motion_picture report song" match="any">
+        <group delimiter=". ">
+          <group delimiter=" ">
+            <text term="volume" form="short" text-case="capitalize-first"/>
+            <number variable="volume" form="numeric"/>
+          </group>
+          <group delimiter=" ">
+            <number variable="number-of-volumes" form="numeric"/>
+            <text term="volume" form="short" plural="true"/>
+          </group>
+          <text macro="edition"/>
+        </group>
+      </else-if>
+      <else-if type="chapter paper-conference" match="any">
+        <group delimiter=". ">
+          <choose>
+            <if variable="page" match="none">
+              <group delimiter=" ">
+                <text term="volume" form="short" text-case="capitalize-first"/>
+                <number variable="volume" form="numeric"/>
+              </group>
+            </if>
+          </choose>
+          <text macro="edition"/>
+        </group>
+      </else-if>
+    </choose>
+  </macro>
+  <macro name="locators-newspaper">
+    <choose>
+      <if type="article-newspaper">
+        <group>
+          <group delimiter=" ">
+            <number variable="edition"/>
+            <text term="edition"/>
+          </group>
+          <group delimiter=" ">
+            <text term="section" form="short"/>
+            <text variable="section"/>
+          </group>
+        </group>
+      </if>
+    </choose>
+  </macro>
+  <macro name="event">
+    <group delimiter=" ">
+      <text term="presented at"/>
+      <text variable="event"/>
+    </group>
+  </macro>
+  <macro name="publisher">
+    <choose>
+      <if type="thesis">
+        <text variable="publisher"/>
+      </if>
+      <else>
+        <group delimiter="; ">
+          <text variable="publisher-place"/>
+          <text variable="publisher"/>
+        </group>
+      </else>
+    </choose>
+  </macro>
+  <macro name="issued">
+    <choose>
+      <if variable="issued">
+        <choose>
+          <if type="graphic report" match="any">
+            <date variable="issued" form="text"/>
+          </if>
+          <else-if type="legal_case">
+            <group delimiter=" ">
+              <text variable="authority"/>
+              <date variable="issued">
+                <date-part name="year"/>
+              </date>
+            </group>
+          </else-if>
+          <else-if type="bill book chapter graphic legal_case legislation motion_picture paper-conference report song thesis" match="any">
+            <date variable="issued">
+              <date-part name="year"/>
+            </date>
+          </else-if>
+          <else>
+            <date variable="issued" form="text"/>
+          </else>
+        </choose>
+      </if>
+      <else-if variable="accessed URL" match="all"/>
+      <else>
+        <text term="no date" form="verb-short"/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="point-locators-subsequent">
+    <choose>
+      <if variable="locator">
+        <choose>
+          <if locator="page" match="none">
+            <group delimiter=" ">
+              <choose>
+                <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
+                  <choose>
+                    <if variable="volume">
+                      <group delimiter=", ">
+                        <group delimiter=" ">
+                          <text term="volume" form="short" text-case="lowercase"/>
+                          <number variable="volume" form="numeric"/>
+                        </group>
+                        <label variable="locator" form="short"/>
+                      </group>
+                    </if>
+                    <else>
+                      <label variable="locator" form="short"/>
+                    </else>
+                  </choose>
+                </if>
+                <else>
+                  <label variable="locator" form="short"/>
+                </else>
+              </choose>
+              <text variable="locator"/>
+            </group>
+          </if>
+          <else-if type="bill book graphic legal_case legislation motion_picture report song" match="any">
+            <group delimiter=":">
+              <number variable="volume" form="numeric"/>
+              <group>
+                <label suffix=". " variable="locator" form="short"/>
+                <text variable="locator"/>
+              </group>
+            </group>
+          </else-if>
+          <else>
+            <label suffix=". " variable="locator" form="short"/>
+            <text variable="locator"/>
+          </else>
+        </choose>
+      </if>
+    </choose>
+  </macro>
+  <macro name="point-locators-join-with-colon">
+    <choose>
+      <if type="article-journal">
+        <choose>
+          <if variable="locator page" match="any">
+            <text macro="point-locators"/>
+          </if>
+        </choose>
+      </if>
+    </choose>
+  </macro>
+  <macro name="point-locators-join-with-comma">
+    <choose>
+      <if type="article-journal" match="none">
+        <text macro="point-locators"/>
+      </if>
+    </choose>
+  </macro>
+  <macro name="point-locators">
+    <choose>
+      <if variable="locator" match="none">
+        <choose>
+          <if type="article-journal chapter paper-conference" match="any">
+            <label suffix=". " variable="page" form="short"/>
+            <text variable="page"/>
+          </if>
+        </choose>
+      </if>
+      <else-if type="article-journal">
+        <group delimiter=" ">
+          <choose>
+            <if locator="page" match="none">
+              <label variable="locator" form="short" suffix=" "/>
+            </if>
+          </choose>
+          <label suffix=". " variable="locator" form="short"/>
+          <text variable="locator"/>
+        </group>
+      </else-if>
+      <else-if type="legal_case"/>
+      <else>
+        <group delimiter=" ">
+          <choose>
+            <if locator="page" match="none">
+              <label variable="locator" form="short"/>
+            </if>
+          </choose>
+          <label text-case="lowercase" suffix=". " variable="locator" form="short"/>
+          <text variable="locator"/>
+        </group>
+      </else>
+    </choose>
+  </macro>
+  <macro name="locators-chapter">
+    <choose>
+      <if type="chapter paper-conference" match="any">
+        <choose>
+          <if variable="author container-author" match="all"/>
+          <else>
+            <choose>
+              <if variable="page">
+                <number variable="volume" suffix=":"/>
+                <text variable="page" prefix="(" suffix=")"/>
+              </if>
+            </choose>
+          </else>
+        </choose>
+      </if>
+    </choose>
+  </macro>
+  <macro name="locators-journal">
+    <choose>
+      <if type="article-journal">
+        <text variable="page"/>
+      </if>
+    </choose>
+  </macro>
+  <macro name="archive-note">
+    <choose>
+      <if type="thesis">
+        <group delimiter=" ">
+          <text variable="archive"/>
+          <text variable="archive_location" prefix="(" suffix=")"/>
+        </group>
+      </if>
+      <else>
+        <group delimiter=", ">
+          <text variable="archive_location"/>
+          <text variable="archive"/>
+          <text variable="archive-place"/>
+        </group>
+      </else>
+    </choose>
+  </macro>
+  <macro name="archive">
+    <choose>
+      <if type="thesis">
+        <group delimiter=" ">
+          <text variable="archive"/>
+          <text variable="archive_location" prefix="(" suffix=")"/>
+        </group>
+      </if>
+      <else>
+        <group delimiter=". ">
+          <text variable="archive_location" text-case="capitalize-first"/>
+          <text variable="archive"/>
+          <text variable="archive-place"/>
+        </group>
+      </else>
+    </choose>
+  </macro>
+  <macro name="issue-note-join-with-space">
+    <choose>
+      <if type="article-journal legal_case" variable="publisher-place publisher" match="any">
+        <choose>
+          <if type="article-newspaper" match="none">
+            <text macro="issue-note"/>
+          </if>
+        </choose>
+      </if>
+    </choose>
+  </macro>
+  <macro name="issue-note-join-with-comma">
+    <choose>
+      <if type="article-journal legal_case" variable="publisher-place publisher" match="none">
+        <text macro="issue-note"/>
+      </if>
+      <else-if type="article-newspaper">
+        <text macro="issue-note"/>
+      </else-if>
+    </choose>
+  </macro>
+  <macro name="issue-note">
+    <choose>
+      <if type="article-journal legal_case" match="any">
+        <text macro="issued" prefix="(" suffix=")"/>
+      </if>
+      <else-if type="article-newspaper">
+        <text macro="issued"/>
+      </else-if>
+      <else-if variable="publisher-place publisher" match="any">
+        <group delimiter=", ">
+          <group delimiter=", ">
+            <choose>
+              <if variable="title" match="none"/>
+              <else-if type="thesis speech" match="any">
+                <text variable="genre"/>
+              </else-if>
+            </choose>
+            <text macro="event"/>
+          </group>
+          <text macro="publisher"/>
+          <text macro="issued"/>
+        </group>
+      </else-if>
+      <else>
+        <text macro="issued"/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="issue-join-with-space">
+    <choose>
+      <if type="article-journal legal_case" match="any">
+        <text macro="issue"/>
+      </if>
+    </choose>
+  </macro>
+  <macro name="issue-join-with-period">
+    <choose>
+      <if type="article-journal legal_case" match="none">
+        <choose>
+          <if type="speech" variable="publisher publisher-place" match="any"/>
+        </choose>
+      </if>
+    </choose>
+  </macro>
+  <macro name="issue-join-with-comma">
+    <choose>
+      <if type="article-journal legal_case" match="none">
+        <group>
+          <text macro="publisher"/>
+        </group>
+      </if>
+    </choose>
+  </macro>
+  <macro name="issue">
+    <choose>
+      <if type="article-journal legal_case" match="any"/>
+      <else-if type="speech">
+        <group delimiter=" ">
+          <group delimiter=" ">
+            <choose>
+              <if variable="title" match="none"/>
+              <else>
+                <text variable="genre" text-case="capitalize-first"/>
+              </else>
+            </choose>
+            <text macro="event"/>
+          </group>
+          <text variable="event-place"/>
+          <text macro="issued"/>
+        </group>
+      </else-if>
+      <else-if type="article-newspaper">
+        <text macro="issued"/>
+      </else-if>
+      <else-if variable="publisher-place publisher" match="any">
+        <group delimiter=", ">
+          <choose>
+            <if type="thesis">
+              <text variable="genre" text-case="capitalize-first"/>
+            </if>
+          </choose>
+          <text macro="publisher"/>
+        </group>
+      </else-if>
+      <else>
+        <text macro="issued"/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="access-note">
+    <group delimiter=", ">
+      <choose>
+        <if type="graphic report" match="any">
+          <text macro="archive-note"/>
+        </if>
+        <else-if type="article-journal bill book chapter legal_case legislation motion_picture paper-conference" match="none">
+          <text macro="archive-note"/>
+        </else-if>
+      </choose>
+      <choose>
+        <if variable="issued" match="any"/>
+      </choose>
+      <choose>
+        <if type="legal_case" match="none">
+          <choose>
+            <if variable="DOI">
+              <text variable="DOI" prefix="doi:"/>
+            </if>
+            <else>
+              <text macro="access"/>
+            </else>
+          </choose>
+        </if>
+      </choose>
+    </group>
+  </macro>
+  <macro name="access">
+    <group delimiter=". ">
+      <choose>
+        <if type="graphic report" match="any">
+          <text macro="archive"/>
+        </if>
+        <else-if type="article-journal bill book chapter legal_case legislation motion_picture paper-conference" match="none">
+          <text macro="archive"/>
+        </else-if>
+      </choose>
+      <choose>
+        <if variable="issued" match="none"/>
+      </choose>
+      <choose>
+        <if type="legal_case" match="none">
+          <choose>
+            <if variable="DOI">
+              <text variable="DOI" prefix=", doi:"/>
+            </if>
+            <else>
+              <text variable="URL"/>
+              <date form="text" variable="accessed" prefix="(" suffix=")"/>
+            </else>
+          </choose>
+        </if>
+      </choose>
+    </group>
+  </macro>
+  <macro name="case-locator-subsequent">
+    <choose>
+      <if type="legal_case">
+        <text macro="locators-note"/>
+      </if>
+    </choose>
+  </macro>
+  <macro name="case-issue-subsequent">
+    <choose>
+      <if type="legal_case">
+        <text macro="issue"/>
+      </if>
+    </choose>
+  </macro>
+  <citation et-al-min="4" et-al-use-first="1" disambiguate-add-names="true">
+    <layout suffix="." delimiter="; ">
+      <choose>
+        <if position="ibid-with-locator">
+          <group delimiter=", ">
+            <text term="ibid"/>
+            <text macro="point-locators-subsequent"/>
+          </group>
+        </if>
+        <else-if position="ibid" match="any">
+          <text term="ibid" text-case="capitalize-first"/>
+        </else-if>
+        <else-if position="subsequent">
+          <group delimiter=", ">
+            <text macro="contributors-short"/>
+            <group delimiter=" ">
+              <group delimiter=", ">
+                <text macro="title-short"/>
+                <text macro="date-disambiguate"/>
+                <text macro="case-locator-subsequent"/>
+              </group>
+              <text macro="case-issue-subsequent"/>
+            </group>
+            <text macro="point-locators-subsequent"/>
+          </group>
+        </else-if>
+        <else>
+          <group delimiter=", ">
+            <group delimiter=", ">
+              <group delimiter=", ">
+                <group delimiter=", ">
+                  <group delimiter=", ">
+                    <group delimiter=", ">
+                      <group delimiter=", ">
+                        <group delimiter=", ">
+                          <text macro="contributors-note"/>
+                          <text macro="title-note"/>
+                        </group>
+                        <text macro="description-note"/>
+                        <text macro="secondary-contributors-note"/>
+                        <text macro="container-title-note"/>
+                        <text macro="container-contributors-note"/>
+                      </group>
+                      <text macro="locators-note-join-with-space"/>
+                    </group>
+                    <text macro="locators-note-join-with-comma"/>
+                    <text macro="collection-title"/>
+                    <text macro="issue-note-join-with-comma"/>
+                  </group>
+                  <text macro="issue-note-join-with-space"/>
+                </group>
+                <text macro="locators-newspaper"/>
+                <text macro="point-locators-join-with-comma"/>
+              </group>
+              <text macro="point-locators-join-with-colon"/>
+            </group>
+            <text macro="access-note"/>
+          </group>
+        </else>
+      </choose>
+    </layout>
+  </citation>
+  <bibliography and="text" delimiter-precedes-et-al="after-inverted-name" et-al-min="11" et-al-use-first="7" sort-separator=" " subsequent-author-substitute="———" entry-spacing="0" hanging-indent="true">
+    <sort>
+      <key macro="contributors-sort"/>
+      <key variable="title"/>
+      <key variable="genre"/>
+      <key variable="issued"/>
+    </sort>
+    <layout suffix=".">
+      <group>
+        <group delimiter=", ">
+          <group delimiter=", ">
+            <group delimiter=", ">
+              <group delimiter=", ">
+                <group delimiter=" ">
+                  <group>
+                    <group delimiter=",  ">
+                      <group delimiter=" ">
+                        <text macro="contributors"/>
+                        <text macro="issued" prefix="(" suffix="),"/>
+                        <text macro="title"/>
+                      </group>
+                      <text macro="description"/>
+                      <text macro="secondary-contributors"/>
+                      <group delimiter=" ">
+                        <text macro="container-contributors"/>
+                        <text macro="container-title"/>
+                        <text macro="locators-chapter"/>
+                      </group>
+                      <text macro="locators-join-with-period"/>
+                    </group>
+                    <text macro="locators-join-with-comma"/>
+                  </group>
+                  <text macro="locators-join-with-space"/>
+                </group>
+                <text macro="collection-title"/>
+                <text macro="issue-join-with-period"/>
+              </group>
+              <text macro="issue-join-with-space"/>
+            </group>
+            <text macro="issue-join-with-comma"/>
+            <text macro="locators-newspaper"/>
+          </group>
+          <text macro="locators-journal"/>
+        </group>
+        <text macro="access"/>
+      </group>
+    </layout>
+  </bibliography>
+</style>


### PR DESCRIPTION
Chicago sitilinin Türkiye’de kullanımının farklı şekilleri bulunmaktadır. Tam anlamıyla birliktelik görülmemektedir. Çalışmanın konusu Bayburt örneğinde olacağı için Bayburt Üniversitesi’nin araştırmacılardan veya öğrencilerinden istemiş olduğu kuralların yazılı olduğu Bayburt Üniversitesi Sosyal Bilimler Enstitüsü “Tez Yazım Kılavuzu” kabul edilerek klasik sisteme göre uyarlanmıştır. Sitil üzerinde yapılan incelemede Türkçe dil yapısına göre uyarlanması gereken etiketler ile Üniversitenin belirlemiş olduğu etiketler tespit edilmiştir. Yapılan incelemede Chicago’dan Türkçe’ye yapılan uyarlamaların iki yönlü olduğu yapılması gerekliliğini ortaya çıkarmıştır. Birincisi etiketlerin bire bir çevirisi, ikincisi etiketlerin Türkçe dil bilgisi kurallarına uyarlanması olmuştur. Türkçe dil bilgisi kurallarına uyum bazı etiketlerin künye içerisindeki yerinin değiştirilmesini gerektirmiştir. CSL Uygulamasında Etiketlerin Türkçeleştirilmesinde CSL’de iki türlü uyarlama vardır. Birincisi varsayılan uyarlamadır. csl uzantılı bir dosyada <style> etiketinde “default-locale=tr-TR” tanımlandığında program Türkiye için uyarlanmış XML dosyasını kullanır. Ancak kimi zaman varsayılan yerelleştirme bazı kaynak gösterme biçimlerinde görevini tam olarak yerine getirememektedir. Böyle durumlarda ikinci uyarlama alanı işleme alınması gerekliliği ortaya çıkmaktadır. CSL sitil yönetiminde yapılacak olan tanımlamalar ile problem çözülebilmektedir. Bu işlemler <locale> </locale> etiketi arasında yapılmıştır. Chicago TR için yazılan yerelleştirme sonucunda Türkçe tanımlaması yapılan bazı etiketleri için “locale”den eklemeler yapılmıştır. Türkçe’ye tanımlamada problem olan etiketler tespit edilerek uyum için gerekli olan etiket ve dil bilgisi kuralları düzenlendi:
1.  Locale “en-EN” dilinden “tr-TR”ye çevrildi. Bu durum Türkçe kelimelere çevirmede önemli aşama kaydettirmiştir. Ancak tam olarak istenilen düzeyde bir sonuç çıkarmamıştır. Bunun için etiketlerin gözden geçirilip Türkçe karşılıkları olmayan etiketler tespit edilmiş ve sonuç olarak yeni düzenlemeler yapılmıştır. Bu işlemler hakkında yeri geldikçe aşağıda bahsedilmiştir.
2.  İki yazarlı bir esere yapılan göndermede Chicago’da yazar soyadı arasında “and” etiketi, Türkçe kullanımda “ve” etiketi olarak kullanılır. Böyle bir uygulamanın Türkiye’deki akademisyenler arasında uygulandığı görülmektedir. Tez kılavuzunda gönderme ve künyelerde “ve” şeklinde örneklendiği görülmüştür. Ayrıca sitil içinde ve’den önce virgül kullanılmaktadır. Türkçe’de ve’den önce virgül kullanılmadığından virgül kaldırılmıştır.
3.  Editörlü kitaplarda yer alan Editör etiketi, editör isminin başından isminin sonuna alınarak parantez içinde (ed.) şeklinde yeniden düzenlendi.
4.  Kitap, dergi, ansiklopedi ve diğer yayın isimlerinin başlığı italic şeklinden bold şekline dönüştürüldü.
5.  Makale ve sözlük maddelerinin başlıklarının tırnak içinde yazılması gerekmektedir. Bu nedenle tırnak işareti biçimi “ …” şekline dönüştürülmüş ve tırnak içinde başlıktan sonra konulan virgül(,) tırnağın dışına çıkarılmıştır. 
6.  Eserde bir konu hakkında ikinci defa atıf gerektiğinde aynı yeri gösteren “İbid” etiketi yerine “aynı yer” etiketi tanımlanmıştır.
7.  Bir kitabın bölümüne ya da ansiklopedik biçimde yazılmış olan makalelerde eserdeki yerini “içinde” etiketi eserin başlığından sonrasına eklenmiştir. Kitap bölümünde sayfalar parantez içine alındı.
8.  Süreli yayınların sayı ve ciltlerini ifade eden etiketler kaldırılarak cilt(sayı) biçimine dönüştürülmüş ve c., cilt:, S., Sayı: gibi ifadeler kullanılmamıştır. 
9.  Kitapların basım yeri ve yayınevi bilgilerini parantez içinden çıkarılmıştır. 
10. Kaynakların sayfalarını verilmesinde s. ve ss. etiketi kullanılmadığından Türkçe sitile sayfa numaralarının önüne sayfanın veya sayfaların kısaltmasını ifade eden s. veya ss.  etiketi eklemesi yapılmıştır.
11. Bibliyografyada eserlerin basım tarihi sondan yazar isminin sonuna eklenmiştir. Eğer eserin yayım tarihi yoksa n.d. etiketinin yerine t.y. etiketi oluşturulmuştur.
12. Bibliyografyada kaynakların bilgileri verilirken ayraç olarak kullanılan noktanın yerine virgül konulmuştur.
13. Elektronik adreslere yapılan atıflarda “erişildi” ifadesi kaldırılarak sadece erişim tarihi parantez içinde verildi.
