### PR TITLE
Update harvard-university-for-the-creative-arts.csl

### DIFF
--- a/harvard-university-for-the-creative-arts.csl
+++ b/harvard-university-for-the-creative-arts.csl
@@ -14,16 +14,16 @@
     <category citation-format="author-date"/>
     <category field="generic-base"/>
     <summary>University for the Creative Arts Harvard style</summary>
-    <updated>2015-09-09T09:33:50+00:00</updated>
+    <updated>2016-01-12T15:44:30+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <macro name="cite-author">
     <choose>
       <if type="broadcast" match="any">
-        <text variable="title" font-style="italic"/>
+        <text variable="title" font-style="italic" suffix="."/>
       </if>
       <else-if type="bill legislation motion_picture map" match="any">
-        <text variable="title" font-style="italic"/>
+        <text variable="title" font-style="italic" suffix="."/>
       </else-if>
       <else-if type="legal_case" match="any">
         <text variable="title" font-style="italic"/>
@@ -136,7 +136,8 @@
   </macro>
   <macro name="translator">
     <names variable="translator">
-      <name delimiter=". " prefix="Translated by " suffix="." and="text" delimiter-precedes-last="never" et-al-min="3" et-al-use-first="1" initialize-with="." name-as-sort-order="all"/>
+      <label form="verb" text-case="capitalize-first"/>
+      <name delimiter=". " prefix=" " suffix="." and="text" delimiter-precedes-last="never" et-al-min="3" et-al-use-first="1" initialize-with="." name-as-sort-order="all"/>
       <et-al font-style="italic"/>
     </names>
   </macro>
@@ -214,9 +215,9 @@
       </else-if>
       <else-if type="motion_picture">
         <text variable="medium" prefix="[" suffix="]"/>
-        <names variable="author">
-          <name prefix=" Directed by " suffix="." and="text" delimiter-precedes-last="never" et-al-min="3" et-al-use-first="1" initialize-with="." name-as-sort-order="all"/>
-          <label form="short" prefix=" "/>
+        <names variable="director author" prefix="Directed by">
+          <label form="short" text-case="capitalize-first" prefix=" "/>
+          <name prefix=" " suffix="." and="text" delimiter-precedes-last="never" et-al-min="3" et-al-use-first="1" initialize-with="." name-as-sort-order="all"/>
           <et-al font-style="italic"/>
         </names>
       </else-if>

--- a/harvard-university-for-the-creative-arts.csl
+++ b/harvard-university-for-the-creative-arts.csl
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" and="text" et-al-min="3" et-al-use-first="1" demote-non-dropping-particle="sort-only" default-locale="en-GB">
-  <!-- This style was edited with the Visual CSL Editor (http://editor.citationstyles.org/visualEditor/) -->
   <info>
     <title>Harvard - University for the Creative Arts</title>
     <title-short>UCA</title-short>
@@ -15,16 +14,16 @@
     <category citation-format="author-date"/>
     <category field="generic-base"/>
     <summary>University for the Creative Arts Harvard style</summary>
-    <updated>2014-08-21T08:35:06+00:00</updated>
+    <updated>2015-09-09T09:33:50+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <macro name="cite-author">
     <choose>
       <if type="broadcast" match="any">
-        <text variable="title" font-style="italic" suffix="."/>
+        <text variable="title" font-style="italic"/>
       </if>
-      <else-if type="bill legislation motion_picture" match="any">
-        <text variable="title" font-style="italic" suffix="."/>
+      <else-if type="bill legislation motion_picture map" match="any">
+        <text variable="title" font-style="italic"/>
       </else-if>
       <else-if type="legal_case" match="any">
         <text variable="title" font-style="italic"/>
@@ -86,13 +85,13 @@
       </else-if>
       <else>
         <choose>
-          <if type="broadcast" match="none">
-            <group delimiter=". ">
+          <if type="broadcast map" match="none">
+            <group delimiter=" ">
               <group delimiter=" ">
                 <text variable="title" font-style="italic" suffix="."/>
                 <text macro="edition-no"/>
               </group>
-              <text variable="collection-title"/>
+              <text variable="collection-title" font-style="italic" prefix="In: " suffix="."/>
             </group>
           </if>
         </choose>
@@ -137,7 +136,7 @@
   </macro>
   <macro name="translator">
     <names variable="translator">
-      <name delimiter=". " prefix="Translated by " suffix="." and="text" delimiter-precedes-last="never" et-al-min="3" et-al-use-first="1" initialize-with="."/>
+      <name delimiter=". " prefix="Translated by " suffix="." and="text" delimiter-precedes-last="never" et-al-min="3" et-al-use-first="1" initialize-with="." name-as-sort-order="all"/>
       <et-al font-style="italic"/>
     </names>
   </macro>
@@ -181,7 +180,7 @@
         <group>
           <text term="in" text-case="capitalize-first" suffix=": "/>
           <names variable="editor" delimiter="." suffix=" ">
-            <name form="short" and="text" delimiter-precedes-last="never" et-al-min="3" et-al-use-first="1" initialize-with="."/>
+            <name and="text" delimiter-precedes-last="never" et-al-min="3" et-al-use-first="1" initialize-with="." name-as-sort-order="all"/>
             <label form="short" plural="never" prefix=" (" suffix=")"/>
             <et-al font-style="italic"/>
           </names>
@@ -216,7 +215,7 @@
       <else-if type="motion_picture">
         <text variable="medium" prefix="[" suffix="]"/>
         <names variable="author">
-          <name and="text" sort-separator=", " initialize-with="." delimiter-precedes-last="never" delimiter=", " prefix=" Directed by " suffix="."/>
+          <name prefix=" Directed by " suffix="." and="text" delimiter-precedes-last="never" et-al-min="3" et-al-use-first="1" initialize-with="." name-as-sort-order="all"/>
           <label form="short" prefix=" "/>
           <et-al font-style="italic"/>
         </names>
@@ -282,7 +281,7 @@
           </choose>
         </group>
       </if>
-      <else-if type="book chapter paper-conference manuscript entry-dictionary entry-encyclopedia thesis motion_picture song report" match="any">
+      <else-if type="book chapter paper-conference manuscript entry-dictionary entry-encyclopedia thesis motion_picture song report map" match="any">
         <group>
           <text variable="event" suffix=". "/>
           <group>
@@ -317,9 +316,9 @@
           <group prefix=" (" suffix=")">
             <text term="accessed" text-case="capitalize-first" suffix=" on "/>
             <date delimiter="" variable="accessed">
-              <date-part name="day" suffix="."/>
-              <date-part name="month" form="numeric" range-delimiter="" suffix="."/>
-              <date-part name="year" form="short" range-delimiter="-"/>
+              <date-part name="day" suffix=" "/>
+              <date-part name="month" range-delimiter="" suffix=" "/>
+              <date-part name="year" range-delimiter="-"/>
             </date>
           </group>
         </group>


### PR DESCRIPTION
Changes to the style which bring it in line with the Harvard used at UCA. Includes updates to way accessed dates are written, initials when more than one author/editor is cited in the bibliography and mentioned as a director or translator, changes to the format of map references.

Style has been tested through your 'CSL Style and Locale Validator'. Hopefully it is ok