### PR TITLE
Change format to "numeric" for radiopaedia.csl

### DIFF
--- a/radiopaedia.csl
+++ b/radiopaedia.csl
@@ -10,7 +10,7 @@
       <email>jeremy@radiopaedia.org</email>
       <uri>http://radiopaedia.org</uri>
     </author>
-    <category citation-format="note"/>
+    <category citation-format="numeric"/>
     <category field="medicine"/>
     <summary>A style format for radiopaedia.org, the online radiology collaborative resource.</summary>
     <updated>2012-10-25T21:15:26+00:00</updated>

--- a/radiopaedia.csl
+++ b/radiopaedia.csl
@@ -108,12 +108,6 @@
     </choose>
     <text macro="recipient-note" prefix=" "/>
   </macro>
-  <macro name="recipient-short">
-    <names variable="recipient">
-      <label form="verb" prefix=" " suffix=" "/>
-      <name form="short" and="text" delimiter=", "/>
-    </names>
-  </macro>
   <macro name="recipient-note">
     <names variable="recipient" delimiter=", ">
       <label form="verb" prefix=" " suffix=" "/>

--- a/radiopaedia.csl
+++ b/radiopaedia.csl
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<style xmlns="http://purl.org/net/xbiblio/csl" class="note" version="1.0" demote-non-dropping-particle="sort-only" default-locale="en-US">
+<style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" demote-non-dropping-particle="sort-only" default-locale="en-US">
   <info>
     <title>Radiopaedia.org</title>
     <id>http://www.zotero.org/styles/radiopaedia</id>

--- a/radiopaedia.csl
+++ b/radiopaedia.csl
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" demote-non-dropping-particle="sort-only" default-locale="en-US">
+<style class="in-text" version="1.0" page-range-format="minimal" demote-non-dropping-particle="sort-only" default-locale="en-US" xmlns="http://purl.org/net/xbiblio/csl">
   <info>
     <title>Radiopaedia.org</title>
     <id>http://www.zotero.org/styles/radiopaedia</id>
@@ -10,10 +10,14 @@
       <email>jeremy@radiopaedia.org</email>
       <uri>http://radiopaedia.org</uri>
     </author>
+    <contributor>
+      <name>Philipp Zumstein</name>
+      <uri>https://github.com/zuphilip</uri>
+    </contributor>
     <category citation-format="numeric"/>
     <category field="medicine"/>
     <summary>A style format for radiopaedia.org, the online radiology collaborative resource.</summary>
-    <updated>2012-10-25T21:15:26+00:00</updated>
+    <updated>2017-04-29T20:57:27+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale>
@@ -24,7 +28,7 @@
   </locale>
   <macro name="contributors">
     <names variable="author">
-      <name name-as-sort-order="first" and="text" sort-separator=" " delimiter=", " delimiter-precedes-last="never"/>
+      <name and="text" delimiter-precedes-last="never" initialize-with="" name-as-sort-order="first" sort-separator=" "/>
       <substitute>
         <text macro="editor"/>
         <text macro="translator"/>
@@ -59,7 +63,7 @@
             <if variable="author">
               <names variable="editor" delimiter=". ">
                 <label form="verb" text-case="capitalize-first" suffix=" "/>
-                <name and="text" delimiter=", "/>
+                <name and="text" initialize-with=""/>
               </names>
             </if>
           </choose>
@@ -67,7 +71,7 @@
             <if variable="author editor" match="any">
               <names variable="translator" delimiter=". ">
                 <label form="verb" text-case="capitalize-first" suffix=" "/>
-                <name and="text" delimiter=", "/>
+                <name and="text" initialize-with=""/>
               </names>
             </if>
           </choose>
@@ -154,10 +158,10 @@
         </choose>
       </if>
       <else-if type="bill book graphic legal_case legislation motion_picture report song" match="any">
-        <text variable="title" font-style="italic"/>
+        <text variable="title" font-style="normal"/>
       </else-if>
       <else>
-        <text variable="title" quotes="true"/>
+        <text variable="title" quotes="false"/>
       </else>
     </choose>
   </macro>
@@ -192,7 +196,7 @@
     </choose>
     <choose>
       <if type="legal_case" match="none">
-        <text variable="container-title" font-style="italic"/>
+        <text variable="container-title-short" strip-periods="true" font-style="normal"/>
       </if>
     </choose>
   </macro>
@@ -235,8 +239,8 @@
   <macro name="locators">
     <choose>
       <if type="article-journal">
-        <text variable="volume" prefix=" "/>
-        <text variable="issue" prefix=", no. "/>
+        <text variable="volume"/>
+        <text variable="issue" prefix=" (" suffix=")"/>
       </if>
       <else-if type="legal_case">
         <text variable="volume" prefix=", "/>
@@ -307,11 +311,7 @@
         </date>
       </else-if>
       <else>
-        <date variable="issued">
-          <date-part name="month" suffix=" "/>
-          <date-part name="day" suffix=", "/>
-          <date-part name="year"/>
-        </date>
+        <date date-parts="year" form="text" variable="issued"/>
       </else>
     </choose>
   </macro>
