### PR TITLE
Update harvard-york-st-john-university.csl

### DIFF
--- a/harvard-york-st-john-university.csl
+++ b/harvard-york-st-john-university.csl
@@ -218,8 +218,8 @@
           </choose>
           <choose>
             <if variable="page">
-              <group>
-                <label variable="page" form="short" suffix=" "/>
+              <group delimiter=" ">
+                <label variable="page" form="short"/>
                 <text variable="page"/>
               </group>
             </if>
@@ -231,8 +231,8 @@
           <text variable="event" suffix=". "/>
           <group delimiter=", ">
             <text macro="publisher"/>
-            <group>
-              <label variable="page" form="short" suffix=" "/>
+            <group delimiter=" ">
+              <label variable="page" form="short"/>
               <text variable="page"/>
             </group>
           </group>


### PR DESCRIPTION
Edits to lines 221 and 222; 234 and 235 - replacing 'suffix' with 'delimiter' for punctuation for these groups
(This was suggested as part of a previous pull request.)

This change is not urgent, but brings the previous changes into line with preferred option. 