### PR TITLE
[onderstepoort] Order inline citations alphabetically

### DIFF
--- a/onderstepoort-journal-of-veterinary-research.csl
+++ b/onderstepoort-journal-of-veterinary-research.csl
@@ -115,6 +115,9 @@
     </group>
   </macro>
   <citation et-al-min="3" et-al-use-first="1" disambiguate-add-names="true" disambiguate-add-givenname="true" disambiguate-add-year-suffix="true">
+    <sort>
+      <key macro="author-short"/>
+    </sort>
     <layout delimiter="; " prefix="(" suffix=")">
       <group delimiter=", ">
         <group delimiter=" ">


### PR DESCRIPTION
<blockquote>In the style guide a the bottom of p.3 ( http://openjournals.net/files/Ref/HARVARD2009%20Reference%20guide.pdf ), where several authors are listed at once, the authors are listed alphabetically.</blockquote> see https://forums.zotero.org/discussion/52840/style-error-onderstepoortjournalofveterinaryresearchcsl/#Item_2