### PR TITLE
Minor fixes to apa-fr-universite-de-montreal.csl

### DIFF
--- a/apa-fr-universite-de-montreal.csl
+++ b/apa-fr-universite-de-montreal.csl
@@ -16,7 +16,7 @@
     <category field="psychology"/>
     <category field="generic-base"/>
     <summary>Adaptation en français canadien des normes de citation de l'APA (6e édition) basée sur le guide des Bibliothèques de l'Université de Montréal.</summary>
-    <updated>2014-06-14T18:27:09+00:00</updated>
+    <updated>2015-12-01T18:06:09+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale>
@@ -28,10 +28,7 @@
       <term name="retrieved">repéré</term>
       <term name="from">à</term>
       <term name="presented at">communication présentée au</term>
-      <term name="page" form="short">
-        <single>p.</single>
-        <multiple>pp.</multiple>
-      </term>
+      <term name="page" form="short">p.</term>
     </terms>
   </locale>
   <macro name="container-contributors">
@@ -200,7 +197,7 @@
   <macro name="publisher">
     <choose>
       <if type="report" match="any">
-        <group delimiter=": ">
+        <group delimiter=" : ">
           <text variable="publisher-place"/>
           <text variable="publisher"/>
         </group>
@@ -224,7 +221,7 @@
           </choose>
           <choose>
             <if type="article-journal article-magazine" match="none">
-              <group delimiter=": ">
+              <group delimiter=" : ">
                 <text variable="publisher-place"/>
                 <text variable="publisher"/>
               </group>


### PR DESCRIPTION
- space added before the ":" as requested by French language typographic rules
- "pp." replaced by "p."