### PR TITLE
Update SGM to Microbiology Society

### DIFF
--- a/dependent/international-journal-of-systematic-and-evolutionary-microbiology.csl
+++ b/dependent/international-journal-of-systematic-and-evolutionary-microbiology.csl
@@ -7,7 +7,7 @@
     <link href="http://www.zotero.org/styles/international-journal-of-systematic-and-evolutionary-microbiology" rel="self"/>
     <link href="http://www.zotero.org/styles/society-for-general-microbiology" rel="independent-parent"/>
     <link href="http://ijs.sgmjournals.org/" rel="documentation"/>
-    <category citation-format="author-date"/>
+    <category citation-format="numeric"/>
     <category field="biology"/>
     <issn>1466-5026</issn>
     <eissn>1466-5034</eissn>

--- a/dependent/international-journal-of-systematic-and-evolutionary-microbiology.csl
+++ b/dependent/international-journal-of-systematic-and-evolutionary-microbiology.csl
@@ -1,17 +1,17 @@
 <?xml version="1.0" encoding="utf-8"?>
 <style xmlns="http://purl.org/net/xbiblio/csl" version="1.0" default-locale="en-GB">
-  <!-- Generated with https://github.com/citation-style-language/utilities/tree/master/generate_dependent_styles/data/sgm -->
+  <!-- Microbiology Society, generated from "microbiology-society" metadata at https://github.com/citation-style-language/journals -->
   <info>
     <title>International Journal of Systematic and Evolutionary Microbiology</title>
     <id>http://www.zotero.org/styles/international-journal-of-systematic-and-evolutionary-microbiology</id>
     <link href="http://www.zotero.org/styles/international-journal-of-systematic-and-evolutionary-microbiology" rel="self"/>
-    <link href="http://www.zotero.org/styles/society-for-general-microbiology" rel="independent-parent"/>
-    <link href="http://ijs.sgmjournals.org/" rel="documentation"/>
+    <link href="http://www.zotero.org/styles/microbiology-society" rel="independent-parent"/>
+    <link href="http://ijs.microbiologyresearch.org/content/journal/ijsem" rel="documentation"/>
     <category citation-format="numeric"/>
     <category field="biology"/>
     <issn>1466-5026</issn>
     <eissn>1466-5034</eissn>
-    <updated>2014-06-05T12:00:00+00:00</updated>
+    <updated>2017-08-09T12:00:00+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
 </style>

--- a/dependent/jmm-case-reports.csl
+++ b/dependent/jmm-case-reports.csl
@@ -1,17 +1,17 @@
 <?xml version="1.0" encoding="utf-8"?>
 <style xmlns="http://purl.org/net/xbiblio/csl" version="1.0" default-locale="en-GB">
-  <!-- Generated with https://github.com/citation-style-language/utilities/tree/master/generate_dependent_styles/data/sgm -->
+  <!-- Microbiology Society, generated from "microbiology-society" metadata at https://github.com/citation-style-language/journals -->
   <info>
     <title>JMM Case Reports</title>
     <id>http://www.zotero.org/styles/jmm-case-reports</id>
     <link href="http://www.zotero.org/styles/jmm-case-reports" rel="self"/>
-    <link href="http://www.zotero.org/styles/society-for-general-microbiology" rel="independent-parent"/>
+    <link href="http://www.zotero.org/styles/microbiology-society" rel="independent-parent"/>
     <link href="http://jmmcr.sgmjournals.org/" rel="documentation"/>
-    <category citation-format="author-date"/>
+    <category citation-format="numeric"/>
     <category field="biology"/>
     <category field="medicine"/>
     <eissn>2053-3721</eissn>
-    <updated>2014-06-05T12:00:00+00:00</updated>
+    <updated>2017-08-09T12:00:00+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
 </style>

--- a/dependent/journal-of-general-virology.csl
+++ b/dependent/journal-of-general-virology.csl
@@ -1,18 +1,18 @@
 <?xml version="1.0" encoding="utf-8"?>
 <style xmlns="http://purl.org/net/xbiblio/csl" version="1.0" default-locale="en-GB">
