### PR TITLE
Create Cladistics.csl

### DIFF
--- a/Cladistics.csl
+++ b/Cladistics.csl
@@ -1,0 +1,254 @@
+<?xml version="1.0" encoding="utf-8"?>
+<style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" 
+
+version="1.0" demote-non-dropping-particle="never" default-locale="en-US">
+  <info>
+    <title>Cladistics</title>
+    <id>http://www.zotero.org/styles/Cladistics</id>
+    <link href="http://www.zotero.org/styles/cladistics" rel="self"/>
+    <link href="http://www.zotero.org/styles/cladistics" rel="template"/>
+    <link href="http://onlinelibrary.wiley.com/journal/10.1111/%28ISSN
+
+%291096-0031/homepage/ForAuthors.html" rel="documentation"/>
+    <author>
+      <name>Steven Vidovic</name>
+      <email>steven.vidovic@port.ac.uk</email>
+    </author>
+    <category citation-format="author-date"/>
+    <category field="biology"/>
+    <category field="generic-base"/>
+    <updated>2015-11-25T15:15:14+00:00</updated>
+    <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This 
+
+work is licensed under a Creative Commons Attribution-ShareAlike 3.0 
+
+License</rights>
+  </info>
+  <macro name="container">
+    <choose>
+      <if type="chapter paper-conference" match="any">
+        <text term="in" prefix=", " suffix=": "/>
+        <names variable="editor translator" delimiter=", " suffix=", ">
+          <name name-as-sort-order="all" sort-separator=", " initialize-
+
+with="." delimiter=", " delimiter-precedes-last="always"/>
+          <label form="short" text-case="capitalize-first" prefix=" (" 
+
+suffix=")"/>
+        </names>
+        <group delimiter=", ">
+          <text variable="container-title" text-case="title"/>
+          <text variable="collection-title" text-case="title"/>
+        </group>
+      </if>
+      <else-if type="bill book graphic legal_case legislation 
+
+motion_picture report song" match="any">
+        <group prefix=", " delimiter=", ">
+          <text variable="container-title"/>
+          <text variable="collection-title"/>
+        </group>
+      </else-if>
+      <else>
+        <group prefix=". " delimiter=", ">
+          <text variable="container-title"/>
+          <text variable="collection-title"/>
+        </group>
+      </else>
+    </choose>
+  </macro>
+  <macro name="author">
+    <names variable="author">
+      <name delimiter-precedes-last="never" initialize-with="." name-as-
+
+sort-order="all"/>
+      <label form="short" prefix=" (" suffix=")" text-case="capitalize-
+
+first"/>
+      <substitute>
+        <names variable="editor"/>
+        <names variable="translator"/>
+        <text macro="title"/>
+      </substitute>
+    </names>
+  </macro>
+  <macro name="author-short">
+    <names variable="author">
+      <name form="short" font-style="normal" and="text" initialize-with=". 
+
+"/>
+      <et-al font-style="italic"/>
+      <substitute>
+        <names variable="editor" font-style="normal"/>
+        <names variable="translator" font-style="normal"/>
+        <choose>
+          <if type="bill book graphic legal_case legislation motion_picture 
+
+report song" match="any">
+            <text variable="title" form="short" font-style="italic"/>
+          </if>
+          <else>
+            <text variable="title" form="short" quotes="true"/>
+          </else>
+        </choose>
+      </substitute>
+    </names>
+  </macro>
+  <macro name="access">
+    <choose>
+      <if variable="DOI">
+        <text variable="DOI" prefix="doi:"/>
+      </if>
+      <else-if type="webpage">
+        <group delimiter=" ">
+          <text value="URL"/>
+          <text variable="URL"/>
+          <group prefix="(" suffix=").">
+            <text term="accessed" suffix=" "/>
+            <date variable="accessed">
+              <date-part name="month" form="numeric" suffix="."/>
+              <date-part name="day" suffix="."/>
+              <date-part name="year" form="short"/>
+            </date>
+          </group>
+        </group>
+      </else-if>
+    </choose>
+  </macro>
+  <macro name="title">
+    <choose>
+      <if type="report thesis" match="any">
+        <text variable="title"/>
+        <group prefix=" (" suffix=")" delimiter=" ">
+          <text variable="genre"/>
+          <text variable="number" prefix="No. "/>
+        </group>
+      </if>
+      <else-if type="bill book graphic legal_case legislation 
+
+motion_picture report song speech" match="any">
+        <text variable="title"/>
+        <text macro="edition" prefix=", "/>
+      </else-if>
+      <else-if type="webpage">
+        <text variable="title"/>
+        <text value="WWW Document" prefix=" [" suffix="]"/>
+      </else-if>
+      <else>
+        <text variable="title"/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="publisher">
+    <group delimiter=", ">
+      <text variable="publisher"/>
+      <text variable="publisher-place"/>
+    </group>
+  </macro>
+  <macro name="event">
+    <choose>
+      <if variable="event">
+        <text term="presented at" text-case="capitalize-first" suffix=" "/>
+        <text variable="event"/>
+      </if>
+    </choose>
+  </macro>
+  <macro name="issued">
+    <choose>
+      <if variable="issued">
+        <date variable="issued">
+          <date-part name="year" font-style="normal"/>
+        </date>
+      </if>
+      <else>
+        <text term="no date" form="short"/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="edition">
+    <group delimiter=" ">
+      <choose>
+        <if is-numeric="edition">
+          <number variable="edition" form="ordinal"/>
+        </if>
+        <else>
+          <text variable="edition" suffix="."/>
+        </else>
+      </choose>
+      <text value="ed"/>
+    </group>
+  </macro>
+  <macro name="locators">
+    <choose>
+      <if type="article-journal article-magazine article-newspaper" 
+
+match="any">
+        <group delimiter=", " prefix=" ">
+          <group>
+            <text variable="volume" form="short"/>
+          </group>
+          <text variable="page"/>
+        </group>
+      </if>
+      <else-if type="bill book graphic legal_case legislation 
+
+motion_picture report song thesis" match="any">
+        <group delimiter=", " prefix=". ">
+          <text macro="event"/>
+          <text macro="publisher"/>
+        </group>
+      </else-if>
+      <else-if type="chapter paper-conference" match="any">
+        <group delimiter=", " prefix=". ">
+          <text macro="event"/>
+          <text macro="publisher"/>
+          <group>
+            <label variable="page" form="short" suffix=" "/>
+            <text variable="page"/>
+          </group>
+        </group>
+      </else-if>
+      <else-if type="patent">
+        <text variable="number" prefix=". "/>
+      </else-if>
+    </choose>
+  </macro>
+  <citation et-al-min="3" et-al-use-first="1" disambiguate-add-
+
+givenname="true" disambiguate-add-year-suffix="true" collapse="year" cite-
+
+group-delimiter=", ">
+    <sort>
+      <key macro="author"/>
+      <key macro="issued" sort="descending"/>
+    </sort>
+    <layout font-style="normal" delimiter="; " prefix="(" suffix=")">
+      <group delimiter=", ">
+        <text macro="author-short" font-style="normal"/>
+        <text macro="issued"/>
+        <group delimiter=" ">
+          <label font-style="normal" variable="locator" form="short"/>
+          <text variable="locator" font-style="normal"/>
+        </group>
+      </group>
+    </layout>
+  </citation>
+  <bibliography hanging-indent="true" entry-spacing="0" line-spacing="1">
+    <sort>
+      <key macro="author"/>
+      <key macro="issued" sort="descending"/>
+    </sort>
+    <layout>
+      <group delimiter="." suffix=".">
+        <text macro="author"/>
+        <text macro="issued" prefix=" "/>
+        <group prefix=". ">
+          <text macro="title" font-style="normal"/>
+          <text macro="container"/>
+          <text macro="locators" font-style="normal"/>
+        </group>
+      </group>
+      <text macro="access" prefix=". "/>
+    </layout>
+  </bibliography>
+</style>

