### PR TITLE
Fix report titles: quotes rather than italics

### DIFF
--- a/chicago-author-date-fr.csl
+++ b/chicago-author-date-fr.csl
@@ -190,7 +190,7 @@
       <if variable="title" match="none">
         <text variable="genre"/>
       </if>
-      <else-if type="bill book graphic legislation motion_picture report song" match="any">
+      <else-if type="bill book graphic legislation motion_picture song" match="any">
         <text variable="title" text-case="title" font-style="italic"/>
         <group delimiter=" " prefix=", ">
           <text term="version"/>
@@ -220,7 +220,7 @@
           </if>
         </choose>
       </if>
-      <else-if type="bill book graphic legislation motion_picture report song" match="any">
+      <else-if type="bill book graphic legislation motion_picture song" match="any">
         <text variable="title" text-case="title" font-style="italic"/>
         <group prefix=" (" suffix=")" delimiter=" ">
           <text term="version"/>


### PR DESCRIPTION
See https://forums.zotero.org/discussion/49362/report-type-in-chicago-style/