### PR TITLE
OSCOLA: roman + no text-case on title-short legislation

### DIFF
--- a/oscola.csl
+++ b/oscola.csl
@@ -199,10 +199,10 @@
   </macro>
   <macro name="title-short">
     <choose>
-      <if type="book legislation motion_picture manuscript" match="any">
+      <if type="book motion_picture manuscript" match="any">
         <text variable="title" font-style="italic" text-case="title" form="short"/>
       </if>
-      <else-if type="bill" match="any">
+      <else-if type="bill legislation" match="any">
         <text variable="title"/>
       </else-if>
       <else-if type="legal_case">


### PR DESCRIPTION
Following up with a fix (thanks to Rintze for flagging the oversight in the previous OSCOLA commit).

Addresses the issue [here](https://forums.zotero.org/discussion/46935/capitalization-in-oscola/#Item_2).