### PR TITLE
Create Skandinavistik.csl

### DIFF
--- a/Skandinavistik.csl
+++ b/Skandinavistik.csl
@@ -2,15 +2,15 @@
 <style class="note" version="1.0" et-al-min="3" sort-separator="." demote-non-dropping-particle="sort-only" default-locale="de-DE" xmlns="http://purl.org/net/xbiblio/csl">
 <!-- This style was edited with the Visual CSL Editor (http://editor.citationstyles.org/visualEditor/) -->
   <info>
-    <title>Skandinavistik</title>
+    <title>Skandinavistik.csl</title>
     <id>http://www.zotero.org/styles/skandinavistik</id>
     <link href="http://www.zotero.org/styles/skandinavistik" rel="self"/>
-    <link href="https://github.com/citation-style-language/styles/blob/master/geistes-und-kulturwissenschaften-heilmann.csl" rel="template"/>
+    <link href="https://www.zotero.org/styles/sozialwissenschaften-heilmann?source=1" rel="template"/>
     <category citation-format="note"/>
     <category field="humanities"/>
     <summary>German style for humanities. Citations in notes; full bibliography.</summary>
     <updated>2016-06-07T09:27:45+00:00</updated>
-    <rights>This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
+    <rights>http://creativecommons.org/licenses/by-sa/3.0/</rights>
   </info>
   <locale xml:lang="de">
     <terms>

--- a/Skandinavistik.csl
+++ b/Skandinavistik.csl
@@ -1,0 +1,392 @@
+<?xml version="1.0" encoding="utf-8"?>
+<style class="note" version="1.0" et-al-min="3" sort-separator="." demote-non-dropping-particle="sort-only" default-locale="de-DE" xmlns="http://purl.org/net/xbiblio/csl">
+<!-- This style was edited with the Visual CSL Editor (http://editor.citationstyles.org/visualEditor/) -->
+  <info>
+    <title>Skandinavistik</title>
+    <id>http://www.zotero.org/styles/skandinavistik</id>
+    <link href="http://www.zotero.org/styles/skandinavistik" rel="self"/>
+    <link href="https://github.com/citation-style-language/styles/blob/master/geistes-und-kulturwissenschaften-heilmann.csl" rel="template"/>
+    <category citation-format="note"/>
+    <category field="humanities"/>
+    <summary>German style for humanities. Citations in notes; full bibliography.</summary>
+    <updated>2016-06-07T09:27:45+00:00</updated>
+    <rights>This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
+  </info>
+  <locale xml:lang="de">
+    <terms>
+      <term name="accessed" form="long">zugegriffen am</term>
+      <term name="accessed" form="short">zug. am</term>
+      <term name="no date" form="long">ohne Datum</term>
+      <term name="no date" form="short">o. D.</term>
+      <term name="ordinal-01">.</term>
+      <term name="ordinal-02">.</term>
+      <term name="ordinal-03">.</term>
+      <term name="ordinal-04">.</term>
+      <term name="long-ordinal-01">erste</term>
+      <term name="long-ordinal-02">zweite</term>
+      <term name="long-ordinal-03">dritte</term>
+      <term name="long-ordinal-04">vierte</term>
+      <term name="long-ordinal-05">fünfte</term>
+      <term name="long-ordinal-06">sechste</term>
+      <term name="long-ordinal-07">siebte</term>
+      <term name="long-ordinal-08">achte</term>
+      <term name="long-ordinal-09">neunte</term>
+      <term name="long-ordinal-10">zehnte</term>
+    </terms>
+  </locale>
+  <macro name="contributors-long">
+    <choose>
+      <if variable="author">
+        <names variable="author">
+          <name name-as-sort-order="first" and="text" sort-separator=", " delimiter=", " delimiter-precedes-last="never"/>
+        </names>
+      </if>
+      <else>
+        <choose>
+          <if type="book">
+            <names variable="editor">
+              <name name-as-sort-order="first" and="text" sort-separator=", " delimiter=", " delimiter-precedes-last="never"/>
+              <label prefix=" (" form="short" suffix=".)"/>
+            </names>
+          </if>
+        </choose>
+      </else>
+    </choose>
+  </macro>
+  <macro name="contributors-short">
+    <choose>
+      <if variable="author">
+        <names variable="author">
+          <name form="short" name-as-sort-order="first" sort-separator="/" delimiter="/" delimiter-precedes-last="always"/>
+        </names>
+      </if>
+      <else>
+        <choose>
+          <if type="book">
+            <names variable="editor">
+              <name form="short" name-as-sort-order="first" sort-separator="/" delimiter="/" delimiter-precedes-last="always"/>
+              <label prefix=" (" form="short" suffix=".)"/>
+            </names>
+          </if>
+        </choose>
+      </else>
+    </choose>
+  </macro>
+  <macro name="secondary-contributors">
+    <choose>
+      <if variable="author" type="book" match="all">
+        <names variable="editor translator" delimiter=",">
+          <label form="verb-short" text-case="lowercase" suffix=" "/>
+          <name and="text" sort-separator=", " delimiter=", " delimiter-precedes-last="never"/>
+        </names>
+      </if>
+    </choose>
+  </macro>
+  <macro name="container-contributors">
+    <choose>
+      <if variable="container-author">
+        <names variable="container-author">
+          <name name-as-sort-order="first" and="text" sort-separator=", " delimiter=", " delimiter-precedes-last="never"/>
+        </names>
+      </if>
+      <else>
+        <choose>
+          <if type="chapter">
+            <names variable="editor">
+              <name name-as-sort-order="first" and="text" sort-separator=", " delimiter=", " delimiter-precedes-last="never"/>
+              <label prefix=" (" form="short" suffix=".)"/>
+            </names>
+          </if>
+        </choose>
+      </else>
+    </choose>
+  </macro>
+  <macro name="secondary-container-contributors">
+    <choose>
+      <if variable="container-author" type="chapter" match="all">
+        <names variable="editor">
+          <label form="verb-short" text-case="lowercase" suffix=" "/>
+          <name and="text" sort-separator=", " delimiter=", " delimiter-precedes-last="never"/>
+        </names>
+      </if>
+    </choose>
+  </macro>
+  <macro name="secondary-collection-contributors">
+    <names variable="collection-editor">
+      <name and="text" sort-separator=", " delimiter=", " delimiter-precedes-last="never"/>
+    </names>
+  </macro>
+  <macro name="title-long">
+    <group delimiter="." suffix=".">
+      <choose>
+        <if type="book">
+          <text variable="title" strip-periods="false" font-style="italic"/>
+        </if>
+        <else>
+          <text variable="title" quotes="false"/>
+        </else>
+      </choose>
+      <choose>
+        <if type="book">
+          <choose>
+            <if variable="volume">
+              <group delimiter=" ">
+                <text term="volume" form="short"/>
+                <text variable="volume"/>
+              </group>
+            </if>
+          </choose>
+        </if>
+      </choose>
+      <text macro="secondary-contributors"/>
+    </group>
+  </macro>
+  <macro name="title-short">
+    <group delimiter=", ">
+      <choose>
+        <if type="book">
+          <text variable="title" form="short"/>
+        </if>
+        <else>
+          <text variable="title" form="short" quotes="true"/>
+        </else>
+      </choose>
+    </group>
+  </macro>
+  <macro name="container">
+    <choose>
+      <if type="chapter">
+        <group>
+          <choose>
+            <if variable="container-author editor" match="any">
+              <text term="in" suffix=": "/>
+            </if>
+          </choose>
+          <text macro="container-contributors" suffix=": "/>
+          <text variable="container-title"/>
+          <choose>
+            <if variable="volume">
+              <group prefix=", " delimiter=" ">
+                <text term="volume" form="short" suffix="."/>
+                <text variable="volume"/>
+              </group>
+            </if>
+          </choose>
+          <text macro="secondary-container-contributors" prefix="."/>
+        </group>
+      </if>
+      <else-if type="article-journal article-magazine" match="any">
+        <group suffix=" ">
+          <text variable="container-title" font-style="italic"/>
+        </group>
+      </else-if>
+      <else-if type="article-newspaper">
+        <group>
+          <text variable="container-title" font-style="italic"/>
+        </group>
+      </else-if>
+    </choose>
+  </macro>
+  <macro name="edition">
+    <choose>
+      <if is-numeric="edition">
+        <number variable="edition" form="ordinal"/>
+        <text prefix=" " term="edition" form="short" suffix="."/>
+      </if>
+      <else-if variable="edition">
+        <text variable="edition"/>
+        <text prefix=" " term="edition" form="short" suffix="."/>
+      </else-if>
+    </choose>
+  </macro>
+  <macro name="issued">
+    <choose>
+      <if type="book chapter" match="any">
+        <choose>
+          <if variable="collection-title">
+            <group prefix=".">
+              <text variable="collection-title"/>
+              <text prefix=" " variable="collection-number"/>
+              <choose>
+                <if variable="collection-editor">
+                  <group delimiter=" " prefix=".">
+                    <text term="editor" form="verb-short" text-case="lowercase"/>
+                    <text macro="secondary-collection-contributors"/>
+                  </group>
+                </if>
+              </choose>
+            </group>
+          </if>
+        </choose>
+        <text macro="edition" prefix=" "/>
+        <group delimiter=" " prefix=" ">
+          <group delimiter=": ">
+            <text variable="publisher-place"/>
+            <text variable="publisher"/>
+          </group>
+          <date variable="issued">
+            <date-part name="year"/>
+          </date>
+        </group>
+      </if>
+      <else-if type="article-journal article-magazine" match="any">
+        <group delimiter=" ">
+          <group delimiter=".">
+            <text variable="volume"/>
+            <text variable="issue"/>
+          </group>
+          <date prefix=" (" variable="issued" suffix=")">
+            <date-part name="year"/>
+          </date>
+        </group>
+      </else-if>
+      <else-if type="article-newspaper">
+        <date prefix=", " variable="issued" form="numeric"/>
+      </else-if>
+      <else-if type="manuscript">
+        <choose>
+          <if variable="publisher-place">
+            <text prefix=", " variable="publisher-place" suffix=" "/>
+          </if>
+          <else>
+            <text prefix=", " value="ohne Ort" suffix=", "/>
+          </else>
+        </choose>
+        <choose>
+          <if variable="issued">
+            <date variable="issued" form="numeric"/>
+          </if>
+          <else>
+            <text term="no date"/>
+          </else>
+        </choose>
+        <text prefix=" (" value="Typoskript" suffix=")"/>
+      </else-if>
+      <else-if type="thesis">
+        <choose>
+          <if variable="collection-title">
+            <group prefix=", ">
+              <text variable="collection-title"/>
+              <text prefix=" " variable="collection-number"/>
+              <choose>
+                <if variable="collection-editor">
+                  <text prefix=", " term="editor" form="verb-short" text-case="lowercase"/>
+                  <text prefix=" " macro="secondary-collection-contributors"/>
+                </if>
+              </choose>
+            </group>
+          </if>
+        </choose>
+        <text prefix=", " variable="genre"/>
+        <group prefix=", " delimiter=" ">
+          <group delimiter=": ">
+            <text variable="publisher-place"/>
+            <text variable="publisher"/>
+          </group>
+          <date variable="issued">
+            <date-part name="year"/>
+          </date>
+        </group>
+      </else-if>
+      <else>
+        <text prefix=", " variable="genre"/>
+        <group delimiter=": ">
+          <text variable="publisher-place"/>
+          <text variable="publisher"/>
+        </group>
+        <choose>
+          <if variable="issued">
+            <date prefix=", " variable="issued" form="numeric"/>
+          </if>
+          <else>
+            <text prefix=", " term="no date"/>
+          </else>
+        </choose>
+      </else>
+    </choose>
+  </macro>
+  <macro name="pages">
+    <choose>
+      <if type="article-journal article-magazine article-newspaper chapter" match="any">
+        <label variable="page" form="short" suffix=". "/>
+        <text variable="page"/>
+      </if>
+    </choose>
+  </macro>
+  <macro name="access">
+    <choose>
+      <if variable="URL">
+        <text variable="URL"/>
+        <group prefix=" (" suffix=")" delimiter=" ">
+          <text term="accessed" text-case="lowercase"/>
+          <date variable="accessed">
+            <date-part name="day" form="numeric" suffix="."/>
+            <date-part name="month" form="numeric" suffix="."/>
+            <date-part name="year"/>
+          </date>
+        </group>
+      </if>
+    </choose>
+  </macro>
+  <macro name="citation-locator">
+    <label variable="locator" form="short" suffix=". "/>
+    <text variable="locator"/>
+  </macro>
+  <citation et-al-min="4" et-al-use-first="1" disambiguate-add-names="true">
+    <layout suffix="." delimiter="; ">
+      <choose>
+        <if position="ibid-with-locator">
+          <text term="ibid" text-case="capitalize-first" suffix="."/>
+          <text macro="citation-locator" prefix="."/>
+        </if>
+        <else-if position="ibid">
+          <text term="ibid" text-case="capitalize-first" suffix="."/>
+        </else-if>
+        <else-if position="subsequent">
+          <text macro="contributors-short" suffix=": "/>
+          <text macro="title-short" suffix="."/>
+          <text macro="citation-locator" prefix="."/>
+        </else-if>
+        <else>
+          <text macro="contributors-long" suffix=": "/>
+          <text macro="title-long"/>
+          <text macro="container" prefix=" In: "/>
+          <text macro="issued"/>
+          <text prefix=", " macro="pages"/>
+          <choose>
+            <if variable="page" type="chapter" match="all">
+              <text prefix=", hier " macro="citation-locator"/>
+            </if>
+            <else-if variable="page" type="article-journal" match="all">
+              <text prefix=", hier " macro="citation-locator"/>
+            </else-if>
+            <else-if variable="page" type="article-magazine" match="all">
+              <text prefix=", hier " macro="citation-locator"/>
+            </else-if>
+            <else-if variable="page" type="article-newspaper" match="all">
+              <text prefix=", hier " macro="citation-locator"/>
+            </else-if>
+            <else>
+              <text prefix=", " macro="citation-locator"/>
+            </else>
+          </choose>
+          <text macro="access" prefix=". "/>
+        </else>
+      </choose>
+    </layout>
+  </citation>
+  <bibliography et-al-min="4" et-al-use-first="1" hanging-indent="true" entry-spacing="0" subsequent-author-substitute="---">
+    <sort>
+      <key macro="contributors-long" names-min="3" names-use-first="3"/>
+      <key macro="title-long"/>
+    </sort>
+    <layout suffix=".">
+      <text macro="contributors-long" suffix=": "/>
+      <text macro="title-long"/>
+      <text macro="container" prefix=" In: "/>
+      <text macro="issued"/>
+      <text prefix=", " macro="pages"/>
+      <text prefix=", " macro="access"/>
+    </layout>
+  </bibliography>
+</style>

--- a/Skandinavistik.csl
+++ b/Skandinavistik.csl
@@ -2,7 +2,7 @@
 <style class="note" version="1.0" et-al-min="3" sort-separator="." demote-non-dropping-particle="sort-only" default-locale="de-DE" xmlns="http://purl.org/net/xbiblio/csl">
 <!-- This style was edited with the Visual CSL Editor (http://editor.citationstyles.org/visualEditor/) -->
   <info>
-    <title>Skandinavistik.csl</title>
+    <title>Skandinavistik</title>
     <id>http://www.zotero.org/styles/skandinavistik</id>
     <link href="http://www.zotero.org/styles/skandinavistik" rel="self"/>
     <link href="https://www.zotero.org/styles/sozialwissenschaften-heilmann?source=1" rel="template"/>
@@ -10,7 +10,7 @@
     <category field="humanities"/>
     <summary>German style for humanities. Citations in notes; full bibliography.</summary>
     <updated>2016-06-07T09:27:45+00:00</updated>
-    <rights>http://creativecommons.org/licenses/by-sa/3.0/</rights>
+    <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale xml:lang="de">
     <terms>


### PR DESCRIPTION
Citation style for German Scandinavian Studies

I took the Style of Heilmann (https://github.com/citation-style-language/styles/blob/master/geistes-und-kulturwissenschaften-heilmann.csl) and changed it according to the style sheet for most of the German Scandinavian Studies.

- using full stops instead of commas to section the parts

- title is in italics (if it's a monography) or the journal title is in italics