### PR TITLE
Show ISSN if not ISBN - in styles based on ČSN ISO690:2011

### DIFF
--- a/iso690-author-date-cs.csl
+++ b/iso690-author-date-cs.csl
@@ -445,15 +445,13 @@
     <choose>
       <if variable="DOI">
         <group>
-          <text term="retrieved" suffix=" " text-case="capitalize-first"/>
-          <text term="from" suffix=": doi:"/>
+          <text term="available at" suffix=": doi:" text-case="capitalize-first"/>
           <text variable="DOI"/>
         </group>
       </if>
       <else-if variable="URL">
         <group>
-          <text term="retrieved" suffix=" " text-case="capitalize-first"/>
-          <text term="from" suffix=": "/>
+          <text term="available at" suffix=": " text-case="capitalize-first"/>
           <text variable="URL"/>
         </group>
       </else-if>

--- a/iso690-author-date-cs.csl
+++ b/iso690-author-date-cs.csl
@@ -429,7 +429,14 @@
     </choose>
   </macro>
   <macro name="isbn">
-    <text variable="ISBN" prefix="ISBN "/>
+    <choose>
+      <if variable="ISBN">
+        <text variable="ISBN" prefix="ISBN "/>
+      </if>
+      <else>
+        <text macro="issn"/>
+      </else>
+    </choose>
   </macro>
   <macro name="issn">
     <text variable="ISSN" prefix="ISSN "/>

--- a/iso690-note-cs.csl
+++ b/iso690-note-cs.csl
@@ -372,7 +372,14 @@
     </choose>
   </macro>
   <macro name="isbn">
-    <text variable="ISBN" prefix="ISBN "/>
+    <choose>
+      <if variable="ISBN">
+        <text variable="ISBN" prefix="ISBN "/>
+      </if>
+      <else>
+        <text macro="issn"/>
+      </else>
+    </choose>
   </macro>
   <macro name="issn">
     <text variable="ISSN" prefix="ISSN "/>

--- a/iso690-note-cs.csl
+++ b/iso690-note-cs.csl
@@ -388,15 +388,13 @@
     <choose>
       <if variable="DOI">
         <group>
-          <text term="retrieved" suffix=" " text-case="capitalize-first"/>
-          <text term="from" suffix=": doi:"/>
+          <text term="available at" suffix=": doi:" text-case="capitalize-first"/>
           <text variable="DOI"/>
         </group>
       </if>
       <else-if variable="URL">
         <group>
-          <text term="retrieved" suffix=" " text-case="capitalize-first"/>
-          <text term="from" suffix=": "/>
+          <text term="available at" suffix=": " text-case="capitalize-first"/>
           <text variable="URL"/>
         </group>
       </else-if>

--- a/iso690-numeric-brackets-cs.csl
+++ b/iso690-numeric-brackets-cs.csl
@@ -402,15 +402,13 @@
     <choose>
       <if variable="DOI">
         <group>
-          <text term="retrieved" suffix=" " text-case="capitalize-first"/>
-          <text term="from" suffix=": doi:"/>
+          <text term="available at" suffix=": doi:" text-case="capitalize-first"/>
           <text variable="DOI"/>
         </group>
       </if>
       <else-if variable="URL">
         <group>
-          <text term="retrieved" suffix=" " text-case="capitalize-first"/>
-          <text term="from" suffix=": "/>
+          <text term="available at" suffix=": " text-case="capitalize-first"/>
           <text variable="URL"/>
         </group>
       </else-if>

--- a/iso690-numeric-brackets-cs.csl
+++ b/iso690-numeric-brackets-cs.csl
@@ -386,7 +386,14 @@
     </choose>
   </macro>
   <macro name="isbn">
-    <text variable="ISBN" prefix="ISBN "/>
+    <choose>
+      <if variable="ISBN">
+        <text variable="ISBN" prefix="ISBN "/>
+      </if>
+      <else>
+        <text macro="issn"/>
+      </else>
+    </choose>
   </macro>
   <macro name="issn">
     <text variable="ISSN" prefix="ISSN "/>

--- a/iso690-numeric-cs.csl
+++ b/iso690-numeric-cs.csl
@@ -402,15 +402,13 @@
     <choose>
       <if variable="DOI">
         <group>
-          <text term="retrieved" suffix=" " text-case="capitalize-first"/>
-          <text term="from" suffix=": doi:"/>
+          <text term="available at" suffix=": doi:" text-case="capitalize-first"/>
           <text variable="DOI"/>
         </group>
       </if>
       <else-if variable="URL">
         <group>
-          <text term="retrieved" suffix=" " text-case="capitalize-first"/>
-          <text term="from" suffix=": "/>
+          <text term="available at" suffix=": " text-case="capitalize-first"/>
           <text variable="URL"/>
         </group>
       </else-if>

--- a/iso690-numeric-cs.csl
+++ b/iso690-numeric-cs.csl
@@ -386,7 +386,14 @@
     </choose>
   </macro>
   <macro name="isbn">
-    <text variable="ISBN" prefix="ISBN "/>
+    <choose>
+      <if variable="ISBN">
+        <text variable="ISBN" prefix="ISBN "/>
+      </if>
+      <else>
+        <text macro="issn"/>
+      </else>
+    </choose>
   </macro>
   <macro name="issn">
     <text variable="ISSN" prefix="ISSN "/>

--- a/vodohospodarske-technicko-ekonomicke-informace-en.csl
+++ b/vodohospodarske-technicko-ekonomicke-informace-en.csl
@@ -386,7 +386,14 @@
     </choose>
   </macro>
   <macro name="isbn">
-    <text variable="ISBN" prefix="ISBN "/>
+    <choose>
+      <if variable="ISBN">
+        <text variable="ISBN" prefix="ISBN "/>
+      </if>
+      <else>
+        <text macro="issn"/>
+      </else>
+    </choose>
   </macro>
   <macro name="issn">
     <text variable="ISSN" prefix="ISSN "/>

--- a/vodohospodarske-technicko-ekonomicke-informace.csl
+++ b/vodohospodarske-technicko-ekonomicke-informace.csl
@@ -390,7 +390,14 @@
     </choose>
   </macro>
   <macro name="isbn">
-    <text variable="ISBN" prefix="ISBN "/>
+    <choose>
+      <if variable="ISBN">
+        <text variable="ISBN" prefix="ISBN "/>
+      </if>
+      <else>
+        <text macro="issn"/>
+      </else>
+    </choose>
   </macro>
   <macro name="issn">
     <text variable="ISSN" prefix="ISSN "/>

--- a/vodohospodarske-technicko-ekonomicke-informace.csl
+++ b/vodohospodarske-technicko-ekonomicke-informace.csl
@@ -406,15 +406,13 @@
     <choose>
       <if variable="DOI">
         <group>
-          <text term="retrieved" suffix=" " text-case="capitalize-first"/>
-          <text term="from" suffix=": doi:"/>
+          <text term="available at" suffix=": doi:" text-case="capitalize-first"/>
           <text variable="DOI"/>
         </group>
       </if>
       <else-if variable="URL">
         <group>
-          <text term="retrieved" suffix=" " text-case="capitalize-first"/>
-          <text term="from" suffix=": "/>
+          <text term="available at" suffix=": " text-case="capitalize-first"/>
           <text variable="URL"/>
         </group>
       </else-if>


### PR DESCRIPTION
Only Mendely users will see the change in output from style; Zotero has not implemented ISSN variable for a lot of document types now.
Some commits have incorrect description "for books" (my mistake); this change is for all document types, which have ISBN.