### PR TITLE
Add dependent/international-archives-of-medicine.csl

### DIFF
--- a/dependent/international-archives-of-medicine.csl
+++ b/dependent/international-archives-of-medicine.csl
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<style xmlns="http://purl.org/net/xbiblio/csl" version="1.0" default-locale="en-US">
+  <info>
+    <title>International Archives of Medicine</title>
+    <title-short>Int Arch Med</title-short>
+    <id>http://www.zotero.org/styles/international-archives-of-medicine</id>
+    <link href="http://www.zotero.org/styles/international-archives-of-medicine" rel="self"/>
+    <link href="http://www.zotero.org/styles/vancouver" rel="independent-parent"/>
+    <link href="http://imed.pub/ojs/index.php/iam/about/submissions" rel="documentation"/>
+    <category citation-format="numeric"/>
+    <category field="medicine"/>
+    <issn>1755-7682</issn>
+    <updated>2016-03-31T09:00:00+00:00</updated>
+    <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
+  </info>
+</style>


### PR DESCRIPTION
This journal is now published by iMed.pub and follows
Vancouver style. Until the end of 2014 it was published
by BioMed Central

https://github.com/citation-style-language/journals/issues/6