### PR TITLE
OU Harvard improvements

### DIFF
--- a/the-open-university-harvard.csl
+++ b/the-open-university-harvard.csl
@@ -15,7 +15,7 @@
     <category citation-format="author-date"/>
     <category field="generic-base"/>
     <summary>The Open University Harvard author-date style</summary>
-    <updated>2016-05-24T06:45:00+00:00</updated>
+    <updated>2016-05-25T07:13:00+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <macro name="editor">
@@ -33,7 +33,6 @@
       <label form="short" prefix=" (" suffix=")"/>
       <substitute>
         <names variable="editor"/>
-        <names variable="director"/>
         <text macro="anon"/>
       </substitute>
     </names>
@@ -194,10 +193,13 @@
       <choose>
         <!-- Specific formats (bibliography) -->
         <if type="motion_picture">
-          <group delimiter=" " suffix=" [Film].">
-            <text macro="title"/>
-            <text macro="year-date" prefix="(" suffix=")"/>
-            <text macro="director"/>
+          <group delimiter=" ">
+            <group delimiter=" " suffix=" [Film].">
+              <text macro="title"/>
+              <text macro="year-date" prefix="(" suffix=")"/>
+              <text macro="director"/>
+            </group>
+            <text macro="publisher"/>
           </group>
         </if>
         <!-- Generic/fallback format (bibliography) -->

--- a/the-open-university-harvard.csl
+++ b/the-open-university-harvard.csl
@@ -175,7 +175,7 @@
               <text macro="year-date"/>
             </group>
             <group>
-              <text term="page" form="short" suffix=" "/>
+              <label variable="locator" form="short" suffix=" "/>
               <text variable="locator"/>
             </group>
           </group>

--- a/the-open-university-harvard.csl
+++ b/the-open-university-harvard.csl
@@ -220,8 +220,8 @@
               <text macro="locators"/>
               <text macro="published-date"/>
               <text macro="pages"/>
-              <text macro="access"/>
             </group>
+            <text macro="access"/>
           </group>
         </else>
       </choose>

--- a/the-open-university-harvard.csl
+++ b/the-open-university-harvard.csl
@@ -64,7 +64,7 @@
           <text term="online" prefix="[" suffix="]." text-case="capitalize-first"/>
           <text term="available at" suffix=":" text-case="capitalize-first"/>
           <text variable="URL"/>
-          <group prefix=" (" delimiter=" " suffix=").">
+          <group prefix="(" delimiter=" " suffix=").">
             <text term="accessed" text-case="capitalize-first"/>
             <date variable="accessed">
               <date-part name="day" suffix=" "/>

--- a/the-open-university-harvard.csl
+++ b/the-open-university-harvard.csl
@@ -9,6 +9,9 @@
       <name>Julian Onions</name>
       <email>julian.onions@gmail.com</email>
     </author>
+    <contributor>
+      <name>Pablo Melchor</name>
+    </contributor>
     <category citation-format="author-date"/>
     <category field="generic-base"/>
     <summary>The Open University Harvard author-date style</summary>

--- a/the-open-university-harvard.csl
+++ b/the-open-university-harvard.csl
@@ -4,7 +4,7 @@
     <title>The Open University (Harvard)</title>
     <id>http://www.zotero.org/styles/the-open-university-harvard</id>
     <link href="http://www.zotero.org/styles/the-open-university-harvard" rel="self"/>
-    <link href="http://www.open.ac.uk/library/help-and-support/referencing-styles" rel="documentation"/>
+    <link href="http://www.open.ac.uk/library/help-and-support/referencing-and-plagiarism" rel="documentation"/>
     <author>
       <name>Julian Onions</name>
       <email>julian.onions@gmail.com</email>

--- a/the-open-university-harvard.csl
+++ b/the-open-university-harvard.csl
@@ -12,7 +12,7 @@
     <category citation-format="author-date"/>
     <category field="generic-base"/>
     <summary>The Open University Harvard author-date style</summary>
-    <updated>2015-06-26T15:51:02+00:00</updated>
+    <updated>2016-05-24T06:45:00+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <macro name="editor">
@@ -30,6 +30,7 @@
       <label form="short" prefix=" (" suffix=")"/>
       <substitute>
         <names variable="editor"/>
+        <names variable="director"/>
         <text macro="anon"/>
       </substitute>
     </names>
@@ -50,19 +51,24 @@
       <name and="symbol" delimiter=", " delimiter-precedes-last="never" initialize-with=". "/>
     </names>
   </macro>
+  <macro name="director">
+    <names variable="author" prefix="Directed by "/>
+  </macro>
   <macro name="access">
     <choose>
       <if variable="URL">
