### PR TITLE
Update university-college-lillebaelt-vancouver.csl

### DIFF
--- a/university-college-lillebaelt-vancouver.csl
+++ b/university-college-lillebaelt-vancouver.csl
@@ -239,7 +239,14 @@
         </group>
       </else-if>
       <else-if type="legislation">
-        <number variable="volume"/>
+        <choose>
+          <if variable="number">
+            <text variable="number"/>
+          </if>
+          <else>
+            <text variable="volume"/>
+          </else>
+        </choose>
         <date variable="issued" prefix=" af " delimiter="/">
           <date-part name="day" form="numeric-leading-zeros"/>
           <date-part name="month" form="numeric-leading-zeros"/>


### PR DESCRIPTION
Now looks in both the 'number' and the 'volume' field for the law-number. In order to comply with the recent Retsinformatin.dk translator.