### PR TITLE
Fix formatting of chapter container and editors

### DIFF
--- a/the-open-university-harvard.csl
+++ b/the-open-university-harvard.csl
@@ -11,6 +11,7 @@
     </author>
     <contributor>
       <name>Pablo Melchor</name>
+      <uri>https://pablomelchor.com/hello/</uri>
     </contributor>
     <category citation-format="author-date"/>
     <category field="generic-base"/>
@@ -21,7 +22,7 @@
   <macro name="editor">
     <names variable="editor" delimiter=", ">
       <name and="text" initialize-with=". " delimiter=", " sort-separator=", " name-as-sort-order="all"/>
-      <label form="short" prefix=" (" suffix=")"/>
+      <label form="short" prefix=" (" suffix=")"  strip-periods="true"/>
     </names>
   </macro>
   <macro name="anon">
@@ -164,8 +165,8 @@
   </macro>
   <macro name="container-prefix">
     <choose>
-      <if type="chapter paper-conference" match="any">
-        <text term="in" text-case="capitalize-first"/>
+      <if type="chapter">
+        <text term="in"/>
       </if>
     </choose>
   </macro>


### PR DESCRIPTION
Adjusting to the style guide (see examples below):

- No capitalize-first for "in" and no period for "(eds)":
Mason, R. (1994) ‘The educational value of ISDN’, in Mason, R. and Bacsich, P. (eds) _ISDN: Applications in Education and Training_, Exeter, Short Run Press, pp. 58–83.

- No container prefix for paper-conference:
Jones, J. (1994) ‘Polymer blends based on compact disc scrap’, _Proceedings of the Annual Technical Conference – Society of Plastics Engineers_. San Francisco, 1–5 May. Brookfield, CT, Society of Plastics Engineers, pp. 2865–7.

