### PR TITLE
Update association-for-computing-machinery.csl

### DIFF
--- a/association-for-computing-machinery.csl
+++ b/association-for-computing-machinery.csl
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
 <style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" demote-non-dropping-particle="sort-only" default-locale="en-US">
-  <!-- This style was edited with the Visual CSL Editor (http://editor.citationstyles.org/visualEditor/) -->
   <info>
     <title>Association for Computing Machinery</title>
     <title-short>ACM</title-short>
     <id>http://www.zotero.org/styles/association-for-computing-machinery</id>
     <link href="http://www.zotero.org/styles/association-for-computing-machinery" rel="self"/>
     <link href="http://www.acm.org/publications/word_style/word-style-toc/" rel="documentation"/>
+    <link href="http://www.acm.org/publications/authors/reference-formatting" rel="documentation"/>
     <author>
       <name>Mattias Jacobsson</name>
       <email>mattias.jacobsson@gmail.com</email>
@@ -15,10 +15,13 @@
       <email>brian.powell@mail.wvu.edu</email>
       <name>Brian M. Powell</name>
     </contributor>
+    <contributor>
+      <name>Patrick O'Brien</name>
+    </contributor>
     <category citation-format="author-date"/>
     <category field="engineering"/>
     <summary>The ACM Journal Reference Format (author-date) variant of the Chicago style</summary>
-    <updated>2014-11-26T15:17:57+00:00</updated>
+    <updated>2017-06-30T12:50:14+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <macro name="editor">
@@ -132,12 +135,13 @@
           </group>
           <text prefix=" " suffix="." macro="publisher"/>
         </if>
-        <else-if type="chapter paper-conference" match="any">
+        <else-if type="chapter paper-conference speech" match="any">
           <text macro="title" prefix=" " suffix="."/>
           <group prefix=" " delimiter=" ">
             <text term="in" text-case="capitalize-first"/>
             <text macro="editor"/>
             <text variable="container-title" font-style="italic" suffix="."/>
+            <text variable="event" font-style="italic" suffix="."/>
             <text variable="collection-title" suffix="."/>
             <group suffix="." delimiter=", ">
               <text macro="publisher" prefix=" "/>


### PR DESCRIPTION
via https://forums.zotero.org/discussion/comment/278951#Comment_278951

Now, the chapters should give the DOI as should a speech, but what if a speech doesn't have a DOI and I want to give the URL. How would that work?