### PR TITLE
Update Chicago author-date macros from fullnote.

### DIFF
--- a/chicago-author-date.csl
+++ b/chicago-author-date.csl
@@ -409,8 +409,34 @@
     </date>
   </macro>
   <macro name="collection-title">
-    <text variable="collection-title" text-case="title"/>
-    <text variable="collection-number" prefix=" "/>
+    <choose>
+      <if match="none" type="article-journal">
+        <choose>
+          <if match="none" is-numeric="collection-number">
+            <group delimiter=", ">
+              <text variable="collection-title" text-case="title"/>
+              <text variable="collection-number"/>
+            </group>
+          </if>
+          <else>
+            <group delimiter=" ">
+              <text variable="collection-title" text-case="title"/>
+              <text variable="collection-number"/>
+            </group>
+          </else>
+        </choose>
+      </if>
+    </choose>
+  </macro>
+  <macro name="collection-title-journal">
+    <choose>
+      <if type="article-journal">
+        <group delimiter=" ">
+          <text variable="collection-title"/>
+          <text variable="collection-number"/>
+        </group>
+      </if>
+    </choose>
   </macro>
   <macro name="event">
     <group>
@@ -508,6 +534,7 @@
       <text macro="container-contributors"/>
       <text macro="edition"/>
       <text macro="locators-chapter"/>
+      <text macro="collection-title-journal" prefix=", " suffix=", "/>
       <text macro="locators"/>
       <text macro="collection-title" prefix=". "/>
       <text macro="issue"/>


### PR DESCRIPTION
This brings over the support for book reviews to Chicago author-date, and fixes a problem in which the DOI and URL were both shown, which isn't specified differently for the author-date style: see CMoS ¶15.9 ("For citations of journals consulted online, Chicago recommends the inclusion of a DOI _or_ a URL; the DOI is preferred to a URL").
