### PR TITLE
Update publisher note (type = thesis)

### DIFF
--- a/de-buck.csl
+++ b/de-buck.csl
@@ -20,7 +20,7 @@
     <category citation-format="note"/>
     <category field="generic-base"/>
     <summary>Annotatie en literatuurlijst volgens P. de Buck e.a., Zoeken en schrijven. Handleiding bij het maken van een historisch werkstuk (Haarlem 1982). Gebaseerd op "MHRA format with full notes and bibliography"</summary>
-    <updated>2016-05-25T12:00:00+01:00</updated>
+    <updated>2016-08-24T19:15:50+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale xml:lang="nl">
@@ -185,8 +185,9 @@
             <choose>
               <if variable="title" match="none"/>
               <else-if type="thesis">
-                <text variable="genre" prefix="unpublished " suffix=","/>
-                <text macro="publisher"/>
+                <text variable="genre"/>
+                <text variable="publisher" suffix=","/>
+                <text variable="publisher-place"/>
                 <text macro="issued"/>
               </else-if>
               <else-if type="speech">


### PR DESCRIPTION
Type "thesis": removed prefix "unpublished" and changed the order in the publisher information, according to De Buck, Zoeken en Schrijven.
[Not sure if I actually proposed this file change already or not (could not find any evidence in my administration), so sorry if this is a duplicate]