### PR TITLE
journal-of-materials-research.csl

### DIFF
--- a/journal-of-materials-research.csl
+++ b/journal-of-materials-research.csl
@@ -2,19 +2,19 @@
 <style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" demote-non-dropping-particle="sort-only" default-locale="en-US">
   <info>
     <title>Journal of Materials Research</title>
-	<title-short>J. Mater. Res.</title-short>
+    <title-short>J. Mater. Res.</title-short>
     <id>http://www.zotero.org/styles/journal-of-materials-research</id>
-	<link href="http://www.zotero.org/styles/journal-of-materials-research" rel="self"/>
-	<link href="http://www.zotero.org/styles/american-physics-society" rel="template"/>
-	<link href="http://www.mrs.org/jmr-format" rel="documentation"/>
+    <link href="http://www.zotero.org/styles/journal-of-materials-research" rel="self"/>
+    <link href="http://www.zotero.org/styles/american-physics-society" rel="template"/>
+    <link href="http://www.mrs.org/jmr-format" rel="documentation"/>
     <author>
       <name>Sonal Dey</name>
       <email>deysonal2012@gmail.com</email>
-	  <uri>https://sites.google.com/site/deysonal2012</uri>
+      <uri>https://sites.google.com/site/deysonal2012</uri>
     </author>
     <category citation-format="numeric"/>
     <category field="physics"/>
-	<issn>0884-2914</issn>
+    <issn>0884-2914</issn>
     <eissn>2044-5326</eissn>
     <summary>A citation style for the Journal of Materials Research.</summary>
     <updated>2016-07-05T15:10:00+00:00</updated>
@@ -154,8 +154,8 @@
         <else-if type="article-journal review" match="any">
           <group delimiter=" ">
             <text macro="title"/>
-			<text variable="container-title" font-style="italic" form="short"/>
-			<group delimiter=", ">
+            <text variable="container-title" font-style="italic" form="short"/>
+            <group delimiter=", ">
               <choose>
                 <if variable="volume">
                   <group delimiter="">
@@ -173,8 +173,8 @@
               <text variable="page-first"/>
             </group>
           </group>
-		  <text macro="year-date" prefix=" (" suffix=")"/>
-        </else-if>		
+          <text macro="year-date" prefix=" (" suffix=")"/>
+        </else-if>
         <else>
           <group delimiter=" ">
             <text variable="container-title" font-style="italic" form="short" text-case="title"/>

--- a/journal-of-materials-research.csl
+++ b/journal-of-materials-research.csl
@@ -5,6 +5,7 @@
 	<title-short>J. Mater. Res.</title-short>
     <id>http://www.zotero.org/styles/journal-of-materials-research</id>
 	<link href="http://www.zotero.org/styles/journal-of-materials-research" rel="self"/>
+	<link href="http://www.zotero.org/styles/american-physics-society" rel="template"/>
 	<link href="http://www.mrs.org/jmr-format" rel="documentation"/>
     <author>
       <name>Sonal Dey</name>

