### PR TITLE
Update harvard-university-for-the-creative-arts.csl

### DIFF
--- a/harvard-university-for-the-creative-arts.csl
+++ b/harvard-university-for-the-creative-arts.csl
@@ -14,22 +14,16 @@
     <category citation-format="author-date"/>
     <category field="generic-base"/>
     <summary>University for the Creative Arts Harvard style</summary>
-    <updated>2016-01-12T15:44:30+00:00</updated>
+    <updated>2017-02-07T11:38:09+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <macro name="cite-author">
     <choose>
-      <if type="broadcast" match="any">
+      <if type="broadcast motion_picture legislation bill map legal_case" match="any">
         <text variable="title" font-style="italic" suffix="."/>
       </if>
-      <else-if type="bill legislation motion_picture map" match="any">
-        <text variable="title" font-style="italic" suffix="."/>
-      </else-if>
-      <else-if type="legal_case" match="any">
-        <text variable="title" font-style="italic"/>
-      </else-if>
       <else>
-        <names variable="author" font-style="normal" font-weight="normal">
+        <names variable="author composer" font-style="normal" font-weight="normal">
           <name font-style="normal" and="text" delimiter-precedes-last="never" et-al-min="3" et-al-use-first="1" initialize-with="." name-as-sort-order="all"/>
           <label form="short" prefix=" "/>
           <et-al font-style="italic"/>
@@ -53,7 +47,7 @@
         <choose>
           <if type="legal_case" match="any">
             <date variable="issued">
-              <date-part name="year" prefix="[" suffix="]"/>
+              <date-part name="year"/>
             </date>
           </if>
           <else-if variable="issued">
@@ -70,7 +64,7 @@
   </macro>
   <macro name="primary-title">
     <choose>
-      <if type="chapter article-journal article-newspaper article-magazine paper-conference post-weblog post" match="any">
+      <if type="chapter article-journal article-newspaper article-magazine paper-conference" match="any">
         <group>
           <text variable="title" prefix="'" suffix="'"/>
         </group>
@@ -79,8 +73,9 @@
         <text variable="collection-number"/>
       </else-if>
       <else-if type="entry-dictionary entry-encyclopedia" match="any">
-        <group>
+        <group delimiter=" ">
           <text variable="title" prefix="'" suffix="' definition."/>
+          <text variable="volume" prefix="Vol " suffix="."/>
         </group>
       </else-if>
       <else>
@@ -100,7 +95,7 @@
   </macro>
   <macro name="genre-online-marker">
     <choose>
-      <if type="report book thesis interview patent speech broadcast motion_picture entry-dictionary" match="any">
+      <if type="report thesis interview patent entry-dictionary" match="any">
         <choose>
           <if variable="URL">
             <choose>
@@ -117,14 +112,23 @@
           </else-if>
         </choose>
       </if>
-      <else-if type="graphic manuscript song personal_communication post-weblog post" match="any">
+      <else-if type="manuscript song post-weblog post personal_communication speech" match="any">
         <group delimiter=". ">
           <text variable="genre" prefix="[" suffix="]"/>
           <text variable="medium" prefix="[" suffix="]"/>
+          <text variable="note" prefix="[" suffix="]"/>
+        </group>
+        <group>
+          <text variable="dimensions" prefix=" " suffix="."/>
         </group>
       </else-if>
-      <else-if type="broadcast">
-        <text variable="medium" prefix="[" suffix="]"/>
+      <else-if type="broadcast"/>
+      <else-if type="graphic" match="any">
+        <group>
+          <text variable="genre"/>
+          <text variable="medium" prefix="[" suffix="]"/>
+          <text variable="note" prefix=" " suffix="."/>
+        </group>
       </else-if>
     </choose>
   </macro>
@@ -165,6 +169,15 @@
             <text variable="archive_location"/>
             <text variable="publisher-place"/>
           </group>
