### PR TITLE
Fix rendering of secondary contributors in APA 6th edition.

### DIFF
--- a/apa.csl
+++ b/apa.csl
@@ -28,7 +28,7 @@
     <category citation-format="author-date"/>
     <category field="psychology"/>
     <category field="generic-base"/>
-    <updated>2014-08-06T01:20:52+00:00</updated>
+    <updated>2014-09-23T18:58:30+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale xml:lang="en">
@@ -56,9 +56,9 @@
   <macro name="secondary-contributors">
     <choose>
       <if type="article-journal chapter paper-conference" match="none">
-        <names variable="translator editor container-author" delimiter=", " prefix=" (" suffix=")">
+        <names variable="translator editor container-author" delimiter=", " prefix=" " suffix=", ">
           <name and="symbol" initialize-with=". " delimiter=", "/>
-          <label form="short" prefix=", " text-case="title"/>
+          <label form="short" prefix=" (" text-case="title" suffix=")"/>
         </names>
       </if>
     </choose>


### PR DESCRIPTION
Render secondary contributors the same as container contributors from commit 38ced9c1de6fa3ce823a4ef322d6c5c4a390fc0f.
