### PR TITLE
Update triangle.csl

### DIFF
--- a/triangle.csl
+++ b/triangle.csl
@@ -4,9 +4,13 @@
     <title>Triangle (French)</title>
     <id>http://www.zotero.org/styles/triangle</id>
     <link href="http://www.zotero.org/styles/triangle" rel="self"/>
-    <link href="http://triangle.ens-lyon.fr/spip.php?rubrique229" rel="documentation"/>
+	<link href="http://triangle.ens-lyon.fr/spip.php?article2179" rel="documentation"/>
     <author>
       <name>Jean-Mark Guérin</name>
+    </author>
+	<author>
+      <name>Carole Boulai</name>
+	  <uri>http://triangle.ens-lyon.fr/spip.php?article202</uri>
     </author>
     <author>
       <name>Cecile Laube</name>
@@ -15,16 +19,17 @@
     <category citation-format="note"/>
     <category field="social_science"/>
     <summary>Derived from Style EHESS-histoire, available at http://www.boiteaoutils.info/2011/06/styles-francais-de-citation-sous-zotero.html
-		First version online in november 2012</summary>
-    <updated>2013-01-25T03:56:29+00:00</updated>
+		First version online in november 2012. Changes made to cover more documents types and to lighten URLS display. Should preferably be used ticking the quoting option (preferences/citer/styles): include URLs addresses in references.</summary>
+    <updated>2016-07-19T04:10:55+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale xml:lang="fr">
     <terms>
-      <term name="editor" form="short">
+      <!-- <term name="editor" form="short">
         <single>(dir.)</single>
         <multiple>(dir.)</multiple>
-      </term>
+      </term> -->
+	  <term name="editor" form="short">(dir.)</term>
       <term name="ordinal-01">ère</term>
       <term name="ordinal-02">e</term>
       <term name="ordinal-03">e</term>
@@ -36,6 +41,10 @@
       </term>
       <term name="editor" form="verb-short">dir. par&#160; </term>
       <term name="editor" form="verb">dirigé par&#160; </term>
+		<term name="collection-editor" form="short">(dir.)</term>
+		  <term name="collection-editor" form="verb-short">dir. par  </term>
+		  <term name="collection-editor" form="verb">dirigé par  </term>
+	<term name="translator" form="short">(trad.)</term>
       <term name="translator" form="verb-short">trad. par&#160;</term>
       <term name="interviewer" form="verb">entretien réalisé par&#160;</term>
       <term name="in">in&#160;:</term>
@@ -43,6 +52,7 @@
       <term name="accessed">consulté le&#160;</term>
       <term name="at">disponible sur&#160;: </term>
       <term name="et-al">et al.</term>
+	  <term name="from">URL</term>
     </terms>
   </locale>
   <!-- INFORMATIONS -->
@@ -51,15 +61,29 @@
   <!-- Fonction du type de référence : cf. http://citationstyles.org/downloads/specification-csl10-20100530.html#appendix-ii-types -->
   <!-- /INFORMATIONS -->
   <!--_-_-_-_-_-SECTION DEFINITION DES MACROS-_-_-_-_-_-_-->
+<!-- MACRO AUTEUR, EDITEUR SCIENTIFIQUE, DIRECTEUR DE COLLECTION (POUR LES NDBP) -->
   <macro name="author">
     <choose>
-      <if variable="author">
+      <if variable="collection-editor">
+			<names variable="collection-editor">
+			  <name form="long" and="text" delimiter-precedes-last="never" delimiter=", " sort-separator=" " font-style="normal">
+				<name-part name="family" font-variant="small-caps"/>
+			  </name>
+			</names>
+			<text term="collection-editor" form="short" prefix="&#160;" suffix=",&#160;"/>
+			<names variable="author">
+				<name form="long" and="text" delimiter-precedes-last="never" delimiter=",&#32;" sort-separator=" " font-style="normal">
+				<name-part name="family" font-variant="small-caps"/>
+			  </name>
+			</names>
+		  </if>
+	  <else-if variable="author">
         <names variable="author">
           <name form="long" and="text" delimiter-precedes-last="never" sort-separator=" " font-style="normal">
             <name-part name="family" font-variant="small-caps"/>
           </name>
         </names>
