### PR TITLE
Update kolner-zeitschrift-fur-soziologie-und-sozialpsychologie.csl

### DIFF
--- a/kolner-zeitschrift-fur-soziologie-und-sozialpsychologie.csl
+++ b/kolner-zeitschrift-fur-soziologie-und-sozialpsychologie.csl
@@ -17,12 +17,15 @@
     <contributor>
       <name>Sebastian Karcher</name>
     </contributor>
+    <contributor>
+      <name>Sebastian Haunss</name>
+    </contributor>
     <category citation-format="author-date"/>
     <category field="sociology"/>
     <issn>0023-2653</issn>
     <eissn>1861-891X</eissn>
     <summary>The KZfSS style</summary>
-    <updated>2015-09-20T18:02:01+00:00</updated>
+    <updated>2015-09-21T10:25:15+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale xml:lang="de">
@@ -33,7 +36,7 @@
   <macro name="editor">
     <names variable="editor">
       <label form="short" text-case="capitalize-first" suffix=" "/>
-      <name and="text" delimiter=", "/>
+      <name and="text" delimiter=", " delimiter-precedes-last="never"/>
     </names>
   </macro>
   <macro name="anon">
@@ -173,7 +176,7 @@
             <text macro="publisher"/>
           </group>
         </else-if>
-        <else-if type="bill book graphic legal_case legislation motion_picture report song" match="any">
+        <else-if type="book" match="any">
           <group delimiter=" ">
             <text macro="title" prefix=" " suffix="."/>
             <text macro="edition"/>
@@ -181,7 +184,16 @@
             <text macro="publisher"/>
           </group>
         </else-if>
-        <else-if type="chapter paper-conference" match="any">
+        <else-if type="bill graphic legal_case legislation motion_picture report song" match="any">
+          <group delimiter=" ">
+            <text macro="title" prefix=" " suffix="."/>
+            <text macro="edition"/>
+            <text macro="editor" suffix="."/>
+            <text macro="publisher"/>
+          </group>
+	  <text prefix=". " macro="access" suffix="."/>
+        </else-if>
+        <else-if type="chapter" match="any">
           <group delimiter=" ">
             <text macro="title" prefix=" " suffix="."/>
             <group delimiter=", " suffix=".">
@@ -197,6 +209,23 @@
             <text macro="publisher"/>
           </group>
         </else-if>
+        <else-if type="paper-conference" match="any">
+          <group delimiter=" ">
+            <text macro="title" prefix=" " suffix="."/>
+            <group delimiter=", " suffix=".">
+              <group delimiter=" ">
+                <text term="in" text-case="capitalize-first"/>
+                <text variable="container-title" font-style="italic"/>
+              </group>
+              <text variable="volume" prefix="vol. "/>
+              <text variable="collection-title" font-style="italic"/>
+              <text macro="editor"/>
+              <text macro="pages"/>
+            </group>
+            <text macro="publisher"/>
+          </group>
+	  <text prefix=". " macro="access" suffix="."/>
+        </else-if>
         <else>
           <group suffix=".">
             <text macro="title" prefix=" "/>
@@ -211,7 +240,6 @@
           </group>
         </else>
       </choose>
-      <text prefix=" " macro="access" suffix="."/>
     </layout>
   </bibliography>
 </style>


### PR DESCRIPTION
Book, articles and chapters should not show URL information even if available in the Zotero entry. Also, for chapters in volumes with multiple editors, the "und" before the last editor should not be preceeded by a komma.