--- a/journal-of-materials-research.csl
+++ b/journal-of-materials-research.csl
@@ -1,0 +1,192 @@
+<?xml version="1.0" encoding="utf-8"?>
+<style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" demote-non-dropping-particle="sort-only" default-locale="en-US">
+  <info>
+    <title>Journal of Materials Research</title>
+	<title-short>J. Mater. Res.</title-short>
+    <id>http://www.zotero.org/styles/journal-of-materials-research</id>
+	<link href="http://www.zotero.org/styles/journal-of-materials-research" rel="self"/>
+	<link href="http://www.mrs.org/jmr-format" rel="documentation"/>
+    <author>
+      <name>Sonal Dey</name>
+      <email>deysonal2012@gmail.com</email>
+	  <uri>https://sites.google.com/site/deysonal2012</uri>
+    </author>
+    <category citation-format="numeric"/>
+    <category field="physics"/>
+	<issn>0884-2914</issn>
+    <eissn>2044-5326</eissn>
+    <summary>A citation style for the Journal of Materials Research from the Materials Research Society.</summary>
+    <updated>2016-07-05T15:10:00+00:00</updated>
+    <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
+  </info>
+  <macro name="author">
+    <names variable="author">
+      <name delimiter=", " initialize-with=". " and="text"/>
+      <label form="long" prefix=", " suffix=" "/>
+      <substitute>
+        <names variable="editor"/>
+        <names variable="translator"/>
+      </substitute>
+    </names>
+  </macro>
+  <macro name="editor">
+    <names variable="editor">
+      <label form="verb" suffix=" "/>
+      <name delimiter=", " initialize-with=". " and="text"/>
+    </names>
+  </macro>
+  <macro name="year-date">
+    <choose>
+      <if variable="issued">
+        <date variable="issued">
+          <date-part name="year"/>
+        </date>
+      </if>
+      <else>
+        <text term="no date" form="short"/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="day-date">
+    <choose>
+      <if variable="issued">
+        <date variable="issued">
+          <date-part name="day" suffix=" "/>
+          <date-part name="month" form="long" suffix=" "/>
+          <date-part name="year"/>
+        </date>
+      </if>
+      <else>
+        <text term="no date" form="short"/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="publisher">
+    <group prefix="(" suffix=")" delimiter=", ">
+      <text variable="publisher"/>
+      <text variable="publisher-place" text-case="title"/>
+      <text macro="year-date"/>
+    </group>
+  </macro>
+  <macro name="edition">
+    <choose>
+      <if is-numeric="edition">
+        <group delimiter=" ">
+          <number variable="edition" form="ordinal"/>
+          <text term="edition" form="short"/>
+        </group>
+      </if>
+      <else>
+        <text variable="edition"/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="title">
+    <choose>
+      <if type="bill book graphic legal_case legislation motion_picture song" match="any">
+        <text variable="title" font-style="italic"/>
+      </if>
+      <else>
+        <text variable="title" suffix="."/>
+      </else>
+    </choose>
+  </macro>
+  <citation collapse="citation-number">
+    <sort>
+      <key variable="citation-number"/>
+    </sort>
+    <layout delimiter="," vertical-align="sup">
+      <text variable="citation-number"/>
+    </layout>
+  </citation>
+  <bibliography entry-spacing="0" second-field-align="flush">
+    <layout suffix=".">
+      <text variable="citation-number" suffix="."/>
+      <text macro="author" suffix=": "/>
+      <choose>
+        <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
+          <group delimiter=" ">
+            <group delimiter=", ">
+              <text variable="title" text-case="title" font-style="italic"/>
+              <text macro="edition"/>
+            </group>
+            <group delimiter=", ">
+              <text macro="publisher"/>
+              <group delimiter=" ">
+                <label variable="page" form="short"/>
+                <text variable="page"/>
+              </group>
+            </group>
+          </group>
+        </if>
+        <else-if type="chapter paper-conference" match="any">
+          <group delimiter=" ">
+            <text term="in"/>
+            <group delimiter=", ">
+              <text variable="container-title" form="short" text-case="title" font-style="italic"/>
+              <text macro="editor"/>
+              <text macro="edition"/>
+            </group>
+            <group delimiter=", ">
+              <text macro="publisher"/>
+              <group delimiter=" ">
+                <label variable="page" form="short"/>
+                <text variable="page"/>
+              </group>
+            </group>
+          </group>
+        </else-if>
+        <else-if type="patent">
+          <group delimiter=" ">
+            <text variable="number"/>
+            <text macro="day-date" prefix="(" suffix=")"/>
+          </group>
+        </else-if>
+        <else-if type="thesis">
+          <group delimiter=", ">
+            <text variable="title" text-case="title"/>
+            <text variable="genre"/>
+            <text variable="publisher"/>
+            <text macro="year-date"/>
+          </group>
+        </else-if>
+        <else-if type="article-journal review" match="any">
+          <group delimiter=" ">
+            <text macro="title"/>
+			<text variable="container-title" font-style="italic" form="short"/>
+			<group delimiter=", ">
+              <choose>
+                <if variable="volume">
+                  <group delimiter="">
+                    <text variable="volume" font-weight="bold"/>
+                    <text variable="issue" prefix="(" suffix=")"/>
+                  </group>
+                </if>
+                <else-if variable="issue">
+                  <group delimiter=" ">
+                    <text term="issue" form="short" text-case="capitalize-first"/>
+                    <text variable="issue"/>
+                  </group>
+                </else-if>
+              </choose>
+              <text variable="page-first"/>
+            </group>
+          </group>
+		  <text macro="year-date" prefix=" (" suffix=")"/>
+        </else-if>		
+        <else>
+          <group delimiter=" ">
+            <text variable="container-title" form="short" text-case="title"/>
+            <group delimiter=", ">
+              <text variable="volume" font-weight="bold"/>
+              <group delimiter=" ">
+                <text variable="page-first" form="short"/>
+                <text macro="year-date" prefix="(" suffix=")"/>
+              </group>
+            </group>
+          </group>
+        </else>
+      </choose>
+    </layout>
+  </bibliography>
+</style>

--- a/journal-of-materials-research.csl
+++ b/journal-of-materials-research.csl
@@ -15,7 +15,7 @@
     <category field="physics"/>
 	<issn>0884-2914</issn>
     <eissn>2044-5326</eissn>
-    <summary>A citation style for the Journal of Materials Research from the Materials Research Society.</summary>
+    <summary>A citation style for the Journal of Materials Research.</summary>
     <updated>2016-07-05T15:10:00+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
@@ -84,7 +84,7 @@
   <macro name="title">
     <choose>
       <if type="bill book graphic legal_case legislation motion_picture song" match="any">
-        <text variable="title" font-style="italic"/>
+        <text variable="title"/>
       </if>
       <else>
         <text variable="title" suffix="."/>
@@ -107,7 +107,7 @@
         <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
           <group delimiter=" ">
             <group delimiter=", ">
-              <text variable="title" text-case="title" font-style="italic"/>
+              <text variable="title" text-case="title"/>
               <text macro="edition"/>
             </group>
             <group delimiter=", ">
@@ -176,7 +176,7 @@
         </else-if>		
         <else>
           <group delimiter=" ">
-            <text variable="container-title" form="short" text-case="title"/>
+            <text variable="container-title" font-style="italic" form="short" text-case="title"/>
             <group delimiter=", ">
               <text variable="volume" font-weight="bold"/>
               <group delimiter=" ">


### PR DESCRIPTION
No style for Journal of Materials Research exists at this point. I have created this new style following the instructions at:

[http://www.mrs.org/jmr-format/](url)

The style is largely based on the "american-physics-society.csl" file but with the necessary changes, e.g.,

1. The delimiter after the last author's name is ":".
2. The full title of the journal is added which ends with ".".
3. The journal name is abbreviated and appears in italics.
4. The volume number is in bold followed by the issue number in parenthesis.
5. Only the first page number appears.
6. The year appears, in parenthesis, at the end.