### PR TITLE
Canadian Journal of Economics: InText Default (Author-Date).csl

### DIFF
--- a/dependent/Canadian Journal of Economics: InText Default (Author-Date).csl
+++ b/dependent/Canadian Journal of Economics: InText Default (Author-Date).csl
@@ -1,0 +1,1 @@
+http://csl.mendeley.com/styles/371811861/CJE-1


### PR DESCRIPTION
Based off of Chicago. Intended use to cite CJE.