### PR TITLE
Add original date and publisher to all Chicago-note styles. Also fix pre...

### DIFF
--- a/chicago-annotated-bibliography.csl
+++ b/chicago-annotated-bibliography.csl
@@ -21,6 +21,10 @@
       <name>Frank Bennett</name>
       <email>biercenator@gmail.com</email>
     </contributor>
+    <contributor>
+      <name>Andrew Dunning</name>
+      <email>andrew.dunning@utoronto.ca</email>
+    </contributor>
     <category citation-format="note"/>
     <category field="generic-base"/>
     <summary>Chicago format with short notes and annotated bibliography</summary>
@@ -345,7 +349,7 @@
     <group delimiter=" ">
       <choose>
         <if type="chapter paper-conference" match="any">
-          <text term="in" text-case="lowercase"/>
+          <text term="in"/>
         </if>
       </choose>
       <choose>
@@ -600,17 +604,63 @@
       </if>
     </choose>
   </macro>
+  <macro name="event-note">
+    <text variable="event"/>
+  </macro>
   <macro name="event">
-    <group delimiter=" ">
-      <text term="presented at"/>
-      <text variable="event"/>
+    <choose>
+      <if variable="title">
+        <group delimiter=" ">
+          <text term="presented at"/>
+          <text variable="event"/>
+        </group>
+      </if>
+      <else>
+        <group delimiter=" ">
+          <text term="presented at" text-case="capitalize-first"/>
+          <text variable="event"/>
+        </group>
+      </else>
+    </choose>
+  </macro>
+  <macro name="originally-published">
+    <group delimiter=", ">
+      <group delimiter=": ">
+        <text variable="original-publisher-place"/>
+        <text variable="original-publisher"/>
+      </group>
+      <date variable="original-date" form="text" date-parts="year"/>
     </group>
+  </macro>
+  <macro name="reprint-note">
+    <!--needs localization-->
+    <choose>
+      <if variable="original-date issued" match="all">
+        <choose>
+          <!--for whatever reason in notes, when we have both original and new publishers, reprint doesn't appear-->
+          <if variable="original-publisher original-publisher-place" match="none">
+            <text value="repr."/>
+          </if>
+        </choose>
+      </if>
+    </choose>
+  </macro>
+  <macro name="reprint">
+    <!--needs localization-->
+    <choose>
+      <if variable="original-date issued" match="all">
+        <text value="reprint"  text-case="capitalize-first"/>
+      </if>
+    </choose>
   </macro>
   <macro name="publisher">
     <choose>
       <if type="thesis">
         <text variable="publisher"/>
       </if>
+      <else-if type="speech">
+        <text variable="event-place"/>
+      </else-if>
       <else>
         <group delimiter=": ">
           <text variable="publisher-place"/>
@@ -644,6 +694,9 @@
           </else>
         </choose>
       </if>
+      <else-if variable="status">
+        <text variable="status"/>
+      </else-if>
       <else-if variable="accessed URL" match="all"/>
       <else>
         <text term="no date" form="short"/>
@@ -662,7 +715,7 @@
                     <if variable="volume">
                       <group delimiter=", ">
                         <group delimiter=" ">
-                          <text term="volume" form="short" text-case="lowercase"/>
+                          <text term="volume" form="short"/>
                           <number variable="volume" form="numeric"/>
                         </group>
                         <label variable="locator" form="short"/>
@@ -877,18 +930,22 @@
       <else-if type="article-newspaper">
         <text macro="issued"/>
       </else-if>
-      <else-if variable="publisher-place publisher" match="any">
+      <else-if variable="publisher-place event-place publisher genre" match="any">
         <group prefix="(" suffix=")" delimiter=", ">
-          <group delimiter=" ">
-            <choose>
-              <if variable="title" match="none"/>
-              <else-if type="thesis speech" match="any">
-                <text variable="genre"/>
-              </else-if>
-            </choose>
-            <text macro="event"/>
+          <choose>
+            <if variable="title" match="none"/>
+            <else-if type="thesis speech" match="any">
+              <text variable="genre"/>
+            </else-if>
+          </choose>
+          <text macro="event-note"/>
+          <group delimiter="; ">
+            <text macro="originally-published"/>
+            <group delimiter=", ">
+              <text macro="reprint-note"/>
+              <text macro="publisher"/>
+            </group>
           </group>
-          <text macro="publisher"/>
           <text macro="issued"/>
         </group>
       </else-if>
