### PR TITLE
Updated annual reviews author-date style

### DIFF
--- a/annual-reviews-author-date.csl
+++ b/annual-reviews-author-date.csl
@@ -168,17 +168,10 @@
         </choose>
       </if>
       <else-if type="chapter" match="any">
-        <choose>
-          <if is-numeric="page" match="all">
-            <group prefix=", ">
-              <label variable="page" form="short" suffix=" "/>
-              <text variable="page"/>
-            </group>
-          </if>
-          <else>
-            <text variable="page" prefix=". "/>
-          </else>
-        </choose>
+        <group prefix=", ">
+          <label variable="page" form="short" suffix=" "/>
+          <text variable="page"/>
+        </group>
       </else-if>
       <else-if type="article-magazine article-newspaper" match="any">
         <group delimiter=", ">


### PR DESCRIPTION
Removed forced sentence case for titles, per new CSL standards. Updated style per current author guidelines: book title capitalization and volume labeling, removed number-of-pages, added URL for online magazine and newspaper articles, fixed editor abbreviation.
