### PR TITLE
Create vietnam-ministry-of-education-and-training-vietnamese-name.csl

### DIFF
--- a/vietnam-ministry-of-education-and-training-vi.csl
+++ b/vietnam-ministry-of-education-and-training-vi.csl
@@ -4,6 +4,7 @@
     <title>Vietnam Ministry of Education and Training (Vietnamese)</title>
     <title-short>BGDDT_TV</title-short>
     <id>http://www.zotero.org/styles/vietnam-ministry-of-education-and-training-vi</id>
+    <link rel="self" href="http://www.zotero.org/styles/vietnam-ministry-of-education-and-training-vi" />
     <link href="http://www.zotero.org/styles/acm-sigchi-proceedings" rel="template" />
     <link href="http://www.vdic.org.vn/en/library/guides.html" rel="documentation"/>
     <author>


### PR DESCRIPTION
Vietnam ministry of education and training style for Vietnamese name, online guide from VDIC: http://www.vdic.org.vn/en/library/guides.html
