### PR TITLE
Create gesellschaft-fur-popularmusikforschung.csl

### DIFF
--- a/gesellschaft-fur-popularmusikforschung.csl
+++ b/gesellschaft-fur-popularmusikforschung.csl
@@ -12,7 +12,7 @@
     </author>
     <category citation-format="author-date"/>
     <category field="humanities"/>
-    <updated>2014-11-15T00:45:02+00:00</updated>
+    <updated>2014-11-17T15:03:57+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale>
@@ -20,6 +20,7 @@
       <term name="et-al">et al.</term>
       <term name="editor" form="verb-short">Hg. v.</term>
       <term name="editor" form="short">Hg.</term>
+      <term name="and">u.</term>
     </terms>
   </locale>
   <macro name="anon">
@@ -37,7 +38,7 @@
   </macro>
   <macro name="author-short">
     <names variable="author" delimiter="; ">
-      <name form="short" delimiter=" / " delimiter-precedes-last="always" et-al-min="3" et-al-use-first="1" initialize-with=". "/>
+      <name form="short" delimiter=" / " delimiter-precedes-last="always" initialize-with=". "/>
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
@@ -179,7 +180,7 @@
       </if>
     </choose>
   </macro>
-  <citation disambiguate-add-year-suffix="true" collapse="year">
+  <citation disambiguate-add-year-suffix="true" collapse="year" et-al-min="3" et-al-use-first="1">
     <sort>
       <key macro="author"/>
       <key variable="issued"/>
@@ -192,7 +193,7 @@
       <text macro="locator-citation" prefix=": "/>
     </layout>
   </citation>
-  <bibliography et-al-min="4" et-al-use-first="4" hanging-indent="true">
+  <bibliography et-al-min="5" et-al-use-first="1" hanging-indent="true">
     <sort>
       <key macro="author"/>
       <key variable="title"/>
@@ -219,9 +220,9 @@
           <if type="chapter paper-conference" match="any"/>
         </choose>
         <text variable="container-title" text-case="title" font-style="italic" prefix=" " suffix="."/>
-        <names variable="editor" font-variant="normal" vertical-align="baseline" delimiter="u. " prefix=" " suffix=".">
-          <label form="verb-short" text-case="sentence" strip-periods="false" font-style="normal" font-variant="normal" suffix=" "/>
-          <name delimiter=" u. " et-al-min="4" et-al-use-first="1"/>
+        <names variable="editor" prefix=" " suffix=".">
+          <label form="verb-short" suffix=" "/>
+          <name delimiter=", " and="text" delimiter-precedes-last="never"/>
         </names>
         <text macro="edition" prefix=" "/>
         <text macro="genre" prefix=" "/>
@@ -239,3 +240,4 @@
     </layout>
   </bibliography>
 </style>
+


### PR DESCRIPTION
Sorry, I am a very newcomer in editing styles. I want to create a new style called "Gesellschaft für Popularmusikforschung (German)" by editing "harvard 7 de", because this style is quite similar to my needs. 

I didn’t manage to solve the following options:
-   Subject: position of editor names in bibliographic entries of an edited book, annual or conference proceedings:

a.  What I managed: entry of a single book chapter or paper-conference, e.g.: 

Helms, Dietrich (2008). "What's the difference? Populäre Musik im System des Pop." In: PopMusicology. Perspektiven der Popmusikwissenschaft. (The latter titel is in italics!) Hg. von Christian Bielefeldt u. Udo Dahmen u. Rolf Großmann. Bielefeld: Transcript.

b.  What I didn’t manage: entry of the whole edited book, e.g.:

Bielefeldt, Christian et. al. (Hgg.) (2008): PopMusicology. Perspektiven der Popmusikwissenschaft. (The latter titel is in italics!) Bielefeld: Transcript.
-   Subject: If container titles contain more than 2 editor names, the delimiter „u.“ should only divide the last 2 editor names. All names before should be devided by a comma (,).

c.  Wrong: 
Hg. von Christian Bielefeldt u. Udo Dahmen u. Rolf Großmann.

d.  True:
Hg. von Christian Bielefeldt, Udo Dahmen u. Rolf Großmann.
-   Subject: Text formatting of the „labels“ within the category „names“ in container titles: I selected the form „verb-short“. There appeares the text: „Hg. von“. I want to alter it into „Hg. v.“. Is that possible? 
-   Subject: Text formatting of the „et. al.“ within the category „names“ in container titles. There appeares the german text: „u. a.“. I want to alter it into „et. al.“. Is that possible?

My motivation of creating this citation style: I am member of the „Gesellschaft für Popularmusikforschung“. The chairman of it had allowed me to create this style regarding their citation standards. If I will have managed all technical (and validation) problems the chairman of course wants to check my edition. 

Here you will find the citation standards of GfPM (Gesellschaft für Popularmusikforschung) which I tried to implement in my edition: http://www.aspm-samples.de/hinweise.html

I am looking forward to beeing supported in my edition in any way! Thanks a lot! 
