### PR TITLE
CSE and ACS - in term

### DIFF
--- a/american-chemical-society-author-date.csl
+++ b/american-chemical-society-author-date.csl
@@ -105,14 +105,19 @@
     <text variable="page"/>
   </macro>
   <macro name="book-container">
-    <group delimiter=" ">
-      <text macro="title" suffix="."/>
+    <group delimiter=". ">
+      <text macro="title"/>
       <choose>
         <if type="entry-dictionary entry-encyclopedia" match="none">
-          <text term="in" text-case="capitalize-first"/>
+          <group delimiter=" ">
+            <text term="in" text-case="capitalize-first"/>
+            <text variable="container-title" font-style="italic"/>
+          </group>
         </if>
+        <else>
+          <text variable="container-title" font-style="italic"/>
+        </else>
       </choose>
-      <text variable="container-title" font-style="italic"/>
     </group>
   </macro>
   <macro name="issued">

--- a/american-chemical-society-page-first.csl
+++ b/american-chemical-society-page-first.csl
@@ -75,8 +75,7 @@
     <text variable="page"/>
   </macro>
   <macro name="book-container">
-    <group delimiter=". ">
-      <text macro="title"/>
+    <group delimiter=" ">
       <choose>
         <if type="entry-dictionary entry-encyclopedia" match="none">
           <group delimiter=" ">

--- a/american-chemical-society-page-first.csl
+++ b/american-chemical-society-page-first.csl
@@ -75,13 +75,19 @@
     <text variable="page"/>
   </macro>
   <macro name="book-container">
-    <group delimiter=" ">
+    <group delimiter=". ">
+      <text macro="title"/>
       <choose>
         <if type="entry-dictionary entry-encyclopedia" match="none">
-          <text term="in" text-case="capitalize-first"/>
+          <group delimiter=" ">
+            <text term="in" text-case="capitalize-first"/>
+            <text variable="container-title" font-style="italic"/>
+          </group>
         </if>
+        <else>
+          <text variable="container-title" font-style="italic"/>
+        </else>
       </choose>
-      <text variable="container-title" font-style="italic"/>
     </group>
   </macro>
   <macro name="issued">

--- a/american-chemical-society-with-titles-no-et-al.csl
+++ b/american-chemical-society-with-titles-no-et-al.csl
@@ -87,14 +87,19 @@
     <text variable="page"/>
   </macro>
   <macro name="book-container">
-    <group delimiter=" ">
-      <text macro="title" suffix="."/>
+    <group delimiter=". ">
+      <text macro="title"/>
       <choose>
         <if type="entry-dictionary entry-encyclopedia" match="none">
-          <text term="in" text-case="capitalize-first"/>
+          <group delimiter=" ">
+            <text term="in" text-case="capitalize-first"/>
+            <text variable="container-title" font-style="italic"/>
+          </group>
         </if>
+        <else>
+          <text variable="container-title" font-style="italic"/>
+        </else>
       </choose>
-      <text variable="container-title" font-style="italic"/>
     </group>
   </macro>
   <macro name="issued">

--- a/american-chemical-society-with-titles-page-first.csl
+++ b/american-chemical-society-with-titles-page-first.csl
@@ -88,14 +88,19 @@
     <text variable="page"/>
   </macro>
   <macro name="book-container">
-    <group delimiter=" ">
-      <text macro="title" suffix="."/>
+    <group delimiter=". ">
+      <text macro="title"/>
       <choose>
         <if type="entry-dictionary entry-encyclopedia" match="none">
-          <text term="in" text-case="capitalize-first"/>
+          <group delimiter=" ">
+            <text term="in" text-case="capitalize-first"/>
+            <text variable="container-title" font-style="italic"/>
+          </group>
         </if>
+        <else>
+          <text variable="container-title" font-style="italic"/>
+        </else>
       </choose>
-      <text variable="container-title" font-style="italic"/>
     </group>
   </macro>
   <macro name="issued">

--- a/american-chemical-society-with-titles-sentence-case-doi.csl
+++ b/american-chemical-society-with-titles-sentence-case-doi.csl
@@ -88,14 +88,19 @@
     <text variable="page"/>
   </macro>
   <macro name="book-container">
-    <group delimiter=" ">
-      <text macro="title" suffix="."/>
+    <group delimiter=". ">
+      <text macro="title"/>
       <choose>
         <if type="entry-dictionary entry-encyclopedia" match="none">
-          <text term="in" text-case="capitalize-first"/>
+          <group delimiter=" ">
+            <text term="in" text-case="capitalize-first"/>
+            <text variable="container-title" font-style="italic"/>
+          </group>
         </if>
+        <else>
+          <text variable="container-title" font-style="italic"/>
+        </else>
       </choose>
-      <text variable="container-title" font-style="italic"/>
     </group>
   </macro>
   <macro name="issued">

--- a/american-chemical-society-with-titles-sentence-case.csl
+++ b/american-chemical-society-with-titles-sentence-case.csl
@@ -88,14 +88,19 @@
     <text variable="page"/>
   </macro>
   <macro name="book-container">
