### PR TITLE
council-of-science-editors -- Secondary author labels and dictionary/encyclopedia entires

### DIFF
--- a/council-of-science-editors-alphabetical.csl
+++ b/council-of-science-editors-alphabetical.csl
@@ -41,7 +41,7 @@
     </names>
   </macro>
   <macro name="author">
-    <names variable="author">
+    <names variable="author" delimiter="; ">
       <name name-as-sort-order="all" sort-separator=" " initialize-with="" delimiter=", " delimiter-precedes-last="always"/>
       <label form="long" prefix=", " strip-periods="true"/>
       <substitute>

--- a/council-of-science-editors-author-date.csl
+++ b/council-of-science-editors-author-date.csl
@@ -39,7 +39,7 @@
     </names>
   </macro>
   <macro name="author">
-    <names variable="author">
+    <names variable="author" delimiter="; ">
       <name name-as-sort-order="all" sort-separator=" " initialize-with="" delimiter=", " delimiter-precedes-last="always"/>
       <label form="long" prefix=", " strip-periods="true"/>
       <substitute>

--- a/council-of-science-editors.csl
+++ b/council-of-science-editors.csl
@@ -14,7 +14,7 @@
     <category citation-format="numeric"/>
     <category field="science"/>
     <summary>The Council of Science Editors style, Citation-Sequence system: numbers in text, sorted by order of appearance in text.</summary>
-    <updated>2014-12-22T16:03:31+00:00</updated>
+    <updated>2014-12-22T17:32:22+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale xml:lang="en">
@@ -36,7 +36,7 @@
     </names>
   </macro>
   <macro name="author">
-    <names variable="author">
+    <names variable="author" delimiter="; ">
       <name name-as-sort-order="all" sort-separator=" " initialize-with="" delimiter=", " delimiter-precedes-last="always"/>
       <label form="long" prefix=", " strip-periods="true"/>
       <substitute>


### PR DESCRIPTION
The labels for secondary authors should not be abbreviated (3rd ed., 29.3.6.1.3). Additionally, if there are both an editor and a translator, both be placed in the primary author position.

Unrelated, dictionary and encyclopedia entries should be formatted the same as book chapters (29.3.7.2.10).
