### PR TITLE
Create social-cognitive-and-affective-neuroscience.csl

### DIFF
--- a/social-cognitive-and-affective-neuroscience.csl
+++ b/social-cognitive-and-affective-neuroscience.csl
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="utf-8"?>
+<style class="in-text" version="1.0" default-locale="en-US" name-delimiter=";" and="text" et-al-min="3" et-al-use-first="1" name-as-sort-order="first" demote-non-dropping-particle="never" xmlns="http://purl.org/net/xbiblio/csl">
+  <info>
+    <title>Social Cognitive and Affective Neuroscience</title>
+    <title-short>SCAN</title-short>
+    <id>http://www.zotero.org/styles/social-cognitive-and-affective-neuroscience</id>
+    <link href="http://www.zotero.org/styles/social-cognitive-and-affective-neuroscience" rel="self"/>
+    <link href="https://academic.oup.com/scan/pages/General_Instructions" rel="documentation"/>
+    <issn>1749-5016</issn>
+    <eissn>1749-5024</eissn>
+    <author>
+      <name>Isidoor Bergfeld</name>
+      <email>i.o.bergfeld@gmail.com</email>
+    </author>
+    <updated>2017-03-28T14:33:42+00:00</updated>
+    <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
+  </info>
+  <citation name-form="short" et-al-min="3" et-al-use-first="1">
+    <sort>
+      <key variable="author"/>
+    </sort>
+    <layout delimiter="; " prefix="(" suffix=")">
+      <names variable="author">
+        <name form="short" delimiter=" " and="symbol" et-al-min="3" et-al-use-first="1" sort-separator=""/>
+        <substitute>
+          <names variable="editor">
+            <name form="short" and="symbol" et-al-min="3" et-al-use-first="1"/>
+          </names>
+        </substitute>
+      </names>
+      <date date-parts="year" form="text" variable="issued" prefix=", "/>
+    </layout>
+  </citation>
+  <bibliography name-delimiter=", " and="symbol" delimiter-precedes-last="always" et-al-min="6" et-al-use-first="6" initialize-with="." name-as-sort-order="all" sort-separator="" hanging-indent="true">
+    <sort>
+      <key variable="author"/>
+    </sort>
+    <layout>
+      <names variable="author">
+        <name and="symbol" et-al-min="6" et-al-use-first="6" initialize-with="." name-as-sort-order="all"/>
+        <substitute>
+          <names variable="editor" suffix=", editors.">
+            <name and="symbol" et-al-min="6" et-al-use-first="6" initialize-with="." name-as-sort-order="all"/>
+          </names>
+        </substitute>
+      </names>
+      <date date-parts="year" form="text" variable="issued" prefix=" (" suffix=")"/>
+      <text variable="title" prefix=" " suffix="."/>
+      <choose>
+        <if type="article-journal" match="any">
+          <text variable="container-title" prefix=" " suffix=","/>
+          <text variable="volume" prefix=" " suffix=","/>
+          <text variable="page" form="short" prefix=" " suffix="."/>
+        </if>
+        <else-if type="book" match="any">
+          <text variable="publisher-place" prefix=" " suffix=":"/>
+          <text variable="publisher" prefix=" " suffix="."/>
+        </else-if>
+        <else-if type="chapter" match="any">
+          <names variable="editor" prefix=" In: " suffix=" (eds.).">
+            <name et-al-min="6" et-al-use-first="6" initialize-with="." name-as-sort-order="all"/>
+          </names>
+          <text variable="container-title" prefix=" " suffix="."/>
+          <text variable="publisher-place" prefix=" " suffix=":"/>
+          <text variable="publisher" prefix=" " suffix="."/>
+          <text variable="page" form="short" prefix=" p. " suffix="."/>
+        </else-if>
+        <else-if type="webpage" match="any">
+          <text variable="URL" form="short" prefix=" "/>
+        </else-if>
+        <else>
+          <text value=""/>
+        </else>
+      </choose>
+    </layout>
+  </bibliography>
+</style>

--- a/social-cognitive-and-affective-neuroscience.csl
+++ b/social-cognitive-and-affective-neuroscience.csl
@@ -8,6 +8,7 @@
     <link href="https://academic.oup.com/scan/pages/General_Instructions" rel="documentation"/>
     <issn>1749-5016</issn>
     <eissn>1749-5024</eissn>
+    <category citation-format="author-date"/>
     <author>
       <name>Isidoor Bergfeld</name>
       <email>i.o.bergfeld@gmail.com</email>


### PR DESCRIPTION
When preparing a manuscript for Social Cognitive and Affective Neuroscience using Mendeley, I noticed no style file for this journal was available. I created one and used it to create references and a bibliography in my manuscript. As far as I can see, no errors occurred. 

Since I already created the csl file, it could be useful for other users, so they don't have to create one themselves.