### PR TITLE
[Science] Various tweaks

### DIFF
--- a/science-without-titles.csl
+++ b/science-without-titles.csl
@@ -26,7 +26,7 @@
     <issn>0036-8075</issn>
     <eissn>1095-9203</eissn>
     <summary>The Science journal style, without the titles of journal articles in the bibliography. Per the Science guidelines, the title is optional, and some authors prefer not to have it.</summary>
-    <updated>2012-09-27T22:06:38+00:00</updated>
+    <updated>2014-06-18T08:06:38+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <macro name="editor">
@@ -38,7 +38,7 @@
   <macro name="author">
     <names variable="author">
       <name sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
-      <label form="short" prefix=", " suffix="." text-case="capitalize-first" strip-periods="true"/>
+      <label form="short" prefix=", " text-case="capitalize-first"/>
       <et-al font-style="italic"/>
       <substitute>
         <names variable="editor"/>
@@ -48,18 +48,24 @@
   <macro name="access">
     <choose>
       <if variable="page" match="none">
-        <choose>
-          <if variable="DOI">
-            <text variable="DOI" prefix=", doi:"/>
-          </if>
-          <else>
-            <group prefix=" (" suffix=")">
-              <text value="available at "/>
-              <text variable="URL"/>
-            </group>
-          </else>
-        </choose>
+        <text macro="access-value"/>
       </if>
+      <else-if is-numeric="page" match="none">
+        <text macro="access-value"/>
+      </else-if>
+    </choose>
+  </macro>
+  <macro name="access-value">
+    <choose>
+      <if variable="DOI">
+        <text variable="DOI" prefix=", doi:"/>
+      </if>
+      <else>
+        <group prefix=" (" suffix=")">
+          <text value="available at "/>
+          <text variable="URL"/>
+        </group>
+      </else>
     </choose>
   </macro>
   <macro name="title">
@@ -71,6 +77,17 @@
         <text variable="title"/>
       </else>
     </choose>
+  </macro>
+  <macro name="article-details">
+    <group delimiter=", ">
+      <group delimiter=". ">
+        <text form="short" variable="container-title" font-style="italic"/>
+        <text variable="volume" font-weight="bold"/>
+      </group>
+      <text variable="page"/>
+    </group>
+    <text macro="issued" prefix=" (" suffix=")"/>
+    <text macro="access"/>
   </macro>
   <macro name="publisher">
     <group delimiter=", ">
@@ -111,73 +128,123 @@
       <text variable="citation-number" font-style="italic"/>
     </layout>
   </citation>
-  <bibliography hanging-indent="false" et-al-min="6" et-al-use-first="1">
+  <bibliography et-al-min="6" et-al-use-first="1" second-field-align="flush">
     <layout suffix=".">
       <text variable="citation-number" suffix=". "/>
-      <text macro="author" suffix=","/>
-      <choose>
-        <if type="thesis">
-          <text value=" thesis, "/>
-          <text macro="publisher"/>
-          <text macro="issued" prefix=" (" suffix=")"/>
-        </if>
-        <else-if type="bill book graphic legal_case legislation motion_picture report song" match="any">
-          <group>
-            <text macro="title" prefix=" "/>
-            <text macro="editor" prefix=" "/>
-          </group>
-          <group prefix=" (" suffix=")">
-            <group delimiter=", ">
-              <text macro="publisher"/>
-              <text macro="edition"/>
-              <text macro="issued"/>
+      <group delimiter=", ">
+        <text macro="author"/>
+        <choose>
+          <if type="thesis">
+            <group delimiter=" ">
+              <group delimiter=", ">
+                <group>
+                  <!-- Always print, even if no university given -->
+                  <text value="thesis"/>
+                </group>
+                <text macro="publisher"/>
+              </group>
+              <text macro="issued" prefix="(" suffix=")"/>
             </group>