-    <group delimiter=" ">
-      <text macro="title" suffix="."/>
+    <group delimiter=". ">
+      <text macro="title"/>
       <choose>
         <if type="entry-dictionary entry-encyclopedia" match="none">
-          <text term="in" text-case="capitalize-first"/>
+          <group delimiter=" ">
+            <text term="in" text-case="capitalize-first"/>
+            <text variable="container-title" font-style="italic"/>
+          </group>
         </if>
+        <else>
+          <text variable="container-title" font-style="italic"/>
+        </else>
       </choose>
-      <text variable="container-title" font-style="italic"/>
     </group>
   </macro>
   <macro name="issued">

--- a/american-chemical-society-with-titles.csl
+++ b/american-chemical-society-with-titles.csl
@@ -87,14 +87,19 @@
     <text variable="page"/>
   </macro>
   <macro name="book-container">
-    <group delimiter=" ">
-      <text macro="title" suffix="."/>
+    <group delimiter=". ">
+      <text macro="title"/>
       <choose>
         <if type="entry-dictionary entry-encyclopedia" match="none">
-          <text term="in" text-case="capitalize-first"/>
+          <group delimiter=" ">
+            <text term="in" text-case="capitalize-first"/>
+            <text variable="container-title" font-style="italic"/>
+          </group>
         </if>
+        <else>
+          <text variable="container-title" font-style="italic"/>
+        </else>
       </choose>
-      <text variable="container-title" font-style="italic"/>
     </group>
   </macro>
   <macro name="issued">

--- a/american-chemical-society.csl
+++ b/american-chemical-society.csl
@@ -74,13 +74,19 @@
     <text variable="page"/>
   </macro>
   <macro name="book-container">
-    <group delimiter=" ">
+    <group delimiter=". ">
+      <text macro="title"/>
       <choose>
         <if type="entry-dictionary entry-encyclopedia" match="none">
-          <text term="in" text-case="capitalize-first"/>
+          <group delimiter=" ">
+            <text term="in" text-case="capitalize-first"/>
+            <text variable="container-title" font-style="italic"/>
+          </group>
         </if>
+        <else>
+          <text variable="container-title" font-style="italic"/>
+        </else>
       </choose>
-      <text variable="container-title" font-style="italic"/>
     </group>
   </macro>
   <macro name="issued">

--- a/american-chemical-society.csl
+++ b/american-chemical-society.csl
@@ -74,8 +74,7 @@
     <text variable="page"/>
   </macro>
   <macro name="book-container">
-    <group delimiter=". ">
-      <text macro="title"/>
+    <group delimiter=" ">
       <choose>
         <if type="entry-dictionary entry-encyclopedia" match="none">
           <group delimiter=" ">

--- a/council-of-science-editors-alphabetical.csl
+++ b/council-of-science-editors-alphabetical.csl
@@ -212,9 +212,11 @@
         <else-if type="chapter paper-conference entry-dictionary entry-encyclopedia" match="any">
           <text macro="title" prefix=" " suffix="."/>
           <group prefix=" " delimiter=" ">
-            <text term="in" text-case="capitalize-first" suffix=":"/>
-            <text macro="editor"/>
-            <text variable="container-title" suffix="."/>
+            <group delimiter=" ">
+              <text term="in" text-case="capitalize-first" suffix=":"/>
+              <text macro="editor"/>
+              <text variable="container-title" suffix="."/>
+            </group>
             <text variable="volume" prefix="Vol. " suffix="."/>
             <text macro="edition"/>
             <group suffix="." delimiter="; ">

--- a/council-of-science-editors-author-date.csl
+++ b/council-of-science-editors-author-date.csl
@@ -227,9 +227,11 @@
           </if>
           <else-if type="chapter paper-conference entry-dictionary entry-encyclopedia" match="any">
             <group prefix=" " delimiter=" ">
-              <text term="in" text-case="capitalize-first" suffix=":"/>
-              <text macro="editor"/>
-              <text variable="container-title" suffix="."/>
+              <group delimiter=" ">
+                <text term="in" text-case="capitalize-first" suffix=":"/>
+                <text macro="editor"/>
+                <text variable="container-title" suffix="."/>
+              </group>
               <text variable="volume" prefix="Vol. " suffix="."/>
               <text macro="edition"/>
               <group suffix="." delimiter=". ">

--- a/council-of-science-editors.csl
+++ b/council-of-science-editors.csl
@@ -205,9 +205,11 @@
         <else-if type="chapter paper-conference entry-dictionary entry-encyclopedia" match="any">
           <text macro="title" prefix=" " suffix="."/>
           <group prefix=" " delimiter=" ">
-            <text term="in" text-case="capitalize-first" suffix=":"/>
-            <text macro="editor"/>
-            <text variable="container-title" suffix="."/>
+            <group delimiter=" ">
+              <text term="in" text-case="capitalize-first" suffix=":"/>
+              <text macro="editor"/>
+              <text variable="container-title" suffix="."/>
+            </group>
             <text variable="volume" prefix="Vol. " suffix="."/>
             <text macro="edition"/>
             <group suffix=".">


### PR DESCRIPTION
Hello

One similar change for american-chemical-society, council-of-science-editors and friends, to prevent extraneous appearance of "in".