### PR TITLE
Significant update of De Buck

### DIFF
--- a/de-buck.csl
+++ b/de-buck.csl
@@ -20,18 +20,21 @@
     <category citation-format="note"/>
     <category field="generic-base"/>
     <summary>Annotatie en literatuurlijst volgens P. de Buck e.a., Zoeken en schrijven. Handleiding bij het maken van een historisch werkstuk (Haarlem 1982). Gebaseerd op "MHRA format with full notes and bibliography"</summary>
-    <updated>2013-01-20T12:26:52+01:00</updated>
+    <updated>2016-05-04T17:23:52+01:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale xml:lang="nl">
     <terms>
       <term name="et-al">e.a.</term>
-      <term name="editor" form="short">
+      <term name="editor" form="verb-short">
         <single>ed.</single>
-        <multiple>eds.</multiple>
+        <multiple>ed.</multiple>
       </term>
       <term name="edition" form="short">druk</term>
-      <term name="translator" form="verb-short">(vert.)</term>
+      <term name="translator" form="verb-short">
+        <single>(vertaler)</single>
+        <multiple>(vertalers)</multiple>
+      </term>
       <term name="volume" form="short">
         <single>dl.</single>
         <multiple>dls.</multiple>
@@ -48,16 +51,15 @@
   <macro name="author">
     <names variable="author" suffix=", ">
       <name name-as-sort-order="first" and="text" sort-separator=", " delimiter=", " delimiter-precedes-last="after-inverted-name" delimiter-precedes-et-al="after-inverted-name"/>
-      <label form="short" prefix=", " suffix="." strip-periods="true"/>
       <substitute>
-        <names variable="editor" suffix=", ">
-          <name name-as-sort-order="first" and="text" delimiter=", " delimiter-precedes-last="after-inverted-name" delimiter-precedes-et-al="after-inverted-name"/>
-          <label form="verb-short" text-case="lowercase" prefix=" " suffix="." strip-periods="true"/>
-        </names>
-        <names variable="container-author" suffix=", ">
-          <name name-as-sort-order="first" and="text" delimiter=", " delimiter-precedes-last="after-inverted-name" delimiter-precedes-et-al="after-inverted-name"/>
-          <label form="verb-short" text-case="lowercase" prefix=" " suffix="." strip-periods="true"/>
-        </names>
+        <choose>
+          <if variable="container-title" match="none">
+            <names variable="editor" suffix=", ">
+              <name name-as-sort-order="first" and="text" delimiter=", " delimiter-precedes-last="after-inverted-name" delimiter-precedes-et-al="after-inverted-name"/>
+              <label form="verb-short" text-case="lowercase" prefix=" " suffix="." strip-periods="true"/>
+            </names>
+          </if>
+        </choose>
         <names variable="translator" suffix=", ">
           <name name-as-sort-order="first" and="text" delimiter=", " delimiter-precedes-last="after-inverted-name" delimiter-precedes-et-al="after-inverted-name"/>
           <label form="verb-short" prefix=" " text-case="lowercase" strip-periods="false"/>
@@ -65,6 +67,14 @@
         <text macro="title-note"/>
       </substitute>
     </names>
+    <choose>
+      <if variable="author editor container-author" match="any">
+        <names variable="translator" suffix=", ">
+          <name and="text" delimiter=", " delimiter-precedes-last="never"/>
+          <label form="verb-short" text-case="lowercase" prefix=" " strip-periods="false"/>
+        </names>
+      </if>
+    </choose>
     <text macro="recipient-note" suffix=", "/>
     <text macro="interviewer-note" suffix=", "/>
   </macro>
@@ -86,14 +96,14 @@
         <names variable="author" suffix=", ">
           <name and="text" sort-separator=", " delimiter=", " delimiter-precedes-last="never"/>
           <substitute>
-            <names variable="editor" suffix=", ">
-              <name and="text" delimiter=", " delimiter-precedes-last="never"/>
-              <label form="verb-short" text-case="lowercase" prefix=" " suffix="." strip-periods="true"/>
-            </names>
-            <names variable="container-author" suffix=", ">
-              <name and="text" delimiter=", " delimiter-precedes-last="never"/>
-              <label form="verb-short" text-case="lowercase" prefix=" " suffix="." strip-periods="true"/>
-            </names>
+            <choose>
+              <if variable="container-title" match="none">
+                <names variable="editor" suffix=", ">
+                  <name and="text" delimiter=", " delimiter-precedes-last="never"/>
+                  <label form="verb-short" text-case="lowercase" prefix=" " suffix="." strip-periods="true"/>
+                </names>
+              </if>
+            </choose>
             <names variable="translator" suffix=", ">
               <name and="text" delimiter=", " delimiter-precedes-last="never"/>
               <label form="verb-short" text-case="lowercase" prefix=" " strip-periods="false"/>
@@ -101,6 +111,14 @@
             <text macro="title-note"/>
           </substitute>
         </names>
+        <choose>
+          <if variable="author editor container-author" match="any">
+            <names variable="translator" suffix=", ">
+              <name and="text" delimiter=", " delimiter-precedes-last="never"/>
+              <label form="verb-short" text-case="lowercase" prefix=" " strip-periods="false"/>
+            </names>
+          </if>
+        </choose>
         <text macro="recipient-note" suffix=", "/>
         <text macro="interviewer-note" suffix=", "/>
       </else>
@@ -128,16 +146,8 @@
       </names>
       <names variable="container-author" delimiter=", ">
         <name and="text" delimiter=", " delimiter-precedes-last="never"/>
-        <label form="verb-short" text-case="lowercase" prefix=" " suffix="." strip-periods="true"/>
       </names>
-      <choose>
-        <if variable="author editor" match="any">
-          <names variable="translator" delimiter=", ">
-            <name and="text" delimiter=", " delimiter-precedes-last="never"/>
-            <label form="verb-short" text-case="lowercase" prefix=" " strip-periods="false"/>
-          </names>
-        </if>
-      </choose>
+      <!--<choose><if variable="author editor container-author" match="any"><names variable="translator" delimiter=", "><name and="text" delimiter=", " delimiter-precedes-last="never"/><label form="verb-short" text-case="lowercase" prefix=" " strip-periods="false"/></names></if></choose>-->
     </group>
   </macro>
   <macro name="collection-title">
@@ -181,7 +191,7 @@
                 <text macro="issued"/>
               </else-if>
               <else-if type="speech">
-                <text variable="genre" prefix="" suffix=","/>
+                <text variable="genre" suffix=","/>
                 <text macro="event"/>
                 <text macro="issued"/>
               </else-if>
@@ -200,7 +210,7 @@
   </macro>
   <macro name="container-title-note">
     <choose>
-      <if type="chapter paper-conference map" match="any">
+      <if type="chapter paper-conference map entry-encyclopedia entry-dictionary" match="any">
         <text term="in" text-case="lowercase" suffix=": "/>
         <text macro="editor-translator" suffix=", "/>
       </if>
@@ -226,13 +236,13 @@
   </macro>
   <macro name="recipient-note">
     <names variable="recipient" delimiter=", ">
-      <label form="verb" prefix=" " text-case="lowercase" suffix=" "/>
+      <label form="verb" text-case="lowercase" suffix=" "/>
       <name and="text" delimiter=", " delimiter-precedes-last="never"/>
     </names>
   </macro>
   <macro name="recipient-short">
     <names variable="recipient" delimiter=", ">
-      <label form="verb" prefix=" " text-case="lowercase" suffix=" "/>
+      <label form="verb" text-case="lowercase" suffix=" "/>
       <name form="short" and="text" delimiter=", " delimiter-precedes-last="never"/>
     </names>
   </macro>
@@ -260,17 +270,21 @@
             <name-part name="family" text-case="capitalize-first"/>
           </name>
           <substitute>
-            <names variable="editor" suffix=", ">
-              <name form="short" and="text" sort-separator=", " delimiter=", " delimiter-precedes-last="never">
-                <name-part name="family" text-case="capitalize-first"/>
-              </name>
-              <label form="verb-short" prefix=" " suffix="." strip-periods="true"/>
-            </names>
+            <choose>
+              <if variable="container-title" match="none">
+                <names variable="editor" suffix=", ">
+                  <name form="short" and="text" sort-separator=", " delimiter=", " delimiter-precedes-last="never">
+                    <name-part name="family" text-case="capitalize-first"/>
+                  </name>
+                  <label form="verb-short" prefix=" " suffix="." strip-periods="true"/>
+                </names>
+              </if>
+            </choose>
             <names variable="translator" suffix=", ">
               <name form="short" and="text" sort-separator=", " delimiter=", " delimiter-precedes-last="never">
                 <name-part name="family" text-case="capitalize-first"/>
               </name>
-              <label form="verb-short" prefix=" " suffix="" strip-periods="false"/>
+              <label form="verb-short" prefix=" " strip-periods="false"/>
             </names>
           </substitute>
         </names>
@@ -281,13 +295,13 @@
   </macro>
   <macro name="interviewer-note">
     <names variable="interviewer" delimiter=", ">
-      <label form="verb" prefix=" " text-case="lowercase" suffix=" "/>
+      <label form="verb" text-case="lowercase" suffix=" "/>
       <name and="text" delimiter=", " delimiter-precedes-last="never"/>
     </names>
   </macro>
   <macro name="interviewer-short">
     <names variable="interviewer" delimiter=", ">
-      <label form="verb" prefix=" " text-case="lowercase" suffix=" "/>
+      <label form="verb" text-case="lowercase" suffix=" "/>
       <name form="short" and="text" delimiter=", " delimiter-precedes-last="never"/>
     </names>
   </macro>
@@ -297,7 +311,7 @@
         <group delimiter=", ">
           <group>
             <text variable="edition" suffix=" "/>
-            <text term="edition" prefix=" "/>
+            <text term="edition"/>
           </group>
           <group>
             <text term="section" suffix=" "/>
@@ -504,7 +518,7 @@
     </choose>
   </macro>
   <citation et-al-min="4" et-al-use-first="1" et-al-subsequent-min="4" et-al-subsequent-use-first="1" disambiguate-add-names="true" disambiguate-add-givenname="true">
-    <layout prefix="" suffix="." delimiter="; ">
+    <layout suffix="." delimiter="; ">
       <choose>
         <if position="ibid-with-locator">
           <group delimiter=", ">
@@ -525,44 +539,19 @@
           <text macro="point-locators" prefix=", "/>
           <text macro="access-note"/>
         </else-if>
-        <else-if variable="author editor" match="all">
-          <choose>
-            <if type="article-journal chapter paper-conference entry-dictionary entry-encyclopedia map" match="any">
-              <group>
-                <text macro="contributors-note" text-case="capitalize-first"/>
-                <text macro="title-note"/>
-                <text macro="editor-translator" prefix=". "/>
-                <text macro="container-title-note" prefix=", "/>
-                <text macro="locators-note" prefix=" "/>
-                <choose>
-                  <if type="map">
-                    <text macro="collection-title" prefix=", " font-style="italic"/>
-                  </if>
-                  <else>
-                    <text macro="collection-title" prefix=", "/>
-                  </else>
-                </choose>
-              </group>
-              <text macro="issue-note"/>
-              <text macro="locators-newspaper" prefix=", "/>
-              <text macro="point-locators"/>
-              <text macro="access-note"/>
-            </if>
-            <else>
-              <group>
-                <text macro="contributors-note" text-case="capitalize-first"/>
-                <text macro="title-note"/>
-                <text macro="locators-note" prefix=" "/>
-                <text macro="editor-translator" prefix=". "/>
-                <text macro="container-title-note" prefix=", "/>
-                <text macro="collection-title" prefix=", "/>
-              </group>
-              <text macro="issue-note"/>
-              <text macro="locators-newspaper" prefix=", "/>
-              <text macro="point-locators"/>
-              <text macro="access-note"/>
-            </else>
-          </choose>
+        <else-if type="book" variable="author editor" match="all">
+          <group>
+            <text macro="contributors-note" text-case="capitalize-first"/>
+            <text macro="title-note"/>
+            <text macro="locators-note" prefix=" "/>
+            <text macro="editor-translator" prefix=". "/>
+            <text macro="container-title-note" prefix=", "/>
+            <text macro="collection-title" prefix=". "/>
+          </group>
+          <text macro="issue-note"/>
+          <text macro="locators-newspaper" prefix=", "/>
+          <text macro="point-locators"/>
+          <text macro="access-note"/>
         </else-if>
         <else>
           <choose>
@@ -574,10 +563,10 @@
                 <text macro="locators-note" prefix=" "/>
                 <choose>
                   <if type="map">
-                    <text macro="collection-title" prefix=", " font-style="italic"/>
+                    <text macro="collection-title" prefix=". " font-style="italic"/>
                   </if>
                   <else>
-                    <text macro="collection-title" prefix=", "/>
+                    <text macro="collection-title" prefix=". "/>
                   </else>
                 </choose>
               </group>
@@ -615,59 +604,19 @@
           <text macro="archive-note"/>
           <text macro="access-note"/>
         </if>
