### PR TITLE
Add new style for journal FinanzArchiv

### DIFF
--- a/finanzarchiv.csl
+++ b/finanzarchiv.csl
@@ -1,0 +1,161 @@
+<?xml version="1.0" encoding="utf-8"?>
+<style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" demote-non-dropping-particle="never" default-locale="en-US">
+<!-- This style was edited with the Visual CSL Editor (http://editor.citationstyles.org/visualEditor/) -->
+  <info>
+    <title>FinanzArchiv : Public Finance Analysis</title>
+    <title-short>FA</title-short>
+    <id>http://www.zotero.org/styles/finanzarchiv</id>
+    <link href="http://www.zotero.org/styles/finanzarchiv" rel="self"/>
+    <link href="http://www.zotero.org/styles/elsevier-harvard" rel="template"/>
+    <link href="http://www.mohr.de/fileadmin/user_upload/Hinweise_Autoren_PDF/FA_2014/Style_guide_4_Feb_2014_.pdf" rel="documentation"/>
+    <link href="http://www.mohr.de/en/nc/journals/economics/finanzarchiv-fa/manuscripts.html" rel="documentation"/>
+    <author>
+      <name>Philipp Zumstein</name>
+      <uri>https://github.com/zuphilip</uri>
+    </author>
+    <category citation-format="author-date"/>
+    <category field="social_science"/>
+    <category field="communications"/>
+    <issn>0015-2218</issn>
+    <eissn>1614-0974</eissn>
+    <summary>This English style is for the journal FinanzArchiv, which is published by Mohr Siebeck. Note that the articles in the beginning of journal names (e.g. The American Economic Review) are NOT automatically delete as the style requests.</summary>
+    <updated>2014-09-15T12:59:16+00:00</updated>
+    <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
+  </info>
+  <locale xml:lang="en">
+    <terms>
+      <term name="accessed">Access Date</term>
+    </terms>
+  </locale>
+  <macro name="author">
+    <names variable="author">
+      <name and="text" delimiter-precedes-last="always" initialize-with="." name-as-sort-order="all"/>
+      <label form="short" prefix=" (" suffix=")" text-case="capitalize-first"/>
+      <substitute>
+        <names variable="editor"/>
+      </substitute>
+    </names>
+  </macro>
+  <macro name="author-short">
+    <names variable="author">
+      <name form="short" and="text" delimiter=", " initialize-with=". "/>
+      <substitute>
+        <names variable="editor"/>
+      </substitute>
+    </names>
+  </macro>
+  <macro name="access">
+    <group delimiter=" ">
+      <text variable="URL"/>
+      <group delimiter=": " prefix="(" suffix=")">
+        <text term="accessed"/>
+        <date variable="accessed">
+          <date-part name="year"/>
+          <date-part name="month" form="numeric" prefix="-"/>
+          <date-part name="day" prefix="-"/>
+        </date>
+      </group>
+    </group>
+  </macro>
+  <macro name="issued">
+    <choose>
+      <if variable="issued">
+        <date variable="issued">
+          <date-part name="year"/>
+        </date>
+      </if>
+      <else>
+        <text term="no date" form="short"/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="edition">
+    <choose>
+      <if is-numeric="edition">
+        <group delimiter=" ">
+          <number variable="edition" form="ordinal"/>
+          <text term="edition" form="short"/>
+        </group>
+      </if>
+      <else>
+        <text variable="edition"/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="publication-details">
+    <group delimiter=", ">
+      <text macro="edition"/>
+      <text variable="publisher"/>
+      <text variable="publisher-place"/>
+    </group>
+  </macro>
+  <citation et-al-min="3" et-al-use-first="1" disambiguate-add-givenname="true" disambiguate-add-year-suffix="true" collapse="year" cite-group-delimiter=", ">
+    <layout prefix="(" suffix=")" delimiter="; ">
+      <group delimiter=", ">
+        <text macro="author-short"/>
+        <text macro="issued"/>
+        <group delimiter=" ">
+          <label variable="locator" form="short"/>
+          <text variable="locator"/>
+        </group>
+      </group>
+    </layout>
+  </citation>
+  <bibliography hanging-indent="true" entry-spacing="0" line-spacing="1">
+    <sort>
+      <key macro="author"/>
+      <key macro="issued" sort="ascending"/>
+    </sort>
+    <layout>
+      <group delimiter=", " suffix=".">
+        <group delimiter=" ">
+          <text macro="author"/>
+          <text macro="issued" prefix="(" suffix=")"/>
+        </group>
+        <text variable="title"/>
+        <choose>
+          <if type="article-journal article-magazine article-newspaper" match="any">
+            <text variable="container-title"/>
+            <text variable="volume"/>
+            <text variable="page"/>
+          </if>
+          <else-if type="report" match="any">
+            <group delimiter=" ">
+              <text variable="collection-title"/>
+              <text variable="genre"/>
+              <text variable="number" prefix="No. "/>
+            </group>
+          </else-if>
+          <else-if type="manuscript" match="any">
+            <text variable="genre"/>
+            <text variable="publisher-place"/>
+            <text value="mimeo"/>
+          </else-if>
+          <else-if type="webpage" match="any">
+            <text macro="access"/>
+          </else-if>
+          <else-if type="chapter paper-conference" match="any">
+            <group delimiter=": ">
+              <text term="in"/>
+              <group delimiter=", ">
+                <names variable="editor translator" delimiter=", ">
+                  <name name-as-sort-order="all" sort-separator=", " initialize-with="." delimiter=", " delimiter-precedes-last="always"/>
+                  <label form="short" text-case="capitalize-first" prefix=" (" suffix=")"/>
+                </names>
+                <text variable="container-title" text-case="title"/>
+              </group>
+            </group>
+            <text macro="publication-details"/>
+          </else-if>
+          <else-if type="thesis" match="any">
+            <text variable="genre"/>
+            <text macro="publication-details"/>
+          </else-if>
+          <else>
+            <text macro="publication-details"/>
+          </else>
+        </choose>
+      </group>
+    </layout>
+  </bibliography>
+</style>


### PR DESCRIPTION
The style guide requires:
   <cite>Journal names should appear without first articles, i.e., “Quarterly Journal of Economics” rather than “The Quarterly Journal of Economics”</cite>
which is AFAIK not possible in CSL. Otherwise everything should be implemented as they want.
