### PR TITLE
Update deutsches-archaologisches-institut.csl

### DIFF
--- a/deutsches-archaologisches-institut.csl
+++ b/deutsches-archaologisches-institut.csl
@@ -4,8 +4,8 @@
   <info>
     <title>Deutsches Archäologisches Institut (German)</title>
     <title-short>DAI</title-short>
-    <id>http://www.zotero.org/styles/deutsches-archaologisches-institut</id>
-    <link href="http://www.zotero.org/styles/deutsches-archaologisches-institut" rel="self"/>
+    <id>http://www.zotero.org/styles/deutsches-archäologisches-institut-german</id>
+    <link href="http://www.zotero.org/styles/deutsches-archäologisches-institut-german" rel="self"/>
     <link href="http://www.zotero.org/styles/american-journal-of-archaeology" rel="template"/>
     <link href="http://www.dainst.org/publikationen/publizieren-beim-dai/richtlinien" rel="documentation"/>
     <author>
@@ -19,7 +19,7 @@
     <category citation-format="author-date"/>
     <category field="anthropology"/>
     <summary>New author-date style meant to meet citation specifications provided by DAI</summary>
-    <updated>2016-10-20T21:26:52+00:00</updated>
+    <updated>2016-10-25T15:48:55+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <macro name="secondary-contributors">
@@ -53,7 +53,7 @@
           <choose>
             <if variable="editor container-title" match="any">
               <text term="in" prefix=", " suffix=": "/>
-              <names variable="editor" font-variant="small-caps">
+              <names variable="editor">
                 <name delimiter=" &#8211; " delimiter-precedes-et-al="never" delimiter-precedes-last="always" initialize-with="."/>
                 <label form="short" prefix=" (" suffix=")" strip-periods="false"/>
               </names>
@@ -186,8 +186,11 @@
       <if type="bill book graphic legal_case motion_picture report song chapter paper-conference" match="any">
         <choose>
           <if is-numeric="edition">
-            <text variable="edition" vertical-align="sup"/>
+            <text variable="edition" vertical-align="sup" prefix=" "/>
           </if>
+          <else>
+            <text value=" "/>
+          </else>
         </choose>
       </if>
     </choose>
@@ -252,11 +255,6 @@
   <macro name="place-date">
     <choose>
       <if type="book thesis chapter" match="any">
-        <choose>
-          <if match="none" is-numeric="edition">
-            <text value=" "/>
-          </if>
-        </choose>
         <text variable="publisher-place" prefix="(" suffix=" "/>
         <text macro="date" suffix=")"/>
       </if>
@@ -348,7 +346,7 @@
         <text macro="locators"/>
         <text macro="issue"/>
         <text macro="series"/>
-        <text macro="edition" prefix=", "/>
+        <text macro="edition"/>
         <text macro="place-date"/>
         <text macro="journal-date"/>
         <text macro="locators-chapter"/>

--- a/deutsches-archaologisches-institut.csl
+++ b/deutsches-archaologisches-institut.csl
@@ -7,7 +7,7 @@
     <id>http://www.zotero.org/styles/deutsches-archaologisches-institut</id>
     <link href="http://www.zotero.org/styles/deutsches-archaologisches-institut" rel="self"/>
     <link href="http://www.zotero.org/styles/american-journal-of-archaeology" rel="template"/>
-    <link href="http://www.dainst.org/it/node/28770?ft=3" rel="documentation"/>
+    <link href="http://www.dainst.org/publikationen/publizieren-beim-dai/richtlinien" rel="documentation"/>
     <author>
       <name>Adam Rabinowitz</name>
       <email>adam.rabinowitz@gmail.com</email>