-        <else-if variable="author editor" match="all">
-          <choose>
-            <if type="article-journal chapter paper-conference entry-dictionary entry-encyclopedia map" match="any">
-              <group>
-                <text macro="author" text-case="capitalize-first"/>
-                <text macro="title-note"/>
-                <text macro="editor-translator" prefix=". " text-case="capitalize-first"/>
-                <text macro="container-title-note" prefix=", "/>
-                <text macro="volume" prefix=" "/>
-                <choose>
-                  <if type="map">
-                    <text macro="collection-title" prefix=", " font-style="italic"/>
-                  </if>
-                  <else>
-                    <text macro="collection-title" prefix=", "/>
-                  </else>
-                </choose>
-              </group>
-              <text macro="issue-note"/>
-              <text macro="locators-newspaper" prefix=", "/>
-              <text macro="point-locators"/>
-              <text macro="access-note"/>
-            </if>
-            <else-if type="personal_communication" match="any">
-              <group>
-                <text macro="author" text-case="capitalize-first"/>
-                <text macro="title-note"/>
-                <text macro="volume" prefix=" "/>
-                <text macro="editor-translator" prefix=". " text-case="capitalize-first"/>
-                <text macro="container-title-note" prefix=", "/>
-                <text macro="collection-title" prefix=", "/>
-              </group>
-              <text macro="issue-note"/>
-              <text macro="locators-newspaper" prefix=", "/>
-              <text macro="point-locators"/>
-              <text macro="access-note"/>
-              <text term="letter" prefix=". [" suffix="]" text-case="capitalize-first"/>
-            </else-if>
-            <else>
-              <group>
-                <text macro="author" text-case="capitalize-first"/>
-                <text macro="title-note"/>
-                <text macro="volume" prefix=" "/>
-                <text macro="editor-translator" prefix=". " text-case="capitalize-first"/>
-                <text macro="container-title-note" prefix=", "/>
-                <text macro="collection-title" prefix=", "/>
-              </group>
-              <text macro="issue-note"/>
-              <text macro="locators-newspaper" prefix=", "/>
-              <text macro="point-locators"/>
-              <text macro="access-note"/>
-            </else>
-          </choose>
+        <else-if type="book" variable="author editor" match="all">
+          <group>
+            <text macro="author" text-case="capitalize-first"/>
+            <text macro="title-note"/>
+            <text macro="volume" prefix=" "/>
+            <text macro="editor-translator" prefix=". " text-case="capitalize-first"/>
+            <text macro="container-title-note" prefix=", "/>
+            <text macro="collection-title" prefix=". "/>
+          </group>
+          <text macro="issue-note"/>
+          <text macro="locators-newspaper" prefix=", "/>
+          <text macro="point-locators"/>
+          <text macro="access-note"/>
         </else-if>
         <else>
           <choose>
@@ -679,10 +628,10 @@
                 <text macro="volume" prefix=" "/>
                 <choose>
                   <if type="map">
-                    <text macro="collection-title" prefix=", " font-style="italic"/>
+                    <text macro="collection-title" prefix=". " font-style="italic"/>
                   </if>
                   <else>
-                    <text macro="collection-title" prefix=", "/>
+                    <text macro="collection-title" prefix=". "/>
                   </else>
                 </choose>
               </group>

--- a/de-buck.csl
+++ b/de-buck.csl
@@ -8,7 +8,7 @@
     <link href="http://forums.zotero.org/discussion/13964/style-sheet-de-buck/" rel="documentation"/>
     <author>
       <name>Rombert Stapel</name>
-      <email>r.j.stapel@hum.leidenuniv.nl</email>
+      <email>rombert.stapel@iisg.nl</email>
     </author>
     <contributor>
       <name>Rintze Zelle</name>
@@ -31,388 +31,775 @@
         <multiple>eds.</multiple>
       </term>
       <term name="edition" form="short">druk</term>
+      <term name="translator" form="verb-short">(vert.)</term>
       <term name="volume" form="short">
         <single>dl.</single>
         <multiple>dls.</multiple>
       </term>
       <term name="at">aldaar</term>
       <term name="note" form="short">noot</term>
+      <term name="folio" form="short">
+        <single>f.</single>
+        <multiple>ff.</multiple>
+      </term>
+      <term name="letter">persoonlijke correspondentie</term>
     </terms>
   </locale>
   <macro name="author">
-    <names variable="author">
-      <name name-as-sort-order="first" and="text" sort-separator=", " delimiter=", " delimiter-precedes-last="always"/>
-      <label form="short" prefix=", "/>
-      <substitute>
-        <names variable="editor"/>
-        <names variable="translator"/>
-        <text macro="title-note"/>
-      </substitute>
-    </names>
-  </macro>
-  <macro name="contributors-note">
-    <names variable="author">
-      <name and="text" sort-separator=", " delimiter=", " delimiter-precedes-last="never"/>
-      <label form="short" prefix=", "/>
-      <substitute>
-        <names variable="editor"/>
-        <names variable="translator"/>
-        <text macro="title-note"/>
-      </substitute>
-    </names>
-    <text macro="recipient-note"/>
-  </macro>
-  <macro name="title-note">
-    <choose>
-      <if type="bill book graphic legal_case motion_picture report song" match="any">
-        <text variable="title" font-style="italic"/>
-      </if>
-      <else-if type="manuscript"/>
-      <else>
-        <text variable="title" prefix="‘" suffix="’"/>
-      </else>
-    </choose>
-  </macro>
-  <macro name="editor-translator">
-    <group delimiter=", ">
-      <names variable="editor" delimiter=", ">
-        <name and="text" delimiter=", " delimiter-precedes-last="never"/>
-        <label form="short" prefix=" "/>
-      </names>
-      <choose>
-        <if variable="author editor" match="any">
-          <names variable="translator" delimiter=", ">
-            <label form="short"/>
-            <name and="text" delimiter=", " delimiter-precedes-last="never"/>
-          </names>
-        </if>
-      </choose>
-    </group>
-  </macro>
-  <macro name="collection-title">
-    <text variable="collection-title"/>
-    <text variable="collection-number" prefix=" "/>
-  </macro>
-  <macro name="locators-note">
-    <choose>
-      <if type="article-journal">
-        <text variable="volume"/>
-      </if>
-      <else-if type="bill book graphic legal_case motion_picture report song chapter paper-conference" match="any">
-        <text variable="volume" form="short"/>
-      </else-if>
-    </choose>
-  </macro>
-  <macro name="volume">
-    <choose>
-      <if type="article-journal">
-        <text variable="volume"/>
-      </if>
-      <else-if type="bill book graphic legal_case motion_picture report song chapter paper-conference" match="any">
-        <text variable="volume" form="short"/>
-      </else-if>
-    </choose>
-  </macro>
-  <macro name="issue-note">
-    <choose>
-      <if type="article-journal">
-        <text macro="issued" prefix=" (" suffix=")"/>
-      </if>
-      <else-if variable="publisher-place publisher" match="any">
-        <group prefix=" (" suffix=")" delimiter=" ">
-          <text macro="edition-note" suffix=";"/>
-          <group delimiter=" ">
+        <names variable="author" suffix=", ">
+            <name name-as-sort-order="first" and="text" sort-separator=", " delimiter=", "
+                delimiter-precedes-last="after-inverted-name"
+                delimiter-precedes-et-al="after-inverted-name"/>
+            <label form="short" prefix=", " suffix="." strip-periods="true"/>
+            <substitute>
+                <names variable="editor" suffix=", ">
+                    <name name-as-sort-order="first" and="text" delimiter=", "
+                        delimiter-precedes-last="after-inverted-name"
+                        delimiter-precedes-et-al="after-inverted-name"/>
+                    <label form="verb-short" text-case="lowercase" prefix=" " suffix="."
+                        strip-periods="true"/>
+                </names>
+                <names variable="container-author" suffix=", ">
+                    <name name-as-sort-order="first" and="text" delimiter=", "
+                        delimiter-precedes-last="after-inverted-name"
+                        delimiter-precedes-et-al="after-inverted-name"/>
+                    <label form="verb-short" text-case="lowercase" prefix=" " suffix="."
+                        strip-periods="true"/>
+                </names>
+                <names variable="translator" suffix=", ">
+                    <name name-as-sort-order="first" and="text" delimiter=", "
+                        delimiter-precedes-last="after-inverted-name"
+                        delimiter-precedes-et-al="after-inverted-name"/>
+                    <label form="verb-short" prefix=" " text-case="lowercase" strip-periods="false"
+                    />
+                </names>
+                <text macro="title-note"/>
+            </substitute>
+        </names>
+        <text macro="recipient-note" suffix=", "/>
+        <text macro="interviewer-note" suffix=", "/>
+    </macro>
+
+    <macro name="contributors-note">
+        <choose>
+            <if variable="author recipient">
+                <names variable="author">
+                    <name and="text" sort-separator=", " delimiter=", "
+                        delimiter-precedes-last="never"/>
+                </names>
+                <text macro="recipient-note" prefix=", " suffix=", "/>
+            </if>
+            <else-if variable="author interviewer">
+                <names variable="author">
+                    <name and="text" sort-separator=", " delimiter=", "
+                        delimiter-precedes-last="never"/>
+                </names>
+                <text macro="interviewer-note" prefix=", " suffix=", "/>
+            </else-if>
+            <else>
+                <names variable="author" suffix=", ">
+                    <name and="text" sort-separator=", " delimiter=", "
+                        delimiter-precedes-last="never"/>
+                    <substitute>
+                        <names variable="editor" suffix=", ">
+                            <name and="text" delimiter=", " delimiter-precedes-last="never"/>
+                            <label form="verb-short" text-case="lowercase" prefix=" " suffix="."
+                                strip-periods="true"/>
+                        </names>
+                        <names variable="container-author" suffix=", ">
+                            <name and="text" delimiter=", " delimiter-precedes-last="never"/>
+                            <label form="verb-short" text-case="lowercase" prefix=" " suffix="."
+                                strip-periods="true"/>
+                        </names>
+                        <names variable="translator" suffix=", ">
+                            <name and="text" delimiter=", " delimiter-precedes-last="never"/>
+                            <label form="verb-short" text-case="lowercase" prefix=" "
+                                strip-periods="false"/>
+                        </names>
+                        <text macro="title-note"/>
+                    </substitute>
+                </names>
+                <text macro="recipient-note" suffix=", "/>
+                <text macro="interviewer-note" suffix=", "/>
+            </else>
+        </choose>
+    </macro>
+
+    <macro name="title-note">
+        <choose>
+            <if type="bill book graphic legal_case motion_picture report song" match="any">
+                <text variable="title" font-style="italic"/>
+            </if>
+            <else-if type="manuscript"/>
+            <else-if type="thesis speech article">
+                <text variable="title"/>
+            </else-if>
+            <else>
+                <text variable="title" prefix="&#8216;" suffix="&#8217;"/>
+            </else>
+        </choose>
+    </macro>
+
+    <macro name="editor-translator">
+        <group delimiter=", ">
+            <names variable="editor" delimiter=", ">
+                <name and="text" delimiter=", " delimiter-precedes-last="never"/>
+                <label form="verb-short" text-case="lowercase" prefix=" " suffix="."
+                    strip-periods="true"/>
+            </names>
+            <names variable="container-author" delimiter=", ">
+                <name and="text" delimiter=", " delimiter-precedes-last="never"/>
+                <label form="verb-short" text-case="lowercase" prefix=" " suffix="."
+                    strip-periods="true"/>
+            </names>
             <choose>
-              <if variable="title" match="none"/>
-              <else-if type="thesis speech" match="any">
-                <text variable="genre" prefix=" "/>
-              </else-if>
+                <if variable="author editor" match="any">
+                    <names variable="translator" delimiter=", ">
+                        <name and="text" delimiter=", " delimiter-precedes-last="never"/>
+                        <label form="verb-short" text-case="lowercase" prefix=" "
+                            strip-periods="false"/>
+                    </names>
+                </if>
             </choose>
-            <text macro="event"/>
-          </group>
-          <text macro="publisher"/>
-          <text macro="issued"/>
         </group>
-      </else-if>
-      <else>
-        <text macro="issued" prefix=" (" suffix=")"/>
-      </else>
-    </choose>
-  </macro>
-  <macro name="container-title-note">
-    <choose>
-      <if type="chapter paper-conference" match="any">
-        <text term="in" text-case="lowercase" suffix=": "/>
-        <text macro="editor-translator" suffix=", "/>
-      </if>
-    </choose>
-    <text variable="container-title" font-style="italic"/>
-  </macro>
-  <macro name="edition-note">
-    <choose>
-      <if type="bill book graphic legal_case motion_picture report song chapter paper-conference" match="any">
+    </macro>
+
+    <macro name="collection-title">
+        <text variable="collection-title"/>
+        <text variable="collection-number" prefix=" "/>
+    </macro>
+
+    <macro name="locators-note">
         <choose>
-          <if is-numeric="edition">
-            <group delimiter=" ">
-              <number variable="edition" form="ordinal"/>
-              <text term="edition" form="short" strip-periods="true"/>
-            </group>
-          </if>
-          <else>
-            <text variable="edition"/>
-          </else>
+            <if type="article-journal">
+                <text variable="volume"/>
+            </if>
+            <else>
+                <text variable="volume" form="short"/>
+            </else>
         </choose>
