### PR TITLE
Create revista-de-filologia-espannola.csl

### DIFF
--- a/revista-de-filologia-espannola.csl
+++ b/revista-de-filologia-espannola.csl
@@ -1,0 +1,182 @@
+<?xml version="1.0" encoding="utf-8"?>
+<style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" et-al-min="10" initialize="false" demote-non-dropping-particle="sort-only" default-locale="es-ES">
+<!-- This style was edited with the Visual CSL Editor (http://editor.citationstyles.org/visualEditor/) -->
+  <info>
+    <title>Revista de Filología Española (Spanish)</title>
+    <title-short>RFE parentético</title-short>
+    <id>http://www.zotero.org/styles/revista-de-filologia-espannola</id>
+    <link href="http://www.zotero.org/styles/revista-de-filología-española" rel="self">http://www.zotero.org/styles/revista-de-filologia-espannola</link>
+    <link href="http://www.zotero.org/styles/the-open-university-harvard" rel="template"/>
+    <link href="http://revistadefilologiaespañola.revistas.csic.es/index.php/rfe/about/submissions#authorGuidelines" rel="documentation"/>
+    <issn>0210-9174</issn>
+    <eissn>1988-8538</eissn>
+    <author>
+      <name>JMFR</name>
+    </author>
+    <category citation-format="author-date"/>
+    <category field="generic-base"/>
+    <summary>RFE citation style</summary>
+    <updated>2014-12-27T11:51:21+00:00</updated>
+    <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
+  </info>
+  <macro name="editor">
+    <names variable="editor" delimiter=", ">
+      <name and="text" et-al-min="10" initialize="false" initialize-with=". "/>
+      <label form="short" prefix=" (" suffix=")"/>
+    </names>
+  </macro>
+  <macro name="anon">
+    <text term="anonymous" form="short" text-case="capitalize-first" strip-periods="true"/>
+  </macro>
+  <macro name="author">
+    <names variable="author">
+      <name font-variant="normal" and="text" delimiter-precedes-last="never" initialize-with=". " name-as-sort-order="first"/>
+      <label form="short" prefix=" (" suffix=")"/>
+      <substitute>
+        <names variable="editor"/>
+        <text macro="anon"/>
+      </substitute>
+    </names>
+  </macro>
+  <macro name="author-short">
+    <names variable="author">
+      <name form="short" and="symbol" delimiter-precedes-last="never" initialize="false" initialize-with=". "/>
+      <substitute>
+        <names variable="editor"/>
+        <names variable="translator"/>
+        <text macro="anon"/>
+      </substitute>
+    </names>
+  </macro>
+  <macro name="access">
+    <choose>
+      <if variable="URL">
+        <text term="online" suffix=": "/>
+        <text value=" "/>
+        <text variable="URL" prefix="&lt;" suffix="&gt;"/>
+        <group delimiter=" " prefix=" [" suffix="]">
+          <text term="accessed" text-case="lowercase" suffix=":"/>
+          <date form="numeric" variable="accessed">
+            <date-part name="day" range-delimiter="-"/>
+            <date-part name="month"/>
+            <date-part name="year"/>
+          </date>
+        </group>
+      </if>
+    </choose>
+  </macro>
+  <macro name="title">
+    <choose>
+      <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
+        <text variable="title" font-style="italic"/>
+      </if>
+      <else>
+        <text variable="title" quotes="true"/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="publisher">
+    <group delimiter=", ">
+      <text variable="publisher-place"/>
+      <text variable="publisher"/>
+    </group>
+  </macro>
+  <macro name="year-date">
+    <choose>
+      <if variable="issued">
+        <date variable="issued">
+          <date-part name="year"/>
+        </date>
+      </if>
+      <else>
+        <text term="no date" form="short"/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="locator">
+    <choose>
+      <if type="article-journal">
+        <text variable="volume"/>
+        <text variable="issue" prefix="/"/>
+      </if>
+    </choose>
+  </macro>
+  <macro name="published-date">
+    <choose>
+      <if type="article-newspaper">
+        <date variable="issued">
+          <date-part name="day" form="ordinal" suffix=" "/>
+          <date-part name="month" form="long"/>
+        </date>
+      </if>
+    </choose>
+  </macro>
+  <macro name="pages">
+    <choose>
+      <if type="chapter paper-conference article-journal" match="any">
+        <label variable="page" form="short" suffix=" "/>
+        <text variable="page"/>
+      </if>
+    </choose>
+  </macro>
+  <macro name="edition">
+    <choose>
+      <if is-numeric="edition">
+        <group delimiter=" ">
+          <number variable="edition" form="ordinal"/>
+          <text term="edition" form="short"/>
+        </group>
+      </if>
+      <else>
+        <text variable="edition" suffix="."/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="container-prefix">
+    <choose>
+      <if type="chapter paper-conference" match="any">
+        <text term="in" text-case="capitalize-first"/>
+      </if>
+    </choose>
+  </macro>
+  <citation et-al-min="3" et-al-use-first="1" disambiguate-add-year-suffix="true" disambiguate-add-names="true" disambiguate-add-givenname="true" collapse="year">
+    <layout prefix="(" suffix=")" delimiter="; ">
+      <group delimiter=", ">
+        <group delimiter=", ">
+          <text macro="author-short"/>
+          <text macro="year-date"/>
+        </group>
+        <group>
+          <text term="page" form="short" suffix=" "/>
+          <text variable="locator"/>
+        </group>
+      </group>
+    </layout>
+  </citation>
+  <bibliography hanging-indent="true">
+    <sort>
+      <key macro="author"/>
+      <key variable="title"/>
+    </sort>
+    <layout suffix=".">
+      <group delimiter=" ">
+        <text macro="author"/>
+        <text macro="year-date" prefix="(" suffix="):"/>
+        <text macro="title" suffix=", "/>
+        <text macro="edition"/>
+        <text macro="container-prefix"/>
+        <group delimiter=", ">
+          <text macro="editor"/>
+          <text variable="container-title" font-style="italic"/>
+          <text variable="collection-title"/>
+          <text variable="genre"/>
+          <text macro="publisher"/>
+          <text macro="locator"/>
+          <text macro="published-date"/>
+          <text macro="pages"/>
+          <text macro="access"/>
+        </group>
+      </group>
+    </layout>
+  </bibliography>
+</style>

--- a/revista-de-filologia-espanola.csl
+++ b/revista-de-filologia-espanola.csl
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
-<style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" et-al-min="10" initialize="false" demote-non-dropping-particle="sort-only" default-locale="es-ES">
+<style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" initialize="false" demote-non-dropping-particle="sort-only" default-locale="es-ES">
 <!-- This style was edited with the Visual CSL Editor (http://editor.citationstyles.org/visualEditor/) -->
   <info>
     <title>Revista de Filología Española (Spanish)</title>
     <title-short>RFE parentético</title-short>
-    <id>http://www.zotero.org/styles/revista-de-filologia-espannola</id>
-    <link href="http://www.zotero.org/styles/revista-de-filología-española" rel="self">http://www.zotero.org/styles/revista-de-filologia-espannola</link>
+    <id>http://www.zotero.org/styles/revista-de-filologia-espanola</id>
+    <link href="http://www.zotero.org/styles/revista-de-filologia-espanola" rel="self">http://www.zotero.org/styles/revista-de-filologia-espanola</link>
     <link href="http://www.zotero.org/styles/the-open-university-harvard" rel="template"/>
     <link href="http://revistadefilologiaespañola.revistas.csic.es/index.php/rfe/about/submissions#authorGuidelines" rel="documentation"/>
     <issn>0210-9174</issn>
@@ -14,14 +14,15 @@
       <name>JMFR</name>
     </author>
     <category citation-format="author-date"/>
-    <category field="generic-base"/>
+    <category field="linguistics"/>
     <summary>RFE citation style</summary>
+    <updated>2014-12-28T09:42:21+00:00</updated>
     <updated>2014-12-27T11:51:21+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <macro name="editor">
     <names variable="editor" delimiter=", ">
-      <name and="text" et-al-min="10" initialize="false" initialize-with=". "/>
+      <name and="text" initialize="false" initialize-with=". "/>
       <label form="short" prefix=" (" suffix=")"/>
     </names>
   </macro>
@@ -135,11 +136,11 @@
   <macro name="container-prefix">
     <choose>
       <if type="chapter paper-conference" match="any">
-        <text term="in" text-case="capitalize-first"/>
+        <text term="en" text-case="capitalize-first"/>
       </if>
     </choose>
   </macro>
-  <citation et-al-min="3" et-al-use-first="1" disambiguate-add-year-suffix="true" disambiguate-add-names="true" disambiguate-add-givenname="true" collapse="year">
+  <citation et-al-min="10" et-al-use-first="3" disambiguate-add-year-suffix="true" disambiguate-add-names="true" disambiguate-add-givenname="true" collapse="year">
     <layout prefix="(" suffix=")" delimiter="; ">
       <group delimiter=", ">
         <group delimiter=", ">

--- a/revista-de-filologia-espanola.csl
+++ b/revista-de-filologia-espanola.csl
@@ -5,7 +5,7 @@
     <title>Revista de Filología Española (Spanish)</title>
     <title-short>RFE parentético</title-short>
     <id>http://www.zotero.org/styles/revista-de-filologia-espanola</id>
-    <link href="http://www.zotero.org/styles/revista-de-filologia-espanola" rel="self">http://www.zotero.org/styles/revista-de-filologia-espanola</link>
+    <link href="http://www.zotero.org/styles/revista-de-filologia-espanola" rel="self"/>
     <link href="http://www.zotero.org/styles/the-open-university-harvard" rel="template"/>
     <link href="http://revistadefilologiaespañola.revistas.csic.es/index.php/rfe/about/submissions#authorGuidelines" rel="documentation"/>
     <issn>0210-9174</issn>
@@ -16,8 +16,7 @@
     <category citation-format="author-date"/>
     <category field="linguistics"/>
     <summary>RFE citation style</summary>
-    <updated>2014-12-28T09:42:21+00:00</updated>
-    <updated>2014-12-27T11:51:21+00:00</updated>
+    <updated>2015-01-04T18:39:00+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <macro name="editor">
@@ -136,7 +135,7 @@
   <macro name="container-prefix">
     <choose>
       <if type="chapter paper-conference" match="any">
-        <text term="en" text-case="capitalize-first"/>
+        <text variable="title" text-case="capitalize-first"/>
       </if>
     </choose>
   </macro>

--- a/revista-de-filologia-espanola.csl
+++ b/revista-de-filologia-espanola.csl
@@ -135,7 +135,7 @@
   <macro name="container-prefix">
     <choose>
       <if type="chapter paper-conference" match="any">
-        <text variable="title" text-case="capitalize-first"/>
+        <text term="in" text-case="capitalize-first"/>
       </if>
     </choose>
   </macro>


### PR DESCRIPTION
Citational software does not have proper style for Spanish language journal on Spanish Language, Literature & Linguistics topic. The Revista de Filología Española is one of the most valued journals and its style is widely used outside in other publications.