### PR TITLE
Update melbourne-school-of-theology.csl

### DIFF
--- a/melbourne-school-of-theology.csl
+++ b/melbourne-school-of-theology.csl
@@ -477,7 +477,7 @@
         <text macro="pages"/>
       </if>
       <else-if type="article-journal">
-        <text variable="locator" prefix=": "/>
+        <text variable="locator" prefix=", "/>
       </else-if>
       <else>
         <text macro="point-locators-note" prefix=", "/>


### PR DESCRIPTION
The character before the page number range for a Journal Article needs to be changed from a colon to a comma to bring this style into line with MST's Style Guide.