-  <!-- Generated with https://github.com/citation-style-language/utilities/tree/master/generate_dependent_styles/data/sgm -->
+  <!-- Microbiology Society, generated from "microbiology-society" metadata at https://github.com/citation-style-language/journals -->
   <info>
     <title>Journal of General Virology</title>
     <id>http://www.zotero.org/styles/journal-of-general-virology</id>
     <link href="http://www.zotero.org/styles/journal-of-general-virology" rel="self"/>
-    <link href="http://www.zotero.org/styles/society-for-general-microbiology" rel="independent-parent"/>
-    <link href="http://vir.sgmjournals.org/" rel="documentation"/>
-    <category citation-format="author-date"/>
+    <link href="http://www.zotero.org/styles/microbiology-society" rel="independent-parent"/>
+    <link href="http://jgv.microbiologyresearch.org/content/journal/jgv" rel="documentation"/>
+    <category citation-format="numeric"/>
     <category field="biology"/>
     <category field="medicine"/>
     <issn>0022-1317</issn>
     <eissn>1465-2099</eissn>
-    <updated>2014-06-05T12:00:00+00:00</updated>
+    <updated>2017-08-09T12:00:00+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
 </style>

--- a/dependent/microbial-genomics.csl
+++ b/dependent/microbial-genomics.csl
@@ -2,16 +2,14 @@
 <style xmlns="http://purl.org/net/xbiblio/csl" version="1.0" default-locale="en-GB">
   <!-- Microbiology Society, generated from "microbiology-society" metadata at https://github.com/citation-style-language/journals -->
   <info>
-    <title>Journal of Medical Microbiology</title>
-    <id>http://www.zotero.org/styles/journal-of-medical-microbiology</id>
-    <link href="http://www.zotero.org/styles/journal-of-medical-microbiology" rel="self"/>
+    <title>Microbial Genomics</title>
+    <id>http://www.zotero.org/styles/microbial-genomics</id>
+    <link href="http://www.zotero.org/styles/microbial-genomics" rel="self"/>
     <link href="http://www.zotero.org/styles/microbiology-society" rel="independent-parent"/>
-    <link href="http://jmm.microbiologyresearch.org/content/journal/jmm" rel="documentation"/>
+    <link href="http://mgen.microbiologyresearch.org/content/journal/mgen" rel="documentation"/>
     <category citation-format="numeric"/>
     <category field="biology"/>
-    <category field="medicine"/>
-    <issn>0022-2615</issn>
-    <eissn>1473-5644</eissn>
+    <eissn>2057-5858</eissn>
     <updated>2017-08-09T12:00:00+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>

--- a/dependent/microbiology.csl
+++ b/dependent/microbiology.csl
@@ -1,17 +1,17 @@
 <?xml version="1.0" encoding="utf-8"?>
 <style xmlns="http://purl.org/net/xbiblio/csl" version="1.0" default-locale="en-GB">
-  <!-- Generated with https://github.com/citation-style-language/utilities/tree/master/generate_dependent_styles/data/sgm -->
+  <!-- Microbiology Society, generated from "microbiology-society" metadata at https://github.com/citation-style-language/journals -->
   <info>
     <title>Microbiology</title>
     <id>http://www.zotero.org/styles/microbiology</id>
     <link href="http://www.zotero.org/styles/microbiology" rel="self"/>
-    <link href="http://www.zotero.org/styles/society-for-general-microbiology" rel="independent-parent"/>
-    <link href="http://mic.sgmjournals.org/" rel="documentation"/>
-    <category citation-format="author-date"/>
+    <link href="http://www.zotero.org/styles/microbiology-society" rel="independent-parent"/>
+    <link href="http://mic.microbiologyresearch.org/content/journal/micro" rel="documentation"/>
+    <category citation-format="numeric"/>
     <category field="biology"/>
     <issn>1350-0872</issn>
     <eissn>1465-2080</eissn>
