### PR TITLE
Chicago French

### DIFF
--- a/chicago-author-date-fr.csl
+++ b/chicago-author-date-fr.csl
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" demote-non-dropping-particle="never" page-range-format="chicago" default-locale="fr">
+<style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" demote-non-dropping-particle="never" page-range-format="chicago" default-locale="fr-FR">
   <info>
     <title>Chicago Manual of Style 16th edition (author-date, French)</title>
     <id>http://www.zotero.org/styles/chicago-author-date-fr</id>

--- a/chicago-fullnote-bibliography-fr.csl
+++ b/chicago-fullnote-bibliography-fr.csl
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<style xmlns="http://purl.org/net/xbiblio/csl" class="note" version="1.0" demote-non-dropping-particle="never" page-range-format="chicago" default-locale="fr">
+<style xmlns="http://purl.org/net/xbiblio/csl" class="note" version="1.0" demote-non-dropping-particle="never" page-range-format="chicago" default-locale="fr-FR">
   <info>
     <title>Chicago Manual of Style 16th edition (full note, French)</title>
     <id>http://www.zotero.org/styles/chicago-fullnote-bibliography-fr</id>


### PR DESCRIPTION
Proposed french adaptation of Chicago Author Date and Chicago Fullnote; following the guidelines published by Université de Montréal. (Results have been checked by UdeM's Librarians.)

http://guides.bib.umontreal.ca/disciplines/483-Citer-selon-le-style-Chicago?tab=2190
