### PR TITLE
Update british-ecological-society.csl

### DIFF
--- a/british-ecological-society.csl
+++ b/british-ecological-society.csl
@@ -20,7 +20,7 @@
     </contributor>
     <category citation-format="author-date"/>
     <category field="biology"/>
-    <updated>2013-04-05T01:56:49+00:00</updated>
+    <updated>2014-09-06T22:02:33+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <macro name="editor-translator">
@@ -130,14 +130,16 @@
           <group prefix=".">
             <group>
               <text variable="container-title" font-style="italic" prefix=" "/>
-              <text variable="collection-title" prefix=" " suffix="."/>
+              <text variable="collection-title" prefix=", " suffix=""/>
               <group suffix=".">
                 <text macro="edition" prefix=", "/>
-                <names variable="editor translator">
-                  <label form="short" prefix=" (" suffix=" " strip-periods="true"/>
-                  <name and="symbol" sort-separator=", " initialize-with="." delimiter=", " delimiter-precedes-last="never" suffix="),"/>
-                </names>
-                <label variable="page" form="short" prefix=" " suffix=" "/>
+                <group prefix=" (" suffix=")">
+                  <names variable="editor translator">
+                    <label form="short" suffix=" " strip-periods="true"/>
+                    <name and="symbol" sort-separator=", " initialize-with="." delimiter=", " delimiter-precedes-last="never" suffix=""/>
+                  </names>
+                </group>
+                <label variable="page" form="short" prefix=", " suffix=" "/>
                 <text variable="page" suffix="."/>
                 <text macro="publisher" prefix=" "/>
               </group>


### PR DESCRIPTION
There were lots of brackets and commas for the editors in an edited book. I tried to fix it (lines 136-142); hopefully I did not screw up with groups!
There was also a problem with the prefix and suffix of collection title (line 133). It was not separated from book title (so I added a comma as prefix) and it ended with a period although the editor list comes right after in brackets.