### PR TITLE
Update zeitschrift-fur-kunstgeschichte.csl

### DIFF
--- a/zeitschrift-fur-kunstgeschichte.csl
+++ b/zeitschrift-fur-kunstgeschichte.csl
@@ -134,8 +134,8 @@
                           <text macro="volume"/>
                         </group>
                         <names variable="editor">
-                          <name and="text" delimiter-precedes-et-al="never" delimiter-precedes-last="never"/>
                           <label form="verb-short" suffix=" "/>
+                          <name and="text" delimiter-precedes-et-al="never" delimiter-precedes-last="never"/>
                         </names>
                       </group>
                     </if>

--- a/zeitschrift-fur-kunstgeschichte.csl
+++ b/zeitschrift-fur-kunstgeschichte.csl
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <style xmlns="http://purl.org/net/xbiblio/csl" class="note" version="1.0" demote-non-dropping-particle="sort-only">
   <info>
     <title>Zeitschrift für Kunstgeschichte</title>
@@ -17,7 +17,7 @@
     <category field="history"/>
     <issn>0044-2992</issn>
     <summary>From the editors: "Die Herausgeber werden im Falle von Editionen, Lexika und Ausstellungskatalogen dem Titel nachgestellt [use encyclopedia articles with or without container-title for that]. Bei gewöhnlichen Sammelbänden werden die Herausgeber dem Titel vorangestellt [use book for that]." Multilingual style; the information for exhibition catalogues should be entered in the field collection-title; locators may use the word "here" or "hier" in front of the page refering to which must be entered individually (the style outputs the locator as it is entered w/o any label or additional text).</summary>
-    <updated>2016-01-16T10:57:41+00:00</updated>
+    <updated>2016-01-28T04:44:25+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale xml:lang="de">
@@ -25,11 +25,13 @@
       <term name="note">wie Anm.</term>
       <term name="et-al">et al.</term>
       <term name="editor" form="short">Hg.</term>
+      <term name="editortranslator" form="verb-short">hg. und übers. von</term>
     </terms>
   </locale>
   <locale xml:lang="en">
     <terms>
       <term name="note">as note</term>
+      <term name="editortranslator" form="verb-short">ed. and trans. by</term>
     </terms>
   </locale>
   <macro name="author-short">
@@ -48,7 +50,7 @@
   </macro>
   <macro name="editor">
     <names variable="editor translator" delimiter=", ">
-      <name delimiter="" prefix=" " and="text" delimiter-precedes-et-al="never" delimiter-precedes-last="never"/>
+      <name and="text" delimiter-precedes-et-al="never" delimiter-precedes-last="never"/>
       <label form="short" prefix=" (" suffix=")"/>
     </names>
   </macro>
@@ -81,6 +83,12 @@
       <text variable="collection-title"/>
       <text variable="collection-number"/>
     </group>
+  </macro>
+  <macro name="translator">
+    <names variable="editor translator" delimiter=", ">
+      <label form="verb-short"/>
+      <name prefix=" " and="text" delimiter-precedes-et-al="never" delimiter-precedes-last="never"/>
+    </names>
   </macro>
   <citation et-al-min="3" et-al-use-first="1" disambiguate-add-names="true">
     <layout delimiter="; " suffix=".">
@@ -126,8 +134,8 @@
                           <text macro="volume"/>
                         </group>
                         <names variable="editor">
+                          <name and="text" delimiter-precedes-et-al="never" delimiter-precedes-last="never"/>
                           <label form="verb-short" suffix=" "/>
-                          <name/>
                         </names>
                       </group>
                     </if>
@@ -149,14 +157,29 @@
                     </group>
                     <names variable="editor translator" delimiter=", ">
                       <label form="verb-short" suffix=" "/>
-                      <name/>
+                      <name and="text" delimiter-precedes-et-al="never" delimiter-precedes-last="never"/>
                     </names>
                   </if>
