### PR TITLE
Update medical-physics.csl

### DIFF
--- a/medical-physics.csl
+++ b/medical-physics.csl
@@ -19,7 +19,7 @@
   </info>
   <macro name="author">
     <names variable="author">
-      <name and="text" initialize-with="."/>
+      <name and="text" et-al-min="7" et-al-use-first="3" initialize-with="."/>
       <label form="short" prefix=" (" suffix=")"/>
       <et-al font-style="italic"/>
       <substitute>

--- a/medical-physics.csl
+++ b/medical-physics.csl
@@ -19,7 +19,7 @@
   </info>
   <macro name="author">
     <names variable="author">
-      <name and="text" et-al-min="7" et-al-use-first="3" initialize-with="."/>
+      <name and="text" initialize-with="."/>
       <label form="short" prefix=" (" suffix=")"/>
       <et-al font-style="italic"/>
       <substitute>
@@ -84,7 +84,7 @@
       <text variable="citation-number"/>
     </layout>
   </citation>
-  <bibliography second-field-align="flush" entry-spacing="0" et-al-min="7" et-al-use-first="1">
+  <bibliography second-field-align="flush" entry-spacing="0" et-al-min="7" et-al-use-first="3">
     <layout suffix=".">
       <text variable="citation-number" vertical-align="sup" suffix=" "/>
       <text macro="author" suffix=", "/>


### PR DESCRIPTION
From the journal publishers: 
> References: We require complete author lists. If there are more than 6 author names in a reference, the first 3 author 
> names are retained with "et al" . Please update your references for completeness and accuracy. 

I have made this correction in the medical-physics.csl file by replacing one line in the authors section with the amended line.