### PR TITLE
Create apa-6th-swedish-legislations-university-of-gothenburg.csl

### DIFF
--- a/apa-6th-swedish-legislations-university-of-gothenburg.csl
+++ b/apa-6th-swedish-legislations-university-of-gothenburg.csl
@@ -1,0 +1,718 @@
+<?xml version="1.0" encoding="utf-8"?>
+<style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" demote-non-dropping-particle="never">
+  <info>
+    <!--- This is a translated and edited version of American Psychological Association 6th edition for University of Gothenburg with support for references to Swedish legislations, motions, propositions and Official Reports of the Swedish Government through the use of the item type "författning/statute" -->
+    <title>American Psychological Association 6th edition - Swedish legislations - University of Gothenburg</title>
+    <title-short>APA 6th - Swedish legislations - GU</title-short>
+    <id>http://www.zotero.org/styles/apa-6th-swedish-legislations-university-of-gothenburg</id>
+    <link href="http://www.zotero.org/styles/apa-6th-swedish-legislations-university-of-gothenburg" rel="self"/>
+    <link href="https://www.zotero.org/styles/apa" rel="template"/>
+    <link href="https://github.com/ub-digit/citation-styles/tree/master/zotero/apa-6th-swedish-legislations-university-of-gothenburg" rel="documentation"/>
+    <author>
+      <name>Björn Ekström</name>
+      <email>bjorn.ekstrom@ub.gu.se</email>
+    </author>
+    <category citation-format="author-date"/>
+    <category field="social_science"/>
+    <category field="law"/>
+    <category field="generic-base"/>
+    <updated>2017-05-04T21:20:38+00:00</updated>
+    <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
+  </info>
+  <locale xml:lang="en">
+    <terms>
+      <term name="editortranslator" form="short">
+        <single>ed. &amp; trans.</single>
+        <multiple>eds. &amp; trans.</multiple>
+      </term>
+      <term name="translator" form="short">
+        <single>trans.</single>
+        <multiple>trans.</multiple>
+      </term>
+    </terms>
+  </locale>
+  <!--- Hack to change "accessed from" to "available at" for type="legislation"-->
+  <locale xml:lang="sv">
+    <terms>
+      <term name="available at">tillgänglig</term>
+    </terms>
+  </locale>
+  <macro name="container-contributors">
+    <choose>
+      <if type="chapter paper-conference entry-dictionary entry-encyclopedia" match="any">
+        <group delimiter=", ">
+          <names variable="container-author" delimiter=", ">
+            <name and="symbol" initialize-with=". " delimiter=", "/>
+            <label form="short" prefix=" (" text-case="title" suffix=")"/>
+          </names>
+          <names variable="editor translator" delimiter=", ">
+            <name and="symbol" initialize-with=". " delimiter=", "/>
+            <label form="short" prefix=" (" text-case="title" suffix=")"/>
+          </names>
+        </group>
+      </if>
+    </choose>
+  </macro>
+  <macro name="secondary-contributors">
+    <choose>
+      <if type="article-journal chapter paper-conference entry-dictionary entry-encyclopedia" match="none">
+        <group delimiter=", " prefix=" (" suffix=")">
+          <names variable="container-author" delimiter=", ">
+            <name and="symbol" initialize-with=". " delimiter=", "/>
+            <label form="short" prefix=", " text-case="title"/>
+          </names>
+          <names variable="editor translator" delimiter=", ">
+            <name and="symbol" initialize-with=". " delimiter=", "/>
+            <label form="short" prefix=", " text-case="title"/>
+          </names>
+        </group>
+      </if>
+    </choose>
+  </macro>
+  <macro name="author">
+    <choose>
+      <if type="legislation">
+        <text variable="container-title" suffix=" "/>
+        <text variable="volume" suffix=". "/>
+      </if>
+    </choose>
+    <names variable="author">
+      <name name-as-sort-order="all" and="symbol" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
+      <label form="short" prefix=" (" suffix=")" text-case="capitalize-first"/>
+      <substitute>
+        <names variable="editor"/>
+        <names variable="translator"/>
+        <choose>
+          <if type="report">
+            <text variable="publisher"/>
+            <text macro="title"/>
+          </if>
+          <else>
+            <text macro="title"/>
+          </else>
+        </choose>
+      </substitute>
+    </names>
+  </macro>
+  <macro name="author-short">
+    <choose>
+      <if type="legislation" match="any">
+        <text variable="container-title" suffix=" "/>
+        <text variable="volume"/>
+      </if>
+    </choose>
+    <names variable="author">
+      <name form="short" and="symbol" delimiter=", " initialize-with=". "/>
+      <substitute>
+        <names variable="editor"/>
+        <names variable="translator"/>
+        <choose>
+          <if type="report">
+            <text variable="publisher"/>
+            <text variable="title" form="short" font-style="italic"/>
+          </if>
+          <else-if type="legal_case">
+            <text variable="title" font-style="italic"/>
+          </else-if>
+          <else-if type="book graphic  motion_picture song" match="any">
+            <text variable="title" form="short" font-style="italic"/>
+          </else-if>
+          <else-if type="legislation"/>
+          <else-if type="bill" match="any">
+            <text variable="title" form="short" font-style="italic"/>
+          </else-if>
+          <else-if variable="reviewed-author">
+            <choose>
+              <if variable="reviewed-title" match="none">
+                <text variable="title" form="short" font-style="italic" prefix="Review of "/>
+              </if>
+              <else>
+                <text variable="title" form="short" quotes="true"/>
+              </else>
+            </choose>
+          </else-if>
+          <else>
+            <text variable="title" form="short" quotes="true"/>
+          </else>
+        </choose>
+      </substitute>
+    </names>
+  </macro>
+  <macro name="access">
+    <choose>
+      <if type="thesis report" match="any">
+        <choose>
+          <if variable="DOI" match="any">
+            <text variable="DOI" prefix="https://doi.org/"/>
+          </if>
+          <else-if variable="archive" match="any">
+            <group>
+              <text term="retrieved" text-case="capitalize-first" suffix=" "/>
+              <text term="from" suffix=" "/>
+              <text variable="archive" suffix="."/>
+              <text variable="archive_location" prefix=" (" suffix=")"/>
+            </group>
+          </else-if>
+          <else>
+            <group>
+              <text term="retrieved" text-case="capitalize-first" suffix=" "/>
+              <text term="from" suffix=" "/>
+              <text variable="URL"/>
+            </group>
+          </else>
+        </choose>
+      </if>
+      <else>
+        <choose>
+          <if variable="DOI">
+            <text variable="DOI" prefix="doi: "/>
+          </if>
+          <else>
+            <choose>
+              <if type="post post-weblog webpage bill" match="any">
+                <group delimiter=" ">
+                  <text term="retrieved" text-case="capitalize-first" suffix=" "/>
+                  <group>
+                    <date variable="accessed" form="numeric" suffix=" "/>
+                  </group>
+                  <text term="from"/>
+                  <text variable="URL"/>
+                </group>
+              </if>
+              <!--- Changes "accessed from" to "Tillgänglig:" for "författning/statute" -->
+              <else-if type="legislation">
+                <group>
+                  <text term="available at" text-case="capitalize-first" suffix=": "/>
+                  <text variable="URL"/>
+                </group>
+              </else-if>
+              <!--- Changes "accessed from" to "Tillgänglig:" for "article-magazine" -->
+              <else-if type="article-magazine">
+                <group>
+                  <text term="available at" text-case="capitalize-first" suffix=": "/>
+                  <text variable="URL"/>
+                </group>
+              </else-if>
+              <else-if type="article-newspaper">
+                <group>
+                  <text term="retrieved" text-case="capitalize-first" suffix=" "/>
+                  <date variable="accessed" form="numeric" suffix=" "/>
+                  <text term="from" suffix=" "/>
+                  <text variable="URL"/>
+                </group>
+              </else-if>
+              <else>
+                <group>
+                  <text term="retrieved" text-case="capitalize-first" suffix=" "/>
+                  <text term="from" suffix=" "/>
+                  <text variable="URL"/>
+                </group>
+              </else>
+            </choose>
+          </else>
+        </choose>
+      </else>
+    </choose>
+  </macro>
+  <macro name="title">
+    <choose>
+      <if type="bill book graphic manuscript motion_picture report song speech thesis" match="any">
+        <choose>
+          <if variable="version" type="book" match="all">
+            <text variable="title"/>
+          </if>
+          <else>
+            <text variable="title" font-style="italic"/>
+          </else>
+        </choose>
+      </if>
+      <else-if variable="reviewed-author">
+        <choose>
+          <if variable="reviewed-title">
+            <group delimiter=" ">
+              <text variable="title"/>
+              <group delimiter=", " prefix="[" suffix="]">
+                <text variable="reviewed-title" font-style="italic" prefix="Review of "/>
+                <names variable="reviewed-author" delimiter=", ">
+                  <label form="verb-short" suffix=" "/>
+                  <name and="symbol" initialize-with=". " delimiter=", "/>
+                </names>
+              </group>
+            </group>
+          </if>
+          <else>
+            <!-- assume `title` is title of reviewed work -->
+            <group delimiter=", " prefix="[" suffix="]">
+              <text variable="title" font-style="italic" prefix="Review of "/>
+              <names variable="reviewed-author" delimiter=", ">
+                <label form="verb-short" suffix=" "/>
+                <name and="symbol" initialize-with=". " delimiter=", "/>
+              </names>
+            </group>
+          </else>
+        </choose>
+      </else-if>
+      <!--- Italizes title for "blog post", "webpage" and "statute" -->
+      <else-if type="post-weblog webpage">
+        <text variable="title" font-style="italic"/>
+      </else-if>
+      <else-if type="legislation">
+        <text variable="title" font-style="italic"/>
+      </else-if>
+      <else>
+        <text variable="title"/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="title-plus-extra">
+    <text macro="title"/>
+    <choose>
+      <if type="report" match="any">
+        <group prefix=" (" suffix=")" delimiter=", ">
+          <group delimiter=", ">
+            <choose>
+              <if variable="genre" match="any">
+                <text variable="genre"/>
+              </if>
+              <else>
+                <text variable="collection-title"/>
+              </else>
+            </choose>
+            <text variable="number"/>
+          </group>
+          <group delimiter="">
+            <text term="version" text-case="capitalize-first"/>
+            <text variable="version"/>
+          </group>
+          <text macro="edition"/>
+        </group>
+      </if>
+      <else-if type="thesis" match="any">
+        <group prefix=" (" suffix=")" delimiter=", ">
+          <group delimiter=" ">
+            <choose>
+              <if variable="genre" match="any">
+                <text variable="genre"/>
+              </if>
+              <else>
+                <text variable="collection-title"/>
+              </else>
+            </choose>
+            <text variable="number" prefix="No. "/>
+          </group>
+          <group delimiter=" ">
+            <text term="version" text-case="capitalize-first"/>
+            <text variable="version"/>
+          </group>
+          <text macro="edition"/>
+        </group>
+      </else-if>
+      <else-if type="post-weblog webpage" match="any">
+        <text variable="genre" prefix=" [" suffix="]"/>
+      </else-if>
+      <else-if variable="version">
+        <group delimiter=" " prefix=" (" suffix=")">
+          <text term="version" text-case="capitalize-first"/>
+          <text variable="version"/>
+        </group>
+      </else-if>
+    </choose>
+    <text macro="format" prefix=" [" suffix="]"/>
+  </macro>
+  <macro name="format">
+    <choose>
+      <if match="any" variable="medium">
+        <text variable="medium" text-case="capitalize-first"/>
+      </if>
+      <else-if type="dataset" match="any">
+        <text value="Data set"/>
+      </else-if>
+    </choose>
+  </macro>
+  <macro name="publisher">
+    <choose>
+      <if type="report" match="any">
+        <group delimiter=": ">
+          <text variable="publisher-place"/>
+          <text variable="publisher"/>
+        </group>
+      </if>
+      <else-if type="thesis" match="any">
+        <group delimiter=" ">
+          <text variable="publisher-place" suffix=": "/>
+          <text variable="publisher"/>
+        </group>
+      </else-if>
+      <else-if type="post-weblog webpage" match="none">
+        <group delimiter=", ">
+          <choose>
+            <if variable="event version" type="speech motion_picture" match="none">
+              <!-- Including version is to avoid printing the programming language for computerProgram /-->
+              <text variable="genre"/>
+            </if>
+          </choose>
+          <choose>
+            <if type="article-journal article-magazine article-newspaper" match="none">
+              <group delimiter=": ">
+                <choose>
+                  <if variable="publisher-place">
+                    <text variable="publisher-place"/>
+                  </if>
+                  <else>
+                    <text variable="event-place"/>
+                  </else>
+                </choose>
+                <text variable="publisher"/>
+              </group>
+            </if>
+          </choose>
+        </group>
+      </else-if>
+    </choose>
+  </macro>
+  <macro name="event">
+    <choose>
+      <if variable="container-title" match="none">
+        <choose>
+          <if variable="event">
+            <choose>
+              <if variable="genre" match="none">
+                <text term="presented at" text-case="capitalize-first" suffix=" "/>
+                <text variable="event"/>
+              </if>
+              <else>
+                <group delimiter=" ">
+                  <text variable="genre" text-case="capitalize-first"/>
+                  <text term="presented at"/>
+                  <text variable="event"/>
+                </group>
+              </else>
+            </choose>
+          </if>
+          <else-if type="speech">
+            <text variable="genre" text-case="capitalize-first"/>
+          </else-if>
+        </choose>
+      </if>
+    </choose>
+  </macro>
+  <macro name="issued">
+    <choose>
+      <if type="bill legal_case legislation" match="none">
+        <choose>
+          <if variable="issued">
+            <group prefix=" (" suffix=")">
+              <date variable="issued">
+                <date-part name="year"/>
+              </date>
+              <text variable="year-suffix"/>
+              <choose>
+                <if type="speech" match="any">
+                  <date variable="issued">
+                    <date-part prefix=", " name="month"/>
+                  </date>
+                </if>
+                <else-if type="article-journal bill book chapter graphic legal_case motion_picture paper-conference report song dataset" match="none">
+                  <date variable="issued">
+                    <date-part prefix=", " name="month"/>
+                    <date-part prefix=" " name="day"/>
+                  </date>
+                </else-if>
+              </choose>
+            </group>
+          </if>
+          <else-if variable="status">
+            <group prefix=" (" suffix=")">
+              <text variable="status"/>
+              <text variable="year-suffix" prefix="-"/>
+            </group>
+          </else-if>
+          <else>
+            <group prefix=" (" suffix=")">
+              <text variable="year-suffix" prefix="-"/>
+            </group>
+          </else>
+        </choose>
+      </if>
+    </choose>
+  </macro>
+  <macro name="issued-sort">
+    <choose>
+      <if type="article-journal bill book chapter graphic legal_case legislation motion_picture paper-conference report song dataset" match="none">
+        <date variable="issued">
+          <date-part name="year"/>
+          <date-part name="month"/>
+          <date-part name="day"/>
+        </date>
+      </if>
+      <else>
+        <date variable="issued">
+          <date-part name="year"/>
+        </date>
+      </else>
+    </choose>
+  </macro>
+  <macro name="issued-year">
+    <choose>
+      <if variable="issued">
+        <group delimiter="/">
+          <date variable="original-date" form="text"/>
+          <group>
+            <date variable="issued">
+              <date-part name="year"/>
+              <date-part name="month" prefix=", "/>
+            </date>
+            <text variable="year-suffix"/>
+          </group>
+        </group>
+      </if>
+      <else-if variable="status">
+        <text variable="status"/>
+        <text variable="year-suffix" prefix="-"/>
+      </else-if>
+      <else-if type="legislation">
+        <text variable="year-suffix" prefix="-"/>
+      </else-if>
+      <else>
+        <text variable="year-suffix" prefix="-"/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="edition">
+    <choose>
+      <if is-numeric="edition">
+        <group delimiter=" ">
+          <number variable="edition" form="ordinal"/>
+          <text term="edition" form="short"/>
+        </group>
+      </if>
+      <else>
+        <text variable="edition"/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="locators">
+    <choose>
+      <if type="article-journal article-magazine" match="any">
+        <group prefix=", " delimiter=", ">
+          <group>
+            <text variable="volume" font-style="italic"/>
+            <text variable="issue" prefix="(" suffix=")"/>
+          </group>
+          <text variable="page"/>
+        </group>
+        <choose>
+          <!--for advanced online publication-->
+          <if variable="issued">
+            <choose>
+              <if variable="page issue" match="none">
+                <text variable="status" prefix=". "/>
+              </if>
+            </choose>
+          </if>
+        </choose>
+      </if>
+      <else-if type="article-newspaper">
+        <group delimiter=" " prefix=", ">
+          <label variable="page" form="short"/>
+          <text variable="page"/>
+        </group>
+      </else-if>
+      <else-if type="book graphic motion_picture report song chapter paper-conference entry-encyclopedia entry-dictionary" match="any">
+        <group prefix=" (" suffix=")" delimiter=", ">
+          <choose>
+            <if type="report" match="none">
+              <!-- edition for report is included in title-plus-extra /-->
+              <text macro="edition"/>
+            </if>
+          </choose>
+          <choose>
+            <if variable="volume" match="any">
+              <group>
+                <text term="volume" form="short" text-case="capitalize-first" suffix=" "/>
+                <number variable="volume" form="numeric"/>
+              </group>
+            </if>
+            <else>
+              <group>
+                <text term="volume" form="short" plural="true" text-case="capitalize-first" suffix=" "/>
+                <number variable="number-of-volumes" form="numeric" prefix="1&#8211;"/>
+              </group>
+            </else>
+          </choose>
+          <group>
+            <label variable="page" form="short" suffix=" "/>
+            <text variable="page"/>
+          </group>
+        </group>
+      </else-if>
+      <else-if type="legal_case">
+        <group prefix=" (" suffix=")" delimiter=" ">
+          <text variable="authority"/>
+          <choose>
+            <if variable="container-title" match="any">
+              <!--Only print year for cases published in reporters-->
+              <date variable="issued" form="numeric" date-parts="year"/>
+            </if>
+            <else>
+              <date variable="issued" form="text"/>
+            </else>
+          </choose>
+        </group>
+      </else-if>
+      <else-if type="bill legislation" match="any">
+        <date variable="issued" prefix=" (" suffix=")">
+          <date-part name="year"/>
+        </date>
+      </else-if>
+    </choose>
+  </macro>
+  <macro name="citation-locator">
+    <group>
+      <choose>
+        <if locator="chapter">
+          <label variable="locator" form="long" text-case="capitalize-first"/>
+        </if>
+        <else>
+          <label variable="locator" form="short"/>
+        </else>
+      </choose>
+      <text variable="locator" prefix=" "/>
+    </group>
+  </macro>
+  <macro name="container">
+    <choose>
+      <if type="post-weblog webpage" match="none">
+        <group>
+          <choose>
+            <if type="chapter paper-conference entry-encyclopedia" match="any">
+              <text term="in" text-case="capitalize-first" suffix=" "/>
+            </if>
+          </choose>
+          <group delimiter=", ">
+            <text macro="container-contributors"/>
+            <text macro="secondary-contributors"/>
+            <text macro="container-title"/>
+          </group>
+        </group>
+      </if>
+    </choose>
+  </macro>
+  <macro name="container-title">
+    <choose>
+      <if type="article article-journal article-magazine article-newspaper" match="any">
+        <text variable="container-title" font-style="italic" text-case="title"/>
+      </if>
+      <else-if type="bill legal_case legislation" match="none">
+        <text variable="container-title" font-style="italic"/>
+      </else-if>
+    </choose>
+  </macro>
+  <macro name="legal-cites">
+    <choose>
+      <if type="legal_case" match="any">
+        <group prefix=", " delimiter=" ">
+          <choose>
+            <if variable="container-title">
+              <text variable="volume"/>
+              <text variable="container-title"/>
+              <group delimiter=" ">
+                <!--change to label variable="section" as that becomes available -->
+                <text term="section" form="symbol"/>
+                <text variable="section"/>
+              </group>
+              <text variable="page"/>
+            </if>
+            <else>
+              <text variable="number" prefix="No. "/>
+            </else>
+          </choose>
+        </group>
+      </if>
+      <!--- Removes paragraph symbol for "författning/statute" -->
+      <else-if type="legislation">
+        <group delimiter=". " prefix=". ">
+          <text variable="section"/>
+        </group>
+      </else-if>
+      <else-if type="bill" match="any">
+        <group delimiter=", " prefix=", ">
+          <choose>
+            <if variable="number">
+              <!--There's a public law number-->
+              <text variable="number" prefix="Pub. L. No. "/>
+              <group delimiter=" ">
+                <!--change to label variable="section" as that becomes available -->
+                <text term="section" form="symbol"/>
+                <text variable="section"/>
+              </group>
+              <group delimiter=" ">
+                <text variable="volume"/>
+                <text variable="container-title"/>
+                <text variable="page-first"/>
+              </group>
+            </if>
+            <else>
+              <group delimiter=" ">
+                <text variable="volume"/>
+                <text variable="container-title"/>
+                <!--change to label variable="section" as that becomes available -->
+                <text term="section" form="symbol"/>
+                <text variable="section"/>
+              </group>
+            </else>
+          </choose>
+        </group>
+      </else-if>
+    </choose>
+  </macro>
+  <macro name="original-date">
+    <choose>
+      <if variable="original-date">
+        <group prefix="(" suffix=")" delimiter=" ">
+          <!---This should be localized-->
+          <text value="Original work published"/>
+          <date variable="original-date" form="text"/>
+        </group>
+      </if>
+    </choose>
+  </macro>
+  <citation et-al-min="6" et-al-use-first="1" et-al-subsequent-min="0" et-al-subsequent-use-first="1" disambiguate-add-year-suffix="true" disambiguate-add-names="true" disambiguate-add-givenname="true" collapse="year" givenname-disambiguation-rule="primary-name">
+    <sort>
+      <key macro="author"/>
+      <key macro="issued-sort"/>
+    </sort>
+    <layout prefix="(" suffix=")" delimiter="; ">
+      <group delimiter=", ">
+        <text macro="author-short"/>
+        <text macro="issued-year"/>
+        <text macro="citation-locator"/>
+      </group>
+    </layout>
+  </citation>
+  <bibliography hanging-indent="true" et-al-min="8" et-al-use-first="6" et-al-use-last="true" entry-spacing="0" line-spacing="2">
+    <sort>
+      <key macro="author"/>
+      <key macro="issued-sort" sort="ascending"/>
+      <key macro="title"/>
+    </sort>
+    <layout>
+      <group suffix=".">
+        <group delimiter=". ">
+          <text macro="author"/>
+          <text macro="issued"/>
+          <text macro="title-plus-extra"/>
+          <text macro="container"/>
+        </group>
+        <text macro="legal-cites"/>
+        <text macro="locators"/>
+        <group delimiter=", " prefix=". ">
+          <text macro="event"/>
+          <text macro="publisher"/>
+        </group>
+      </group>
+      <text macro="access" prefix=" "/>
+      <text macro="original-date" prefix=" "/>
+    </layout>
+  </bibliography>
+</style>

