### PR TITLE
Ama

### DIFF
--- a/american-marketing-association.csl
+++ b/american-marketing-association.csl
@@ -1,10 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
 <style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" demote-non-dropping-particle="sort-only" page-range-format="chicago" default-locale="en-US">
   <info>
-    <title>Journal of Marketing</title>
-    <id>http://www.zotero.org/styles/journal-of-marketing</id>
-    <link href="http://www.zotero.org/styles/journal-of-marketing" rel="self"/>
-    <link href="https://www.ama.org/Publications/JournalofMarketing/Pages/JMAccepted.aspx#3" rel="documentation"/>
+    <title>American Marketing Association</title>
+    <title-short>AMA</title-short>
+    <id>http://www.zotero.org/styles/american-marketing-association</id>
+    <link href="http://www.zotero.org/styles/american-marketing-association" rel="self"/>
+    <link href="https://www.ama.org/publications/JournalOfMarketing/Documents/AMA_Reference_Style.pdf" rel="documentation"/>
+    <link href="https://www.ama.org/publications/JournalOfMarketingResearch/Documents/AMA_Reference_Style.pdf" rel="documentation"/>
     <author>
       <name>Sebastian Karcher</name>
     </author>
@@ -15,10 +17,8 @@
     <category citation-format="author-date"/>
     <category field="social_science"/>
     <category field="communications"/>
-    <issn>0022-2429</issn>
-    <eissn>1547-7185</eissn>
-    <summary>Style for the Journal of Marketing, published by the American Marketing Association</summary>
-    <updated>2012-09-27T22:06:38+00:00</updated>
+    <summary>AMA Reference List Style published by the American Marketing Association</summary>
+    <updated>2014-10-17T21:46:29+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <macro name="container-contributors">
@@ -43,7 +43,7 @@
   </macro>
   <macro name="author">
     <names variable="author">
-      <name name-as-sort-order="first" and="text" sort-separator=", " delimiter=", " delimiter-precedes-last="always"/>
+      <name and="text" name-as-sort-order="first"/>
       <label form="short" prefix=" (" suffix=")" text-case="capitalize-first"/>
       <substitute>
         <names variable="editor"/>
@@ -136,7 +136,7 @@
     <choose>
       <if type="article-journal article-magazine article-newspaper" match="any">
         <group delimiter=", ">
-          <group>
+          <group delimiter=" ">
             <text variable="volume"/>
             <text variable="issue" prefix="(" suffix=")"/>
           </group>

--- a/dependent/journal-of-international-marketing.csl
+++ b/dependent/journal-of-international-marketing.csl
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" demote-non-dropping-particle="sort-only" page-range-format="chicago" default-locale="en-US">
+  <info>
+    <title>Journal of International Marketing</title>
+    <title-short>JIM</title-short>
+    <id>http://www.zotero.org/styles/journal-of-international-marketing</id>
+    <link href="http://www.zotero.org/styles/journal-of-international-marketing" rel="self"/>
+    <link href="https://www.ama.org/publications/JournalOfInternationalMarketing/Pages/JIM_Accepted_Ms.aspx#references" rel="documentation"/>
+    <link href="http://www.zotero.org/styles/american-marketing-association" rel="independent-parent"/>
+    <category citation-format="author-date"/>
+    <category field="social_science"/>
+    <category field="communications"/>
+    <issn>1069-031X</issn>
+    <eissn>1547-7215</eissn>
+    <summary>Style for the Journal of International Marketing, published by the American Marketing Association</summary>
+    <updated>2014-10-18T00:06:38+00:00</updated>
+    <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
+  </info>
+</style>

