### PR TITLE
Update Patents in APA and align related versions

### DIFF
--- a/apa-annotated-bibliography.csl
+++ b/apa-annotated-bibliography.csl
@@ -101,7 +101,7 @@
   <macro name="author-short">
     <choose>
       <if type="patent" variable="number" match="all">
-        <text variable="number"/>
+        <text macro="patent-number"/>
       </if>
       <else>
         <names variable="author">
@@ -141,6 +141,16 @@
         </names>
       </else>
     </choose>
+  </macro>
+  <macro name="patent-number">
+    <!-- genre: U.S. Patent number: 123,445-->
+    <group delimiter=" ">
+      <group delimiter=" ">
+	<text variable="genre"/>
+	<text term="issue" form="short" text-case="capitalize-first"/>
+      </group>
+      <text variable="number"/>
+    </group>
   </macro>
   <macro name="access">
     <choose>
@@ -236,7 +246,7 @@
         </choose>
       </else-if>
       <else-if type="patent" variable="number" match="all">
-        <text variable="number" font-style="italic"/>
+        <text macro="patent-number" font-style="italic"/>
       </else-if>
       <else>
         <text variable="title"/>

--- a/apa-annotated-bibliography.csl
+++ b/apa-annotated-bibliography.csl
@@ -99,41 +99,48 @@
     </names>
   </macro>
   <macro name="author-short">
-    <names variable="author">
-      <name form="short" and="symbol" delimiter=", " initialize-with=". "/>
-      <substitute>
-        <names variable="editor"/>
-        <names variable="translator"/>
-        <choose>
-          <if type="report">
-            <text variable="publisher"/>
-            <text variable="title" form="short" font-style="italic"/>
-          </if>
-          <else-if type="legal_case">
-            <text variable="title" font-style="italic"/>
-          </else-if>
-          <else-if type="book graphic  motion_picture song" match="any">
-            <text variable="title" form="short" font-style="italic"/>
-          </else-if>
-          <else-if type="bill legislation" match="any">
-            <text variable="title" form="short"/>
-          </else-if>
-          <else-if variable="reviewed-author">
+    <choose>
+      <if type="patent" variable="number" match="all">
+        <text variable="number"/>
+      </if>
+      <else>
+        <names variable="author">
+          <name form="short" and="symbol" delimiter=", " initialize-with=". "/>
+          <substitute>
+            <names variable="editor"/>
+            <names variable="translator"/>
             <choose>
-              <if variable="reviewed-title" match="none">
-                <text variable="title" form="short" font-style="italic" prefix="Review of "/>
+              <if type="report">
+                <text variable="publisher"/>
+                <text variable="title" form="short" font-style="italic"/>
               </if>
+              <else-if type="legal_case">
+                <text variable="title" font-style="italic"/>
+              </else-if>
+              <else-if type="book graphic  motion_picture song" match="any">
+                <text variable="title" form="short" font-style="italic"/>
+              </else-if>
+              <else-if type="bill legislation" match="any">
+                <text variable="title" form="short"/>
+              </else-if>
+              <else-if variable="reviewed-author">
+                <choose>
+                  <if variable="reviewed-title" match="none">
+                    <text variable="title" form="short" font-style="italic" prefix="Review of "/>
+                  </if>
+                  <else>
+                    <text variable="title" form="short" quotes="true"/>
+                  </else>
+                </choose>
+              </else-if>
               <else>
                 <text variable="title" form="short" quotes="true"/>
               </else>
             </choose>
-          </else-if>
-          <else>
-            <text variable="title" form="short" quotes="true"/>
-          </else>
-        </choose>
-      </substitute>
-    </names>
+          </substitute>
+        </names>
+      </else>
+    </choose>
   </macro>
   <macro name="access">
     <choose>
@@ -142,6 +149,13 @@
           <if variable="DOI" match="any">
             <text variable="DOI" prefix="https://doi.org/"/>
           </if>
+          <else-if variable="URL" match="any">
+            <group>
+              <text term="retrieved" text-case="capitalize-first" suffix=" "/>
+              <text term="from" suffix=" "/>
+              <text variable="URL"/>
+            </group>
+          </else-if>
           <else-if variable="archive" match="any">
             <group>
               <text term="retrieved" text-case="capitalize-first" suffix=" "/>
@@ -150,13 +164,6 @@
               <text variable="archive_location" prefix=" (" suffix=")"/>
             </group>
           </else-if>
-          <else>
-            <group>
-              <text term="retrieved" text-case="capitalize-first" suffix=" "/>
-              <text term="from" suffix=" "/>
-              <text variable="URL"/>
-            </group>
-          </else>
         </choose>
       </if>
       <else>
@@ -166,7 +173,7 @@
           </if>
           <else>
             <choose>
-              <if type="webpage">
+              <if type="post post-weblog webpage" match="any">
                 <group delimiter=" ">
                   <text term="retrieved" text-case="capitalize-first" suffix=" "/>
                   <group>
@@ -227,6 +234,9 @@
             </group>
           </else>
         </choose>
+      </else-if>
+      <else-if type="patent" variable="number" match="all">
+        <text variable="number" font-style="italic"/>
       </else-if>
       <else>
         <text variable="title"/>
@@ -292,6 +302,19 @@
           <text variable="publisher-place"/>
         </group>
       </else-if>
+      <else-if type="patent">
+        <group delimiter=": ">
+          <text variable="publisher-place"/>
+          <choose>
+            <if variable="publisher">
+              <text variable="publisher"/>
+            </if>
+            <else>
+              <text variable="authority"/>
+            </else>
+          </choose>
+        </group>
+      </else-if>
       <else-if type="post-weblog webpage" match="none">
         <group delimiter=", ">
           <choose>
@@ -301,7 +324,7 @@
             </if>
           </choose>
           <choose>
-            <if type="article-journal article-magazine" match="none">
+            <if type="article-journal article-magazine article-newspaper" match="none">
               <group delimiter=": ">
                 <choose>
                   <if variable="publisher-place">

--- a/apa-cv.csl
+++ b/apa-cv.csl
@@ -101,7 +101,7 @@
   <macro name="author-short">
     <choose>
       <if type="patent" variable="number" match="all">
