### PR TITLE
Fix deutsche medizinische wochenschrift

### DIFF
--- a/deutsche-medizinische-wochenschrift.csl
+++ b/deutsche-medizinische-wochenschrift.csl
@@ -153,15 +153,15 @@
     <choose>
       <if type="book" match="any">
         <group delimiter=". ">
+          <group suffix=". Aufl.">
+            <number variable="edition"/>
+          </group>
           <text macro="publisher"/>
-          <group delimiter=" ">
-            <number variable="number-of-pages"/>
-            <label variable="number-of-pages" form="short"/>
-          </group>
-          <group delimiter=" ">
-            <number variable="edition" form="ordinal"/>
-            <label variable="edition" form="short"/>
-          </group>
+        </group>
+        <group prefix="; ">
+          <date variable="issued">
+            <date-part name="year"/>
+          </date>
         </group>
       </if>
       <else-if type="chapter" match="any">

--- a/deutsche-medizinische-wochenschrift.csl
+++ b/deutsche-medizinische-wochenschrift.csl
@@ -267,8 +267,7 @@
   </citation>
   <bibliography entry-spacing="0" second-field-align="flush" line-spacing="1">
     <sort>
-      <key macro="author" names-min="2" names-use-first="1" names-use-last="false"/>
-      <key macro="author-last-names"/>
+      <key variable="citation-number"/>
     </sort>
     <layout>
       <text variable="citation-number" suffix=" "/>

--- a/deutsche-medizinische-wochenschrift.csl
+++ b/deutsche-medizinische-wochenschrift.csl
@@ -60,11 +60,11 @@
   <macro name="title">
     <choose>
       <if type="bill graphic legal_case legislation motion_picture song thesis webpage manuscript" match="any">
-        <text variable="title" font-style="italic"/>
+        <text variable="title"/>
       </if>
       <else-if type="book" match="any">
         <group delimiter=", ">
-          <text variable="title" font-style="italic"/>
+          <text variable="title"/>
           <group>
             <label variable="volume" form="short" suffix=" " text-case="capitalize-first"/>
             <text variable="volume"/>
@@ -230,7 +230,18 @@
       <else-if type="webpage" match="any">
         <group delimiter=". ">
           <text variable="container-title"/>
-          <text variable="URL" form="short"/>
+          <group delimiter="; ">
+            <group prefix="Im Internet: ">
+              <text variable="URL" form="short"/>
+            </group>
+            <group prefix="Stand: ">
+              <date variable="accessed" delimiter=".">
+                <date-part name="day" form="numeric-leading-zeros"/>
+                <date-part name="month" form="numeric-leading-zeros"/>
+                <date-part name="year"/>
+              </date>
+            </group>
+          </group>
         </group>
       </else-if>
       <else-if type="manuscript">

--- a/deutsche-medizinische-wochenschrift.csl
+++ b/deutsche-medizinische-wochenschrift.csl
@@ -38,7 +38,7 @@
   </locale>
   <macro name="author">
     <names variable="author">
-      <name initialize-with="" delimiter=", " name-as-sort-order="all" sort-separator=" " et-al-min="4" et-al-use-first="3"/>
+      <name initialize-with="" delimiter=", " delimiter-precedes-et-al="never" name-as-sort-order="all" sort-separator=" " et-al-min="4" et-al-use-first="3"/>
       <label form="short" prefix=", "/>
       <substitute>
         <names variable="editor"/>

--- a/deutsche-medizinische-wochenschrift.csl
+++ b/deutsche-medizinische-wochenschrift.csl
@@ -47,15 +47,6 @@
       </substitute>
     </names>
   </macro>
-  <macro name="author-last-names">
-    <names variable="author">
-      <name form="short" et-al-min="99" et-al-use-first="99"/>
-      <substitute>
-        <names variable="editor"/>
-        <names variable="translator"/>
-      </substitute>
-    </names>
-  </macro>
   <macro name="editor">
     <names variable="editor">
       <label form="short" suffix=" " plural="never"/>

