### PR TITLE
Update mammal-review.csl

### DIFF
--- a/mammal-review.csl
+++ b/mammal-review.csl
@@ -18,7 +18,7 @@
     <category field="zoology"/>
     <issn>0305-1838</issn>
     <eissn>1365-2907</eissn>
-    <updated>2012-09-09T22:24:43+00:00</updated>
+    <updated>2015-03-24T13:44:48+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale xml:lang="en">
@@ -40,6 +40,7 @@
     <names variable="author">
       <name name-as-sort-order="all" sort-separator=" " initialize-with="" delimiter=", " delimiter-precedes-et-al="never"/>
       <label form="short" prefix=" (" suffix=")" strip-periods="true"/>
+      <et-al font-style="italic"/>
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
@@ -50,6 +51,7 @@
   <macro name="author-short">
     <names variable="author">
       <name form="short" and="symbol" delimiter=", " initialize-with=". "/>
+      <et-al font-style="italic"/>
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
@@ -95,7 +97,7 @@
       </if>
     </choose>
   </macro>
-  <citation collapse="year-suffix" et-al-min="3" et-al-use-first="1" disambiguate-add-year-suffix="true" disambiguate-add-names="true">
+  <citation collapse="year-suffix" et-al-min="3" et-al-use-first="1" disambiguate-add-year-suffix="true">
     <sort>
       <key variable="issued"/>
       <key variable="author"/>
@@ -126,10 +128,10 @@
       <choose>
         <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
           <group>
-            <text macro="title" prefix=" "/>
+            <text macro="title" prefix=" ", suffix="."/>
             <text macro="edition"/>
           </group>
-          <text prefix=" " suffix=" " macro="publisher"/>
+          <text prefix=" " suffix=". " macro="publisher"/>
         </if>
         <else-if type="chapter paper-conference" match="any">
           <text macro="title" prefix=" "/>
@@ -141,7 +143,7 @@
           </group>
           <group>
             <text variable="container-title" font-style="italic" prefix=" " suffix=","/>
-            <text variable="collection-title" prefix=" " suffix="."/>
+            <text variable="collection-title" prefix=" " suffix=","/>
             <group suffix=".">
               <text variable="page" prefix=" " suffix="."/>
               <text macro="publisher" prefix=" "/>
@@ -162,9 +164,6 @@
           </group>
         </else>
       </choose>
-      <group>
-        <text variable="URL" text-decoration="none" prefix=" "/>
-      </group>
     </layout>
   </bibliography>
 </style>

--- a/mammal-review.csl
+++ b/mammal-review.csl
@@ -40,7 +40,6 @@
     <names variable="author">
       <name name-as-sort-order="all" sort-separator=" " initialize-with="" delimiter=", " delimiter-precedes-et-al="never"/>
       <label form="short" prefix=" (" suffix=")" strip-periods="true"/>
-      <et-al font-style="italic"/>
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
@@ -51,7 +50,6 @@
   <macro name="author-short">
     <names variable="author">
       <name form="short" and="symbol" delimiter=", " initialize-with=". "/>
-      <et-al font-style="italic"/>
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
@@ -87,8 +85,8 @@
       <if type="bill book chapter graphic legal_case legislation motion_picture paper-conference report song" match="any">
         <choose>
           <if is-numeric="edition">
-            <number variable="edition" form="ordinal" prefix=", "/>
-            <text term="edition" form="short" prefix=" " suffix=" "/>
+            <number variable="edition" form="ordinal"/>
+            <text term="edition" form="short" prefix=" "/>
           </if>
           <else>
             <text variable="edition" suffix="."/>
@@ -127,39 +125,37 @@
       </date>
       <choose>
         <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
-          <group>
-            <text macro="title" prefix=" " suffix="."/>
+          <group prefix=" " suffix="." delimiter=", ">
+            <text macro="title"/>
             <text macro="edition"/>
           </group>
           <text prefix=" " suffix=". " macro="publisher"/>
         </if>
         <else-if type="chapter paper-conference" match="any">
-          <text macro="title" prefix=" "/>
-          <group prefix=".">
+          <text macro="title" prefix=" " suffix="."/>
+          <group prefix=" In: ">
             <names variable="editor translator">
-              <name prefix=" In: " name-as-sort-order="all" suffix=" " sort-separator=" " initialize-with="" delimiter=", " delimiter-precedes-et-al="never"/>
-              <label form="short" prefix="(" suffix=")" strip-periods="true"/>
+              <name name-as-sort-order="all" suffix="" sort-separator=" " initialize-with="" delimiter=", " delimiter-precedes-et-al="never"/>
+              <label form="short" prefix=" (" suffix=")" strip-periods="true"/>
             </names>
           </group>
-          <group>
-            <text variable="container-title" font-style="italic" prefix=" " suffix=","/>
-            <text variable="collection-title" prefix=" " suffix=","/>
-            <group suffix=".">
-              <text variable="page" prefix=" " suffix="."/>
-              <text macro="publisher" prefix=" "/>
+          <group prefix=" " delimiter=", " suffix=".">
+            <text variable="container-title" font-style="italic"/>
+            <text variable="collection-title"/>
+            <group delimiter=". ">
+              <text variable="page"/>
+              <text macro="publisher"/>
             </group>
           </group>
         </else-if>
         <else>
-          <group suffix=".">
-            <text macro="title" prefix=" "/>
-            <text macro="editor-translator" prefix=" "/>
+          <group prefix=" " suffix=".">
+            <text macro="title"/>
+            <text macro="editor-translator"/>
           </group>
           <group prefix=" " suffix=".">
             <text variable="container-title" font-style="italic"/>
-            <group prefix=" ">
-              <text variable="volume"/>
-            </group>
+            <text variable="volume" prefix=" "/>
             <text variable="page" prefix=": "/>
           </group>
         </else>

--- a/mammal-review.csl
+++ b/mammal-review.csl
@@ -128,7 +128,7 @@
       <choose>
         <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
           <group>
-            <text macro="title" prefix=" ", suffix="."/>
+            <text macro="title" prefix=" " suffix="."/>
             <text macro="edition"/>
           </group>
           <text prefix=" " suffix=". " macro="publisher"/>


### PR DESCRIPTION
According to the guidelines,
1) "et al." should be in italics in the text. New lines 43 and 54 added.
2) When there are more than one citation for a given year by the same first author, it should be differentiated with letters but not by adding more authors. Guidelines: "Where more than one reference by the same author(s) appeared in the same year, use '2009a, b' in both text and References". Line 98 edited (new line 100).
3) The URL should not appear in the reference list (no mention of it and not in the examples in the guidelines). Lines 165-167 deleted.
4) For a book chapter, the page numbers should be preceded by ",". This works, except if there is a collection, which ends with a period. Line 144 edited (new line 146).
5) For a book, title and publisher should both end with a period. Modifications to line 129 (new line 131) and to line 132 (new line 134), respectively.