### PR TITLE
Set "demote-non-dropping-particle" to "display-and-sort"

### DIFF
--- a/chicago-author-date.csl
+++ b/chicago-author-date.csl
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" demote-non-dropping-particle="never" page-range-format="chicago">
+<style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" demote-non-dropping-particle="display-and-sort" page-range-format="chicago">
   <info>
     <title>Chicago Manual of Style 16th edition (author-date)</title>
     <id>http://www.zotero.org/styles/chicago-author-date</id>


### PR DESCRIPTION
CMS 16e calls for "van den Keere" (in-text) and "Keere, Pieter van den" (index & references) (16.71), and "al-Hakim" (in-text) and "Hakim, Tawfiq al-" (index & references) (16.76). This requires "display-and-sort".

Actually, _all_ Chicago styles, and, most likely, most other styles, too, need to be updated. Could someone batch-edit at least all of the Chicago styles?