### PR TITLE
Delete adjacent spaces in edition/publisher pattern

### DIFF
--- a/acta-anaesthesiologica-scandinavica.csl
+++ b/acta-anaesthesiologica-scandinavica.csl
@@ -121,8 +121,10 @@
       <text macro="title" suffix=". "/>
       <choose>
         <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
-          <text macro="edition" prefix=" " suffix=" "/>
-          <text macro="publisher" prefix=" "/>
+          <group prefix=" " delimiter=" ">
+            <text macro="edition"/>
+            <text macro="publisher"/>
+          </group>
         </if>
         <else-if type="chapter paper-conference" match="any">
           <group prefix=" " suffix=". ">

--- a/acta-societatis-botanicorum-poloniae.csl
+++ b/acta-societatis-botanicorum-poloniae.csl
@@ -114,8 +114,10 @@
       <text macro="title" suffix=". "/>
       <choose>
         <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
-          <text macro="edition" prefix=" " suffix=" "/>
-          <text macro="publisher" prefix=" "/>
+          <group prefix=" " delimiter=" ">
+            <text macro="edition"/>
+            <text macro="publisher"/>
+          </group>
           <group prefix="(" suffix="). ">
             <text variable="collection-title" suffix="; "/>
             <text variable="volume" prefix="vol "/>

--- a/annals-of-neurology.csl
+++ b/annals-of-neurology.csl
@@ -122,8 +122,10 @@
       <text macro="title" suffix=". "/>
       <choose>
         <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
-          <text macro="edition" prefix=" " suffix=" "/>
-          <text macro="publisher" prefix=" " suffix="."/>
+          <group prefix=" " delimiter=" " suffix=".">
+            <text macro="edition"/>
+            <text macro="publisher"/>
+          </group>
         </if>
         <else-if type="chapter paper-conference" match="any">
           <group prefix=" " suffix=". ">

--- a/annals-of-oncology.csl
+++ b/annals-of-oncology.csl
@@ -93,14 +93,18 @@
           <text macro="title"/>
           <choose>
             <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
-              <text macro="edition" suffix=" "/>
-              <text macro="publisher" prefix=" "/>
+              <group delimiter=" ">
+                <text macro="edition"/>
+                <text macro="publisher"/>
+              </group>
             </if>
             <else-if type="chapter paper-conference" match="any">
               <text macro="editor"/>
               <text macro="container-title" suffix=", "/>
-              <text macro="edition" suffix=". "/>
-              <text macro="publisher" prefix=" "/>
+              <group delimiter=" ">
+                <text macro="edition" suffix="."/>
+                <text macro="publisher"/>
+              </group>
             </else-if>
             <else>
               <text macro="container-title" suffix=" "/>

--- a/archives-of-physical-medicine-and-rehabilitation.csl
+++ b/archives-of-physical-medicine-and-rehabilitation.csl
@@ -121,8 +121,10 @@
       <text macro="title" suffix=". "/>
       <choose>
         <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
-          <text macro="edition" prefix=" " suffix=" "/>
-          <text macro="publisher" prefix=" "/>
+          <group prefix=" " delimiter=" ">
+            <text macro="edition"/>
+            <text macro="publisher"/>
+          </group>
         </if>
         <else-if type="chapter paper-conference" match="any">
           <group prefix=" " suffix=". ">

--- a/arzneimitteltherapie.csl
+++ b/arzneimitteltherapie.csl
@@ -130,8 +130,10 @@
       <text macro="title" suffix=". "/>
       <choose>
         <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
-          <text macro="edition" prefix=" " suffix=" "/>
-          <text macro="publisher" prefix=" "/>
+          <group prefix=" " delimiter=" ">
+            <text macro="edition"/>
+            <text macro="publisher"/>
+          </group>
         </if>
         <else-if type="chapter paper-conference" match="any">
           <group prefix=" " suffix=". ">

--- a/aviation-space-and-environmental-medicine.csl
+++ b/aviation-space-and-environmental-medicine.csl
@@ -137,8 +137,10 @@
       <text macro="title" suffix=". "/>
       <choose>
         <if type="bill book graphic legal_case legislation motion_picture report song thesis" match="any">
