### PR TITLE
Update apa.csl

### DIFF
--- a/apa.csl
+++ b/apa.csl
@@ -79,8 +79,14 @@
       <name name-as-sort-order="all" and="symbol" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
       <label form="short" prefix=" (" suffix=")" text-case="capitalize-first"/>
       <substitute>
-        <names variable="editor"/>
-        <names variable="translator"/>
+        <names variable="editor">
+          <name name-as-sort-order="all" and="symbol" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
+          <label form="short" prefix=" (" suffix=")" text-case="capitalize-first"/>
+        </names>
+        <names variable="translator">
+          <name name-as-sort-order="all" and="symbol" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
+          <label form="short" prefix=" (" suffix=")" text-case="capitalize-first"/>
+        </names>
         <choose>
           <if type="report">
             <text variable="publisher"/>
@@ -97,8 +103,12 @@
     <names variable="author">
       <name form="short" and="symbol" delimiter=", " initialize-with=". "/>
       <substitute>
-        <names variable="editor"/>
-        <names variable="translator"/>
+        <names variable="editor">
+          <name form="short" and="symbol" delimiter=", " initialize-with=". "/>
+        </names>
+        <names variable="translator">
+          <name form="short" and="symbol" delimiter=", " initialize-with=". "/>
+        </names>
         <choose>
           <if type="report">
             <text variable="publisher"/>


### PR DESCRIPTION
The "name" and "label" commands were not applied to the substitute variables "editor" and "translator".