### PR TITLE
Et Al Tests

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,14 +1,14 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    csl (1.4.3)
+    csl (1.4.5)
       namae (~> 0.7)
     diff-lcs (1.2.5)
     fuubar (2.0.0)
       rspec (~> 3.0)
       ruby-progressbar (~> 1.4)
     mini_portile2 (2.0.0)
-    namae (0.10.1)
+    namae (0.11.0)
     nokogiri (1.6.7.2)
       mini_portile2 (~> 2.0.0.rc2)
     nokogiri (1.6.7.2-x86-mingw32)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -148,8 +148,7 @@ Independents = Hash[collect_styles.each_with_index.map { |path, i|
 # Make sure we always have the basenames of all independent styles stored
 if ENV['CSL_TEST'] != nil
   INDEPENDENTS_BASENAMES = Dir[File.join(STYLE_ROOT, '*.csl')].map { |path|
-    filename = File.basename(path)
-    basename = filename[0..-5]
+    File.basename(path, '.csl')
   }
 else
   INDEPENDENTS_BASENAMES = Independents.keys
@@ -157,15 +156,14 @@ end
 
 # Store basenames of dependent styles
 DEPENDENTS_BASENAMES = Dir[File.join(STYLE_ROOT, 'dependent', '*.csl')].map { |path|
-  filename = File.basename(path)
-  basename = filename[0..-5]
+  File.basename(path, '.csl')
 }
 
 # Make sure the parents of selected dependents are loaded
 # (necessary for citation-format comparison)
 if ENV['CSL_TEST'] != nil
   parent_basenames = []
-  
+
   Dependents.each_pair do |basename, (filename, path, style)|
     if style.has_independent_parent_link?
       parent_basename = style.independent_parent_link[/[^\/]+$/]
@@ -174,21 +172,21 @@ if ENV['CSL_TEST'] != nil
       end
     end
   end
-  
+
   # eliminate parents that already have been loaded
   parent_basenames.reject! do |basename|
     Independents.has_key?(basename)
   end
-  
+
   # load extra parents
   extra_independents = Hash[parent_basenames.each_with_index.map { |basename, i|
     print '.'  if i % 120 == 0
-    
+
     # convert basename to path
     path = File.join(STYLE_ROOT, basename + '.csl')
     load_style(path)
   }]
-  
+
   # combine hashes
   Independents.merge!(extra_independents)
 end

--- a/spec/styles_spec.rb
+++ b/spec/styles_spec.rb
@@ -1,6 +1,6 @@
 shared_examples "style" do |basename, (filename, path, style), in_dependent_subdir|
   before(:all) { @style_validates = CSL.validate(path).length.zero? }
-  
+
   it "must validate against the CSL 1.0.1 schema
      Please check your style at http://validator.citationstyles.org/" do
     expect(@style_validates).to be true
@@ -15,29 +15,29 @@ shared_examples "style" do |basename, (filename, path, style), in_dependent_subd
   it "must have a conventional file name" do
     expect(filename).to match(/^[a-z\d]+(-[a-z\d]+)*\.csl$/)
   end
-  
+
   unless style.nil?
     if !in_dependent_subdir
       it 'must be an independent style (dependent styles must be placed in the "dependent" subdirectory)' do
         expect(style).to be_independent
       end
-      
+
       it 'must have a "self" link' do
         expect(style).to have_self_link
       end
-      
+
       it '"template" link must point to an existing independent style' do
         if style.has_template_link?
           template_link = style.template_link
           link_prefix = "http://www.zotero.org/styles/"
-          
+
           expect(template_link).to match(%r{^#{link_prefix}})
           template_ID = template_link[link_prefix.length..-1]
-          
+
           expect(INDEPENDENTS_BASENAMES).to include(template_ID)
         end
       end
-      
+
       unless CITATION_FORMAT_FILTER.include?(basename)
 
         it 'must define a citation-format (<category citation-format="..."/>)' do
@@ -52,7 +52,7 @@ shared_examples "style" do |basename, (filename, path, style), in_dependent_subd
           end
         end
       end
-      
+
       it "must define all macros that are called by <text/> and <key/> elements" do
         style.descendants!.each do |node|
           if node.matches?(/^key|text$/, :macro => /./)
@@ -60,7 +60,7 @@ shared_examples "style" do |basename, (filename, path, style), in_dependent_subd
           end
         end
       end
-      
+
       unless UNUSED_MACROS_FILTER.include?(basename)
         it "may not have any unused macros" do
           available_macros = style.macros.keys.sort
@@ -73,24 +73,24 @@ shared_examples "style" do |basename, (filename, path, style), in_dependent_subd
           expect(available_macros - used_macros).to eq([])
         end
       end
-      
+
     end
-    
-    if in_dependent_subdir      
+
+    if in_dependent_subdir
       it "must be a dependent style (independent styles must be placed in the root directory)" do
         expect(style).to be_dependent
       end
-      
+
       it '"independent-parent" link must point to an existing independent style' do
         parent_ID_link = style.independent_parent_link
         link_prefix = "http://www.zotero.org/styles/"
-        
+
         expect(parent_ID_link).to match(%r{^#{link_prefix}})
         parent_ID = parent_ID_link[link_prefix.length..-1]
-        
+
         expect(INDEPENDENTS_BASENAMES).to include(parent_ID)
       end
-      
+
       it 'may not have <macro/>, <citation/>, or <bibliography/> elements' do
         expect(style).not_to have_macro
         expect(style).not_to have_citation
@@ -99,7 +99,7 @@ shared_examples "style" do |basename, (filename, path, style), in_dependent_subd
 
       it 'may not have a "template" link' do
         expect(style).not_to have_template_link
-      end  
+      end
 
       it 'must define a citation-format (<category citation-format="..."/>)' do
         expect(style.citation_format).not_to be_nil
@@ -110,7 +110,7 @@ shared_examples "style" do |basename, (filename, path, style), in_dependent_subd
         parent = Independents[parent][-1]
 
         expect(style.citation_format).to eq(parent.citation_format)
-      end    
+      end
     end
 
     it "must have an <info/> element" do
@@ -138,9 +138,9 @@ shared_examples "style" do |basename, (filename, path, style), in_dependent_subd
     it "must have the correct Creative Commons BY-SA license URL" do
       if style.info.has_rights?
        expect(style.info.rights[:license]).to eq(CSL_LICENSE_URL)
-     end
+      end
     end
-    
+
     it "must have the correct Creative Commons BY-SA license text" do
       if style.info.has_rights?
         expect(style.info.rights.text).to eq(CSL_LICENSE_TEXT)


### PR DESCRIPTION
The test does something similar to what citeproc-ruby does when rendering styles: looks at every `<names>` and fetches its `<name>` (or creates a `<name>` as a stand-in if there is none) then checks the attributes of that node inheriting from the closest `<bibliography>` or `<citation>` and `<style>`.

The tricky part is `<names>` inside a `<macro>` -- when rendering styles this is not a problem, because the processor will know in what context the macro is being rendered, but when checking the styles generically, I would argue it makes sense to run the checks twice, inheriting from both possible rendering nodes respectively.

The tests check that both `et-al-min` and `et-al-use-first` are defined (or that both are not defined) and that min is greater than or equal to use first. Both checks are repeated for the 'subsequent' variants.

I'm not 100% sure that this works. There are about 40 styles that fail the tests; I did a few spot checks and the failures seemed legit to me.

Let me know what you think!

(continuation of http://xbiblio-devel.2463403.n2.nabble.com/CSL-Specificaton-question-et-al-min-et-al-use-first-tp7579481p7579487.html)