### PR TITLE
modern-language-association-6th-edition-note Editor label fixes

### DIFF
--- a/modern-language-association-6th-edition-note.csl
+++ b/modern-language-association-6th-edition-note.csl
@@ -38,7 +38,7 @@
       <choose>
         <if variable="author">
           <names variable="editor" delimiter=", ">
-            <label form="verb-short" text-case="lowercase" suffix=" "/>
+            <label form="verb-short" text-case="capitalize-first" suffix=" "/>
             <name and="text" delimiter=", "/>
           </names>
           <choose>
@@ -56,7 +56,7 @@
       <choose>
         <if variable="author editor" match="any">
           <names variable="translator" delimiter=", ">
-            <label form="verb-short" text-case="lowercase" suffix=" "/>
+            <label form="verb-short" text-case="capitalize-first" suffix=" "/>
             <name and="text" delimiter=", "/>
           </names>
         </if>
@@ -84,7 +84,7 @@
           <choose>
             <if variable="author">
               <names variable="editor" delimiter=". ">
-                <label form="verb" text-case="capitalize-first" suffix=" "/>
+                <label form="verb-short" text-case="capitalize-first" suffix=" "/>
                 <name and="text" delimiter=", "/>
               </names>
             </if>
@@ -92,7 +92,7 @@
           <choose>
             <if variable="author editor" match="any">
               <names variable="translator" delimiter=". ">
-                <label form="verb" text-case="capitalize-first" suffix=" "/>
+                <label form="verb-short" text-case="capitalize-first" suffix=" "/>
                 <name and="text" delimiter=", "/>
               </names>
             </if>
@@ -108,7 +108,7 @@
           <choose>
             <if variable="author">
               <names variable="editor" delimiter=", ">
-                <label form="verb" text-case="lowercase" suffix=" "/>
+                <label form="verb-short" text-case="capitalize-first" suffix=" "/>
                 <name and="text" delimiter=", "/>
               </names>
               <choose>
@@ -126,7 +126,7 @@
           <choose>
             <if variable="author editor" match="any">
               <names variable="translator" delimiter=", ">
-                <label form="verb" text-case="lowercase" suffix=" "/>
+                <label form="verb-short" text-case="lowercase" suffix=" "/>
                 <name and="text" delimiter=", "/>
               </names>
             </if>
@@ -430,9 +430,6 @@
           <group>
             <text term="volume" form="short" text-case="capitalize-first" suffix=" "/>
             <number variable="volume" form="numeric"/>
-          </group>
-          <group>
-            <text term="volume" form="short" prefix=" " plural="true"/>
           </group>
           <text macro="edition"/>
         </group>
@@ -756,9 +753,9 @@
             <text macro="title-note"/>
             <text macro="description-note"/>
             <text macro="secondary-contributors-note"/>
-            <text macro="container-title-note"/>
-            <text macro="container-contributors-note"/>
           </group>
+          <text macro="container-title-note" suffix=". "/>
+          <text macro="container-contributors-note"/>
           <text macro="locators-note"/>
           <text macro="collection-title" prefix=", "/>
           <text macro="issue-note"/>
@@ -782,8 +779,8 @@
         <text macro="title"/>
         <text macro="description"/>
         <text macro="secondary-contributors"/>
-        <group delimiter=", ">
-          <text macro="container-title"/>
+        <text macro="container-title"/>
+       <group delimiter=", ">
           <text macro="container-contributors"/>
           <text macro="locators-chapter"/>
         </group>


### PR DESCRIPTION
The label editor should be preceded by a full-stop (not a comma), be abbreviated, and start with a capital letter.

Also, remove a group containing a stray text tag.

