### PR TITLE
Update iso690-author-date-es.csl

### DIFF
--- a/iso690-author-date-es.csl
+++ b/iso690-author-date-es.csl
@@ -201,7 +201,7 @@
   </macro>
   <macro name="issue">
     <group delimiter=", ">
-      <text variable="volume" prefix="Vol. "/>
+      <text variable="volume" prefix="vol. "/>
       <text variable="issue" prefix="no. "/>
       <text variable="page" prefix="pp. "/>
     </group>
@@ -343,7 +343,7 @@
           <group>
             <text macro="author" suffix=" "/>
             <text macro="year-date" suffix=". "/>
-            <text macro="title" suffix=". "/>
+            <text macro="title" suffix=", "/>
             <text macro="edition" suffix=". "/>
             <text macro="issue" suffix=". "/>
             <text macro="accessed" suffix=". "/>
@@ -366,7 +366,7 @@
             <text macro="url" suffix=". "/>
           </group>
         </else-if>
-        <else-if type="chapter entry entry-dictionary entry-encyclopedia" match="any">
+        <else-if type="entry entry-dictionary entry-encyclopedia" match="any">
           <group>
             <text macro="author" suffix=" "/>
             <text macro="year-date" suffix=". "/>
@@ -374,6 +374,21 @@
             <text macro="edition" suffix=". "/>
             <text macro="publisher-place" suffix=": "/>
             <text macro="publisher" suffix=". "/>
+            <text macro="collection" suffix=", "/>
+            <text macro="page" suffix=". "/>
+            <text macro="accessed" suffix=". "/>
+            <text macro="isbn" suffix=". "/>
+            <text macro="url" suffix=". "/>
+          </group>
+        </else-if>
+        <else-if type="chapter">
+          <group>
+            <text macro="author" suffix=" "/>
+            <text macro="year-date" suffix=". "/>
+            <text macro="title" suffix=". "/>
+            <text macro="edition" suffix=". "/>
+            <text macro="publisher-place" suffix=": "/>
+            <text macro="publisher" suffix=", "/>
             <text macro="collection" suffix=", "/>
             <text macro="page" suffix=". "/>
             <text macro="accessed" suffix=". "/>


### PR DESCRIPTION
Changes made: 1) Changed stop by a comma in line 114 so that a stop appears after container-author; 2) Changed "Vol" (uppercase) in line 204 by "vol" (lowercase) for reference coherence; 3) Changed stop by a comma in line 346 so that a stop appears after the title and before the volume/issue in article-journal and article-magazine; 4) Isolated chapter (line 384 on) to provide a comma after the publisher and before the pages.
