### PR TITLE
Add the period after contributors

### DIFF
--- a/mcgill-fr.csl
+++ b/mcgill-fr.csl
@@ -381,8 +381,10 @@
     <text macro="URL"/>
   </macro>
   <macro name="chapter">
-    <text macro="contributors" suffix=" "/>
-    <text macro="title-chapter-special"/>
+    <group delimiter=". ">
+      <text macro="contributors"/>
+      <text macro="title-chapter-special"/>
+    </group>
     <group delimiter=", ">
       <text macro="secondary-contributors" strip-periods="true"/>
       <text macro="container-contributors" strip-periods="true"/>
@@ -412,12 +414,14 @@
     <text macro="URL"/>
   </macro>
   <macro name="thesis">
-    <text macro="contributors" suffix=" "/>
+    <group delimiter=". ">
+      <text macro="contributors"/>
     <group delimiter=", ">
       <text variable="title" font-style="italic"/>
       <text variable="genre"/>
       <text variable="publisher" strip-periods="true"/>
       <text macro="issued-year"/>
+    </group>
     </group>
     <text macro="URL"/>
   </macro>
@@ -552,7 +556,8 @@
     <text macro="URL"/>
   </macro>
   <macro name="book">
-    <text macro="contributors" suffix=" "/>
+    <group delimiter=". ">
+    <text macro="contributors"/>
     <group delimiter=", ">
       <text variable="title" font-style="italic"/>
       <text macro="edition" strip-periods="true"/>
@@ -565,6 +570,7 @@
       <text variable="publisher-place" strip-periods="true"/>
       <text variable="publisher" strip-periods="true"/>
       <text macro="issued-year"/>
+    </group>
     </group>
     <text macro="URL"/>
   </macro>
@@ -592,7 +598,8 @@
     <text macro="URL"/>
   </macro>
   <macro name="article-newspaper">
-    <text macro="contributors" suffix=" "/>
+    <group delimiter=". ">
+    <text macro="contributors"/>
     <group delimiter=", ">
       <text variable="title" quotes="true"/>
       <choose>
@@ -608,6 +615,7 @@
         <text term="section" form="short" suffix=" " strip-periods="true"/>
         <text variable="section" strip-periods="true"/>
       </group>
+    </group>
     </group>
     <text macro="issued" prefix=" (" suffix=")"/>
     <text variable="page" prefix=" "/>
@@ -639,7 +647,8 @@
     <text macro="URL"/>
   </macro>
   <macro name="article-magazine">
-    <text macro="contributors" suffix=" "/>
+    <group delimiter=". ">
+    <text macro="contributors"/>
     <group delimiter=" ">
       <text variable="title" quotes="true" suffix=","/>
       <text variable="container-title" font-style="italic"/>
@@ -659,6 +668,7 @@
       </choose>
       <text macro="issued" prefix="(" suffix=")"/>
       <text variable="page"/>
+    </group>
     </group>
     <text macro="URL"/>
   </macro>
@@ -686,7 +696,8 @@
     <text macro="URL"/>
   </macro>
   <macro name="article-journal">
-    <text macro="contributors" suffix=" "/>
+    <group delimiter=". ">
+    <text macro="contributors"/>
     <group delimiter=" ">
       <text variable="title" quotes="true"/>
       <choose>
@@ -704,6 +715,7 @@
       </choose>
       <text variable="container-title" form="short" strip-periods="true"/>
       <text variable="page"/>
+    </group>
     </group>
     <text macro="URL"/>
   </macro>
@@ -836,7 +848,8 @@
     <text macro="URL"/>
   </macro>
   <macro name="entrydic-bib">
-    <text macro="contributors" suffix=" "/>
+    <group delimiter=". ">
+    <text macro="contributors"/>
     <group delimiter=", ">
       <text variable="container-title" font-style="italic"/>
       <text macro="edition" strip-periods="true"/>
@@ -847,6 +860,7 @@
       <text variable="publisher-place" strip-periods="true"/>
       <text variable="publisher" strip-periods="true"/>
       <text macro="issued-year"/>
+    </group>
     </group>
     <text macro="URL"/>
   </macro>
@@ -870,7 +884,8 @@
     <text macro="URL"/>
   </macro>
   <macro name="entryencyclo-bib">
-    <text macro="contributors" suffix=" "/>
+    <group delimiter=". ">
+    <text macro="contributors"/>
     <group delimiter=", ">
       <group delimiter=" ">
         <text variable="page" strip-periods="true"/>
@@ -884,6 +899,7 @@
       <text macro="translator-note" strip-periods="true"/>
       <text variable="publisher-place" strip-periods="true"/>
       <text variable="publisher" strip-periods="true"/>
+    </group>
     </group>
     <text macro="URL"/>
   </macro>
@@ -1087,7 +1103,8 @@
           <text macro="entryencyclo-bib"/>
         </else-if>
         <else>
-          <text macro="contributors" suffix=" "/>
+          <group delimiter=". ">
+          <text macro="contributors"/>
           <group delimiter=", ">
             <text variable="title" font-style="italic"/>
             <text macro="description"/>
@@ -1106,6 +1123,7 @@
             <text variable="volume" strip-periods="true"/>
             <text macro="issued"/>
             <text variable="page" strip-periods="true"/>
+          </group>
           </group>
         </else>
       </choose>


### PR DESCRIPTION
Fix the break since https://github.com/citation-style-language/styles/commit/7f34dc546bee8024653f758b712c7f7ef76983b8 

https://github.com/citation-style-language/styles/commit/7f34dc546bee8024653f758b712c7f7ef76983b8  breaks the McGill-fr.csl
According to the McGill style, Name should not have periods but should end by a period in bibliography (and a comma in notes).