+        </group>
+      </else-if>
+      <else-if type="map" match="any">
+        <group delimiter=" ">
+          <text variable="genre" prefix="[" suffix="]"/>
+          <text variable="scale" suffix="."/>
+          <text variable="publisher-place" suffix=":"/>
+          <text variable="publisher" suffix="."/>
+          <text variable="collection-title" prefix="(" suffix=")"/>
         </group>
       </else-if>
       <else>
@@ -213,12 +226,19 @@
       <else-if type="patent">
         <text variable="number" suffix="."/>
       </else-if>
-      <else-if type="motion_picture">
-        <text variable="medium" prefix="[" suffix="]"/>
+      <else-if type="motion_picture broadcast">
+        <text variable="medium" prefix="[" suffix="] "/>
         <names variable="author" prefix="Directed by ">
           <name suffix="." and="text" delimiter-precedes-last="never" et-al-min="3" et-al-use-first="1" initialize-with="." name-as-sort-order="all"/>
           <et-al font-style="italic"/>
         </names>
+        <text variable="note" prefix=" [" suffix="]"/>
+      </else-if>
+      <else-if type="book" match="any">
+        <text variable="medium" prefix="[" suffix="]"/>
+      </else-if>
+      <else-if type="webpage" match="any">
+        <text variable="genre" prefix="[" suffix="]"/>
       </else-if>
       <else>
         <choose>
@@ -273,7 +293,7 @@
           <choose>
             <if variable="URL">
               <choose>
-                <if type="article-journal article-magazine article-newspaper bill chapter entry-dictionary entry-encyclopedia legislation paper-conference" match="any">
+                <if type="article-magazine bill chapter legislation paper-conference article-journal article-newspaper entry-dictionary entry-encyclopedia book" match="any">
                   <text term="online" prefix="[" suffix="]"/>
                 </if>
               </choose>
@@ -301,8 +321,12 @@
             <date delimiter=" " variable="issued" suffix=".">
               <date-part name="day"/>
               <date-part name="month"/>
+              <date-part name="year"/>
             </date>
           </group>
+        </group>
+        <group>
+          <text variable="dimensions" prefix=" " suffix="."/>
         </group>
       </else-if>
     </choose>

--- a/harvard-university-for-the-creative-arts.csl
+++ b/harvard-university-for-the-creative-arts.csl
@@ -65,9 +65,7 @@
   <macro name="primary-title">
     <choose>
       <if type="chapter article-journal article-newspaper article-magazine paper-conference" match="any">
-        <group>
-          <text variable="title" prefix="'" suffix="'"/>
-        </group>
+        <text variable="title" prefix="'" suffix="'"/>
       </if>
       <else-if type="bill legal_case legislation motion_picture" match="any">
         <text variable="collection-number"/>
@@ -118,9 +116,7 @@
           <text variable="medium" prefix="[" suffix="]"/>
           <text variable="note" prefix="[" suffix="]"/>
         </group>
-        <group>
-          <text variable="dimensions" prefix=" " suffix="."/>
-        </group>
+        <text variable="dimensions" prefix=" " suffix="."/>
       </else-if>
       <else-if type="broadcast"/>
       <else-if type="graphic" match="any">
@@ -325,9 +321,7 @@
             </date>
           </group>
         </group>
-        <group>
-          <text variable="dimensions" prefix=" " suffix="."/>
-        </group>
+        <text variable="dimensions" prefix=" " suffix="."/>
       </else-if>
     </choose>
   </macro>
@@ -372,9 +366,7 @@
           <text macro="author-short"/>
           <text macro="year-date"/>
         </group>
-        <group>
-          <text variable="locator"/>
-        </group>
+        <text variable="locator"/>
       </group>
     </layout>
   </citation>


### PR DESCRIPTION
Style has always referenced basic material - books, journals, websites well. But this update should bring improvements to other source types such as maps, artworks and online material which are increasingly popular to reference by students at UCA. I hadn't updated the style for a while as UCA had a subscription to RefME and they looked after it within their site, since they have been taken over our University is looking to recommend Zotero in the first instance so major updates are required.