### PR TITLE
Update meteoritics-and-planetary-science.csl

### DIFF
--- a/meteoritics-and-planetary-science.csl
+++ b/meteoritics-and-planetary-science.csl
@@ -112,8 +112,12 @@
     <text term="in" text-case="capitalize-first" suffix=" "/>
     <text variable="container-title" font-style="italic"/>
   </macro>
-  <citation et-al-min="3" et-al-use-first="1" disambiguate-add-year-suffix="true" disambiguate-add-names="true" disambiguate-add-givenname="true" collapse="year">
-    <layout prefix="(" suffix=")" delimiter="; ">
+<citation et-al-min="3" et-al-use-first="1" disambiguate-add-year-suffix="true" collapse="year">
+    <sort>
+      <key macro="author"/>
+      <key macro="year-date"/>
+    </sort>
+  <layout prefix="(" suffix=")" delimiter="; ">
       <group delimiter=", ">
         <group delimiter=" ">
           <text macro="author-short"/>
@@ -125,8 +129,8 @@
   </citation>
   <bibliography hanging-indent="true" et-al-min="10" et-al-use-first="1">
     <sort>
-      <key macro="author"/>
-      <key variable="title"/>
+      <key macro="author-short" names-use-first="1" names-min="2"/>
+      <key macro="year-date"/>
     </sort>
     <layout suffix=".">
       <group delimiter=" ">
@@ -183,7 +187,7 @@
           </group>
           <group prefix=" " suffix="." delimiter=" ">
             <text variable="container-title" font-style="italic"/>
-            <group delimiter=": ">
+            <group delimiter=":">
               <text variable="volume"/>
               <text variable="page"/>
             </group>

--- a/meteoritics-and-planetary-science.csl
+++ b/meteoritics-and-planetary-science.csl
@@ -112,12 +112,12 @@
     <text term="in" text-case="capitalize-first" suffix=" "/>
     <text variable="container-title" font-style="italic"/>
   </macro>
-<citation et-al-min="3" et-al-use-first="1" disambiguate-add-year-suffix="true" collapse="year">
+  <citation et-al-min="3" et-al-use-first="1" disambiguate-add-year-suffix="true" collapse="year">
     <sort>
-      <key macro="author"/>
+      <key macro="author-short" names-use-first="1" names-min="2"/>
       <key macro="year-date"/>
     </sort>
-  <layout prefix="(" suffix=")" delimiter="; ">
+    <layout prefix="(" suffix=")" delimiter="; ">
       <group delimiter=", ">
         <group delimiter=" ">
           <text macro="author-short"/>


### PR DESCRIPTION
-Sort in-line citations by author and year, and remove disambiguation option when multiple authors are similar - only year+suffix (e.g. 2016a) is used to disambiguate multiple papers by same author.
-Sort biblio by first author only, then by year. Ignores 2nd+ authorship in alphabetization, as per MaPS policy.
-Removed space after colon separating volume and issue as per MaPS policy.