### PR TITLE
Create escuela-nacional-de-antropologia-e-historia-author-date

### DIFF
--- a/escuela-nacional-de-antropologia-e-historia-author-date
+++ b/escuela-nacional-de-antropologia-e-historia-author-date
@@ -1,0 +1,570 @@
+<?xml version="1.0" encoding="utf-8"?>
+<style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" demote-non-dropping-particle="sort-only" default-locale="es-MX">
+  <info>
+    <title>Escuela Nacional de Antropología e Historia (autor-fecha)</title>
+    <title-short>ENAH (autor-fecha)</title-short>
+    <id>http://www.zotero.org/styles/escuela-nacional-de-antropologia-e-historia-author-date</id>
+    <link href="http://www.zotero.org/styles/escuela-nacional-de-antropologia-e-historia-author-date" rel="self"/>
+    <link href="http://www.enah.edu.mx/index.php/difu-cul/publicaciones/normas-editoriales.pdf" rel="documentation"/>
+    <link href="http://www.zotero.org/styles/chicago-author-date" rel="templete"/>
+    <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
+    <author>
+      <name>Juan Ignacio Flores Salgado</name>
+      <email>natch.nacht@gmail.com</email>
+      <uri>https://www.mendeley.com/profiles/juan-ignacio-flores-salgado/</uri>
+    </author>
+    <contributor>
+      <name>Inés Segovia Camelo</name>
+      <email>publicaciones.enah@inah.gob.mx</email>
+      <uri>http://www.enah.edu.mx/index.php/difu-cul/publicaciones</uri>
+    </contributor>
+    <category citation-format="author-date" field="anthropology and history"/>
+    <summary>Estilo de citas de la Escuela Nacional de Antropología e Historia -- variante autor-fecha</summary>
+    <updated>2015-06-25T20:21:07-06:00</updated>
+    <issn>1405-7778</issn><!--ISSN revista Cuicuilco-->
+  </info>
+  <!--  Colaboradores secundarios (editor, coord., o traductor)-->
+  <macro name="secondary-contributors">
+    <choose>
+      <if type="motion_picture musical_score">
+        <names variable="director"  delimiter=". " prefix=", ">
+          <label form="verb" text-case="lowercase" prefix=" " suffix=" " plural="contextual"/>
+          <name and="text" delimiter=", " delimiter-precedes-last="never"/>
+        </names>
+      </if>
+    </choose>
+    <choose>
+      <if type="chapter paper-conference">
+        <if variable="translator">
+          <names variable="translator" delimiter=". " prefix=". ">
+            <name and="text" delimiter=", " delimiter-precedes-last="never"/>
+            <label form="short" text-case="lowercase" prefix=" (" suffix=")" plural="contextual"/>
+          </names>
+        </if>
+      </if>
+      <else>
+        <if variable="editor">
+          <names variable="editor" delimiter=". " prefix=", ">
+            <name and="text" delimiter=", " delimiter-precedes-last="never"/>
+            <label form="short" text-case="lowercase" prefix=" (" suffix=")" plural="contextual"/>
+          </names>
+        </if>
+      </else>
+    </choose>
+  </macro>
+  <!-- Contribuidores de contenido-->
+  <macro name="container-contributors">
+    <choose>
+      <if type="chapter paper-conference" match="any">
+        <group prefix=", " delimiter=", ">
+          <names variable="container-author editor " delimiter=", ">
+            <label form="short" prefix=" (" suffix="), " plural="contextual"/>
+            <name and="text" delimiter=", "/>
+            <et-al font-style="italic"/>
+          </names>
+        </group>
+      </if>
+    </choose>
+  </macro>
+  <!-- Director -->
+  <macro name="director">
+    <choose>
+      <if type="motion_picture">
+        <text term="director" form="short" prefix=" (" suffix=") " plural="contextual"/>
+      </if>
+    </choose>
+  </macro>
+  <!-- Editor -->
+  <macro name="editor">
+    <names variable="editor">
+      <name name-as-sort-order="first" and="text" sort-separator=" " delimiter=", " delimiter-precedes-last="never"/>
+      <label form="short" prefix=" (" suffix="), "/>
+      <et-al font-style="italic"/>
+    </names>
+  </macro>
+  <!-- Traductor -->
+  <macro name="translator">
+    <names variable="translator">
+      <name name-as-sort-order="first" and="text" sort-separator=", " delimiter=", " delimiter-precedes-last="never"/>
+      <label form="short" prefix=" (" suffix="), " plural="contextual"/>
+    </names>
+  </macro>
+  <!-- Anónimo -->
+  <macro name="anon">
+    <text term="anonymous" form="long" text-case="capitalize-first" strip-periods="true"/>
+  </macro>
+  <!-- recipiente -->
+  <macro name="recipient">
+    <choose>
+      <if type="personal_communication">
+        <choose>
+          <if variable="genre">
+            <text variable="genre" text-case="capitalize-first"/>
+          </if>
+          <else>
+            <text term="letter" text-case="capitalize-first"/>
+          </else>
+        </choose>
+      </if>
+    </choose>
+    <names variable="recipient" delimiter=", ">
+      <label form="verb" prefix=" " text-case="lowercase" suffix=" "/>
+      <name and="text" delimiter=", "/>
+    </names>
+  </macro>
+  <!-- Autores -->
+  <macro name="contributors">
+    <group delimiter=" ">
+      <names variable="author">
+        <name and="text" name-as-sort-order="first" sort-separator=", " delimiter=", " delimiter-precedes-last="never" font-variant="small-caps"/>
+        <label form="short" plural="contextual" prefix=", " />
+        <et-al font-style="italic" font-variant="normal"/>
+        <substitute>
+          <names variable="editor" />
+          <label form="short" plural="contextual" prefix=" (" suffix=")"/>
+          <names variable="translator"/>
+          <label form="short" plural="contextual" prefix=" (" suffix=")"/>
+          <text macro="anon"/>
+          <text variable="publisher"/>
+        </substitute>
+      </names>
+      <text macro="director"/>
+      <text macro="publisher-place" font-style="italic"/>
+    </group>
+  </macro>
+  <!-- autor para referencia en el texto -->
+  <macro name="contributors-short">
+    <names variable="author">
+      <name form="short" and="text" delimiter=", " initialize-with=". "/>
+      <et-al font-style="italic"/>
+      <substitute>
+        <names variable="editor"/>
+        <names variable="translator"/>
+        <text macro="anon"/>
+      </substitute>
+    </names>
+  </macro>
+  <!-- entrevistador-->
+  <macro name="interviewer">
+    <names variable="interviewer" delimiter=", ">
+      <label form="verb" prefix=" " text-case="capitalize-first" suffix=" "/>
+      <name and="text" delimiter=", "/>
+      <text variable="publisher"/>
+    </names>
+  </macro>
+  <!-- Sobre hipervínculos en fichas -->
+  <macro name="access">
+    <group delimiter="">
+      <choose>
+        <if variable="URL">
+          <text variable="URL" prefix="&#60;" suffix="&#62;"/>
+          <group>
+            <text term="accessed" text-case="capitalize-first" prefix=". " suffix=" "/>
+            <date variable="accessed" form="text">
+              <date-part name="day" prefix="el " suffix=" de "/>
+              <date-part name="month" suffix=" de "/>
+              <date-part name="year"/>
+            </date>
+          </group>
+        </if>
+        <else-if>
+          <text variable="DOI" prefix="doi: "/>
+          <if variable="DOI issued" match="all">
+            <if variable="URL accessed" match="all">
+              <text term="available at" text-case="capitalize-first" suffix=": "/>
+              <text variable="URL"/>
+              <group prefix=" [" suffix="]">
+                <text term="accessed" text-case="capitalize-first" suffix=" "/>
+                <date variable="accessed">
+                  <date-part name="day" suffix=", "/>
+                  <date-part name="month" suffix=" "/>
+                  <date-part name="year"/>
+                </date>
+              </group>
+            </if>
+          </if>
+        </else-if>
+      </choose>
+    </group>
+  </macro>
+  <!-- Título -->
+  <macro name="title">
+    <choose>
+      <if variable="title" match="none">
+        <choose>
+          <if type="personal_communication" match="none">
+            <text variable="genre" text-case="capitalize-first"/>
+          </if>
+        </choose>
+      </if>
+      <else-if type="article bill book graphic legal_case thesis legislation motion_picture song" match="any">
+        <text variable="title" text-case="title" font-style="italic"/>
+      </else-if>
+      <else>
+        <text variable="title" text-case="title"/>
+      </else>
+    </choose>
+  </macro>
+  <!-- Edición -->
+  <macro name="edition">
+    <choose>
+      <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
+        <choose>
+          <if is-numeric="edition">
+            <group delimiter=" " prefix=". ">
+              <number variable="edition" form="ordinal"/>
+              <text term="edition" form="short" strip-periods="true"/>
+            </group>
+          </if>
+          <else>
+            <text variable="edition" prefix=". "/>
+          </else>
+        </choose>
+      </if>
+      <else-if type="chapter  paper-conference" match="any">
+        <choose>
+          <if is-numeric="edition">
+            <group delimiter=" " prefix=". ">
+              <number variable="edition" form="ordinal"/>
+              <text term="edition" form="short"/>
+            </group>
+          </if>
+          <else>
+            <text variable="edition" prefix=", "/>
+          </else>
+        </choose>
+      </else-if>
+    </choose>
+  </macro>
+  <!-- localizadores del título (vol., núm.) -->
+  <macro name="locators-title">
+    <choose>
+      <if type="bill book chapter graphic legal_case legislation motion_picture report song" match="any">
+        <group prefix=", " delimiter=". ">
+          <group>
+            <text term="volume" form="short" text-case="lowercase" suffix=" "/>
+            <number variable="volume" form="numeric"/>
+          </group>
+          <group>
+            <number variable="number-of-volumes" form="numeric"/>
+            <text term="volume" form="short" prefix=" " plural="true"/>
+          </group>
+        </group>
+      </if>
+      <else-if type="legal_case">
+        <text variable="volume" prefix=", "/>
+        <text variable="container-title" prefix=" "/>
+        <text variable="page" prefix=" "/>
+      </else-if>
+      <else-if type="article-journal">
+        <if variable="volume">
+          <text variable="volume" prefix=", "/>
+          <text variable="issue" prefix=" (" suffix=")"/>
+        </if>
+        <else>
+          <text variable="issue" prefix=" (" suffix=")"/>
+        </else>
+      </else-if>
+      <else-if type="chapter paper-conference" match="any">
+        <choose>
+          <if variable="page" match="none">
+            <group prefix=", ">
+              <text term="volume" form="short" text-case="lowercase" suffix=" "/>
+              <number variable="volume" form="numeric"/>
+            </group>
+          </if>
+        </choose>
+      </else-if>
+    </choose>
+  </macro>
+  <!-- localizadores de página según el tipo de entrada -->
+  <macro name="locators">
+    <choose>
+      <if type="chapter paper-conference article-journal" match="any">
+        <choose>
+          <if variable="page">
+            <text variable="page" prefix=": " suffix=""/>
+          </if>
+          <else>
+            <text variable="volumen"/>
+          </else>
+        </choose>
+      </if>
+    </choose>
+    <choose>
+      <if type="article-newspaper">
+        <group prefix=", " delimiter=", ">
+          <group>
+            <text variable="edition" suffix=", "/>
+            <text term="edition" prefix=" "/>
+          </group>
+          <group>
+            <text variable="section" form="short" suffix=" "/>
+            <text term="section"/>
+          </group>
+        </group>
+        <group>
+          <text variable="page" prefix=": " suffix=". "/>
+        </group>
+      </if>
+    </choose>
+    <choose>
+      <if type="webpage">
+        <group prefix=", " delimiter=", ">
+          <group>
+            <text variable="edition" suffix=" "/>
+            <text term="edition" prefix=" "/>
+          </group>
+          <group>
+            <text variable="section" form="short" suffix=" "/>
+            <text term="section"/>
+          </group>
+        </group>
+      </if>
+    </choose>
+    <choose>
+      <if type="motion-picture musical-score" match="any">
+        <group>
+          <text variable="length" suffix=" "/>
+          <text value="mins." prefix=" "/>
+        </group>
+      </if>
+    </choose>
+  </macro>
+  <!-- índicador en referencia en texto -->
+  <macro name="point-locators">
+    <choose>
+      <if variable="locator">
+        <choose>
+          <if locator="page" match="none">
+            <choose>
+              <if type="book bill graphic legal_case legislation motion_picture report song" match="any">
+                <choose>
+                  <if variable="volume">
+                    <group>
+                      <text term="volume" form="short" suffix=" "/>
+                      <number variable="volume" form="numeric"/>
+                      <label variable="locator" form="short" prefix=", " suffix=" "/>
+                    </group>
+                  </if>
+                  <else>
+                    <label variable="locator" form="short" suffix=" "/>
+                  </else>
+                </choose>
+              </if>
+              <else>
+                <label variable="locator" form="short" suffix=" "/>
+              </else>
+            </choose>
+          </if>
+          <else-if type="bill graphic legal_case legislation motion_picture report song" match="any">
+            <number variable="volume" form="numeric" suffix=":"/>
+          </else-if>
+        </choose>
+        <text variable="locator"/>
+      </if>
+    </choose>
+  </macro>
+  <!-- Título del contenedor -->
+  <macro name="container-title">
+    <choose>
+      <if type="chapter paper-conference">
+        <text term="in" text-case="lowercase" prefix=", " suffix=" "/>
+      </if>
+    </choose>
+    <choose>
+      <if type="paper-conference">
+        <text variable="container-title" text-case="title" font-style="normal"/>
+      </if>
+      <else-if type="chapter">
+        <text variable="container-title" text-case="title" font-style="italic"/>
+      </else-if>
+      <else-if type="legal_case" match="none">
+        <text variable="container-title" text-case="title" font-style="italic" prefix=". "/>
+      </else-if>
+    </choose>
+  </macro>
+  <!-- Editorial y lugar de publicación -->
+  <macro name="publisher">
+    <group>
+      <if variable="collection-title">
+        <text variable="publisher"/>
+        <text macro="collection-title" prefix=" " suffix=". "/>
+        <text variable="publisher-place"/>
+      </if>
+      <else-if variable="publisher-place">
+        <text variable="publisher" suffix=". "/>
+        <text variable="publisher-place"/>
+      </else-if>
+      <else>
+        <text variable="publisher"/>
+      </else>
+    </group>
+  </macro>
+  <!-- fecha de publicación -->
+  <macro name="date">
+    <choose>
+      <if variable="issued">
+        <date variable="issued">
+          <date-part name="year"/>
+        </date>
+      </if>
+      <else-if variable="accessed">
+        <date variable="accessed">
+          <date-part name="year"/>
+        </date>
+      </else-if>
+      <else>
+        <text term="no date" form="short" text-case="lowercase"/>
+      </else>
+    </choose>
+  </macro>
+  <!-- Periodo -->
+  <macro name="day-month">
+    <date variable="issued">
+      <date-part name="day" suffix=" de "/>
+      <date-part name="month"/>
+    </date>
+  </macro>
+  <!-- Colección -->
+  <macro name="collection-title">
+    <text variable="collection-title" text-case="title" prefix="(" suffix=")"/>
+    <text variable="collection-number" prefix="( " suffix=")"/>
+  </macro>
+  <!-- Evento -->
+  <macro name="event">
+    <group>
+      <text term="presented at" suffix=" "/>
+      <text variable="event"/>
+    </group>
+  </macro>
+  <!-- Descripción -->
+  <macro name="description">
+    <choose>
+      <if type="interview">
+        <group delimiter=". ">
+          <text macro="interviewer"/>
+          <text variable="genre" text-case="capitalize-first"/>
+        </group>
+      </if>
+    </choose>
+    <choose>
+      <if type="thesis">
+        <group delimiter=" ">
+          <text value="Tesis de" text-case="lowercase" prefix=", "/>
+          <text variable="genre" suffix="."/>
+        </group>
+      </if>
+    </choose>
+    <choose>
+      <if type="report">
+        <text variable="number"/>
+      </if>
+    </choose>
+    <group delimiter=" " prefix=" (" suffix=")">
+      <text term="version"/>
+      <text variable="version"/>
+    </group>
+  </macro>
+  <!-- Para indicar el tipo de soporte -->
+  <macro name="media">
+    <if variable="genre">
+      <choose>
+        <group>
+          <if type="article-journal article-newspaper book chapter interview" match="any">
+            <text variable="genre" font-variant="small-caps" prefix=" [" suffix="]"/>
+          </if>
+        </group>
+      </choose>
+      <choose>
+        <group>
+          <if type="article" match="any">
+            <text variable="genre" prefix=" [" suffix="]"/>
+          </if>
+        </group>
+      </choose>
+      <choose>
+        <group>
+          <if type="motion_picture song" match="any">
+            <text variable="genre" font-variant="small-caps" prefix=" ["/>
+            <text variable="page"  prefix=", " suffix=" mins.]"/>
+          </if>
+        </group>
+      </choose>
+    </if>
+  </macro>
+  <!-- Emisión -->
+  <macro name="issue">
+    <choose>
+      <if type="article-journal">
+        <text macro="day-month" prefix=", " suffix=""/>
+      </if>
+      <else-if type="legal_case">
+        <text variable="authority" prefix=". "/>
+      </else-if>
+      <else-if type="speech">
+        <group prefix=" " delimiter=", ">
+          <text macro="event"/>
+          <text macro="day-month"/>
+          <text variable="event-place"/>
+        </group>
+      </else-if>
+      <else-if type="article-newspaper article-magazine personal_communication" match="any">
+        <text macro="day-month" prefix=", "/>
+      </else-if>
+      <else>
+        <group prefix=". " delimiter=", ">
+          <text macro="publisher"/>
+        </group>
+      </else>
+    </choose>
+  </macro>
+  <!--Para generar la cita-->
+  <citation et-al-min="2" et-al-use-first="1" collapse="year" after-collapse-delimiter="; " disambiguate-add-year-suffix="true" disambiguate-add-names="true" disambiguate-add-givenname="true" givenname-disambiguation-rule="primary-name-with-initials" >
+    <layout prefix="[" suffix="]" delimiter="; " delimiter-precedes-last="never" and="text">
+      <sort>
+        <key macro="date"/>
+      </sort>
+      <group delimiter=": ">
+        <group delimiter=" ">
+          <text macro="contributors-short"/>
+          <text macro="date"/>
+        </group>
+        <text macro="point-locators"/>
+      </group>
+    </layout>
+  </citation>
+  <!-- Para generar la bibliografía -->
+  <bibliography et-al-min="4" et-al-use-first="3" subsequent-author-substitute="" entry-spacing="0">
+    <sort>
+      <key macro="contributors"/>
+      <key macro="date"/>
+    </sort>
+    <layout suffix=".">
+      <group display="block">
+        <text macro="contributors"/>
+        <et-al font-style="italic"  text-case="uppercase"/>
+      </group>
+      <group display="left-margin">
+        <text macro="date" suffix=" "/>
+        <date variable="original-date" prefix="[" suffix="]">
+          <date-part name="year"/>
+        </date>
+      </group>
+      <group display="right-inline">
+        <group>
+          <text macro="title"/>
+          <text macro="description"/>
+          <text macro="container-title"/>
+          <text macro="locators-title"/>
+          <text macro="secondary-contributors"/>
+          <text macro="edition"/>
+          <text macro="issue"/>
+          <text macro="locators"/>
+          <text macro="access" prefix=". "/>
+          <text macro="media"/>
+        </group>
+      </group>
+    </layout>
+  </bibliography>
+</style>


### PR DESCRIPTION
This is the author-date CSL citation style file for the Escuela Nacional de Antropología e Historia in Mexico City, based on the new Editorial Standards of the school. They were developed to facilitate the clarity of critical apparatus in  publications (books, manuals, magazines and bulletins), theses and homework, using bibliographic managers such as Mendeley.