### PR TITLE
New version of Infoclio styles

### DIFF
--- a/infoclio-de.csl
+++ b/infoclio-de.csl
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
-<style xmlns="http://purl.org/net/xbiblio/csl" class="note" default-locale="de-CH" version="1.0" demote-non-dropping-particle="sort-only">
+<style xmlns="http://purl.org/net/xbiblio/csl" class="note" default-locale="de-CH" version="1.0"
+       name-delimiter="; " delimiter-precedes-last="always" delimiter-precedes-et-al="never">
   <info>
     <title>Infoclio (German - Switzerland)</title>
     <id>http://www.zotero.org/styles/infoclio-de</id>
     <link href="http://www.zotero.org/styles/infoclio-de" rel="self"/>
     <link href="http://www.zotero.org/styles/infoclio-fr-smallcaps" rel="template"/>
-    <link href="https://github.com/citation-style-language/styles/pull/234" rel="documentation"/>
-    <link href="http://www.infoclio.ch/de/node/133932" rel="documentation"/>
+    <link href="https://www.infoclio.ch/de/node/133932" rel="documentation"/>
     <author>
       <name>Nicolas Chachereau</name>
       <email>nicolas.chachereau@unil.ch</email>
@@ -26,318 +26,21 @@
     <category citation-format="note"/>
     <category field="history"/>
     <category field="social_science"/>
-    <updated>2013-11-08T17:47:37+01:00</updated>
+    <updated>2015-08-28T15:05:38+02:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale xml:lang="de">
     <terms>
       <term name="editor" form="short">Hg.</term>
-      <term name="and">; </term>
-      <term name="et-al">; u. a.</term>
+      <term name="interviewer" form="verb">Interview geführt von</term>
+      <term name="accessed">Stand</term>
+      <term name="letter">Schreiben</term>
+      <term name="number-of-volumes" form="short">Bd.</term>
+      <term name="no date" form="short">o. D.</term>
     </terms>
   </locale>
-  <macro name="author-or-editor">
-    <choose>
-      <if variable="author">
-        <names variable="author">
-          <name sort-separator=", " delimiter="; "/>
-        </names>
-      </if>
-      <else-if variable="editor">
-        <text macro="editor"/>
-      </else-if>
-    </choose>
-  </macro>
-  <macro name="editor">
-    <names variable="editor">
-      <name sort-separator=", " delimiter="; "/>
-      <label form="short" prefix="&#160;(" suffix=")"/>
-    </names>
-  </macro>
-  <macro name="title">
-    <choose>
-      <if type="book thesis" match="any">
-        <text variable="title"/>
-      </if>
-      <else-if type="chapter paper-conference" match="any">
-        <group delimiter=" ">
-          <text variable="title" suffix=","/>
-          <text value="in:"/>
-          <text macro="editor" suffix=":"/>
-          <text variable="container-title"/>
-        </group>
-      </else-if>
-      <else-if type="article-journal">
-        <text variable="title" suffix=", "/>
-        <text value="in: "/>
-        <text variable="container-title"/>
-        <choose>
-          <if is-numeric="volume">
-            <number variable="volume" prefix=" "/>
-            <choose>
-              <if is-numeric="issue">
-                <text value="&#160;"/>
-                <number variable="issue" prefix="(" suffix=")"/>
-              </if>
-            </choose>
-          </if>
-          <else-if is-numeric="issue">
-            <number variable="issue" prefix=" (" suffix=")"/>
-          </else-if>
-        </choose>
-      </else-if>
-      <else-if type="article-newspaper article-magazine entry-encyclopedia entry-dictionary broadcast" match="any">
-        <text variable="title" suffix=", "/>
-        <text value="in: "/>
-        <text variable="container-title"/>
-      </else-if>
-      <else-if type="webpage post post-weblog" match="any">
-        <group delimiter=", ">
-          <text variable="title"/>
-          <text variable="container-title"/>
-        </group>
-      </else-if>
-      <else-if type="report">
-        <group delimiter=", ">
-          <text variable="title" quotes="true"/>
-          <text variable="genre"/>
-          <group delimiter=" ">
-            <text variable="collection-title" font-style="italic"/>
-            <number variable="number"/>
-          </group>
-        </group>
-      </else-if>
-      <else-if type="song">
-        <group delimiter=", ">
-          <text variable="title"/>
-          <group delimiter=" ">
-            <text variable="collection-title"/>
-            <number variable="number"/>
-          </group>
-        </group>
-      </else-if>
-      <else-if type="interview">
-        <group delimiter=", ">
-          <text variable="title"/>
-          <names variable="interviewer" delimiter=", ">
-            <label form="verb" prefix=" " suffix=" "/>
-            <name sort-separator=", " delimiter="; "/>
-          </names>
-        </group>
-      </else-if>
-      <else>
-        <text variable="title"/>
-      </else>
-    </choose>
-  </macro>
-  <!-- fin macro "title" -->
-  <macro name="volume-or-medium">
-    <choose>
-      <if type="book chapter entry-encyclopedia entry-dictionary" match="any">
-        <choose>
-          <if is-numeric="volume number-of-volumes" match="all">
-            <text term="volume" form="short" suffix=".&#160;"/>
-            <number variable="volume"/>
-            <number variable="number-of-volumes" prefix=" / "/>
-          </if>
-          <else-if is-numeric="volume">
-            <text term="volume" form="short" suffix=".&#160;"/>
-            <number variable="volume"/>
-          </else-if>
-          <else-if is-numeric="number-of-volumes">
-            <number variable="number-of-volumes"/>
-            <text term="volume" form="short" prefix="&#160;" suffix="."/>
-          </else-if>
-        </choose>
-      </if>
-      <else-if type="motion_picture song broadcast" match="any">
-        <group delimiter=", ">
-          <text variable="medium"/>
-          <text variable="dimensions"/>
-        </group>
-      </else-if>
-    </choose>
-  </macro>
-  <macro name="place">
-    <choose>
-      <if type="book chapter paper-conference entry-encyclopedia entry-dictionary" match="any">
-        <choose>
-          <if variable="publisher-place">
-            <text variable="publisher-place"/>
-          </if>
-          <else>
-            <text value="o. O."/>
-          </else>
-        </choose>
-      </if>
-      <else-if type="report motion_picture broadcast song" match="any">
-        <group delimiter=", ">
-          <text variable="publisher"/>
-          <text variable="publisher-place"/>
-        </group>
-      </else-if>
-      <else-if type="thesis">
-        <group delimiter=", ">
-          <text variable="genre"/>
-          <text variable="publisher"/>
-          <text variable="publisher-place"/>
-        </group>
-      </else-if>
-      <else-if type="speech">
-        <group delimiter=", ">
-          <text variable="genre"/>
-          <text variable="event"/>
-          <text variable="event-place"/>
-        </group>
-      </else-if>
-    </choose>
-  </macro>
-  <macro name="url">
-    <choose>
-      <if variable="URL">
-        <text variable="URL" prefix="&lt;" suffix="&gt;, "/>
-        <text value="Stand: "/>
-        <date variable="accessed" form="numeric" date-parts="year-month-day"/>
-      </if>
-    </choose>
-  </macro>
-  <macro name="date-pages-and-collection">
-    <group delimiter=", ">
-      <text macro="date"/>
-      <text macro="artwork-info"/>
-      <text macro="locator-or-pages"/>
-    </group>
-    <text macro="collection"/>
-  </macro>
-  <macro name="date">
-    <choose>
-      <if type="book chapter paper-conference motion_picture" match="any">
-        <choose>
-          <if variable="issued">
-            <date variable="issued">
-              <date-part name="year"/>
-            </date>
-            <choose>
-              <if is-numeric="edition">
-                <number vertical-align="sup" variable="edition"/>
-              </if>
-            </choose>
-          </if>
-          <else>
-            <text value="o. J."/>
-          </else>
-        </choose>
-      </if>
-      <else-if type="article-journal" match="any">
-        <choose>
-          <if variable="issued">
-            <date variable="issued" form="text" date-parts="year-month"/>
-          </if>
-          <else>
-            <text value="o. J."/>
-          </else>
-        </choose>
-      </else-if>
-      <else-if type="article-newspaper article-magazine webpage post post-weblog report broadcast entry-encyclopedia entry-dictionary speech" match="any">
-        <group delimiter=", ">
-          <choose>
-            <if variable="issued">
-              <date variable="issued" form="text" date-parts="year-month-day"/>
-            </if>
-            <else>
-              <text value="o. J."/>
-            </else>
-          </choose>
-          <text macro="url"/>
-        </group>
-      </else-if>
-      <else-if type="song">
-        <choose>
-          <if variable="issued">
-            <group delimiter=", ">
-              <date variable="issued" form="text"/>
-              <text macro="url"/>
-            </group>
-          </if>
-          <else>
-            <text macro="url"/>
-          </else>
-        </choose>
-      </else-if>
-      <else>
-        <choose>
-          <if variable="issued">
-            <date variable="issued" form="text" date-parts="year-month-day"/>
-          </if>
-          <else-if variable="original-date">
-            <date variable="original-date" form="text" date-parts="year-month-day"/>
-          </else-if>
-          <else-if variable="event-date">
-            <date variable="event-date" form="text" date-parts="year-month-day"/>
-          </else-if>
-          <else>
-            <text value="o. J."/>
-          </else>
-        </choose>
-      </else>
-    </choose>
-  </macro>
-  <!-- fin macro "date" -->
-  <macro name="artwork-info">
-    <choose>
-      <if type="graphic">
-        <group delimiter=", ">
-          <text variable="medium"/>
-          <text variable="dimensions"/>
-          <text variable="genre"/>
-          <text variable="archive"/>
-          <text variable="archive_location"/>
-        </group>
-      </if>
-    </choose>
-  </macro>
-  <macro name="locator">
-    <group delimiter="&#160;">
-      <label variable="locator" form="short"/>
-      <text variable="locator"/>
-    </group>
-  </macro>
-  <macro name="locator-or-pages">
-    <choose>
-      <if variable="locator">
-        <text macro="locator"/>
-      </if>
-      <else>
-        <group delimiter="&#160;">
-          <label variable="page" form="short"/>
-          <text variable="page"/>
-        </group>
-      </else>
-    </choose>
-  </macro>
-  <macro name="collection">
-    <choose>
-      <if type="book chapter paper-conference" match="any">
-        <group prefix=" (" suffix=")" delimiter=" ">
-          <text variable="collection-title"/>
-          <choose>
-            <if is-numeric="collection-number">
-              <number variable="collection-number"/>
-            </if>
-          </choose>
-        </group>
-      </if>
-    </choose>
-  </macro>
-  <macro name="complete-reference">
-    <text macro="author-or-editor" suffix=": "/>
-    <text macro="title" suffix=", "/>
-    <text macro="volume-or-medium" suffix=", "/>
-    <text macro="place" suffix=" "/>
-    <text macro="date-pages-and-collection"/>
-  </macro>
-  <citation name-form="long" and="text" sort-separator=", " name-as-sort-order="all" delimiter-precedes-last="never" et-al-min="4" et-al-use-first="3">
-    <!-- the attributes on citation are inheritable name options -->
+
+  <citation>
     <layout suffix="." delimiter="&#160;; ">
       <choose>
         <if position="ibid-with-locator">