@@ -361,7 +361,7 @@
   <macro name="issue">
     <choose>
       <if type="article-journal legal_case" match="any">
-        <text macro="issued" prefix=" (" suffix=")"/>
+        <text macro="issued" prefix=". " suffix=";"/>
       </if>
       <else-if type="speech">
         <choose>
@@ -375,14 +375,14 @@
         <text macro="issued" prefix=", "/>
       </else-if>
       <else-if variable="publisher-place publisher" match="any">
-        <group prefix=". " delimiter=", ">
+        <group delimiter=", " prefix=" ">
+          <text macro="issued" prefix="(" suffix=")"/>
           <choose>
             <if type="thesis">
               <text variable="genre" text-case="capitalize-first"/>
             </if>
           </choose>
           <text macro="publisher"/>
-          <text macro="issued"/>
         </group>
       </else-if>
       <else>
@@ -417,16 +417,19 @@
       </choose>
     </group>
   </macro>
-  <citation et-al-min="3" et-al-use-first="1" disambiguate-add-names="true">
-    <layout suffix="." delimiter="; ">
-      <group delimiter=", ">
-        <text macro="contributors-short"/>
-        <text macro="title-short"/>
-        <text macro="point-locators-subsequent"/>
+  <citation collapse="citation-number">
+    <sort>
+      <key variable="citation-number"/>
+    </sort>
+    <layout delimiter="," vertical-align="sup">
+      <text variable="citation-number"/>
+      <group prefix="(" suffix=")">
+        <label variable="locator" form="short" strip-periods="true"/>
+        <text variable="locator"/>
       </group>
     </layout>
   </citation>
-  <bibliography hanging-indent="true" et-al-min="5" et-al-use-first="3" subsequent-author-substitute="" entry-spacing="0">
+  <bibliography et-al-min="5" et-al-use-first="3" initialize-with="" subsequent-author-substitute="" entry-spacing="0" hanging-indent="true">
     <sort>
       <key macro="contributors-sort"/>
       <key variable="title"/>
@@ -445,9 +448,9 @@
           <text macro="pages-chapter"/>
         </group>
       </group>
+      <text macro="issue"/>
       <text macro="locators"/>
       <text macro="collection-title" prefix=". "/>
-      <text macro="issue"/>
       <text macro="locators-newspaper" prefix=", "/>
       <text macro="pages-article"/>
       <text macro="access" prefix=". "/>

--- a/radiopaedia.csl
+++ b/radiopaedia.csl
@@ -36,16 +36,6 @@
     </names>
     <text macro="recipient" prefix=". "/>
   </macro>
-  <macro name="contributors-short">
-    <names variable="author">
-      <name form="short" and="text" delimiter=", "/>
-      <substitute>
-        <names variable="editor"/>
-        <names variable="translator"/>
-      </substitute>
-    </names>
-    <text macro="recipient-short"/>
-  </macro>
   <macro name="contributors-sort">
     <names variable="author">
       <name name-as-sort-order="first" and="text" sort-separator=" " delimiter=", " delimiter-precedes-last="never"/>
@@ -162,29 +152,6 @@
       </else-if>
       <else>
         <text variable="title" quotes="false"/>
-      </else>
-    </choose>
-  </macro>
-  <macro name="title-short">
-    <choose>
-      <if variable="title" match="none">
-        <choose>
-          <if type="interview">
-            <text term="interview"/>
-          </if>
-          <else-if type="manuscript speech" match="any">
-            <text variable="genre" form="short"/>
-          </else-if>
-          <else-if type="personal_communication">
-            <text macro="issued"/>
-          </else-if>
-        </choose>
-      </if>
-      <else-if type="bill book graphic legal_case legislation motion_picture report song" match="any">
-        <text variable="title" form="short" font-style="italic"/>
-      </else-if>
-      <else>
-        <text variable="title" form="short" quotes="true"/>
       </else>
     </choose>
   </macro>
@@ -329,27 +296,6 @@
         <text variable="page" prefix=": "/>
       </if>
     </choose>
-  </macro>
-  <macro name="point-locators-subsequent">
-    <group>
-      <choose>
-        <if locator="page" match="none">
-          <choose>
-            <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
-              <group suffix=", ">
-                <text term="volume" form="short" suffix=" "/>
-                <number variable="volume" form="numeric"/>
-              </group>
-            </if>
-          </choose>
-          <label variable="locator" form="short" suffix=" "/>
-        </if>
-        <else-if type="bill book graphic legal_case legislation motion_picture report song" match="any">
-          <number variable="volume" form="numeric" suffix=":"/>
-        </else-if>
-      </choose>
-      <text variable="locator"/>
-    </group>
   </macro>
   <macro name="archive">
     <group delimiter=". ">


### PR DESCRIPTION
This is an online resource and therefore (foot-)notes does not
make much sense, also it is a super-scripted number in the text.

HT @adam3smith which noted this "outliner" for medicine styles