### PR TITLE
Two small corrections to the AGLC style

### DIFF
--- a/australian-guide-to-legal-citation.csl
+++ b/australian-guide-to-legal-citation.csl
@@ -32,7 +32,7 @@
     <category citation-format="note"/>
     <category field="law"/>
     <summary>A modification of the Bluebook legal citation style for Australian conditions.</summary>
-    <updated>2015-11-10T00:40:00+00:00</updated>
+    <updated>2016-07-05T05:38:10+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale>
@@ -361,7 +361,10 @@
     <choose>
       <if type="article-journal article-magazine article-newspaper legal_case" match="any">
         <group delimiter=" ">
-          <text variable="volume"/>
+          <group>
+            <text variable="volume"/>
+            <text variable="issue" prefix="(" suffix=")"/>
+          </group>
           <choose>
             <if type="legal_case">
               <choose>
@@ -525,12 +528,12 @@
               </group>
               <text macro="page-first"/>
               <text variable="locator"/>
-              <choose>
-                <if type="legal_case bill legislation manuscript" match="any">
-                  <text macro="title-short" text-case="title" quotes="true" prefix=" (" suffix=")"/>
-                </if>
-              </choose>
             </group>
+            <choose>
+              <if type="legal_case bill legislation manuscript" match="any">
+                <text macro="title-short" text-case="title" quotes="true" prefix=" (" suffix=")"/>
+              </if>
+            </choose>
             <text macro="URL"/>
           </group>
         </else>


### PR DESCRIPTION
Users of the style at Melbourne Law School have requested that the issue number be available for journal articles. Per rule 4.4 of AGLC this should be in the format of Vol(Issue). 

As well, short titles were appearing with an extra comma due to the delimiter on the group the macro was in. This shifts short title outside the group to fix that.

E.g.: 
"Overseas Tankship (UK) Ltd v Morts Dock and Engineering Co Ltd [1961] AC 388, 390, (‘Wagon Mound [No. 1]’)."
was displaying instead of
"Overseas Tankship (UK) Ltd v Morts Dock and Engineering Co Ltd [1961] AC 388, 390 (‘Wagon Mound [No. 1]’)."