### PR TITLE
Update harvard7de.csl

### DIFF
--- a/harvard7de.csl
+++ b/harvard7de.csl
@@ -1,52 +1,30 @@
 <?xml version="1.0" encoding="utf-8"?>
 <style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" demote-non-dropping-particle="sort-only" default-locale="de-DE">
+<!-- This style was edited with the Visual CSL Editor (http://editor.citationstyles.org/visualEditor/) -->
   <info>
-    <title>Harvard Reference format 7 (author-date, German)</title>
-    <id>http://www.zotero.org/styles/harvard7de</id>
-    <link href="http://www.zotero.org/styles/harvard7de" rel="self"/>
-    <link href="http://www.institut-praxisforschung.ch/Portals/0/Jonas/Harvard-Zitierweise.pdf" rel="documentation"/>
-    <!--please e-mail me about bugs, suggestions etc! mmoole@googlemail.com  -->
-    <!-- useful things:
-      non breaking space: &#160;
-      narrow no break space: uni202F / &#8239; - but this is not supported widely!
-      em dash: &#8212;
-
-    -->
-    <contributor>
-      <name>Julian Onions</name>
-      <email>julian.onions@gmail.com</email>
-    </contributor>
-    <contributor>
-      <name>Sven Rothe</name>
-      <email>mmoole@googlemail.com</email>
-    </contributor>
+    <title>GfPM bas. Harvard7de</title>
+    <title-short>GfPM</title-short>
+    <id>http://www.zotero.org/styles/gfpm-bas-harvard7de</id>
+    <link href="http://www.zotero.org/styles/gfpm-bas-harvard7de" rel="self"/>
+    <link rel="documentation"/>
     <category citation-format="author-date"/>
     <category field="generic-base"/>
-    <summary>A Harvard author-date style variant, mostly german</summary>
-    <updated>2012-09-27T22:06:38+00:00</updated>
+    <updated>2014-10-24T17:37:49+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
-  <!-- Definieren zusätzlicher Lokalisierungen -->
   <locale xml:lang="de">
     <terms>
-      <term name="anonymous" form="short">o.&#160;A.</term>
-      <term name="no date" form="short">o.&#160;J.</term>
-      <!-- <term name="et-al">et&#160;al.</term> -->
+      <term name="accessed" form="verb-short">o. A.</term>
+      <term name="no date" form="short">o. J.</term>
     </terms>
   </locale>
-  <!-- Definieren der einzelnen Makros/Bausteine -->
-  <macro name="editor">
-    <names variable="editor" delimiter="; ">
-      <name name-as-sort-order="all" sort-separator=", " delimiter="; " delimiter-precedes-last="always" form="long"/>
-      <label form="short" prefix=" (" suffix=")"/>
-    </names>
-  </macro>
+  <macro name="editor"/>
   <macro name="anon">
     <text term="anonymous" form="short"/>
   </macro>
   <macro name="author">
-    <names variable="author" delimiter="; ">
-      <name name-as-sort-order="all" sort-separator=", " delimiter="; " delimiter-precedes-last="always" form="long"/>
+    <names variable="author" delimiter=" ">
+      <name delimiter=" / " delimiter-precedes-last="always" name-as-sort-order="all"/>
       <label form="short" prefix=" (" suffix=")"/>
       <substitute>
         <text macro="editor"/>
@@ -56,12 +34,11 @@
   </macro>
   <macro name="author-short">
     <names variable="author" delimiter="; ">
-      <name form="short" delimiter=", " initialize-with=". " delimiter-precedes-last="always"/>
-      <!-- Trennzeichen ,    optional: and="symbol" and="text" -->
+      <name form="short" delimiter=" / " delimiter-precedes-last="always" et-al-min="3" et-al-use-first="1" initialize-with=". "/>
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <text macro="anon"/>
+        <text macro="editor"/>
       </substitute>
     </names>
   </macro>
@@ -106,10 +83,10 @@
   <macro name="title">
     <choose>
       <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
-        <text variable="title" font-style="italic"/>
+        <text variable="title" strip-periods="false" font-style="italic" suffix="."/>
       </if>
       <else>
-        <text variable="title" prefix="„" suffix="“"/>
+        <text variable="title" text-case="title" strip-periods="false" quotes="false" prefix="„" suffix=".“"/>
       </else>
     </choose>
   </macro>
@@ -118,8 +95,7 @@
       <if type="report thesis" match="any">
         <group prefix=" (" suffix=")">
           <text variable="genre"/>
-          <!--<text term="number" form="short" suffix=" "/>-->
-          <text variable="number" prefix=" Nr.&#160;"/>
+          <text variable="number" prefix=" Nr. "/>
         </group>
       </if>
     </choose>
@@ -153,18 +129,14 @@
     <choose>
       <if type="article-journal article-magazine" match="any">
         <text variable="volume" suffix=" "/>
-        <!-- <date variable="issued">
-          <date-part name="year" prefix="(" suffix=")"/>
-          </date>-->
         <text variable="issue" prefix="(" suffix=")"/>
       </if>
     </choose>
   </macro>
   <macro name="locator-citation">
     <group>
-      <label variable="locator" form="short"/>
-      <!-- Kurze Form des Bezeichners z.b. der Seitenangabe (S. , Kap. ) -->
-      <text variable="locator" prefix="&#160;"/>
+      <label form="short"/>
+      <text variable="locator"/>
     </group>
   </macro>
   <macro name="published-date">
@@ -181,8 +153,15 @@
   <macro name="pages">
     <choose>
       <if type="chapter paper-conference article-journal article-magazine article-newspaper" match="any">
-        <label variable="page" form="short" suffix=".&#160;" strip-periods="true"/>
+        <label variable="page" form="short" suffix=". " strip-periods="true"/>
         <text variable="page"/>
+      </if>
+    </choose>
+  </macro>
+  <macro name="duration">
+    <choose>
+      <if type="broadcast motion_picture song interview " match="any">
+        <text variable="note" suffix="duration"/>
       </if>
     </choose>
   </macro>
@@ -190,7 +169,7 @@
     <choose>
       <if is-numeric="edition">
         <group>
-          <number variable="edition" form="numeric" suffix=".&#160;"/>
+          <number variable="edition" form="numeric" suffix=". "/>
           <text term="edition" form="short"/>
         </group>
       </if>
@@ -209,27 +188,20 @@
   <macro name="isbn">
     <text variable="ISBN" prefix="ISBN: "/>
   </macro>
-  <!-- Zusammensetzen des Kurzbeleges -->
-  <citation et-al-min="3" et-al-use-first="1" disambiguate-add-year-suffix="true" collapse="year">
-    <!-- ab 3 Autoren 'u.a.' , dabei ersten Autor anzeigen, ...  -->
+  <citation et-al-min="3" et-al-use-first="1" et-al-subsequent-min="3" et-al-subsequent-use-first="1" disambiguate-add-year-suffix="true" collapse="year">
     <sort>
       <key macro="author"/>
       <key variable="issued"/>
     </sort>
     <layout prefix="(" suffix=")" delimiter="; ">
-      <!-- Klammern um die Kurzbelege, Trennzeichen ; -->
-      <group delimiter=", ">
+      <group delimiter=" ">
         <text macro="author-short"/>
         <text macro="year-date"/>
       </group>
       <text macro="locator-citation" prefix=": "/>
     </layout>
   </citation>
-  <!-- Zusammensetzen des Literaturverzeichnisses -->
   <bibliography hanging-indent="true" et-al-min="4" et-al-use-first="3">
-    <!-- ab 2ter Zeile einrücken, u.a. ab 4 Namen, die ersten 3 Namen ausgeben -->
-    <!-- zusätzliche Optionen für obige Zeile: -->
-    <!-- entry-spacing="0" // Zeilenabstand zwischen den Einträgen -->
     <sort>
       <key macro="author"/>
       <key variable="title"/>
@@ -239,7 +211,7 @@
       <group suffix=".">
         <choose>
           <if type="chapter paper-conference" match="any">
-            <group delimiter="; ">
+            <group delimiter=" / ">
               <text macro="author"/>
             </group>
           </if>
@@ -250,15 +222,19 @@
             </group>
           </else>
         </choose>
-        <text macro="year-date" prefix=" (" suffix="):"/>
-        <text macro="title" prefix=" " suffix="."/>
+        <text macro="year-date" prefix=" (" suffix=")."/>
+        <text macro="title" prefix=" "/>
         <text macro="container-prefix" prefix=" "/>
         <choose>
           <if type="chapter paper-conference" match="any">
             <text macro="editor" prefix=" "/>
           </if>
         </choose>
-        <text variable="container-title" font-style="italic" prefix=" " suffix="."/>
+        <text variable="container-title" text-case="title" font-style="italic" prefix=" " suffix="."/>
+        <names variable="editor" font-variant="normal" vertical-align="baseline" delimiter="u. " prefix=" " suffix=".">
+          <label form="verb-short" text-case="sentence" strip-periods="false" font-style="normal" font-variant="normal" suffix=" "/>
+          <name delimiter=" u. " delimiter-precedes-last="always"/>
+        </names>
         <text macro="edition" prefix=" "/>
         <text macro="genre" prefix=" "/>
         <text macro="publisher" prefix=" "/>
@@ -268,12 +244,11 @@
           <text macro="locator" prefix=" "/>
           <text macro="published-date" prefix=" "/>
           <text macro="pages" prefix=", "/>
-          <!--<text macro="duration"/>-->
           <text macro="access" prefix=" "/>
           <text macro="doi" prefix=", "/>
         </group>
       </group>
-      <text macro="isbn" prefix=" &#8212;&#160;"/>
+      <text prefix=" — "/>
     </layout>
   </bibliography>
 </style>


### PR DESCRIPTION
Sorry, I am a very newcomer in editing styles. I want to create a new style called "gfpm-bas-harvard7de" by editing "harvard 7 de", because this style is quite similar to my needs. 

I made the following alterations:
- cite (Ex.): "Pfleiderer, 2014, S. 345" goes to "Pfleiderer 2014: 345"
- cite (Ex.): "Helms; Phleps, 2014, S. 345" goes to "Helms / Phleps 2014: 345"
- biblio (Ex.): new: Helms, Dietrich (2008). "What's the difference? Populäre Musik im System des Pop." In: PopMusicology. Perspektiven der Popmusikwissenschaft. (The latter titel is in italics!) Hg. von Christian Bielefeldt u. Udo Dahmen u. Rolf Großmann. Bielefeld: Transcript.
- biblio: I didn't manage to edit the following option: bibliographic entry of a proceeding or edited volume as a whole, e.g. with the editor-names in front of the entry.

I am looking forward to beeing supported in my edition in any way! Thanks a lot! 

Here you will find the standards of GfPM (Gesellschaft für Popularmusikforschung) Germany, which I tried to implement in the new style: http://www.aspm-samples.de/hinweise.html
