### PR TITLE
Update to APA provost

### DIFF
--- a/apa-fr-provost.csl
+++ b/apa-fr-provost.csl
@@ -174,25 +174,15 @@
       <else-if type="report">
         <text variable="title" font-style="italic"/>
         <group prefix=" (" suffix=")" delimiter=" ">
-          <choose>
-            <if variable="number" match="any">
-              <text value="Rapport" suffix=" "/>
-              <text variable="number" prefix="No. "/>
-            </if>
-          </choose>
+          <text value="Rapport"/>
+          <text variable="number" prefix="No. "/>
         </group>
       </else-if>
       <else-if type="patent" match="any">
-        <choose>
-          <if variable="number" match="any">
-            <group>
-              <text value="Brevet" font-style="italic" suffix=" "/>
-              <text value="n" font-style="italic"/>
-              <text value="o" vertical-align="sup" font-style="italic" suffix=" "/>
-              <text variable="number" font-style="italic"/>
-            </group>
-          </if>
-        </choose>
+        <group delimiter=" ">
+          <text value="Brevet" font-style="italic"/>
+          <text term="issue" form="short" font-style="italic"/><text variable="number" font-style="italic"/>
+        </group>
       </else-if>
       <else-if type="legislation">
         <text variable="title" font-style="italic"/>
@@ -287,9 +277,9 @@
                   <if variable="jurisdiction" match="any">
                     <text variable="jurisdiction"/>
                   </if>
-                  <else-if variable="publisher-place" match="any">
+                  <else>
                     <text variable="publisher-place"/>
-                  </else-if>
+                  </else>
                 </choose>
                 <text variable="authority"/>
               </group>

--- a/apa-fr-provost.csl
+++ b/apa-fr-provost.csl
@@ -181,7 +181,8 @@
       <else-if type="patent" match="any">
         <group delimiter=" ">
           <text value="Brevet" font-style="italic"/>
-          <text term="issue" form="short" font-style="italic"/><text variable="number" font-style="italic"/>
+          <text term="issue" form="short" font-style="italic"/>
+          <text variable="number" font-style="italic"/>
         </group>
       </else-if>
       <else-if type="legislation">

--- a/apa-fr-provost.csl
+++ b/apa-fr-provost.csl
@@ -15,7 +15,7 @@
     <category field="psychology"/>
     <category field="generic-base"/>
     <summary>Style basé sur la version francophone du livre « Normes de présentation d’un travail de recherche », 4e édition, par Marc A. Provost ... [et al.] selon les normes APA, 6e édition</summary>
-    <updated>2013-10-23T03:11:09+00:00</updated>
+    <updated>2014-09-21T00:39:49+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale xml:lang="fr">
@@ -174,15 +174,43 @@
       <else-if type="report">
         <text variable="title" font-style="italic"/>
         <group prefix=" (" suffix=")" delimiter=" ">
-          <text variable="genre"/>
-          <text variable="number" prefix="No. "/>
+          <choose>
+            <if variable="number" match="any">
+              <text value="Rapport" suffix=" "/>
+              <text variable="number" prefix="No. "/>
+            </if>
+          </choose>
         </group>
+      </else-if>
+      <else-if type="patent" match="any">
+        <choose>
+          <if variable="number" match="any">
+            <group>
+              <text value="Brevet" font-style="italic" suffix=" "/>
+              <text value="n" font-style="italic"/>
+              <text value="o" vertical-align="sup" font-style="italic" suffix=" "/>
+              <text variable="number" font-style="italic"/>
+            </group>
+          </if>
+        </choose>
       </else-if>
       <else-if type="legislation">
         <text variable="title" font-style="italic"/>
         <group prefix=" (" suffix=")" delimiter="&#160;; ">
           <text variable="number"/>
           <text variable="container-title"/>
+        </group>
+      </else-if>
+      <else-if type="post-weblog post speech map" match="any">
+        <group delimiter=" ">
+          <text variable="title"/>
+          <text variable="genre" prefix="[" suffix="]"/>
+        </group>
+      </else-if>
+      <else-if type="motion_picture" match="any">
+        <group delimiter=" ">
+          <text variable="title" font-style="italic"/>
+          <text variable="medium" prefix="[" suffix="]"/>
         </group>
       </else-if>
       <else-if type="book graphic motion_picture report song manuscript speech" match="any">
@@ -192,18 +220,14 @@
             <group delimiter=" ">
               <text variable="title"/>
               <group delimiter=" " prefix="(" suffix=")">