@@ -350,9 +53,7 @@
           <text term="ibid"/>
         </else-if>
         <else-if position="subsequent">
-          <text macro="author-or-editor" suffix=": "/>
-          <text variable="title" form="short"/>
-          <text macro="locator" prefix=", "/>
+          <text macro="subsequent-reference"/>
         </else-if>
         <else>
           <text macro="complete-reference"/>
@@ -360,14 +61,427 @@
       </choose>
     </layout>
   </citation>
-  <bibliography name-form="long" and="text" sort-separator=", " name-as-sort-order="all" delimiter-precedes-last="never" et-al-min="4" et-al-use-first="3">
-    <!-- the attributes on bibliography are inheritable name options -->
+
+  <bibliography>
     <sort>
-      <key macro="author-or-editor" names-min="3" names-use-first="3"/>
+      <key macro="creator" names-min="3" names-use-first="3"/>
       <key variable="issued" sort="descending"/>
     </sort>
     <layout suffix=".">
       <text macro="complete-reference"/>
     </layout>
   </bibliography>
+
+  <macro name="complete-reference">
+    <group delimiter=". ">
+      <group delimiter=", ">
+        <group delimiter=": ">
+          <text macro="creator"/>
+          <group delimiter=", ">
+            <text macro="title"/>
+            <group delimiter=": ">
+              <text macro="in"/>
+              <text macro="container-creator"/>
+              <group delimiter=", ">
+                <group delimiter=" ">
+                  <text macro="container-information"/>
+                  <text macro="journal-volume"/>
+                </group>
+                <text macro="volumes"/>
+              </group>
+            </group>
+            <text macro="type-description"/>
+          </group>
+        </group>
+        <text macro="alt-publisher"/>
+        <group delimiter=" ">
+          <text macro="place"/>
+          <text macro="date"/>
+          <date variable="original-date" form="text" prefix="[" suffix="]"/>
+          <text macro="book-series"/>
+        </group>
+        <text macro="artwork-description"/>
+        <text macro="archive-location"/>
+        <text macro="pages"/>
+        <text macro="url-web-documents-only"/>
+      </group>
+      <text macro="url-non-web-documents"/>
+    </group>
+  </macro>
+
+  <macro name="subsequent-reference">
+    <group delimiter=", ">
+      <group delimiter=": ">
+        <text macro="creator-for-subsequent"/>
+        <text macro="identifier-for-subsequent"/>
+      </group>
+      <date variable="issued" form="numeric" date-parts="year"/>
+      <text macro="locator"/>
+    </group>
+  </macro>
+
+  <macro name="creator">
+    <names variable="author">
+      <name sort-separator=", "
+            name-as-sort-order="all"
+            et-al-min="4" et-al-use-first="3"/>
+      <label form="short" prefix="&#160;(" suffix=")"/>
+      <substitute>
+        <names variable="editor"/>
+        <names variable="composer"/>
+        <names variable="director"/>
+      </substitute>
+    </names>
+  </macro>
+
+  <macro name="creator-for-subsequent">
+    <names variable="author">
+      <name form="short"
+            et-al-min="4" et-al-use-first="1"/>
+      <label form="short" prefix="&#160;(" suffix=")"/>
+      <substitute>
+        <names variable="editor"/>
+        <names variable="composer"/>
+        <names variable="director"/>
+      </substitute>
+    </names>
+  </macro>
+
+  <macro name="title">
+    <text variable="title"/>
+  </macro>
+
+  <macro name="identifier-for-subsequent">
+    <choose>
+      <if variable="title title-short" match="any">
+        <text variable="title" form="short"/>
+      </if>
+      <else-if type="personal_communication">
+        <group delimiter=" ">
+          <text term="letter"/>
+          <names variable="recipient">
+            <label form="verb" prefix=" " suffix=" "/>
+            <name et-al-min="2" et-al-use-first="1"/>
+          </names>
+        </group>
+      </else-if>
+      <else-if type="interview">
+        <names variable="interviewer" delimiter=", ">
+          <label form="verb" prefix=" " suffix=" "/>
+          <name et-al-min="2" et-al-use-first="1"/>
+        </names>
+      </else-if>
+      <else-if type="report song broadcast motion_picture
+                     webpage post post-weblog" match="any">
+        <!-- these types have either collection-title or container-title -->
+        <text variable="collection-title"/>
+        <text variable="container-title"/>
+      </else-if>
+    </choose>
+  </macro>
+
+  <macro name="in">
+    <choose>
+      <if type="chapter paper-conference
+                entry-encyclopedia entry-dictionary
+                article-magazine article-newspaper article-journal"
+          match="any">
+        <text term="in"/>
+      </if>
+    </choose>
+  </macro>
+
+  <macro name="container-creator">
+    <choose>
+      <if type="chapter paper-conference" match="any">
+        <names variable="editor">
+          <name sort-separator=", "
+                name-as-sort-order="all"
+                et-al-min="4" et-al-use-first="3"/>
+          <label form="short" prefix="&#160;(" suffix=")"/>
+          <substitute>
+            <names variable="container-author"/>
+            <names variable="collection-editor"/>
+          </substitute>
+        </names>
+      </if>
+    </choose>
+  </macro>
+
+  <macro name="container-information">
+    <choose>
+      <if type="chapter paper-conference
+                entry-encyclopedia entry-dictionary
+                article-newspaper article-magazine article-journal" match="any">
+        <text variable="container-title"/>
+      </if>
+      <else-if type="report song broadcast motion_picture
+                     webpage post post-weblog" match="any">
+        <group delimiter=", ">
+          <text variable="genre"/>
+          <!-- these types have either collection-title or container-title -->
+          <text variable="collection-title"/>
+          <text variable="container-title"/>
+        </group>
+      </else-if>
+    </choose>
+  </macro>
+  
+  <macro name="journal-volume">
+    <choose>
+      <if type="article-journal">
+        <group delimiter="&#160;">
+          <number variable="volume"/>
+          <number variable="issue" prefix="(" suffix=")"/>
+        </group>
+      </if>
+      <else-if type="report song broadcast" match="any">
+        <number variable="number"/>
+      </else-if>
+    </choose>
+  </macro>
+  
+  <macro name="volumes">
+    <choose>
+      <if type="book chapter
+                entry-encyclopedia entry-dictionary
+                song motion_picture" match="any">
+        <group delimiter=" / ">
+          <group delimiter="&#160;">
+            <label variable="volume" form="short"/>
+            <number variable="volume"/>
+          </group>
+          <group delimiter="&#160;">
+            <number variable="number-of-volumes"/>
+            <choose>
+              <if variable="volume" match="none">
+                <label variable="number-of-volumes" form="short"/>
+              </if>
+            </choose>
+          </group>
+        </group>
+      </if>
+    </choose>
+  </macro>
+
+  <macro name="type-description">
+    <choose>
+      <if type="manuscript thesis speech" match="any">
+        <text variable="genre"/>
+      </if>
+      <else-if type="personal_communication">
+        <group delimiter=", ">
+          <group delimiter=" ">
+            <text term="letter"/>
+            <names variable="recipient">
+              <label form="verb" prefix=" " suffix=" "/>
+              <name and="text" delimiter-precedes-last="never"/>
+            </names>
+          </group>
+          <text variable="genre"/>
+        </group>
+      </else-if>
+      <else-if type="interview">
+        <names variable="interviewer" delimiter=", ">
+          <label form="verb" prefix=" " suffix=" "/>
+          <name and="text" delimiter-precedes-last="never"/>
+        </names>
+      </else-if>
+      <else-if type="motion_picture song broadcast" match="any">
+        <group delimiter=", ">
+          <text variable="medium"/>
+          <!-- refers to duration -->
+          <text variable="dimensions"/>
+        </group>
+      </else-if>
+      <!-- Computer Program -->
+      <else-if type="book">
+        <choose>
+          <if variable="version medium" match="any">
+            <group delimiter=", ">
+              <group delimiter=" ">
+                <text term="version"/>
+                <text variable="version"/>
+              </group>
+              <text variable="medium"/>
+            </group>
+          </if>
+        </choose>
+      </else-if>
+    </choose>
+  </macro>
+
+  <macro name="alt-publisher">
+    <choose>
+      <if type="book chapter
+                paper-conference
+                entry-dictionary entry-encyclopedia" match="none">
+        <!-- university for theses,
+             institution for reports,
+             label for songs,
+             distributor for films,
+             studio for video recordings,
+             network for broadcasts -->
+        <text variable="publisher"/>
+      </if>
+    </choose>
+  </macro>
+
+  <macro name="place">
+    <choose>
+      <if type="speech">
+        <group delimiter=", ">
+          <text variable="event"/>
+          <text variable="event-place"/>
+        </group>
+      </if>
+      <else>
+        <text variable="publisher-place"/>
+      </else>
+    </choose>
+  </macro>
+          
+  <macro name="date">
+    <choose>
+      <if type="book chapter paper-conference thesis" match="any">
+        <choose>
+          <if variable="issued">
+            <date variable="issued" form="numeric" date-parts="year"/>
+            <choose>
+              <if is-numeric="edition">
+                <number vertical-align="sup" variable="edition"/>
+              </if>
+            </choose>
+          </if>
+          <else>
+            <text term="no date" form="short"/>
+          </else>
+        </choose>
+      </if>
+      <else-if type="article-journal article-newspaper article-magazine
+                     graphic entry-encyclopedia entry-dictionary
+                     report speech interview
+                     manuscript personal_communication" match="any">
+        <choose>
+          <if variable="issued">
+            <date variable="issued" form="numeric" date-parts="year-month-day"/>
+          </if>
+          <else>
+            <text term="no date" form="short"/>
+          </else>
+        </choose>
+      </else-if>
+      <else>
+        <date variable="issued" form="numeric" date-parts="year-month-day"/>
+      </else>
+    </choose>
+  </macro>
+
+  <macro name="pages">
+    <choose>
+      <if variable="locator">
+        <text macro="locator"/>
+      </if>
+      <else>
+        <group delimiter="&#160;">
+          <label variable="page" form="short"/>
+          <text variable="page"/>
+        </group>
+      </else>
+    </choose>
+  </macro>
+
+  <macro name="locator">
+    <group delimiter="&#160;">
+      <label variable="locator" form="short"/>
+      <text variable="locator"/>
+    </group>
+  </macro>
+
+  <macro name="book-series">
+    <choose>
+      <if type="book chapter paper-conference
+                entry-dictionary entry-encyclopedia" match="any">
+        <group prefix="(" suffix=")" delimiter=" ">
+          <text variable="collection-title"/>
+          <choose>
+            <if is-numeric="collection-number">
+              <number variable="collection-number"/>
+            </if>
+          </choose>
+        </group>
+      </if>
+    </choose>
+  </macro>
+
+  <macro name="artwork-description">
+    <choose>
+      <if type="graphic">
+        <group delimiter=", ">
+          <text variable="medium"/>
+          <text variable="dimensions"/>
+          <text variable="genre"/>
+        </group>
+      </if>
+    </choose>
+  </macro>
+
+  <macro name="archive-location">
+    <choose>
+      <if variable="archive">
+        <group delimiter=", ">
+          <text variable="archive"/>
+          <text variable="archive_location"/>
+          <text variable="call-number" prefix="Signatur: "/>
+        </group>
+      </if>
+    </choose>
+  </macro>
+
+  <macro name="url-web-documents-only">
+    <choose>
+      <if type="webpage post post-weblog">
+          <text macro="url"/>
+      </if>
+    </choose>
+  </macro>
+
+  <macro name="url-non-web-documents">
+    <choose>
+      <if variable="DOI">
+        <text term="online" text-case="capitalize-first" suffix=": "/>
+        <group delimiter=", ">
+          <text variable="source"/>
+          <group delimiter=": ">
+            <text value="DOI"/>
+            <text variable="DOI"/>
+          </group>
+        </group>
+      </if>
+      <else-if variable="URL">
+        <choose>
+          <if type="webpage post post-weblog" match="none">
+            <group delimiter=" ">
+              <text term="online" text-case="capitalize-first" suffix=": "/>
+              <group delimiter=", ">
+                <text variable="source"/>
+                <text macro="url"/>
+              </group>
+            </group>
+          </if>
+        </choose>
+      </else-if>
+    </choose>
+  </macro>
+
+  <macro name="url">
+    <group delimiter=", ">
+      <text variable="URL" prefix="&lt;" suffix="&gt;"/>
+      <group delimiter=": ">
+        <text term="accessed"/>
+        <date variable="accessed" form="numeric" date-parts="year-month-day"/>
+      </group>
+    </group>
+  </macro>
+
 </style>

