### PR TITLE
Add article-newspaper to publisher exclusions

### DIFF
--- a/apa.csl
+++ b/apa.csl
@@ -300,7 +300,7 @@
             </if>
           </choose>
           <choose>
-            <if type="article-journal article-magazine" match="none">
+            <if type="article-journal article-magazine article-newspaper" match="none">
               <group delimiter=": ">
                 <choose>
                   <if variable="publisher-place">


### PR DESCRIPTION
Newspapers also need to be excluded per the manual 6.30: 

> Periodical publisher names and locations are generally not included in references, in accordance with long practice. 