@@ -974,7 +1031,13 @@
               <text variable="genre" text-case="capitalize-first"/>
             </if>
           </choose>
-          <text macro="publisher"/>
+          <group delimiter=". ">
+            <text macro="originally-published"/>
+            <group delimiter=", ">
+              <text macro="reprint"/>
+              <text macro="publisher"/>
+            </group>
+          </group>
           <text macro="issued"/>
         </group>
       </else-if>

--- a/chicago-fullnote-bibliography-no-ibid.csl
+++ b/chicago-fullnote-bibliography-no-ibid.csl
@@ -349,7 +349,7 @@
     <group delimiter=" ">
       <choose>
         <if type="chapter paper-conference" match="any">
-          <text term="in" text-case="lowercase"/>
+          <text term="in"/>
         </if>
       </choose>
       <choose>
@@ -604,17 +604,63 @@
       </if>
     </choose>
   </macro>
+  <macro name="event-note">
+    <text variable="event"/>
+  </macro>
   <macro name="event">
-    <group delimiter=" ">
-      <text term="presented at"/>
-      <text variable="event"/>
+    <choose>
+      <if variable="title">
+        <group delimiter=" ">
+          <text term="presented at"/>
+          <text variable="event"/>
+        </group>
+      </if>
+      <else>
+        <group delimiter=" ">
+          <text term="presented at" text-case="capitalize-first"/>
+          <text variable="event"/>
+        </group>
+      </else>
+    </choose>
+  </macro>
+  <macro name="originally-published">
+    <group delimiter=", ">
+      <group delimiter=": ">
+        <text variable="original-publisher-place"/>
+        <text variable="original-publisher"/>
+      </group>
+      <date variable="original-date" form="text" date-parts="year"/>
     </group>
+  </macro>
+  <macro name="reprint-note">
+    <!--needs localization-->
+    <choose>
+      <if variable="original-date issued" match="all">
+        <choose>
+          <!--for whatever reason in notes, when we have both original and new publishers, reprint doesn't appear-->
+          <if variable="original-publisher original-publisher-place" match="none">
+            <text value="repr."/>
+          </if>
+        </choose>
+      </if>
+    </choose>
+  </macro>
+  <macro name="reprint">
+    <!--needs localization-->
+    <choose>
+      <if variable="original-date issued" match="all">
+        <text value="reprint"  text-case="capitalize-first"/>
+      </if>
+    </choose>
   </macro>
   <macro name="publisher">
     <choose>
       <if type="thesis">
         <text variable="publisher"/>
       </if>
+      <else-if type="speech">
+        <text variable="event-place"/>
+      </else-if>
       <else>
         <group delimiter=": ">
           <text variable="publisher-place"/>
@@ -648,6 +694,9 @@
           </else>
         </choose>
       </if>
+      <else-if variable="status">
+        <text variable="status"/>
+      </else-if>
       <else-if variable="accessed URL" match="all"/>
       <else>
         <text term="no date" form="short"/>
@@ -666,7 +715,7 @@
                     <if variable="volume">
                       <group delimiter=", ">
                         <group delimiter=" ">
-                          <text term="volume" form="short" text-case="lowercase"/>
+                          <text term="volume" form="short"/>
                           <number variable="volume" form="numeric"/>
                         </group>
                         <label variable="locator" form="short"/>
@@ -881,18 +930,22 @@
       <else-if type="article-newspaper">
         <text macro="issued"/>
       </else-if>
-      <else-if variable="publisher-place publisher" match="any">
+      <else-if variable="publisher-place event-place publisher genre" match="any">
         <group prefix="(" suffix=")" delimiter=", ">
-          <group delimiter=" ">
-            <choose>
-              <if variable="title" match="none"/>
-              <else-if type="thesis speech" match="any">
-                <text variable="genre"/>
-              </else-if>
-            </choose>
-            <text macro="event"/>
+          <choose>
+            <if variable="title" match="none"/>
+            <else-if type="thesis speech" match="any">
+              <text variable="genre"/>
+            </else-if>
+          </choose>
+          <text macro="event-note"/>
+          <group delimiter="; ">
+            <text macro="originally-published"/>
+            <group delimiter=", ">
+              <text macro="reprint-note"/>
+              <text macro="publisher"/>
+            </group>
           </group>
-          <text macro="publisher"/>
           <text macro="issued"/>
         </group>
       </else-if>
@@ -978,7 +1031,13 @@
               <text variable="genre" text-case="capitalize-first"/>
             </if>
           </choose>