-      </if>
+      </else-if>
       <else-if variable="editor">
         <names variable="editor">
           <name form="long" and="text" delimiter-precedes-last="never" sort-separator=" " font-style="normal">
@@ -70,15 +94,30 @@
       </else-if>
     </choose>
   </macro>
+   <!-- MACRO AUTEUR, EDITEUR SCIENTIFIQUE, DIRECTEUR DE COLLECTION (POUR LA BIBLIO) -->
   <macro name="author-bib">
     <choose>
-      <if variable="author">
+	<if variable="collection-editor">
+			<names variable="collection-editor">
+			  <name name-as-sort-order="all" form="long" and="text" delimiter-precedes-last="never" delimiter=", " sort-separator=" " font-style="normal">
+				<name-part name="family" font-variant="small-caps"/>
+			  </name>
+			</names>
+			<text term="collection-editor" form="short" prefix="&#160;" suffix=",&#160;"/>
+			<names variable="author">
+				<name name-as-sort-order="all" form="long" and="text" delimiter-precedes-last="never" delimiter=",&#32;" sort-separator=" " font-style="normal">
+				<name-part name="family" font-variant="small-caps"/>
+			  </name>
+
+			</names>
+		  </if>
+      <else-if variable="author">
         <names variable="author">
           <name name-as-sort-order="all" form="long" and="text" delimiter-precedes-last="never" sort-separator=" " font-style="normal">
             <name-part name="family" font-variant="small-caps"/>
           </name>
         </names>
-      </if>
+      </else-if>
       <else-if variable="editor">
         <names variable="editor">
           <name name-as-sort-order="all" form="long" and="text" delimiter-precedes-last="never" sort-separator=" " font-style="normal">
@@ -89,6 +128,7 @@
       </else-if>
     </choose>
   </macro>
+<!-- MACRO EDITEUR SCIENTIFIQUE APPELEE SEULEMENT PAR LA MACRO TITLE, type : chapitres d'ouvrage -->
   <macro name="editor">
     <names variable="editor">
       <name form="long" and="text" delimiter-precedes-last="never" sort-separator=" " font-style="normal">
@@ -97,13 +137,34 @@
       <label form="short" prefix="&#160;"/>
     </names>
   </macro>
-  <macro name="translator">
-    <names variable="translator">
-      <name form="long" and="text" delimiter-precedes-last="never" sort-separator=" " font-style="normal" prefix=" traduit par ">
-        <name-part name="family" font-variant="small-caps"/>
-      </name>
-    </names>
-  </macro>
+	<!-- MACRO TRANSLATOR (POUR LES NDBP ET LA BIBLIO)-->
+	  <macro name="translator">
+	  <choose>
+	  <if variable="translator">
+		<names variable="translator">
+		  <name form="long" and="text" delimiter-precedes-last="never" delimiter=",&#32;" sort-separator=" " font-style="normal">
+			<name-part name="family" font-variant="small-caps"/>
+		  </name>
+		</names>
+		<text term="translator" form="short" prefix="&#160;"/>
+		</if>
+		</choose>
+	  </macro>
+	 <!-- MACRO INTERVIEWER (POUR LES NDBP ET LA BIBLIO)-->
+	  <macro name="interviewer">
+	  <choose>
+	  <if variable="interviewer">
+	  <text term="interviewer" form="verb" prefix="&#160;"/>
+		<names variable="interviewer">
+		  <name form="long" and="text" delimiter-precedes-last="never" delimiter=",&#32;" sort-separator=" " font-style="normal">
+			<name-part name="family" font-variant="small-caps"/>
+		  </name>
+		</names>
+		</if>
+		</choose>
+		<text variable="medium" prefix=",&#160;" font-style="italic"/>
+	  </macro>
+	  <!-- MACRO TITLE, PAR TYPE DE DOCT (POUR LES NDBP ET LA BIBLIO) APPELLE MACRO EDITOR-->  
   <macro name="title">
     <choose>
       <if type="figure graphic motion_picture" match="any">
