### PR TITLE
University of Cape Town (Harvard style)

### DIFF
--- a/harvard-university-of-cape-town.csl
+++ b/harvard-university-of-cape-town.csl
@@ -1,108 +1,200 @@
 <?xml version="1.0" encoding="utf-8"?>
 <style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" demote-non-dropping-particle="sort-only" default-locale="en-GB">
   <info>
-    <title>Harvard - University of Gloucestershire</title>
-    <id>http://www.zotero.org/styles/harvard-university-of-gloucestershire</id>
-    <link href="http://www.zotero.org/styles/harvard-university-of-gloucestershire" rel="self"/>
-    <link href="http://www.zotero.org/styles/harvard-the-university-of-sheffield-town-and-regional-planning" rel="template"/>
-    <link href="http://ist.glos.ac.uk/referencing/harvard/" rel="documentation"/>
+    <title>Harvard - University of Cape Town</title>
+    <id>http://www.zotero.org/styles/harvard-university-of-cape-town</id>
+    <link href="http://www.zotero.org/styles/harvard-university-of-cape-town" rel="self"/>
+    <link href="http://www.zotero.org/styles/harvard-university-of-gloucestershire" rel="template"/>
+    <link href="http://www.lib.uct.ac.za/wp-content/uploads/2014/02/harvard-uct-2014.pdf" rel="documentation"/>
+    <!-- Sample data: https://gist.github.com/aurimasv/14da71a5d1def6e6ed86 -->
     <author>
-      <name>Francis Barton</name>
-      <email>fbarton@glos.ac.uk</email>
+      <name>Aurimas Vinckevicius</name>
+      <email>aurimas.dev@gmail.com</email>
     </author>
     <category citation-format="author-date"/>
     <category field="generic-base"/>
-    <category field="social_science"/>
-    <updated>2012-09-28T02:06:38+00:00</updated>
+    <updated>2014-06-17T23:06:38+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale xmlns="http://purl.org/net/xbiblio/csl" xml:lang="en-GB">
     <terms>
-      <term name="editor" form="verb-short">ed. by</term>
-      <term name="editor" form="short">
-        <single>ed.</single>
-        <multiple>eds.</multiple>
-      </term>
-      <term name="no date">n.d.</term>
-      <term name="et-al">et al.</term>
-      <term name="page">
-        <single>page</single>
-        <multiple>pages</multiple>
-      </term>
-      <term name="page" form="short">
-        <single>p.</single>
-        <multiple>pp.</multiple>
-      </term>
-      <term name="retrieved">Available from</term>
-      <term name="in">In</term>
+      <term name="volume" form="short">v.</term>
+      <term name="available at">available</term>
+      <term name="open-quote">“</term>
+      <term name="close-quote">”</term>
+      <term name="open-inner-quote">‘</term>
+      <term name="close-inner-quote">’</term>
     </terms>
   </locale>
   <macro name="editor-translator">
-    <names variable="editor translator" prefix="(" suffix=")" delimiter=", ">
-      <name and="symbol" initialize-with="." delimiter=", "/>
-      <label form="short" prefix=", " text-case="capitalize-first"/>
-    </names>
+      <choose>
+        <if variable="editor">
+          <names variable="editor">
+            <name and="symbol" initialize-with="." delimiter=", "/>
+            <label form="short" prefix=", " text-case="capitalize-first"/>
+          </names>
+        </if>
+      </choose>
+      <choose>
+        <if variable="translator">
+          <names variable="translator">
+            <label form="verb" text-case="capitalize-first" suffix=" "/>
+            <name and="symbol" delimiter=", "/>
+          </names>
+        </if>
+      </choose>
   </macro>
   <macro name="author">
     <names variable="author">
-      <name name-as-sort-order="all" and="symbol" sort-separator=", " initialize-with="." delimiter=", " delimiter-precedes-last="never"/>
-      <label form="short" prefix=" (" suffix=".)" text-case="capitalize-first" strip-periods="true"/>
-      <et-al term="et-al" font-style="italic"/>
+      <name name-as-sort-order="all" and="symbol" sort-separator=", " initialize-with="." delimiter=", " delimiter-precedes-last="never" et-al-min="9" et-al-use-first="8"/>
+      <label form="short" prefix=" " text-case="capitalize-first"/>
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
         <choose>
-          <if type="article-journal article-magazine article-newspaper broadcast interview manuscript map patent personal_communication song speech thesis webpage" match="any">
-            <text variable="container-title"/>
+          <if type="bill book graphic legal_case legislation motion_picture report song webpage" match="any">
+            <text variable="title" font-style="italic"/>
           </if>
