### PR TITLE
Add volume to vancouver styles

### DIFF
--- a/vancouver-author-date.csl
+++ b/vancouver-author-date.csl
@@ -25,6 +25,10 @@
       <date-part name="day"/>
     </date>
     <terms>
+      <term name="collection-editor" form="long">
+        <single>editor</single>
+        <multiple>editors</multiple>
+      </term>
       <term name="retrieved">available</term>
       <term name="section" form="short">sect.</term>
     </terms>
@@ -131,7 +135,17 @@
         </group>
       </else-if>
       <else>
-        <text variable="container-title" suffix="." form="short"/>
+        <group delimiter=", " suffix=".">
+          <choose>
+            <if variable="collection-title" match="none">
+              <group delimiter=" ">
+                <label variable="volume" form="short" text-case="capitalize-first"/>
+                <text variable="volume"/>
+              </group>
+            </if>
+          </choose>
+          <text variable="container-title"/>
+        </group>
       </else>
     </choose>
   </macro>
@@ -251,6 +265,29 @@
       </group>
     </layout>
   </citation>
+  <macro name="series-details">
+    <choose>
+      <if type="article-journal article-magazine article-newspaper review review-book" match="none">
+        <choose>
+          <if variable="collection-title">
+            <group delimiter=" " prefix="(" suffix=")">
+              <names variable="collection-editor" suffix=".">
+                <name sort-separator=" " initialize-with="" name-as-sort-order="all" delimiter=", " delimiter-precedes-last="always"/>
+                <label form="long" prefix=", "/>
+              </names>
+              <group delimiter="; ">
+                <text variable="collection-title"/> 
+                <group delimiter=" ">
+                  <label variable="volume" form="short"/>
+                  <text variable="volume"/>
+                </group>
+              </group>
+            </group>
+          </if>
+        </choose>
+      </if>
+    </choose>
+  </macro>
   <bibliography et-al-min="7" et-al-use-first="6" hanging-indent="true">
     <sort>
       <key macro="author"/>
@@ -272,6 +309,7 @@
           <text macro="pages"/>
         </group>
       </group>
+      <text macro="series-details" suffix=". "/>
       <text macro="report-details" suffix=". "/>
       <text macro="access"/>
     </layout>

--- a/vancouver-brackets-no-et-al.csl
+++ b/vancouver-brackets-no-et-al.csl
@@ -33,6 +33,10 @@
       <date-part name="day"/>
     </date>
     <terms>
+      <term name="collection-editor" form="long">
+        <single>editor</single>
+        <multiple>editors</multiple>
+      </term>
       <term name="presented at">presented at</term>
       <term name="retrieved">available</term>
       <term name="section" form="short">sect.</term>
@@ -157,7 +161,17 @@
         </group>
       </else-if>
       <else>
-        <text variable="container-title" suffix="."/>
+        <group delimiter=", " suffix=".">
+          <choose>
+            <if variable="collection-title" match="none">
+              <group delimiter=" ">
+                <label variable="volume" form="short" text-case="capitalize-first"/>
+                <text variable="volume"/>
+              </group>
+            </if>
+          </choose>
+          <text variable="container-title"/>
+        </group>
       </else>
     </choose>
   </macro>
@@ -281,6 +295,29 @@
       </if>
     </choose>
   </macro>
+  <macro name="collection-details">
+    <choose>
+      <if type="article-journal article-magazine article-newspaper review review-book" match="none">
+        <choose>
+          <if variable="collection-title">
+            <group delimiter=" " prefix="(" suffix=")">
+              <names variable="collection-editor" suffix=".">
+                <name sort-separator=" " initialize-with="" name-as-sort-order="all" delimiter=", " delimiter-precedes-last="always"/>
+                <label form="long" prefix=", "/>
+              </names>
+              <group delimiter="; ">
+                <text variable="collection-title"/> 
+                <group delimiter=" ">
+                  <label variable="volume" form="short"/>
+                  <text variable="volume"/>
+                </group>
+              </group>
+            </group>
+          </if>
+        </choose>
+      </if>
+    </choose>
+  </macro>
   <macro name="report-details">
     <choose>
       <if type="report">
@@ -313,6 +350,7 @@
           <text macro="pages"/>
         </group>
       </group>
+      <text macro="collection-details" suffix=". "/>
       <text macro="report-details" suffix=". "/>
       <text macro="access"/>
     </layout>

--- a/vancouver-brackets.csl
+++ b/vancouver-brackets.csl
@@ -29,6 +29,10 @@
       <date-part name="day"/>
     </date>
     <terms>