-        <text variable="number"/>
+        <text macro="patent-number"/>
       </if>
       <else>
         <names variable="author">
@@ -141,6 +141,16 @@
         </names>
       </else>
     </choose>
+  </macro>
+  <macro name="patent-number">
+    <!-- genre: U.S. Patent number: 123,445-->
+    <group delimiter=" ">
+      <group delimiter=" ">
+	<text variable="genre"/>
+	<text term="issue" form="short" text-case="capitalize-first"/>
+      </group>
+      <text variable="number"/>
+    </group>
   </macro>
   <macro name="access">
     <choose>
@@ -236,7 +246,7 @@
         </choose>
       </else-if>
       <else-if type="patent" variable="number" match="all">
-        <text variable="number" font-style="italic"/>
+        <text macro="patent-number" font-style="italic"/>
       </else-if>
       <else>
         <text variable="title"/>

--- a/apa-cv.csl
+++ b/apa-cv.csl
@@ -99,41 +99,48 @@
     </names>
   </macro>
   <macro name="author-short">
-    <names variable="author">
-      <name form="short" and="symbol" delimiter=", " initialize-with=". "/>
-      <substitute>
-        <names variable="editor"/>
-        <names variable="translator"/>
-        <choose>
-          <if type="report">
-            <text variable="publisher"/>
-            <text variable="title" form="short" font-style="italic"/>
-          </if>
-          <else-if type="legal_case">
-            <text variable="title" font-style="italic"/>
-          </else-if>
-          <else-if type="book graphic  motion_picture song" match="any">
-            <text variable="title" form="short" font-style="italic"/>
-          </else-if>
-          <else-if type="bill legislation" match="any">
-            <text variable="title" form="short"/>
-          </else-if>
-          <else-if variable="reviewed-author">
+    <choose>
+      <if type="patent" variable="number" match="all">
+        <text variable="number"/>
+      </if>
+      <else>
+        <names variable="author">
+          <name form="short" and="symbol" delimiter=", " initialize-with=". "/>
+          <substitute>
+            <names variable="editor"/>
+            <names variable="translator"/>
             <choose>
-              <if variable="reviewed-title" match="none">
-                <text variable="title" form="short" font-style="italic" prefix="Review of "/>
+              <if type="report">
+                <text variable="publisher"/>
+                <text variable="title" form="short" font-style="italic"/>
               </if>
+              <else-if type="legal_case">
+                <text variable="title" font-style="italic"/>
+              </else-if>
+              <else-if type="book graphic  motion_picture song" match="any">
+                <text variable="title" form="short" font-style="italic"/>
+              </else-if>
+              <else-if type="bill legislation" match="any">
+                <text variable="title" form="short"/>
+              </else-if>
+              <else-if variable="reviewed-author">
+                <choose>
+                  <if variable="reviewed-title" match="none">
+                    <text variable="title" form="short" font-style="italic" prefix="Review of "/>
+                  </if>
+                  <else>
+                    <text variable="title" form="short" quotes="true"/>
+                  </else>
+                </choose>
+              </else-if>
               <else>
                 <text variable="title" form="short" quotes="true"/>
               </else>
             </choose>
-          </else-if>
-          <else>
-            <text variable="title" form="short" quotes="true"/>
-          </else>
-        </choose>
-      </substitute>
-    </names>
+          </substitute>
+        </names>
+      </else>
+    </choose>
   </macro>
   <macro name="access">
     <choose>
@@ -142,6 +149,13 @@
           <if variable="DOI" match="any">
             <text variable="DOI" prefix="https://doi.org/"/>
           </if>
+          <else-if variable="URL" match="any">
+            <group>
+              <text term="retrieved" text-case="capitalize-first" suffix=" "/>
+              <text term="from" suffix=" "/>
+              <text variable="URL"/>
+            </group>
+          </else-if>
           <else-if variable="archive" match="any">
             <group>
               <text term="retrieved" text-case="capitalize-first" suffix=" "/>
@@ -150,13 +164,6 @@
               <text variable="archive_location" prefix=" (" suffix=")"/>
             </group>
           </else-if>
-          <else>
-            <group>
-              <text term="retrieved" text-case="capitalize-first" suffix=" "/>
-              <text term="from" suffix=" "/>
-              <text variable="URL"/>
-            </group>
-          </else>
         </choose>
       </if>
       <else>
@@ -166,7 +173,7 @@
           </if>
           <else>
             <choose>
-              <if type="webpage">
+              <if type="post post-weblog webpage" match="any">
                 <group delimiter=" ">
                   <text term="retrieved" text-case="capitalize-first" suffix=" "/>
                   <group>
@@ -227,6 +234,9 @@
             </group>
           </else>
         </choose>
+      </else-if>
+      <else-if type="patent" variable="number" match="all">
+        <text variable="number" font-style="italic"/>
       </else-if>
       <else>
         <text variable="title"/>
@@ -292,6 +302,19 @@
           <text variable="publisher-place"/>
         </group>
       </else-if>
+      <else-if type="patent">
+        <group delimiter=": ">
+          <text variable="publisher-place"/>
+          <choose>
+            <if variable="publisher">
+              <text variable="publisher"/>
+            </if>
+            <else>
+              <text variable="authority"/>
+            </else>
+          </choose>
+        </group>
+      </else-if>
       <else-if type="post-weblog webpage" match="none">
         <group delimiter=", ">
           <choose>
@@ -301,7 +324,7 @@
             </if>
           </choose>
           <choose>
-            <if type="article-journal article-magazine" match="none">
+            <if type="article-journal article-magazine article-newspaper" match="none">
               <group delimiter=": ">
                 <choose>
                   <if variable="publisher-place">

--- a/apa-no-ampersand.csl
+++ b/apa-no-ampersand.csl
@@ -101,7 +101,7 @@
   <macro name="author-short">
     <choose>
       <if type="patent" variable="number" match="all">
-        <text variable="number"/>
+        <text macro="patent-number"/>
       </if>
       <else>
         <names variable="author">
