### PR TITLE
Style Error - extra space on first line

### DIFF
--- a/springer-lecture-notes-in-computer-science.csl
+++ b/springer-lecture-notes-in-computer-science.csl
@@ -69,7 +69,7 @@
   <bibliography entry-spacing="0" second-field-align="flush">
     <layout suffix=".">
       <text variable="citation-number" suffix="."/>
-      <text macro="author" prefix=" " suffix=": "/>
+      <text macro="author" suffix=": "/>
       <choose>
         <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
           <group delimiter=" ">


### PR DESCRIPTION
I believe there is an extra space " " between the citation-number and the author, which are already separated by a tab. This makes entries with 2 or more lines to be misaligned.

The style link is:

https://www.zotero.org/styles/springer-lecture-notes-in-computer-science

And the change proposed is:

<code> [Line 72] <text macro="author" prefix=" " suffix=": "/> </code>

Should be:

<code> [Line 72] <text macro="author" suffix=": "/> </code>

Best regards,

P.L.
