### PR TITLE
Update APA and CPoS

### DIFF
--- a/apa.csl
+++ b/apa.csl
@@ -141,6 +141,13 @@
           <if variable="DOI" match="any">
             <text variable="DOI" prefix="https://doi.org/"/>
           </if>
+          <else-if variable="URL" match="any">
+            <group>
+              <text term="retrieved" text-case="capitalize-first" suffix=" "/>
+              <text term="from" suffix=" "/>
+              <text variable="URL"/>
+            </group>
+          </else-if>
           <else-if variable="archive" match="any">
             <group>
               <text term="retrieved" text-case="capitalize-first" suffix=" "/>
@@ -149,13 +156,6 @@
               <text variable="archive_location" prefix=" (" suffix=")"/>
             </group>
           </else-if>
-          <else>
-            <group>
-              <text term="retrieved" text-case="capitalize-first" suffix=" "/>
-              <text term="from" suffix=" "/>
-              <text variable="URL"/>
-            </group>
-          </else>
         </choose>
       </if>
       <else>

--- a/comparative-population-studies.csl
+++ b/comparative-population-studies.csl
@@ -20,7 +20,7 @@
   </info>
   <macro name="container">
     <choose>
-      <if type="chapter paper-conference" match="any">
+      <if type="chapter paper-conference entry-encyclopedia entry-dictionary" match="any">
         <text term="in" text-case="capitalize-first" suffix=": "/>
         <names variable="editor translator" delimiter="; " suffix=": ">
           <name delimiter-precedes-last="always" initialize-with="." name-as-sort-order="all" font-style="italic"/>
@@ -206,7 +206,7 @@
       <text variable="publisher-place"/>
       <text variable="publisher"/>
       <choose>
-        <if type="chapter paper-conference" match="any">
+        <if type="chapter paper-conference entry-encyclopedia entry-dictionary" match="any">
           <text variable="page"/>
         </if>
       </choose>


### PR DESCRIPTION
For APA:
Switch the priority of URL and Archive name/number for theses and reports. URL is used much more commonly in practice and both are acceptable. URL is more user-friendly.

For CPoS:
Add support for dictionary and encyclopedia entries.