@@ -141,6 +141,16 @@
         </names>
       </else>
     </choose>
+  </macro>
+  <macro name="patent-number">
+    <!-- genre: U.S. Patent number: 123,445-->
+    <group delimiter=" ">
+      <group delimiter=" ">
+	<text variable="genre"/>
+	<text term="issue" form="short" text-case="capitalize-first"/>
+      </group>
+      <text variable="number"/>
+    </group>
   </macro>
   <macro name="access">
     <choose>
@@ -236,7 +246,7 @@
         </choose>
       </else-if>
       <else-if type="patent" variable="number" match="all">
-        <text variable="number" font-style="italic"/>
+        <text macro="patent-number" font-style="italic"/>
       </else-if>
       <else>
         <text variable="title"/>

--- a/apa-no-ampersand.csl
+++ b/apa-no-ampersand.csl
@@ -99,41 +99,48 @@
     </names>
   </macro>
   <macro name="author-short">
-    <names variable="author">
-      <name form="short" and="text" delimiter=", " initialize-with=". "/>
-      <substitute>
-        <names variable="editor"/>
-        <names variable="translator"/>
-        <choose>
-          <if type="report">
-            <text variable="publisher"/>
-            <text variable="title" form="short" font-style="italic"/>
-          </if>
-          <else-if type="legal_case">
-            <text variable="title" font-style="italic"/>
-          </else-if>
-          <else-if type="book graphic  motion_picture song" match="any">
-            <text variable="title" form="short" font-style="italic"/>
-          </else-if>
-          <else-if type="bill legislation" match="any">
-            <text variable="title" form="short"/>
-          </else-if>
-          <else-if variable="reviewed-author">
+    <choose>
+      <if type="patent" variable="number" match="all">
+        <text variable="number"/>
+      </if>
+      <else>
+        <names variable="author">
+          <name form="short" and="symbol" delimiter=", " initialize-with=". "/>
+          <substitute>
+            <names variable="editor"/>
+            <names variable="translator"/>
             <choose>
-              <if variable="reviewed-title" match="none">
-                <text variable="title" form="short" font-style="italic" prefix="Review of "/>
+              <if type="report">
+                <text variable="publisher"/>
+                <text variable="title" form="short" font-style="italic"/>
               </if>
+              <else-if type="legal_case">
+                <text variable="title" font-style="italic"/>
+              </else-if>
+              <else-if type="book graphic  motion_picture song" match="any">
+                <text variable="title" form="short" font-style="italic"/>
+              </else-if>
+              <else-if type="bill legislation" match="any">
+                <text variable="title" form="short"/>
+              </else-if>
+              <else-if variable="reviewed-author">
+                <choose>
+                  <if variable="reviewed-title" match="none">
+                    <text variable="title" form="short" font-style="italic" prefix="Review of "/>
+                  </if>
+                  <else>
+                    <text variable="title" form="short" quotes="true"/>
+                  </else>
+                </choose>
+              </else-if>
               <else>
                 <text variable="title" form="short" quotes="true"/>
               </else>
             </choose>
-          </else-if>
-          <else>
-            <text variable="title" form="short" quotes="true"/>
-          </else>
-        </choose>
-      </substitute>
-    </names>
+          </substitute>
+        </names>
+      </else>
+    </choose>
   </macro>
   <macro name="access">
     <choose>
@@ -142,6 +149,13 @@
           <if variable="DOI" match="any">
             <text variable="DOI" prefix="https://doi.org/"/>
           </if>
+          <else-if variable="URL" match="any">
+            <group>
+              <text term="retrieved" text-case="capitalize-first" suffix=" "/>
+              <text term="from" suffix=" "/>
+              <text variable="URL"/>
+            </group>
+          </else-if>
           <else-if variable="archive" match="any">
             <group>
               <text term="retrieved" text-case="capitalize-first" suffix=" "/>
@@ -150,13 +164,6 @@
               <text variable="archive_location" prefix=" (" suffix=")"/>
             </group>
           </else-if>
-          <else>
-            <group>
-              <text term="retrieved" text-case="capitalize-first" suffix=" "/>
-              <text term="from" suffix=" "/>
-              <text variable="URL"/>
-            </group>
-          </else>
         </choose>
       </if>
       <else>
@@ -166,7 +173,7 @@
           </if>
           <else>
             <choose>
-              <if type="webpage">
+              <if type="post post-weblog webpage" match="any">
                 <group delimiter=" ">
                   <text term="retrieved" text-case="capitalize-first" suffix=" "/>
                   <group>
@@ -227,6 +234,9 @@
             </group>
           </else>
         </choose>
+      </else-if>
+      <else-if type="patent" variable="number" match="all">
+        <text variable="number" font-style="italic"/>
       </else-if>
       <else>
         <text variable="title"/>
@@ -292,6 +302,19 @@
           <text variable="publisher-place"/>
         </group>
       </else-if>
+      <else-if type="patent">
+        <group delimiter=": ">
+          <text variable="publisher-place"/>
+          <choose>
+            <if variable="publisher">
+              <text variable="publisher"/>
+            </if>
+            <else>
+              <text variable="authority"/>
+            </else>
+          </choose>
+        </group>
+      </else-if>
       <else-if type="post-weblog webpage" match="none">
         <group delimiter=", ">
           <choose>
@@ -301,7 +324,7 @@
             </if>
           </choose>
           <choose>
-            <if type="article-journal article-magazine" match="none">
+            <if type="article-journal article-magazine article-newspaper" match="none">
               <group delimiter=": ">
                 <choose>
                   <if variable="publisher-place">

--- a/apa-no-doi-no-issue.csl
+++ b/apa-no-doi-no-issue.csl
@@ -101,7 +101,7 @@
   <macro name="author-short">
     <choose>
       <if type="patent" variable="number" match="all">
-        <text variable="number"/>
+        <text macro="patent-number"/>
       </if>
       <else>
         <names variable="author">
@@ -141,6 +141,16 @@
         </names>
       </else>
     </choose>
