### PR TITLE
Fixed issue with inconsistent volume identifiers.

### DIFF
--- a/melbourne-school-of-theology.csl
+++ b/melbourne-school-of-theology.csl
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <style xmlns="http://purl.org/net/xbiblio/csl" class="note" version="1.0" and="symbol" page-range-format="expanded" demote-non-dropping-particle="sort-only" default-locale="en-GB">
-  <!-- This style was edited with the Visual CSL Editor (http://editor.citationstyles.org/visualEditor/#) -->
+<!-- This style was edited with the Visual CSL Editor (http://editor.citationstyles.org/visualEditor/) -->
   <info>
     <title>Melbourne School of Theology</title>
     <title-short>MST</title-short>
@@ -15,7 +15,7 @@
     <category citation-format="note"/>
     <category field="theology"/>
     <summary>Melbourne School of Theology format based on the Essay Style Guide</summary>
-    <updated>2013-08-19T03:49:16+00:00</updated>
+    <updated>2014-08-21T03:02:49+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale xml:lang="en-GB">
@@ -563,9 +563,9 @@
             </if>
           </choose>
         </if>
-        <else-if variable="volume">
+        <else-if variable="volume" match="all">
           <choose>
-            <if type="chapter paper-conference" match="any">
+            <if type="chapter paper-conference" match="all">
               <choose>
                 <if position="subsequent">
                   <group delimiter=" " suffix=", ">
@@ -575,9 +575,9 @@
                   </group>
                 </if>
               </choose>
-              <number variable="volume" form="numeric" suffix=":"/>
             </if>
           </choose>
+          <number suffix=":" variable="volume"/>
         </else-if>
       </choose>
       <text variable="locator"/>
@@ -659,9 +659,52 @@
             </group>
             <text macro="publisher"/>
             <text macro="issued"/>
+          </group>
+        </group>
+      </else-if>
+      <else>
+        <text macro="issued" prefix=", "/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="issue-bib">
+    <choose>
+      <if type="article-journal">
+        <text variable="volume" prefix=" "/>
+        <text variable="issue" prefix=", no. "/>
+        <text macro="issued" prefix=" (" suffix=")"/>
+      </if>
+      <else-if variable="publisher-place publisher" match="any">
+        <group prefix=" (" suffix=")">
+          <group delimiter="; " suffix="; ">
+            <group>
+              <number variable="number-of-volumes" form="numeric"/>
+              <text term="volume" form="short" plural="true" strip-periods="true" prefix=" "/>
+            </group>
+            <text macro="container-contributors-note"/>
+            <text macro="locators-note"/>
+            <text macro="collection-title"/>
+          </group>
+          <group delimiter=", ">
+            <group delimiter=" ">
+              <choose>
+                <if variable="title" match="none"/>
+                <else-if type="speech" match="any">
+                  <choose>
+                    <if match="none" variable="publisher-place">
+                      <text value="Unpublished "/>
+                    </if>
+                  </choose>
+                  <text variable="genre"/>
+                </else-if>
+              </choose>
+              <text macro="event"/>
+            </group>
+            <text macro="publisher"/>
+            <text macro="issued"/>
             <group>
               <text term="volume" form="short" suffix=" "/>
-              <number variable="volume" form="numeric"/>
+              <number variable="volume"/>
             </group>
           </group>
         </group>
@@ -805,7 +848,7 @@
         <text macro="description-note"/>
         <text macro="container-title-note"/>
       </group>
-      <text macro="issue-note"/>
+      <text macro="issue-bib"/>
       <text macro="locators-newspaper" prefix=", "/>
       <text macro="point-locators"/>
       <text macro="access-note" prefix=", "/>


### PR DESCRIPTION
This fixes and issue with the way that the volume number is displayed in first footnoted citations, for clarity and uniformity with subsequent citations.  It takes the volume number out of the parentheses, and formats it as xx:xxx-xxx.  The bibliography has not changed, but due to previous formatting, a new macro had to be added.
