### PR TITLE
Update journal-of-historical-linguistics.csl

### DIFF
--- a/journal-of-historical-linguistics.csl
+++ b/journal-of-historical-linguistics.csl
@@ -16,7 +16,7 @@
     <category field="linguistics"/>
     <issn>2210-2116</issn>
     <eissn>2210-2124</eissn>
-    <updated>2017-03-10T10:33:29+00:00</updated>
+    <updated>2017-03-10T10:39:18+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <macro name="editor-translator">
@@ -28,7 +28,7 @@
   </macro>
   <macro name="author">
     <names variable="author">
-      <name delimiter-precedes-last="always" initialize="false" initialize-with="." name-as-sort-order="all" sort-separator=" "/>
+      <name delimiter-precedes-last="always" initialize="false" initialize-with="." name-as-sort-order="first"/>
       <et-al font-style="italic"/>
       <label form="short" prefix=" (" suffix=")" text-case="capitalize-first"/>
       <substitute>

--- a/journal-of-historical-linguistics.csl
+++ b/journal-of-historical-linguistics.csl
@@ -16,7 +16,7 @@
     <category field="linguistics"/>
     <issn>2210-2116</issn>
     <eissn>2210-2124</eissn>
-    <updated>2017-03-07T18:40:10+00:00</updated>
+    <updated>2017-03-10T10:33:29+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <macro name="editor-translator">
@@ -111,15 +111,13 @@
           <text macro="title" prefix=" "/>
           <group prefix=".">
             <group>
-              <group suffix=".">
-                <names variable="editor translator">
-                  <name name-as-sort-order="all" sort-separator=" " initialize-with="" delimiter=", " delimiter-precedes-last="always" prefix=" In: " suffix=","/>
+              <group prefix=" " suffix=".">
+                <text term="in" text-case="capitalize-first" suffix=" "/>
+                <names variable="editor translator" delimiter="," suffix=",">
+                  <name delimiter=" " and="symbol" delimiter-precedes-last="always" initialize-with="" name-as-sort-order="all" sort-separator=" "/>
                   <label form="short" prefix=" "/>
                 </names>
-                <text variable="collection-title" prefix=" " suffix="." font-style="italic"/>
-                <text variable="container-title" prefix=" " suffix="." font-style="italic"/>
-                <text macro="publisher" prefix=" " suffix=", "/>
-                <text variable="page" suffix="."/>
+                <text variable="page" prefix=" " suffix="."/>
               </group>
             </group>
           </group>
@@ -142,7 +140,7 @@
               <text variable="volume"/>
               <text variable="issue"/>
             </group>
-            <text variable="page" prefix=""/>
+            <text variable="page"/>
           </group>
         </else>
       </choose>

--- a/journal-of-historical-linguistics.csl
+++ b/journal-of-historical-linguistics.csl
@@ -16,9 +16,14 @@
     <category field="linguistics"/>
     <issn>2210-2116</issn>
     <eissn>2210-2124</eissn>
-    <updated>2017-03-10T10:39:18+00:00</updated>
+    <updated>2017-03-13T12:03:31+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
+  <locale xml:lang="en">
+    <terms>
+      <term name="by">ed. by</term>
+    </terms>
+  </locale>
   <macro name="editor-translator">
     <names variable="editor translator" prefix="(" suffix=")" delimiter=", ">
       <name and="text" initialize-with="" delimiter=", "/>
@@ -28,7 +33,7 @@
   </macro>
   <macro name="author">
     <names variable="author">
-      <name delimiter-precedes-last="always" initialize="false" initialize-with="." name-as-sort-order="first"/>
+      <name delimiter-precedes-last="contextual" initialize="false" initialize-with="." name-as-sort-order="first" and="symbol"/>
       <et-al font-style="italic"/>
       <label form="short" prefix=" (" suffix=")" text-case="capitalize-first"/>
       <substitute>
@@ -94,7 +99,7 @@
       <key macro="author-short"/>
       <key variable="issued"/>
     </sort>
-    <layout>
+    <layout suffix=".">
       <text macro="author" text-case="capitalize-first" suffix="."/>
       <date variable="issued" text-case="uppercase" prefix=" " suffix=".">
         <date-part name="year"/>
@@ -108,17 +113,18 @@
           <text prefix=" " suffix="." macro="publisher"/>
         </if>
         <else-if type="chapter paper-conference" match="any">
-          <text macro="title" prefix=" "/>
+          <text macro="title" prefix=" " suffix="."/>
           <group prefix=".">
-            <group>
-              <group prefix=" " suffix=".">
-                <text term="in" text-case="capitalize-first" suffix=" "/>
+            <group delimiter=" " prefix=" ">
+              <text variable="container-title" font-style="italic"/>
+              <group suffix=".">
+                <text term="by" suffix=" "/>
                 <names variable="editor translator" delimiter="," suffix=",">
-                  <name delimiter=" " and="symbol" delimiter-precedes-last="always" initialize-with="" name-as-sort-order="all" sort-separator=" "/>
-                  <label form="short" prefix=" "/>
+                  <name delimiter=" " and="symbol" delimiter-precedes-last="never" initialize="false" name-as-sort-order="first" sort-separator=" "/>
                 </names>
                 <text variable="page" prefix=" " suffix="."/>
               </group>
+              <text macro="publisher"/>
             </group>
           </group>
         </else-if>


### PR DESCRIPTION
via error request: https://forums.zotero.org/discussion/comment/271743/#Comment_271743 
It should come out as In Hall PA & Soskice D, eds., (comma between names and label), but comes out as In Hall PA & Soskice D eds.,

Am I missing something?