### PR TITLE
NJW (and other German law journals)

### DIFF
--- a/neue-juristische-wochenschrift.csl
+++ b/neue-juristische-wochenschrift.csl
@@ -73,17 +73,6 @@
       <date date-parts="year" form="text" variable="issued"/>
     </group>
   </macro>
-  <macro name="inbook">
-    <group delimiter=": ">
-      <text term="in"/>
-      <group delimiter=", ">
-        <names variable="editor">
-          <name form="short" delimiter="/" initialize-with=""/>
-        </names>
-        <text variable="title"/>
-      </group>
-    </group>
-  </macro>
   <macro name="firstpage-locator">
     <text variable="page-first"/>
     <text variable="locator" prefix=", "/>
@@ -93,7 +82,7 @@
       <if match="any" is-numeric="edition">
         <group delimiter=" ">
           <number vertical-align="baseline" suffix=" " variable="edition" form="ordinal"/>
-          <text term="edition" form="short"/>
+          <text term="edition" form="short" suffix="."/>
         </group>
       </if>
       <else>
@@ -195,7 +184,7 @@
               <!-- is the case published in a journal? -->
               <if variable="container-title">
                 <text variable="authority" suffix=" "/>
-                <text variable="container-title-short" suffix=" "/>
+                <text variable="container-title" form="short" suffix=" "/>
                 <text variable="volume" suffix=", "/>
                 <text macro="firstpage-locator"/>
               </if>


### PR DESCRIPTION
This style is based on the "Juristische Zitierweise (Stüber)" style by Oliver Wolf and Philipp Zumstein
    (https://www.zotero.org/styles/juristische-zitierweise), but the citation is adapted for the style of
    German law journals, such as NJW (Neue Juristische Wochenschrift), MMR (Multimedia und Recht) etc., as follows:
    - Citations are in-text. In German legal journals sometimes citations are used in footnotes, sometimes in-text,
      although the citation itself does not differ. With "in-text", you can choose for yourself and create the
      footnotes yourself using your word-processor if necessary.
    - Citations do not end with ".". The "." is obsolete for in-text citations. Furthermore, citations in German law
      journals are often accompanied by supplemental text and explanations.
    - Commentaries and handbooks should use publication type "entry-encyclopedia". See details below.
    - note that some law journals use slightly different citation