--- a/Cladistics.csl
+++ b/Cladistics.csl
@@ -1,15 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
-<style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" 
-
-version="1.0" demote-non-dropping-particle="never" default-locale="en-US">
+<style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" demote-non-dropping-particle="never" default-locale="en-US">
   <info>
     <title>Cladistics</title>
     <id>http://www.zotero.org/styles/Cladistics</id>
     <link href="http://www.zotero.org/styles/cladistics" rel="self"/>
     <link href="http://www.zotero.org/styles/cladistics" rel="template"/>
-    <link href="http://onlinelibrary.wiley.com/journal/10.1111/%28ISSN
-
-%291096-0031/homepage/ForAuthors.html" rel="documentation"/>
+    <link href="http://onlinelibrary.wiley.com/journal/10.1111/%28ISSN%291096-0031/homepage/ForAuthors.html" rel="documentation"/>
     <author>
       <name>Steven Vidovic</name>
       <email>steven.vidovic@port.ac.uk</email>
@@ -17,33 +13,23 @@ version="1.0" demote-non-dropping-particle="never" default-locale="en-US">
     <category citation-format="author-date"/>
     <category field="biology"/>
     <category field="generic-base"/>
-    <updated>2015-11-25T15:15:14+00:00</updated>
-    <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This 
-
-work is licensed under a Creative Commons Attribution-ShareAlike 3.0 
-
-License</rights>
+    <updated>2015-11-25T18:14:03+00:00</updated>
+    <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <macro name="container">
     <choose>
       <if type="chapter paper-conference" match="any">
         <text term="in" prefix=", " suffix=": "/>
         <names variable="editor translator" delimiter=", " suffix=", ">
-          <name name-as-sort-order="all" sort-separator=", " initialize-
-
-with="." delimiter=", " delimiter-precedes-last="always"/>
-          <label form="short" text-case="capitalize-first" prefix=" (" 
-
-suffix=")"/>
+          <name name-as-sort-order="all" sort-separator=", " initialize-with="." delimiter=", " delimiter-precedes-last="always"/>
+          <label form="short" text-case="capitalize-first" prefix=" (" suffix=")"/>
         </names>
         <group delimiter=", ">
           <text variable="container-title" text-case="title"/>
           <text variable="collection-title" text-case="title"/>
         </group>
       </if>
