### PR TITLE
Add translator info in the-open-university-harvard

### DIFF
--- a/the-open-university-harvard.csl
+++ b/the-open-university-harvard.csl
@@ -44,6 +44,11 @@
       </substitute>
     </names>
   </macro>
+  <macro name="translator">
+    <names variable="translator">
+      <name and="symbol" delimiter=", " delimiter-precedes-last="never" initialize-with=". "/>
+    </names>
+  </macro>
   <macro name="access">
     <choose>
       <if variable="URL">
@@ -163,7 +168,10 @@
       <group delimiter=" ">
         <text macro="author"/>
         <text macro="year-date" prefix="(" suffix=")"/>
-        <text macro="title" suffix=","/>
+        <group delimiter=" " suffix=",">
+          <text macro="title"/>
+          <text macro="translator" prefix="(trans. " suffix=")"/>
+        </group>
         <text macro="edition"/>
         <text macro="container-prefix"/>
         <group delimiter=", ">


### PR DESCRIPTION
The translator info was missing. Created macro and group with title in bibliography to respect the format specified in the guide with a single comma after the group (http://www.open.ac.uk/libraryservices/documents/Harvard_citation_hlp.pdf):

_Title of Book_ (trans. A. Translator), Place of publication, Publisher.