### PR TITLE
Rewritten Elementa style

### DIFF
--- a/elementa.csl
+++ b/elementa.csl
@@ -7,7 +7,10 @@
     <id>http://www.zotero.org/styles/elementa</id>
     <link href="http://www.zotero.org/styles/elementa" rel="self"/>
     <link href="https://home.elementascience.org/for-authors/style-guide/" rel="documentation"/>
+    <link href="http://lynn-library.libguides.com/cse" rel="documentation"/>
+    <link href="http://writing.wisc.edu/Handbook/DocCSE_CitationSystems.html" rel="documentation"/>
     <link href="http://www.zotero.org/styles/council-of-science-editors-author-date" rel="template"/>
+    <link href="http://www.zotero.org/styles/apa" rel="template"/>
     <author>
       <name>Akos Kokai</name>
       <email>akokai@berkeley.edu</email>
@@ -15,7 +18,7 @@
     <category citation-format="author-date"/>
     <category field="science"/>
     <summary>Based on The Council of Science Editors style, Name-Year system: author-date in text, sorted in alphabetical order by author.</summary>
-    <updated>2016-07-23T08:00:00+00:00</updated>
+    <updated>2016-07-26T01:00:00+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale xml:lang="en">
@@ -31,122 +34,51 @@
       <term name="no date">n.d.</term>
     </terms>
   </locale>
-  <macro name="editor">
-    <names variable="editor translator" delimiter="; " suffix=".">
-      <name delimiter-precedes-last="always" initialize-with="" name-as-sort-order="all" sort-separator=" "/>
-      <label prefix=", "/>
-    </names>
-  </macro>
   <macro name="author">
     <names variable="author" delimiter="; ">
       <name name-as-sort-order="all" sort-separator=" " initialize-with="" delimiter=", " delimiter-precedes-last="always"/>
       <label form="long" prefix=", " strip-periods="true"/>
       <substitute>
         <names variable="editor translator"/>
-        <text variable="title"/>
+        <names variable="editor"/>
+        <names variable="collection-editor"/>
+        <names variable="translator"/>
+        <choose>
+          <if type="report">
+            <text variable="publisher"/>
+            <text macro="title"/>
+          </if>
+          <else>
+            <text macro="title"/>
+          </else>
+        </choose>
       </substitute>
     </names>
   </macro>
   <macro name="author-short">
     <names variable="author">
-      <name form="short" delimiter=", " initialize-with="." and="text"/>
+      <name form="short" delimiter=", " initialize-with="" and="text"/>
       <substitute>
         <names variable="editor"/>
         <names variable="collection-editor"/>
         <names variable="translator"/>
-        <text variable="title-short"/>
-        <text variable="title"/>
+        <choose>
+          <if type="report">
+            <text variable="publisher"/>
+            <text macro="title"/>
+          </if>
+          <else>
+            <text macro="title"/>
+          </else>
+        </choose>
       </substitute>
     </names>
   </macro>
