### PR TITLE
Require et-al-min to be greater than et-al-use-first (fix)

### DIFF
--- a/acta-naturae.csl
+++ b/acta-naturae.csl
@@ -112,7 +112,7 @@
       </group>
     </layout>
   </citation>
-  <bibliography et-al-min="10" et-al-use-first="10" second-field-align="flush">
+  <bibliography et-al-min="11" et-al-use-first="10" second-field-align="flush">
     <layout>
       <text variable="citation-number" suffix=". "/>
       <text macro="author"/>

--- a/amphibia-reptilia.csl
+++ b/amphibia-reptilia.csl
@@ -26,7 +26,7 @@
   </macro>
   <macro name="author">
     <names variable="author">
-      <name delimiter-precedes-et-al="never" delimiter-precedes-last="never" et-al-min="19" et-al-use-first="19" et-al-subsequent-min="19" et-al-subsequent-use-first="19" initialize-with="." name-as-sort-order="all"/>
+      <name delimiter-precedes-et-al="never" delimiter-precedes-last="never" initialize-with="." name-as-sort-order="all"/>
     </names>
   </macro>
   <macro name="issued">
@@ -46,7 +46,7 @@
       <label form="short" text-case="capitalize-first" prefix=", "/>
     </names>
   </macro>
-  <citation et-al-min="3" et-al-use-first="1" disambiguate-add-year-suffix="true" collapse="year">
+  <citation et-al-min="4" et-al-use-first="1" disambiguate-add-year-suffix="true" collapse="year">
     <sort>
       <key macro="issued"/>
       <key macro="author"/>
@@ -58,7 +58,7 @@
       </group>
     </layout>
   </citation>
-  <bibliography et-al-min="7" et-al-use-first="6">
+  <bibliography>
     <sort>
       <key macro="author"/>
       <key macro="issued"/>

--- a/arachnology.csl
+++ b/arachnology.csl
@@ -147,7 +147,7 @@
       </else>
     </choose>
   </macro>
-  <citation and="text" et-al-min="3" et-al-use-first="2" disambiguate-add-year-suffix="true" givenname-disambiguation-rule="primary-name" collapse="year-suffix">
+  <citation and="text" et-al-min="3" et-al-use-first="1" disambiguate-add-year-suffix="true" givenname-disambiguation-rule="primary-name" collapse="year-suffix">
     <sort>
       <key macro="author-short"/>
       <key macro="year-date"/>
@@ -162,7 +162,7 @@
       </group>
     </layout>
   </citation>
-  <bibliography et-al-min="99" et-al-use-first="99" hanging-indent="true">
+  <bibliography et-al-min="99" et-al-use-first="98" hanging-indent="true">
     <sort>
       <key macro="author"/>
       <key macro="year-date"/>

--- a/archeologies-et-sciences-de-lantiquite.csl
+++ b/archeologies-et-sciences-de-lantiquite.csl
@@ -605,7 +605,7 @@
       </date>
     </group>
   </macro>
-  <citation et-al-min="15" et-al-use-first="15" initialize-with="." disambiguate-add-year-suffix="true">
+  <citation et-al-min="15" et-al-use-first="14" initialize-with="." disambiguate-add-year-suffix="true">
     <layout suffix="." delimiter=" ; ">
       <choose>
         <if position="ibid-with-locator">
@@ -640,7 +640,7 @@
       </choose>
     </layout>
   </citation>
-  <bibliography et-al-min="15" et-al-use-first="15" initialize-with="." hanging-indent="true">
+  <bibliography et-al-min="15" et-al-use-first="14" initialize-with="." hanging-indent="true">
     <sort>
       <key macro="author-bib"/>
       <key variable="issued" sort="descending"/>

--- a/babes-bolyai-university-faculty-of-orthodox-theology.csl
+++ b/babes-bolyai-university-faculty-of-orthodox-theology.csl
@@ -301,7 +301,7 @@
       </choose>
     </layout>
   </citation>
-  <bibliography hanging-indent="true" et-al-min="6" et-al-use-first="6" entry-spacing="0">
+  <bibliography hanging-indent="true" et-al-min="6" et-al-use-first="5" entry-spacing="0">
     <sort>
       <key macro="author-bib"/>
       <key variable="issue"/>

--- a/bibtex.csl
+++ b/bibtex.csl
@@ -127,7 +127,7 @@
   <macro name="edition">
     <text variable="edition"/>
   </macro>
-  <citation et-al-min="10" et-al-use-first="10" disambiguate-add-year-suffix="true" disambiguate-add-names="false" disambiguate-add-givenname="false" collapse="year">
+  <citation et-al-min="11" et-al-use-first="10" disambiguate-add-year-suffix="true" disambiguate-add-names="false" disambiguate-add-givenname="false" collapse="year">
     <sort>
       <key macro="author"/>
       <key variable="issued"/>
@@ -136,7 +136,7 @@
       <text macro="citeKey"/>
     </layout>
   </citation>
-  <bibliography hanging-indent="false" et-al-min="10" et-al-use-first="10">
+  <bibliography hanging-indent="false" et-al-min="11" et-al-use-first="10">
     <sort>
       <key macro="author"/>
       <key variable="issued"/>

--- a/briefings-in-bioinformatics.csl
+++ b/briefings-in-bioinformatics.csl
@@ -29,7 +29,7 @@
       <text variable="citation-number"/>
     </layout>
   </citation>
-  <bibliography et-al-min="3" et-al-use-first="3" entry-spacing="0">
+  <bibliography et-al-min="4" et-al-use-first="3" entry-spacing="0">
     <layout>
       <text variable="citation-number" suffix=". "/>
       <text macro="author"/>

--- a/campus-adventiste-du-saleve-faculte-adventiste-de-theologie.csl
+++ b/campus-adventiste-du-saleve-faculte-adventiste-de-theologie.csl
@@ -45,7 +45,7 @@
     <choose>
       <if variable="author">
         <names variable="author" font-variant="normal" suffix=", ">
-          <name font-style="normal" delimiter-precedes-et-al="always" delimiter-precedes-last="always" et-al-min="3" et-al-use-first="3" et-al-subsequent-min="3" et-al-subsequent-use-first="1" initialize="false" sort-separator=" ">
+          <name font-style="normal" delimiter-precedes-et-al="always" delimiter-precedes-last="always" et-al-min="4" et-al-use-first="3" et-al-subsequent-min="3" et-al-subsequent-use-first="1" initialize="false" sort-separator=" ">
             <name-part name="family" text-case="sentence" font-variant="small-caps"/>
           </name>
           <et-al font-style="italic"/>
@@ -53,7 +53,7 @@
       </if>
       <else-if variable="editor">
         <names variable="editor" suffix=", ">
-          <name font-style="normal" delimiter-precedes-last="never" et-al-min="3" et-al-use-first="3" et-al-subsequent-min="3" et-al-subsequent-use-first="1" sort-separator=" ">
+          <name font-style="normal" delimiter-precedes-last="never" et-al-min="4" et-al-use-first="3" et-al-subsequent-min="3" et-al-subsequent-use-first="1" sort-separator=" ">
             <name-part name="family" font-variant="small-caps"/>
           </name>
           <label form="short" prefix="&#160;(" suffix=".)"/>
@@ -65,7 +65,7 @@
     <choose>
       <if variable="author">
         <names variable="author" suffix=", ">
-          <name font-style="normal" delimiter-precedes-et-al="always" delimiter-precedes-last="always" et-al-min="3" et-al-use-first="3" et-al-subsequent-min="1" et-al-subsequent-use-first="1" initialize="false" initialize-with="." name-as-sort-order="all" sort-separator=" ">
+          <name font-style="normal" delimiter-precedes-et-al="always" delimiter-precedes-last="always" et-al-min="4" et-al-use-first="3" et-al-subsequent-min="3" et-al-subsequent-use-first="1" initialize="false" initialize-with="." name-as-sort-order="all" sort-separator=" ">
             <name-part name="family" text-case="sentence" font-variant="small-caps"/>
           </name>
           <et-al font-style="italic"/>
@@ -73,7 +73,7 @@
       </if>
       <else-if variable="editor">
         <names variable="editor" suffix=", ">