-          <text macro="edition" prefix=" " suffix=" "/>
-          <text macro="publisher" prefix=" " suffix="."/>
+          <group prefix=" " delimiter=" " suffix=".">
+            <text macro="edition"/>
+            <text macro="publisher"/>
+          </group>
         </if>
         <else-if type="chapter paper-conference" match="any">
           <group prefix=" " suffix=". ">

--- a/biochemical-society-transactions.csl
+++ b/biochemical-society-transactions.csl
@@ -127,8 +127,10 @@
       <text macro="title" suffix=". "/>
       <choose>
         <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
-          <text macro="edition" prefix=" " suffix=" "/>
-          <text macro="publisher" prefix=" "/>
+          <group prefix=" " delimiter=" ">
+            <text macro="edition"/>
+            <text macro="publisher"/>
+          </group>
         </if>
         <else-if type="chapter paper-conference" match="any">
           <group prefix=" " suffix=". ">

--- a/brain.csl
+++ b/brain.csl
@@ -135,8 +135,10 @@
       <text macro="title" suffix=". "/>
       <choose>
         <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
-          <text macro="edition" prefix=" " suffix=" "/>
-          <text macro="publisher" prefix=" "/>
+          <group prefix=" " delimiter=" ">
+            <text macro="edition"/>
+            <text macro="publisher"/>
+          </group>
         </if>
         <else-if type="chapter paper-conference" match="any">
           <group prefix=" " suffix=". ">

--- a/chest.csl
+++ b/chest.csl
@@ -126,8 +126,10 @@
       <text macro="title" suffix=". "/>
       <choose>
         <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
-          <text macro="edition" prefix=" " suffix=" "/>
-          <text macro="publisher" prefix=" "/>
+          <group prefix=" " delimiter=" ">
+            <text macro="edition"/>
+            <text macro="publisher"/>
+          </group>
         </if>
         <else-if type="chapter paper-conference" match="any">
           <group prefix=" " suffix=". ">

--- a/circulation.csl
+++ b/circulation.csl
@@ -131,8 +131,10 @@
       <text macro="title" suffix=". "/>
       <choose>
         <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
-          <text macro="edition" prefix=" " suffix=" "/>
-          <text macro="publisher" prefix=" "/>
+          <group prefix=" " delimiter=" ">
+            <text macro="edition"/>
+            <text macro="publisher"/>
+          </group>
         </if>
         <else-if type="chapter paper-conference" match="any">
           <group prefix=" " suffix=". ">

--- a/clinical-infectious-diseases.csl
+++ b/clinical-infectious-diseases.csl
@@ -124,8 +124,10 @@
       <text macro="title" suffix=". "/>
       <choose>
         <if type="bill book graphic legal_case legislation motion_picture report song webpage" match="any">
-          <text macro="edition" prefix=" " suffix=" "/>
-          <text macro="publisher" prefix=" "/>
+          <group prefix=" " delimiter=" ">
+            <text macro="edition"/>
+            <text macro="publisher"/>
+          </group>
         </if>
         <else-if type="chapter paper-conference" match="any">
           <group prefix=" " suffix=". ">

--- a/critical-care-medicine.csl
+++ b/critical-care-medicine.csl
@@ -91,8 +91,10 @@
       <text macro="title" suffix=". "/>
       <choose>
         <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
-          <text macro="edition" prefix=" " suffix=" "/>
-          <text macro="publisher" prefix=" "/>
+          <group prefix=" " delimiter=" ">
+            <text macro="edition"/>
+            <text macro="publisher"/>
+          </group>
         </if>
         <else-if type="chapter paper-conference" match="any">
           <group prefix=" " suffix=". ">

--- a/european-journal-of-clinical-microbiology-and-infectious-diseases.csl
+++ b/european-journal-of-clinical-microbiology-and-infectious-diseases.csl
@@ -121,8 +121,10 @@
       <text macro="title" suffix=". "/>
       <choose>
         <if type="bill book graphic legal_case motion_picture report song" match="any">
