### PR TITLE
Patch 1

### DIFF
--- a/wiley-vch-books.csl
+++ b/wiley-vch-books.csl
@@ -1,10 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
-<style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" demote-non-dropping-particle="sort-only" default-locale="en-US">
+<style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" demote-non-dropping-particle="sort-only">
+<!--style class="in-text" version="1.0" and="text" delimiter-precedes-et-al="always" delimiter-precedes-last="always" et-al-min="5" et-al-use-first="3" initialize-with="." name-as-sort-order="all" demote-non-dropping-particle="never" default-locale="en" xmlns="http://purl.org/net/xbiblio/csl" -->
+<!-- This style was edited with the Visual CSL Editor (http://editor.citationstyles.org/visualEditor/) -->
   <info>
     <title>Wiley-VCH books</title>
     <id>http://www.zotero.org/styles/wiley-vch-books</id>
     <link href="http://www.zotero.org/styles/wiley-vch-books" rel="self"/>
-    <link href="http://www.zotero.org/styles/ieee" rel="template"/>
     <link href="http://www.wiley-vch.de/publish/en/authors/auguidelines" rel="documentation"/>
     <author>
       <name>Maksim Ivanov</name>
@@ -13,7 +14,7 @@
     <category citation-format="numeric"/>
     <category field="engineering"/>
     <category field="generic-base"/>
-    <updated>2014-10-21T16:33:45</updated>
+    <updated>2015-04-04T21:18:21+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale xml:lang="en">
@@ -23,290 +24,89 @@
       <term name="available at">available</term>
     </terms>
   </locale>
-  <!-- Macros -->
-  <macro name="edition">
-    <choose>
-      <if type="bill book chapter graphic legal_case legislation motion_picture paper-conference report song" match="any">
-        <choose>
-          <if is-numeric="edition">
-            <group delimiter=" ">
-              <number variable="edition" form="ordinal"/>
-              <text term="edition" form="short"/>
-            </group>
-          </if>
-          <else>
-            <text variable="edition" text-case="capitalize-first" suffix="."/>
-          </else>
-        </choose>
-      </if>
-    </choose>
-  </macro>
-  <macro name="issued">
-    <choose>
-      <if type="article-journal report" match="any">
-        <date variable="issued">
-          <!--date-part name="month" form="short" suffix=" "/-->
-          <date-part name="year" form="long" prefix="(" suffix=")"/>
-        </date>
-      </if>
-      <else-if type=" bill book chapter graphic legal_case legislation motion_picture paper-conference song thesis" match="any">
-        <date variable="issued">
-          <date-part name="year" form="long"/>
-        </date>
-      </else-if>
-      <else>
-        <date variable="issued">
-          <date-part name="day" form="numeric-leading-zeros" suffix="-"/>
-          <date-part name="month" form="short" suffix="-" strip-periods="true"/>
-          <date-part name="year" form="long"/>
-        </date>
-      </else>
-    </choose>
-  </macro>
-  <macro name="author">
-    <names variable="author">
-      <name initialize-with=". " delimiter=", " and="text"/>
-      <label form="short" prefix=", " text-case="capitalize-first"/>
+  <macro name="authors">
+    <names variable="author" delimiter=", ">
+      <name/>
+      <label form="short" text-case="lowercase" prefix=" (" suffix=")"/>
       <substitute>
-        <names variable="editor"/>
-        <names variable="translator"/>
+        <names variable="editor translator recipient">
+          <name/>
+        </names>
       </substitute>
     </names>
-  </macro>
-  <macro name="editor">
-    <names variable="editor">
-      <name initialize-with=". " delimiter=", " and="text"/>
-      <label form="short" prefix=" (" suffix=")" text-case="capitalize-first"/>
-    </names>
-  </macro>
-  <macro name="locators">
-    <group delimiter=", ">
-      <text macro="edition"/>
-      <number variable="volume" font-weight="bold" form="numeric"/>
-      <number variable="issue" form="numeric"/>
-    </group>
-  </macro>
-  <macro name="title">
-    <choose>
-      <if type="bill book graphic legal_case legislation motion_picture song" match="any">
-        <text variable="title" font-style="italic"/>
-      </if>
-      <else>
-        <text variable="title" quotes="true"/>
-      </else>
-    </choose>
-  </macro>
-  <macro name="publisher">
-    <choose>
-      <if type=" bill book chapter graphic legal_case legislation motion_picture paper-conference song" match="any">
-        <group delimiter=": ">
-          <text variable="publisher-place"/>
-          <text variable="publisher"/>
-        </group>
-      </if>
-      <else>
-        <group delimiter=", ">
-          <text variable="publisher"/>
-          <text variable="publisher-place"/>
-        </group>
-      </else>
-    </choose>
-  </macro>
-  <macro name="event">
-    <choose>
-      <if type="paper-conference speech" match="any">
-        <choose>
-          <!-- Published Conference Paper -->
-          <if variable="container-title">
-            <group delimiter=", ">
-              <group delimiter=" ">
-                <text term="in"/>
-                <text variable="container-title" font-style="italic"/>
-              </group>
-              <text variable="event-place"/>
-            </group>
-          </if>
-          <!-- Unpublished Conference Paper -->
-          <else>
-            <group delimiter=", ">
-              <group delimiter=" ">
-                <text term="presented at"/>
-                <text variable="event"/>
-              </group>
-              <text variable="event-place"/>
-            </group>
-          </else>
-        </choose>
-      </if>
-    </choose>
-  </macro>
-  <macro name="access">
-    <choose>
-      <if type="webpage">
-        <choose>
-          <if variable="URL">
-            <group delimiter=". ">
-              <text term="online" prefix="[" suffix="]" text-case="capitalize-first"/>
-              <group delimiter=": ">
-                <text term="available at" text-case="capitalize-first"/>
-                <text variable="URL"/>
-              </group>
-              <group prefix="[" suffix="]" delimiter=": ">
-                <text term="accessed" text-case="capitalize-first"/>
-                <date variable="accessed">
-                  <date-part name="day" form="numeric-leading-zeros" suffix="-"/>
-                  <date-part name="month" form="short" suffix="-" strip-periods="true"/>
-                  <date-part name="year" form="long"/>
-                </date>
-              </group>
-            </group>
-          </if>
-        </choose>
-      </if>
-    </choose>
-  </macro>
-  <macro name="page">
-    <group>
-      <!--label variable="page" form="short" suffix=" "/ -->
-      <text variable="page"/>
-    </group>
   </macro>
   <macro name="citation-locator">
     <group delimiter=" ">
       <choose>
-        <if locator="page">
+        <if match="any" locator="page">
           <label variable="locator" form="short"/>
         </if>
         <else>
-          <label variable="locator" form="short" text-case="capitalize-first"/>
+          <label text-case="capitalize-first" variable="locator" form="short"/>
         </else>
       </choose>
       <text variable="locator"/>
     </group>
   </macro>
-  <!-- Citation -->
   <citation collapse="citation-number">
-    <sort>
-      <key variable="citation-number"/>
-    </sort>
-    <layout prefix="[" suffix="]" delimiter=", ">
-      <group delimiter=", ">
-        <text variable="citation-number"/>
-        <text macro="citation-locator"/>
-      </group>
+    <layout delimiter="," prefix="[" suffix="]">
+      <text variable="citation-number" text-case="lowercase" strip-periods="false" font-weight="normal"/>
+      <text macro="citation-locator" prefix=", "/>
     </layout>
   </citation>
-  <!-- Bibliography -->
-  <bibliography entry-spacing="0" second-field-align="flush">
+  <bibliography second-field-align="flush" entry-spacing="0">
     <layout suffix=".">
-      <!-- Citation Number -->
-      <text variable="citation-number" prefix="" suffix="."/>
-      <!-- Author(s) -->
-      <text macro="author" suffix=", "/>
-      <!-- Rest of Citation -->
+      <text variable="citation-number" suffix="."/>
+      <text macro="authors"/>
       <choose>
-        <!-- Specific Formats -->
-        <if type="article-journal">
-          <group delimiter=", ">
-            <text macro="title"/>
-            <text variable="container-title" font-style="italic" form="short"/>
-            <text macro="locators"/>
-            <group delimiter=" ">
-              <text macro="page"/>
-              <text macro="issued"/>
-            </group>
-          </group>
+        <if match="all" is-uncertain-date="issued accessed original-date container">
+          <text term="in press" prefix=" (" suffix=")"/>
         </if>
-        <else-if type="paper-conference speech" match="any">
-          <group delimiter=", ">
-            <text macro="title"/>
-            <text macro="event"/>
-            <text macro="locators"/>
-            <text macro="page"/>
-            <text macro="issued"/>
-          </group>
+        <else>
+          <date date-parts="year" form="text" variable="issued" prefix=" (" suffix=")"/>
+        </else>
+      </choose>
+      <choose>
+        <if type="article-journal" match="any">
+          <text variable="title" prefix=" " suffix="."/>
+          <text variable="container-title" form="short" font-style="italic" prefix=" "/>
+          <text variable="volume" font-weight="bold" prefix=" "/>
+          <text variable="issue" form="short" font-weight="normal" prefix=" (" suffix=")"/>
+          <text variable="page" prefix=", "/>
+        </if>
+        <else-if type="book" match="any">
+          <text variable="title" font-style="italic" prefix=" "/>
+          <text variable="publisher" prefix=", "/>
+          <text variable="publisher-place" prefix=", "/>
         </else-if>
-        <else-if type="report">
-          <group delimiter=", ">
-            <text macro="title"/>
-            <text macro="publisher"/>
-            <group delimiter=" ">
-              <text variable="genre"/>
-              <text variable="number"/>
-            </group>
-            <text macro="issued"/>
-          </group>
-        </else-if>
-        <else-if type="thesis">
-          <group delimiter=", ">
-            <text macro="title"/>
-            <text variable="genre"/>
-            <text macro="publisher"/>
-            <text macro="issued"/>
-          </group>
-        </else-if>
-        <else-if type="webpage post-weblog" match="any">
-          <group delimiter=", " suffix=". ">
-            <text macro="title"/>
-            <text variable="container-title" font-style="italic"/>
-            <text macro="issued"/>
-          </group>
-          <text macro="access"/>
-        </else-if>
-        <else-if type="patent">
-          <text macro="title" suffix=", "/>
-          <text variable="number"/>
-          <text macro="issued"/>
-        </else-if>
-        <!-- Generic/Fallback Formats -->
-        <else-if type="bill book graphic legal_case legislation motion_picture report song" match="any">
-          <group delimiter=", " suffix=". ">
-            <text macro="title"/>
-            <text macro="locators"/>
-          </group>
-          <group delimiter=", ">
-            <text macro="publisher"/>
-            <text macro="page"/>
-            <text macro="issued"/>
-          </group>
-        </else-if>
-        <else-if type="article-magazine article-newspaper broadcast interview manuscript map patent personal_communication song speech thesis webpage" match="any">
-          <group delimiter=", ">
-            <text macro="title"/>
-            <text variable="container-title" font-style="italic"/>
-            <text macro="locators"/>
-            <text macro="publisher"/>
-            <text macro="page"/>
-            <text macro="issued"/>
-          </group>
-        </else-if>
-        <else-if type="chapter paper-conference" match="any">
-          <group delimiter=", " suffix=", ">
-            <text macro="title"/>
-            <group delimiter=" ">
-              <text term="in"/>
-              <text variable="container-title" font-style="italic"/>
-            </group>
-            <text macro="locators"/>
-          </group>
-          <text macro="editor" suffix=", "/>
-          <group delimiter=", ">
-            <text macro="page"/>
-            <text macro="publisher"/>
-            <text macro="issued"/>
-          </group>
+        <else-if type="chapter" match="any">
+          <text variable="title" prefix=" "/>
+          <text variable="container-title" font-style="italic" prefix=", in "/>
+          <choose>
+            <if match="any" is-numeric="volume">
+              <text variable="volume" form="short" prefix=", vol. "/>
+            </if>
+            <else-if match="any" is-numeric="edition">
+              <text variable="edition" form="short" prefix=", "/>
+              <text term="edition" form="short"/>
+            </else-if>
+          </choose>
+          <text variable="publisher" prefix=", "/>
+          <text variable="publisher-place" prefix=", "/>
+          <choose>
+            <if match="any" variable="page">
+              <text term="page" form="short" plural="true" prefix=", " suffix=" "/>
+              <text variable="page"/>
+            </if>
+          </choose>
         </else-if>
         <else>
-          <group delimiter=", " suffix=". ">
-            <text macro="title"/>
-            <text variable="container-title" font-style="italic"/>
-            <text macro="locators"/>
-          </group>
-          <group delimiter=", ">
-            <text macro="publisher"/>
-            <text macro="page"/>
-            <text macro="issued"/>
-          </group>
+          <text variable="title" quotes="true" prefix=" "/>
+          <text variable="container-title" form="short" font-style="italic" prefix=", "/>
+          <text variable="number" prefix=", "/>
+          <text variable="volume" prefix=" "/>
+          <text variable="issue" font-weight="bold" prefix=" (" suffix=")"/>
+          <text variable="page" prefix=", "/>
         </else>
       </choose>
     </layout>

--- a/wiley-vch-books.csl
+++ b/wiley-vch-books.csl
@@ -29,9 +29,9 @@
       <name/>
       <label form="short" text-case="lowercase" prefix=" (" suffix=")"/>
       <substitute>
-        <names variable="editor translator recipient">
-          <name/>
-        </names>
+        <names variable="editor"/>
+        <names variable="translator"/>
+        <names variable="recipient"/>
       </substitute>
     </names>
   </macro>


### PR DESCRIPTION
Unfortunately, the previous version was not conforming the instructions on citation style by Wiley. As it is not based on any template now, it supports articles, books and chapters well, everything else uses fall-back style, which is based on article. But I have no examples to check how it works. On the other hand, it supports the most important types of references.

Hopefully it is fine now.