### PR TITLE
Create APOLLON_Hochschule_der_Gesundheitswirtschaft_(German).csl

### DIFF
--- a/dependent/APOLLON_Hochschule_der_Gesundheitswirtschaft_(German).csl
+++ b/dependent/APOLLON_Hochschule_der_Gesundheitswirtschaft_(German).csl
@@ -1,0 +1,178 @@
+<?xml version="1.0" encoding="utf-8"?>
+<style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" name-delimiter="; " initialize-with="." names-delimiter="; " demote-non-dropping-particle="sort-only" default-locale="de-DE">
+  <info>
+    <title>APOLLON Hochschule der Gesundheitswirtschaft (German)</title>
+    <id>http://www.zotero.org/styles/apollon-hochschule-der-Gesundheitswirtschaft(German)</id>
+    <link href="http://www.zotero.org/styles/apollon-hochschule-de-Gesundheitswirtschaft (German)" rel="self"/>
+    <link href="https://www.zotero.org/styles/american-journal-of-physical-anthropology?source=1" rel="template"/>
+    <link href="https://www.apollon-hochschule.de/" rel="documentation"/>
+    <author>
+      <name>Julia Willenbrock</name>
+      <email>julia.willenbrock@apollon-hochschule.de</email>
+    </author>
+    <category citation-format="author-date"/>
+    <category field="science"/>
+    <summary>Style for APOLLON Hochschule</summary>
+    <updated>2014-05-22T13:21:19+00:00</updated>
+    <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
+  </info>
+  <locale xml:lang="de">
+    <terms>
+      <term name="et-al">et al.</term>
+      <term name="anonymous">O. V. </term>
+    </terms>
+  </locale>
+  <macro name="editor">
+    <names variable="editor">
+      <name delimiter-precedes-last="always" initialize-with="." name-as-sort-order="all"/>
+      <label form="short" plural="never" prefix=" (" suffix="):"/>
+    </names>
+  </macro>
+  <macro name="anon">
+    <text term="anonymous" text-case="capitalize-first" strip-periods="false" font-variant="normal" prefix=" "/>
+    <date date-parts="year" form="numeric" variable="issued"/>
+  </macro>
+  <macro name="author">
+    <group suffix=".">
+      <names variable="author">
+        <name delimiter="; " delimiter-precedes-et-al="never" et-al-min="4" et-al-use-first="4" initialize-with="." name-as-sort-order="all"/>
+        <label form="short" strip-periods="true" prefix=" "/>
+      </names>
+    </group>
+  </macro>
+  <macro name="author-short">
+    <names variable="author">
+      <name form="short" delimiter="; " et-al-use-first="1" initialize-with="."/>
+      <substitute>
+        <names variable="editor"/>
+        <text macro="anon"/>
+      </substitute>
+    </names>
+  </macro>
+  <macro name="access">
+    <group>
+      <text variable="URL" text-decoration="underline"/>
+      <date form="numeric" variable="accessed" prefix=" (" suffix=")."/>
+    </group>
+  </macro>
+  <macro name="title">
+    <text variable="title" font-style="italic"/>
+  </macro>
+  <macro name="locator">
+    <label variable="locator" form="short" strip-periods="true"/>
+    <text variable="locator" prefix=" "/>
+  </macro>
+  <macro name="publisher">
+    <group delimiter=": ">
+      <text variable="publisher-place"/>
+      <text variable="publisher"/>
+    </group>
+  </macro>
+  <macro name="issued">
+    <date variable="issued" delimiter=" ">
+      <date-part name="year"/>
+      <date-part name="month" prefix=" "/>
+      <date-part name="day" prefix=" "/>
+    </date>
+    <group prefix=" [" suffix="]" delimiter=" ">
+      <text term="cited"/>
+      <date variable="accessed">
+        <date-part name="year"/>
+        <date-part name="month" prefix=" "/>
+        <date-part name="day" prefix=" "/>
+      </date>
+    </group>
+  </macro>
+  <macro name="pages">
+    <text variable="page" prefix="S. "/>
+  </macro>
+  <macro name="journal">
+    <text variable="container-title" suffix=","/>
+    <choose>
+      <if type="article-journal"/>
+      <else>
+        <date form="numeric" variable="issued" prefix=" " suffix=","/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="edition">
+    <choose>
+      <if is-numeric="edition">
+        <group delimiter=" ">
+          <number variable="edition" form="ordinal"/>
+          <text term="edition" form="short"/>
+        </group>
+      </if>
+      <else>
+        <text variable="edition" suffix="."/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="year-issued">
+    <date variable="issued">
+      <date-part name="year"/>
+    </date>
+  </macro>
+  <citation et-al-min="3" et-al-use-first="1" disambiguate-add-year-suffix="true" collapse="year-suffix">
+    <sort>
+      <key macro="year-issued"/>
+      <key macro="author-short"/>
+    </sort>
+    <layout prefix="(" suffix=")" delimiter="; ">
+      <group delimiter=", ">
+        <text macro="author-short"/>
+        <date variable="issued" delimiter=" ">
+          <date-part name="year"/>
+        </date>
+        <text macro="pages"/>
+      </group>
+    </layout>
+  </citation>
+  <bibliography hanging-indent="true" et-al-min="10" et-al-use-first="9">
+    <sort>
+      <key macro="author"/>
+      <key macro="year-issued"/>
+    </sort>
+    <layout>
+      <text macro="author"/>
+      <date variable="issued" prefix=" (" suffix=").">
+        <date-part name="year"/>
+      </date>
+      <text macro="title" font-style="italic" prefix=" " suffix="."/>
+      <choose>
+        <if type="book article webpage report thesis manuscript" match="any">
+          <group prefix=" " suffix="." delimiter=" ">
+            <text macro="edition"/>
+            <text macro="editor" prefix="(" suffix=")"/>
+          </group>
+          <text prefix=" " suffix="." macro="publisher"/>
+        </if>
+        <else-if type="chapter" match="any">
+          <group prefix=" " delimiter=" ">
+            <text term="in" text-case="capitalize-first" suffix=":"/>
+            <text macro="editor"/>
+            <text variable="container-title" suffix="."/>
+            <text variable="volume" prefix="Vol. " suffix="."/>
+            <text macro="edition"/>
+            <text variable="collection-title" suffix="."/>
+            <group suffix=".">
+              <text macro="publisher"/>
+              <group suffix="." prefix=". " delimiter=". ">
+                <text macro="pages"/>
+              </group>
+            </group>
+          </group>
+        </else-if>
+        <else>
+          <group prefix=" " suffix=".">
+            <text macro="journal"/>
+            <text variable="volume" prefix=" " suffix=" "/>
+            <number prefix="(" suffix="), " variable="issue"/>
+            <text variable="page" prefix=" S. "/>
+          </group>
+        </else>
+      </choose>
+      <text prefix=" " macro="access"/>
+    </layout>
+  </bibliography>
+</style>


### PR DESCRIPTION
APOLLON-Hochschule-der-Gesundheitswirtschaft-(German).csl
The existing style "American Journal of Physical Anthropology" was edited to "APOLLON Hochschule der Gesundheitswirtschaft (German)" primarily for authors of the private College.
Several changes were made:
The authors names are delimited by a semicolon, the first names are initialized with a dot, sort seperator is a comma. The date is in round braces. The title is italic. The language was changed to German. In case of a Journal the volume and issue (in braces) and the exact issues date was added. The container title seperates with a comma to the issued date. The access date of URLs was added. The term "et al" is used when more than 4 authors are present. The inline citation uses "et al" when 2 or more authors are present. The editor is in braces and seperates with a colon.
