### PR TITLE
Create APOLLON-Hochschule(German).csl

### DIFF
--- a/APOLLON Hochschule der Gesundheitwirtschaft (German).csl
+++ b/APOLLON Hochschule der Gesundheitwirtschaft (German).csl
@@ -2,10 +2,10 @@
 <style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" name-delimiter="; " initialize-with="." names-delimiter="; " demote-non-dropping-particle="sort-only" default-locale="de-DE">
   <info>
     <title>APOLLON Hochschule der Gesundheitswirtschaft (German)</title>
-    <id>http://www.zotero.org/styles/apollon-hochschule-der-Gesundheitswirtschaft.(german)</id>
-    <link href="http://www.zotero.org/styles/apollon-hochschule-german" rel="self"/>
+    <id>http://www.zotero.org/styles/apollon-hochschule-der-Gesundheitswirtschaft-(German)</id>
+    <link href="http://www.zotero.org/styles/apollon-hochschule-der-Gesundheitswirtschaft-(German)" rel="self"/>
     <link href="https://www.zotero.org/styles/american-journal-of-physical-anthropology?source=1" rel="template"/>
-    <link href="http://www.apollon-press.de/publikationen/apollon-schriftenreihen/" rel="documentation"/>
+    <link href="http://www.apollon-hochschule.de/" rel="documentation"/>
     <author>
       <name>Julia Willenbrock</name>
       <email>julia.willenbrock@apollon-hochschule.de</email>


### PR DESCRIPTION
An existing style was edited to APOLLON Style for authors of the private College.
Several changes were made:
The authors names are delimited by a semicolon, the first names are initialized with a dot, sort seperator is a comma. The date is in round braces. The title is italic. The language was changed to German. In case of a Journal the volume and issue (in braces) and the exact issues date was added. The container title seperates with a comma to the issued date. The access date of URLs was added. The term "et al" is used when more than 4 authors are present. The inline citation uses "et al" when 2 or more authors are present. The editor is in braces and seperates with a colon.
