### PR TITLE
Fixed formatting error in Chest style.

### DIFF
--- a/chest.csl
+++ b/chest.csl
@@ -71,7 +71,7 @@
     <choose>
       <if type="article-journal article-magazine" match="any">
         <group suffix=" ">
-          <text variable="container-title" form="short" strip-periods="true"/>
+          <text variable="container-title" form="short" strip-periods="true" font-style="italic"/>
           <choose>
             <if variable="URL">
               <text term="internet" prefix=" [" suffix="]" text-case="capitalize-first"/>


### PR DESCRIPTION
With a friend in medicine field writing his thesis, we spotted a small problem in the Chest style. This journal requires italic titles for journal titles. 

As we can read here : http://journal.publications.chestnet.org/ss/forauthors.aspx#References

    Publication source (italicized), when referring to a journal, the journal name should be abbreviated according to Index Medicus