### PR TITLE
Fix some et-al statements

### DIFF
--- a/deutsche-sprache.csl
+++ b/deutsche-sprache.csl
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" et-al-min="4" et-al-use-first="1" demote-non-dropping-particle="never" default-locale="de-DE">
+<style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" demote-non-dropping-particle="never" default-locale="de-DE">
   <info>
     <title>Deutsche Sprache (German)</title>
     <id>http://www.zotero.org/styles/deutsche-sprache</id>
@@ -105,7 +105,7 @@
       </substitute>
     </names>
   </macro>
-  <citation disambiguate-add-year-suffix="true" collapse="year-suffix">
+  <citation et-al-min="4" et-al-use-first="1" disambiguate-add-year-suffix="true" collapse="year-suffix">
     <layout delimiter="; " prefix="(" suffix=")">
       <group delimiter=", ">
         <choose>
@@ -123,7 +123,7 @@
       </group>
     </layout>
   </citation>
-  <bibliography>
+  <bibliography et-al-min="4" et-al-use-first="1">
     <sort>
       <key macro="creator-short"/>
       <key macro="creator-year-short"/>

--- a/fachhochschule-vorarlberg.csl
+++ b/fachhochschule-vorarlberg.csl
@@ -230,7 +230,7 @@
     </choose>
   </macro>
   <!-- Hier beginnt die Formatierung für das Kurzzitat im Text - this is where the citation starts -->
-  <citation et-al-min="4" et-al-use-first="1" et-al-subsequent-min="4" et-al-subsequent-use-first="1" disambiguate-add-year-suffix="true" disambiguate-add-names="true" disambiguate-add-givenname="true" collapse="year">
+  <citation et-al-min="4" et-al-use-first="1" disambiguate-add-year-suffix="true" disambiguate-add-names="true" disambiguate-add-givenname="true" collapse="year">
     <layout prefix="(" suffix=")" delimiter="; ">
       <text macro="author-short"/>
       <text macro="year-date"/>

--- a/leviathan.csl
+++ b/leviathan.csl
@@ -471,7 +471,7 @@ a) mit Name "collection-editor" (in jedem Fall)
    NACHWEISE
 ================================================================================
 -->
-  <citation et-al-min="2" et-al-use-first="1" et-al-subsequent-min="2" et-al-subsequent-use-first="1" disambiguate-add-year-suffix="true" disambiguate-add-names="true" disambiguate-add-givenname="true">
+  <citation et-al-min="2" et-al-use-first="1" disambiguate-add-year-suffix="true" disambiguate-add-names="true" disambiguate-add-givenname="true">
     <layout prefix="(" suffix=")" delimiter="; ">
       <choose>
         <!-- "Ebd." (bei unmittelbar aufeinanderfolgenden Nachweisen) -->

--- a/soziale-welt.csl
+++ b/soziale-welt.csl
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" et-al-min="4" et-al-use-first="3" demote-non-dropping-particle="sort-only" default-locale="de-DE">
+<style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" demote-non-dropping-particle="sort-only" default-locale="de-DE">
   <!-- This style was edited with the Visual CSL Editor (http://steveridout.com/csl/visualEditor/) -->
   <info>
     <title>Soziale Welt (German)</title>

--- a/sozialpadagogisches-institut-berlin-walter-may.csl
+++ b/sozialpadagogisches-institut-berlin-walter-may.csl
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" et-al-min="4" et-al-use-first="3" demote-non-dropping-particle="sort-only" default-locale="de-DE">
+<style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" demote-non-dropping-particle="sort-only" default-locale="de-DE">
   <info>
     <title>Sozialpädagogisches Institut Berlin - Walter May (German)</title>
     <title-short>SPI</title-short>

--- a/sozialwissenschaften-heilmann.csl
+++ b/sozialwissenschaften-heilmann.csl
@@ -250,7 +250,7 @@
   <macro name="citation-locator">
     <text variable="locator"/>
   </macro>
-  <citation et-al-min="4" et-al-use-first="1" et-al-subsequent-min="4" et-al-subsequent-use-first="1" disambiguate-add-names="true" disambiguate-add-givenname="true" disambiguate-add-year-suffix="true" collapse="year-suffix-ranged" year-suffix-delimiter=", ">
+  <citation et-al-min="4" et-al-use-first="1" disambiguate-add-names="true" disambiguate-add-givenname="true" disambiguate-add-year-suffix="true" collapse="year-suffix-ranged" year-suffix-delimiter=", ">
     <layout prefix="(" suffix=")" delimiter="; ">
       <choose>
         <if position="ibid-with-locator">


### PR DESCRIPTION
(I looked at the German author-date styles)
- move the et-al statements from style to citation, bibliography (deutsche-sprache.csl)
- delete et-al-subsequent if it is the same (fachhochschule-vorarlberg.csl, leviathan.csl, sozialwissenschaften-heilmann.csl)
- delete et-al statement in style-node if there are et-al statements in the citation, bibliography-nodes (soziale-welt.csl, sozialpadagogisches-institut-berlin-walter-may.csl)
