### PR TITLE
PMC-22661 - add support for ahead-of-print

### DIFF
--- a/american-medical-association.csl
+++ b/american-medical-association.csl
@@ -77,6 +77,17 @@
         <text variable="title"/>
       </else>
     </choose>
+    <choose>
+      <if variable='volume'>
+      </if>
+      <else>
+        <group prefix=' [' suffix=']'>
+          <!-- FIXME: this should be localized -->
+          <text value='published online ahead of print '/>
+          <date variable="epub-date" form="text"/>
+        </group>
+      </else>
+    </choose>
   </macro>
   <macro name="publisher">
     <group delimiter=": ">
@@ -97,6 +108,7 @@
       </else>
     </choose>
   </macro>
+
   <citation collapse="citation-number">
     <sort>
       <key variable="citation-number"/>

--- a/apa.csl
+++ b/apa.csl
@@ -150,6 +150,14 @@
       </if>
       <else>
         <choose>
+          <if variable='volume'>
+          </if>
+          <else>
+            <!-- FIXME: this should be localized -->
+            <text value='Advance online publication. '/>
+          </else>
+        </choose>
+        <choose>
           <if variable="DOI">
             <text variable="DOI" prefix="http://doi.org/"/>
           </if>


### PR DESCRIPTION
This pull request modifies both american-medical-association.csl and apa.csl, to add support for ahead-of-print, as described in the xbiblio-devel email thread, [How to encode and process "ahead of print"](http://sourceforge.net/p/xbiblio/mailman/message/34179904/).

Note that american-medical-association.csl uses a new date field, `epub-date`; so this PR should not be merged before support for that is added.