### PR TITLE
Delete more unnecessary et-al-subsequent statements

### DIFF
--- a/associacao-brasileira-de-normas-tecnicas-ipea.csl
+++ b/associacao-brasileira-de-normas-tecnicas-ipea.csl
@@ -345,7 +345,7 @@
   </macro>
   <!--Citacao-->
   <!--et al. aparece a partir de 04 autores-->
-  <citation et-al-min="4" et-al-use-first="1" et-al-subsequent-min="4" et-al-subsequent-use-first="1" disambiguate-add-year-suffix="true" disambiguate-add-names="true" disambiguate-add-givenname="true" collapse="year-suffix">
+  <citation et-al-min="4" et-al-use-first="1" disambiguate-add-year-suffix="true" disambiguate-add-names="true" disambiguate-add-givenname="true" collapse="year-suffix">
     <sort>
       <key macro="author"/>
       <!--Puxa o autor primeiro-->

--- a/associacao-brasileira-de-normas-tecnicas-ufjf.csl
+++ b/associacao-brasileira-de-normas-tecnicas-ufjf.csl
@@ -454,7 +454,7 @@
       </else>
     </choose>
   </macro>
-  <citation et-al-min="4" et-al-use-first="1" et-al-subsequent-min="4" et-al-subsequent-use-first="1" disambiguate-add-year-suffix="true" disambiguate-add-names="true" disambiguate-add-givenname="true" collapse="year-suffix" givenname-disambiguation-rule="primary-name" year-suffix-delimiter=", ">
+  <citation et-al-min="4" et-al-use-first="1" disambiguate-add-year-suffix="true" disambiguate-add-names="true" disambiguate-add-givenname="true" collapse="year-suffix" givenname-disambiguation-rule="primary-name" year-suffix-delimiter=", ">
     <sort>
       <key macro="author"/>
       <key macro="issued-year"/>

--- a/associacao-brasileira-de-normas-tecnicas-ufmg-face-full.csl
+++ b/associacao-brasileira-de-normas-tecnicas-ufmg-face-full.csl
@@ -394,7 +394,7 @@
       </else>
     </choose>
   </macro>
-  <citation et-al-min="4" et-al-use-first="1" et-al-subsequent-min="4" et-al-subsequent-use-first="1" disambiguate-add-year-suffix="true" disambiguate-add-names="true" disambiguate-add-givenname="true" collapse="year-suffix" givenname-disambiguation-rule="primary-name" year-suffix-delimiter=", ">
+  <citation et-al-min="4" et-al-use-first="1" disambiguate-add-year-suffix="true" disambiguate-add-names="true" disambiguate-add-givenname="true" collapse="year-suffix" givenname-disambiguation-rule="primary-name" year-suffix-delimiter=", ">
     <sort>
       <key macro="author"/>
       <key macro="issued-year"/>

--- a/associacao-brasileira-de-normas-tecnicas-ufmg-face-initials.csl
+++ b/associacao-brasileira-de-normas-tecnicas-ufmg-face-initials.csl
@@ -393,7 +393,7 @@
       </else>
     </choose>
   </macro>
-  <citation et-al-min="4" et-al-use-first="1" et-al-subsequent-min="4" et-al-subsequent-use-first="1" disambiguate-add-year-suffix="true" disambiguate-add-names="true" disambiguate-add-givenname="true" collapse="year-suffix" givenname-disambiguation-rule="primary-name" year-suffix-delimiter=", ">
+  <citation et-al-min="4" et-al-use-first="1" disambiguate-add-year-suffix="true" disambiguate-add-names="true" disambiguate-add-givenname="true" collapse="year-suffix" givenname-disambiguation-rule="primary-name" year-suffix-delimiter=", ">
     <sort>
       <key macro="author"/>
       <key macro="issued-year"/>

--- a/associacao-brasileira-de-normas-tecnicas.csl
+++ b/associacao-brasileira-de-normas-tecnicas.csl
@@ -362,7 +362,7 @@ em caixa alta. Utiliza-se antes do nome da conferencia a expressao "In". Segundo
   </macro>
   <!--Citacao-->
   <!--et al. aparece a partir de 04 autores-->