+      <term name="collection-editor" form="long">
+        <single>editor</single>
+        <multiple>editors</multiple>
+      </term>
       <term name="presented at">presented at</term>
       <term name="retrieved">available</term>
       <term name="section" form="short">sect.</term>
@@ -153,7 +157,17 @@
         </group>
       </else-if>
       <else>
-        <text variable="container-title" suffix="."/>
+        <group delimiter=", " suffix=".">
+          <choose>
+            <if variable="collection-title" match="none">
+              <group delimiter=" ">
+                <label variable="volume" form="short" text-case="capitalize-first"/>
+                <text variable="volume"/>
+              </group>
+            </if>
+          </choose>
+          <text variable="container-title"/>
+        </group>
       </else>
     </choose>
   </macro>
@@ -277,6 +291,29 @@
       </if>
     </choose>
   </macro>
+  <macro name="collection-details">
+    <choose>
+      <if type="article-journal article-magazine article-newspaper review review-book" match="none">
+        <choose>
+          <if variable="collection-title">
+            <group delimiter=" " prefix="(" suffix=")">
+              <names variable="collection-editor" suffix=".">
+                <name sort-separator=" " initialize-with="" name-as-sort-order="all" delimiter=", " delimiter-precedes-last="always"/>
+                <label form="long" prefix=", "/>
+              </names>
+              <group delimiter="; ">
+                <text variable="collection-title"/> 
+                <group delimiter=" ">
+                  <label variable="volume" form="short"/>
+                  <text variable="volume"/>
+                </group>
+              </group>
+            </group>
+          </if>
+        </choose>
+      </if>
+    </choose>
+  </macro>
   <macro name="report-details">
     <choose>
       <if type="report">
@@ -314,6 +351,7 @@
           <text macro="pages"/>
         </group>
       </group>
+      <text macro="collection-details" suffix=". "/>
       <text macro="report-details" suffix=". "/>
       <text macro="access"/>
     </layout>

--- a/vancouver-fr-ca.csl
+++ b/vancouver-fr-ca.csl
@@ -28,6 +28,10 @@
       <term name="in">dans</term>
       <term name="cited">cité le</term>
       <term name="internet">en ligne</term>
+      <term name="collection-editor" form="long">
+        <single>rédacteur</single>
+        <multiple>rédacteurs</multiple>
+      </term>
       <term name="editor">
         <single>rédacteur</single>
         <multiple>rédacteurs</multiple>
@@ -133,7 +137,18 @@
         </group>
       </else-if>
       <else>
-        <text variable="container-title" suffix="."/>
+        <group delimiter=", " suffix=".">
+          <choose>
+            <if variable="collection-title" match="none">
+              <group delimiter=" ">
+                <label variable="volume" form="short" text-case="capitalize-first"/>
+                <text variable="volume"/>
+              </group>
+            </if>
+          </choose>
+          <text variable="container-title"/>
+        </group>
+
       </else>
     </choose>
   </macro>
@@ -249,6 +264,29 @@
       </if>
     </choose>
   </macro>
+  <macro name="collection-details">
+    <choose>
+      <if type="article-journal article-magazine article-newspaper review review-book" match="none">
+        <choose>
+          <if variable="collection-title">
+            <group delimiter=" " prefix="(" suffix=")">
+              <names variable="collection-editor" suffix=".">
+                <name sort-separator=" " initialize-with="" name-as-sort-order="all" delimiter=", " delimiter-precedes-last="always"/>
+                <label form="long" prefix=", "/>
+              </names>
+              <group delimiter="; ">
+                <text variable="collection-title"/> 
+                <group delimiter=" ">
+                  <label variable="volume" form="short"/>
+                  <text variable="volume"/>
+                </group>
+              </group>
+            </group>
+          </if>
+        </choose>
+      </if>
+    </choose>
+  </macro>
   <macro name="report-details">
     <choose>
       <if type="report">
@@ -318,6 +356,7 @@
               <text macro="pages"/>
             </group>
           </group>
+          <text macro="collection-details" suffix=". "/>
           <text macro="report-details" suffix=". "/>
           <text macro="media-details" suffix=". "/>
         </else>

--- a/vancouver-superscript.csl
+++ b/vancouver-superscript.csl
@@ -29,6 +29,10 @@
       <date-part name="day"/>
     </date>
     <terms>
