### PR TITLE
Update scientia-agriculturae-bohemica.csl

### DIFF
--- a/scientia-agriculturae-bohemica.csl
+++ b/scientia-agriculturae-bohemica.csl
@@ -35,6 +35,7 @@
       <et-al font-style="normal" font-weight="normal"/>
       <substitute>
         <names variable="editor"/>
+        <names variable="collection-editor"/>
         <names variable="translator"/>
         <text variable="title"/>
       </substitute>
@@ -45,6 +46,7 @@
       <name name-as-sort-order="all" sort-separator=" " initialize-with="" delimiter-precedes-last="never" delimiter-precedes-et-al="never"/>
       <substitute>
         <names variable="editor"/>
+        <names variable="collection-editor"/>
         <names variable="translator"/>
         <text variable="title"/>
       </substitute>


### PR DESCRIPTION
add "collection-editor" to the substitute of the author
Explanation: for document type "Report" is "collection-editor" available only in Zotero and not "editor".