### PR TITLE
Update associacao-brasileira-de-normas-tecnicas.csl

### DIFF
--- a/associacao-brasileira-de-normas-tecnicas.csl
+++ b/associacao-brasileira-de-normas-tecnicas.csl
@@ -589,7 +589,7 @@ em caixa alta. Utiliza-se antes do nome da conferencia a expressao "In". Segundo
         <else-if type="paper-conference">
           <text macro="author" suffix=". "/>
           <!--Autor-->
-          <text macro="title"/>
+          <text macro="title" suffix=". "/>
           <!--Titulo-->
           <text macro="container-contributors"/>
           <!--Nomes de editore-->


### PR DESCRIPTION
Fixed Conference Proceedings missing a dot at the and of the conference's name