### PR TITLE
SIGCHI proceedings format shouldn't default to "et al"

### DIFF
--- a/acm-sigchi-proceedings.csl
+++ b/acm-sigchi-proceedings.csl
@@ -115,7 +115,7 @@
       </group>
     </layout>
   </citation>
-  <bibliography et-al-min="7" et-al-use-first="3" second-field-align="flush" entry-spacing="0">
+  <bibliography second-field-align="flush" entry-spacing="0">
     <sort>
       <key macro="author"/>
       <key variable="issued"/>


### PR DESCRIPTION
The SIGCHI reference format is based on the ACM reference format and this does not include "et al" for any references (that I can find). Given no indication otherwise, I don't think the SIGCHI reference format should truncate the list of authors either.

Example with current CSL file:
![csl-current](https://cloud.githubusercontent.com/assets/844463/18988115/14101082-86fd-11e6-9b0a-16f3a91ff8ba.png)

Example from the ACM Digital Library of the ACM reference:
![acm](https://cloud.githubusercontent.com/assets/844463/18988122/19f4e5e0-86fd-11e6-8dd3-1969a5621be8.png)

Example with the modified CSL file:
![csl-proposed](https://cloud.githubusercontent.com/assets/844463/18988128/1fec42f4-86fd-11e6-9251-18b078437fb2.png)

