### PR TITLE
Add delimiter chicago-annotated-bibliography.csl

### DIFF
--- a/chicago-annotated-bibliography.csl
+++ b/chicago-annotated-bibliography.csl
@@ -1136,8 +1136,8 @@
           <text macro="locators-journal-join-with-colon"/>
         </group>
         <text macro="access"/>
+        <text variable="note" display="block"/>
       </group>
-      <text variable="note" display="block"/>
     </layout>
   </bibliography>
 </style>


### PR DESCRIPTION
The CMoS specification for notes is vague. However, the present behaviour is to set annotations immediately after the bibliographic data with no delimiter. I have shifted the note macro so that:

(Present behaviour:)

> “Messiah — A Christ‐Mass Song.” Autograph. Nanki Music Library, Tokyo, n.d. N-3 30Attributed to William Sharp.

we have:

> “Messiah — A Christ‐Mass Song.” Autograph. Nanki Music Library, Tokyo, n.d. N-3 30. Attributed to William Sharp.