-  <citation et-al-min="4" et-al-use-first="1" et-al-subsequent-min="4" et-al-subsequent-use-first="1" collapse="year" disambiguate-add-year-suffix="true">
+  <citation et-al-min="4" et-al-use-first="1" collapse="year" disambiguate-add-year-suffix="true">
     <sort>
       <key macro="author"/>
       <!--Puxa o autor primeiro-->

--- a/australian-historical-studies.csl
+++ b/australian-historical-studies.csl
@@ -347,7 +347,7 @@
       <text variable="URL"/>
     </group>
   </macro>
-  <citation et-al-min="4" et-al-use-first="1" et-al-subsequent-min="4" et-al-subsequent-use-first="1" disambiguate-add-names="true" disambiguate-add-givenname="true">
+  <citation et-al-min="4" et-al-use-first="1" disambiguate-add-names="true" disambiguate-add-givenname="true">
     <layout suffix="." delimiter="; ">
       <choose>
         <if position="ibid-with-locator">

--- a/bibtex.csl
+++ b/bibtex.csl
@@ -127,7 +127,7 @@
   <macro name="edition">
     <text variable="edition"/>
   </macro>
-  <citation et-al-min="10" et-al-use-first="10" et-al-subsequent-min="10" et-al-subsequent-use-first="10" disambiguate-add-year-suffix="true" disambiguate-add-names="false" disambiguate-add-givenname="false" collapse="year">
+  <citation et-al-min="10" et-al-use-first="10" disambiguate-add-year-suffix="true" disambiguate-add-names="false" disambiguate-add-givenname="false" collapse="year">
     <sort>
       <key macro="author"/>
       <key variable="issued"/>

--- a/chicago-author-date-de.csl
+++ b/chicago-author-date-de.csl
@@ -357,7 +357,7 @@
       </else>
     </choose>
   </macro>
-  <citation et-al-min="4" et-al-use-first="1" et-al-subsequent-min="4" et-al-subsequent-use-first="1" disambiguate-add-year-suffix="true" disambiguate-add-names="true" disambiguate-add-givenname="true">
+  <citation et-al-min="4" et-al-use-first="1" disambiguate-add-year-suffix="true" disambiguate-add-names="true" disambiguate-add-givenname="true">
     <layout prefix="(" suffix=")" delimiter="; ">
       <group delimiter=", ">
         <group delimiter=" ">

--- a/early-medieval-europe.csl
+++ b/early-medieval-europe.csl
@@ -197,7 +197,7 @@
       </if>
     </choose>
   </macro>
-  <citation et-al-min="4" et-al-use-first="1" et-al-subsequent-min="4" et-al-subsequent-use-first="1" disambiguate-add-names="true">
+  <citation et-al-min="4" et-al-use-first="1" disambiguate-add-names="true">
     <layout suffix="." delimiter="; ">
       <choose>
         <if position="subsequent">

--- a/geological-magazine.csl
+++ b/geological-magazine.csl
@@ -100,7 +100,7 @@
       <text variable="page"/>
     </group>
   </macro>
-  <citation et-al-min="4" et-al-use-first="1" et-al-subsequent-min="4" et-al-subsequent-use-first="1" disambiguate-add-year-suffix="true">
+  <citation et-al-min="4" et-al-use-first="1" disambiguate-add-year-suffix="true">
     <layout prefix="(" suffix=")" delimiter="; ">
       <group delimiter=", ">
         <group delimiter=" ">

--- a/geopolitics.csl
+++ b/geopolitics.csl
@@ -357,7 +357,7 @@
       </choose>
     </group>
   </macro>
-  <citation et-al-min="4" et-al-use-first="1" et-al-subsequent-min="4" et-al-subsequent-use-first="1" disambiguate-add-names="true">
+  <citation et-al-min="4" et-al-use-first="1" disambiguate-add-names="true">
     <layout suffix="." delimiter="; ">
       <choose>
         <if position="subsequent">