-          <name font-style="normal" delimiter-precedes-last="never" et-al-min="3" et-al-use-first="3" et-al-subsequent-min="3" et-al-subsequent-use-first="1" name-as-sort-order="all" sort-separator=" ">
+          <name font-style="normal" delimiter-precedes-last="never" et-al-min="4" et-al-use-first="3" et-al-subsequent-min="3" et-al-subsequent-use-first="1" name-as-sort-order="all" sort-separator=" ">
             <name-part name="family" font-variant="small-caps"/>
           </name>
           <label form="short" prefix="&#160;(" suffix=".)"/>
@@ -579,7 +579,7 @@
       </if>
     </choose>
   </macro>
-  <citation et-al-min="3" et-al-use-first="3" et-al-subsequent-min="3" et-al-subsequent-use-first="1">
+  <citation et-al-min="4" et-al-use-first="3" et-al-subsequent-min="3" et-al-subsequent-use-first="1">
     <layout suffix="." delimiter="&#160;; ">
       <choose>
         <if position="ibid-with-locator">

--- a/chinese-gb7714-1987-numeric.csl
+++ b/chinese-gb7714-1987-numeric.csl
@@ -178,7 +178,7 @@
       <text variable="citation-number"/>
     </layout>
   </citation>
-  <bibliography et-al-min="3" et-al-use-first="3" second-field-align="flush" entry-spacing="0">
+  <bibliography et-al-min="3" et-al-use-first="1" second-field-align="flush" entry-spacing="0">
     <layout suffix=".">
       <text variable="citation-number" prefix="[" suffix="]"/>
       <text macro="author" suffix=". "/>

--- a/chinese-gb7714-2005-numeric.csl
+++ b/chinese-gb7714-2005-numeric.csl
@@ -189,7 +189,7 @@
       <text variable="citation-number"/>
     </layout>
   </citation>
-  <bibliography et-al-min="3" et-al-use-first="3" second-field-align="flush" entry-spacing="0">
+  <bibliography et-al-min="3" et-al-use-first="1" second-field-align="flush" entry-spacing="0">
     <layout suffix=".">
       <text variable="citation-number" prefix="[" suffix="]"/>
       <text macro="author" suffix=". "/>

