### PR TITLE
Update university-college-lillebaelt-harvard.csl

### DIFF
--- a/university-college-lillebaelt-harvard.csl
+++ b/university-college-lillebaelt-harvard.csl
@@ -31,11 +31,6 @@
               <date-part name="year"/>
             </date>
           </if>
-          <else>
-            <date variable="issued">
-              <date-part name="year"/>
-            </date>
-          </else>
         </choose>
       </if>
       <else>
@@ -53,7 +48,7 @@
       <date-part name="year"/>
     </date>
   </macro>
-  <!--                                                  SORTING MACRO -->
+<!--                                                  SORTING MACRO -->
   <macro name="alphabeticize">
     <names variable="author">
       <name name-as-sort-order="all" initialize-with="."/>
@@ -76,7 +71,7 @@
     <choose>
       <if is-numeric="locator">
         <label variable="locator" form="short"/>
-        <text variable="locator"/>
+        <text variable="locator" prefix=" "/>
       </if>
       <else>
         <text variable="locator"/>
@@ -119,7 +114,7 @@
       <name name-as-sort-order="all" initialize-with="." and="symbol"/>
       <label form="short" prefix=" " suffix="."/>
       <substitute>
-        <names variable="editor"/>
+        <names variable="editor"></names>
       </substitute>
     </names>
   </macro>
@@ -137,7 +132,14 @@
   <macro name="medium">
     <choose>
       <if variable="genre">
-        <text variable="genre" prefix=" [" suffix="]"/>
+        <group prefix=" " delimiter=", ">
+          <text variable="genre" prefix="[" suffix="]"/>
+          <choose>
+            <if variable="URL">
+              <text term="online" text-case="capitalize-first" prefix="[" suffix="]"/>
+            </if>
+          </choose>
+        </group>
       </if>
       <else-if variable="URL">
         <text term="online" text-case="capitalize-first" prefix=" [" suffix="]"/>
@@ -150,7 +152,7 @@
         <text term="in" suffix=" "/>
         <group delimiter=". ">
           <names variable="editor" delimiter=", ">
-            <name initialize-with="."/>
+            <name initialize-with="."></name>
             <label form="short" prefix=" "/>
           </names>
           <date variable="issued">
@@ -217,13 +219,14 @@
     </group>
   </macro>
   <macro name="access">
-    <text term="available at" text-case="capitalize-first" suffix=": "/>
-    <text variable="URL"/>
     <choose>
-      <if variable="accessed">
-        <text term="accessed" text-case="capitalize-first" prefix=" [" suffix=" "/>
-        <date variable="accessed" form="numeric" suffix="]">
-        </date>
+      <if variable="URL">
+        <text term="available at" text-case="capitalize-first" suffix=": "></text>
+        <text variable="URL" text-decoration="underline"></text>
+        <group prefix=" [" suffix="]" delimiter=" ">
+          <text term="accessed" text-case="capitalize-first"/>
+          <date variable="accessed" form="numeric"/>
+        </group>
       </if>
     </choose>
   </macro>


### PR DESCRIPTION
Small corrections:
In macro 'access': underline URLs and suppress 'available at'-term when there's no URL.
In macro 'medium': add 'Online' term (if applicable) after genre.
In macro 'issued': remove repetition of issued year.