### PR TITLE
Update ecology-letters.csl

### DIFF
--- a/ecology-letters.csl
+++ b/ecology-letters.csl
@@ -24,7 +24,7 @@
     <choose>
       <if type="chapter paper-conference" match="any">
         <text term="in" text-case="capitalize-first" suffix=": "/>
-        <text variable="container-title" font-style="italic" form="short"/>
+        <text variable="container-title" font-style="italic"/>
         <text variable="collection-title" prefix=", "/>
         <names variable="editor translator" prefix=" (" delimiter=", " suffix=")">
           <label form="short" suffix=" "/>
@@ -191,7 +191,7 @@
       </else-if>
     </choose>
   </macro>
-  <citation et-al-min="3" et-al-use-first="1" disambiguate-add-year-suffix="true" collapse="year">
+  <citation et-al-min="3" et-al-use-first="1" disambiguate-add-year-suffix="true" collapse="year-suffix" year-suffix-delimiter=", ">
     <sort>
       <key macro="issued"/>
       <key macro="author"/>


### PR DESCRIPTION
Changes proposed for:
- book title not abbreviated anymore for book chapters (line 27). 
Guidelines of Ecology Letters: "Last name, Initials. et al. (Year). Full title of chapter. In: (Full title of book), Edition (only include this if not the first edition) {  [ed(s).]  [Editors(s) last name, initials]  }. Publisher, City (Include state and country for USA and UK), pp. (page range)."
- in text citations of several works by the same authors and years are now "a, b" (line 194). 
Guidelines of Ecology Letters: "References made to works by the same author(s) and publication year should be included after the year of publication. For instance James et al. 1986a, b"