### PR TITLE
Update the-geological-society-of-america.csl

### DIFF
--- a/the-geological-society-of-america.csl
+++ b/the-geological-society-of-america.csl
@@ -159,6 +159,13 @@
           </group>
         </else>
       </choose>
+      <group> 
+         <text variable="URL" prefix=" "/>
+         <date variable="accessed" prefix=" (accessed " suffix=")">
+               <date-part name="month" suffix=" "/>
+               <date-part name="year"/>
+         </date>
+      </group>
     </layout>
   </bibliography>
 </style>


### PR DESCRIPTION
Adds a group to the end of bibliography layout to support references to website content as well as document transferred from websites by adding "URL" and "accessed" date variables.  Follows instructions and examples  from http://www.geosociety.org/pubs/documents/GSA_RefGuide_Examples_000.pdf