### PR TITLE
Delete two spaces in who-europe-harvard.csl

### DIFF
--- a/who-europe-harvard.csl
+++ b/who-europe-harvard.csl
@@ -51,8 +51,8 @@
       <if variable="URL">
         <group delimiter=", ">
           <text variable="URL"/>
-          <group>
-            <text value="accessed"/>
+          <group delimiter=" ">
+            <text term="accessed"/>
             <date variable="accessed">
               <date-part name="day" suffix=" "/>
               <date-part name="month" suffix=" "/>

--- a/who-europe-harvard.csl
+++ b/who-europe-harvard.csl
@@ -52,8 +52,8 @@
         <group delimiter=", ">
           <text variable="URL"/>
           <group>
-            <text value="accessed "/>
-            <date variable="accessed ">
+            <text value="accessed"/>
+            <date variable="accessed">
               <date-part name="day" suffix=" "/>
               <date-part name="month" suffix=" "/>
               <date-part name="year"/>


### PR DESCRIPTION
These two spaces are unnecessary and make problems when analyzing the XML files.