### PR TITLE
Update zookeys.csl

### DIFF
--- a/zookeys.csl
+++ b/zookeys.csl
@@ -97,8 +97,8 @@
   <macro name="publisher">
     <choose>
       <if type="thesis" match="none">
-        <group prefix="" suffix="" delimiter=", ">
-          <text variable="publisher" suffix=""/>
+        <group delimiter=", ">
+          <text variable="publisher"/>
           <text variable="publisher-place"/>
         </group>
         <text variable="genre" prefix=". "/>
@@ -211,7 +211,7 @@
             <text macro="edition"/>
             <text macro="editor" suffix="."/>
           </group>
-          <group prefix=" " suffix="" delimiter=", ">
+          <group prefix=" " delimiter=", ">
             <text macro="publisher"/>
             <text variable="page" prefix=" " suffix="pp."/>
           </group>

--- a/zookeys.csl
+++ b/zookeys.csl
@@ -47,7 +47,7 @@
   </macro>
   <macro name="author-short">
     <names variable="author">
-      <name form="short" delimiter=" " and="text" delimiter-precedes-last="never" et-al-min="3" et-al-use-first="1" initialize-with=". "/>
+      <name form="short" delimiter=" " and="text" delimiter-precedes-last="never" et-al-min="3" et-al-use-first="1" et-al-subsequent-min="3" et-al-subsequent-use-first="1" initialize-with=". "/>
       <et-al font-style="normal"/>
       <substitute>
         <names variable="editor"/>

--- a/zookeys.csl
+++ b/zookeys.csl
@@ -15,7 +15,7 @@
     <issn>1313-2989</issn>
     <eissn>1313-2970</eissn>
     <summary>The ZooKeys style.</summary>
-    <updated>2013-09-12T00:00:00+00:00</updated>
+    <updated>2015-11-06T21:38:15+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale xml:lang="en-US">
@@ -38,7 +38,7 @@
     <names variable="author">
       <name delimiter-precedes-last="never" initialize-with="" name-as-sort-order="all" sort-separator=" "/>
       <et-al font-style="italic"/>
-      <label form="short" prefix=" " text-case="lowercase"/>
+      <label form="short" prefix=" " suffix="." text-case="lowercase" strip-periods="true"/>
       <substitute>
         <names variable="editor"/>
         <text macro="anon"/>
@@ -47,7 +47,7 @@
   </macro>
   <macro name="author-short">
     <names variable="author">
-      <name form="short" delimiter=" " and="text" delimiter-precedes-last="never" et-al-min="3" et-al-use-first="1" et-al-subsequent-min="3" et-al-subsequent-use-first="1" initialize-with=". "/>
+      <name form="short" delimiter=" " and="text" delimiter-precedes-last="never" initialize-with=". "/>
       <et-al font-style="normal"/>
       <substitute>
         <names variable="editor"/>
@@ -97,8 +97,8 @@
   <macro name="publisher">
     <choose>
       <if type="thesis" match="none">
-        <group delimiter=", ">
-          <text variable="publisher"/>
+        <group prefix="" suffix="" delimiter=", ">
+          <text variable="publisher" suffix=""/>
           <text variable="publisher-place"/>
         </group>
         <text variable="genre" prefix=". "/>
@@ -130,7 +130,7 @@
       <if is-numeric="edition">
         <group delimiter=" ">
           <number variable="edition" form="ordinal"/>
-          <text term="edition" form="short"/>
+          <text term="edition" form="short" suffix="." strip-periods="true"/>
         </group>
       </if>
       <else>
@@ -151,7 +151,7 @@
       </else>
     </choose>
   </macro>
-  <citation et-al-min="2" et-al-use-first="2" et-al-subsequent-min="2" et-al-subsequent-use-first="1" disambiguate-add-year-suffix="true" disambiguate-add-names="true" disambiguate-add-givenname="true" collapse="year" givenname-disambiguation-rule="primary-name">
+  <citation name-form="short" et-al-min="3" et-al-use-first="1" et-al-subsequent-min="3" et-al-subsequent-use-first="1" disambiguate-add-names="true" disambiguate-add-givenname="true" disambiguate-add-year-suffix="true" givenname-disambiguation-rule="primary-name" collapse="year">
     <sort>
       <key macro="year-date"/>
       <key macro="author-short"/>
@@ -211,7 +211,7 @@
             <text macro="edition"/>
             <text macro="editor" suffix="."/>
           </group>
-          <group prefix=" " delimiter=", ">
+          <group prefix=" " suffix="" delimiter=", ">
             <text macro="publisher"/>
             <text variable="page" prefix=" " suffix="pp."/>
           </group>


### PR DESCRIPTION
Minor bug fix so that "et al." inline citations display correctly when a reference is used two or more times.