### PR TITLE
Revert "Update journal-of-chromatography-a.csl"

### DIFF
--- a/dependent/journal-of-chromatography-a.csl
+++ b/dependent/journal-of-chromatography-a.csl
@@ -4,7 +4,7 @@
     <title>Journal of Chromatography A</title>
     <id>http://www.zotero.org/styles/journal-of-chromatography-a</id>
     <link href="http://www.zotero.org/styles/journal-of-chromatography-a" rel="self"/>
-    <link href="http://www.zotero.org/styles/elsevier-without-titles" rel="independent-parent"/>
+    <link href="http://www.zotero.org/styles/elsevier-with-titles" rel="independent-parent"/>
     <category citation-format="numeric"/>
     <issn>0021-9673</issn>
     <updated>2013-08-19T12:00:00+00:00</updated>


### PR DESCRIPTION
This reverts commit dcd4c2a1c38521a511393a7add9c9e5611b6badf.

So now it matches the internal Elsevier guide and http://www.elsevier.com/journals/journal-of-chromatography-a/0021-9673/guide-for-authors

I suspect that when dcd4c2a1c38521a511393a7add9c9e5611b6badf was
introduced the public Guide for Authors was not updated yet.