### PR TITLE
MLA8 Vol prefix is added regardless of if volume variable is set

### DIFF
--- a/modern-language-association-8th-edition.csl
+++ b/modern-language-association-8th-edition.csl
@@ -122,24 +122,28 @@
   </macro>
   <macro name="number">
     <group delimiter=", ">
-      <group delimiter=" ">
+      <group>
         <choose>
-          <if variable="volume" match="any">
-            <choose>
-              <!--lowercase if we have a preceding element-->
-              <if variable="edition container-title" match="any">
-                <text term="volume" form="short"/>
-              </if>
-              <else-if variable="author editor" match="all">
-                <!--other contributors preceding the volume-->
-                <text term="volume" form="short"/>
-              </else-if>
-              <else>
-                <text term="volume" form="short" text-case="capitalize-first"/>
-              </else>
-            </choose>
-            <text variable="volume"/>
+          <!--lowercase if we have a preceding element-->
+          <if variable="edition container-title" match="any">
+            <group delimiter=" ">
+              <text term="volume" form="short"/>
+              <text variable="volume"/>
+            </group>
           </if>
+          <!--other contributors preceding the volume-->
+          <else-if variable="author editor" match="all">
+            <group delimiter=" ">
+              <text term="volume" form="short"/>
+              <text variable="volume"/>
+            </group>
+          </else-if>
+          <else>
+            <group delimiter=" ">
+              <text term="volume" form="short" text-case="capitalize-first"/>
+              <text variable="volume"/>
+            </group>
+          </else>
         </choose>
       </group>
       <group delimiter=" ">

--- a/modern-language-association-8th-edition.csl
+++ b/modern-language-association-8th-edition.csl
@@ -124,19 +124,23 @@
     <group delimiter=", ">
       <group delimiter=" ">
         <choose>
-          <!--lowercase if we have a preceding element-->
-          <if variable="edition container-title" match="any">
-            <text term="volume" form="short"/>
+          <if variable="volume" match="any">
+            <choose>
+              <!--lowercase if we have a preceding element-->
+              <if variable="edition container-title" match="any">
+                <text term="volume" form="short"/>
+              </if>
+              <else-if variable="author editor" match="all">
+                <!--other contributors preceding the volume-->
+                <text term="volume" form="short"/>
+              </else-if>
+              <else>
+                <text term="volume" form="short" text-case="capitalize-first"/>
+              </else>
+            </choose>
+            <text variable="volume"/>
           </if>
-          <else-if variable="author editor" match="all">
-            <!--other contributors preceding the volume-->
-            <text term="volume" form="short"/>
-          </else-if>
-          <else>
-            <text term="volume" form="short" text-case="capitalize-first"/>
-          </else>
         </choose>
-        <text variable="volume"/>
       </group>
       <group delimiter=" ">
         <text term="issue" form="short"/>


### PR DESCRIPTION
Found that the MLA 8 format was always printing the vol.  prefix even when no volume was specified.  The diff doesn't look clean but I just wrapped the handling of the volume code in an choose if block to test if the volume was set.