### PR TITLE
<macro name="substitute-title"> for unsigned articles

### DIFF
--- a/chicago-author-date.csl
+++ b/chicago-author-date.csl
@@ -101,7 +101,6 @@
         <text macro="container-title"/> 
       </if>
     </choose>
-    <text macro="title"/> 
   </macro>
   <macro name="contributors">
     <group delimiter=". ">
@@ -112,6 +111,7 @@
           <names variable="editor"/>
           <names variable="translator"/>
           <text macro="substitute-title"/>
+          <text macro="title"/>
         </substitute>
       </names>
       <text macro="recipient"/>
@@ -124,6 +124,7 @@
         <names variable="editor"/>
         <names variable="translator"/>
         <text macro="substitute-title"/>
+        <text macro="title"/>
       </substitute>
     </names>
   </macro>


### PR DESCRIPTION
Added <macro name="substitute-title"> to cope with unsigned articles and reviews, where the name of the newspaper or periodical (=container-title) needs to stand in place of the author (see CMoS 14.207 and 14.217). See discussion at https://forums.zotero.org/discussion/37961/choose-element-inside-substitute/
