### PR TITLE
Update australian-guide-to-legal-citation.csl

### DIFF
--- a/australian-guide-to-legal-citation.csl
+++ b/australian-guide-to-legal-citation.csl
@@ -25,10 +25,14 @@
       <name>Nic Suzor</name>
       <email>nic@suzor.com</email>
     </author>
+    <contributor>
+      <name>Tim Baxter</name>
+      <email>tbaxter1@unimelb.edu.au</email>
+    </contributor>
     <category citation-format="note"/>
     <category field="law"/>
     <summary>A modification of the Bluebook legal citation style for Australian conditions.</summary>
-    <updated>2015-04-15T02:43:49+00:00</updated>
+    <updated>2015-11-10T00:40:00+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale>
@@ -165,14 +169,9 @@
   </macro>
   <macro name="editor">
     <group>
-      <choose>
-        <if type="chapter paper-conference" match="any">
-          <text term="in" suffix=" "/>
-        </if>
-      </choose>
       <names variable="editor translator" delimiter=", ">
         <name delimiter-precedes-last="never" and="text" delimiter=", " initialize="false" initialize-with=""/>
-        <label form="short" prefix=" (" suffix=")" strip-periods="true"/>
+        <label form="short" strip-periods="true" prefix=" (" suffix="), "/>
       </names>
     </group>
   </macro>
@@ -340,9 +339,10 @@
   <macro name="book-container">
     <choose>
       <if type="chapter paper-conference" match="any">
+        <text term="in" suffix=" "/>
         <group>
           <text macro="editor"/>
-          <text variable="container-title" font-style="italic" prefix=", "/>
+          <text variable="container-title" font-style="italic"/>
         </group>
       </if>
       <else-if type="webpage">

--- a/australian-guide-to-legal-citation.csl
+++ b/australian-guide-to-legal-citation.csl
@@ -171,7 +171,7 @@
     <group>
       <names variable="editor translator" delimiter=", ">
         <name delimiter-precedes-last="never" and="text" delimiter=", " initialize="false" initialize-with=""/>
-        <label form="short" strip-periods="true" prefix=" (" suffix="), "/>
+        <label form="short" strip-periods="true" prefix=" (" suffix=")"/>
       </names>
     </group>
   </macro>
@@ -340,7 +340,7 @@
     <choose>
       <if type="chapter paper-conference" match="any">
         <text term="in" suffix=" "/>
-        <group>
+        <group delimiter=", ">
           <text macro="editor"/>
           <text variable="container-title" font-style="italic"/>
         </group>


### PR DESCRIPTION
The current version of the AGLC CSL file inserts an extraneous comma for book sections without a listed editor or translator with the output being "Author, 'Title' in , Container" where those fields are blank.

Moved the comma from being a prefix to the container title to being a suffix to the name label.