### PR TITLE
Update the-isme-journal.csl: ISMEJ uses and="text" for author-short

### DIFF
--- a/the-isme-journal.csl
+++ b/the-isme-journal.csl
@@ -45,7 +45,7 @@
   </macro>
   <macro name="author-short">
     <names variable="author">
-      <name form="short" and="symbol" delimiter=", " delimiter-precedes-last="never"/>
+      <name form="short" and="text" delimiter=", " delimiter-precedes-last="never"/>
       <et-al font-style="italic"/>
       <substitute>
         <names variable="editor"/>


### PR DESCRIPTION
The author guideline says to use the ampersand (http://mts-isme.nature.com/cgi-bin/main.plex?form_type=display_auth_instructions), but actually published papers use the text "and".
