### PR TITLE
Update university-college-lillebaelt-harvard.csl

### DIFF
--- a/university-college-lillebaelt-harvard.csl
+++ b/university-college-lillebaelt-harvard.csl
@@ -28,7 +28,7 @@ Sorts items by author(s), publication year and title.
 -->
   <macro name="alphabetize">
     <text macro="author-referencelist"/>
-    <text macro="year-citation"/>
+    <text macro="year-or-no-year"/>
     <text variable="title"/>
   </macro>
   <!--                                                                                                               MACRO   AUTHOR-CITATION
@@ -117,39 +117,8 @@ Used both for citations and reference list.
       </else-if>
     </choose>
   </macro>
-  <!--                                                                                                               MACRO   YEAR-CITATION
-Chapters with an 'original-date' outputs the original publication year. Other items calls the 'year-or-no-year'-macro.
--->
-  <macro name="year-citation">
-    <choose>
-      <if variable="original-date">
-        <date variable="original-date">
-          <date-part name="year"/>
-        </date>
-      </if>
-      <else>
-        <text macro="year-or-no-year"/>
-      </else>
-    </choose>
-  </macro>
-  <!--                                                                                                               MACRO   YEAR-REFERENCELIST
-Chapters with an 'original-date' outputs the original publication year. Chapters without 'original-date' have no output. Other items calls the 'year-or-no-year'-macro.
-The only difference between this macro and 'Year-citation', is that chapters without an original date will not generate any output. The publication year will instead be rendered in the container part of the reference.
--->
-  <macro name="year-referencelist">
-    <choose>
-      <if type="chapter">
-        <date variable="original-date">
-          <date-part name="year"/>
-        </date>
-      </if>
-      <else>
-        <text macro="year-or-no-year"/>
-      </else>
-    </choose>
-  </macro>
   <!--                                                                                                               MACRO   YEAR-OR-NO-YEAR
-Ensures that primary legislation does not show a publication year. Both 'Year-citation' and 'Year-referencelist' leads here.
+Ensures that primary legislation does not show a publication year.
 Calls the 'year'-macro.
 -->
   <macro name="year-or-no-year">
@@ -430,7 +399,7 @@ Adds page number or other locator to citations.
         <else>
           <group delimiter=" ">
             <text macro="author-citation"/>
-            <text macro="year-citation"/>
+            <text macro="year-or-no-year"/>
           </group>
           <text macro="page" prefix=", "/>
         </else>
@@ -447,7 +416,7 @@ Adds page number or other locator to citations.
       <group display="block" delimiter=", " suffix=".">
         <text macro="author-referencelist"/>
         <group delimiter=". ">
-          <text macro="year-referencelist"/>
+          <text macro="year-or-no-year"/>
           <text macro="title-and-container"/>
           <text macro="publisher"/>
         </group>


### PR DESCRIPTION
'original-date' is now ignored, and the publiced year for book chapters are moved forward to just after the author name.