### PR TITLE
Update international-journal-of-wildland-fire.csl

### DIFF
--- a/international-journal-of-wildland-fire.csl
+++ b/international-journal-of-wildland-fire.csl
@@ -18,7 +18,7 @@
       the Australian Journal of Botany and several other Australian journals.  It has been
       validated for the journal, book, book chapter, report, and conference paper citation
       styles.  This style is in the public domain.</summary>
-    <updated>2012-10-18T22:38:43+00:00</updated>
+    <updated>2014-11-25T17:35:42+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <macro name="editor-translator">
@@ -110,7 +110,7 @@
     <group>
       <choose>
         <if type="article-journal">
-          <text variable="container-title" form="short" strip-periods="true"/>
+          <text variable="container-title" strip-periods="true"/>
         </if>
         <else>
           <text variable="container-title" form="short"/>
@@ -189,7 +189,6 @@
             <text variable="collection-title" prefix=" " suffix="."/>
             <group delimiter=". ">
               <group prefix=" " delimiter=" ">
-                <label variable="page" form="short" suffix=" " text-case="capitalize-first" strip-periods="true"/>
                 <text variable="page"/>
               </group>
               <text macro="publisher"/>
@@ -206,7 +205,7 @@
             </names>
             <text variable="collection-title" prefix=" " suffix="."/>
             <group delimiter=". ">
-              <group prefix=" ">
+              <group delimiter=" " prefix=" ">
                 <label variable="page" form="short"/>
                 <text variable="page"/>
               </group>
@@ -223,7 +222,6 @@
             <text macro="container-title" font-style="italic"/>
             <group suffix=", ">
               <text variable="volume" prefix=" " font-weight="bold"/>
-              <text variable="issue" prefix="(" suffix=")"/>
             </group>
             <text variable="page" prefix=" "/>
           </group>


### PR DESCRIPTION
- full journal title should appear
- no page labels for inproceeding articles
- issue number is not given
- fix some spacing

I will take this style as a reference style for the 2nd group in #1253 .
