### PR TITLE
Update citation & bibliography formats for webpage

### DIFF
--- a/the-open-university-harvard.csl
+++ b/the-open-university-harvard.csl
@@ -32,8 +32,16 @@
       <name name-as-sort-order="all" and="text" sort-separator=", " delimiter=", " delimiter-precedes-last="never" form="long" initialize-with=". "/>
       <label form="short" prefix=" (" suffix=")"/>
       <substitute>
-        <names variable="editor"/>
-        <text macro="anon"/>
+        <choose>
+          <if type="webpage">
+            <text variable="container-title"/>
+            <text variable="URL"/>
+          </if>
+          <else>
+            <names variable="editor"/>
+            <text macro="anon"/>
+          </else>
+        </choose>
       </substitute>
     </names>
   </macro>
@@ -41,9 +49,17 @@
     <names variable="author">
       <name form="short" and="text" delimiter=", " delimiter-precedes-last="never" initialize-with=". "/>
       <substitute>
-        <names variable="editor"/>
-        <names variable="translator"/>
-        <text macro="anon"/>
+        <choose>
+          <if type="webpage">
+            <text variable="container-title"/>
+            <text variable="URL"/>
+          </if>
+          <else>
+            <names variable="editor"/>
+            <names variable="translator"/>
+            <text macro="anon"/>
+          </else>
+        </choose>
       </substitute>
     </names>
   </macro>
@@ -77,7 +93,7 @@
   </macro>
   <macro name="title">
     <choose>
-      <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
+      <if type="bill book graphic legal_case legislation motion_picture report song webpage" match="any">
         <text variable="title" font-style="italic"/>
       </if>
       <else>
@@ -202,6 +218,14 @@
             <text macro="publisher"/>
           </group>
         </if>
+        <else-if type="webpage">
+          <group delimiter=" ">
+            <text macro="author"/>
+            <text macro="year-date" prefix="(" suffix=")"/>
+            <text macro="title"/>
+            <text macro="access"/>
+          </group>
+        </else-if>
         <!-- Generic/fallback format (bibliography) -->
         <else>
           <group delimiter=" ">


### PR DESCRIPTION
From the OU Harvard guide:
'Use the title of the website if you cannot identify its author. Use the website’s URL if you cannot identify its author or title.'

**Full reference format**:
Author, A. (year of publication/last updated) _Title of Website_ [Online]. Available at URL (Accessed date).

The examples show that _Title of Website_ is best filled with the actual page title. It must be displayed in italics.