### PR TITLE
added thesis

### DIFF
--- a/acm-sigchi-proceedings.csl
+++ b/acm-sigchi-proceedings.csl
@@ -129,7 +129,7 @@
       </group>
       <group suffix=".">
         <choose>
-          <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
+          <if type="thesis bill book graphic legal_case legislation motion_picture report song" match="any">
             <text macro="book-publisher" suffix="."/>
           </if>
           <else-if type="paper-conference">

--- a/acm-sigchi-proceedings.csl
+++ b/acm-sigchi-proceedings.csl
@@ -129,7 +129,7 @@
       </group>
       <group suffix=".">
         <choose>
-          <if type="thesis bill book graphic legal_case legislation motion_picture report song" match="any">
+          <if type="bill book graphic legal_case legislation motion_picture report song thesis" match="any">
             <text macro="book-publisher" suffix="."/>
           </if>
           <else-if type="paper-conference">


### PR DESCRIPTION
Before this small change my citations for PhD theses were missing the institution name:

Kimberly D Anderson. 2011. Appraisal learning networks: How university archivists learn to appraise through social interaction.

instead of:

Kimberly D Anderson. 2011. Appraisal learning networks: How university archivists learn to appraise through social interaction. University of California, Los Angeles.

