### PR TITLE
Fix bibliography names Nucleic Acids Research

### DIFF
--- a/nucleic-acids-research.csl
+++ b/nucleic-acids-research.csl
@@ -23,13 +23,14 @@
   </info>
   <macro name="editor">
     <names variable="editor" delimiter=", ">
-      <name initialize-with="." name-as-sort-order="all" sort-separator=", " delimiter=", " delimiter-precedes-last="always"/>
+      <name initialize-with="." name-as-sort-order="all" sort-separator="," delimiter=", " delimiter-precedes-last="always"/>
       <label form="short" prefix=" (" suffix=")" strip-periods="true"/>
     </names>
   </macro>
   <macro name="author">
     <names variable="author">
-      <name name-as-sort-order="all" sort-separator=", " initialize-with="." delimiter=", " and="text" delimiter-precedes-last="never"/>
+      <name name-as-sort-order="all" sort-separator="," initialize-with="." delimiter=", " and="text" delimiter-precedes-last="never"/>
+      <et-al font-style="italic"/>
       <label form="short" prefix=" "/>
       <substitute>
         <names variable="editor"/>


### PR DESCRIPTION
According to the [documentation](http://www.oxfordjournals.org/nar/for_authors/msprep_submission.html)
- _et al._ should be italic.
- there should only be a comma separating last names from initials, not a comma and a space.
