### PR TITLE
Some more fixes in et-al statements

### DIFF
--- a/foerster-geisteswissenschaft.csl
+++ b/foerster-geisteswissenschaft.csl
@@ -841,7 +841,7 @@ REGELN FÜR DIE SORTIERUNG IM LITERATURVERZEICHNIS
 ================================================================================
 ERSTELLUNG DER FUßNOTEN
 ================================================================================-->
-  <citation et-al-min="4" et-al-use-first="1" et-al-subsequent-min="4" et-al-subsequent-use-first="1" disambiguate-add-names="true">
+  <citation et-al-min="4" et-al-use-first="1" disambiguate-add-names="true">
     <layout suffix="." delimiter="; ">
       <choose>
         <!-- "Ebd." (bei unmittelbar aufeinanderfolgenden Nachweisen) -->

--- a/geistes-und-kulturwissenschaften-heilmann.csl
+++ b/geistes-und-kulturwissenschaften-heilmann.csl
@@ -334,7 +334,7 @@
     <label variable="locator" form="short" suffix=".&#160;"/>
     <text variable="locator"/>
   </macro>
-  <citation et-al-min="4" et-al-use-first="1" et-al-subsequent-min="4" et-al-subsequent-use-first="1" disambiguate-add-names="true">
+  <citation et-al-min="4" et-al-use-first="1" disambiguate-add-names="true">
     <layout suffix="." delimiter="; ">
       <choose>
         <if position="ibid-with-locator">

--- a/nccr-mediality.csl
+++ b/nccr-mediality.csl
@@ -292,7 +292,7 @@
   <macro name="citation-locator">
     <text variable="locator" prefix="S.&#160;"/>
   </macro>
-  <citation et-al-min="4" et-al-use-first="1" et-al-subsequent-min="4" et-al-subsequent-use-first="1" disambiguate-add-names="true">
+  <citation et-al-min="4" et-al-use-first="1" disambiguate-add-names="true">
     <layout suffix="." delimiter="; ">
       <choose>
         <if position="ibid-with-locator">

--- a/soziologie.csl
+++ b/soziologie.csl
@@ -76,7 +76,7 @@
   </macro>
   <macro name="author-short">
     <names variable="author" delimiter=", ">
-      <name form="short" et-al-min="3" et-al-use-first="1" initialize-with=". "/>
+      <name form="short" initialize-with=". "/>
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>

--- a/technische-universitat-munchen-unternehmensfuhrung.csl
+++ b/technische-universitat-munchen-unternehmensfuhrung.csl
@@ -39,7 +39,7 @@
   </locale>
   <macro name="author">
     <names variable="author">
-      <name and="symbol" delimiter-precedes-last="never" et-al-subsequent-min="10000" initialize-with=". " name-as-sort-order="all"/>
+      <name and="symbol" delimiter-precedes-last="never" initialize-with=". " name-as-sort-order="all"/>
     </names>
   </macro>
   <macro name="author-short">

--- a/zeitschrift-fur-medienwissenschaft.csl
+++ b/zeitschrift-fur-medienwissenschaft.csl
@@ -528,7 +528,7 @@ a) mit Name "collection-editor" (in jedem Fall)
    NACHWEISE (in Anmerkungen)
 ================================================================================
 -->
-  <citation et-al-min="4" et-al-use-first="1" et-al-subsequent-min="4" et-al-subsequent-use-first="1" disambiguate-add-names="true">
+  <citation et-al-min="4" et-al-use-first="1" disambiguate-add-names="true">
     <layout suffix="." delimiter="; ">
       <choose>
         <!-- "Ebd." (bei unmittelbar aufeinanderfolgenden Nachweisen) -->

--- a/zeitschrift-fur-soziologie.csl
+++ b/zeitschrift-fur-soziologie.csl
@@ -69,7 +69,7 @@
   </macro>
   <macro name="author-short">
     <names variable="author" delimiter=", ">
-      <name form="short" and="symbol" et-al-min="3" et-al-use-first="1" initialize-with=". "/>
+      <name form="short" and="symbol" initialize-with=". "/>
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>


### PR DESCRIPTION
continuation of #1109 

(note that the author-short macros are only called within the citation node, and there is already the et-al statements)
