### PR TITLE
Update rapid-communications-in-mass-spectrometry.csl

### DIFF
--- a/rapid-communications-in-mass-spectrometry.csl
+++ b/rapid-communications-in-mass-spectrometry.csl
@@ -17,7 +17,7 @@
     <eissn>1097-0231</eissn>
     <summary>Rapid Communications in Mass Spectrometry citation style based on Angewandte Chemie.  
 	I have verified the style is correct for articles, books, book chapters, and reports, but I don't know about other formats.</summary>
-    <updated>2015-01-17T13:00:26+00:00</updated>
+    <updated>2015-01-17T17:41:33+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <macro name="author">
@@ -129,10 +129,16 @@
           <group delimiter=". ">
             <text macro="author"/>
             <text macro="title"/>
-            <group delimiter=", " prefix=" ">
-              <text variable="title" text-case="title" font-style="italic"/>
-              <text macro="year-date"/>
-              <text variable="number"/>
+            <group delimiter=", ">
+              <group delimiter=" ">
+                <text variable="authority" font-style="italic"/>
+                <text variable="number"/>
+              </group>
+              <date variable="issued">
+                <date-part name="month" suffix=" "/>
+                <date-part name="day" suffix=", "/>
+                <date-part name="year" font-weight="bold"/>
+              </date>
             </group>
           </group>
         </else-if>
@@ -141,9 +147,9 @@
             <text macro="author"/>
             <text macro="title"/>
             <group delimiter=", " prefix=" ">
-              <text variable="title" text-case="title"/>
-              <text variable="genre"/>
+              <text variable="genre" text-case="capitalize-first" font-style="italic"/>
               <text variable="publisher"/>
+              <text variable="publisher-place"/>
               <text macro="year-date"/>
             </group>
           </group>
@@ -153,7 +159,6 @@
             <text macro="author"/>
             <text macro="title"/>
             <group delimiter=", " prefix=" ">
-              <text variable="title" quotes="true"/>
               <text macro="access"/>
               <text macro="year-date"/>
             </group>

--- a/rapid-communications-in-mass-spectrometry.csl
+++ b/rapid-communications-in-mass-spectrometry.csl
@@ -17,7 +17,7 @@
     <eissn>1097-0231</eissn>
     <summary>Rapid Communications in Mass Spectrometry citation style based on Angewandte Chemie.  
 	I have verified the style is correct for articles, books, book chapters, and reports, but I don't know about other formats.</summary>
-    <updated>2014-04-22T12:00:00+00:00</updated>
+    <updated>2015-01-17T13:00:26+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <macro name="author">
@@ -90,68 +90,79 @@
       <text variable="citation-number"/>
     </layout>
   </citation>
-  <bibliography entry-spacing="0" second-field-align="flush" et-al-min="15" et-al-use-first="14">
+  <bibliography et-al-min="15" et-al-use-first="14" second-field-align="flush" entry-spacing="0">
     <layout suffix=".">
       <text variable="citation-number" prefix="[" suffix="]"/>
       <choose>
         <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
-          <text macro="author" prefix=" " suffix=". "/>
-          <text macro="title" prefix=" " suffix=". "/>
-          <group delimiter=", ">
-            <text macro="publisher"/>
-            <text macro="year-date"/>
+          <group delimiter=". " prefix=" ">
+            <text macro="author"/>
+            <text macro="title"/>
+            <group delimiter=", ">
+              <text macro="publisher"/>
+              <text macro="year-date"/>
+            </group>
           </group>
         </if>
         <else-if type="chapter paper-conference" match="any">
-          <group delimiter=", ">
-            <group delimiter=" ">
-              <text macro="author" prefix=" " suffix=", "/>
-              <text macro="title" prefix=" " suffix=", "/>
-              <text term="in"/>
-              <text variable="container-title" text-case="title" font-style="italic"/>
+          <group delimiter=". ">
+            <group delimiter=", " prefix=" ">
+              <text macro="author"/>
+              <text macro="title"/>
+              <group delimiter=" ">
+                <text term="in"/>
+                <text variable="container-title" text-case="title" font-style="italic"/>
+              </group>
+              <text macro="editor" prefix="(" suffix=")"/>
             </group>
-          </group>
-          <text macro="editor" prefix=" (" suffix="). "/>
-          <group delimiter=", ">
-            <text macro="publisher"/>
-            <text macro="year-date"/>
-            <group delimiter=" ">
-              <text variable="page" prefix=" pp. "/>
+            <group delimiter=", ">
+              <text macro="publisher"/>
+              <text macro="year-date"/>
+              <group delimiter=" ">
+                <label variable="page" form="short"/>
+                <text variable="page"/>
+              </group>
             </group>
           </group>
         </else-if>
         <else-if type="patent">
-          <group delimiter=", ">
-            <text macro="author" prefix=" " suffix=". "/>
-            <text macro="title" prefix=" " suffix=". "/>
-            <text variable="title" text-case="title" font-style="italic"/>
-            <text macro="year-date"/>
-            <text variable="number"/>
+          <group delimiter=". ">
+            <text macro="author"/>
+            <text macro="title"/>
+            <group delimiter=", " prefix=" ">
+              <text variable="title" text-case="title" font-style="italic"/>
+              <text macro="year-date"/>
+              <text variable="number"/>
+            </group>
           </group>
         </else-if>
         <else-if type="thesis">
-          <group delimiter=", ">
-            <text macro="author" prefix=" " suffix=". "/>
-            <text macro="title" prefix=" " suffix=". "/>
-            <text variable="title" text-case="title"/>
-            <text variable="genre"/>
-            <text variable="publisher"/>
-            <text macro="year-date"/>
+          <group delimiter=". ">
+            <text macro="author"/>
+            <text macro="title"/>
+            <group delimiter=", " prefix=" ">
+              <text variable="title" text-case="title"/>
+              <text variable="genre"/>
+              <text variable="publisher"/>
+              <text macro="year-date"/>
+            </group>
           </group>
         </else-if>
         <else-if type="webpage">
-          <group delimiter=", ">
-            <text macro="author" prefix=" " suffix=". "/>
-            <text macro="title" prefix=" " suffix=". "/>
-            <text variable="title" quotes="true"/>
-            <text macro="access"/>
-            <text macro="year-date"/>
+          <group delimiter=". ">
+            <text macro="author"/>
+            <text macro="title"/>
+            <group delimiter=", " prefix=" ">
+              <text variable="title" quotes="true"/>
+              <text macro="access"/>
+              <text macro="year-date"/>
+            </group>
           </group>
         </else-if>
         <else>
-          <group delimiter=" ">
-            <text macro="author" prefix=" " suffix=". "/>
-            <text macro="title" prefix=" " suffix=". "/>
+          <group delimiter=" " prefix=" ">
+            <text macro="author" suffix="."/>
+            <text macro="title" suffix="."/>
             <text variable="container-title" form="short" font-style="italic"/>
             <group delimiter=", ">
               <text macro="year-date"/>


### PR DESCRIPTION
This should improve the correct punctation in the style. I don't have any examples for `patent`, `thesis`, or `webpage`, but it seemed natural to fix it in this way. However, in these cases the `title` is renderd twice (which seems like an error) and I don't know which version is the correct one. Ping @hanvanzan

(I excluded this style from #1334, because it is too special)