--- a/clinical-spine-surgery.csl
+++ b/clinical-spine-surgery.csl
@@ -2,19 +2,19 @@
 <style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" demote-non-dropping-particle="sort-only" default-locale="en-US">
   <!-- This style was edited with the Visual CSL Editor (http://editor.citationstyles.org/visualEditor/) -->
   <info>
-    <title>Journal of Spinal Disorders &amp; Techniques</title>
-    <id>http://www.zotero.org/styles/journal-of-spinal-disorders-and-techniques</id>
-    <link href="http://www.zotero.org/styles/journal-of-spinal-disorders-and-techniques" rel="self"/>
+    <title>Clinical Spine Surgery</title>
+    <id>http://www.zotero.org/styles/clinical-spine-surgery</id>
+    <link href="http://www.zotero.org/styles/clinical-spine-surgery" rel="self"/>
     <link href="http://www.zotero.org/styles/american-medical-association" rel="template"/>
-    <link href="http://edmgr.ovid.com/jsdt/accounts/ifauth.htm" rel="documentation"/>
+    <link href="http://journals.lww.com/jspinaldisorders/Pages/Information-for-Authors.aspx" rel="documentation"/>
     <author>
       <name>Paul Millhouse</name>
       <email>dryphi@gmail.com</email>
     </author>
     <category citation-format="numeric"/>
     <category field="medicine"/>
-    <issn>1536-0652</issn>
-    <eissn>1539-2465</eissn>
+    <issn>2380-0186</issn>
+    <eissn>2380-0194</eissn>
     <summary>Based on the American Medical Association style as used in JAMA, without the DOI, and with et al after three authors</summary>
     <updated>2013-07-24T01:42:58+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
@@ -28,7 +28,7 @@
   <macro name="author">
     <group suffix=".">
       <names variable="author">
-        <name delimiter-precedes-last="always" et-al-min="3" et-al-use-first="3" initialize-with="" name-as-sort-order="all" sort-separator=" "/>
+        <name delimiter-precedes-last="always" initialize-with="" name-as-sort-order="all" sort-separator=" "/>
         <label form="short" prefix=", "/>
         <substitute>
           <names variable="editor"/>
@@ -78,7 +78,7 @@
       </group>
     </layout>
   </citation>
-  <bibliography hanging-indent="false" et-al-min="7" et-al-use-first="3">
+  <bibliography hanging-indent="false" et-al-min="4" et-al-use-first="3">
     <layout>
       <text variable="citation-number" suffix=". "/>
       <text macro="author"/>

--- a/din-1505-2-numeric-alphabetical.csl
+++ b/din-1505-2-numeric-alphabetical.csl
@@ -217,7 +217,7 @@
     </layout>
   </citation>
   <!-- End of in-text citation -->
-  <bibliography hanging-indent="true" et-al-min="9" et-al-use-first="9" entry-spacing="0" second-field-align="flush">
+  <bibliography hanging-indent="true" et-al-min="9" et-al-use-first="8" entry-spacing="0" second-field-align="flush">
     <sort>
       <key macro="author-sort"/>
       <key variable="issued"/>

--- a/din-1505-2-numeric.csl
+++ b/din-1505-2-numeric.csl
@@ -207,7 +207,7 @@
     </layout>
   </citation>
   <!-- End of in-text citation -->
-  <bibliography hanging-indent="true" et-al-min="9" et-al-use-first="9" entry-spacing="0" second-field-align="flush">
+  <bibliography hanging-indent="true" et-al-min="9" et-al-use-first="8" entry-spacing="0" second-field-align="flush">
     <layout>
       <!-- Citation Number -->
       <text variable="citation-number" prefix="[" suffix="]"/>

--- a/din-1505-2.csl
+++ b/din-1505-2.csl
@@ -277,7 +277,7 @@
       </group>
     </layout>
   </citation>
-  <bibliography hanging-indent="true" et-al-min="9" et-al-use-first="9">
+  <bibliography hanging-indent="true" et-al-min="9" et-al-use-first="8">
     <sort>
       <key macro="author"/>
       <key variable="issued"/>

--- a/environmental-and-engineering-geoscience.csl
+++ b/environmental-and-engineering-geoscience.csl
@@ -74,7 +74,7 @@
       </group>
     </layout>
   </citation>
-  <bibliography hanging-indent="true" et-al-min="15" et-al-use-first="15">
+  <bibliography hanging-indent="true" et-al-min="15" et-al-use-first="14">
     <sort>
       <key macro="author-short"/>
       <key variable="title"/>

--- a/environmental-health-perspectives.csl
+++ b/environmental-health-perspectives.csl
@@ -131,7 +131,7 @@
       </group>
     </layout>
   </citation>
-  <bibliography hanging-indent="true" et-al-min="6" et-al-use-first="6">
+  <bibliography hanging-indent="true" et-al-min="7" et-al-use-first="6">
     <sort>
       <key macro="author"/>
       <key variable="title"/>

--- a/european-journal-of-international-law.csl
+++ b/european-journal-of-international-law.csl
@@ -5,7 +5,7 @@
     <id>http://www.zotero.org/styles/european-journal-of-international-law</id>
     <link href="http://www.zotero.org/styles/european-journal-of-international-law" rel="self"/>
     <link href="http://www.zotero.org/styles/vienna-legal" rel="template"/>
-    <link href="http://www.ejil.org/about/Stylesheet_EJIL_2014.pdf" rel="documentation"/>
+    <link href="http://www.ejil.org/about/Stylesheet_EJIL_2016.pdf" rel="documentation"/>
     <author>
       <name>Catherine Brendow</name>
       <email>catherine.brendow@graduateinstitute.ch</email>
@@ -24,13 +24,13 @@
   </locale>
   <macro name="editor">
     <names variable="editor" delimiter=", ">
-      <name prefix=" " and="text" delimiter-precedes-last="never" et-al-min="4" et-al-use-first="1" initialize-with=". "/>
+      <name prefix=" " and="text" delimiter-precedes-last="never" initialize-with=". "/>
       <label form="short" prefix=" (" suffix="), "/>
     </names>
   </macro>
   <macro name="author">
     <names variable="author">
-      <name form="short" and="text" delimiter-precedes-last="never" et-al-min="4" et-al-use-first="1" initialize-with="" sort-separator=""/>
+      <name form="short" and="text" delimiter-precedes-last="never" initialize-with="" sort-separator=""/>
       <label form="short" prefix=" (" suffix=")"/>
       <substitute>
         <names variable="editor"/>
@@ -39,7 +39,7 @@
   </macro>
   <macro name="author-bibliography">
     <names variable="author">
-      <name and="text" delimiter-precedes-last="never" et-al-min="4" et-al-use-first="1" initialize-with="." name-as-sort-order="all" sort-separator=" "/>
+      <name and="text" delimiter-precedes-last="never" initialize-with="." name-as-sort-order="all" sort-separator=" "/>
       <label form="short" prefix=" (" suffix=")"/>
       <substitute>
         <names variable="editor"/>
@@ -48,10 +48,10 @@
   </macro>
   <macro name="author-long">
     <names variable="author">
-      <name and="text" delimiter-precedes-last="never" et-al-min="4" et-al-use-first="1" initialize-with=". "/>
+      <name and="text" delimiter-precedes-last="never" initialize-with=". "/>
       <substitute>
         <names variable="editor">
-          <name and="text" delimiter-precedes-last="never" et-al-min="4" et-al-use-first="1" initialize-with=". " sort-separator=" "/>
+          <name and="text" delimiter-precedes-last="never" initialize-with=". " sort-separator=" "/>
           <label form="short" prefix=" (" suffix=")"/>
         </names>
       </substitute>
@@ -134,7 +134,7 @@
       </if>
     </choose>
   </macro>
-  <citation et-al-min="6" et-al-use-first="1" et-al-subsequent-min="3" et-al-subsequent-use-first="1" collapse="year">
+  <citation collapse="year">
     <sort>
       <key macro="author"/>
       <key variable="issued"/>
@@ -266,7 +266,7 @@
       </choose>
     </layout>
   </citation>
-  <bibliography hanging-indent="true" et-al-min="6" et-al-use-first="6">
+  <bibliography hanging-indent="true">
     <sort>
       <key macro="author-bibliography"/>
       <key variable="title"/>
@@ -322,7 +322,7 @@
         <else-if type="article-journal article-magazine article-newspaper interview manuscript map personal_communication speech" match="any">
           <group delimiter=" ">
             <names variable="author" suffix=", ">
-              <name form="short" and="text" et-al-min="4" et-al-use-first="1"/>
+              <name form="short" and="text"/>
             </names>
             <text variable="title" text-case="title" prefix="'" suffix="', "/>
             <text variable="volume"/>

--- a/evolutionary-anthropology.csl
+++ b/evolutionary-anthropology.csl
@@ -191,7 +191,7 @@
       <text variable="citation-number"/>
     </layout>
   </citation>
-  <bibliography et-al-min="3" et-al-use-first="3">
+  <bibliography et-al-min="3" et-al-use-first="1">
     <layout>
       <text variable="citation-number" suffix=" " font-weight="bold"/>
       <group delimiter=". " suffix=". ">

--- a/fertility-and-sterility.csl
+++ b/fertility-and-sterility.csl
@@ -116,7 +116,7 @@
       <text variable="citation-number"/>
     </layout>
   </citation>
-  <bibliography et-al-min="6" et-al-use-first="6" second-field-align="flush">
+  <bibliography et-al-min="7" et-al-use-first="6" second-field-align="flush">
     <layout>
       <text variable="citation-number" suffix=". "/>
       <text macro="author"/>

--- a/genetics-and-molecular-biology.csl
+++ b/genetics-and-molecular-biology.csl
@@ -91,7 +91,7 @@
       </group>
     </layout>
   </citation>
-  <bibliography et-al-min="10" et-al-use-first="10">
+  <bibliography et-al-min="11" et-al-use-first="10">
     <sort>
       <key macro="author"/>
       <key variable="author" sort="ascending"/>

--- a/handbook-of-clinical-neurology.csl
+++ b/handbook-of-clinical-neurology.csl
@@ -202,7 +202,7 @@
       </group>
     </layout>
   </citation>
-  <bibliography et-al-min="3" et-al-use-first="3" hanging-indent="true" entry-spacing="0" line-spacing="1">
+  <bibliography et-al-min="4" et-al-use-first="3" hanging-indent="true" entry-spacing="0" line-spacing="1">
     <sort>
       <key macro="author"/>
       <key macro="issued" sort="descending"/>

--- a/harvard-newcastle-university.csl
+++ b/harvard-newcastle-university.csl
@@ -26,7 +26,7 @@
   </macro>
   <macro name="author">
     <names variable="author">
-      <name and="symbol" delimiter-precedes-last="never" et-al-min="19" et-al-use-first="19" et-al-subsequent-min="19" et-al-subsequent-use-first="19" initialize-with="." name-as-sort-order="all"/>
+      <name and="symbol" delimiter-precedes-last="never" initialize-with="." name-as-sort-order="all"/>
       <label form="short" prefix=" (" suffix=".)"/>
       <substitute>
         <names variable="editor"/>
@@ -36,7 +36,7 @@
   </macro>
   <macro name="author-short">
     <names variable="author">
-      <name form="short" and="symbol" et-al-min="3" et-al-use-last="true" initialize-with=". " sort-separator=","/>
+      <name form="short" and="symbol" et-al-use-last="true" initialize-with=". " sort-separator=","/>
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
@@ -161,7 +161,7 @@
       </group>
     </layout>
   </citation>
-  <bibliography hanging-indent="true" et-al-min="3" et-al-use-first="1">
+  <bibliography hanging-indent="true" et-al-min="20" et-al-use-first="19">
     <sort>
       <key macro="author"/>
       <key variable="title"/>

--- a/harvard-the-university-of-sheffield-town-and-regional-planning.csl
+++ b/harvard-the-university-of-sheffield-town-and-regional-planning.csl
@@ -6,7 +6,7 @@
     <link href="http://www.zotero.org/styles/harvard-the-university-of-sheffield-town-and-regional-planning" rel="self"/>
     <link href="http://www.zotero.org/styles/apa" rel="template"/>
     <link href="http://www.zotero.org/styles/urban-studies" rel="template"/>
-    <link href="http://www.librarydevelopment.group.shef.ac.uk/isr.html" rel="documentation"/>
+    <link href="http://www.librarydevelopment.group.shef.ac.uk/referencing.html" rel="documentation"/>
     <author>
       <name>Alexandru Ghita</name>
     </author>
@@ -83,7 +83,7 @@
       <text variable="publisher"/>
     </group>
   </macro>
-  <citation et-al-min="3" et-al-use-first="1" disambiguate-add-year-suffix="true" disambiguate-add-names="true" disambiguate-add-givenname="true" collapse="year">
+  <citation et-al-min="4" et-al-use-first="1" disambiguate-add-year-suffix="true" disambiguate-add-names="true" disambiguate-add-givenname="true" collapse="year">
     <sort>
       <key variable="issued" sort="descending"/>
       <key macro="author"/>
@@ -101,7 +101,7 @@
       </group>
     </layout>
   </citation>
-  <bibliography hanging-indent="true" et-al-min="6" et-al-use-first="6">
+  <bibliography hanging-indent="true" et-al-min="20" et-al-use-first="1">
     <sort>
       <key macro="author"/>
       <key variable="issued"/>

--- a/harvard-university-of-birmingham.csl
+++ b/harvard-university-of-birmingham.csl
@@ -263,7 +263,7 @@
       </group>
     </layout>
   </citation>
-  <bibliography hanging-indent="false" et-al-min="3" et-al-use-first="3">
+  <bibliography hanging-indent="false" et-al-min="4" et-al-use-first="3">
     <sort>
       <key macro="author"/>
       <key macro="year-date" sort="ascending"/>

--- a/harvard-university-of-gloucestershire.csl
+++ b/harvard-university-of-gloucestershire.csl
@@ -110,7 +110,7 @@
       <text variable="publisher"/>
     </group>
   </macro>
-  <citation et-al-min="3" et-al-use-first="1" disambiguate-add-year-suffix="true" year-suffix-delimiter="," disambiguate-add-names="true" disambiguate-add-givenname="false" collapse="year-suffix">
+  <citation et-al-min="4" et-al-use-first="1" disambiguate-add-year-suffix="true" year-suffix-delimiter="," disambiguate-add-names="true" disambiguate-add-givenname="false" collapse="year-suffix">
     <sort>
       <key variable="issued" sort="ascending"/>
       <key macro="author"/>
@@ -128,7 +128,7 @@
       </group>
     </layout>
   </citation>
-  <bibliography hanging-indent="false" et-al-min="6" et-al-use-first="6" entry-spacing="0" line-spacing="1">
+  <bibliography hanging-indent="false" et-al-min="99" et-al-use-first="98" entry-spacing="0" line-spacing="1">
     <sort>
       <key macro="author"/>
       <key variable="issued"/>

--- a/harvard-university-of-worcester.csl
+++ b/harvard-university-of-worcester.csl
@@ -4,7 +4,7 @@
     <title>University of Worcester - Harvard</title>
     <id>http://www.zotero.org/styles/harvard-university-of-worcester</id>
     <link href="http://www.zotero.org/styles/harvard-university-of-worcester" rel="self"/>
-    <link href="http://www.worc.ac.uk/ils/documents/Harvard_referencing" rel="documentation"/>
+    <link href="http://library.worc.ac.uk/guides/study-skills/referencing" rel="documentation"/>
     <author>
       <name>Christopher Hill</name>
       <uri>http://www.mendeley.com/profiles/christopher-hill7/</uri>
@@ -25,7 +25,7 @@
   </macro>
   <macro name="author">
     <names variable="author">
-      <name and="symbol" delimiter-precedes-et-al="never" delimiter-precedes-last="never" et-al-min="19" et-al-use-first="19" initialize-with="." name-as-sort-order="all"/>
+      <name and="symbol" delimiter-precedes-et-al="never" delimiter-precedes-last="never" initialize-with="." name-as-sort-order="all"/>
       <label form="short" prefix=" "/>
       <substitute>
         <text macro="substitute-author"/>
@@ -261,7 +261,7 @@
       </else>
     </choose>
   </macro>
-  <citation et-al-min="3" et-al-use-first="1" sort-separator="," disambiguate-add-year-suffix="true" collapse="year">
+  <citation et-al-min="4" et-al-use-first="1" sort-separator="," disambiguate-add-year-suffix="true" collapse="year">
     <sort>
       <key macro="author" names-use-last="true"/>
     </sort>
@@ -276,7 +276,7 @@
       </group>
     </layout>
   </citation>
-  <bibliography et-al-use-first="19" et-al-min="20" hanging-indent="false">
+  <bibliography et-al-min="4" et-al-use-first="1" hanging-indent="false">
     <sort>
       <key macro="author"/>
       <key variable="title"/>

--- a/hong-kong-journal-of-radiology.csl
+++ b/hong-kong-journal-of-radiology.csl
@@ -124,7 +124,7 @@
       <text variable="citation-number"/>
     </layout>
   </citation>
-  <bibliography et-al-min="99" et-al-use-first="99" second-field-align="flush">
+  <bibliography et-al-min="99" et-al-use-first="98" second-field-align="flush">
     <layout>
       <text variable="citation-number" suffix=". "/>
       <text macro="author"/>

--- a/human-resource-management-journal.csl
+++ b/human-resource-management-journal.csl
@@ -212,7 +212,7 @@
       </group>
     </layout>
   </citation>
-  <bibliography hanging-indent="true" et-al-min="6" et-al-use-first="6" entry-spacing="0">
+  <bibliography hanging-indent="true" et-al-min="8" et-al-use-first="6" et-al-use-last="true" entry-spacing="0">
     <sort>
       <key macro="author"/>
       <key variable="issued"/>

--- a/immunological-reviews.csl
+++ b/immunological-reviews.csl
@@ -46,7 +46,7 @@
         <else-if type="article-journal">
           <text variable="citation-number" suffix=".          "/>
           <names variable="author" suffix=". ">
-            <name et-al-min="7" et-al-use-first="7" delimiter=", " name-as-sort-order="all" sort-separator=", " form="long" initialize-with=""/>
+            <name et-al-min="7" et-al-use-first="3" delimiter=", " name-as-sort-order="all" sort-separator=", " form="long" initialize-with=""/>
           </names>
           <text variable="title" suffix=". "/>
           <text variable="container-title" form="short" suffix=" "/>

--- a/inter-ro.csl
+++ b/inter-ro.csl
@@ -296,7 +296,7 @@
       </choose>
     </layout>
   </citation>
-  <bibliography hanging-indent="true" et-al-min="6" et-al-use-first="6" entry-spacing="0">
+  <bibliography hanging-indent="true" et-al-min="7" et-al-use-first="6" entry-spacing="0">
     <sort>
       <key macro="author-bib"/>
       <key variable="issue"/>

--- a/journal-of-animal-physiology-and-animal-nutrition.csl
+++ b/journal-of-animal-physiology-and-animal-nutrition.csl
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" et-al-min="2" et-al-use-first="2" et-al-subsequent-min="3" et-al-subsequent-use-first="1" page-range-format="expanded" initialize-with-hyphen="false" demote-non-dropping-particle="never" default-locale="en-GB">
+<style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" page-range-format="expanded" initialize-with-hyphen="false" demote-non-dropping-particle="never" default-locale="en-GB">
   <info>
     <title>Journal of Animal Physiology and Animal Nutrition</title>
     <title-short>JAPAN</title-short>
@@ -282,7 +282,7 @@
       </group>
     </layout>
   </citation>
-  <bibliography delimiter-precedes-et-al="never" delimiter-precedes-last="never" et-al-min="19" et-al-use-first="19" name-as-sort-order="first" entry-spacing="0" line-spacing="2">
+  <bibliography delimiter-precedes-et-al="never" delimiter-precedes-last="never" et-al-min="20" et-al-use-first="19" name-as-sort-order="first" entry-spacing="0" line-spacing="2">
     <sort>
       <key macro="author" names-min="1" names-use-first="1"/>
       <key macro="issued-year" sort="ascending"/>

--- a/journal-of-biological-regulators-and-homeostatic-agents.csl
+++ b/journal-of-biological-regulators-and-homeostatic-agents.csl
@@ -19,7 +19,7 @@
   </info>
   <macro name="author">
     <names variable="author" suffix=". ">
-      <name et-al-min="19" et-al-use-first="19" initialize-with="" name-as-sort-order="all" sort-separator=" "/>
+      <name et-al-min="20" et-al-use-first="19" initialize-with="" name-as-sort-order="all" sort-separator=" "/>
       <label form="long" prefix=", "/>
       <substitute>
         <names variable="editor"/>

--- a/journal-of-burn-care-and-research.csl
+++ b/journal-of-burn-care-and-research.csl
@@ -108,7 +108,7 @@
       </group>
     </layout>
   </citation>
-  <bibliography hanging-indent="false" et-al-min="3" et-al-use-first="3" second-field-align="flush">
+  <bibliography hanging-indent="false" et-al-min="4" et-al-use-first="3" second-field-align="flush">
     <layout>
       <text variable="citation-number" suffix=". "/>
       <text macro="author"/>

--- a/journal-of-management-studies.csl
+++ b/journal-of-management-studies.csl
@@ -210,7 +210,7 @@
       </group>
     </layout>
   </citation>
-  <bibliography hanging-indent="true" et-al-min="6" et-al-use-first="6" entry-spacing="0">
+  <bibliography hanging-indent="true" et-al-min="7" et-al-use-first="6" entry-spacing="0">
     <sort>
       <key macro="author"/>
       <key variable="issued"/>

--- a/journal-of-the-american-society-of-brewing-chemists.csl
+++ b/journal-of-the-american-society-of-brewing-chemists.csl
@@ -71,7 +71,7 @@
       </group>
     </layout>
   </citation>
-  <bibliography hanging-indent="true" et-al-min="6" et-al-use-first="6" entry-spacing="0">
+  <bibliography hanging-indent="true" et-al-min="7" et-al-use-first="6" entry-spacing="0">
     <sort>
       <key macro="author"/>
       <key variable="issued"/>

--- a/journal-of-the-korean-society-of-civil-engineers.csl
+++ b/journal-of-the-korean-society-of-civil-engineers.csl
@@ -75,7 +75,7 @@
       </group>
     </layout>
   </citation>
-  <bibliography delimiter-precedes-last="never" et-al-min="15" et-al-use-first="15" hanging-indent="true">
+  <bibliography delimiter-precedes-last="never" et-al-min="16" et-al-use-first="15" hanging-indent="true">
     <sort>
       <key macro="author-short"/>
       <key variable="issued"/>

--- a/ksce-journal-of-civil-engineering.csl
+++ b/ksce-journal-of-civil-engineering.csl
@@ -71,7 +71,7 @@
       </group>
     </layout>
   </citation>
-  <bibliography delimiter-precedes-last="never" et-al-min="15" et-al-use-first="15" hanging-indent="true">
+  <bibliography delimiter-precedes-last="never" et-al-min="16" et-al-use-first="15" hanging-indent="true">
     <sort>
       <key macro="author-short"/>
       <key variable="title"/>

--- a/leiden-journal-of-international-law.csl
+++ b/leiden-journal-of-international-law.csl
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<style xmlns="http://purl.org/net/xbiblio/csl" class="note" version="1.0" and="symbol" et-al-min="3" initialize-with="." sort-separator=" " initialize-with-hyphen="false" demote-non-dropping-particle="never" default-locale="en-GB">
+<style xmlns="http://purl.org/net/xbiblio/csl" class="note" version="1.0" and="symbol" initialize-with="." sort-separator=" " initialize-with-hyphen="false" demote-non-dropping-particle="never" default-locale="en-GB">
   <info>
     <title>Leiden Journal of International Law</title>
     <title-short>LJIL</title-short>
@@ -40,7 +40,7 @@
       <term name="et-al">et al</term>
     </terms>
   </locale>
-  <citation and="symbol" et-al-min="3" et-al-use-first="1" et-al-subsequent-min="1" et-al-subsequent-use-first="1" initialize-with=".">
+  <citation and="symbol" et-al-min="3" et-al-use-first="1" initialize-with=".">
     <layout delimiter="; ">
       <choose>
         <if position="ibid-with-locator">

--- a/limnetica.csl
+++ b/limnetica.csl
@@ -44,7 +44,7 @@
   </macro>
   <macro name="author-short">
     <names variable="author">
-      <name form="short" and="symbol" et-al-min="3" et-al-use-first="1" initialize-with=". "/>
+      <name form="short" and="symbol" initialize-with=". "/>
       <et-al font-style="italic"/>
       <substitute>
         <names variable="editor"/>
@@ -143,7 +143,7 @@
       </else>
     </choose>
   </macro>
-  <citation and="text" et-al-min="3" et-al-use-first="2" disambiguate-add-year-suffix="true" givenname-disambiguation-rule="primary-name" collapse="year-suffix">
+  <citation and="text" et-al-min="3" et-al-use-first="1" disambiguate-add-year-suffix="true" givenname-disambiguation-rule="primary-name" collapse="year-suffix">
     <sort>
       <key macro="year-date"/>
       <key macro="author-short"/>
@@ -158,7 +158,7 @@
       </group>
     </layout>
   </citation>
-  <bibliography et-al-min="99" et-al-use-first="99" hanging-indent="true">
+  <bibliography et-al-min="99" et-al-use-first="98" hanging-indent="true">
     <sort>
       <key macro="author"/>
       <key macro="year-date"/>

--- a/mohr-siebeck-recht.csl
+++ b/mohr-siebeck-recht.csl
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<style xmlns="http://purl.org/net/xbiblio/csl" class="note" version="1.0" delimiter-precedes-et-al="never" delimiter-precedes-last="never" et-al-min="10" et-al-use-first="10" initialize="false" page-range-format="expanded" demote-non-dropping-particle="never" default-locale="de-AT">
+<style xmlns="http://purl.org/net/xbiblio/csl" class="note" version="1.0" delimiter-precedes-et-al="never" delimiter-precedes-last="never" et-al-min="11" et-al-use-first="10" initialize="false" page-range-format="expanded" demote-non-dropping-particle="never" default-locale="de-AT">
   <info>
     <title>Mohr Siebeck - Recht (German - Austria)</title>
     <id>http://www.zotero.org/styles/mohr-siebeck-recht</id>
@@ -17,20 +17,20 @@
   </info>
   <macro name="author-article-journal">
     <names variable="author" font-style="italic">
-      <name form="short" delimiter="/" delimiter-precedes-et-al="never" delimiter-precedes-last="never" et-al-min="5" et-al-use-first="5" initialize="false"/>
+      <name form="short" delimiter="/" delimiter-precedes-et-al="never" delimiter-precedes-last="never" et-al-min="6" et-al-use-first="5" initialize="false"/>
       <et-al font-style="italic"/>
     </names>
   </macro>
   <macro name="author-book">
     <names variable="author" font-style="italic">
-      <name form="short" delimiter="/" delimiter-precedes-et-al="never" delimiter-precedes-last="never" et-al-min="5" et-al-use-first="5" initialize="false"/>
+      <name form="short" delimiter="/" delimiter-precedes-et-al="never" delimiter-precedes-last="never" et-al-min="6" et-al-use-first="5" initialize="false"/>
       <et-al/>
     </names>
     <text variable="title" form="short" prefix=", " suffix=" "/>
   </macro>
   <macro name="author-chapter">
     <names variable="author" font-style="italic">
-      <name form="short" font-style="italic" delimiter="/" delimiter-precedes-et-al="never" delimiter-precedes-last="never" et-al-min="5" et-al-use-first="5" initialize="false"/>
+      <name form="short" font-style="italic" delimiter="/" delimiter-precedes-et-al="never" delimiter-precedes-last="never" et-al-min="6" et-al-use-first="5" initialize="false"/>
       <et-al font-style="italic"/>
     </names>
     <text value="in: " prefix=", "/>
@@ -38,7 +38,7 @@
   </macro>
   <macro name="author-article-newspaper">
     <names variable="author" font-style="normal">
-      <name form="short" delimiter="/ " delimiter-precedes-et-al="never" delimiter-precedes-last="never" et-al-min="19" et-al-use-first="19" initialize="false"/>
+      <name form="short" delimiter="/ " delimiter-precedes-et-al="never" delimiter-precedes-last="never" et-al-min="20" et-al-use-first="19" initialize="false"/>
     </names>
   </macro>
   <macro name="authority">
@@ -153,7 +153,7 @@
       <choose>
         <if type="article-journal" match="any">
           <names variable="author" font-style="italic">
-            <name font-style="italic" delimiter="/" delimiter-precedes-et-al="never" delimiter-precedes-last="never" et-al-min="6" et-al-use-first="6" initialize="false" name-as-sort-order="all"/>
+            <name font-style="italic" delimiter="/" delimiter-precedes-et-al="never" delimiter-precedes-last="never" et-al-min="7" et-al-use-first="6" initialize="false" name-as-sort-order="all"/>
           </names>
           <text variable="title" prefix=": " suffix=", "/>
           <text variable="collection-title" suffix=", "/>
@@ -163,7 +163,7 @@
         </if>
         <else-if type="book" match="all">
           <names variable="author">
-            <name font-style="italic" delimiter="/" delimiter-precedes-et-al="never" delimiter-precedes-last="never" et-al-min="6" et-al-use-first="6" initialize="false" name-as-sort-order="all"/>
+            <name font-style="italic" delimiter="/" delimiter-precedes-et-al="never" delimiter-precedes-last="never" et-al-min="7" et-al-use-first="6" initialize="false" name-as-sort-order="all"/>
           </names>
           <text variable="title" prefix=": " suffix=", "/>
           <choose>
@@ -182,13 +182,13 @@
         </else-if>
         <else-if type="chapter" match="any">
           <names variable="author" font-style="italic">
-            <name font-style="italic" delimiter="/" delimiter-precedes-et-al="never" delimiter-precedes-last="never" et-al-min="6" et-al-use-first="6" initialize="false" name-as-sort-order="all"/>
+            <name font-style="italic" delimiter="/" delimiter-precedes-et-al="never" delimiter-precedes-last="never" et-al-min="7" et-al-use-first="6" initialize="false" name-as-sort-order="all"/>
           </names>
           <text variable="title" prefix=": " suffix=", "/>
           <choose>
             <if match="all" variable="editor">
               <names variable="editor" font-variant="normal" delimiter="/" prefix="in: " suffix=" (Hrsg.): ">
-                <name form="short" delimiter="/" delimiter-precedes-et-al="never" delimiter-precedes-last="never" et-al-min="6" et-al-use-first="6" name-as-sort-order="all"/>
+                <name form="short" delimiter="/" delimiter-precedes-et-al="never" delimiter-precedes-last="never" et-al-min="7" et-al-use-first="6" name-as-sort-order="all"/>
               </names>
               <text variable="container-title" suffix=", "/>
             </if>
@@ -207,7 +207,7 @@
           <choose>
             <if match="all" variable="editor">
               <names variable="editor" font-style="italic" delimiter="/">
-                <name font-style="italic" delimiter="/" delimiter-precedes-et-al="never" delimiter-precedes-last="never" et-al-min="6" et-al-use-first="6" initialize="false" name-as-sort-order="all"/>
+                <name font-style="italic" delimiter="/" delimiter-precedes-et-al="never" delimiter-precedes-last="never" et-al-min="7" et-al-use-first="6" initialize="false" name-as-sort-order="all"/>
               </names>
               <text value="(Hrsg.): "/>
             </if>

--- a/moore-theological-college.csl
+++ b/moore-theological-college.csl
@@ -677,7 +677,7 @@
       </choose>
     </layout>
   </citation>
-  <bibliography hanging-indent="true" et-al-min="6" et-al-use-first="6" subsequent-author-substitute="_____" entry-spacing="0">
+  <bibliography hanging-indent="true" et-al-min="7" et-al-use-first="6" subsequent-author-substitute="_____" entry-spacing="0">
     <sort>
       <key macro="sort-key"/>
     </sort>

--- a/national-natural-science-foundation-of-china.csl
+++ b/national-natural-science-foundation-of-china.csl
@@ -21,7 +21,7 @@
   </info>
   <macro name="author">
     <names variable="author">
-      <name delimiter-precedes-last="always" et-al-min="999" et-al-use-first="800" initialize-with=" " name-as-sort-order="all" sort-separator=" ">
+      <name delimiter-precedes-last="always" et-al-min="99" et-al-use-first="98" initialize-with=" " name-as-sort-order="all" sort-separator=" ">
         <name-part name="given" text-case="uppercase" font-variant="normal"/>
       </name>
     </names>
@@ -156,7 +156,7 @@
       <text variable="citation-number"/>
     </layout>
   </citation>
-  <bibliography et-al-min="3" et-al-use-first="3" second-field-align="flush" entry-spacing="0">
+  <bibliography et-al-min="4" et-al-use-first="3" second-field-align="flush" entry-spacing="0">
     <layout suffix=".">
       <text variable="citation-number" prefix="[" suffix="]"/>
       <text macro="author" suffix=". "/>

--- a/new-phytologist.csl
+++ b/new-phytologist.csl
@@ -87,7 +87,7 @@
       </group>
     </layout>
   </citation>
-  <bibliography et-al-min="10" et-al-use-first="10" hanging-indent="false">
+  <bibliography et-al-min="11" et-al-use-first="10" hanging-indent="false">
     <sort>
       <key macro="author-short"/>
       <key variable="issued"/>

--- a/owbarth-verlag.csl
+++ b/owbarth-verlag.csl
@@ -227,7 +227,7 @@
       </group>
     </layout>
   </citation>
-  <bibliography hanging-indent="true" et-al-min="9" et-al-use-first="9">
+  <bibliography hanging-indent="true" et-al-min="10" et-al-use-first="9">
     <sort>
       <key macro="author"/>
       <key variable="issued"/>

--- a/palaeontologia-electronica.csl
+++ b/palaeontologia-electronica.csl
@@ -194,7 +194,7 @@
       </group>
     </layout>
   </citation>
-  <bibliography hanging-indent="true" et-al-min="99" et-al-use-first="99" entry-spacing="0" line-spacing="2">
+  <bibliography hanging-indent="true" et-al-min="99" et-al-use-first="98" entry-spacing="0" line-spacing="2">
     <sort>
       <key macro="author"/>
       <key variable="issued"/>

--- a/pontifical-athenaeum-regina-apostolorum.csl
+++ b/pontifical-athenaeum-regina-apostolorum.csl
@@ -385,7 +385,7 @@
       </choose>
     </layout>
   </citation>
-  <bibliography et-al-use-first="6" et-al-min="6" hanging-indent="true" subsequent-author-substitute="&#8211;&#8211;&#8211;">
+  <bibliography et-al-min="7" et-al-use-first="6" hanging-indent="true" subsequent-author-substitute="&#8211;&#8211;&#8211;">
     <sort>
       <key macro="author"/>
       <key variable="title"/>

--- a/protein-science.csl
+++ b/protein-science.csl
@@ -96,7 +96,7 @@
       </group>
     </layout>
   </citation>
-  <bibliography hanging-indent="false" et-al-min="10" et-al-use-first="10">
+  <bibliography hanging-indent="false" et-al-min="11" et-al-use-first="10">
     <layout>
       <text variable="citation-number" suffix=". "/>
       <text macro="author"/>

--- a/renamed-styles.json
+++ b/renamed-styles.json
@@ -347,6 +347,7 @@
     "journal-of-physical-chemistry": "the-journal-of-physical-chemistry-a",
     "journal-of-prosthetic-dentistry": "the-journal-of-prosthetic-dentistry",
     "journal-of-science-teacher-education": "springer-socpsych-author-date",
+    "journal-of-spinal-disorders-and-techniques": "clinical-spine-surgery",
     "journal-of-the-american-academy-of-physician-assistants": "jaapa",
     "journal-of-the-american-dental-association": "the-journal-of-the-american-dental-association",
     "journal-of-the-american-medical-association": "jama",

--- a/revue-de-medecine-veterinaire.csl
+++ b/revue-de-medecine-veterinaire.csl
@@ -74,7 +74,7 @@
       <text variable="citation-number"/>
     </layout>
   </citation>
-  <bibliography et-al-min="99" et-al-use-first="99">
+  <bibliography et-al-min="99" et-al-use-first="98">
     <sort>
       <key macro="author"/>
       <key variable="issued"/>

--- a/romanian-humanities.csl
+++ b/romanian-humanities.csl
@@ -284,7 +284,7 @@
       </choose>
     </layout>
   </citation>
-  <bibliography hanging-indent="true" et-al-min="6" et-al-use-first="6" entry-spacing="0">
+  <bibliography hanging-indent="true" et-al-min="7" et-al-use-first="6" entry-spacing="0">
     <sort>
       <key macro="author-bib"/>
       <key variable="issue"/>

--- a/rtf-scan.csl
+++ b/rtf-scan.csl
@@ -44,7 +44,7 @@
       </else>
     </choose>
   </macro>
-  <citation et-al-min="1" et-al-use-first="1" disambiguate-add-year-suffix="true" disambiguate-add-names="true" disambiguate-add-givenname="true">
+  <citation et-al-min="2" et-al-use-first="1" disambiguate-add-year-suffix="true" disambiguate-add-names="true" disambiguate-add-givenname="true">
     <sort>
       <key macro="author-short"/>
       <key macro="title"/>
@@ -58,7 +58,7 @@
       </group>
     </layout>
   </citation>
-  <bibliography hanging-indent="true" et-al-min="1" et-al-use-first="1">
+  <bibliography hanging-indent="true" et-al-min="2" et-al-use-first="1">
     <sort>
       <key macro="author-short"/>
       <key macro="year-date"/>

--- a/seminaire-saint-sulpice-ecole-theologie.csl
+++ b/seminaire-saint-sulpice-ecole-theologie.csl
@@ -36,7 +36,7 @@
     <choose>
       <if variable="author">
         <names variable="author" font-variant="normal" suffix=", ">
-          <name font-style="normal" delimiter-precedes-et-al="always" delimiter-precedes-last="always" et-al-min="3" et-al-use-first="3" et-al-subsequent-min="3" et-al-subsequent-use-first="1" initialize="false" sort-separator=" ">
+          <name font-style="normal" delimiter-precedes-et-al="always" delimiter-precedes-last="always" et-al-min="4" et-al-use-first="3" et-al-subsequent-min="3" et-al-subsequent-use-first="1" initialize="false" sort-separator=" ">
             <name-part name="family" text-case="sentence" font-variant="small-caps"/>
           </name>
           <et-al font-style="italic"/>
@@ -44,7 +44,7 @@
       </if>
       <else-if variable="editor">
         <names variable="editor" suffix=", ">
-          <name font-style="normal" delimiter-precedes-last="never" et-al-min="3" et-al-use-first="3" et-al-subsequent-min="3" et-al-subsequent-use-first="1" sort-separator=" ">
+          <name font-style="normal" delimiter-precedes-last="never" et-al-min="4" et-al-use-first="3" et-al-subsequent-min="3" et-al-subsequent-use-first="1" sort-separator=" ">
             <name-part name="family" font-variant="small-caps"/>
           </name>
           <label form="short" prefix="&#160;(" suffix=".)"/>
@@ -56,7 +56,7 @@
     <choose>
       <if variable="author">
         <names variable="author" suffix=", ">
-          <name font-style="normal" delimiter-precedes-et-al="always" delimiter-precedes-last="always" et-al-min="3" et-al-use-first="3" et-al-subsequent-min="1" et-al-subsequent-use-first="1" initialize="false" initialize-with="." name-as-sort-order="all" sort-separator=" ">
+          <name font-style="normal" delimiter-precedes-et-al="always" delimiter-precedes-last="always" et-al-min="4" et-al-use-first="3" et-al-subsequent-min="3" et-al-subsequent-use-first="1" initialize="false" initialize-with="." name-as-sort-order="all" sort-separator=" ">
             <name-part name="family" text-case="sentence" font-variant="small-caps"/>
           </name>
           <et-al font-style="italic"/>
@@ -64,7 +64,7 @@
       </if>
       <else-if variable="editor">
         <names variable="editor" suffix=", ">
-          <name font-style="normal" delimiter-precedes-last="never" et-al-min="3" et-al-use-first="3" et-al-subsequent-min="3" et-al-subsequent-use-first="1" name-as-sort-order="all" sort-separator=" ">
+          <name font-style="normal" delimiter-precedes-last="never" et-al-min="4" et-al-use-first="3" et-al-subsequent-min="3" et-al-subsequent-use-first="1" name-as-sort-order="all" sort-separator=" ">
             <name-part name="family" font-variant="small-caps"/>
           </name>
           <label form="short" prefix="&#160;(" suffix=".)"/>
@@ -498,7 +498,7 @@
     <label plural="never" suffix=" " variable="page" form="short"/>
     <text variable="locator" form="short"/>
   </macro>
-  <citation et-al-min="3" et-al-use-first="3" et-al-subsequent-min="3" et-al-subsequent-use-first="1">
+  <citation et-al-min="4" et-al-use-first="3" et-al-subsequent-min="3" et-al-subsequent-use-first="1">
     <layout suffix="." delimiter="&#160;; ">
       <choose>
         <if position="ibid-with-locator">

--- a/service-medical-de-l-assurance-maladie.csl
+++ b/service-medical-de-l-assurance-maladie.csl
@@ -335,7 +335,7 @@
       </group>
     </layout>
   </citation>
-  <bibliography et-al-min="6" et-al-use-first="6">
+  <bibliography et-al-min="7" et-al-use-first="6">
     <sort>
       <key variable="issued" sort="descending"/>
       <key variable="author"/>

--- a/spanish-legal.csl
+++ b/spanish-legal.csl
@@ -286,7 +286,7 @@
       </choose>
     </layout>
   </citation>
-  <bibliography hanging-indent="true" et-al-min="6" et-al-use-first="6">
+  <bibliography hanging-indent="true" et-al-min="7" et-al-use-first="6">
     <sort>
       <key macro="author-bibliography"/>
       <key variable="title"/>

--- a/spec/styles_spec.rb
+++ b/spec/styles_spec.rb
@@ -114,7 +114,7 @@ shared_examples "style" do |basename, (filename, path, style, error), in_depende
                   "expected et-al-min (#{min}) and et-al-use-first (#{first}) to be of same type"
 
                 unless min.nil?
-                  expect(min.to_i).to be >= first.to_i,
+                  expect(min.to_i).to be > first.to_i,
                     "expected et-al-min (#{min}) to be greater than et-al-use-first (#{first})"
                 end
 
@@ -125,7 +125,7 @@ shared_examples "style" do |basename, (filename, path, style, error), in_depende
                   "expected et-al-subsequent-min (#{min}) and et-al-subsequent-use-first (#{first}) to be of same type"
 
                 unless min.nil?
-                  expect(min.to_i).to be >= first.to_i,
+                  expect(min.to_i).to be > first.to_i,
                     "expected et-al-subsequent-min (#{min}) to be greater than et-al-subsequent-use-first (#{first})"
                 end
               end

--- a/spip-cite.csl
+++ b/spip-cite.csl
@@ -17,7 +17,7 @@
   <citation>
     <layout>
       <names variable="author" prefix="(" suffix=" ">
-        <name et-al-min="1" et-al-use-first="1" delimiter="; " name-as-sort-order="all" sort-separator=", " form="long"/>
+        <name et-al-min="2" et-al-use-first="1" delimiter="; " name-as-sort-order="all" sort-separator=", " form="long"/>
       </names>
       <date variable="issued" prefix=" " suffix=") ">
         <date-part name="year" form="long"/>

--- a/sunway-college-johor-bahru.csl
+++ b/sunway-college-johor-bahru.csl
@@ -306,7 +306,7 @@ TO DO
       </group>
     </layout>
   </citation>
-  <bibliography et-al-min="99" et-al-use-first="99" hanging-indent="false" entry-spacing="1" line-spacing="1" subsequent-author-substitute="―" subsequent-author-substitute-rule="complete-all">
+  <bibliography et-al-min="99" et-al-use-first="98" hanging-indent="false" entry-spacing="1" line-spacing="1" subsequent-author-substitute="―" subsequent-author-substitute-rule="complete-all">
     <sort>
       <key macro="author"/>
       <key macro="year-date"/>

--- a/surgical-neurology-international.csl
+++ b/surgical-neurology-international.csl
@@ -120,7 +120,7 @@
       <text variable="citation-number"/>
     </layout>
   </citation>
-  <bibliography et-al-min="6" et-al-use-first="6">
+  <bibliography et-al-min="7" et-al-use-first="6">
     <sort>
       <key macro="author-sort"/>
       <key variable="title"/>

--- a/the-journal-of-adhesive-dentistry.csl
+++ b/the-journal-of-adhesive-dentistry.csl
@@ -21,7 +21,7 @@
   </info>
   <macro name="author">
     <names variable="author" suffix=". ">
-      <name et-al-min="19" et-al-use-first="19" initialize-with="" name-as-sort-order="all" sort-separator=" "/>
+      <name et-al-min="99" et-al-use-first="98" initialize-with="" name-as-sort-order="all" sort-separator=" "/>
       <label form="long" prefix=", "/>
       <substitute>
         <names variable="editor"/>

--- a/the-journal-of-eukaryotic-microbiology.csl
+++ b/the-journal-of-eukaryotic-microbiology.csl
@@ -101,7 +101,7 @@
       </if>
     </choose>
   </macro>
-  <citation et-al-min="4" et-al-use-first="1" disambiguate-add-year-suffix="true" disambiguate-add-names="true" disambiguate-add-givenname="true" givenname-disambiguation-rule="by-cite" collapse="year-suffix">
+  <citation et-al-min="3" et-al-use-first="1" disambiguate-add-year-suffix="true" disambiguate-add-names="true" disambiguate-add-givenname="true" givenname-disambiguation-rule="by-cite" collapse="year-suffix">
     <sort>
       <key macro="year-date"/>
       <key macro="author-short"/>
@@ -114,7 +114,7 @@
       <text variable="locator" prefix=": "/>
     </layout>
   </citation>
-  <bibliography hanging-indent="false" et-al-min="10" et-al-use-first="10">
+  <bibliography hanging-indent="false" et-al-min="99" et-al-use-first="98">
     <sort>
       <key macro="author"/>
       <key macro="year-date"/>

--- a/the-journal-of-hellenic-studies.csl
+++ b/the-journal-of-hellenic-studies.csl
@@ -173,7 +173,7 @@
       </else>
     </choose>
   </macro>
-  <citation et-al-min="3" et-al-use-first="1" et-al-subsequent-min="1" et-al-subsequent-use-first="1" disambiguate-add-year-suffix="true" disambiguate-add-names="true" disambiguate-add-givenname="true">
+  <citation et-al-min="3" et-al-use-first="1" disambiguate-add-year-suffix="true" disambiguate-add-names="true" disambiguate-add-givenname="true">
     <layout delimiter="; ">
       <group delimiter=" ">
         <text macro="author-short"/>

--- a/the-open-university-a251.csl
+++ b/the-open-university-a251.csl
@@ -101,7 +101,7 @@
       <text variable="locator" prefix=" "/>
     </layout>
   </citation>
-  <bibliography hanging-indent="true" et-al-min="6" et-al-use-first="6">
+  <bibliography hanging-indent="true" et-al-min="7" et-al-use-first="6">
     <sort>
       <key macro="author"/>
     </sort>

--- a/thrombosis-and-haemostasis.csl
+++ b/thrombosis-and-haemostasis.csl
@@ -46,7 +46,7 @@
   </locale>
   <macro name="author">
     <names variable="author">
-      <name delimiter-precedes-last="always" et-al-min="3" et-al-use-first="3" initialize-with="" name-as-sort-order="all" sort-separator=" "/>
+      <name delimiter-precedes-last="always" initialize-with="" name-as-sort-order="all" sort-separator=" "/>
       <label form="long" prefix=", "/>
       <substitute>
         <names variable="editor"/>
@@ -233,7 +233,7 @@
       <text variable="citation-number"/>
     </layout>
   </citation>
-  <bibliography et-al-min="7" et-al-use-first="6" second-field-align="flush">
+  <bibliography et-al-min="4" et-al-use-first="3" second-field-align="flush">
     <layout>
       <text variable="citation-number" suffix=". "/>
       <group delimiter=". " suffix=". ">

--- a/universidade-estadual-do-oeste-do-parana-programa-institucional-de-bolsas-de-iniciacao-cientifica.csl
+++ b/universidade-estadual-do-oeste-do-parana-programa-institucional-de-bolsas-de-iniciacao-cientifica.csl
@@ -60,7 +60,7 @@
   </locale>
   <macro name="author">
     <names variable="author">
-      <name suffix="." and="symbol" delimiter-precedes-last="never" et-al-min="6" et-al-use-first="6" initialize-with="." name-as-sort-order="all"/>
+      <name suffix="." and="symbol" delimiter-precedes-last="never" et-al-min="7" et-al-use-first="6" initialize-with="." name-as-sort-order="all"/>
       <et-al font-style="italic"/>
       <label form="short" strip-periods="true" prefix=" (" suffix=")"/>
       <substitute>
@@ -94,7 +94,7 @@
       <if type="chapter" match="any">
         <text term="in" text-case="capitalize-first" prefix=" " suffix=" "/>
         <names variable="editor translator" delimiter=", " suffix=" ">
-          <name and="symbol" et-al-min="3" et-al-use-first="3" initialize-with="." name-as-sort-order="all"/>
+          <name and="symbol" et-al-min="4" et-al-use-first="3" initialize-with="." name-as-sort-order="all"/>
           <label form="symbol" plural="always" text-case="capitalize-first" strip-periods="true" prefix=" (" suffix=".),"/>
         </names>
       </if>

--- a/universitat-bremen-institut-fur-politikwissenschaft.csl
+++ b/universitat-bremen-institut-fur-politikwissenschaft.csl
@@ -268,7 +268,7 @@
       </group>
     </layout>
   </citation>
-  <bibliography hanging-indent="false" et-al-min="10" et-al-use-first="10">
+  <bibliography hanging-indent="false" et-al-min="11" et-al-use-first="10">
     <sort>
       <key macro="author"/>
       <key variable="issued"/>

--- a/university-of-south-australia-harvard-2011.csl
+++ b/university-of-south-australia-harvard-2011.csl
@@ -290,7 +290,7 @@ TO DO
       </group>
     </layout>
   </citation>
-  <bibliography et-al-min="99" et-al-use-first="99" hanging-indent="false" entry-spacing="1" line-spacing="1">
+  <bibliography et-al-min="99" et-al-use-first="98" hanging-indent="false" entry-spacing="1" line-spacing="1">
     <sort>
       <key macro="author"/>
       <key macro="year-date"/>

--- a/university-of-south-australia-harvard-2013.csl
+++ b/university-of-south-australia-harvard-2013.csl
@@ -298,7 +298,7 @@ TO DO
       </group>
     </layout>
   </citation>
-  <bibliography et-al-min="99" et-al-use-first="99" hanging-indent="false" entry-spacing="1" line-spacing="1" subsequent-author-substitute="―" subsequent-author-substitute-rule="complete-all">
+  <bibliography et-al-min="99" et-al-use-first="98" hanging-indent="false" entry-spacing="1" line-spacing="1" subsequent-author-substitute="―" subsequent-author-substitute-rule="complete-all">
     <sort>
       <key macro="author"/>
       <key macro="year-date"/>

--- a/urban-studies.csl
+++ b/urban-studies.csl
@@ -103,7 +103,7 @@
       </group>
     </layout>
   </citation>
-  <bibliography hanging-indent="true" et-al-min="6" et-al-use-first="6">
+  <bibliography hanging-indent="true" et-al-min="7" et-al-use-first="6">
     <sort>
       <key macro="author"/>
       <key variable="issued"/>

--- a/victoria-university-harvard.csl
+++ b/victoria-university-harvard.csl
@@ -298,7 +298,7 @@ TO DO
       </group>
     </layout>
   </citation>
-  <bibliography et-al-min="99" et-al-use-first="99" hanging-indent="false" entry-spacing="1" line-spacing="1" subsequent-author-substitute="―" subsequent-author-substitute-rule="complete-all">
+  <bibliography et-al-min="99" et-al-use-first="98" hanging-indent="false" entry-spacing="1" line-spacing="1" subsequent-author-substitute="―" subsequent-author-substitute-rule="complete-all">
     <sort>
       <key macro="author"/>
       <key macro="year-date"/>

--- a/vienna-legal.csl
+++ b/vienna-legal.csl
@@ -303,7 +303,7 @@
       </choose>
     </layout>
   </citation>
-  <bibliography hanging-indent="true" et-al-min="6" et-al-use-first="6">
+  <bibliography hanging-indent="true" et-al-min="7" et-al-use-first="6">
     <sort>
       <key macro="author-bibliography"/>
       <key variable="title"/>

--- a/vietnam-ministry-of-education-and-training-en.csl
+++ b/vietnam-ministry-of-education-and-training-en.csl
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" et-al-min="3" et-al-use-first="3" demote-non-dropping-particle="sort-only" default-locale="en-US">
+<style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" et-al-min="4" et-al-use-first="3" demote-non-dropping-particle="sort-only" default-locale="en-US">
   <info>
     <title>Vietnam Ministry of Education and Training (English)</title>
     <title-short>BGDDT_TA</title-short>

--- a/vietnam-ministry-of-education-and-training-vi.csl
+++ b/vietnam-ministry-of-education-and-training-vi.csl
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" and="text" delimiter-precedes-et-al="never" et-al-min="3" et-al-use-first="3" initialize-with="." demote-non-dropping-particle="sort-only" default-locale="vi-VN">
+<style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" and="text" delimiter-precedes-et-al="never" et-al-min="4" et-al-use-first="3" initialize-with="." demote-non-dropping-particle="sort-only" default-locale="vi-VN">
   <info>
     <title>Vietnam Ministry of Education and Training (Vietnamese)</title>
     <title-short>BGDDT_TV</title-short>


### PR DESCRIPTION
Fix small bug in testing of et-al attribute values. (et-al(-subsequent)-min should have a higher value than et-al(-subsequent)-use-first)

(original code from https://github.com/citation-style-language/styles/pull/2207)