+  </macro>
+  <macro name="patent-number">
+    <!-- genre: U.S. Patent number: 123,445-->
+    <group delimiter=" ">
+      <group delimiter=" ">
+	<text variable="genre"/>
+	<text term="issue" form="short" text-case="capitalize-first"/>
+      </group>
+      <text variable="number"/>
+    </group>
   </macro>
   <macro name="access">
     <choose>
@@ -237,7 +247,7 @@
         </choose>
       </else-if>
       <else-if type="patent" variable="number" match="all">
-        <text variable="number" font-style="italic"/>
+        <text macro="patent-number" font-style="italic"/>
       </else-if>
       <else>
         <text variable="title"/>

--- a/apa-no-doi-no-issue.csl
+++ b/apa-no-doi-no-issue.csl
@@ -24,6 +24,10 @@
     <contributor>
       <name>Sebastian Karcher</name>
     </contributor>
+    <contributor>
+      <name> Brenton M. Wiernik</name>
+      <email>zotero@wiernik.org</email>
+    </contributor>
     <category citation-format="author-date"/>
     <category field="psychology"/>
     <category field="generic-base"/>
@@ -46,20 +50,32 @@
   <macro name="container-contributors">
     <choose>
       <if type="chapter paper-conference entry-dictionary entry-encyclopedia" match="any">
-        <names variable="editor translator container-author" delimiter=", " suffix=", ">
-          <name and="symbol" initialize-with=". " delimiter=", "/>
-          <label form="short" prefix=" (" text-case="title" suffix=")"/>
-        </names>
+        <group delimiter=", ">
+          <names variable="container-author" delimiter=", ">
+            <name and="symbol" initialize-with=". " delimiter=", "/>
+            <label form="short" prefix=" (" text-case="title" suffix=")"/>
+          </names>
+          <names variable="editor translator" delimiter=", ">
+            <name and="symbol" initialize-with=". " delimiter=", "/>
+            <label form="short" prefix=" (" text-case="title" suffix=")"/>
+          </names>
+        </group>
       </if>
     </choose>
   </macro>
   <macro name="secondary-contributors">
     <choose>
       <if type="article-journal chapter paper-conference entry-dictionary entry-encyclopedia" match="none">
-        <names variable="translator editor container-author" delimiter=", " prefix=" (" suffix=")">
-          <name and="symbol" initialize-with=". " delimiter=", "/>
-          <label form="short" prefix=", " text-case="title"/>
-        </names>
+        <group delimiter=", " prefix=" (" suffix=")">
+          <names variable="container-author" delimiter=", ">
+            <name and="symbol" initialize-with=". " delimiter=", "/>
+            <label form="short" prefix=", " text-case="title"/>
+          </names>
+          <names variable="editor translator" delimiter=", ">
+            <name and="symbol" initialize-with=". " delimiter=", "/>
+            <label form="short" prefix=", " text-case="title"/>
+          </names>
+        </group>
       </if>
     </choose>
   </macro>
@@ -83,28 +99,48 @@
     </names>
   </macro>
   <macro name="author-short">
-    <names variable="author">
-      <name form="short" and="symbol" delimiter=", " initialize-with=". "/>
-      <substitute>
-        <names variable="editor"/>
-        <names variable="translator"/>
-        <choose>
-          <if type="report">
-            <text variable="publisher"/>
-            <text variable="title" form="short" font-style="italic"/>
-          </if>
-          <else-if type="legal_case">
-            <text variable="title" font-style="italic"/>
-          </else-if>
-          <else-if type="bill book graphic legislation motion_picture song" match="any">
-            <text variable="title" form="short" font-style="italic"/>
-          </else-if>
-          <else>
-            <text variable="title" form="short" quotes="true"/>
-          </else>
-        </choose>
-      </substitute>
-    </names>
+    <choose>
+      <if type="patent" variable="number" match="all">
+        <text variable="number"/>
+      </if>
+      <else>
+        <names variable="author">
+          <name form="short" and="symbol" delimiter=", " initialize-with=". "/>
+          <substitute>
+            <names variable="editor"/>
+            <names variable="translator"/>
+            <choose>
+              <if type="report">
+                <text variable="publisher"/>
+                <text variable="title" form="short" font-style="italic"/>
+              </if>
+              <else-if type="legal_case">
+                <text variable="title" font-style="italic"/>
+              </else-if>
+              <else-if type="book graphic  motion_picture song" match="any">
+                <text variable="title" form="short" font-style="italic"/>
+              </else-if>
+              <else-if type="bill legislation" match="any">
+                <text variable="title" form="short"/>
+              </else-if>
+              <else-if variable="reviewed-author">
+                <choose>
+                  <if variable="reviewed-title" match="none">
+                    <text variable="title" form="short" font-style="italic" prefix="Review of "/>
+                  </if>
+                  <else>
+                    <text variable="title" form="short" quotes="true"/>
+                  </else>
+                </choose>
+              </else-if>
+              <else>
+                <text variable="title" form="short" quotes="true"/>
+              </else>
+            </choose>
+          </substitute>
+        </names>
+      </else>
+    </choose>
   </macro>
   <macro name="access">
     <choose>
@@ -163,7 +199,7 @@
   </macro>
   <macro name="title">
     <choose>
-      <if type="report thesis book graphic motion_picture report song manuscript speech" match="any">
+      <if type="book graphic manuscript motion_picture report song speech thesis" match="any">
         <choose>
           <if variable="version" type="book" match="all">
             <!---This is a hack until we have a computer program type -->
@@ -174,6 +210,35 @@
           </else>
         </choose>
       </if>
+      <else-if variable="reviewed-author">
+        <choose>
+          <if variable="reviewed-title">
+            <group delimiter=" ">
+              <text variable="title"/>
+              <group delimiter=", " prefix="[" suffix="]">
+                <text variable="reviewed-title" font-style="italic" prefix="Review of "/>
+                <names variable="reviewed-author" delimiter=", ">
+                  <label form="verb-short" suffix=" "/>
+                  <name and="symbol" initialize-with=". " delimiter=", "/>
+                </names>
+              </group>
+            </group>
+          </if>
+          <else>
+            <!-- assume `title` is title of reviewed work -->
+            <group delimiter=", " prefix="[" suffix="]">
+              <text variable="title" font-style="italic" prefix="Review of "/>
+              <names variable="reviewed-author" delimiter=", ">
+                <label form="verb-short" suffix=" "/>
+                <name and="symbol" initialize-with=". " delimiter=", "/>
+              </names>
+            </group>
+          </else>
+        </choose>
+      </else-if>
+      <else-if type="patent" variable="number" match="all">
+        <text variable="number" font-style="italic"/>
+      </else-if>
       <else>
         <text variable="title"/>
       </else>