--- a/infoclio-fr-nocaps.csl
+++ b/infoclio-fr-nocaps.csl
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
-<style xmlns="http://purl.org/net/xbiblio/csl" class="note" default-locale="fr-FR" version="1.0" demote-non-dropping-particle="never">
+<style xmlns="http://purl.org/net/xbiblio/csl" class="note" default-locale="fr-FR" version="1.0"
+       delimiter-precedes-last="never" delimiter-precedes-et-al="never" and="text">
   <info>
     <title>Infoclio (sans majuscules, French)</title>
     <id>http://www.zotero.org/styles/infoclio-fr-nocaps</id>
     <link href="http://www.zotero.org/styles/infoclio-fr-nocaps" rel="self"/>
     <link href="http://www.zotero.org/styles/infoclio-fr-smallcaps" rel="template"/>
-    <link href="https://github.com/citation-style-language/styles/pull/234" rel="documentation"/>
-    <link href="http://www.infoclio.ch/de/node/133932" rel="documentation"/>
+    <link href="https://www.infoclio.ch/fr/node/138218" rel="documentation"/>
     <author>
       <name>Nicolas Chachereau</name>
       <email>nicolas.chachereau@unil.ch</email>
@@ -26,17 +26,17 @@
     <category citation-format="note"/>
     <category field="history"/>
     <category field="social_science"/>
-    <updated>2013-11-11T09:47:27+01:00</updated>
+    <updated>2015-08-28T15:07:44+02:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale xml:lang="fr">
+    <date form="numeric">
+      <date-part name="day" form="numeric-leading-zeros" suffix="."/>
+      <date-part name="month" form="numeric-leading-zeros" suffix="."/>
+      <date-part name="year"/>
+    </date>
     <terms>
-      <!-- &#7497; correspond à un petit "e" placé en exposant: 1e, 2e... -->
-      <term name="ordinal-01">&#7497;</term>
-      <term name="ordinal-02">&#7497;</term>
-      <term name="ordinal-03">&#7497;</term>
-      <term name="ordinal-04">&#7497;</term>
-      <term name="cited">cit.</term>
+      <term name="cited" form="short">cit.</term>
       <term name="page" form="short">
         <single>p.</single>
         <multiple>pp.</multiple>
@@ -45,282 +45,448 @@
         <single>éd.</single>
         <multiple>éds</multiple>
       </term>
+      <term name="interviewer" form="verb">entretien réalisé par</term>
+      <term name="letter">courrier</term>
+      <term name="number-of-volumes" form="short">vol.</term>
     </terms>
   </locale>
-  <macro name="author-or-editor">
-    <choose>
-      <if variable="author">
-        <names variable="author">
-          <name sort-separator=" "/>
-          <et-al font-style="italic"/>
-        </names>
-      </if>
-      <else-if variable="editor">
-        <text macro="editor"/>
-      </else-if>
-    </choose>
+
+  <citation>
+    <layout suffix="." delimiter="&#160;; ">
+      <choose>
+        <if position="ibid-with-locator">
+          <group delimiter=", ">
+            <text term="ibid"/>
+            <text macro="locator"/>
+          </group>
+        </if>
+        <else-if position="ibid">
+          <text term="ibid"/>
+        </else-if>
+        <else-if position="subsequent">
+          <text macro="subsequent-reference"/>
+        </else-if>
+        <else>
+          <text macro="complete-reference"/>
+        </else>
+      </choose>
+    </layout>
+  </citation>
+
+  <bibliography>
+    <sort>
+      <key macro="creator" names-min="3" names-use-first="3"/>
+      <key variable="issued" sort="descending"/>
+    </sort>
+    <layout suffix=".">
+      <text macro="complete-reference"/>
+    </layout>
+  </bibliography>
+
+  <macro name="complete-reference">
+    <group delimiter=". ">
+      <group delimiter=", ">
+        <text macro="creator"/>
+        <text macro="title"/>
+        <group delimiter=": ">
+          <text macro="in"/>
+          <group delimiter=", ">
+            <text macro="container-creator"/>
+            <group delimiter=" ">
+              <text macro="container-information"/>
+              <text macro="journal-volume"/>
+            </group>
+            <text macro="volumes"/>
+          </group>
+        </group>
+        <text macro="type-description"/>
+        <text macro="alt-publisher"/>
+        <text macro="edition"/>
+        <text macro="place"/>
+        <text macro="publishing-house"/>
+        <group delimiter=" ">
+          <text macro="date"/>
+          <date variable="original-date" form="text" prefix="[" suffix="]"/>
+          <text macro="book-series"/>
+        </group>
+        <text macro="artwork-description"/>
+        <text macro="archive-location"/>
+        <text macro="pages"/>
+        <text macro="url-web-documents-only"/>
+      </group>
+      <text macro="url-non-web-documents"/>
+    </group>
   </macro>
-  <macro name="editor">
-    <names variable="editor">
-      <name sort-separator=" "/>
-      <et-al font-style="italic"/>
+
+  <macro name="subsequent-reference">
+    <group delimiter=", ">
+      <text macro="creator-for-subsequent"/>
+      <text macro="identifier-for-subsequent"/>
+      <text macro="op-cit"/>
+      <date variable="issued" form="numeric" date-parts="year"/>
+      <text macro="locator"/>
+    </group>
+  </macro>
+
+  <macro name="creator">
+    <names variable="author">
+      <name sort-separator=" "
+            name-as-sort-order="all"
+            et-al-min="4" et-al-use-first="3"/>
       <label form="short" prefix="&#160;(" suffix=")"/>
+      <et-al font-style="italic"/>
+      <substitute>
+        <names variable="editor"/>
+        <names variable="composer"/>
+        <names variable="director"/>
+      </substitute>
     </names>
   </macro>
+
+  <macro name="creator-for-subsequent">
+    <names variable="author">
+      <name form="short"
+            et-al-min="4" et-al-use-first="1"/>
+      <label form="short" prefix="&#160;(" suffix=")"/>
+      <et-al font-style="italic"/>
+      <substitute>
+        <names variable="editor"/>
+        <names variable="composer"/>
+        <names variable="director"/>
+      </substitute>
+    </names>
+  </macro>
+
   <macro name="title">
     <choose>
-      <if type="book thesis graphic motion_picture" match="any">
+      <if type="book thesis graphic" match="any">
         <text variable="title" font-style="italic"/>
       </if>
