### PR TITLE
Omit "medium" field in APA blog citations.

### DIFF
--- a/apa.csl
+++ b/apa.csl
@@ -244,6 +244,7 @@
           </group>
           <text macro="edition"/>
         </group>
+        <text macro="format" prefix=" [" suffix="]"/>
       </if>
       <else-if type="post-weblog webpage" match="any">
         <text variable="genre" prefix=" [" suffix="]"/>
@@ -253,9 +254,9 @@
           <text term="version" text-case="capitalize-first"/>
           <text variable="version"/>
         </group>
+        <text macro="format" prefix=" [" suffix="]"/>
       </else-if>
     </choose>
-    <text macro="format" prefix=" [" suffix="]"/>
   </macro>
   <macro name="format">
     <choose>


### PR DESCRIPTION
According to the Publication Manual of the American Psychological Association, 6th Ed., p. 215, the general citation form for internet message boards, electronic mailing lists, and other online communities (including blogs) is:

```
Author, A. A. (Year, Month Day). Title of Post [Description of form]. Retrieved from http://www.xxxx
```

Currently, if a citation with a `type` of `post-weblog` or `webpage` has a `medium` specified, the medium will be outputted in brackets after the genre, which is also in brackets.

This is awkward aesthetically, but aside from that, a medium is probably not needed in blog or webpage citations, since in general, they will already have a description of form (genre) specified.