-      </if>
-    </choose>
-  </macro>
-  <macro name="recipient-note">
-    <names variable="recipient" delimiter=", ">
-      <label form="verb" prefix=" " text-case="lowercase" suffix=" "/>
-      <name and="text" delimiter=", "/>
-    </names>
-  </macro>
-  <macro name="recipient-short">
-    <names variable="recipient">
-      <label form="verb" prefix=" " text-case="lowercase" suffix=" "/>
-      <name form="short" and="text" delimiter=", "/>
-    </names>
-  </macro>
-  <macro name="contributors-short">
-    <names variable="author">
-      <name form="short" and="text" sort-separator=", " delimiter=", " delimiter-precedes-last="never"/>
-      <substitute>
-        <names variable="editor"/>
-        <names variable="translator"/>
-      </substitute>
-    </names>
-    <text macro="recipient-short"/>
-  </macro>
-  <macro name="locators-newspaper">
-    <choose>
-      <if type="article-newspaper">
+    </macro>
+
+    <macro name="volume">
+        <choose>
+            <if type="article-journal">
+                <text variable="volume"/>
+            </if>
+            <else>
+                <text variable="volume" form="short"/>
+            </else>
+        </choose>
+    </macro>
+
+    <macro name="issue-note">
+        <choose>
+            <if type="article-journal">
+                <text macro="issued" prefix=" (" suffix=")"/>
+            </if>
+            <else-if variable="publisher-place publisher" match="any">
+                <group prefix=" (" suffix=")" delimiter=" ">
+                    <text macro="edition-note" suffix=";"/>
+                    <group delimiter=" ">
+                        <choose>
+                            <if variable="title" match="none"/>
+                            <else-if type="thesis">
+                                <text variable="genre" prefix="unpublished " suffix=","/>
+                                <text macro="publisher"/>
+                                <text macro="issued"/>
+                            </else-if>
+                            <else-if type="speech">
+                                <text variable="genre" prefix="" suffix=","/>
+                                <text macro="event"/>
+                                <text macro="issued"/>
+                            </else-if>
+                            <else>
+                                <text macro="publisher"/>
+                                <text macro="issued"/>
+                            </else>
+                        </choose>
+                    </group>
+                </group>
+            </else-if>
+            <else>
+                <text macro="issued" prefix=" (" suffix=")"/>
+            </else>
+        </choose>
+    </macro>
+
+    <macro name="container-title-note">
+        <choose>
+            <if type="chapter paper-conference map" match="any">
+                <text term="in" text-case="lowercase" suffix=": "/>
+                <text macro="editor-translator" suffix=", "/>
+            </if>
+        </choose>
+        <text variable="container-title" font-style="italic"/>
+    </macro>
+
+    <macro name="edition-note">
+        <choose>
+            <if
+                type="bill book graphic legal_case motion_picture report song chapter paper-conference map"
+                match="any">
+                <choose>
+                    <if is-numeric="edition">
+                        <group delimiter=" ">
+                            <number variable="edition" form="ordinal"/>
+                            <text term="edition" form="short" strip-periods="true"/>
+                        </group>
+                    </if>
+                    <else>
+                        <text variable="edition"/>
+                    </else>
+                </choose>
+            </if>
+        </choose>
+    </macro>
+
+    <macro name="recipient-note">
+        <names variable="recipient" delimiter=", ">
+            <label form="verb" prefix=" " text-case="lowercase" suffix=" "/>
+            <name and="text" delimiter=", " delimiter-precedes-last="never"/>
+        </names>
+    </macro>
+
+    <macro name="recipient-short">
+        <names variable="recipient" delimiter=", ">
+            <label form="verb" prefix=" " text-case="lowercase" suffix=" "/>
+            <name form="short" and="text" delimiter=", " delimiter-precedes-last="never"/>
+        </names>
+    </macro>
+
+    <macro name="contributors-short">
+        <choose>
+            <if variable="author recipient">
+                <names variable="author">
+                    <name form="short" and="text" sort-separator=", " delimiter=", "
+                        delimiter-precedes-last="never">
+                        <name-part name="family" text-case="capitalize-first"/>
+                    </name>
+                </names>
+                <text macro="recipient-short" prefix=", " suffix=", "/>
+            </if>
+            <else-if variable="author interviewer">
+                <names variable="author">
+                    <name form="short" and="text" sort-separator=", " delimiter=", "
+                        delimiter-precedes-last="never">
+                        <name-part name="family" text-case="capitalize-first"/>
+                    </name>
+                </names>
+                <text macro="interviewer-short" prefix=", " suffix=", "/>
+            </else-if>
+            <else>
+                <names variable="author" suffix=", ">
+                    <name form="short" and="text" sort-separator=", " delimiter=", "
+                        delimiter-precedes-last="never">
+                        <name-part name="family" text-case="capitalize-first"/>
+                    </name>
+                    <substitute>
+                        <names variable="editor" suffix=", ">
+                            <name form="short" and="text" sort-separator=", " delimiter=", "
+                                delimiter-precedes-last="never">
+                                <name-part name="family" text-case="capitalize-first"/>
+                            </name>
+                            <label form="verb-short" prefix=" " suffix="." strip-periods="true"/>
+                        </names>
+                        <names variable="translator" suffix=", ">
+                            <name form="short" and="text" sort-separator=", " delimiter=", "
+                                delimiter-precedes-last="never">
+                                <name-part name="family" text-case="capitalize-first"/>
+                            </name>
+                            <label form="verb-short" prefix=" " suffix="" strip-periods="false"/>
+                        </names>
+                    </substitute>
+                </names>
+                <text macro="recipient-short" suffix=", "/>
+                <text macro="interviewer-short" suffix=", "/>
+            </else>
+        </choose>
+    </macro>
+
+    <macro name="interviewer-note">
+        <names variable="interviewer" delimiter=", ">
+            <label form="verb" prefix=" " text-case="lowercase" suffix=" "/>
+            <name and="text" delimiter=", " delimiter-precedes-last="never"/>
+        </names>
+    </macro>
+
+    <macro name="interviewer-short">
+        <names variable="interviewer" delimiter=", ">
+            <label form="verb" prefix=" " text-case="lowercase" suffix=" "/>
+            <name form="short" and="text" delimiter=", " delimiter-precedes-last="never"/>
+        </names>
+    </macro>
+
+    <macro name="locators-newspaper">
+        <choose>
+            <if type="article-newspaper">
+                <group delimiter=", ">
+                    <group>
+                        <text variable="edition" suffix=" "/>
+                        <text term="edition" prefix=" "/>
+                    </group>
+                    <group>
+                        <text term="section" suffix=" "/>
+                        <text variable="section" suffix=","/>
+                    </group>
+                </group>
+            </if>
+        </choose>
+    </macro>
+
+    <macro name="event">
+        <group>
+            <text term="presented at" suffix=" "/>
+            <text variable="event"/>
+        </group>
+    </macro>
+
+    <macro name="publisher">
+        <group delimiter=": ">
+            <text variable="publisher-place"/>
+            <text variable="publisher"/>
+        </group>
+    </macro>
+
+    <macro name="issued">
+        <choose>
+            <if type="graphic report article-newspaper personal_communication speech" match="any">
+                <choose>
+                    <if match="any" variable="note">
+                        <text variable="note"/>
+                    </if>
+                    <else>
+                        <date variable="issued">
+                            <date-part name="day" suffix=" "/>
+                            <date-part name="month" suffix=" "/>
+                            <date-part name="year"/>
+                        </date>
+                    </else>
+                </choose>
+            </if>
+            <else>
+                <choose>
+                    <if match="any" variable="note">
+                        <text variable="note"/>
+                    </if>
+                    <else>
+                        <date variable="issued">
+                            <date-part name="year"/>
+                        </date>
+                    </else>
+                </choose>
+            </else>
+        </choose>
+    </macro>
+
+    <macro name="pages">
+        <choose>
+            <if type="article-journal">
+                <text variable="page" prefix=" "/>
+            </if>
+            <else>
+                <choose>
+                    <if variable="volume">
+                        <text variable="page" prefix=" "/>
+                    </if>
+                    <else>
+                        <text variable="page" prefix=" "/>
+                    </else>
+                </choose>
+            </else>
+        </choose>
+    </macro>
+
+
+    <macro name="point-locators">
+        <text macro="pages"/>
+        <choose>
+            <if
+                type="chapter paper-conference article-journal article-magazine article-newspaper entry-dictionary entry-encyclopedia article"
+                match="any">
+                <choose>
+                    <if locator="page">
+                        <group prefix=", ">
+                            <text term="at" suffix=" "/>
+                            <text variable="locator"/>
+                        </group>
+                    </if>
+                    <else-if locator="folio">
+                        <group prefix=", ">
+                            <text term="at" suffix=" "/>
+                            <label variable="locator" form="short" prefix=" " suffix=" "/>
+                            <text variable="locator"/>
+                        </group>
+                    </else-if>
+                    <else-if locator="note">
+                        <group prefix=", ">
+                            <text term="at" suffix=" "/>
+                            <text variable="locator"/>
+                        </group>
+                    </else-if>
+                    <else>
+                        <group prefix=", ">
+                            <text term="at" prefix=" " suffix=" "/>
+                            <text variable="locator"/>
+                        </group>
+                    </else>
+                </choose>
+            </if>
+            <else-if type="manuscript">
+                <choose>
+                    <if locator="page">
+                        <text variable="locator"/>
+                    </if>
+                    <else>
+                        <label variable="locator" form="short" suffix=" "/>
+                        <text variable="locator"/>
+                    </else>
+                </choose>
+            </else-if>
+            <else>
+                <choose>
+                    <if locator="folio">
+                        <label variable="locator" form="short" prefix=" " suffix=" "/>
+                        <text variable="locator"/>
+                    </if>
+                    <else>
+                        <text variable="locator" prefix=" "/>
+                    </else>
+                </choose>
+            </else>
+        </choose>
+    </macro>
+
+    <macro name="archive-note">
         <group delimiter=", ">
-          <group delimiter=" ">
-            <text variable="edition"/>
-            <text term="edition"/>
-          </group>
-          <group>
-            <text term="section" suffix=" "/>
-            <text variable="section"/>
-          </group>
+            <text variable="publisher-place"/>
+            <text variable="archive"/>
+            <text variable="archive_location"/>
         </group>
-      </if>
-    </choose>
-  </macro>
-  <macro name="event">
-    <group>
-      <text term="presented at" suffix=" "/>
-      <text variable="event"/>
-    </group>
-  </macro>
-  <macro name="publisher">
-    <group delimiter=": ">
-      <text variable="publisher-place"/>
-      <text variable="publisher"/>
-    </group>
-  </macro>
-  <macro name="issued">
-    <choose>
-      <if type="graphic report article-newspaper" match="any">
-        <date variable="issued">
-          <date-part name="day" suffix=" "/>
-          <date-part name="month" suffix=" "/>
-          <date-part name="year"/>
-        </date>
-      </if>
-      <else-if type="bill book graphic legal_case motion_picture report song thesis chapter paper-conference" match="any">
-        <date variable="issued">
-          <date-part name="year"/>
-        </date>
-      </else-if>
-      <else>
-        <date variable="issued">
-          <date-part name="year"/>
-        </date>
-      </else>
-    </choose>
-  </macro>
-  <macro name="pages">
-    <choose>
-      <if type="article-journal">
-        <text variable="page" prefix=" "/>
-      </if>
-      <else>
-        <choose>
-          <if variable="volume">
-            <text variable="page" prefix=" "/>
-          </if>
-          <else>
-            <text variable="page" prefix=" "/>
-          </else>
-        </choose>
-      </else>
-    </choose>
-  </macro>
-  <macro name="point-locators">
-    <text macro="pages"/>
-    <choose>
-      <if type="chapter paper-conference article-journal article-magazine article-newspaper" match="any">
-        <choose>
-          <if variable="page">
-            <group prefix=", ">
-              <text term="at" suffix=" "/>
-              <text variable="locator"/>
-            </group>
-          </if>
-          <else-if variable="note">
-            <group prefix=", ">
-              <text term="at" suffix=" "/>
-              <text variable="locator"/>
-            </group>
-          </else-if>
-          <else>
-            <text term="at" suffix=" "/>
-            <text variable="locator"/>
-          </else>
-        </choose>
-      </if>
-      <else-if type="bill book graphic legal_case motion_picture report song thesis webpage" match="any">
-        <text variable="locator" prefix=" "/>
-      </else-if>
-      <else-if type=" manuscript" match="any">
-        <label variable="locator" form="short" suffix=" "/>
-        <text variable="locator"/>
-      </else-if>
-    </choose>
-  </macro>
-  <macro name="archive-note">
-    <group delimiter=", ">
-      <text variable="publisher-place"/>
-      <text variable="archive"/>
-      <text variable="archive_location"/>
-    </group>
-  </macro>
-  <macro name="access-note">
-    <group delimiter=", ">
-      <choose>
-        <if type="graphic report" match="any">
-          <text macro="archive-note" prefix=", "/>
-        </if>
-        <else-if type="bill book graphic legal_case motion_picture report song article-journal article-magazine article-newspaper thesis chapter paper-conference entry-encyclopedia entry-dictionary" match="none">
-          <text macro="archive-note" prefix=", "/>
-        </else-if>
-      </choose>
-    </group>
-    <choose>
-      <if variable="DOI">
-        <text variable="DOI" prefix=" &lt;doi:" suffix="&gt;"/>
-      </if>
-      <else>
-        <text variable="URL" prefix=" &lt;" suffix="&gt;"/>
-        <group prefix=" [" suffix="]">
-          <text term="accessed" text-case="lowercase"/>
-          <date variable="accessed">
-            <date-part name="day" prefix=" "/>
-            <date-part name="month" prefix=" "/>
-            <date-part name="year" prefix=" "/>
-          </date>
-        </group>
-      </else>
-    </choose>
-  </macro>
-  <macro name="short-title-note">
-    <choose>
-      <if type="bill book graphic legal_case motion_picture report song" match="any">
-        <text variable="title" font-style="italic" form="short"/>
-        <text macro="locators-note" prefix=" "/>
-      </if>
-      <else-if type="manuscript">
+    </macro>
+
+    <macro name="access-note">
         <group delimiter=", ">
