### PR TITLE
Update iso690-numeric-brackets-cs.csl

### DIFF
--- a/iso690-numeric-brackets-cs.csl
+++ b/iso690-numeric-brackets-cs.csl
@@ -29,7 +29,6 @@
     <names variable="author">
       <name and="text" name-as-sort-order="all" sort-separator=", " delimiter=", " delimiter-precedes-last="never">
         <name-part name="family" text-case="uppercase"/>
-        <name-part name="given"/>
       </name>
     </names>
   </macro>
@@ -37,7 +36,6 @@
     <names variable="editor">
       <name and="text" name-as-sort-order="all" sort-separator=", " delimiter=", " delimiter-precedes-last="never">
         <name-part name="family" text-case="uppercase"/>
-        <name-part name="given"/>
       </name>
       <label prefix=", " form="short" suffix="."/>
     </names>
@@ -46,7 +44,6 @@
     <names variable="editor">
       <name and="text" delimiter=", " delimiter-precedes-last="never">
         <name-part name="family" text-case="uppercase"/>
-        <name-part name="given"/>
       </name>
       <label prefix=", " form="short" suffix=". "/>
     </names>
@@ -55,7 +52,6 @@
     <names variable="translator">
       <name and="text" delimiter=", " delimiter-precedes-last="never">
         <name-part name="family" text-case="uppercase"/>
-        <name-part name="given"/>
       </name>
       <label prefix=" (" form="short" suffix=".)"/>
     </names>
@@ -65,7 +61,6 @@
     <names variable="translator">
       <name and="text" delimiter=", " delimiter-precedes-last="never">
         <name-part name="family" text-case="uppercase"/>
-        <name-part name="given"/>
       </name>
     </names>
   </macro>
@@ -74,7 +69,6 @@
     <names variable="illustrator">
       <name and="text" delimiter=", " delimiter-precedes-last="never">
         <name-part name="family" text-case="uppercase"/>
-        <name-part name="given"/>
       </name>
     </names>
   </macro>
@@ -115,7 +109,6 @@
     <names variable="container-author">
       <name and="text" delimiter=", " delimiter-precedes-last="never">
         <name-part name="family" text-case="uppercase"/>
-        <name-part name="given"/>
       </name>
     </names>
   </macro>

--- a/iso690-numeric-brackets-cs.csl
+++ b/iso690-numeric-brackets-cs.csl
@@ -17,7 +17,7 @@
     <category citation-format="numeric"/>
     <category field="generic-base"/>
     <summary>Style based on ČSN ISO 690:2011</summary>
-    <updated>2013-04-15T18:07:00+00:00</updated>
+    <updated>2015-04-13T13:37:28+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale>
@@ -27,7 +27,7 @@
   </locale>
   <macro name="author">
     <names variable="author">
-      <name and="text" name-as-sort-order="first" sort-separator=", " delimiter=", " delimiter-precedes-last="never">
+      <name and="text" name-as-sort-order="all" sort-separator=", " delimiter=", " delimiter-precedes-last="never">
         <name-part name="family" text-case="uppercase"/>
         <name-part name="given"/>
       </name>
@@ -35,9 +35,9 @@
   </macro>
   <macro name="editor">
     <names variable="editor">
-      <name and="text" name-as-sort-order="first" sort-separator=", " delimiter=", " delimiter-precedes-last="never">
-        <name-part name="given"/>
+      <name and="text" name-as-sort-order="all" sort-separator=", " delimiter=", " delimiter-precedes-last="never">
         <name-part name="family" text-case="uppercase"/>
+        <name-part name="given"/>
       </name>
       <label prefix=", " form="short" suffix="."/>
     </names>
@@ -54,8 +54,8 @@
   <macro name="translator">
     <names variable="translator">
       <name and="text" delimiter=", " delimiter-precedes-last="never">
-        <name-part name="given"/>
         <name-part name="family" text-case="uppercase"/>
+        <name-part name="given"/>
       </name>
       <label prefix=" (" form="short" suffix=".)"/>
     </names>
@@ -114,8 +114,8 @@
   <macro name="container-author">
     <names variable="container-author">
       <name and="text" delimiter=", " delimiter-precedes-last="never">
-        <name-part name="given"/>
         <name-part name="family" text-case="uppercase"/>
+        <name-part name="given"/>
       </name>
     </names>
   </macro>
@@ -661,3 +661,4 @@
     </layout>
   </bibliography>
 </style>
+


### PR DESCRIPTION
The list of references contained in some styles first author with family-name first, and subsequent authors in opposite order. Fixed that by changing the name-as-sort-order to "all" and putting <name-part name="family" text-case="uppercase"/> before <name-part name="given"/> everywhere. So the result is the order is family-name, given-name always.