--- a/harvard-european-archaeology.csl
+++ b/harvard-european-archaeology.csl
@@ -117,7 +117,7 @@
       <text variable="page"/>
     </group>
   </macro>
-  <citation et-al-min="2" et-al-use-first="1" et-al-subsequent-min="2" et-al-subsequent-use-first="1" disambiguate-add-year-suffix="true" disambiguate-add-names="true" disambiguate-add-givenname="true">
+  <citation et-al-min="2" et-al-use-first="1" disambiguate-add-year-suffix="true" disambiguate-add-names="true" disambiguate-add-givenname="true">
     <layout prefix="(" suffix=")" delimiter="; ">
       <group delimiter=", ">
         <group delimiter=" ">

--- a/harvard-university-of-birmingham.csl
+++ b/harvard-university-of-birmingham.csl
@@ -263,7 +263,7 @@
       </group>
     </layout>
   </citation>
-  <bibliography hanging-indent="false" et-al-min="3" et-al-use-first="3" et-al-subsequent-min="3" et-al-subsequent-use-first="3">
+  <bibliography hanging-indent="false" et-al-min="3" et-al-use-first="3">
     <sort>
       <key macro="author"/>
       <key macro="year-date" sort="ascending"/>

--- a/health-services-research.csl
+++ b/health-services-research.csl
@@ -139,7 +139,7 @@
       <text variable="page"/>
     </group>
   </macro>
-  <citation et-al-min="4" et-al-use-first="1" et-al-subsequent-min="4" et-al-subsequent-use-first="1" disambiguate-add-year-suffix="true" disambiguate-add-names="false" disambiguate-add-givenname="true" collapse="year-suffix">
+  <citation et-al-min="4" et-al-use-first="1" disambiguate-add-year-suffix="true" disambiguate-add-names="false" disambiguate-add-givenname="true" collapse="year-suffix">
     <layout prefix="(" suffix=")" delimiter="; ">
       <group delimiter=", ">
         <group delimiter=" ">

--- a/iso690-full-note-sk.csl
+++ b/iso690-full-note-sk.csl
@@ -312,7 +312,7 @@
       </date>
     </group>
   </macro>
-  <citation et-al-min="4" et-al-use-first="1" et-al-subsequent-min="4" et-al-subsequent-use-first="1" disambiguate-add-names="true">
+  <citation et-al-min="4" et-al-use-first="1" disambiguate-add-names="true">
     <layout suffix="." delimiter="; ">
       <choose>
         <if position="subsequent">

--- a/jahrbuch-der-osterreichischen-byzantinischen-gesellschaft.csl
+++ b/jahrbuch-der-osterreichischen-byzantinischen-gesellschaft.csl
@@ -178,7 +178,7 @@
     </date>
   </macro>
   <!--Citation-->
-  <citation et-al-min="4" et-al-use-first="1" et-al-subsequent-min="4" et-al-subsequent-use-first="1" disambiguate-add-names="true" disambiguate-add-givenname="true">
+  <citation et-al-min="4" et-al-use-first="1" disambiguate-add-names="true" disambiguate-add-givenname="true">
     <layout prefix="" suffix="." delimiter="; ">
       <choose>
         <if position="subsequent">

--- a/javnost-the-public.csl
+++ b/javnost-the-public.csl
@@ -89,7 +89,7 @@
       </else>
     </choose>
   </macro>
-  <citation et-al-min="4" et-al-use-first="1" et-al-subsequent-min="4" et-al-subsequent-use-first="1" disambiguate-add-year-suffix="true" disambiguate-add-names="true" collapse="year">
+  <citation et-al-min="4" et-al-use-first="1" disambiguate-add-year-suffix="true" disambiguate-add-names="true" collapse="year">
     <layout prefix="(" suffix=")" delimiter="; ">
       <group delimiter=", ">
         <group delimiter=" ">

--- a/london-south-bank-university-numeric.csl
+++ b/london-south-bank-university-numeric.csl
@@ -126,7 +126,7 @@
       <text variable="citation-number"/>
     </layout>
   </citation>