-          <text macro="publisher"/>
+          <group delimiter=". ">
+            <text macro="originally-published"/>
+            <group delimiter=", ">
+              <text macro="reprint"/>
+              <text macro="publisher"/>
+            </group>
+          </group>
           <text macro="issued"/>
         </group>
       </else-if>

--- a/chicago-fullnote-bibliography.csl
+++ b/chicago-fullnote-bibliography.csl
@@ -28,7 +28,7 @@
     <category citation-format="note"/>
     <category field="generic-base"/>
     <summary>Chicago format with full notes and bibliography</summary>
-    <updated>2014-05-15T18:02:53+00:00</updated>
+    <updated>2014-05-16T16:30:10+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale xml:lang="en">
@@ -604,11 +604,54 @@
       </if>
     </choose>
   </macro>
+  <macro name="event-note">
+    <text variable="event"/>
+  </macro>
   <macro name="event">
-    <group delimiter=" ">
-      <text term="presented at"/>
-      <text variable="event"/>
+    <choose>
+      <if variable="title">
+        <group delimiter=" ">
+          <text term="presented at"/>
+          <text variable="event"/>
+        </group>
+      </if>
+      <else>
+        <group delimiter=" ">
+          <text term="presented at" text-case="capitalize-first"/>
+          <text variable="event"/>
+        </group>
+      </else>
+    </choose>
+  </macro>
+  <macro name="originally-published">
+    <group delimiter=", ">
+      <group delimiter=": ">
+        <text variable="original-publisher-place"/>
+        <text variable="original-publisher"/>
+      </group>
+      <date variable="original-date" form="text" date-parts="year"/>
     </group>
+  </macro>
+  <macro name="reprint-note">
+    <!--needs localization-->
+    <choose>
+      <if variable="original-date issued" match="all">
+        <choose>
+          <!--for whatever reason in notes, when we have both original and new publishers, reprint doesn't appear-->
+          <if variable="original-publisher original-publisher-place" match="none">
+            <text value="repr."/>
+          </if>
+        </choose>
+      </if>
+    </choose>
+  </macro>
+  <macro name="reprint">
+    <!--needs localization-->
+    <choose>
+      <if variable="original-date issued" match="all">
+        <text value="reprint"  text-case="capitalize-first"/>
+      </if>
+    </choose>
   </macro>
   <macro name="publisher">
     <choose>
@@ -651,6 +694,9 @@
           </else>
         </choose>
       </if>
+      <else-if variable="status">
+        <text variable="status"/>
+      </else-if>
       <else-if variable="accessed URL" match="all"/>
       <else>
         <text term="no date" form="short"/>
@@ -886,16 +932,20 @@
       </else-if>
       <else-if variable="publisher-place event-place publisher genre" match="any">
         <group prefix="(" suffix=")" delimiter=", ">
-          <group delimiter=" ">
-            <choose>
-              <if variable="title" match="none"/>
-              <else-if type="thesis speech" match="any">
-                <text variable="genre"/>
-              </else-if>
-            </choose>
-            <text macro="event"/>
+          <choose>
+            <if variable="title" match="none"/>
+            <else-if type="thesis speech" match="any">
+              <text variable="genre"/>
+            </else-if>
+          </choose>
+          <text macro="event-note"/>
+          <group delimiter="; ">
+            <text macro="originally-published"/>
+            <group delimiter=", ">
+              <text macro="reprint-note"/>
+              <text macro="publisher"/>
+            </group>
           </group>
-          <text macro="publisher"/>
           <text macro="issued"/>
         </group>
       </else-if>
@@ -981,7 +1031,13 @@
               <text variable="genre" text-case="capitalize-first"/>
             </if>
           </choose>
-          <text macro="publisher"/>
+          <group delimiter=". ">
+            <text macro="originally-published"/>
+            <group delimiter=", ">
+              <text macro="reprint"/>
+              <text macro="publisher"/>
+            </group>
+          </group>
           <text macro="issued"/>
         </group>
       </else-if>

--- a/chicago-library-list.csl
+++ b/chicago-library-list.csl
@@ -349,7 +349,7 @@
     <group delimiter=" ">
       <choose>
         <if type="chapter paper-conference" match="any">
-          <text term="in" text-case="lowercase"/>
+          <text term="in"/>
         </if>
       </choose>
       <choose>
@@ -604,17 +604,63 @@
       </if>
     </choose>
   </macro>
+  <macro name="event-note">
+    <text variable="event"/>
+  </macro>
   <macro name="event">
