### PR TITLE
Update coral-reefs.csl

### DIFF
--- a/coral-reefs.csl
+++ b/coral-reefs.csl
@@ -14,7 +14,7 @@
     <category field="biology"/>
     <issn>0722-4028</issn>
     <eissn>1432-0975</eissn>
-    <updated>2012-09-27T22:06:38+00:00</updated>
+    <updated>2016-04-06T12:36:12+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <macro name="author">
@@ -73,7 +73,7 @@
           <text variable="publisher-place" suffix=" "/>
         </else-if>
         <else-if type="paper-conference">
-          <text variable="event" prefix=" " suffix=" "/>
+          <text variable="event" prefix=" " strip-periods="true" suffix=" "/>
           <text variable="volume" suffix=":"/>
           <text variable="page"/>
         </else-if>
@@ -89,7 +89,7 @@
         </else-if>
         <else>
           <group suffix=" ">
-            <text variable="container-title" suffix=" " form="short"/>
+            <text variable="container-title" form="short" strip-periods="true" suffix=" "/>
             <text variable="volume" suffix=":"/>
             <text variable="page"/>
           </group>


### PR DESCRIPTION
Journal abbreviations should be without periods. Same is true for conference proceedings.