-  <bibliography et-al-min="2" et-al-use-first="1" et-al-subsequent-min="2" et-al-subsequent-use-first="1" initialize-with="." second-field-align="flush" entry-spacing="2">
+  <bibliography et-al-min="2" et-al-use-first="1" initialize-with="." second-field-align="flush" entry-spacing="2">
     <layout>
       <text variable="citation-number" suffix=" "/>
       <group delimiter=" " suffix=" ">

--- a/mcgill-fr.csl
+++ b/mcgill-fr.csl
@@ -929,7 +929,7 @@
       </else>
     </choose>
   </macro>
-  <citation et-al-min="4" et-al-use-first="1" et-al-subsequent-min="4" et-al-subsequent-use-first="1" disambiguate-add-names="true" delimiter-precedes-et-al="never">
+  <citation et-al-min="4" et-al-use-first="1" disambiguate-add-names="true" delimiter-precedes-et-al="never">
     <layout suffix="." delimiter="; ">
       <choose>
         <if position="ibid-with-locator">

--- a/modern-language-association-6th-edition-note.csl
+++ b/modern-language-association-6th-edition-note.csl
@@ -731,7 +731,7 @@
       </choose>
     </group>
   </macro>
-  <citation et-al-min="4" et-al-use-first="1" et-al-subsequent-min="4" et-al-subsequent-use-first="1" disambiguate-add-names="true">
+  <citation et-al-min="4" et-al-use-first="1" disambiguate-add-names="true">
     <layout suffix="." delimiter="; ">
       <choose>
         <if position="ibid-with-locator">

--- a/mohr-siebeck-recht.csl
+++ b/mohr-siebeck-recht.csl
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<style xmlns="http://purl.org/net/xbiblio/csl" class="note" version="1.0" delimiter-precedes-et-al="never" delimiter-precedes-last="never" et-al-min="10" et-al-use-first="10" et-al-subsequent-min="10" et-al-subsequent-use-first="10" initialize="false" page-range-format="expanded" demote-non-dropping-particle="never" default-locale="de-AT">
+<style xmlns="http://purl.org/net/xbiblio/csl" class="note" version="1.0" delimiter-precedes-et-al="never" delimiter-precedes-last="never" et-al-min="10" et-al-use-first="10" initialize="false" page-range-format="expanded" demote-non-dropping-particle="never" default-locale="de-AT">
   <info>
     <title>Mohr Siebeck - Recht (German - Austria)</title>
     <id>http://www.zotero.org/styles/mohr-siebeck-recht</id>
@@ -17,20 +17,20 @@
   </info>
   <macro name="author-article-journal">
     <names variable="author" font-style="italic">
-      <name form="short" delimiter="/" delimiter-precedes-et-al="never" delimiter-precedes-last="never" et-al-min="5" et-al-use-first="5" et-al-subsequent-min="5" et-al-subsequent-use-first="5" initialize="false"/>
+      <name form="short" delimiter="/" delimiter-precedes-et-al="never" delimiter-precedes-last="never" et-al-min="5" et-al-use-first="5" initialize="false"/>
       <et-al font-style="italic"/>
     </names>
   </macro>
   <macro name="author-book">
     <names variable="author" font-style="italic">
-      <name form="short" delimiter="/" delimiter-precedes-et-al="never" delimiter-precedes-last="never" et-al-min="5" et-al-use-first="5" et-al-subsequent-min="5" et-al-subsequent-use-first="5" initialize="false"/>
+      <name form="short" delimiter="/" delimiter-precedes-et-al="never" delimiter-precedes-last="never" et-al-min="5" et-al-use-first="5" initialize="false"/>
       <et-al/>
     </names>
     <text variable="title" form="short" prefix=", " suffix=" "/>
   </macro>
   <macro name="author-chapter">
     <names variable="author" font-style="italic">
-      <name form="short" font-style="italic" delimiter="/" delimiter-precedes-et-al="never" delimiter-precedes-last="never" et-al-min="5" et-al-use-first="5" et-al-subsequent-min="5" et-al-subsequent-use-first="5" initialize="false"/>
+      <name form="short" font-style="italic" delimiter="/" delimiter-precedes-et-al="never" delimiter-precedes-last="never" et-al-min="5" et-al-use-first="5" initialize="false"/>
       <et-al font-style="italic"/>
     </names>
     <text value="in: " prefix=", "/>
