### PR TITLE
Update the-journal-of-pure-and-applied-chemistry-research.csl

### DIFF
--- a/the-journal-of-pure-and-applied-chemistry-research.csl
+++ b/the-journal-of-pure-and-applied-chemistry-research.csl
@@ -3,7 +3,7 @@
   <!-- This style was edited with the Visual CSL Editor (http://editor.citationstyles.org/visualEditor/) -->
   <info>
     <title>The Journal of Pure and Applied Chemistry Research</title>
-    <title-short>JPACR</title-short>
+    <title-short>J. Pure App. Chem. Res.</title-short>
     <id>http://www.zotero.org/styles/the-journal-of-pure-and-applied-chemistry-research</id>
     <link href="http://www.zotero.org/styles/the-journal-of-pure-and-applied-chemistry-research" rel="self"/>
     <link href="http://www.zotero.org/styles/american-chemical-society" rel="template"/>
@@ -42,7 +42,7 @@
   </locale>
   <macro name="editor">
     <group delimiter="; ">
-      <names variable="editor translator" delimiter="; ">
+      <names variable="editor translator" delimiter=", ">
         <name sort-separator=", " initialize-with=". " name-as-sort-order="all" delimiter=", " delimiter-precedes-last="always"/>
         <label form="short" prefix=", " text-case="title"/>
       </names>
@@ -59,7 +59,7 @@
     </names>
   </macro>
   <macro name="publisher">
-    <group delimiter=": ">
+    <group delimiter=", ">
       <text variable="publisher"/>
       <text variable="publisher-place"/>
     </group>
@@ -177,7 +177,7 @@
           </group>
         </else-if>
         <else-if type="bill book graphic legal_case legislation motion_picture report song" match="any">
-          <group delimiter="; ">
+          <group delimiter=", ">
             <group delimiter=", ">
               <text variable="title" font-style="italic"/>
               <text macro="edition"/>
@@ -212,7 +212,7 @@
           </group>
         </else-if>
         <else-if type="chapter paper-conference entry-dictionary entry-encyclopedia" match="any">
-          <group delimiter="; ">
+          <group delimiter=", ">
             <text macro="book-container"/>
             <text macro="editor"/>
             <text macro="series"/>
@@ -230,7 +230,7 @@
           <group delimiter=" ">
             <text variable="title"/>
             <text variable="URL"/>
-            <date variable="accessed" prefix="(accessed " suffix=")" delimiter=" ">
+            <date variable="accessed" prefix="(accessed date" suffix=")" delimiter=" ">
               <date-part name="month" form="short" strip-periods="true"/>
               <date-part name="day" suffix=", "/>
               <date-part name="year"/>

--- a/the-journal-of-pure-and-applied-chemistry-research.csl
+++ b/the-journal-of-pure-and-applied-chemistry-research.csl
@@ -3,7 +3,7 @@
   <!-- This style was edited with the Visual CSL Editor (http://editor.citationstyles.org/visualEditor/) -->
   <info>
     <title>The Journal of Pure and Applied Chemistry Research</title>
-    <title-short>J. Pure App. Chem. Res.</title-short>
+    <title-short>JPACR</title-short>
     <id>http://www.zotero.org/styles/the-journal-of-pure-and-applied-chemistry-research</id>
     <link href="http://www.zotero.org/styles/the-journal-of-pure-and-applied-chemistry-research" rel="self"/>
     <link href="http://www.zotero.org/styles/american-chemical-society" rel="template"/>

--- a/the-journal-of-pure-and-applied-chemistry-research.csl
+++ b/the-journal-of-pure-and-applied-chemistry-research.csl
@@ -26,6 +26,7 @@
   </info>
   <locale xml:lang="en">
     <terms>
+      <term name="accessed">accessed date</term>
       <term name="editortranslator" form="short">
         <single>ed. and translator</single>
         <multiple>eds. and translators</multiple>
@@ -230,11 +231,14 @@
           <group delimiter=" ">
             <text variable="title"/>
             <text variable="URL"/>
-            <date variable="accessed" prefix="(accessed date" suffix=")" delimiter=" ">
-              <date-part name="month" form="short" strip-periods="true"/>
-              <date-part name="day" suffix=", "/>
-              <date-part name="year"/>
-            </date>
+            <group delimiter=" " prefix="(" suffix=")">
+              <text term="accessed" text-case="capitalize-first"/>
+              <date variable="accessed" delimiter=" ">
+                <date-part name="month" form="short" strip-periods="true"/>
+                <date-part name="day" suffix=", "/>
+                <date-part name="year"/>
+              </date>
+            </group>
           </group>
         </else-if>
         <else>


### PR DESCRIPTION
Hello, I have updated the CSL. is it still look like ACS style? how to get the real repository in Mendeley CSL so that I can get the real name of my repository (The Journal of Pure and Applied Chemistry Research) as I proposed? Thank you for your help.