### PR TITLE
Update zookeys.csl

### DIFF
--- a/zookeys.csl
+++ b/zookeys.csl
@@ -15,7 +15,7 @@
     <issn>1313-2989</issn>
     <eissn>1313-2970</eissn>
     <summary>The ZooKeys style.</summary>
-    <updated>2015-11-06T21:38:15+00:00</updated>
+    <updated>2015-11-07T07:40:10+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale xml:lang="en-US">
@@ -174,8 +174,8 @@
     </sort>
     <layout suffix=" ">
       <text macro="author" suffix=" ("/>
-      <date variable="issued">
-        <date-part name="year" suffix=")"/>
+      <date variable="issued" suffix=")">
+        <date-part name="year"/>
       </date>
       <choose>
         <if type="book" match="any">


### PR DESCRIPTION
Small bug fix to ensure that references that are disambiguated by appending an alphabetic character to the year (e.g., Smith 1996a, Smith 1996b) display correctly in the bibliography.