### PR TITLE
council-of-science-edtiors - The semicolon is a delimiter, not a prefix.

### DIFF
--- a/council-of-science-editors-alphabetical.csl
+++ b/council-of-science-editors-alphabetical.csl
@@ -201,10 +201,12 @@
             <text macro="edition"/>
             <text macro="editor"/>
           </group>
-          <text prefix=" " macro="publisher"/>
-          <group suffix="." prefix="; " delimiter=". ">
-            <text macro="issued"/>
-            <text macro="pages"/>
+          <group prefix=" " delimiter="; ">
+            <text macro="publisher"/>
+            <group suffix="." delimiter=". ">
+              <text macro="issued"/>
+              <text macro="pages"/>
+            </group>
           </group>
         </if>
         <else-if type="chapter paper-conference entry-dictionary entry-encyclopedia" match="any">
@@ -215,9 +217,9 @@
             <text variable="container-title" suffix="."/>
             <text variable="volume" prefix="Vol. " suffix="."/>
             <text macro="edition"/>
-            <group suffix=".">
+            <group suffix="." delimiter="; ">
               <text macro="publisher"/>
-              <group suffix="." prefix="; " delimiter=". ">
+              <group suffix="." delimiter=". ">
                 <text macro="issued"/>
                 <text macro="pages"/>
               </group>

--- a/council-of-science-editors.csl
+++ b/council-of-science-editors.csl
@@ -191,12 +191,14 @@
             <text macro="title" suffix="."/>
             <text macro="edition"/>
             <text macro="editor"/>
-          </group>
-          <text prefix=" " macro="publisher"/>
-          <group suffix="." prefix="; " delimiter=". ">
-            <date variable="issued">
-              <date-part name="year"/>
-            </date>
+            <group prefix=" " delimiter="; ">
+              <text macro="publisher"/>
+              <group suffix="." delimiter=". ">
+                <date variable="issued">
+                  <date-part name="year"/>
+                </date>
+              </group>
+            </group>
             <text macro="pages"/>
           </group>
         </if>
@@ -209,12 +211,14 @@
             <text variable="volume" prefix="Vol. " suffix="."/>
             <text macro="edition"/>
             <group suffix=".">
-              <text macro="publisher"/>
-              <group suffix="." prefix="; " delimiter=". ">
-                <date variable="issued">
-                  <date-part name="year"/>
-                </date>
-                <text macro="pages"/>
+              <group prefix=" " delimiter="; ">
+                <text macro="publisher"/>
+                <group suffix="." delimiter=". ">
+                  <date variable="issued">
+                    <date-part name="year"/>
+                  </date>
+                  <text macro="pages"/>
+                </group>
               </group>
             </group>
           </group>


### PR DESCRIPTION
Two of the CSE styles specify the semicolon as a prefix for the group containing the issued and pages macro. Really, it's a delimiter between that group and the preceding publisher macro. This change makes an extraneous semi-colon go away.