+                  <else-if match="any" variable="translator">
+                    <choose>
+                      <if match="none" variable="author">
+                        <names variable="editor">
+                          <name and="text" delimiter-precedes-et-al="never" delimiter-precedes-last="never"/>
+                          <label form="short" prefix=" (" suffix=")"/>
+                        </names>
+                      </if>
+                    </choose>
+                    <group delimiter=" ">
+                      <text variable="title" font-style="italic" suffix=","/>
+                      <text macro="translator"/>
+                      <text macro="collection-with-number"/>
+                    </group>
+                  </else-if>
                   <else>
                     <choose>
                       <if match="none" variable="author">
                         <names variable="editor">
-                          <name/>
+                          <name and="text" delimiter-precedes-et-al="never" delimiter-precedes-last="never"/>
                           <label form="short" prefix=" (" suffix=")"/>
                         </names>
                       </if>
@@ -206,7 +229,7 @@
                     </group>
                     <names variable="editor">
                       <label form="verb-short" suffix=" "/>
-                      <name/>
+                      <name and="text" delimiter-precedes-et-al="never" delimiter-precedes-last="never"/>
                     </names>
                   </group>
                 </if>
@@ -228,14 +251,29 @@
                 </group>
                 <names variable="editor translator" delimiter=", ">
                   <label form="verb-short" suffix=" "/>
-                  <name/>
+                  <name and="text" delimiter-precedes-et-al="never" delimiter-precedes-last="never"/>
                 </names>
               </if>
+              <else-if match="any" variable="translator">
+                <choose>
+                  <if match="none" variable="author">
+                    <names variable="editor">
+                      <name and="text" delimiter-precedes-et-al="never" delimiter-precedes-last="never"/>
+                      <label form="short" prefix=" (" suffix=")"/>
+                    </names>
+                  </if>
+                </choose>
+                <group delimiter=" ">
+                  <text variable="title" font-style="italic" suffix=","/>
+                  <text macro="translator"/>
+                  <text macro="collection-with-number"/>
+                </group>
+              </else-if>
               <else>
                 <choose>
                   <if match="none" variable="author">
                     <names variable="editor">
-                      <name/>
+                      <name and="text" delimiter-precedes-et-al="never" delimiter-precedes-last="never"/>
                       <label form="short" prefix=" (" suffix=")"/>
                     </names>
                   </if>

--- a/zeitschrift-fur-kunstgeschichte.csl
+++ b/zeitschrift-fur-kunstgeschichte.csl
@@ -17,7 +17,7 @@
     <category field="history"/>
     <issn>0044-2992</issn>
     <summary>From the editors: "Die Herausgeber werden im Falle von Editionen, Lexika und Ausstellungskatalogen dem Titel nachgestellt [use encyclopedia articles with or without container-title for that]. Bei gewöhnlichen Sammelbänden werden die Herausgeber dem Titel vorangestellt [use book for that]." Multilingual style; the information for exhibition catalogues should be entered in the field collection-title; locators may use the word "here" or "hier" in front of the page refering to which must be entered individually (the style outputs the locator as it is entered w/o any label or additional text).</summary>
-    <updated>2016-01-31T04:44:25+00:00</updated>
+    <updated>2016-01-28T04:44:25+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale xml:lang="de">
@@ -134,8 +134,8 @@
                           <text macro="volume"/>
                         </group>
                         <names variable="editor">
-                          <label form="verb-short" suffix=" "/>
                           <name and="text" delimiter-precedes-et-al="never" delimiter-precedes-last="never"/>
+                          <label form="verb-short" suffix=" "/>
                         </names>
                       </group>
                     </if>
@@ -164,8 +164,8 @@
                     <choose>
                       <if match="none" variable="author">
                         <names variable="editor">
-                          <label form="short" prefix=" (" suffix=")"/>
                           <name and="text" delimiter-precedes-et-al="never" delimiter-precedes-last="never"/>
+                          <label form="short" prefix=" (" suffix=")"/>
                         </names>
                       </if>
                     </choose>
@@ -179,8 +179,8 @@
                     <choose>
                       <if match="none" variable="author">
                         <names variable="editor">
-                          <label form="short" prefix=" (" suffix=")"/>
                           <name and="text" delimiter-precedes-et-al="never" delimiter-precedes-last="never"/>
+                          <label form="short" prefix=" (" suffix=")"/>
                         </names>
                       </if>
                     </choose>
