### PR TITLE
Include parse error messages in test output

### DIFF
--- a/spec/dependent_styles_spec.rb
+++ b/spec/dependent_styles_spec.rb
@@ -1,4 +1,4 @@
-Dependents.each_pair do |id, (filename, path, style)|
+Dependents.each_pair do |id, (filename, path, style, reason)|
 
   describe "dependent style #{id}" do
 
@@ -11,7 +11,7 @@ Dependents.each_pair do |id, (filename, path, style)|
     end
 
     it "was successfully parsed" do
-      expect(style).to be_a(CSL::Style)
+      expect(style).to be_a(CSL::Style), reason
     end
 
     unless style.nil?

--- a/spec/independent_styles_spec.rb
+++ b/spec/independent_styles_spec.rb
@@ -1,4 +1,4 @@
-Independents.each_pair do |id, (filename, path, style)|
+Independents.each_pair do |id, (filename, path, style, reason)|
 
   describe "independent style #{id}" do
 
@@ -11,7 +11,7 @@ Independents.each_pair do |id, (filename, path, style)|
     end
 
     it "was successfully parsed" do
-      expect(style).to be_a(CSL::Style)
+      expect(style).to be_a(CSL::Style), reason
     end
 
     unless style.nil?

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -61,8 +61,9 @@ def load_style(path)
 
   begin
     style = CSL::Style.load(path)
-  rescue
+  rescue => e
     # failed to parse the style. we'll report the error later
+    return [id, [filename, path, nil, e.message]]
   end
 
   unless style.nil?


### PR DESCRIPTION
Example output:

![screen shot 2015-12-17 at 12 27 42 am](https://cloud.githubusercontent.com/assets/325102/11857129/f9dfaa5e-a455-11e5-924d-66addc8f2eb6.png)
