### PR TITLE
Update council-of-science-editors.csl

### DIFF
--- a/council-of-science-editors.csl
+++ b/council-of-science-editors.csl
@@ -1,20 +1,22 @@
 <?xml version="1.0" encoding="utf-8"?>
 <style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" demote-non-dropping-particle="sort-only" default-locale="en-US">
-  <!-- This style was edited with the Visual CSL Editor (http://steveridout.com/csl/visualEditor/) -->
   <info>
     <title>Council of Science Editors, Citation-Sequence (numeric)</title>
     <title-short>CSE C-S</title-short>
     <id>http://www.zotero.org/styles/council-of-science-editors</id>
     <link href="http://www.zotero.org/styles/council-of-science-editors" rel="self"/>
-    <link href="http://bcs.bedfordstmartins.com/resdoc5e/RES5e_ch11_o.html" rel="documentation"/>
+    <link href="http://www.scientificstyleandformat.org/Tools/SSF-Citation-Quick-Guide.html" rel="documentation"/>
     <author>
       <name>Julian Onions</name>
       <email>julian.onions@gmail.com</email>
     </author>
+    <contributor>
+      <name>Patrick O'Brien</name>
+    </contributor>
     <category citation-format="numeric"/>
     <category field="science"/>
-    <summary>The Council of Science Editors style, Citation-Sequence system: numbers in text, sorted by order of appearance in text.</summary>
-    <updated>2014-12-22T17:32:22+00:00</updated>
+    <summary>The Council of Science Editors style 8th edition, Citation-Sequence system: numbers in text, sorted by order of appearance in text.</summary>
+    <updated>2017-07-19T13:51:13+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale xml:lang="en">
@@ -79,19 +81,8 @@
       <date variable="issued" delimiter=" ">
         <date-part name="year"/>
       </date>
-      <!-- (8th edition. 2014-07-13)
-        The month and day of the month or the season must be included in 4
-        situations:
-      -->
       <choose>
         <if type="patent article-newspaper webpage" match="any">
-          <!--
-            2)   when citing patents;
-            3)   with newspaper articles;
-            4)   for dates of update/revision and citation when citing electronic
-              publications. If desired, the month, day, and season may be used in
-              other situations. (electronic journal/magazine articles covered below?)
-          -->
           <date variable="issued" delimiter=" ">
             <date-part name="month" form="short" strip-periods="true"/>
             <date-part name="day"/>
@@ -100,9 +91,6 @@
         <else-if type="article-journal article-magazine" match="any">
           <choose>
             <if variable="volume issue" match="none">
-              <!--
-                1)   when citing a journal that has no volume or issue number;
-              -->
               <date variable="issued" delimiter=" ">
                 <date-part name="month" form="short" strip-periods="true"/>
                 <date-part name="day"/>
@@ -122,19 +110,9 @@
     </group>
   </macro>
   <macro name="pages">
-    <group delimiter="; ">
-      <group>
-        <label variable="page" form="short" suffix=" " plural="never"/>
-        <text variable="page"/>
-      </group>
-      <group>
-        <text variable="number-of-pages"/>
-        <choose>
-          <if is-numeric="number-of-pages">
-            <label variable="number-of-pages" form="short" prefix=" " plural="never"/>
-          </if>
-        </choose>
-      </group>
+    <group>
+      <label variable="page" form="short" suffix=" " plural="never"/>
+      <text variable="page"/>
     </group>
   </macro>
   <macro name="edition">
@@ -168,6 +146,9 @@
         </group>
       </else>
     </choose>
+  </macro>
+  <macro name="doi">
+    <text variable="DOI" prefix=". doi:"/>
   </macro>
   <citation collapse="citation-number">
     <sort>
@@ -210,7 +191,10 @@
               <text macro="editor"/>
               <text variable="container-title" suffix="."/>
             </group>
-            <text variable="volume" prefix="Vol. " suffix="."/>
+            <group delimiter=" " suffix=".">
+              <label text-case="capitalize-first" variable="volume" form="short"/>
+              <text variable="volume"/>
+            </group>
             <text macro="edition"/>
             <group suffix=".">
               <group prefix=" " delimiter="; ">
@@ -262,6 +246,7 @@
       </choose>
       <text prefix=" " macro="collection"/>
       <text prefix=" " macro="access"/>
+      <text macro="doi"/>
     </layout>
   </bibliography>
 </style>

--- a/council-of-science-editors.csl
+++ b/council-of-science-editors.csl
@@ -147,9 +147,6 @@
       </else>
     </choose>
   </macro>
-  <macro name="doi">
-    <text variable="DOI" prefix=". doi:"/>
-  </macro>
   <citation collapse="citation-number">
     <sort>
       <key variable="citation-number"/>
@@ -246,7 +243,7 @@
       </choose>
       <text prefix=" " macro="collection"/>
       <text prefix=" " macro="access"/>
-      <text macro="doi"/>
+      <text variable="DOI" prefix=". doi:"/>
     </layout>
   </bibliography>
 </style>


### PR DESCRIPTION
via https://forums.zotero.org/discussion/comment/267127/#Comment_267127
and https://github.com/citation-style-language/styles/issues/2749
Added the doi bit.
It already had the URL and [accessed] bit.
I'll do the same for the other numeric style once you give me green lights and add it into this PR.