-          <text variable="publisher-place"/>
-          <text variable="title" form="short"/>
-          <text variable="archive_location"/>
+            <choose>
+                <if
+                    type="book article-journal article-magazine thesis chapter manuscript paper-conference entry-encyclopedia entry-dictionary"
+                    match="none">
+                    <group delimiter=", " prefix=", ">
+                        <text variable="archive"/>
+                        <text variable="archive_location"/>
+                    </group>
+                </if>
+            </choose>
         </group>
-      </else-if>
-      <else>
-        <text variable="title" prefix="‘" suffix="’" form="short"/>
-      </else>
-    </choose>
-  </macro>
-  <macro name="point-locators-subsequent">
-    <choose>
-      <if variable="page">
-        <text variable="locator"/>
-      </if>
-      <else-if type=" manuscript" match="any">
-        <label variable="locator" form="short" suffix=" "/>
-        <text variable="locator"/>
-      </else-if>
-      <else>
-        <text variable="locator"/>
-      </else>
-    </choose>
-  </macro>
-  <citation et-al-min="4" et-al-use-first="1" disambiguate-add-names="true" disambiguate-add-givenname="true">
-    <layout suffix="." delimiter="; ">
-      <choose>
-        <if position="ibid-with-locator">
-          <group delimiter=", ">
-            <text term="ibid" text-case="capitalize-first"/>
-            <text macro="point-locators-subsequent"/>
-          </group>
-        </if>
-        <else-if position="ibid">
-          <text term="ibid" text-case="capitalize-first"/>
-        </else-if>
-        <else-if position="subsequent">
-          <text macro="contributors-short" suffix=", "/>
-          <text macro="short-title-note"/>
-          <text macro="point-locators-subsequent" prefix=", "/>
-        </else-if>
-        <else-if type="manuscript">
-          <text macro="archive-note"/>
-          <text macro="point-locators" prefix=", "/>
-        </else-if>
-        <else>
-          <group>
-            <text macro="contributors-note" suffix=", "/>
-            <text macro="title-note"/>
-            <text macro="container-title-note" prefix=", "/>
-            <text macro="collection-title" prefix=". "/>
-            <text macro="locators-note" prefix=" "/>
-          </group>
-          <text macro="issue-note"/>
-          <text macro="locators-newspaper" prefix=", "/>
-          <text macro="point-locators"/>
-          <text macro="access-note"/>
-        </else>
-      </choose>
-    </layout>
-  </citation>
-  <bibliography hanging-indent="true" et-al-min="4" et-al-use-first="1" subsequent-author-substitute="&#8212;&#8212;&#8212;">
-    <sort>
-      <key macro="author"/>
-      <key variable="title"/>
-    </sort>
-    <layout suffix=".">
-      <choose>
-        <if type="manuscript">
-          <text macro="archive-note"/>
-        </if>
-        <else>
-          <group>
-            <text macro="author" suffix=", "/>
-            <text macro="title-note"/>
-            <text macro="container-title-note" prefix=", "/>
-            <text macro="collection-title" prefix=". "/>
-            <text macro="volume" prefix=" "/>
-          </group>
-          <text macro="issue-note"/>
-          <text macro="locators-newspaper" prefix=", "/>
-          <text macro="pages"/>
-          <text macro="access-note"/>
-        </else>
-      </choose>
-    </layout>
-  </bibliography>
+        <choose>
+            <if variable="DOI">
+                <text variable="DOI" prefix=" &lt;doi:" suffix="&gt;"/>
+            </if>
+            <else>
+                <text variable="URL" prefix=" &lt;" suffix="&gt;"/>
+                <group prefix=" [" suffix="]">
+                    <text term="accessed" text-case="lowercase"/>
+                    <date variable="accessed">
+                        <date-part name="day" prefix=" "/>
+                        <date-part name="month" prefix=" "/>
+                        <date-part name="year" prefix=" "/>
+                    </date>
+                </group>
+            </else>
+        </choose>
+    </macro>
+
+    <macro name="short-title-note">
+        <choose>
+            <if type="bill book graphic legal_case motion_picture report song" match="any">
+                <text variable="title" font-style="italic" form="short"/>
+                <text macro="locators-note" prefix=" "/>
+            </if>
+            <else-if type="manuscript">
+                <group delimiter=", ">
+                    <text variable="publisher-place"/>
+                    <text variable="title" form="short"/>
+                    <text variable="archive_location"/>
+                </group>
+            </else-if>
+            <else-if type="thesis speech article">
+                <text variable="title" form="short"/>
+            </else-if>
+            <else>
+                <text variable="title" prefix="&#8216;" suffix="&#8217;" form="short"/>
+            </else>
+        </choose>
+    </macro>
+
+    <macro name="point-locators-subsequent">
+        <choose>
+            <if locator="page">
+                <text variable="locator"/>
+            </if>
+            <else-if locator="folio">
+                <label variable="locator" form="short" suffix=" "/>
+                <text variable="locator"/>
+            </else-if>
+            <else-if type="manuscript">
+                <choose>
+                    <if locator="page">
+                        <text variable="locator"/>
+                    </if>
+                    <else>
+                        <label variable="locator" form="short" suffix=" "/>
+                        <text variable="locator"/>
+                    </else>
+                </choose>
+            </else-if>
+            <else>
+                <text variable="locator"/>
+            </else>
+        </choose>
+    </macro>
+
+    <citation et-al-min="4" et-al-use-first="1" et-al-subsequent-min="4"
+        et-al-subsequent-use-first="1" disambiguate-add-names="true"
+        disambiguate-add-givenname="true">
+        <layout prefix="" suffix="." delimiter="; ">
+            <choose>
+                <if position="ibid-with-locator">
+                    <group delimiter=", ">
+                        <text term="ibid" text-case="capitalize-first"/>
+                        <text macro="point-locators-subsequent"/>
+                    </group>
+                </if>
+                <else-if position="ibid">
+                    <text term="ibid" text-case="capitalize-first"/>
+                </else-if>
+                <else-if position="subsequent">
+                    <text macro="contributors-short" text-case="capitalize-first"/>
+                    <text macro="short-title-note"/>
+                    <text macro="point-locators-subsequent" prefix=", "/>
+                </else-if>
+                <else-if type="manuscript">
+                    <text macro="archive-note"/>
+                    <text macro="point-locators" prefix=", "/>
+                    <text macro="access-note"/>
+                </else-if>
+                <else-if variable="author editor" match="all">
+                    <choose>
+                        <if
+                            type="article-journal chapter paper-conference entry-dictionary entry-encyclopedia map"
+                            match="any">
+                            <group>
+                                <text macro="contributors-note" text-case="capitalize-first"/>
+                                <text macro="title-note"/>
+                                <text macro="editor-translator" prefix=". "/>
+                                <text macro="container-title-note" prefix=", "/>
+                                <text macro="locators-note" prefix=" "/>
+                                <choose>
+                                    <if type="map">
+                                        <text macro="collection-title" prefix=", "
+                                            font-style="italic"/>
+                                    </if>
+                                    <else>
+                                        <text macro="collection-title" prefix=", "/>
+                                    </else>
+                                </choose>
+                            </group>
+                            <text macro="issue-note"/>
+                            <text macro="locators-newspaper" prefix=", "/>
+                            <text macro="point-locators"/>
+                            <text macro="access-note"/>
+                        </if>
+                        <else>
+                            <group>
+                                <text macro="contributors-note" text-case="capitalize-first"/>
+                                <text macro="title-note"/>
+                                <text macro="locators-note" prefix=" "/>
+                                <text macro="editor-translator" prefix=". "/>
+                                <text macro="container-title-note" prefix=", "/>
+                                <text macro="collection-title" prefix=", "/>
+                            </group>
+                            <text macro="issue-note"/>
+                            <text macro="locators-newspaper" prefix=", "/>
+                            <text macro="point-locators"/>
+                            <text macro="access-note"/>
+                        </else>
+                    </choose>
+                </else-if>
+                <else>
+                    <choose>
+                        <if
+                            type="article-journal chapter paper-conference entry-dictionary entry-encyclopedia map"
+                            match="any">
+                            <group>
+                                <text macro="contributors-note" text-case="capitalize-first"/>
+                                <text macro="title-note"/>
+                                <text macro="container-title-note" prefix=", "/>
+                                <text macro="locators-note" prefix=" "/>
+                                <choose>
+                                    <if type="map">
+                                        <text macro="collection-title" prefix=", "
+                                            font-style="italic"/>
+                                    </if>
+                                    <else>
+                                        <text macro="collection-title" prefix=", "/>
+                                    </else>
+                                </choose>
+                            </group>
+                            <text macro="issue-note"/>
+                            <text macro="locators-newspaper" prefix=", "/>
+                            <text macro="point-locators"/>
+                            <text macro="access-note"/>
+                        </if>
+                        <else>
+                            <group>
+                                <text macro="contributors-note" text-case="capitalize-first"/>
+                                <text macro="title-note"/>
+                                <text macro="locators-note" prefix=" "/>
+                                <text macro="container-title-note" prefix=", "/>
+                                <text macro="collection-title" prefix=". "/>
+                            </group>
+                            <text macro="issue-note"/>
+                            <text macro="locators-newspaper" prefix=", "/>
+                            <text macro="point-locators"/>
+                            <text macro="access-note"/>
+                        </else>
+                    </choose>
+                </else>
+            </choose>
+        </layout>
+    </citation>
+
+    <bibliography hanging-indent="true" et-al-min="4" et-al-use-first="1"
+        subsequent-author-substitute="---" subsequent-author-substitute-rule="partial-each"
+        entry-spacing="1" line-spacing="1">
+        <sort>
+            <key macro="author"/>
+            <key variable="title"/>
+        </sort>
+        <layout suffix=".">
+            <choose>
+                <if type="manuscript">
+                    <text macro="archive-note"/>
+                    <text macro="access-note"/>
+                </if>
+                <else-if variable="author editor" match="all">
+                    <choose>
+                        <if
+                            type="article-journal chapter paper-conference entry-dictionary entry-encyclopedia map"
+                            match="any">
+                            <group>
+                                <text macro="author" text-case="capitalize-first"/>
+                                <text macro="title-note"/>
+                                <text macro="editor-translator" prefix=". "
+                                    text-case="capitalize-first"/>
+                                <text macro="container-title-note" prefix=", "/>
+                                <text macro="volume" prefix=" "/>
+                                <choose>
+                                    <if type="map">
+                                        <text macro="collection-title" prefix=", "
+                                            font-style="italic"/>
+                                    </if>
+                                    <else>
+                                        <text macro="collection-title" prefix=", "/>
+                                    </else>
+                                </choose>
+                            </group>
+                            <text macro="issue-note"/>
+                            <text macro="locators-newspaper" prefix=", "/>
+                            <text macro="point-locators"/>
+                            <text macro="access-note"/>
+                        </if>
+                        <else-if type="personal_communication" match="any">
+                            <group>
+                                <text macro="author" text-case="capitalize-first"/>
+                                <text macro="title-note"/>
+                                <text macro="volume" prefix=" "/>
+                                <text macro="editor-translator" prefix=". "
+                                    text-case="capitalize-first"/>
+                                <text macro="container-title-note" prefix=", "/>
+                                <text macro="collection-title" prefix=", "/>
+                            </group>
+                            <text macro="issue-note"/>
+                            <text macro="locators-newspaper" prefix=", "/>
+                            <text macro="point-locators"/>
+                            <text macro="access-note"/>
+                            <text term="letter" prefix=". [" suffix="]" text-case="capitalize-first"
+                            />
+                        </else-if>
+                        <else>
+                            <group>
+                                <text macro="author" text-case="capitalize-first"/>
+                                <text macro="title-note"/>
+                                <text macro="volume" prefix=" "/>
+                                <text macro="editor-translator" prefix=". "
+                                    text-case="capitalize-first"/>
+                                <text macro="container-title-note" prefix=", "/>
+                                <text macro="collection-title" prefix=", "/>
+                            </group>
+                            <text macro="issue-note"/>
+                            <text macro="locators-newspaper" prefix=", "/>
+                            <text macro="point-locators"/>
+                            <text macro="access-note"/>
+                        </else>
+                    </choose>
+                </else-if>
+                <else>
+                    <choose>
+                        <if
+                            type="article-journal chapter paper-conference entry-dictionary entry-encyclopedia map"
+                            match="any">
+                            <group>
+                                <text macro="author" text-case="capitalize-first"/>
+                                <text macro="title-note"/>
+                                <text macro="container-title-note" prefix=", "/>
+                                <text macro="volume" prefix=" "/>
+                                <choose>
+                                    <if type="map">
+                                        <text macro="collection-title" prefix=", "
+                                            font-style="italic"/>
+                                    </if>
+                                    <else>
+                                        <text macro="collection-title" prefix=", "/>
+                                    </else>
+                                </choose>
+                            </group>
+                            <text macro="issue-note"/>
+                            <text macro="locators-newspaper" prefix=", "/>
+                            <text macro="pages"/>
+                            <text macro="access-note"/>
+                        </if>
+                        <else-if type="personal_communication">
+                            <group>
+                                <text macro="author" text-case="capitalize-first"/>
+                                <text macro="title-note"/>
+                                <text macro="volume" prefix=" "/>
+                                <text macro="container-title-note" prefix=", "/>
+                                <text macro="collection-title" prefix=". "/>
+                            </group>
+                            <text macro="issue-note"/>
+                            <text macro="locators-newspaper" prefix=", "/>
+                            <text macro="pages"/>
+                            <text macro="access-note"/>
+                            <text term="letter" prefix=". [" suffix="]" text-case="capitalize-first"
+                            />
+                        </else-if>
+                        <else>
+                            <group>
+                                <text macro="author" text-case="capitalize-first"/>
+                                <text macro="title-note"/>
+                                <text macro="volume" prefix=" "/>
+                                <text macro="container-title-note" prefix=", "/>
+                                <text macro="collection-title" prefix=". "/>
+                            </group>
+                            <text macro="issue-note"/>
+                            <text macro="locators-newspaper" prefix=", "/>
+                            <text macro="pages"/>
+                            <text macro="access-note"/>
+                        </else>
+                    </choose>
+                </else>
+            </choose>
+        </layout>
+    </bibliography>
 </style>

