### PR TITLE
Update nature.csl

### DIFF
--- a/nature.csl
+++ b/nature.csl
@@ -41,15 +41,17 @@
       <else-if variable="DOI">
         <text variable="DOI" prefix="doi:"/>
       </else-if>
-      <else-if variable="URL">
-        <text variable="URL" prefix="Available at: " suffix=". "/>
-	<group prefix="(Accessed: " suffix=")">
+      <else-if type="webpage" variable="URL" match="all">        
+        <text term="available at" text-case="capitalize-first" suffix=": "/>
+        <text variable="URL" suffix=". "/>
+        <group prefix="(" suffix=")" delimiter=": ">
+          <text term="accessed" text-case="capitalize-first"/>
           <date variable="accessed">
             <date-part name="day" suffix=" " form="ordinal"/>
             <date-part name="month" suffix=" "/>
             <date-part name="year"/>
           </date>
-      	</group>      
+        </group>
       </else-if>
     </choose>
   </macro>
@@ -116,11 +118,7 @@
         </group>
         <text variable="page"/>
         <text macro="issuance"/>
-	<choose>
-	  <if type="webpage" match="all">
-            <text macro="access"/>
-	  </if>
-        </choose>
+        <text macro="access"/>
       </group>
     </layout>
   </bibliography>

--- a/nature.csl
+++ b/nature.csl
@@ -14,7 +14,7 @@
     <category field="generic-base"/>
     <issn>0028-0836</issn>
     <eissn>1476-4687</eissn>
-    <updated>2014-06-22T03:46:28+00:00</updated>
+    <updated>2014-09-10T06:11:43+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <macro name="title">
@@ -42,8 +42,14 @@
         <text variable="DOI" prefix="doi:"/>
       </else-if>
       <else-if variable="URL">
-        <text term="at"/>
-        <text variable="URL" prefix=" &lt;" suffix="&gt;"/>
+        <text variable="URL" prefix="Available at: " suffix=". "/>
+	<group prefix="(Accessed: " suffix=")">
+          <date variable="accessed">
+            <date-part name="day" suffix=" " form="ordinal"/>
+            <date-part name="month" suffix=" "/>
+            <date-part name="year"/>
+          </date>
+      	</group>      
       </else-if>
     </choose>
   </macro>
@@ -110,7 +116,11 @@
         </group>
         <text variable="page"/>
         <text macro="issuance"/>
-        <text macro="access"/>
+	<choose>
+	  <if type="webpage" match="all">
+            <text macro="access"/>
+	  </if>
+        </choose>
       </group>
     </layout>
   </bibliography>


### PR DESCRIPTION
This is the example from the Nature guidelines for citing a website:
"Buckley, M. and Reid, A., Global food safety - keeping food safe from farm to table. Technical report. (2010) Available at: insert website here. (Accessed: 4th November 2012)".

I have therefore edited lines 45-52 to format the URL and add the access date, and added lines 119-123 so that URL and access date are shown only for webpages. It works as intended (as far as I could check), but I'm not sure whether it is the best way to do so!