### PR TITLE
GBE: Remove parentheses around the year

### DIFF
--- a/genome-biology-and-evolution.csl
+++ b/genome-biology-and-evolution.csl
@@ -116,7 +116,7 @@
     </choose>
   </macro>
   <citation et-al-min="3" et-al-use-first="1" disambiguate-add-year-suffix="true" disambiguate-add-names="true" disambiguate-add-givenname="true" collapse="year">
-    <layout prefix="(" suffix=")" delimiter="; ">
+    <layout delimiter="; ">
       <group delimiter=", ">
         <group delimiter=" ">
           <text macro="author-short"/>


### PR DESCRIPTION
I'm using `genome-biology-and-evolution.csl` with Pandoc. A reference such as `(@foo)` expands to `(Foo et al. (2015))`, whereas it should expand to `(Foo et al. 2015)`. This patch removes the parentheses around the year.