### PR TITLE
Fix inline citations

### DIFF
--- a/florida-entomologist.csl
+++ b/florida-entomologist.csl
@@ -48,7 +48,7 @@
   </macro>
   <macro name="author-short">
     <names variable="author">
-      <name form="short" delimiter=" " and="text" delimiter-precedes-last="never" initialize-with=". "/>
+      <name form="short" delimiter=" " and="symbol" delimiter-precedes-last="never" initialize-with=". "/>
       <et-al font-style="normal"/>
       <substitute>
         <names variable="editor"/>
@@ -156,7 +156,7 @@
       <key macro="year-date"/>
       <key macro="author-short"/>
     </sort>
-    <layout delimiter=", " prefix="(" suffix=")">
+    <layout delimiter="; " prefix="(" suffix=")">
       <group delimiter=", ">
         <group delimiter=" ">
           <text macro="author-short"/>


### PR DESCRIPTION
Fixed inline citations so that they use semicolons and "&" instead of "and".