--- a/apa-6th-swedish-legislations-university-of-gothenburg.csl
+++ b/apa-6th-swedish-legislations-university-of-gothenburg.csl
@@ -3,10 +3,10 @@
   <info>
     <!--- This is a translated and edited version of American Psychological Association 6th edition for University of Gothenburg with support for references to Swedish legislations, motions, propositions and Official Reports of the Swedish Government through the use of the item type "författning/statute" -->
     <title>American Psychological Association 6th edition - Swedish legislations - University of Gothenburg</title>
-    <title-short>APA 6th - Swedish legislations - GU</title-short>
+    <title-short>APA 6th - GU - Swedish legislations</title-short>
     <id>http://www.zotero.org/styles/apa-6th-swedish-legislations-university-of-gothenburg</id>
     <link href="http://www.zotero.org/styles/apa-6th-swedish-legislations-university-of-gothenburg" rel="self"/>
-    <link href="https://www.zotero.org/styles/apa" rel="template"/>
+    <link href="http://www.zotero.org/styles/apa" rel="template"/>
     <link href="https://github.com/ub-digit/citation-styles/tree/master/zotero/apa-6th-swedish-legislations-university-of-gothenburg" rel="documentation"/>
     <author>
       <name>Björn Ekström</name>
@@ -19,24 +19,13 @@
     <updated>2017-05-04T21:20:38+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
