### PR TITLE
Create archiv-fur-die-civilistische-praxis.csl

### DIFF
--- a/archiv-fur-die-civilistische-praxis.csl
+++ b/archiv-fur-die-civilistische-praxis.csl
@@ -17,7 +17,7 @@
     <issn>0003-8997</issn>
     <eissn>1868-7113</eissn>
     <summary>Use type entry-encopledia for part of &quot;Gesetzeskommentar&quot;. The style does not need any bibliography, but for completeness (preview) it shows here the appearance of the footnotes.</summary>
-    <updated>2014-11-15T19:34:03+00:00</updated>
+    <updated>2014-11-15T20:40:58+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale xml:lang="de">
@@ -25,11 +25,6 @@
       <term name="editor" form="short">Hg.</term>
     </terms>
   </locale>
-  <macro name="author">
-    <names variable="author">
-      <name form="short" font-style="italic" font-variant="normal" delimiter="/" delimiter-precedes-last="always" initialize-with="."/>
-    </names>
-  </macro>
   <macro name="author-short">
     <names variable="author">
       <name form="short" font-style="italic" font-variant="normal" delimiter="/" initialize-with=". "/>
@@ -47,12 +42,6 @@
       </else>
     </choose>
   </macro>
-  <macro name="collection-info">
-    <group delimiter=" ">
-      <text variable="collection-title" form="short"/>
-      <text variable="collection-number"/>
-    </group>
-  </macro>
   <macro name="edition">
     <choose>
       <if match="any" is-numeric="edition">
@@ -64,12 +53,15 @@
       </else>
     </choose>
   </macro>
+  <macro name="page">
+    <text variable="page-first" suffix=" ff"/>
+  </macro>
   <citation et-al-min="4" et-al-use-first="1" disambiguate-add-givenname="true" collapse="year">
     <layout delimiter="; ">
       <choose>
         <if match="any" position="first">
           <group delimiter=", ">
-            <text macro="author"/>
+            <text macro="author-short"/>
             <choose>
               <if type="article-journal article-magazine article-newspaper" match="any">
                 <text variable="container-title" form="short"/>
@@ -84,7 +76,7 @@
                     <text macro="issued"/>
                   </else>
                 </choose>
-                <text variable="page"/>
+                <text macro="page"/>
               </if>
               <else-if type="chapter paper-conference entry-encyclopedia" match="any">
                 <group delimiter=" ">
@@ -96,7 +88,7 @@
                     </names>
                     <text variable="container-title" text-case="title"/>
                     <text macro="issued"/>
-                    <text variable="page"/>
+                    <text macro="page"/>
                   </group>
                 </group>
               </else-if>
@@ -142,12 +134,12 @@
   </citation>
   <bibliography et-al-min="4" et-al-use-first="1">
     <sort>
-      <key macro="author"/>
+      <key macro="author-short"/>
       <key macro="issued" sort="ascending"/>
     </sort>
     <layout>
       <group delimiter=", ">
-        <text macro="author"/>
+        <text macro="author-short"/>
         <choose>
           <if type="article-journal article-magazine article-newspaper" match="any">
             <text variable="container-title" form="short"/>
@@ -162,7 +154,7 @@
                 <text macro="issued"/>
               </else>
             </choose>
-            <text variable="page"/>
+            <text macro="page"/>
           </if>
           <else-if type="chapter paper-conference entry-encyclopedia" match="any">
             <group delimiter=" ">
@@ -174,7 +166,7 @@
                 </names>
                 <text variable="container-title" text-case="title"/>
                 <text macro="issued"/>
-                <text variable="page"/>
+                <text macro="page"/>
               </group>
             </group>
           </else-if>


### PR DESCRIPTION
Some issues in the style guide for this journal are not implemented automatic but have to be handled manually, e.g. "Festschriften" should not mention editors (i.e. delete them manually), <strike>pages for journal article should maybe more fuzzy like "328 ff"</strike> or what a "Archivzeitschrift" is where volume is shown.