@@ -115,12 +176,13 @@
       <else-if type="bill book legal_case song" match="any">
         <text variable="title" text-case="capitalize-first" font-style="italic"/>
       </else-if>
-      <else-if type="article-journal article-newspaper article-magazine" match="any">
-        <group delimiter=", ">
-          <text variable="title" text-case="capitalize-first" prefix="«&#160;" suffix="&#160;»" font-style="normal"/>
-          <text variable="container-title" font-style="italic"/>
-        </group>
-      </else-if>
+		<!-- AJOUT DES TYPES PAGES WEB ET BILLETS DE BLOG POUR AFFICHAGE DE LEUR TITRE ET DU TITRE DE LEUR CONTAINER-->
+		  <else-if type="article-journal article-newspaper article-magazine webpage post-weblog" match="any">
+			<group delimiter=", ">
+			  <text variable="title" text-case="capitalize-first" prefix="«&#160;" suffix="&#160;»" font-style="normal"/>
+			  <text variable="container-title" font-style="italic"/>
+			</group>
+		  </else-if>
       <else-if type="thesis" match="any">
         <group>
           <text variable="title" text-case="capitalize-first" font-style="italic" suffix=","/>
@@ -138,7 +200,8 @@
           <text variable="genre" prefix=" "/>
         </group>
       </else-if>
-      <else-if type="chapter entry-dictionary entry-encyclopedia" match="any">
+		  <!-- AFFICHAGE TITRE DES ACTES POUR ARTICLE COLLOQUE-->
+		  <else-if type="chapter entry-dictionary entry-encyclopedia paper-conference" match="any">
         <group>
           <text variable="title" text-case="capitalize-first" prefix="«&#160;" suffix="&#160;»,"/>
           <text value="in" font-style="italic" suffix=" " prefix=" "/>
@@ -151,6 +214,7 @@
       </else>
     </choose>
   </macro>
+	  <!-- MACRO PUB-PLACE (POUR LES NDBP ET LA BIBLIO)-->
   <macro name="pub-place">
     <choose>
       <if type="bill book chapter entry-dictionary entry-encyclopedia thesis graphic legal_case manuscript motion_picture paper-conference report song" match="any">
@@ -158,6 +222,7 @@
       </if>
     </choose>
   </macro>
+	  <!-- MACRO PUBLISHER (POUR LES NDBP ET LA BIBLIO)-->
   <macro name="publisher">
     <choose>
       <if type="bill book chapter entry-dictionary entry-encyclopedia graphic legal_case motion_picture paper-conference report song thesis" match="any">
@@ -165,6 +230,7 @@
       </if>
     </choose>
   </macro>
+	  <!-- MACRO DATE, VOLUME, PAGES PAR TYPE DE DOCT (POUR LES NDBP)-->
   <macro name="yearpage-ndbp">
     <choose>
       <if type="bill book graphic legal_case motion_picture paper-conference manuscript report song thesis" match="any">
@@ -172,8 +238,9 @@
           <date variable="issued">
             <date-part name="year"/>
           </date>
+		  <!-- UTILISATION DU CHAMP VOLUME POUR AFFICHAGE DU NUMERO POUR LES NUMEROS SPECIAUX DE REVUES QUI UTILISENT LE TYPE "BOOK"-->
           <group>
-            <text term="volume" form="short" suffix="."/>
+            <text term="issue" form="short" suffix="&#160;"/>
             <text variable="number-of-volumes" prefix=". " suffix="/"/>
             <text variable="volume"/>
           </group>