@@ -258,8 +258,8 @@
                 <choose>
                   <if match="none" variable="author">
                     <names variable="editor">
-                      <label form="short" prefix=" (" suffix=")"/>
                       <name and="text" delimiter-precedes-et-al="never" delimiter-precedes-last="never"/>
+                      <label form="short" prefix=" (" suffix=")"/>
                     </names>
                   </if>
                 </choose>
@@ -273,8 +273,8 @@
                 <choose>
                   <if match="none" variable="author">
                     <names variable="editor">
-                      <label form="short" prefix=" (" suffix=")"/>
                       <name and="text" delimiter-precedes-et-al="never" delimiter-precedes-last="never"/>
+                      <label form="short" prefix=" (" suffix=")"/>
                     </names>
                   </if>
                 </choose>

--- a/zeitschrift-fur-kunstgeschichte.csl
+++ b/zeitschrift-fur-kunstgeschichte.csl
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <style xmlns="http://purl.org/net/xbiblio/csl" class="note" version="1.0" demote-non-dropping-particle="sort-only">
   <info>
     <title>Zeitschrift für Kunstgeschichte</title>
@@ -17,7 +17,7 @@
     <category field="history"/>
     <issn>0044-2992</issn>
     <summary>From the editors: "Die Herausgeber werden im Falle von Editionen, Lexika und Ausstellungskatalogen dem Titel nachgestellt [use encyclopedia articles with or without container-title for that]. Bei gewöhnlichen Sammelbänden werden die Herausgeber dem Titel vorangestellt [use book for that]." Multilingual style; the information for exhibition catalogues should be entered in the field collection-title; locators may use the word "here" or "hier" in front of the page refering to which must be entered individually (the style outputs the locator as it is entered w/o any label or additional text).</summary>
-    <updated>2016-01-28T04:44:25+00:00</updated>
+    <updated>2016-01-31T04:44:25+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale xml:lang="de">
@@ -134,8 +134,8 @@
                           <text macro="volume"/>
                         </group>
                         <names variable="editor">
-                          <name and="text" delimiter-precedes-et-al="never" delimiter-precedes-last="never"/>
                           <label form="verb-short" suffix=" "/>
+                          <name and="text" delimiter-precedes-et-al="never" delimiter-precedes-last="never"/>
                         </names>
                       </group>
                     </if>
@@ -164,8 +164,8 @@
                     <choose>
                       <if match="none" variable="author">
                         <names variable="editor">
-                          <name and="text" delimiter-precedes-et-al="never" delimiter-precedes-last="never"/>
                           <label form="short" prefix=" (" suffix=")"/>
+                          <name and="text" delimiter-precedes-et-al="never" delimiter-precedes-last="never"/>
                         </names>
                       </if>
                     </choose>
@@ -179,8 +179,8 @@
                     <choose>
                       <if match="none" variable="author">
                         <names variable="editor">
-                          <name and="text" delimiter-precedes-et-al="never" delimiter-precedes-last="never"/>
                           <label form="short" prefix=" (" suffix=")"/>
+                          <name and="text" delimiter-precedes-et-al="never" delimiter-precedes-last="never"/>
                         </names>
                       </if>
                     </choose>
@@ -258,8 +258,8 @@
                 <choose>
                   <if match="none" variable="author">
                     <names variable="editor">
-                      <name and="text" delimiter-precedes-et-al="never" delimiter-precedes-last="never"/>
                       <label form="short" prefix=" (" suffix=")"/>
+                      <name and="text" delimiter-precedes-et-al="never" delimiter-precedes-last="never"/>
                     </names>
                   </if>
                 </choose>
@@ -273,8 +273,8 @@
                 <choose>
                   <if match="none" variable="author">
                     <names variable="editor">
-                      <name and="text" delimiter-precedes-et-al="never" delimiter-precedes-last="never"/>
                       <label form="short" prefix=" (" suffix=")"/>
+                      <name and="text" delimiter-precedes-et-al="never" delimiter-precedes-last="never"/>
                     </names>
                   </if>
                 </choose>


### PR DESCRIPTION
unnecessary terms deleted;
"transl." corrected to "trans.";
delimiter changed (in <macro name="translator"> and <macro name="editor">)