### PR TITLE
Create yakugaku-zasshi.csl

### DIFF
--- a/dependent/yakugaku-zasshi.csl
+++ b/dependent/yakugaku-zasshi.csl
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" demote-non-dropping-particle="sort-only" default-locale="en-US">
+  <info>
+    <title>Yakugaku Zasshi (Journal of the Pharmaceutical Society of Japan)</title>
+    <id>http://www.zotero.org/styles/yakugaku-zasshi</id>
+    <link href="http://www.zotero.org/styles/yakugaku-zasshi" rel="self"/>
+    <link href="http://www.zotero.org/styles/chemical-and-pharmaceutical-bulletin" rel="independent-parent"/>
+    <link href="http://yakushi.pharm.or.jp/j_regulations.pdf" rel="documentation"/>
+    <author>
+      <name>Shoji Takahashi</name>
+      <email>s.takahashi@elsevier.com</email>
+      <uri>http://www.mendeley.com/profiles/shoji-takahashi3/</uri>
+    </author>
+    <category citation-format="numeric"/>
+    <category field="chemistry"/>
+    <issn>0031-6903</issn>
+    <eissn>1347-5231</eissn>
+    <updated>2015-12-12T10:21:20+00:00</updated>
+    <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
+  </info>
+</style>


### PR DESCRIPTION
This is a dependent style of Chemical and Pharmaceutical Bulletin.

<title>Yakugaku Zasshi (Journal of the Pharmaceutical Society of Japan)</title>
The reason for the second name in parentheses is that the official name of this journal is "Yakugaku Zasshi" in Japanese but it also has an English name "Journal of the Pharmaceutical Society of Japan" too.
http://yakushi.pharm.or.jp/