### PR TITLE
Update to us-geological-survey style

### DIFF
--- a/us-geological-survey.csl
+++ b/us-geological-survey.csl
@@ -132,24 +132,26 @@
           </group>
         </else-if>
         <else-if type="webpage">
-          <text variable="title" prefix=" " suffix=","/>
-          <group prefix=" ">
-            <text term="accessed"/>
-          </group>
-          <group prefix=" ">
-            <date variable="accessed">
-              <date-part name="month" form="long" suffix=" "/>
-              <date-part name="day" form="numeric" suffix=", "/>
-              <date-part name="year" form="long"/>
-            </date>
-          </group>
-          <group prefix=" ">
-            <text term="at"/>
-            <text variable="container-title" prefix=" "/>
-          </group>
-          <group prefix=" ">
-            <text term="at"/>
-            <text variable="URL" prefix=" "/>
+          <group prefix=" " delimiter=", ">
+            <text variable="title"/>
+            <group delimiter=" ">
+              <text term="accessed"/>
+              <date variable="accessed">
+                <date-part name="month" form="long" suffix=" "/>
+                <date-part name="day" form="numeric" suffix=", "/>
+                <date-part name="year" form="long"/>
+              </date>
+            </group>
+            <group delimiter=" ">
+              <group delimiter=" ">
+                <text term="at"/>
+                <text variable="container-title"/>
+              </group>
+              <group delimiter=" ">
+                <text term="at"/>
+                <text variable="URL"/>
+              </group>
+            </group>
           </group>
         </else-if>
         <else-if type="chapter paper-conference" match="any">

--- a/us-geological-survey.csl
+++ b/us-geological-survey.csl
@@ -96,7 +96,7 @@
       </group>
       <choose>
         <if type="report">
-          <group prefix=" " delimiter=", " suffix=".">
+          <group prefix=" " delimiter=", " suffix=".,">
             <group delimiter=" ">
               <text variable="title" suffix=":"/>
               <text variable="publisher"/>
@@ -107,6 +107,24 @@
               <text variable="page" suffix=" "/>
               <label variable="page" form="short" plural="never"/>
             </group>
+          </group>
+          <group prefix=" ">
+            <text term="accessed"/>
+          <group prefix=" " suffix=",">
+            <date variable="accessed">
+              <date-part name="month" form="long" suffix=" "/>
+              <date-part name="day" form="numeric" suffix=", "/>
+              <date-part name="year" form="long"/>
+            </date>
+          </group>
+          <group prefix=" ">
+            <text term="at"/>
+            <text variable="container-title" prefix=" " suffix=" "/>
+          </group>
+          <group prefix=" " suffix=".">
+            <text term="at"/>
+            <text variable="URL" prefix=" "/>
+          </group>
           </group>
         </if>
         <else-if type="bill book graphic legal_case legislation motion_picture report song" match="any">

--- a/us-geological-survey.csl
+++ b/us-geological-survey.csl
@@ -107,27 +107,27 @@
               <text variable="page" suffix=" "/>
               <label variable="page" form="short" plural="never"/>
             </group>
-          <group prefix=" ">
-            <text term="accessed"/>
-          <group prefix=" " suffix=",">
-            <date variable="accessed">
-              <date-part name="month" form="long" suffix=" "/>
-              <date-part name="day" form="numeric" suffix=", "/>
-              <date-part name="year" form="long"/>
-            </date>
-          </group>
-          <group prefix=" ">
-            <text term="at"/>
-            <text variable="container-title" prefix=" " suffix=" "/>
-          </group>
-          <group prefix=" " suffix=".">
-            <text term="at"/>
-            <text variable="URL" prefix=" "/>
-          </group>
-          </group>
+            <group prefix=" ">
+              <text term="accessed"/>
+              <group prefix=" " suffix=",">
+                <date variable="accessed">
+                  <date-part name="month" form="long" suffix=" "/>
+                  <date-part name="day" form="numeric" suffix=", "/>
+                  <date-part name="year" form="long"/>
+                </date>
+              </group>
+              <group prefix=" ">
+                <text term="at"/>
+                <text variable="container-title" prefix=" " suffix=" "/>
+              </group>
+              <group prefix=" " suffix=" ">
+                <text term="at"/>
+                <text variable="URL" prefix=" "/>
+              </group>
+            </group>
           </group>
         </if>
