### PR TITLE
Update council-of-science-editors-alphabetical.csl to 8th edition

### DIFF
--- a/council-of-science-editors-alphabetical.csl
+++ b/council-of-science-editors-alphabetical.csl
@@ -1,25 +1,27 @@
 <?xml version="1.0" encoding="utf-8"?>
 <style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" demote-non-dropping-particle="sort-only" default-locale="en-US">
-  <!-- This style was edited with the Visual CSL Editor (http://steveridout.com/csl/visualEditor/) -->
   <info>
     <title>Council of Science Editors, Citation-Name (numeric, sorted alphabetically)</title>
     <title-short>CSE C-N</title-short>
     <id>http://www.zotero.org/styles/council-of-science-editors-alphabetical</id>
     <link href="http://www.zotero.org/styles/council-of-science-editors-alphabetical" rel="self"/>
     <link href="http://www.zotero.org/styles/council-of-science-editors" rel="template"/>
-    <link href="http://bcs.bedfordstmartins.com/resdoc5e/RES5e_ch11_o.html" rel="documentation"/>
+    <link href="http://www.scientificstyleandformat.org/Tools/SSF-Citation-Quick-Guide.html" rel="documentation"/>
     <author>
       <name>Julian Onions</name>
       <email>julian.onions@gmail.com</email>
     </author>
+    <contributor>
+      <name>Patrick O'Brien</name>
+    </contributor>
     <contributor>
       <name>Aurimas Vinckevicius</name>
       <email>aurimas.dev@gmail.com</email>
     </contributor>
     <category citation-format="numeric"/>
     <category field="science"/>
-    <summary>The Council of Science Editors style, Citation-Name system: numbers in text, sorted in alphabetical order by author.</summary>
-    <updated>2014-12-22T17:37:09+00:00</updated>
+    <summary>The Council of Science Editors style 8th edition, Citation-Name system: numbers in text, sorted in alphabetical order by author.</summary>
+    <updated>2017-07-20T08:32:51+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale xml:lang="en">
@@ -84,19 +86,8 @@
       <date variable="issued" delimiter=" ">
         <date-part name="year"/>
       </date>
-      <!-- (8th edition. 2014-07-13)
-        The month and day of the month or the season must be included in 4
-        situations:
-      -->
       <choose>
         <if type="patent article-newspaper webpage" match="any">
-          <!--
-            2)   when citing patents;
-            3)   with newspaper articles;
-            4)   for dates of update/revision and citation when citing electronic
-              publications. If desired, the month, day, and season may be used in
-              other situations. (electronic journal/magazine articles covered below?)
-          -->
           <date variable="issued" delimiter=" ">
             <date-part name="month" form="short" strip-periods="true"/>
             <date-part name="day"/>
@@ -105,9 +96,6 @@
         <else-if type="article-journal article-magazine" match="any">
           <choose>
             <if variable="volume issue" match="none">
-              <!--
-                1)   when citing a journal that has no volume or issue number;
-              -->
               <date variable="issued" delimiter=" ">
                 <date-part name="month" form="short" strip-periods="true"/>
                 <date-part name="day"/>
@@ -127,19 +115,9 @@
     </group>
   </macro>
   <macro name="pages">
-    <group delimiter="; ">
-      <group>
-        <label variable="page" form="short" suffix=" " plural="never"/>
-        <text variable="page"/>
-      </group>
-      <group>
-        <text variable="number-of-pages"/>
-        <choose>
-          <if is-numeric="number-of-pages">
-            <label variable="number-of-pages" form="short" prefix=" " plural="never"/>
-          </if>
-        </choose>
-      </group>
+    <group>
+      <label variable="page" form="short" suffix=" " plural="never"/>
+      <text variable="page"/>
     </group>
   </macro>
   <macro name="edition">
@@ -217,7 +195,10 @@
               <text macro="editor"/>
               <text variable="container-title" suffix="."/>
             </group>
-            <text variable="volume" prefix="Vol. " suffix="."/>
+            <group delimiter=" " suffix=".">
+              <label text-case="capitalize-first" variable="volume" form="short"/>
+              <text variable="volume"/>
+            </group>
             <text macro="edition"/>
             <group suffix="." delimiter="; ">
               <text macro="publisher"/>
@@ -264,6 +245,7 @@
       </choose>
       <text prefix=" " macro="collection"/>
       <text prefix=" " macro="access"/>
+      <text variable="DOI" prefix=". doi:"/>
     </layout>
   </bibliography>
 </style>


### PR DESCRIPTION
via https://forums.zotero.org/discussion/comment/267127/#Comment_267127
and https://github.com/citation-style-language/styles/issues/2749
Added the doi bit.
It already had the URL and [accessed] bit.
"Normal" numeric style dealt with here: https://github.com/citation-style-language/styles/pull/2829