### PR TITLE
american-chemical-society Misc. changes

### DIFF
--- a/american-chemical-society-author-date.csl
+++ b/american-chemical-society-author-date.csl
@@ -23,11 +23,33 @@
     <updated>2012-09-27T22:06:38+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
+  <locale xml:lang="en">
+    <terms>
+      <term name="editortranslator" form="short">
+        <single>ed. and translator</single>
+        <multiple>eds. and translators</multiple>
+      </term>
+      <term name="translator" form="short">
+        <single>translator</single>
+        <multiple>translators</multiple>
+      </term>
+      <term name="collection-editor" form="short">
+        <single>series ed.</single>
+        <multiple>series eds.</multiple>
+      </term>
+    </terms>
+  </locale>
   <macro name="editor">
-    <names variable="editor">
-      <name sort-separator=", " initialize-with=". " name-as-sort-order="all" delimiter=", " delimiter-precedes-last="always"/>
-      <label form="short" prefix=", " text-case="capitalize-first"/>
-    </names>
+    <group delimiter="; ">
+      <names variable="editor translator" delimiter="; ">
+        <name sort-separator=", " initialize-with=". " name-as-sort-order="all" delimiter=", " delimiter-precedes-last="always"/>
+        <label form="short" prefix=", " text-case="title"/>
+      </names>
+      <names variable="collection-editor">
+        <name sort-separator=", " initialize-with=". " name-as-sort-order="all" delimiter=", " delimiter-precedes-last="always"/>
+        <label form="short" prefix=", " text-case="title"/>
+      </names>
+    </group>
   </macro>
   <macro name="author">
     <names variable="author" suffix=".">

--- a/american-chemical-society-author-date.csl
+++ b/american-chemical-society-author-date.csl
@@ -85,7 +85,11 @@
   <macro name="book-container">
     <group delimiter=" ">
       <text macro="title" suffix="."/>
-      <text term="in" text-case="capitalize-first"/>
+      <choose>
+        <if type="entry-dictionary entry-encyclopedia" match="none">
+          <text term="in" text-case="capitalize-first"/>
+        </if>
+      </choose>
       <text variable="container-title" font-style="italic"/>
     </group>
   </macro>
@@ -195,7 +199,7 @@
             <date variable="issued" form="text"/>
           </group>
         </else-if>
-        <else-if type="chapter paper-conference" match="any">
+        <else-if type="chapter paper-conference entry-dictionary entry-encyclopedia" match="any">
           <group delimiter="; ">
             <text macro="book-container"/>
             <text macro="editor"/>

--- a/american-chemical-society-author-date.csl
+++ b/american-chemical-society-author-date.csl
@@ -227,7 +227,20 @@
             <text variable="container-title" font-style="italic" form="short"/>
             <group delimiter=", ">
               <text macro="issued" font-weight="bold"/>
-              <text variable="volume" font-style="italic"/>
+             <choose>
+                <if variable="volume">
+                  <group delimiter=" ">
+                    <text variable="volume" font-style="italic"/>
+                    <text variable="issue" prefix="(" suffix=")"/>
+                  </group>
+                </if>
+                <else-if variable="issue">
+                  <group delimiter=" ">
+                    <text term="issue" form="short" text-case="capitalize-first"/>
+                    <text variable="issue"/>
+                  </group>
+                </else-if>
+              </choose>
               <text variable="page"/>
             </group>
           </group>

--- a/american-chemical-society-page-first.csl
+++ b/american-chemical-society-page-first.csl
@@ -21,11 +21,33 @@
     <updated>2012-09-27T22:06:38+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
+  <locale xml:lang="en">
+    <terms>
+      <term name="editortranslator" form="short">
+        <single>ed. and translator</single>
+        <multiple>eds. and translators</multiple>
+      </term>
+      <term name="translator" form="short">
+        <single>translator</single>
+        <multiple>translators</multiple>
+      </term>
+      <term name="collection-editor" form="short">
+        <single>series ed.</single>
+        <multiple>series eds.</multiple>
+      </term>
+    </terms>
+  </locale>
   <macro name="editor">
