### PR TITLE
Update archiv-fur-geschichte-der-philosophie.csl

### DIFF
--- a/archiv-fur-geschichte-der-philosophie.csl
+++ b/archiv-fur-geschichte-der-philosophie.csl
@@ -6,6 +6,7 @@
     <id>http://www.zotero.org/styles/archiv-fur-geschichte-der-philosophie</id>
     <link href="http://www.zotero.org/styles/archiv-fur-geschichte-der-philosophie" rel="self"/>
     <link href="http://www.zotero.org/styles/environment-and-planning" rel="template"/>
+    <link href="http://www.degruyter.com/view/supplement/s16130650_Autorenrichtlinien_de.pdf" rel="documentation"/>
     <link href="www.degruyter.com/view/supplement/s16130650_Instructions_for_Authors_en.pdf" rel="documentation"/>
     <author>
       <name>Jamie Dow</name>


### PR DESCRIPTION
The other link to the documentation seems not to work currently. However, it seems there might be an English and German version of the instructions for authors. 

FYI
<blockquote>Das AGPh nimmt Beiträge in den Sprachen Deutsch, Englisch und Französisch zur Begutachtung an.</blockquote>