@@ -183,9 +248,23 @@
     <text macro="title"/>
     <choose>
       <if type="report thesis" match="any">
-        <group prefix=" (" suffix=")" delimiter=" ">
-          <text variable="genre"/>
-          <text variable="number" prefix="No. "/>
+        <group prefix=" (" suffix=")" delimiter=", ">
+          <group delimiter=" ">
+            <choose>
+              <if variable="genre" match="any">
+                <text variable="genre"/>
+              </if>
+              <else>
+                <text variable="collection-title"/>
+              </else>
+            </choose>
+            <text variable="number" prefix="No. "/>
+          </group>
+          <group delimiter=" ">
+            <text term="version" text-case="capitalize-first"/>
+            <text variable="version"/>
+          </group>
+          <text macro="edition"/>
         </group>
       </if>
       <else-if type="post-weblog webpage" match="any">
@@ -198,10 +277,17 @@
         </group>
       </else-if>
     </choose>
-    <text macro="format"/>
+    <text macro="format" prefix=" [" suffix="]"/>
   </macro>
   <macro name="format">
-    <text variable="medium" text-case="capitalize-first" prefix=" [" suffix="]"/>
+    <choose>
+      <if match="any" variable="medium">
+        <text variable="medium" text-case="capitalize-first"/>
+      </if>
+      <else-if type="dataset" match="any">
+        <text value="Data set"/>
+      </else-if>
+    </choose>
   </macro>
   <macro name="publisher">
     <choose>
@@ -217,16 +303,29 @@
           <text variable="publisher-place"/>
         </group>
       </else-if>
+      <else-if type="patent">
+        <group delimiter=": ">
+          <text variable="publisher-place"/>
+          <choose>
+            <if variable="publisher">
+              <text variable="publisher"/>
+            </if>
+            <else>
+              <text variable="authority"/>
+            </else>
+          </choose>
+        </group>
+      </else-if>
       <else-if type="post-weblog webpage" match="none">
         <group delimiter=", ">
           <choose>
-            <if variable="event version" type="speech" match="none">
+            <if variable="event version" type="speech motion_picture" match="none">
               <!-- Including version is to avoid printing the programming language for computerProgram /-->
               <text variable="genre"/>
             </if>
           </choose>
           <choose>
-            <if type="article-journal article-magazine" match="none">
+            <if type="article-journal article-magazine article-newspaper" match="none">
               <group delimiter=": ">
                 <choose>
                   <if variable="publisher-place">
@@ -286,7 +385,7 @@
                     <date-part prefix=", " name="month"/>
                   </date>
                 </if>
-                <else-if type="article-journal bill book chapter graphic legal_case legislation motion_picture paper-conference report song" match="none">
+                <else-if type="article-journal bill book chapter graphic legal_case legislation motion_picture paper-conference report song dataset" match="none">
                   <date variable="issued">
                     <date-part prefix=", " name="month"/>
                     <date-part prefix=" " name="day"/>
@@ -313,7 +412,7 @@
   </macro>
   <macro name="issued-sort">
     <choose>
-      <if type="article-journal bill book chapter graphic legal_case legislation motion_picture paper-conference report song" match="none">
+      <if type="article-journal bill book chapter graphic legal_case legislation motion_picture paper-conference report song dataset" match="none">
         <date variable="issued">
           <date-part name="year"/>
           <date-part name="month"/>
@@ -331,13 +430,13 @@
     <choose>
       <if variable="issued">
         <group delimiter="/">
+          <date variable="original-date" form="text"/>
           <group>
             <date variable="issued">
               <date-part name="year"/>
             </date>
             <text variable="year-suffix"/>
           </group>
-          <date variable="original-date" form="text"/>
         </group>
       </if>
       <else-if variable="status">
@@ -391,7 +490,12 @@
       </else-if>
       <else-if type="book graphic motion_picture report song chapter paper-conference entry-encyclopedia entry-dictionary" match="any">
         <group prefix=" (" suffix=")" delimiter=", ">
-          <text macro="edition"/>
+          <choose>
+            <if type="report" match="none">
+              <!-- edition for report is included in title-plus-extra /-->
+              <text macro="edition"/>
+            </if>
+          </choose>
           <choose>
             <if variable="volume" match="any">
               <group>
@@ -415,7 +519,15 @@
       <else-if type="legal_case">
         <group prefix=" (" suffix=")" delimiter=" ">
           <text variable="authority"/>
-          <date variable="issued" form="text"/>
+          <choose>
+            <if variable="container-title" match="any">
+              <!--Only print year for cases published in reporters-->
+              <date variable="issued" form="numeric" date-parts="year"/>
+            </if>
+            <else>
+              <date variable="issued" form="text"/>
+            </else>
+          </choose>
         </group>
       </else-if>
       <else-if type="bill legislation" match="any">
@@ -447,9 +559,11 @@
               <text term="in" text-case="capitalize-first" suffix=" "/>
             </if>
           </choose>
-          <text macro="container-contributors"/>
-          <text macro="secondary-contributors"/>
-          <text macro="container-title"/>
+          <group delimiter=", ">
+            <text macro="container-contributors"/>
+            <text macro="secondary-contributors"/>
+            <text macro="container-title"/>
+          </group>
         </group>
       </if>
     </choose>
@@ -466,8 +580,8 @@
   </macro>
   <macro name="legal-cites">
     <choose>
-      <if type="bill legal_case legislation" match="any">
-        <group delimiter=" " prefix=", ">
+      <if type="legal_case" match="any">
+        <group prefix=", " delimiter=" ">
           <choose>
             <if variable="container-title">
               <text variable="volume"/>
