### PR TITLE
Create zeitschrift-fur-theologie-und-kirche.csl

### DIFF
--- a/zeitschrift-fur-theologie-und-kirche.csl
+++ b/zeitschrift-fur-theologie-und-kirche.csl
@@ -48,19 +48,6 @@
       </else>
     </choose>
   </macro>
-  <macro name="edition">
-    <choose>
-      <if is-numeric="edition">
-        <group delimiter=" ">
-          <number variable="edition" form="ordinal"/>
-          <text term="edition" form="short"/>
-        </group>
-      </if>
-      <else>
-        <text variable="edition"/>
-      </else>
-    </choose>
-  </macro>
   <macro name="date-and-edition">
     <group>
       <date form="text" variable="original-date" suffix=" ">


### PR DESCRIPTION
- The style does not need any bibliography, but for completeness (preview) it shows here the appearance of the footnotes.
- AFAIK special abbreviations on names Ch. for Christoph, Ph. for Philipp, Th. for Theodor cannot implemented.
- The "Ders./Dies." aka <a href="https://www.zotero.org/support/kb/idem">idem</a> things have to be added manually.

It seems to be important that the test for ibid-with-locator is before the test for ibid (at least in my very small tests).
