### PR TITLE
Simultaneous pages and locators

### DIFF
--- a/svensk-exegetisk-arsbok.csl
+++ b/svensk-exegetisk-arsbok.csl
@@ -15,7 +15,7 @@
     <category field="theology"/>
     <issn>1100-2298</issn>
     <summary>Svensk exegetisk årsbok (full note)</summary>
-    <updated>2015-08-10T16:00:00+00:00</updated>
+    <updated>2016-02-15T16:00:00+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale xml:lang="sv-SE">
@@ -556,8 +556,11 @@
       <if variable="locator" match="none">
         <text macro="pages"/>
       </if>
-      <else-if type="article-journal">
-        <text variable="locator" prefix=": "/>
+      <else-if type="article-journal chapter" match="any">
+        <group delimiter=", hic ">
+          <text macro="pages"/>
+          <text variable="locator"/>
+        </group>
       </else-if>
       <else>
         <text macro="point-locators-subsequent" prefix=", "/>
@@ -599,7 +602,7 @@
     <choose>
       <if type="article-journal">
         <text variable="volume" prefix=" "/>
-        <text variable="issue" prefix=", no. "/>
+        <text variable="issue" prefix="/"/>
         <text macro="issued" prefix=" (" suffix=")"/>
       </if>
       <else-if variable="publisher-place publisher" match="any">
@@ -761,7 +764,7 @@
       </choose>
     </layout>
   </citation>
-  <bibliography hanging-indent="true" et-al-min="10" et-al-use-first="9" subsequent-author-substitute="&#8212;&#8212;&#8212;" entry-spacing="0">
+  <bibliography hanging-indent="true" et-al-min="10" et-al-use-first="9" subsequent-author-substitute="———" entry-spacing="0">
     <sort>
       <key macro="contributors-sort"/>
       <key variable="title"/>


### PR DESCRIPTION
In this update to svensk-exegetisk-arsbok.csl, I have added the full page ranges to the first reference of articles, even if a more specific page range is to be given.

Peter A. Brunt, “On Historical Fragments and Epitomes,” CQ 30/2 (1980): 477–94, hic 478–81.

Is there a way to replace the Latin "hic" with "here" if the document is in English, and with "här" if it is in Swedish?