### PR TITLE
Remove an annoying extra space

### DIFF
--- a/modern-language-association-with-url.csl
+++ b/modern-language-association-with-url.csl
@@ -88,13 +88,13 @@
     </names>
   </macro>
   <macro name="access">
-    <group delimiter=" ">
+    <group delimiter=". ">
       <date variable="accessed">
         <date-part name="day" suffix=" "/>
         <date-part name="month" form="short" suffix=" "/>
         <date-part name="year"/>
       </date>
-      <text variable="URL" prefix=". &lt;" suffix="&gt;"/>
+      <text variable="URL" prefix="&lt;" suffix="&gt;"/>
     </group>
   </macro>
   <macro name="issued-full-date">


### PR DESCRIPTION
This change prevents an extra space from appearing before the period preceding the URL.