-  <macro name="review">
-    <group delimiter=". ">
-      <text variable="reviewed-title"/>
-      <text macro="container-title"/>
-    </group>
-  </macro>
-  <macro name="access">
-    <choose>
-      <if variable="DOI">
-        <text variable="DOI" prefix="doi: "/>
-      </if>
-      <else-if variable="URL">
-        <group suffix=". " delimiter=" ">
-          <text term="available at" text-case="capitalize-first"/>
-          <text variable="URL"/>
-        </group>
-        <group suffix=". " delimiter=" ">
-          <text term="accessed" text-case="capitalize-first"/>
-          <date variable="accessed" delimiter=" ">
-            <date-part name="year"/>
-            <date-part name="month" form="short" strip-periods="true"/>
-            <date-part name="day"/>
-          </date>
-        </group>
-      </else-if>
-    </choose>
-  </macro>
-  <macro name="title">
-    <group delimiter=" ">
-      <choose>
-        <if type="book">
-          <text variable="title" font-style="italic" text-case="title"/>
-        </if>
-        <else>
-          <text variable="title"/>
-        </else>
-      </choose>
-      <choose>
-        <if type="thesis dataset" match="any">
-          <text variable="genre" form="long" prefix="[" suffix="]"/>
-        </if>
-      </choose>
-    </group>
-  </macro>
-  <macro name="container-title">
-    <choose>
-      <if type="chapter">
-        <text variable="container-title" font-style="italic" text-case="title"/>
-      </if>
-      <else-if type="article-magazine article-newspaper">
-        <text variable="container-title" font-style="italic"/>
-      </else-if>
-      <else-if type="article-journal">
-        <text variable="container-title" form="short" font-style="italic" strip-periods="true"/>
-      </else-if>
-      <else>
-        <text variable="container-title"/>
-      </else>
-    </choose>
-  </macro>
-  <macro name="publisher">
-    <group delimiter=": ">
-      <choose>
-        <if type="thesis">
-          <text variable="publisher-place" prefix="[" suffix="]"/>
-        </if>
-        <else>
-          <text variable="publisher-place"/>
-        </else>
-      </choose>
-      <text variable="publisher"/>
-    </group>
-  </macro>
-  <macro name="pages">
-    <group delimiter="; ">
-      <group>
-        <label variable="page" form="short" suffix=" " plural="never"/>
-        <text variable="page"/>
-      </group>
-      <group>
-        <text variable="number-of-pages"/>
-        <choose>
-          <if is-numeric="number-of-pages">
-            <label variable="number-of-pages" form="short" prefix=" " plural="never"/>
-          </if>
-        </choose>
-      </group>
-    </group>
+  <macro name="container-contributors">
+    <names variable="editor translator" delimiter="; ">
+      <name delimiter-precedes-last="always" initialize-with="" name-as-sort-order="all" sort-separator=" "/>
+      <label prefix=", "/>
+    </names>
   </macro>
   <macro name="year">
     <choose>
@@ -192,33 +124,231 @@
       </else>
     </choose>
   </macro>
+  <macro name="locator-date">
+    <date variable="issued" delimiter=" ">
+      <date-part name="year"/>
+      <date-part name="month" form="short" strip-periods="true"/>
+      <date-part name="day"/>
+    </date>
+  </macro>
+  <macro name="title">
+    <group delimiter=" ">
+      <choose>
+        <if type="book">
+          <text variable="title" font-style="italic" text-case="title"/>
+        </if>
+        <else>
+          <text variable="title"/>
+        </else>
+      </choose>
+      <choose>
+        <if type="thesis dataset speech interview broadcast" match="any">
+          <text variable="genre" form="long" prefix="[" suffix="]"/>
+        </if>
+      </choose>
+      <choose>
+        <!-- Book reviews -->
+        <if variable="reviewed-author">
+          <choose>
+            <if variable="reviewed-title">
+              <group delimiter=" ">
+                <text variable="title"/>
+                <group delimiter=", " prefix="[" suffix="]">
+                  <text variable="reviewed-title" font-style="italic" prefix="Review of "/>
+                  <names variable="reviewed-author" delimiter=", ">
+                    <label form="verb-short" suffix=" "/>
+                    <name and="text" initialize-with="" delimiter=", "/>
+                  </names>
+                </group>
+              </group>
+            </if>
+            <else>
+              <!-- assume `title` is title of reviewed work -->
+              <group delimiter=", " prefix="[" suffix="]">
+                <text variable="title" font-style="italic" prefix="Review of "/>
+                <names variable="reviewed-author" delimiter=", ">
+                  <label form="verb-short" suffix=" "/>
+                  <name and="text" initialize-with="" delimiter=", "/>
+                </names>
+              </group>
+            </else>
+          </choose>
+        </if>
+      </choose>
+    </group>
+  </macro>
+  <macro name="container-title">
+    <choose>
+      <if type="chapter">
+        <text variable="container-title" font-style="italic" text-case="title"/>
+      </if>
+      <else-if type="article-magazine article-newspaper">
+        <text variable="container-title" font-style="italic"/>
+      </else-if>
+      <else-if type="article-journal">
+        <text variable="container-title" form="short" font-style="italic" strip-periods="true"/>
+      </else-if>
+      <else>
+        <text variable="container-title"/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="container">
+    <group>
+      <choose>
+        <if type="chapter entry-dictionary entry-encyclopedia" match="any">
+          <text term="in" text-case="capitalize-first" suffix=": "/>
+        </if>
+      </choose>
+      <choose>
+        <if type="bill legal_case legislation" match="none">
+          <group delimiter=". ">
+            <text macro="container-contributors"/>
+            <text macro="container-title"/>
+          </group>
+        </if>
+      </choose>
+    </group>
+  </macro>
   <macro name="edition">
     <choose>
       <if is-numeric="edition">
         <group delimiter=" ">
           <number variable="edition" form="ordinal"/>