-          <text macro="edition" prefix=" " suffix=" "/>
-          <text macro="publisher" prefix=" "/>
+          <group prefix=" " delimiter=" ">
+            <text macro="edition"/>
+            <text macro="publisher"/>
+          </group>
         </if>
         <else-if type="chapter paper-conference" match="any">
           <group prefix=" " suffix=". ">

--- a/european-journal-of-human-genetics.csl
+++ b/european-journal-of-human-genetics.csl
@@ -118,8 +118,10 @@
       <text macro="title" suffix=". "/>
       <choose>
         <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
-          <text macro="edition" prefix=" " suffix=" "/>
-          <text macro="publisher" prefix=" "/>
+          <group prefix=" " delimiter=" ">
+            <text macro="edition"/>
+            <text macro="publisher"/>
+          </group>
         </if>
         <else-if type="chapter paper-conference" match="any">
           <group prefix=" " suffix=". ">

--- a/european-journal-of-ophthalmology.csl
+++ b/european-journal-of-ophthalmology.csl
@@ -139,9 +139,11 @@
       <text macro="title" suffix=". "/>
       <choose>
         <if type="bill book graphic legal_case legislation motion_picture report song thesis" match="any">
-          <text macro="edition" prefix=" " suffix=" "/>
-          <text macro="publisher" prefix=" "/>
-          <text variable="number-of-pages" suffix=" p." prefix=" "/>
+          <group prefix=" " delimiter=" ">
+            <text macro="edition"/>
+            <text macro="publisher"/>
+            <text variable="number-of-pages" suffix=" p."/>
+          </group>
         </if>
         <else-if type="chapter paper-conference" match="any">
           <group prefix=" " suffix=". ">

--- a/experimental-dermatology.csl
+++ b/experimental-dermatology.csl
@@ -91,8 +91,10 @@
       <text macro="title" suffix=". "/>
       <choose>
         <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
-          <text macro="edition" prefix=" " suffix=" "/>
-          <text macro="publisher" prefix=" " suffix="."/>
+          <group prefix=" " suffix="." delimiter=" ">
+            <text macro="edition"/>
+            <text macro="publisher"/>
+          </group>
         </if>
         <else-if type="chapter paper-conference" match="any">
           <group suffix=". ">

--- a/fertility-and-sterility.csl
+++ b/fertility-and-sterility.csl
@@ -123,8 +123,10 @@
       <text macro="title" suffix=". "/>
       <choose>
         <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
-          <text macro="edition" prefix=" " suffix=" "/>
-          <text macro="publisher" prefix=" "/>
+          <group prefix=" " delimiter=" ">
+            <text macro="edition"/>
+            <text macro="publisher"/>
+          </group>
         </if>
         <else-if type="chapter paper-conference" match="any">
           <group prefix=" " suffix=". ">

--- a/future-science-group.csl
+++ b/future-science-group.csl
@@ -123,8 +123,10 @@
       <text macro="title" suffix=". "/>
       <choose>
         <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
-          <text macro="edition" prefix=" " suffix=" "/>
-          <text macro="publisher" prefix=" "/>
+          <group prefix=" " delimiter=" ">
+            <text macro="edition"/>
+            <text macro="publisher"/>
+          </group>
         </if>
         <else-if type="chapter paper-conference" match="any">
           <group prefix=" " suffix=". ">

--- a/hepatology.csl
+++ b/hepatology.csl
@@ -131,8 +131,10 @@
       <text macro="title" suffix=". "/>
       <choose>
         <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
-          <text macro="edition" prefix=" " suffix=" "/>
-          <text macro="publisher" prefix=" "/>
+          <group prefix=" " delimiter=" ">
+            <text macro="edition"/>
+            <text macro="publisher"/>
+          </group>
         </if>
         <else-if type="chapter paper-conference" match="any">
           <group prefix=" " suffix=". ">

--- a/hong-kong-journal-of-radiology.csl
+++ b/hong-kong-journal-of-radiology.csl
@@ -131,8 +131,10 @@
       <text macro="title" suffix=". "/>
       <choose>
         <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
