### PR TITLE
Health Reform Observer: InText Defaut (Author-Date).csl

### DIFF
--- a/dependent/Health Reform Observer: InText Defaut (Author-Date).csl
+++ b/dependent/Health Reform Observer: InText Defaut (Author-Date).csl
@@ -1,0 +1,1 @@
+http://csl.mendeley.com/styles/371811861/HRO-1


### PR DESCRIPTION
Based off of Harvard. Intended use for Health Reform Observer – Observatoire des Réformes de Santé.