### PR TITLE
Update iso690-author-date-cs.csl

### DIFF
--- a/iso690-author-date-cs.csl
+++ b/iso690-author-date-cs.csl
@@ -283,17 +283,17 @@
       </if>
     </choose>
   </macro>
-  <macro name="date-day-month">
+  <!--<macro name="date-day-month">
     <choose>
       <if variable="issued">
         <date variable="issued">
           <date-part name="day" suffix=".&#160;"/>
-          <date-part name="month" form="numeric" suffix="."/>
+          <date-part name="month" form="numeric" suffix="."/>-->
           <!--date-part name="year"/-->
-        </date>
+        <!--</date>
       </if>
     </choose>
-  </macro>
+  </macro>-->
   <macro name="scale">
     <group delimiter="&#160;">
       <text term="scale" text-case="capitalize-first"/>
@@ -533,7 +533,7 @@
             <group delimiter=" ">
               <group delimiter=", ">
                 <text macro="publisher-info"/>
-                <text macro="date-day-month"/>
+                <!--<text macro="date-day-month"/>-->
                 <text macro="issue"/>
               </group>
               <text macro="accessed"/>
@@ -568,7 +568,7 @@
             <text macro="genre"/>
             <text macro="publisher-place"/>
             <group delimiter=" ">
-              <text macro="date-day-month"/>
+              <!--<text macro="date-day-month"/>-->
               <text macro="accessed"/>
             </group>
             <text macro="page"/>
@@ -688,7 +688,7 @@
             <text macro="title"/>
             <text macro="interviewer"/>
             <!--text macro="event"/-->
-            <text macro="date-day-month"/>
+            <!--<text macro="date-day-month"/>-->
           </group>
         </else-if>
         <else>


### PR DESCRIPTION
We've discussed with Mr Kratochvíl probability of correct data input from Zotero users (especially from students). Because the current output from style is not fully correct according to ISO 690 (https://forums.zotero.org/discussion/57000/conditional-display-of-date-of-conference-meeting#latest) we've concluded do not display the date twice in the bibliography. If will be implemented the test of date parts into the CSL (https://github.com/citation-style-language/csl-evolution/issues/2) then it will be changed to full compliance with the ISO 690.