### PR TITLE
Update harvard-university-for-the-creative-arts.csl

### DIFF
--- a/harvard-university-for-the-creative-arts.csl
+++ b/harvard-university-for-the-creative-arts.csl
@@ -45,6 +45,7 @@
     <names variable="editor">
       <name and="text" delimiter-precedes-last="never" initialize-with="." name-as-sort-order="all"/>
       <label form="short" text-case="lowercase" prefix=" (" suffix=")"/>
+      <et-al font-style="italic"/>
     </names>
   </macro>
   <macro name="year-date">
@@ -87,7 +88,7 @@
         <choose>
           <if type="broadcast" match="none">
             <group delimiter=". ">
-              <group delimiter=". ">
+              <group delimiter=" ">
                 <text variable="title" font-style="italic" suffix="."/>
                 <text macro="edition-no"/>
               </group>
@@ -137,6 +138,7 @@
   <macro name="translator">
     <names variable="translator">
       <name delimiter=". " prefix="Translated by " suffix="." and="text" delimiter-precedes-last="never" et-al-min="3" et-al-use-first="1" initialize-with="."/>
+      <et-al font-style="italic"/>
     </names>
   </macro>
   <macro name="bill-detail">
@@ -181,9 +183,10 @@
           <names variable="editor" delimiter="." suffix=" ">
             <name form="short" and="text" delimiter-precedes-last="never" et-al-min="3" et-al-use-first="1" initialize-with="."/>
             <label form="short" plural="never" prefix=" (" suffix=")"/>
+            <et-al font-style="italic"/>
           </names>
           <group delimiter=", ">
-            <group font-style="normal" font-variant="normal" delimiter=".">
+            <group font-style="normal" font-variant="normal">
               <text variable="container-title" font-style="italic" suffix="."/>
               <text variable="collection-title" font-style="italic"/>
               <choose>
@@ -215,6 +218,7 @@
         <names variable="author">
           <name and="text" sort-separator=", " initialize-with="." delimiter-precedes-last="never" delimiter=", " prefix=" Directed by " suffix="."/>
           <label form="short" prefix=" "/>
+          <et-al font-style="italic"/>
         </names>
       </else-if>
       <else>


### PR DESCRIPTION
Fix issue where two full stops appeared before the edition of books and dictionaries.

Italicise et al when referring to not just authors, - editors, directors, translators - which were previously written in normal font
