### PR TITLE
Update american-journal-of-archaeology.csl

### DIFF
--- a/american-journal-of-archaeology.csl
+++ b/american-journal-of-archaeology.csl
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" demote-non-dropping-particle="sort-only" default-locale="en-US">
+<!-- This style was edited with the Visual CSL Editor (http://editor.citationstyles.org/visualEditor/) -->
   <info>
     <title>American Journal of Archaeology</title>
     <id>http://www.zotero.org/styles/american-journal-of-archaeology</id>
@@ -14,7 +15,7 @@
     <issn>0002-9114</issn>
     <eissn>1939-828X</eissn>
     <summary>The American Journal of Archaeology style</summary>
-    <updated>2012-10-25T21:15:26+00:00</updated>
+    <updated>2014-09-14T17:29:42+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale>
@@ -50,10 +51,10 @@
   <macro name="container-contributors">
     <choose>
       <if type="chapter paper-conference" match="any">
-        <group prefix="," delimiter=", ">
+        <group prefix=",">
           <choose>
             <if variable="author">
-              <text value="edited by" prefix=" "/>
+              <text value="edited by " prefix=" "/>
               <names variable="editor">
                 <name and="text" delimiter=", "/>
               </names>
@@ -194,8 +195,8 @@
   <macro name="locators">
     <choose>
       <if type="article-journal">
-        <text variable="volume" prefix=" "/>
-        <text variable="issue" prefix=" "/>
+        <text variable="volume" form="short" prefix=" "/>
+        <text variable="issue" form="short" prefix=" "/>
       </if>
       <else-if type="bill book graphic legal_case legislation motion_picture report song" match="any">
         <group prefix=". " delimiter=". ">
@@ -216,7 +217,7 @@
       <if type="chapter paper-conference" match="any">
         <group prefix=", ">
           <text variable="volume" suffix=":"/>
-          <text variable="page"/>
+          <text variable="page" form="short"/>
         </group>
       </if>
     </choose>
@@ -236,7 +237,7 @@
         </group>
       </if>
       <else-if type="article-journal">
-        <text variable="page" prefix=": "/>
+        <text variable="page" prefix=":"/>
       </else-if>
     </choose>
   </macro>
@@ -251,7 +252,7 @@
     </group>
   </macro>
   <macro name="container-prefix">
-    <text term="in" text-case="capitalize-first"/>
+    <text term="in" form="short" text-case="capitalize-first"/>
   </macro>
   <macro name="container-title">
     <choose>
@@ -259,7 +260,7 @@
         <text macro="container-prefix" suffix=" "/>
       </if>
     </choose>
-    <text variable="container-title" font-style="italic"/>
+    <text variable="container-title" form="short" font-style="italic"/>
   </macro>
   <macro name="publisher">
     <group delimiter=": ">
@@ -279,7 +280,7 @@
     </date>
   </macro>
   <macro name="collection-title">
-    <text variable="collection-title"/>
+    <text variable="collection-title" form="short"/>
     <text variable="collection-number" prefix=" "/>
   </macro>
   <macro name="event">
@@ -345,7 +346,7 @@
       </group>
     </layout>
   </citation>
-  <bibliography hanging-indent="true" et-al-min="11" et-al-use-first="7" subsequent-author-substitute="&#8212;&#8212;&#8212;" entry-spacing="0">
+  <bibliography hanging-indent="true" et-al-min="11" et-al-use-first="7" subsequent-author-substitute="â€”â€”â€”" entry-spacing="0">
     <sort>
       <key macro="contributors"/>
       <key variable="issued"/>


### PR DESCRIPTION
1) Removes comma which appears after "edited by" but before first editor's name.
2) Removes whitespace between semicolon and page numbers for journal articles.