### PR TITLE
update suggested to institute-of-physics-harvard to include report numbers

### DIFF
--- a/institute-of-physics-harvard.csl
+++ b/institute-of-physics-harvard.csl
@@ -98,6 +98,13 @@
       <text variable="page"/>
     </group>
   </macro>
+  <macro name="report-details">
+    <choose>
+      <if type="report">
+        <text variable="number" prefix="Report "/>
+      </if>
+    </choose>
+	</macro>
   <macro name="volume">
     <group delimiter=" ">
       <text term="volume" form="short" strip-periods="true"/>
@@ -138,6 +145,7 @@
               <text macro="volume"/>
               <text macro="editor"/>
             </group>
+			<text macro="report-details" suffix=", "/>
             <text macro="publisher"/>
           </group>
         </if>


### PR DESCRIPTION
[only one commit made, commit message copied here]
Using the current IOP-harvard dependent style
http://www.zotero.org/styles/physics-in-medicine-and-biology, report
numbers are not shown in report-type bibliography items. However,
report-type bibliography items are listed with report numbers in the
bibliography of articles appearing in the journal Physics in Medicine
and Biology. This, probably, is done manually by the user, by adding
the report number in the title field of a bibliography database (such
as Papers 3 for Mac).
This proposed update makes explicit use of the report number field and
formats it in Roman numerals, as at the format guidelines of IOP for
these type of references.
Example
Andreo P, Burns D T, Hohlfeld K, Huq M, Kanai T, Laitano R F, Smyth V
and Vynckier S 2000 Absorbed Dose Determination in External Beam
Radiotherapy, An International Code of Practice for Dosimetry Based on
Standards of Absorbed Dose to Water Report TRS-398, (Vienna:
International Atomic Energy Agency)
