### PR TITLE
Update harvard-cape-peninsula-university-of-technology.csl

### DIFF
--- a/harvard-cape-peninsula-university-of-technology.csl
+++ b/harvard-cape-peninsula-university-of-technology.csl
@@ -109,8 +109,8 @@
   <citation et-al-min="3" et-al-use-first="1" disambiguate-add-year-suffix="true" disambiguate-add-names="true" disambiguate-add-givenname="true">
     <layout prefix="(" suffix=")" delimiter="; ">
       <group>
-        <text macro="author-short"/>
-        <text macro="year-date" prefix=", "/>
+        <text macro="author-short" suffix=", "/>
+        <text macro="year-date"/>
       </group>
       <group>
         <choose>

--- a/harvard-cape-peninsula-university-of-technology.csl
+++ b/harvard-cape-peninsula-university-of-technology.csl
@@ -109,8 +109,10 @@
   <citation et-al-min="3" et-al-use-first="1" disambiguate-add-year-suffix="true" disambiguate-add-names="true" disambiguate-add-givenname="true">
     <layout prefix="(" suffix=")" delimiter="; ">
       <group>
-        <text macro="author-short" suffix=", "/>
-        <text macro="year-date"/>
+        <group delimiter=", "/>
+          <text macro="author-short"/>
+          <text macro="year-date"/>
+        </group>
       </group>
       <group>
         <choose>


### PR DESCRIPTION
moved the comma-space to the suffix of the in-text author, instead of a prefix to the year.