@@ -38,7 +38,7 @@
   </macro>
   <macro name="author-article-newspaper">
     <names variable="author" font-style="normal">
-      <name form="short" delimiter="/ " delimiter-precedes-et-al="never" delimiter-precedes-last="never" et-al-min="19" et-al-use-first="19" et-al-subsequent-min="19" et-al-subsequent-use-first="19" initialize="false"/>
+      <name form="short" delimiter="/ " delimiter-precedes-et-al="never" delimiter-precedes-last="never" et-al-min="19" et-al-use-first="19" initialize="false"/>
     </names>
   </macro>
   <macro name="authority">
@@ -149,7 +149,7 @@
       <choose>
         <if type="article-journal" match="any">
           <names variable="author" font-style="italic">
-            <name font-style="italic" delimiter="/" delimiter-precedes-et-al="never" delimiter-precedes-last="never" et-al-min="6" et-al-use-first="6" et-al-subsequent-min="6" et-al-subsequent-use-first="6" initialize="false" name-as-sort-order="all"/>
+            <name font-style="italic" delimiter="/" delimiter-precedes-et-al="never" delimiter-precedes-last="never" et-al-min="6" et-al-use-first="6" initialize="false" name-as-sort-order="all"/>
           </names>
           <text variable="title" prefix=": " suffix=", "/>
           <text variable="collection-title" suffix=", "/>
@@ -159,7 +159,7 @@
         </if>
         <else-if type="book" match="all">
           <names variable="author">
-            <name font-style="italic" delimiter="/" delimiter-precedes-et-al="never" delimiter-precedes-last="never" et-al-min="6" et-al-use-first="6" et-al-subsequent-min="6" et-al-subsequent-use-first="6" initialize="false" name-as-sort-order="all"/>
+            <name font-style="italic" delimiter="/" delimiter-precedes-et-al="never" delimiter-precedes-last="never" et-al-min="6" et-al-use-first="6" initialize="false" name-as-sort-order="all"/>
           </names>
           <text variable="title" prefix=": " suffix=", "/>
           <choose>
@@ -178,13 +178,13 @@
         </else-if>
         <else-if type="chapter" match="any">
           <names variable="author" font-style="italic">
-            <name font-style="italic" delimiter="/" delimiter-precedes-et-al="never" delimiter-precedes-last="never" et-al-min="6" et-al-use-first="6" et-al-subsequent-min="6" et-al-subsequent-use-first="6" initialize="false" name-as-sort-order="all"/>
+            <name font-style="italic" delimiter="/" delimiter-precedes-et-al="never" delimiter-precedes-last="never" et-al-min="6" et-al-use-first="6" initialize="false" name-as-sort-order="all"/>
           </names>
           <text variable="title" prefix=": " suffix=", "/>
           <choose>
             <if match="all" variable="editor">
               <names variable="editor" font-variant="normal" delimiter="/" prefix="in: " suffix=" (Hrsg.): ">
-                <name form="short" delimiter="/" delimiter-precedes-et-al="never" delimiter-precedes-last="never" et-al-min="6" et-al-use-first="6" et-al-subsequent-min="6" et-al-subsequent-use-first="6" name-as-sort-order="all"/>
+                <name form="short" delimiter="/" delimiter-precedes-et-al="never" delimiter-precedes-last="never" et-al-min="6" et-al-use-first="6" name-as-sort-order="all"/>
               </names>
               <text variable="container-title" suffix=", "/>
             </if>
@@ -203,7 +203,7 @@
           <choose>
             <if match="all" variable="editor">
               <names variable="editor" font-style="italic" delimiter="/">
