### PR TITLE
Update associacao-brasileira-de-normas-tecnicas-ufmg-face-full.csl

### DIFF
--- a/associacao-brasileira-de-normas-tecnicas-ufmg-face-full.csl
+++ b/associacao-brasileira-de-normas-tecnicas-ufmg-face-full.csl
@@ -511,7 +511,7 @@
             <text macro="author" suffix=". "/>
             <text macro="title" suffix=". "/>
             <text macro="issued-year" suffix=". "/>
-            <text variable="number-of-pages" suffix=" f. "/>
+            <text variable="page" suffix=" f. "/>
             <text variable="genre" suffix=" &#8211; "/>
             <text variable="publisher" suffix=", "/>
             <text variable="publisher-place" suffix=", "/>


### PR DESCRIPTION
Correção de variável que não permitia aparecer o número de páginas na bibliografia de uma tese. 

(de 'number-of-pages' para 'page')