### PR TITLE
Update universite-laval-departement-des-sciences-historiques.csl

### DIFF
--- a/universite-laval-departement-des-sciences-historiques.csl
+++ b/universite-laval-departement-des-sciences-historiques.csl
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <style class="note" version="1.0" initialize="false" initialize-with-hyphen="false" default-locale="fr-CA" xmlns="http://purl.org/net/xbiblio/csl">
+<!-- This style was edited with the Visual CSL Editor (http://editor.citationstyles.org/visualEditor/) -->
   <info>
     <title>Université Laval - Département des sciences historiques (French - Canada)</title>
     <id>http://www.zotero.org/styles/universite-laval-departement-des-sciences-historiques</id>
@@ -12,7 +13,7 @@
     <category citation-format="note"/>
     <category field="history"/>
     <summary>Le style bibliographique pour citation et références du Département des sciences historiques de l'Université Laval    </summary>
-    <updated>2016-04-22T00:27:37+00:00</updated>
+    <updated>2016-04-26T05:41:58+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <macro name="author-bibliography">
@@ -31,7 +32,7 @@
     </names>
   </macro>
   <macro name="editor-bibliography">
-    <names variable="editor" suffix=". ">
+    <names variable="editor">
       <name and="text" delimiter-precedes-et-al="never" delimiter-precedes-last="never" et-al-min="3" et-al-use-first="1" initialize="false" initialize-with="." name-as-sort-order="first">
         <name-part name="family" text-case="uppercase"/>
         <name-part name="given" text-case="capitalize-first"/>
@@ -49,14 +50,16 @@
     </names>
   </macro>
   <macro name="publisher">
-    <text variable="publisher-place" prefix=" " suffix=", "/>
-    <text variable="publisher"/>
+    <group delimiter=", ">
+      <text variable="publisher-place" prefix=" "/>
+      <text variable="publisher"/>
+    </group>
   </macro>
   <macro name="access">
     <choose>
       <if variable="URL">
         <choose>
-          <if type="webpage article-newspaper broadcast figure graphic paper-conference post post-weblog song" match="any">
+          <if type="webpage article-newspaper broadcast figure graphic post post-weblog song" match="any">
             <text variable="URL"/>
             <text macro="accessed-date"/>
           </if>
@@ -133,19 +136,19 @@
   <macro name="collection">
     <choose>
       <if variable="collection-number">
-        <text variable="collection-title" prefix="Coll. "/>
+        <text variable="collection-title" prefix=" Coll. "/>
         <text variable="collection-number" prefix=", "/>
       </if>
       <else>
-        <text variable="collection-title" prefix="Coll. "/>
+        <text variable="collection-title" prefix=" Coll. "/>
       </else>
     </choose>
   </macro>
   <macro name="locators">
-    <group delimiter=",">
-      <text variable="volume" prefix=" vol. "/>
+    <group delimiter=", ">
+      <text variable="volume" prefix="vol. "/>
       <group>
-        <text variable="issue" prefix=" n° "/>
+        <text variable="issue" prefix="n° "/>
         <choose>
           <if match="any" variable="volume issue">
             <text macro="year-date" prefix=" (" suffix=")"/>
@@ -155,87 +158,127 @@
           </else>
         </choose>
       </group>
-      <text variable="page" prefix=" p. "/>
     </group>
   </macro>
-  <macro name="end-part">
-    <group delimiter=", " suffix=".">
-      <text macro="publisher"/>
-      <text macro="year-date"/>
-      <choose>
-        <if type="article article-journal article-magazine article-newspaper entry-dictionary entry-encyclopedia paper-conference chapter webpage" match="any">
-          <text variable="page" prefix="p." suffix="."/>
-        </if>
-        <else>
-          <text variable="number-of-pages" suffix=" p."/>
-        </else>
-      </choose>
-    </group>
+  <macro name="pages-bibliography">
+    <choose>
+      <if type="article article-journal article-magazine article-newspaper entry entry-dictionary entry-encyclopedia chapter paper-conference webpage" match="any">
+        <label plural="never" suffix=" " variable="page" form="short"/>
+        <text variable="page"/>
+      </if>
+      <else>
+        <text variable="number-of-pages"/>
+        <label prefix=" " variable="number-of-pages" form="short"/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="pages-citation">
+    <label plural="never" suffix=" " variable="page" form="short"/>
   </macro>
   <citation et-al-min="4" et-al-use-first="1" disambiguate-add-year-suffix="true" disambiguate-add-names="true" disambiguate-add-givenname="true">
-    <layout>
-      <group delimiter=", ">
-        <text macro="author-citation"/>
-        <text macro="title"/>
+    <layout delimiter=" ; ">
+      <choose>
+        <if match="all" position="first">
+          <group delimiter=", ">
+            <text macro="author-citation"/>
+            <text macro="title"/>
+            <choose>
+              <if type="chapter paper-conference webpage entry entry-dictionary entry-encyclopedia" match="any">
+                <group delimiter=", ">
+                  <text macro="editor-citation"/>
+                  <text macro="journal-title"/>
+                </group>
+              </if>
+              <else-if type="article article-journal article-magazine article-newspaper review" match="none">
+                <text macro="edition"/>
+              </else-if>
+            </choose>
+            <choose>
+              <if type="article article-journal article-magazine article-newspaper review" match="any">
+                <group delimiter=", ">
+                  <text macro="journal-title"/>
+                  <text macro="locators"/>
+                  <text macro="pages-citation"/>
+                </group>
+              </if>
+              <else>
+                <group delimiter=", ">
+                  <choose>
+                    <if type="thesis" match="any">
+                      <text value="Thèse"/>
+                    </if>
+                  </choose>
+                  <text macro="publisher"/>
+                  <text macro="year-date"/>
+                  <text macro="pages-citation"/>
+                </group>
+              </else>
+            </choose>
+            <text macro="access"/>
+          </group>
+        </if>
+        <else-if match="any" position="ibid ibid-with-locator">
+          <group delimiter=", ">
+            <text term="ibid" text-case="capitalize-first" font-style="italic" suffix="."/>
+            <text macro="pages-citation"/>
+          </group>
+        </else-if>
+        <else>
+          <group delimiter=", ">
+            <text macro="author-citation"/>
+            <text value="op. cit" font-style="italic" suffix="."/>
+            <text macro="year-date"/>
+            <text macro="pages-citation"/>
+          </group>
+        </else>
+      </choose>
+    </layout>
+  </citation>
+  <bibliography hanging-indent="true">
+    <sort>
+      <key macro="author-bibliography"/>
+      <key macro="year-date"/>
+    </sort>
+    <layout suffix=".">
+      <group delimiter=". ">
+        <text macro="author-bibliography"/>
+        <text macro="title" strip-periods="false" font-weight="normal" vertical-align="baseline"/>
         <choose>
-          <if type="thesis" match="any">
-            <text value="Thèse"/>
-            <text macro="end-part"/>
-          </if>
-          <else-if type="chapter paper-conference webpage" match="any">
-            <text macro="editor-citation"/>
-            <group delimiter=",">
+          <if type="chapter paper-conference webpage entry entry-dictionary entry-encyclopedia" match="any">
+            <group delimiter=". ">
+              <text macro="editor-bibliography"/>
               <text macro="journal-title"/>
-              <text macro="end-part"/>
             </group>
-          </else-if>
-          <else-if type="article article-journal article-magazine article-newspaper review" match="any">
-            <text macro="journal-title"/>
-            <text macro="locators"/>
-          </else-if>
-          <else>
+          </if>
+          <else-if type="article article-journal article-magazine article-newspaper review" match="none">
             <text macro="edition"/>
-            <text macro="end-part"/>
-            <text macro="collection"/>
+          </else-if>
+        </choose>
+        <choose>
+          <if type="article article-journal article-magazine article-newspaper review" match="any">
+            <group delimiter=", ">
+              <text macro="journal-title"/>
+              <text macro="locators"/>
+              <text macro="pages-bibliography"/>
+            </group>
+          </if>
+          <else>
+            <group delimiter=", ">
+              <choose>
+                <if type="thesis" match="any">
+                  <text value="Thèse"/>
+                </if>
+              </choose>
+              <text macro="publisher"/>
+              <text macro="year-date"/>
+              <text macro="pages-bibliography"/>
+              <text macro="collection"/>
+            </group>
           </else>
         </choose>
         <text macro="access"/>
       </group>
     </layout>
-  </citation>
-  <bibliography hanging-indent="true" subsequent-author-substitute="---">
-    <sort>
-      <key macro="author-bibliography"/>
-      <key macro="year-date"/>
-    </sort>
-    <layout>
-      <text macro="author-bibliography" suffix=". "/>
-      <text macro="title" strip-periods="false" font-weight="normal" vertical-align="baseline" suffix=". "/>
-      <choose>
-        <if type="thesis">
-          <text value="Thèse" suffix=", "/>
-          <text macro="end-part"/>
-        </if>
-        <else-if type="chapter paper-conference webpage entry-dictionary entry entry-encyclopedia article" match="any">
-          <text macro="editor-bibliography"/>
-          <group delimiter="." suffix=". ">
-            <text macro="journal-title"/>
-            <text macro="end-part"/>
-          </group>
-        </else-if>
-        <else-if type="article article-journal article-magazine article-newspaper review" match="any">
-          <group delimiter="," suffix=". ">
-            <text macro="journal-title"/>
-            <text macro="locators"/>
-          </group>
-        </else-if>
-        <else>
-          <text macro="edition" suffix="."/>
-          <text macro="end-part"/>
-          <text macro="collection"/>
-        </else>
-      </choose>
-      <text macro="access" suffix=","/>
-    </layout>
   </bibliography>
 </style>
+e

--- a/universite-laval-departement-des-sciences-historiques.csl
+++ b/universite-laval-departement-des-sciences-historiques.csl
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <style class="note" version="1.0" initialize="false" initialize-with-hyphen="false" default-locale="fr-CA" xmlns="http://purl.org/net/xbiblio/csl">
-<!-- This style was edited with the Visual CSL Editor (http://editor.citationstyles.org/visualEditor/) -->
   <info>
     <title>Université Laval - Département des sciences historiques (French - Canada)</title>
     <id>http://www.zotero.org/styles/universite-laval-departement-des-sciences-historiques</id>
@@ -13,7 +12,7 @@
     <category citation-format="note"/>
     <category field="history"/>
     <summary>Le style bibliographique pour citation et références du Département des sciences historiques de l'Université Laval    </summary>
-    <updated>2016-04-26T05:41:58+00:00</updated>
+    <updated>2016-04-26T18:18:31+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <macro name="author-bibliography">
@@ -175,6 +174,20 @@
   <macro name="pages-citation">
     <label plural="never" suffix=" " variable="page" form="short"/>
   </macro>
+  <macro name="thesis">
+    <choose>
+      <if type="thesis" match="all">
+        <choose>
+          <if match="all" variable="genre">
+            <text variable="genre" text-case="capitalize-first"/>
+          </if>
+          <else>
+            <text value="Thèse"/>
+          </else>
+        </choose>
+      </if>
+    </choose>
+  </macro>
   <citation et-al-min="4" et-al-use-first="1" disambiguate-add-year-suffix="true" disambiguate-add-names="true" disambiguate-add-givenname="true">
     <layout delimiter=" ; ">
       <choose>
@@ -203,11 +216,7 @@
               </if>
               <else>
                 <group delimiter=", ">
-                  <choose>
-                    <if type="thesis" match="any">
-                      <text value="Thèse"/>
-                    </if>
-                  </choose>
+                  <text macro="thesis"/>
                   <text macro="publisher"/>
                   <text macro="year-date"/>
                   <text macro="pages-citation"/>
@@ -264,11 +273,7 @@
           </if>
           <else>
             <group delimiter=", ">
-              <choose>
-                <if type="thesis" match="any">
-                  <text value="Thèse"/>
-                </if>
-              </choose>
+              <text macro="thesis"/>
               <text macro="publisher"/>
               <text macro="year-date"/>
               <text macro="pages-bibliography"/>

--- a/universite-laval-departement-des-sciences-historiques.csl
+++ b/universite-laval-departement-des-sciences-historiques.csl
@@ -281,4 +281,3 @@
     </layout>
   </bibliography>
 </style>
-e

--- a/universite-laval-departement-des-sciences-historiques.csl
+++ b/universite-laval-departement-des-sciences-historiques.csl
@@ -12,7 +12,7 @@
     <category citation-format="note"/>
     <category field="history"/>
     <summary>Le style bibliographique pour citation et références du Département des sciences historiques de l'Université Laval    </summary>
-    <updated>2016-04-26T18:18:31+00:00</updated>
+    <updated>2016-04-26T22:16:12+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <macro name="author-bibliography">
@@ -173,6 +173,7 @@
   </macro>
   <macro name="pages-citation">
     <label plural="never" suffix=" " variable="page" form="short"/>
+    <text variable="locator" form="short"/>
   </macro>
   <macro name="thesis">
     <choose>


### PR DESCRIPTION
This is a big update, which includes many changes. 

It goes like this:
1. Much cleaner code. I revised the syntax, mostly because there was still some mistakes with random double commas and periods. Use of groups helped a lot in that way. 
2. Both "citation" and "bibliography" layout were reconstructed completely, following a MUCH simpler pattern: macro-macro-condition(for exceptions)-condition(for articles vs books, mostly)-macro. I isolated smaller logical conditions instead of ONE BIG condition. 
3. The "end-part" macro was also removed, since macros for publisher, year and pages were made adequate (and also because citation and bibliography are so different, "end-part" was basically the source of some problems).

As for smaller changes:
4. Removed the "---" substitution, as stated by the documentation. Authors will be repeated for each of their works in bibliography.
5. Removed "paper-conference" as condition for URL display.
6. Added " ; " between each cite in citation.
7. Added "Ibid." and "op. cit." conditions for citation, as stated by the documentation.
8. Added macros "pages-bibliography" and "pages-citation", as they are not used in the same way.

This version has been tested with 120 different entries now, and seems to be fully functional. Although, two technical problems remain:
1. Documentation asks for an explicit differentiation of "Doctorate thesis" and "Master thesis" ("Thèse de doctorat" and "Mémoire de maîtrise"). For now, I have not yet found a way to implement it, so only "Thèse" appears.
2. Even though "note" is stated as "class", Word does not show citation as footnote (ex: like '1' appears next to quote, and refers to the citation at the bottom of the page, preceded by the same '1'). We still have to manually "Add a footnote", and then select the correct entry (any clue would be helpful for that).