### PR TITLE
Fix punctionat before et al. in deutsche-gesellschaft-fur-psychologie.csl

### DIFF
--- a/deutsche-gesellschaft-fur-psychologie.csl
+++ b/deutsche-gesellschaft-fur-psychologie.csl
@@ -7,6 +7,7 @@
     <link href="http://www.zotero.org/styles/deutsche-gesellschaft-fur-psychologie" rel="self"/>
     <link href="http://www.psychologie.uni-bonn.de/studium/richtlinien-zur-manuskriptgestaltung" rel="documentation"/>
     <link href="https://github.com/citation-style-language/styles/pull/432" rel="documentation"/>
+    <link href="http://hub.culturegraph.org/about/BSZ-267173628/html" rel="documentation"/>
     <author>
       <name>Daniel Hirsbrunner</name>
       <email>dhirsbrunner@gmx.ch</email>


### PR DESCRIPTION
Cf. https://forums.zotero.org/discussion/39655/style-error-deutschegesellschaftfurpsychologie/
