### PR TITLE
Web sites & Sorting thirdly by title

### DIFF
--- a/ecology-letters.csl
+++ b/ecology-letters.csl
@@ -17,7 +17,7 @@
     <category field="biology"/>
     <issn>1461-023X</issn>
     <eissn>1461-0248</eissn>
-    <updated>2013-02-20T13:28:44+00:00</updated>
+    <updated>2015-05-20T08:52:23+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <macro name="container">
@@ -73,9 +73,15 @@
     <choose>
       <if type="webpage">
         <group>
-          <text value="URL" suffix=" "/>
-          <text variable="URL"/>
+          <text value="Available at:" suffix=" "/>
+          <text variable="URL" suffix="."/>
         </group>
+        <text value="Last accessed" prefix=" " suffix=" "/>
+        <date variable="accessed">
+          <date-part name="day" suffix=" "/>
+          <date-part name="month" suffix=" "/>
+          <date-part name="year"/>
+        </date>
       </if>
     </choose>
   </macro>
@@ -92,8 +98,7 @@
         <text variable="title" font-style="italic"/>
       </else-if>
       <else-if type="webpage">
-        <text variable="title"/>
-        <text value="WWW Document" prefix=" [" suffix="]"/>
+        <text variable="title" font-style="italic"/>
       </else-if>
       <else>
         <text variable="title"/>
@@ -207,9 +212,10 @@
     <sort>
       <key macro="author"/>
       <key macro="issued" sort="ascending"/>
+      <key macro="title"/>
     </sort>
     <layout>
-      <group display="block">
+      <group display="block"> 
         <text variable="citation-number" suffix="."/>
       </group>
       <group suffix=".">

--- a/ecology-letters.csl
+++ b/ecology-letters.csl
@@ -73,7 +73,7 @@
     <choose>
       <if type="webpage">
         <group>
-          <text value="Available at:" suffix=" "/>
+          <text term="available at" text-case="capitalize-first" suffix=": "/>
           <text variable="URL" suffix="."/>
         </group>
         <text value="Last accessed" prefix=" " suffix=" "/>
@@ -215,7 +215,7 @@
       <key macro="title"/>
     </sort>
     <layout>
-      <group display="block"> 
+      <group display="block">
         <text variable="citation-number" suffix="."/>
       </group>
       <group suffix=".">


### PR DESCRIPTION
The web site bibliographic entry format wasn't in agreement with what the guidelines suggest:
Format from journal's guidelines: Authorship or Source. (Year). Title of web document or web page (italics). Available at: [URL]. Last accessed DD MONTH YYYY. 
Example from journal's guidelines: National Science Foundation (2010). Ocean acidification (italics). Available at: http://www.nsf.gov/pubs/2010/nsf10530/nsf10530.htm. Last accessed 7 September 2010. 

In the case of same authors in same year, the style wasn't sorting by title.