+          <else>
+            <text variable="title" quotes="true" text-case="capitalize-first"/>
+          </else>
         </choose>
       </substitute>
     </names>
   </macro>
   <macro name="author-short">
     <names variable="author">
-      <name form="short" and="symbol" delimiter=", " initialize-with="."/>
+      <name form="short" and="symbol" delimiter=", " initialize-with="." delimiter-precedes-last="never" et-al-min="4" et-al-use-first="1"/>
       <substitute>
-        <names variable="editor">
-          <name form="short" and="symbol" delimiter=", " initialize-with="."/>
-        </names>
-        <names variable="translator">
-          <name form="short" and="symbol" delimiter=", " initialize-with="."/>
-        </names>
+        <names variable="editor"/>
+        <names variable="translator"/>
         <choose>
-          <if type="bill book graphic legal_case legislation motion_picture report song thesis" match="any">
-            <text variable="title" font-style="italic"/>
+          <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
+          <!-- Note that webpage title is italicized in bibliography, but quoted in text -->
+            <text variable="title" form="short" font-style="italic"/>
           </if>
           <else>
-            <text variable="title" form="short" quotes="false"/>
+            <text variable="title" form="short" quotes="true" text-case="capitalize-first"/>
           </else>
         </choose>
       </substitute>
     </names>
   </macro>
+  <macro name="author-count">
+    <names variable="author">
+      <name form="count"/>
+    </names>
+  </macro>
+  <macro name="date-issued">
+    <!--
+      Show "in press" for journal articles with non-numeric pages
+      (i.e. "in press" in page field)
+    -->
+    <choose>
+      <if type="article-journal" match="none">
+        <text macro="date-issued-year"/>
+      </if>
+      <else-if variable="page" match="none">
+        <text macro="date-issued-year"/>
+      </else-if>
+      <else-if is-numeric="page">
+        <text macro="date-issued-year"/>
+      </else-if>
+      <else>
+        <text term="in press" prefix="(" suffix=")"/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="date-issued-no-parentheses">
+    <!--
+      Same as date-issued, but no parentheses around "in press"
+    -->
+    <choose>
+      <if type="article-journal" match="none">
+        <text macro="date-issued-year"/>
+      </if>
+      <else-if variable="page" match="none">
+        <text macro="date-issued-year"/>
+      </else-if>
+      <else-if is-numeric="page">
+        <text macro="date-issued-year"/>
+      </else-if>
+      <else>
+        <text term="in press"/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="date-issued-year">
+    <choose>
+      <if variable="issued">
+        <date variable="issued">
+          <date-part name="year"/>
+        </date>
+      </if>
+      <else>
+        <text term="no date" form="short"/>
+      </else>
+    </choose>
+  </macro>
   <macro name="access">
-    <group>
-      <group>
-        <text term="retrieved" suffix=": "/>
-        <text variable="URL" prefix="&lt;" suffix="&gt; "/>
-      </group>
-      <text term="accessed" text-case="capitalize-first" prefix="[" suffix=": "/>
-      <date variable="accessed">
-        <date-part name="day" suffix=" "/>
-        <date-part name="month" suffix=" "/>
-        <date-part name="year" suffix="]"/>
-      </date>
-    </group>
+    <choose>
+      <if variable="DOI">
+        <text variable="DOI" prefix="DOI: "/>
+      </if>
+      <else-if variable="URL">
+        <group delimiter=" ">
+          <group>
+            <text term="available at" suffix=": " text-case="capitalize-first"/>
+            <text variable="URL"/>
+          </group>
+          <text macro="date-access"/>
+        </group>
+      </else-if>
+      <else-if variable="source accessed" match="all">
+        <group delimiter=" ">
+          <text variable="source"/>
+          <text macro="date-access"/>
+        </group>
+      </else-if>
+    </choose>
+  </macro>
+  <macro name="date-access">
+    <date variable="accessed" prefix="[" suffix="]">
+      <date-part name="year"/>
+      <date-part name="month" form="long" prefix=", "/>
+      <date-part name="day" form="numeric-leading-zeros" prefix=" "/>
+    </date>
   </macro>
   <macro name="title">
     <choose>
