### PR TITLE
Do not substitute title for journal articles in Chicago author-date.

### DIFF
--- a/chicago-author-date.csl
+++ b/chicago-author-date.csl
@@ -24,7 +24,7 @@
     <category citation-format="author-date"/>
     <category field="generic-base"/>
     <summary>The author-date variant of the Chicago style</summary>
-    <updated>2015-01-01T23:37:43+00:00</updated>
+    <updated>2015-03-02T23:37:43+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale xml:lang="en">
@@ -97,7 +97,7 @@
   </macro>
   <macro name="substitute-title">
     <choose>
-      <if type="article-journal article-magazine article-newspaper review review-book" match="any">
+      <if type="article-magazine article-newspaper review review-book" match="any">
         <text macro="container-title"/>
       </if>
     </choose>


### PR DESCRIPTION
This is from citation-style-language/styles#1028, which implemented CMoS 14.207 and 14.217, referring specifically to 'Unsigned newspaper articles' and 'Unsigned reviews'. With journal articles, it gives some strange results, such as:

> *Sacris Erudiri*. 1948. ‘A Proposed New Edition of Early Christian Texts’ 1: 405–14. doi:10.1484/J.SE.2.305052.