### PR TITLE
Update science.csl

### DIFF
--- a/science.csl
+++ b/science.csl
@@ -151,7 +151,7 @@
             <text macro="editor" prefix=" "/>
           </group>
           <group prefix=" ">
-            <text macro="title" suffix=", "/>
+            <text macro="title" suffix=". "/>
             <text form="short" variable="container-title" font-style="italic" suffix=" "/>
             <text variable="volume" font-weight="bold"/>
             <text variable="page" prefix=", "/>


### PR DESCRIPTION
Change journal article title suffix to ". " from ", " following the Science citation style: 

Titles of cited articles can now be included, with words in lower case except for proper nouns, followed by a period. 

http://www.sciencemag.org/site/feature/contribinfo/prep/res/refs.xhtml