-    <group delimiter=" ">
-      <text term="presented at"/>
-      <text variable="event"/>
+    <choose>
+      <if variable="title">
+        <group delimiter=" ">
+          <text term="presented at"/>
+          <text variable="event"/>
+        </group>
+      </if>
+      <else>
+        <group delimiter=" ">
+          <text term="presented at" text-case="capitalize-first"/>
+          <text variable="event"/>
+        </group>
+      </else>
+    </choose>
+  </macro>
+  <macro name="originally-published">
+    <group delimiter=", ">
+      <group delimiter=": ">
+        <text variable="original-publisher-place"/>
+        <text variable="original-publisher"/>
+      </group>
+      <date variable="original-date" form="text" date-parts="year"/>
     </group>
+  </macro>
+  <macro name="reprint-note">
+    <!--needs localization-->
+    <choose>
+      <if variable="original-date issued" match="all">
+        <choose>
+          <!--for whatever reason in notes, when we have both original and new publishers, reprint doesn't appear-->
+          <if variable="original-publisher original-publisher-place" match="none">
+            <text value="repr."/>
+          </if>
+        </choose>
+      </if>
+    </choose>
+  </macro>
+  <macro name="reprint">
+    <!--needs localization-->
+    <choose>
+      <if variable="original-date issued" match="all">
+        <text value="reprint"  text-case="capitalize-first"/>
+      </if>
+    </choose>
   </macro>
   <macro name="publisher">
     <choose>
       <if type="thesis">
         <text variable="publisher"/>
       </if>
+      <else-if type="speech">
+        <text variable="event-place"/>
+      </else-if>
       <else>
         <group delimiter=": ">
           <text variable="publisher-place"/>
@@ -648,6 +694,9 @@
           </else>
         </choose>
       </if>
+      <else-if variable="status">
+        <text variable="status"/>
+      </else-if>
       <else-if variable="accessed URL" match="all"/>
       <else>
         <text term="no date" form="short"/>
@@ -666,7 +715,7 @@
                     <if variable="volume">
                       <group delimiter=", ">
                         <group delimiter=" ">
-                          <text term="volume" form="short" text-case="lowercase"/>
+                          <text term="volume" form="short"/>
                           <number variable="volume" form="numeric"/>
                         </group>
                         <label variable="locator" form="short"/>
@@ -881,18 +930,22 @@
       <else-if type="article-newspaper">
         <text macro="issued"/>
       </else-if>
-      <else-if variable="publisher-place publisher" match="any">
+      <else-if variable="publisher-place event-place publisher genre" match="any">
         <group prefix="(" suffix=")" delimiter=", ">
-          <group delimiter=" ">
-            <choose>
-              <if variable="title" match="none"/>
-              <else-if type="thesis speech" match="any">
-                <text variable="genre"/>
-              </else-if>
-            </choose>
-            <text macro="event"/>
+          <choose>
+            <if variable="title" match="none"/>
+            <else-if type="thesis speech" match="any">
+              <text variable="genre"/>
+            </else-if>
+          </choose>
+          <text macro="event-note"/>
+          <group delimiter="; ">
+            <text macro="originally-published"/>
+            <group delimiter=", ">
+              <text macro="reprint-note"/>
+              <text macro="publisher"/>
+            </group>
           </group>
-          <text macro="publisher"/>
           <text macro="issued"/>
         </group>
       </else-if>
@@ -978,7 +1031,13 @@
               <text variable="genre" text-case="capitalize-first"/>
             </if>
           </choose>
-          <text macro="publisher"/>
+          <group delimiter=". ">
+            <text macro="originally-published"/>
+            <group delimiter=", ">
+              <text macro="reprint"/>
+              <text macro="publisher"/>
+            </group>
+          </group>
           <text macro="issued"/>
         </group>
       </else-if>

--- a/chicago-note-biblio-no-ibid.csl
+++ b/chicago-note-biblio-no-ibid.csl
@@ -349,7 +349,7 @@
     <group delimiter=" ">
       <choose>
         <if type="chapter paper-conference" match="any">
-          <text term="in" text-case="lowercase"/>
+          <text term="in"/>
         </if>
       </choose>
       <choose>
@@ -604,17 +604,63 @@
       </if>
     </choose>
   </macro>
+  <macro name="event-note">
+    <text variable="event"/>
+  </macro>
   <macro name="event">