--- a/deutsche-medizinische-wochenschrift.csl
+++ b/deutsche-medizinische-wochenschrift.csl
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" page-range-format="expanded" demote-non-dropping-particle="never" default-locale="en-US">
+<style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" page-range-format="expanded" demote-non-dropping-particle="never" default-locale="de-DE">
   <info>
     <title>Deutsche Medizinische Wochenschrift (German)</title>
     <title-short>DMW</title-short>
@@ -23,17 +23,9 @@
     <updated>2017-05-05T22:00:00+02:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
-  <locale xml:lang="en">
+  <locale xml:lang="de">
     <terms>
-      <term name="editor" form="short">
-        <single>ed</single>
-        <multiple>eds</multiple>
-      </term>
-      <term name="month-03" form="short">March</term>
-      <term name="month-04" form="short">April</term>
-      <term name="month-05" form="short">May</term>
-      <term name="month-06" form="short">June</term>
-      <term name="month-07" form="short">July</term>
+      <term name="et-al">et al.</term>
     </terms>
   </locale>
   <macro name="author">

--- a/deutsche-medizinische-wochenschrift.csl
+++ b/deutsche-medizinische-wochenschrift.csl
@@ -11,11 +11,16 @@
       <name>Robert Wagner</name>
       <email>robert.wagner@med.uni-tuebingen.de</email>
     </author>
+    <contributor>
+      <name>Daniel Kraus</name>
+      <email>bovender@bovender.de</email>
+      <uri>https://www.bovender.de</uri>
+    </contributor>
     <category citation-format="numeric"/>
     <category field="medicine"/>
     <issn>0012-0472</issn>
     <eissn>1439-4413</eissn>
-    <updated>2014-07-07T19:33:00+01:00</updated>
+    <updated>2017-05-05T22:00:00+02:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale xml:lang="en">

--- a/deutsche-medizinische-wochenschrift.csl
+++ b/deutsche-medizinische-wochenschrift.csl
@@ -38,7 +38,7 @@
   </locale>
   <macro name="author">
     <names variable="author">
-      <name initialize-with="" delimiter=", " delimiter-precedes-et-al="never" name-as-sort-order="all" sort-separator=" " et-al-min="4" et-al-use-first="3"/>
+      <name initialize-with="" delimiter=", " delimiter-precedes-et-al="never" name-as-sort-order="all" sort-separator=" "/>
       <label form="short" prefix=", "/>
       <substitute>
         <names variable="editor"/>
@@ -50,15 +50,12 @@
   <macro name="editor">
     <names variable="editor">
       <label form="short" suffix=" " plural="never"/>
-      <name initialize-with="" delimiter=", " et-al-min="7" et-al-use-first="5"/>
+      <name initialize-with="" delimiter=", "/>
     </names>
   </macro>
   <macro name="title">
     <choose>
-      <if type="bill graphic legal_case legislation motion_picture song thesis webpage manuscript" match="any">
-        <text variable="title"/>
-      </if>
-      <else-if type="book" match="any">
+      <if type="book" match="any">
         <group delimiter=", ">
           <text variable="title"/>
           <group>
@@ -66,7 +63,7 @@
             <text variable="volume"/>
           </group>
         </group>
-      </else-if>
+      </if>
       <else>
         <text variable="title"/>
       </else>
@@ -109,10 +106,8 @@
       <if type="article-journal chapter paper-conference" match="any">
         <choose>
           <if variable="volume">
-            <group>
-              <group suffix=": ">
-                <text variable="volume"/>
-              </group>
+            <group delimiter=": ">
+              <text variable="volume"/>
               <text variable="page"/>
             </group>
           </if>
@@ -149,16 +144,15 @@
     <choose>
       <if type="book" match="any">
         <group delimiter=". ">
-          <group suffix=". Aufl.">
-            <number variable="edition"/>
+          <group delimiter=" ">
+            <number variable="edition" form="ordinal"/>
+            <label variable="edition" form="short"/>
           </group>
           <text macro="publisher"/>
         </group>
