### PR TITLE
Update vancouver-fr-ca.csl (delete PMCID macro)

### DIFF
--- a/vancouver-fr-ca.csl
+++ b/vancouver-fr-ca.csl
@@ -245,14 +245,6 @@
       </group>
     </group>
   </macro>
-  <macro name="pmcid">
-    <text variable="PMCID" prefix="PMCID: "/>
-    <choose>
-      <if variable="PMCID" match="none">
-        <text variable="PMID" prefix="PMID: "/>
-      </if>
-    </choose>
-  </macro>
   <citation collapse="citation-number">
     <sort>
       <key variable="citation-number"/>
@@ -291,7 +283,6 @@
 		  <text macro="report-details" suffix=". "/>
         </else>
       </choose>
-      <text macro="pmcid" suffix=". "/>
       <text macro="access"/>
     </layout>
   </bibliography>


### PR DESCRIPTION
This delete the PM(C)ID macro (request of @adam3smith.)
