### PR TITLE
Update risk-analysis.csl

### DIFF
--- a/risk-analysis.csl
+++ b/risk-analysis.csl
@@ -19,7 +19,7 @@
   <macro name="editor">
     <names variable="editor">
       <name name-as-sort-order="all" sort-separator=" " initialize-with="" delimiter=", " delimiter-precedes-last="always"/>
-      <label form="short" prefix=", "/>
+      <label form="short" prefix=" (" suffix=")" strip-periods="true"/>
     </names>
   </macro>
   <macro name="anon">
@@ -51,7 +51,7 @@
   <macro name="title">
     <choose>
       <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
-        <text variable="title" font-style="italic"/>
+        <text variable="title" text-case="title"/>
       </if>
       <else>
         <text variable="title"/>
@@ -114,10 +114,10 @@
         <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
           <group suffix="." prefix=" " delimiter=" ">
             <text macro="edition"/>
-            <text macro="editor" prefix="(" suffix=")"/>
+            <text macro="editor" prefix=" "/>
           </group>
           <text prefix=" " macro="publisher"/>
-          <group suffix="." prefix="; ">
+          <group suffix="." prefix=", ">
             <date variable="issued">
               <date-part name="year"/>
             </date>
@@ -126,19 +126,20 @@
         </if>
         <else-if type="chapter paper-conference" match="any">
           <group prefix=" ">
-            <text term="in" text-case="capitalize-first" suffix=": "/>
-            <text macro="editor"/>
-            <text variable="container-title" font-style="italic" prefix=" " suffix="."/>
+            <label variable="page" form="short" text-case="capitalize-first"/>
+            <text variable="page" prefix=" " suffix=" "/>
+            <text term="in" text-case="lowercase" suffix=" "/>
+            <text macro="editor" suffix=". "/>
+            <text variable="container-title" text-case="title" prefix=" " suffix="."/>
             <text variable="volume" prefix="Vol " suffix="."/>
             <text macro="edition" prefix=" "/>
             <text variable="collection-title" prefix=" " suffix="."/>
             <group suffix=".">
               <text macro="publisher" prefix=" "/>
-              <group suffix="." prefix="; ">
+              <group suffix="." prefix=", ">
                 <date variable="issued">
                   <date-part name="year"/>
                 </date>
-                <text variable="page" prefix=":"/>
               </group>
             </group>
           </group>
@@ -183,7 +184,7 @@
         <else>
           <text macro="editor" prefix=" " suffix="."/>
           <group prefix=" " suffix=".">
-            <text variable="container-title" font-style="italic" suffix="."/>
+            <text variable="container-title" suffix=","/>
             <group delimiter=";" prefix=" ">
               <date variable="issued">
                 <date-part name="year"/>


### PR DESCRIPTION
The Risk Analysis style has a few minor errors in punctuation, font style, and placement of items, which I think I've corrected with these changes.  The changes I've made are as follows:

l.22: changed label form to achieve label of: "(eds)"
l.54: changed to remove italics and put in title case
l.117: removed parantheses around editor text
l.120: changed "; " to ", " in prefix
l.129: added line with label variable "page"
l.130: added line with text variable "page"
l.131: changed format of text term "in"
l.132: added suffix ". "
l.133: removed italics, added text-case="title"
l.139: changed prefix from "; " to ", "
l.142f: removed line with page text
l.187: removed italics; changed suffix from "." to ","