-          <text macro="edition" prefix=" " suffix=" "/>
-          <text macro="publisher" prefix=" "/>
+          <group prefix=" " delimiter=" ">
+            <text macro="edition"/>
+            <text macro="publisher"/>
+          </group>
         </if>
         <else-if type="chapter paper-conference" match="any">
           <group prefix=" " suffix=". ">

--- a/hypotheses-in-the-life-sciences.csl
+++ b/hypotheses-in-the-life-sciences.csl
@@ -137,8 +137,10 @@
       <text macro="title" suffix=". "/>
       <choose>
         <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
-          <text macro="edition" prefix=" " suffix=" "/>
-          <text macro="publisher" prefix=" "/>
+          <group prefix=" " delimiter=" ">
+          <text macro="edition"/>
+          <text macro="publisher"/>
+          </group>
         </if>
         <else-if type="chapter paper-conference" match="any">
           <group prefix=" " suffix=". ">

--- a/international-journal-of-cancer.csl
+++ b/international-journal-of-cancer.csl
@@ -132,8 +132,10 @@
       <text macro="title" suffix=". "/>
       <choose>
         <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
-          <text macro="edition" prefix=" " suffix=" "/>
-          <text macro="publisher" prefix=" "/>
+          <group prefix=" " delimiter=" ">
+            <text macro="edition"/>
+            <text macro="publisher"/>
+          </group>
           <text variable="number-of-pages" suffix="p"/>
         </if>
         <else-if type="chapter paper-conference" match="any">

--- a/journal-of-forensic-sciences.csl
+++ b/journal-of-forensic-sciences.csl
@@ -121,8 +121,10 @@
       <text macro="title" suffix=".  "/>
       <choose>
         <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
-          <text macro="edition" prefix=" " suffix=" "/>
-          <text macro="publisher" prefix=" "/>
+          <group prefix=" " delimiter=" ">
+            <text macro="edition"/>
+            <text macro="publisher"/>
+          </group>
         </if>
         <else-if type="chapter paper-conference" match="any">
           <group prefix=" " suffix=".  ">

--- a/journal-of-orthopaedic-trauma.csl
+++ b/journal-of-orthopaedic-trauma.csl
@@ -127,8 +127,10 @@
       <text macro="title" suffix=". "/>
       <choose>
         <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
-          <text macro="edition" prefix=" " suffix=" "/>
-          <text macro="publisher" prefix=" "/>
+          <group prefix=" " delimiter=" ">
+            <text macro="edition"/>
+            <text macro="publisher"/>
+          </group>
         </if>
         <else-if type="chapter paper-conference" match="any">
           <group prefix=" " suffix=". ">

--- a/journal-of-perinatal-medicine.csl
+++ b/journal-of-perinatal-medicine.csl
@@ -137,8 +137,8 @@
       <choose>
         <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
           <group prefix=". " delimiter=" " suffix=".">
-            <text macro="edition" suffix=" "/>
-            <text macro="publisher" prefix=" "/>
+            <text macro="edition"/>
+            <text macro="publisher"/>
           </group>
         </if>
         <else-if type="chapter paper-conference" match="any">

--- a/journal-of-shoulder-and-elbow-surgery.csl
+++ b/journal-of-shoulder-and-elbow-surgery.csl
@@ -131,8 +131,10 @@
       <text macro="title" suffix=". "/>
       <choose>
         <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
-          <text macro="edition" prefix=" " suffix=" "/>
-          <text macro="publisher" prefix=" "/>
+          <group prefix=" " delimiter=" ">
+            <text macro="edition"/>
+            <text macro="publisher"/>
+          </group>
         </if>
         <else-if type="chapter paper-conference" match="any">
           <group prefix=" " suffix=". ">

--- a/journal-of-the-american-society-of-nephrology.csl
+++ b/journal-of-the-american-society-of-nephrology.csl
@@ -126,8 +126,10 @@
       <text macro="title" suffix=". "/>
       <choose>
         <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
-          <text macro="edition" prefix=" " suffix=" "/>
-          <text macro="publisher" prefix=" "/>
+          <group prefix=" " delimiter=" ">
+            <text macro="edition"/>
+            <text macro="publisher"/>
+          </group>
         </if>
         <else-if type="chapter paper-conference" match="any">
           <group prefix=" " suffix=", ">

