### PR TITLE
Update and rename universita-pontificia-salesiana-en.csl to universita-p...

### DIFF
--- a/universita-pontificia-salesiana.csl
+++ b/universita-pontificia-salesiana.csl
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
-<style xmlns="http://purl.org/net/xbiblio/csl" class="note" version="1.0" demote-non-dropping-particle="display-and-sort" default-locale="en-US">
+<style xmlns="http://purl.org/net/xbiblio/csl" class="note" version="1.0" demote-non-dropping-particle="display-and-sort">
   <info>
-    <title>Università Pontificia Salesiana (English)</title>
-    <title-short>UPS-en</title-short>
-    <id>http://www.zotero.org/styles/universita-pontificia-salesiana-en</id>
-    <link href="http://www.zotero.org/styles/universita-pontificia-salesiana-en" rel="self"/>
+    <title>Università Pontificia Salesiana</title>
+    <title-short>UPS</title-short>
+    <id>http://www.zotero.org/styles/universita-pontificia-salesiana</id>
+    <link href="http://www.zotero.org/styles/universita-pontificia-salesiana" rel="self"/>
     <link href="http://www.unisal.it" rel="documentation"/>
     <link href="http://www.worldcat.org/oclc/868533390" rel="documentation"/>    
     <author>
@@ -23,8 +23,8 @@
     <category field="humanities"/>
     <category field="philosophy"/>
     <category field="social_science"/>
-    <summary>Università Pontificia Salesiana (English)</summary>
-    <updated>2014-10-15T00:00:00+00:00</updated>
+    <summary>Università Pontificia Salesiana</summary>
+    <updated>2014-10-20T00:00:00+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <macro name="editor">


### PR DESCRIPTION
...ontificia-salesiana.csl

The dependent styles (universita-pontificia-salesiana-fr/es/pt-br) are not working (they use the English locale). I think the reason is that the parent has the default locale "en-US".
I'm proposing a new generic UPS style, without default locale, and will correct the "independent-link" link later).
Please, suggest another change if this is not the reason of the problem.