--- a/de-buck.csl
+++ b/de-buck.csl
@@ -46,760 +46,681 @@
     </terms>
   </locale>
   <macro name="author">
+    <names variable="author" suffix=", ">
+      <name name-as-sort-order="first" and="text" sort-separator=", " delimiter=", " delimiter-precedes-last="after-inverted-name" delimiter-precedes-et-al="after-inverted-name"/>
+      <label form="short" prefix=", " suffix="." strip-periods="true"/>
+      <substitute>
+        <names variable="editor" suffix=", ">
+          <name name-as-sort-order="first" and="text" delimiter=", " delimiter-precedes-last="after-inverted-name" delimiter-precedes-et-al="after-inverted-name"/>
+          <label form="verb-short" text-case="lowercase" prefix=" " suffix="." strip-periods="true"/>
+        </names>
+        <names variable="container-author" suffix=", ">
+          <name name-as-sort-order="first" and="text" delimiter=", " delimiter-precedes-last="after-inverted-name" delimiter-precedes-et-al="after-inverted-name"/>
+          <label form="verb-short" text-case="lowercase" prefix=" " suffix="." strip-periods="true"/>
+        </names>
+        <names variable="translator" suffix=", ">
+          <name name-as-sort-order="first" and="text" delimiter=", " delimiter-precedes-last="after-inverted-name" delimiter-precedes-et-al="after-inverted-name"/>
+          <label form="verb-short" prefix=" " text-case="lowercase" strip-periods="false"/>
+        </names>
+        <text macro="title-note"/>
+      </substitute>
+    </names>
+    <text macro="recipient-note" suffix=", "/>
+    <text macro="interviewer-note" suffix=", "/>
+  </macro>
+  <macro name="contributors-note">
+    <choose>
+      <if variable="author recipient">
+        <names variable="author">
+          <name and="text" sort-separator=", " delimiter=", " delimiter-precedes-last="never"/>
+        </names>
+        <text macro="recipient-note" prefix=", " suffix=", "/>
+      </if>
+      <else-if variable="author interviewer">
+        <names variable="author">
+          <name and="text" sort-separator=", " delimiter=", " delimiter-precedes-last="never"/>
+        </names>
+        <text macro="interviewer-note" prefix=", " suffix=", "/>
+      </else-if>
+      <else>
         <names variable="author" suffix=", ">
-            <name name-as-sort-order="first" and="text" sort-separator=", " delimiter=", "
-                delimiter-precedes-last="after-inverted-name"
-                delimiter-precedes-et-al="after-inverted-name"/>
-            <label form="short" prefix=", " suffix="." strip-periods="true"/>
-            <substitute>
-                <names variable="editor" suffix=", ">
-                    <name name-as-sort-order="first" and="text" delimiter=", "
-                        delimiter-precedes-last="after-inverted-name"
-                        delimiter-precedes-et-al="after-inverted-name"/>
-                    <label form="verb-short" text-case="lowercase" prefix=" " suffix="."
-                        strip-periods="true"/>
-                </names>
-                <names variable="container-author" suffix=", ">
-                    <name name-as-sort-order="first" and="text" delimiter=", "
-                        delimiter-precedes-last="after-inverted-name"
-                        delimiter-precedes-et-al="after-inverted-name"/>
-                    <label form="verb-short" text-case="lowercase" prefix=" " suffix="."
-                        strip-periods="true"/>
-                </names>
-                <names variable="translator" suffix=", ">
-                    <name name-as-sort-order="first" and="text" delimiter=", "
-                        delimiter-precedes-last="after-inverted-name"
-                        delimiter-precedes-et-al="after-inverted-name"/>
-                    <label form="verb-short" prefix=" " text-case="lowercase" strip-periods="false"
-                    />
-                </names>
-                <text macro="title-note"/>
-            </substitute>
+          <name and="text" sort-separator=", " delimiter=", " delimiter-precedes-last="never"/>
+          <substitute>
+            <names variable="editor" suffix=", ">
+              <name and="text" delimiter=", " delimiter-precedes-last="never"/>
+              <label form="verb-short" text-case="lowercase" prefix=" " suffix="." strip-periods="true"/>
+            </names>
+            <names variable="container-author" suffix=", ">
+              <name and="text" delimiter=", " delimiter-precedes-last="never"/>
+              <label form="verb-short" text-case="lowercase" prefix=" " suffix="." strip-periods="true"/>
+            </names>
+            <names variable="translator" suffix=", ">
+              <name and="text" delimiter=", " delimiter-precedes-last="never"/>
+              <label form="verb-short" text-case="lowercase" prefix=" " strip-periods="false"/>
+            </names>
+            <text macro="title-note"/>
+          </substitute>
         </names>
         <text macro="recipient-note" suffix=", "/>
         <text macro="interviewer-note" suffix=", "/>
-    </macro>
-
-    <macro name="contributors-note">
-        <choose>
-            <if variable="author recipient">
-                <names variable="author">
-                    <name and="text" sort-separator=", " delimiter=", "
-                        delimiter-precedes-last="never"/>
-                </names>
-                <text macro="recipient-note" prefix=", " suffix=", "/>
-            </if>
-            <else-if variable="author interviewer">
-                <names variable="author">
-                    <name and="text" sort-separator=", " delimiter=", "
-                        delimiter-precedes-last="never"/>
-                </names>
-                <text macro="interviewer-note" prefix=", " suffix=", "/>
-            </else-if>
-            <else>
-                <names variable="author" suffix=", ">
-                    <name and="text" sort-separator=", " delimiter=", "
-                        delimiter-precedes-last="never"/>
-                    <substitute>
-                        <names variable="editor" suffix=", ">
-                            <name and="text" delimiter=", " delimiter-precedes-last="never"/>
-                            <label form="verb-short" text-case="lowercase" prefix=" " suffix="."
-                                strip-periods="true"/>
-                        </names>
-                        <names variable="container-author" suffix=", ">
-                            <name and="text" delimiter=", " delimiter-precedes-last="never"/>
-                            <label form="verb-short" text-case="lowercase" prefix=" " suffix="."
-                                strip-periods="true"/>
-                        </names>
-                        <names variable="translator" suffix=", ">
-                            <name and="text" delimiter=", " delimiter-precedes-last="never"/>
-                            <label form="verb-short" text-case="lowercase" prefix=" "
-                                strip-periods="false"/>
-                        </names>
-                        <text macro="title-note"/>
-                    </substitute>
-                </names>
-                <text macro="recipient-note" suffix=", "/>
-                <text macro="interviewer-note" suffix=", "/>
-            </else>
-        </choose>
-    </macro>
-
-    <macro name="title-note">
-        <choose>
-            <if type="bill book graphic legal_case motion_picture report song" match="any">
-                <text variable="title" font-style="italic"/>
-            </if>
-            <else-if type="manuscript"/>
-            <else-if type="thesis speech article">
-                <text variable="title"/>
-            </else-if>
-            <else>
-                <text variable="title" prefix="&#8216;" suffix="&#8217;"/>
-            </else>
-        </choose>
-    </macro>
-
-    <macro name="editor-translator">
-        <group delimiter=", ">
-            <names variable="editor" delimiter=", ">
-                <name and="text" delimiter=", " delimiter-precedes-last="never"/>
-                <label form="verb-short" text-case="lowercase" prefix=" " suffix="."
-                    strip-periods="true"/>
-            </names>
-            <names variable="container-author" delimiter=", ">
-                <name and="text" delimiter=", " delimiter-precedes-last="never"/>
-                <label form="verb-short" text-case="lowercase" prefix=" " suffix="."
-                    strip-periods="true"/>
-            </names>
+      </else>
+    </choose>
+  </macro>
+  <macro name="title-note">
+    <choose>
+      <if type="bill book graphic legal_case motion_picture report song" match="any">
+        <text variable="title" font-style="italic"/>
+      </if>
+      <else-if type="manuscript"/>
+      <else-if type="thesis speech article">
+        <text variable="title"/>
+      </else-if>
+      <else>
+        <text variable="title" prefix="‘" suffix="’"/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="editor-translator">
+    <group delimiter=", ">
+      <names variable="editor" delimiter=", ">
+        <name and="text" delimiter=", " delimiter-precedes-last="never"/>
+        <label form="verb-short" text-case="lowercase" prefix=" " suffix="." strip-periods="true"/>
+      </names>
+      <names variable="container-author" delimiter=", ">
+        <name and="text" delimiter=", " delimiter-precedes-last="never"/>
+        <label form="verb-short" text-case="lowercase" prefix=" " suffix="." strip-periods="true"/>
+      </names>
+      <choose>
+        <if variable="author editor" match="any">
+          <names variable="translator" delimiter=", ">
+            <name and="text" delimiter=", " delimiter-precedes-last="never"/>
+            <label form="verb-short" text-case="lowercase" prefix=" " strip-periods="false"/>
+          </names>
+        </if>
+      </choose>
+    </group>
+  </macro>
+  <macro name="collection-title">
+    <text variable="collection-title"/>
+    <text variable="collection-number" prefix=" "/>
+  </macro>
+  <macro name="locators-note">
+    <choose>
+      <if type="article-journal">
+        <text variable="volume"/>
+      </if>
+      <else>
+        <text variable="volume" form="short"/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="volume">
+    <choose>
+      <if type="article-journal">
+        <text variable="volume"/>
+      </if>
+      <else>
+        <text variable="volume" form="short"/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="issue-note">
+    <choose>
+      <if type="article-journal">
+        <text macro="issued" prefix=" (" suffix=")"/>
+      </if>
+      <else-if variable="publisher-place publisher" match="any">
+        <group prefix=" (" suffix=")" delimiter=" ">
+          <text macro="edition-note" suffix=";"/>
+          <group delimiter=" ">
             <choose>
-                <if variable="author editor" match="any">
-                    <names variable="translator" delimiter=", ">
-                        <name and="text" delimiter=", " delimiter-precedes-last="never"/>
-                        <label form="verb-short" text-case="lowercase" prefix=" "
-                            strip-periods="false"/>
-                    </names>
-                </if>
+              <if variable="title" match="none"/>
+              <else-if type="thesis">
+                <text variable="genre" prefix="unpublished " suffix=","/>
+                <text macro="publisher"/>
+                <text macro="issued"/>
+              </else-if>
+              <else-if type="speech">
+                <text variable="genre" prefix="" suffix=","/>
+                <text macro="event"/>
+                <text macro="issued"/>
+              </else-if>
+              <else>
+                <text macro="publisher"/>
+                <text macro="issued"/>
+              </else>
             </choose>
+          </group>
         </group>
-    </macro>
-
-    <macro name="collection-title">
-        <text variable="collection-title"/>
-        <text variable="collection-number" prefix=" "/>
-    </macro>
-
-    <macro name="locators-note">
+      </else-if>
+      <else>
+        <text macro="issued" prefix=" (" suffix=")"/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="container-title-note">
+    <choose>
+      <if type="chapter paper-conference map" match="any">
+        <text term="in" text-case="lowercase" suffix=": "/>
+        <text macro="editor-translator" suffix=", "/>
+      </if>
+    </choose>
+    <text variable="container-title" font-style="italic"/>
+  </macro>
+  <macro name="edition-note">
+    <choose>
+      <if type="bill book graphic legal_case motion_picture report song chapter paper-conference map" match="any">
         <choose>
-            <if type="article-journal">
-                <text variable="volume"/>
-            </if>
-            <else>
-                <text variable="volume" form="short"/>
-            </else>
+          <if is-numeric="edition">
+            <group delimiter=" ">
+              <number variable="edition" form="ordinal"/>
+              <text term="edition" form="short" strip-periods="true"/>
+            </group>
+          </if>
+          <else>
+            <text variable="edition"/>
+          </else>
         </choose>