+      <term name="collection-editor" form="long">
+        <single>editor</single>
+        <multiple>editors</multiple>
+      </term>
       <term name="presented at">presented at</term>
       <term name="retrieved">available</term>
       <term name="section" form="short">sect.</term>
@@ -153,7 +157,17 @@
         </group>
       </else-if>
       <else>
-        <text variable="container-title" suffix="."/>
+        <group delimiter=", " suffix=".">
+          <choose>
+            <if variable="collection-title" match="none">
+              <group delimiter=" ">
+                <label variable="volume" form="short" text-case="capitalize-first"/>
+                <text variable="volume"/>
+              </group>
+            </if>
+          </choose>
+          <text variable="container-title"/>
+        </group>
       </else>
     </choose>
   </macro>
@@ -277,6 +291,29 @@
       </if>
     </choose>
   </macro>
+  <macro name="collection-details">
+    <choose>
+      <if type="article-journal article-magazine article-newspaper review review-book" match="none">
+        <choose>
+          <if variable="collection-title">
+            <group delimiter=" " prefix="(" suffix=")">
+              <names variable="collection-editor" suffix=".">
+                <name sort-separator=" " initialize-with="" name-as-sort-order="all" delimiter=", " delimiter-precedes-last="always"/>
+                <label form="long" prefix=", "/>
+              </names>
+              <group delimiter="; ">
+                <text variable="collection-title"/> 
+                <group delimiter=" ">
+                  <label variable="volume" form="short"/>
+                  <text variable="volume"/>
+                </group>
+              </group>
+            </group>
+          </if>
+        </choose>
+      </if>
+    </choose>
+  </macro>
   <macro name="report-details">
     <choose>
       <if type="report">
@@ -314,6 +351,7 @@
           <text macro="pages"/>
         </group>
       </group>
+      <text macro="collection-details" suffix=". "/>
       <text macro="report-details" suffix=". "/>
       <text macro="access"/>
     </layout>

--- a/vancouver.csl
+++ b/vancouver.csl
@@ -29,6 +29,10 @@
       <date-part name="day"/>
     </date>
     <terms>
+      <term name="collection-editor" form="long">
+        <single>editor</single>
+        <multiple>editors</multiple>
+      </term>
       <term name="presented at">presented at</term>
       <term name="retrieved">available</term>
       <term name="section" form="short">sect.</term>
@@ -153,7 +157,17 @@
         </group>
       </else-if>
       <else>
-        <text variable="container-title" suffix="."/>
+        <group delimiter=", " suffix=".">
+          <choose>
+            <if variable="collection-title" match="none">
+              <group delimiter=" ">
+                <label variable="volume" form="short" text-case="capitalize-first"/>
+                <text variable="volume"/>
+              </group>
+            </if>
+          </choose>
+          <text variable="container-title"/>
+        </group>
       </else>
     </choose>
   </macro>
@@ -277,6 +291,29 @@
       </if>
     </choose>
   </macro>
+  <macro name="collection-details">
+    <choose>
+      <if type="article-journal article-magazine article-newspaper review review-book" match="none">
+        <choose>
+          <if variable="collection-title">
+            <group delimiter=" " prefix="(" suffix=")">
+              <names variable="collection-editor" suffix=".">
+                <name sort-separator=" " initialize-with="" name-as-sort-order="all" delimiter=", " delimiter-precedes-last="always"/>
+                <label form="long" prefix=", "/>
+              </names>
+              <group delimiter="; ">
+                <text variable="collection-title"/> 
+                <group delimiter=" ">
+                  <label variable="volume" form="short"/>
+                  <text variable="volume"/>
+                </group>
+              </group>
+            </group>
+          </if>
+        </choose>
+      </if>
+    </choose>
+  </macro>
   <macro name="report-details">
     <choose>
       <if type="report">
@@ -314,6 +351,7 @@
           <text macro="pages"/>
         </group>
       </group>
+      <text macro="collection-details" suffix=". "/>
       <text macro="report-details" suffix=". "/>
       <text macro="access"/>
     </layout>


### PR DESCRIPTION
Hello

This pull request add volume for some types where it was not already displayed, primarily for books. Where the volume should be displayed depends on if the book is in a collection, in which case collection-editor and collection-title also need to be displayed.

I didn't change these styles because it's not clear to me if they should be changed:

vancouver-brackets-only-year-no-issue.csl
vancouver-superscript-brackets-only-year.csl
vancouver-superscript-only-year.csl

Imperial's style guide doesn't seem to address this case, so I didn't change it either:

vancouver-imperial-college-london.csl