-      <else-if type="chapter paper-conference" match="any">
-        <group delimiter=" ">
-          <text variable="title" quotes="true" suffix=","/>
-          <text value="in" font-style="italic"/>
-          <text macro="editor" suffix=","/>
-          <text variable="container-title" font-style="italic"/>
-        </group>
+      <else-if type="article
+                     article-magazine article-newspaper article-journal
+                     entry entry-dictionary entry-encyclopedia
+                     report chapter paper-conference
+                     post post-weblog webpage
+                     song broadcast" match="any">
+        <text variable="title" quotes="true"/>
       </else-if>
-      <else-if type="article-journal">
-        <group delimiter=", ">
-          <text variable="title" quotes="true"/>
-          <group>
-            <text variable="container-title" font-style="italic"/>
+      <else-if type="motion_picture">
+        <choose>
+          <if variable="collection-title">
+            <text variable="title" quotes="true"/>
+          </if>
+          <else>
+            <text variable="title" font-style="italic"/>
+          </else>
+        </choose>
+      </else-if>
+      <else>
+        <text variable="title"/>
+      </else>
+    </choose>
+  </macro>
+
+  <macro name="identifier-for-subsequent">
+    <choose>
+      <if variable="title title-short" match="any">
+        <choose>
+          <if type="book thesis graphic" match="any">
+            <text variable="title" font-style="italic" form="short"/>
+          </if>
+          <else-if type="article
+                         article-magazine article-newspaper article-journal
+                         entry entry-dictionary entry-encyclopedia
+                         report chapter paper-conference
+                         post post-weblog webpage
+                         song broadcast" match="any">
+            <text variable="title" quotes="true" form="short"/>
+          </else-if>
+          <else-if type="motion_picture">
             <choose>
-              <if is-numeric="volume">
-                <number variable="volume" prefix=" "/>
-                <choose>
-                  <if is-numeric="issue">
-                    <text value="&#160;"/>
-                    <number variable="issue" prefix="(" suffix=")"/>
-                  </if>
-                </choose>
+              <if variable="collection-title">
+                <text variable="title" quotes="true"/>
               </if>
-              <else-if is-numeric="issue">
-                <number variable="issue" prefix=" (" suffix=")"/>
-              </else-if>
+              <else>
+                <text variable="title" font-style="italic"/>
+              </else>
             </choose>
-          </group>
-        </group>
-      </else-if>
-      <else-if type="article-newspaper article-magazine entry-encyclopedia entry-dictionary broadcast" match="any">
-        <group delimiter=", ">
-          <text variable="title" quotes="true"/>
-          <text variable="container-title" font-style="italic"/>
-        </group>
-      </else-if>
-      <else-if type="webpage post post-weblog" match="any">
-        <group delimiter=", ">
-          <text variable="title" quotes="true"/>
-          <text variable="container-title" font-style="italic"/>
-        </group>
-      </else-if>
-      <else-if type="report">
-        <group delimiter=", ">
-          <text variable="title" quotes="true"/>
-          <text variable="genre"/>
-          <group delimiter=" ">
-            <text variable="collection-title" font-style="italic"/>
-            <number variable="number"/>
-          </group>
-        </group>
-      </else-if>
-      <else-if type="song">
-        <group delimiter=", ">
-          <text variable="title" quotes="true"/>
-          <group delimiter=" ">
-            <text variable="collection-title" font-style="italic"/>
-            <number variable="number"/>
-          </group>
-        </group>
-      </else-if>
-      <else-if type="interview">
-        <group delimiter=", ">
-          <text variable="title" quotes="true"/>
-          <names variable="interviewer" delimiter=", ">
+          </else-if>
+          <else>
+            <text variable="title" form="short"/>
+          </else>
+        </choose>
+      </if>
+      <else-if type="personal_communication">
+        <group delimiter=" ">
+          <text term="letter"/>
+          <names variable="recipient">
             <label form="verb" prefix=" " suffix=" "/>
-            <name sort-separator=" "/>
+            <name et-al-min="3" et-al-use-first="1"/>
             <et-al font-style="italic"/>
           </names>
         </group>
       </else-if>
-      <else>
-        <text variable="title" quotes="true"/>
-      </else>
+      <else-if type="interview">
+        <names variable="interviewer" delimiter=", ">
+          <label form="verb" prefix=" " suffix=" "/>
+          <name et-al-min="3" et-al-use-first="1"/>
+          <et-al font-style="italic"/>
+        </names>
+      </else-if>
+      <else-if type="report song broadcast motion_picture
+                     webpage post post-weblog" match="any">
+        <!-- these types have either collection-title or container-title -->
+        <text variable="collection-title" font-style="italic"/>
+        <text variable="container-title" font-style="italic"/>
+      </else-if>
     </choose>
   </macro>
-  <!-- fin macro "title" -->
-  <macro name="volume-or-medium">
+
+  <macro name="op-cit">
+     <group font-style="italic" delimiter="&#160;" suffix=".">
+      <choose>
+        <if type="article
+                  article-magazine article-newspaper article-journal
+                  entry entry-dictionary entry-encyclopedia
+                  chapter paper-conference
+                  post post-weblog" match="any">
+          <text value="art."/>
+        </if>
+        <else-if type="manuscript personal_communication interview
+                       report webpage" match="any">
+          <text value="doc."/>
+        </else-if>
+        <else-if type="book thesis graphic
+                       motion_picture song broadcast" match="any">
+          <text value="op."/>
+        </else-if>
+      </choose>
+      <text term="cited" form="short"/>
+    </group>
+  </macro>
+
+  <macro name="in">
     <choose>
-      <if type="book chapter entry-encyclopedia entry-dictionary" match="any">
-        <choose>
-          <if is-numeric="volume number-of-volumes" match="all">
-            <text term="volume" form="short" suffix=".&#160;"/>
-            <number variable="volume"/>
-            <number variable="number-of-volumes" prefix=" / "/>
-          </if>
-          <else-if is-numeric="volume">
-            <text term="volume" form="short" suffix=".&#160;"/>
-            <number variable="volume"/>
-          </else-if>
-          <else-if is-numeric="number-of-volumes">
-            <number variable="number-of-volumes"/>
-            <text term="volume" form="short" prefix="&#160;" suffix="."/>
-          </else-if>
-        </choose>
+      <if type="chapter paper-conference
+                entry-encyclopedia entry-dictionary"
+          match="any">
+        <text term="in"/>
       </if>
+    </choose>
+  </macro>
+
+  <macro name="container-creator">
+    <choose>
+      <if type="chapter paper-conference" match="any">
+        <names variable="editor">
+          <name sort-separator=" "
+                name-as-sort-order="all"
+                et-al-min="4" et-al-use-first="3"/>
+          <label form="short" prefix="&#160;(" suffix=")"/>
+          <et-al font-style="italic"/>
+          <substitute>
+            <names variable="container-author"/>
+            <names variable="collection-editor"/>
+          </substitute>
+        </names>
+      </if>
+    </choose>
+  </macro>
+
+  <macro name="container-information">
+    <choose>
+      <if type="chapter paper-conference
+                entry-encyclopedia entry-dictionary
+                article-newspaper article-magazine article-journal" match="any">
+        <text variable="container-title" font-style="italic"/>
+      </if>
+      <else-if type="report song broadcast motion_picture
+                     webpage post post-weblog" match="any">
+        <group delimiter=", ">
+          <text variable="genre"/>
+          <!-- these types have either collection-title or container-title -->
+          <text variable="collection-title" font-style="italic"/>
+          <text variable="container-title" font-style="italic"/>
+        </group>
+      </else-if>
+    </choose>
+  </macro>
+  
+  <macro name="journal-volume">
+    <choose>
+      <if type="article-journal">
+        <group delimiter="&#160;">
+          <number variable="volume"/>
+          <number variable="issue" prefix="(" suffix=")"/>
+        </group>
+      </if>
+      <else-if type="report song broadcast" match="any">
+        <number variable="number"/>
+      </else-if>
+    </choose>
+  </macro>
+  
+  <macro name="volumes">
+    <choose>
+      <if type="book chapter
+                entry-encyclopedia entry-dictionary
+                song motion_picture" match="any">
+        <group delimiter=" / ">
+          <group delimiter="&#160;">
+            <label variable="volume" form="short"/>
+            <number variable="volume"/>
+          </group>
+          <group delimiter="&#160;">
+            <number variable="number-of-volumes"/>
+            <choose>
+              <if variable="volume" match="none">
+                <label variable="number-of-volumes" form="short"/>
+              </if>
+            </choose>
+          </group>
+        </group>
+      </if>
+    </choose>
+  </macro>
+
+  <macro name="type-description">
+    <choose>
+      <if type="manuscript thesis speech" match="any">
+        <text variable="genre"/>
+      </if>
+      <else-if type="personal_communication">
+        <group delimiter=", ">
+          <group delimiter=" ">
+            <text term="letter"/>
+            <names variable="recipient">
+              <label form="verb" prefix=" " suffix=" "/>
+              <name/>
+            </names>
+          </group>
+          <text variable="genre"/>
+        </group>
+      </else-if>
+      <else-if type="interview">
+        <names variable="interviewer" delimiter=", ">
+          <label form="verb" prefix=" " suffix=" "/>
+          <name/>
+        </names>
+      </else-if>
       <else-if type="motion_picture song broadcast" match="any">
         <group delimiter=", ">
           <text variable="medium"/>
+          <!-- refers to duration -->
           <text variable="dimensions"/>
         </group>
       </else-if>