-        <text term="online" prefix="[" suffix="]" text-case="capitalize-first"/>
-        <text value=" Available at: "/>
-        <text variable="URL"/>
-        <group prefix=" (" delimiter=" " suffix=").">
-          <text term="accessed" text-case="capitalize-first"/>
-          <date variable="accessed">
-            <date-part name="day" suffix=" "/>
-            <date-part name="month" suffix=" "/>
-            <date-part name="year"/>
-          </date>
+        <group delimiter=" ">
+          <text term="online" prefix="[" suffix="]." text-case="capitalize-first"/>
+          <text term="available at" suffix=":" text-case="capitalize-first"/>
+          <text variable="URL"/>
+          <group prefix=" (" delimiter=" " suffix=").">
+            <text term="accessed" text-case="capitalize-first"/>
+            <date variable="accessed">
+              <date-part name="day" suffix=" "/>
+              <date-part name="month" suffix=" "/>
+              <date-part name="year"/>
+            </date>
+          </group>
         </group>
       </if>
     </choose>
@@ -151,16 +157,28 @@
       <key macro="author-short"/>
     </sort>
     <layout prefix="(" suffix=")" delimiter="; ">
-      <group delimiter=", ">
-        <group delimiter=", ">
-          <text macro="author-short"/>
-          <text macro="year-date"/>
-        </group>
-        <group>
-          <text term="page" form="short" suffix=" "/>
-          <text variable="locator"/>
-        </group>
-      </group>
+      <choose>
+        <!-- Specific formats (citation) -->
+        <if type="motion_picture">
+          <group delimiter=", ">
+            <text macro="title"/>
+            <text macro="year-date"/>
+          </group>
+        </if>
+        <!-- Generic/fallback format (bibliography) -->
+        <else>
+          <group delimiter=", ">
+            <group delimiter=", ">
+              <text macro="author-short"/>
+              <text macro="year-date"/>
+            </group>
+            <group>
+              <text term="page" form="short" suffix=" "/>
+              <text variable="locator"/>
+            </group>
+          </group>
+        </else>
+      </choose>
     </layout>
   </citation>
   <bibliography>
@@ -170,27 +188,40 @@
       <key variable="title"/>
     </sort>
     <layout suffix=".">
-      <group delimiter=" ">
-        <text macro="author"/>
-        <text macro="year-date" prefix="(" suffix=")"/>
-        <group delimiter=" " suffix=",">
-          <text macro="title"/>
-          <text macro="translator" prefix="(" suffix=")"/>
-        </group>
-        <text macro="edition"/>
-        <text macro="container-prefix"/>
-        <group delimiter=", ">
-          <text macro="editor"/>
-          <text variable="container-title" font-style="italic"/>
-          <text variable="collection-title"/>
-          <text variable="genre"/>
-          <text macro="publisher"/>
-          <text macro="locators"/>
-          <text macro="published-date"/>
-          <text macro="pages"/>
-          <text macro="access"/>
-        </group>
-      </group>
+      <choose>
+        <!-- Specific formats (bibliography) -->
+        <if type="motion_picture">
+          <group delimiter=" " suffix=" [Film].">
+            <text macro="title"/>
+            <text macro="year-date" prefix="(" suffix=")"/>
+            <text macro="director"/>
+          </group>
+        </if>
+        <!-- Generic/fallback format (bibliography) -->
+        <else>
+          <group delimiter=" ">
+            <text macro="author"/>
+            <text macro="year-date" prefix="(" suffix=")"/>
+            <group delimiter=" " suffix=",">
+              <text macro="title"/>
+              <text macro="translator" prefix="(" suffix=")"/>
+            </group>
+            <text macro="edition"/>
+            <text macro="container-prefix"/>
+            <group delimiter=", ">
+              <text macro="editor"/>
+              <text variable="container-title" font-style="italic"/>
+              <text variable="collection-title"/>
+              <text variable="genre"/>
+              <text macro="publisher"/>
+              <text macro="locators"/>
+              <text macro="published-date"/>
+              <text macro="pages"/>
+              <text macro="access"/>
+            </group>
+          </group>
+        </else>
+      </choose>
     </layout>
   </bibliography>
 </style>

--- a/the-open-university-harvard.csl
+++ b/the-open-university-harvard.csl
@@ -167,7 +167,7 @@
             <text macro="year-date"/>
           </group>
         </if>
-        <!-- Generic/fallback format (bibliography) -->
+        <!-- Generic/fallback format (citation) -->
         <else>
           <group delimiter=", ">
             <group delimiter=", ">


### PR DESCRIPTION
- Change documentation URL for easier access to the PDF version, which does not require an OU login
- Create 'director' macro for use in film references
- 'access' macro: use the 'available at' term instead of hardcoded text; replace hardcoded spacing with group delimiter
- Prepare citation and bibliography for type specific formats
- Create type specific formats for films

Example of film citation:
(_Lord of the Rings: The Two Towers_, 2003)

Example of film bibliography reference:
_Lord of the Rings: The Two Towers_ (2003) Directed by Peter Jackson [Film]. New York, Newline Productions Inc.