-          <text term="edition" form="short"/>
+          <label variable="edition" form="short"/>
         </group>
       </if>
       <else>
-        <text variable="edition" suffix="."/>
+        <text variable="edition"/>
       </else>
     </choose>
   </macro>
-    <macro name="volume">
+  <macro name="pages">
+    <group delimiter="; ">
+      <group>
+        <label variable="page" form="short" suffix=" " plural="never"/>
+        <text variable="page"/>
+      </group>
+      <group>
+        <text variable="number-of-pages"/>
+        <choose>
+          <if is-numeric="number-of-pages">
+            <label variable="number-of-pages" form="short" prefix=" " plural="never"/>
+          </if>
+        </choose>
+      </group>
+    </group>
+  </macro>
+  <macro name="journal-locators">
+    <group suffix=".">
+      <choose>
+        <if variable="volume issue page" match="none">
+          <choose>
+            <if type="article-journal review review-book">
+              <text term="in press" prefix=", "/>
+            </if>
+          </choose>
+        </if>
+        <else>
+          <group>
+            <text variable="volume" prefix=" " font-weight="bold"/>
+            <text variable="issue" prefix="(" suffix=")"/>
+            <text variable="page" prefix=": "/>
+          </group>
+        </else>
+      </choose>
+    </group>
+  </macro>
+  <macro name="locators">
     <choose>
-      <if type="article-journal">
-        <group>
-          <text variable="volume" font-weight="bold"/>
-          <text variable="issue" prefix="(" suffix=")"/>
+      <if type="article-journal article-magazine article-newspaper review review-book" match="any">
+        <text macro="journal-locators"/>
+      </if>
+      <else-if type="paper-conference">
+        <choose>
+          <if variable="container-title">
+            <text macro="journal-locators"/>
+          </if>
+          <else>
+            <text macro="locator-date" suffix="."/>
+          </else>
+        </choose>
+      </else-if>
+      <else-if type="bill legal_case legislation" match="none">
+        <text macro="edition" suffix="."/>
+      </else-if>
+    </choose>
+  </macro>
+  <macro name="legal-cites">
+    <!-- Bluebook style; adapted from apa.csl -->
+    <choose>
+      <if type="bill legal_case legislation" match="any">
+        <group delimiter=" ">
+          <choose>
+            <if variable="container-title">
+              <text variable="volume"/>
+              <text variable="container-title"/>
+              <label variable="section" form="symbol"/>
+              <text variable="section"/>
+              <text variable="page"/>
+            </if>
+            <else>
+              <choose>
+                <if type="legal_case">
+                  <text variable="number" prefix="No. "/>
+                </if>
+                <else>
+                  <text variable="number" prefix="Pub. L. No. "/>
+                  <label variable="section" form="symbol"/>
+                  <text variable="section"/>
+                </else>
+              </choose>
+            </else>
+          </choose>
         </group>
       </if>