-    <names variable="editor">
-      <name sort-separator=", " initialize-with=". " name-as-sort-order="all" delimiter=", " delimiter-precedes-last="always"/>
-      <label form="short" prefix=", " text-case="capitalize-first"/>
-    </names>
+    <group delimiter="; ">
+      <names variable="editor translator" delimiter="; ">
+        <name sort-separator=", " initialize-with=". " name-as-sort-order="all" delimiter=", " delimiter-precedes-last="always"/>
+        <label form="short" prefix=", " text-case="title"/>
+      </names>
+      <names variable="collection-editor">
+        <name sort-separator=", " initialize-with=". " name-as-sort-order="all" delimiter=", " delimiter-precedes-last="always"/>
+        <label form="short" prefix=", " text-case="title"/>
+      </names>
+    </group>
   </macro>
   <macro name="author">
     <names variable="author" suffix=".">

--- a/american-chemical-society-page-first.csl
+++ b/american-chemical-society-page-first.csl
@@ -183,7 +183,20 @@
             <text variable="container-title" font-style="italic" form="short"/>
             <group delimiter=", ">
               <text macro="issued" font-weight="bold"/>
-              <text variable="volume" font-style="italic"/>
+             <choose>
+                <if variable="volume">
+                  <group delimiter=" ">
+                    <text variable="volume" font-style="italic"/>
+                    <text variable="issue" prefix="(" suffix=")"/>
+                  </group>
+                </if>
+                <else-if variable="issue">
+                  <group delimiter=" ">
+                    <text term="issue" form="short" text-case="capitalize-first"/>
+                    <text variable="issue"/>
+                  </group>
+                </else-if>
+              </choose>
               <text variable="page-first"/>
             </group>
           </group>

--- a/american-chemical-society-page-first.csl
+++ b/american-chemical-society-page-first.csl
@@ -54,7 +54,11 @@
   </macro>
   <macro name="book-container">
     <group delimiter=" ">
-      <text term="in" text-case="capitalize-first"/>
+      <choose>
+        <if type="entry-dictionary entry-encyclopedia" match="none">
+          <text term="in" text-case="capitalize-first"/>
+        </if>
+      </choose>
       <text variable="container-title" font-style="italic"/>
     </group>
   </macro>
@@ -152,7 +156,7 @@
             <date variable="issued" form="text"/>
           </group>
         </else-if>
-        <else-if type="chapter paper-conference" match="any">
+        <else-if type="chapter paper-conference entry-dictionary entry-encyclopedia" match="any">
           <group delimiter="; ">
             <text macro="book-container"/>
             <text macro="editor"/>

--- a/american-chemical-society-with-titles-no-et-al.csl
+++ b/american-chemical-society-with-titles-no-et-al.csl
@@ -23,11 +23,33 @@
     <updated>2012-09-27T22:06:38+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
+  <locale xml:lang="en">
+    <terms>
+      <term name="editortranslator" form="short">
+        <single>ed. and translator</single>
+        <multiple>eds. and translators</multiple>
+      </term>
+      <term name="translator" form="short">
+        <single>translator</single>
+        <multiple>translators</multiple>
+      </term>
+      <term name="collection-editor" form="short">
+        <single>series ed.</single>
+        <multiple>series eds.</multiple>
+      </term>
+    </terms>
+  </locale>
   <macro name="editor">
