### PR TITLE
Create zeitschrift-fuer-deutsche-philologie.csl

### DIFF
--- a/zeitschrift-fur-deutsche-philologie.csl
+++ b/zeitschrift-fur-deutsche-philologie.csl
@@ -4,8 +4,8 @@
   <info>
     <title>Zeitschrift für deutsche Philologie (German)</title>
     <title-short>ZfdPh</title-short>
-    <id>http://www.zotero.org/styles/zeitschrift-fuer-deutsche-philologie</id>
-    <link href="http://www.zotero.org/styles/zeitschrift-fuer-deutsche-philologie" rel="self"/>
+    <id>http://www.zotero.org/styles/zeitschrift-fur-deutsche-philologie</id>
+    <link href="http://www.zotero.org/styles/zeitschrift-fur-deutsche-philologie" rel="self"/>
     <link href="http://www.zotero.org/styles/kritische-ausgabe" rel="template"/>
     <link href="http://www.esv.info/download/zeitschriften/ZfdPh/autorenhinweise.pdf" rel="documentation"/>
     <link href="http://www.zfdphdigital.de/inhalt.html" rel="documentation"/>
@@ -18,7 +18,7 @@
     <issn>0044-2496</issn>
     <eissn>1865-2018</eissn>
     <summary>Zitierstil der Zeitschrift für Deutsche Philologie des Erich Schmidt Verlags</summary>
-    <updated>2014-09-02T21:18:46+00:00</updated>
+    <updated>2014-09-03T04:55:13+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale xml:lang="de">
@@ -47,7 +47,7 @@
   </macro>
   <macro name="editor">
     <choose>
-      <if type="entry-encyclopedia" match="any" variable="author editor"/>
+      <if type="entry-encyclopedia" match="all" variable="author editor"/>
       <else>
         <names variable="editor">
           <label form="verb-short" text-case="lowercase"/>
@@ -146,7 +146,7 @@
                   <text variable="publisher-place"/>
                   <group>
                     <text macro="edition-if-unveraendert" vertical-align="sup"/>
-                    <date date-parts="year" form="text" variable="issued">
+                    <date variable="issued">
                       <date-part name="year"/>
                     </date>
                   </group>
@@ -192,7 +192,7 @@
                 <text variable="publisher-place"/>
                 <group>
                   <text macro="edition-if-unveraendert" vertical-align="sup"/>
-                  <date date-parts="year" form="text" variable="issued">
+                  <date variable="issued">
                     <date-part name="year"/>
                   </date>
                 </group>


### PR DESCRIPTION
This should fulfill this <a href="https://forums.zotero.org/discussion/21423/style-request-zeitschrift-fuer-deutsche-philologie-zfph-german-humanities/">old style request</a>.

Please note
- I suggest in this style to use encyclopediaArticle for "Werke in Editionen" and the style will then print the "Ders./Dies." instead of the editors (which are then the same as the authors). I will ignore gender-specific wording here.
- Normally, only footnotes are used and not bibliography. However, this csl style implements also a bibliogrpahy and should at least fulfill the needs for "Literaturangaben in sprachwissenschaftlichen Beiträgen" (point 10).

@adam3smith Thank you for the good starting point "Kritische Ausgabe (German)"!
