### PR TITLE
Sort bibliography, as citations:  date descending

### DIFF
--- a/elsevier-harvard.csl
+++ b/elsevier-harvard.csl
@@ -221,7 +221,7 @@
   <bibliography hanging-indent="true" entry-spacing="0" line-spacing="1">
     <sort>
       <key macro="author"/>
-      <key macro="issued" sort="ascending"/>
+      <key macro="issued" sort="descending"/>
     </sort>
     <layout>
       <group suffix=".">


### PR DESCRIPTION
As reported in email from Carsten Allefeld.