-    <updated>2014-06-05T12:00:00+00:00</updated>
+    <updated>2017-08-09T12:00:00+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
 </style>

--- a/microbiology-society.csl
+++ b/microbiology-society.csl
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" demote-non-dropping-particle="sort-only" default-locale="en-GB">
   <info>
-    <title>Society for General Microbiology</title>
-    <id>http://www.zotero.org/styles/society-for-general-microbiology</id>
-    <link href="http://www.zotero.org/styles/society-for-general-microbiology" rel="self"/>
+    <title>Microbiology Society</title>
+    <id>http://www.zotero.org/styles/microbiology-society</id>
+    <link href="http://www.zotero.org/styles/microbiology-society" rel="self"/>
     <link href="http://www.zotero.org/styles/sage-vancouver" rel="template"/>
     <link href="http://www.microbiologyresearch.org/authors/information-for-authors#references" rel="documentation"/>
     <author>

--- a/renamed-styles.json
+++ b/renamed-styles.json
@@ -438,6 +438,7 @@
     "silence": "biomed-central",
     "small-wiley": "small",
     "smartt": "biomed-central",
+    "society-for-general-microbiology": "microbiology-society",
     "soil-biology-biochemistry": "soil-biology-and-biochemistry",
     "sozialwissenschaften-teilmann": "sozialwissenschaften-heilmann",
     "sports-medicine-arthroscopy-rehabilitation-therapy-and-technology": "biomed-central",

--- a/society-for-general-microbiology.csl
+++ b/society-for-general-microbiology.csl
@@ -4,75 +4,110 @@
     <title>Society for General Microbiology</title>
     <id>http://www.zotero.org/styles/society-for-general-microbiology</id>
     <link href="http://www.zotero.org/styles/society-for-general-microbiology" rel="self"/>
-    <link href="http://mic.sgmjournals.org/site/misc/ifora2.xhtml#style-refs" rel="documentation"/>
+    <link href="http://www.zotero.org/styles/sage-vancouver" rel="template"/>
+    <link href="http://www.microbiologyresearch.org/authors/information-for-authors#references" rel="documentation"/>
     <author>
-      <name>Rintze Zelle</name>
-      <uri>http://twitter.com/rintzezelle</uri>
+      <name>Patrick O'Brien</name>
     </author>
-    <category citation-format="author-date"/>
+    <category citation-format="numeric"/>
     <category field="biology"/>
-    <updated>2012-09-27T22:06:38+00:00</updated>
+    <updated>2017-08-09T21:14:38+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
-  <locale xml:lang="en">
-    <terms>
-      <term name="edition" form="short">edn</term>
-      <term name="and others">&amp; other authors</term>
-    </terms>
-  </locale>
-  <macro name="container-contributors">
-    <choose>
-      <if type="chapter paper-conference" match="any">
-        <names variable="editor translator" delimiter=", ">
-          <label form="verb" prefix=". " text-case="capitalize-first" suffix=" "/>
-          <name and="symbol" initialize-with=". " delimiter=", " delimiter-precedes-last="never"/>
-        </names>
-      </if>
-    </choose>
-  </macro>
-  <macro name="secondary-contributors">
-    <choose>
-      <if type="chapter paper-conference" match="none">
-        <names variable="editor translator" delimiter=", " prefix=" (" suffix=")">
-          <name and="symbol" initialize-with=". " delimiter=", " delimiter-precedes-last="never"/>
-          <label form="short" prefix=", " text-case="capitalize-first"/>
-        </names>
-      </if>
-    </choose>
-  </macro>
   <macro name="author">
