### PR TITLE
Update stroke.csl

### DIFF
--- a/stroke.csl
+++ b/stroke.csl
@@ -4,7 +4,7 @@
     <title>Stroke</title>
     <id>http://www.zotero.org/styles/stroke</id>
     <link href="http://www.zotero.org/styles/stroke" rel="self"/>
-    <link href="http://stroke.ahajournals.org/misc/ifora.shtml" rel="documentation"/>
+    <link href="http://stroke.ahajournals.org/content/instructionsforau" rel="documentation"/>
     <author>
       <name>Michael Berkowitz</name>
       <email>mberkowi@gmu.edu</email>
@@ -20,6 +20,10 @@
       <name>Richard Karnesky</name>
       <email>karnesky+zotero@gmail.com</email>
       <uri>http://arc.nucapt.northwestern.edu/Richard_Karnesky</uri>
+    </contributor>
+    <contributor>
+      <name>Christian Rubbert</name>
+      <email>christian.rubbert@med.uni-duesseldorf.de</email>
     </contributor>
     <category citation-format="numeric"/>
     <category field="medicine"/>
@@ -125,7 +129,7 @@
       <text variable="citation-number"/>
     </layout>
   </citation>
-  <bibliography second-field-align="flush">
+  <bibliography second-field-align="flush" et-al-min="7" et-al-use-first="6">
     <layout>
       <text variable="citation-number" suffix=". "/>
       <text macro="author"/>

--- a/stroke.csl
+++ b/stroke.csl
@@ -4,7 +4,7 @@
     <title>Stroke</title>
     <id>http://www.zotero.org/styles/stroke</id>
     <link href="http://www.zotero.org/styles/stroke" rel="self"/>
-    <link href="http://stroke.ahajournals.org/content/instructionsforau" rel="documentation"/>
+    <link href="http://stroke.ahajournals.org/content/general-preparation#References" rel="documentation"/>
     <author>
       <name>Michael Berkowitz</name>
       <email>mberkowi@gmu.edu</email>


### PR DESCRIPTION
Hey community,

I made some minor updates to stroke.csl:

- Update link to documentation
- Honor guideline "References with more than 6 authors should list the first 6 authors followed by et al."

Best regards,
crubb