### PR TITLE
Create harvard-deakin-university.csl

### DIFF
--- a/harvard-deakin-university.csl
+++ b/harvard-deakin-university.csl
@@ -1,0 +1,214 @@
+<?xml version="1.0" encoding="utf-8"?>
+<style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" demote-non-dropping-particle="sort-only" default-locale="en-GB">
+  <info>
+    <title>Harvard - Deakin University </title>
+    <id>http://www.zotero.org/styles/harvard-deakin-university</id>
+    <link href="http://www.zotero.org/styles/harvard-deakin-university" rel="self"/>
+    <link href="http://www.deakin.edu.au/students/studying/study-support/referencing/harvard" rel="documentation"/>
+        <category citation-format="author-date"/>
+    <category field="generic-base"/>
+    <summary>Style for Deakin University </summary>
+    <updated>2016-09-15T11:36:24+00:00</updated>
+    <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
+  </info>
+  <locale xml:lang="en">
+    <terms>
+      <term name="page">
+        <single>page</single>
+        <multiple>pages</multiple>
+      </term>
+      <term name="page" form="short">
+        <single>p.</single>
+        <multiple>pp.</multiple>
+      </term>
+      <term name="no date">n.d.</term>
+      <term name="et-al">et al.</term>
+      <term name="editor" form="short">
+        <single>ed.</single>
+        <multiple>eds</multiple>
+      </term>
+      <term name="translator" form="short">
+        <single>trans.</single>
+        <multiple>trans</multiple>
+      </term>
+      <term name="edition" form="short">edn</term>
+      <term name="volume" form="short">vol.</term>
+      <term name="chapter" form="short">ch.</term>
+    </terms>
+  </locale>
+  <macro name="editor">
+    <names variable="editor" delimiter=", ">
+      <name and="symbol" initialize-with="" delimiter=", "/>
+      <label form="short" prefix=" (" suffix=")" strip-periods="true"/>
+    </names>
+  </macro>
+  <macro name="noauthor_title">
+    <!-- This macro is only called when author is empty and the trick with substitute automatically suppresses repeating elements -->
+    <choose>
+      <if type="article-newspaper">
+        <names variable="author">
+          <name/>
+          <substitute>
+            <text variable="container-title" font-style="italic"/>
+          </substitute>
+        </names>
+      </if>
+      <else>
+        <names variable="author">
+          <name/>
+          <substitute>
+            <text macro="title" font-style="normal"/>
+          </substitute>
+        </names>
+      </else>
+    </choose>
+  </macro>
+  <macro name="author">
+    <names variable="author">
+      <name name-as-sort-order="all" and="symbol" sort-separator=", " initialize-with="" delimiter=", " delimiter-precedes-last="never"/>
+      <label form="short" prefix=" (" suffix=")"/>
+      <substitute>
+        <names variable="editor"/>
+        <names variable="translator"/>
+        <text macro="noauthor_title"/>
+      </substitute>
+    </names>
+  </macro>
+  <macro name="author-short">
+    <names variable="author">
+      <name form="short" and="symbol" delimiter=", " delimiter-precedes-last="never" initialize-with=". "/>
+      <substitute>
+        <names variable="editor"/>
+        <names variable="translator"/>
+        <text macro="noauthor_title"/>
+      </substitute>
+    </names>
+  </macro>
+  <macro name="access">
+    <choose>
+      <if variable="URL">
+        <text term="retrieved"/>
+        <group prefix=" " delimiter=", ">
+          <date variable="retrieved">
+            <date-part name="month" suffix=" "/>
+            <date-part name="day" suffix=", "/>
+            <date-part name="year"/>
+          </date>
+          <group>
+            <text term="from"/>
+            <text variable="URL" prefix=" &lt;" suffix="&gt;"/>
+          </group>
+        </group>
+      </if>
+    </choose>
+  </macro>
+  <macro name="title">
+    <choose>
+      <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
+        <text variable="title" font-style="italic"/>
+      </if>
+      <else>
+        <text variable="title" quotes="true"/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="publisher">
+    <group delimiter=", ">
+      <text variable="publisher"/>
+      <text variable="publisher-place"/>
+    </group>
+  </macro>
+  <macro name="year-date">
+    <choose>
+      <if variable="issued">
+        <date variable="issued">
+          <date-part name="year"/>
+        </date>
+      </if>
+      <else>
+        <text term="no date" form="short"/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="pages">
+    <label variable="page" form="short" suffix=" "/>
+    <text variable="page"/>
+  </macro>
+  <macro name="edition">
+    <choose>
+      <if is-numeric="edition">
+        <group delimiter=" ">
+          <number variable="edition" form="ordinal"/>
+          <text term="edition" form="short"/>
+        </group>
+      </if>
+      <else>
+        <text variable="edition" suffix="."/>
+      </else>
+    </choose>
+  </macro>
+  <citation et-al-min="4" et-al-subsequent-use-first="1" disambiguate-add-year-suffix="true" disambiguate-add-names="true" disambiguate-add-givenname="true" collapse="year">
+    <layout prefix="(" suffix=")" delimiter="; ">
+      <group delimiter=", ">
+        <group delimiter=" ">
+          <text macro="author-short"/>
+          <text macro="year-date"/>
+        </group>
+        <group>
+          <label variable="locator" form="short"/>
+          <text variable="locator"/>
+        </group>
+      </group>
+    </layout>
+  </citation>
+  <bibliography hanging-indent="false">
+    <sort>
+      <key macro="author"/>
+      <key macro="year-date"/>
+    </sort>
+    <layout suffix=".">
+      <text macro="author"/>
+      <date variable="issued" prefix=" " suffix=",">
+        <date-part name="year"/>
+      </date>
+      <choose>
+        <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
+          <group prefix=" " delimiter=" " suffix=",">
+            <text macro="title"/>
+            <text macro="edition"/>
+            <text macro="editor"/>
+          </group>
+          <text prefix=" " macro="publisher"/>
+        </if>
+        <else-if type="chapter paper-conference" match="any">
+          <text macro="title" prefix=" "/>
+          <group delimiter=" " prefix=", ">
+            <text term="in"/>
+            <group delimiter=", ">
+              <text macro="editor"/>
+              <text variable="container-title" font-style="italic"/>
+              <text variable="collection-title"/>
+              <text macro="publisher"/>
+              <text macro="pages"/>
+            </group>
+          </group>
+        </else-if>
+        <else>
+          <group suffix=",">
+            <text macro="title" prefix=" "/>
+            <text macro="editor" prefix=" "/>
+          </group>
+          <group prefix=" ">
+            <text variable="container-title" font-style="italic"/>
+            <group prefix=", " delimiter=", ">
+              <text variable="volume" prefix="vol. "/>
+              <text variable="issue" prefix="no. "/>
+              <text macro="pages"/>
+            </group>
+          </group>
+        </else>
+      </choose>
+      <text prefix=", " macro="access"/>
+    </layout>
+  </bibliography>
+</style>

