### PR TITLE
Update pnas.csl

### DIFF
--- a/pnas.csl
+++ b/pnas.csl
@@ -14,6 +14,10 @@
       <name>Rintze Zelle</name>
       <uri>http://twitter.com/rintzezelle</uri>
     </contributor>
+    <contributor>
+      <name>Bela Hausmann</name>
+      <uri>https://github.com/and3k</uri>
+    </contributor>
     <category citation-format="numeric"/>
     <category field="science"/>
     <issn>0027-8424</issn>
@@ -40,17 +44,24 @@
   </macro>
   <macro name="access">
     <choose>
-      <if variable="URL">
-        <text value="Available at:" suffix=" "/>
-        <text variable="URL"/>
-        <group prefix=" [" suffix="]">
-          <text term="accessed" text-case="capitalize-first" suffix=" "/>
-          <date variable="accessed">
-            <date-part name="month" suffix=" "/>
-            <date-part name="day" suffix=", "/>
-            <date-part name="year"/>
-          </date>
-        </group>
+      <if variable="page" match="none">
+        <choose>
+          <if variable="DOI">
+            <text variable="DOI" prefix="doi:"/>
+          </if>
+          <else-if variable="URL">
+            <text value="Available at:" suffix=" "/>
+            <text variable="URL"/>
+            <group prefix=" [" suffix="]">
+            <text term="accessed" text-case="capitalize-first" suffix=" "/>
+            <date variable="accessed">
+                <date-part name="month" suffix=" "/>
+                <date-part name="day" suffix=", "/>
+                <date-part name="year"/>
+            </date>
+            </group>
+          </else-if>
+        </choose>
       </if>
     </choose>
   </macro>


### PR DESCRIPTION
PNAS does not have links after all articles. I modified pnas.csl accordingly, so URLs are only shown if there is no page number (like e.g. in The ISME Journal CSL).