-      <else>
-        <text variable="volume"/>
-      </else>
     </choose>
+  </macro>
+  <macro name="event">
+    <choose>
+      <if variable="event">
+        <choose>
+          <if variable="container-title" match="none">
+          <!-- Don't give event info if part of a publication
+               (e.g., conference proceedings) -->
+            <choose>
+              <if type="paper-conference" match="none">
+                <group delimiter=" ">
+                  <text variable="genre" text-case="capitalize-first"/>
+                  <text term="presented at" text-case="capitalize-first"/>
+                </group>
+              </if>
+            </choose>
+            <group prefix=" " suffix="." delimiter="; ">
+              <text variable="event"/>
+              <text variable="event-place"/>
+            </group>
+          </if>
+        </choose>
+      </if>
+    </choose>
+  </macro>
+  <macro name="publisher">
+    <group delimiter=": ">
+      <choose>
+        <if type="thesis">
+          <text variable="publisher-place" prefix="[" suffix="]"/>
+        </if>
+        <else-if variable="event" match="none">
+          <text variable="publisher-place"/>
+        </else-if>
+      </choose>
+      <text variable="publisher"/>
+    </group>
   </macro>
   <macro name="collection">
+    <!-- This is to appear at the end of the citation:
+         after publisher, before access. -->
     <choose>
       <if type="report">
         <group prefix=" " suffix="." delimiter=" ">
@@ -226,7 +356,7 @@
           <text variable="number" prefix="Report No.: "/>
         </group>
       </if>
-      <else>
+      <else-if type="book">
         <group prefix=" (" suffix=")." delimiter=" ">
           <names variable="collection-editor" suffix=". ">
             <name delimiter-precedes-last="always" initialize-with="" name-as-sort-order="all" sort-separator=" "/>
@@ -234,11 +364,45 @@
           </names>
           <group delimiter="; ">
             <text variable="collection-title"/>
-            <text macro="volume" prefix="Vol. "/>
-            <text variable="collection-number" prefix="Vol. "/>
+            <choose>
+              <if variable="collection-number">
+                <group>
+                  <text term="volume" form="short" text-case="capitalize-first" suffix=". "/>
+                  <text variable="collection-number"/>
+                </group>
+              </if>
+              <else>
+                <group>
+                  <label variable="volume" form="short" text-case="capitalize-first" suffix=". "/>
+                  <text variable="volume"/>
+                </group>
+              </else>
+            </choose>
           </group>
         </group>
-      </else>
+      </else-if>
+      <!-- Add other types that need collection info after publisher. -->
+    </choose>
+  </macro>
+  <macro name="access">
+    <choose>
+      <if variable="DOI">
+        <text variable="DOI" prefix="doi: "/>
+      </if>
+      <else-if variable="URL">
+        <group suffix=". " delimiter=" ">
+          <text term="available at" text-case="capitalize-first"/>
+          <text variable="URL"/>
+        </group>
+        <group suffix=". " delimiter=" ">
+          <text term="accessed" text-case="capitalize-first"/>
+          <date variable="accessed" delimiter=" ">
+            <date-part name="year"/>
+            <date-part name="month" form="short" strip-periods="true"/>
+            <date-part name="day"/>
+          </date>
+        </group>
+      </else-if>
     </choose>
   </macro>
   <citation et-al-min="3" et-al-use-first="1" disambiguate-add-year-suffix="true" disambiguate-add-names="true" disambiguate-add-givenname="true">
@@ -260,65 +424,18 @@
       <key macro="year-date"/>
     </sort>
     <layout>
-      <group suffix="." delimiter=". ">
+      <group delimiter=". " suffix=".">
         <text macro="author"/>
         <text macro="year-date"/>
         <text macro="title"/>
