### PR TITLE
MaPS Update biblio and et al

### DIFF
--- a/meteoritics-and-planetary-science.csl
+++ b/meteoritics-and-planetary-science.csl
@@ -114,8 +114,8 @@
   </macro>
   <citation et-al-min="3" et-al-use-first="1" disambiguate-add-year-suffix="true" collapse="year">
     <sort>
-      <key macro="author-short" names-use-first="1" names-min="2"/>
       <key macro="year-date"/>
+      <key macro="author-short" names-use-first="1" names-min="2"/>
     </sort>
     <layout prefix="(" suffix=")" delimiter="; ">
       <group delimiter=", ">
@@ -127,7 +127,7 @@
       </group>
     </layout>
   </citation>
-  <bibliography hanging-indent="true" et-al-min="10" et-al-use-first="1">
+  <bibliography hanging-indent="true">
     <sort>
       <key macro="author-short" names-use-first="1" names-min="2"/>
       <key macro="year-date"/>


### PR DESCRIPTION
-Biblio should never be truncated. All authors should be listed, regardless of number. My previous modification erroneously truncated the authorship list.
Unresolved Issue: In-line citations should be ordered by date preferentially, and author groups should stay together. So, for example, correct: (Leitz et al. 1999, 2009; Arding 2005). Incorrect would be (Arding 2005; Leitz et al. 1999, 2009) or (Arding 2005; Leitz et al. 1999, Leitz et al. 2009). I think the sort code messes with this format, as the original code grouped appropriately but did not arrange by date correctly. Can the in-line citation be sorted after the multiple papers by the same author have been grouped?