### PR TITLE
Update spie-journals.csl for new specification

### DIFF
--- a/spie-journals.csl
+++ b/spie-journals.csl
@@ -4,7 +4,7 @@
     <title>SPIE journals</title>
     <id>http://www.zotero.org/styles/spie-journals</id>
     <link href="http://www.zotero.org/styles/spie-journals" rel="self"/>
-    <link href="http://spie.org/x3658.xml" rel="documentation"/>
+    <link href="http://spie.org/x85036.xml" rel="documentation"/>
     <author>
       <name>Yurkin Maxim</name>
       <email>yurkin@gmail.com</email>
@@ -13,12 +13,12 @@
     <category citation-format="numeric"/>
     <category field="physics"/>
     <category field="engineering"/>
-    <summary>Designed for SPIE e-journals, based on information at http://spie.org/x3658.xml, including sample manuscript.
-			Covers all the document type described there. The information for SPIE paper journals is less detailed, and it did not
-			explicitly specify the need to include DOI. However, the inclusion of DOI is probably not bad, so this style can be used
-			for all SPIE journals.</summary>
+    <summary>Designed for SPIE journals, based on information at http://spie.org/x85036.xml and sample .docx manuscript given there 	         (http://spie.org/Documents/Publications/Journals/journal%20Word%20template.doc). The latter probably originated from the style for e-journals (which was previously available at http://spie.org/x3658.xml), and thus slightly contradicts former requirements. The differences are:
+    1) style on the web page requires using et al., when there are more than three authors - we follow this rule.
+    2) style in the sample manuscript asks to add DOI if available, while the style on the web page says nothing about it - we do include DOI (this should not harm in all cases).
+    Also previous versions of this style were based on more detailed instructions for SPIE e-journals (including larger number of document types). Those details are present in the current version as well, but no more supported by a documented style.</summary>
     <published>2009-10-24T23:00:00+06:00</published>
-    <updated>2012-09-27T22:06:38+00:00</updated>
+    <updated>2014-05-11T15:09:48+06:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <!-- Locale terms -->
@@ -126,7 +126,7 @@
   </macro>
   <macro name="accessed">
     <!-- full date in brackets -->
-    <date variable="accessed" prefix=" (" suffix=")">
+    <date variable="accessed" prefix=" (accessed " suffix=")">
       <date-part name="day" suffix=" "/>
       <date-part name="month" form="long" suffix=" "/>
       <date-part name="year"/>
@@ -182,18 +182,14 @@
     <sort>
       <key variable="citation-number"/>
     </sort>
-    <layout prefix="[" suffix="]" delimiter=",">
+    <layout vertical-align="sup" delimiter=",">
       <text variable="citation-number"/>
-      <group prefix=", " delimiter=" ">
-        <label variable="locator" form="short"/>
-        <text variable="locator"/>
-      </group>
     </layout>
   </citation>
   <!-- Bibliography -->
-  <bibliography et-al-min="10" et-al-use-first="9" entry-spacing="0" second-field-align="flush">
+  <bibliography et-al-min="4" et-al-use-first="1" entry-spacing="0" second-field-align="flush">
     <layout suffix=".">
-      <text variable="citation-number" prefix="[" suffix="] "/>
+      <text variable="citation-number" suffix="."/>
       <text macro="author" suffix=", "/>
       <choose>
         <if type="webpage">
@@ -236,9 +232,7 @@
               <group delimiter=", ">
                 <text macro="title"/>
                 <text macro="container"/>
-                <!-- Zotero 2.1 do not support date ranges, which are common for conferences.
-								However, it should start working without any changes to the style once Zotero's handling of
-								'date' fields will improve. -->
+                <!-- Zotero 2.1 do not support date ranges, which are common for conferences. However, it should start working without any changes to the style once Zotero's handling of 'date' fields will improve. -->
                 <text macro="issued"/>
                 <text variable="event-place"/>
                 <text variable="page"/>


### PR DESCRIPTION
Authors list is now contracted (et al.) when more than 3.
In-text citation is now a superscript. Additional labels (page, chapter, etc.) are now not possible.
Changed format of list numbers in bibliography, from "[2]" to "2.".
Added "accessed" to corresponding date of webpages.
