### PR TITLE
APA-no-doi-no-issue: Remove DOI from output

### DIFF
--- a/apa-no-doi-no-issue.csl
+++ b/apa-no-doi-no-issue.csl
@@ -130,32 +130,25 @@
       <else>
         <choose>
           <if variable="page" match="none">
-            <choose>
-              <if variable="DOI">
-                <text variable="DOI" prefix="doi:"/>
-              </if>
-              <else>
-                <choose>
-                  <if type="webpage">
-                    <group delimiter=" ">
-                      <text term="retrieved" text-case="capitalize-first" suffix=" "/>
-                      <group>
-                        <date variable="accessed" form="text" suffix=", "/>
-                      </group>
-                      <text term="from"/>
-                      <text variable="URL"/>
-                    </group>
-                  </if>
-                  <else>
+              <choose>
+                <if type="webpage">
+                  <group delimiter=" ">
+                    <text term="retrieved" text-case="capitalize-first" suffix=" "/>
                     <group>
-                      <text term="retrieved" text-case="capitalize-first" suffix=" "/>
-                      <text term="from" suffix=" "/>
-                      <text variable="URL"/>
+                      <date variable="accessed" form="text" suffix=", "/>
                     </group>
-                  </else>
-                </choose>
-              </else>
-            </choose>
+                    <text term="from"/>
+                    <text variable="URL"/>
+                  </group>
+                </if>
+                <else>
+                  <group>
+                    <text term="retrieved" text-case="capitalize-first" suffix=" "/>
+                    <text term="from" suffix=" "/>
+                    <text variable="URL"/>
+                  </group>
+                </else>
+              </choose>
           </if>
         </choose>
       </else>


### PR DESCRIPTION
So unless I'm missing something, why does apa-no-doi-no-issue actually display the DOI?