### PR TITLE
Update society-for-general-microbiology.csl

### DIFF
--- a/society-for-general-microbiology.csl
+++ b/society-for-general-microbiology.csl
@@ -172,13 +172,17 @@
     </group>
   </macro>
   <macro name="container-title">
-    <choose>
-      <if type="chapter paper-conference" match="any">
-        <text term="in" text-case="capitalize-first" suffix=" "/>
-      </if>
-    </choose>
-    <text variable="container-title" font-style="italic" form="short" strip-periods="true"/>
-    <text variable="collection-title" prefix=", "/>
+    <group>
+      <choose>
+        <if type="chapter paper-conference" match="any">
+          <text term="in" text-case="capitalize-first" suffix=" "/>
+        </if>
+      </choose>
+      <group delimiter=", ">
+        <text variable="container-title" font-style="italic" form="short" strip-periods="true"/>
+        <text variable="collection-title"/>
+      </group>
+    </group>
   </macro>
   <macro name="key-creators">
     <names variable="author">


### PR DESCRIPTION
 * use a group for container-title, collection-title to correct errornous comma when no container-title is present (see https://forums.zotero.org/discussion/47569/microbiology-journal-book-series-issue/ ) 
 * use another group to avoid to output "in " when containter-title and collection-title are missing