### PR TITLE
Update us-geological-survey.csl

### DIFF
--- a/us-geological-survey.csl
+++ b/us-geological-survey.csl
@@ -88,11 +88,18 @@
       </group>
       <choose>
         <if type="report">
-          <text variable="title" prefix=" " suffix=":"/>
-          <text variable="publisher" prefix=" "/>
-          <text variable="genre" prefix=" "/>
-          <text variable="number" prefix =" " suffix=","/>
-          <text variable="page" prefix=" p. " suffix="."/>
+           <group prefix=" " delimiter=", " suffix=".">
+            <group delimiter=" ">
+              <text variable="title" suffix=":"/>
+              <text variable="publisher"/>
+              <text variable="genre"/>
+              <text variable="number"/>
+            </group>
+            <group>
+              <label variable="page" form="short" plural="never" suffix=" "/>
+              <text variable="page"/>
+            </group>
+          </group>
         </if>
         <else-if type="bill book graphic legal_case legislation motion_picture report song" match="any">
           <group suffix=":">

--- a/us-geological-survey.csl
+++ b/us-geological-survey.csl
@@ -89,8 +89,10 @@
       <choose>
         <if type="report">
           <text variable="title" prefix=" " suffix=":"/>
-          <text variable="publisher" prefix=" " suffix=","/>
-          <text variable="collection-title" prefix=" "/>
+          <text variable="publisher" prefix=" "/>
+          <text variable="genre" prefix=" "/>
+          <text variable="number" prefix =" " suffix=","/>
+          <text variable="page" prefix=" p. " suffix="."/>
         </if>
         <else-if type="bill book graphic legal_case legislation motion_picture report song" match="any">
           <group suffix=":">


### PR DESCRIPTION
USGS Reports need to have the report type and number in the bibliography.  This edits changes the USGS style for reports to:

> Moix, M.W., Barks, C.S., and Funkhouser, J.E., 2003, Water quality and streamflow gains and losses of Osage and Prairie Creeks, Benton County, Arkansas, July 2001: U.S. Geological Survey Water-Resources Investigations Report 03-4187, p. 35.

Note that the report type ("Water-Resources Investigations Report") and number ("03-4187") are pulled into the citation.