--- a/karger-journals-author-date.csl
+++ b/karger-journals-author-date.csl
@@ -149,8 +149,8 @@
       <choose>
         <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
           <group prefix=". " delimiter=" " suffix=".">
-            <text macro="edition" suffix=" "/>
-            <text macro="publisher" prefix=" "/>
+            <text macro="edition"/>
+            <text macro="publisher"/>
           </group>
         </if>
         <else-if type="chapter paper-conference" match="any">

--- a/karger-journals.csl
+++ b/karger-journals.csl
@@ -136,8 +136,8 @@
       <choose>
         <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
           <group prefix=". " delimiter=" " suffix=".">
-            <text macro="edition" suffix=" "/>
-            <text macro="publisher" prefix=" "/>
+            <text macro="edition"/>
+            <text macro="publisher"/>
           </group>
         </if>
         <else-if type="chapter paper-conference" match="any">

--- a/landes-bioscience-journals.csl
+++ b/landes-bioscience-journals.csl
@@ -120,8 +120,10 @@
       <text macro="title" suffix=". "/>
       <choose>
         <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
-          <text macro="edition" prefix=" " suffix=" "/>
-          <text macro="publisher" prefix=" "/>
+          <group prefix=" " delimiter=" ">
+            <text macro="edition"/>
+            <text macro="publisher"/>
+          </group>
         </if>
         <else-if type="chapter paper-conference" match="any">
           <group prefix=" " suffix=". ">

--- a/liver-international.csl
+++ b/liver-international.csl
@@ -128,8 +128,10 @@
       <text macro="title" suffix=". "/>
       <choose>
         <if type="bill book graphic legal_case motion_picture report song" match="any">
-          <text macro="edition" prefix=" " suffix=" "/>
-          <text macro="publisher" prefix=" "/>
+          <group prefix=" " delimiter=" ">
+            <text macro="edition"/>
+            <text macro="publisher"/>
+          </group>
         </if>
         <else-if type="chapter paper-conference" match="any">
           <group prefix=" " suffix=". ">

--- a/medicine-and-science-in-sports-and-exercise.csl
+++ b/medicine-and-science-in-sports-and-exercise.csl
@@ -122,9 +122,11 @@
       <text macro="author"/>
       <choose>
         <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
-          <text variable="title" suffix=". " font-style="italic"/>
-          <text macro="edition" prefix=" " suffix=" "/>
-          <text macro="publisher" prefix=" " suffix="."/>
+          <group delimiter=" ">
+            <text variable="title" suffix="." font-style="italic"/>
+            <text macro="edition"/>
+            <text macro="publisher" suffix="."/>
+          </group>
           <text variable="number-of-pages"/>
         </if>
         <else-if type="chapter paper-conference" match="any">

--- a/molecular-psychiatry-letters.csl
+++ b/molecular-psychiatry-letters.csl
@@ -152,9 +152,11 @@
       <text macro="title" suffix=". "/>
       <choose>
         <if type="bill book graphic legal_case legislation motion_picture report song thesis" match="any">
-          <text macro="edition" prefix=" " suffix=" "/>
-          <text macro="publisher" prefix=" "/>
-          <text variable="number-of-pages" suffix=" p." prefix=" "/>
+          <group prefix=" " delimiter=" ">
+            <text macro="edition"/>
+            <text macro="publisher"/>
+            <text variable="number-of-pages" suffix=" p."/>
+          </group>
         </if>
         <else-if type="chapter paper-conference" match="any">
           <group prefix=" " suffix=". ">

--- a/nano-biomedicine-and-engineering.csl
+++ b/nano-biomedicine-and-engineering.csl
@@ -135,8 +135,10 @@
       <text macro="title" suffix=". "/>
       <choose>
         <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
-          <text macro="edition" prefix=" " suffix=" "/>
-          <text macro="publisher" prefix=" "/>
+          <group prefix=" " delimiter=" ">
+            <text macro="edition"/>
+            <text macro="publisher"/>
+          </group>
         </if>
         <else-if type="chapter paper-conference" match="any">
           <group prefix=" " suffix=". ">

