### PR TITLE
Update exercer.csl

### DIFF
--- a/exercer.csl
+++ b/exercer.csl
@@ -23,6 +23,7 @@
       <date-part name="year"/>
     </date>
     <terms>
+      <term name="page-range-delimiter">-</term>
       <term name="presented at">présenté à</term>
       <term name="retrieved">disponible</term>
       <term name="from">sur</term>


### PR DESCRIPTION
Some users reported a bug in the hyphen delimiting pages, wich appears as a square.  
Insertion in line 26: <term name="page-range-delimiter">-</term>