### PR TITLE
Use title case for titles in MHRA author-date.

### DIFF
--- a/modern-humanities-research-association-author-date.csl
+++ b/modern-humanities-research-association-author-date.csl
@@ -20,7 +20,7 @@
     <category citation-format="author-date"/>
     <category field="generic-base"/>
     <summary>MHRA author date format. This is rather poorly specified in the style guide, so it includes some (hopefully reasonable) assumptions: et al for 3+ author; "and" between two authors; no added names, but added given names for disambiguation.</summary>
-    <updated>2014-03-12T15:55:55+00:00</updated>
+    <updated>2015-03-02T23:37:43+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale xml:lang="en">
@@ -55,10 +55,10 @@
   <macro name="title">
     <choose>
       <if type="bill book graphic legal_case motion_picture report song" match="any">
-        <text variable="title" font-style="italic"/>
+        <text variable="title" text-case="title" font-style="italic"/>
       </if>
       <else>
-        <text variable="title" quotes="true"/>
+        <text variable="title" text-case="title" quotes="true"/>
       </else>
     </choose>
   </macro>

--- a/modern-humanities-research-association-author-date.csl
+++ b/modern-humanities-research-association-author-date.csl
@@ -143,7 +143,7 @@
     </choose>
   </macro>
   <macro name="container-title-note">
-    <text variable="container-title" font-style="italic"/>
+    <text variable="container-title" text-case="title" font-style="italic"/>
   </macro>
   <macro name="edition-note">
     <choose>

--- a/modern-humanities-research-association.csl
+++ b/modern-humanities-research-association.csl
@@ -251,7 +251,7 @@
         <text term="in" suffix=" "/>
       </if>
     </choose>
-    <text variable="container-title" font-style="italic"/>
+    <text variable="container-title" text-case="title" font-style="italic"/>
   </macro>
   <macro name="edition-note">
     <choose>


### PR DESCRIPTION
I believe this was changed in the third edition of the guide. This style still needs a bit of work to bring it in line with recent modifications to the note version of MHRA.

Another thing I've noticed about the MHRA styles: because its method of indicating a DOI is to print the URL with the resolver, we're putting `http://dx.doi.org/` as a prefix to the DOI, but this causes problems for versions of citeproc that try to automatically link it, because it cannot not recognize the prefix as being part of the URL. Is there a better way of doing this?