### PR TITLE
Update university-college-lillebaelt-harvard.csl

### DIFF
--- a/university-college-lillebaelt-harvard.csl
+++ b/university-college-lillebaelt-harvard.csl
@@ -25,9 +25,18 @@
   <macro name="issued">
     <choose>
       <if type="chapter">
-        <date variable="original-date">
-          <date-part name="year"/>
-        </date>
+        <choose>
+          <if variable="original-date">
+            <date variable="original-date">
+              <date-part name="year"/>
+            </date>
+          </if>
+          <else>
+            <date variable="issued">
+              <date-part name="year"/>
+            </date>
+          </else>
+        </choose>
       </if>
       <else>
         <date variable="issued">


### PR DESCRIPTION
Just correcting an embarrassing oversight:
The 'original-date' field should be displayed in the citation of chapters if it is provided. But since that field most often is empty, I need to substitute with the ordinary 'date' field.