### PR TITLE
remove space at "u.a." (et-al term)

### DIFF
--- a/der-moderne-staat.csl
+++ b/der-moderne-staat.csl
@@ -19,9 +19,9 @@
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale xml:lang="de">
-  	<terms>
-		<term name="et-al">u.a.</term>
-	</terms>
+    <terms>
+      <term name="et-al">u.a.</term>
+    </terms>
   </locale>
   <macro name="editor">
     <names variable="editor" font-style="italic" delimiter=", ">

--- a/der-moderne-staat.csl
+++ b/der-moderne-staat.csl
@@ -18,6 +18,11 @@
     <updated>2015-02-09T08:06:28+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
+  <locale xml:lang="de">
+  	<terms>
+		<term name="et-al">u.a.</term>
+	</terms>
+  </locale>
   <macro name="editor">
     <names variable="editor" font-style="italic" delimiter=", ">
       <name delimiter="/" suffix=" " name-as-sort-order="all"/>


### PR DESCRIPTION
Journal's style guide requests to use "u.a." instead of "et al.". the previous version used "u. a." (with a space between u. and a.). Fixed that.