### PR TITLE
changes to hiob ludolf

### DIFF
--- a/hiob-ludolf-centre-for-ethiopian-studies-long-names.csl
+++ b/hiob-ludolf-centre-for-ethiopian-studies-long-names.csl
@@ -2,7 +2,7 @@
 <style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" demote-non-dropping-particle="sort-only" default-locale="en-GB">
   <info>
     <title>Hiob Ludolf Centre for Ethiopian Studies (long names)</title>
-    <title-short>HLCES (Hamburg) Names Long </title-short>
+    <title-short>HLCES (Hamburg) long names</title-short>
     <id>http://www.zotero.org/styles/hiob-ludolf-centre-for-ethiopian-studies-long-names</id>
     <link href="http://www.zotero.org/styles/hiob-ludolf-centre-for-ethiopian-studies-long-names" rel="self"/>
     <link href="http://www.zotero.org/styles/hiob-ludolf-centre-for-ethiopian-studies" rel="template"/>

--- a/hiob-ludolf-centre-for-ethiopian-studies-long-names.csl
+++ b/hiob-ludolf-centre-for-ethiopian-studies-long-names.csl
@@ -1,16 +1,17 @@
 <?xml version="1.0" encoding="utf-8"?>
 <style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" demote-non-dropping-particle="sort-only" default-locale="en-GB">
   <info>
-    <title>Hiob Ludolf Centre for Ethiopian Studies Names Long</title>
+    <title>Hiob Ludolf Centre for Ethiopian Studies (long names)</title>
     <title-short>HLCES (Hamburg) Names Long </title-short>
-    <id>http://www.zotero.org/styles/hiob-ludolf-centre-for-ethiopian-studies-names-long</id>
-    <link href="http://www.zotero.org/styles/hiob-ludolf-centre-for-ethiopian-studies-names-long" rel="self"/>
+    <id>http://www.zotero.org/styles/hiob-ludolf-centre-for-ethiopian-studies-long-names</id>
+    <link href="http://www.zotero.org/styles/hiob-ludolf-centre-for-ethiopian-studies-long-names" rel="self"/>
+    <link href="http://www.zotero.org/styles/hiob-ludolf-centre-for-ethiopian-studies" rel="template"/>
     <link href="http://www1.uni-hamburg.de/COMST/bulletin.html" rel="documentation"/>
     <author>
       <name>Eugenia Sokolinski</name>
       <email>eugenia.sokolinski@uni-hamburg.de</email>
     </author>
-<contributor>
+    <contributor>
       <name>Alessandro Bausi</name>
       <email>alessandro.bausi@uni-hamburg.de</email>
     </contributor>
@@ -38,12 +39,11 @@
         <single>ed.</single>
         <multiple>eds</multiple>
       </term>
-    <term name="translator" form="short">tr.</term>
-    <term name="editortranslator" form="short">
-          <single>ed., tr.</single>
-          <multiple>eds, trans.</multiple>
-        </term>
-      
+      <term name="translator" form="short">tr.</term>
+      <term name="editortranslator" form="short">
+        <single>ed., tr.</single>
+        <multiple>eds, trans.</multiple>
+      </term>
     </terms>
   </locale>
   <macro name="container-contributors">
@@ -64,7 +64,7 @@
             <label form="short" suffix=" "/>
             <name and="text" sort-separator=""/>
           </names>
-          </group>
+        </group>
       </if>
     </choose>
   </macro>

--- a/hiob-ludolf-centre-for-ethiopian-studies-long-names.csl
+++ b/hiob-ludolf-centre-for-ethiopian-studies-long-names.csl
@@ -26,14 +26,6 @@
   </info>
   <locale xml:lang="en-GB">
     <terms>
-      <term name="ordinal">th</term>
-      <term name="ordinal-01">st</term>
-      <term name="ordinal-02">nd</term>
-      <term name="ordinal-03">rd</term>
-      <term name="ordinal-04">th</term>
-      <term name="ordinal-11">th</term>
-      <term name="ordinal-12">th</term>
-      <term name="ordinal-13">th</term>
       <term name="available at">see</term>
       <term name="editor" form="short">
         <single>ed.</single>

