### PR TITLE
Correct minor formatting errors

### DIFF
--- a/journal-of-dairy-science.csl
+++ b/journal-of-dairy-science.csl
@@ -18,7 +18,7 @@
     <issn>0022-0302</issn>
     <eissn>1525-3198</eissn>
     <summary>Style based on the 2016 Journal of Dairy Science &quot;Instructions to Authors: Style and Form&quot;</summary>
-    <updated>2016-12-09T19:47:54+00:00</updated>
+    <updated>2016-12-17T19:17:21+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <macro name="editor">
@@ -53,7 +53,7 @@
         <text variable="title" text-case="title"/>
       </if>
       <else>
-        <text variable="title" form="short" text-case="sentence"/>
+        <text variable="title"/>
       </else>
     </choose>
   </macro>
@@ -163,7 +163,7 @@
           <group prefix=" ">
             <text macro="title"/>
             <text variable="container-title" form="short" font-style="normal" prefix=". "/>
-            <group delimiter=":" prefix=". ">
+            <group delimiter=":" prefix=" ">
               <text variable="volume"/>
               <text variable="page"/>
             </group>


### PR DESCRIPTION
Removed formatting of titles using sentence case; removed unnecessary trailing period on container-title.