-  <locale xml:lang="en">
-    <terms>
-      <term name="editortranslator" form="short">
-        <single>ed. &amp; trans.</single>
-        <multiple>eds. &amp; trans.</multiple>
-      </term>
-      <term name="translator" form="short">
-        <single>trans.</single>
-        <multiple>trans.</multiple>
-      </term>
-    </terms>
-  </locale>
-  <!--- Hack to change "accessed from" to "available at" for type="legislation"-->
+  <!--- Hack to change "tillgänglig vid" to "tillgänglig" for Swedish locale.-->
   <locale xml:lang="sv">
     <terms>
       <term name="available at">tillgänglig</term>
     </terms>
   </locale>
+    <!--- End hack.-->
   <macro name="container-contributors">
     <choose>
       <if type="chapter paper-conference entry-dictionary entry-encyclopedia" match="any">
@@ -677,7 +666,7 @@
       </if>
     </choose>
   </macro>
-  <citation et-al-min="6" et-al-use-first="1" et-al-subsequent-min="0" et-al-subsequent-use-first="1" disambiguate-add-year-suffix="true" disambiguate-add-names="true" disambiguate-add-givenname="true" collapse="year" givenname-disambiguation-rule="primary-name">
+  <citation et-al-min="6" et-al-use-first="1" disambiguate-add-year-suffix="true" disambiguate-add-names="true" disambiguate-add-givenname="true" collapse="year" givenname-disambiguation-rule="primary-name">
     <sort>
       <key macro="author"/>
       <key macro="issued-sort"/>

