### PR TITLE
Create european-journal-of-endocrinology.csl

### DIFF
--- a/european-journal-of-endocrinology.csl
+++ b/european-journal-of-endocrinology.csl
@@ -18,6 +18,11 @@
     <updated>2016-12-29T23:48:11+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
+  <locale xml:lang="en">
+    <terms>
+      <term name="edition" form="short">edn</term>
+    </terms>
+  </locale>
   <macro name="author">
     <names variable="author">
       <name initialize-with="" name-as-sort-order="all" sort-separator=" "/>
@@ -27,13 +32,12 @@
     </names>
   </macro>
   <macro name="editor">
-    <group prefix="Eds ">
-      <names variable="editor" suffix=". ">
-        <name and="symbol" initialize-with="" name-as-sort-order="all" sort-separator=" ">
-          <name-part name="given" text-case="uppercase"/>
-        </name>
-      </names>
-    </group>
+    <names variable="editor" suffix=". ">
+      <label form="short" strip-periods="true" text-case="capitalize-first" suffix=" "/>
+      <name and="symbol" initialize-with="" name-as-sort-order="all" sort-separator=" ">
+        <name-part name="given" text-case="uppercase"/>
+      </name>
+    </names>
   </macro>
   <macro name="publisher">
     <group delimiter=": " suffix=",">
@@ -80,7 +84,10 @@
   <macro name="edition">
     <choose>
       <if is-numeric="edition">
-        <number prefix="edn " variable="edition" suffix=", "/>
+        <group delimiter=" " suffix=", ">
+          <text term="edition" form="short"/>
+          <number variable="edition"/>
+        </group>
       </if>
       <else>
         <text variable="edition" suffix="."/>
@@ -90,18 +97,14 @@
   <macro name="date">
     <choose>
       <if type="article-journal article-magazine article-newspaper" match="any">
-        <group prefix=" ">
-          <date delimiter=" " variable="issued" suffix=" ">
-            <date-part name="year"/>
-          </date>
-        </group>
+        <date delimiter=" " variable="issued" prefix=" " suffix=" ">
+          <date-part name="year"/>
+        </date>
       </if>
       <else>
-        <group suffix=".">
-          <date variable="issued">
-            <date-part name="year"/>
-          </date>
-        </group>
+        <date variable="issued" suffix=".">
+          <date-part name="year"/>
+        </date>
       </else>
     </choose>
   </macro>
@@ -111,7 +114,10 @@
         <text variable="page"/>
       </if>
       <else>
-        <text variable="page" prefix=" pp " suffix=". "/>
+        <group delimiter=" " prefix=" " suffix=". ">
+          <label variable="page" form="short" strip-periods="true"/>
+          <text variable="page"/>
+        </group>
       </else>
     </choose>
   </macro>

--- a/european-journal-of-endocrinology.csl
+++ b/european-journal-of-endocrinology.csl
@@ -1,0 +1,151 @@
+<?xml version="1.0" encoding="utf-8"?>
+<style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" and="symbol" et-al-use-last="true" page-range-format="expanded" initialize-with-hyphen="false" default-locale="en-GB">
+  <info>
+    <title>European Journal of Endocrinology</title>
+    <title-short>Eur J Endocrinol</title-short>
+    <id>http://www.zotero.org/styles/european-journal-of-endocrinology</id>
+    <link rel="self" href="http://www.zotero.org/styles/european-journal-of-endocrinology"/>
+    <link href="http://www.zotero.org/styles/vancouver" rel="template"/>
+    <link href="http://www.eje-online.org/site/misc/For-Authors.xhtml" rel="documentation"/>
+    <author>
+      <name>Sylvère Störmann</name>
+      <email>sylvere.stoermann@med.uni-muenchen.de</email>
+    </author>
+    <category citation-format="numeric"/>
+    <category field="medicine"/>
+    <eissn>1479-683X</eissn>
+    <issnl>0804-4643</issnl>
+    <updated>2016-12-29T23:48:11+00:00</updated>
+    <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
+  </info>
+  <macro name="author">
+    <names variable="author">
+      <name initialize-with="" name-as-sort-order="all" sort-separator=" "/>
+      <substitute>
+        <names variable="editor"/>
+      </substitute>
+    </names>
+  </macro>
+  <macro name="editor">
+    <group prefix="Eds ">
+      <names variable="editor" suffix=". ">
+        <name and="symbol" initialize-with="" name-as-sort-order="all" sort-separator=" ">
+          <name-part name="given" text-case="uppercase"/>
+        </name>
+      </names>
+    </group>
+  </macro>
+  <macro name="publisher">
+    <group delimiter=": " suffix=",">
+      <text variable="publisher-place"/>
+      <text variable="publisher"/>
+    </group>
+  </macro>
+  <macro name="container-title">
+    <choose>
+      <if type="chapter book" match="any">
+        <group suffix=".">
+          <choose>
+            <if match="any" variable="container-title">
+              <text term="in" text-case="capitalize-first" suffix=" "/>
+              <group delimiter=" " suffix=",">
+                <text variable="container-title" strip-periods="false" quotes="false" font-style="italic" font-variant="normal" text-decoration="none"/>
+              </group>
+            </if>
+          </choose>
+          <text macro="edition" prefix=" "/>
+          <choose>
+            <if match="any" variable="chapter-number">
+              <group suffix=", ">
+                <number prefix="ch. " variable="chapter-number"/>
+              </group>
+            </if>
+          </choose>
+          <text macro="pages"/>
+          <text macro="editor" font-variant="normal"/>
+          <text macro="publisher"/>
+          <text macro="date"/>
+        </group>
+      </if>
+      <else>
+        <group suffix=".">
+          <text variable="container-title" font-style="italic"/>
+          <text macro="date"/>
+          <text macro="journal-location"/>
+          <text macro="pages"/>
+        </group>
+        <text variable="DOI" prefix=" (doi:" suffix=")"/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="title">
+    <text variable="title" font-style="normal"/>
+  </macro>
+  <macro name="edition">
+    <choose>
+      <if is-numeric="edition">
+        <group delimiter=" " suffix=", ">
+          <number prefix="edn " variable="edition"/>
+        </group>
+      </if>
+      <else>
+        <text variable="edition" suffix="."/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="date">
+    <choose>
+      <if type="article-journal article-magazine article-newspaper" match="any">
+        <group prefix=" ">
+          <date delimiter=" " variable="issued" suffix=" ">
+            <date-part name="year"/>
+          </date>
+        </group>
+      </if>
+      <else>
+        <group suffix=".">
+          <date variable="issued">
+            <date-part name="year"/>
+          </date>
+        </group>
+      </else>
+    </choose>
+  </macro>
+  <macro name="pages">
+    <choose>
+      <if type="article-journal article-magazine article-newspaper" match="any">
+        <text variable="page"/>
+      </if>
+      <else>
+        <text variable="page" prefix=" pp " suffix=". "/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="journal-location">
+    <choose>
+      <if type="article-journal article-magazine" match="any">
+        <text variable="volume" font-weight="bold" suffix=" "/>
+      </if>
+    </choose>
+  </macro>
+  <citation near-note-distance="0">
+    <sort>
+      <key variable="citation-number"/>
+    </sort>
+    <layout delimiter=", " prefix="(" suffix=")">
+      <text variable="citation-number"/>
+    </layout>
+  </citation>
+  <bibliography et-al-min="31" et-al-use-first="30" second-field-align="flush">
+    <layout>
+      <text variable="citation-number" suffix=". "/>
+      <group delimiter=". " suffix=". ">
+        <text macro="author"/>
+        <text macro="title"/>
+      </group>
+      <group delimiter=" ">
+        <text macro="container-title"/>
+      </group>
+    </layout>
+  </bibliography>
+</style>