-    <names variable="author">
-      <name name-as-sort-order="all" and="symbol" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="never" delimiter-precedes-et-al="never"/>
-      <et-al term="and others"/>
-      <label form="short" prefix=" (" suffix=")" text-case="capitalize-first"/>
+    <names variable="author" font-weight="bold" suffix=". ">
+      <name font-weight="normal" delimiter-precedes-last="always" initialize-with="" name-as-sort-order="all" sort-separator=" "/>
+      <et-al font-style="italic"/>
+      <label form="short" prefix=" (" suffix=")" strip-periods="true"/>
       <substitute>
-        <names variable="editor"/>
-        <names variable="translator"/>
-        <text macro="title"/>
+        <names variable="editor" font-weight="normal"/>
+        <text variable="title"/>
       </substitute>
     </names>
   </macro>
-  <macro name="author-short">
-    <names variable="author">
-      <name form="short" and="symbol" delimiter=", " initialize-with=". "/>
-      <et-al font-style="italic"/>
-      <substitute>
-        <names variable="editor"/>
-        <names variable="translator"/>
+  <macro name="editor">
+    <names variable="editor">
+      <name sort-separator=" " initialize-with="" name-as-sort-order="all" delimiter=", " delimiter-precedes-last="always"/>
+      <label strip-periods="true" prefix=" (" suffix=")"/>
+    </names>
+  </macro>
+  <macro name="date">
+    <choose>
+      <if type="article-newspaper report" match="any">
+        <date variable="issued" form="text"/>
+      </if>
+      <else>
+        <date variable="issued" form="text" date-parts="year"/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="publisher">
+    <group delimiter="; ">
+      <group delimiter=" ">
+        <text variable="genre" text-case="title"/>
+        <text variable="number"/>
+      </group>
+      <group delimiter=": ">
         <choose>
-          <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
-            <text variable="title" form="short" font-style="italic"/>
+          <if type="thesis" match="none">
+            <text variable="publisher-place"/>
+          </if>
+        </choose>
+        <text variable="publisher"/>
+      </group>
+      <choose>
+        <if variable="URL" match="none">
+          <text macro="date"/>
+        </if>
+      </choose>
+    </group>
+  </macro>
+  <macro name="access">
+    <choose>
+      <if variable="page" match="none">
+        <choose>
+          <if variable="DOI" match="any">
+            <group prefix=". " delimiter=". ">
+              <date variable="issued" form="text" prefix="Epub ahead of print "/>
+              <text variable="DOI" prefix="DOI: "/>
+            </group>
           </if>
           <else>
-            <text variable="title" form="short" quotes="true"/>
+            <group delimiter=" " prefix=". ">
+              <text variable="URL"/>
+              <text macro="accessed-date"/>
+            </group>
           </else>
         </choose>
-      </substitute>
-    </names>
+      </if>
+    </choose>
+  </macro>
+  <macro name="accessed-date">
+    <choose>
+      <if variable="URL">
+        <group prefix="(" suffix=")" delimiter=", ">
+          <text macro="date"/>
+          <group delimiter=" ">
+            <text term="accessed"/>
+            <date variable="accessed" form="text"/>
+          </group>
+        </group>
+      </if>
+    </choose>
+  </macro>
+  <macro name="container-title">
+    <choose>
+      <if type="article-journal" match="any">
+        <text variable="container-title" form="short" strip-periods="true" font-style="italic"/>
+      </if>
+      <else>
+        <text variable="container-title" font-style="italic"/>
+      </else>
+    </choose>
   </macro>
   <macro name="title">
     <choose>
-      <if type="bill book graphic legal_case legislation motion_picture report song thesis" match="any">
+      <if type="book patent report thesis" match="any">
         <text variable="title" font-style="italic"/>
       </if>
       <else>
@@ -80,54 +115,11 @@
       </else>
     </choose>
   </macro>
-  <macro name="publisher">
-    <text variable="genre" suffix=", "/>
-    <group delimiter=": ">
-      <text variable="publisher-place"/>
-      <text variable="publisher"/>
+  <macro name="page">
+    <group delimiter=" ">
+      <label variable="page" form="short"/>
+      <text variable="page"/>
     </group>
