### PR TITLE
Update institut-national-de-sante-publique-du-quebec-topo.csl

### DIFF
--- a/institut-national-de-sante-publique-du-quebec-topo.csl
+++ b/institut-national-de-sante-publique-du-quebec-topo.csl
@@ -144,7 +144,7 @@
     <sort>
       <key variable="citation-number"/>
     </sort>
-    <layout prefix="(" suffix=")" delimiter=",">
+    <layout prefix="(" suffix=")" delimiter="," vertical-align="sup">
       <text variable="citation-number"/>
     </layout>
   </citation>


### PR DESCRIPTION
Correction au code en conformité avec une mise à jour du Guide des styles INSPQ-TOPO et INSPQ-NAPP pour Zotero de l'Institut national de santé publique du Québec.
Le renvoi bibliographique numérique dans le texte apparaîtra en exposant après la correction.
Le guide est ici :
https://www.inspq.qc.ca/pdf/publications/CollectionTOPO/TOPO-NAPP_styleguide.pdf