--- a/university-of-gothenburg-apa-swedish-legislations.csl
+++ b/university-of-gothenburg-apa-swedish-legislations.csl
@@ -13,7 +13,7 @@
     </author>
     <category citation-format="author-date"/>
     <category field="law"/>
-    <summary>This is a translated and edited version of American Psychological Association 6th edition for University of Gothenburg with support for references to Swedish legislations, motions, propositions and Official Reports of the Swedish Government through the use of the item type "statute" (författning), for use in Swedish and English.</summary>
+    <summary>This is a translated and edited version of American Psychological Association 6th edition for University of Gothenburg with support for references to Swedish legislations, motions, propositions and Official Reports of the Swedish Government through the use of the Zotero item type "statute" (författning), for use in Swedish and English.</summary>
     <updated>2017-05-04T21:20:38+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
@@ -231,7 +231,7 @@
           </else>
         </choose>
       </else-if>
-      <!--- Italizes title for "blog post", "webpage" and "statute" -->
+      <!--- Italizes title for "blog post", "webpage" and Zotero item type "statute" -->
       <else-if type="post-weblog webpage">
         <text variable="title" font-style="italic"/>
       </else-if>
@@ -608,7 +608,7 @@
           </choose>
         </group>
       </if>
-      <!--- Removes paragraph symbol for "författning/statute" -->
+      <!--- Removes paragraph symbol for Zotero item type "författning/statute" -->
       <else-if type="legislation">
         <group delimiter=". " prefix=". ">
           <text variable="section"/>

