### PR TITLE
Spell out "editor(s)" and add comma between and

### DIFF
--- a/utah-geological-survey.csl
+++ b/utah-geological-survey.csl
@@ -135,9 +135,9 @@
           <group prefix=", ">
             <text term="in" font-style="italic"/>
             <names variable="editor translator" prefix=" " suffix="," delimiter=", ">
-              <name and="text" sort-separator=", " initialize-with=".," name-as-sort-order="all"/>
+              <name and="text" sort-separator=", " initialize-with="." name-as-sort-order="all" delimiter-precedes-last="always"/>
               <et-al term="and others"/>
-              <label form="long" prefix=" "/>
+              <label prefix=","/>
             </names>
             <text variable="event" prefix=" " suffix=" &#8211;"/>
             <text variable="container-title" prefix=" " suffix=":"/>

--- a/utah-geological-survey.csl
+++ b/utah-geological-survey.csl
@@ -137,7 +137,7 @@
             <names variable="editor translator" prefix=" " suffix="," delimiter=", ">
               <name and="text" sort-separator=", " initialize-with="." name-as-sort-order="all" delimiter-precedes-last="always"/>
               <et-al term="and others"/>
-              <label prefix=","/>
+              <label prefix=", "/>
             </names>
             <text variable="event" prefix=" " suffix=" &#8211;"/>
             <text variable="container-title" prefix=" " suffix=":"/>

--- a/utah-geological-survey.csl
+++ b/utah-geological-survey.csl
@@ -135,9 +135,9 @@
           <group prefix=", ">
             <text term="in" font-style="italic"/>
             <names variable="editor translator" prefix=" " suffix="," delimiter=", ">
-              <name and="text" sort-separator=", " initialize-with="." name-as-sort-order="all"/>
+              <name and="text" sort-separator=", " initialize-with=".," name-as-sort-order="all"/>
               <et-al term="and others"/>
-              <label form="short" prefix=" "/>
+              <label form="long" prefix=" "/>
             </names>
             <text variable="event" prefix=" " suffix=" &#8211;"/>
             <text variable="container-title" prefix=" " suffix=":"/>


### PR DESCRIPTION
Following example of pg. 20 in the section `Documents having compilers/editors` of http://files.geology.utah.gov/online/c/c-105.pdf. Fixes the abbreviation `eds.` to the correct `editors` and adds a comma between the initials of the first editor and the word "and".