### PR TITLE
Update onderstepoort-journal-of-veterinary-research.csl

### DIFF
--- a/onderstepoort-journal-of-veterinary-research.csl
+++ b/onderstepoort-journal-of-veterinary-research.csl
@@ -17,7 +17,7 @@
     <eissn>2219-0635</eissn>
     <issnl>0030-2465</issnl>
     <summary>This is the style for the Onderstepoort Journal of Veterinary Research, based on Harvard Style</summary>
-    <updated>2014-06-09T06:47:33+00:00</updated>
+    <updated>2015-08-03T21:22:47+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <macro name="editor">
@@ -121,7 +121,7 @@
           <text macro="author-short"/>
           <text macro="year-date"/>
         </group>
-        <group>
+        <group delimiter=" ">
           <label variable="locator" form="short"/>
           <text variable="locator"/>
         </group>
@@ -134,57 +134,57 @@
       <key variable="title"/>
     </sort>
     <layout>
-      <text macro="author" suffix=","/>
-      <date variable="issued" prefix=" " suffix=",">
-        <date-part name="year"/>
-      </date>
-      <choose>
-        <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
-          <group delimiter=", " prefix=" " suffix=",">
-            <text macro="title"/>
-            <text macro="edition"/>
-            <text macro="editor"/>
-          </group>
-          <text prefix=" " suffix="." macro="publisher"/>
-        </if>
-        <else-if type="chapter paper-conference" match="any">
-          <text macro="title" prefix=" " suffix="."/>
-          <group prefix=" " delimiter=" ">
-            <text term="in" text-case="capitalize-first"/>
-            <text macro="editor"/>
-            <text variable="container-title" font-style="italic" suffix=","/>
-            <text variable="collection-title" suffix="."/>
-            <text variable="event" suffix="."/>
-            <group suffix="." delimiter=", ">
-              <text macro="pages"/>
-              <text macro="publisher" prefix=" "/>
+      <group delimiter=", " suffix=".">
+        <text macro="author"/>
+        <date variable="issued">
+          <date-part name="year"/>
+        </date>
+        <choose>
+          <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
+            <group delimiter=", ">
+              <text macro="title"/>
+              <text macro="edition"/>
+              <text macro="editor"/>
             </group>
-          </group>
-        </else-if>
-        <else-if type="thesis">
-          <group delimiter=", " prefix=" " suffix=".">
-            <text macro="title"/>
-            <text variable="genre" suffix=", "/>
             <text macro="publisher"/>
-          </group>
-        </else-if>
-        <else>
-          <group suffix=",">
-            <text macro="title" prefix=" "/>
-            <text macro="editor" prefix=" "/>
-          </group>
-          <group prefix=" " suffix=",">
-            <text variable="container-title" font-style="italic"/>
-            <group prefix=" ">
-              <text variable="volume"/>
+          </if>
+          <else-if type="chapter paper-conference" match="any">
+            <text macro="title"/>
+            <group delimiter=" ">
+              <text term="in"/>
+              <text macro="editor"/>
+              <text variable="container-title" font-style="italic" suffix=","/>
+              <text variable="collection-title" suffix="."/>
+              <text variable="event" suffix="."/>
+              <group suffix="." delimiter=", ">
+                <text macro="pages"/>
+                <text macro="publisher" prefix=" "/>
+              </group>
             </group>
-            <group prefix=", ">
-              <text variable="page"/>
+          </else-if>
+          <else-if type="thesis">
+            <text macro="title"/>
+            <text variable="genre"/>
+            <text macro="publisher"/>
+          </else-if>
+          <else>
+            <group>
+              <text macro="title"/>
+              <text macro="editor" prefix=" "/>
             </group>
-          </group>
-        </else>
-      </choose>
-      <text prefix=" " macro="access" suffix="."/>
+            <group>
+              <text variable="container-title" font-style="italic"/>
+              <group prefix=" ">
+                <text variable="volume"/>
+              </group>
+              <group prefix=", ">
+                <text variable="page"/>
+              </group>
+            </group>
+          </else>
+        </choose>
+        <text macro="access"/>
+      </group>
     </layout>
   </bibliography>
 </style>


### PR DESCRIPTION
This make interpunctation more stable. Created a large group with `delimiter=, " and delete the now unnecessary prefix/suffix.

Ref https://forums.zotero.org/discussion/50936/replace-comma-with-fullstop-period-if-no-url/#Item_2