### PR TITLE
Update academy-of-management-review.csl

### DIFF
--- a/academy-of-management-review.csl
+++ b/academy-of-management-review.csl
@@ -5,7 +5,7 @@
     <title-short>AMR</title-short>
     <id>http://www.zotero.org/styles/academy-of-management-review</id>
     <link href="http://www.zotero.org/styles/academy-of-management-review" rel="self"/>
-    <link href="http://journals.aomonline.org/amr/AMRstyleguide.pdf" rel="documentation"/>
+    <link href="http://aom.org/uploadedFiles/Publications/AMR/AMR%20Style%20Guide%202014.pdf" rel="documentation"/>
     <author>
       <name>Sebastian Karcher</name>
     </author>
@@ -220,7 +220,7 @@
       <text macro="citation-locator" prefix=":"/>
     </layout>
   </citation>
-  <bibliography hanging-indent="true" et-al-min="6" et-al-use-first="6" entry-spacing="0" line-spacing="2">
+  <bibliography hanging-indent="true" et-al-min="6" et-al-use-first="5" entry-spacing="0" line-spacing="2">
     <sort>
       <key macro="author"/>
       <key macro="issued-year"/>


### PR DESCRIPTION
Ah, that is more complicated to read:

<blockquote>
If a work has two authors, cite both names
every time the work is cited in the text. If the
work has more than two authors, cite all authors
the first time the reference occurs; in subsequent
citations of the same work, include only the sur-
name of the first author followed by “et al.” (not
underlined) and the year.

However, for works with six or more authors, use
only the surname of the first author followed by
et al. whenever the work is cited.
</blockquote>

Thus, the citations are okay. However, there is no sentence about the et-al rule in bibliography. Therefore, I just changed it to the 6/5 setting (which should be consistent with the previous version, but be more logical csl). Okay?