### PR TITLE
Update universite-de-liege-histoire.csl

### DIFF
--- a/universite-de-liege-histoire.csl
+++ b/universite-de-liege-histoire.csl
@@ -48,23 +48,15 @@
     </names>
   </macro>
   <macro name="author-bib">
-    <choose>
-      <if variable="author">
         <names variable="author">
           <name initialize-with="." delimiter=", " form="long" and="text" delimiter-precedes-last="never" font-style="normal" name-as-sort-order="all" sort-separator=" ">
             <name-part name="family" font-variant="small-caps"/>
           </name>
-        </names>
-      </if>
-      <else-if variable="editor">
-        <names variable="editor">
-          <name initialize-with="." delimiter=", " form="long" and="text" delimiter-precedes-last="never" font-style="normal" name-as-sort-order="all" sort-separator=" ">
-            <name-part name="family" font-variant="small-caps"/>
-          </name>
           <label form="short" prefix="&#160;(" suffix=".)"/>
+            <substitute>
+              <names variable="editor"/>
+            </substitute>
         </names>
-      </else-if>
-    </choose>
   </macro>
   <macro name="editor">
     <names variable="editor">


### PR DESCRIPTION
1. Removed the comma as sort-separator and replaced it by a space. Change required as to reflect University of Liège Department of History citation's rules. (cf. http://www.schist.ulg.ac.be/biblio/trav.htm )
2. Fixed macro "author" (shorter & "editors" not redundant) as suggested by rmzelle & adam3smith (Thanks to them !)

NB: validates on https://simonster.github.io/csl-validator.js/
