### PR TITLE
Create Experimental-Dermatology.csl

### DIFF
--- a/experimental-dermatology.csl
+++ b/experimental-dermatology.csl
@@ -86,7 +86,7 @@
   </citation>
   <bibliography et-al-min="4" et-al-use-first="3" second-field-align="flush">
     <layout>
-      <text variable="citation-number" suffix=". "/>
+      <text variable="citation-number" font-weight="bold" suffix=" "/>
       <text macro="author"/>
       <text macro="title" suffix=". "/>
       <choose>


### PR DESCRIPTION
This style is for the journal Experimental Dermatology. The description in the author guidelines are not really complete, but this style here covers references to books, journal articles and chapters in edited books.