@@ -191,33 +258,7 @@
           </group>
         </group>
       </else-if>
-      <else-if type="article-newspaper article-magazine" match="any">
-        <group delimiter=" " font-style="normal">
-          <label variable="page" form="short"/>
-          <text variable="page"/>
-        </group>
-        <group delimiter=" " font-style="normal">
-          <choose>
-            <if variable="locator" match="any">
-              <text variable="locator" prefix="p.&#160;"/>
-            </if>
-            <else-if variable="locator" match="none">
-              <label variable="page" form="short"/>
-            </else-if>
-          </choose>
-        </group>
-      </else-if>
-      <else-if type="webpage" match="any">
-        <group delimiter=", " font-style="normal">
-          <date variable="issued" form="text">
-            <date-part name="day"/>
-            <date-part name="month" text-case="lowercase"/>
-            <date-part name="year"/>
-          </date>
-          <text variable="container-title"/>
-        </group>
-      </else-if>
-      <else-if type="article-journal chapter" match="any">
+      <else-if type="article-journal chapter article-newspaper article-magazine" match="any">
         <group delimiter=" " font-style="normal">
           <label variable="page" form="short"/>
           <text variable="page"/>
@@ -225,69 +266,56 @@
       </else-if>
     </choose>
   </macro>
+	  <!-- MACRO DATE, VOLUME, PAGES PAR TYPE DE DOCT (POUR LA BIBLIO)-->
   <macro name="yearpage-bib">
     <choose>
-      <if type="bill book graphic legal_case motion_picture paper-conference manuscript report song thesis" match="any">
-        <group delimiter=", ">
-          <group delimiter=", " font-style="normal">
-            <date variable="issued">
-              <date-part name="year"/>
-            </date>
-            <group>
-              <text term="volume" form="short" suffix="."/>
-              <text variable="number-of-volumes" prefix=". " suffix="/"/>
-              <text variable="volume"/>
-            </group>
-            <text variable="number-of-pages" suffix="&#160;p."/>
-            <text variable="page" suffix="&#160;p."/>
-            <!-- pour les rapports-->
-          </group>
-          <group>
-            <label variable="locator" form="short"/>
-            <text variable="locator"/>
-          </group>
-        </group>
-      </if>
-      <else-if type="chapter entry-dictionary entry-encyclopedia" match="any">
-        <group delimiter=", " font-style="normal">
-          <date variable="issued">
-            <date-part name="year"/>
-          </date>
-          <group>
-            <text term="volume" form="short" suffix="."/>
-            <text variable="number-of-volumes" prefix=". " suffix="/"/>
-            <text variable="volume"/>
-          </group>
-          <group>
-            <label variable="page" form="short"/>
-            <text variable="page" prefix="&#160;"/>
-          </group>
-        </group>
+<if type="bill book graphic legal_case motion_picture manuscript report song thesis" match="any">
+			<group delimiter=", ">
+			  <group delimiter=", " font-style="normal">
+				<date variable="issued">
+				  <date-part name="year"/>
+				</date>
+				<!-- UTILISATION DU CHAMP VOLUME POUR AFFICHAGE DU NUMERO POUR LES NUMEROS SPECIAUX DE REVUES QUI UTILISENT LE TYPE "BOOK"-->
+				<group>
+				  <text term="issue" form="short" suffix="&#160;"/>
+				  <text variable="number-of-volumes" prefix=". " suffix="/"/>
+				  <text variable="volume"/>
+				</group>
+				<text variable="number-of-pages" suffix="&#160;p."/>
+				<text variable="page" suffix="&#160;p."/>
+			  </group>
+			  <group>
+				<label variable="locator" form="short"/>
+				<text variable="locator"/>
+			  </group>
+			</group>
+		  </if>
+		  <else-if type="chapter entry-dictionary entry-encyclopedia paper-conference" match="any">
+			<group delimiter=", " font-style="normal">
+			  <date variable="issued">
+				<date-part name="year"/>
+			  </date>
+			  <group>
+				<text term="volume" form="short" suffix="."/>
+				<text variable="number-of-volumes" prefix=". " suffix="/"/>
+				<text variable="volume"/>
+			  </group>
+			  <group>
+				<label variable="page" form="short"/>
+				<text variable="page" prefix="&#160;"/>
+			  </group>
+			</group>
+		  </else-if>
+		  <else-if type="article-journal article-newspaper article-magazine" match="any">
+			<group delimiter=" " font-style="normal">
+			  <label variable="page" form="short"/>
+			  <text variable="page"/>
+			</group>
       </else-if>