-      <else-if type="bill book graphic legal_case legislation 
-
-motion_picture report song" match="any">
+      <else-if type="bill book graphic legal_case legislation motion_picture report song" match="any">
         <group prefix=", " delimiter=", ">
           <text variable="container-title"/>
           <text variable="collection-title"/>
@@ -51,7 +37,7 @@ motion_picture report song" match="any">
       </else-if>
       <else>
         <group prefix=". " delimiter=", ">
-          <text variable="container-title"/>
+          <text variable="container-title" suffix="."/>
           <text variable="collection-title"/>
         </group>
       </else>
@@ -59,12 +45,8 @@ motion_picture report song" match="any">
   </macro>
   <macro name="author">
     <names variable="author">
-      <name delimiter-precedes-last="never" initialize-with="." name-as-
-
-sort-order="all"/>
-      <label form="short" prefix=" (" suffix=")" text-case="capitalize-
-
-first"/>
+      <name delimiter-precedes-last="never" initialize-with="." name-as-sort-order="all"/>
+      <label form="short" prefix=" (" suffix=")" text-case="capitalize-first"/>
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
@@ -74,17 +56,13 @@ first"/>
   </macro>
   <macro name="author-short">
     <names variable="author">
-      <name form="short" font-style="normal" and="text" initialize-with=". 
-
-"/>
+      <name form="short" font-style="normal" and="text" initialize-with=". "/>
       <et-al font-style="italic"/>
       <substitute>
         <names variable="editor" font-style="normal"/>
         <names variable="translator" font-style="normal"/>
         <choose>
-          <if type="bill book graphic legal_case legislation motion_picture 
-
-report song" match="any">
+          <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
             <text variable="title" form="short" font-style="italic"/>
           </if>
           <else>
@@ -124,9 +102,7 @@ report song" match="any">
           <text variable="number" prefix="No. "/>
         </group>
       </if>
-      <else-if type="bill book graphic legal_case legislation 
-
-motion_picture report song speech" match="any">
+      <else-if type="bill book graphic legal_case legislation motion_picture report song speech" match="any">
         <text variable="title"/>
         <text macro="edition" prefix=", "/>
       </else-if>
@@ -180,9 +156,7 @@ motion_picture report song speech" match="any">
   </macro>
   <macro name="locators">
     <choose>
-      <if type="article-journal article-magazine article-newspaper" 
-
-match="any">
+      <if type="article-journal article-magazine article-newspaper" match="any">
         <group delimiter=", " prefix=" ">
           <group>
             <text variable="volume" form="short"/>
@@ -190,9 +164,7 @@ match="any">
           <text variable="page"/>
         </group>
       </if>
-      <else-if type="bill book graphic legal_case legislation 
-
-motion_picture report song thesis" match="any">
+      <else-if type="bill book graphic legal_case legislation motion_picture report song thesis" match="any">
         <group delimiter=", " prefix=". ">
           <text macro="event"/>
           <text macro="publisher"/>
@@ -213,11 +185,7 @@ motion_picture report song thesis" match="any">
       </else-if>
     </choose>
   </macro>
-  <citation et-al-min="3" et-al-use-first="1" disambiguate-add-
-
-givenname="true" disambiguate-add-year-suffix="true" collapse="year" cite-
-
-group-delimiter=", ">
+  <citation et-al-min="3" et-al-use-first="1" disambiguate-add-givenname="true" disambiguate-add-year-suffix="true" collapse="year" cite-group-delimiter=", ">
     <sort>
       <key macro="author"/>
       <key macro="issued" sort="descending"/>

--- a/cladistics.csl
+++ b/cladistics.csl
@@ -2,9 +2,9 @@
 <style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" demote-non-dropping-particle="never" default-locale="en-US">
   <info>
     <title>Cladistics</title>
-    <id>http://www.zotero.org/styles/Cladistics</id>
+    <id>http://www.zotero.org/styles/cladistics</id>
     <link href="http://www.zotero.org/styles/cladistics" rel="self"/>
-    <link href="http://www.zotero.org/styles/cladistics" rel="template"/>
+    <link href="http://www.zotero.org/styles/elsevier-harvard" rel="template"/>
     <link href="http://onlinelibrary.wiley.com/journal/10.1111/%28ISSN%291096-0031/homepage/ForAuthors.html" rel="documentation"/>
     <author>
       <name>Steven Vidovic</name>
@@ -12,8 +12,9 @@
     </author>
     <category citation-format="author-date"/>
     <category field="biology"/>
-    <category field="generic-base"/>
-    <updated>2015-11-25T18:14:03+00:00</updated>
+    <issn>0748-3007</issn>
+    <eissn>1096-0031</eissn>
+    <updated>2015-11-25T19:04:56+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <macro name="container">


### PR DESCRIPTION
Cladistics journal reference style. The reference style is similar to Elsevier Harvard, with italicized et al. for in-text reference. The bibliography has no italics, there is a "." at the end of the author list and the date is out of brackets. There is a "." after the journal title.