### PR TITLE
Update universite-de-liege-histoire.csl

### DIFF
--- a/universite-de-liege-histoire.csl
+++ b/universite-de-liege-histoire.csl
@@ -40,14 +40,14 @@
     <choose>
       <if variable="author">
         <names variable="author">
-          <name initialize-with="." delimiter=", " form="long" and="text" delimiter-precedes-last="never" font-style="normal" name-as-sort-order="all" sort-separator=", ">
+          <name initialize-with="." delimiter=", " form="long" and="text" delimiter-precedes-last="never" font-style="normal" name-as-sort-order="all" sort-separator=" ">
             <name-part name="family" font-variant="small-caps"/>
           </name>
         </names>
       </if>
       <else-if variable="editor">
         <names variable="editor">
-          <name initialize-with="." delimiter=", " form="long" and="text" delimiter-precedes-last="never" font-style="normal" name-as-sort-order="all" sort-separator=", ">
+          <name initialize-with="." delimiter=", " form="long" and="text" delimiter-precedes-last="never" font-style="normal" name-as-sort-order="all" sort-separator=" ">
             <name-part name="family" font-variant="small-caps"/>
           </name>
           <label form="short" prefix="&#160;(" suffix=".)"/>
@@ -59,14 +59,14 @@
     <choose>
       <if variable="author">
         <names variable="author">
-          <name initialize-with="." delimiter=", " form="long" and="text" delimiter-precedes-last="never" font-style="normal" name-as-sort-order="all" sort-separator=", ">
+          <name initialize-with="." delimiter=", " form="long" and="text" delimiter-precedes-last="never" font-style="normal" name-as-sort-order="all" sort-separator=" ">
             <name-part name="family" font-variant="small-caps"/>
           </name>
         </names>
       </if>
       <else-if variable="editor">
         <names variable="editor">
-          <name initialize-with="." delimiter=", " form="long" and="text" delimiter-precedes-last="never" font-style="normal" name-as-sort-order="all" sort-separator=", ">
+          <name initialize-with="." delimiter=", " form="long" and="text" delimiter-precedes-last="never" font-style="normal" name-as-sort-order="all" sort-separator=" ">
             <name-part name="family" font-variant="small-caps"/>
           </name>
           <label form="short" prefix="&#160;(" suffix=".)"/>
@@ -76,7 +76,7 @@
   </macro>
   <macro name="editor">
     <names variable="editor">
-      <name initialize-with="." delimiter=", " form="long" and="text" delimiter-precedes-last="never" font-style="normal" name-as-sort-order="all" sort-separator=", ">
+      <name initialize-with="." delimiter=", " form="long" and="text" delimiter-precedes-last="never" font-style="normal" name-as-sort-order="all" sort-separator=" ">
         <name-part name="family" font-variant="small-caps"/>
       </name>
       <label form="short" prefix="&#160;(" suffix=".)"/>
@@ -84,7 +84,7 @@
   </macro>
   <macro name="translator">
     <names variable="translator">
-      <name initialize-with="." delimiter=", " form="long" and="text" delimiter-precedes-last="never" font-style="normal" name-as-sort-order="all" sort-separator=", " prefix=" traduit par ">
+      <name initialize-with="." delimiter=", " form="long" and="text" delimiter-precedes-last="never" font-style="normal" name-as-sort-order="all" sort-separator=" " prefix=" traduit par ">
         <name-part name="family" font-variant="small-caps"/>
       </name>
     </names>


### PR DESCRIPTION
Removed the comma as sort-separator and replaced it by a space. Change required as to reflect University of Liège Department of History citation's rules. (cf. http://www.schist.ulg.ac.be/biblio/trav.htm )