@@ -480,23 +594,40 @@
               <text variable="page"/>
             </if>
             <else>
-              <choose>
-                <if type="legal_case">
-                  <text variable="number" prefix="No. "/>
-                </if>
-                <else>
-                  <text variable="number" prefix="Pub. L. No. "/>
-                  <group delimiter=" ">
-                    <!--change to label variable="section" as that becomes available -->
-                    <text term="section" form="symbol"/>
-                    <text variable="section"/>
-                  </group>
-                </else>
-              </choose>
+              <text variable="number" prefix="No. "/>
             </else>
           </choose>
         </group>
       </if>
+      <else-if type="bill legislation" match="any">
+        <group delimiter=", " prefix=", ">
+          <choose>
+            <if variable="number">
+              <!--There's a public law number-->
+              <text variable="number" prefix="Pub. L. No. "/>
+              <group delimiter=" ">
+                <!--change to label variable="section" as that becomes available -->
+                <text term="section" form="symbol"/>
+                <text variable="section"/>
+              </group>
+              <group delimiter=" ">
+                <text variable="volume"/>
+                <text variable="container-title"/>
+                <text variable="page-first"/>
+              </group>
+            </if>
+            <else>
+              <group delimiter=" ">
+                <text variable="volume"/>
+                <text variable="container-title"/>
+                <!--change to label variable="section" as that becomes available -->
+                <text term="section" form="symbol"/>
+                <text variable="section"/>
+              </group>
+            </else>
+          </choose>
+        </group>
+      </else-if>
     </choose>
   </macro>
   <macro name="original-date">

--- a/apa-old-doi-prefix.csl
+++ b/apa-old-doi-prefix.csl
@@ -98,41 +98,48 @@
     </names>
   </macro>
   <macro name="author-short">
-    <names variable="author">
-      <name form="short" and="symbol" delimiter=", " initialize-with=". "/>
-      <substitute>
-        <names variable="editor"/>
-        <names variable="translator"/>
-        <choose>
-          <if type="report">
-            <text variable="publisher"/>
-            <text variable="title" form="short" font-style="italic"/>
-          </if>
-          <else-if type="legal_case">
-            <text variable="title" font-style="italic"/>
-          </else-if>
-          <else-if type="book graphic  motion_picture song" match="any">
-            <text variable="title" form="short" font-style="italic"/>
-          </else-if>
-          <else-if type="bill legislation" match="any">
-            <text variable="title" form="short"/>
-          </else-if>
-          <else-if variable="reviewed-author">
+    <choose>
+      <if type="patent" variable="number" match="all">
+        <text variable="number"/>
+      </if>
+      <else>
+        <names variable="author">
+          <name form="short" and="symbol" delimiter=", " initialize-with=". "/>
+          <substitute>
+            <names variable="editor"/>
+            <names variable="translator"/>
             <choose>
-              <if variable="reviewed-title" match="none">
-                <text variable="title" form="short" font-style="italic" prefix="Review of "/>
+              <if type="report">
+                <text variable="publisher"/>
+                <text variable="title" form="short" font-style="italic"/>
               </if>
+              <else-if type="legal_case">
+                <text variable="title" font-style="italic"/>
+              </else-if>
+              <else-if type="book graphic  motion_picture song" match="any">
+                <text variable="title" form="short" font-style="italic"/>
+              </else-if>
+              <else-if type="bill legislation" match="any">
+                <text variable="title" form="short"/>
+              </else-if>
+              <else-if variable="reviewed-author">
+                <choose>
+                  <if variable="reviewed-title" match="none">
+                    <text variable="title" form="short" font-style="italic" prefix="Review of "/>
+                  </if>
+                  <else>
+                    <text variable="title" form="short" quotes="true"/>
+                  </else>
+                </choose>
+              </else-if>
               <else>
                 <text variable="title" form="short" quotes="true"/>
               </else>
             </choose>
-          </else-if>
-          <else>
-            <text variable="title" form="short" quotes="true"/>
-          </else>
-        </choose>
-      </substitute>
-    </names>
+          </substitute>
+        </names>
+      </else>
+    </choose>
   </macro>
   <macro name="access">
     <choose>
@@ -141,6 +148,13 @@
           <if variable="DOI" match="any">
             <text variable="DOI" prefix="doi:/"/>
           </if>
+          <else-if variable="URL" match="any">
+            <group>
+              <text term="retrieved" text-case="capitalize-first" suffix=" "/>
+              <text term="from" suffix=" "/>
+              <text variable="URL"/>
+            </group>
+          </else-if>
           <else-if variable="archive" match="any">
             <group>
               <text term="retrieved" text-case="capitalize-first" suffix=" "/>
@@ -149,13 +163,6 @@
               <text variable="archive_location" prefix=" (" suffix=")"/>
             </group>
           </else-if>
-          <else>
-            <group>
-              <text term="retrieved" text-case="capitalize-first" suffix=" "/>
-              <text term="from" suffix=" "/>
-              <text variable="URL"/>
-            </group>
-          </else>
         </choose>
       </if>
       <else>
@@ -165,7 +172,7 @@
           </if>
           <else>
             <choose>
-              <if type="webpage">
+              <if type="post post-weblog webpage" match="any">
                 <group delimiter=" ">
                   <text term="retrieved" text-case="capitalize-first" suffix=" "/>
                   <group>
@@ -226,6 +233,9 @@
             </group>
           </else>
         </choose>
+      </else-if>
+      <else-if type="patent" variable="number" match="all">
+        <text variable="number" font-style="italic"/>
       </else-if>
       <else>
         <text variable="title"/>
@@ -291,6 +301,19 @@
           <text variable="publisher-place"/>
         </group>
       </else-if>
+      <else-if type="patent">
+        <group delimiter=": ">
+          <text variable="publisher-place"/>
+          <choose>
+            <if variable="publisher">
+              <text variable="publisher"/>
+            </if>
+            <else>
+              <text variable="authority"/>
+            </else>
+          </choose>
+        </group>
+      </else-if>
       <else-if type="post-weblog webpage" match="none">
         <group delimiter=", ">
           <choose>