-    <names variable="editor">
-      <name sort-separator=", " initialize-with=". " name-as-sort-order="all" delimiter=", " delimiter-precedes-last="always"/>
-      <label form="short" prefix=", " text-case="capitalize-first"/>
-    </names>
+    <group delimiter="; ">
+      <names variable="editor translator" delimiter="; ">
+        <name sort-separator=", " initialize-with=". " name-as-sort-order="all" delimiter=", " delimiter-precedes-last="always"/>
+        <label form="short" prefix=", " text-case="title"/>
+      </names>
+      <names variable="collection-editor">
+        <name sort-separator=", " initialize-with=". " name-as-sort-order="all" delimiter=", " delimiter-precedes-last="always"/>
+        <label form="short" prefix=", " text-case="title"/>
+      </names>
+    </group>
   </macro>
   <macro name="author">
     <names variable="author" suffix=".">

--- a/american-chemical-society-with-titles-no-et-al.csl
+++ b/american-chemical-society-with-titles-no-et-al.csl
@@ -198,7 +198,20 @@
             <text variable="container-title" font-style="italic" form="short"/>
             <group delimiter=", ">
               <text macro="issued" font-weight="bold"/>
-              <text variable="volume" font-style="italic"/>
+             <choose>
+                <if variable="volume">
+                  <group delimiter=" ">
+                    <text variable="volume" font-style="italic"/>
+                    <text variable="issue" prefix="(" suffix=")"/>
+                  </group>
+                </if>
+                <else-if variable="issue">
+                  <group delimiter=" ">
+                    <text term="issue" form="short" text-case="capitalize-first"/>
+                    <text variable="issue"/>
+                  </group>
+                </else-if>
+              </choose>
               <text variable="page"/>
             </group>
           </group>

--- a/american-chemical-society-with-titles-no-et-al.csl
+++ b/american-chemical-society-with-titles-no-et-al.csl
@@ -67,7 +67,11 @@
   <macro name="book-container">
     <group delimiter=" ">
       <text macro="title" suffix="."/>
-      <text term="in" text-case="capitalize-first"/>
+      <choose>
+        <if type="entry-dictionary entry-encyclopedia" match="none">
+          <text term="in" text-case="capitalize-first"/>
+        </if>
+      </choose>
       <text variable="container-title" font-style="italic"/>
     </group>
   </macro>
@@ -166,7 +170,7 @@
             <date variable="issued" form="text"/>
           </group>
         </else-if>
-        <else-if type="chapter paper-conference" match="any">
+        <else-if type="chapter paper-conference entry-dictionary entry-encyclopedia" match="any">
           <group delimiter="; ">
             <text macro="book-container"/>
             <text macro="editor"/>

--- a/american-chemical-society-with-titles-page-first.csl
+++ b/american-chemical-society-with-titles-page-first.csl
@@ -68,7 +68,11 @@
   <macro name="book-container">
     <group delimiter=" ">
       <text macro="title" suffix="."/>
-      <text term="in" text-case="capitalize-first"/>
+      <choose>
+        <if type="entry-dictionary entry-encyclopedia" match="none">
+          <text term="in" text-case="capitalize-first"/>
+        </if>
+      </choose>
       <text variable="container-title" font-style="italic"/>
     </group>
   </macro>
@@ -167,7 +171,7 @@
             <date variable="issued" form="text"/>
           </group>
         </else-if>
-        <else-if type="chapter paper-conference" match="any">
+        <else-if type="chapter paper-conference entry-dictionary entry-encyclopedia" match="any">
           <group delimiter="; ">
             <text macro="book-container"/>
             <text macro="editor"/>

--- a/american-chemical-society-with-titles-page-first.csl
+++ b/american-chemical-society-with-titles-page-first.csl
@@ -199,7 +199,20 @@
             <text variable="container-title" font-style="italic" form="short"/>
             <group delimiter=", ">
               <text macro="issued" font-weight="bold"/>
-              <text variable="volume" font-style="italic"/>
+             <choose>
+                <if variable="volume">
+                  <group delimiter=" ">
+                    <text variable="volume" font-style="italic"/>
+                    <text variable="issue" prefix="(" suffix=")"/>
+                  </group>
+                </if>
+                <else-if variable="issue">
+                  <group delimiter=" ">
+                    <text term="issue" form="short" text-case="capitalize-first"/>
+                    <text variable="issue"/>
+                  </group>
+                </else-if>
+              </choose>
               <text variable="page-first"/>
             </group>
           </group>

