### PR TITLE
Update society-of-biblical-literature-fullnote-bibliography.csl

### DIFF
--- a/society-of-biblical-literature-fullnote-bibliography.csl
+++ b/society-of-biblical-literature-fullnote-bibliography.csl
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<style xmlns="http://purl.org/net/xbiblio/csl" class="note" version="1.0" demote-non-dropping-particle="sort-only" page-range-format="chicago">
+<style xmlns="http://purl.org/net/xbiblio/csl" class="note" version="1.0" demote-non-dropping-particle="sort-only" page-range-format="chicago" default-locale="en-US">
   <info>
     <title>Society of Biblical Literature 2nd edition (full note)</title>
     <id>http://www.zotero.org/styles/society-of-biblical-literature-fullnote-bibliography</id>
@@ -447,7 +447,7 @@
   <macro name="locators">
     <choose>
       <if type="article-journal">
-          <group prefix=" " delimiter=".">
+        <group prefix=" " delimiter=".">
           <text variable="volume"/>
           <number variable="issue"/>
         </group>

--- a/society-of-biblical-literature-fullnote-bibliography.csl
+++ b/society-of-biblical-literature-fullnote-bibliography.csl
@@ -447,8 +447,8 @@
   <macro name="locators">
     <choose>
       <if type="article-journal">
-        <text variable="volume" prefix=" "/>
-        <group prefix=".">
+          <group prefix=" " delimiter=".">
+          <text variable="volume"/>
           <number variable="issue"/>
         </group>
       </if>

--- a/society-of-biblical-literature-fullnote-bibliography.csl
+++ b/society-of-biblical-literature-fullnote-bibliography.csl
@@ -38,23 +38,6 @@
       <term name="translator" form="verb-short">trans.</term>
     </terms>
   </locale>
-  <locale xml:lang="en-GB">
-    <style-options punctuation-in-quote="true"/>
-    <terms>
-      <term name="open-quote">“</term>
-      <term name="close-quote">”</term>
-      <term name="open-inner-quote">‘</term>
-      <term name="close-inner-quote">’</term>
-      <term name="editor" form="verb-short">ed.</term>
-      <term name="container-author" form="verb">by</term>
-      <term name="translator" form="verb-short">trans.</term>
-      <term name="editortranslator" form="verb">
-        <single>edited and translated by</single>
-        <multiple>edited and translated by</multiple>
-      </term>
-      <term name="translator" form="short">trans.</term>
-    </terms>
-  </locale>
   <macro name="editor-translator">
     <group delimiter=", ">
       <choose>

--- a/society-of-biblical-literature-fullnote-bibliography.csl
+++ b/society-of-biblical-literature-fullnote-bibliography.csl
@@ -28,14 +28,11 @@
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale xml:lang="en-US">
-    <date form="text" delimiter=" ">
-      <date-part name="day"/>
-      <date-part name="month"/>
-      <date-part name="year"/>
-    </date>
     <terms>
       <term name="editor" form="verb-short">ed.</term>
       <term name="translator" form="verb-short">trans.</term>
+      <term name="translator" form="short">trans.</term>
+      <term name="editortranslator" form="verb">edited and translated by</term>
     </terms>
   </locale>
   <macro name="editor-translator">

--- a/society-of-biblical-literature-fullnote-bibliography.csl
+++ b/society-of-biblical-literature-fullnote-bibliography.csl
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<style xmlns="http://purl.org/net/xbiblio/csl" class="note" version="1.0" demote-non-dropping-particle="sort-only" default-locale="en-US" page-range-format="chicago">
+<style xmlns="http://purl.org/net/xbiblio/csl" class="note" version="1.0" demote-non-dropping-particle="sort-only" page-range-format="chicago">
   <info>
     <title>Society of Biblical Literature 2nd edition (full note)</title>
     <id>http://www.zotero.org/styles/society-of-biblical-literature-fullnote-bibliography</id>
@@ -24,7 +24,7 @@
     <category citation-format="note"/>
     <category field="theology"/>
     <summary>Society of Biblical Literature format with full notes and bibliography</summary>
-    <updated>2012-10-26T01:15:26+00:00</updated>
+    <updated>2016-11-30T13:46:46+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale xml:lang="en-US">
@@ -36,6 +36,23 @@
     <terms>
       <term name="editor" form="verb-short">ed.</term>
       <term name="translator" form="verb-short">trans.</term>
+    </terms>
+  </locale>
+  <locale xml:lang="en-GB">
+    <style-options punctuation-in-quote="true"/>
+    <terms>
+      <term name="open-quote">“</term>
+      <term name="close-quote">”</term>
+      <term name="open-inner-quote">‘</term>
+      <term name="close-inner-quote">’</term>
+      <term name="editor" form="verb-short">ed.</term>
+      <term name="container-author" form="verb">by</term>
+      <term name="translator" form="verb-short">trans.</term>
+      <term name="editortranslator" form="verb">
+        <single>edited and translated by</single>
+        <multiple>edited and translated by</multiple>
+      </term>
+      <term name="translator" form="short">trans.</term>
     </terms>
   </locale>
   <macro name="editor-translator">
@@ -451,8 +468,7 @@
     <choose>
       <if type="article-journal">
         <text variable="volume" prefix=" "/>
-        <group prefix=", ">
-          <text term="issue" form="short" suffix=" "/>
+        <group prefix=".">
           <number variable="issue"/>
         </group>
       </if>
@@ -631,7 +647,7 @@
     <choose>
       <if type="article-journal">
         <text variable="volume" prefix=" "/>
-        <text variable="issue" prefix=", no. "/>
+        <text variable="issue" prefix="."/>
         <text macro="issued" prefix=" (" suffix=")"/>
       </if>
       <else-if variable="publisher-place publisher" match="any">


### PR DESCRIPTION
Changes:
1) Removed default-locale, as it prevented Zotero from changing locale
2) Added en-GB locale options
3) Removed "no." prefix for journal article issue numbers (see https://forums.zotero.org/discussion/62504/style-error-society-of-biblical-literature-2nd-edition-full-note)