### PR TITLE
FIX springer-basic for cases where is same lead author

### DIFF
--- a/springer-basic-author-date.csl
+++ b/springer-basic-author-date.csl
@@ -84,7 +84,7 @@
       <date-part name="year"/>
     </date>
   </macro>
-  <citation et-al-min="3" et-al-use-first="1" disambiguate-add-givenname="true" disambiguate-add-year-suffix="true" collapse="year-suffix" cite-group-delimiter=", ">
+  <citation et-al-min="3" et-al-use-first="1" disambiguate-add-year-suffix="true" collapse="year-suffix" cite-group-delimiter=", ">
     <sort>
       <key variable="issued"/>
       <key macro="author"/>

--- a/springer-basic-author-date.csl
+++ b/springer-basic-author-date.csl
@@ -84,7 +84,7 @@
       <date-part name="year"/>
     </date>
   </macro>
-  <citation et-al-min="3" et-al-use-first="1" disambiguate-add-year-suffix="true">
+  <citation et-al-min="3" et-al-use-first="1" disambiguate-add-givenname="true" disambiguate-add-year-suffix="true" collapse="year-suffix" cite-group-delimiter=", ">
     <sort>
       <key variable="issued"/>
       <key macro="author"/>


### PR DESCRIPTION
Previous behavior was not right:
i.e. same author lets say Mikolaj, who published in 2014 and 2009, the similar thing.
citing it before resulted in:

(Mikolaj 2014; Mikolaj 2009) instead of collapsing it into (Mikolaj 2014, 2009).

Another noncompliant to springer format was the situation with same author and year:
lets say Mikolaj et al published in 2009  even 4 publications:

previous behaviour was like this:

(Mikolaj et al. 2009a; Mikolaj et al. 2009b; Mikolaj et al. 2009c; Mikolaj et al. 2009d)

correct behaviour would be (Mikolaj et al. 2009a, b, c, d)

I am 100% sure that this is how it should look in geoscience springer journals (i.e. International Journal of Earth Sciences); I looked also to some other scientific Springer journal requirements in other fields, it looks the same, thats why I want to fix that in the `springer-base`, as it is propagated to those styles (If I understand correctly).