### PR TITLE
Create german-council-of-economic-experts.csl

### DIFF
--- a/german-council-of-economic-experts.csl
+++ b/german-council-of-economic-experts.csl
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<style xmlns="http://purl.org/net/xbiblio/csl" version="1.0" class="in-text" default-locale="de-DE" demote-non-dropping-particle="sort-only">
+<style xmlns="http://purl.org/net/xbiblio/csl" version="1.0" class="in-text" demote-non-dropping-particle="sort-only">
   <!-- This style was edited with the Visual CSL Editor (http://editor.citationstyles.org/visualEditor/) -->
   <info>
     <title>German Council of Economic Experts</title>

--- a/german-council-of-economic-experts.csl
+++ b/german-council-of-economic-experts.csl
@@ -1,0 +1,314 @@
+<?xml version="1.0" encoding="utf-8"?>
+<style xmlns="http://purl.org/net/xbiblio/csl" version="1.0" class="in-text" default-locale="de-DE" demote-non-dropping-particle="sort-only">
+  <!-- This style was edited with the Visual CSL Editor (http://editor.citationstyles.org/visualEditor/) -->
+  <info>
+    <title>German Council for Economic Experts</title>
+    <title-short>GCEE</title-short>
+    <id>http://www.zotero.org/styles/german-council-for-economic-experts</id>
+    <link href="http://www.zotero.org/styles/german-council-for-economic-experts" rel="self"/>
+    <author>
+      <name>Chris-Gabriel Islam</name>
+      <email>chris-gabriel.islam@destatis.de</email>
+      <uri>http://www.sachverstaendigenrat-wirtschaft.de/index.html</uri>
+    </author>
+    <category citation-format="author-date"/>
+    <category field="political_science"/>
+    <summary>Style for the German Council of Economic Experts</summary>
+    <updated>2017-03-09T14:32:02+00:00</updated>
+    <rights>This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License: http://creativecommons.org/licenses/by-sa/3.0/</rights>
+  </info>
+  <locale xml:lang="de">
+    <terms>
+      <term name="accessed">Stand</term>
+      <term name="et-al">et al.</term>
+      <term name="ordinal-01">.</term>
+      <term name="ordinal-02">.</term>
+      <term name="ordinal-03">.</term>
+      <term name="ordinal-04">.</term>
+      <term name="long-ordinal-01">erste</term>
+      <term name="long-ordinal-02">zweite</term>
+      <term name="long-ordinal-03">dritte</term>
+      <term name="long-ordinal-04">vierte</term>
+      <term name="long-ordinal-05">f�nfte</term>
+      <term name="long-ordinal-06">sechste</term>
+      <term name="long-ordinal-07">siebte</term>
+      <term name="long-ordinal-08">achte</term>
+      <term name="long-ordinal-09">neunte</term>
+      <term name="long-ordinal-10">zehnte</term>
+    </terms>
+  </locale>
+  <macro name="contributors-long">
+    <choose>
+      <if variable="author">
+        <names variable="author">
+          <name and="text" delimiter-precedes-last="never" initialize-with="." name-as-sort-order="first"/>
+        </names>
+      </if>
+      <else>
+        <choose>
+          <if type="book">
+            <names variable="editor">
+              <name name-as-sort-order="first" and="text" sort-separator=", " delimiter=", " delimiter-precedes-last="never"/>
+              <label prefix=" (" form="short" suffix=".)"/>
+            </names>
+          </if>
+        </choose>
+      </else>
+    </choose>
+  </macro>
+  <macro name="contributors-short">
+    <choose>
+      <if match="any" variable="author">
+        <names variable="author">
+          <name form="short" and="text" delimiter-precedes-last="never" initialize-with="." name-as-sort-order="first"/>
+        </names>
+      </if>
+      <else>
+        <choose>
+          <if type="book" match="any">
+            <names variable="editor">
+              <name form="short" and="text" delimiter-precedes-last="never" initialize-with="." name-as-sort-order="first"/>
+            </names>
+          </if>
+        </choose>
+      </else>
+    </choose>
+  </macro>
+  <macro name="secondary-contributors">
+    <choose>
+      <if variable="author" type="book" match="all">
+        <names variable="editor translator" delimiter=", ">
+          <label prefix="" form="verb-short" text-case="lowercase" suffix=". "/>
+          <name and="text" sort-separator=", " delimiter=", " delimiter-precedes-last="never" initialize-with="."/>
+        </names>
+      </if>
+    </choose>
+  </macro>
+  <macro name="container-contributors">
+    <choose>
+      <if variable="container-author">
+        <names variable="container-author">
+          <name name-as-sort-order="first" and="text" sort-separator=", " delimiter=", " delimiter-precedes-last="never" initialize-with=". "/>
+        </names>
+      </if>
+      <else>
+        <choose>
+          <if type="chapter">
+            <names variable="editor">
+              <name name-as-sort-order="first" and="text" sort-separator=", " delimiter=", " delimiter-precedes-last="never" initialize-with=". "/>
+              <label prefix=" (" form="short" suffix=".)"/>
+            </names>
+          </if>
+        </choose>
+      </else>
+    </choose>
+  </macro>
+  <macro name="secondary-container-contributors">
+    <choose>
+      <if variable="container-author" type="chapter" match="all">
+        <names variable="editor">
+          <label prefix="" form="verb-short" text-case="lowercase" suffix=". "/>
+          <name and="text" sort-separator=", " delimiter=", " delimiter-precedes-last="never"/>
+        </names>
+      </if>
+    </choose>
+  </macro>
+  <macro name="secondary-collection-contributors">
+    <names variable="collection-editor">
+      <name and="text" sort-separator=", " delimiter=", " delimiter-precedes-last="never"/>
+    </names>
+  </macro>
+  <macro name="collection">
+    <text variable="collection-title"/>
+    <choose>
+      <if is-numeric="collection-number">
+        <text prefix=" " variable="collection-number"/>
+      </if>
+      <else>
+        <text prefix=", " variable="collection-number"/>
+      </else>
+    </choose>
+    <choose>
+      <if variable="collection-editor">
+        <text prefix=", " term="editor" form="verb-short" text-case="lowercase" suffix="."/>
+        <text prefix=" " macro="secondary-collection-contributors"/>
+      </if>
+    </choose>
+  </macro>
+  <macro name="edition">
+    <choose>
+      <if is-numeric="edition">
+        <number variable="edition" form="ordinal"/>
+        <text prefix=" " term="edition"/>
+      </if>
+      <else-if variable="edition">
+        <text variable="edition"/>
+        <text prefix=" " term="edition" form="short" suffix="."/>
+      </else-if>
+    </choose>
+  </macro>
+  <macro name="publisher">
+    <choose>
+      <if variable="publisher-place">
+        <text prefix="" variable="publisher" suffix=", "/>
+      </if>
+      <else>
+        <text variable="publisher"/>
+      </else>
+    </choose>
+    <text variable="publisher-place"/>
+  </macro>
+  <macro name="access">
+    <choose>
+      <if type="webpage">
+        <text variable="URL"/>
+        <group delimiter=" " prefix=", ">
+          <text term="accessed" text-case="capitalize-first"/>
+          <date variable="accessed">
+            <date-part name="day" form="numeric" suffix="."/>
+            <date-part name="month" form="numeric" suffix="."/>
+            <date-part name="year"/>
+          </date>
+        </group>
+      </if>
+    </choose>
+  </macro>
+  <macro name="date">
+    <date variable="issued" prefix="">
+      <date-part name="year" vertical-align="baseline"/>
+    </date>
+  </macro>
+  <macro name="title">
+    <group delimiter=", ">
+      <choose>
+        <if type="book">
+          <text variable="title" font-style="normal"/>
+        </if>
+        <else>
+          <text variable="title" form="long" quotes="false" font-style="normal"/>
+        </else>
+      </choose>
+      <text macro="secondary-contributors"/>
+    </group>
+  </macro>
+  <macro name="container">
+    <choose>
+      <if type="chapter">
+        <choose>
+          <if variable="container-author editor" match="any">
+            <text term="in" suffix=": "/>
+          </if>
+        </choose>
+        <text macro="container-contributors" suffix=": "/>
+        <text variable="container-title"/>
+        <text prefix=", " macro="secondary-container-contributors"/>
+      </if>
+      <else-if type="article-journal article-magazine article-newspaper" match="all">
+        <text variable="container-title" font-style="normal"/>
+      </else-if>
+      <else-if type="speech" match="any">
+        <text value="Rede"/>
+        <text variable="event" prefix=", "/>
+        <text variable="event-place" prefix=", "/>
+      </else-if>
+      <else-if type="paper-conference" match="any">
+        <text value="Konferenzpapier" suffix=", "/>
+        <text variable="event"/>
+      </else-if>
+      <else-if type="bill" match="any">
+        <text variable="number" suffix=", "/>
+        <text variable="authority" form="short"/>
+      </else-if>
+      <else-if type="personal_communication" match="any">
+        <text variable="genre"/>
+      </else-if>
+    </choose>
+  </macro>
+  <macro name="issued">
+    <choose>
+      <if type="report">
+        <text variable="collection-title" prefix=", "/>
+        <text variable="genre" prefix=", "/>
+        <text variable="number" prefix=" "/>
+        <text variable="publisher" prefix=", "/>
+        <text variable="publisher-place" prefix=", "/>
+      </if>
+      <else-if type="article-journal article-newspaper article-magazine" match="any">
+        <number prefix=" " variable="volume"/>
+      </else-if>
+    </choose>
+    <choose>
+      <if type="article-newspaper" match="any">
+        <text variable="publisher-place" prefix=", "/>
+      </if>
+    </choose>
+    <choose>
+      <if type="chapter book" match="any">
+        <text macro="collection" prefix=", "/>
+        <choose>
+          <if variable="volume">
+            <text term="volume" form="short" prefix=", " suffix=". "/>
+            <text variable="volume"/>
+          </if>
+        </choose>
+        <text macro="edition" prefix=", "/>
+        <text macro="publisher" prefix=", "/>
+      </if>
+    </choose>
+  </macro>
+  <macro name="pages">
+    <choose>
+      <if type="article-journal article-magazine article-newspaper chapter" match="any">
+        <text variable="page"/>
+      </if>
+    </choose>
+  </macro>
+  <macro name="citation-locator">
+    <text variable="locator"/>
+  </macro>
+  <macro name="exact-date">
+    <choose>
+      <if type="article-newspaper manuscript speech legal_case legislation interview paper-conference pamphlet article bill report personal_communication" match="all">
+        <date variable="issued">
+          <date-part name="day" prefix=", " suffix=". "/>
+          <date-part name="month"/>
+        </date>
+      </if>
+    </choose>
+  </macro>
+  <macro name="sort-key">
+    <text macro="contributors-long" suffix=" "/>
+    <text macro="date" suffix=" "/>
+  </macro>
+  <macro name="mimeo">
+    <choose>
+      <if type="manuscript" match="any">
+        <text value="mimeo" prefix=", "/>
+      </if>
+    </choose>
+  </macro>
+  <citation et-al-min="3" et-al-use-first="1" et-al-subsequent-min="3" et-al-subsequent-use-first="1" disambiguate-add-names="true" disambiguate-add-year-suffix="true" collapse="year" year-suffix-delimiter=", ">
+    <layout prefix="(" suffix=")" delimiter="; ">
+      <text macro="contributors-short" suffix=", "/>
+      <text macro="date"/>
+      <text macro="citation-locator" prefix=": "/>
+    </layout>
+  </citation>
+  <bibliography et-al-min="7" et-al-use-first="1" entry-spacing="0" hanging-indent="true">
+    <sort>
+      <key macro="contributors-long"/>
+      <key macro="date" sort="descending"/>
+    </sort>
+    <layout suffix=".">
+      <text macro="contributors-long"/>
+      <text prefix=" (" macro="date" suffix="), "/>
+      <text macro="title"/>
+      <text prefix=", " macro="container"/>
+      <text macro="issued"/>
+      <text prefix=", " macro="pages"/>
+      <text prefix=", " macro="access"/>
+      <text macro="exact-date"/>
+      <text macro="mimeo"/>
+    </layout>
+  </bibliography>
+</style>

--- a/german-council-of-economic-experts.csl
+++ b/german-council-of-economic-experts.csl
@@ -2,10 +2,10 @@
 <style xmlns="http://purl.org/net/xbiblio/csl" version="1.0" class="in-text" default-locale="de-DE" demote-non-dropping-particle="sort-only">
   <!-- This style was edited with the Visual CSL Editor (http://editor.citationstyles.org/visualEditor/) -->
   <info>
-    <title>German Council for Economic Experts</title>
+    <title>German Council of Economic Experts</title>
     <title-short>GCEE</title-short>
-    <id>http://www.zotero.org/styles/german-council-for-economic-experts</id>
-    <link href="http://www.zotero.org/styles/german-council-for-economic-experts" rel="self"/>
+    <id>http://www.zotero.org/styles/german-council-of-economic-experts</id>
+    <link href="http://www.zotero.org/styles/german-council-of-economic-experts" rel="self"/>
     <author>
       <name>Chris-Gabriel Islam</name>
       <email>chris-gabriel.islam@destatis.de</email>
@@ -14,8 +14,8 @@
     <category citation-format="author-date"/>
     <category field="political_science"/>
     <summary>Style for the German Council of Economic Experts</summary>
-    <updated>2017-03-09T14:32:02+00:00</updated>
-    <rights>This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License: http://creativecommons.org/licenses/by-sa/3.0/</rights>
+    <updated>2017-03-09T15:05:44+00:00</updated>
+    <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale xml:lang="de">
     <terms>
@@ -29,7 +29,7 @@
       <term name="long-ordinal-02">zweite</term>
       <term name="long-ordinal-03">dritte</term>
       <term name="long-ordinal-04">vierte</term>
-      <term name="long-ordinal-05">f�nfte</term>
+      <term name="long-ordinal-05">f nfte</term>
       <term name="long-ordinal-06">sechste</term>
       <term name="long-ordinal-07">siebte</term>
       <term name="long-ordinal-08">achte</term>
@@ -275,10 +275,6 @@
         </date>
       </if>
     </choose>
-  </macro>
-  <macro name="sort-key">
-    <text macro="contributors-long" suffix=" "/>
-    <text macro="date" suffix=" "/>
   </macro>
   <macro name="mimeo">
     <choose>

--- a/german-council-of-economic-experts.csl
+++ b/german-council-of-economic-experts.csl
@@ -7,7 +7,7 @@
     <id>http://www.zotero.org/styles/german-council-of-economic-experts</id>
     <link href="http://www.zotero.org/styles/german-council-of-economic-experts" rel="self"/>
     <link href="https://www.sachverstaendigenrat-wirtschaft.de/fileadmin/dateiablage/Sonstiges/SVR_Styleguide_Literaturverzeichnis_Stand_16.03.2017.pdf" rel="documentation"/>
-    <link href="http://www.zotero.org/styles/tah-soz" rel="template"/>
+    <link href="http://www.zotero.org/styles/sozialwissenschaften-heilmann" rel="template"/>
     <author>
       <name>Chris-Gabriel Islam</name>
       <email>chris-gabriel.islam@destatis.de</email>

--- a/german-council-of-economic-experts.csl
+++ b/german-council-of-economic-experts.csl
@@ -6,6 +6,8 @@
     <title-short>GCEE</title-short>
     <id>http://www.zotero.org/styles/german-council-of-economic-experts</id>
     <link href="http://www.zotero.org/styles/german-council-of-economic-experts" rel="self"/>
+    <link href="https://www.sachverstaendigenrat-wirtschaft.de/fileadmin/dateiablage/Sonstiges/SVR_Styleguide_Literaturverzeichnis_Stand_16.03.2017.pdf" rel="documentation"/>
+    <link href="http://www.zotero.org/styles/tah-soz" rel="template"/>
     <author>
       <name>Chris-Gabriel Islam</name>
       <email>chris-gabriel.islam@destatis.de</email>

--- a/german-council-of-economic-experts.csl
+++ b/german-council-of-economic-experts.csl
@@ -31,7 +31,7 @@
       <term name="long-ordinal-02">zweite</term>
       <term name="long-ordinal-03">dritte</term>
       <term name="long-ordinal-04">vierte</term>
-      <term name="long-ordinal-05">f nfte</term>
+      <term name="long-ordinal-05">fünfte</term>
       <term name="long-ordinal-06">sechste</term>
       <term name="long-ordinal-07">siebte</term>
       <term name="long-ordinal-08">achte</term>


### PR DESCRIPTION
The German Council of Economic Experts provides an own citation style. In order to distribute this style to all contributors, I hereby want to upload this style.