-            <text variable="URL" prefix="; "/>
-          </group>
-          <text macro="pages" prefix=", "/>
-        </else-if>
-        <else-if type="chapter paper-conference" match="any">
-          <group prefix=" ">
-            <text term="in"/>
-            <text variable="container-title" font-style="italic" prefix=" " suffix=","/>
-            <text variable="collection-title" prefix=" " suffix="."/>
-            <text macro="editor" prefix=" "/>
-            <group prefix=" (" suffix=")" delimiter=", ">
-              <text macro="publisher"/>
-              <text macro="issued"/>
+          </if>
+          <else-if type="bill book graphic legal_case legislation motion_picture song chapter paper-conference" match="any">
+            <group delimiter=" ">
+              <choose>
+                <if type="chapter paper-conference" match="any">
+                  <group delimiter=", ">
+                    <group delimiter=" ">
+                      <text term="in"/>
+                      <text variable="container-title" font-style="italic"/>
+                    </group>
+                    <text macro="editor"/>
+                  </group>
+                </if>
+                <else>
+                  <text macro="title"/>
+                </else>
+              </choose>
+              <group prefix="(" suffix=")" delimiter="; ">
+                <group delimiter=", ">
+                  <text macro="publisher"/>
+                  <text macro="edition"/>
+                  <text macro="issued"/>
+                </group>
+                <text variable="URL"/>
+              </group>
             </group>
-          </group>
-          <group delimiter=", " prefix=", ">
-            <text macro="volume"/>
+            <group delimiter=" of ">
+              <group>
+                <label variable="volume" form="short" suffix=" "/>
+                <number variable="volume"/>
+              </group>
+              <text variable="collection-title" font-style="italic"/>
+            </group>
+            <choose>
+              <if type="chapter paper-conference" match="any">
+                <text macro="pages"/>
+              </if>
+            </choose>
+          </else-if>
+          <else-if type="article-journal">
+            <choose>
+              <if variable="page">
+                <choose>
+                  <if is-numeric="page" match="none">
+                    <group>
+                      <group delimiter=", ">
+                        <text variable="container-title" form="short" font-style="italic"/>
+                        <group>
+                          <text term="in press"/>
+                        </group>
+                      </group>
+                      <text macro="access"/>
+                    </group>
+                  </if>
+                  <else>
+                    <text macro="article-details"/>
+                  </else>
+                </choose>
+              </if>
+              <else>
+                <text macro="article-details"/>
+              </else>
+            </choose>
+          </else-if>
+          <else-if type="report">
+            <group>
+              <group delimiter=", ">
+                <text variable="title" quotes="true"/>
+                <text variable="collection-title" font-style="italic"/>
+              </group>
+              <group prefix=" (" suffix=")" delimiter=", ">
+                <group delimiter=" ">
+                  <text variable="genre" form="short"/>
+                  <number variable="number"/>
+                </group>
+                <text variable="publisher"/>
+                <text variable="publisher-place"/>
+                <text macro="issued"/>
+              </group>
+            </group>
             <text macro="pages"/>
-          </group>
-        </else-if>
-        <else-if type="article-journal">
-          <group suffix=".">
-            <text macro="editor" prefix=" "/>
-          </group>
-          <group prefix=" ">
-            <text form="short" variable="container-title" font-style="italic" suffix=" "/>
-            <text variable="volume" font-weight="bold"/>
-            <text variable="page" prefix=", "/>
-          </group>
-          <text macro="issued" prefix=" (" suffix=")"/>
-          <text macro="access"/>
-        </else-if>
-        <else>
-          <group suffix=".">
-            <text macro="editor" prefix=" "/>
-          </group>
-          <group prefix=" ">
-            <text macro="title"/>
-            <text form="short" variable="container-title" font-style="italic" suffix=" "/>
-            <text variable="volume" font-weight="bold"/>
-            <text variable="page" prefix=", "/>
-          </group>
-          <text macro="issued" prefix=" (" suffix=")"/>
-          <text macro="access"/>
-        </else>
-      </choose>
+            <text macro="access"/>
+          </else-if>
+          <else>
+            <group>
+              <group delimiter=", ">
+                <text macro="editor"/>
+                <group delimiter=". ">
+                  <text macro="title"/>
+                  <text form="short" variable="container-title" font-style="italic"/>
+                  <text variable="volume" font-weight="bold"/>
+                </group>
+              </group>
+              <text macro="issued" prefix=" (" suffix=")"/>
+            </group>
+            <text macro="pages"/>
+            <text macro="access"/>
+          </else>
+        </choose>
+      </group>
     </layout>
   </bibliography>
 </style>

--- a/science.csl
+++ b/science.csl
@@ -20,7 +20,7 @@
     <issn>0036-8075</issn>
     <eissn>1095-9203</eissn>
     <summary>The Science journal style.</summary>
