### PR TITLE
Update and rename vancouver.csl to materials-research-letters.csl

### DIFF
--- a/materials-research-letters.csl
+++ b/materials-research-letters.csl
@@ -1,10 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" demote-non-dropping-particle="sort-only" page-range-format="minimal">
   <info>
-    <title>Vancouver</title>
-    <id>http://www.zotero.org/styles/vancouver</id>
-    <link href="http://www.zotero.org/styles/vancouver" rel="self"/>
-    <link href="http://www.nlm.nih.gov/bsd/uniform_requirements.html" rel="documentation"/>
+    <title>Materials Researsch Letters</title>
+    <id>http://www.zotero.org/styles/Materials_Researsch_Letters</id>
+    <link href="http://www.zotero.org/styles/Materials_Researsch_Letters" rel="self"/>
     <author>
       <name>Michael Berkowitz</name>
       <email>mberkowi@gmu.edu</email>
@@ -16,9 +15,12 @@
     <contributor>
       <name>Sebastian Karcher</name>
     </contributor>
+    <contributor>
+      <name>Xiaolong Ma</name>
+    </contributor>
     <category citation-format="numeric"/>
-    <category field="medicine"/>
-    <summary>Vancouver style as outlined by International Committee of Medical Journal Editors Uniform Requirements for Manuscripts Submitted to Biomedical Journals: Sample References</summary>
+    <category field="science"/>
+    <summary>Materials Researsch Letters style as outlined by the Journal Editors Uniform Requirements for Manuscripts Submitted to Materials Researsch Letters: Sample References</summary>
     <updated>2014-09-06T16:03:01+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>


### PR DESCRIPTION
Just change the style title to facilitate users finding the exact citation style of the specific journal