### PR TITLE
Add style: Elementa (author-date)

### DIFF
--- a/elementa-author-date.csl
+++ b/elementa-author-date.csl
@@ -67,21 +67,20 @@
       <if variable="DOI">
         <text variable="DOI" prefix="doi: "/>
       </if>
-      <else-if variable="URL">
-        <choose>
-          <if variable="accessed" match="any">
-            <group suffix=". " delimiter=" ">
-              <text term="accessed" text-case="capitalize-first"/>
-              <date variable="accessed" delimiter=" ">
-                <date-part name="year"/>
-                <date-part name="month" form="short" strip-periods="true"/>
-                <date-part name="day"/>
-              </date>
-            </group>
-          </if>
-        </choose>
-        <text variable="URL"/>
-      </else-if>
+      <else variable="URL">
+        <group suffix=". " delimiter=" ">
+          <text term="available at" text-case="capitalize-first"/>
+          <text variable="URL"/>
+        </group>
+        <group suffix=". " delimiter=" ">
+          <text term="accessed" text-case="capitalize-first"/>
+          <date variable="accessed" delimiter=" ">
+            <date-part name="year"/>
+            <date-part name="month" form="short" strip-periods="true"/>
+            <date-part name="day"/>
+          </date>
+        </group>
+      </else>
     </choose>
   </macro>
   <macro name="title">

--- a/elementa-author-date.csl
+++ b/elementa-author-date.csl
@@ -227,7 +227,7 @@
       <text variable="locator" prefix=": "/>
     </layout>
   </citation>
-  <bibliography hanging-indent="false" et-al-min="11" et-al-use-first="10">
+  <bibliography hanging-indent="true" et-al-min="11" et-al-use-first="10">
     <sort>
       <key macro="author"/>
       <key macro="year-date"/>

--- a/elementa-author-date.csl
+++ b/elementa-author-date.csl
@@ -142,6 +142,11 @@
       </group>
     </group>
   </macro>
+  <macro name="year">
+    <date variable="issued" delimiter=" ">
+      <date-part name="year"/>
+    </date>
+  </macro>
   <macro name="year-date">
     <group delimiter=" ">
       <date variable="issued" delimiter=" ">
@@ -215,9 +220,9 @@
       <key macro="author-short"/>
     </sort>
     <layout prefix="(" suffix=")" delimiter="; ">
-      <group delimiter=" ">
+      <group delimiter=", ">
         <text macro="author-short"/>
-        <text macro="year-date"/>
+        <text macro="year"/>
       </group>
       <text variable="locator" prefix=": "/>
     </layout>

--- a/elementa-author-date.csl
+++ b/elementa-author-date.csl
@@ -67,7 +67,7 @@
       <if variable="DOI">
         <text variable="DOI" prefix="doi: "/>
       </if>
-      <else variable="URL">
+      <else-if variable="URL">
         <group suffix=". " delimiter=" ">
           <text term="available at" text-case="capitalize-first"/>
           <text variable="URL"/>
@@ -80,7 +80,7 @@
             <date-part name="day"/>
           </date>
         </group>
-      </else>
+      </else-if>
     </choose>
   </macro>
   <macro name="title">