--- a/harvard-deakin-university.csl
+++ b/harvard-deakin-university.csl
@@ -3,7 +3,8 @@
   <info>
     <title>Harvard - Deakin University </title>
     <id>http://www.zotero.org/styles/harvard-deakin-university</id>
-    <link href="http://www.zotero.org/styles/harvard-deakin-university" rel="template"/>
+    <link href="http://www.zotero.org/styles/harvard-deakin-university" rel="self"/>
+    <link href="http://www.zotero.org/styles/harvard-the-university-of-melbourne" rel="template"/>
     <link href="http://www.deakin.edu.au/students/studying/study-support/referencing/harvard" rel="documentation"/>
         <category citation-format="author-date"/>
     <category field="generic-base"/>

--- a/harvard-deakin-university.csl
+++ b/harvard-deakin-university.csl
@@ -89,7 +89,7 @@
       <if variable="URL">
         <text term="retrieved"/>
         <group prefix=" " delimiter=", ">
-          <date variable="retrieved">
+          <date variable="accessed">
             <date-part name="month" suffix=" "/>
             <date-part name="day" suffix=", "/>
             <date-part name="year"/>

--- a/harvard-deakin-university.csl
+++ b/harvard-deakin-university.csl
@@ -3,7 +3,7 @@
   <info>
     <title>Harvard - Deakin University </title>
     <id>http://www.zotero.org/styles/harvard-deakin-university</id>
-    <link href="http://www.zotero.org/styles/harvard-deakin-university" rel="self"/>
+    <link href="http://www.zotero.org/styles/harvard-deakin-university" rel="template"/>
     <link href="http://www.deakin.edu.au/students/studying/study-support/referencing/harvard" rel="documentation"/>
         <category citation-format="author-date"/>
     <category field="generic-base"/>

--- a/harvard-deakin-university.csl
+++ b/harvard-deakin-university.csl
@@ -13,16 +13,6 @@
   </info>
   <locale xml:lang="en">
     <terms>
-      <term name="page">
-        <single>page</single>
-        <multiple>pages</multiple>
-      </term>
-      <term name="page" form="short">
-        <single>p.</single>
-        <multiple>pp.</multiple>
-      </term>
-      <term name="no date">n.d.</term>
-      <term name="et-al">et al.</term>
       <term name="editor" form="short">
         <single>ed.</single>
         <multiple>eds</multiple>


### PR DESCRIPTION
Minor changes have been made to reflect Deakin university harvard style referencing. 
changed the wording 'accessed' to 'retrieved' and removed the hanging indent.