--- a/dependent/journal-of-marketing-research.csl
+++ b/dependent/journal-of-marketing-research.csl
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" demote-non-dropping-particle="sort-only" page-range-format="chicago" default-locale="en-US">
+  <info>
+    <title>Journal of Marketing Research</title>
+    <title-short>JMR</title-short>
+    <id>http://www.zotero.org/styles/journal-of-marketing-research</id>
+    <link href="http://www.zotero.org/styles/journal-of-marketing-research" rel="self"/>
+    <link href="https://www.ama.org/publications/JournalOfMarketingResearch/Pages/JMR_Accepted_Ms.aspx#references" rel="documentation"/>
+    <link href="http://www.zotero.org/styles/american-marketing-association" rel="independent-parent"/>
+    <category citation-format="author-date"/>
+    <category field="social_science"/>
+    <category field="communications"/>
+    <issn>0022-2437</issn>
+    <eissn>1547-7193</eissn>
+    <summary>Style for theJournal of Marketing Research, published by the American Marketing Association</summary>
+    <updated>2014-10-18T00:10:38+00:00</updated>
+    <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
+  </info>
+</style>

--- a/dependent/journal-of-marketing.csl
+++ b/dependent/journal-of-marketing.csl
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" demote-non-dropping-particle="sort-only" page-range-format="chicago" default-locale="en-US">
+  <info>
+    <title>Journal of Marketing</title>
+    <title-short>JM</title-short>
+    <id>http://www.zotero.org/styles/journal-of-marketing</id>
+    <link href="http://www.zotero.org/styles/journal-of-marketing" rel="self"/>
+    <link href="https://www.ama.org/Publications/JournalofMarketing/Pages/JMAccepted.aspx#3" rel="documentation"/>
+    <link href="http://www.zotero.org/styles/american-marketing-association" rel="independent-parent"/>
+    <category citation-format="author-date"/>
+    <category field="social_science"/>
+    <category field="communications"/>
+    <issn>0022-2429</issn>
+    <eissn>1547-7185</eissn>
+    <summary>Style for the Journal of Marketing, published by the American Marketing Association</summary>
+    <updated>2014-10-17T23:56:38+00:00</updated>
+    <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
+  </info>
+</style>

--- a/dependent/journal-of-public-policy-and-marketing.csl
+++ b/dependent/journal-of-public-policy-and-marketing.csl
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" demote-non-dropping-particle="sort-only" page-range-format="chicago" default-locale="en-US">
+  <info>
+    <title>Journal of Public Policy &amp; Marketing</title>
+    <id>http://www.zotero.org/styles/journal-of-public-policy-and-marketing</id>
+    <link href="http://www.zotero.org/styles/journal-of-public-policy-and-marketing" rel="self"/>
+    <link href="https://www.ama.org/publications/JournalOfPublicPolicyAndMarketing/Pages/JPPMAccepted.aspx" rel="documentation"/>
+    <link href="http://www.zotero.org/styles/american-marketing-association" rel="independent-parent"/>
+    <category citation-format="author-date"/>
+    <category field="social_science"/>
+    <category field="communications"/>
+    <issn>0743-9156</issn>
+    <eissn>1547-7207</eissn>
+    <summary>Style for the Journal of Public Policy &amp; Marketing, published by the American Marketing Association</summary>
+    <updated>2014-10-18T00:16:38+00:00</updated>
+    <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
+  </info>
+</style>

--- a/law-and-society-review.csl
+++ b/law-and-society-review.csl
@@ -4,7 +4,7 @@
     <title>Law &amp; Society Review</title>
     <id>http://www.zotero.org/styles/law-and-society-review</id>
     <link href="http://www.zotero.org/styles/law-and-society-review" rel="self"/>
-    <link href="http://www.zotero.org/styles/journal-of-marketing" rel="template"/>
+    <link href="http://www.zotero.org/styles/american-marketing-association" rel="template"/>
     <link href="http://www.lawandsociety.org/review/review_stylesheet.html" rel="documentation"/>
     <author>
       <name>Sebastian Karcher</name>


### PR DESCRIPTION
Renamed the style for the Journal of Marketing into "AMA Reference List Style", they used that label on all their documents and corrected two small errors. Then, I created 4 dependent styles to that for the 4 journals of the AMA (American Marketing Association).

See also https://forums.zotero.org/discussion/32527/can-we-have-ama-reference-list-style-in-zotero/