--- a/university-of-gothenburg-apa-swedish-legislations.csl
+++ b/university-of-gothenburg-apa-swedish-legislations.csl
@@ -129,7 +129,7 @@
       <if type="thesis report" match="any">
         <choose>
           <if variable="DOI" match="any">
-            <text variable="DOI" prefix="https://doi.org/"/>
+            <text variable="DOI" prefix="doi: "/>
           </if>
           <else-if variable="archive" match="any">
             <group>

--- a/university-of-gothenburg-apa-swedish-legislations.csl
+++ b/university-of-gothenburg-apa-swedish-legislations.csl
@@ -6,7 +6,7 @@
     <id>http://www.zotero.org/styles/university-of-gothenburg-apa-swedish-legislations</id>
     <link href="http://www.zotero.org/styles/university-of-gothenburg-apa-swedish-legislations" rel="self"/>
     <link href="http://www.zotero.org/styles/apa" rel="template"/>
-    <link href="https://github.com/ub-digit/citation-styles/tree/master/zotero/university-of-gothenburg-apa-swedish-legislations" rel="documentation"/>
+    <link href="https://github.com/ub-digit/citation-styles/tree/master/zotero/university-of-gothenburg-apa-swedish-legislations/README.md" rel="documentation"/>
     <author>
       <name>Björn Ekström</name>
       <email>bjorn.ekstrom@ub.gu.se</email>