-    </choose>
-  </macro>
-  <macro name="place-and-publisher">
-    <choose>
-      <if type="book chapter paper-conference" match="any">
-        <group delimiter=", ">
-          <choose>
-            <if variable="publisher-place">
-              <text variable="publisher-place"/>
-            </if>
-            <else>
-              <text value="[s. l.]"/>
-            </else>
-          </choose>
-          <text variable="publisher"/>
-        </group>
-      </if>
-      <else-if type="report motion_picture broadcast song" match="any">
-        <group delimiter=", ">
-          <text variable="publisher-place"/>
-          <text variable="publisher"/>
-        </group>
-      </else-if>
-      <else-if type="thesis">
-        <group delimiter=", ">
-          <text variable="genre"/>
-          <text variable="publisher-place"/>
-          <text variable="publisher"/>
-        </group>
-      </else-if>
-      <else-if type="speech">
-        <group delimiter=", ">
-          <text variable="genre"/>
-          <text variable="event"/>
-          <text variable="event-place"/>
-        </group>
-      </else-if>
-    </choose>
-  </macro>
-  <macro name="url">
-    <choose>
-      <if variable="URL">
-        <text variable="URL" prefix="&lt;" suffix="&gt;, "/>
-        <group delimiter=" ">
-          <text term="accessed"/>
-          <date variable="accessed" form="text" date-parts="year-month-day"/>
-        </group>
-      </if>
-    </choose>
-  </macro>
-  <macro name="date-pages-and-collection">
-    <group delimiter=", ">
-      <text macro="date"/>
-      <text macro="artwork-info"/>
-      <text macro="locator-or-pages"/>
-    </group>
-    <text macro="collection"/>
-  </macro>
-  <macro name="date">
-    <choose>
-      <if type="book chapter paper-conference motion_picture" match="any">
+      <!-- Computer Program -->
+      <else-if type="book">
         <choose>
-          <if variable="issued">
-            <date variable="issued">
-              <date-part name="year"/>
-            </date>
-          </if>
-          <else>
-            <text value="[s. d.]"/>
-          </else>
-        </choose>
-      </if>
-      <else-if type="article-journal" match="any">
-        <choose>
-          <if variable="issued">
-            <date variable="issued" form="text" date-parts="year-month"/>
-          </if>
-          <else>
-            <text value="[s. d.]"/>
-          </else>
-        </choose>
-      </else-if>
-      <else-if type="article-newspaper article-magazine webpage post post-weblog report broadcast entry-encyclopedia entry-dictionary speech" match="any">
-        <group delimiter=", ">
-          <choose>
-            <if variable="issued">
-              <date variable="issued" form="text" date-parts="year-month-day"/>
-            </if>
-            <else>
-              <text value="[s. d.]"/>
-            </else>
-          </choose>
-          <text macro="url"/>
-        </group>
-      </else-if>
-      <else-if type="song">
-        <choose>
-          <if variable="issued">
+          <if variable="version medium" match="any">
             <group delimiter=", ">
-              <date variable="issued" form="text"/>
-              <text macro="url"/>
+              <group delimiter=" ">
+                <text term="version"/>
+                <text variable="version"/>
+              </group>
+              <text variable="medium"/>
+            </group>
+          </if>
+        </choose>
+      </else-if>
+    </choose>
+  </macro>
+
+  <macro name="alt-publisher">
+    <choose>
+      <if type="book chapter
+                thesis report
+                paper-conference
+                entry-dictionary entry-encyclopedia" match="none">
+        <!--
+             label for songs,
+             distributor for films,
+             studio for video recordings,
+             network for broadcasts -->
+        <text variable="publisher"/>
+      </if>
+    </choose>
+  </macro>
+
+  <macro name="edition">
+    <choose>
+      <if type="book chapter
+                entry-dictionary entry-encyclopedia" match="any">
+        <choose>
+          <if is-numeric="edition">
+            <group delimiter="&#160;">
+              <number variable="edition" form="ordinal"/>
+              <label variable="edition"/>
             </group>
           </if>
           <else>
-            <text macro="url"/>
+            <text variable="edition"/>
+          </else>
+        </choose>
+      </if>
+    </choose>
+  </macro>
+
+  <macro name="place">
+    <choose>
+      <if type="speech">
+        <group delimiter=", ">
+          <text variable="event"/>
+          <text variable="event-place"/>
+        </group>
+      </if>
+      <else>
+        <text variable="publisher-place"/>
+      </else>
+    </choose>
+  </macro>
+
+  <macro name="publishing-house">
+    <choose>
+      <if type="book chapter thesis report
+                paper-conference
+                entry-dictionary entry-encyclopedia" match="any">
+        <text variable="publisher"/>
+      </if>
+    </choose>
+  </macro>
+
+  <macro name="date">
+    <choose>
+      <if type="book chapter paper-conference thesis" match="any">
+        <choose>
+          <if variable="issued">
+            <date variable="issued" form="numeric" date-parts="year"/>
+          </if>
+          <else>
+            <text term="no date" form="short"/>
+          </else>
+        </choose>
+      </if>
+      <else-if type="article-journal article-newspaper article-magazine
+                     graphic entry-encyclopedia entry-dictionary
+                     report speech interview
+                     manuscript personal_communication" match="any">
+        <choose>
+          <if variable="issued">
+            <date variable="issued" form="numeric" date-parts="year-month-day"/>
+          </if>
+          <else>
+            <text term="no date" form="short"/>
           </else>
         </choose>
       </else-if>
       <else>
-        <choose>
-          <if variable="issued">
-            <date variable="issued" form="text" date-parts="year-month-day"/>
-          </if>
-          <else-if variable="original-date">
-            <date variable="original-date" form="text" date-parts="year-month-day"/>
-          </else-if>
-          <else-if variable="event-date">
-            <date variable="event-date" form="text" date-parts="year-month-day"/>
-          </else-if>
-          <else>
-            <text value="[s. d.]"/>
-          </else>
-        </choose>
+        <date variable="issued" form="numeric" date-parts="year-month-day"/>
       </else>
     </choose>
   </macro>
-  <!-- fin macro "date" -->
-  <macro name="artwork-info">
-    <choose>
-      <if type="graphic">
-        <group delimiter=", ">
-          <text variable="medium"/>
-          <text variable="dimensions"/>
-          <text variable="genre"/>
-          <text variable="archive"/>
-          <text variable="archive_location"/>
-        </group>
-      </if>
-    </choose>
-  </macro>
-  <macro name="locator">
-    <group delimiter="&#160;">
-      <label variable="locator" form="short"/>
-      <text variable="locator"/>
-    </group>
-  </macro>
-  <macro name="locator-or-pages">
+
+  <macro name="pages">
     <choose>
       <if variable="locator">
         <text macro="locator"/>
@@ -333,10 +499,19 @@
       </else>
     </choose>
   </macro>
-  <macro name="collection">
+
+  <macro name="locator">
+    <group delimiter="&#160;">
+      <label variable="locator" form="short"/>
+      <text variable="locator"/>
+    </group>
+  </macro>
+
+  <macro name="book-series">
     <choose>
-      <if type="book chapter paper-conference" match="any">
-        <group prefix=" (" suffix=")" delimiter=" ">
+      <if type="book chapter paper-conference
+                entry-dictionary entry-encyclopedia" match="any">
+        <group prefix="(" suffix=")" delimiter=" ">
           <text variable="collection-title"/>
           <choose>
             <if is-numeric="collection-number">
@@ -347,80 +522,75 @@
       </if>
     </choose>
   </macro>
-  <macro name="edition">
+
+  <macro name="artwork-description">
     <choose>
-      <if type="book chapter paper-conference" match="any">
-        <choose>
-          <if is-numeric="edition">
-            <number variable="edition" form="ordinal"/>
-            <text term="edition" prefix="&#160;"/>
-          </if>
-        </choose>
+      <if type="graphic">
+        <group delimiter=", ">
+          <text variable="medium"/>
+          <text variable="dimensions"/>
+          <text variable="genre"/>
+        </group>
       </if>
     </choose>
   </macro>
-  <macro name="complete-reference">
+
+  <macro name="archive-location">
+    <choose>
+      <if variable="archive">
+        <group delimiter=", ">
+          <text variable="archive"/>
+          <text variable="archive_location"/>
+          <text variable="call-number" prefix="Cote: "/>
+        </group>
+      </if>
+    </choose>
+  </macro>
+
+  <macro name="url-web-documents-only">
+    <choose>
+      <if type="webpage post post-weblog">
+          <text macro="url"/>
+      </if>
+    </choose>
+  </macro>
+
+  <macro name="url-non-web-documents">
+    <choose>
+      <if variable="DOI">
+        <text term="online" text-case="capitalize-first" suffix=": "/>
+        <group delimiter=", ">
+          <text variable="source"/>
+          <group delimiter=": ">
+            <text value="DOI"/>
+            <text variable="DOI"/>
+          </group>
+        </group>
+      </if>
+      <else-if variable="URL">
+        <choose>
+          <if type="webpage post post-weblog" match="none">
+            <group delimiter=" ">
+              <text term="online" text-case="capitalize-first" suffix=": "/>
+              <group delimiter=", ">
+                <text variable="source"/>
+                <text macro="url"/>
+              </group>
+            </group>
+          </if>
+        </choose>
+      </else-if>
+    </choose>
+  </macro>
+
+  <macro name="url">
     <group delimiter=", ">
-      <text macro="author-or-editor"/>
-      <text macro="title"/>
-      <text macro="volume-or-medium"/>
-      <text macro="edition"/>
-      <text macro="place-and-publisher"/>
-      <text macro="date-pages-and-collection"/>
+      <text variable="URL" prefix="&lt;" suffix="&gt;"/>
+      <group delimiter=" ">
+        <text term="accessed"/>
+        <date variable="accessed" form="numeric" date-parts="year-month-day"/>
+      </group>
     </group>
   </macro>
