### PR TITLE
Modification bibliography for book

### DIFF
--- a/ets-ecole-de-technologie-superieure.csl
+++ b/ets-ecole-de-technologie-superieure.csl
@@ -163,21 +163,42 @@
           </group>
         </if>
         <else-if type="book" match="any">
-          <group delimiter=". " prefix=", ">
-            <text macro="edition"/>
-            <text macro="collection"/>
-            <group delimiter=", ">
-              <text macro="publisher"/>
-              <choose>
-                <if match="any" variable="number-of-pages">
-                  <text variable="number-of-pages" suffix=" p"/>
-                </if>
-                <else-if match="any" variable="page">
-                  <text variable="page" suffix=" p"/>
-                </else-if>
-              </choose>
-            </group>
-          </group>
+					<choose>
+            <if match="any" variable="edition">
+              <group delimiter=". " prefix=", ">
+                <text macro="edition"/>
+                <text macro="collection"/>
+                <group delimiter=", ">
+                  <text macro="publisher"/>
+                  <choose>
+                    <if match="any" variable="number-of-pages">
+                      <text variable="number-of-pages" suffix=" p"/>
+                    </if>
+                    <else-if match="any" variable="page">
+                      <text variable="page" suffix=" p"/>
+                    </else-if>
+                  </choose>
+                </group>
+              </group>
+            </if>
+            <else>
+              <group delimiter=". " prefix=". ">
+                <text macro="edition"/>
+                <text macro="collection"/>
+                <group delimiter=", ">
+                  <text macro="publisher"/>
+                  <choose>
+                    <if match="any" variable="number-of-pages">
+                      <text variable="number-of-pages" suffix=" p"/>
+                    </if>
+                    <else-if match="any" variable="page">
+                      <text variable="page" suffix=" p"/>
+                    </else-if>
+                  </choose>
+                </group>
+              </group>
+            </else>
+          </choose>
         </else-if>
         <else-if type="patent">
           <group delimiter=". " prefix=". ">


### PR DESCRIPTION
The citation style didn't match the school style for books. A punctuation problem was solved by adding a `<choose>` and creating two different options.