### PR TITLE
use contextual delim-precedes-last for Amer Sociol Assoc

### DIFF
--- a/american-sociological-association.csl
+++ b/american-sociological-association.csl
@@ -27,7 +27,7 @@
   </macro>
   <macro name="author">
     <names variable="author">
-      <name and="text" name-as-sort-order="first" sort-separator=", " delimiter=", " delimiter-precedes-last="always" initialize="false" initialize-with=". "/>
+      <name and="text" name-as-sort-order="first" sort-separator=", " delimiter=", " delimiter-precedes-last="contextual" initialize="false" initialize-with=". "/>
       <label form="short" prefix=", "/>
       <substitute>
         <names variable="editor"/>


### PR DESCRIPTION
This fixed our support issue as follows:

In ASA, sources with **two authors** currently have an extra comma after the first author's first name. The comma after the first name should be removed (p. 46 in ASA guide).

**Current Output:**
Kirchenbaum, Michele, and Caity Selleck. 2014. _The Greatest Book About Libraries Ever_. New York, NY: Pearson.

**Expected Output:**
Kirchenbaum, Michele and Caity Selleck. 2014. _The Greatest Book About Libraries Ever_. New York, NY: Pearson.

Note: This does not apply to citations with 3+ authors.