-  <citation name-form="long" and="text" sort-separator=", " name-as-sort-order="all" delimiter-precedes-last="never" et-al-min="4">
-    <!-- the attributes on citation are inheritable name options -->
-    <layout suffix="." delimiter="&#160;; ">
-      <choose>
-        <if position="ibid-with-locator">
-          <group delimiter=", ">
-            <text term="ibid" font-style="italic" suffix="."/>
-            <text macro="locator"/>
-          </group>
-        </if>
-        <else-if position="ibid">
-          <text term="ibid" font-style="italic"/>
-        </else-if>
-        <else-if position="subsequent">
-          <group delimiter=", ">
-            <text macro="author-or-editor"/>
-            <choose>
-              <if type="book thesis" match="any">
-                <text variable="title" form="short" font-style="italic"/>
-              </if>
-              <else>
-                <text variable="title" form="short" quotes="true"/>
-              </else>
-            </choose>
-            <group font-style="italic" delimiter="&#160;">
-              <choose>
-                <if type="article article-magazine article-newspaper article-journal entry entry-dictionary entry-encyclopedia chapter" match="any">
-                  <text value="art."/>
-                </if>
-                <else>
-                  <text value="op."/>
-                </else>
-              </choose>
-              <text term="cited" suffix="."/>
-            </group>
-            <text macro="locator"/>
-          </group>
-        </else-if>
-        <else>
-          <text macro="complete-reference"/>
-        </else>
-      </choose>
-    </layout>
-  </citation>
-  <bibliography name-form="long" and="text" sort-separator=", " name-as-sort-order="all" delimiter-precedes-last="never" et-al-min="4">
-    <!-- the attributes on bibliography are inheritable name options -->
-    <sort>
-      <key macro="author-or-editor" names-min="3" names-use-first="3"/>
-      <key variable="issued" sort="descending"/>
-    </sort>
-    <layout suffix=".">
-      <text macro="complete-reference"/>
-    </layout>
-  </bibliography>
+
 </style>

--- a/infoclio-fr-smallcaps.csl
+++ b/infoclio-fr-smallcaps.csl
@@ -3,8 +3,8 @@
        delimiter-precedes-last="never" delimiter-precedes-et-al="never" and="text">
   <info>
     <title>Infoclio (petites majuscules, French)</title>
-    <id>http://www.zotero.org/styles/infoclio-fr</id>
-    <link href="http://www.zotero.org/styles/infoclio-fr" rel="self"/>
+    <id>http://www.zotero.org/styles/infoclio-fr-smallcaps</id>
+    <link href="http://www.zotero.org/styles/infoclio-fr-smallcaps" rel="self"/>
     <link href="https://www.infoclio.ch/fr/node/138218" rel="documentation"/>
     <author>
       <name>Nicolas Chachereau</name>

--- a/infoclio-fr-smallcaps.csl
+++ b/infoclio-fr-smallcaps.csl
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
-<style xmlns="http://purl.org/net/xbiblio/csl" class="note" default-locale="fr-FR" version="1.0" demote-non-dropping-particle="never">
+<style xmlns="http://purl.org/net/xbiblio/csl" class="note" default-locale="fr-FR" version="1.0"
+       delimiter-precedes-last="never" delimiter-precedes-et-al="never" and="text">
   <info>
     <title>Infoclio (petites majuscules, French)</title>
-    <id>http://www.zotero.org/styles/infoclio-fr-smallcaps</id>
-    <link href="http://www.zotero.org/styles/infoclio-fr-smallcaps" rel="self"/>
-    <link href="https://github.com/citation-style-language/styles/pull/234" rel="documentation"/>
-    <link href="http://www.infoclio.ch/de/node/133932" rel="documentation"/>
+    <id>http://www.zotero.org/styles/infoclio-fr</id>
+    <link href="http://www.zotero.org/styles/infoclio-fr" rel="self"/>
+    <link href="https://www.infoclio.ch/fr/node/138218" rel="documentation"/>
     <author>
       <name>Nicolas Chachereau</name>
       <email>nicolas.chachereau@unil.ch</email>
@@ -25,17 +25,17 @@
     <category citation-format="note"/>
     <category field="history"/>
     <category field="social_science"/>
-    <updated>2013-11-08T17:47:45+01:00</updated>
+    <updated>2015-08-28T15:07:37+02:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale xml:lang="fr">
+    <date form="numeric">
+      <date-part name="day" form="numeric-leading-zeros" suffix="."/>
+      <date-part name="month" form="numeric-leading-zeros" suffix="."/>
+      <date-part name="year"/>
+    </date>
     <terms>
-      <!-- &#7497; correspond à un petit "e" placé en exposant: 1e, 2e... -->
-      <term name="ordinal-01">&#7497;</term>
-      <term name="ordinal-02">&#7497;</term>
-      <term name="ordinal-03">&#7497;</term>
-      <term name="ordinal-04">&#7497;</term>
-      <term name="cited">cit.</term>
+      <term name="cited" form="short">cit.</term>
       <term name="page" form="short">
         <single>p.</single>
         <multiple>pp.</multiple>
@@ -44,288 +44,454 @@
         <single>éd.</single>
         <multiple>éds</multiple>
       </term>
+      <term name="interviewer" form="verb">entretien réalisé par</term>
+      <term name="letter">courrier</term>
+      <term name="number-of-volumes" form="short">vol.</term>
     </terms>
   </locale>
-  <macro name="author-or-editor">
-    <choose>
-      <if variable="author">
-        <names variable="author">
-          <name sort-separator=" ">
-            <name-part name="family" font-variant="small-caps"/>
-          </name>
-          <et-al font-style="italic"/>
-        </names>
-      </if>
-      <else-if variable="editor">
-        <text macro="editor"/>
-      </else-if>
-    </choose>
+
+  <citation>
+    <layout suffix="." delimiter="&#160;; ">
+      <choose>
+        <if position="ibid-with-locator">
+          <group delimiter=", ">
+            <text term="ibid"/>
+            <text macro="locator"/>
+          </group>
+        </if>
+        <else-if position="ibid">
+          <text term="ibid"/>
+        </else-if>
+        <else-if position="subsequent">
+          <text macro="subsequent-reference"/>
+        </else-if>
+        <else>
+          <text macro="complete-reference"/>
+        </else>
+      </choose>
+    </layout>
+  </citation>
+
+  <bibliography>
+    <sort>
+      <key macro="creator" names-min="3" names-use-first="3"/>
+      <key variable="issued" sort="descending"/>
+    </sort>
+    <layout suffix=".">
+      <text macro="complete-reference"/>
+    </layout>
+  </bibliography>
+
+  <macro name="complete-reference">
+    <group delimiter=". ">
+      <group delimiter=", ">
+        <text macro="creator"/>
+        <text macro="title"/>
+        <group delimiter=": ">
+          <text macro="in"/>
+          <group delimiter=", ">
+            <text macro="container-creator"/>
+            <group delimiter=" ">
+              <text macro="container-information"/>
+              <text macro="journal-volume"/>
+            </group>
+            <text macro="volumes"/>
+          </group>
+        </group>
+        <text macro="type-description"/>
+        <text macro="alt-publisher"/>
+        <text macro="edition"/>
+        <text macro="place"/>
+        <text macro="publishing-house"/>
+        <group delimiter=" ">
+          <text macro="date"/>
+          <date variable="original-date" form="text" prefix="[" suffix="]"/>
+          <text macro="book-series"/>
+        </group>
+        <text macro="artwork-description"/>
+        <text macro="archive-location"/>
+        <text macro="pages"/>
+        <text macro="url-web-documents-only"/>
+      </group>
+      <text macro="url-non-web-documents"/>
+    </group>
   </macro>
-  <macro name="editor">
-    <names variable="editor">
-      <name sort-separator=" ">
+
+  <macro name="subsequent-reference">
+    <group delimiter=", ">
+      <text macro="creator-for-subsequent"/>
+      <text macro="identifier-for-subsequent"/>
+      <text macro="op-cit"/>
+      <date variable="issued" form="numeric" date-parts="year"/>
+      <text macro="locator"/>
+    </group>
+  </macro>
+
+  <macro name="creator">
+    <names variable="author">
+      <name sort-separator=" "
+            name-as-sort-order="all"
+            et-al-min="4" et-al-use-first="3">
         <name-part name="family" font-variant="small-caps"/>
       </name>
-      <et-al font-style="italic"/>
       <label form="short" prefix="&#160;(" suffix=")"/>
+      <et-al font-style="italic"/>
+      <substitute>
+        <names variable="editor"/>
+        <names variable="composer"/>
+        <names variable="director"/>
+      </substitute>
     </names>
   </macro>
+
+  <macro name="creator-for-subsequent">
+    <names variable="author">
+      <name form="short"
+            et-al-min="4" et-al-use-first="1">
+        <name-part name="family" font-variant="small-caps"/>
+      </name>
+      <label form="short" prefix="&#160;(" suffix=")"/>
+      <et-al font-style="italic"/>
+      <substitute>
+        <names variable="editor"/>
+        <names variable="composer"/>
+        <names variable="director"/>
+      </substitute>
+    </names>
+  </macro>
+
   <macro name="title">
     <choose>
-      <if type="book thesis graphic motion_picture" match="any">
+      <if type="book thesis graphic" match="any">
         <text variable="title" font-style="italic"/>
       </if>
-      <else-if type="chapter paper-conference" match="any">
-        <group delimiter=" ">
-          <text variable="title" quotes="true" suffix=","/>
-          <text value="in" font-style="italic"/>
-          <text macro="editor" suffix=","/>
-          <text variable="container-title" font-style="italic"/>
-        </group>
+      <else-if type="article
+                     article-magazine article-newspaper article-journal
+                     entry entry-dictionary entry-encyclopedia
+                     report chapter paper-conference
+                     post post-weblog webpage
+                     song broadcast" match="any">
+        <text variable="title" quotes="true"/>
       </else-if>
-      <else-if type="article-journal">
-        <group delimiter=", ">
-          <text variable="title" quotes="true"/>
-          <group>
-            <text variable="container-title" font-style="italic"/>
+      <else-if type="motion_picture">
+        <choose>
+          <if variable="collection-title">
+            <text variable="title" quotes="true"/>
+          </if>
+          <else>
+            <text variable="title" font-style="italic"/>
+          </else>
+        </choose>
+      </else-if>
+      <else>
+        <text variable="title"/>
+      </else>
+    </choose>
+  </macro>
+
+  <macro name="identifier-for-subsequent">
+    <choose>
+      <if variable="title title-short" match="any">
+        <choose>
+          <if type="book thesis graphic" match="any">
+            <text variable="title" font-style="italic" form="short"/>
+          </if>
+          <else-if type="article
+                         article-magazine article-newspaper article-journal
+                         entry entry-dictionary entry-encyclopedia
+                         report chapter paper-conference
+                         post post-weblog webpage
+                         song broadcast" match="any">
+            <text variable="title" quotes="true" form="short"/>
+          </else-if>
+          <else-if type="motion_picture">
             <choose>
