### PR TITLE
Update university-college-lillebaelt-apa.csl

### DIFF
--- a/university-college-lillebaelt-apa.csl
+++ b/university-college-lillebaelt-apa.csl
@@ -180,16 +180,6 @@
       <if type="post-weblog chapter entry-dictionary entry-encyclopedia paper-conference article-journal article-magazine article-newspaper" match="any">
         <text variable="title"/>
       </if>
-      <else-if type="legislation">
-        <choose>
-          <if variable="author">
-            <text variable="title" font-style="italic"/>
-          </if>
-          <else>
-            <text variable="title"/>
-          </else>
-        </choose>
-      </else-if>
       <else>
         <choose>
           <if variable="version">
@@ -488,7 +478,14 @@
     <!---                                                                                                                                                                              MACRO: legal-cites -->
     <choose>
       <if type="legal_case legislation" match="any">
-        <text variable="volume" prefix=", "/>
+        <choose>
+          <if variable="number">
+            <text variable="number" prefix=", "/>
+          </if>
+          <else>
+            <text variable="volume" prefix=", "/>
+          </else>
+        </choose>
         <date variable="issued" prefix=" af " delimiter="/">
           <date-part name="day"/>
           <date-part name="month" form="numeric-leading-zeros"/>


### PR DESCRIPTION
Two things:

1) Looks for legislation number in the 'number' field, before using the 'volume' field. To comply with the recent 'Retsinformation.js' translator.

2) Corrected statutes to have their titles written in italics in the bibliography. As per the documentation for the style.