### PR TITLE
Update harvard-institut-fur-praxisforschung-de.csl

### DIFF
--- a/harvard-institut-fur-praxisforschung-de.csl
+++ b/harvard-institut-fur-praxisforschung-de.csl
@@ -5,7 +5,8 @@
     <id>http://www.zotero.org/styles/harvard-institut-fur-praxisforschung-de</id>
     <link href="http://www.zotero.org/styles/harvard-institut-fur-praxisforschung-de" rel="self"/>
     <link href="http://www.zotero.org/styles/harvard7de" rel="template"/>
-    <link href="http://www.institut-praxisforschung.ch/Portals/0/Jonas/Harvard-Zitierweise.pdf" rel="documentation"/>
+    <link href="http://www.institut-praxisforschung.com/app/download/6167762784/Harvard-Zitierweise.pdf?t=1410296308" rel="documentation"/>
+    <link href="http://www.institut-praxisforschung.com/publikationen/studienhilfen/" rel="documentation"/>
     <!--please e-mail me about bugs, suggestions etc! saskia.mestern@gmail.com  -->
     <!-- useful things:
       non breaking space: &#160;


### PR DESCRIPTION
fix documentation link (and add link for parent page)
