### PR TITLE
Fix report titles: quotes rather than italics

### DIFF
--- a/chicago-author-date-de.csl
+++ b/chicago-author-date-de.csl
@@ -188,7 +188,7 @@
           </if>
         </choose>
       </if>
-      <else-if type="bill book graphic legal_case legislation motion_picture report song" match="any">
+      <else-if type="bill book graphic legal_case legislation motion_picture song" match="any">
         <text variable="title" font-style="italic"/>
       </else-if>
       <else>


### PR DESCRIPTION
See https://forums.zotero.org/discussion/49362/report-type-in-chicago-style/