--- a/university-of-gothenburg-apa-swedish-legislations.csl
+++ b/university-of-gothenburg-apa-swedish-legislations.csl
@@ -1,11 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" demote-non-dropping-particle="never">
   <info>
-    <!--- This is a translated and edited version of American Psychological Association 6th edition for University of Gothenburg with support for references to Swedish legislations, motions, propositions and Official Reports of the Swedish Government through the use of the item type "författning/statute" -->
-    <title>American Psychological Association 6th edition - Swedish legislations - University of Gothenburg</title>
-    <title-short>APA 6th - GU - Swedish legislations</title-short>
-    <id>http://www.zotero.org/styles/apa-6th-swedish-legislations-university-of-gothenburg</id>
-    <link href="http://www.zotero.org/styles/apa-6th-swedish-legislations-university-of-gothenburg" rel="self"/>
+    <title>University of Gothenburg - APA (Swedish legislations)</title>
+    <title-short>GU - APA - Swedish legislations</title-short>
+    <id>http://www.zotero.org/styles/university-of-gothenburg-apa-swedish-legislations</id>
+    <link href="http://www.zotero.org/styles/university-of-gothenburg-apa-swedish-legislations" rel="self"/>
     <link href="http://www.zotero.org/styles/apa" rel="template"/>
     <link href="https://github.com/ub-digit/citation-styles/tree/master/zotero/apa-6th-swedish-legislations-university-of-gothenburg" rel="documentation"/>
     <author>
