### PR TITLE
Add translator and original-title to CSE

### DIFF
--- a/council-of-science-editors-alphabetical.csl
+++ b/council-of-science-editors-alphabetical.csl
@@ -19,7 +19,7 @@
     <category citation-format="numeric"/>
     <category field="science"/>
     <summary>The Council of Science Editors style, Citation-Name system: numbers in text, sorted in alphabetical order by author.</summary>
-    <updated>2014-09-18T15:35:17+00:00</updated>
+    <updated>2014-09-22T14:39:18+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale xml:lang="en">
@@ -62,17 +62,7 @@
   </macro>
   <macro name="title">
     <group delimiter=" ">
-      <choose>
-        <if match="any" variable="original-title">
-          <group delimiter=" ">
-            <text variable="original-title"/>
-            <text variable="title" prefix="[" suffix="]"/>
-          </group>
-        </if>
-        <else>
-          <text variable="title"/>
-        </else>
-      </choose>
+      <text variable="title"/>
       <choose>
         <if type="thesis" match="any">
           <text variable="genre" form="long" prefix="[" suffix="]"/>

--- a/council-of-science-editors-author-date.csl
+++ b/council-of-science-editors-author-date.csl
@@ -17,7 +17,7 @@
     <category citation-format="author-date"/>
     <category field="science"/>
     <summary>The Council of Science Editors style, Name-Year system: author-date in text, sorted in alphabetical order by author.</summary>
-    <updated>2014-09-18T15:42:44+00:00</updated>
+    <updated>2014-09-22T14:40:29+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale xml:lang="en">
@@ -80,17 +80,7 @@
   </macro>
   <macro name="title">
     <group delimiter=" ">
-      <choose>
-        <if match="any" variable="original-title">
-          <group delimiter=" ">
-            <text variable="original-title"/>
-            <text variable="title" prefix="[" suffix="]"/>
-          </group>
-        </if>
-        <else>
-          <text variable="title"/>
-        </else>
-      </choose>
+      <text variable="title"/>
       <choose>
         <if type="thesis" match="any">
           <text variable="genre" form="long" prefix="[" suffix="]"/>

--- a/council-of-science-editors.csl
+++ b/council-of-science-editors.csl
@@ -14,7 +14,7 @@
     <category citation-format="numeric"/>
     <category field="science"/>
     <summary>The Council of Science Editors style, Citation-Sequence system: numbers in text, sorted by order of appearance in text.</summary>
-    <updated>2014-09-18T15:29:43+00:00</updated>
+    <updated>2014-09-22T14:38:54+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale xml:lang="en">
@@ -51,17 +51,7 @@
   </macro>
   <macro name="title">
     <group delimiter=" ">
-      <choose>
-        <if match="any" variable="original-title">
-          <group delimiter=" ">
-            <text variable="original-title"/>
-            <text variable="title" prefix="[" suffix="]"/>
-          </group>
-        </if>
-        <else>
-          <text variable="title"/>
-        </else>
-      </choose>
+      <text variable="title"/>
       <choose>
         <if type="thesis" match="any">
           <text variable="genre" form="long" prefix="[" suffix="]"/>


### PR DESCRIPTION
Hi,

The Council of Science editors says that translators should be listed with the editors as secondary authors (8th ed., 29.3.6.1.3). The roles should be separated by semi-colons, combining those who are both editors and translators.

If the title is a translation, the translated title should be in square brackets after the translation (29.3.6.2.1).

Also, the secondary authors of books should not be in parentheses (29.3.7.2.2). The same for the other types that CSE defines and is used for that if-block. (maps 29.3.6.9, legal cases 29.3.7.10, technical reports 29.3.6.4.1, thesis 29.3.7.5.1, audiovisuals, 29.3.7.11.1). Maybe this changed from the 7th edition?
