### PR TITLE
Update emu-austral-ornithology.csl

### DIFF
--- a/emu-austral-ornithology.csl
+++ b/emu-austral-ornithology.csl
@@ -14,7 +14,7 @@
     <issn>0158-4197</issn>
     <eissn>1448-5540</eissn>
     <summary>Emu - Austral Ornithology</summary>
-    <updated>2014-11-13T22:48:39+00:00</updated>
+    <updated>2014-11-20T21:21:48+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <macro name="editor">
@@ -29,7 +29,7 @@
   <macro name="author">
     <names variable="author">
       <name name-as-sort-order="all" and="text" sort-separator=", " initialize-with=". " delimiter-precedes-last="always" delimiter=", "/>
-      <label form="short" prefix=" "/>
+      <label form="short" text-case="capitalize-first" prefix=" (" suffix=")"/>
       <substitute>
         <names variable="editor"/>
         <text macro="anon"/>
@@ -49,7 +49,13 @@
   </macro>
   <macro name="access">
     <choose>
-      <if variable="URL">
+      <if variable="DOI">
+        <group delimiter=":">
+          <text value="doi"/>
+          <text variable="DOI"/>
+        </group>
+      </if>
+      <else-if variable="URL">
         <text value="Available at:" suffix=" "/>
         <text variable="URL"/>
         <group prefix=" [Verified " suffix="]">
@@ -59,7 +65,7 @@
             <date-part name="year"/>
           </date>
         </group>
-      </if>
+      </else-if>
     </choose>
   </macro>
   <macro name="title">
@@ -110,6 +116,9 @@
     </group>
   </macro>
   <citation et-al-min="3" et-al-use-first="1" disambiguate-add-year-suffix="true" disambiguate-add-names="true">
+    <sort>
+      <key macro="year-date"/>
+    </sort>
     <layout prefix="(" suffix=")" delimiter="; ">
       <group delimiter=", ">
         <group delimiter=" ">
@@ -150,16 +159,16 @@
             <text macro="editor" prefix="(" suffix=".)"/>
             <text variable="collection-title" suffix="."/>
             <text variable="event" suffix="."/>
-            <group suffix="." delimiter=". ">
+            <group delimiter=". ">
               <text macro="pages" prefix=" "/>
-              <text macro="publisher" prefix="(" suffix=")"/>
+              <text macro="publisher" prefix="(" suffix=".)"/>
             </group>
           </group>
         </else-if>
         <else-if type="thesis">
           <group prefix=" " suffix="." delimiter=" ">
             <text macro="title" suffix="."/>
-            <text variable="genre" suffix=","/>
+            <text variable="genre" text-case="capitalize-first" suffix=","/>
             <text variable="publisher"/>
             <text variable="publisher-place"/>
           </group>
@@ -176,7 +185,17 @@
                   <text variable="genre"/>
                 </else>
               </choose>
-              <text variable="number" prefix=" "/>
+              <choose>
+                <if match="any" is-numeric="number">
+                  <group delimiter=" ">
+                    <text value="No."/>
+                    <text variable="number"/>
+                  </group>
+                </if>
+                <else>
+                  <text variable="number"/>
+                </else>
+              </choose>
             </group>
             <group delimiter=", ">
               <text variable="publisher"/>
@@ -196,7 +215,7 @@
           </group>
         </else>
       </choose>
-      <text prefix=" " macro="access" suffix="."/>
+      <text prefix=" " macro="access"/>
     </layout>
   </bibliography>
 </style>


### PR DESCRIPTION
That will be my reference style for the first group in #1253 . Small changes according to the style guide and the sample issue for the journal. In the style guide there is for example the following example (bold format is from me):

Turbott, E. G. <b>(Ed.)</b> (1990). ´Checklist of the Birds of New Zealand and the Ross Dependency, Antarctica.´ (Random Century: Auckland, NZ<b>.)</b>
