### PR TITLE
Potential fix for MLA style; question about `source` variable

### DIFF
--- a/modern-language-association-with-url.csl
+++ b/modern-language-association-with-url.csl
@@ -158,9 +158,11 @@
       <else>
         <choose>
           <if variable="URL DOI" match="any">
-            <text variable="source" prefix=" " suffix=". " font-style="italic"/>
-            <text value="Web" prefix=" "/>
-            <text prefix=". " suffix="." macro="access"/>
+            <text variable="source" prefix=" " suffix="." font-style="italic"/>
+            <group>
+              <text value="Web." prefix=" "/>
+            </group>
+            <text prefix=" " suffix="." macro="access"/>
           </if>
           <else>
             <text value="Print" prefix=" "/>

--- a/modern-language-association.csl
+++ b/modern-language-association.csl
@@ -157,11 +157,11 @@
       <else>
         <choose>
           <if variable="URL DOI" match="any">
-            <text variable="source" prefix=" " suffix=". " font-style="italic"/>
+            <text variable="source" prefix=" " suffix="." font-style="italic"/>
             <group>
-              <text value="Web" prefix=" "/>
+              <text value="Web." prefix=" "/>
             </group>
-            <text prefix=". " suffix="." macro="access"/>
+            <text prefix=" " suffix="." macro="access"/>
           </if>
           <else>
             <text value="Print" prefix=" "/>


### PR DESCRIPTION
We are generating citeproc-json that doesn't include the `source` or `access` fields.  Right now, for the MLA style, this is causing the medium of publication to be dropped, but it probably should be "Web".

A general question is:  should we be giving these values?   According to [the spec](http://citationstyles.org/downloads/specification.html#standard-variables), `source` is "from whence the item originates (e.g. a library catalog or database)".  But, we're generating these styles from data in our (PMC) archive, so it's not at all clear.  Should we use `PMC`?  Then, that appears in the citation, but it doesn't really seem to make sense.