-              <if is-numeric="volume">
-                <number variable="volume" prefix=" "/>
-                <choose>
-                  <if is-numeric="issue">
-                    <text value="&#160;"/>
-                    <number variable="issue" prefix="(" suffix=")"/>
-                  </if>
-                </choose>
+              <if variable="collection-title">
+                <text variable="title" quotes="true"/>
               </if>
-              <else-if is-numeric="issue">
-                <number variable="issue" prefix=" (" suffix=")"/>
-              </else-if>
+              <else>
+                <text variable="title" font-style="italic"/>
+              </else>
             </choose>
-          </group>
-        </group>
-      </else-if>
-      <else-if type="article-newspaper article-magazine entry-encyclopedia entry-dictionary broadcast" match="any">
-        <group delimiter=", ">
-          <text variable="title" quotes="true"/>
-          <text variable="container-title" font-style="italic"/>
-        </group>
-      </else-if>
-      <else-if type="webpage post post-weblog" match="any">
-        <group delimiter=", ">
-          <text variable="title" quotes="true"/>
-          <text variable="container-title" font-style="italic"/>
-        </group>
-      </else-if>
-      <else-if type="report">
-        <group delimiter=", ">
-          <text variable="title" quotes="true"/>
-          <text variable="genre"/>
-          <group delimiter=" ">
-            <text variable="collection-title" font-style="italic"/>
-            <number variable="number"/>
-          </group>
-        </group>
-      </else-if>
-      <else-if type="song">
-        <group delimiter=", ">
-          <text variable="title" quotes="true"/>
-          <group delimiter=" ">
-            <text variable="collection-title" font-style="italic"/>
-            <number variable="number"/>
-          </group>
-        </group>
-      </else-if>
-      <else-if type="interview">
-        <group delimiter=", ">
-          <text variable="title" quotes="true"/>
-          <names variable="interviewer" delimiter=", ">
+          </else-if>
+          <else>
+            <text variable="title" form="short"/>
+          </else>
+        </choose>
+      </if>
+      <else-if type="personal_communication">
+        <group delimiter=" ">
+          <text term="letter"/>
+          <names variable="recipient">
             <label form="verb" prefix=" " suffix=" "/>
-            <name sort-separator=" ">
-              <name-part name="family" font-variant="small-caps"/>
-            </name>
+            <name et-al-min="3" et-al-use-first="1"/>
             <et-al font-style="italic"/>
           </names>
         </group>
       </else-if>
-      <else>
-        <text variable="title" quotes="true"/>
-      </else>
+      <else-if type="interview">
+        <names variable="interviewer" delimiter=", ">
+          <label form="verb" prefix=" " suffix=" "/>
+          <name et-al-min="3" et-al-use-first="1"/>
+          <et-al font-style="italic"/>
+        </names>
+      </else-if>
+      <else-if type="report song broadcast motion_picture
+                     webpage post post-weblog" match="any">
+        <!-- these types have either collection-title or container-title -->
+        <text variable="collection-title" font-style="italic"/>
+        <text variable="container-title" font-style="italic"/>
+      </else-if>
     </choose>
   </macro>
-  <!-- fin macro "title" -->
-  <macro name="volume-or-medium">
+
+  <macro name="op-cit">
+     <group font-style="italic" delimiter="&#160;" suffix=".">
+      <choose>
+        <if type="article
+                  article-magazine article-newspaper article-journal
+                  entry entry-dictionary entry-encyclopedia
+                  chapter paper-conference
+                  post post-weblog" match="any">
+          <text value="art."/>
+        </if>
+        <else-if type="manuscript personal_communication interview
+                       report webpage" match="any">
+          <text value="doc."/>
+        </else-if>
+        <else-if type="book thesis graphic
+                       motion_picture song broadcast" match="any">
+          <text value="op."/>
+        </else-if>
+      </choose>
+      <text term="cited" form="short"/>
+    </group>
+  </macro>
+
+  <macro name="in">
     <choose>
-      <if type="book chapter entry-encyclopedia entry-dictionary" match="any">
-        <choose>
-          <if is-numeric="volume number-of-volumes" match="all">
-            <text term="volume" form="short" suffix=".&#160;"/>
-            <number variable="volume"/>
-            <number variable="number-of-volumes" prefix=" / "/>
-          </if>
-          <else-if is-numeric="volume">
-            <text term="volume" form="short" suffix=".&#160;"/>
-            <number variable="volume"/>
-          </else-if>
-          <else-if is-numeric="number-of-volumes">
-            <number variable="number-of-volumes"/>
-            <text term="volume" form="short" prefix="&#160;" suffix="."/>
-          </else-if>
-        </choose>
+      <if type="chapter paper-conference
+                entry-encyclopedia entry-dictionary"
+          match="any">
+        <text term="in"/>
       </if>
+    </choose>
+  </macro>
+
+  <macro name="container-creator">
+    <choose>
+      <if type="chapter paper-conference" match="any">
+        <names variable="editor">
+          <name sort-separator=" "
+                name-as-sort-order="all"
+                et-al-min="4" et-al-use-first="3">
+            <name-part name="family" font-variant="small-caps"/>
+          </name>
+          <label form="short" prefix="&#160;(" suffix=")"/>
+          <et-al font-style="italic"/>
+          <substitute>
+            <names variable="container-author"/>
+            <names variable="collection-editor"/>
+          </substitute>
+        </names>
+      </if>
+    </choose>
+  </macro>
+
+  <macro name="container-information">
+    <choose>
+      <if type="chapter paper-conference
+                entry-encyclopedia entry-dictionary
+                article-newspaper article-magazine article-journal" match="any">
+        <text variable="container-title" font-style="italic"/>
+      </if>
+      <else-if type="report song broadcast motion_picture
+                     webpage post post-weblog" match="any">
+        <group delimiter=", ">
+          <text variable="genre"/>
+          <!-- these types have either collection-title or container-title -->
+          <text variable="collection-title" font-style="italic"/>
+          <text variable="container-title" font-style="italic"/>
+        </group>
+      </else-if>
+    </choose>
+  </macro>
+  
+  <macro name="journal-volume">
+    <choose>
+      <if type="article-journal">
+        <group delimiter="&#160;">
+          <number variable="volume"/>
+          <number variable="issue" prefix="(" suffix=")"/>
+        </group>
+      </if>
+      <else-if type="report song broadcast" match="any">
+        <number variable="number"/>
+      </else-if>
+    </choose>
+  </macro>
+  
+  <macro name="volumes">
+    <choose>
+      <if type="book chapter
+                entry-encyclopedia entry-dictionary
+                song motion_picture" match="any">
+        <group delimiter=" / ">
+          <group delimiter="&#160;">
+            <label variable="volume" form="short"/>
+            <number variable="volume"/>
+          </group>
+          <group delimiter="&#160;">
+            <number variable="number-of-volumes"/>
+            <choose>
+              <if variable="volume" match="none">
+                <label variable="number-of-volumes" form="short"/>
+              </if>
+            </choose>
+          </group>
+        </group>
+      </if>
+    </choose>
+  </macro>
+
+  <macro name="type-description">
+    <choose>
+      <if type="manuscript thesis speech" match="any">
+        <text variable="genre"/>
+      </if>
+      <else-if type="personal_communication">
+        <group delimiter=", ">
+          <group delimiter=" ">
+            <text term="letter"/>
+            <names variable="recipient">
+              <label form="verb" prefix=" " suffix=" "/>
+              <name/>
+            </names>
+          </group>
+          <text variable="genre"/>
+        </group>
+      </else-if>
+      <else-if type="interview">
+        <names variable="interviewer" delimiter=", ">
+          <label form="verb" prefix=" " suffix=" "/>
+          <name/>
+        </names>
+      </else-if>
       <else-if type="motion_picture song broadcast" match="any">
         <group delimiter=", ">
           <text variable="medium"/>
+          <!-- refers to duration -->
           <text variable="dimensions"/>
         </group>
       </else-if>
-    </choose>
-  </macro>
-  <macro name="place-and-publisher">
-    <choose>
-      <if type="book chapter paper-conference" match="any">
-        <group delimiter=", ">
-          <choose>
-            <if variable="publisher-place">
-              <text variable="publisher-place"/>
-            </if>
-            <else>
-              <text value="[s. l.]"/>
-            </else>
-          </choose>
-          <text variable="publisher"/>
-        </group>
-      </if>
-      <else-if type="report motion_picture broadcast song" match="any">
-        <group delimiter=", ">
-          <text variable="publisher-place"/>
-          <text variable="publisher"/>
-        </group>
-      </else-if>
-      <else-if type="thesis">
-        <group delimiter=", ">
-          <text variable="genre"/>
-          <text variable="publisher-place"/>
-          <text variable="publisher"/>
-        </group>
-      </else-if>
-      <else-if type="speech">
-        <group delimiter=", ">
-          <text variable="genre"/>
-          <text variable="event"/>
-          <text variable="event-place"/>
-        </group>
-      </else-if>
-    </choose>
-  </macro>
-  <macro name="url">
-    <choose>
-      <if variable="URL">
-        <text variable="URL" prefix="&lt;" suffix="&gt;, "/>
-        <group delimiter=" ">
-          <text term="accessed"/>
-          <date variable="accessed" form="text" date-parts="year-month-day"/>
-        </group>
-      </if>
-    </choose>
-  </macro>
-  <macro name="date-pages-and-collection">
-    <group delimiter=", ">
-      <text macro="date"/>
-      <text macro="artwork-info"/>
-      <text macro="locator-or-pages"/>
-    </group>
-    <text macro="collection"/>
-  </macro>
-  <macro name="date">
-    <choose>
-      <if type="book chapter paper-conference motion_picture" match="any">
+      <!-- Computer Program -->
+      <else-if type="book">
         <choose>
