### PR TITLE
Style error: MISQ sets comma before edition or volume for books and chapters

### DIFF
--- a/mis-quarterly.csl
+++ b/mis-quarterly.csl
@@ -37,9 +37,12 @@
     <contributor>
       <name>Gerit Wagner</name>
     </contributor>
+    <contributor>
+      <name>Dennis Riehle</name>
+    </contributor>
     <category citation-format="author-date"/>
     <issn>0276-7783</issn>
-    <updated>2014-07-18T10:20:00+00:00</updated>
+    <updated>2014-12-10T00:32:45+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale xml:lang="en-US">
@@ -150,7 +153,7 @@
         </group>
       </if>
       <else-if type="bill book graphic legal_case legislation manuscript motion_picture report song speech" match="any">
-        <text variable="title" font-style="italic" suffix=", "/>
+        <text variable="title" font-style="italic"/>
       </else-if>
       <else>
         <text variable="title" quotes="true" suffix=","/>
@@ -214,14 +217,12 @@
   <macro name="issued">
     <choose>
       <if variable="issued">
-        <group prefix=" " suffix=".">
-          <date variable="issued">
-            <date-part name="year"/>
-          </date>
-        </group>
+        <date variable="issued">
+          <date-part name="year"/>
+        </date>
       </if>
       <else>
-        <text prefix=" (" term="no date" suffix=")." form="short"/>
+        <text prefix="(" term="no date" suffix=")" form="short"/>
       </else>
     </choose>
   </macro>
@@ -253,15 +254,13 @@
   <macro name="locators">
     <choose>
       <if type="article-journal article-magazine article-newspaper" match="any">
-        <group prefix=" " delimiter=", ">
-          <group prefix="(" suffix=")" delimiter=":">
-            <text variable="volume"/>
-            <text variable="issue"/>
-          </group>
+        <group prefix="(" suffix=")" delimiter=":">
+          <text variable="volume"/>
+          <text variable="issue"/>
         </group>
       </if>
       <else-if type="bill book chapter graphic legal_case legislation motion_picture paper-conference report song" match="any">
-        <group prefix=" (" suffix=") " delimiter=", ">
+        <group prefix=" (" suffix=")" delimiter=", ">
           <text macro="edition"/>
           <group>
             <text term="volume" form="short" plural="true" text-case="capitalize-first" suffix=" "/>
@@ -282,30 +281,14 @@
     </group>
   </macro>
   <macro name="container-phrase">
-    <!-- Container phrase accounts for avoiding comma after Journal titles
-       and adding " in " before proceedings title or book title -->
-    <choose>
-      <if type="article-journal article-magazine article-newspaper" match="none">
-        <group suffix=", ">
-          <choose>
-            <if type="chapter paper-conference" match="any">
-              <text term="in" suffix=" "/>
-            </if>
-          </choose>
-          <text variable="container-title" font-style="italic"/>
-        </group>
-      </if>
-      <else>
-        <group>
-          <choose>
-            <if type="chapter paper-conference" match="any">
-              <text term="in" suffix=" "/>
-            </if>
-          </choose>
-          <text variable="container-title" font-style="italic"/>
-        </group>
-      </else>
-    </choose>
+    <group>
+      <choose>
+        <if type="chapter paper-conference" match="any">
+          <text term="in" suffix=" "/>
+        </if>
+      </choose>
+      <text variable="container-title" font-style="italic"/>
+    </group>
   </macro>
   <citation et-al-min="3" et-al-use-first="1" disambiguate-add-year-suffix="true" disambiguate-add-names="true" disambiguate-add-givenname="true" givenname-disambiguation-rule="by-cite" collapse="year">
     <sort>
@@ -330,18 +313,20 @@
     <layout>
       <group suffix=".">
         <text macro="author" suffix="."/>
-        <text macro="issued" suffix=" "/>
-        <group delimiter=" " suffix=" ">
-          <text macro="title"/>
-          <text macro="container-phrase"/>
+        <text macro="issued" prefix=" " suffix="."/>
+        <group delimiter="" prefix=" ">
+          <group delimiter=" ">
+            <text macro="title"/>
+            <text macro="container-phrase"/>
+          </group>
+          <group delimiter=", ">
+            <text variable="collection-title"/>
+            <text macro="container-contributors"/>
+            <text macro="secondary-contributors"/>
+          </group>
+          <text macro="locators" prefix=" "/>
         </group>
-        <group delimiter=", " suffix=", ">
-          <text variable="collection-title"/>
-          <text macro="container-contributors"/>
-          <text macro="secondary-contributors"/>
-        </group>
-        <text macro="locators"/>
-        <group delimiter=", ">
+        <group delimiter=", " prefix=", ">
           <text macro="event"/>
           <text macro="publisher"/>
         </group>


