### PR TITLE
Add pamphlet pages for map type

### DIFF
--- a/utah-geological-survey.csl
+++ b/utah-geological-survey.csl
@@ -152,7 +152,7 @@
         <else-if type="map">
           <text variable="title" prefix=" "/>
           <text variable="collection-title" prefix=": "/>
-          <text variable="note" prefix=", " suffix=" p. pamphlet"/>
+          <text variable="number-of-pages" prefix=", " suffix=" p. pamphlet"/>
           <text variable="scale" prefix=", scale "/>
         </else-if>
         <else-if type="speech">

--- a/utah-geological-survey.csl
+++ b/utah-geological-survey.csl
@@ -152,6 +152,7 @@
         <else-if type="map">
           <text variable="title" prefix=" "/>
           <text variable="collection-title" prefix=": "/>
+          <text variable="note" prefix=", " suffix=" p. pamphlet"/>
           <text variable="scale" prefix=", scale "/>
         </else-if>
         <else-if type="speech">


### PR DESCRIPTION
This is an attempted fix for the map type output in the bibliography. The style guide (http://files.geology.utah.gov/online/c/c-105.pdf) indicates that if a map includes a pamphlet, it should include  ", # p. pamphlet," after the series title and before the scale.