### PR TITLE
Formatting tweaks for the-open-university-harvard

### DIFF
--- a/the-open-university-harvard.csl
+++ b/the-open-university-harvard.csl
@@ -12,7 +12,7 @@
     <category citation-format="author-date"/>
     <category field="generic-base"/>
     <summary>The Open University Harvard author-date style</summary>
-    <updated>2012-09-27T22:06:38+00:00</updated>
+    <updated>2015-06-26T15:51:02+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <macro name="editor">
@@ -47,10 +47,10 @@
   <macro name="access">
     <choose>
       <if variable="URL">
-        <text term="online" prefix="[" suffix="]"/>
-        <text value=" Available from: "/>
+        <text term="online" prefix="[" suffix="]" text-case="capitalize-first"/>
+        <text value=" Available at: "/>
         <text variable="URL"/>
-        <group prefix=" (" delimiter=" " suffix=")">
+        <group prefix=" (" delimiter=" " suffix=").">
           <text term="accessed" text-case="capitalize-first"/>
           <date variable="accessed">
             <date-part name="day" suffix=" "/>
@@ -153,7 +153,7 @@
       </group>
     </layout>
   </citation>
-  <bibliography hanging-indent="true">
+  <bibliography hanging-indent="false">
     <sort>
       <key macro="author"/>
       <key macro="year-date"/>

--- a/the-open-university-harvard.csl
+++ b/the-open-university-harvard.csl
@@ -44,6 +44,12 @@
       </substitute>
     </names>
   </macro>
+  <macro name="translator">
+    <names variable="translator">
+      <label form="short" plural="always" suffix=" "/>
+      <name and="symbol" delimiter=", " delimiter-precedes-last="never" initialize-with=". "/>
+    </names>
+  </macro>
   <macro name="access">
     <choose>
       <if variable="URL">
@@ -153,7 +159,7 @@
       </group>
     </layout>
   </citation>
-  <bibliography hanging-indent="false">
+  <bibliography>
     <sort>
       <key macro="author"/>
       <key macro="year-date"/>
@@ -163,7 +169,10 @@
       <group delimiter=" ">
         <text macro="author"/>
         <text macro="year-date" prefix="(" suffix=")"/>
-        <text macro="title" suffix=","/>
+        <group delimiter=" " suffix=",">
+          <text macro="title"/>
+          <text macro="translator" prefix="(" suffix=")"/>
+        </group>
         <text macro="edition"/>
         <text macro="container-prefix"/>
         <group delimiter=", ">

--- a/the-open-university-harvard.csl
+++ b/the-open-university-harvard.csl
@@ -95,13 +95,17 @@
       </else>
     </choose>
   </macro>
-  <macro name="locator">
-    <choose>
-      <if type="article-journal">
-        <text variable="volume"/>
-        <text variable="issue" prefix="(" suffix=")"/>
-      </if>
-    </choose>
+  <macro name="locators">
+    <group delimiter=", ">
+      <group delimiter=" ">
+        <text term="volume" form="short"/>
+        <number variable="volume" form="numeric"/>
+      </group>
+      <group delimiter=" ">
+        <text term="issue" form="short"/>
+        <number variable="issue" form="numeric"/>
+      </group>
+    </group>
   </macro>
   <macro name="published-date">
     <choose>
@@ -181,7 +185,7 @@
           <text variable="collection-title"/>
           <text variable="genre"/>
           <text macro="publisher"/>
-          <text macro="locator"/>
+          <text macro="locators"/>
           <text macro="published-date"/>
           <text macro="pages"/>
           <text macro="access"/>


### PR DESCRIPTION
Small details that were not exactly as defined in the OU Harvard guide to citing references:
http://www.open.ac.uk/libraryservices/documents/Harvard_citation_hlp.pdf

- [online] is capitalized in the guide 
- "Available from:" is "Available at:" in the guide
- Missing full stop after access info
- The sample reference list in the guide has no hanging indent