### PR TITLE
MHRA fallback for non-numeric volume

### DIFF
--- a/modern-humanities-research-association.csl
+++ b/modern-humanities-research-association.csl
@@ -253,6 +253,9 @@
           <if is-numeric="volume">
             <number variable="volume" form="roman" font-variant="small-caps"/>
           </if>
+          <else>
+            <text variable="volume" font-variant="small-caps"/>
+          </else>
         </choose>
       </if>
     </choose>


### PR DESCRIPTION
Print-out the volume field "as is" when it is not numeric (e.g. if the user has typed in the roman numerals).
See https://forums.zotero.org/discussion/63174/problem-with-modern-humanities-research-association-3rd-edition#latest

Side note: the Zotero Style Editor seems to ignore the "small-caps" font-variant setting for cs:text, but it works fine when inserted in a Word document.