-    </macro>
-
-    <macro name="volume">
-        <choose>
-            <if type="article-journal">
-                <text variable="volume"/>
-            </if>
-            <else>
-                <text variable="volume" form="short"/>
-            </else>
-        </choose>
-    </macro>
-
-    <macro name="issue-note">
-        <choose>
-            <if type="article-journal">
-                <text macro="issued" prefix=" (" suffix=")"/>
-            </if>
-            <else-if variable="publisher-place publisher" match="any">
-                <group prefix=" (" suffix=")" delimiter=" ">
-                    <text macro="edition-note" suffix=";"/>
-                    <group delimiter=" ">
-                        <choose>
-                            <if variable="title" match="none"/>
-                            <else-if type="thesis">
-                                <text variable="genre" prefix="unpublished " suffix=","/>
-                                <text macro="publisher"/>
-                                <text macro="issued"/>
-                            </else-if>
-                            <else-if type="speech">
-                                <text variable="genre" prefix="" suffix=","/>
-                                <text macro="event"/>
-                                <text macro="issued"/>
-                            </else-if>
-                            <else>
-                                <text macro="publisher"/>
-                                <text macro="issued"/>
-                            </else>
-                        </choose>
-                    </group>
-                </group>
-            </else-if>
-            <else>
-                <text macro="issued" prefix=" (" suffix=")"/>
-            </else>
-        </choose>
-    </macro>
-
-    <macro name="container-title-note">
-        <choose>
-            <if type="chapter paper-conference map" match="any">
-                <text term="in" text-case="lowercase" suffix=": "/>
-                <text macro="editor-translator" suffix=", "/>
-            </if>
-        </choose>
-        <text variable="container-title" font-style="italic"/>
-    </macro>
-
-    <macro name="edition-note">
-        <choose>
-            <if
-                type="bill book graphic legal_case motion_picture report song chapter paper-conference map"
-                match="any">
-                <choose>
-                    <if is-numeric="edition">
-                        <group delimiter=" ">
-                            <number variable="edition" form="ordinal"/>
-                            <text term="edition" form="short" strip-periods="true"/>
-                        </group>
-                    </if>
-                    <else>
-                        <text variable="edition"/>
-                    </else>
-                </choose>
-            </if>
-        </choose>
-    </macro>
-
-    <macro name="recipient-note">
-        <names variable="recipient" delimiter=", ">
-            <label form="verb" prefix=" " text-case="lowercase" suffix=" "/>
-            <name and="text" delimiter=", " delimiter-precedes-last="never"/>
+      </if>
+    </choose>
+  </macro>
+  <macro name="recipient-note">
+    <names variable="recipient" delimiter=", ">
+      <label form="verb" prefix=" " text-case="lowercase" suffix=" "/>
+      <name and="text" delimiter=", " delimiter-precedes-last="never"/>
+    </names>
+  </macro>
+  <macro name="recipient-short">
+    <names variable="recipient" delimiter=", ">
+      <label form="verb" prefix=" " text-case="lowercase" suffix=" "/>
+      <name form="short" and="text" delimiter=", " delimiter-precedes-last="never"/>
+    </names>
+  </macro>
+  <macro name="contributors-short">
+    <choose>
+      <if variable="author recipient">
+        <names variable="author">
+          <name form="short" and="text" sort-separator=", " delimiter=", " delimiter-precedes-last="never">
+            <name-part name="family" text-case="capitalize-first"/>
+          </name>
         </names>
-    </macro>
-
-    <macro name="recipient-short">
-        <names variable="recipient" delimiter=", ">
-            <label form="verb" prefix=" " text-case="lowercase" suffix=" "/>
-            <name form="short" and="text" delimiter=", " delimiter-precedes-last="never"/>
+        <text macro="recipient-short" prefix=", " suffix=", "/>
+      </if>
+      <else-if variable="author interviewer">
+        <names variable="author">
+          <name form="short" and="text" sort-separator=", " delimiter=", " delimiter-precedes-last="never">
+            <name-part name="family" text-case="capitalize-first"/>
+          </name>
         </names>
-    </macro>
-
-    <macro name="contributors-short">
-        <choose>
-            <if variable="author recipient">
-                <names variable="author">
-                    <name form="short" and="text" sort-separator=", " delimiter=", "
-                        delimiter-precedes-last="never">
-                        <name-part name="family" text-case="capitalize-first"/>
-                    </name>
-                </names>
-                <text macro="recipient-short" prefix=", " suffix=", "/>
-            </if>
-            <else-if variable="author interviewer">
-                <names variable="author">
-                    <name form="short" and="text" sort-separator=", " delimiter=", "
-                        delimiter-precedes-last="never">
-                        <name-part name="family" text-case="capitalize-first"/>
-                    </name>
-                </names>
-                <text macro="interviewer-short" prefix=", " suffix=", "/>
-            </else-if>
-            <else>
-                <names variable="author" suffix=", ">
-                    <name form="short" and="text" sort-separator=", " delimiter=", "
-                        delimiter-precedes-last="never">
-                        <name-part name="family" text-case="capitalize-first"/>
-                    </name>
-                    <substitute>
-                        <names variable="editor" suffix=", ">
-                            <name form="short" and="text" sort-separator=", " delimiter=", "
-                                delimiter-precedes-last="never">
-                                <name-part name="family" text-case="capitalize-first"/>
-                            </name>
-                            <label form="verb-short" prefix=" " suffix="." strip-periods="true"/>
-                        </names>
-                        <names variable="translator" suffix=", ">
-                            <name form="short" and="text" sort-separator=", " delimiter=", "
-                                delimiter-precedes-last="never">
-                                <name-part name="family" text-case="capitalize-first"/>
-                            </name>
-                            <label form="verb-short" prefix=" " suffix="" strip-periods="false"/>
-                        </names>
-                    </substitute>
-                </names>
-                <text macro="recipient-short" suffix=", "/>
-                <text macro="interviewer-short" suffix=", "/>
-            </else>
-        </choose>
-    </macro>
-
-    <macro name="interviewer-note">
-        <names variable="interviewer" delimiter=", ">
-            <label form="verb" prefix=" " text-case="lowercase" suffix=" "/>
-            <name and="text" delimiter=", " delimiter-precedes-last="never"/>
+        <text macro="interviewer-short" prefix=", " suffix=", "/>
+      </else-if>
+      <else>
+        <names variable="author" suffix=", ">
+          <name form="short" and="text" sort-separator=", " delimiter=", " delimiter-precedes-last="never">
+            <name-part name="family" text-case="capitalize-first"/>
+          </name>
+          <substitute>
+            <names variable="editor" suffix=", ">
+              <name form="short" and="text" sort-separator=", " delimiter=", " delimiter-precedes-last="never">
+                <name-part name="family" text-case="capitalize-first"/>
+              </name>
+              <label form="verb-short" prefix=" " suffix="." strip-periods="true"/>
+            </names>
+            <names variable="translator" suffix=", ">
+              <name form="short" and="text" sort-separator=", " delimiter=", " delimiter-precedes-last="never">
+                <name-part name="family" text-case="capitalize-first"/>
+              </name>
+              <label form="verb-short" prefix=" " suffix="" strip-periods="false"/>
+            </names>
+          </substitute>
         </names>
-    </macro>
-
-    <macro name="interviewer-short">
-        <names variable="interviewer" delimiter=", ">
-            <label form="verb" prefix=" " text-case="lowercase" suffix=" "/>
-            <name form="short" and="text" delimiter=", " delimiter-precedes-last="never"/>
-        </names>
-    </macro>
-
-    <macro name="locators-newspaper">
-        <choose>
-            <if type="article-newspaper">
-                <group delimiter=", ">
-                    <group>
-                        <text variable="edition" suffix=" "/>
-                        <text term="edition" prefix=" "/>
-                    </group>
-                    <group>
-                        <text term="section" suffix=" "/>
-                        <text variable="section" suffix=","/>
-                    </group>
-                </group>
-            </if>
-        </choose>
-    </macro>
-
-    <macro name="event">
-        <group>
-            <text term="presented at" suffix=" "/>
-            <text variable="event"/>
-        </group>
-    </macro>
-
-    <macro name="publisher">
-        <group delimiter=": ">
-            <text variable="publisher-place"/>
-            <text variable="publisher"/>
-        </group>
-    </macro>
-
-    <macro name="issued">
-        <choose>
-            <if type="graphic report article-newspaper personal_communication speech" match="any">
-                <choose>
-                    <if match="any" variable="note">
-                        <text variable="note"/>
-                    </if>
-                    <else>
-                        <date variable="issued">
-                            <date-part name="day" suffix=" "/>
-                            <date-part name="month" suffix=" "/>
-                            <date-part name="year"/>
-                        </date>
-                    </else>
-                </choose>
-            </if>
-            <else>
-                <choose>
-                    <if match="any" variable="note">
-                        <text variable="note"/>
-                    </if>
-                    <else>
-                        <date variable="issued">
-                            <date-part name="year"/>
-                        </date>
-                    </else>
-                </choose>
-            </else>
-        </choose>
-    </macro>
-
-    <macro name="pages">
-        <choose>
-            <if type="article-journal">
-                <text variable="page" prefix=" "/>
-            </if>
-            <else>
-                <choose>
-                    <if variable="volume">
-                        <text variable="page" prefix=" "/>
-                    </if>
-                    <else>
-                        <text variable="page" prefix=" "/>
-                    </else>
-                </choose>
-            </else>
-        </choose>
-    </macro>
-
-
-    <macro name="point-locators">
-        <text macro="pages"/>
-        <choose>
-            <if
-                type="chapter paper-conference article-journal article-magazine article-newspaper entry-dictionary entry-encyclopedia article"
-                match="any">
-                <choose>
-                    <if locator="page">
-                        <group prefix=", ">
-                            <text term="at" suffix=" "/>
-                            <text variable="locator"/>
-                        </group>
-                    </if>
-                    <else-if locator="folio">
-                        <group prefix=", ">
-                            <text term="at" suffix=" "/>
-                            <label variable="locator" form="short" prefix=" " suffix=" "/>
-                            <text variable="locator"/>
-                        </group>
-                    </else-if>
-                    <else-if locator="note">
-                        <group prefix=", ">
-                            <text term="at" suffix=" "/>
-                            <text variable="locator"/>
-                        </group>
-                    </else-if>
-                    <else>
-                        <group prefix=", ">
-                            <text term="at" prefix=" " suffix=" "/>
-                            <text variable="locator"/>
-                        </group>
-                    </else>
-                </choose>
-            </if>
-            <else-if type="manuscript">
-                <choose>
-                    <if locator="page">
-                        <text variable="locator"/>
-                    </if>
-                    <else>
-                        <label variable="locator" form="short" suffix=" "/>
-                        <text variable="locator"/>
-                    </else>
-                </choose>
-            </else-if>
-            <else>
-                <choose>
-                    <if locator="folio">
-                        <label variable="locator" form="short" prefix=" " suffix=" "/>
-                        <text variable="locator"/>
-                    </if>
-                    <else>
-                        <text variable="locator" prefix=" "/>
-                    </else>
-                </choose>
-            </else>
-        </choose>
-    </macro>
-
-    <macro name="archive-note">
+        <text macro="recipient-short" suffix=", "/>
+        <text macro="interviewer-short" suffix=", "/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="interviewer-note">
+    <names variable="interviewer" delimiter=", ">
+      <label form="verb" prefix=" " text-case="lowercase" suffix=" "/>
+      <name and="text" delimiter=", " delimiter-precedes-last="never"/>
+    </names>
+  </macro>
+  <macro name="interviewer-short">
+    <names variable="interviewer" delimiter=", ">
+      <label form="verb" prefix=" " text-case="lowercase" suffix=" "/>
+      <name form="short" and="text" delimiter=", " delimiter-precedes-last="never"/>
+    </names>
+  </macro>
+  <macro name="locators-newspaper">
+    <choose>
+      <if type="article-newspaper">
         <group delimiter=", ">
-            <text variable="publisher-place"/>
+          <group>
+            <text variable="edition" suffix=" "/>
+            <text term="edition" prefix=" "/>
+          </group>
+          <group>
+            <text term="section" suffix=" "/>
+            <text variable="section" suffix=","/>
+          </group>
+        </group>
+      </if>
+    </choose>
+  </macro>
+  <macro name="event">
+    <group>
+      <text term="presented at" suffix=" "/>
+      <text variable="event"/>
+    </group>
+  </macro>
+  <macro name="publisher">
+    <group delimiter=": ">
+      <text variable="publisher-place"/>
+      <text variable="publisher"/>
+    </group>
+  </macro>
+  <macro name="issued">
+    <choose>
+      <if type="graphic report article-newspaper personal_communication speech" match="any">
+        <choose>
+          <if match="any" variable="note">
+            <text variable="note"/>
+          </if>
+          <else>
+            <date variable="issued">
+              <date-part name="day" suffix=" "/>
+              <date-part name="month" suffix=" "/>
+              <date-part name="year"/>
+            </date>
+          </else>
+        </choose>
+      </if>
+      <else>
+        <choose>
+          <if match="any" variable="note">
+            <text variable="note"/>
+          </if>
+          <else>
+            <date variable="issued">
+              <date-part name="year"/>
+            </date>
+          </else>
+        </choose>
+      </else>
+    </choose>
+  </macro>
+  <macro name="pages">
+    <choose>
+      <if type="article-journal">
+        <text variable="page" prefix=" "/>
+      </if>
+      <else>
+        <choose>
+          <if variable="volume">
+            <text variable="page" prefix=" "/>
+          </if>
+          <else>
+            <text variable="page" prefix=" "/>
+          </else>
+        </choose>
+      </else>
+    </choose>
+  </macro>
+  <macro name="point-locators">
+    <text macro="pages"/>
+    <choose>
+      <if type="chapter paper-conference article-journal article-magazine article-newspaper entry-dictionary entry-encyclopedia article" match="any">
+        <choose>
+          <if locator="page">
+            <group prefix=", ">
+              <text term="at" suffix=" "/>
+              <text variable="locator"/>
+            </group>
+          </if>
+          <else-if locator="folio">
+            <group prefix=", ">
+              <text term="at" suffix=" "/>
+              <label variable="locator" form="short" prefix=" " suffix=" "/>
+              <text variable="locator"/>
+            </group>
+          </else-if>
+          <else-if locator="note">
+            <group prefix=", ">
+              <text term="at" suffix=" "/>
+              <text variable="locator"/>
+            </group>
+          </else-if>
+          <else>
+            <group prefix=", ">
+              <text term="at" prefix=" " suffix=" "/>
+              <text variable="locator"/>
+            </group>
+          </else>
+        </choose>
+      </if>
+      <else-if type="manuscript">
+        <choose>
+          <if locator="page">
+            <text variable="locator"/>
+          </if>
+          <else>
+            <label variable="locator" form="short" suffix=" "/>
+            <text variable="locator"/>
+          </else>
+        </choose>
+      </else-if>
+      <else>
+        <choose>
+          <if locator="folio">
+            <label variable="locator" form="short" prefix=" " suffix=" "/>
+            <text variable="locator"/>
+          </if>
+          <else>
+            <text variable="locator" prefix=" "/>
+          </else>
+        </choose>
+      </else>
+    </choose>
+  </macro>
+  <macro name="archive-note">
+    <group delimiter=", ">
+      <text variable="publisher-place"/>
+      <text variable="archive"/>
+      <text variable="archive_location"/>
+    </group>
+  </macro>
+  <macro name="access-note">
+    <group delimiter=", ">
+      <choose>
+        <if type="book article-journal article-magazine thesis chapter manuscript paper-conference entry-encyclopedia entry-dictionary" match="none">
+          <group delimiter=", " prefix=", ">
             <text variable="archive"/>
             <text variable="archive_location"/>
