### PR TITLE
Change style for JID

### DIFF
--- a/journal-of-investigative-dermatology.csl
+++ b/journal-of-investigative-dermatology.csl
@@ -2,18 +2,12 @@
 <style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" demote-non-dropping-particle="sort-only" page-range-format="minimal">
 <!-- This style was edited with the Visual CSL Editor (http://editor.citationstyles.org/visualEditor/) -->
   <info>
-    <title>Journal of investigative dermatology</title>
+    <title>Journal of Investigative Dermatology</title>
     <title-short>J Invest Dermatol</title-short>
     <id>http://www.zotero.org/styles/journal-of-investigative-dermatology</id>
     <link href="http://www.zotero.org/styles/journal-of-investigative-dermatology" rel="self"/>
     <link href="http://www.zotero.org/styles/vancouver" rel="template"/>
-    <link href="http://endnote.com/downloads/style/journal-investigative-dermatology" rel="documentation"/>
     <link href="http://www.jidonline.org/content/authorinfo" rel="documentation"/>
-    <author>
-      <name>Charles Parnot</name>
-      <email>charles.parnot@gmail.com</email>
-      <uri>http://twitter.com/cparnot</uri>
-    </author>
     <author>
       <name>Max Gordon</name>
       <email>max@gforge.se</email>
@@ -22,7 +16,6 @@
     <category citation-format="author-date"/>
     <category field="biology"/>
     <eissn>1523-1747</eissn>
-    <issnl>0022-202X</issnl>
     <summary>This style based on the Vancouver author-date style</summary>
     <updated>2016-09-23T20:19:12+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
@@ -38,23 +31,6 @@
       <term name="section" form="short">sect.</term>
     </terms>
   </locale>
-  <locale xml:lang="fr">
-    <date form="text" delimiter=" ">
-      <date-part name="day"/>
-      <date-part name="month" form="short" strip-periods="true"/>
-      <date-part name="year"/>
-    </date>
-    <terms>
-      <term name="retrieved">disponible</term>
-      <term name="from">sur</term>
-    </terms>
-  </locale>
-  <locale xml:lang="de">
-    <terms>
-      <term name="retrieved">verfügbar</term>
-      <term name="from">unter</term>
-    </terms>
-  </locale>
   <macro name="author-short-in-citation">
     <names variable="author">
       <name form="short" and="text"/>
@@ -66,7 +42,7 @@
   </macro>
   <macro name="author-in-citation">
     <names variable="author">
-      <name sort-separator=" " initialize-with="" name-as-sort-order="all" delimiter=", " delimiter-precedes-last="always"/>
+      <name form="short" and="text" sort-separator=" " initialize-with="" name-as-sort-order="all" delimiter=", " delimiter-precedes-last="always"/>
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
@@ -96,7 +72,7 @@
   </macro>
   <macro name="author">
     <names variable="author">
-      <name delimiter-precedes-last="always" et-al-min="6" et-al-use-first="6" initialize-with="" name-as-sort-order="all" sort-separator=" "/>
+      <name delimiter-precedes-last="always" initialize-with="" name-as-sort-order="all" sort-separator=" "/>
       <label form="long" prefix=", "/>
       <substitute>
         <names variable="editor"/>

--- a/journal-of-investigative-dermatology.csl
+++ b/journal-of-investigative-dermatology.csl
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" demote-non-dropping-particle="sort-only" page-range-format="minimal">
+<style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" demote-non-dropping-particle="sort-only" page-range-format="minimal" default-locale="en-US">
 <!-- This style was edited with the Visual CSL Editor (http://editor.citationstyles.org/visualEditor/) -->
   <info>
     <title>Journal of Investigative Dermatology</title>
@@ -76,6 +76,7 @@
       <label form="long" prefix=", "/>
       <substitute>
         <names variable="editor"/>
+        <names variable="translator"/>
       </substitute>
     </names>
   </macro>

--- a/journal-of-investigative-dermatology.csl
+++ b/journal-of-investigative-dermatology.csl
@@ -1,156 +1,198 @@
 <?xml version="1.0" encoding="utf-8"?>
-<style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" page-range-format="minimal" demote-non-dropping-particle="sort-only" default-locale="en-US">
-  <!-- This style was edited with the Visual CSL Editor (http://steveridout.com/csl/visualEditor/) -->
+<style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" demote-non-dropping-particle="sort-only" page-range-format="minimal">
+<!-- This style was edited with the Visual CSL Editor (http://editor.citationstyles.org/visualEditor/) -->
   <info>
-    <title>Journal of Investigative Dermatology</title>
+    <title>Journal of investigative dermatology</title>
+    <title-short>J Invest Dermatol</title-short>
     <id>http://www.zotero.org/styles/journal-of-investigative-dermatology</id>
     <link href="http://www.zotero.org/styles/journal-of-investigative-dermatology" rel="self"/>
-    <link href="http://www.zotero.org/styles/ecology-letters" rel="template"/>
-    <link href="http://www.nature.com/jid/author_instructions.html" rel="documentation"/>
+    <link href="http://www.zotero.org/styles/vancouver" rel="template"/>
+    <link href="http://endnote.com/downloads/style/journal-investigative-dermatology" rel="documentation"/>
+    <link href="http://www.jidonline.org/content/authorinfo" rel="documentation"/>
     <author>
-      <name>Sebastian Karcher</name>
+      <name>Charles Parnot</name>
+      <email>charles.parnot@gmail.com</email>
+      <uri>http://twitter.com/cparnot</uri>
+    </author>
+    <author>
+      <name>Max Gordon</name>
+      <email>max@gforge.se</email>
+      <uri>http://gforge.se</uri>
     </author>
     <category citation-format="author-date"/>
     <category field="biology"/>
-    <issn>0022-202X</issn>
     <eissn>1523-1747</eissn>
-    <updated>2012-09-14T21:22:32+00:00</updated>
+    <issnl>0022-202X</issnl>
+    <summary>This style based on the Vancouver author-date style</summary>
+    <updated>2016-09-23T20:19:12+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale xml:lang="en">
+    <date form="text" delimiter=" ">
+      <date-part name="year"/>
+      <date-part name="month" form="short" strip-periods="true"/>
+      <date-part name="day"/>
+    </date>
     <terms>
-      <term name="editor" form="short">
-        <single>ed.</single>
-        <multiple>eds</multiple>
-      </term>
+      <term name="retrieved">available</term>
+      <term name="section" form="short">sect.</term>
     </terms>
   </locale>
-  <macro name="container">
+  <locale xml:lang="fr">
+    <date form="text" delimiter=" ">
+      <date-part name="day"/>
+      <date-part name="month" form="short" strip-periods="true"/>
+      <date-part name="year"/>
+    </date>
+    <terms>
+      <term name="retrieved">disponible</term>
+      <term name="from">sur</term>
+    </terms>
+  </locale>
+  <locale xml:lang="de">
+    <terms>
+      <term name="retrieved">verfügbar</term>
+      <term name="from">unter</term>
+    </terms>
+  </locale>
+  <macro name="author-short-in-citation">
+    <names variable="author">
+      <name form="short" and="text"/>
+      <substitute>
+        <names variable="editor"/>
+        <names variable="translator"/>
+      </substitute>
+    </names>
+  </macro>
+  <macro name="author-in-citation">
+    <names variable="author">
+      <name sort-separator=" " initialize-with="" name-as-sort-order="all" delimiter=", " delimiter-precedes-last="always"/>
+      <substitute>
+        <names variable="editor"/>
+        <names variable="translator"/>
+      </substitute>
+    </names>
+  </macro>
+  <macro name="year-in-citation">
+    <date variable="issued">
+      <date-part name="year"/>
+    </date>
+  </macro>
+  <macro name="issued-sort">
     <choose>
-      <if type="chapter paper-conference" match="any">
-        <text term="in" form="long" plural="false" text-case="capitalize-first" font-style="italic" suffix=": "/>
-        <text variable="container-title" font-style="italic" form="short"/>
-        <text variable="collection-title" prefix=", "/>
-        <names variable="editor translator" prefix=" (" delimiter=", " suffix=")">
-          <name delimiter-precedes-last="never" initialize-with="" name-as-sort-order="all"/>
-          <label form="short" strip-periods="false" prefix=" "/>
-        </names>
+      <if type="article-journal bill book chapter graphic legal_case legislation motion_picture paper-conference report song" match="none">
+        <date variable="issued">
+          <date-part name="year"/>
+          <date-part name="month"/>
+          <date-part name="day"/>
+        </date>
       </if>
       <else>
-        <group delimiter=", ">
-          <text variable="container-title" form="short" strip-periods="true" font-style="italic"/>
-          <text variable="collection-title"/>
-        </group>
+        <date variable="issued">
+          <date-part name="year"/>
+        </date>
       </else>
     </choose>
   </macro>
   <macro name="author">
     <names variable="author">
-      <name delimiter-precedes-last="never" initialize-with="" name-as-sort-order="all"/>
-      <label form="short" strip-periods="false" prefix=" (" suffix=")"/>
-      <et-al font-style="italic"/>
+      <name delimiter-precedes-last="always" et-al-min="6" et-al-use-first="6" initialize-with="" name-as-sort-order="all" sort-separator=" "/>
+      <label form="long" prefix=", "/>
       <substitute>
         <names variable="editor"/>
-        <names variable="translator"/>
-        <text macro="title"/>
       </substitute>
     </names>
   </macro>
-  <macro name="author-short">
-    <names variable="author">
-      <name form="short" and="text" initialize-with=". "/>
-      <substitute>
-        <names variable="editor"/>
-        <names variable="translator"/>
-        <choose>
-          <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
-            <text variable="title" form="short" font-style="italic"/>
-          </if>
-          <else>
-            <text variable="title" form="short" quotes="true"/>
-          </else>
-        </choose>
-      </substitute>
-    </names>
+  <macro name="editor">
+    <group delimiter=": ">
+      <choose>
+        <if type="chapter paper-conference" match="any">
+          <text term="in" text-case="capitalize-first"/>
+        </if>
+      </choose>
+      <names variable="editor" suffix=".">
+        <name sort-separator=" " initialize-with="" name-as-sort-order="all" delimiter=", " delimiter-precedes-last="always"/>
+        <label form="long" prefix=", "/>
+      </names>
+    </group>
+  </macro>
+  <macro name="publisher">
+    <group delimiter=": " suffix=";">
+      <choose>
+        <if type="thesis">
+          <text variable="publisher-place" prefix="[" suffix="]"/>
+        </if>
+        <else>
+          <text variable="publisher-place"/>
+        </else>
+      </choose>
+      <text variable="publisher"/>
+    </group>
   </macro>
   <macro name="access">
     <choose>
-      <if type="webpage">
-        <group>
-          <text value="URL" suffix=" "/>
+      <if variable="URL">
+        <group delimiter=": ">
+          <group delimiter=" ">
+            <text term="retrieved" text-case="capitalize-first"/>
+            <text term="from"/>
+          </group>
           <text variable="URL"/>
         </group>
       </if>
     </choose>
   </macro>
-  <macro name="title">
+  <macro name="accessed-date">
     <choose>
-      <if type="report thesis" match="any">
-        <text variable="title" font-style="italic"/>
-        <group prefix=" (" suffix=")">
-          <text variable="genre"/>
-          <text variable="number" prefix=" No. "/>
+      <if variable="URL">
+        <group prefix="[" suffix="]" delimiter=" ">
+          <text term="cited" text-case="lowercase"/>
+          <date variable="accessed" form="text"/>
         </group>
       </if>
-      <else-if type="bill book graphic legal_case legislation motion_picture report song speech" match="any">
-        <text variable="title" font-style="italic"/>
-      </else-if>
-      <else-if type="webpage">
-        <text variable="title"/>
-        <text value="WWW Document" prefix=" [" suffix="]"/>
-      </else-if>
-      <else>
-        <text variable="title"/>
-      </else>
     </choose>
   </macro>
-  <macro name="publisher">
+  <macro name="container-title">
     <choose>
-      <if type="report thesis" match="any">
+      <if type="article-journal article-magazine chapter paper-conference article-newspaper" match="any">
+        <group suffix="." delimiter=" ">
+          <text variable="container-title" form="short"/>
+        </group>
+        <text macro="edition" prefix=" "/>
+      </if>
+      <else-if type="bill legislation" match="any">
         <group delimiter=", ">
-          <text variable="publisher"/>
-          <text variable="publisher-place"/>
+          <group delimiter=". ">
+            <text variable="container-title" form="short"/>
+            <group delimiter=" ">
+              <text term="section" form="short" text-case="capitalize-first"/>
+              <text variable="section"/>
+            </group>
+          </group>
+          <text variable="number"/>
         </group>
-      </if>
-      <else>
-        <text variable="genre" suffix=", "/>
-        <group delimiter=": ">
-          <text variable="publisher"/>
-          <text variable="publisher-place"/>
-        </group>
-      </else>
-    </choose>
-  </macro>
-  <macro name="event">
-    <choose>
-      <if variable="event">
-        <text term="presented at" text-case="capitalize-first" suffix=" "/>
-        <text variable="event"/>
-      </if>
-    </choose>
-  </macro>
-  <macro name="issued">
-    <choose>
-      <if variable="issued">
-        <date variable="issued">
-          <date-part name="year"/>
-        </date>
-      </if>
-      <else-if variable="accessed">
-        <choose>
-          <if type="webpage">
-            <date variable="accessed">
-              <date-part name="year"/>
-            </date>
-          </if>
-          <else>
-            <text term="no date" form="short"/>
-          </else>
-        </choose>
       </else-if>
       <else>
-        <text term="no date" form="short"/>
+        <text variable="container-title" suffix="." form="short"/>
       </else>
+    </choose>
+  </macro>
+  <macro name="title">
+    <text variable="title"/>
+    <choose>
+      <if type="article-journal article-magazine chapter paper-conference article-newspaper" match="none">
+        <choose>
+          <if variable="URL">
+            <text term="internet" prefix=" [" suffix="]" text-case="capitalize-first"/>
+          </if>
+        </choose>
+        <text macro="edition" prefix=". "/>
+      </if>
+    </choose>
+    <choose>
+      <if type="thesis">
+        <text variable="genre" prefix=" [" suffix="]"/>
+      </if>
     </choose>
   </macro>
   <macro name="edition">
@@ -158,7 +200,7 @@
       <if is-numeric="edition">
         <group delimiter=" ">
           <number variable="edition" form="ordinal"/>
-          <text value="edn"/>
+          <text term="edition" form="short"/>
         </group>
       </if>
       <else>
@@ -166,62 +208,102 @@
       </else>
     </choose>
   </macro>
-  <macro name="locators">
+  <macro name="date">
     <choose>
       <if type="article-journal article-magazine article-newspaper" match="any">
-        <group delimiter=": " prefix=" ">
-          <group>
-            <text variable="volume"/>
-          </group>
-          <text variable="page"/>
+        <group suffix=";" delimiter=" ">
+          <date date-parts="year" form="text" variable="issued"/>
         </group>
       </if>
-      <else-if type="bill book graphic legal_case legislation motion_picture report song" match="any">
-        <group delimiter=". " prefix=". ">
-          <text macro="edition"/>
-          <text macro="event"/>
-          <text macro="publisher"/>
+      <else-if type="bill legislation" match="any">
+        <group delimiter=", ">
+          <date variable="issued" delimiter=" ">
+            <date-part name="month" form="short" strip-periods="true"/>
+            <date-part name="day"/>
+          </date>
+          <date variable="issued">
+            <date-part name="year"/>
+          </date>
         </group>
       </else-if>
-      <else-if type="chapter paper-conference" match="any">
-        <group delimiter=", " prefix=". ">
-          <text macro="event"/>
-          <text macro="publisher"/>
-          <group>
-            <text variable="page"/>
-          </group>
-        </group>
+      <else-if type="report">
+        <date variable="issued" delimiter=" ">
+          <date-part name="year"/>
+          <date-part name="month" form="short" strip-periods="true"/>
+        </date>
       </else-if>
+      <else>
+        <group suffix=".">
+          <date variable="issued">
+            <date-part name="year"/>
+          </date>
+          <text macro="accessed-date" prefix=" "/>
+        </group>
+      </else>
     </choose>
   </macro>
-  <citation et-al-min="3" et-al-use-first="1" disambiguate-add-year-suffix="true" collapse="year">
+  <macro name="pages">
+    <choose>
+      <if type="article-journal article-magazine article-newspaper" match="any">
+        <text variable="page" prefix=":"/>
+      </if>
+      <else>
+        <group prefix=" " delimiter=" ">
+          <label variable="page" form="short" plural="never"/>
+          <text variable="page"/>
+        </group>
+      </else>
+    </choose>
+  </macro>
+  <macro name="journal-location">
+    <choose>
+      <if type="article-journal article-magazine" match="any">
+        <text variable="volume"/>
+        <text variable="issue" prefix="(" suffix=")"/>
+      </if>
+    </choose>
+  </macro>
+  <macro name="report-details">
+    <choose>
+      <if type="report">
+        <text variable="number" prefix="Report No.: "/>
+      </if>
+    </choose>
+  </macro>
+  <citation et-al-min="3" et-al-use-first="1" disambiguate-add-year-suffix="true">
     <sort>
-      <key macro="issued"/>
-      <key macro="author"/>
+      <key macro="author-in-citation"/>
+      <key variable="issued" sort="descending"/>
     </sort>
     <layout prefix="(" suffix=")" delimiter="; ">
       <group delimiter=" ">
-        <text macro="author-short"/>
-        <text macro="issued"/>
+        <text macro="author-short-in-citation"/>
+        <text macro="year-in-citation"/>
       </group>
     </layout>
   </citation>
-  <bibliography et-al-min="4" et-al-use-first="3" entry-spacing="0" line-spacing="2" hanging-indent="true">
+  <bibliography et-al-min="7" et-al-use-first="6">
     <sort>
-      <key macro="author"/>
-      <key macro="issued" sort="ascending"/>
+      <key macro="author-in-citation"/>
+      <key macro="issued-sort" sort="ascending"/>
     </sort>
     <layout>
-      <group suffix=".">
+      <group delimiter=". " suffix=". ">
         <text macro="author"/>
-        <text macro="issued" prefix=" (" suffix="). "/>
-        <group delimiter=". ">
-          <text macro="title"/>
-          <text macro="container"/>
-        </group>
-        <text macro="locators"/>
+        <text macro="title"/>
       </group>
-      <text macro="access" prefix=". "/>
+      <group delimiter=" " suffix=" ">
+        <text macro="editor"/>
+        <text macro="container-title"/>
+        <text macro="publisher"/>
+        <group>
+          <text macro="date"/>
+          <text macro="journal-location"/>
+          <text macro="pages"/>
+        </group>
+      </group>
+      <text macro="report-details" suffix=". "/>
+      <text macro="access"/>
     </layout>
   </bibliography>
 </style>

--- a/journal-of-investigative-dermatology.csl
+++ b/journal-of-investigative-dermatology.csl
@@ -15,6 +15,7 @@
     </author>
     <category citation-format="author-date"/>
     <category field="biology"/>
+    <issn>0022-202X</issn>
     <eissn>1523-1747</eissn>
     <summary>This style based on the Vancouver author-date style</summary>
     <updated>2016-09-23T20:19:12+00:00</updated>


### PR DESCRIPTION
The previous style did not match the suggested formatting from the journal. Using their [Endnote style format](http://endnote.com/downloads/style/journal-investigative-dermatology) a set of references should look like this:

# Inline

And then (Sutphen et al., 2016) blah (Gordon et al., 2016, Krupic et al., 2016) etc  (Silverman et al., 2016, Skoldenberg et al., 2016)

# bibliography

Gordon M, Rysinska A, Garland A, Rolfson O, Aspberg S, Eisler T, et al. Increased Long-Term Cardiovascular Risk After Total Hip Arthroplasty: A Nationwide Cohort Study. Medicine (Baltimore) 2016;95(6):e2662.

Krupic F, Eisler T, Skoldenberg O, Fatahi N. Experience of anaesthesia nurses of perioperative communication in hip fracture patients with dementia. Scand J Caring Sci 2016;30(1):99-107.

Silverman EJ, Ashley B, Sheth NP. Metal-on-metal total hip arthroplasty: is there still a role in 2016? Current reviews in musculoskeletal medicine 2016.

Skoldenberg O, Rysinska A, Eisler T, Salemyr M, Boden H, Muren O. Denosumab for treating periprosthetic osteolysis; study protocol for a randomized, double-blind, placebo-controlled trial. BMC Musculoskelet Disord 2016;17:174.

Sutphen SA, MacLaughlin LH, Madsen AA, Russell JH, McShane MA. Prevalence of Pseudotumor in Patients After Metal-On-Metal Hip Arthroplasty Evaluated with Metal Ion Analysis and MARS-MRI. J Arthroplasty 2016;31(1):260-3.