### PR TITLE
Create journal-of-the-american-college-of-surgeons.csl

### DIFF
--- a/journal-of-the-american-college-of-surgeons.csl
+++ b/journal-of-the-american-college-of-surgeons.csl
@@ -21,7 +21,7 @@
   <macro name="editor">
     <names variable="editor">
       <name name-as-sort-order="all" sort-separator=" " initialize-with="" delimiter=", " delimiter-precedes-last="always"/>
-      <label form="long" prefix=", " suffix="eds." strip-periods="true"/>
+      <label form="short" prefix=", " strip-periods="true"/>
     </names>
   </macro>
   <macro name="anon">


### PR DESCRIPTION
This is a style sheet for the Journal of the American College of Surgeons. It implements the formatting described here http://www.elsevier.com/journals/journal-of-the-american-college-of-surgeons/1072-7515/guide-for-authors#ref
