### PR TITLE
Update the-isme-journal.csl

### DIFF
--- a/the-isme-journal.csl
+++ b/the-isme-journal.csl
@@ -5,6 +5,7 @@
     <id>http://www.zotero.org/styles/the-isme-journal</id>
     <link href="http://www.zotero.org/styles/the-isme-journal" rel="self"/>
     <link href="http://mts-isme.nature.com/cgi-bin/main.plex?form_type=display_auth_instructions" rel="documentation"/>
+    <link href="http://www.nature.com/ismej/ismej_new_gta.pdf" rel="documentation"/>
     <author>
       <name>Jessica Leigh</name>
       <email>blackwednesday@gmail.com</email>
@@ -18,12 +19,12 @@
     <issn>1751-7362</issn>
     <eissn>1751-7370</eissn>
     <summary>The ISME Journal style, which is not the same as for Nature</summary>
-    <updated>2015-09-07T00:00:00+00:00</updated>
+    <updated>2015-09-08T15:52:49Z</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <macro name="editor">
     <names variable="editor">
-      <name and="symbol" delimiter=", " name-as-sort-order="all" sort-separator=", " initialize-with="">
+      <name delimiter=", " name-as-sort-order="all" sort-separator=" " initialize-with="">
         <name-part name="family" text-case="capitalize-first"/>
         <name-part name="given" text-case="capitalize-first"/>
       </name>
@@ -59,24 +60,23 @@
   </macro>
   <macro name="access">
     <choose>
-      <if variable="page" match="none">
-        <choose>
-          <if variable="DOI">
-            <text variable="DOI" prefix="doi:"/>
-          </if>
-          <else-if variable="URL">
-            <text variable="URL"/>
-            <group prefix=" (" suffix=")">
-              <text term="accessed" text-case="capitalize-first" suffix=" "/>
-              <date variable="accessed">
-                <date-part name="month" suffix=" "/>
-                <date-part name="day" suffix=", "/>
-                <date-part name="year"/>
-              </date>
-            </group>
-          </else-if>
-        </choose>
-      </if>
+      <if type="book" match="any"/>
+      <else-if variable="page"/>
+      <else-if variable="DOI">
+        <text value="e-pub ahead of print, "/>
+        <text variable="DOI" prefix="doi: "/>
+      </else-if>
+      <else-if variable="URL">
+        <text variable="URL"/>
+        <group prefix=" (" suffix=")">
+          <text term="accessed" text-case="capitalize-first" suffix=" "/>
+          <date variable="accessed">
+            <date-part name="month" suffix=" "/>
+            <date-part name="day" suffix=", "/>
+            <date-part name="year"/>
+          </date>
+        </group>
+      </else-if>
     </choose>
   </macro>
   <macro name="title">
@@ -126,7 +126,7 @@
       </else>
     </choose>
   </macro>
-  <citation et-al-min="3" et-al-use-first="1" disambiguate-add-year-suffix="true" disambiguate-add-names="true" disambiguate-add-givenname="true" collapse="year">
+  <citation et-al-min="3" et-al-use-first="1" disambiguate-add-year-suffix="true" collapse="year">
     <layout prefix="(" suffix=")" delimiter="; ">
       <group delimiter=", ">
         <text macro="author-short"/>
@@ -140,69 +140,73 @@
       <key macro="author"/>
       <key variable="title"/>
     </sort>
-    <layout suffix=".">
-      <group delimiter=" ">
-        <text macro="author" suffix="."/>
-        <text macro="year-date" prefix="(" suffix=")."/>
-      </group>
-      <choose>
-        <if type="article-newspaper article-magazine" match="any">
-          <group delimiter=" ">
+    <layout>
+      <group delimiter=". " suffix=".">
+        <group delimiter=" ">
+          <text macro="author" suffix="."/>
+          <text macro="year-date" prefix="(" suffix=")."/>
+        </group>
+        <choose>
+          <if type="article-newspaper article-magazine" match="any">
+            <group delimiter=" ">
+              <text macro="title" prefix=" " suffix="."/>
+            </group>
+            <group prefix=" " delimiter=", ">
+              <text variable="container-title"/>
+              <text macro="day-month"/>
+              <text variable="edition"/>
+            </group>
+          </if>
+          <else-if type="thesis">
             <text macro="title" prefix=" " suffix="."/>
