### PR TITLE
Internationalise "accessed" in american-sociological-association.csl

### DIFF
--- a/american-sociological-association.csl
+++ b/american-sociological-association.csl
@@ -61,11 +61,7 @@
       <choose>
         <if variable="URL">
           <text term="retrieved" text-case="capitalize-first" suffix=" "/>
-          <date variable="accessed">
-            <date-part name="month" suffix=" "/>
-            <date-part name="day" suffix=", "/>
-            <date-part name="year"/>
-          </date>
+          <date variable="accessed" form="text" suffix=" "/>
           <group prefix=" (" suffix=")">
             <text variable="URL"/>
           </group>


### PR DESCRIPTION
This has worked for me in Norwegian, but I haven't tried it in US English. I believe I got the code from the latest Chicago Manual of Style which ASA is based on, so it should really work fine.
