### PR TITLE
Update the-journal-of-indian-prosthodontic-society.csl

### DIFF
--- a/dependent/the-journal-of-indian-prosthodontic-society.csl
+++ b/dependent/the-journal-of-indian-prosthodontic-society.csl
@@ -4,13 +4,13 @@
     <title>The Journal of Indian Prosthodontic Society</title>
     <id>http://www.zotero.org/styles/the-journal-of-indian-prosthodontic-society</id>
     <link href="http://www.zotero.org/styles/the-journal-of-indian-prosthodontic-society" rel="self"/>
-    <link href="http://www.zotero.org/styles/springer-vancouver" rel="independent-parent"/>
-    <link href="http://www.springer.com/medicine/dentistry/journal/13191" rel="documentation"/>
+    <link href="http://www.zotero.org/styles/vancouver" rel="independent-parent"/>
+    <link href="http://www.j-ips.org/contributors.asp" rel="documentation"/>
     <category citation-format="numeric"/>
     <category field="medicine"/>
     <issn>0972-4052</issn>
     <eissn>1998-4057</eissn>
-    <updated>2012-09-09T21:58:08+00:00</updated>
+    <updated>2016-02-13T12:00:00+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
 </style>


### PR DESCRIPTION
From [Springer page](https://www.springer.com/medicine/dentistry/journal/13191):
<blockquote>This journal has been discontinued with effect from 13th January 2015. The Journal has moved to Medknow Publications http://www.journalonweb.com/jips/.</blockquote>