-      <if type="bill book graphic legal_case legislation motion_picture report song thesis" match="any">
-        <text variable="title" text-case="title" font-style="italic"/>
+      <if type="bill book graphic legal_case legislation motion_picture report song webpage" match="any">
+        <text variable="title" font-style="italic"/>
       </if>
       <else>
-        <text variable="title" text-case="title"/>
+        <text variable="title"/>
       </else>
     </choose>
+  </macro>
+  <macro name="book-details">
+    <group delimiter=". ">
+      <group delimiter=" ">
+        <number variable="edition" form="ordinal"/>
+        <label variable="edition" form="short"/>
+      </group>
+      <group delimiter=" ">
+        <label variable="volume" form="short" text-case="capitalize-first"/>
+        <text variable="volume"/>
+      </group>
+      <text macro="editor-translator"/>
+      <group delimiter=" " prefix="(" suffix=")">
+        <text variable="collection-title"/>
+        <group delimiter=" ">
+          <label variable="issue" form="short"/>
+          <text variable="collection-number"/>
+        </group>
+      </group>
+      <text macro="publisher"/>
+    </group>
   </macro>
   <macro name="publisher">
     <group delimiter=": ">
@@ -110,94 +202,114 @@
       <text variable="publisher"/>
     </group>
   </macro>
-  <citation et-al-min="3" et-al-use-first="1" disambiguate-add-year-suffix="true" year-suffix-delimiter="," disambiguate-add-names="true" disambiguate-add-givenname="false" collapse="year-suffix">
+  <citation disambiguate-add-year-suffix="true" year-suffix-delimiter="," disambiguate-add-names="true" disambiguate-add-givenname="false" collapse="year-suffix">
     <sort>
-      <key variable="issued" sort="ascending"/>
+      <key macro="date-issued-no-parentheses"/>
       <key macro="author"/>
     </sort>
     <layout prefix="(" suffix=")" delimiter="; ">
       <group delimiter=", ">
         <text macro="author-short"/>
-        <date variable="issued">
-          <date-part name="year"/>
-        </date>
-        <group>
-          <label variable="locator" form="short"/>
-          <text variable="locator" prefix=" "/>
-        </group>
+        <text macro="date-issued-no-parentheses"/>
+      </group>
+      <group>
+        <choose>
+          <if locator="page" match="any">
+            <text variable="locator" prefix=": "/>
+          </if>
+          <else>
+            <label variable="locator" form="short" prefix=", "/>
+            <text variable="locator" prefix=" "/>
+          </else>
+        </choose>
       </group>
     </layout>
   </citation>
-  <bibliography hanging-indent="false" et-al-min="6" et-al-use-first="6" entry-spacing="0" line-spacing="1">
+  <bibliography entry-spacing="0">
     <sort>
-      <key macro="author"/>
-      <key variable="issued"/>
+      <key macro="author-short" names-min="1" names-use-first="1"/>
+      <key macro="author-count" names-min="3" names-use-first="3"/>
+      <key macro="author" names-min="3" names-use-first="1"/>
+      <key macro="date-issued-no-parentheses"/>
     </sort>
-    <layout>
-      <text macro="author" suffix=" "/>
-      <date variable="issued" prefix=" (" suffix=")">
-        <date-part name="year"/>
-      </date>
-      <choose>
-        <if type="bill book graphic legal_case legislation motion_picture post-weblog report song webpage" match="any">
-          <group suffix=",">
-            <text macro="title" prefix=" "/>
-            <text macro="editor-translator" prefix=" "/>
-          </group>
-          <text prefix=" " suffix=" " macro="publisher"/>
-        </if>
-        <else-if type="thesis" match="any">
-          <text macro="title" prefix=" " suffix=", "/>
-          <group prefix=", ">
-            <text term="in" suffix=": " font-style="italic"/>
-            <names variable="editor translator" delimiter=", ">
-              <name and="symbol" name-as-sort-order="all" sort-separator=", " initialize-with="."/>
-              <label form="short" prefix=" " suffix=" "/>
-            </names>
+    <layout suffix=".">
+      <group delimiter=". ">
+        <text macro="author"/>
+        <text macro="date-issued"/>
+        <choose>
+          <if type="bill book graphic legal_case legislation motion_picture post-weblog song webpage" match="any">
+            <text macro="title"/>
+            <text macro="book-details"/>
+          </if>
+          <else-if type="article-journal article-magazine" match="any">
+            <text macro="title"/>
             <text variable="container-title" font-style="italic"/>
