### PR TITLE
Update springer-basic-author-date.csl

### DIFF
--- a/springer-basic-author-date.csl
+++ b/springer-basic-author-date.csl
@@ -24,7 +24,7 @@
   </info>
   <locale>
     <terms>
-      <term name="et-al">et al</term>
+      <term name="and others">et al</term>
       <term name="edition" form="short">edn.</term>
     </terms>
   </locale>
@@ -41,6 +41,7 @@
     <names variable="author">
       <name sort-separator=" " initialize-with="" name-as-sort-order="all" delimiter=", " delimiter-precedes-last="always"/>
       <label form="short" strip-periods="true" prefix=" (" suffix=")"/>
+      <et-al term="and others"/>
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
@@ -52,6 +53,7 @@
     <names variable="editor">
       <name sort-separator=" " initialize-with="" name-as-sort-order="all" delimiter=", " delimiter-precedes-last="always"/>
       <label form="short" strip-periods="true" prefix=" (" suffix=")"/>
+      <et-al term="and others"/>
     </names>
   </macro>
   <macro name="edition">


### PR DESCRIPTION
There should be a point in citations in "et al." but no point in references in "et al". This can be found in the the guidelines and also in articles from the corresponding journals. Or do I miss something here? (The use of the other term "and others" defined to a variant of "et al" seems to be the only fix which CSL let me do...)