### PR TITLE
Update international-journal-of-exercise-science.csl

### DIFF
--- a/international-journal-of-exercise-science.csl
+++ b/international-journal-of-exercise-science.csl
@@ -4,7 +4,7 @@
     <title>International Journal of Exercise Science</title>
     <id>http://www.zotero.org/styles/international-journal-of-exercise-science</id>
     <link href="http://www.zotero.org/styles/international-journal-of-exercise-science" rel="self"/>
-    <link href="http://digitalcommons.wku.edu/ijes/policies.html" rel="documentation"/>
+    <link href="http://digitalcommons.wku.edu/ijes/styleguide.html" rel="documentation"/>
     <author>
       <name>Sebastian Karcher</name>
     </author>
@@ -20,7 +20,7 @@
     <category field="medicine"/>
     <issn>1939-795X</issn>
     <summary>Vancouver style for the Journal IJES</summary>
-    <updated>2012-09-27T22:06:38+00:00</updated>
+    <updated>2013-09-08T00:04:27+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <macro name="author">
@@ -55,12 +55,12 @@
       <text macro="accessed-date" prefix=" "/>
     </group>
   </macro>
-  <macro name="access">
+  <!--<macro name="access">
     <group>
       <text value="Available from: "/>
       <text variable="URL"/>
     </group>
-  </macro>
+  </macro>-->
   <macro name="accessed-date">
     <choose>
       <if variable="URL">
@@ -156,7 +156,10 @@
         <else>
           <text macro="journal-title"/>
           <group delimiter=": ">
-            <text variable="volume"/>
+            <group>
+              <text variable="volume"/>
+              <text variable="issue" prefix="(" suffix=")"/>
+            </group>
             <text variable="page"/>
           </group>
           <date variable="issued" prefix=", " suffix=".">
@@ -164,7 +167,7 @@
           </date>
         </else>
       </choose>
-      <text macro="access"/>
+      <!--<text macro="access"/>-->
     </layout>
   </bibliography>
 </style>


### PR DESCRIPTION
Add issue (https://forums.zotero.org/discussion/comment/274378/#Comment_274378)
Turn off macro "access", because the URL is not needed by the guide for authors (http://digitalcommons.wku.edu/ijes/styleguide.html) and I did not find URL link in any article available on the journal pages (I've tested only five articles).