### PR TITLE
Sort inline citations by date then author

### DIFF
--- a/utah-geological-survey.csl
+++ b/utah-geological-survey.csl
@@ -60,8 +60,8 @@
   </macro>
   <citation et-al-min="3" et-al-use-first="1" disambiguate-add-year-suffix="true" disambiguate-add-names="false" disambiguate-add-givenname="false">
     <sort>
-      <key macro="author-short"/>
       <key variable="issued"/>
+      <key macro="author-short"/>
     </sort>
     <layout prefix="(" suffix=")" delimiter="; ">
       <group delimiter=", ">


### PR DESCRIPTION
Page 17 of the style guide (http://files.geology.utah.gov/online/c/c-105.pdf) states that when a sentence requires multiple
references, they are listed in chronologic-alphabetic order -- chronological first, then alphabetical.