### PR TITLE
Update nccr-mediality.csl

### DIFF
--- a/nccr-mediality.csl
+++ b/nccr-mediality.csl
@@ -256,8 +256,8 @@
             <number variable="issue"/>
           </else>
         </choose>
-        <date prefix=", " variable="issued">
-          <date-part name="year"/>
+        <date prefix=" (" variable="issued">
+          <date-part name="year" suffix=")"/>
         </date>
       </else-if>
     </choose>

--- a/nccr-mediality.csl
+++ b/nccr-mediality.csl
@@ -256,8 +256,8 @@
             <number variable="issue"/>
           </else>
         </choose>
-        <date prefix=" (" variable="issued">
-          <date-part name="year" suffix=")"/>
+        <date variable="issued" prefix=" (" suffix=")">
+          <date-part name="year"/>
         </date>
       </else-if>
     </choose>


### PR DESCRIPTION
Changement in agreement with Claudio Notz (Style author).
The date (year) of a journal article of this style is supposed to be in brackets, not after a comma. E. g.: 

> Andrea Köhler: Kilroy was here. Das Phantom des Buches – Literatur der Postmoderne, in: Merkur. Deutsche Zeitschrift für euroäisches Denken, 52/H 09/10 (1998), S. 840–851

instead of

> Andrea Köhler: Kilroy was here. Das Phantom des Buches – Literatur der Postmoderne, in: Merkur. Deutsche Zeitschrift für euroäisches Denken, 52/H 09/10, 1998, S. 840–851