-    <group delimiter=" ">
-      <text term="presented at"/>
-      <text variable="event"/>
+    <choose>
+      <if variable="title">
+        <group delimiter=" ">
+          <text term="presented at"/>
+          <text variable="event"/>
+        </group>
+      </if>
+      <else>
+        <group delimiter=" ">
+          <text term="presented at" text-case="capitalize-first"/>
+          <text variable="event"/>
+        </group>
+      </else>
+    </choose>
+  </macro>
+  <macro name="originally-published">
+    <group delimiter=", ">
+      <group delimiter=": ">
+        <text variable="original-publisher-place"/>
+        <text variable="original-publisher"/>
+      </group>
+      <date variable="original-date" form="text" date-parts="year"/>
     </group>
+  </macro>
+  <macro name="reprint-note">
+    <!--needs localization-->
+    <choose>
+      <if variable="original-date issued" match="all">
+        <choose>
+          <!--for whatever reason in notes, when we have both original and new publishers, reprint doesn't appear-->
+          <if variable="original-publisher original-publisher-place" match="none">
+            <text value="repr."/>
+          </if>
+        </choose>
+      </if>
+    </choose>
+  </macro>
+  <macro name="reprint">
+    <!--needs localization-->
+    <choose>
+      <if variable="original-date issued" match="all">
+        <text value="reprint"  text-case="capitalize-first"/>
+      </if>
+    </choose>
   </macro>
   <macro name="publisher">
     <choose>
       <if type="thesis">
         <text variable="publisher"/>
       </if>
+      <else-if type="speech">
+        <text variable="event-place"/>
+      </else-if>
       <else>
         <group delimiter=": ">
           <text variable="publisher-place"/>
@@ -648,6 +694,9 @@
           </else>
         </choose>
       </if>
+      <else-if variable="status">
+        <text variable="status"/>
+      </else-if>
       <else-if variable="accessed URL" match="all"/>
       <else>
         <text term="no date" form="short"/>
@@ -666,7 +715,7 @@
                     <if variable="volume">
                       <group delimiter=", ">
                         <group delimiter=" ">
-                          <text term="volume" form="short" text-case="lowercase"/>
+                          <text term="volume" form="short"/>
                           <number variable="volume" form="numeric"/>
                         </group>
                         <label variable="locator" form="short"/>
@@ -881,18 +930,22 @@
       <else-if type="article-newspaper">
         <text macro="issued"/>
       </else-if>
-      <else-if variable="publisher-place publisher" match="any">
+      <else-if variable="publisher-place event-place publisher genre" match="any">
         <group prefix="(" suffix=")" delimiter=", ">
-          <group delimiter=" ">
-            <choose>
-              <if variable="title" match="none"/>
-              <else-if type="thesis speech" match="any">
-                <text variable="genre"/>
-              </else-if>
-            </choose>
-            <text macro="event"/>
+          <choose>
+            <if variable="title" match="none"/>
+            <else-if type="thesis speech" match="any">
+              <text variable="genre"/>
+            </else-if>
+          </choose>
+          <text macro="event-note"/>
+          <group delimiter="; ">
+            <text macro="originally-published"/>
+            <group delimiter=", ">
+              <text macro="reprint-note"/>
+              <text macro="publisher"/>
+            </group>
           </group>
-          <text macro="publisher"/>
           <text macro="issued"/>
         </group>
       </else-if>
@@ -978,7 +1031,13 @@
               <text variable="genre" text-case="capitalize-first"/>
             </if>
           </choose>
-          <text macro="publisher"/>
+          <group delimiter=". ">
+            <text macro="originally-published"/>
+            <group delimiter=", ">
+              <text macro="reprint"/>
+              <text macro="publisher"/>
+            </group>
+          </group>
           <text macro="issued"/>
         </group>
       </else-if>

--- a/chicago-note-bibliography.csl
+++ b/chicago-note-bibliography.csl
@@ -349,7 +349,7 @@
     <group delimiter=" ">
       <choose>
         <if type="chapter paper-conference" match="any">
-          <text term="in" text-case="lowercase"/>
+          <text term="in"/>
         </if>
       </choose>
       <choose>
@@ -604,17 +604,63 @@
       </if>
     </choose>
   </macro>
+  <macro name="event-note">
+    <text variable="event"/>
+  </macro>
   <macro name="event">