### PR DESCRIPTION
The current implementation of the MISQ style sets a comma before the edition (or volume) of books or books refered to as book chapters, e.g.:

Agresti, A. 2012. Analysis of Ordinal Categorical Data, (2nd ed.) Hoboken, New Jersey: Wiley.

Even though the MISQ itself is rather unclear about this issue (no example given at http://www.misq.org/manuscript-guidelines), I suggest to change this behaviour. I have found the following citations in recent MISQ papers, which I think reflect the correct way of formatting this bibliography entry:

In Chen et al. 2010: 
- Andrews, K. R. 1980. The Concept of Corporate Strategy (2nd ed.), Homewood, IL: Richard D. Irwin, Inc.
- Liddell Hart, B. H. 1967. Strategy: The Indirect Approach (4th ed.), London: Faber, pp. 430.

In Mazmanian et al. 2014:
- Suchman, L. 2007. Human–Machine Reconfigurations: Plans and Situated Actions (2nd ed.), New York: Cambridge University Press.

**_Examples - before and after:**_

Book with edtion:
- Agresti, A. 2012. Analysis of Ordinal Categorical Data, (2nd ed.) Hoboken, New Jersey: Wiley.
- Agresti, A. 2012. Analysis of Ordinal Categorical Data (2nd ed.), Hoboken, New Jersey: Wiley.

Book with volume:
- Robinson, W. P., and Rackstraw, S. J. 1972. A Question of Answers, (Vol. 1) London: Routledge & Kegan Paul Books.
- Robinson, W. P., and Rackstraw, S. J. 1972. A Question of Answers (Vol. 1), London: Routledge & Kegan Paul Books.

Chapter of a book with edition:
- Hatch, M. J. 2012. “Organizational Culture,” in Organization Theory, (3rd ed.) Oxford: Oxford University Press, pp. 159–173.
- Hatch, M. J. 2012. “Organizational Culture,” in Organization Theory (3rd ed.), Oxford: Oxford University Press, pp. 159–173.

Nothing changed for journal articles:
- Piccoli, G., and Ives, B. 2005. “Review: IT-dependent strategic initiatives and sustained competitive advantage: a review and synthesis of the literature,” MIS Quarterly (29:4), pp. 747–776.
- Piccoli, G., and Ives, B. 2005. “Review: IT-dependent strategic initiatives and sustained competitive advantage: a review and synthesis of the literature,” MIS Quarterly (29:4), pp. 747–776.

Nothing changed for conference papers:
- Richter, A., and Riemer, K. 2013. “The Contextual Nature Of Enterprise Social Networking: A Multi Case Study Comparison,” in Proceedings of the 21st European Conference on Information Systems, Sofia.
- Richter, A., and Riemer, K. 2013. “The Contextual Nature Of Enterprise Social Networking: A Multi Case Study Comparison,” in Proceedings of the 21st European Conference on Information Systems, Sofia.

**_References used for the examples above as BibTeX:**_

```
@book{Agresti2012,
  address = {Hoboken, New Jersey},
  author = {Agresti, Alan},
  edition = {2},
  isbn = {9780470593998},
  publisher = {Wiley},
  title = {{Analysis of Ordinal Categorical Data}},
  year = {2012}
}
@book{Robinson1972,
  address = {London},
  author = {Robinson, W.P. and Rackstraw, Susan J.},
  isbn = {0710069863},
  publisher = {Routledge \& Kegan Paul Books},
  title = {{A Question of Answers}},
  volume = {1},
  year = {1972}
}
@incollection{Hatch2012,
  address = {Oxford},
  author = {Hatch, Mary J.},
  booktitle = {Organization Theory},
  edition = {3rd},
  isbn = {9780199640379},
  pages = {159--173},
  publisher = {Oxford University Press},
  title = {{Organizational Culture}},
  year = {2012}
}
@article{Piccoli2005,
  author = {Piccoli, Gabriele and Ives, Blake},
  journal = {MIS Quarterly},
  number = {4},
  pages = {747--776},
  title = {{Review: IT-dependent strategic initiatives and sustained competitive advantage: a review and synthesis of the literature}},
  volume = {29},
  year = {2005}
}
@inproceedings{Richter2013,
  address = {Sofia},
  author = {Richter, Alexander and Riemer, Kai},
  booktitle = {Proceedings of the 21st European Conference on Information Systems},
  title = {{The Contextual Nature Of Enterprise Social Networking: A Multi Case Study Comparison}},
  year = {2013}
}
```

The software I use is Mendeley Desktop.
