### PR TITLE
Docu journal-of-geriatric-psychiatry-and-neurology

### DIFF
--- a/journal-of-geriatric-psychiatry-and-neurology.csl
+++ b/journal-of-geriatric-psychiatry-and-neurology.csl
@@ -5,7 +5,7 @@
     <id>http://www.zotero.org/styles/journal-of-geriatric-psychiatry-and-neurology</id>
     <link href="http://www.zotero.org/styles/journal-of-geriatric-psychiatry-and-neurology" rel="self"/>
     <link href="http://www.zotero.org/styles/american-medical-association" rel="template"/>
-    <link href="http://www.sagepub.com/journals/Journal201662/manuscriptSubmission" rel="documentation"/>
+    <link href="https://us.sagepub.com/en-us/nam/journal-of-geriatric-psychiatry-and-neurology/journal201662#submission-guidelines" rel="documentation"/>
     <author>
       <name>Sebastian Karcher</name>
     </author>


### PR DESCRIPTION
Update the docu link according to the 301 redirection (this is the first on my list).

I checked also the archived version http://web.archive.org/web/20140824045750/http://www.sagepub.com/journals/Journal201662/manuscriptSubmission which seems to be unchanged. However, I am not sure, that was really necessary.