@@ -300,7 +323,7 @@
             </if>
           </choose>
           <choose>
-            <if type="article-journal article-magazine" match="none">
+            <if type="article-journal article-magazine article-newspaper" match="none">
               <group delimiter=": ">
                 <choose>
                   <if variable="publisher-place">

--- a/apa-old-doi-prefix.csl
+++ b/apa-old-doi-prefix.csl
@@ -100,7 +100,7 @@
   <macro name="author-short">
     <choose>
       <if type="patent" variable="number" match="all">
-        <text variable="number"/>
+        <text macro="patent-number"/>
       </if>
       <else>
         <names variable="author">
@@ -140,6 +140,16 @@
         </names>
       </else>
     </choose>
+  </macro>
+  <macro name="patent-number">
+    <!-- genre: U.S. Patent number: 123,445-->
+    <group delimiter=" ">
+      <group delimiter=" ">
+	<text variable="genre"/>
+	<text term="issue" form="short" text-case="capitalize-first"/>
+      </group>
+      <text variable="number"/>
+    </group>
   </macro>
   <macro name="access">
     <choose>
@@ -235,7 +245,7 @@
         </choose>
       </else-if>
       <else-if type="patent" variable="number" match="all">
-        <text variable="number" font-style="italic"/>
+        <text macro="patent-number" font-style="italic"/>
       </else-if>
       <else>
         <text variable="title"/>

--- a/apa-single-spaced.csl
+++ b/apa-single-spaced.csl
@@ -101,7 +101,7 @@
   <macro name="author-short">
     <choose>
       <if type="patent" variable="number" match="all">
-        <text variable="number"/>
+        <text macro="patent-number"/>
       </if>
       <else>
         <names variable="author">
@@ -141,6 +141,16 @@
         </names>
       </else>
     </choose>
+  </macro>
+  <macro name="patent-number">
+    <!-- genre: U.S. Patent number: 123,445-->
+    <group delimiter=" ">
+      <group delimiter=" ">
+	<text variable="genre"/>
+	<text term="issue" form="short" text-case="capitalize-first"/>
+      </group>
+      <text variable="number"/>
+    </group>
   </macro>
   <macro name="access">
     <choose>
@@ -236,7 +246,7 @@
         </choose>
       </else-if>
       <else-if type="patent" variable="number" match="all">
-        <text variable="number" font-style="italic"/>
+        <text macro="patent-number" font-style="italic"/>
       </else-if>
       <else>
         <text variable="title"/>

--- a/apa-single-spaced.csl
+++ b/apa-single-spaced.csl
@@ -99,41 +99,48 @@
     </names>
   </macro>
   <macro name="author-short">
-    <names variable="author">
-      <name form="short" and="symbol" delimiter=", " initialize-with=". "/>
-      <substitute>
-        <names variable="editor"/>
-        <names variable="translator"/>
-        <choose>
-          <if type="report">
-            <text variable="publisher"/>
-            <text variable="title" form="short" font-style="italic"/>
-          </if>
-          <else-if type="legal_case">
-            <text variable="title" font-style="italic"/>
-          </else-if>
-          <else-if type="book graphic  motion_picture song" match="any">
-            <text variable="title" form="short" font-style="italic"/>
-          </else-if>
-          <else-if type="bill legislation" match="any">
-            <text variable="title" form="short"/>
-          </else-if>
-          <else-if variable="reviewed-author">
+    <choose>
+      <if type="patent" variable="number" match="all">
+        <text variable="number"/>
+      </if>
+      <else>
+        <names variable="author">
+          <name form="short" and="symbol" delimiter=", " initialize-with=". "/>
+          <substitute>
+            <names variable="editor"/>
+            <names variable="translator"/>
             <choose>
-              <if variable="reviewed-title" match="none">
-                <text variable="title" form="short" font-style="italic" prefix="Review of "/>
+              <if type="report">
+                <text variable="publisher"/>
+                <text variable="title" form="short" font-style="italic"/>
               </if>
+              <else-if type="legal_case">
+                <text variable="title" font-style="italic"/>
+              </else-if>
+              <else-if type="book graphic  motion_picture song" match="any">
+                <text variable="title" form="short" font-style="italic"/>
+              </else-if>
+              <else-if type="bill legislation" match="any">
+                <text variable="title" form="short"/>
+              </else-if>
+              <else-if variable="reviewed-author">
+                <choose>
+                  <if variable="reviewed-title" match="none">
+                    <text variable="title" form="short" font-style="italic" prefix="Review of "/>
+                  </if>
+                  <else>
+                    <text variable="title" form="short" quotes="true"/>
+                  </else>
+                </choose>
+              </else-if>
               <else>
                 <text variable="title" form="short" quotes="true"/>
               </else>
             </choose>
-          </else-if>
-          <else>
-            <text variable="title" form="short" quotes="true"/>
-          </else>
-        </choose>
-      </substitute>
-    </names>
+          </substitute>
+        </names>
+      </else>
+    </choose>
   </macro>
   <macro name="access">
     <choose>
@@ -142,6 +149,13 @@
           <if variable="DOI" match="any">
             <text variable="DOI" prefix="https://doi.org/"/>
           </if>
+          <else-if variable="URL" match="any">
+            <group>
+              <text term="retrieved" text-case="capitalize-first" suffix=" "/>
+              <text term="from" suffix=" "/>
+              <text variable="URL"/>
+            </group>
+          </else-if>
           <else-if variable="archive" match="any">
             <group>
               <text term="retrieved" text-case="capitalize-first" suffix=" "/>
@@ -150,13 +164,6 @@
               <text variable="archive_location" prefix=" (" suffix=")"/>
             </group>
           </else-if>
-          <else>
-            <group>
-              <text term="retrieved" text-case="capitalize-first" suffix=" "/>
-              <text term="from" suffix=" "/>
-              <text variable="URL"/>
-            </group>
-          </else>
         </choose>
       </if>
       <else>
@@ -166,7 +173,7 @@
           </if>
           <else>
             <choose>
