### PR TITLE
Improve feedback non-validating/non-parsing styles

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -61,9 +61,8 @@ def load_style(path)
 
   begin
     style = CSL::Style.load(path)
-  rescue => e
+  rescue
     # failed to parse the style. we'll report the error later
-    return [basename, [filename, path, nil, e.message]]
   end
 
   unless style.nil?
@@ -161,7 +160,7 @@ end
 if ENV['CSL_TEST'] != nil
   parent_basenames = []
   
-  Dependents.each_pair do |basename, (filename, path, style, reason)|
+  Dependents.each_pair do |basename, (filename, path, style)|
     if style.has_independent_parent_link?
       parent_basename = style.independent_parent_link[/[^\/]+$/]
       if !parent_basenames.include?(parent_basename)

--- a/spec/styles_spec.rb
+++ b/spec/styles_spec.rb
@@ -1,14 +1,24 @@
-shared_examples "style" do |basename, (filename, path, style, reason), in_dependent_subdir|
-  it "must validate against the CSL 1.0.1 schema" do
-    expect(CSL.validate(path)).to eq([])
+shared_examples "style" do |basename, (filename, path, style), in_dependent_subdir|
+  let(:style_validates) { 
+    if CSL.validate(path).length == 0
+      true
+    else
+      false
+    end
+  }
+  
+  it "must validate against the CSL 1.0.1 schema (please check your style at http://validator.citationstyles.org/)" do
+    expect(style_validates).to be true
+  end
+
+  it "must be parsable as a CSL style" do
+    if style_validates
+      expect(style).to be_a(CSL::Style)
+    end
   end
 
   it "must have a conventional file name" do
     expect(filename).to match(/^[a-z\d]+(-[a-z\d]+)*\.csl$/)
-  end
-
-  it "must be parsable as a CSL style" do
-    expect(style).to be_a(CSL::Style), reason
   end
   
   unless style.nil?
@@ -137,16 +147,16 @@ shared_examples "style" do |basename, (filename, path, style, reason), in_depend
   end
 end
 
-Independents.each_pair do |basename, (filename, path, style, reason)|
+Independents.each_pair do |basename, (filename, path, style)|
   in_dependent_subdir = false
   describe "#{basename}:" do
-    include_examples "style", basename, [filename, path, style, reason], in_dependent_subdir
+    include_examples "style", basename, [filename, path, style], in_dependent_subdir
   end
 end
 
-Dependents.each_pair do |basename, (filename, path, style, reason)|
+Dependents.each_pair do |basename, (filename, path, style)|
   in_dependent_subdir = true
   describe "dependent/#{basename}:" do
-    include_examples "style", basename, [filename, path, style, reason], in_dependent_subdir
+    include_examples "style", basename, [filename, path, style], in_dependent_subdir
   end
 end

--- a/spec/styles_spec.rb
+++ b/spec/styles_spec.rb
@@ -1,13 +1,8 @@
 shared_examples "style" do |basename, (filename, path, style), in_dependent_subdir|
-  let(:style_validates) { 
-    if CSL.validate(path).length == 0
-      true
-    else
-      false
-    end
-  }
+  let(:style_validates) { CSL.validate(path).length.zero? }
   
-  it "must validate against the CSL 1.0.1 schema (please check your style at http://validator.citationstyles.org/)" do
+  it "must validate against the CSL 1.0.1 schema
+     Please check your style at http://validator.citationstyles.org/" do
     expect(style_validates).to be true
   end
 


### PR DESCRIPTION
One more. This rolls back https://github.com/inukshuk/styles/commit/94bcce850fdd06fdd4ed31bbece971d679f32748 (see #1818), since we recently came to the conclusion that Nokogiri’s validation error messages aren’t very good: https://github.com/citation-style-language/styles/pull/1918#issuecomment-193882842

It’s probably much less confusing to steer users to our Jing-based validator, which usually gives much clearer validation messages.

With this pull request we also skip the “does-this-style-parse” check for invalid styles.

cc @inukshuk, @adam3smith