### PR TITLE
Create ajme-elsevier-vancouver.csl

### DIFF
--- a/alexandria-journal-of-medicine.csl
+++ b/alexandria-journal-of-medicine.csl
@@ -6,7 +6,7 @@
         <id>http://www.zotero.org/styles/alexandria-journal-of-medicine</id>
         <link href="http://www.zotero.org/styles/alexandria-journal-of-medicine" rel="self"/>
         <link href="http://www.zotero.org/styles/elsevier-vancouver" rel="template"/>
-        <link href="http://www.elsevier.com/journals/progress-in-materials-science/2090-5068/guide-for-authors#Refs" rel="documentation"/>
+        <link href="http://www.elsevier.com/journals/alexandria-journal-of-medicine/2090-5068/guide-for-authors#68000" rel="documentation"/>
         <author>
             <name>Ramanathan</name>
             <email>Ra.Ganapathi@elsevier.com</email>


### PR DESCRIPTION
New CSL file for AJME vancouver based Non-standard journal.