--- a/nature-publishing-group-vancouver.csl
+++ b/nature-publishing-group-vancouver.csl
@@ -115,8 +115,10 @@
       <text macro="title" suffix=". "/>
       <choose>
         <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
-          <text macro="edition" prefix=" " suffix=" "/>
-          <text macro="publisher" prefix=" "/>
+          <group prefix=" " delimiter=" ">
+            <text macro="edition"/>
+            <text macro="publisher"/>
+          </group>
         </if>
         <else-if type="chapter paper-conference" match="any">
           <group prefix=" " suffix=". ">

--- a/neurology-india.csl
+++ b/neurology-india.csl
@@ -121,8 +121,10 @@
       <text macro="title" suffix=". "/>
       <choose>
         <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
-          <text macro="edition" prefix=" " suffix=" "/>
-          <text macro="publisher" prefix=" "/>
+          <group prefix=" " delimiter=" ">
+            <text macro="edition"/>
+            <text macro="publisher"/>
+          </group>
         </if>
         <else-if type="chapter paper-conference" match="any">
           <group prefix=" " suffix=". ">

--- a/pediatric-research.csl
+++ b/pediatric-research.csl
@@ -122,8 +122,10 @@
       <text macro="title" suffix=". "/>
       <choose>
         <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
-          <text macro="edition" prefix=" " suffix=" "/>
-          <text macro="publisher" prefix=" "/>
+          <group prefix=" " delimiter=" ">
+            <text macro="edition"/>
+            <text macro="publisher"/>
+          </group>
         </if>
         <else-if type="chapter paper-conference" match="any">
           <group prefix=" " suffix=". ">

--- a/psychiatry-and-clinical-neurosciences.csl
+++ b/psychiatry-and-clinical-neurosciences.csl
@@ -120,8 +120,10 @@
       <text macro="title" suffix=". "/>
       <choose>
         <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
-          <text macro="edition" prefix=" " suffix=" "/>
-          <text macro="publisher" prefix=" "/>
+          <group prefix=" " delimiter=" ">
+            <text macro="edition"/>
+            <text macro="publisher"/>
+          </group>
         </if>
         <else-if type="chapter paper-conference" match="any">
           <group prefix=" " suffix=". ">

--- a/sage-vancouver.csl
+++ b/sage-vancouver.csl
@@ -126,8 +126,10 @@
       <text macro="title" suffix=". "/>
       <choose>
         <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
-          <text macro="edition" prefix=" " suffix=" "/>
-          <text macro="publisher" prefix=" "/>
+          <group prefix=" " delimiter=" ">
+            <text macro="edition"/>
+            <text macro="publisher"/>
+          </group>
         </if>
         <else-if type="chapter paper-conference" match="any">
           <group prefix=" " suffix=". ">

--- a/scandinavian-journal-of-infectious-diseases.csl
+++ b/scandinavian-journal-of-infectious-diseases.csl
@@ -120,8 +120,10 @@
       <text macro="title" suffix=". "/>
       <choose>
         <if type="bill book graphic legal_case motion_picture report song" match="any">
-          <text macro="edition" prefix=" " suffix=" "/>
-          <text macro="publisher" prefix=" "/>
+          <group prefix=" " delimiter=" ">
+            <text macro="edition"/>
+            <text macro="publisher"/>
+          </group>
         </if>
         <else-if type="chapter paper-conference" match="any">
           <group prefix=" " suffix=". ">

--- a/seminars-in-pediatric-neurology.csl
+++ b/seminars-in-pediatric-neurology.csl
@@ -90,8 +90,10 @@
       <text macro="title" suffix=". "/>
       <choose>
         <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
-          <text macro="edition" prefix=" " suffix=" "/>
-          <text macro="publisher" prefix=" "/>
+          <group prefix=" " delimiter=" ">
+            <text macro="edition"/>
+            <text macro="publisher"/>
+          </group>
         </if>
         <else-if type="chapter paper-conference" match="any">
           <group prefix=" " suffix=". ">

--- a/sexual-development.csl
+++ b/sexual-development.csl
@@ -149,8 +149,8 @@
       <choose>
         <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
           <group prefix=". " delimiter=" " suffix=".">
