### PR TITLE
Update leviathan.csl

### DIFF
--- a/leviathan.csl
+++ b/leviathan.csl
@@ -1,26 +1,25 @@
 <?xml version="1.0" encoding="utf-8"?>
-<style class="in-text" version="1.0" demote-non-dropping-particle="sort-only" default-locale="de-DE" xmlns="http://purl.org/net/xbiblio/csl">
-<!-- This style was edited with the Visual CSL Editor (http://editor.citationstyles.org/visualEditor/) -->
+<style class="note" version="1.0" demote-non-dropping-particle="sort-only" default-locale="de-DE" xmlns="http://purl.org/net/xbiblio/csl">
   <info>
     <title>Leviathan (German)</title>
     <id>http://www.zotero.org/styles/leviathan</id>
     <link href="http://www.zotero.org/styles/leviathan" rel="self"/>
     <link href="http://www.wzb.eu/de/publikationen/leviathan" rel="documentation"/>
     <author>
-      <name>Till A. Heilmann</name>
-      <email>mail@tillheilmann.info</email>
-      <uri>http://www.tillheilmann.info</uri>
-    </author>
-    <author>
       <name>Philipp Zumstein</name>
       <uri>https://github.com/zuphilip</uri>
     </author>
-    <category citation-format="author-date"/>
+    <contributor>
+      <name>Till A. Heilmann</name>
+      <email>mail@tillheilmann.info</email>
+      <uri>http://www.tillheilmann.info</uri>
+    </contributor>
+    <category citation-format="note"/>
     <category field="social_science"/>
     <issn>0340-0425</issn>
     <eissn>1861-8588</eissn>
     <summary>Style for Leviathan. Berliner Zeitschrift für Sozialwissenschaft. - The URL is at the moment only shown for articles in magazines and newspapers. - If you need only references to a webpage but no entry in the bibliography, maybe just use the export function or do this manually.</summary>
-    <updated>2014-09-17T10:18:15+00:00</updated>
+    <updated>2014-09-18T06:38:32+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale xml:lang="de">


### PR DESCRIPTION
The style changed very much since 2012, see also #1110. The update is more or less a complete rewrite of the Leviathan style which should implement the current style guidelines (I checked the guide lines I received and 3-4 current articles). More details:
- I implemented only the things which are either mentioned in the style guide or I have seen (consistently) in current articles (e.g. collection-title, translators, doi are not implemented). 
- I updated the quotation marks according to the current articles (also the style guide uses different quotation marks).
- The URL is at the moment only shown for articles in magazines and newspapers, because I have seen that in current articles (style guide does not say anything about that).
- References to webpages are very confusing: the hints in the style guide are not what I have seen in current articles, and that was not always consistent. It seems also that references to webpages are given in the footnote but not listed in the bibliography, which would mean AFAIK that one has to do that anyway manually (or with the export function).
- Although most references are given in footnotes, it is mentioned in the style guide: "Bei bloßen Literaturhinweisen ohne Zitat in den Fußnoten [...]". Therefore, I left the category to "author-date" and did not change it to "note", but I am not sure about that.
- The style should support originalDate accordingly, whenever this will be possible in Zotero.