-      <else-if type="article-journal chapter" match="any">
-        <group delimiter=" " font-style="normal">
-          <label variable="page" form="short"/>
-          <text variable="page"/>
-        </group>
-      </else-if>
-      <else-if type="article-newspaper article-magazine" match="any">
-        <group delimiter=" " font-style="normal">
-          <label variable="page" form="short"/>
-          <text variable="page"/>
-        </group>
-      </else-if>
-      <else-if type="webpage" match="any">
-        <group delimiter=", " font-style="normal">
-          <date variable="issued" form="text">
-            <date-part name="day"/>
-            <date-part name="month" text-case="lowercase"/>
-            <date-part name="year"/>
-          </date>
-          <text variable="container-title"/>
-        </group>
-      </else-if>
+	<!-- SUPPRESSION PAGES WEB ET BILLETS DE BLOGS : AFFICHAGE TITRE DU SITE WEB ET DATE VIA LA MACRO TITLE-->  
     </choose>
   </macro>
+	  	  <!-- MACRO EDITION : MENTION D'EDITION POUR OUVRAGE OU DATE D'EDITION POUR ARTICLE (POUR LES NDBP ET LA BIBLIO). APELLE LES MACROS VOLUME ET ISSUE.-->
   <macro name="edition">
     <choose>
       <if type="bill book graphic legal_case motion_picture report song chapter paper-conference" match="any">
@@ -295,7 +323,8 @@
           <if is-numeric="edition">
             <group delimiter=" ">
               <number variable="edition" form="ordinal"/>
-              <text term="edition" form="short"/>
+			  <text term="edition" form="short" suffix="." strip-periods="true"/>
+              <!-- <text term="edition" form="short"/> -->
             </group>
           </if>
           <else>
@@ -303,8 +332,8 @@
           </else>
         </choose>
       </if>
-      <else-if type="article-journal article-magazine article-newspaper" match="any">
-        <group font-style="normal">
+      <else-if type="article-journal article-magazine article-newspaper interview webpage post-weblog" match="any">
+		<group font-style="normal">
           <choose>
             <if variable="issued">
               <date variable="issued">
@@ -323,6 +352,7 @@
     </choose>
     <text macro="issue" prefix=", "/>
   </macro>
+<!-- MACRO VOLUME PAR TYPE DE FORMAT DU CHAMP : NUMERIQUE OU TEXTE, APPELEE SEULEMENT PAR LA MACRO EDITION-->
   <macro name="volume">
     <choose>
       <if is-numeric="volume">
@@ -334,6 +364,7 @@
       </else>
     </choose>
   </macro>
+	  <!-- MACRO ISSUE PAR TYPE DE FORMAT DU CHAMP : NUMERIQUE OU TEXTE, APPELEE SEULEMENT PAR LA MACRO EDITION -->
   <macro name="issue">
     <choose>
       <if is-numeric="issue">
@@ -345,6 +376,8 @@
       </else>
     </choose>
   </macro>
