### PR TITLE
Remove unnecessary suffix after available-at

### DIFF
--- a/the-open-university-harvard.csl
+++ b/the-open-university-harvard.csl
@@ -61,7 +61,7 @@
       <if variable="URL">
         <group delimiter=" ">
           <text term="online" prefix="[" suffix="]." text-case="capitalize-first"/>
-          <text term="available at" suffix=":" text-case="capitalize-first"/>
+          <text term="available at" text-case="capitalize-first"/>
           <text variable="URL"/>
           <group prefix="(" delimiter=" " suffix=").">
             <text term="accessed" text-case="capitalize-first"/>


### PR DESCRIPTION
No colon in the OU Harvard specification.