### PR TITLE
Update systematic-and-applied-microbiology.csl

### DIFF
--- a/systematic-and-applied-microbiology.csl
+++ b/systematic-and-applied-microbiology.csl
@@ -112,14 +112,14 @@
     </choose>
   </macro>
   <citation collapse="citation-number">
-    <sort>
-      <key variable="citation-number" sort="ascending"/>
-    </sort>
     <layout delimiter="," prefix="[" suffix="]">
       <text variable="citation-number"/>
     </layout>
   </citation>
   <bibliography entry-spacing="0" second-field-align="flush">
+    <sort>
+      <key variable="author"/>
+    </sort>  
     <layout suffix=".">
       <text variable="citation-number" prefix="[" suffix="]"/>
       <text macro="author" suffix=" "/>


### PR DESCRIPTION
removed the sorting node from under ‘Inline Citations’ and added a new Sort node under ‘Bibliography’ header specifying 'author'