### PR TITLE
Changed Bibliography "hanging-indent" to "false"

### DIFF
--- a/harvard-university-of-worcester.csl
+++ b/harvard-university-of-worcester.csl
@@ -276,7 +276,7 @@
       </group>
     </layout>
   </citation>
-  <bibliography et-al-use-first="4" et-al-min="5" hanging-indent="true">
+  <bibliography et-al-use-first="4" et-al-min="5" hanging-indent="false">
     <sort>
       <key macro="author"/>
       <key variable="title"/>


### PR DESCRIPTION
Changing this bibliography property as it is undesirable to have a hanging indent in our style. (This was left over from a starter-style and not picked up using the Visual Editor)