-  </macro>
-  <macro name="event">
-    <choose>
-      <if variable="event">
-        <text term="presented at" text-case="capitalize-first" suffix=" "/>
-        <text variable="event"/>
-      </if>
-    </choose>
-  </macro>
-  <macro name="issued">
-    <choose>
-      <if variable="issued">
-        <group prefix="(" suffix=").">
-          <date variable="issued">
-            <date-part name="year"/>
-          </date>
-          <choose>
-            <if type="article-journal bill book chapter graphic legal_case legislation motion_picture paper-conference report song" match="none">
-              <date variable="issued">
-                <date-part prefix=", " name="month"/>
-                <date-part prefix=" " name="day"/>
-              </date>
-            </if>
-          </choose>
-        </group>
-      </if>
-      <else>
-        <text prefix=" (" term="no date" suffix=")." form="short"/>
-      </else>
-    </choose>
-  </macro>
-  <macro name="issued-year">
-    <choose>
-      <if variable="issued">
-        <date variable="issued">
-          <date-part name="year"/>
-        </date>
-      </if>
-      <else>
-        <text term="no date" form="short"/>
-      </else>
-    </choose>
   </macro>
   <macro name="edition">
     <choose>
@@ -142,102 +134,64 @@
       </else>
     </choose>
   </macro>
-  <macro name="locators">
-    <choose>
-      <if type="article-journal article-magazine article-newspaper" match="any">
-        <group prefix=" " delimiter=", ">
-          <text variable="volume" font-weight="bold"/>
-          <text variable="page"/>
-        </group>
-      </if>
-      <else-if type="bill book chapter graphic legal_case legislation motion_picture paper-conference report song" match="any">
-        <group prefix=", " suffix="." delimiter=", ">
-          <text macro="edition"/>
-        </group>
-      </else-if>
-    </choose>
-    <choose>
-      <if type="chapter paper-conference" match="any">
-        <group prefix=", ">
-          <label variable="page" form="short" suffix=" "/>
-          <text variable="page"/>
-        </group>
-      </if>
-    </choose>
-  </macro>
-  <macro name="citation-locator">
-    <group>
-      <label variable="locator" form="short"/>
-      <text variable="locator" prefix=" "/>
-    </group>
-  </macro>
-  <macro name="container-title">
-    <group>
-      <choose>
-        <if type="chapter paper-conference" match="any">
-          <text term="in" text-case="capitalize-first" suffix=" "/>
-        </if>
-      </choose>
-      <group delimiter=", ">
-        <text variable="container-title" font-style="italic" form="short" strip-periods="true"/>
-        <text variable="collection-title"/>
-      </group>
-    </group>
-  </macro>
-  <macro name="key-creators">
-    <names variable="author">
-      <name/>
-      <substitute>
-        <names variable="editor"/>
-        <names variable="translator"/>
-      </substitute>
-    </names>
-  </macro>
-  <macro name="key-creators-count">
-    <names variable="author">
-      <name form="count"/>
-      <substitute>
-        <names variable="editor"/>
-        <names variable="translator"/>
-      </substitute>
-    </names>
-  </macro>
-  <citation et-al-min="3" et-al-use-first="1" disambiguate-add-year-suffix="true" collapse="year-suffix" year-suffix-delimiter=", ">
+  <citation collapse="citation-number">
     <sort>
-      <key macro="author"/>
-      <key macro="issued-year"/>
+      <key variable="citation-number"/>
     </sort>
-    <layout prefix="(" suffix=")" delimiter="; ">
-      <group delimiter=", ">
-        <text macro="author-short"/>
-        <text macro="issued-year"/>
-        <text macro="citation-locator"/>
-      </group>
+    <layout delimiter=", " prefix="[" suffix="]">
+      <text variable="citation-number"/>
     </layout>
   </citation>
