### PR TITLE
Update biological-journal-of-the-linnean-society.csl

### DIFF
--- a/biological-journal-of-the-linnean-society.csl
+++ b/biological-journal-of-the-linnean-society.csl
@@ -26,7 +26,7 @@
   </macro>
   <macro name="author">
     <names variable="author">
-      <name name-as-sort-order="all" sort-separator=" " initialize-with="" delimiter=", " and="symbol" delimiter-precedes-last="always" font-weight="bold"/>
+      <name name-as-sort-order="all" sort-separator=" " initialize-with="" delimiter=", " and="symbol" delimiter-precedes-last="never" font-weight="bold"/>
       <et-al font-style="italic"/>
       <label form="short" prefix=" (" suffix=")" text-case="capitalize-first"/>
       <substitute>

--- a/biological-journal-of-the-linnean-society.csl
+++ b/biological-journal-of-the-linnean-society.csl
@@ -26,7 +26,7 @@
   </macro>
   <macro name="author">
     <names variable="author">
-      <name name-as-sort-order="all" sort-separator=" " initialize-with="" delimiter=", " delimiter-precedes-last="always" font-weight="bold"/>
+      <name name-as-sort-order="all" sort-separator=" " initialize-with="" delimiter=", " and="symbol" delimiter-precedes-last="always" font-weight="bold"/>
       <et-al font-style="italic"/>
       <label form="short" prefix=" (" suffix=")" text-case="capitalize-first"/>
       <substitute>
@@ -88,7 +88,7 @@
       </group>
     </layout>
   </citation>
-  <bibliography et-al-min="10" et-al-use-first="10" hanging-indent="false">
+  <bibliography hanging-indent="false">
     <sort>
       <key macro="author-short"/>
       <key variable="issued"/>


### PR DESCRIPTION
Updated to reflect edits made by journal copyeditor to recently typeset MS.

- list of authors in bibliography should not be truncated and replaced with et al; "Journal style is to include all author names for each reference in the reference list"
- Comma should not precede ampersand in in-text citations to references: correct style is "(Smith, Jones & Weston 2014)".  I believe that setting and="symbol" does not express the delimiter before the ampersand – do I need to do anything else?