### PR TITLE
Locator follows locale

### DIFF
--- a/svensk-exegetisk-arsbok.csl
+++ b/svensk-exegetisk-arsbok.csl
@@ -15,7 +15,7 @@
     <category field="theology"/>
     <issn>1100-2298</issn>
     <summary>Svensk exegetisk årsbok (full note)</summary>
-    <updated>2016-02-15T16:00:00+00:00</updated>
+    <updated>2016-02-18T10:30:00+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale xml:lang="sv-SE">
@@ -27,13 +27,20 @@
     <terms>
       <term name="editor" form="verb-short">red.</term>
       <term name="translator" form="verb-short">övers.</term>
+      <term name="at">här</term>
     </terms>
   </locale>
   <locale xml:lang="en">
     <terms>
       <term name="editor" form="verb-short">ed.</term>
       <term name="translator" form="verb-short">trans.</term>
+      <term name="at">here</term>
     </terms>
+  </locale>
+  <locale>
+	  <terms>
+  		<term name="at">hic</term>
+  	</terms>
   </locale>
   <macro name="editor-translator">
     <group delimiter=", ">
@@ -557,8 +564,9 @@
         <text macro="pages"/>
       </if>
       <else-if type="article-journal chapter" match="any">
-        <group delimiter=", hic ">
-          <text macro="pages"/>
+        <text macro="pages"/>
+        <group prefix=", " delimiter=" ">
+          <text term="at"/>
           <text variable="locator"/>
         </group>
       </else-if>
@@ -764,8 +772,8 @@
       </choose>
     </layout>
   </citation>
-  <bibliography hanging-indent="true" et-al-min="10" et-al-use-first="9" subsequent-author-substitute="———" entry-spacing="0">
-    <sort>
+  <bibliography hanging-indent="true" et-al-min="10" et-al-use-first="9" subsequent-author-substitute="&#8212;&#8212;&#8212;" entry-spacing="0">
+       <sort>
       <key macro="contributors-sort"/>
       <key variable="title"/>
       <key variable="genre"/>


### PR DESCRIPTION
The "hic" separating the full page range from the locator will now be "here" if the document is written in English, "här" if it is in Swedish, and "hic" otherwise.