### PR TITLE
Update irish-historical-studies.csl

### DIFF
--- a/irish-historical-studies.csl
+++ b/irish-historical-studies.csl
@@ -3,9 +3,10 @@
   <!-- INTRODUCTION -->
   <info>
     <title>Irish Historical Studies</title>
+    <title-short>IHS</title-short>
     <id>http://www.zotero.org/styles/irish-historical-studies</id>
     <link href="http://www.zotero.org/styles/irish-historical-studies" rel="self"/>
-    <link href="http://www.irishhistoricalstudies.ie/" rel="documentation"/>
+    <link href="http://www.irishhistoricalstudies.ie/rulesforcontribs.pdf" rel="documentation"/>
     <author>
       <name>Emma Reisz</name>
       <email>emma.reisz@gmail.com</email>
@@ -13,8 +14,9 @@
     <category citation-format="note"/>
     <category field="history"/>
     <issn>0021-1214</issn>
+    <summary>Style used by Irish Historical Studies and in several universities.</summary>
     <published>2010-11-28T17:00:00+00:00</published>
-    <updated>2012-09-27T22:06:38+00:00</updated>
+    <updated>2014-08-07T14:15:00+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <!-- DEFINING ABBREVIATIONS USED FOR STANDARD TERMS -->
@@ -707,11 +709,15 @@
   <macro name="URL">
     <group delimiter=" ">
       <text variable="URL" prefix="(" suffix=")"/>
-      <date variable="accessed" prefix="(" suffix=")">
-        <date-part name="day" suffix=" "/>
-        <date-part name="month" form="short" suffix=" "/>
-        <date-part name="year"/>
-      </date>
+      <choose>
+        <if type="broadcast entry-dictionary entry-encyclopedia graphic post post-weblog report song speech webpage" match="any">
+          <date variable="accessed" prefix="(" suffix=")">
+			<date-part name="day" suffix=" "/>
+			<date-part name="month" form="short" suffix=" "/>
+			<date-part name="year"/>
+		  </date>
+        </if>
+      </choose>
     </group>
   </macro>
   <macro name="access">


### PR DESCRIPTION
This revision suppresses the access date when it is not required for IHS style.

The revision simplifies the citation of e.g. paper journal articles also available online for which an online access date has been scraped automatically. Currently for such items the access date must be manually removed from the library entry for the style to fomat correctly.
