### PR TITLE
Update harvard-york-st-john-university.csl

### DIFF
--- a/harvard-york-st-john-university.csl
+++ b/harvard-york-st-john-university.csl
@@ -287,9 +287,12 @@
     </choose>
   </macro>
   <citation et-al-min="4" et-al-use-first="1" disambiguate-add-year-suffix="true" disambiguate-add-names="true" disambiguate-add-givenname="true" givenname-disambiguation-rule="all-names-with-initials" name-as-sort-order="all" collapse="year">
+    <sort>
+      <key macro="year-date"/>
+    </sort>
     <layout prefix="(" suffix=")" delimiter="; ">
       <group delimiter=", ">
-        <group delimiter=", ">
+        <group delimiter=" ">
           <text macro="author-short"/>
           <text macro="year-date"/>
         </group>


### PR DESCRIPTION
Updates to style to ensure it matches YSJU citation requirements: removal of delimiter in author date citation and multiple citations sorted by date order