-      </group>
-      <group suffix=".">
-        <choose>
-          <if type="bill book graphic legal_case legislation motion_picture report song thesis" match="any">
-            <group prefix=" " suffix="." delimiter=" ">
-              <text macro="edition"/>
-              <text macro="editor"/>
-            </group>
-            <group prefix=" " suffix="." delimiter=". "> 
-              <text macro="publisher"/>
-              <text macro="collection"/>
-            </group>
-          </if>
-          <else-if type="chapter entry-dictionary entry-encyclopedia" match="any">
-            <group prefix=" " delimiter=" ">
-              <group delimiter=" ">
-                <text term="in" text-case="capitalize-first" suffix=":"/>
-                <text macro="editor"/>
-                <text macro="container-title" suffix="."/>
-              </group>
-              <text macro="volume" prefix="Vol. " suffix="."/>
-              <text macro="edition"/>
-              <group suffix="." delimiter=". ">
-                <text macro="publisher"/>
-                <text prefix=" " macro="collection"/>
-                <text macro="pages"/>
-              </group>
-            </group>
-          </else-if>
-          <else-if type="paper-conference">
-            <group prefix=" " suffix="." delimiter="; ">
-              <text variable="event"/>
-              <text variable="event-place"/>
-            </group>
-          </else-if>
-          <else-if type="review review-book" match="any">
-            <text macro="editor" prefix=" " suffix="."/>
-            <group prefix=" " suffix=".">
-              <text macro="review" suffix="."/>
-              <group prefix=" ">
-                <text macro="volume"/>
-                <text variable="issue" prefix="(" suffix=")"/>
-              </group>
-              <text variable="page" prefix=":"/>
-            </group>
-          </else-if>
-          <else>
-            <text macro="editor" suffix="." prefix=" "/>
-            <group prefix=" " suffix=".">
-              <text macro="container-title"/>
-              <text macro="volume" prefix=" "/>
-              <text variable="page" prefix=": "/>
-            </group>
-          </else>
-        </choose>
+        <group delimiter="">
+          <text macro="container"/>
+          <text macro="locators"/>
+        </group>
+        <text macro="legal-cites"/>
+        <text macro="event"/>
+        <text macro="publisher"/>
+        <text macro="collection"/>
       </group>
       <text prefix=" " macro="access"/>
     </layout>

--- a/elementa.csl
+++ b/elementa.csl
@@ -15,7 +15,7 @@
     <category citation-format="author-date"/>
     <category field="science"/>
     <summary>Based on The Council of Science Editors style, Name-Year system: author-date in text, sorted in alphabetical order by author.</summary>
-    <updated>2016-07-16T08:00:00+00:00</updated>
+    <updated>2016-07-23T08:00:00+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale xml:lang="en">

--- a/elementa.csl
+++ b/elementa.csl
@@ -217,20 +217,24 @@
     </choose>
   </macro>
   <macro name="pages">
-    <group delimiter="; ">
-      <group>
-        <label variable="page" form="short" suffix=" " plural="never"/>
-        <text variable="page"/>
-      </group>
-      <group>
-        <text variable="number-of-pages"/>
-        <choose>
-          <if is-numeric="number-of-pages">
-            <label variable="number-of-pages" form="short" prefix=" " plural="never"/>
-          </if>
-        </choose>
-      </group>
-    </group>
+    <choose>
+      <if type="chapter entry-dictionary entry-encyclopedia" match="any">
+        <group delimiter="; ">
+          <group>
+            <label variable="page" form="short" suffix=" " plural="never"/>
+            <text variable="page"/>
+          </group>
+          <group>
+            <text variable="number-of-pages"/>
+            <choose>
+              <if is-numeric="number-of-pages">
+                <label variable="number-of-pages" form="short" prefix=" " plural="never"/>
+              </if>
+            </choose>
+          </group>
+        </group>
+      </if>
+    </choose>
   </macro>
   <macro name="journal-locators">
     <group suffix=".">
@@ -440,6 +444,7 @@
         <text macro="legal-cites"/>
         <text macro="event"/>
         <text macro="publisher"/>