--- a/european-journal-of-endocrinology.csl
+++ b/european-journal-of-endocrinology.csl
@@ -4,17 +4,17 @@
     <title>European Journal of Endocrinology</title>
     <title-short>Eur J Endocrinol</title-short>
     <id>http://www.zotero.org/styles/european-journal-of-endocrinology</id>
-    <link rel="self" href="http://www.zotero.org/styles/european-journal-of-endocrinology"/>
+    <link href="http://www.zotero.org/styles/european-journal-of-endocrinology" rel="self"/>
     <link href="http://www.zotero.org/styles/vancouver" rel="template"/>
-    <link href="http://www.eje-online.org/site/misc/For-Authors.xhtml" rel="documentation"/>
+    <link href="http://www.eje-online.org/site/misc/For-Authors.xhtml#refs" rel="documentation"/>
     <author>
       <name>Sylvère Störmann</name>
       <email>sylvere.stoermann@med.uni-muenchen.de</email>
     </author>
     <category citation-format="numeric"/>
     <category field="medicine"/>
+    <issn>0804-4643</issn>
     <eissn>1479-683X</eissn>
-    <issnl>0804-4643</issnl>
     <updated>2016-12-29T23:48:11+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
@@ -48,21 +48,17 @@
           <choose>
             <if match="any" variable="container-title">
               <text term="in" text-case="capitalize-first" suffix=" "/>
-              <group delimiter=" " suffix=",">
-                <text variable="container-title" strip-periods="false" quotes="false" font-style="italic" font-variant="normal" text-decoration="none"/>
-              </group>
+              <text variable="container-title" font-style="italic" suffix=","/>
             </if>
           </choose>
           <text macro="edition" prefix=" "/>
           <choose>
             <if match="any" variable="chapter-number">
-              <group suffix=", ">
-                <number prefix="ch. " variable="chapter-number"/>
-              </group>
+              <number prefix="ch. " variable="chapter-number" suffix=", "/>
             </if>
           </choose>
           <text macro="pages"/>
-          <text macro="editor" font-variant="normal"/>
+          <text macro="editor"/>
           <text macro="publisher"/>
           <text macro="date"/>
         </group>
@@ -79,14 +75,12 @@
     </choose>
   </macro>
   <macro name="title">
-    <text variable="title" font-style="normal"/>
+    <text variable="title"/>
   </macro>
   <macro name="edition">
     <choose>
       <if is-numeric="edition">
-        <group delimiter=" " suffix=", ">
-          <number prefix="edn " variable="edition"/>
-        </group>
+        <number prefix="edn " variable="edition" suffix=", "/>
       </if>
       <else>
         <text variable="edition" suffix="."/>
@@ -143,9 +137,7 @@
         <text macro="author"/>
         <text macro="title"/>
       </group>
-      <group delimiter=" ">
-        <text macro="container-title"/>
-      </group>
+      <text macro="container-title"/>
     </layout>
   </bibliography>
 </style>


### PR DESCRIPTION
Style for European Journal of Endocrinology, based on Vancouver style
Documentation (http://www.eje-online.org/site/misc/For-Authors.xhtml) is sparse and includes only three example references (2x article-journal, 1x chapter). Other details were derived from the bibliography of actual and recent publications in the journal.