--- a/hiob-ludolf-centre-for-ethiopian-studies-names-long.csl
+++ b/hiob-ludolf-centre-for-ethiopian-studies-names-long.csl
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" demote-non-dropping-particle="sort-only" default-locale="en-GB">
   <info>
-    <title>Hiob Ludolf Centre for Ethiopian Studies</title>
-    <title-short>HLCES (Hamburg)</title-short>
-    <id>http://www.zotero.org/styles/hiob-ludolf-centre-for-ethiopian-studies</id>
-    <link href="http://www.zotero.org/styles/hiob-ludolf-centre-for-ethiopian-studies" rel="self"/>
+    <title>Hiob Ludolf Centre for Ethiopian Studies Names Long</title>
+    <title-short>HLCES (Hamburg) Names Long </title-short>
+    <id>http://www.zotero.org/styles/hiob-ludolf-centre-for-ethiopian-studies-names-long</id>
+    <link href="http://www.zotero.org/styles/hiob-ludolf-centre-for-ethiopian-studies-names-long" rel="self"/>
     <link href="http://www1.uni-hamburg.de/COMST/bulletin.html" rel="documentation"/>
     <author>
       <name>Eugenia Sokolinski</name>

--- a/hiob-ludolf-centre-for-ethiopian-studies-names-long.csl
+++ b/hiob-ludolf-centre-for-ethiopian-studies-names-long.csl
@@ -1,20 +1,18 @@
 <?xml version="1.0" encoding="utf-8"?>
 <style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" demote-non-dropping-particle="sort-only" default-locale="en-GB">