+        <text macro="pages"/>
         <text macro="collection"/>
       </group>
       <text prefix=" " macro="access"/>

--- a/elementa.csl
+++ b/elementa.csl
@@ -97,7 +97,7 @@
         </else>
       </choose>
       <choose>
-        <if type="thesis dataset paper-conference" match="any">
+        <if type="thesis dataset" match="any">
           <text variable="genre" form="long" prefix="[" suffix="]"/>
         </if>
       </choose>
@@ -223,7 +223,7 @@
       <if type="report">
         <group prefix=" " suffix="." delimiter=" ">
           <text variable="collection-title"/>
-          <text variable="number" prefix=" Report No.: "/>
+          <text variable="number" prefix="Report No.: "/>
         </group>
       </if>
       <else>
@@ -272,10 +272,12 @@
               <text macro="edition"/>
               <text macro="editor"/>
             </group>
-            <text prefix=" " macro="publisher"/>
-            <text prefix=" " macro="collection"/>
+            <group prefix=" " suffix="." delimiter=". "> 
+              <text macro="publisher"/>
+              <text macro="collection"/>
+            </group>
           </if>
-          <else-if type="chapter paper-conference entry-dictionary entry-encyclopedia" match="any">
+          <else-if type="chapter entry-dictionary entry-encyclopedia" match="any">
             <group prefix=" " delimiter=" ">
               <group delimiter=" ">
                 <text term="in" text-case="capitalize-first" suffix=":"/>
@@ -289,6 +291,12 @@
                 <text prefix=" " macro="collection"/>
                 <text macro="pages"/>
               </group>
+            </group>
+          </else-if>
+          <else-if type="paper-conference">
+            <group prefix=" " suffix="." delimiter="; ">
+              <text variable="event"/>
+              <text variable="event-place"/>
             </group>
           </else-if>
           <else-if type="review review-book" match="any">

--- a/elementa.csl
+++ b/elementa.csl
@@ -124,13 +124,6 @@
       </else>
     </choose>
   </macro>
-  <macro name="locator-date">
-    <date variable="issued" delimiter=" ">
-      <date-part name="year"/>
-      <date-part name="month" form="short" strip-periods="true"/>
-      <date-part name="day"/>
-    </date>
-  </macro>
   <macro name="title">
     <group delimiter=" ">
       <choose>
@@ -270,7 +263,11 @@
             <text macro="journal-locators"/>
           </if>
           <else>
-            <text macro="locator-date" suffix="."/>
+            <date variable="issued" delimiter=" " suffix=".">
+              <date-part name="year"/>
+              <date-part name="month" form="short" strip-periods="true"/>
+              <date-part name="day"/>
+            </date>
           </else>
         </choose>
       </else-if>
@@ -288,7 +285,11 @@
             <if variable="container-title">
               <text variable="volume"/>
               <text variable="container-title"/>
-              <label variable="section" form="symbol"/>
+              <group delimiter=" ">
+                <!--change to label variable="section" as that becomes available -->
+                <text term="section" form="symbol"/>
+                <text variable="section"/>
+              </group>
               <text variable="section"/>
               <text variable="page"/>
             </if>
@@ -299,7 +300,11 @@
                 </if>
                 <else>
                   <text variable="number" prefix="Pub. L. No. "/>
-                  <label variable="section" form="symbol"/>
+                  <group delimiter=" ">
+                    <!--change to label variable="section" as that becomes available -->
+                    <text term="section" form="symbol"/>
+                    <text variable="section"/>
+                  </group>
                   <text variable="section"/>
                 </else>
               </choose>


### PR DESCRIPTION
- Reorganized the macros to parallel how `apa.csl` is organized (but with Elementa style specifications). Improved readability of the CSL document, in my opinion.
- Added the legal citation handling that's in APA. 
- Checked against the journal guidelines with many citation types...