-  <bibliography hanging-indent="true" et-al-min="11" et-al-use-first="9" entry-spacing="0" line-spacing="2">
-    <sort>
-      <key macro="key-creators" names-min="1" names-use-first="1"/>
-      <key macro="key-creators-count" names-min="3" names-use-first="3"/>
-      <key macro="key-creators" names-min="3" names-use-first="1"/>
-      <key macro="issued-year"/>
-    </sort>
+  <bibliography et-al-min="6" et-al-use-first="5" second-field-align="flush">
     <layout suffix=".">
-      <text macro="author" suffix=". " font-weight="bold"/>
-      <text macro="issued" suffix=" " font-weight="bold"/>
-      <group delimiter=". ">
-        <text macro="title"/>
-        <text macro="container-title"/>
-      </group>
-      <text macro="locators"/>
-      <text macro="container-contributors"/>
-      <text macro="secondary-contributors"/>
-      <group delimiter=". " prefix=". ">
-        <group delimiter=", ">
-          <text macro="event"/>
-          <text macro="publisher"/>
-        </group>
-      </group>
+      <text variable="citation-number" suffix="."/>
+      <text macro="author" font-weight="normal"/>
+      <text macro="title"/>
+      <choose>
+        <if type="bill book graphic legal_case legislation motion_picture patent report song thesis" match="any">
+          <group delimiter=". " prefix=". ">
+            <text macro="edition"/>
+            <text macro="publisher"/>
+          </group>
+        </if>
+        <else-if type="chapter paper-conference" match="any">
+          <group delimiter=". " prefix=". ">
+            <group delimiter=". ">
+              <group delimiter=" ">
+                <text term="in" suffix=":" text-case="capitalize-first"/>
+                <text macro="editor" suffix="."/>
+                <text variable="container-title" font-style="italic"/>
+              </group>
+              <text macro="publisher"/>
+            </group>
+            <text macro="page"/>
+          </group>
+        </else-if>
+        <else-if type="article-newspaper article-magazine" match="any">
+          <group delimiter=", " prefix=". ">
+            <text macro="container-title"/>
+            <text macro="date"/>
+            <text macro="page"/>
+          </group>
+        </else-if>
+        <else>
+          <group delimiter=";" prefix=". ">
+            <group delimiter=" ">
+              <text macro="container-title"/>
+              <choose>
+                <if variable="page" match="any">
+                  <text macro="date"/>
+                </if>
+              </choose>
+            </group>
+            <group delimiter=":">
+              <text variable="volume"/>
+              <text variable="page"/>
+            </group>
+          </group>
+        </else>
+      </choose>
+      <text macro="access"/>
     </layout>
   </bibliography>
 </style>

--- a/society-for-general-microbiology.csl
+++ b/society-for-general-microbiology.csl
@@ -16,11 +16,11 @@
   </info>
   <macro name="author">
     <names variable="author" font-weight="bold" suffix=". ">
-      <name font-weight="normal" delimiter-precedes-last="always" initialize-with="" name-as-sort-order="all" sort-separator=" "/>
+      <name delimiter-precedes-last="always" initialize-with="" name-as-sort-order="all" sort-separator=" "/>
       <et-al font-style="italic"/>
       <label form="short" prefix=" (" suffix=")" strip-periods="true"/>
       <substitute>
-        <names variable="editor" font-weight="normal"/>
+        <names variable="editor"/>
         <text variable="title"/>
       </substitute>
     </names>
@@ -145,7 +145,7 @@
   <bibliography et-al-min="6" et-al-use-first="5" second-field-align="flush">
     <layout suffix=".">
       <text variable="citation-number" suffix="."/>
-      <text macro="author" font-weight="normal"/>
+      <text macro="author"/>
       <text macro="title"/>
       <choose>
         <if type="bill book graphic legal_case legislation motion_picture patent report song thesis" match="any">


### PR DESCRIPTION
Replaces #2877.

Apparently the Society for General Microbiology changed its name to Microbiology Society in 2015 (see e.g. https://www.microbiologysociety.org/about/our-history/timeline.html).