### PR TITLE
Council of Science Editors - Collection information and extent of a work

### DIFF
--- a/council-of-science-editors-alphabetical.csl
+++ b/council-of-science-editors-alphabetical.csl
@@ -19,7 +19,7 @@
     <category citation-format="numeric"/>
     <category field="science"/>
     <summary>The Council of Science Editors style, Citation-Name system: numbers in text, sorted in alphabetical order by author.</summary>
-    <updated>2014-09-22T14:39:18+00:00</updated>
+    <updated>2014-11-10T19:29:45+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale xml:lang="en">
@@ -159,7 +159,10 @@
   <macro name="collection">
     <choose>
       <if type="report">
-        <text variable="collection-number" prefix=" Report No.: " suffix="."/>
+         <group prefix=" " suffix="." delimiter=" ">
+           <text variable="collection-title"/>
+           <text variable="number" prefix=" Report No.: "/>
+          </group>
       </if>
       <else>
          <group prefix=" (" suffix=")." delimiter=" ">

--- a/council-of-science-editors-author-date.csl
+++ b/council-of-science-editors-author-date.csl
@@ -17,7 +17,7 @@
     <category citation-format="author-date"/>
     <category field="science"/>
     <summary>The Council of Science Editors style, Name-Year system: author-date in text, sorted in alphabetical order by author.</summary>
-    <updated>2014-09-22T14:40:29+00:00</updated>
+    <updated>2014-11-10T19:29:35+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale xml:lang="en">
@@ -169,7 +169,10 @@
   <macro name="collection">
     <choose>
       <if type="report">
-        <text variable="collection-number" prefix=" Report No.: " suffix="."/>
+        <group prefix=" " suffix="." delimiter=" ">
+           <text variable="collection-title"/>
+           <text variable="number" prefix=" Report No.: "/>
+          </group>
       </if>
       <else>
          <group prefix=" (" suffix=")." delimiter=" ">

--- a/council-of-science-editors.csl
+++ b/council-of-science-editors.csl
@@ -14,7 +14,7 @@
     <category citation-format="numeric"/>
     <category field="science"/>
     <summary>The Council of Science Editors style, Citation-Sequence system: numbers in text, sorted by order of appearance in text.</summary>
-    <updated>2014-09-22T14:38:54+00:00</updated>
+    <updated>2014-11-10T19:29:14+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale xml:lang="en">
@@ -154,7 +154,10 @@
   <macro name="collection">
     <choose>
       <if type="report">
-        <text variable="collection-number" prefix=" Report No.: " suffix="."/>
+         <group prefix=" " suffix="." delimiter=" ">
+           <text variable="collection-title"/>
+           <text variable="number" prefix=" Report No.: "/>
+         </group>
       </if>
       <else>
          <group prefix=" (" suffix=")." delimiter=" ">


### PR DESCRIPTION
CSE says series information should follow "the date of publication (and pagination, if included) in the citation-sequence and citation-name systems and follows the publisher in the name-year. In all systems, the series is enclosed within parentheses" (8th ed., 29.3.6.11). These patches moves the series title to those places, add the series editors, and puts it all in parentheses. Alternatively, if it's a report, display the report number (29.3.7.4).

Also, these patches add extent of a work to the pages macro. When it's a number, the count is "followed by a space and 'p.' (29.3.6.9.2). If it's not a number, assume that some other pagination is used.
