### PR TITLE
Update international-atomic-energy-agency.csl

### DIFF
--- a/international-atomic-energy-agency.csl
+++ b/international-atomic-energy-agency.csl
@@ -139,7 +139,7 @@
     <sort>
       <key variable="citation-number"/>
     </sort>
-    <layout delimiter="," prefix="[" suffix="]">
+    <layout delimiter=", " prefix="[" suffix="]">
       <text variable="citation-number"/>
     </layout>
   </citation>


### PR DESCRIPTION
Per IAEA style manual Chapter 11, II.8 there should be a space after any comma when identifying multiple citation numbers (e.g. [17,18] should be [17, 18]). Please update the style accordingly.