-                <name font-style="italic" delimiter="/" delimiter-precedes-et-al="never" delimiter-precedes-last="never" et-al-min="6" et-al-use-first="6" et-al-subsequent-min="6" et-al-subsequent-use-first="6" initialize="false" name-as-sort-order="all"/>
+                <name font-style="italic" delimiter="/" delimiter-precedes-et-al="never" delimiter-precedes-last="never" et-al-min="6" et-al-use-first="6" initialize="false" name-as-sort-order="all"/>
               </names>
               <text value="(Hrsg.): "/>
             </if>

--- a/moore-theological-college.csl
+++ b/moore-theological-college.csl
@@ -644,7 +644,7 @@
     <text variable="title" suffix=" "/>
     <text variable="genre"/>
   </macro>
-  <citation et-al-min="4" et-al-use-first="1" et-al-subsequent-min="4" et-al-subsequent-use-first="1" disambiguate-add-names="true">
+  <citation et-al-min="4" et-al-use-first="1" disambiguate-add-names="true">
     <layout suffix="." delimiter="; ">
       <choose>
         <if position="subsequent">

--- a/norma-portuguesa-405.csl
+++ b/norma-portuguesa-405.csl
@@ -327,7 +327,7 @@
       <text variable="ISBN" prefix=". ISBN "/>
     </group>
   </macro>
-  <citation et-al-min="4" et-al-use-first="1" et-al-subsequent-min="4" et-al-subsequent-use-first="1" collapse="year">
+  <citation et-al-min="4" et-al-use-first="1" collapse="year">
     <sort>
       <key macro="author"/>
       <key variable="issued"/>

--- a/pontifical-athenaeum-regina-apostolorum.csl
+++ b/pontifical-athenaeum-regina-apostolorum.csl
@@ -348,7 +348,7 @@
       </else-if>
     </choose>
   </macro>
-  <citation disambiguate-add-names="true" disambiguate-add-givenname="true" disambiguate-add-year-suffix="false" et-al-min="4" et-al-use-first="1" et-al-subsequent-min="4" et-al-subsequent-use-first="1">
+  <citation disambiguate-add-names="true" disambiguate-add-givenname="true" disambiguate-add-year-suffix="false" et-al-min="4" et-al-use-first="1">
     <layout suffix="." delimiter="; ">
       <choose>
         <if position="ibid-with-locator">

--- a/romanian-humanities.csl
+++ b/romanian-humanities.csl
@@ -168,7 +168,7 @@
       <text variable="page" prefix=" "/>
     </group>
   </macro>
-  <citation et-al-min="4" et-al-use-first="1" et-al-subsequent-min="4" et-al-subsequent-use-first="1" disambiguate-add-year-suffix="false" disambiguate-add-names="true" disambiguate-add-givenname="true">
+  <citation et-al-min="4" et-al-use-first="1" disambiguate-add-year-suffix="false" disambiguate-add-names="true" disambiguate-add-givenname="true">
     <layout suffix="." delimiter="; ">
       <choose>
         <if position="ibid-with-locator">

--- a/the-british-journal-of-sociology.csl
+++ b/the-british-journal-of-sociology.csl
@@ -115,7 +115,7 @@
       </else>
     </choose>
   </macro>
-  <citation et-al-min="4" et-al-use-first="1" et-al-subsequent-min="4" et-al-subsequent-use-first="1" disambiguate-add-year-suffix="true" disambiguate-add-names="true" disambiguate-add-givenname="true" collapse="year-suffix">
+  <citation et-al-min="4" et-al-use-first="1" disambiguate-add-year-suffix="true" disambiguate-add-names="true" disambiguate-add-givenname="true" collapse="year-suffix">
     <layout prefix="(" suffix=")" delimiter="; ">
       <group delimiter=": ">
         <group delimiter=" ">

--- a/the-open-university-a251.csl
+++ b/the-open-university-a251.csl
@@ -94,7 +94,7 @@
       <text variable="publisher"/>
     </group>
   </macro>
-  <citation et-al-min="2" et-al-use-first="1" et-al-subsequent-min="2" et-al-subsequent-use-first="1" disambiguate-add-year-suffix="true" disambiguate-add-names="true" disambiguate-add-givenname="true">
+  <citation et-al-min="2" et-al-use-first="1" disambiguate-add-year-suffix="true" disambiguate-add-names="true" disambiguate-add-givenname="true">
     <layout prefix="(" suffix=")" delimiter="; ">
       <text macro="author-short"/>
       <label variable="locator" prefix=", " form="short"/>