+          </group>
+        </if>
+      </choose>
+    </group>
+    <choose>
+      <if variable="DOI">
+        <text variable="DOI" prefix=" &lt;doi:" suffix="&gt;"/>
+      </if>
+      <else>
+        <text variable="URL" prefix=" &lt;" suffix="&gt;"/>
+        <group prefix=" [" suffix="]">
+          <text term="accessed" text-case="lowercase"/>
+          <date variable="accessed">
+            <date-part name="day" prefix=" "/>
+            <date-part name="month" prefix=" "/>
+            <date-part name="year" prefix=" "/>
+          </date>
         </group>
-    </macro>
-
-    <macro name="access-note">
+      </else>
+    </choose>
+  </macro>
+  <macro name="short-title-note">
+    <choose>
+      <if type="bill book graphic legal_case motion_picture report song" match="any">
+        <text variable="title" font-style="italic" form="short"/>
+        <text macro="locators-note" prefix=" "/>
+      </if>
+      <else-if type="manuscript">
         <group delimiter=", ">
-            <choose>
-                <if
-                    type="book article-journal article-magazine thesis chapter manuscript paper-conference entry-encyclopedia entry-dictionary"
-                    match="none">
-                    <group delimiter=", " prefix=", ">
-                        <text variable="archive"/>
-                        <text variable="archive_location"/>
-                    </group>
-                </if>
-            </choose>
+          <text variable="publisher-place"/>
+          <text variable="title" form="short"/>
+          <text variable="archive_location"/>
         </group>
+      </else-if>
+      <else-if type="thesis speech article">
+        <text variable="title" form="short"/>
+      </else-if>
+      <else>
+        <text variable="title" prefix="‘" suffix="’" form="short"/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="point-locators-subsequent">
+    <choose>
+      <if locator="page">
+        <text variable="locator"/>
+      </if>
+      <else-if locator="folio">
+        <label variable="locator" form="short" suffix=" "/>
+        <text variable="locator"/>
+      </else-if>
+      <else-if type="manuscript">
         <choose>
-            <if variable="DOI">
-                <text variable="DOI" prefix=" &lt;doi:" suffix="&gt;"/>
-            </if>
-            <else>
-                <text variable="URL" prefix=" &lt;" suffix="&gt;"/>
-                <group prefix=" [" suffix="]">
-                    <text term="accessed" text-case="lowercase"/>
-                    <date variable="accessed">
-                        <date-part name="day" prefix=" "/>
-                        <date-part name="month" prefix=" "/>
-                        <date-part name="year" prefix=" "/>
-                    </date>
-                </group>
-            </else>
+          <if locator="page">
+            <text variable="locator"/>
+          </if>
+          <else>
+            <label variable="locator" form="short" suffix=" "/>
+            <text variable="locator"/>
+          </else>
         </choose>
-    </macro>
-
-    <macro name="short-title-note">
-        <choose>
-            <if type="bill book graphic legal_case motion_picture report song" match="any">
-                <text variable="title" font-style="italic" form="short"/>
+      </else-if>
+      <else>
+        <text variable="locator"/>
+      </else>
+    </choose>
+  </macro>
+  <citation et-al-min="4" et-al-use-first="1" et-al-subsequent-min="4" et-al-subsequent-use-first="1" disambiguate-add-names="true" disambiguate-add-givenname="true">
+    <layout prefix="" suffix="." delimiter="; ">
+      <choose>
+        <if position="ibid-with-locator">
+          <group delimiter=", ">
+            <text term="ibid" text-case="capitalize-first"/>
+            <text macro="point-locators-subsequent"/>
+          </group>
+        </if>
+        <else-if position="ibid">
+          <text term="ibid" text-case="capitalize-first"/>
+        </else-if>
+        <else-if position="subsequent">
+          <text macro="contributors-short" text-case="capitalize-first"/>
+          <text macro="short-title-note"/>
+          <text macro="point-locators-subsequent" prefix=", "/>
+        </else-if>
+        <else-if type="manuscript">
+          <text macro="archive-note"/>
+          <text macro="point-locators" prefix=", "/>
+          <text macro="access-note"/>
+        </else-if>
+        <else-if variable="author editor" match="all">
+          <choose>
+            <if type="article-journal chapter paper-conference entry-dictionary entry-encyclopedia map" match="any">
+              <group>
+                <text macro="contributors-note" text-case="capitalize-first"/>
+                <text macro="title-note"/>
+                <text macro="editor-translator" prefix=". "/>
+                <text macro="container-title-note" prefix=", "/>
                 <text macro="locators-note" prefix=" "/>
-            </if>
-            <else-if type="manuscript">
-                <group delimiter=", ">
-                    <text variable="publisher-place"/>
-                    <text variable="title" form="short"/>
-                    <text variable="archive_location"/>
-                </group>
-            </else-if>
-            <else-if type="thesis speech article">
-                <text variable="title" form="short"/>
-            </else-if>
-            <else>
-                <text variable="title" prefix="&#8216;" suffix="&#8217;" form="short"/>
-            </else>
-        </choose>
-    </macro>
-
-    <macro name="point-locators-subsequent">
-        <choose>
-            <if locator="page">
-                <text variable="locator"/>
-            </if>
-            <else-if locator="folio">
-                <label variable="locator" form="short" suffix=" "/>
-                <text variable="locator"/>
-            </else-if>
-            <else-if type="manuscript">
                 <choose>
-                    <if locator="page">
-                        <text variable="locator"/>
-                    </if>
-                    <else>
-                        <label variable="locator" form="short" suffix=" "/>
-                        <text variable="locator"/>
-                    </else>
+                  <if type="map">
+                    <text macro="collection-title" prefix=", " font-style="italic"/>
+                  </if>
+                  <else>
+                    <text macro="collection-title" prefix=", "/>
+                  </else>
                 </choose>
+              </group>
+              <text macro="issue-note"/>
+              <text macro="locators-newspaper" prefix=", "/>
+              <text macro="point-locators"/>
+              <text macro="access-note"/>
+            </if>
+            <else>
+              <group>
+                <text macro="contributors-note" text-case="capitalize-first"/>
+                <text macro="title-note"/>
+                <text macro="locators-note" prefix=" "/>
+                <text macro="editor-translator" prefix=". "/>
+                <text macro="container-title-note" prefix=", "/>
+                <text macro="collection-title" prefix=", "/>
+              </group>
+              <text macro="issue-note"/>
+              <text macro="locators-newspaper" prefix=", "/>
+              <text macro="point-locators"/>
+              <text macro="access-note"/>
+            </else>
+          </choose>
+        </else-if>
+        <else>
+          <choose>
+            <if type="article-journal chapter paper-conference entry-dictionary entry-encyclopedia map" match="any">
+              <group>
+                <text macro="contributors-note" text-case="capitalize-first"/>
+                <text macro="title-note"/>
+                <text macro="container-title-note" prefix=", "/>
+                <text macro="locators-note" prefix=" "/>
+                <choose>
+                  <if type="map">
+                    <text macro="collection-title" prefix=", " font-style="italic"/>
+                  </if>
+                  <else>
+                    <text macro="collection-title" prefix=", "/>
+                  </else>
+                </choose>
+              </group>
+              <text macro="issue-note"/>
+              <text macro="locators-newspaper" prefix=", "/>
+              <text macro="point-locators"/>
+              <text macro="access-note"/>
+            </if>
+            <else>
+              <group>
+                <text macro="contributors-note" text-case="capitalize-first"/>
+                <text macro="title-note"/>
+                <text macro="locators-note" prefix=" "/>
+                <text macro="container-title-note" prefix=", "/>
+                <text macro="collection-title" prefix=". "/>
+              </group>
+              <text macro="issue-note"/>
+              <text macro="locators-newspaper" prefix=", "/>
+              <text macro="point-locators"/>
+              <text macro="access-note"/>
+            </else>
+          </choose>
+        </else>
+      </choose>
+    </layout>
+  </citation>
+  <bibliography hanging-indent="true" et-al-min="4" et-al-use-first="1" subsequent-author-substitute="---" subsequent-author-substitute-rule="partial-each" entry-spacing="1" line-spacing="1">
+    <sort>
+      <key macro="author"/>
+      <key variable="title"/>
+    </sort>
+    <layout suffix=".">
+      <choose>
+        <if type="manuscript">
+          <text macro="archive-note"/>
+          <text macro="access-note"/>
+        </if>
+        <else-if variable="author editor" match="all">
+          <choose>
+            <if type="article-journal chapter paper-conference entry-dictionary entry-encyclopedia map" match="any">
+              <group>
+                <text macro="author" text-case="capitalize-first"/>
+                <text macro="title-note"/>
+                <text macro="editor-translator" prefix=". " text-case="capitalize-first"/>
+                <text macro="container-title-note" prefix=", "/>
+                <text macro="volume" prefix=" "/>
+                <choose>
+                  <if type="map">
+                    <text macro="collection-title" prefix=", " font-style="italic"/>
+                  </if>
+                  <else>
+                    <text macro="collection-title" prefix=", "/>
+                  </else>
+                </choose>
+              </group>
+              <text macro="issue-note"/>
+              <text macro="locators-newspaper" prefix=", "/>
+              <text macro="point-locators"/>
+              <text macro="access-note"/>
+            </if>
+            <else-if type="personal_communication" match="any">
+              <group>
+                <text macro="author" text-case="capitalize-first"/>
+                <text macro="title-note"/>
+                <text macro="volume" prefix=" "/>
+                <text macro="editor-translator" prefix=". " text-case="capitalize-first"/>
+                <text macro="container-title-note" prefix=", "/>
+                <text macro="collection-title" prefix=", "/>
+              </group>
+              <text macro="issue-note"/>
+              <text macro="locators-newspaper" prefix=", "/>
+              <text macro="point-locators"/>
+              <text macro="access-note"/>
+              <text term="letter" prefix=". [" suffix="]" text-case="capitalize-first"/>
             </else-if>
             <else>
-                <text variable="locator"/>
+              <group>
+                <text macro="author" text-case="capitalize-first"/>
+                <text macro="title-note"/>
+                <text macro="volume" prefix=" "/>
+                <text macro="editor-translator" prefix=". " text-case="capitalize-first"/>
+                <text macro="container-title-note" prefix=", "/>
+                <text macro="collection-title" prefix=", "/>
+              </group>
+              <text macro="issue-note"/>
+              <text macro="locators-newspaper" prefix=", "/>
+              <text macro="point-locators"/>
+              <text macro="access-note"/>
             </else>