-          </group>
-          <group prefix=" " delimiter=", ">
-            <text variable="container-title"/>
-            <text macro="day-month"/>
-            <text variable="edition"/>
-          </group>
-        </if>
-        <else-if type="thesis">
-          <text macro="title" prefix=" " suffix="."/>
-          <group prefix=" " delimiter=", ">
-            <text macro="edition"/>
-            <text macro="editor" suffix="."/>
-            <text variable="genre"/>
-            <text macro="publisher"/>
-          </group>
-        </else-if>
-        <else-if type="bill book graphic legal_case legislation motion_picture report song" match="any">
-          <group delimiter=" ">
-            <text macro="title" prefix=" " suffix="."/>
-            <text macro="edition"/>
-            <text macro="publisher"/>
-          </group>
-        </else-if>
-        <else-if type="chapter paper-conference" match="any">
-          <group delimiter=" ">
-            <text macro="title" prefix=" " suffix="."/>
-            <group prefix="In: " delimiter=", " suffix=".">
-              <text variable="container-title" font-style="italic"/>
-              <group delimiter=" ">
-                <text macro="editor" prefix=" "/>
-                <text variable="collection-title"/>
-                <text variable="volume" prefix="Vol. "/>
-                <text macro="series-editor"/>
+            <group prefix=" " delimiter=", ">
+              <text macro="edition"/>
+              <text macro="editor" suffix="."/>
+              <text variable="genre"/>
+              <text macro="publisher"/>
+            </group>
+          </else-if>
+          <else-if type="bill book graphic legal_case legislation motion_picture report song" match="any">
+            <group delimiter=" ">
+              <text macro="title" prefix=" " suffix="."/>
+              <text macro="edition"/>
+              <text macro="publisher"/>
+            </group>
+          </else-if>
+          <else-if type="chapter paper-conference" match="any">
+            <group delimiter=" ">
+              <text macro="title" prefix=" " suffix="."/>
+              <group prefix="In: " delimiter=". " suffix=".">
+                <group delimiter=" ">
+                  <text macro="editor" prefix=" "/>
+                  <text variable="collection-title"/>
+                  <text variable="volume" prefix="Vol. "/>
+                  <text macro="series-editor"/>
+                </group>
+                <text variable="container-title" font-style="italic"/>
+                <group delimiter=", ">
+                  <text macro="publisher" prefix=" "/>
+                  <text macro="page" prefix=" "/>
+                </group>
               </group>
-              <text macro="publisher" prefix=" "/>
-              <text macro="page" prefix=" "/>
             </group>
-          </group>
-        </else-if>
-        <else>
-          <group suffix=".">
-            <text macro="title" prefix=" "/>
-            <text macro="editor" prefix=" "/>
-          </group>
-          <group prefix=" " suffix="." delimiter=" ">
-            <text variable="container-title" form="short" strip-periods="true" font-style="italic"/>
-            <group delimiter=": ">
-              <text variable="volume" font-weight="bold"/>
-              <text variable="page"/>
+          </else-if>
+          <else>
+            <group suffix=".">
+              <text macro="title" prefix=" "/>
+              <text macro="editor" prefix=" "/>
             </group>
-          </group>
-        </else>
-      </choose>
-      <text prefix=" " macro="access" suffix="."/>
+            <group prefix=" " suffix="." delimiter=" ">
+              <text variable="container-title" form="short" strip-periods="true" font-style="italic"/>
+              <group delimiter=": ">
+                <text variable="volume" font-weight="bold"/>
+                <text variable="page"/>
+              </group>
+            </group>
+          </else>
+        </choose>
+        <text prefix=" " macro="access" suffix="."/>
+      </group>
     </layout>
   </bibliography>
 </style>


### PR DESCRIPTION
* fixed editor macro: sort-separator is just a blank space, and no "and" symbol
* books never have doi/URLs
* doi’s have a pre-label of "e-pub ahead of print", and there is a space after doi
* disambiguate-add-names and disambiguate-add-givenname should both be false
* fixed master layout, so there is always a period before the access macro
* fixed book chapter layout: editor first, then container/etc, separated by periods

Changes are based on http://www.nature.com/ismej/ismej_new_gta.pdf and the articles from the current ISMEJ.