@@ -13,19 +12,17 @@
       <email>bjorn.ekstrom@ub.gu.se</email>
     </author>
     <category citation-format="author-date"/>
-    <category field="social_science"/>
     <category field="law"/>
-    <category field="generic-base"/>
+    <summary>This is a translated and edited version of American Psychological Association 6th edition for University of Gothenburg with support for references to Swedish legislations, motions, propositions and Official Reports of the Swedish Government through the use of the item type "statute" (författning), for use in Swedish and English.</summary>
     <updated>2017-05-04T21:20:38+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
-  <!--- Hack to change "tillgänglig vid" to "tillgänglig" for Swedish locale.-->
+  <!--- Change "tillgänglig vid" to "tillgänglig" for Swedish locale.-->
   <locale xml:lang="sv">
     <terms>
       <term name="available at">tillgänglig</term>
     </terms>
   </locale>
-    <!--- End hack.-->
   <macro name="container-contributors">
     <choose>
       <if type="chapter paper-conference entry-dictionary entry-encyclopedia" match="any">
@@ -168,15 +165,8 @@
                   <text variable="URL"/>
                 </group>
               </if>
-              <!--- Changes "accessed from" to "Tillgänglig:" for "författning/statute" -->
-              <else-if type="legislation">
-                <group>
-                  <text term="available at" text-case="capitalize-first" suffix=": "/>
-                  <text variable="URL"/>
-                </group>
-              </else-if>
-              <!--- Changes "accessed from" to "Tillgänglig:" for "article-magazine" -->
-              <else-if type="article-magazine">
+              <!--- Changes "accessed from" to "Tillgänglig:" -->
+              <else-if type="legislation article-magazine" match="any">
                 <group>
                   <text term="available at" text-case="capitalize-first" suffix=": "/>
                   <text variable="URL"/>

--- a/university-of-gothenburg-apa-swedish-legislations.csl
+++ b/university-of-gothenburg-apa-swedish-legislations.csl
@@ -6,7 +6,7 @@
     <id>http://www.zotero.org/styles/university-of-gothenburg-apa-swedish-legislations</id>
     <link href="http://www.zotero.org/styles/university-of-gothenburg-apa-swedish-legislations" rel="self"/>
     <link href="http://www.zotero.org/styles/apa" rel="template"/>
-    <link href="https://github.com/ub-digit/citation-styles/tree/master/zotero/apa-6th-swedish-legislations-university-of-gothenburg" rel="documentation"/>
+    <link href="https://github.com/ub-digit/citation-styles/tree/master/zotero/university-of-gothenburg-apa-swedish-legislations" rel="documentation"/>
     <author>
       <name>Björn Ekström</name>
       <email>bjorn.ekstrom@ub.gu.se</email>


### PR DESCRIPTION
Style providing support for references to Swedish legislation, motions and propositions as well as to Official Reports of the Swedish Government.