--- a/american-chemical-society-with-titles-page-first.csl
+++ b/american-chemical-society-with-titles-page-first.csl
@@ -24,11 +24,33 @@
     <updated>2012-09-27T22:06:38+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
+  <locale xml:lang="en">
+    <terms>
+      <term name="editortranslator" form="short">
+        <single>ed. and translator</single>
+        <multiple>eds. and translators</multiple>
+      </term>
+      <term name="translator" form="short">
+        <single>translator</single>
+        <multiple>translators</multiple>
+      </term>
+      <term name="collection-editor" form="short">
+        <single>series ed.</single>
+        <multiple>series eds.</multiple>
+      </term>
+    </terms>
+  </locale>
   <macro name="editor">
-    <names variable="editor">
-      <name sort-separator=", " initialize-with=". " name-as-sort-order="all" delimiter=", " delimiter-precedes-last="always"/>
-      <label form="short" prefix=", " text-case="capitalize-first"/>
-    </names>
+    <group delimiter="; ">
+      <names variable="editor translator" delimiter="; ">
+        <name sort-separator=", " initialize-with=". " name-as-sort-order="all" delimiter=", " delimiter-precedes-last="always"/>
+        <label form="short" prefix=", " text-case="title"/>
+      </names>
+      <names variable="collection-editor">
+        <name sort-separator=", " initialize-with=". " name-as-sort-order="all" delimiter=", " delimiter-precedes-last="always"/>
+        <label form="short" prefix=", " text-case="title"/>
+      </names>
+    </group>
   </macro>
   <macro name="author">
     <names variable="author" suffix=".">

--- a/american-chemical-society-with-titles-sentence-case-doi.csl
+++ b/american-chemical-society-with-titles-sentence-case-doi.csl
@@ -68,7 +68,11 @@
   <macro name="book-container">
     <group delimiter=" ">
       <text macro="title" suffix="."/>
-      <text term="in" text-case="capitalize-first"/>
+      <choose>
+        <if type="entry-dictionary entry-encyclopedia" match="none">
+          <text term="in" text-case="capitalize-first"/>
+        </if>
+      </choose>
       <text variable="container-title" font-style="italic"/>
     </group>
   </macro>
@@ -167,7 +171,7 @@
             <date variable="issued" form="text"/>
           </group>
         </else-if>
-        <else-if type="chapter paper-conference" match="any">
+        <else-if type="chapter paper-conference entry-dictionary entry-encyclopedia" match="any">
           <group delimiter="; ">
             <text macro="book-container"/>
             <text macro="editor"/>

--- a/american-chemical-society-with-titles-sentence-case-doi.csl
+++ b/american-chemical-society-with-titles-sentence-case-doi.csl
@@ -199,7 +199,21 @@
             <text variable="container-title" font-style="italic" form="short"/>
             <group delimiter=", ">
               <text macro="issued" font-weight="bold"/>
-              <text variable="volume" font-style="italic"/>
+             <choose>
+                <if variable="volume">
+                  <group delimiter=" ">
+                    <text variable="volume" font-style="italic"/>
+                    <text variable="issue" prefix="(" suffix=")"/>
+                  </group>
+                </if>
+                <else-if variable="issue">
+                  <group delimiter=" ">
+                    <text term="issue" form="short" text-case="capitalize-first"/>
+                    <text variable="issue"/>
+                  </group>
+                </else-if>
+              </choose>
+
               <text variable="page"/>
             </group>
             <text variable="DOI" prefix="DOI: "/>

--- a/american-chemical-society-with-titles-sentence-case-doi.csl
+++ b/american-chemical-society-with-titles-sentence-case-doi.csl
@@ -24,11 +24,33 @@
     <updated>2012-09-27T22:06:38+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
