### PR TITLE
Add DOI, PMID and PMCID to Council of Science Editors

### DIFF
--- a/council-of-science-editors-alphabetical.csl
+++ b/council-of-science-editors-alphabetical.csl
@@ -133,7 +133,7 @@
     </choose>
   </macro>
   <macro name="notes">
-    <group delimter=". ">
+    <group delimiter=". ">
       <text variable="DOI" prefix="doi:"/>
       <text variable="PMID" prefix="pmid:"/>
       <text variable="PMCID" prefix="pmcid:"/>

--- a/council-of-science-editors-author-date.csl
+++ b/council-of-science-editors-author-date.csl
@@ -143,7 +143,7 @@
     </choose>
   </macro>
   <macro name="notes">
-    <group delimter=". ">
+    <group delimiter=". ">
       <text variable="DOI" prefix="doi:"/>
       <text variable="PMID" prefix="pmid:"/>
       <text variable="PMCID" prefix="pmcid:"/>

--- a/council-of-science-editors.csl
+++ b/council-of-science-editors.csl
@@ -128,7 +128,7 @@
     </choose>
   </macro>
   <macro name="notes">
-    <group delimter=". ">
+    <group delimiter=". ">
       <text variable="DOI" prefix="doi:"/>
       <text variable="PMID" prefix="pmid:"/>
       <text variable="PMCID" prefix="pmcid:"/>


### PR DESCRIPTION
Add DOI, PMID and PMCID to the "notes" section. The 8th ed. says that these can be added there (29.3.6.13.10).
