### PR TITLE
Exclude book from archive-note macro.

### DIFF
--- a/modern-humanities-research-association.csl
+++ b/modern-humanities-research-association.csl
@@ -406,7 +406,7 @@
   <macro name="access-note">
     <group delimiter=", ">
       <choose>
-        <if type="article-journal bill chapter legal_case legislation paper-conference" match="none">
+        <if type="article-journal bill book chapter legal_case legislation paper-conference" match="none">
           <text macro="archive-note" prefix=", "/>
         </if>
       </choose>


### PR DESCRIPTION
This prevents the place from occurring again, should `archive-place` be provided for an entry. I cannot think of any situation where this would be desirable. The Better CSL JSON plugin exports `archive-place` for all books alongside `publisher-place`, for some reason.