-            <text macro="edition" suffix=" "/>
-            <text macro="publisher" prefix=" "/>
+            <text macro="edition"/>
+            <text macro="publisher"/>
           </group>
         </if>
         <else-if type="chapter paper-conference" match="any">

--- a/societe-nationale-des-groupements-techniques-veterinaires.csl
+++ b/societe-nationale-des-groupements-techniques-veterinaires.csl
@@ -94,8 +94,10 @@
       <text macro="title" suffix=". "/>
       <choose>
         <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
-          <text macro="edition" prefix=" " suffix=" "/>
-          <text macro="publisher" prefix=" "/>
+          <group prefix=" " delimiter=" ">
+            <text macro="edition"/>
+            <text macro="publisher"/>
+          </group>
         </if>
         <else-if type="chapter paper-conference" match="any">
           <group prefix=" " suffix=". ">

--- a/strahlentherapie-und-onkologie.csl
+++ b/strahlentherapie-und-onkologie.csl
@@ -126,8 +126,10 @@
       <text macro="title" suffix=". "/>
       <choose>
         <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
-          <text macro="edition" prefix=" " suffix=" "/>
-          <text macro="publisher" prefix=" "/>
+          <group prefix=" " delimiter=" ">
+            <text macro="edition"/>
+            <text macro="publisher"/>
+          </group>
         </if>
         <else-if type="chapter paper-conference" match="any">
           <group prefix=" " suffix=". ">

--- a/stroke.csl
+++ b/stroke.csl
@@ -132,8 +132,10 @@
       <text macro="title" suffix=". "/>
       <choose>
         <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
-          <text macro="edition" prefix=" " suffix=" "/>
-          <text macro="publisher" prefix=" "/>
+          <group prefix=" " delimiter=" ">
+            <text macro="edition"/>
+            <text macro="publisher"/>
+          </group>
         </if>
         <else-if type="chapter paper-conference" match="any">
           <group prefix=" " suffix=". ">

--- a/the-american-journal-of-gastroenterology.csl
+++ b/the-american-journal-of-gastroenterology.csl
@@ -90,8 +90,10 @@
       <text macro="title" suffix=". "/>
       <choose>
         <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
-          <text macro="edition" prefix=" " suffix=" "/>
-          <text macro="publisher" prefix=" "/>
+          <group prefix=" " delimiter=" ">
+            <text macro="edition"/>
+            <text macro="publisher"/>
+          </group>
         </if>
         <else-if type="chapter paper-conference" match="any">
           <group prefix=" " suffix=". ">

--- a/the-american-journal-of-psychiatry.csl
+++ b/the-american-journal-of-psychiatry.csl
@@ -83,8 +83,10 @@
       <text macro="title" suffix=". "/>
       <choose>
         <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
-          <text macro="edition" prefix=" " suffix=" "/>
-          <text macro="publisher" prefix=" "/>
+          <group prefix=" " delimiter=" ">
+            <text macro="edition"/>
+            <text macro="publisher"/>
+          </group>
         </if>
         <else-if type="chapter paper-conference" match="any">
           <group prefix=" " suffix=". ">

--- a/the-british-journal-of-cardiology.csl
+++ b/the-british-journal-of-cardiology.csl
@@ -100,8 +100,10 @@
       <text macro="title" suffix=". "/>
       <choose>
         <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
-          <text macro="edition" prefix=" " suffix=" "/>
-          <text macro="publisher" prefix=" "/>
+          <group prefix=" " delimiter=" ">
+            <text macro="edition"/>
+            <text macro="publisher"/>
+          </group>
         </if>
         <else-if type="chapter paper-conference" match="any">
           <group prefix=" " suffix=". ">

--- a/the-new-england-journal-of-medicine.csl
+++ b/the-new-england-journal-of-medicine.csl
@@ -129,8 +129,10 @@
       <text macro="title" suffix=". "/>
       <choose>
         <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