+  <locale xml:lang="en">
+    <terms>
+      <term name="editortranslator" form="short">
+        <single>ed. and translator</single>
+        <multiple>eds. and translators</multiple>
+      </term>
+      <term name="translator" form="short">
+        <single>translator</single>
+        <multiple>translators</multiple>
+      </term>
+      <term name="collection-editor" form="short">
+        <single>series ed.</single>
+        <multiple>series eds.</multiple>
+      </term>
+    </terms>
+  </locale>
   <macro name="editor">
-    <names variable="editor">
-      <name sort-separator=", " initialize-with=". " name-as-sort-order="all" delimiter=", " delimiter-precedes-last="always"/>
-      <label form="short" prefix=", " text-case="capitalize-first"/>
-    </names>
+    <group delimiter="; ">
+      <names variable="editor translator" delimiter="; ">
+        <name sort-separator=", " initialize-with=". " name-as-sort-order="all" delimiter=", " delimiter-precedes-last="always"/>
+        <label form="short" prefix=", " text-case="title"/>
+      </names>
+      <names variable="collection-editor">
+        <name sort-separator=", " initialize-with=". " name-as-sort-order="all" delimiter=", " delimiter-precedes-last="always"/>
+        <label form="short" prefix=", " text-case="title"/>
+      </names>
+    </group>
   </macro>
   <macro name="author">
     <names variable="author" suffix=".">

--- a/american-chemical-society-with-titles-sentence-case.csl
+++ b/american-chemical-society-with-titles-sentence-case.csl
@@ -68,7 +68,11 @@
   <macro name="book-container">
     <group delimiter=" ">
       <text macro="title" suffix="."/>
-      <text term="in" text-case="capitalize-first"/>
+      <choose>
+        <if type="entry-dictionary entry-encyclopedia" match="none">
+          <text term="in" text-case="capitalize-first"/>
+        </if>
+      </choose>
       <text variable="container-title" font-style="italic"/>
     </group>
   </macro>
@@ -167,7 +171,7 @@
             <date variable="issued" form="text"/>
           </group>
         </else-if>
-        <else-if type="chapter paper-conference" match="any">
+        <else-if type="chapter paper-conference entry-dictionary entry-encyclopedia" match="any">
           <group delimiter="; ">
             <text macro="book-container"/>
             <text macro="editor"/>

--- a/american-chemical-society-with-titles-sentence-case.csl
+++ b/american-chemical-society-with-titles-sentence-case.csl
@@ -199,7 +199,21 @@
             <text variable="container-title" font-style="italic" form="short"/>
             <group delimiter=", ">
               <text macro="issued" font-weight="bold"/>
-              <text variable="volume" font-style="italic"/>
+             <choose>
+                <if variable="volume">
+                  <group delimiter=" ">
+                    <text variable="volume" font-style="italic"/>
+                    <text variable="issue" prefix="(" suffix=")"/>
+                  </group>
+                </if>
+                <else-if variable="issue">
+                  <group delimiter=" ">
+                    <text term="issue" form="short" text-case="capitalize-first"/>
+                    <text variable="issue"/>
+                  </group>
+                </else-if>
+              </choose>
+
               <text variable="page"/>
             </group>
           </group>

--- a/american-chemical-society-with-titles-sentence-case.csl
+++ b/american-chemical-society-with-titles-sentence-case.csl
@@ -24,11 +24,33 @@
     <updated>2012-09-27T22:06:38+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
+  <locale xml:lang="en">
+    <terms>
+      <term name="editortranslator" form="short">
+        <single>ed. and translator</single>
+        <multiple>eds. and translators</multiple>
+      </term>
+      <term name="translator" form="short">
+        <single>translator</single>
+        <multiple>translators</multiple>
+      </term>
+      <term name="collection-editor" form="short">
+        <single>series ed.</single>
+        <multiple>series eds.</multiple>
+      </term>
+    </terms>
+  </locale>
   <macro name="editor">
