### PR TITLE
Create springer-fachzeitschriften-medizin-psychologie.csl

### DIFF
--- a/springer-fachzeitschriften-medizin-psychologie.csl
+++ b/springer-fachzeitschriften-medizin-psychologie.csl
@@ -14,8 +14,8 @@
     <category citation-format="numeric"/>
     <category field="medicine"/>
     <category field="psychology"/>
-    <summary>Springer Basic style (German, numeric, brackets, alphabetical) for Springer journals in medicine and psychology (linked to EndNote_Literaturstyle_SpringerFachzeitschriftenMedizinPsychologie_StandDez2012.zip).</summary>
-    <updated>2015-01-12T21:55:01+00:00</updated>
+    <summary>Springer Basic style (German, numeric, brackets, alphabetical) for Springer journals in medicine and psychology.</summary>
+    <updated>2015-01-17T17:55:52+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale xml:lang="de">
@@ -151,10 +151,12 @@
           </group>
         </else-if>
         <else>
-          <group>
-            <text variable="container-title" form="short" suffix=" "/>
-            <text variable="volume" suffix=":"/>
-            <text variable="page" suffix="."/>
+          <group delimiter=": ">
+            <group delimiter=" ">
+              <text variable="container-title" form="short"/>
+              <text variable="volume"/>
+            </group>
+            <text variable="page"/>
           </group>
         </else>
       </choose>

