### PR TITLE
Update apa.csl to italicize book titles

### DIFF
--- a/apa.csl
+++ b/apa.csl
@@ -184,7 +184,7 @@
         <choose>
           <if variable="version" type="book" match="all">
             <!---This is a hack until we have a computer program type -->
-            <text variable="title"/>
+            <text variable="title" font-style="italic"/>
           </if>
           <else>
             <text variable="title" font-style="italic"/>


### PR DESCRIPTION
Book titles should be italicized in APA 6th.  See: https://owl.english.purdue.edu/owl/resource/560/08/