-    <names variable="editor">
-      <name sort-separator=", " initialize-with=". " name-as-sort-order="all" delimiter=", " delimiter-precedes-last="always"/>
-      <label form="short" prefix=", " text-case="capitalize-first"/>
-    </names>
+    <group delimiter="; ">
+      <names variable="editor translator" delimiter="; ">
+        <name sort-separator=", " initialize-with=". " name-as-sort-order="all" delimiter=", " delimiter-precedes-last="always"/>
+        <label form="short" prefix=", " text-case="title"/>
+      </names>
+      <names variable="collection-editor">
+        <name sort-separator=", " initialize-with=". " name-as-sort-order="all" delimiter=", " delimiter-precedes-last="always"/>
+        <label form="short" prefix=", " text-case="title"/>
+      </names>
+    </group>
   </macro>
   <macro name="author">
     <names variable="author" suffix=".">

--- a/american-chemical-society-with-titles.csl
+++ b/american-chemical-society-with-titles.csl
@@ -23,11 +23,33 @@
     <updated>2012-09-27T22:06:38+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
+  <locale xml:lang="en">
+    <terms>
+      <term name="editortranslator" form="short">
+        <single>ed. and translator</single>
+        <multiple>eds. and translators</multiple>
+      </term>
+      <term name="translator" form="short">
+        <single>translator</single>
+        <multiple>translators</multiple>
+      </term>
+      <term name="collection-editor" form="short">
+        <single>series ed.</single>
+        <multiple>series eds.</multiple>
+      </term>
+    </terms>
+  </locale>
   <macro name="editor">
-    <names variable="editor">
-      <name sort-separator=", " initialize-with=". " name-as-sort-order="all" delimiter=", " delimiter-precedes-last="always"/>
-      <label form="short" prefix=", " text-case="capitalize-first"/>
-    </names>
+    <group delimiter="; ">
+      <names variable="editor translator" delimiter="; ">
+        <name sort-separator=", " initialize-with=". " name-as-sort-order="all" delimiter=", " delimiter-precedes-last="always"/>
+        <label form="short" prefix=", " text-case="title"/>
+      </names>
+      <names variable="collection-editor">
+        <name sort-separator=", " initialize-with=". " name-as-sort-order="all" delimiter=", " delimiter-precedes-last="always"/>
+        <label form="short" prefix=", " text-case="title"/>
+      </names>
+    </group>
   </macro>
   <macro name="author">
     <names variable="author" suffix=".">

--- a/american-chemical-society-with-titles.csl
+++ b/american-chemical-society-with-titles.csl
@@ -67,7 +67,11 @@
   <macro name="book-container">
     <group delimiter=" ">
       <text macro="title" suffix="."/>
-      <text term="in" text-case="capitalize-first"/>
+      <choose>
+        <if type="entry-dictionary entry-encyclopedia" match="none">
+          <text term="in" text-case="capitalize-first"/>
+        </if>
+      </choose>
       <text variable="container-title" font-style="italic"/>
     </group>
   </macro>
@@ -166,7 +170,7 @@
             <date variable="issued" form="text"/>
           </group>
         </else-if>
-        <else-if type="chapter paper-conference" match="any">
+        <else-if type="chapter paper-conference entry-dictionary entry-encyclopedia" match="any">
           <group delimiter="; ">
             <text macro="book-container"/>
             <text macro="editor"/>

--- a/american-chemical-society-with-titles.csl
+++ b/american-chemical-society-with-titles.csl
@@ -198,7 +198,20 @@
             <text variable="container-title" font-style="italic" form="short"/>
             <group delimiter=", ">
               <text macro="issued" font-weight="bold"/>
