### PR TITLE
Create ameghiniana.csl

### DIFF
--- a/ameghiniana.csl
+++ b/ameghiniana.csl
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" demote-non-dropping-particle="sort-only">
+<style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" demote-non-dropping-particle="sort-only" default-locale="en-GB">
   <info>
     <title>Ameghiniana</title>
     <title-short>Ameghiniana</title-short>


### PR DESCRIPTION
This is the citation style for Ameghiniana, the journal of the Asociación Paleontológica Argentina. www.ameghiniana.org.ar
