### PR TITLE
Enable shelbot

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,8 @@ notifications:
     on_failure: always
   webhooks:
     urls:
+      - https://shelbot.herokuapp.com/build
       - https://styles-update.zotero.org:8827/
     on_success: always
-    on_failure: never
+    on_failure: always
+    on_start: never


### PR DESCRIPTION
We should be able to enable the bot now, that the distribution updater should ignore failed builds.

See https://github.com/citation-style-language/distribution-updater/pull/1#issuecomment-144756239