-        </choose>
-    </macro>
-
-    <citation et-al-min="4" et-al-use-first="1" et-al-subsequent-min="4"
-        et-al-subsequent-use-first="1" disambiguate-add-names="true"
-        disambiguate-add-givenname="true">
-        <layout prefix="" suffix="." delimiter="; ">
-            <choose>
-                <if position="ibid-with-locator">
-                    <group delimiter=", ">
-                        <text term="ibid" text-case="capitalize-first"/>
-                        <text macro="point-locators-subsequent"/>
-                    </group>
-                </if>
-                <else-if position="ibid">
-                    <text term="ibid" text-case="capitalize-first"/>
-                </else-if>
-                <else-if position="subsequent">
-                    <text macro="contributors-short" text-case="capitalize-first"/>
-                    <text macro="short-title-note"/>
-                    <text macro="point-locators-subsequent" prefix=", "/>
-                </else-if>
-                <else-if type="manuscript">
-                    <text macro="archive-note"/>
-                    <text macro="point-locators" prefix=", "/>
-                    <text macro="access-note"/>
-                </else-if>
-                <else-if variable="author editor" match="all">
-                    <choose>
-                        <if
-                            type="article-journal chapter paper-conference entry-dictionary entry-encyclopedia map"
-                            match="any">
-                            <group>
-                                <text macro="contributors-note" text-case="capitalize-first"/>
-                                <text macro="title-note"/>
-                                <text macro="editor-translator" prefix=". "/>
-                                <text macro="container-title-note" prefix=", "/>
-                                <text macro="locators-note" prefix=" "/>
-                                <choose>
-                                    <if type="map">
-                                        <text macro="collection-title" prefix=", "
-                                            font-style="italic"/>
-                                    </if>
-                                    <else>
-                                        <text macro="collection-title" prefix=", "/>
-                                    </else>
-                                </choose>
-                            </group>
-                            <text macro="issue-note"/>
-                            <text macro="locators-newspaper" prefix=", "/>
-                            <text macro="point-locators"/>
-                            <text macro="access-note"/>
-                        </if>
-                        <else>
-                            <group>
-                                <text macro="contributors-note" text-case="capitalize-first"/>
-                                <text macro="title-note"/>
-                                <text macro="locators-note" prefix=" "/>
-                                <text macro="editor-translator" prefix=". "/>
-                                <text macro="container-title-note" prefix=", "/>
-                                <text macro="collection-title" prefix=", "/>
-                            </group>
-                            <text macro="issue-note"/>
-                            <text macro="locators-newspaper" prefix=", "/>
-                            <text macro="point-locators"/>
-                            <text macro="access-note"/>
-                        </else>
-                    </choose>
-                </else-if>
-                <else>
-                    <choose>
-                        <if
-                            type="article-journal chapter paper-conference entry-dictionary entry-encyclopedia map"
-                            match="any">
-                            <group>
-                                <text macro="contributors-note" text-case="capitalize-first"/>
-                                <text macro="title-note"/>
-                                <text macro="container-title-note" prefix=", "/>
-                                <text macro="locators-note" prefix=" "/>
-                                <choose>
-                                    <if type="map">
-                                        <text macro="collection-title" prefix=", "
-                                            font-style="italic"/>
-                                    </if>
-                                    <else>
-                                        <text macro="collection-title" prefix=", "/>
-                                    </else>
-                                </choose>
-                            </group>
-                            <text macro="issue-note"/>
-                            <text macro="locators-newspaper" prefix=", "/>
-                            <text macro="point-locators"/>
-                            <text macro="access-note"/>
-                        </if>
-                        <else>
-                            <group>
-                                <text macro="contributors-note" text-case="capitalize-first"/>
-                                <text macro="title-note"/>
-                                <text macro="locators-note" prefix=" "/>
-                                <text macro="container-title-note" prefix=", "/>
-                                <text macro="collection-title" prefix=". "/>
-                            </group>
-                            <text macro="issue-note"/>
-                            <text macro="locators-newspaper" prefix=", "/>
-                            <text macro="point-locators"/>
-                            <text macro="access-note"/>
-                        </else>
-                    </choose>
-                </else>
-            </choose>
-        </layout>
-    </citation>
-
-    <bibliography hanging-indent="true" et-al-min="4" et-al-use-first="1"
-        subsequent-author-substitute="---" subsequent-author-substitute-rule="partial-each"
-        entry-spacing="1" line-spacing="1">
-        <sort>
-            <key macro="author"/>
-            <key variable="title"/>
-        </sort>
-        <layout suffix=".">
-            <choose>
-                <if type="manuscript">
-                    <text macro="archive-note"/>
-                    <text macro="access-note"/>
-                </if>
-                <else-if variable="author editor" match="all">
-                    <choose>
-                        <if
-                            type="article-journal chapter paper-conference entry-dictionary entry-encyclopedia map"
-                            match="any">
-                            <group>
-                                <text macro="author" text-case="capitalize-first"/>
-                                <text macro="title-note"/>
-                                <text macro="editor-translator" prefix=". "
-                                    text-case="capitalize-first"/>
-                                <text macro="container-title-note" prefix=", "/>
-                                <text macro="volume" prefix=" "/>
-                                <choose>
-                                    <if type="map">
-                                        <text macro="collection-title" prefix=", "
-                                            font-style="italic"/>
-                                    </if>
-                                    <else>
-                                        <text macro="collection-title" prefix=", "/>
-                                    </else>
-                                </choose>
-                            </group>
-                            <text macro="issue-note"/>
-                            <text macro="locators-newspaper" prefix=", "/>
-                            <text macro="point-locators"/>
-                            <text macro="access-note"/>
-                        </if>
-                        <else-if type="personal_communication" match="any">
-                            <group>
-                                <text macro="author" text-case="capitalize-first"/>
-                                <text macro="title-note"/>
-                                <text macro="volume" prefix=" "/>
-                                <text macro="editor-translator" prefix=". "
-                                    text-case="capitalize-first"/>
-                                <text macro="container-title-note" prefix=", "/>
-                                <text macro="collection-title" prefix=", "/>
-                            </group>
-                            <text macro="issue-note"/>
-                            <text macro="locators-newspaper" prefix=", "/>
-                            <text macro="point-locators"/>
-                            <text macro="access-note"/>
-                            <text term="letter" prefix=". [" suffix="]" text-case="capitalize-first"
-                            />
-                        </else-if>
-                        <else>
-                            <group>
-                                <text macro="author" text-case="capitalize-first"/>
-                                <text macro="title-note"/>
-                                <text macro="volume" prefix=" "/>
-                                <text macro="editor-translator" prefix=". "
-                                    text-case="capitalize-first"/>
-                                <text macro="container-title-note" prefix=", "/>
-                                <text macro="collection-title" prefix=", "/>
-                            </group>
-                            <text macro="issue-note"/>
-                            <text macro="locators-newspaper" prefix=", "/>
-                            <text macro="point-locators"/>
-                            <text macro="access-note"/>
-                        </else>
-                    </choose>
-                </else-if>
-                <else>
-                    <choose>
-                        <if
-                            type="article-journal chapter paper-conference entry-dictionary entry-encyclopedia map"
-                            match="any">
-                            <group>
-                                <text macro="author" text-case="capitalize-first"/>
-                                <text macro="title-note"/>
-                                <text macro="container-title-note" prefix=", "/>
-                                <text macro="volume" prefix=" "/>
-                                <choose>
-                                    <if type="map">
-                                        <text macro="collection-title" prefix=", "
-                                            font-style="italic"/>
-                                    </if>
-                                    <else>
-                                        <text macro="collection-title" prefix=", "/>
-                                    </else>
-                                </choose>
-                            </group>
-                            <text macro="issue-note"/>
-                            <text macro="locators-newspaper" prefix=", "/>
-                            <text macro="pages"/>
-                            <text macro="access-note"/>
-                        </if>
-                        <else-if type="personal_communication">
-                            <group>
-                                <text macro="author" text-case="capitalize-first"/>
-                                <text macro="title-note"/>
-                                <text macro="volume" prefix=" "/>
-                                <text macro="container-title-note" prefix=", "/>
-                                <text macro="collection-title" prefix=". "/>
-                            </group>
-                            <text macro="issue-note"/>
-                            <text macro="locators-newspaper" prefix=", "/>
-                            <text macro="pages"/>
-                            <text macro="access-note"/>
-                            <text term="letter" prefix=". [" suffix="]" text-case="capitalize-first"
-                            />
-                        </else-if>
-                        <else>
-                            <group>
-                                <text macro="author" text-case="capitalize-first"/>
-                                <text macro="title-note"/>
-                                <text macro="volume" prefix=" "/>
-                                <text macro="container-title-note" prefix=", "/>
-                                <text macro="collection-title" prefix=". "/>
-                            </group>
-                            <text macro="issue-note"/>
-                            <text macro="locators-newspaper" prefix=", "/>
-                            <text macro="pages"/>
-                            <text macro="access-note"/>
-                        </else>
-                    </choose>
-                </else>
-            </choose>
-        </layout>
-    </bibliography>
+          </choose>
+        </else-if>
+        <else>
+          <choose>
+            <if type="article-journal chapter paper-conference entry-dictionary entry-encyclopedia map" match="any">
+              <group>
+                <text macro="author" text-case="capitalize-first"/>
+                <text macro="title-note"/>
+                <text macro="container-title-note" prefix=", "/>
+                <text macro="volume" prefix=" "/>
+                <choose>
+                  <if type="map">
+                    <text macro="collection-title" prefix=", " font-style="italic"/>
+                  </if>
+                  <else>
+                    <text macro="collection-title" prefix=", "/>
+                  </else>
+                </choose>
+              </group>
+              <text macro="issue-note"/>
+              <text macro="locators-newspaper" prefix=", "/>
+              <text macro="pages"/>
+              <text macro="access-note"/>
+            </if>
+            <else-if type="personal_communication">
+              <group>
+                <text macro="author" text-case="capitalize-first"/>
+                <text macro="title-note"/>
+                <text macro="volume" prefix=" "/>
+                <text macro="container-title-note" prefix=", "/>
+                <text macro="collection-title" prefix=". "/>
+              </group>
+              <text macro="issue-note"/>
+              <text macro="locators-newspaper" prefix=", "/>
+              <text macro="pages"/>
+              <text macro="access-note"/>
+              <text term="letter" prefix=". [" suffix="]" text-case="capitalize-first"/>
+            </else-if>
+            <else>
+              <group>
+                <text macro="author" text-case="capitalize-first"/>
+                <text macro="title-note"/>
+                <text macro="volume" prefix=" "/>
+                <text macro="container-title-note" prefix=", "/>
+                <text macro="collection-title" prefix=". "/>
+              </group>
+              <text macro="issue-note"/>
+              <text macro="locators-newspaper" prefix=", "/>
+              <text macro="pages"/>
+              <text macro="access-note"/>
+            </else>
+          </choose>
+        </else>
+      </choose>
+    </layout>
+  </bibliography>
 </style>

--- a/de-buck.csl
+++ b/de-buck.csl
@@ -32,8 +32,8 @@
       </term>
       <term name="edition" form="short">druk</term>
       <term name="translator" form="verb-short">
-        <single>(vertaler)</single>
-        <multiple>(vertalers)</multiple>
+        <single>vertaler</single>
+        <multiple>vertalers</multiple>
       </term>
       <term name="volume" form="short">
         <single>dl.</single>
@@ -62,7 +62,7 @@
         </choose>
         <names variable="translator" suffix=", ">
           <name name-as-sort-order="first" and="text" delimiter=", " delimiter-precedes-last="after-inverted-name" delimiter-precedes-et-al="after-inverted-name"/>
-          <label form="verb-short" prefix=" " text-case="lowercase" strip-periods="false"/>
+          <label form="verb-short" prefix=" (" suffix=")" text-case="lowercase" strip-periods="false"/>
         </names>
         <text macro="title-note"/>
       </substitute>
@@ -70,7 +70,7 @@
     <choose>
       <if variable="author editor container-author" match="any">
         <names variable="translator" suffix=", ">
-          <name and="text" delimiter=", " delimiter-precedes-last="never"/>
+          <name and="text" delimiter=", " prefix="(" suffix=")" delimiter-precedes-last="never"/>
           <label form="verb-short" text-case="lowercase" prefix=" " strip-periods="false"/>
         </names>
       </if>
@@ -115,7 +115,7 @@
           <if variable="author editor container-author" match="any">
             <names variable="translator" suffix=", ">
               <name and="text" delimiter=", " delimiter-precedes-last="never"/>
-              <label form="verb-short" text-case="lowercase" prefix=" " strip-periods="false"/>
+              <label form="verb-short" text-case="lowercase" prefix=" (" suffix=")" strip-periods="false"/>
             </names>
           </if>
         </choose>
@@ -147,7 +147,6 @@
       <names variable="container-author" delimiter=", ">
         <name and="text" delimiter=", " delimiter-precedes-last="never"/>
       </names>
-      <!--<choose><if variable="author editor container-author" match="any"><names variable="translator" delimiter=", "><name and="text" delimiter=", " delimiter-precedes-last="never"/><label form="verb-short" text-case="lowercase" prefix=" " strip-periods="false"/></names></if></choose>-->
     </group>
   </macro>
   <macro name="collection-title">
@@ -284,7 +283,7 @@
               <name form="short" and="text" sort-separator=", " delimiter=", " delimiter-precedes-last="never">
                 <name-part name="family" text-case="capitalize-first"/>
               </name>
-              <label form="verb-short" prefix=" " strip-periods="false"/>
+              <label form="verb-short" prefix=" (" suffix=")" strip-periods="false"/>
             </names>
           </substitute>
         </names>


### PR DESCRIPTION
My previous version of De Buck stylesheet still contained numerous mistakes. I have created a complete new update, which solves all issues known to me at the moment:
- Extended the application of the stylesheet to all possible file types
- Solved the issue that non-dropping particles were not capitalised in short-name format or first name in bibliography (G. de Koning > De Koning or De Koning, G.)
- Now able to refer to folio nrs. in books etc.
- Solved incorrect order of volume-nr. and series-nr.
- Added a book-author in book chapters etc.
- Added option for personal communication
- Added "recipient" and "interviewer" to relevant file types
- Added URL's to manuscripts
- Removed label "p." for page, which was always added to manuscripts.
- Solved issues with incorrect delimiters in both citation and bibliography
- Solved issue with translators
- Solved some issues with websites, presentations, theses, and other less common file types.
- Added the option of using date ranges (etc.) for publication dates, which are very common when working with Medieval/Early Modern material for instance, by including this information in the Zotero field "Extra" (note)
- Further minor changes