### PR TITLE
Fix interpunctation in biological-psychiatry.csl

### DIFF
--- a/biological-psychiatry.csl
+++ b/biological-psychiatry.csl
@@ -28,14 +28,14 @@
     <category field="medicine"/>
     <issn>0006-3223</issn>
     <eissn>1873-2402</eissn>
-    <updated>2012-10-18T22:38:43+00:00</updated>
+    <updated>2015-03-18T20:24:20+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <macro name="container-contributors">
     <choose>
       <if type="chapter paper-conference" match="any">
         <text term="in" text-case="capitalize-first" suffix=": "/>
-        <names variable="editor translator" suffix=". ">
+        <names variable="editor translator">
           <name sort-separator=" " initialize-with="" name-as-sort-order="all" delimiter=", " delimiter-precedes-last="always"/>
           <label form="long" prefix=", "/>
           <et-al font-style="italic"/>
@@ -46,9 +46,9 @@
   <macro name="secondary-contributors">
     <choose>
       <if type="chapter paper-conference" match="none">
-        <names variable="editor translator" delimiter=", " prefix=" (" suffix=")">
+        <names variable="editor translator" delimiter=", ">
           <name and="symbol" initialize-with=". " delimiter=", "/>
-          <label form="long" prefix=", " suffix="."/>
+          <label prefix=", "/>
           <et-al font-style="italic"/>
         </names>
       </if>
@@ -98,8 +98,8 @@
   <macro name="title">
     <choose>
       <if type="bill book graphic legal_case legislation motion_picture report song thesis" match="any">
-        <group suffix=". " delimiter=", ">
-          <text variable="title" font-style="italic" suffix=". "/>
+        <group delimiter=", ">
+          <text variable="title" font-style="italic"/>
           <text macro="edition"/>
         </group>
       </if>
@@ -109,24 +109,21 @@
     </choose>
   </macro>
   <macro name="publisher">
-    <text variable="genre" suffix=", "/>
     <group delimiter=": ">
       <text variable="publisher-place"/>
       <text variable="publisher"/>
     </group>
   </macro>
   <macro name="event">
-    <choose>
-      <if variable="event">
-        <text term="presented at" text-case="capitalize-first" suffix=" "/>
-        <text variable="event"/>
-      </if>
-    </choose>
+    <group delimiter=" ">
+      <text term="presented at" text-case="capitalize-first"/>
+      <text variable="event"/>
+    </group>
   </macro>
   <macro name="issued">
     <choose>
       <if variable="issued">
-        <group prefix=" (" suffix=")">
+        <group>
           <date variable="issued">
             <date-part name="year"/>
           </date>
@@ -141,7 +138,7 @@
         </group>
       </if>
       <else>
-        <text prefix=" (" term="no date" suffix=")." form="short"/>
+        <text term="no date" form="short"/>
       </else>
     </choose>
   </macro>
@@ -154,31 +151,14 @@
         </group>
       </if>
       <else>
-        <text variable="edition" suffix="."/>
+        <text variable="edition"/>
       </else>
     </choose>
   </macro>
   <macro name="locators">
     <choose>
-      <if type="article-journal article-magazine article-newspaper" match="any">
-        <group prefix=" " suffix=": " delimiter=", ">
-          <group>
-            <text variable="volume"/>
-          </group>
-        </group>
-      </if>
-      <else-if type="bill book chapter graphic legal_case legislation motion_picture paper-conference report song" match="any">
-        <group prefix=" (" suffix=") " delimiter=", ">
-          <group>
-            <text term="volume" form="short" plural="true" text-case="capitalize-first" suffix=" "/>
-            <number variable="number-of-volumes" form="numeric" prefix="1-"/>
-          </group>
-          <group>
-            <text term="volume" form="short" text-case="capitalize-first" suffix=" "/>
-            <number variable="volume" form="numeric"/>
-          </group>
-        </group>
-      </else-if>
+      <if type="article-journal article-magazine article-newspaper" match="any"/>
+      <else-if type="bill book chapter graphic legal_case legislation motion_picture paper-conference report song" match="any"/>
     </choose>
   </macro>
   <macro name="pages">
@@ -187,8 +167,8 @@
         <text variable="page"/>
       </if>
       <else-if type="bill book chapter graphic legal_case legislation motion_picture paper-conference report song" match="any">
-        <group>
-          <label variable="page" form="short" prefix=", " suffix=" " strip-periods="true"/>
+        <group delimiter=" ">
+          <label strip-periods="true" variable="page" form="short"/>
           <text variable="page"/>
         </group>
       </else-if>
@@ -209,12 +189,12 @@
     <layout suffix=".">
       <text variable="citation-number" suffix=". "/>
       <text macro="author"/>
-      <text macro="issued" suffix=": "/>
-      <group delimiter=". ">
+      <text macro="issued" prefix=" (" suffix="): "/>
+      <group delimiter=". " suffix=". ">
         <text macro="title"/>
-        <group>
-          <text macro="container-contributors"/>
-          <text macro="secondary-contributors"/>
+        <group delimiter=" ">
+          <text macro="container-contributors" suffix="."/>
+          <text macro="secondary-contributors" prefix="(" suffix=")"/>
           <group delimiter=", ">
             <text variable="container-title" font-style="italic" form="short" strip-periods="true"/>
             <choose>
@@ -226,15 +206,33 @@
           </group>
         </group>
       </group>
-      <text macro="locators"/>
-      <group>
-        <group delimiter=", ">
-          <text macro="event"/>
-          <text macro="publisher"/>
-        </group>
-        <text macro="pages"/>
-        <text macro="access" prefix=". "/>
-      </group>
+      <choose>
+        <if type="article article-journal article-magazine article-newspaper" match="any">
+          <group delimiter=": " prefix=" ">
+            <text variable="volume"/>
+            <text macro="pages"/>
+          </group>
+        </if>
+        <else>
+          <group delimiter=", " prefix=" ">
+            <group delimiter=", " prefix="(" suffix=")">
+              <group>
+                <text term="volume" form="short" plural="true" text-case="capitalize-first" suffix=" "/>
+                <number variable="number-of-volumes" form="numeric" prefix="1-"/>
+              </group>
+              <group>
+                <text term="volume" form="short" text-case="capitalize-first" suffix=" "/>
+                <number variable="volume" form="numeric"/>
+              </group>
+            </group>
+            <text macro="event"/>
+            <text variable="genre"/>
+            <text macro="publisher"/>
+            <text macro="pages"/>
+          </group>
+        </else>
+      </choose>
+      <text macro="access" prefix=". "/>
     </layout>
   </bibliography>
 </style>

--- a/biological-psychiatry.csl
+++ b/biological-psychiatry.csl
@@ -155,12 +155,6 @@
       </else>
     </choose>
   </macro>
-  <macro name="locators">
-    <choose>
-      <if type="article-journal article-magazine article-newspaper" match="any"/>
-      <else-if type="bill book chapter graphic legal_case legislation motion_picture paper-conference report song" match="any"/>
-    </choose>
-  </macro>
   <macro name="pages">
     <choose>
       <if type="article-journal" match="any">


### PR DESCRIPTION
This should now work smoothly w.r.t. to the interpunctations. However, the style guid is not covering every case and in the discipline normally only journal articles are cited. Therefore I tried to be consistent with everything I saw and add the rest as it seems to fit into the style. Moreover, I tried to take as the interpunctions outside the macros whenever possible.( Problems with interpuncations were reported: https://forums.zotero.org/discussion/47615/style-error-biological-psychiatry/#Item_2 )