### PR TITLE
Fix for patents, conference papers, and thesis.

### DIFF
--- a/harvard-cranfield-university.csl
+++ b/harvard-cranfield-university.csl
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" and="text" name-as-sort-order="all" demote-non-dropping-particle="sort-only" default-locale="en-GB">
+<style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" and="text" name-as-sort-order="all" demote-non-dropping-particle="sort-only" 
+default-locale="en-GB">
   <info>
     <title>Harvard - Cranfield University</title>
     <title-short>Cranfield Harvard</title-short>
@@ -19,7 +20,7 @@
     <category citation-format="author-date"/>
     <category field="generic-base"/>
     <summary>The Harvard author-date style - adapted for Cranfield University</summary>
-    <updated>2015-02-05T14:56:27+00:00</updated>
+    <updated>2015-02-19T11:33:48+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <macro name="editor">
@@ -239,7 +240,6 @@
             <text macro="title" font-style="italic"/>
             <text macro="edition"/>
             <text variable="genre"/>
-            <text value="Thesis"/>
             <text macro="publisher"/>
           </group>
         </else-if>
@@ -272,7 +272,8 @@
             <text macro="pages"/>
           </group>
         </else-if>
-        <else-if type="article-magazine article-newspaper broadcast interview manuscript map patent personal_communication song speech thesis webpage motion_picture" match="any">
+        <else-if type="article-magazine article-newspaper broadcast interview manuscript map personal_communication song speech thesis webpage motion_picture" 
+match="any">
           <group suffix=",">
             <text macro="title" prefix=" "/>
             <text macro="editor" prefix=" "/>
@@ -347,7 +348,7 @@
             <text macro="editor"/>
           </group>
           <text variable="container-title" font-style="italic" suffix="."/>
-          <group>
+          <group suffix=".">
             <text macro="publisher"/>
             <text macro="pages"/>
           </group>


### PR DESCRIPTION
Corrected erroneous full stops in patents and conference paper.
Removed thesis variable in thesis (use genre instead).

Squash of three commits in [#1410](https://github.com/citation-style-language/styles/pull/1410).