### PR TITLE
Update vancouver.csl

### DIFF
--- a/vancouver.csl
+++ b/vancouver.csl
@@ -31,6 +31,10 @@
     <terms>
       <term name="retrieved">available</term>
       <term name="section" form="short">sect.</term>
+      <term name="original-author">
+        <single>inventor</single>
+        <multiple>inventors</multiple>
+      </term>
     </terms>
   </locale>
   <locale xml:lang="fr">
@@ -42,6 +46,10 @@
     <terms>
       <term name="retrieved">disponible</term>
       <term name="from">sur</term>
+      <term name="original-author">
+        <single>inventeur</single>
+        <multiple>inventeurs</multiple>
+      </term>
     </terms>
   </locale>
   <locale xml:lang="de">


### PR DESCRIPTION
Changes: 
- display "inventor" after inventor's name
- correctly display webpages (according to 2011 update)
- display PMCID, or PMID (if available)
