### PR TITLE
Update american-medical-association.csl

### DIFF
--- a/american-medical-association.csl
+++ b/american-medical-association.csl
@@ -14,10 +14,14 @@
       <name>Christian Pietsch</name>
       <uri>http://purl.org/net/pietsch</uri>
     </contributor>
+    <contributor>
+      <name>Serge Y. Stroobandt</name>
+      <uri>http://stroobandt.com</uri>
+    </contributor>
     <category citation-format="numeric"/>
     <category field="medicine"/>
     <summary>The American Medical Association style as used in JAMA.</summary>
-    <updated>2012-09-30T23:10:36+00:00</updated>
+    <updated>2014-06-05T23:30:00+01:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale xml:lang="en">
@@ -156,7 +160,7 @@
           <group prefix=" ">
             <text term="in" text-case="capitalize-first" suffix=": "/>
             <text macro="editor"/>
-            <text variable="container-title" font-style="italic" prefix=" " suffix="."/>
+            <text variable="container-title" font-style="italic" prefix=" " text-case="title" suffix="."/>
             <text variable="volume" prefix="Vol " suffix="."/>
             <text macro="edition" prefix=" "/>
             <text variable="collection-title" prefix=" " suffix="."/>


### PR DESCRIPTION
Line 163: text-case="title" for type="chapter paper-conference" in bibliography,
as per http://medlib.bu.edu/facts/faq2.cfm/content/citationsama.cfm
Other american-medical-association variants probably need updating as well.
