### PR TITLE
Update juristische-zitierweise.csl

### DIFF
--- a/juristische-zitierweise.csl
+++ b/juristische-zitierweise.csl
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <style xmlns="http://purl.org/net/xbiblio/csl" version="1.0" class="note" default-locale="de-DE">
+  <!-- This style was edited with the Visual CSL Editor (http://editor.citationstyles.org/visualEditor/) -->
   <info>
     <title>Juristische Zitierweise (Stüber) (German)</title>
     <id>http://www.zotero.org/styles/juristische-zitierweise</id>
@@ -16,7 +17,7 @@
     <category citation-format="note"/>
     <category field="law"/>
     <summary>Juristische Zitierweise nach Stüber www.niederle-media.de/Zitieren.pdf</summary>
-    <updated>2014-08-10T15:11:07+00:00</updated>
+    <updated>2017-01-29T14:33:14+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <macro name="author">
@@ -47,12 +48,6 @@
       </substitute>
     </names>
   </macro>
-  <macro name="journalname-year">
-    <group delimiter=" ">
-      <text variable="container-title" form="short"/>
-      <date date-parts="year" form="text" variable="issued"/>
-    </group>
-  </macro>
   <macro name="inbook">
     <group delimiter=": ">
       <text term="in"/>
@@ -76,10 +71,30 @@
         <if type="article-journal">
           <group delimiter=", ">
             <text macro="author-note"/>
-            <text macro="journalname-year"/>
-            <text macro="locator-with-label"/>
+            <group delimiter=" ">
+              <text variable="container-title" form="short"/>
+              <date date-parts="year" form="text" variable="issued"/>
+            </group>
+            <group delimiter=" ">
+              <text variable="page-first"/>
+              <text variable="locator" prefix="(" suffix=")"/>
+            </group>
           </group>
         </if>
+        <else-if type="article-magazine" match="all" variable="volume">
+          <group delimiter=", ">
+            <text macro="author-note"/>
+            <group delimiter=" ">
+              <text variable="container-title" form="short"/>
+              <text variable="volume"/>
+              <date date-parts="year" form="text" variable="issued" prefix="(" suffix=")"/>
+            </group>
+            <group delimiter=" ">
+              <text variable="page-first"/>
+              <text variable="locator" prefix="(" suffix=")"/>
+            </group>
+          </group>
+        </else-if>
         <else-if type="book">
           <group delimiter=", ">
             <text macro="autor-editor-note"/>
@@ -109,13 +124,18 @@
               <else>
                 <text variable="authority"/>
                 <group delimiter=" - ">
-                  <date form="numeric" variable="issued" prefix="v. "/>
+                  <group delimiter=" ">
+                    <text variable="genre"/>
+                    <date form="numeric" variable="issued" prefix="v. "/>
+                  </group>
                   <text variable="number"/>
                 </group>
               </else>
             </choose>
-            <text variable="container-title"/>
-            <text variable="volume"/>
+            <group delimiter=" ">
+              <text variable="container-title"/>
+              <text variable="volume"/>
+            </group>
             <text macro="firstpage-locator"/>
           </group>
         </else-if>
@@ -134,52 +154,73 @@
       <key macro="author"/>
       <key variable="issued"/>
     </sort>
-    <layout>
+    <layout suffix=".">
       <choose>
         <if type="article-journal">
-          <text macro="author"/>
-          <text variable="title" prefix=", " suffix=", "/>
-          <text variable="container-title" suffix=" "/>
-          <date variable="issued" suffix=", ">
-            <date-part name="year" form="long"/>
-            <date-part name="month" form="numeric"/>
-            <date-part name="day" form="ordinal"/>
-          </date>
-          <text variable="page" suffix="."/>
+          <group delimiter=", ">
+            <text macro="author"/>
+            <text variable="title"/>
+            <group delimiter=" ">
+              <text variable="container-title" form="short" suffix=" "/>
+              <date date-parts="year" form="text" variable="issued"/>
+            </group>
+            <text variable="page"/>
+          </group>
         </if>
+        <else-if type="article-magazine" match="all" variable="volume">
+          <group delimiter=", ">
+            <text macro="author-note"/>
+            <group delimiter=" ">
+              <text variable="container-title" form="short"/>
+              <text variable="volume"/>
+              <date date-parts="year" form="text" variable="issued" prefix="(" suffix=")"/>
+            </group>
+            <text variable="page"/>
+          </group>
+        </else-if>
         <else-if type="book">
-          <text macro="author"/>
-          <text variable="title" prefix=", " suffix=", "/>
-          <text variable="edition" suffix=" "/>
-          <text variable="publisher-place" suffix=" "/>
-          <date variable="issued" suffix=". ">
-            <date-part name="year" form="long"/>
-          </date>
+          <group delimiter=", ">
+            <text macro="author"/>
+            <text variable="title"/>
+            <text variable="edition" suffix=" "/>
+            <group delimiter=" ">
+              <text variable="publisher-place" suffix=" "/>
+              <date date-parts="year" form="text" variable="issued"/>
+            </group>
+          </group>
         </else-if>
         <else-if type="chapter">
-          <text macro="author"/>
-          <group prefix=", " delimiter="; ">
-            <text term="in"/>
-            <names variable="editor" font-style="italic">
-              <name delimiter="/" name-as-sort-order="all" sort-separator=", " form="long"/>
-              <label form="short" prefix=" (" suffix=")"/>
-            </names>
+          <group delimiter=", ">
+            <text macro="author"/>
+            <text variable="title"/>
+            <group delimiter=":  ">
+              <text term="in"/>
+              <group delimiter=", ">
+                <names variable="editor" font-style="italic">
+                  <name delimiter="/" name-as-sort-order="all" sort-separator=", " form="long"/>
+                  <label form="short" prefix=" (" suffix=")"/>
+                </names>
+                <text variable="container-title"/>
+              </group>
+            </group>
+            <text variable="edition"/>
+            <group delimiter=" ">
+              <text variable="publisher-place"/>
+              <date date-parts="year" form="text" variable="issued"/>
+            </group>
+            <text variable="page"/>
           </group>
-          <text variable="container-title" prefix=", " suffix=", "/>
-          <text variable="edition" suffix=" "/>
-          <text variable="publisher-place" suffix=" "/>
-          <date variable="issued" suffix=". ">
-            <date-part name="year" form="long"/>
-          </date>
-          <text variable="page" suffix="."/>
         </else-if>
         <else-if type="thesis">
-          <text macro="author"/>
-          <text variable="title" prefix=", " suffix=", Diss. jur., "/>
-          <text variable="publisher-place" suffix=" "/>
-          <date variable="issued" suffix=". ">
-            <date-part name="year" form="long"/>
-          </date>
+          <group delimiter=", ">
+            <text macro="author"/>
+            <text variable="title"/>
+            <text variable="genre"/>
+            <group delimiter=" ">
+              <text variable="publisher-place"/>
+              <date date-parts="year" form="text" variable="issued"/>
+            </group>
+          </group>
         </else-if>
         <else-if type="entry-encyclopedia">
           <text macro="author"/>
@@ -195,20 +236,34 @@
           <text value="Bearbeiter," suffix=" " font-style="italic"/>
           <text value="in: " suffix=" "/>
           <text variable="title" form="short"/>
-          <text value=")." suffix=" "/>
+          <text value=")" suffix=" "/>
+        </else-if>
+        <else-if type="webpage" match="any">
+          <group delimiter=", ">
+            <text macro="author"/>
+            <text variable="title"/>
+            <group delimiter=" ">
+              <text variable="URL"/>
+              <group delimiter=" " prefix="(" suffix=")">
+                <text term="accessed"/>
+                <date form="numeric" variable="accessed"/>
+              </group>
+            </group>
+          </group>
         </else-if>
         <else>
           <text macro="author"/>
           <text variable="title" prefix=", " suffix=", "/>
           <text variable="container-title" suffix=" "/>
-          <date variable="issued" suffix=", ">
-            <date-part name="year" form="long"/>
-            <date-part name="month" form="numeric"/>
-            <date-part name="day" form="ordinal"/>
-          </date>
-          <text variable="page" suffix="."/>
+          <date date-parts="year" form="text" variable="issued" suffix=", "/>
+          <text variable="page"/>
         </else>
       </choose>
     </layout>
   </bibliography>
+  <locale xml:lang="de-DE">
+    <terms>
+      <term name="accessed">besucht am</term>
+    </terms>
+  </locale>
 </style>

--- a/juristische-zitierweise.csl
+++ b/juristische-zitierweise.csl
@@ -20,6 +20,11 @@
     <updated>2017-01-29T14:33:14+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
+  <locale xml:lang="de-DE">
+    <terms>
+      <term name="accessed">besucht am</term>
+    </terms>
+  </locale>
   <macro name="author">
     <names variable="author" font-style="italic">
       <name delimiter="/ " name-as-sort-order="all" sort-separator=", " form="long"/>
@@ -261,9 +266,4 @@
       </choose>
     </layout>
   </bibliography>
-  <locale xml:lang="de-DE">
-    <terms>
-      <term name="accessed">besucht am</term>
-    </terms>
-  </locale>
 </style>


### PR DESCRIPTION
* Fix citations for journal articles, i.e. add first page, no label, locator in parenthesis
* Besides the normal citations to journals, there are some special "archive" journals which are cited differently, i.e. they use volume and the year is in parenthesis --> I covered that in the type of `magazineArticle` which then just has to manually switched to
* Add `genre` to legal cases which will add "Urt."/"Urteil" or "Beschl."/"Beschluss" or similar types
* Use `genre` in thesis instead of fixed term
* Handle webpage type in bibliography
* Improve spacing and delimiters in bibliography + some other cleanup work

All this should be in accordance to the Stüber's Richtlinien.

As a second step I would like then to look more closely to the commentaries (which are always a little hard to understand and deal with).