### PR TITLE
New style ISO 690:2010 "note" for french locale, with op.cit and ibid

### DIFF
--- a/iso690-note-opcit-fr.csl
+++ b/iso690-note-opcit-fr.csl
@@ -1,0 +1,670 @@
+<?xml version="1.0" encoding="utf-8"?>
+<style xmlns="http://purl.org/net/xbiblio/csl" class="note" version="1.0" demote-non-dropping-particle="never" default-locale="fr-FR">
+  <info>
+    <title>ISO-690 (note, no abstract, opcit, French)</title>
+    <id>http://www.zotero.org/styles/iso690-note-opcit-fr</id>
+    <link href="http://www.zotero.org/styles/iso690-note-opcit-fr" rel="self"/>
+    <author>
+      <name>Mathieu Saby</name>
+      <email>mathsabypro@gmail.com</email>
+    </author>
+    <category citation-format="note"/>
+    <category field="generic-base"/>
+    <summary>Style based on ISO 690:2010(F), with notes and bibliography, derived from Mellifluo, Grolimund, Hardegger and Giraud author-date version.</summary>
+    <updated>2014-07-28T23:18:55+00:00</updated>
+    <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
+  </info>
+  <locale>
+    <terms>
+<!-- Only terms different from those in locale-fr-FR.xml are given -->
+      <term name="in">dans</term>
+      <term name="online">en&#160;ligne</term>
+      <term name="accessed">consulté&#160;le</term>
+      <term name="available at">disponible à l'adresse</term>
+      <term name="cited">op.&#160;cit.</term>
+      <term name="editor" form="short">
+<!-- Dir. (Sous la direction de) = most common term in french for editorial responsability of a collective work-->
+        <single>dir.</single>
+        <multiple>dir.</multiple>
+      </term>
+    </terms>
+  </locale>
+  <macro name="author">
+    <names variable="author">
+      <name and="text" name-as-sort-order="all" sort-separator=", " delimiter=", " delimiter-precedes-last="never">
+        <name-part name="family" text-case="uppercase"/>
+        <name-part name="given"/>
+      </name>
+    </names>
+  </macro>
+  <macro name="editor">
+    <names variable="editor">
+      <name and="text" name-as-sort-order="all" sort-separator=", " delimiter=", " delimiter-precedes-last="never">
+        <name-part name="family" text-case="uppercase"/>
+        <name-part name="given"/>
+      </name>
+      <label prefix=" (" form="short" suffix=".)"/>
+    </names>
+  </macro>
+  <macro name="translator">
+    <names variable="translator">
+      <label text-case="capitalize-first" form="verb-short" suffix=" "/>
+      <name and="text" sort-separator=" " delimiter=", " delimiter-precedes-last="never">
+        <name-part name="family" text-case="uppercase"/>
+        <name-part name="given"/>
+      </name>
+    </names>
+  </macro>
+  <macro name="responsability">
+    <choose>
+      <if type="patent">
+<!-- FIXME
+Patent main creator should be Zotero "assignee", which is not yet mapped against any CSL field
+-->
+      </if>
+      <else-if variable="author editor" match="any">
+        <choose>
+          <if variable="author">
+            <text macro="author"/>
+          </if>
+          <else-if variable="editor">
+            <text macro="editor"/>
+          </else-if>
+        </choose>
+      </else-if>
+    </choose>
+  </macro>
+  <macro name="patent-inventor">
+    <text value="Inventeur(s)" suffix="&#8239;: "/>
+    <names variable="author">
+      <name and="text" sort-separator=" " delimiter=", " delimiter-precedes-last="never">
+        <name-part name="family" text-case="uppercase"/>
+        <name-part name="given"/>
+      </name>
+    </names>
+  </macro>
+  <macro name="secondary-responsability">
+<!-- FIXME : improve management of secondary responsabiliy for other types -->
+    <choose>
+      <if type="patent">
+        <text macro="patent-inventor"/>
+      </if>
+    </choose>
+    <text macro="translator"/>
+  </macro>
+  <macro name="container-author">
+    <names variable="container-author">
+      <name and="text" name-as-sort-order="all" sort-separator=", " delimiter=", " delimiter-precedes-last="never">
+        <name-part name="family" text-case="uppercase"/>
+        <name-part name="given"/>
+      </name>
+    </names>
+  </macro>
+  <macro name="container-responsability">
+    <choose>
+      <if variable="container-author editor" match="any">
+        <choose>
+          <if variable="container-author">
+            <text macro="container-author"/>
+          </if>
+          <else-if variable="editor">
+            <text macro="editor"/>
+          </else-if>
+        </choose>
+      </if>
+    </choose>
+  </macro>
+  <macro name="title">
+    <choose>
+      <if type="paper-conference speech chapter article-journal article-magazine article-newspaper post-weblog post webpage broadcast" match="any">
+        <choose>
+          <if variable="container-title">   
+            <text variable="title" suffix=". "/>
+            <choose>
+              <if type="article-journal article-magazine article-newspaper" match="none">
+                <text term="in" text-case="capitalize-first" suffix="&#8239;: "/>
+              </if>
+            </choose>
+            <choose>
+              <if variable="container-author editor" match="any">
+                <text macro="container-responsability"/>
+                <choose>
+                  <if variable="container-title event" match="any">
+                    <text value=", "/>
+                  </if>
+                </choose>
+              </if>
+            </choose>
+            <choose>
+              <if variable="container-title">
+                <text variable="container-title" font-style="italic"/>
+              </if>
+              <else>
+                <text variable="event" font-style="italic"/>
+<!-- variable event: used for congresses-->
+              </else>
+            </choose>
+          </if>
+          <else>
+            <text variable="title" font-style="italic"/>
+          </else>
+        </choose>    
+      </if>
+      <else>
+        <text variable="title" font-style="italic"/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="thesis-report-genre">
+	<choose>
+      <if type="report">
+<!-- Title:Report type n°XXX
+or   Title:Report n°XXX (if no report type)
+or   Title:Report type (if no number)
+-->
+        <choose>
+          <if variable="number">
+			<choose> 
+              <if variable="genre">
+                <group delimiter=" ">
+                  <text variable="genre"/>
+                  <text term="issue" form="short"/>
+                </group>
+              </if>
+              <else>
+                <group delimiter=" ">
+                  <text value="Rapport"/>
+                  <text term="issue" form="short"/>
+                </group>
+              </else>
+            </choose>
+			<text variable="number"/>
+          </if>
+          <else-if variable="genre">
+            <text variable="genre"/>
+          </else-if>
+        </choose>
+      </if>
+      <else-if type="thesis">
+        <text variable="genre"/>
+      </else-if>
+	</choose>
+  </macro>
+  <macro name="volume">
+<!-- If the volume field contains "Tome 1, vol. 2", this string is displayed. If it contains only a number, 'vol.' is added before-->
+    <choose>
+      <if type="article-newspaper article-journal article-magazine" match="none">
+<!-- For article-newspaper article-journal article-magazine, volume is managed in 'issue-pagination-locator' macro-->
+        <choose>
+          <if is-numeric="volume">
+            <text term="volume" form="short" text-case="capitalize-first" suffix="&#160;"/>
+            <text variable="volume"/>
+          </if>
+          <else>
+            <text variable="volume"/>
+          </else>
+        </choose>
+      </if>
+    </choose>
+  </macro>
+  <macro name="numberOfVolumes">
+<!-- If the number-of-volume field contains '3 Tomes, 2 vol.', this string is displayed. If it contains only a number, 'vol.' is added after-->
+    <choose>
+      <if is-numeric="number-of-volumes">
+        <text variable="number-of-volumes"/>
+        <text term="volume" form="short" prefix="&#160;"/>
+      </if>
+      <else>
+        <text variable="number-of-volumes"/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="number">
+<!-- Display only for patents.
+For report, number is managed in title macro-->
+    <choose>
+      <if type="patent" match="any">
+        <text variable="number"/>
+      </if>
+    </choose>
+  </macro>
+  <macro name="online">
+    <choose>
+      <if variable="URL DOI" match="any">
+        <text term="online"/>
+      </if>
+    </choose>
+  </macro>
+  <macro name="medium_designation">
+<!--
+Reference : ISO 690:2010 §7 (physical ressources) and §15.2.2 (online ressources)
+§7 Medium designation
+"If necessary, information about the nature of the information resource and/or the form in which it is made available should be given in brackets. See also 15.2.2 on the medium designation for electronic information resources.
+EXAMPLES [Braille] [cine film (35 mm)] [computer tape reel] [CD] [DVD] [Blu-ray disc] [film strip (35 mm)] [globe] [map] [microfiche (48x)] [microfilm reel (16 mm negative)] [photograph] [score] [slide (2 in.)] [sound disc (45 rpm)] [videocassette (VHS PAL)] [wall chart]"
+
+§ 15.2.2 Type of medium
+"The type of medium for the electronic information resource should be given in the medium designation (see Clause 7).
+EXAMPLES [online] [disc]
+If desired, the specific type of electronic information resource may also be given.
+EXAMPLE 3 EXAMPLE 4
+[online database] [online serial] [computer program] [electronic mail] [digital image] [podcast] [audiofile]"
+
+It is not always possible to get this information from Zotero data once they are transformed in CSL data. Sometimes it can be guessed from the presence of URL or a DOI (for [online]), from the type of the ressource, from "medium" field, or from the "genre" fields. Some CSL types are mapped with several Zotero types (personal_communication = letter + instantMessage ; song = podcast + audioRecording, etc.). In those cases, it will be difficult to guess the proper medium designator.
+"genre" and "medium" fields can also be used, but cautiously, as their meaning depends on the ressource type. In most cases, their content does not match the "medium designator" as defined in the standard.
+
+CSL definition for medium field:
+'medium description (e.g. "CD", "DVD", etc.)'
+medium field is used in those CSL types: 
+    graphic         (mapped against artwork:artworkMedium (medium))
+    song            (mapped against podcast:audioFileType (medium))
+    song            (mapped against audioRecording:audioRecordingFormat (medium))
+    broadcast       (mapped against radioBroadcast:audioRecordingFormat (medium))
+    broadcast       (mapped against tvBroadcast:videoRecordingFormat (medium))
+    book            (mapped against computerProgram:system)
+    motion_picture  (mapped against film:videoRecordingFormat (medium))
+    motion_picture  (mapped against videoRecording:videoRecordingFormat (medium))
+    interview       (mapped against interview:interviewMedium (medium))
+
+CSL definition for genre field:
+'class, type or genre of the item (e.g. "adventure" for an adventure movie, "PhD dissertation" for a PhD thesis)'
+genre field is used in those CSL types: 
+    post-weblog             (mapped against blogPost:websiteType (type))
+    book                    (mapped against computerProgram:programmingLanguage)
+    motion_picture          (mapped against film:genre (type))
+    post                    (mapped against forumPost:postType (type))
+    personal_communication  (mapped against letter:genre)
+    manuscript              (mapped against manuscript:manuscriptType (type))
+    map                     (mapped against map:mapType (type))
+    speech                  (mapped against presentation:presentationType (type))
+    report                  (mapped against report:reportType (type))
+    thesis                  (mapped against thesis:thesisType (type))
+    webpage                 (mapped against webpage:websiteType (type))
+
+-->
+    <choose>
+      <if type="book">
+        <choose>
+          <if variable="medium version" match="any">
+<!-- softwares can only be identified in some cases: type book + use of medium or version fields
+but the medium field should not be treated as a medium (it describes the "system")-->
+            <text value="logiciel" prefix="[" suffix="]"/>
+          </if>
+        </choose>
+      </if>
+      <else-if type="map">
+<!-- For type "map", the genre field should be used (labelled as "type" in Zotero) and not the medium field
+If no information is provided, generic medium "carte" is used
+If the map is avalaible online, add "en ligne"-->
+        <group delimiter=" " prefix="[" suffix="]">
+          <choose>
+            <if variable="genre">
+              <text variable="genre"/>
+            </if>
+            <else>
+              <text value="carte"/>
+            </else>
+          </choose>
+          <text macro="online"/>
+        </group>
+      </else-if>
+      <else-if type="manuscript">
+<!-- For type "manuscript", the genre field should be used (labelled as "type" in Zotero) and not the medium field
+If no information is provided, generic medium "manuscrit" is used
+If the mss is avalaible online, add "en ligne"-->
+        <group delimiter=" " prefix="[" suffix="]">
+          <choose>
+            <if variable="genre">
+              <text variable="genre"/>
+            </if>
+            <else>
+              <text value="manuscrit"/>
+            </else>
+          </choose>
+          <text macro="online"/>
+        </group>
+      </else-if>
+      <else-if type="graphic">
+        <group delimiter=" " prefix="[" suffix="]">
+          <choose>
+            <if variable="medium">
+              <text variable="medium"/>
+            </if>
+            <else>
+              <text value="image"/>
+            </else>
+          </choose>
+          <text macro="online"/>
+        </group>
+      </else-if>
+      <else-if type="song">
+<!--can be a podcast (medium= type of file) or a physical recording. No try to guess a generic medium-->
+        <group delimiter=" " prefix="[" suffix="]">
+          <choose>
+            <if variable="medium">
+              <text variable="medium"/>
+            </if>
+          </choose>
+          <text macro="online"/>
+        </group>
+      </else-if>
+      <else>
+          <text macro="online" prefix="[" suffix="]"/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="date">
+<!-- We could display only year for books and monographs, but I'm not sure it is mandatory or important
+FIXME Add a way to manage uncertain dates and range date. limit-day-ordinals-to-day-1 is defined in locale, but seems to have no effect
+-->
+    <choose>
+      <if variable="issued">
+        <choose>
+          <if type="article-journal">
+            <date variable="issued">
+              <date-part name="month" form="long" text-case="capitalize-first" suffix=" "/>
+              <date-part name="year" form="long"/>
+            </date>
+          </if>
+          <else>
+            <date variable="issued">
+              <date-part name="day" suffix=" "/>
+              <date-part name="month" form="long" suffix=" "/>
+              <date-part name="year" form="long"/>
+            </date>
+          </else>
+        </choose>
+      </if>
+      <else>
+        <text term="no date" form="short" prefix="[" suffix="]"/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="edition">
+    <choose>
+      <if is-numeric="edition">
+        <group delimiter=" ">
+          <number variable="edition" form="ordinal"/>
+          <text term="edition" form="short"/>
+        </group>
+      </if>
+      <else>
+        <text variable="edition" text-case="capitalize-first" suffix="."/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="publisher-place">
+    <choose>
+      <if type="book map thesis report chapter entry entry-dictionary entry-encyclopedia" match="any">
+        <choose>
+          <if variable="publisher-place">
+            <text variable="publisher-place"/>
+          </if>
+          <else>
+            <text value="s.&#160;l." prefix="[" suffix="]" text-case="capitalize-first"/>
+          </else>
+        </choose>
+      </if>
+      <else>
+        <choose>
+          <if variable="publisher-place">
+            <text variable="publisher-place"/>
+          </if>
+        </choose>
+      </else>
+    </choose>
+  </macro>
+  <macro name="publisher">
+    <choose>
+      <if type="book map thesis report chapter entry entry-dictionary entry-encyclopedia" match="any">
+        <choose>
+          <if variable="publisher">
+            <text variable="publisher"/>
+          </if>
+          <else>
+            <text value="s.&#160;n." prefix="[" suffix="]"/>
+          </else>
+        </choose>
+      </if>
+      <else>
+        <choose>
+          <if variable="publisher">
+            <text variable="publisher"/>
+          </if>
+        </choose>
+      </else>
+    </choose>
+  </macro>
+  <macro name="accessed">
+    <choose>
+      <if variable="URL">
+        <group prefix=" [" suffix="]">
+          <text term="accessed" text-case="capitalize-first"/>
+          <date variable="accessed">
+            <date-part name="day" prefix="&#160;"/>
+            <date-part name="month" prefix="&#160;"/>
+            <date-part name="year" prefix="&#160;"/>
+          </date>
+        </group>
+      </if>
+    </choose>
+  </macro>
+  <macro name="collection">
+    <group delimiter=", ">
+      <text variable="collection-title"/>
+      <text variable="collection-number"/>
+    </group>
+  </macro>
+  <macro name="locator">
+    <group>
+      <label variable="locator" form="short" suffix="&#160;"/>
+      <text variable="locator"/>
+    </group>
+  </macro>
+  <macro name="issue-pagination-locator">
+<!-- used for issues of serials, (pagination of books and monographs), and locator of specific passages
+If a locator is used, it replaces the original pagination-->
+    <choose>
+      <if type="article-newspaper article-journal article-magazine" match="any">
+        <group delimiter=", ">
+          <group>
+            <text term="volume" form="short" text-case="capitalize-first" suffix="&#160;"/>
+            <text variable="volume"/>
+          </group>
+          <group>
+            <text term="issue" form="short" suffix="&#160;"/>
+            <text variable="issue"/>
+          </group>
+          <choose>
+            <if variable="locator">
+              <text macro="locator"/>
+            </if>
+            <else>
+              <group>
+                <text term="page" form="short" suffix="&#160;"/>
+                <text variable="page"/>
+              </group>
+            </else>
+          </choose>
+        </group>
+      </if>
+      <else-if variable="locator">
+        <text macro="locator"/>
+      </else-if>
+      <else-if type="chapter entry entry-dictionary entry-encyclopedia paper-conference" match="any">
+        <group>
+          <text term="page" form="short" suffix="&#160;"/>
+          <text variable="page"/>
+        </group>
+      </else-if>
+      <else-if type="report patent book thesis manuscript" match="any">
+<!--
+Uncomment to mention the number of pages of books and monographs
+        <text variable="number-of-pages"/>
+        <text term="page" form="short" prefix="&#160;"/>
+
+-->
+      </else-if>
+    </choose>
+  </macro>
+  <macro name="isbn">
+    <text variable="ISBN" prefix="ISBN&#160;"/>
+  </macro>
+  <macro name="doi">
+    <text variable="DOI" prefix="DOI&#160;"/>
+  </macro>
+  <macro name="url">
+    <choose>
+      <if variable="URL">
+        <group>
+          <text term="available at" suffix="&#8239;: " text-case="capitalize-first"/>
+          <text variable="URL"/>
+        </group>
+      </if>
+    </choose>
+  </macro>
+  <macro name="archive">
+    <group delimiter="&#8239;:&#160;">
+      <text variable="archive" text-case="capitalize-first"/>
+      <text variable="archive_location" text-case="capitalize-first"/>
+      <text variable="call-number"/>
+    </group>
+  </macro>
+  <macro name="access">
+    <group delimiter=". ">
+      <choose>
+        <if variable="DOI">
+          <text macro="doi"/>
+        </if>
+        <else>
+          <text macro="url"/>
+        </else>
+      </choose>
+      <text macro="archive"/>
+    </group>
+  </macro>
+  <macro name="abstract">
+    <text variable="abstract"/>
+  </macro>
+  <macro name="note">
+    <text variable="note" text-case="capitalize-first"/>
+  </macro>
+  <macro name="short-reference">
+    <group delimiter=". ">
+      <text macro="responsability"/>
+      <group delimiter=" ">
+        <group delimiter=". ">
+          <text macro="title"/>
+<!-- volume : used for books and monographs (a volume of a multivolume book)-->
+          <text macro="volume"/>
+        </group>
+<!-- medium : [online], [map], [software], etc.-->
+        <text macro="medium_designation"/>
+      </group>
+      <text macro="thesis-report-genre"/>
+      <text macro="edition"/>
+<!-- secondary-responsability : used for patent inventors and translators -->
+<!--  <text macro="secondary-responsability"/> -->
+      <group delimiter=", ">
+        <group delimiter=". ">
+          <group delimiter="&#8239;: ">
+            <text macro="publisher-place"/>
+            <text macro="publisher"/>
+          </group>
+          <text macro="number"/>
+        </group>
+        <group delimiter=", ">
+          <text macro="date"/>
+          <text macro="numberOfVolumes"/>
+          <text macro="issue-pagination-locator"/>
+        </group>
+      </group>
+<!--  
+      <text macro="accessed"/>
+      <text macro="collection"/>
+      <text macro="isbn"/>
+      <text macro="access"/>
+      <text macro="note"/>
+-->
+    </group>
+  </macro>
+  <macro name="complete-reference">
+    <group delimiter=". ">
+      <text macro="responsability"/>
+      <group delimiter=" ">
+        <group delimiter=". ">
+          <text macro="title"/>
+<!-- volume : used for books and monographs (a volume of a multivolume book)-->
+          <text macro="volume"/>
+        </group>
+<!-- medium : [online], [map], [software], etc.-->
+        <text macro="medium_designation"/>
+      </group>
+      <text macro="thesis-report-genre"/>
+      <text macro="edition"/>
+<!-- secondary-responsability : used for patent inventors and translators -->
+      <text macro="secondary-responsability"/>
+      <group delimiter=", ">
+        <group delimiter=". ">
+          <group delimiter="&#8239;: ">
+            <text macro="publisher-place"/>
+            <text macro="publisher"/>
+          </group>
+          <text macro="number"/>
+        </group>
+        <group delimiter=", ">
+          <text macro="date"/>
+          <text macro="numberOfVolumes"/>
+          <text macro="issue-pagination-locator"/>
+        </group>
+      </group> 
+      <text macro="accessed"/>
+      <text macro="collection"/>
+      <text macro="isbn"/>
+      <text macro="access"/>
+      <text macro="note"/>
+    </group>
+  </macro>
+  <citation et-al-min="4" et-al-use-first="3" near-note-distance="5">
+    <layout suffix="." delimiter="&#8239;; ">
+      <choose>
+        <if position="ibid-with-locator">
+          <group delimiter=", ">
+            <text term="ibid" font-style="italic"/>
+            <text macro="locator"/>
+              </group>
+        </if>
+        <else-if position="ibid">
+          <text term="ibid" font-style="italic"/>
+        </else-if>
+        <else-if position="near-note">
+          <group delimiter=", ">
+            <group delimiter=". ">
+              <text macro="responsability" />
+              <text term="cited" font-style="italic"/>
+            </group>
+            <choose>
+              <if variable="locator">
+                <text macro="locator"/>
+              </if>
+            </choose>
+          </group>
+        </else-if>
+        <else-if position="subsequent">
+          <text macro="short-reference"/>
+        </else-if>
+        <else>
+          <text macro="complete-reference"/>
+        </else>
+      </choose>
+    </layout>
+  </citation>
+  <bibliography>
+    <sort>
+      <key macro="responsability"/>
+      <key macro="title"/>
+    </sort>
+    <layout>
+      <text macro ="complete-reference"/>
+    </layout>
+  </bibliography>
+</style>


