### PR TITLE
apa.csl: add post and post-weblog to date accessed

### DIFF
--- a/apa.csl
+++ b/apa.csl
@@ -165,7 +165,7 @@
           </if>
           <else>
             <choose>
-              <if type="webpage">
+              <if type="post post-weblog webpage" match="any">
                 <group delimiter=" ">
                   <text term="retrieved" text-case="capitalize-first" suffix=" "/>
                   <group>


### PR DESCRIPTION
Fix from issue #2648.