### PR TITLE
Update zeitschrift-fur-kunstgeschichte.csl

### DIFF
--- a/zeitschrift-fur-kunstgeschichte.csl
+++ b/zeitschrift-fur-kunstgeschichte.csl
@@ -12,12 +12,16 @@
       <name>Philipp Zumstein</name>
       <uri>https://github.com/zuphilip/</uri>
     </author>
+    <contributor>
+      <name>Anna Simon</name>
+      <email>simonanna@gmx.net</email>
+    </contributor>
     <category citation-format="note"/>
     <category field="humanities"/>
     <category field="history"/>
     <issn>0044-2992</issn>
     <summary>From the editors: "Die Herausgeber werden im Falle von Editionen, Lexika und Ausstellungskatalogen dem Titel nachgestellt [use encyclopedia articles with or without container-title for that]. Bei gewöhnlichen Sammelbänden werden die Herausgeber dem Titel vorangestellt [use book for that]." Multilingual style; the information for exhibition catalogues should be entered in the field collection-title; locators may use the word "here" or "hier" in front of the page refering to which must be entered individually (the style outputs the locator as it is entered w/o any label or additional text).</summary>
-    <updated>2016-01-28T04:44:25+00:00</updated>
+    <updated>2016-02-03T17:41:02+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale xml:lang="de">
@@ -26,6 +30,7 @@
       <term name="et-al">et al.</term>
       <term name="editor" form="short">Hg.</term>
       <term name="editortranslator" form="verb-short">hg. und übers. von</term>
+      <term name="accessed">letzter Zugriff am</term>
     </terms>
   </locale>
   <locale xml:lang="en">
@@ -89,6 +94,29 @@
       <label form="verb-short"/>
       <name prefix=" " and="text" delimiter-precedes-et-al="never" delimiter-precedes-last="never"/>
     </names>
+  </macro>
+  <macro name="contributors-long">
+    <choose>
+      <if variable="author">
+        <names variable="author">
+          <name name-as-sort-order="first" and="text" sort-separator=", " delimiter=", " delimiter-precedes-last="never"/>
+        </names>
+      </if>
+      <else>
+        <choose>
+          <if type="book">
+            <names variable="editor">
+              <name name-as-sort-order="first" and="text" sort-separator=", " delimiter=", " delimiter-precedes-last="never"/>
+              <label prefix=" (" form="short" suffix=".)"/>
+            </names>
+          </if>
+        </choose>
+      </else>
+    </choose>
+  </macro>
+  <macro name="yearandtitle">
+    <date date-parts="year" form="text" variable="issued"/>
+    <text variable="title"/>
   </macro>
   <citation et-al-min="3" et-al-use-first="1" disambiguate-add-names="true">
     <layout delimiter="; " suffix=".">
@@ -192,6 +220,11 @@
                 </choose>
               </else>
             </choose>
+            <choose>
+              <if type="thesis">
+                <text variable="publisher" prefix="Diss., "/>
+              </if>
+            </choose>
             <group delimiter=" ">
               <text variable="publisher-place"/>
               <group>
@@ -204,12 +237,25 @@
           </group>
         </else>
       </choose>
+      <choose>
+        <if variable="URL" match="any">
+          <group>
+            <text variable="URL" prefix=", "/>
+            <text term="accessed" prefix=" ("/>
+            <date variable="accessed" prefix=" " delimiter="." suffix=")">
+              <date-part name="day"/>
+              <date-part name="month" form="numeric"/>
+              <date-part name="year"/>
+            </date>
+          </group>
+        </if>
+      </choose>
     </layout>
   </citation>
   <bibliography et-al-min="3" et-al-use-first="1" subsequent-author-substitute="&#8212;&#8212;&#8212;" entry-spacing="0" hanging-indent="true">
     <sort>
-      <key macro="author"/>
-      <key variable="issued"/>
+      <key macro="contributors-long" names-min="3" names-use-first="3"/>
+      <key macro="yearandtitle"/>
     </sort>
     <layout suffix=".">
       <group delimiter=", ">
@@ -286,6 +332,11 @@
             </choose>
           </else>
         </choose>
+        <choose>
+          <if type="thesis">
+            <text variable="publisher" prefix="Diss., "/>
+          </if>
+        </choose>
         <group delimiter=" ">
           <text variable="publisher-place"/>
           <group>
@@ -295,6 +346,19 @@
         </group>
         <text variable="page" prefix=" "/>
       </group>
