### PR TITLE
fixed spacing, simplified user input for theses

### DIFF
--- a/melbourne-school-of-theology.csl
+++ b/melbourne-school-of-theology.csl
@@ -15,7 +15,7 @@
     <category citation-format="note"/>
     <category field="theology"/>
     <summary>Melbourne School of Theology format based on the Essay Style Guide</summary>
-    <updated>2016-03-14T03:14:57+00:00</updated>
+    <updated>2016-04-19T23:48:20+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale xml:lang="en-GB">
@@ -324,13 +324,14 @@
     <group delimiter=": ">
       <choose>
         <if type="thesis" match="any">
-          <group delimiter=",">
+          <group delimiter=", ">
             <text variable="publisher"/>
             <text variable="publisher-place"/>
           </group>
           <group delimiter=" ">
             <text value="Unpublished"/>
             <text variable="genre"/>
+            <text value="dissertation"/>
           </group>
         </if>
         <else>


### PR DESCRIPTION
Simplified the user input for the genre value in thesis type by allowing the user to add only the level, and not requiring them to add the value "dissertation" in the (primarily Zotero) "type" field.  Also fixed spacing between publisher and publisher-place macros.