-          </group>
-          <text variable="genre"/>
-          <text macro="publisher" prefix=", " suffix=". "/>
-          <group>
-            <label variable="page" form="short"/>
-            <text variable="page"/>
-          </group>
-        </else-if>
-        <else-if type="chapter paper-conference" match="any">
-          <text macro="title" prefix=" "/>
-          <group prefix=", ">
-            <text term="in" suffix=": " font-style="italic"/>
-            <names variable="editor translator" delimiter=", ">
-              <name and="symbol" name-as-sort-order="all" sort-separator=", " initialize-with="."/>
-              <label form="short" prefix=" " suffix=" "/>
-            </names>
-            <text variable="container-title" font-style="italic" suffix=", "/>
-          </group>
-          <text variable="collection-title" font-style="italic" suffix=", "/>
-          <text macro="publisher" suffix=", "/>
-          <group>
-            <label variable="page" form="short"/>
-            <text variable="page"/>
-          </group>
-        </else-if>
-        <else>
-          <group suffix=", ">
-            <text macro="title" prefix=" "/>
-            <text macro="editor-translator" prefix=" "/>
-          </group>
-          <group prefix=" " suffix=" ">
-            <text variable="container-title" font-style="italic"/>
-            <group prefix=" ">
-              <text variable="volume"/>
-              <text variable="issue" prefix=" (" suffix=")"/>
-            </group>
-            <group prefix=": ">
+            <group delimiter=":">
+              <choose>
+                <if variable="volume issue" match="any">
+                  <group>
+                    <text variable="volume"/>
+                    <text variable="issue" prefix="(" suffix=")"/>
+                  </group>
+                </if>
+                <else>
+                  <date variable="issued" prefix="(" suffix=")">
+                    <date-part name="month" form="long"/>
+                    <date-part name="day" prefix=", "/>
+                  </date>
+                </else>
+              </choose>
               <text variable="page"/>
             </group>
-          </group>
-        </else>
-      </choose>
-      <text prefix=" " macro="access"/>
+          </else-if>
+          <else-if type="article-newspaper" match="any">
+            <text macro="title"/>
+            <group delimiter=" ">
+              <text variable="container-title" font-style="italic"/>
+              <text variable="publisher-place" prefix="(" suffix=")"/>
+            </group>
+            <group delimiter=": ">
+              <date variable="issued">
+                <date-part name="day" suffix=" "/>
+                <date-part name="month" form="long"/>
+              </date>
+              <text variable="page"/>
+            </group>
+          </else-if>
+          <else-if type="thesis" match="any">
+            <text macro="title"/>
+            <text variable="genre"/>
+            <text variable="publisher"/>
+          </else-if>
+          <else-if type="chapter paper-conference entry-encyclopedia entry-dictionary" match="any">
+            <text macro="title"/>
+            <group delimiter=" ">
+              <text term="in" text-case="capitalize-first"/>
+              <text variable="container-title" font-style="italic"/>
+            </group>
+            <text macro="book-details"/>
+            <text variable="page"/>
+          </else-if>
+          <else-if type="patent" match="any">
+            <group font-style="italic">
+              <text variable="number" prefix="Patent No. "/>
+            </group>
+            <group delimiter=": ">
+              <text macro="publisher"/>
+              <text variable="authority"/>
+            </group>
+          </else-if>
+          <else-if type="report" match="any">
+            <text macro="title"/>
+            <group delimiter=" " prefix="(" suffix=")">
+              <text variable="genre" text-case="capitalize-first"/>
+              <text variable="number"/>
+            </group>
+            <text macro="publisher"/>
+          </else-if>
+        </choose>
+        <text macro="access"/>
+      </group>
     </layout>
   </bibliography>
 </style>


### PR DESCRIPTION
See https://forums.zotero.org/discussion/36596/harvard-citation-style-help-needed/ for request

Covers items in the guide down to Government Publications

For in press papers, enter "in press" in the Pages field

Do not suppress URL display for proper formatting. Remove Access Date to avoid references to electronic resources (via URL or Library Catalog)

Known limitations:
- Encyclopedia/Dictionary entries are formatted as chapters rather that the special formatting in the guide
- Edition ordinals are not superscripted
- Conference date is not included
- Weekly newspaper publications should be entered as magazines. No support for date ranges.
- No special issues or sections for journal articles
- For patents, no country is prefixed to "Patent No." part.
- No support for Standards
- For citing journal supplements, use the "Suppl. (October, 11)" string as volume
- First author is not capitalized in in-text citations, but appears correctly in bibliography (e.g. "de la Ray")
