### PR TITLE
Update iso690-author-date-es.csl

### DIFF
--- a/iso690-author-date-es.csl
+++ b/iso690-author-date-es.csl
@@ -180,7 +180,7 @@
   </macro>
   <macro name="publisher-place">
     <choose>
-      <if type="patent manuscript article-newspaper broadcast motion_picture song" match="any">
+      <if type="patent manuscript article-newspaper broadcast motion_picture song entry-encyclopedia entry-dictionary" match="any">
         <choose>
           <if variable="publisher-place">
             <text variable="publisher-place"/>
@@ -208,7 +208,7 @@
   </macro>
   <macro name="publisher">
     <choose>
-      <if type="broadcast motion_picture song report" match="any">
+      <if type="broadcast motion_picture song report entry-encyclopedia entry-dictionary" match="any">
         <choose>
           <if variable="publisher">
             <text variable="publisher"/>


### PR DESCRIPTION
Added "entry-encyclopedia entry-dictionary" to lines 183 and 211 to prevent "s.n" and "s.l." of publisher and publisher-place from appearing in the reference of dictionary and encyclopedia entries that are only published on the web (e.g. wikipedia).