+      <choose>
+        <if variable="URL" match="any">
+          <group>
+            <text variable="URL" prefix=", "/>
+            <text term="accessed" prefix=" ("/>
+            <date variable="accessed" prefix=" " delimiter="." suffix=")">
+              <date-part name="day"/>
+              <date-part name="month" form="numeric"/>
+              <date-part name="year"/>
+            </date>
+          </group>
+        </if>
+      </choose>
     </layout>
   </bibliography>
 </style>

--- a/zeitschrift-fur-kunstgeschichte.csl
+++ b/zeitschrift-fur-kunstgeschichte.csl
@@ -95,28 +95,22 @@
       <name prefix=" " and="text" delimiter-precedes-et-al="never" delimiter-precedes-last="never"/>
     </names>
   </macro>
-  <macro name="contributors-long">
+  <macro name="sort-bibliography">
     <choose>
-      <if variable="author">
+      <if variable="author" match="any">
         <names variable="author">
           <name name-as-sort-order="first" and="text" sort-separator=", " delimiter=", " delimiter-precedes-last="never"/>
         </names>
       </if>
+      <else-if type="book">
+        <names variable="editor">
+          <name name-as-sort-order="first" and="text" sort-separator=", " delimiter=", " delimiter-precedes-last="never"/>
+        </names>
+      </else-if>
       <else>
-        <choose>
-          <if type="book">
-            <names variable="editor">
-              <name name-as-sort-order="first" and="text" sort-separator=", " delimiter=", " delimiter-precedes-last="never"/>
-              <label prefix=" (" form="short" suffix=".)"/>
-            </names>
-          </if>
-        </choose>
+        <text variable="title"/>
       </else>
     </choose>
-  </macro>
-  <macro name="yearandtitle">
-    <date date-parts="year" form="text" variable="issued"/>
-    <text variable="title"/>
   </macro>
   <citation et-al-min="3" et-al-use-first="1" disambiguate-add-names="true">
     <layout delimiter="; " suffix=".">
@@ -254,12 +248,15 @@
   </citation>
   <bibliography et-al-min="3" et-al-use-first="1" subsequent-author-substitute="&#8212;&#8212;&#8212;" entry-spacing="0" hanging-indent="true">
     <sort>
-      <key macro="contributors-long"/>
-      <key macro="yearandtitle"/>
+      <key macro="sort-bibliography"/>
     </sort>
     <layout suffix=".">
       <group delimiter=", ">
-        <text macro="author"/>
+        <group>
+          <names variable="author" delimiter=", ">
+            <name and="text" delimiter-precedes-et-al="never" delimiter-precedes-last="never" name-as-sort-order="first"/>
+          </names>
+        </group>
         <choose>
           <if match="any" variable="container-title">
             <text variable="title"/>
@@ -319,7 +316,7 @@
                 <choose>
                   <if match="none" variable="author">
                     <names variable="editor">
-                      <name and="text" delimiter-precedes-et-al="never" delimiter-precedes-last="never"/>
+                      <name and="text" delimiter-precedes-et-al="never" delimiter-precedes-last="never" name-as-sort-order="first"/>
                       <label form="short" prefix=" (" suffix=")"/>
                     </names>
                   </if>

--- a/zeitschrift-fur-kunstgeschichte.csl
+++ b/zeitschrift-fur-kunstgeschichte.csl
@@ -254,7 +254,7 @@
   </citation>
   <bibliography et-al-min="3" et-al-use-first="1" subsequent-author-substitute="&#8212;&#8212;&#8212;" entry-spacing="0" hanging-indent="true">
     <sort>
-      <key macro="contributors-long" names-min="3" names-use-first="3"/>
+      <key macro="contributors-long"/>
       <key macro="yearandtitle"/>
     </sort>
     <layout suffix=".">


### PR DESCRIPTION
I added the url to online-publications (or publications that were also published online eventually);
I added the university and "Diss." to theses;
I corrected the sorting order of the bibliography (in the previous version edited books sometimes landed at the end): I think the bibliography should be sorted by author/editor and year with the exception of exhibition catalogues which should be at the end of the bibliography and sorted by year (and title); I have pasted some code form "Geistes- und Kulturwissenschaften (Heilmann)", it appears to work correctly but I am not sure if it is the best solution.

Please note that I will not be able to make any corrections for a few days from tomorrow because I will not have a computer.