### PR TITLE
Append space to citation number suffix [ieee/ieee-with-url styles]

### DIFF
--- a/ieee-with-url.csl
+++ b/ieee-with-url.csl
@@ -220,7 +220,7 @@
   <bibliography entry-spacing="0" second-field-align="flush">
     <layout>
       <!-- Citation Number -->
-      <text variable="citation-number" prefix="[" suffix="]"/>
+      <text variable="citation-number" prefix="[" suffix="]&#8195;"/>
       <!-- Author(s) -->
       <text macro="author" suffix=", "/>
       <!-- Rest of Citation -->

--- a/ieee.csl
+++ b/ieee.csl
@@ -225,7 +225,7 @@
   <bibliography entry-spacing="0" second-field-align="flush">
     <layout suffix=".">
       <!-- Citation Number -->
-      <text variable="citation-number" prefix="[" suffix="]"/>
+      <text variable="citation-number" prefix="[" suffix="]&#8195;"/>
       <!-- Author(s) -->
       <text macro="author" suffix=", "/>
       <!-- Rest of Citation -->


### PR DESCRIPTION
Hi,

There seems to be a space missing after the citation number in the `ieee ` and `ieee-with-url` styles. Judging by this IEEE [style guide](http://www.ieee.org/documents/ieeecitationref.pdf) it looks to be about the width of an em space, so I've appended `&#8195;` to the end of the citation number.

(Incidentally, I'm working with [jekyll-scholar](https://github.com/inukshuk/jekyll-scholar) and `&emsp;` was being translated to `&amp;emsp;`. I'm not sure what the root of this is, but the decimal encoding works fine.)