### PR TITLE
Update apa-fr-provost.csl

### DIFF
--- a/apa-fr-provost.csl
+++ b/apa-fr-provost.csl
@@ -20,6 +20,10 @@
   </info>
   <locale xml:lang="fr">
     <terms>
+      <term name="editor" form="short">
+        <single>éd.</single>
+        <multiple>éds</multiple>
+      </term>
       <term name="editortranslator" form="short">
         <single>éd. &amp; trad.</single>
         <multiple>éd. &amp; trad.</multiple>


### PR DESCRIPTION
I added the term name="editor" in order to get "éd." when there is only one editor and "éds" for multiple editors.