-    <group delimiter=" ">
-      <text term="presented at"/>
-      <text variable="event"/>
+    <choose>
+      <if variable="title">
+        <group delimiter=" ">
+          <text term="presented at"/>
+          <text variable="event"/>
+        </group>
+      </if>
+      <else>
+        <group delimiter=" ">
+          <text term="presented at" text-case="capitalize-first"/>
+          <text variable="event"/>
+        </group>
+      </else>
+    </choose>
+  </macro>
+  <macro name="originally-published">
+    <group delimiter=", ">
+      <group delimiter=": ">
+        <text variable="original-publisher-place"/>
+        <text variable="original-publisher"/>
+      </group>
+      <date variable="original-date" form="text" date-parts="year"/>
     </group>
+  </macro>
+  <macro name="reprint-note">
+    <!--needs localization-->
+    <choose>
+      <if variable="original-date issued" match="all">
+        <choose>
+          <!--for whatever reason in notes, when we have both original and new publishers, reprint doesn't appear-->
+          <if variable="original-publisher original-publisher-place" match="none">
+            <text value="repr."/>
+          </if>
+        </choose>
+      </if>
+    </choose>
+  </macro>
+  <macro name="reprint">
+    <!--needs localization-->
+    <choose>
+      <if variable="original-date issued" match="all">
+        <text value="reprint"  text-case="capitalize-first"/>
+      </if>
+    </choose>
   </macro>
   <macro name="publisher">
     <choose>
       <if type="thesis">
         <text variable="publisher"/>
       </if>
+      <else-if type="speech">
+        <text variable="event-place"/>
+      </else-if>
       <else>
         <group delimiter=": ">
           <text variable="publisher-place"/>
@@ -648,6 +694,9 @@
           </else>
         </choose>
       </if>
+      <else-if variable="status">
+        <text variable="status"/>
+      </else-if>
       <else-if variable="accessed URL" match="all"/>
       <else>
         <text term="no date" form="short"/>
@@ -666,7 +715,7 @@
                     <if variable="volume">
                       <group delimiter=", ">
                         <group delimiter=" ">
-                          <text term="volume" form="short" text-case="lowercase"/>
+                          <text term="volume" form="short"/>
                           <number variable="volume" form="numeric"/>
                         </group>
                         <label variable="locator" form="short"/>
@@ -881,18 +930,22 @@
       <else-if type="article-newspaper">
         <text macro="issued"/>
       </else-if>
-      <else-if variable="publisher-place publisher" match="any">
+      <else-if variable="publisher-place event-place publisher genre" match="any">
         <group prefix="(" suffix=")" delimiter=", ">
-          <group delimiter=" ">
-            <choose>
-              <if variable="title" match="none"/>
-              <else-if type="thesis speech" match="any">
-                <text variable="genre"/>
-              </else-if>
-            </choose>
-            <text macro="event"/>
+          <choose>
+            <if variable="title" match="none"/>
+            <else-if type="thesis speech" match="any">
+              <text variable="genre"/>
+            </else-if>
+          </choose>
+          <text macro="event-note"/>
+          <group delimiter="; ">
+            <text macro="originally-published"/>
+            <group delimiter=", ">
+              <text macro="reprint-note"/>
+              <text macro="publisher"/>
+            </group>
           </group>
-          <text macro="publisher"/>
           <text macro="issued"/>
         </group>
       </else-if>
@@ -978,7 +1031,13 @@
               <text variable="genre" text-case="capitalize-first"/>
             </if>
           </choose>
-          <text macro="publisher"/>
+          <group delimiter=". ">
+            <text macro="originally-published"/>
+            <group delimiter=", ">
+              <text macro="reprint"/>
+              <text macro="publisher"/>
+            </group>
+          </group>
           <text macro="issued"/>
         </group>
       </else-if>


### PR DESCRIPTION
...sentations without title and note format for presentations.
With just original date:
N: 23. Jacques Barzun, Simple and Direct: A Rhetoric for Writers, rev. ed. (1985; repr., Chicago: University of Chicago Press, 1994), 152–53. 
B: Schweitzer, Albert. J. S. Bach. Translated by Ernest Newman. 2 vols. 1911. Reprint, New York: Dover, 1966. 

with original publisher:
N: Ernest Gowers, The Complete Plain Words, 3rd ed. (London: H.M. Stationery Office, 1986; Harmondsworth, UK: Penguin Books, 1987)
B: Fitzgerald, F. Scott. The Great Gatsby. New York: Scribner, 1925. Reprint, New York: Collier Books, 1992. 

also allows "status" for forthcoming if there's no date.
"Reprint" and "repr." are currently hardcoded, require localization.