--- a/turabian-fullnote-bibliography.csl
+++ b/turabian-fullnote-bibliography.csl
@@ -734,7 +734,7 @@
       </choose>
     </group>
   </macro>
-  <citation et-al-min="4" et-al-use-first="1" et-al-subsequent-min="4" et-al-subsequent-use-first="1" disambiguate-add-names="true">
+  <citation et-al-min="4" et-al-use-first="1" disambiguate-add-names="true">
     <layout suffix="." delimiter="; ">
       <choose>
         <if position="ibid-with-locator">

--- a/u-schylku-starozytnosci.csl
+++ b/u-schylku-starozytnosci.csl
@@ -230,7 +230,7 @@
     <text variable="publisher-place" prefix="" suffix=""/>
   </macro>
   <!--Citation-->
-  <citation et-al-min="4" et-al-use-first="1" et-al-subsequent-min="4" et-al-subsequent-use-first="1" disambiguate-add-names="true" disambiguate-add-givenname="true">
+  <citation et-al-min="4" et-al-use-first="1" disambiguate-add-names="true" disambiguate-add-givenname="true">
     <layout prefix="" suffix="." delimiter="; ">
       <choose>
         <if position="ibid-with-locator">

--- a/universidad-evangelica-del-paraguay.csl
+++ b/universidad-evangelica-del-paraguay.csl
@@ -146,7 +146,7 @@
       <name form="short" and="text" delimiter=", " delimiter-precedes-last="never" initialize-with=". "/>
     </names>
   </macro>
-  <citation et-al-min="4" et-al-use-first="1" et-al-subsequent-min="4" et-al-subsequent-use-first="1" collapse="year">
+  <citation et-al-min="4" et-al-use-first="1" collapse="year">
     <layout prefix="(" suffix=")" delimiter="; ">
       <choose>
         <if type="bill book graphic legal_case legislation motion_picture report song" match="any">

--- a/universita-di-bologna-lettere.csl
+++ b/universita-di-bologna-lettere.csl
@@ -567,7 +567,7 @@
       </choose>
     </group>
   </macro>
-  <citation et-al-min="4" et-al-use-first="1" et-al-subsequent-min="4" et-al-subsequent-use-first="1">
+  <citation et-al-min="4" et-al-use-first="1">
     <layout delimiter="; ">
       <choose>
         <if position="ibid-with-locator">

