### PR TITLE
Replace "complete-all" with "partial-each"  in bibliography

### DIFF
--- a/associacao-brasileira-de-normas-tecnicas-ufrgs.csl
+++ b/associacao-brasileira-de-normas-tecnicas-ufrgs.csl
@@ -436,8 +436,8 @@
     </layout>
   </citation>
   <!-- BIBLIOGRAFIA 
-  et al. aparece a partir de 4 autores -->
-  <bibliography hanging-indent="false" et-al-min="4" et-al-use-first="1" entry-spacing="1" subsequent-author-substitute="______." subsequent-author-substitute-rule="complete-all">
+  et al. aparece a partir de 4 autores. Mesmos autores subsequentes são substituídos por 6 sublinhas -->
+  <bibliography hanging-indent="false" et-al-min="4" et-al-use-first="1" entry-spacing="1" subsequent-author-substitute="______" subsequent-author-substitute-rule="partial-each">
     <sort>
       <key macro="author"/>
       <!-- Organiza primeiro pela ordem de autor -->


### PR DESCRIPTION
To conform with Technical Standards Brazilian Association ABNT NBR-6023-2002, p. 21, item 9.1.2.