-    <updated>2012-09-27T22:06:38+00:00</updated>
+    <updated>2014-06-18T08:06:38+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <macro name="editor">
@@ -32,7 +32,7 @@
   <macro name="author">
     <names variable="author">
       <name sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
-      <label form="short" prefix=", " suffix="." text-case="capitalize-first" strip-periods="true"/>
+      <label form="short" prefix=", " text-case="capitalize-first"/>
       <et-al font-style="italic"/>
       <substitute>
         <names variable="editor"/>
@@ -42,18 +42,24 @@
   <macro name="access">
     <choose>
       <if variable="page" match="none">
-        <choose>
-          <if variable="DOI">
-            <text variable="DOI" prefix=", doi:"/>
-          </if>
-          <else>
-            <group prefix=" (" suffix=")">
-              <text value="available at "/>
-              <text variable="URL"/>
-            </group>
-          </else>
-        </choose>
+        <text macro="access-value"/>
       </if>
+      <else-if is-numeric="page" match="none">
+        <text macro="access-value"/>
+      </else-if>
+    </choose>
+  </macro>
+  <macro name="access-value">
+    <choose>
+      <if variable="DOI">
+        <text variable="DOI" prefix=", doi:"/>
+      </if>
+      <else>
+        <group prefix=" (" suffix=")">
+          <text value="available at "/>
+          <text variable="URL"/>
+        </group>
+      </else>
     </choose>
   </macro>
   <macro name="title">
@@ -65,6 +71,18 @@
         <text variable="title"/>
       </else>
     </choose>
+  </macro>
+  <macro name="article-details">
+    <group delimiter=", ">
+      <group delimiter=". ">
+        <text macro="title"/>
+        <text form="short" variable="container-title" font-style="italic"/>
+        <text variable="volume" font-weight="bold"/>
+      </group>
+      <text variable="page"/>
+    </group>
+    <text macro="issued" prefix=" (" suffix=")"/>
+    <text macro="access"/>
   </macro>
   <macro name="publisher">
     <group delimiter=", ">
@@ -108,71 +126,120 @@
   <bibliography et-al-min="6" et-al-use-first="1" second-field-align="flush">
     <layout suffix=".">
       <text variable="citation-number" suffix=". "/>
-      <text macro="author" suffix=","/>
-      <choose>
-        <if type="thesis">
-          <text value=" thesis, "/>
-          <text macro="publisher"/>
-          <text macro="issued" prefix=" (" suffix=")"/>
-        </if>
-        <else-if type="bill book graphic legal_case legislation motion_picture report song" match="any">
-          <group>
-            <text macro="title" prefix=" "/>
-            <text macro="editor" prefix=" "/>
-          </group>
-          <group prefix=" (" suffix=")">
-            <group delimiter=", ">
-              <text macro="publisher"/>
-              <text macro="edition"/>
-              <text macro="issued"/>
+      <group delimiter=", ">
+        <text macro="author"/>
+        <choose>
+          <if type="thesis">
+            <group delimiter=" ">
+              <group delimiter=", ">
+                <group>
+                  <!-- Always print, even if no university given -->
+                  <text value="thesis"/>
+                </group>
+                <text macro="publisher"/>
+              </group>
+              <text macro="issued" prefix="(" suffix=")"/>
             </group>
-            <text variable="URL" prefix="; "/>
-          </group>
-          <text macro="pages" prefix=", "/>
-        </else-if>
-        <else-if type="chapter paper-conference" match="any">
-          <group prefix=" ">
-            <text term="in"/>
-            <text variable="container-title" font-style="italic" prefix=" " suffix=","/>
-            <text variable="collection-title" prefix=" " suffix="."/>
-            <text macro="editor" prefix=" "/>
-            <group prefix=" (" suffix=")" delimiter=", ">
-              <text macro="publisher"/>
-              <text macro="issued"/>
+          </if>
+          <else-if type="bill book graphic legal_case legislation motion_picture song chapter paper-conference" match="any">
+            <group delimiter=" ">
+              <choose>
+                <if type="chapter paper-conference" match="any">
+                  <group delimiter=", ">
+                    <group delimiter=" ">
+                      <text term="in"/>
+                      <text variable="container-title" font-style="italic"/>
+                    </group>
+                    <text macro="editor"/>
+                  </group>
+                </if>
+                <else>
+                  <text macro="title"/>
+                </else>
+              </choose>
+              <group prefix="(" suffix=")" delimiter="; ">
+                <group delimiter=", ">
+                  <text macro="publisher"/>
+                  <text macro="edition"/>
+                  <text macro="issued"/>
+                </group>
+                <text variable="URL"/>
+              </group>
             </group>
