### PR TITLE
Update iso690-numeric-en.csl

### DIFF
--- a/iso690-numeric-en.csl
+++ b/iso690-numeric-en.csl
@@ -488,7 +488,6 @@
       </choose>
       <group display="right-inline">
         <text macro="archive"/>
-        <text macro="archive_location"/>
       </group>
       <group display="right-inline">
         <text macro="abstract"/>


### PR DESCRIPTION
Deleting the <text macro="archive_location"/> in the layout because it's already contained in the macro "archive". There was a repetition of the archive location in the final output.