### PR TITLE
Update harvard-coventry-university.csl

### DIFF
--- a/harvard-coventry-university.csl
+++ b/harvard-coventry-university.csl
@@ -53,11 +53,6 @@
       <name and="text" sort-separator=", " initialize-with="." delimiter=", "/>
     </names>
   </macro>
-  <macro name="cite-editor">
-    <names variable="editor" delimiter=", ">
-      <name form="short" and="text" delimiter=", " initialize-with=". "/>
-    </names>
-  </macro>
   <macro name="bookauthor">
     <names variable="container-author">
       <name name-as-sort-order="all" and="text" sort-separator=", " initialize-with="." delimiter=", "/>
@@ -91,10 +86,10 @@
       <else>
         <names variable="author">
           <name name-as-sort-order="all" and="text" sort-separator=", " initialize-with="." delimiter=", " form="long"/>
-          <label form="short" prefix=" " strip-periods="false"/>
+          <label form="short" prefix=" (" suffix=")"/>
           <substitute>
-            <text macro="editor"/>
-            <text variable="title" text-case="title" quotes="true" font-style="normal" text-decoration="none"/>
+            <names variable="editor"/>
+            <text macro="title"/>
           </substitute>
         </names>
       </else>
@@ -119,8 +114,8 @@
         <names variable="author">
           <name form="short" and="text" delimiter=", " initialize-with=". "/>
           <substitute>
-            <text macro="cite-editor"/>
-            <text variable="title" text-case="title" quotes="true" font-style="normal"/>
+            <names variable="editor"/>
+            <text macro="title"/>
           </substitute>
         </names>
       </else>

--- a/harvard-coventry-university.csl
+++ b/harvard-coventry-university.csl
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" demote-non-dropping-particle="sort-only" default-locale="en-GB">
-  <!-- This style was edited with the Visual CSL Editor (http://editor.citationstyles.org/visualEditor/) -->
   <info>
     <title>Coventry University - Harvard</title>
     <title-short>CU Harvard</title-short>
@@ -17,7 +16,7 @@
     <category citation-format="author-date"/>
     <category field="generic-base"/>
     <summary>The Harvard author-date style - adapted for use at Coventry University. See usage notes at http://www.oak-wood.co.uk/oss/coventry-harvard-csl</summary>
-    <updated>2013-11-11T13:19:48+00:00</updated>
+    <updated>2017-04-26T14:55:36+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale>
@@ -98,7 +97,7 @@
           <label form="short" prefix=" " strip-periods="false"/>
           <substitute>
             <text macro="editor"/>
-            <text macro="anon"/>
+            <text variable="container-title" text-case="title" quotes="true" font-style="normal" text-decoration="none"/>
           </substitute>
         </names>
       </else>
@@ -124,7 +123,7 @@
           <name form="short" and="text" delimiter=", " initialize-with=". "/>
           <substitute>
             <text macro="cite-editor"/>
-            <text macro="anon"/>
+            <text variable="container-title" text-case="title" quotes="true" font-style="normal"/>
           </substitute>
         </names>
       </else>
@@ -284,7 +283,7 @@
     <layout prefix="(" suffix=")" delimiter=", ">
       <choose>
         <if locator="page">
-          <group delimiter=":&#160;">
+          <group delimiter=": ">
             <group delimiter=" ">
               <text macro="author-short"/>
               <text macro="year-date"/>
@@ -293,12 +292,12 @@
           </group>
         </if>
         <else>
-          <group delimiter=",&#160;">
+          <group delimiter=", ">
             <group delimiter=" ">
               <text macro="author-short"/>
               <text macro="year-date"/>
             </group>
-            <group delimiter="&#160;">
+            <group delimiter=" ">
               <label variable="locator" form="short" strip-periods="false"/>
               <text variable="locator"/>
             </group>

--- a/harvard-coventry-university.csl
+++ b/harvard-coventry-university.csl
@@ -16,7 +16,7 @@
     <category citation-format="author-date"/>
     <category field="generic-base"/>
     <summary>The Harvard author-date style - adapted for use at Coventry University. See usage notes at http://www.oak-wood.co.uk/oss/coventry-harvard-csl</summary>
-    <updated>2017-04-26T14:55:36+00:00</updated>
+    <updated>2017-05-01T15:25:24+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale>
@@ -65,9 +65,6 @@
         <text macro="edby"/>
       </substitute>
     </names>
-  </macro>
-  <macro name="anon">
-    <text term="anonymous" form="short" text-case="capitalize-first"/>
   </macro>
   <macro name="author">
     <choose>

--- a/harvard-coventry-university.csl
+++ b/harvard-coventry-university.csl
@@ -97,7 +97,7 @@
           <label form="short" prefix=" " strip-periods="false"/>
           <substitute>
             <text macro="editor"/>
-            <text variable="container-title" text-case="title" quotes="true" font-style="normal" text-decoration="none"/>
+            <text variable="title" text-case="title" quotes="true" font-style="normal" text-decoration="none"/>
           </substitute>
         </names>
       </else>
@@ -123,7 +123,7 @@
           <name form="short" and="text" delimiter=", " initialize-with=". "/>
           <substitute>
             <text macro="cite-editor"/>
-            <text variable="container-title" text-case="title" quotes="true" font-style="normal"/>
+            <text variable="title" text-case="title" quotes="true" font-style="normal"/>
           </substitute>
         </names>
       </else>

--- a/harvard-coventry-university.csl
+++ b/harvard-coventry-university.csl
@@ -275,7 +275,7 @@
     <layout prefix="(" suffix=")" delimiter=", ">
       <choose>
         <if locator="page">
-          <group delimiter=": ">
+          <group delimiter=":&#160;">
             <group delimiter=" ">
               <text macro="author-short"/>
               <text macro="year-date"/>
@@ -284,12 +284,12 @@
           </group>
         </if>
         <else>
-          <group delimiter=", ">
+          <group delimiter=",&#160;">
             <group delimiter=" ">
               <text macro="author-short"/>
               <text macro="year-date"/>
             </group>
-            <group delimiter=" ">
+            <group delimiter="&#160;">
               <label variable="locator" form="short" strip-periods="false"/>
               <text variable="locator"/>
             </group>


### PR DESCRIPTION
From EasyBib: A user reported that when she cites websites like https://www.nice.org.uk/guidance/cg181/chapter/1-Recommendations#lipid-modification-therapy-for-the-primary-and-secondary-prevention-of-cvd-2 in Harvard - Coventry University, "anon" is showing up as the author for each one. I'm not finding that listed in any author or contributor tags in the page source, and when I cite a different web URL in Harvard CU and remove the author, "anon" shows up. CU says this is not correct.

Fix: remove "anon" from website citations with no author in Harvard CU