### PR TITLE
Fix for items with both title and reviewed-title

### DIFF
--- a/chicago-author-date.csl
+++ b/chicago-author-date.csl
@@ -24,7 +24,7 @@
     <category citation-format="author-date"/>
     <category field="generic-base"/>
     <summary>The author-date variant of the Chicago style</summary>
-    <updated>2015-03-29T10:53:00+00:00</updated>
+    <updated>2015-04-06T20:30:00+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale xml:lang="en">
@@ -207,13 +207,29 @@
         </group>
       </else-if>
       <else-if variable="reviewed-author">
-        <group delimiter=", ">
-          <text variable="title" font-style="italic" prefix="Review of "/>
-          <names variable="reviewed-author">
-            <label form="verb-short" text-case="lowercase" suffix=" "/>
-            <name and="text" delimiter=", "/>
-          </names>
-        </group>
+        <choose>
+          <if variable="reviewed-title">
+            <group delimiter=". ">
+              <text variable="title" text-case="title" quotes="true"/>
+              <group delimiter=", ">
+                <text variable="reviewed-title" font-style="italic" prefix="Review of "/>
+                <names variable="reviewed-author">
+                  <label form="verb-short" text-case="lowercase" suffix=" "/>
+                  <name and="text" delimiter=", "/>
+                </names>
+              </group>
+            </group>
+          </if>
+          <else>
+            <group delimiter=", ">
+              <text variable="title" font-style="italic" prefix="Review of "/>
+              <names variable="reviewed-author">
+                <label form="verb-short" text-case="lowercase" suffix=" "/>
+                <name and="text" delimiter=", "/>
+              </names>
+            </group>
+          </else>
+        </choose>
       </else-if>
       <else-if type="legal_case interview" match="any">
         <text variable="title"/>
@@ -238,7 +254,7 @@
           </else>
         </choose>
       </if>
-      <else-if type="chapter  paper-conference" match="any">
+      <else-if type="chapter paper-conference" match="any">
         <choose>
           <if is-numeric="edition">
             <group delimiter=" " prefix=", ">


### PR DESCRIPTION
Adapted from the following example for the notes style (CMoS, 16e, 14.215 – there seem to be no such examples in ch. 15):
2. David Kamp, “Deconstructing Dinner,” review of *The Omnivore’s Dilemma: A Natural History of Four Meals*, by Michael Pollan, *New York Times*, April 23, 2006, Sunday Book Review, http://www.nytimes.com/2006/04/23/books/review/23kamp.html.
Logic: If there's a reviewed-author and a title only, assume the title is the title of the reviewed work. If there's a reviewed-author, a title, and a reviewed-title, assume the title is the title of the review, and reviewed-title is the title of the reviewed work.
This would of course work better if Zotero had a proper review item type, and if CSL had reviewed-editor, reviewed-director, etc., and supported entering more than one reviewed work, too.