### PR TITLE
Create universita-pontificia-salesiana.csl

### DIFF
--- a/universita-pontificia-salesiana.csl
+++ b/universita-pontificia-salesiana.csl
@@ -23,8 +23,8 @@
     <category field="humanities"/>
     <category field="philosophy"/>
     <category field="social_science"/>
-    <summary>Università Pontificia Salesiana</summary>
-    <updated>2014-10-20T00:00:00+00:00</updated>
+    <summary>Università Pontificia Salesiana. Style without default-locale to be parent of other styles. See https://github.com/citation-style-language/styles/pull/1194</summary>
+    <updated>2014-10-21T00:00:00+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <macro name="editor">


### PR DESCRIPTION
The dependent styles of universita-pontificia-salesiana-en.csl are not working; they are using the en-US locale (default in the parent), and not their own default locale (that should override the parent's default-locale according to http://citationstyles.org/downloads/specification.html#the-root-element-cs-style and https://forums.zotero.org/discussion/40526/overrule-the-language-of-citation-style/ but it's not happening).
I don't know if this is a bug, but I'm trying another solution: a "general" UPS style, without default-locale, and the dependent styles with their own locale.
I'll change the link in "independent-parent" of the dependent styles later.