--- a/elementa-author-date.csl
+++ b/elementa-author-date.csl
@@ -1,0 +1,287 @@
+<?xml version="1.0" encoding="utf-8"?>
+<style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" demote-non-dropping-particle="sort-only" default-locale="en-US">
+  <info>
+    <title>Elementa (author-date)</title>
+    <title-short>Elementa</title-short>
+    <eissn>2325-1026</eissn>
+    <id>http://www.zotero.org/styles/elementa-author-date</id>
+    <link href="http://www.zotero.org/styles/elementa-author-date" rel="self"/>
+    <link href="https://home.elementascience.org/for-authors/style-guide/" rel="documentation"/>
+    <link href="http://www.zotero.org/styles/council-of-science-editors-author-date" rel="template"/>
+    <author>
+      <name>Akos Kokai</name>
+      <email>akokai@berkeley.edu</email>
+    </author>
+    <category citation-format="author-date"/>
+    <category field="science"/>
+    <summary>Based on The Council of Science Editors style, Name-Year system: author-date in text, sorted in alphabetical order by author.</summary>
+    <updated>2016-07-16T08:00:00+00:00</updated>
+    <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
+  </info>
+  <locale xml:lang="en">
+    <terms>
+      <term name="editortranslator" form="long">
+        <single>editor and translator</single>
+        <multiple>editors and translators</multiple>
+      </term>
+      <term name="collection-editor" form="long">
+        <single>editor</single>
+        <multiple>editors</multiple>
+      </term>
+    </terms>
+  </locale>
+  <macro name="editor">
+    <names variable="editor translator" delimiter="; " suffix=".">
+      <name delimiter-precedes-last="always" initialize-with="" name-as-sort-order="all" sort-separator=" "/>
+      <label prefix=", "/>
+    </names>
+  </macro>
+  <macro name="author">
+    <names variable="author" delimiter="; ">
+      <name name-as-sort-order="all" sort-separator=" " initialize-with="" delimiter=", " delimiter-precedes-last="always"/>
+      <label form="long" prefix=", " strip-periods="true"/>
+      <substitute>
+        <names variable="editor translator"/>
+        <text variable="title"/>
+      </substitute>
+    </names>
+  </macro>
+  <macro name="author-short">
+    <names variable="author">
+      <name form="short" delimiter=", " initialize-with="." and="text"/>
+      <substitute>
+        <names variable="editor"/>
+        <names variable="translator"/>
+        <text variable="title-short"/>
+      </substitute>
+    </names>
+  </macro>
+  <macro name="review">
+    <group delimiter=". ">
+      <text variable="reviewed-title"/>
+      <text variable="container-title"/>
+    </group>
+  </macro>
+  <macro name="access">
+    <choose>
+      <if variable="DOI">
+        <text variable="DOI" prefix="doi: "/>
+      </if>
+      <else-if variable="URL">
+        <choose>
+          <if variable="accessed" match="any">
+            <group suffix=". " delimiter=" ">
+              <text term="accessed" text-case="capitalize-first"/>
+              <date variable="accessed" delimiter=" ">
+                <date-part name="year"/>
+                <date-part name="month" form="short" strip-periods="true"/>
+                <date-part name="day"/>
+              </date>
+            </group>
+          </if>
+        </choose>
+        <text variable="URL"/>
+      </else-if>
+    </choose>
+  </macro>
+  <macro name="title">
+    <group delimiter=" ">
+      <choose>
+        <if type="book">
+          <text variable="title" font-style="italic"/>
+        </if>
+        <else>
+          <text variable="title"/>
+        </else>
+      </choose>
+      <choose>
+        <if type="thesis" match="any">
+          <text variable="genre" form="long" prefix="[" suffix="]"/>
+        </if>
+      </choose>
+    </group>
+  </macro>
+  <macro name="container-title">
+    <choose>
+      <if type="book article-magazine article-newspaper">
+        <text variable="container-title" font-style="italic"/>
+      </if>
+      <else-if type="article-journal">
+        <text variable="container-title" form="short" font-style="italic"/>
+      </else-if>
+      <else>
+        <text variable="container-title"/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="publisher">
+    <group delimiter=": ">
+      <choose>
+        <if type="thesis">
+          <text variable="publisher-place" prefix="[" suffix="]"/>
+        </if>
+        <else>
+          <text variable="publisher-place"/>
+        </else>
+      </choose>
+      <text variable="publisher"/>
+    </group>
+  </macro>
+  <macro name="pages">
+    <group delimiter="; ">
+      <group>
+        <label variable="page" form="short" suffix=" " plural="never"/>
+        <text variable="page"/>
+      </group>
+      <group>
+        <text variable="number-of-pages"/>
+        <choose>
+          <if is-numeric="number-of-pages">
+            <label variable="number-of-pages" form="short" prefix=" " plural="never"/>
+          </if>
+        </choose>
+      </group>
+    </group>
+  </macro>
+  <macro name="year-date">
+    <group delimiter=" ">
+      <date variable="issued" delimiter=" ">
+        <date-part name="year"/>
+      </date>
+      <choose>
+        <if type="patent article-newspaper webpage" match="any">
+          <date variable="issued" delimiter=" ">
+            <date-part name="month" form="short" strip-periods="true"/>
+            <date-part name="day"/>
+          </date>
+        </if>
+        <else-if type="article-journal article-magazine" match="any">
+          <choose>
+            <if variable="volume issue" match="none">
+              <date variable="issued" delimiter=" ">
+                <date-part name="month" form="short" strip-periods="true"/>
+                <date-part name="day"/>
+              </date>
+            </if>
+          </choose>
+        </else-if>
+      </choose>
+    </group>
+  </macro>
+  <macro name="edition">
+    <choose>
+      <if is-numeric="edition">
+        <group delimiter=" ">
+          <number variable="edition" form="ordinal"/>
+          <text term="edition" form="short"/>
+        </group>
+      </if>
+      <else>
+        <text variable="edition" suffix="."/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="collection">
+    <choose>
+      <if type="report">
+        <group prefix=" " suffix="." delimiter=" ">
+          <text variable="collection-title"/>
+          <text variable="number" prefix=" Report No.: "/>
+        </group>
+      </if>
+      <else>
+        <group prefix=" (" suffix=")." delimiter=" ">
+          <names variable="collection-editor" suffix=". ">
+            <name delimiter-precedes-last="always" initialize-with="" name-as-sort-order="all" sort-separator=" "/>
+            <label prefix=", "/>
+          </names>
+          <text variable="collection-title"/>
+        </group>
+      </else>
+    </choose>
+  </macro>
+  <macro name="volume">
+    <choose>
+      <if type="article-journal">
+        <text variable="volume" font-weight="bold"/>
+      </if>
+      <else>
+        <text variable="volume"/>
+      </else>
+    </choose>
+  </macro>
+  <citation et-al-min="3" et-al-use-first="1" disambiguate-add-year-suffix="true" disambiguate-add-names="true" disambiguate-add-givenname="true">
+    <sort>
+      <key macro="year-date"/>
+      <key macro="author-short"/>
+    </sort>
+    <layout prefix="(" suffix=")" delimiter="; ">
+      <group delimiter=" ">
+        <text macro="author-short"/>
+        <text macro="year-date"/>
+      </group>
+      <text variable="locator" prefix=": "/>
+    </layout>
+  </citation>
+  <bibliography hanging-indent="false" et-al-min="11" et-al-use-first="10">
+    <sort>
+      <key macro="author"/>
+      <key macro="year-date"/>
+    </sort>
+    <layout>
+      <group suffix="." delimiter=". ">
+        <text macro="author"/>
+        <text macro="year-date"/>
+        <text macro="title"/>
+      </group>
+      <group suffix=".">
+        <choose>
+          <if type="bill book graphic legal_case legislation motion_picture report song thesis" match="any">
+            <group prefix=" " suffix="." delimiter=" ">
+              <text macro="edition"/>
+              <text macro="editor"/>
+            </group>
+            <text prefix=" " macro="publisher"/>
+            <text prefix=" " macro="collection"/>
+          </if>
+          <else-if type="chapter paper-conference entry-dictionary entry-encyclopedia" match="any">
+            <group prefix=" " delimiter=" ">
+              <group delimiter=" ">
+                <text term="in" text-case="capitalize-first" suffix=":"/>
+                <text macro="editor"/>
+                <text variable="container-title" suffix="."/>
+              </group>
+              <text macro="volume" prefix="Vol. " suffix="."/>
+              <text macro="edition"/>
+              <group suffix="." delimiter=". ">
+                <text macro="publisher"/>
+                <text prefix=" " macro="collection"/>
+                <text macro="pages"/>
+              </group>
+            </group>
+          </else-if>
+          <else-if type="review review-book" match="any">
+            <text macro="editor" prefix=" " suffix="."/>
+            <group prefix=" " suffix=".">
+              <text macro="review" suffix="."/>
+              <group prefix=" ">
+                <text macro="volume"/>
+                <text variable="issue" prefix="(" suffix=")"/>
+              </group>
+              <text variable="page" prefix=":"/>
+            </group>
+          </else-if>
+          <else>
+            <text macro="editor" suffix="." prefix=" "/>
+            <group prefix=" " suffix=".">
+              <text macro="container-title"/>
+              <text macro="volume" prefix=" "/>
+              <text variable="page" prefix=":"/>
+            </group>
+          </else>
+        </choose>
+      </group>
+      <text prefix=" " macro="access"/>
+    </layout>
+  </bibliography>
+</style>

--- a/elementa.csl
+++ b/elementa.csl
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" demote-non-dropping-particle="sort-only" default-locale="en-US">
   <info>
-    <title>Elementa (author-date)</title>
+    <title>Elementa</title>
     <title-short>Elementa</title-short>
     <eissn>2325-1026</eissn>
-    <id>http://www.zotero.org/styles/elementa-author-date</id>
-    <link href="http://www.zotero.org/styles/elementa-author-date" rel="self"/>
+    <id>http://www.zotero.org/styles/elementa</id>
+    <link href="http://www.zotero.org/styles/elementa" rel="self"/>
     <link href="https://home.elementascience.org/for-authors/style-guide/" rel="documentation"/>
     <link href="http://www.zotero.org/styles/council-of-science-editors-author-date" rel="template"/>
     <author>


### PR DESCRIPTION
For the journal [Elementa](http://www.elementascience.org/). Based on The Council of Science Editors style, Name-Year system: author-date in text, sorted in alphabetical order by author.
XML validated by validator.nu.