### PR TITLE
Create journal-of-retailing.csl

### DIFF
--- a/journal-of-retailing.csl
+++ b/journal-of-retailing.csl
@@ -6,6 +6,7 @@
     <link href="http://www.zotero.org/styles/journal-of-retailing" rel="self"/>
     <link href="http://www.zotero.org/styles/journal-of-interactive-marketing" rel="template"/>
     <link href="http://www.elsevier.com/journals/journal-of-retailing/0022-4359/guide-for-authors#68000" rel="documentation"/>
+    <link href="https://github.com/citation-style-language/styles/pull/1175" rel="documentation"/>
     <author>
       <name>Philipp Zumstein</name>
     </author>
@@ -13,7 +14,8 @@
     <category field="social_science"/>
     <category field="communications"/>
     <issn>0022-4359</issn>
-    <summary>Style for the Journal of Retailing published by Elsevier</summary>
+    <summary>Style for the Journal of Retailing published by Elsevier following the current articles which not always match the referred style guide (maybe outdated?).
+    </summary>
     <updated>2014-10-15T18:35:56+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>


### PR DESCRIPTION
I checked current articles which are indeed looking like the same style as the Journal of Interactive Marketing except the rendering of the issue number ( https://forums.zotero.org/discussion/39790/style-request-journal-of-interactive-marketing/#Item_32 ). This style is therefore just a copy of the other one with a very small change (some parts look a little strange, but I don't want to do a complete rewriting and it seems to work reasonable well). However, the citation style guide which is under the documentation link looks differently in some details (not italics, order of editors for chapter and conference paper, comma/point after author names and year). @grnathan2000 : It is an Elsevier journal; do you know anything about this citation style and/or the style guide?
