### PR TITLE
Update Medical Physics

### DIFF
--- a/medical-physics.csl
+++ b/medical-physics.csl
@@ -69,7 +69,7 @@
   <macro name="title">
     <choose>
       <if type="article-journal chapter paper-conference article-magazine" match="any">
-        <text variable="title" form="long" quotes="true"/>
+        <text variable="title" form="long" quotes="false"/>
       </if>
       <else>
         <text variable="title" form="long" font-style="italic"/>

--- a/medical-physics.csl
+++ b/medical-physics.csl
@@ -69,10 +69,10 @@
   <macro name="title">
     <choose>
       <if type="article-journal chapter paper-conference article-magazine" match="any">
-        <text variable="title" form="long" quotes="false"/>
+        <text variable="title"/>
       </if>
       <else>
-        <text variable="title" form="long" font-style="italic"/>
+        <text variable="title" font-style="italic"/>
       </else>
     </choose>
   </macro>


### PR DESCRIPTION
I made the update to this journal's style in May, 2017, and it was correct at that time.  Since that time this journal changed their style to eliminate the quotations around the journal title, as demonstrated now about 2/3 of the way down this page:  http://aapm.onlinelibrary.wiley.com/hub/journal/10.1002/%28ISSN%292473-4209/about/author-guidelines.html