### PR TITLE
Separate abstract from the rest using full stop in APA.

### DIFF
--- a/apa-annotated-bibliography.csl
+++ b/apa-annotated-bibliography.csl
@@ -544,7 +544,7 @@
       </group>
       <text macro="access" prefix=" "/>
       <text macro="original-date" prefix=" "/>
-      <text variable="abstract" display="block"/>
+      <text variable="abstract" display="block" prefix=". "/>
     </layout>
   </bibliography>
 </style>


### PR DESCRIPTION
Abstract in APA annotated style is not separated from previous
item. This change adds a full stop and a space prefix before the
abstract.