-        <group prefix="; ">
-          <date variable="issued">
-            <date-part name="year"/>
-          </date>
-        </group>
+        <date variable="issued" prefix="; ">
+          <date-part name="year"/>
+        </date>
       </if>
       <else-if type="chapter" match="any">
         <group delimiter=". ">
@@ -227,16 +221,12 @@
         <group delimiter=". ">
           <text variable="container-title"/>
           <group delimiter="; ">
-            <group prefix="Im Internet: ">
-              <text variable="URL" form="short"/>
-            </group>
-            <group prefix="Stand: ">
-              <date variable="accessed" delimiter=".">
-                <date-part name="day" form="numeric-leading-zeros"/>
-                <date-part name="month" form="numeric-leading-zeros"/>
-                <date-part name="year"/>
-              </date>
-            </group>
+            <text variable="URL" prefix="Im Internet: "/>
+            <date variable="accessed" delimiter="." prefix="Stand: ">
+              <date-part name="day" form="numeric-leading-zeros"/>
+              <date-part name="month" form="numeric-leading-zeros"/>
+              <date-part name="year"/>
+            </date>
           </group>
         </group>
       </else-if>
@@ -256,7 +246,7 @@
       <text variable="citation-number"/>
     </layout>
   </citation>
-  <bibliography entry-spacing="0" second-field-align="flush" line-spacing="1">
+  <bibliography entry-spacing="0" second-field-align="flush" line-spacing="1" et-al-min="4" et-al-use-first="3">
     <sort>
       <key variable="citation-number"/>
     </sort>

--- a/deutsche-medizinische-wochenschrift.csl
+++ b/deutsche-medizinische-wochenschrift.csl
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" page-range-format="chicago" demote-non-dropping-particle="never" default-locale="en-US">
+<style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" page-range-format="expanded" demote-non-dropping-particle="never" default-locale="en-US">
   <info>
     <title>Deutsche Medizinische Wochenschrift (German)</title>
     <title-short>DMW</title-short>

--- a/deutsche-medizinische-wochenschrift.csl
+++ b/deutsche-medizinische-wochenschrift.csl
@@ -33,7 +33,7 @@
   </locale>
   <macro name="author">
     <names variable="author">
-      <name initialize-with="" delimiter=", " name-as-sort-order="all" sort-separator=" " et-al-min="5" et-al-use-first="4" font-style="italic"/>
+      <name initialize-with="" delimiter=", " name-as-sort-order="all" sort-separator=" " et-al-min="4" et-al-use-first="3"/>
       <label form="short" prefix=", "/>
       <substitute>
         <names variable="editor"/>

--- a/deutsche-medizinische-wochenschrift.csl
+++ b/deutsche-medizinische-wochenschrift.csl
@@ -92,7 +92,7 @@
   </macro>
   <macro name="year-date">
     <date variable="issued">
-      <date-part name="year" prefix=" " suffix=";"/>
+      <date-part name="year" prefix=" " suffix="; "/>
     </date>
   </macro>
   <macro name="date-m-d">
@@ -113,7 +113,7 @@
       <if type="article-journal chapter paper-conference" match="any">
         <choose>
           <if variable="volume">
-            <group prefix=". ">
+            <group>
               <group suffix=": ">
                 <text variable="volume"/>
               </group>

--- a/deutsche-medizinische-wochenschrift.csl
+++ b/deutsche-medizinische-wochenschrift.csl
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" page-range-format="chicago" demote-non-dropping-particle="never" default-locale="de-DE">
+<style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" page-range-format="chicago" demote-non-dropping-particle="never" default-locale="en-US">
   <info>
     <title>Deutsche Medizinische Wochenschrift (German)</title>
     <title-short>DMW</title-short>


### PR DESCRIPTION
DMW is a German medical journal. The style did not meet the [requirements](https://www.thieme.de/statics/dokumente/thieme/final/de/dokumente/zw_dmw/Autorenrichtlinien_Uebersicht_Dossier.pdf) (see page 5, "Literaturverzeichnis"). I've fixed the style for the three types of publications that are explicitly defined by DMW, journal article, book, and web page.