+	  <!-- MACRO COLLECTION PAR TYPE DE FORMAT DU CHAMP : NUMERIQUE OU TEXTE (POUR LES NDBP ET LA BIBLIO)-->
+	  <!-- RETRAIT DE coll. : MACRO UTILISEE DANS LA PREMIERE VERSION DU STYLE TRIANGLE :
   <macro name="collection">
     <choose>
       <if is-numeric="collection-number">
@@ -355,13 +388,18 @@
         <text variable="collection-title" prefix=" coll.&#160;«&#160;" suffix="&#160;»"/>
       </else>
     </choose>
-  </macro>
+  </macro> -->
+  	  <macro name="collection">
+			<text variable="collection-title" prefix=" "/>
+			<text variable="collection-number" prefix=", n˚&#160;"/>
+	  </macro>
+	   <!-- MACRO URL (POUR LES NDBP) -->
   <!-- (Ajout d'une url pour les références...)-->
   <!-- I/ ...des notes de bas de pages-->
+  <!-- ANCIENNE VERSION DE LA MACRO 
   <macro name="internet-ndbp">
     <choose>
-      <if type="article-newspaper webpage post-weblog" match="any">
-        <!-- l'URL N'apparait que pour les documents ci-dessus-->
+      <if type="article-newspaper webpage post post-weblog" match="any">
         <choose>
           <if variable="URL" match="any">
             <group>
@@ -387,7 +425,7 @@
           </else-if>
         </choose>
       </if>
-      <else-if type="article-journal article-magazine book chapter thesis" match="any">
+      <else-if type="article-journal article-newspaper article-magazine book chapter thesis" match="any">
         <choose>
           <if variable="URL" match="any">
             <text value="."/>
@@ -398,12 +436,34 @@
         </choose>
       </else-if>
     </choose>
-  </macro>
+  </macro>-->
+  <!-- NOUVELLE MACRO 2016-->
+   <macro name="internet-ndbp">
+		<choose>
+		<if variable="DOI">
+            <text variable="DOI" prefix="doi:"/>
+          </if>
+          <else-if variable="URL">
+            <choose>
+              <if type="webpage post-weblog">
+                  <text value="URL complète en biblio"/>
+              </if>
+              <else>
+					<text value="URL complète en biblio"/>
+              </else>
+            </choose>
+          </else-if>
+		  </choose>
+		  </macro>
+	  <!-- MACRO URL (POUR LA BIBLIO)-->
   <!-- II/ ...de la bibliographie-->
-  <macro name="internet-bib">
+   <!-- ANCIENNE VERSION DE LA MACRO : 
+   <macro name="internet-bib">
     <choose>
       <if variable="URL" match="any">
-        <group>
+	  <choose>
+        <if type="webpage post-weblog" match="any">
+		<group>
           <text variable="URL" text-decoration="underline" prefix="&#160;[&#160;"/>
           <text value="&#160;]" suffix=",&#160;" text-case="capitalize-first"/>
           <text term="accessed" suffix=":&#160;"/>
@@ -413,23 +473,55 @@
             <date-part name="year"/>
           </date>
         </group>
-      </if>
+		</if>
+		<else-if type="article-journal article-newspaper article-magazine chapter entry-dictionary entry-encyclopedia paper-conference" match="any">
+			<group>
+          <text variable="URL" text-decoration="underline" prefix="&#160;[&#160;"/>
+          <text value="&#160;]"/>
+		  </group>  
+		</else-if>
+		</choose>
+	  </if>
       <else-if variable="DOI" match="any">
         <group>
           <text value="http://dx.doi.org/" text-decoration="underline" prefix="&#160;[&#160;"/>
           <text variable="DOI" text-decoration="underline"/>
-          <text value="&#160;]" suffix=",&#160;" text-case="capitalize-first"/>
-          <text term="accessed" suffix="&#160;:&#160;"/>
-          <date variable="accessed" form="text" suffix=".">
-            <date-part name="day"/>
-            <date-part name="month" text-case="lowercase"/>
-            <date-part name="year"/>
-          </date>
+          <text value="&#160;]"/>
         </group>
       </else-if>
     </choose>
-  </macro>
-  <!--_-_-_-_-_-SECTION DEFINITION DES Notes de bas de pages (citation)-_-_-_-_-_-_-->
+  </macro>-->
+  <!-- NOUVELLE MACRO 2016-->
+   <macro name="internet-bib">
+		<choose>
+		<if variable="DOI">
+            <text variable="DOI" prefix="doi:"/>
+          </if>
+          <else-if variable="URL">
+            <choose>
+              <if type="webpage post-weblog">
+                <group delimiter=" ">
+                  <group>
+                    <date variable="accessed" form="text" suffix=", " prefix="consulté le "/>
+                  </group>
+                  <text term="from" suffix="&#160;:&#160;"/>
+                  <text variable="URL"/>
+                </group>
+              </if>
+              <else>
+                <group delimiter=" ">
+                  <group>
+                    <date variable="accessed" form="text" suffix=", " prefix="consulté le "/>
+                  </group>
+                  <text term="from" suffix="&#160;:"/>
+                  <text variable="URL"/>
+                </group>
+              </else>
+            </choose>
+          </else-if>
+		  </choose>
+	</macro>
+  <!--_-_-_-_-_-SECTION DEFINITION DES NDBP (citation)-_-_-_-_-_-_-->
   <citation>
     <layout suffix="." delimiter="&#160;">
       <choose>
@@ -462,6 +554,7 @@
             <text macro="author"/>
             <text macro="title"/>
             <text macro="translator"/>
+			<text macro="interviewer"/>
             <text macro="edition"/>
             <text macro="pub-place"/>
             <text macro="publisher"/>
@@ -473,13 +566,13 @@
             <!-- intégration automatique de la localisation (pages indiqués)-->
             <text variable="locator" prefix=",&#160;p.&#160;"/>
             <!-- intégration de la macro-test pour les adresses internet-->
-            <text macro="internet-ndbp"/>
+            <text macro="internet-ndbp" prefix=",&#160;"/>
           </group>
         </else>
       </choose>
     </layout>
   </citation>
-  <!--_-_-_-_-_-SECTION DEFINITION DES références bibliographiques (bibliography)-_-_-_-_-_-_-->
+  <!--_-_-_-_-_-SECTION DEFINITION DE LA BIBLIO (bibliography)-_-_-_-_-_-_-->
   <bibliography>
     <sort>
       <key macro="author" names-min="3" names-use-first="3"/>
@@ -490,15 +583,16 @@
         <text macro="author-bib"/>
         <text macro="title"/>
         <text macro="translator"/>
+		<text macro="interviewer"/>
         <text macro="edition"/>
         <text macro="pub-place"/>
         <text macro="publisher"/>
         <text macro="collection"/>
         <text macro="yearpage-bib"/>
-        <!-- intégration automatique de la localisation (pages indiqués)-->
+        <!-- intégration automatique de la localisation (pages indiqués)--> 
         <text variable="locator" prefix="p.&#160;"/>
-        <!-- intégration de la macro-test pour les adresses internet-->
-        <text macro="internet-bib"/>
+        <!-- intégration de la macro-test pour les adresses internet--> 
+		<text macro="internet-bib"/>		
       </group>
     </layout>
   </bibliography>


### PR DESCRIPTION
First version online in november 2012. Changes made in 2016 to cover more document types and to lighten URLs display. 
This style should preferably be used **ticking the citation option in Zotero preferences (cite/styles): include URLs of paper articles in references.** 

Principal changes in macros : 
- author and author-bib : collection-editor added
- collection : suppression of "coll."
- yearpage and yearpage-ndbp : adding issue number
- internet-bib and internet-ndbp : changing URL and DOI displays

Other changes : more document types are now better taken into account : webpage, post-weblog, paper-conference, report, thesis, article-magazine, interview.