### PR TITLE
Corrected use of et al. in author lists

### DIFF
--- a/ieee.csl
+++ b/ieee.csl
@@ -82,7 +82,7 @@
     <names variable="author">
       <name and="text" et-al-min="7" et-al-use-first="1" initialize-with=". "/>
       <label form="short" prefix=", " text-case="capitalize-first"/>
-      <et-al font-style="italic" prefix=" "/>
+      <et-al font-style="italic"/>
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>

--- a/ieee.csl
+++ b/ieee.csl
@@ -28,7 +28,7 @@
     <category citation-format="numeric"/>
     <category field="engineering"/>
     <category field="generic-base"/>
-    <updated>2013-12-17T18:04:02+00:00</updated>
+    <updated>2016-10-06T15:32:30+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale xml:lang="en">
@@ -80,8 +80,9 @@
   </macro>
   <macro name="author">
     <names variable="author">
-      <name initialize-with=". " delimiter=", " and="text"/>
+      <name and="text" et-al-min="7" et-al-use-first="1" initialize-with=". "/>
       <label form="short" prefix=", " text-case="capitalize-first"/>
+      <et-al font-style="italic" prefix=" "/>
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>


### PR DESCRIPTION
Latest IEEE style guide says "If there are more than six names listed, use et al. after the first author." (p. 34)

[IEEE_style_manual.pdf](https://github.com/citation-style-language/styles/files/514202/IEEE_style_manual.pdf)
