### PR TITLE
Update south-african-journal-of-enology-and-viticulture.csl

### DIFF
--- a/south-african-journal-of-enology-and-viticulture.csl
+++ b/south-african-journal-of-enology-and-viticulture.csl
@@ -2,6 +2,7 @@
 <style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" demote-non-dropping-particle="sort-only" default-locale="en-GB">
   <info>
     <title>South African Journal of Enology and Viticulture</title>
+    <title-short>SAJEV</title-short>
     <id>http://www.zotero.org/styles/south-african-journal-of-enology-and-viticulture</id>
     <link href="http://www.zotero.org/styles/south-african-journal-of-enology-and-viticulture" rel="self"/>
     <link href="http://www.zotero.org/styles/harvard-stellenbosch-university" rel="template"/>
@@ -11,16 +12,19 @@
       <email>yr@sun.ac.za</email>
       <uri>http://www.mendeley.com/profiles/yusuf-ras/</uri>
     </author>
+    <contributor>
+      <name>Patrick O'Brien</name>
+      <email>obrienpat86@gmail.com</email>
+    </contributor>
     <category citation-format="author-date"/>
     <category field="biology"/>
     <issn>0253-939X</issn>
     <eissn>2224-7904</eissn>
-    <updated>2016-11-11T08:01:34+00:00</updated>
+    <updated>2017-02-10T10:43:26+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale xml:lang="en-GB">
     <terms>
-      <term name="available at">available</term>
       <term name="open-quote">“</term>
       <term name="close-quote">”</term>
       <term name="open-inner-quote">‘</term>
@@ -32,7 +36,7 @@
       <if variable="editor">
         <names variable="editor">
           <name and="symbol" initialize-with="." delimiter=", "/>
-          <label form="short" prefix=" (" suffix=")"/>
+          <label form="short" strip-periods="true" prefix=" (" suffix=")"/>
         </names>
       </if>
     </choose>
@@ -46,7 +50,7 @@
     </choose>
   </macro>
   <macro name="author">
-    <names variable="author">
+    <names variable="author" suffix=",">
       <name name-as-sort-order="all" and="symbol" sort-separator=", " initialize-with="." delimiter=", " delimiter-precedes-last="never" et-al-min="3" et-al-use-first="2"/>
       <label form="short" prefix=" " text-case="capitalize-first"/>
       <substitute>
@@ -65,7 +69,7 @@
   </macro>
   <macro name="author-short">
     <names variable="author">
-      <name form="short" and="symbol" delimiter-precedes-last="never" et-al-subsequent-min="3" et-al-subsequent-use-first="1" initialize-with="." sort-separator=" "/>
+      <name form="short" and="symbol" delimiter-precedes-last="never" et-al-min="3" et-al-use-first="1" initialize-with="." sort-separator=" "/>
       <et-al font-style="italic"/>
       <substitute>
         <names variable="editor"/>
@@ -133,7 +137,7 @@
   <macro name="title">
     <choose>
       <if type="bill book graphic legal_case legislation motion_picture report song webpage" match="any">
-        <text variable="title" font-style="italic"/>
+        <text variable="title" font-style="normal"/>
       </if>
       <else>
         <text variable="title"/>
@@ -142,7 +146,7 @@
   </macro>
   <macro name="book-details">
     <group delimiter=". ">
-      <group delimiter=" ">
+      <group delimiter=" " prefix="(" suffix=")">
         <number variable="edition" form="ordinal"/>
         <label variable="edition" form="short"/>
       </group>
@@ -150,7 +154,6 @@
         <label variable="volume" form="short" text-case="capitalize-first"/>
         <text variable="volume"/>
       </group>
-      <text macro="editor-translator"/>
       <group delimiter=" " prefix="(" suffix=")">
         <text variable="collection-title"/>
         <group delimiter=" ">
@@ -162,9 +165,9 @@
     </group>
   </macro>
   <macro name="publisher">
-    <group delimiter=": ">
-      <text variable="publisher-place"/>
+    <group delimiter=", ">
       <text variable="publisher"/>
+      <text variable="publisher-place"/>
     </group>
   </macro>
   <citation disambiguate-add-year-suffix="true" year-suffix-delimiter="," disambiguate-add-names="true" disambiguate-add-givenname="false" collapse="year-suffix">
@@ -180,7 +183,7 @@
       <group>
         <choose>
           <if locator="page" match="any">
-            <text variable="locator" prefix=": "/>
+            <text variable="locator" prefix=" "/>
           </if>
           <else>
             <label variable="locator" form="short" prefix=", "/>
@@ -198,24 +201,22 @@
       <key macro="date-issued-no-parentheses"/>
     </sort>
     <layout suffix=".">
-      <group delimiter=". ">
+      <group delimiter=" ">
         <text macro="author"/>
-        <text macro="date-issued"/>
+        <text macro="date-issued" suffix="."/>
         <choose>
-          <if type="bill book graphic legal_case legislation motion_picture post-weblog song webpage" match="any">
-            <text macro="title"/>
+          <if type="bill book graphic legal_case legislation motion_picture post-weblog song" match="any">
+            <text macro="title" suffix="."/>
             <text macro="book-details"/>
           </if>
           <else-if type="article-journal article-magazine" match="any">
             <text macro="title"/>
             <text variable="container-title" form="short"/>
-            <group delimiter=":">
+            <group delimiter=", ">
               <choose>
                 <if variable="volume issue" match="any">
-                  <group>
-                    <text variable="volume"/>
-                    <text variable="issue" prefix="(" suffix=")"/>
-                  </group>
+                  <text variable="volume"/>
+                  <text variable="issue"/>
                 </if>
                 <else>
                   <date variable="issued" prefix="(" suffix=")">
@@ -249,9 +250,10 @@
           <else-if type="chapter paper-conference entry-encyclopedia entry-dictionary" match="any">
             <text macro="title"/>
             <group delimiter=" ">
-              <text term="in" text-case="capitalize-first"/>
+              <text term="in" text-case="capitalize-first" suffix=":"/>
+              <text macro="editor-translator" suffix="."/>
+              <text variable="container-title" form="short" suffix="."/>
               <text macro="book-details"/>
-              <text variable="container-title" form="short"/>
             </group>
             <text variable="page"/>
           </else-if>
@@ -263,6 +265,12 @@
               <text macro="publisher"/>
               <text variable="authority"/>
             </group>
+          </else-if>
+          <else-if type="webpage post-weblog" match="any">
+            <text macro="title"/>
+            <text term="available at" text-case="capitalize-first"/>
+            <text variable="URL"/>
+            <text macro="publisher"/>
           </else-if>
           <else-if type="report" match="any">
             <text macro="title"/>


### PR DESCRIPTION
To continue https://github.com/citation-style-language/styles/pull/2351

Style properly adapted for journals, books, chapters. Style guide and actual publications match! This style was off from it.
author-short et-al stuff is just standard, et-al-min=3, use-first=1.

Style guidelines: http://www.journals.ac.za/index.php/sajev/about/submissions#authorGuidelines

Free publications all here: http://www.sawislibrary.co.za/dbtw-wpd/textbase/sajev.htm

(Rintze: This was all edited in the CSL editor, mostly via the Visual Editor)