### PR TITLE
Create vancouver-fr-ca.csl

### DIFF
--- a/vancouver-fr-ca.csl
+++ b/vancouver-fr-ca.csl
@@ -1,0 +1,298 @@
+<?xml version="1.0" encoding="utf-8"?>
+<style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" demote-non-dropping-particle="sort-only" page-range-format="minimal" default-locale="fr-CA">
+  <info>
+    <title>Vancouver (French - Canada)</title>
+    <id>http://www.zotero.org/styles/vancouver-fr-ca</id>
+    <link href="http://www.zotero.org/styles/vancouver-fr-ca" rel="self"/>
+    <link href="http://www.zotero.org/styles/vancouver" rel="template"/>
+    <link href="http://guides.bib.umontreal.ca/disciplines/247-Citer-selon-le-style-Vancouver?tab=1004" rel="documentation"/>
+    <author>
+      <name>Florian Martin-Bariteau</name>
+      <email>f.martin-bariteau@umontreal.ca</email>
+      <uri>http://f-mb.org/</uri>
+    </author>
+    <category citation-format="numeric"/>
+    <category field="medicine"/>
+    <summary>Adaptation en français de la norme Vancouver, basée sur le guide des Bibliothèques de l'Université de Montréal.</summary>
+    <updated>2014-06-30T23:13:00+00:00</updated>
+    <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
+  </info>
+  <locale>
+    <date form="text" delimiter=" ">
+      <date-part name="day"/>
+      <date-part name="month" form="short" strip-periods="true"/>
+      <date-part name="year"/>
+    </date>
+    <terms>
+      <term name="retrieved">disponible</term>
+      <term name="in">dans</term>
+      <term name="cited">cité le</term>
+      <term name="internet">en ligne</term>
+      <term name="editor">
+        <single>rédacteur</single>
+        <multiple>rédacteurs</multiple>
+      </term>
+      <term name="original-author">
+        <single>inventeur</single>
+        <multiple>inventeurs</multiple>
+      </term>
+    </terms>
+  </locale>
+  <macro name="author">
+    <names variable="author">
+      <name sort-separator=" " initialize-with="" name-as-sort-order="all" delimiter=", " delimiter-precedes-last="always"/>
+      <label form="long" prefix=", "/>
+      <substitute>
+        <names variable="editor"/>
+      </substitute>          
+    </names>
+    <choose>
+      <if type="patent">
+        <text term="original-author" prefix=", "/>
+      </if>
+    </choose>    
+  </macro>
+  <macro name="editor">
+    <names variable="editor" suffix=".">
+      <name sort-separator=" " initialize-with="" name-as-sort-order="all" delimiter=", " delimiter-precedes-last="always"/>
+      <label form="long" prefix=", "/>
+    </names>
+  </macro>
+  <macro name="publisher">
+    <group delimiter=": " suffix=";">
+      <choose>
+        <if type="thesis">
+          <text variable="publisher-place" prefix="[" suffix="]"/>
+        </if>
+        <else>
+          <text variable="publisher-place"/>
+        </else>
+      </choose>
+      <text variable="publisher"/>
+    </group>
+  </macro>
+  <macro name="access">
+    <choose>
+      <if variable="URL">
+        <group delimiter=": ">
+          <group delimiter=" ">
+            <text term="retrieved" text-case="capitalize-first"/>
+          </group>
+          <text variable="URL"/>
+        </group>
+      </if>
+    </choose>
+  </macro>
+  <macro name="accessed-date">
+    <choose>
+      <if variable="URL">
+        <group prefix="[" suffix="]" delimiter=" ">
+          <text term="cited" text-case="lowercase"/>
+          <date variable="accessed" form="text"/>
+        </group>
+      </if>
+    </choose>
+  </macro>
+  <macro name="container-title">
+    <choose>
+      <if type="article-journal article-magazine chapter paper-conference article-newspaper" match="any">
+        <group suffix="." delimiter=" ">
+          <choose>
+            <if type="article-journal">
+              <text variable="container-title" form="short" strip-periods="true"/>
+            </if>
+            <else>
+              <text variable="container-title" strip-periods="true"/>
+            </else>
+          </choose>
+          <text macro="edition"/>
+          <choose>
+            <if variable="URL">
+              <text term="internet" prefix="[" suffix="]" text-case="capitalize-first"/>
+            </if>
+          </choose>
+        </group>
+      </if>
+      <!--add event-name and event-place once they become available-->
+      <else-if type="bill legislation" match="any">
+        <group delimiter=", ">
+          <group delimiter=". ">
+            <text variable="container-title"/>
+            <group delimiter=" ">
+              <text term="section" form="short" text-case="capitalize-first"/>
+              <text variable="section"/>
+            </group>
+          </group>
+          <text variable="number"/>
+        </group>
+      </else-if>
+      <else>
+        <text variable="container-title" suffix="."/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="title">
+    <text variable="title"/>
+    <choose>
+      <if type="thesis">
+        <text variable="genre" prefix=" [" suffix="]. "/>
+      </if>
+    </choose>
+    <choose>
+      <if type="article-journal article-magazine chapter paper-conference article-newspaper" match="none">
+        <text macro="edition" prefix=". "/>
+        <choose>
+          <if variable="URL">
+            <text term="internet" prefix=" [" suffix="]" text-case="capitalize-first"/>
+          </if>
+        </choose>
+      </if>
+    </choose>
+  </macro>
+  <macro name="edition">
+    <choose>
+      <if is-numeric="edition">
+        <group delimiter=" ">
+          <number variable="edition" form="ordinal"/>
+          <text term="edition" form="short"/>
+        </group>
+      </if>
+      <else>
+        <text variable="edition" suffix="."/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="date">
+    <choose>
+      <if type="article-journal article-magazine article-newspaper webpage" match="any">
+        <group suffix=";" delimiter=" ">
+          <date variable="issued" form="text"/>
+          <text macro="accessed-date"/>
+        </group>
+      </if>
+      <else-if type="bill legislation" match="any">
+        <group delimiter=", ">
+          <date variable="issued" form="text"/>
+        </group>
+      </else-if>
+      <else-if type="report">
+        <date variable="issued" delimiter=" ">
+       	  <date-part name="month" form="short" strip-periods="true"/>
+          <date-part name="year"/>
+        </date>
+      </else-if>
+      <else-if type="patent">
+        <group suffix=".">
+          <group delimiter=", ">
+            <text variable="number"/>
+            <date variable="issued" form="text"/>
+          </group>
+          <text macro="accessed-date" prefix=" "/>
+        </group>
+      </else-if>
+      <else>
+        <group suffix=".">
+          <date variable="issued">
+            <date-part name="year"/>
+          </date>
+          <text macro="accessed-date" prefix=" "/>
+        </group>
+      </else>
+    </choose>
+  </macro>
+  <macro name="pages">
+    <choose>
+      <if type="article-journal article-magazine article-newspaper" match="any">
+        <text variable="page" prefix=":"/>
+      </if>
+      <else-if type="book" match="any">
+        <text variable="number-of-pages" prefix=" " suffix=" p"/>
+      </else-if>
+      <else>
+        <group prefix=" " delimiter=" ">
+          <label variable="page" form="short" plural="never"/>
+          <text variable="page"/>
+        </group>
+      </else>
+    </choose>
+  </macro>
+  <macro name="journal-location">
+    <choose>
+      <if type="article-journal article-magazine" match="any">
+        <text variable="volume"/>
+        <text variable="issue" prefix="(" suffix=")"/>
+      </if>
+    </choose>
+  </macro>
+  <macro name="report-details">
+    <choose>
+      <if type="report">
+        <text variable="number" prefix="Rapport no "/>
+      </if>
+    </choose>
+  </macro>
+  <macro name="webpage-details">
+  	<text variable="container-title"/>
+    <text term="internet" prefix=" [" suffix="]. " text-case="capitalize-first"/>
+    <group delimiter="; " suffix=". ">
+      <group delimiter=". ">
+        <text macro="author"/>
+        <text variable="title"/>
+      </group>
+      <group delimiter=" ">
+        <date variable="issued" form="text"/>
+        <text macro="accessed-date"/>
+      </group>
+    </group>
+  </macro>
+  <macro name="pmcid">
+    <text variable="PMCID" prefix="PMCID: "/>
+    <choose>
+      <if variable="PMCID" match="none">
+        <text variable="PMID" prefix="PMID: "/>
+      </if>
+    </choose>
+  </macro>
+  <citation collapse="citation-number">
+    <sort>
+      <key variable="citation-number"/>
+    </sort>
+    <layout prefix="(" suffix=")" delimiter=",">
+      <text variable="citation-number"/>
+    </layout>
+  </citation>
+  <bibliography et-al-min="7" et-al-use-first="6" second-field-align="flush">
+    <layout>
+      <text variable="citation-number" suffix=". "/>
+      <choose>
+        <if type="webpage">
+      	  <text macro="webpage-details"/>
+        </if>
+        <else>
+		  <group delimiter=". " suffix=". ">
+			<text macro="author"/>
+			<text macro="title"/>
+		  </group>
+		  <group delimiter=" " suffix=". ">
+			<choose>
+			  <if type="chapter paper-conference" match="any">
+				<text term="in" text-case="capitalize-first" suffix=": "/>
+			  </if>
+			</choose>
+			<text macro="editor"/>
+			<text macro="container-title"/>
+			<text macro="publisher"/>
+			<group>
+			  <text macro="date"/>
+			  <text macro="journal-location"/>
+			  <text macro="pages"/>
+			</group>
+		  </group>
+		  <text macro="report-details" suffix=". "/>
+        </else>
+      </choose>
+      <text macro="pmcid" suffix=". "/>
+      <text macro="access"/>
+    </layout>
+  </bibliography>
+</style>


### PR DESCRIPTION
Hello,

I know the policy is to localised rather than create new files. However, due to multiple date formats, no use of some terms and change in fields orders, vancouver.csl can not be localised in French Canadian.

I named the file -fr-ca.csl, and not just -fr.csl, because maybe fr-FR users are pleased with the localised vancouver.csl...

(The style also improve coding in vancouver.csl (PMID, webpages, etc.); I'll push this improvements to vancouver.csl in a separate pull request.)

Thanks.