-              <text variable="volume" font-style="italic"/>
+              <choose>
+                <if variable="volume">
+                  <group delimiter=" ">
+                    <text variable="volume" font-style="italic"/>
+                    <text variable="issue" prefix="(" suffix=")"/>
+                  </group>
+                </if>
+                <else-if variable="issue">
+                  <group delimiter=" ">
+                    <text term="issue" form="short" text-case="capitalize-first"/>
+                    <text variable="issue"/>
+                  </group>
+                </else-if>
+              </choose>
               <text variable="page"/>
             </group>
           </group>

--- a/american-chemical-society.csl
+++ b/american-chemical-society.csl
@@ -20,11 +20,33 @@
     <updated>2012-09-27T22:06:38+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
+  <locale xml:lang="en">
+    <terms>
+      <term name="editortranslator" form="short">
+        <single>ed. and translator</single>
+        <multiple>eds. and translators</multiple>
+      </term>
+      <term name="translator" form="short">
+        <single>translator</single>
+        <multiple>translators</multiple>
+      </term>
+      <term name="collection-editor" form="short">
+        <single>series ed.</single>
+        <multiple>series eds.</multiple>
+      </term>
+    </terms>
+  </locale>
   <macro name="editor">
-    <names variable="editor">
-      <name sort-separator=", " initialize-with=". " name-as-sort-order="all" delimiter=", " delimiter-precedes-last="always"/>
-      <label form="short" prefix=", " text-case="capitalize-first"/>
-    </names>
+    <group delimiter="; ">
+      <names variable="editor translator" delimiter="; ">
+        <name sort-separator=", " initialize-with=". " name-as-sort-order="all" delimiter=", " delimiter-precedes-last="always"/>
+        <label form="short" prefix=", " text-case="title"/>
+      </names>
+      <names variable="collection-editor">
+        <name sort-separator=", " initialize-with=". " name-as-sort-order="all" delimiter=", " delimiter-precedes-last="always"/>
+        <label form="short" prefix=", " text-case="title"/>
+      </names>
+    </group>
   </macro>
   <macro name="author">
     <names variable="author" suffix=".">

--- a/american-chemical-society.csl
+++ b/american-chemical-society.csl
@@ -182,7 +182,20 @@
             <text variable="container-title" font-style="italic" form="short"/>
             <group delimiter=", ">
               <text macro="issued" font-weight="bold"/>
-              <text variable="volume" font-style="italic"/>
+             <choose>
+                <if variable="volume">
+                  <group delimiter=" ">
+                    <text variable="volume" font-style="italic"/>
+                    <text variable="issue" prefix="(" suffix=")"/>
+                  </group>
+                </if>
+                <else-if variable="issue">
+                  <group delimiter=" ">
+                    <text term="issue" form="short" text-case="capitalize-first"/>
+                    <text variable="issue"/>
+                  </group>
+                </else-if>
+              </choose>
               <text variable="page"/>
             </group>
           </group>

--- a/american-chemical-society.csl
+++ b/american-chemical-society.csl
@@ -53,7 +53,11 @@
   </macro>
   <macro name="book-container">
     <group delimiter=" ">
-      <text term="in" text-case="capitalize-first"/>
+      <choose>
+        <if type="entry-dictionary entry-encyclopedia" match="none">
+          <text term="in" text-case="capitalize-first"/>
+        </if>
+      </choose>
       <text variable="container-title" font-style="italic"/>
     </group>
   </macro>
@@ -151,7 +155,7 @@
             <date variable="issued" form="text"/>
           </group>
         </else-if>
-        <else-if type="chapter paper-conference" match="any">
+        <else-if type="chapter paper-conference entry-dictionary entry-encyclopedia" match="any">
           <group delimiter="; ">
             <text macro="book-container"/>
             <text macro="editor"/>


### PR DESCRIPTION
Fixes:
* Include issue number for journal articles.
* Format encyclopedia and dictionary articles correctly.

These, with the references in the commit messages, should be self-explanatory.

Change:
* Include translators and series editors.

Translators are mentioned in the "miscellaneous information" section in the manual as "additional information about a book that is important for the reader to know". Collection editors aren't specifically mentioned, but they would go here, too.