### PR TITLE
Fix report titles: quotes rather than italics

### DIFF
--- a/chicago-author-date.csl
+++ b/chicago-author-date.csl
@@ -199,7 +199,7 @@
           </if>
         </choose>
       </if>
-      <else-if type="bill book graphic legislation motion_picture report song" match="any">
+      <else-if type="bill book graphic legislation motion_picture song" match="any">
         <text variable="title" text-case="title" font-style="italic"/>
         <group prefix=" (" suffix=")" delimiter=" ">
           <text term="version"/>


### PR DESCRIPTION
See https://forums.zotero.org/discussion/49362/report-type-in-chicago-style/