### PR TITLE
Update australian-guide-to-legal-citation.csl

### DIFF
--- a/australian-guide-to-legal-citation.csl
+++ b/australian-guide-to-legal-citation.csl
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <style xmlns="http://purl.org/net/xbiblio/csl" class="note" version="1.0" demote-non-dropping-particle="sort-only" default-locale="en-GB">
-<!-- This style was edited with the Visual CSL Editor (http://editor.citationstyles.org/visualEditor/) -->
   <info>
     <title>Australian Guide to Legal Citation</title>
     <title-short>AGLC</title-short>
@@ -29,7 +28,7 @@
     <category citation-format="note"/>
     <category field="law"/>
     <summary>A modification of the Bluebook legal citation style for Australian conditions.</summary>
-    <updated>2015-04-09T06:46:12+00:00</updated>
+    <updated>2015-04-15T02:43:49+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale>
@@ -37,7 +36,9 @@
       <term name="et-al">et al</term>
     </terms>
   </locale>
+  <!--Authors and Persons-->
   <macro name="author-note">
+    <!--for bills & hearing this should start with jurisdiction once available-->
     <choose>
       <if type="interview">
         <group delimiter=", ">
@@ -120,6 +121,7 @@
     </choose>
   </macro>
   <macro name="author">
+    <!--for bills & hearing this should start with jurisdiction once available-->
     <choose>
       <if type="interview">
         <group delimiter=", ">
@@ -174,6 +176,7 @@
       </names>
     </group>
   </macro>
+  <!-- Titles -->
   <macro name="title">
     <choose>
       <if type="book legislation webpage thesis motion_picture manuscript" match="any">
@@ -183,7 +186,7 @@
         <text variable="title" text-case="title"/>
       </else-if>
       <else-if type="legal_case">
-        <text variable="title" strip-periods="true" font-style="italic"/>
+        <text variable="title" font-style="italic" strip-periods="true" />
       </else-if>
       <else>
         <text variable="title" quotes="true" text-case="title"/>
@@ -192,14 +195,15 @@
   </macro>
   <macro name="title-short">
     <choose>
-      <if type="book legislation webpage thesis motion_picture manuscript" match="any">
-        <text variable="title" font-style="italic" text-case="title" form="short"/>
+      <if type="book legislation webpage thesis motion_picture manuscript legal_case article" match="any">
+        <text variable="title-short" font-style="italic" text-case="title" form="short"/>
       </if>
       <else>
-        <text variable="title" form="short" text-case="title" quotes="false"/>
+        <text variable="title" quotes="false" text-case="title" form="short"/>
       </else>
     </choose>
   </macro>
+  <!--Dates-->
   <macro name="issued-year">
     <date variable="issued" form="text" date-parts="year"/>
   </macro>
@@ -221,6 +225,7 @@
             <text macro="issued-year" prefix="(" suffix=")"/>
           </if>
           <else-if variable="container-title volume number" match="any">
+            <!--no year in square brackets for unreported case w/o medium neutral citation-->
             <text macro="issued-year" prefix="[" suffix="]"/>
           </else-if>
         </choose>
@@ -236,6 +241,7 @@
       </else-if>
     </choose>
   </macro>
+  <!--publication info -->
   <macro name="publisher">
     <choose>
       <if type="book chapter paper-conference article-newspaper report legislation motion_picture speech interview thesis" match="any">
@@ -254,15 +260,18 @@
               <text variable="publisher-place"/>
             </if>
             <else-if type="legislation bill" match="any">
+              <!--this should be jurisdiction we use code instead-->
               <text variable="container-title"/>
             </else-if>
             <else>
+              <!--this won't work in Zotero yet, but does no harm -->
               <names variable="director">
                 <label form="verb" text-case="capitalize-first" suffix=" "/>
                 <name delimiter-precedes-last="never" and="text" delimiter=", " initialize="false" initialize-with=""/>
               </names>
               <text variable="publisher"/>
               <choose>
+                <!--if none of these, this we don't want edition either. Might be Loose-Leaf-->
                 <if variable="publisher issued genre container-title" match="any">
                   <text macro="edition"/>
                 </if>
@@ -360,6 +369,7 @@
                   <text variable="container-title" form="short"/>
                 </if>
                 <else-if variable="authority number" match="all">
+                  <!--Assume that only cases with a Medium Neutral Citation have a docket number -->
                   <group delimiter=" ">
                     <text variable="authority" form="short" strip-periods="true"/>
                     <text variable="number"/>
@@ -389,6 +399,7 @@
   <macro name="page-first">
     <text variable="page-first"/>
   </macro>
+  <!--Others -->
   <macro name="manuscript-catchall">
     <choose>
       <if type="manuscript">
@@ -421,6 +432,7 @@
         </choose>
       </else-if>
       <else-if type="manuscript">
+        <!--Manuscript here as a stand-in for Treaty. Not perfect -->
         <text value="4"/>
       </else-if>
       <else>
@@ -443,11 +455,20 @@
         <else-if position="subsequent">
           <choose>
             <if type="legal_case bill legislation manuscript" match="any">
+              <!--don't use short form and above note for legal citations -->
               <group delimiter=" ">
                 <group delimiter=", ">
                   <text macro="author-note"/>
-                  <text macro="title-short" font-style="italic"/>
+                  <choose>
+                    <if match="any" variable="title-short">
+                      <text macro="title-short"/>
+                    </if>
+                    <else>
+                      <text macro="title"/>
+                    </else>
+                  </choose>
                 </group>
+                <!-- we could work with title-short here-->
                 <group delimiter=" ">
                   <text macro="date-parenthesis"/>
                   <text macro="article-case-info"/>
@@ -478,6 +499,7 @@
           </choose>
         </else-if>
         <else>
+          <!--general whole citation -->
           <group delimiter=" ">
             <group delimiter=", ">
               <group delimiter=" ">
@@ -503,12 +525,12 @@
               </group>
               <text macro="page-first"/>
               <text variable="locator"/>
+              <choose>
+                <if type="legal_case bill legislation manuscript" match="any">
+                  <text macro="title-short" text-case="title" quotes="true" prefix=" (" suffix=")"/>
+                </if>
+              </choose>
             </group>
-            <choose>
-              <if type="legal_case bill legislation" match="any">
-                <text macro="title-short" quotes="true" font-style="italic" prefix=" (" suffix=")"/>
-              </if>
-            </choose>
             <text macro="URL"/>
           </group>
         </else>

--- a/australian-guide-to-legal-citation.csl
+++ b/australian-guide-to-legal-citation.csl
@@ -195,11 +195,11 @@
   </macro>
   <macro name="title-short">
     <choose>
-      <if type="book legislation webpage thesis motion_picture manuscript legal_case article" match="any">
-        <text variable="title-short" font-style="italic" text-case="title" form="short"/>
+      <if type="book legislation webpage thesis motion_picture manuscript legal_case" match="any">
+        <text variable="title-short" font-style="italic" text-case="title" />
       </if>
       <else>
-        <text variable="title" quotes="false" text-case="title" form="short"/>
+        <text variable="title" quotes="true" text-case="title" form="short"/>
       </else>
     </choose>
   </macro>

--- a/australian-guide-to-legal-citation.csl
+++ b/australian-guide-to-legal-citation.csl
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <style xmlns="http://purl.org/net/xbiblio/csl" class="note" version="1.0" demote-non-dropping-particle="sort-only" default-locale="en-GB">
+<!-- This style was edited with the Visual CSL Editor (http://editor.citationstyles.org/visualEditor/) -->
   <info>
     <title>Australian Guide to Legal Citation</title>
     <title-short>AGLC</title-short>
@@ -28,7 +29,7 @@
     <category citation-format="note"/>
     <category field="law"/>
     <summary>A modification of the Bluebook legal citation style for Australian conditions.</summary>
-    <updated>2012-10-25T21:15:26+00:00</updated>
+    <updated>2015-04-09T06:46:12+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale>
@@ -36,9 +37,7 @@
       <term name="et-al">et al</term>
     </terms>
   </locale>
-  <!--Authors and Persons-->
   <macro name="author-note">
-    <!--for bills & hearing this should start with jurisdiction once available-->
     <choose>
       <if type="interview">
         <group delimiter=", ">
@@ -121,7 +120,6 @@
     </choose>
   </macro>
   <macro name="author">
-    <!--for bills & hearing this should start with jurisdiction once available-->
     <choose>
       <if type="interview">
         <group delimiter=", ">
@@ -176,7 +174,6 @@
       </names>
     </group>
   </macro>
-  <!-- Titles -->
   <macro name="title">
     <choose>
       <if type="book legislation webpage thesis motion_picture manuscript" match="any">
@@ -186,7 +183,7 @@
         <text variable="title" text-case="title"/>
       </else-if>
       <else-if type="legal_case">
-        <text variable="title" font-style="italic" strip-periods="true" form="short"/>
+        <text variable="title" strip-periods="true" font-style="italic"/>
       </else-if>
       <else>
         <text variable="title" quotes="true" text-case="title"/>
@@ -199,11 +196,10 @@
         <text variable="title" font-style="italic" text-case="title" form="short"/>
       </if>
       <else>
-        <text variable="title" quotes="true" text-case="title" form="short"/>
+        <text variable="title" form="short" text-case="title" quotes="false"/>
       </else>
     </choose>
   </macro>
-  <!--Dates-->
   <macro name="issued-year">
     <date variable="issued" form="text" date-parts="year"/>
   </macro>
@@ -225,7 +221,6 @@
             <text macro="issued-year" prefix="(" suffix=")"/>
           </if>
           <else-if variable="container-title volume number" match="any">
-            <!--no year in square brackets for unreported case w/o medium neutral citation-->
             <text macro="issued-year" prefix="[" suffix="]"/>
           </else-if>
         </choose>
@@ -241,7 +236,6 @@
       </else-if>
     </choose>
   </macro>
-  <!--publication info -->
   <macro name="publisher">
     <choose>
       <if type="book chapter paper-conference article-newspaper report legislation motion_picture speech interview thesis" match="any">
@@ -260,18 +254,15 @@
               <text variable="publisher-place"/>
             </if>
             <else-if type="legislation bill" match="any">
-              <!--this should be jurisdiction we use code instead-->
               <text variable="container-title"/>
             </else-if>
             <else>
-              <!--this won't work in Zotero yet, but does no harm -->
               <names variable="director">
                 <label form="verb" text-case="capitalize-first" suffix=" "/>
                 <name delimiter-precedes-last="never" and="text" delimiter=", " initialize="false" initialize-with=""/>
               </names>
               <text variable="publisher"/>
               <choose>
-                <!--if none of these, this we don't want edition either. Might be Loose-Leaf-->
                 <if variable="publisher issued genre container-title" match="any">
                   <text macro="edition"/>
                 </if>
@@ -369,7 +360,6 @@
                   <text variable="container-title" form="short"/>
                 </if>
                 <else-if variable="authority number" match="all">
-                  <!--Assume that only cases with a Medium Neutral Citation have a docket number -->
                   <group delimiter=" ">
                     <text variable="authority" form="short" strip-periods="true"/>
                     <text variable="number"/>
@@ -399,7 +389,6 @@
   <macro name="page-first">
     <text variable="page-first"/>
   </macro>
-  <!--Others -->
   <macro name="manuscript-catchall">
     <choose>
       <if type="manuscript">
@@ -432,7 +421,6 @@
         </choose>
       </else-if>
       <else-if type="manuscript">
-        <!--Manuscript here as a stand-in for Treaty. Not perfect -->
         <text value="4"/>
       </else-if>
       <else>
@@ -455,13 +443,11 @@
         <else-if position="subsequent">
           <choose>
             <if type="legal_case bill legislation manuscript" match="any">
-              <!--don't use short form and above note for legal citations -->
               <group delimiter=" ">
                 <group delimiter=", ">
                   <text macro="author-note"/>
-                  <text macro="title"/>
+                  <text macro="title-short" font-style="italic"/>
                 </group>
-                <!-- we could work with title-short here-->
                 <group delimiter=" ">
                   <text macro="date-parenthesis"/>
                   <text macro="article-case-info"/>
@@ -492,7 +478,6 @@
           </choose>
         </else-if>
         <else>
-          <!--general whole citation -->
           <group delimiter=" ">
             <group delimiter=", ">
               <group delimiter=" ">
@@ -519,6 +504,11 @@
               <text macro="page-first"/>
               <text variable="locator"/>
             </group>
+            <choose>
+              <if type="legal_case bill legislation" match="any">
+                <text macro="title-short" quotes="true" font-style="italic" prefix=" (" suffix=")"/>
+              </if>
+            </choose>
             <text macro="URL"/>
           </group>
         </else>


### PR DESCRIPTION
Small update to allow definition of short titles for legislation, bills and cases in the first instance that they are used and use of the short title in subsequent refs in compliance with rule 2.1.14 in AGLC3.

For example:
(1) Conference of the Parties, UNFCCC, Decision 2/CP.15, UN Doc FCCC/CP/2009/11/Add.1 (30 March 2010) (‘<i>Copenhagen Accord</i>’).
(2) <i>Mabo v Queensland</i> [No 2] (1992) 175 CLR 1 (‘<i>Mabo [No 2]</i>’).
(3) <i>Copenhagen Accord</i>.
(4) <i>Mabo [No 2]</i> (1992) 175 CLR 1.