### PR TITLE
Render full title of first-reference legal cases

### DIFF
--- a/oscola.csl
+++ b/oscola.csl
@@ -190,7 +190,7 @@
         <text variable="title" text-case="title"/>
       </else-if>
       <else-if type="legal_case">
-        <text variable="title" font-style="italic" strip-periods="true" form="short"/>
+        <text variable="title" font-style="italic" strip-periods="true"/>
       </else-if>
       <else>
         <text variable="title" quotes="true" text-case="title"/>


### PR DESCRIPTION
As far as I can tell, the first reference to a case should use the full title. It works a little differently in MLZ, where form="short" on legal types ignores the shortTitle value. That design (in MLZ) is debatable; but for official Zotero and other clients, the full title is definitely correct. I think.
