### PR TITLE
Create iso690-note-fr

### DIFF
--- a/iso690-note-fr.csl
+++ b/iso690-note-fr.csl
@@ -4,6 +4,8 @@
     <title>ISO-690 (note, no abstract, French)</title>
     <id>http://www.zotero.org/styles/iso690-note-fr</id>
     <link href="http://www.zotero.org/styles/iso690-note-fr" rel="self"/>
+    <link href="http://www.zotero.org/styles/iso690-author-date-fr-no-abstract" rel="template"/>
+    <link href="https://github.com/msaby/wip-zotero-styles/blob/master/README.md#iso690-note-fr" rel="documentation"/>
     <author>
       <name>Mathieu Saby</name>
       <email>mathsabypro@gmail.com</email>


### PR DESCRIPTION
New style ISO 690:2010 "note" for french locale
full description here https://github.com/msaby/wip-zotero-styles/blob/master/README.md

ISO 690:2010 is not freely available in french translation, but the english version is available here:
http://www.medline.org.cn/attachment/201364/1370309271657.pdf

The only differences between the two versions are the translation of a few english words, like medium types (map->carte, etc.)