--- a/universite-laval-faculte-de-theologie-et-de-sciences-religieuses.csl
+++ b/universite-laval-faculte-de-theologie-et-de-sciences-religieuses.csl
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<style xmlns="http://purl.org/net/xbiblio/csl" class="note" version="1.0" and="text" delimiter-precedes-et-al="never" delimiter-precedes-last="never" et-al-min="4" et-al-use-first="1" et-al-subsequent-min="4" et-al-subsequent-use-first="1" demote-non-dropping-particle="sort-only" default-locale="fr-CA">
+<style xmlns="http://purl.org/net/xbiblio/csl" class="note" version="1.0" and="text" delimiter-precedes-et-al="never" delimiter-precedes-last="never" et-al-min="4" et-al-use-first="1" demote-non-dropping-particle="sort-only" default-locale="fr-CA">
   <!-- This style was edited with the Visual CSL Editor (http://editor.citationstyles.org/visualEditor/) -->
   <info>
     <title>Université Laval - Faculté de théologie et de sciences religieuses (French - Canada)</title>
@@ -157,7 +157,7 @@
   </macro>
   <macro name="editor">
     <names variable="editor" suffix=" (dir.)">
-      <name and="text" delimiter-precedes-et-al="never" delimiter-precedes-last="never" et-al-min="4" et-al-use-first="1" et-al-subsequent-min="4" et-al-subsequent-use-first="1" name-as-sort-order="first"/>
+      <name and="text" delimiter-precedes-et-al="never" delimiter-precedes-last="never" et-al-min="4" et-al-use-first="1" name-as-sort-order="first"/>
     </names>
   </macro>
   <macro name="translator">
@@ -186,7 +186,7 @@
   <macro name="contributors">
     <group delimiter=", ">
       <names variable="author">
-        <name and="text" delimiter-precedes-last="always" et-al-min="4" et-al-use-first="1" et-al-subsequent-min="4" et-al-subsequent-use-first="1" name-as-sort-order="first"/>
+        <name and="text" delimiter-precedes-last="always" et-al-min="4" et-al-use-first="1" name-as-sort-order="first"/>
         <substitute>
           <text macro="editor"/>
           <text macro="translator"/>
@@ -204,7 +204,7 @@
   <macro name="contributors-short">
     <group delimiter=" ">
       <names variable="author">
-        <name and="text" et-al-min="4" et-al-use-first="1" et-al-subsequent-min="4" et-al-subsequent-use-first="1" initialize-with="."/>
+        <name and="text" et-al-min="4" et-al-use-first="1" initialize-with="."/>
         <substitute>
           <names variable="editor"/>
           <names variable="translator"/>

--- a/university-of-south-australia-harvard-2011.csl
+++ b/university-of-south-australia-harvard-2011.csl
@@ -272,7 +272,7 @@ TO DO
       </else>
     </choose>
   </macro>
-  <citation et-al-min="4" et-al-use-first="1" et-al-subsequent-min="4" et-al-subsequent-use-first="1" disambiguate-add-givenname="true" disambiguate-add-year-suffix="true" collapse="year">
+  <citation et-al-min="4" et-al-use-first="1" disambiguate-add-givenname="true" disambiguate-add-year-suffix="true" collapse="year">
     <sort>
       <key macro="author-short"/>
       <key macro="year-date"/>

--- a/university-of-south-australia-harvard-2013.csl
+++ b/university-of-south-australia-harvard-2013.csl
@@ -280,7 +280,7 @@ TO DO
       </if>
     </choose>
   </macro>
-  <citation et-al-min="4" et-al-use-first="1" et-al-subsequent-min="4" et-al-subsequent-use-first="1" disambiguate-add-givenname="true" disambiguate-add-year-suffix="true" collapse="year">
+  <citation et-al-min="4" et-al-use-first="1" disambiguate-add-givenname="true" disambiguate-add-year-suffix="true" collapse="year">
     <sort>
       <key macro="author-short"/>
       <key macro="year-date"/>

--- a/urban-habitats.csl
+++ b/urban-habitats.csl
@@ -109,7 +109,7 @@
       <text variable="page"/>
     </group>
   </macro>
-  <citation et-al-min="4" et-al-use-first="1" et-al-subsequent-min="4" et-al-subsequent-use-first="1" disambiguate-add-year-suffix="true" disambiguate-add-names="true" disambiguate-add-givenname="true" collapse="year">
+  <citation et-al-min="4" et-al-use-first="1" disambiguate-add-year-suffix="true" disambiguate-add-names="true" disambiguate-add-givenname="true" collapse="year">
     <layout prefix="(" suffix=")" delimiter="; ">
       <group delimiter=", ">
         <group delimiter=" ">

--- a/wheaton-college-phd-in-biblical-and-theological-studies.csl
+++ b/wheaton-college-phd-in-biblical-and-theological-studies.csl
@@ -734,7 +734,7 @@
       </choose>
     </group>
   </macro>
-  <citation et-al-min="4" et-al-use-first="1" et-al-subsequent-min="4" et-al-subsequent-use-first="1" disambiguate-add-names="true">
+  <citation et-al-min="4" et-al-use-first="1" disambiguate-add-names="true">
     <layout delimiter="; ">
       <choose>
         <if position="ibid-with-locator">


### PR DESCRIPTION
- if at any node (et-al-min == et-al-subsequent-min && et-al-use-first == et-al-subsequent-use-first) then delete the two et-al-subsequent attribute
- some automatic detection and correction with a perl script, but also some manual edits still needed
- continuation of #1109 and #1111
