### PR TITLE
Update modern-language-association.csl

### DIFF
--- a/modern-language-association.csl
+++ b/modern-language-association.csl
@@ -33,7 +33,7 @@
     <category citation-format="author"/>
     <category field="generic-base"/>
     <summary>This style adheres to the MLA 7th edition handbook and contains modifications to these types of sources: e-mail, forum posts, interviews, manuscripts, maps, presentations, TV broadcasts, and web pages.</summary>
-    <updated>2014-07-06T20:05:10+00:00</updated>
+    <updated>2017-04-27T18:03:35+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale xml:lang="en">
@@ -153,6 +153,9 @@
             <text value="Audio Recording" prefix=" "/>
           </else>
         </choose>
+      </else-if>
+      <else-if type="graphic" match="any">
+        <text variable="medium"/>
       </else-if>
       <else>
         <choose>

--- a/modern-language-association.csl
+++ b/modern-language-association.csl
@@ -154,8 +154,8 @@
           </else>
         </choose>
       </else-if>
-      <else-if type="graphic" match="any">
-        <text variable="medium"/>
+      <else-if type="graphic" variable="medium" match="all">
+        <text variable="medium" prefix=" "/>
       </else-if>
       <else>
         <choose>


### PR DESCRIPTION
MLA 7 says for a work of visual art the medium of composition should be indicated. Our photograph citation leaves out "photograph."

Current: Cloyd, Allie. The Wedding. 1945. Museum of the City of New York, New York.
Expected: Cloyd, Allie. The Wedding. 1945. Photograph. Museum of the City of New York, New York.

I have added "graphic" to medium macro. 