### PR TITLE
Update zeitschrift-fur-padagogik.csl

### DIFF
--- a/zeitschrift-fur-padagogik.csl
+++ b/zeitschrift-fur-padagogik.csl
@@ -15,7 +15,7 @@
     <category field="psychology"/>
     <issn>0044-3247</issn>
     <summary>The difference to the DGfP style is the rendering of URLs and access date.</summary>
-    <updated>2015-02-19T20:11:32+00:00</updated>
+    <updated>2015-02-19T20:13:15+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale xml:lang="de">
@@ -82,10 +82,10 @@
             <text variable="DOI"/>
           </if>
           <else-if variable="URL">
-            <text value="VerfÃ¼gbar unter:" suffix=" "/>
+            <text term="available at" suffix=": " text-case="capitalize-first"/>
             <group delimiter=" ">
               <text variable="URL"/>
-              <group>
+              <group suffix=".">
                 <text value="Stand:" prefix="[" suffix=" "/>
                 <date variable="accessed">
                   <date-part name="day" suffix="."/>
@@ -279,7 +279,7 @@
           <text macro="publisher"/>
         </group>
       </group>
-      <text macro="access" prefix=" " suffix="."/>
+      <text macro="access" prefix=" "/>
     </layout>
   </bibliography>
 </style>


### PR DESCRIPTION
Sorry, that was previously still the old version with the point after doi's etc. Moreover, there was a problem with the character encoding. This should fix both issues.