-                <text term="version" text-case="capitalize-first"/>
+                <text term="version"/>
                 <text variable="version"/>
               </group>
+              <text value="Logiciel" prefix="[" suffix="]"/>
             </group>
           </if>
           <else>
             <text variable="title" font-style="italic"/>
-            <choose>
-              <if type="book">
-                <text variable="volume" font-style="italic" prefix=", "/>
-              </if>
-            </choose>
           </else>
         </choose>
       </else-if>
@@ -226,11 +250,14 @@
           <text variable="publisher-place"/>
         </group>
       </else-if>
-      <else>
+      <else-if type="speech" match="any">
+        <text variable="publisher-place"/>
+      </else-if>
+      <else-if type="map post-weblog post" match="none">
         <group delimiter=", ">
           <choose>
             <if variable="event" match="none">
-              <text variable="genre"/>
+              <text variable="genre" prefix="[" suffix="]"/>
             </if>
           </choose>
           <choose>
@@ -254,15 +281,28 @@
                 </choose>
               </group>
             </if>
-            <else-if type="article-journal article-magazine" match="none">
+            <else-if type="patent">
+              <group delimiter=": ">
+                <choose>
+                  <if variable="jurisdiction" match="any">
+                    <text variable="jurisdiction"/>
+                  </if>
+                  <else-if variable="publisher-place" match="any">
+                    <text variable="publisher-place"/>
+                  </else-if>
+                </choose>
+                <text variable="authority"/>
+              </group>
+            </else-if>
+            <else-if type="article-journal article-magazine article-newspaper" match="none">
               <group delimiter="&#160;: ">
-                <text variable="publisher"/>
                 <text variable="publisher-place"/>
+                <text variable="publisher"/>
               </group>
             </else-if>
           </choose>
         </group>
-      </else>
+      </else-if>
     </choose>
   </macro>
   <macro name="event">
@@ -309,7 +349,7 @@
               </date>
               <text variable="year-suffix"/>
               <choose>
-                <if type="article-journal bill book chapter graphic legal_case legislation motion_picture paper-conference report song thesis" match="none">
+                <if type="article-journal bill book chapter graphic legal_case legislation paper-conference report song entry-encyclopedia thesis patent" match="none">
                   <group prefix=", ">
                     <date variable="issued">
                       <date-part name="day"/>
@@ -400,22 +440,9 @@
           <text variable="page"/>
         </group>
       </else-if>
-      <else-if type="book chapter" match="any">
+      <else-if type="book chapter graphic motion_picture song paper-conference entry-encyclopedia" match="any">
         <group prefix=" (" suffix=")" delimiter=", ">
           <text macro="edition"/>
-          <group>
-            <label variable="page" form="short" suffix=" "/>
-            <text variable="page"/>
-          </group>
-        </group>
-      </else-if>
-      <else-if type="graphic motion_picture report song paper-conference" match="any">
-        <group prefix=" (" suffix=")" delimiter=", ">
-          <text macro="edition"/>
-          <group>
-            <text term="volume" form="short" plural="true" text-case="capitalize-first" suffix=" "/>
-            <number variable="number-of-volumes" form="numeric" prefix="1-"/>
-          </group>
           <group>
             <text term="volume" form="short" text-case="capitalize-first" suffix=" "/>
             <number variable="volume" form="numeric"/>
@@ -468,11 +495,6 @@
     <choose>
       <if type="bill legal_case legislation" match="none">
         <text variable="container-title" font-style="italic"/>
-        <choose>
-          <if type="chapter">
-            <text variable="volume" font-style="italic" prefix=", "/>
-          </if>
-        </choose>
       </if>
       <else>
         <group delimiter=" " prefix=", ">

--- a/apa-fr-provost.csl
+++ b/apa-fr-provost.csl
@@ -15,7 +15,7 @@
     <category field="psychology"/>
     <category field="generic-base"/>
     <summary>Style basé sur la version francophone du livre « Normes de présentation d’un travail de recherche », 4e édition, par Marc A. Provost ... [et al.] selon les normes APA, 6e édition</summary>
-    <updated>2014-09-21T00:39:49+00:00</updated>
+    <updated>2017-02-16T00:00:00+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale xml:lang="fr">


### PR DESCRIPTION
Update to correct some inconsistencies regarding the use of volume field, to add some document types (e.g. Patent) and to add genre between [ ] for some documents. All those changes were made in respect with the Provost Guidelines in « Normes de présentation d'un travail de recherche » 4th edition.