### PR TITLE
Update mcgill-en.csl

### DIFF
--- a/mcgill-en.csl
+++ b/mcgill-en.csl
@@ -37,6 +37,18 @@
         <single>para</single>
         <multiple>paras</multiple>
       </term>
+      <term name="sub verbo" form="short">
+			  <single></single>
+			  <multiple></multiple>
+			</term>
+			<term name="section" form="short">
+			  <single>s</single>
+		    <multiple>ss</multiple>
+		  </term>
+		  <term name="chapter" form="short">
+		    <single>ch</single>
+			  <multiple>chs</multiple>
+	    </term>
     </terms>
   </locale>
   <macro name="editor">
@@ -116,7 +128,7 @@
       <else-if type="book thesis" match="any">
         <text value="3"/>
       </else-if>
-      <else-if type="article-journal chapter article-newspaper" match="any">
+      <else-if type="article-journal chapter article-newspaper article-magazine" match="any">
         <text value="4"/>
       </else-if>
       <else>
@@ -190,6 +202,15 @@ all the other tests should have been done... -->
     </group>
     <text macro="internet-location"/>
   </macro>
+  <macro name="render-article-magazine">		
+		<group delimiter=" ">		
+	    <text variable="title" quotes="true" suffix=","/>		
+			<text macro="container-title" font-style="italic"/>		
+			<text macro="issued-long" prefix="(" suffix=")"/>		
+			<text variable="page-first"/>		
+		</group>		
+		<text macro="internet-location"/>		
+	</macro>
   <macro name="render-webpage">
     <group delimiter=" ">
       <text variable="title" quotes="true" suffix=","/>
@@ -281,7 +302,7 @@ all the other tests should have been done... -->
           </choose>
         </if>
         <else>
-          <label variable="locator" form="short" strip-periods="true" prefix=", "/>
+          <label variable="locator" plural="contextual" form="short" strip-periods="true" prefix=", "/>
         </else>
       </choose>
       <text variable="locator"/>
@@ -377,9 +398,12 @@ Not implemented: "cited to" for cases, construct short casenames, adding ref to 
                     <else-if type="thesis">
                       <text macro="render-thesis"/>
                     </else-if>
-                    <else-if type="article-newspaper article-magazine" match="any">
+                    <else-if type="article-newspaper" match="any">
                       <text macro="render-article-newspaper"/>
                     </else-if>
+                    <else-if type="article-magazine">		
+				                  <text macro="render-article-magazine"/>		
+				                </else-if>
                     <else-if type="webpage post-weblog" match="any">
                       <text macro="render-webpage"/>
                     </else-if>
@@ -409,7 +433,7 @@ Not implemented: "cited to" for cases, construct short casenames, adding ref to 
       </choose>
     </layout>
   </citation>
-  <bibliography et-al-min="4" et-al-use-first="1">
+  <bibliography et-al-min="4" et-al-use-first="1" subsequent-author-substitute="&#8212;&#8212;&#8212;">
     <sort>
       <key macro="sort-by-type"/>
       <key macro="author-bib"/>
@@ -440,8 +464,11 @@ Not implemented: "cited to" for cases, construct short casenames, adding ref to 
               <else-if type="thesis">
                 <text macro="render-thesis"/>
               </else-if>
-              <else-if type="article-newspaper article-magazine" match="any">
+              <else-if type="article-newspaper">
                 <text macro="render-article-newspaper"/>
+              </else-if>
+              <else-if type="article-magazine">		
+                <text macro="render-article-magazine"/>		
               </else-if>
               <else-if type="book">
                 <text macro="render-book"/>

--- a/mcgill-en.csl
+++ b/mcgill-en.csl
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <style xmlns="http://purl.org/net/xbiblio/csl" version="1.0" class="note" default-locale="en-US">
   <info>
     <title>Canadian Guide to Uniform Legal Citation 7th edition (McGill Guide)</title>
@@ -38,17 +38,17 @@
         <multiple>paras</multiple>
       </term>
       <term name="sub verbo" form="short">
-			  <single></single>
-			  <multiple></multiple>
-			</term>
-			<term name="section" form="short">
-			  <single>s</single>
-		    <multiple>ss</multiple>
-		  </term>
-		  <term name="chapter" form="short">
-		    <single>ch</single>
-			  <multiple>chs</multiple>
-	    </term>
+        <single/>
+        <multiple/>
+      </term>
+      <term name="section" form="short">
+        <single>s</single>
+        <multiple>ss</multiple>
+      </term>
+      <term name="chapter" form="short">
+        <single>ch</single>
+        <multiple>chs</multiple>
+      </term>
     </terms>
   </locale>
   <macro name="editor">
@@ -202,15 +202,15 @@ all the other tests should have been done... -->
     </group>
     <text macro="internet-location"/>
   </macro>
-  <macro name="render-article-magazine">		
-		<group delimiter=" ">		
-	    <text variable="title" quotes="true" suffix=","/>		
-			<text macro="container-title" font-style="italic"/>		
-			<text macro="issued-long" prefix="(" suffix=")"/>		
-			<text variable="page-first"/>		
-		</group>		
-		<text macro="internet-location"/>		
-	</macro>
+  <macro name="render-article-magazine">
+    <group delimiter=" ">
+      <text variable="title" quotes="true" suffix=","/>
+      <text macro="container-title" font-style="italic"/>
+      <text macro="issued-long" prefix="(" suffix=")"/>
+      <text variable="page-first"/>
+    </group>
+    <text macro="internet-location"/>
+  </macro>
   <macro name="render-webpage">
     <group delimiter=" ">
       <text variable="title" quotes="true" suffix=","/>
@@ -401,9 +401,9 @@ Not implemented: "cited to" for cases, construct short casenames, adding ref to 
                     <else-if type="article-newspaper" match="any">
                       <text macro="render-article-newspaper"/>
                     </else-if>
-                    <else-if type="article-magazine">		
-				                  <text macro="render-article-magazine"/>		
-				                </else-if>
+                    <else-if type="article-magazine">
+                      <text macro="render-article-magazine"/>
+                    </else-if>
                     <else-if type="webpage post-weblog" match="any">
                       <text macro="render-webpage"/>
                     </else-if>
@@ -467,8 +467,8 @@ Not implemented: "cited to" for cases, construct short casenames, adding ref to 
               <else-if type="article-newspaper">
                 <text macro="render-article-newspaper"/>
               </else-if>
-              <else-if type="article-magazine">		
-                <text macro="render-article-magazine"/>		
+              <else-if type="article-magazine">
+                <text macro="render-article-magazine"/>
               </else-if>
               <else-if type="book">
                 <text macro="render-book"/>

--- a/mcgill-en.csl
+++ b/mcgill-en.csl
@@ -37,10 +37,12 @@
         <single>para</single>
         <multiple>paras</multiple>
       </term>
+      <!-- the usual workaround for inserting "Art" or "Arts" (article) pinpointers is to type the term directly into the pinpoint box, and to use sub verbo for a blank pinpointer. However, for clarity and compliance, this functionality needs to be activated by the user by taking the element below out of documentation
       <term name="sub verbo" form="short">
         <single/>
         <multiple/>
       </term>
+      -->
       <term name="section" form="short">
         <single>s</single>
         <multiple>ss</multiple>


### PR DESCRIPTION
Added new plural terms for section, chapter and "other" 
add separate rendering for magazine articles, and sort them with journals and book chapters in bibliography
make pinpoint plurality contextual
for subsequent author in bibliography, substitute three em dashes