-              <if type="webpage">
+              <if type="post post-weblog webpage" match="any">
                 <group delimiter=" ">
                   <text term="retrieved" text-case="capitalize-first" suffix=" "/>
                   <group>
@@ -227,6 +234,9 @@
             </group>
           </else>
         </choose>
+      </else-if>
+      <else-if type="patent" variable="number" match="all">
+        <text variable="number" font-style="italic"/>
       </else-if>
       <else>
         <text variable="title"/>
@@ -292,6 +302,19 @@
           <text variable="publisher-place"/>
         </group>
       </else-if>
+      <else-if type="patent">
+        <group delimiter=": ">
+          <text variable="publisher-place"/>
+          <choose>
+            <if variable="publisher">
+              <text variable="publisher"/>
+            </if>
+            <else>
+              <text variable="authority"/>
+            </else>
+          </choose>
+        </group>
+      </else-if>
       <else-if type="post-weblog webpage" match="none">
         <group delimiter=", ">
           <choose>
@@ -301,7 +324,7 @@
             </if>
           </choose>
           <choose>
-            <if type="article-journal article-magazine" match="none">
+            <if type="article-journal article-magazine article-newspaper" match="none">
               <group delimiter=": ">
                 <choose>
                   <if variable="publisher-place">

--- a/apa.csl
+++ b/apa.csl
@@ -100,7 +100,7 @@
   <macro name="author-short">
     <choose>
       <if type="patent" variable="number" match="all">
-        <text variable="number"/>
+        <text macro="patent-number"/>
       </if>
       <else>
         <names variable="author">
@@ -140,6 +140,16 @@
         </names>
       </else>
     </choose>
+  </macro>
+  <macro name="patent-number">
+    <!-- genre: U.S. Patent number: 123,445-->
+    <group delimiter=" ">
+      <group delimiter=" ">
+	<text variable="genre"/>
+	<text term="issue" form="short" text-case="capitalize-first"/>
+      </group>
+      <text variable="number"/>
+    </group>
   </macro>
   <macro name="access">
     <choose>
@@ -235,7 +245,7 @@
         </choose>
       </else-if>
       <else-if type="patent" variable="number" match="all">
-        <text variable="number" font-style="italic"/>
+        <text macro="patent-number" font-style="italic"/>
       </else-if>
       <else>
         <text variable="title"/>

--- a/apa.csl
+++ b/apa.csl
@@ -98,41 +98,48 @@
     </names>
   </macro>
   <macro name="author-short">
-    <names variable="author">
-      <name form="short" and="symbol" delimiter=", " initialize-with=". "/>
-      <substitute>
-        <names variable="editor"/>
-        <names variable="translator"/>
-        <choose>
-          <if type="report">
-            <text variable="publisher"/>
-            <text variable="title" form="short" font-style="italic"/>
-          </if>
-          <else-if type="legal_case">
-            <text variable="title" font-style="italic"/>
-          </else-if>
-          <else-if type="book graphic  motion_picture song" match="any">
-            <text variable="title" form="short" font-style="italic"/>
-          </else-if>
-          <else-if type="bill legislation" match="any">
-            <text variable="title" form="short"/>
-          </else-if>
-          <else-if variable="reviewed-author">
+    <choose>
+      <if type="patent" variable="number" match="all">
+        <text variable="number"/>
+      </if>
+      <else>
+        <names variable="author">
+          <name form="short" and="symbol" delimiter=", " initialize-with=". "/>
+          <substitute>
+            <names variable="editor"/>
+            <names variable="translator"/>
             <choose>
-              <if variable="reviewed-title" match="none">
-                <text variable="title" form="short" font-style="italic" prefix="Review of "/>
+              <if type="report">
+                <text variable="publisher"/>
+                <text variable="title" form="short" font-style="italic"/>
               </if>
+              <else-if type="legal_case">
+                <text variable="title" font-style="italic"/>
+              </else-if>
+              <else-if type="book graphic  motion_picture song" match="any">
+                <text variable="title" form="short" font-style="italic"/>
+              </else-if>
+              <else-if type="bill legislation" match="any">
+                <text variable="title" form="short"/>
+              </else-if>
+              <else-if variable="reviewed-author">
+                <choose>
+                  <if variable="reviewed-title" match="none">
+                    <text variable="title" form="short" font-style="italic" prefix="Review of "/>
+                  </if>
+                  <else>
+                    <text variable="title" form="short" quotes="true"/>
+                  </else>
+                </choose>
+              </else-if>
               <else>
                 <text variable="title" form="short" quotes="true"/>
               </else>
             </choose>
-          </else-if>
-          <else>
-            <text variable="title" form="short" quotes="true"/>
-          </else>
-        </choose>
-      </substitute>
-    </names>
+          </substitute>
+        </names>
+      </else>
+    </choose>
   </macro>
   <macro name="access">
     <choose>
@@ -227,6 +234,9 @@
           </else>
         </choose>
       </else-if>
+      <else-if type="patent" variable="number" match="all">
+        <text variable="number" font-style="italic"/>
+      </else-if>
       <else>
         <text variable="title"/>
       </else>
@@ -289,6 +299,19 @@
         <group delimiter=", ">
           <text variable="publisher"/>
           <text variable="publisher-place"/>
+        </group>
+      </else-if>
+      <else-if type="patent">
+        <group delimiter=": ">
+          <text variable="publisher-place"/>
+          <choose>
+            <if variable="publisher">
+              <text variable="publisher"/>
+            </if>
+            <else>
+              <text variable="authority"/>
+            </else>
+          </choose>
         </group>
       </else-if>
       <else-if type="post-weblog webpage" match="none">


### PR DESCRIPTION
Patents in APA are really weird:

Reference list entry:
Smith, I. M. (1988).*U.S. Patent No. 123,445*. Washington, DC: U.S. Patent and
Trademark Office.

Text citation:
U.S. Patent No. 123,445 (1988)

@bwiernik if you wouldn't mind taking a look at the changes to apa.csl -- I think you can ignore the rest, those just align similar styles to the "master" copy.
(U.S. Patent No. 123,445, 1988)

edit: a lot of the changes are indenting. Much easier to see what's actually new using `?w=1` at the end of the diff URL