### PR TITLE
Proposal: lluelles-noibid.csl

### DIFF
--- a/dependent/lluelles-lexisnexis.csl
+++ b/dependent/lluelles-lexisnexis.csl
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<style xmlns="http://purl.org/net/xbiblio/csl" class="note" version="1.0" default-locale="fr-CA">
+  <info>
+    <title>LexisNexis Québec (Guide Lluelles, no Ibid., French - Canada)</title>
+    <title-short>LexisNexis Québec</title-short>
+    <id>http://www.zotero.org/styles/lluelles-lexisnexis</id>
+    <link href="http://www.zotero.org/styles/lluelles-lexisnexis" rel="self"/>
+    <link href="http://www.zotero.org/styles/lluelles-no-ibid" rel="independent-parent"/>
+    <link href="http://f-mb.github.io/cslegal/" rel="documentation"/>
+    <category citation-format="note"/>
+    <category field="law"/>
+    <summary>Ce style est adapté aux règles de rédaction des publications québécoises en langue française de LexisNexis Canada : notes complètes, sans Ibid., basé sur la 7e édition du Guide des références pour la rédaction juridique (Guide Lluelles), et sur lluelles.csl et lluelles-noibid.csl.</summary>
+    <updated>2014-05-15T12:00:00+00:00</updated>
+    <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
+  </info>
+</style>

--- a/lluelles-no-ibid.csl
+++ b/lluelles-no-ibid.csl
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <style xmlns="http://purl.org/net/xbiblio/csl" class="note" version="1.0" default-locale="fr-CA">
   <info>
-    <title>LexisNexis Québec (Guide Lluelles modifié, French - Canada)</title>
-    <id>http://www.zotero.org/styles/lluelles-lexisnexis</id>
-    <link href="http://www.zotero.org/styles/lluelles-lexisnexis" rel="self"/>
+    <title>Guide des références pour la rédaction juridique 7e édition (Notes complètes) (Guide Lluelles, no Ibid., French - Canada)</title>
+    <id>http://www.zotero.org/styles/lluelles-no-ibid</id>
+    <link href="http://www.zotero.org/styles/lluelles-no-ibid" rel="self"/>
     <link href="http://www.zotero.org/styles/lluelles" rel="template"/>
     <link href="http://f-mb.github.io/cslegal/" rel="documentation"/>
     <author>
@@ -13,11 +13,11 @@
     </author>
     <category citation-format="note"/>
     <category field="law"/>
-    <summary>Ce style est adapté aux règles de rédaction des publications québécoises en langue française de LexisNexis Canada : notes complètes, pas d'ibid, basé sur la 7e édition du Guide des références pour la rédaction juridique (Guide Lluelles), et sur lluelles.csl.
+    <summary>Ce style est un style de notes complètes, sans ibid, basé sur la 7e édition du Guide des références pour la rédaction juridique (Guide Lluelles), et sur lluelles.csl.
       Ce style peut demander un usage particulier des champs du logiciel de gestion bibliographique. Plus d'infos: http://f-mb.github.io/cslegal/
-      This style is for citations in LexisNexis Canada's Québec french publications : full notes, no ibid, based on the 7th edition of the Guide Lluelles, and on the lluelles.csl.
+      This style is a full notes, no ibid style, based on the 7th edition of the Guide Lluelles, and on the lluelles.csl.
       This style may require use of specific fields in the reference manager. More infos: http://f-mb.github.io/cslegal/</summary>
-    <updated>2014-06-28T19:04:00+00:00</updated>
+    <updated>2015-12-01T18:23:00+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale xml:lang="fr">


### PR DESCRIPTION
I propose to rename lluelles-lexisnexis.csl as lluelles-noibid.csl as, basically, this is the Lluelles Style but with no Ibid. It has been used by LexisNexis Québec for years, but more and more people rely on it. I think it would be better to rename it as the "Guide Lluelles - No Ibid".

With this pull request:
- lluelles-lexisnexis.csl would become lluelles-noibid.csl 
- and a dependent style referring to lluelles-noibid.csl would be create for LexisNexis Québec, with the former ID lluelles-lexisnexis.csl.

I am not sure this is how I/we should do that... so open to any suggestion!

Best,

Florian