-          </group>
-          <group delimiter=", " prefix=", ">
-            <text macro="volume"/>
+            <group delimiter=" of ">
+              <group>
+                <label variable="volume" form="short" suffix=" "/>
+                <number variable="volume"/>
+              </group>
+              <text variable="collection-title" font-style="italic"/>
+            </group>
+            <choose>
+              <if type="chapter paper-conference" match="any">
+                <text macro="pages"/>
+              </if>
+            </choose>
+          </else-if>
+          <else-if type="article-journal">
+            <choose>
+              <if variable="page">
+                <choose>
+                  <if is-numeric="page" match="none">
+                    <group>
+                      <group delimiter=", ">
+                        <text variable="container-title" form="short" font-style="italic"/>
+                        <group>
+                          <text term="in press"/>
+                        </group>
+                      </group>
+                      <text macro="access"/>
+                    </group>
+                  </if>
+                  <else>
+                    <text macro="article-details"/>
+                  </else>
+                </choose>
+              </if>
+              <else>
+                <text macro="article-details"/>
+              </else>
+            </choose>
+          </else-if>
+          <else-if type="report">
+            <group>
+              <group delimiter=", ">
+                <text variable="title" quotes="true"/>
+                <text variable="collection-title" font-style="italic"/>
+              </group>
+              <group prefix=" (" suffix=")" delimiter=", ">
+                <group delimiter=" ">
+                  <text variable="genre" form="short"/>
+                  <number variable="number"/>
+                </group>
+                <text variable="publisher"/>
+                <text variable="publisher-place"/>
+                <text macro="issued"/>
+              </group>
+            </group>
             <text macro="pages"/>
-          </group>
-        </else-if>
-        <else-if type="article-journal">
-          <group suffix=".">
-            <text macro="editor" prefix=" "/>
-          </group>
-          <group prefix=" ">
-            <text macro="title" suffix=". "/>
-            <text form="short" variable="container-title" font-style="italic" suffix=" "/>
-            <text variable="volume" font-weight="bold"/>
-            <text variable="page" prefix=", "/>
-          </group>
-          <text macro="issued" prefix=" (" suffix=")"/>
-          <text macro="access"/>
-        </else-if>
-        <else>
-          <group suffix=".">
-            <text macro="editor" prefix=" "/>
-          </group>
-          <group prefix=" ">
-            <text macro="title"/>
-            <text form="short" variable="container-title" font-style="italic" suffix=" "/>
-            <text variable="volume" font-weight="bold"/>
-            <text variable="page" prefix=", "/>
-          </group>
-          <text macro="issued" prefix=" (" suffix=")"/>
-          <text macro="access"/>
-        </else>
-      </choose>
+            <text macro="access"/>
+          </else-if>
+          <else>
+            <group>
+              <group delimiter=", ">
+                <text macro="editor"/>
+                <group delimiter=". ">
+                  <text macro="title"/>
+                  <text form="short" variable="container-title" font-style="italic"/>
+                  <text variable="volume" font-weight="bold"/>
+                </group>
+              </group>
+              <text macro="issued" prefix=" (" suffix=")"/>
+            </group>
+            <text macro="pages"/>
+            <text macro="access"/>
+          </else>
+        </choose>
+      </group>
     </layout>
   </bibliography>
 </style>


### PR DESCRIPTION
- No comma before volume of parentheses (unless there's an unreasonable amount of data missing)
- Add better support for reports
- Consolidate book details for chapters and books so there are no discrepancies between the two

Note that "without-titles" version is just science with titles copy-pasted and `<text variable="title">` removed from article-details macro. They are identical otherwise.

Re https://forums.zotero.org/discussion/37615/science-style-error-commas-instead-of-periods-after-journal-article-titles/

Though I'm not sure that my first note on that post is possible to address without putting the name in "Last, First" form.

> There should be a comma before "Jr." part.
