### PR TITLE
Update Journal of Sleep Research

### DIFF
--- a/journal-of-sleep-research.csl
+++ b/journal-of-sleep-research.csl
@@ -2,14 +2,14 @@
 <style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" demote-non-dropping-particle="sort-only" default-locale="en-US">
   <!-- This style was edited with the Visual CSL Editor (http://editor.citationstyles.org/visualEditor/) -->
   <info>
-    <title>Journal of Sleep Research</title>
-    <id>http://www.zotero.org/styles/journal-of-sleep-research</id>
+    <title>Journal of Sleep Research New</title>
+    <id>http://www.zotero.org/styles/journal-of-sleep-research-new</id>
     <link href="http://www.zotero.org/styles/journal-of-sleep-research" rel="self"/>
     <link href="http://www.zotero.org/styles/springer-mathphys-author-date" rel="template"/>
     <link href="http://onlinelibrary.wiley.com/journal/10.1111/(ISSN)1365-2869/homepage/ForAuthors.html" rel="documentation"/>
     <author>
-      <name>Omar Harb</name>
-      <email>omarharb@hotmail.com</email>
+      <name>Omar Harb - Mike Borghese</name>
+      <email>omarharb@hotmail.com - mborg031@gmail.com</email>
     </author>
     <category citation-format="author-date"/>
     <category field="science"/>
@@ -106,7 +106,7 @@
       </group>
     </layout>
   </citation>
-  <bibliography entry-spacing="0">
+  <bibliography entry-spacing="0" et-al-min="6" et-al-use-first="3">
     <sort>
       <key macro="author-in-citation"/>
       <key macro="issued-sort" sort="ascending"/>

--- a/journal-of-sleep-research.csl
+++ b/journal-of-sleep-research.csl
@@ -8,9 +8,13 @@
     <link href="http://www.zotero.org/styles/springer-mathphys-author-date" rel="template"/>
     <link href="http://onlinelibrary.wiley.com/journal/10.1111/(ISSN)1365-2869/homepage/ForAuthors.html" rel="documentation"/>
     <author>
-      <name>Omar Harb - Mike Borghese</name>
-      <email>omarharb@hotmail.com - mborg031@gmail.com</email>
+      <name>Omar Harb</name>
+      <email>omarharb@hotmail.com</email>
     </author>
+    <contributor>
+      <name>Mike Borghese</name>
+      <email>mborg031@gmail.com</email>      
+    </contributor>
     <category citation-format="author-date"/>
     <category field="science"/>
     <issn>0962-1105</issn>
@@ -106,7 +110,7 @@
       </group>
     </layout>
   </citation>
-  <bibliography entry-spacing="0" et-al-min="6" et-al-use-first="3">
+  <bibliography entry-spacing="0" et-al-min="7" et-al-use-first="3">
     <sort>
       <key macro="author-in-citation"/>
       <key macro="issued-sort" sort="ascending"/>

--- a/journal-of-sleep-research.csl
+++ b/journal-of-sleep-research.csl
@@ -2,8 +2,8 @@
 <style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" demote-non-dropping-particle="sort-only" default-locale="en-US">
   <!-- This style was edited with the Visual CSL Editor (http://editor.citationstyles.org/visualEditor/) -->
   <info>
-    <title>Journal of Sleep Research New</title>
-    <id>http://www.zotero.org/styles/journal-of-sleep-research-new</id>
+    <title>Journal of Sleep Research</title>
+    <id>http://www.zotero.org/styles/journal-of-sleep-research</id>
     <link href="http://www.zotero.org/styles/journal-of-sleep-research" rel="self"/>
     <link href="http://www.zotero.org/styles/springer-mathphys-author-date" rel="template"/>
     <link href="http://onlinelibrary.wiley.com/journal/10.1111/(ISSN)1365-2869/homepage/ForAuthors.html" rel="documentation"/>


### PR DESCRIPTION
The bibliography has been changed to truncate the reference list if there are more than 6 authors to the first 3 authors with "et al.". 

This change is required as per the Journal of Sleep Research author guidelines (http://onlinelibrary.wiley.com/journal/10.1111/(ISSN)1365-2869/homepage/ForAuthors.html).