-  <!-- This style was edited with the Visual CSL Editor (http://editor.citationstyles.org/visualEditor/) -->
   <info>
-    <title>Hiob Ludolf Centre for Ethiopian Studies (with URL/DOI)</title>
+    <title>Hiob Ludolf Centre for Ethiopian Studies</title>
     <title-short>HLCES (Hamburg)</title-short>
-    <id>http://www.zotero.org/styles/hiob-ludolf-centre-for-ethiopian-studies-with-url-doi</id>
-    <link href="http://www.zotero.org/styles/hiob-ludolf-centre-for-ethiopian-studies-with-url-doi" rel="self"/>
+    <id>http://www.zotero.org/styles/hiob-ludolf-centre-for-ethiopian-studies</id>
+    <link href="http://www.zotero.org/styles/hiob-ludolf-centre-for-ethiopian-studies" rel="self"/>
     <link href="http://www1.uni-hamburg.de/COMST/bulletin.html" rel="documentation"/>
     <author>
       <name>Eugenia Sokolinski</name>
       <email>eugenia.sokolinski@uni-hamburg.de</email>
     </author>
-
-    <contributor>
+<contributor>
       <name>Alessandro Bausi</name>
-      <email>Alessandro.Bausi@uni-hamburg.de</email>
+      <email>alessandro.bausi@uni-hamburg.de</email>
     </contributor>
     <category citation-format="author-date"/>
     <category field="humanities"/>
@@ -41,8 +39,8 @@
   <macro name="container-contributors">
     <choose>
       <if type="chapter entry-encyclopedia paper-conference" match="any">
-        <names variable="editor translator" delimiter=", ">
-          <name and="text" initialize-with="."/>
+        <names variable="editor translator" delimiter=", " prefix=" ">
+          <name and="text"/>
           <label form="short" prefix=", " suffix=","/>
         </names>
       </if>
@@ -54,11 +52,11 @@
         <group delimiter=", " prefix=", ">
           <names variable="editor" delimiter=", ">
             <label form="short" plural="never" suffix=" "/>
-            <name and="text" initialize-with="." sort-separator=""/>
+            <name and="text" sort-separator=""/>
           </names>
           <names variable="translator">
             <label form="short" plural="always" suffix=" "/>
-            <name initialize-with="." sort-separator=""/>
+            <name  sort-separator=""/>
           </names>
         </group>
       </if>
@@ -66,7 +64,7 @@
   </macro>
   <macro name="author">
     <names variable="author">
-      <name and="text" delimiter-precedes-et-al="never" initialize-with="." name-as-sort-order="first"/>
+      <name and="text" delimiter-precedes-et-al="never" name-as-sort-order="first"/>
       <label form="short" text-case="lowercase" prefix=", " suffix=","/>
       <substitute>
         <names variable="editor"/>
@@ -94,28 +92,25 @@
   </macro>
   <macro name="access">
     <choose>
-      <if match="any" variable="URL">
-        <group prefix=" (" suffix=")">
-          <text term="available at" suffix=" "/>
-          <text variable="URL" prefix="&lt;" suffix="&gt;"/>
-          <choose>
-            <if variable="accessed">
-              <text term="accessed" prefix=", "/>
-              <date variable="accessed">
-                <date-part name="day" form="numeric" prefix=" "/>
-                <date-part name="month" form="long" prefix=" "/>
-                <date-part name="year" prefix=" "/>
-              </date>
-            </if>
-          </choose>
-        </group>
-      </if>
-    </choose>
-    <choose>
-      <if variable="DOI">
-        <group prefix=" (" suffix=")">
-          <text variable="DOI" prefix="DOI: "/>
-        </group>
+      <if type="webpage">
+        <choose>
+          <if match="any" variable="URL">
+            <group prefix=" (" suffix=")">
+              <text term="available at" suffix=" "/>
+              <text variable="URL" prefix="&lt;" suffix="&gt;"/>
+              <choose>
+                <if variable="accessed">
+                  <text term="accessed" prefix=", "/>
+                  <date variable="accessed">
+                    <date-part name="day" form="numeric" prefix=" "/>
+                    <date-part name="month" form="long" prefix=" "/>
+                    <date-part name="year" prefix=" "/>
+                  </date>
+                </if>
+              </choose>
+            </group>
+          </if>
+        </choose>
       </if>
     </choose>
   </macro>
@@ -187,11 +182,11 @@
         <choose>
           <if variable="genre" match="none">
             <text term="presented at" text-case="lowercase" suffix=" "/>
-            <text variable="event"/>
+            <text variable="event" font-style="italic"/>
           </if>
           <else>
             <group delimiter=" ">
-              <text variable="genre" text-case="lowercase"/>
+              <text variable="genre"/>
               <text term="presented at"/>
               <text variable="event"/>
             </group>

--- a/hiob-ludolf-centre-for-ethiopian-studies-names-long.csl
+++ b/hiob-ludolf-centre-for-ethiopian-studies-names-long.csl
@@ -14,6 +14,10 @@
       <name>Alessandro Bausi</name>
       <email>alessandro.bausi@uni-hamburg.de</email>
     </contributor>
+    <contributor>
+      <name>Pietro Liuzzo</name>
+      <email>pietro.liuzzo@uni-hamburg.de</email>
+    </contributor>
     <category citation-format="author-date"/>
     <category field="humanities"/>
     <updated>2016-09-10T19:36:18+00:00</updated>
@@ -34,6 +38,7 @@
         <single>ed.</single>
         <multiple>eds</multiple>
       </term>
+    <term name="translator" form="short">tr.</term>
     </terms>
   </locale>
   <macro name="container-contributors">
@@ -135,7 +140,7 @@
     <choose>
       <if type="thesis" match="any">
         <group delimiter=", " prefix="(" suffix=")">
-          <text value="Diss."/>
+          <text variable="genre"/>
           <group delimiter=": ">
             <text variable="publisher-place"/>
             <text variable="publisher"/>
@@ -228,7 +233,7 @@
         </group>
       </if>
       <else>
-        <text variable="edition" suffix="."/>
+        <text variable="edition"/>
       </else>
     </choose>
   </macro>
@@ -264,7 +269,7 @@
   <macro name="container-phrase">
     <group>
       <choose>
-        <if type="chapter entry-encyclopedia" match="any">
+        <if type="chapter entry-encyclopedia paper-conference" match="any">
           <text term="in" suffix=" "/>
         </if>
       </choose>
@@ -309,6 +314,11 @@
               <if type="article article-journal article-magazine article-newspaper" match="any">
                 <text value=","/>
               </if>
+              <else-if type="paper-conference" match="any">
+                <group prefix=", ">
+                  <number variable="volume"/>
+                </group>
+              </else-if>
               <else>
                 <group prefix=", ">
                   <number variable="volume" form="ordinal"/>
@@ -334,3 +344,4 @@
     </layout>
   </bibliography>
 </style>
+

--- a/hiob-ludolf-centre-for-ethiopian-studies-names-long.csl
+++ b/hiob-ludolf-centre-for-ethiopian-studies-names-long.csl
@@ -39,6 +39,11 @@
         <multiple>eds</multiple>
       </term>
     <term name="translator" form="short">tr.</term>
+    <term name="editortranslator" form="short">
+          <single>ed., tr.</single>
+          <multiple>eds, trans.</multiple>
+        </term>
+      
     </terms>
   </locale>
   <macro name="container-contributors">
@@ -55,15 +60,11 @@
     <choose>
       <if type="chapter entry-encyclopedia paper-conference" match="none">
         <group delimiter=", " prefix=", ">
-          <names variable="editor" delimiter=", ">
-            <label form="short" plural="never" suffix=" "/>
+          <names variable="editor translator" delimiter=", ">
+            <label form="short" suffix=" "/>
             <name and="text" sort-separator=""/>
           </names>
-          <names variable="translator">
-            <label form="short" plural="always" suffix=" "/>
-            <name  sort-separator=""/>
-          </names>
-        </group>
+          </group>
       </if>
     </choose>
   </macro>
@@ -139,7 +140,7 @@
   <macro name="publisher">
     <choose>
       <if type="thesis" match="any">
-        <group delimiter=", " prefix="(" suffix=")">
+        <group delimiter=", " prefix=", " suffix="">
           <text variable="genre"/>
           <group delimiter=": ">
             <text variable="publisher-place"/>
@@ -344,4 +345,3 @@
     </layout>
   </bibliography>
 </style>
-

--- a/hiob-ludolf-centre-for-ethiopian-studies-with-url-doi.csl
+++ b/hiob-ludolf-centre-for-ethiopian-studies-with-url-doi.csl
@@ -14,7 +14,7 @@
 
     <contributor>
       <name>Alessandro Bausi</name>
-      <email>Alessandro.Bausi@uni-hamburg.de</email>
+      <email>alessandro.bausi@uni-hamburg.de</email>
     </contributor>
     <contributor>
       <name>Pietro Liuzzo</name>
@@ -41,6 +41,11 @@
         <multiple>eds</multiple>
       </term>
     <term name="translator" form="short">tr.</term>
+    <term name="editortranslator" form="short">
+          <single>ed., tr.</single>
+          <multiple>eds, trans.</multiple>
+        </term>
+      
     </terms>
   </locale>
   <macro name="container-contributors">
@@ -57,15 +62,11 @@
     <choose>
       <if type="chapter entry-encyclopedia paper-conference" match="none">
         <group delimiter=", " prefix=", ">
-          <names variable="editor" delimiter=", ">
-            <label form="short" plural="never" suffix=" "/>
+          <names variable="editor translator" delimiter=", ">
+            <label form="short" suffix=" "/>
             <name and="text" initialize-with="." sort-separator=""/>
           </names>
-          <names variable="translator">
-            <label form="short" plural="always" suffix=" "/>
-            <name initialize-with="." sort-separator=""/>
-          </names>
-        </group>
+          </group>
       </if>
     </choose>
   </macro>
@@ -144,7 +145,7 @@
   <macro name="publisher">
     <choose>
       <if type="thesis" match="any">
-        <group delimiter=", " prefix="(" suffix=")">
+        <group delimiter=", " prefix=", " suffix="">
           <text variable="genre"/>
           <group delimiter=": ">
             <text variable="publisher-place"/>
@@ -349,4 +350,3 @@
     </layout>
   </bibliography>
 </style>
-

--- a/hiob-ludolf-centre-for-ethiopian-studies-with-url-doi.csl
+++ b/hiob-ludolf-centre-for-ethiopian-studies-with-url-doi.csl
@@ -16,6 +16,10 @@
       <name>Alessandro Bausi</name>
       <email>Alessandro.Bausi@uni-hamburg.de</email>
     </contributor>
+    <contributor>
+      <name>Pietro Liuzzo</name>
+      <email>pietro.liuzzo@uni-hamburg.de</email>
+    </contributor>
     <category citation-format="author-date"/>
     <category field="humanities"/>
     <updated>2016-09-10T19:36:18+00:00</updated>
@@ -36,12 +40,13 @@
         <single>ed.</single>
         <multiple>eds</multiple>
       </term>
+    <term name="translator" form="short">tr.</term>
     </terms>
   </locale>
   <macro name="container-contributors">
     <choose>
       <if type="chapter entry-encyclopedia paper-conference" match="any">
-        <names variable="editor translator" delimiter=", ">
+        <names variable="editor translator" delimiter=", " prefix=" ">
           <name and="text" initialize-with="."/>
           <label form="short" prefix=", " suffix=","/>
         </names>
@@ -140,7 +145,7 @@
     <choose>
       <if type="thesis" match="any">
         <group delimiter=", " prefix="(" suffix=")">
-          <text value="Diss."/>
+          <text variable="genre"/>
           <group delimiter=": ">
             <text variable="publisher-place"/>
             <text variable="publisher"/>
@@ -187,11 +192,11 @@
         <choose>
           <if variable="genre" match="none">
             <text term="presented at" text-case="lowercase" suffix=" "/>
-            <text variable="event"/>
+            <text variable="event" font-style="italic"/>
           </if>
           <else>
             <group delimiter=" ">
-              <text variable="genre" text-case="lowercase"/>
+              <text variable="genre"/>
               <text term="presented at"/>
               <text variable="event"/>
             </group>
@@ -233,7 +238,7 @@
         </group>
       </if>
       <else>
-        <text variable="edition" suffix="."/>
+        <text variable="edition"/>
       </else>
     </choose>
   </macro>
@@ -269,7 +274,7 @@
   <macro name="container-phrase">
     <group>
       <choose>
-        <if type="chapter entry-encyclopedia" match="any">
+        <if type="chapter entry-encyclopedia paper-conference" match="any">
           <text term="in" suffix=" "/>
         </if>
       </choose>
@@ -314,6 +319,11 @@
               <if type="article article-journal article-magazine article-newspaper" match="any">
                 <text value=","/>
               </if>
+              <else-if type="paper-conference" match="any">
+                <group prefix=", ">
+                  <number variable="volume"/>
+                </group>
+              </else-if>
               <else>
                 <group prefix=", ">
                   <number variable="volume" form="ordinal"/>
@@ -339,3 +349,4 @@
     </layout>
   </bibliography>
 </style>
+

--- a/hiob-ludolf-centre-for-ethiopian-studies-with-url-doi.csl
+++ b/hiob-ludolf-centre-for-ethiopian-studies-with-url-doi.csl
@@ -11,7 +11,6 @@
       <name>Eugenia Sokolinski</name>
       <email>eugenia.sokolinski@uni-hamburg.de</email>
     </author>
-
     <contributor>
       <name>Alessandro Bausi</name>
       <email>alessandro.bausi@uni-hamburg.de</email>
@@ -40,12 +39,11 @@
         <single>ed.</single>
         <multiple>eds</multiple>
       </term>
-    <term name="translator" form="short">tr.</term>
-    <term name="editortranslator" form="short">
-          <single>ed., tr.</single>
-          <multiple>eds, trans.</multiple>
-        </term>
-      
+      <term name="translator" form="short">tr.</term>
+      <term name="editortranslator" form="short">
+        <single>ed., tr.</single>
+        <multiple>eds, trans.</multiple>
+      </term>
     </terms>
   </locale>
   <macro name="container-contributors">
@@ -66,7 +64,7 @@
             <label form="short" suffix=" "/>
             <name and="text" initialize-with="." sort-separator=""/>
           </names>
-          </group>
+        </group>
       </if>
     </choose>
   </macro>

--- a/hiob-ludolf-centre-for-ethiopian-studies-with-url-doi.csl
+++ b/hiob-ludolf-centre-for-ethiopian-studies-with-url-doi.csl
@@ -26,14 +26,6 @@
   </info>
   <locale xml:lang="en-GB">
     <terms>
-      <term name="ordinal">th</term>
-      <term name="ordinal-01">st</term>
-      <term name="ordinal-02">nd</term>
-      <term name="ordinal-03">rd</term>
-      <term name="ordinal-04">th</term>
-      <term name="ordinal-11">th</term>
-      <term name="ordinal-12">th</term>
-      <term name="ordinal-13">th</term>
       <term name="available at">see</term>
       <term name="editor" form="short">
         <single>ed.</single>

--- a/hiob-ludolf-centre-for-ethiopian-studies.csl
+++ b/hiob-ludolf-centre-for-ethiopian-studies.csl
@@ -14,6 +14,10 @@
       <name>Alessandro Bausi</name>
       <email>alessandro.bausi@uni-hamburg.de</email>
     </contributor>
+    <contributor>
+      <name>Pietro Liuzzo</name>
+      <email>pietro.liuzzo@uni-hamburg.de</email>
+    </contributor>
     <category citation-format="author-date"/>
     <category field="humanities"/>
     <updated>2016-09-10T19:36:18+00:00</updated>
@@ -34,6 +38,7 @@
         <single>ed.</single>
         <multiple>eds</multiple>
       </term>
+    <term name="translator" form="short">tr.</term>
     </terms>
   </locale>
   <macro name="container-contributors">
@@ -135,7 +140,7 @@
     <choose>
       <if type="thesis" match="any">
         <group delimiter=", " prefix="(" suffix=")">
-          <text value="Diss."/>
+          <text variable="genre"/>
           <group delimiter=": ">
             <text variable="publisher-place"/>
             <text variable="publisher"/>
@@ -228,7 +233,7 @@
         </group>
       </if>
       <else>
-        <text variable="edition" suffix="."/>
+        <text variable="edition"/>
       </else>
     </choose>
   </macro>
@@ -264,7 +269,7 @@
   <macro name="container-phrase">
     <group>
       <choose>
-        <if type="chapter entry-encyclopedia" match="any">
+        <if type="chapter entry-encyclopedia paper-conference" match="any">
           <text term="in" suffix=" "/>
         </if>
       </choose>
@@ -309,6 +314,11 @@
               <if type="article article-journal article-magazine article-newspaper" match="any">
                 <text value=","/>
               </if>
+              <else-if type="paper-conference" match="any">
+                <group prefix=", ">
+                  <number variable="volume"/>
+                </group>
+              </else-if>
               <else>
                 <group prefix=", ">
                   <number variable="volume" form="ordinal"/>
@@ -334,3 +344,4 @@
     </layout>
   </bibliography>
 </style>
+

--- a/hiob-ludolf-centre-for-ethiopian-studies.csl
+++ b/hiob-ludolf-centre-for-ethiopian-studies.csl
@@ -39,6 +39,11 @@
         <multiple>eds</multiple>
       </term>
     <term name="translator" form="short">tr.</term>
+    <term name="editortranslator" form="short">
+          <single>ed., tr.</single>
+          <multiple>eds, trans.</multiple>
+        </term>
+      
     </terms>
   </locale>
   <macro name="container-contributors">
@@ -55,15 +60,11 @@
     <choose>
       <if type="chapter entry-encyclopedia paper-conference" match="none">
         <group delimiter=", " prefix=", ">
-          <names variable="editor" delimiter=", ">
-            <label form="short" plural="never" suffix=" "/>
+          <names variable="editor translator" delimiter=", ">
+            <label form="short" suffix=" "/>
             <name and="text" initialize-with="." sort-separator=""/>
           </names>
-          <names variable="translator">
-            <label form="short" plural="always" suffix=" "/>
-            <name initialize-with="." sort-separator=""/>
-          </names>
-        </group>
+          </group>
       </if>
     </choose>
   </macro>
@@ -139,7 +140,7 @@
   <macro name="publisher">
     <choose>
       <if type="thesis" match="any">
-        <group delimiter=", " prefix="(" suffix=")">
+        <group delimiter=", " prefix=", " suffix="">
           <text variable="genre"/>
           <group delimiter=": ">
             <text variable="publisher-place"/>
@@ -344,4 +345,3 @@
     </layout>
   </bibliography>
 </style>
-

--- a/hiob-ludolf-centre-for-ethiopian-studies.csl
+++ b/hiob-ludolf-centre-for-ethiopian-studies.csl
@@ -10,9 +10,13 @@
       <name>Eugenia Sokolinski</name>
       <email>eugenia.sokolinski@uni-hamburg.de</email>
     </author>
+<contributor>
+      <name>Alessandro Bausi</name>
+      <email>alessandro.bausi@uni-hamburg.de</email>
+    </contributor>
     <category citation-format="author-date"/>
     <category field="humanities"/>
-    <updated>2016-03-30T21:24:28+00:00</updated>
+    <updated>2016-09-10T19:36:18+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale xml:lang="en-GB">
@@ -34,7 +38,7 @@
   </locale>
   <macro name="container-contributors">
     <choose>
-      <if type="chapter paper-conference" match="any">
+      <if type="chapter entry-encyclopedia paper-conference" match="any">
         <names variable="editor translator" delimiter=", " prefix=" ">
           <name and="text" initialize-with="."/>
           <label form="short" prefix=", " suffix=","/>
@@ -44,7 +48,7 @@
   </macro>
   <macro name="secondary-contributors">
     <choose>
-      <if type="chapter paper-conference" match="none">
+      <if type="chapter entry-encyclopedia paper-conference" match="none">
         <group delimiter=", " prefix=", ">
           <names variable="editor" delimiter=", ">
             <label form="short" plural="never" suffix=" "/>
@@ -260,7 +264,7 @@
   <macro name="container-phrase">
     <group>
       <choose>
-        <if type="chapter" match="any">
+        <if type="chapter entry-encyclopedia" match="any">
           <text term="in" suffix=" "/>
         </if>
       </choose>
@@ -316,7 +320,7 @@
             <text variable="collection-title"/>
             <number variable="collection-number"/>
           </group>
-          <text macro="locators" prefix=" "/>
+          <text macro="locators" prefix=", "/>
         </group>
         <group delimiter=", " prefix=" ">
           <text macro="event"/>

--- a/hiob-ludolf-centre-for-ethiopian-studies.csl
+++ b/hiob-ludolf-centre-for-ethiopian-studies.csl
@@ -25,14 +25,6 @@
   </info>
   <locale xml:lang="en-GB">
     <terms>
-      <term name="ordinal">th</term>
-      <term name="ordinal-01">st</term>
-      <term name="ordinal-02">nd</term>
-      <term name="ordinal-03">rd</term>
-      <term name="ordinal-04">th</term>
-      <term name="ordinal-11">th</term>
-      <term name="ordinal-12">th</term>
-      <term name="ordinal-13">th</term>
       <term name="available at">see</term>
       <term name="editor" form="short">
         <single>ed.</single>

--- a/hiob-ludolf-centre-for-ethiopian-studies.csl
+++ b/hiob-ludolf-centre-for-ethiopian-studies.csl
@@ -10,7 +10,7 @@
       <name>Eugenia Sokolinski</name>
       <email>eugenia.sokolinski@uni-hamburg.de</email>
     </author>
-<contributor>
+    <contributor>
       <name>Alessandro Bausi</name>
       <email>alessandro.bausi@uni-hamburg.de</email>
     </contributor>
@@ -38,12 +38,11 @@
         <single>ed.</single>
         <multiple>eds</multiple>
       </term>
-    <term name="translator" form="short">tr.</term>
-    <term name="editortranslator" form="short">
-          <single>ed., tr.</single>
-          <multiple>eds, trans.</multiple>
-        </term>
-      
+      <term name="translator" form="short">tr.</term>
+      <term name="editortranslator" form="short">
+        <single>ed., tr.</single>
+        <multiple>eds, trans.</multiple>
+      </term>
     </terms>
   </locale>
   <macro name="container-contributors">
@@ -64,7 +63,7 @@
             <label form="short" suffix=" "/>
             <name and="text" initialize-with="." sort-separator=""/>
           </names>
-          </group>
+        </group>
       </if>
     </choose>
   </macro>


### PR DESCRIPTION
added style with full names
added class encyclopaedia entry everywhere

This was elaborated by prof. bausi to obtain a result closer to the one desired for the Center publications with regard to encyclopaedia entry, e.g.

Bausi, Alessandro 2010. ‘Wängelä Wärq (Golden Gospel)’, in Alessandro Bausi and Siegbert Uhlig, eds, Encyclopaedia Aethiopica, IV (Wiesbaden: Harrassowitz, 2010), 1130b–1132a.
instead of what we got before
Bausi, A. 2010. ‘Wängelä Wärq (Golden Gospel)’, Encyclopaedia Aethiopica, IV (Wiesbaden: Harrassowitz, 2010), 1130b–1132a.