-        <else-if type="bill book graphic legal_case legislation motion_picture report song" match="any">
+        <else-if type="bill book graphic legal_case legislation motion_picture song" match="any">
           <group suffix=":">
             <text variable="title" prefix=" "/>
             <text macro="editor-translator" prefix=" "/>
@@ -154,7 +154,7 @@
             <text term="from"/>
             <text variable="container-title" prefix=" " suffix=" "/>
           </group>
-          <group prefix=" " suffix=".">
+          <group prefix=" " suffix=" ">
             <text term="at"/>
             <text variable="URL" prefix=" "/>
           </group>

--- a/us-geological-survey.csl
+++ b/us-geological-survey.csl
@@ -96,7 +96,7 @@
       </group>
       <choose>
         <if type="report">
-          <group prefix=" " delimiter=", " suffix=".,">
+          <group prefix=" " delimiter=", " suffix=" ">
             <group delimiter=" ">
               <text variable="title" suffix=":"/>
               <text variable="publisher"/>
@@ -107,7 +107,6 @@
               <text variable="page" suffix=" "/>
               <label variable="page" form="short" plural="never"/>
             </group>
-          </group>
           <group prefix=" ">
             <text term="accessed"/>
           <group prefix=" " suffix=",">
@@ -124,6 +123,7 @@
           <group prefix=" " suffix=".">
             <text term="at"/>
             <text variable="URL" prefix=" "/>
+          </group>
           </group>
           </group>
         </if>

--- a/us-geological-survey.csl
+++ b/us-geological-survey.csl
@@ -46,14 +46,7 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
-            <text variable="title" form="short" font-style="italic"/>
-          </if>
-          <else>
-            <text variable="title" form="short" quotes="true"/>
-          </else>
-        </choose>
+        <text variable="title" form="short"/>
       </substitute>
     </names>
   </macro>
@@ -96,7 +89,7 @@
       </group>
       <choose>
         <if type="report">
-          <group prefix=" " delimiter=", " suffix=" ">
+          <group prefix=" " delimiter=", ">
             <group delimiter=" ">
               <text variable="title" suffix=":"/>
               <text variable="publisher"/>
@@ -118,9 +111,9 @@
               </group>
               <group prefix=" ">
                 <text term="at"/>
-                <text variable="container-title" prefix=" " suffix=" "/>
+                <text variable="container-title" prefix=" "/>
               </group>
-              <group prefix=" " suffix=" ">
+              <group prefix=" ">
                 <text term="at"/>
                 <text variable="URL" prefix=" "/>
               </group>
@@ -145,16 +138,16 @@
           </group>
           <group prefix=" ">
             <date variable="accessed">
-              <date-part name="month" form="numeric" suffix="/"/>
-              <date-part name="day" form="numeric-leading-zeros" suffix="/"/>
-              <date-part name="year" form="long" suffix=" "/>
+              <date-part name="month" form="long" suffix=" "/>
+              <date-part name="day" form="numeric" suffix=", "/>
+              <date-part name="year" form="long"/>
             </date>
           </group>
           <group prefix=" ">
-            <text term="from"/>
-            <text variable="container-title" prefix=" " suffix=" "/>
+            <text term="at"/>
+            <text variable="container-title" prefix=" "/>
           </group>
-          <group prefix=" " suffix=" ">
+          <group prefix=" ">
             <text term="at"/>
             <text variable="URL" prefix=" "/>
           </group>


### PR DESCRIPTION
This update changes the report citation type to include a URL and access date,
following recent requirements by the USGS.
Note: the addition may not correctly ignore urls when one is not provided with the report