--- a/deutsches-archaologisches-institut.csl
+++ b/deutsches-archaologisches-institut.csl
@@ -2,7 +2,7 @@
 <style class="in-text" version="1.0" delimiter-precedes-et-al="never" initialize-with="." demote-non-dropping-particle="sort-only" default-locale="de" xmlns="http://purl.org/net/xbiblio/csl">
 <!-- This style was edited with the Visual CSL Editor (http://editor.citationstyles.org/visualEditor/#) -->
   <info>
-    <title>Deutsches Archäologisches Institut</title>
+    <title>Deutsches Archäologisches Institut (German)</title>
     <title-short>DAI</title-short>
     <id>http://www.zotero.org/styles/deutsches-archaologisches-institut</id>
     <link href="http://www.zotero.org/styles/deutsches-archaologisches-institut" rel="self"/>
@@ -29,7 +29,7 @@
           <choose>
             <if variable="author">
               <names variable="editor" font-variant="normal">
-                <name delimiter=" – " initialize-with=". "/>
+                <name delimiter=" &#8211; " initialize-with=". "/>
                 <label form="short" strip-periods="true" prefix=" (" suffix=")"/>
               </names>
             </if>
@@ -52,9 +52,9 @@
         <group>
           <choose>
             <if variable="editor container-title" match="any">
-              <text value=", in" suffix=": "/>
+              <text term="in" prefix=", " suffix=": "/>
               <names variable="editor" font-variant="small-caps">
-                <name delimiter=" – " delimiter-precedes-et-al="never" delimiter-precedes-last="always" initialize-with="."/>
+                <name delimiter=" &#8211; " delimiter-precedes-et-al="never" delimiter-precedes-last="always" initialize-with="."/>
                 <label form="short" prefix=" (" suffix=")" strip-periods="false"/>
               </names>
               <text macro="collection-title" prefix=", "/>
@@ -76,13 +76,13 @@
   </macro>
   <macro name="editor">
     <names variable="editor">
-      <name delimiter=" – " delimiter-precedes-et-al="never" delimiter-precedes-last="always" initialize-with=". "/>
+      <name delimiter=" &#8211; " delimiter-precedes-et-al="never" delimiter-precedes-last="always" initialize-with=". "/>
       <label form="short" prefix=" (" suffix=")" strip-periods="false"/>
     </names>
   </macro>
   <macro name="translator">
     <names variable="translator">
-      <name delimiter=" – " delimiter-precedes-et-al="never" delimiter-precedes-last="always" initialize-with=". "/>
+      <name delimiter=" &#8211; " delimiter-precedes-et-al="never" delimiter-precedes-last="always" initialize-with=". "/>
       <label form="verb-short" prefix=", " suffix="." strip-periods="false"/>
     </names>
   </macro>
@@ -108,7 +108,7 @@
     <choose>
       <if variable="author">
         <names variable="author">
-          <name delimiter=" – " delimiter-precedes-et-al="never" delimiter-precedes-last="always" initialize-with=". "/>
+          <name delimiter=" &#8211; " delimiter-precedes-et-al="never" delimiter-precedes-last="always" initialize-with=". "/>
           <label form="short" text-case="lowercase" strip-periods="false"/>
         </names>
       </if>
@@ -128,12 +128,12 @@
     <choose>
       <if variable="author">
         <names variable="author">
-          <name form="short" delimiter=" – " et-al-min="3" et-al-use-first="1"/>
+          <name form="short" delimiter=" &#8211; " et-al-min="3" et-al-use-first="1"/>
         </names>
       </if>
       <else-if variable="editor">
         <names variable="editor">
-          <name form="short" delimiter=" – " et-al-min="3" et-al-use-first="1"/>
+          <name form="short" delimiter=" &#8211; " et-al-min="3" et-al-use-first="1"/>
         </names>
       </else-if>
       <else-if variable="translator">
@@ -148,12 +148,12 @@
     <choose>
       <if variable="author">
         <names variable="author">
-          <name form="short" delimiter=" – " et-al-min="3" et-al-use-first="1"/>
+          <name form="short" delimiter=" &#8211; " et-al-min="3" et-al-use-first="1"/>
         </names>
       </if>
       <else-if variable="editor">
         <names variable="editor">
-          <name form="short" delimiter=" – " delimiter-precedes-last="always" et-al-min="3" et-al-use-first="1"/>
+          <name form="short" delimiter=" &#8211; " delimiter-precedes-last="always" et-al-min="3" et-al-use-first="1"/>
         </names>
       </else-if>
       <else-if variable="translator">

--- a/deutsches-archaologisches-institut.csl
+++ b/deutsches-archaologisches-institut.csl
@@ -4,8 +4,8 @@
   <info>
     <title>Deutsches Archäologisches Institut (German)</title>
     <title-short>DAI</title-short>
-    <id>http://www.zotero.org/styles/deutsches-archäologisches-institut-german</id>
-    <link href="http://www.zotero.org/styles/deutsches-archäologisches-institut-german" rel="self"/>
+    <id>http://www.zotero.org/styles/deutsches-archaologisches-institut</id>
+    <link href="http://www.zotero.org/styles/deutsches-archaologisches-institut" rel="self"/>
     <link href="http://www.zotero.org/styles/american-journal-of-archaeology" rel="template"/>
     <link href="http://www.dainst.org/publikationen/publizieren-beim-dai/richtlinien" rel="documentation"/>
     <author>

--- a/deutsches-archaologisches-institut.csl
+++ b/deutsches-archaologisches-institut.csl
@@ -19,7 +19,7 @@
     <category citation-format="author-date"/>
     <category field="anthropology"/>
     <summary>New author-date style meant to meet citation specifications provided by DAI</summary>
-    <updated>2016-10-20T21:00:18+00:00</updated>
+    <updated>2016-10-20T21:26:52+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <macro name="secondary-contributors">
@@ -245,13 +245,6 @@
       </choose>
       <text variable="locator"/>
     </group>
-  </macro>
-  <macro name="container-title-short">
-    <choose>
-      <if match="any" variable="container-title-short">
-        <text variable="container-title-short"/>
-      </if>
-    </choose>
   </macro>
   <macro name="date">
     <date variable="issued">

--- a/deutsches-archaologisches-institut.csl
+++ b/deutsches-archaologisches-institut.csl
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<style class="in-text" version="1.0" delimiter-precedes-et-al="never" initialize-with="." demote-non-dropping-particle="sort-only" default-locale="de" xmlns="http://purl.org/net/xbiblio/csl">
+<style class="in-text" version="1.0" delimiter-precedes-et-al="never" initialize-with="." demote-non-dropping-particle="sort-only" default-locale="de-DE" xmlns="http://purl.org/net/xbiblio/csl">
 <!-- This style was edited with the Visual CSL Editor (http://editor.citationstyles.org/visualEditor/#) -->
   <info>
     <title>Deutsches Archäologisches Institut (German)</title>
@@ -28,7 +28,7 @@
         <group delimiter=". ">
           <choose>
             <if variable="author">
-              <names variable="editor" font-variant="normal">
+              <names variable="editor">
                 <name delimiter=" &#8211; " initialize-with=". "/>
                 <label form="short" strip-periods="true" prefix=" (" suffix=")"/>
               </names>
@@ -36,7 +36,7 @@
           </choose>
           <choose>
             <if variable="author editor" match="any">
-              <names variable="translator" font-variant="normal">
+              <names variable="translator">
                 <name and="text" initialize-with="."/>
                 <label form="verb" text-case="capitalize-first" suffix=" "/>
               </names>
@@ -211,9 +211,7 @@
   <macro name="locators-chapter">
     <choose>
       <if type="chapter paper-conference" match="any">
-        <group prefix=" ">
-          <text variable="page"/>
-        </group>
+        <text variable="page" prefix=" "/>
       </if>
     </choose>
   </macro>

--- a/deutsches-archaologisches-institut.csl
+++ b/deutsches-archaologisches-institut.csl
@@ -4,8 +4,8 @@
   <info>
     <title>Deutsches Archäologisches Institut</title>
     <title-short>DAI</title-short>
-    <id>http://www.zotero.org/styles/deutsches-archaeologisches-institut</id>
-    <link href="http://www.zotero.org/styles/deutsches-archaeologisches-institut" rel="self"/>
+    <id>http://www.zotero.org/styles/deutsches-archaologisches-institut</id>
+    <link href="http://www.zotero.org/styles/deutsches-archaologisches-institut" rel="self"/>
     <link href="http://www.zotero.org/styles/american-journal-of-archaeology" rel="template"/>
     <link href="http://www.dainst.org/it/node/28770?ft=3" rel="documentation"/>
     <author>

--- a/deutsches-archaologisches-institut.csl
+++ b/deutsches-archaologisches-institut.csl
@@ -1,20 +1,25 @@
 <?xml version="1.0" encoding="utf-8"?>
-<style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" demote-non-dropping-particle="sort-only" default-locale="en-US">
+<style class="in-text" version="1.0" delimiter-precedes-et-al="never" initialize-with="." demote-non-dropping-particle="sort-only" default-locale="de" xmlns="http://purl.org/net/xbiblio/csl">
+<!-- This style was edited with the Visual CSL Editor (http://editor.citationstyles.org/visualEditor/#) -->
   <info>
     <title>Deutsches Archäologisches Institut</title>
     <title-short>DAI</title-short>
-    <id>http://www.zotero.org/styles/deutsches-archaologisches-institut</id>
-    <link href="http://www.zotero.org/styles/deutsches-archaologisches-institut" rel="self"/>
+    <id>http://www.zotero.org/styles/deutsches-archäologisches-institut</id>
+    <link href="http://www.zotero.org/styles/deutsches-archäologisches-institut" rel="self"/>
     <link href="http://www.zotero.org/styles/american-journal-of-archaeology" rel="template"/>
     <link href="http://www.dainst.org/it/node/28770?ft=3" rel="documentation"/>
     <author>
       <name>Adam Rabinowitz</name>
       <email>adam.rabinowitz@gmail.com</email>
     </author>
+    <contributor>
+      <name>DAI - Bibliothek</name>
+      <email>zenondai@dainst.de</email>
+    </contributor>
     <category citation-format="author-date"/>
     <category field="anthropology"/>
     <summary>New author-date style meant to meet citation specifications provided by DAI</summary>
-    <updated>2011-12-23T01:46:03+00:00</updated>
+    <updated>2016-10-20T21:00:18+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <macro name="secondary-contributors">
@@ -23,17 +28,17 @@
         <group delimiter=". ">
           <choose>
             <if variable="author">
-              <names variable="editor">
-                <name delimiter=" &#8211; " initialize-with=". "/>
-                <label form="short" prefix=" (" suffix=")" strip-periods="true"/>
+              <names variable="editor" font-variant="normal">
+                <name delimiter=" – " initialize-with=". "/>
+                <label form="short" strip-periods="true" prefix=" (" suffix=")"/>
               </names>
             </if>
           </choose>
           <choose>
             <if variable="author editor" match="any">
-              <names variable="translator">
+              <names variable="translator" font-variant="normal">
+                <name and="text" initialize-with="."/>
                 <label form="verb" text-case="capitalize-first" suffix=" "/>
-                <name and="text" delimiter=", "/>
               </names>
             </if>
           </choose>
@@ -46,24 +51,20 @@
       <if type="chapter paper-conference" match="any">
         <group>
           <choose>
-            <if variable="author">
-              <text value="in" prefix=" " suffix=": "/>
-              <names variable="editor">
-                <name form="short" delimiter=" &#8211; " delimiter-precedes-last="always"/>
+            <if variable="editor container-title" match="any">
+              <text value=", in" suffix=": "/>
+              <names variable="editor" font-variant="small-caps">
+                <name delimiter=" – " delimiter-precedes-et-al="never" delimiter-precedes-last="always" initialize-with="."/>
                 <label form="short" prefix=" (" suffix=")" strip-periods="false"/>
               </names>
-              <text macro="date" prefix=" "/>
-            </if>
-          </choose>
-          <choose>
-            <if variable="author editor" match="any">
-              <names variable="translator">
-                <name delimiter=" &#8211; "/>
-              </names>
+              <text macro="collection-title" prefix=", "/>
             </if>
           </choose>
         </group>
       </if>
+      <else-if type="article article-journal article-magazine article-newspaper" match="any">
+        <text variable="container-title" prefix=", "/>
+      </else-if>
     </choose>
   </macro>
   <macro name="anon">
@@ -75,13 +76,13 @@
   </macro>
   <macro name="editor">
     <names variable="editor">
-      <name delimiter=" &#8211; " delimiter-precedes-last="always" et-al-min="11" et-al-use-first="7" initialize-with=". "/>
+      <name delimiter=" – " delimiter-precedes-et-al="never" delimiter-precedes-last="always" initialize-with=". "/>
       <label form="short" prefix=" (" suffix=")" strip-periods="false"/>
     </names>
   </macro>
   <macro name="translator">
     <names variable="translator">
-      <name delimiter=" &#8211; " delimiter-precedes-last="always" initialize-with=". "/>
+      <name delimiter=" – " delimiter-precedes-et-al="never" delimiter-precedes-last="always" initialize-with=". "/>
       <label form="verb-short" prefix=", " suffix="." strip-periods="false"/>
     </names>
   </macro>
@@ -107,8 +108,8 @@
     <choose>
       <if variable="author">
         <names variable="author">
-          <name delimiter=" &#8211; " delimiter-precedes-last="always" et-al-min="11" et-al-use-first="7" initialize-with=". "/>
-          <label form="short" prefix=", " suffix="." text-case="lowercase" strip-periods="false"/>
+          <name delimiter=" – " delimiter-precedes-et-al="never" delimiter-precedes-last="always" initialize-with=". "/>
+          <label form="short" text-case="lowercase" strip-periods="false"/>
         </names>
       </if>
       <else-if variable="editor">
@@ -127,12 +128,12 @@
     <choose>
       <if variable="author">
         <names variable="author">
-          <name form="short" delimiter=" &#8211; " et-al-min="3" et-al-use-first="1"/>
+          <name form="short" delimiter=" – " et-al-min="3" et-al-use-first="1"/>
         </names>
       </if>
       <else-if variable="editor">
         <names variable="editor">
-          <name form="short" delimiter=" &#8211; " et-al-min="3" et-al-use-first="1"/>
+          <name form="short" delimiter=" – " et-al-min="3" et-al-use-first="1"/>
         </names>
       </else-if>
       <else-if variable="translator">
@@ -147,12 +148,12 @@
     <choose>
       <if variable="author">
         <names variable="author">
-          <name form="short" delimiter=" &#8211; " et-al-min="3" et-al-use-first="1"/>
+          <name form="short" delimiter=" – " et-al-min="3" et-al-use-first="1"/>
         </names>
       </if>
       <else-if variable="editor">
         <names variable="editor">
-          <name form="short" delimiter=" &#8211; " delimiter-precedes-last="always" et-al-min="3" et-al-use-first="1"/>
+          <name form="short" delimiter=" – " delimiter-precedes-last="always" et-al-min="3" et-al-use-first="1"/>
         </names>
       </else-if>
       <else-if variable="translator">
@@ -173,10 +174,10 @@
         </choose>
       </if>
       <else-if type="bill book graphic legal_case motion_picture report song thesis" match="any">
-        <text variable="title"/>
+        <text variable="title" strip-periods="true"/>
       </else-if>
       <else>
-        <text variable="title" prefix="" suffix=", " quotes="false"/>
+        <text variable="title" strip-periods="true" quotes="false"/>
       </else>
     </choose>
   </macro>
@@ -185,14 +186,8 @@
       <if type="bill book graphic legal_case motion_picture report song chapter paper-conference" match="any">
         <choose>
           <if is-numeric="edition">
-            <group delimiter=" ">
-              <number variable="edition" form="ordinal"/>
-              <text term="edition" form="short"/>
-            </group>
+            <text variable="edition" vertical-align="sup"/>
           </if>
-          <else>
-            <text variable="edition" suffix="."/>
-          </else>
         </choose>
       </if>
     </choose>
@@ -216,7 +211,7 @@
   <macro name="locators-chapter">
     <choose>
       <if type="chapter paper-conference" match="any">
-        <group prefix=", ">
+        <group prefix=" ">
           <text variable="page"/>
         </group>
       </if>
@@ -225,10 +220,10 @@
   <macro name="locators-article">
     <choose>
       <if type="article-newspaper">
-        <group prefix=", " delimiter=", ">
+        <group delimiter=", ">
           <group delimiter=" ">
-            <text variable="edition"/>
-            <text term="edition"/>
+            <text variable="edition" prefix=", "/>
+            <text term="edition" prefix=", "/>
           </group>
           <group>
             <text term="section" form="short" suffix=" "/>
@@ -252,18 +247,11 @@
     </group>
   </macro>
   <macro name="container-title-short">
-    <group>
-      <choose>
-        <if type="article-journal">
-          <choose>
-            <if variable="container-title-short" match="none">
-              <text variable="container-title"/>
-            </if>
-          </choose>
-          <text variable="container-title-short"/>
-        </if>
-      </choose>
-    </group>
+    <choose>
+      <if match="any" variable="container-title-short">
+        <text variable="container-title-short"/>
+      </if>
+    </choose>
   </macro>
   <macro name="date">
     <date variable="issued">
@@ -272,8 +260,13 @@
   </macro>
   <macro name="place-date">
     <choose>
-      <if type="book thesis" match="any">
-        <text variable="publisher-place" prefix=" (" suffix=" "/>
+      <if type="book thesis chapter" match="any">
+        <choose>
+          <if match="none" is-numeric="edition">
+            <text value=" "/>
+          </if>
+        </choose>
+        <text variable="publisher-place" prefix="(" suffix=" "/>
         <text macro="date" suffix=")"/>
       </if>
     </choose>
@@ -281,7 +274,7 @@
   <macro name="journal-date">
     <choose>
       <if type="article-journal">
-        <text macro="date"/>
+        <text macro="date" prefix=", "/>
       </if>
     </choose>
   </macro>
@@ -292,7 +285,7 @@
     </date>
   </macro>
   <macro name="collection-title">
-    <text variable="collection-title"/>
+    <text variable="container-title" strip-periods="true"/>
   </macro>
   <macro name="event">
     <group>
@@ -323,6 +316,14 @@
       </else>
     </choose>
   </macro>
+  <macro name="series">
+    <choose>
+      <if match="any" variable="collection-title">
+        <text variable="collection-title" strip-periods="true" prefix=", "/>
+        <text variable="collection-number" prefix=" "/>
+      </if>
+    </choose>
+  </macro>
   <citation et-al-min="3" et-al-use-first="1" disambiguate-add-year-suffix="true">
     <sort>
       <key variable="issued"/>
@@ -350,14 +351,13 @@
       </group>
       <group>
         <text macro="contributors" suffix=", "/>
-        <text macro="title"/>
+        <text macro="title" strip-periods="true"/>
         <text macro="secondary-contributors"/>
         <text macro="short-container-contributors"/>
-        <text macro="edition" prefix=", "/>
-        <text macro="container-title-short"/>
-        <text macro="locators" suffix=", "/>
-        <text macro="collection-title" prefix=", "/>
+        <text macro="locators"/>
         <text macro="issue"/>
+        <text macro="series"/>
+        <text macro="edition" prefix=", "/>
         <text macro="place-date"/>
         <text macro="journal-date"/>
         <text macro="locators-chapter"/>

--- a/deutsches-archaologisches-institut.csl
+++ b/deutsches-archaologisches-institut.csl
@@ -4,8 +4,8 @@
   <info>
     <title>Deutsches Archäologisches Institut</title>
     <title-short>DAI</title-short>
-    <id>http://www.zotero.org/styles/deutsches-archäologisches-institut</id>
-    <link href="http://www.zotero.org/styles/deutsches-archäologisches-institut" rel="self"/>
+    <id>http://www.zotero.org/styles/deutsches-archaeologisches-institut</id>
+    <link href="http://www.zotero.org/styles/deutsches-archaeologisches-institut" rel="self"/>
     <link href="http://www.zotero.org/styles/american-journal-of-archaeology" rel="template"/>
     <link href="http://www.dainst.org/it/node/28770?ft=3" rel="documentation"/>
     <author>


### PR DESCRIPTION
Added display of booktitles for chapters. Changed 'et al.' to 'u. a.'. Stripped periods from title fields. Display of '(Hrsg.)' instead of '(eds.)'. Only display edition if number and superscripted. No commas before page numbers, except for articles. Included series number (and series title) for publications in series.
One problem left: In chapters the editors of the book are not displayed correctly; e.g. it should be 'M. Alexianu' and not 'Alexianu, Marius'