### PR TITLE
Add RIS format to enable exporting citations to RIS.

### DIFF
--- a/ris.csl
+++ b/ris.csl
@@ -1,0 +1,196 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" demote-non-dropping-particle="sort-only">
+<!-- This style was edited with the Visual CSL Editor (http://editor.citationstyles.org/visualEditor/) -->
+  <info>
+    <title>RIS</title>
+    <title-short>RIS</title-short>
+    <id>http://www.zotero.org/styles/ris</id>
+    <link href="http://www.zotero.org/styles/ris" rel="self"/>
+    <link href="http://www.refman.com/support/risformat_intro.asp" rel="documentation"/>
+    <author>
+      <name>Brandon Huber</name>
+    </author>
+    <contributor>
+      <name>Tom Philpot</name>
+      <email>tom.philpot@faithlife.com</email>
+    </contributor>
+    <category field="generic-base"/>
+    <summary>RIS format</summary>
+    <updated>2014-10-23T07:18:21+00:00</updated>
+    <rights>This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License: http://creativecommons.org/licenses/by-sa/3.0/</rights>
+  </info>
+  <macro name="zotero2bibtexType">
+    <choose>
+      <if type="book graphic legal_case legislation" match="any">
+        <text value="BOOK"/>
+      </if>
+      <else-if type="bill" match="any">
+        <text value="BILL"/>
+      </else-if>
+      <else-if type="motion_picture" match="any">
+        <text value="MPCT"/>
+      </else-if>
+      <else-if type="chapter" match="any">
+        <text value="CHAP"/>
+      </else-if>
+      <else-if type="paper-conference" match="any">
+        <text value="CPAPER"/>
+      </else-if>
+      <else-if type="article article-journal" match="any">
+        <text value="JOUR"/>
+      </else-if>
+      <else-if type="article-newspaper" match="any">
+        <text value="NEWS"/>
+      </else-if>
+      <else-if type="article-magazine" match="any">
+        <text value="MGZN"/>
+      </else-if>
+      <else-if type="thesis" match="any">
+        <text value="THES"/>
+      </else-if>
+      <else-if type="manuscript" match="any">
+        <text value="MANSCPT"/>
+      </else-if>
+      <else-if type="report" match="any">
+        <text value="RPRT"/>
+      </else-if>
+      <else-if type="entry-dictionary" match="any">
+        <text value="DICT"/>
+      </else-if>
+      <else-if type="entry-encyclopedia" match="any">
+        <text value="ENCYC"/>
+      </else-if>
+      <else-if type="song" match="any">
+        <text value="MUSIC"/>
+      </else-if>
+      <else>
+        <text value="MISC"/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="issued-year">
+    <date variable="issued" prefix="PY  - ">
+      <date-part name="year"/>
+    </date>
+  </macro>
+  <macro name="original-date">
+    <date variable="original-date" prefix="OP  - ">
+      <date-part name="year"/>
+      <text value="/"/>
+      <date-part name="month" form="numeric-leading-zeros" strip-periods="true"/>
+      <text value="/"/>
+      <date-part name="day" form="numeric-leading-zeros" strip-periods="true"/>
+    </date>
+  </macro>
+  <macro name="author">
+    <names variable="author">
+      <name sort-separator=", " name-as-sort-order="all" prefix="AU  - " delimiter="&lt;br /&gt;AU  - " delimiter-precedes-last="always"/>
+      <label form="long" text-case="capitalize-first"/>
+    </names>
+  </macro>
+  <macro name="editor">
+    <choose>
+      <if type="book" match="any">
+        <names variable="editor">
+          <name delimiter="&lt;br /&gt;A3  - " prefix="A3  - " name-as-sort-order="all"/>
+        </names>
+      </if>
+      <else>
+        <names variable="editor">
+          <name delimiter="&lt;br /&gt;A2  - " prefix="A2  - " name-as-sort-order="all"/>
+        </names>
+      </else>
+    </choose>
+  </macro>
+  <macro name="translator">
+    <names variable="translator">
+      <name sort-separator=", " name-as-sort-order="all" prefix="TA  - " delimiter="&lt;br /&gt;TA  - " delimiter-precedes-last="always"/>
+    </names>
+  </macro>
+  <macro name="title">
+    <text variable="title" prefix="TI  - "/>
+  </macro>
+  <macro name="number">
+    <text variable="issue"/>
+    <text variable="number"/>
+  </macro>
+  <macro name="container-title">
+    <choose>
+      <if type="article article-journal" match="any">
+        <text variable="container-title" prefix="JO  - "/>
+      </if>
+      <else>
+        <text variable="container-title" prefix="T2  - "/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="pages">
+    <choose>
+      <if type="book manuscript" match="any">
+        <group delimiter="&lt;br /&gt;">
+          <text variable="page" prefix="SE  - "/>
+          <text variable="number-of-pages" prefix="SP  - "/>
+        </group>
+      </if>
+      <else-if type="article article-journal" match="any">
+        <group delimiter="&lt;br /&gt;">
+          <text variable="page" prefix="M2  - "/>
+          <text variable="number-of-pages" prefix="SP  - "/>
+        </group>
+      </else-if>
+      <else>
+        <text variable="page" prefix="SP  - "/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="edition">
+    <text variable="edition" prefix="ET  - "/>
+  </macro>
+  <macro name="ris">
+    <group prefix="" suffix="&lt;br /&gt;ER  - &lt;br /&gt;" delimiter="&lt;br /&gt;">
+      <text macro="zotero2bibtexType" prefix="TY  - "/>
+      <text macro="title"/>
+      <text variable="abstract" prefix="AB  - "/>
+      <text macro="author"/>
+      <text variable="publisher-place" prefix="CY  - "/>
+      <text macro="original-date"/>
+      <text variable="DOI" prefix="DO  - "/>
+      <text macro="edition"/>
+      <text macro="container-title"/>
+      <text variable="volume" prefix="VL  - "/>
+      <text variable="number-of-volumes" prefix="NV  - "/>
+      <text variable="ISBN" prefix="SN  - "/>
+      <text variable="URL" prefix="UR  - "/>
+      <text variable="note" prefix="N1  - "/>
+      <text macro="number" prefix="IS  - "/>
+      <text variable="publisher" prefix="PB  - "/>
+      <text macro="editor"/>
+      <text macro="translator"/>
+      <text macro="issued-year"/>
+      <text macro="pages"/>
+      <text variable="keyword" prefix="KW  - "/>
+    </group>
+  </macro>
+  <citation hanging-indent="false" et-al-min="10" et-al-use-first="10">
+    <sort>
+      <key macro="author"/>
+      <key variable="issued"/>
+    </sort>
+    <layout>
+      <group delimiter="&lt;br /&gt;">
+        <text macro="ris"/>
+      </group>
+    </layout>
+  </citation>
+  <bibliography hanging-indent="false" et-al-min="10" et-al-use-first="10">
+    <sort>
+      <key macro="author"/>
+      <key variable="issued"/>
+    </sort>
+    <layout>
+      <group delimiter="&lt;br /&gt;">
+        <text macro="ris"/>
+      </group>
+    </layout>
+  </bibliography>
+</style>


### PR DESCRIPTION
An initial implementation of RIS export format.

Possible issues:
- Use of <br /> tags for line breaks
- Doesn't attempt to exhaustively map all the fields of all the RIS types to all the possible CSL variables.

This is a minimally viable CSL for our needs at Faithlife for use in Logos Bible Software, but we'd prefer to have this integrated upstream so the community can improve it and others can benefit.
