### PR TITLE
Update national-science-foundation-grant-proposals.csl

### DIFF
--- a/national-science-foundation-grant-proposals.csl
+++ b/national-science-foundation-grant-proposals.csl
@@ -15,7 +15,7 @@
     <updated>2012-09-14T21:22:32+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
-  <citation>
+  <citation collapse="citation-number">
     <sort>
       <key variable="citation-number"/>
     </sort>
@@ -37,8 +37,10 @@
         <date-part name="year" form="long"/>
       </date>
       <text variable="page" suffix=". "/>
-      <text variable="DOI" prefix="doi:" suffix=", "/>
-      <text variable="URL" prefix="Available at " suffix=" "/>
+      <group delimeter=", ">
+	      <text variable="DOI" prefix="doi:"/>
+	      <text variable="URL" prefix="Available at " suffix=" "/>
+      </group>
     </layout>
   </bibliography>
 </style>


### PR DESCRIPTION
Modifications to collapse numeric citations from [1,2,3,4] to [1-4] and to avoid a trailing comma after DOIs.

The format still deals very poorly with non-journal references (e.g., books) and is quite strange in terms of the placement of the year between journal volume and page numbers.