### PR DESCRIPTION
Description here (in french) : https://github.com/msaby/wip-zotero-styles#iso690-note-opcit-fr

ISO 690:2010 is not freely available in french translation, but the english version is available here:
http://www.medline.org.cn/attachment/201364/1370309271657.pdf

ISO 690 does not give a lot of details for the way of handling note references, and the advices given in the standard in Annexes are not normative by themselves.
In France, with note references, we often use "op. cit" and "ibid".
This style differs from original ISO 690 "note" for french locale in the way of handling references:
4 types of references:
- 1st occurrence : complete reference in the note
  Exemple: NOM, Prénom des créateurs principaux (fonction). Titre. Volume [Medium]. Type de rapport n° Numéro de rapport. Type de thèse. Mention d'édition. Fonction des créateurs secondaires Prénom NOM des créateurs secondaires. Lieu : Editeur. Numéro (brevets uniquement). Date. [Consulté le Date d'accès]. Collection. ISBN. URL ou DOI. Archive : localisation ou cote. Notes
- other occurrences : lighter reference (sans auteurs secondaires, collections, isbn, doi, url, date d'accès, archive et cote, notes)
  Exemple: NOM, Prénom des créateurs principaux (fonction). Titre. Volume [Medium]. Type de rapport n° Numéro de rapport. Type de thèse. Mention d'édition. Lieu : Editeur. Numéro (brevets uniquement). Date
- ibid. : if the refrence is the same as the reference cited in previous note
  Exemple: Ibid., p. 34.
- op. cit. : if the reference is the same as a reference cited in one of of the 5 last notes
