### PR TITLE
Update american-chemical-society.csl

### DIFF
--- a/american-chemical-society.csl
+++ b/american-chemical-society.csl
@@ -128,7 +128,10 @@
       <choose>
         <if type="article-journal review" match="any">
           <group delimiter=" ">
-            <text variable="container-title" font-style="italic" form="short"/>
+            <group delimiter=". ">
+              <text variable="title"/>
+              <text variable="container-title" font-style="italic" form="short"/>
+            </group>
             <group delimiter=", ">
               <text macro="issued" font-weight="bold"/>
               <choose>


### PR DESCRIPTION
A client noticed that the title was missing from journal references in ACS style. Based on my reading of the guide the title should be added as proposed.