### PR TITLE
Update cahiers-d-ethnomusicologie.csl

### DIFF
--- a/cahiers-d-ethnomusicologie.csl
+++ b/cahiers-d-ethnomusicologie.csl
@@ -133,7 +133,7 @@
     <choose>
       <if variable="issued">
         <date variable="issued">
-          <date-part name="year" form="long" suffix=" "/>
+          <date-part name="year" form="long"/>
         </date>
       </if>
       <else>
@@ -311,12 +311,11 @@
   </macro>
   <citation et-al-min="3" et-al-use-first="1" disambiguate-add-year-suffix="true" disambiguate-add-names="true" disambiguate-add-givenname="true" collapse="year" year-suffix-delimiter=", " after-collapse-delimiter="&#160;; ">
     <layout prefix="(" suffix=")" delimiter="&#160;; ">
-      <group delimiter=", ">
+      <group delimiter="&#160;">
         <text macro="author-citation"/>
         <text macro="year-date"/>
       </group>
-      <group delimiter="&#160;">
-        <label variable="locator" form="short"/>
+      <group prefix="&#160;: ">
         <text variable="locator"/>
       </group>
     </layout>
@@ -345,7 +344,7 @@
             <text macro="collection" suffix=". "/>
           </if>
           <else-if type="article-journal article-magazine" match="any">
-            <text macro="title"/>
+            <text macro="title" suffix=" "/>
             <text macro="edition" suffix=". "/>
             <text macro="issue" suffix=". "/>
             <text macro="accessed" suffix=". "/>


### PR DESCRIPTION
1. Corrected a couple discrepancies in `<citation>` between the style and the journal’s guidelines. Should now look like this: (Rouget 1990 : 247)

2. Added missing whitespace between journal title and issue number for articles