-          <text macro="edition" prefix=" " suffix=" "/>
-          <text macro="publisher" prefix=" "/>
+          <group prefix=" " delimiter=" ">
+            <text macro="edition"/>
+            <text macro="publisher"/>
+          </group>
         </if>
         <else-if type="chapter paper-conference" match="any">
           <group prefix=" " suffix=". ">

--- a/traffic.csl
+++ b/traffic.csl
@@ -129,8 +129,10 @@
       <text macro="title" suffix=". "/>
       <choose>
         <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
-          <text macro="edition" prefix=" " suffix=" "/>
-          <text macro="publisher" prefix=" "/>
+          <group prefix=" " delimiter=" ">
+            <text macro="edition"/>
+            <text macro="publisher"/>
+          </group>
         </if>
         <else-if type="chapter paper-conference" match="any">
           <group prefix=" " suffix=". ">

--- a/universite-de-picardie-jules-verne-ufr-de-medecine.csl
+++ b/universite-de-picardie-jules-verne-ufr-de-medecine.csl
@@ -119,8 +119,10 @@
       <text macro="title" suffix=". "/>
       <choose>
         <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
-          <text macro="edition" prefix=" " suffix=" "/>
-          <text macro="publisher" prefix=" "/>
+          <group prefix=" " delimiter=" ">
+            <text macro="edition"/>
+            <text macro="publisher"/>
+          </group>
         </if>
         <else-if type="chapter paper-conference" match="any">
           <group prefix=" " suffix=". ">

--- a/vancouver-brackets-only-year-no-issue.csl
+++ b/vancouver-brackets-only-year-no-issue.csl
@@ -137,8 +137,10 @@
       <text macro="title" suffix=". "/>
       <choose>
         <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
-          <text macro="edition" prefix=" " suffix=" "/>
-          <text macro="publisher" prefix=" "/>
+          <group prefix=" " delimiter=" ">
+            <text macro="edition"/>
+            <text macro="publisher"/>
+          </group>
         </if>
         <else-if type="chapter paper-conference" match="any">
           <group prefix=" " suffix=". ">

--- a/vancouver-superscript-brackets-only-year.csl
+++ b/vancouver-superscript-brackets-only-year.csl
@@ -130,8 +130,10 @@
       <text macro="title" suffix=". "/>
       <choose>
         <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
-          <text macro="edition" prefix=" " suffix=" "/>
-          <text macro="publisher" prefix=" "/>
+          <group prefix=" " delimiter=" ">
+            <text macro="edition"/>
+            <text macro="publisher"/>
+          </group>
         </if>
         <else-if type="chapter paper-conference" match="any">
           <group prefix=" " suffix=". ">

--- a/vancouver-superscript-only-year.csl
+++ b/vancouver-superscript-only-year.csl
@@ -132,8 +132,10 @@
       <text macro="title" suffix=". "/>
       <choose>
         <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
-          <text macro="edition" prefix=" " suffix=" "/>
-          <text macro="publisher" prefix=" "/>
+          <group prefix=" " delimiter=" ">
+            <text macro="edition"/>
+            <text macro="publisher"/>
+          </group>
         </if>
         <else-if type="chapter paper-conference" match="any">
           <group prefix=" " suffix=". ">

--- a/world-journal-of-gastroenterology.csl
+++ b/world-journal-of-gastroenterology.csl
@@ -137,8 +137,10 @@
       <text macro="title" suffix=". "/>
       <choose>
         <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
-          <text macro="edition" prefix=" " suffix=" "/>
-          <text macro="publisher" prefix=" "/>
+          <group prefix=" " delimiter=" ">
+            <text macro="edition"/>
+            <text macro="publisher"/>
+          </group>
         </if>
         <else-if type="chapter paper-conference" match="any">
           <group prefix=" " suffix=". ">


### PR DESCRIPTION
Replacing the prefix/suffix adjacent spaces with group and one delimiter space, as described generally in #1301 . Search for this pattern here (57 hits in 56 files):

```
<[^/>]*"edition"[^/>]*suffix="[^"/>]* "[^/>]*/?>\s*\r\n\s*<[^/>]*"publisher"[^/>]*prefix=" [^"/>]*"[^/>]*/?>
```

@adam3smith et al: Happy New Year to you!