--- a/springer-fachzeitschriften-medizin-psychologie.csl
+++ b/springer-fachzeitschriften-medizin-psychologie.csl
@@ -1,0 +1,163 @@
+<?xml version="1.0" encoding="utf-8"?>
+<style class="in-text" version="1.0" demote-non-dropping-particle="sort-only" default-locale="de-DE" xmlns="http://purl.org/net/xbiblio/csl">
+  <info>
+    <title>Springer Fachzeitschriften Medizin Psychologie (German)</title>
+    <id>http://www.zotero.org/styles/springer-fachzeitschriften-medizin-psychologie</id>
+    <link href="http://www.zotero.org/styles/springer-fachzeitschriften-medizin-psychologie" rel="self"/>
+    <link href="http://www.zotero.org/styles/springer-basic-brackets-no-et-al-alphabetical" rel="template"/>
+    <link href="http://static.springer.com/sgw/documents/135255/application/pdf/Musterbeitrag_Uebersichten_Leitthema_Schwerpunkt.pdf" rel="documentation"/>
+    <link href="http://static.springer.com/sgw/documents/69331/application/pdf/Leitfaden_Uebersichten_Leitthemen_Schwerpunkt.pdf" rel="documentation"/>
+    <author>
+      <name>Philipp Zumstein</name>
+      <uri>https://github.com/zuphilip</uri>
+    </author>
+    <category citation-format="numeric"/>
+    <category field="medicine"/>
+    <category field="psychology"/>
+    <summary>Springer Basic style (German, numeric, brackets, alphabetical) for Springer journals in medicine and psychology (linked to EndNote_Literaturstyle_SpringerFachzeitschriftenMedizinPsychologie_StandDez2012.zip).</summary>
+    <updated>2015-01-12T21:55:01+00:00</updated>
+    <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
+  </info>
+  <locale xml:lang="de">
+    <terms>
+      <term name="et-al">et al</term>
+    </terms>
+  </locale>
+  <macro name="author">
+    <names variable="author">
+      <name delimiter-precedes-et-al="never" delimiter-precedes-last="always" initialize-with="" name-as-sort-order="all" sort-separator=" "/>
+      <substitute>
+        <names variable="editor"/>
+        <names variable="translator"/>
+      </substitute>
+    </names>
+  </macro>
+  <macro name="editor">
+    <text term="in" text-case="capitalize-first" suffix=": "/>
+    <names variable="editor">
+      <name sort-separator=" " initialize-with="" name-as-sort-order="all" delimiter=", " delimiter-precedes-last="always"/>
+      <label form="short" strip-periods="true" prefix=" (" suffix=")"/>
+    </names>
+  </macro>
+  <macro name="edition">
+    <choose>
+      <if is-numeric="edition">
+        <group delimiter=" ">
+          <number variable="edition" form="ordinal"/>
+          <text term="edition" form="short" strip-periods="true"/>
+        </group>
+      </if>
+      <else>
+        <text variable="edition"/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="year">
+    <date variable="issued">
+      <date-part name="year"/>
+    </date>
+  </macro>
+  <macro name="title">
+    <choose>
+      <if type="book">
+        <group delimiter=", " suffix=". ">
+          <text variable="title"/>
+          <text macro="edition"/>
+        </group>
+      </if>
+      <else>
+        <text variable="title" suffix=". "/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="year-parenth">
+    <date prefix="(" suffix=")" variable="issued">
+      <date-part name="year"/>
+    </date>
+  </macro>
+  <citation collapse="citation-number">
+    <sort>
+      <key variable="citation-number"/>
+    </sort>
+    <layout prefix="[" suffix="]" delimiter=", ">
+      <text variable="citation-number"/>
+    </layout>
+  </citation>
+  <bibliography et-al-min="5" et-al-use-first="3" hanging-indent="true">
+    <sort>
+      <key macro="author"/>
+      <key macro="year"/>
+    </sort>
+    <layout>
+      <text variable="citation-number" suffix=". "/>
+      <group delimiter=" ">
+        <text macro="author"/>
+        <text macro="year-parenth"/>
+        <text macro="title"/>
+      </group>
+      <choose>
+        <if variable="page">
+          <choose>
+            <if type="chapter paper-conference" match="any">
+              <text macro="editor"/>
+              <group prefix=" " delimiter=", " suffix=". ">
+                <text variable="container-title" form="short"/>
+                <text macro="edition"/>
+              </group>
+              <text variable="publisher" suffix=", "/>
+              <text variable="publisher-place" suffix=", "/>
+              <group delimiter=" ">
+                <label variable="page" form="short" strip-periods="true"/>
+                <text variable="page"/>
+              </group>
+            </if>
+            <else>
+              <group>
+                <text variable="container-title" suffix=" " form="short" strip-periods="true"/>
+                <text variable="volume" suffix=":"/>
+                <text variable="page" suffix="."/>
+                <text prefix=" doi: " variable="DOI"/>
+              </group>
+            </else>
+          </choose>
+        </if>
+        <else-if variable="DOI">
+          <group delimiter=". ">
+            <text variable="container-title" form="short" strip-periods="true"/>
+            <text prefix="doi: " variable="DOI"/>
+          </group>
+        </else-if>
+        <else-if type="bill book graphic legal_case legislation motion_picture report song" match="any">
+          <group delimiter=", ">
+            <text variable="publisher"/>
+            <text variable="publisher-place"/>
+          </group>
+        </else-if>
+        <else-if type="webpage">
+          <group>
+            <text variable="URL" suffix=". "/>
+            <text term="accessed" text-case="capitalize-first" suffix=": "/>
+            <date variable="accessed">
+              <date-part name="day" form="numeric-leading-zeros" suffix=". "/>
+              <date-part name="month" strip-periods="true" suffix=" "/>
+              <date-part name="year"/>
+            </date>
+          </group>
+        </else-if>
+        <else-if type="thesis">
+          <group delimiter=", ">
+            <text variable="genre"/>
+            <text variable="publisher"/>
+          </group>
+        </else-if>
+        <else>
+          <group>
+            <text variable="container-title" form="short" suffix=" "/>
+            <text variable="volume" suffix=":"/>
+            <text variable="page" suffix="."/>
+          </group>
+        </else>
+      </choose>
+    </layout>
+  </bibliography>
+</style>


### PR DESCRIPTION
This is a general new German Springer style, see https://forums.zotero.org/discussion/45511/style-for-springer-journal-zeitschrift-fuer-rheumatologie/ . Differences to `http://www.zotero.org/styles/springer-basic-brackets-no-et-al-alphabetical` are:
 * It uses German terms like "Hrsg" and "S".
 * It follows the 5/3 et al rule.
 * It uses "et al" without a period.

I would like to connect this afterwards to ~51 German journals which I have identified.