-          <if variable="issued">
-            <date variable="issued">
-              <date-part name="year"/>
-            </date>
-          </if>
-          <else>
-            <text value="[s. d.]"/>
-          </else>
-        </choose>
-      </if>
-      <else-if type="article-journal" match="any">
-        <choose>
-          <if variable="issued">
-            <date variable="issued" form="text" date-parts="year-month"/>
-          </if>
-          <else>
-            <text value="[s. d.]"/>
-          </else>
-        </choose>
-      </else-if>
-      <else-if type="article-newspaper article-magazine webpage post post-weblog report broadcast entry-encyclopedia entry-dictionary speech" match="any">
-        <group delimiter=", ">
-          <choose>
-            <if variable="issued">
-              <date variable="issued" form="text" date-parts="year-month-day"/>
-            </if>
-            <else>
-              <text value="[s. d.]"/>
-            </else>
-          </choose>
-          <text macro="url"/>
-        </group>
-      </else-if>
-      <else-if type="song">
-        <choose>
-          <if variable="issued">
+          <if variable="version medium" match="any">
             <group delimiter=", ">
-              <date variable="issued" form="text"/>
-              <text macro="url"/>
+              <group delimiter=" ">
+                <text term="version"/>
+                <text variable="version"/>
+              </group>
+              <text variable="medium"/>
+            </group>
+          </if>
+        </choose>
+      </else-if>
+    </choose>
+  </macro>
+
+  <macro name="alt-publisher">
+    <choose>
+      <if type="book chapter
+                thesis report
+                paper-conference
+                entry-dictionary entry-encyclopedia" match="none">
+        <!--
+             label for songs,
+             distributor for films,
+             studio for video recordings,
+             network for broadcasts -->
+        <text variable="publisher"/>
+      </if>
+    </choose>
+  </macro>
+
+  <macro name="edition">
+    <choose>
+      <if type="book chapter
+                entry-dictionary entry-encyclopedia" match="any">
+        <choose>
+          <if is-numeric="edition">
+            <group delimiter="&#160;">
+              <number variable="edition" form="ordinal"/>
+              <label variable="edition"/>
             </group>
           </if>
           <else>
-            <text macro="url"/>
+            <text variable="edition"/>
+          </else>
+        </choose>
+      </if>
+    </choose>
+  </macro>
+
+  <macro name="place">
+    <choose>
+      <if type="speech">
+        <group delimiter=", ">
+          <text variable="event"/>
+          <text variable="event-place"/>
+        </group>
+      </if>
+      <else>
+        <text variable="publisher-place"/>
+      </else>
+    </choose>
+  </macro>
+
+  <macro name="publishing-house">
+    <choose>
+      <if type="book chapter thesis report
+                paper-conference
+                entry-dictionary entry-encyclopedia" match="any">
+        <text variable="publisher"/>
+      </if>
+    </choose>
+  </macro>
+
+  <macro name="date">
+    <choose>
+      <if type="book chapter paper-conference thesis" match="any">
+        <choose>
+          <if variable="issued">
+            <date variable="issued" form="numeric" date-parts="year"/>
+          </if>
+          <else>
+            <text term="no date" form="short"/>
+          </else>
+        </choose>
+      </if>
+      <else-if type="article-journal article-newspaper article-magazine
+                     graphic entry-encyclopedia entry-dictionary
+                     report speech interview
+                     manuscript personal_communication" match="any">
+        <choose>
+          <if variable="issued">
+            <date variable="issued" form="numeric" date-parts="year-month-day"/>
+          </if>
+          <else>
+            <text term="no date" form="short"/>
           </else>
         </choose>
       </else-if>
       <else>
-        <choose>
-          <if variable="issued">
-            <date variable="issued" form="text" date-parts="year-month-day"/>
-          </if>
-          <else-if variable="original-date">
-            <date variable="original-date" form="text" date-parts="year-month-day"/>
-          </else-if>
-          <else-if variable="event-date">
-            <date variable="event-date" form="text" date-parts="year-month-day"/>
-          </else-if>
-          <else>
-            <text value="[s. d.]"/>
-          </else>
-        </choose>
+        <date variable="issued" form="numeric" date-parts="year-month-day"/>
       </else>
     </choose>
   </macro>
-  <!-- fin macro "date" -->
-  <macro name="artwork-info">
-    <choose>
-      <if type="graphic">
-        <group delimiter=", ">
-          <text variable="medium"/>
-          <text variable="dimensions"/>
-          <text variable="genre"/>
-          <text variable="archive"/>
-          <text variable="archive_location"/>
-        </group>
-      </if>
-    </choose>
-  </macro>
-  <macro name="locator">
-    <group delimiter="&#160;">
-      <label variable="locator" form="short"/>
-      <text variable="locator"/>
-    </group>
-  </macro>
-  <macro name="locator-or-pages">
+
+  <macro name="pages">
     <choose>
       <if variable="locator">
         <text macro="locator"/>
@@ -338,10 +504,19 @@
       </else>
     </choose>
   </macro>
-  <macro name="collection">
+
+  <macro name="locator">
+    <group delimiter="&#160;">
+      <label variable="locator" form="short"/>
+      <text variable="locator"/>
+    </group>
+  </macro>
+
+  <macro name="book-series">
     <choose>
-      <if type="book chapter paper-conference" match="any">
-        <group prefix=" (" suffix=")" delimiter=" ">
+      <if type="book chapter paper-conference
+                entry-dictionary entry-encyclopedia" match="any">
+        <group prefix="(" suffix=")" delimiter=" ">
           <text variable="collection-title"/>
           <choose>
             <if is-numeric="collection-number">
@@ -352,80 +527,75 @@
       </if>
     </choose>
   </macro>
-  <macro name="edition">
+
+  <macro name="artwork-description">
     <choose>
-      <if type="book chapter paper-conference" match="any">
-        <choose>
-          <if is-numeric="edition">
-            <number variable="edition" form="ordinal"/>
-            <text term="edition" prefix="&#160;"/>
-          </if>
-        </choose>
+      <if type="graphic">
+        <group delimiter=", ">
+          <text variable="medium"/>
+          <text variable="dimensions"/>
+          <text variable="genre"/>
+        </group>
       </if>
     </choose>
   </macro>
-  <macro name="complete-reference">
+
+  <macro name="archive-location">
+    <choose>
+      <if variable="archive">
+        <group delimiter=", ">
+          <text variable="archive"/>
+          <text variable="archive_location"/>
+          <text variable="call-number" prefix="Cote: "/>
+        </group>
+      </if>
+    </choose>
+  </macro>
+
+  <macro name="url-web-documents-only">
+    <choose>
+      <if type="webpage post post-weblog">
+          <text macro="url"/>
+      </if>
+    </choose>
+  </macro>
+
+  <macro name="url-non-web-documents">
+    <choose>
+      <if variable="DOI">
+        <text term="online" text-case="capitalize-first" suffix=": "/>
+        <group delimiter=", ">
+          <text variable="source"/>
+          <group delimiter=": ">
+            <text value="DOI"/>
+            <text variable="DOI"/>
+          </group>
+        </group>
+      </if>
+      <else-if variable="URL">
+        <choose>
+          <if type="webpage post post-weblog" match="none">
+            <group delimiter=" ">
+              <text term="online" text-case="capitalize-first" suffix=": "/>
+              <group delimiter=", ">
+                <text variable="source"/>
+                <text macro="url"/>
+              </group>
+            </group>
+          </if>
+        </choose>
+      </else-if>
+    </choose>
+  </macro>
+
+  <macro name="url">
     <group delimiter=", ">
-      <text macro="author-or-editor"/>
-      <text macro="title"/>
-      <text macro="volume-or-medium"/>
-      <text macro="edition"/>
-      <text macro="place-and-publisher"/>
-      <text macro="date-pages-and-collection"/>
+      <text variable="URL" prefix="&lt;" suffix="&gt;"/>
+      <group delimiter=" ">
+        <text term="accessed"/>
+        <date variable="accessed" form="numeric" date-parts="year-month-day"/>
+      </group>
     </group>
   </macro>
-  <citation name-form="long" and="text" sort-separator=", " name-as-sort-order="all" delimiter-precedes-last="never" et-al-min="4">
-    <!-- the attributes on citation are inheritable name options -->
-    <layout suffix="." delimiter="&#160;; ">
-      <choose>
-        <if position="ibid-with-locator">
-          <group delimiter=", ">
-            <text term="ibid" font-style="italic" suffix="."/>
-            <text macro="locator"/>
-          </group>
-        </if>
-        <else-if position="ibid">
-          <text term="ibid" font-style="italic"/>
-        </else-if>
-        <else-if position="subsequent">
-          <group delimiter=", ">
-            <text macro="author-or-editor"/>
-            <choose>
-              <if type="book thesis" match="any">
-                <text variable="title" form="short" font-style="italic"/>
-              </if>
-              <else>
-                <text variable="title" form="short" quotes="true"/>
-              </else>
-            </choose>
-            <group font-style="italic" delimiter="&#160;">
-              <choose>
-                <if type="article article-magazine article-newspaper article-journal entry entry-dictionary entry-encyclopedia chapter" match="any">
-                  <text value="art."/>
-                </if>
-                <else>
-                  <text value="op."/>
-                </else>
-              </choose>
-              <text term="cited" suffix="."/>
-            </group>
-            <text macro="locator"/>
-          </group>
-        </else-if>
-        <else>
-          <text macro="complete-reference"/>
-        </else>
-      </choose>
-    </layout>
-  </citation>
-  <bibliography name-form="long" and="text" sort-separator=", " name-as-sort-order="all" delimiter-precedes-last="never" et-al-min="4">
-    <!-- the attributes on bibliography are inheritable name options -->
-    <sort>
-      <key macro="author-or-editor" names-min="3" names-use-first="3"/>
-      <key variable="issued" sort="descending"/>
-    </sort>
-    <layout suffix=".">
-      <text macro="complete-reference"/>
-    </layout>
-  </bibliography>
+
 </style>


### PR DESCRIPTION
This is a major update to a custom style for history students in Switzerland. See https://github.com/citation-style-language/styles/pull/234 for the original pull request.

We now have a proper documentation:
- [in French](https://www.infoclio.ch/fr/node/138218)
- [in German](https://www.infoclio.ch/de/node/133932)

Changes include:
- Support for additional item types such as manuscript, personal_communication, and improvements for audio and film types
- URL or DOI are included in the references
- Archival information is included, allowing better citation of primary sources
- Support for original-date