### PR TITLE
Abbreviation for pages should never be plural for Council for Science Editors

### DIFF
--- a/council-of-science-editors-alphabetical.csl
+++ b/council-of-science-editors-alphabetical.csl
@@ -116,7 +116,7 @@
     </group>
   </macro>
   <macro name="pages">
-    <label variable="page" form="short" suffix=" "/>
+    <label variable="page" form="short" suffix=" " plural="never"/>
     <text variable="page"/>
   </macro>
   <macro name="edition">

--- a/council-of-science-editors.csl
+++ b/council-of-science-editors.csl
@@ -111,7 +111,7 @@
     </group>
   </macro>
   <macro name="pages">
-    <label variable="page" form="short" suffix=" "/>
+    <label variable="page" form="short" suffix=" " plural="never"/>
     <text variable="page"/>
   </macro>
   <macro name="edition">


### PR DESCRIPTION
According to the 8th edition of CSE (29.3.6.9), "pages" should be abbreviated as "p.", not "pp.". council-of-science-editors-author-date.csl already does this.

This replaces pull request #1045.
