### PR TITLE
Avoid capitalization of unneeded words.

### DIFF
--- a/chicago-author-date.csl
+++ b/chicago-author-date.csl
@@ -401,7 +401,7 @@
     </choose>
     <choose>
       <if type="legal_case" match="none">
-        <text variable="container-title" text-case="title" font-style="italic"/>
+        <text variable="container-title" font-style="italic"/>
       </if>
     </choose>
   </macro>


### PR DESCRIPTION
This PR removes the ``text-case="title"`` for the title container macro in order to avoid capitalizing unneeded words, for example "Journal of Political Economy" should not be "Journal Of Political Economy" (the "of" should be left as is.