### PR TITLE
Fix for editor translator in container-contributors & secondary-contributors macros

### DIFF
--- a/apa.csl
+++ b/apa.csl
@@ -45,20 +45,32 @@
   <macro name="container-contributors">
     <choose>
       <if type="chapter paper-conference entry-dictionary entry-encyclopedia" match="any">
-        <names variable="editor translator container-author" delimiter=", " suffix=", ">
-          <name and="symbol" initialize-with=". " delimiter=", "/>
-          <label form="short" prefix=" (" text-case="title" suffix=")"/>
-        </names>
+        <group delimiter=", " suffix=", ">
+          <names variable="container-author" delimiter=", ">
+            <name and="symbol" initialize-with=". " delimiter=", "/>
+            <label form="short" prefix=" (" text-case="title" suffix=")"/>
+          </names>
+          <names variable="editor translator" delimiter=", ">
+            <name and="symbol" initialize-with=". " delimiter=", "/>
+            <label form="short" prefix=" (" text-case="title" suffix=")"/>
+          </names>
+        </group>
       </if>
     </choose>
   </macro>
   <macro name="secondary-contributors">
     <choose>
       <if type="article-journal chapter paper-conference entry-dictionary entry-encyclopedia" match="none">
-        <names variable="translator editor container-author" delimiter=", " prefix=" (" suffix=")">
-          <name and="symbol" initialize-with=". " delimiter=", "/>
-          <label form="short" prefix=", " text-case="title"/>
-        </names>
+        <group delimiter=", " prefix=" (" suffix=")">
+          <names variable="container-author" delimiter=", ">
+            <name and="symbol" initialize-with=". " delimiter=", "/>
+            <label form="short" prefix=", " text-case="title"/>
+          </names>
+          <names variable="editor translator" delimiter=", ">
+            <name and="symbol" initialize-with=". " delimiter=", "/>
+            <label form="short" prefix=", " text-case="title"/>
+          </names>
+        </group>
       </if>
     </choose>
   </macro>
@@ -158,7 +170,7 @@
   </macro>
   <macro name="title">
     <choose>
-      <if type="report thesis book graphic motion_picture report song manuscript speech" match="any">
+      <if type="book graphic manuscript motion_picture report song speech thesis" match="any">
         <choose>
           <if variable="version" type="book" match="all">
             <!---This is a hack until we have a computer program type -->


### PR DESCRIPTION
Similar issue to the one discussed in https://github.com/citation-style-language/styles/pull/1465.
Not quite sure about the format here, though. Common sense would suggest author(s) come before editor(s) and translator(s) – but how are authors separated then from editors/translators in the output? Couldn't find any example in the manual.