### PR TITLE
Create canadian-journal-economics-default.csl

### DIFF
--- a/dependent/canadian-journal-economics-default.csl
+++ b/dependent/canadian-journal-economics-default.csl
@@ -1,0 +1,1 @@
+http://csl.mendeley.com/styles/371811861/canadian-journal-economics-default


### PR DESCRIPTION
Based off Chicago. Intended to cite CJE. In-text citations appear as (author-date).