### PR TITLE
Updates to hiob-ludolf-centre-* styles to align to Aethiopica guidelines

### DIFF
--- a/hiob-ludolf-centre-for-ethiopian-studies-long-names.csl
+++ b/hiob-ludolf-centre-for-ethiopian-studies-long-names.csl
@@ -127,7 +127,11 @@
         <text variable="title" font-style="italic"/>
         <group prefix=" (" suffix=") ">
           <text variable="genre"/>
-          <choose><if variable="number"><text variable="number" prefix=" No. "/></if></choose>
+          <choose>
+            <if variable="number">
+              <text variable="number" prefix=" No. "/>
+            </if>
+          </choose>
         </group>
       </if>
       <else-if type="bill book graphic legal_case legislation manuscript motion_picture report song speech webpage thesis" match="any">
@@ -205,15 +209,18 @@
   <macro name="issued">
     <choose>
       <if type="webpage" match="none">
-        <choose><if variable="issued">
-        <date variable="issued">
-          <date-part name="year"/>
-        </date>
-      </if>
+        <choose>
+          <if variable="issued">
+            <date variable="issued">
+              <date-part name="year"/>
+            </date>
+          </if>
           <else>
-        <text term="no date" form="short"/>
-      </else></choose></if>
-      </choose>
+            <text term="no date" form="short"/>
+          </else>
+        </choose>
+      </if>
+    </choose>
   </macro>
   <macro name="issued-year">
     <choose>
@@ -287,19 +294,18 @@
       <choose>
         <if type="entry-encyclopedia">
           <group delimiter=", ">
-            <text variable="title" quotes="true"></text>
+            <text variable="title" quotes="true"/>
             <text variable="title-short" font-style="italic"/>
             <group delimiter=" ">
-              <text variable="volume"></text>
+              <text variable="volume"/>
               <text macro="issued-year" prefix=" (" suffix=")"/>
             </group>
             <text variable="page"/>
             <text macro="citation-locator"/>
           </group>
-          <text macro="author-with-initials" prefix=" (" suffix=")"></text>
+          <text macro="author-with-initials" prefix=" (" suffix=")"/>
         </if>
         <else>
-       
           <group delimiter=", ">
             <group delimiter=" ">
               <text macro="author-short"/>
@@ -307,7 +313,7 @@
             </group>
             <text macro="citation-locator"/>
           </group>
-      </else>
+        </else>
       </choose>
     </layout>
   </citation>
@@ -317,13 +323,17 @@
       <key macro="issued-year" sort="ascending"/>
     </sort>
     <layout>
-      <choose><if type="book" match="any">
-        <choose><if variable="title-short" match="any">
-          <group suffix=". ">
-            <text variable="title-short"></text>
-          </group>
-        </if></choose>
-      </if></choose>
+      <choose>
+        <if type="book" match="any">
+          <choose>
+            <if variable="title-short" match="any">
+              <group suffix=". ">
+                <text variable="title-short"/>
+              </group>
+            </if>
+          </choose>
+        </if>
+      </choose>
       <group suffix=".">
         <text macro="author"/>
         <text macro="issued" prefix=" " suffix="."/>

--- a/hiob-ludolf-centre-for-ethiopian-studies-long-names.csl
+++ b/hiob-ludolf-centre-for-ethiopian-studies-long-names.csl
@@ -21,7 +21,7 @@
     </contributor>
     <category citation-format="author-date"/>
     <category field="humanities"/>
-    <updated>2016-09-10T19:36:18+00:00</updated>
+    <updated>2017-10-02T08:36:15+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale xml:lang="en-GB">
@@ -71,6 +71,16 @@
       </substitute>
     </names>
   </macro>
+  <macro name="author-with-initials">
+    <names variable="author">
+      <name and="text" delimiter-precedes-et-al="never" initialize-with="." sort-separator=" "/>
+      <label form="short" text-case="lowercase" prefix=", " suffix=","/>
+      <substitute>
+        <names variable="editor"/>
+        <names variable="translator"/>
+      </substitute>
+    </names>
+  </macro>
   <macro name="author-short">
     <names variable="author">
       <name form="short" and="text" delimiter=", " initialize-with=". "/>
@@ -93,8 +103,7 @@
       <if type="webpage">
         <choose>
           <if match="any" variable="URL">
-            <group prefix=" (" suffix=")">
-              <text term="available at" suffix=" "/>
+            <group prefix=" " suffix="">
               <text variable="URL" prefix="&lt;" suffix="&gt;"/>
               <choose>
                 <if variable="accessed">
@@ -115,10 +124,10 @@
   <macro name="title">
     <choose>
       <if type="report webpage" match="any">
-        <text variable="title" quotes="true"/>
-        <group prefix=" " suffix=" ">
+        <text variable="title" font-style="italic"/>
+        <group prefix=" (" suffix=") ">
           <text variable="genre"/>
-          <text variable="number" prefix=" No. "/>
+          <choose><if variable="number"><text variable="number" prefix=" No. "/></if></choose>
         </group>
       </if>
       <else-if type="bill book graphic legal_case legislation manuscript motion_picture report song speech webpage thesis" match="any">
@@ -132,13 +141,13 @@
   <macro name="publisher">
     <choose>
       <if type="thesis" match="any">
-        <group delimiter=", " prefix=", " suffix="">
-          <text variable="genre"/>
+        <group suffix="">
+          <text variable="genre" suffix=", "/>
           <group delimiter=": ">
             <text variable="publisher-place"/>
             <text variable="publisher"/>
           </group>
-          <date date-parts="year" form="text" variable="issued"/>
+          <date date-parts="year" form="text" variable="issued" prefix=" (" suffix=")"/>
         </group>
       </if>
       <else>
@@ -195,15 +204,16 @@
   </macro>
   <macro name="issued">
     <choose>
-      <if variable="issued">
+      <if type="webpage" match="none">
+        <choose><if variable="issued">
         <date variable="issued">
           <date-part name="year"/>
         </date>
       </if>
-      <else>
+          <else>
         <text term="no date" form="short"/>
-      </else>
-    </choose>
+      </else></choose></if>
+      </choose>
   </macro>
   <macro name="issued-year">
     <choose>
@@ -274,13 +284,31 @@
       <key macro="issued-year"/>
     </sort>
     <layout delimiter="; ">
-      <group delimiter=", ">
-        <group delimiter=" ">
-          <text macro="author-short"/>
-          <text macro="issued-year"/>
-        </group>
-        <text macro="citation-locator"/>
-      </group>
+      <choose>
+        <if type="entry-encyclopedia">
+          <group delimiter=", ">
+            <text variable="title" quotes="true"></text>
+            <text variable="title-short" font-style="italic"/>
+            <group delimiter=" ">
+              <text variable="volume"></text>
+              <text macro="issued-year" prefix=" (" suffix=")"/>
+            </group>
+            <text variable="page"/>
+            <text macro="citation-locator"/>
+          </group>
+          <text macro="author-with-initials" prefix=" (" suffix=")"></text>
+        </if>
+        <else>
+       
+          <group delimiter=", ">
+            <group delimiter=" ">
+              <text macro="author-short"/>
+              <text macro="issued-year"/>
+            </group>
+            <text macro="citation-locator"/>
+          </group>
+      </else>
+      </choose>
     </layout>
   </citation>
   <bibliography entry-spacing="1" line-spacing="1" hanging-indent="true">
@@ -289,6 +317,13 @@
       <key macro="issued-year" sort="ascending"/>
     </sort>
     <layout>
+      <choose><if type="book" match="any">
+        <choose><if variable="title-short" match="any">
+          <group suffix=". ">
+            <text variable="title-short"></text>
+          </group>
+        </if></choose>
+      </if></choose>
       <group suffix=".">
         <text macro="author"/>
         <text macro="issued" prefix=" " suffix="."/>

--- a/hiob-ludolf-centre-for-ethiopian-studies-with-url-doi.csl
+++ b/hiob-ludolf-centre-for-ethiopian-studies-with-url-doi.csl
@@ -70,7 +70,7 @@
       </substitute>
     </names>
   </macro>
- <macro name="author-with-initials">
+  <macro name="author-with-initials">
     <names variable="author">
       <name and="text" delimiter-precedes-et-al="never" initialize-with="." sort-separator=" "/>
       <label form="short" text-case="lowercase" prefix=", " suffix=","/>
@@ -113,7 +113,7 @@
                     <date-part name="year" prefix=" "/>
                   </date>
                 </if>
-                </choose>
+              </choose>
             </group>
           </if>
         </choose>
@@ -133,7 +133,11 @@
         <text variable="title" font-style="italic"/>
         <group prefix=" (" suffix=") ">
           <text variable="genre"/>
-          <choose><if variable="number"><text variable="number" prefix=" No. "/></if></choose>
+          <choose>
+            <if variable="number">
+              <text variable="number" prefix=" No. "/>
+            </if>
+          </choose>
         </group>
       </if>
       <else-if type="bill book graphic legal_case legislation manuscript motion_picture report song speech webpage thesis" match="any">
@@ -211,15 +215,18 @@
   <macro name="issued">
     <choose>
       <if type="webpage" match="none">
-        <choose><if variable="issued">
-        <date variable="issued">
-          <date-part name="year"/>
-        </date>
-      </if>
+        <choose>
+          <if variable="issued">
+            <date variable="issued">
+              <date-part name="year"/>
+            </date>
+          </if>
           <else>
-        <text term="no date" form="short"/>
-      </else></choose></if>
-      </choose>
+            <text term="no date" form="short"/>
+          </else>
+        </choose>
+      </if>
+    </choose>
   </macro>
   <macro name="issued-year">
     <choose>
@@ -293,19 +300,18 @@
       <choose>
         <if type="entry-encyclopedia">
           <group delimiter=", ">
-            <text variable="title" quotes="true"></text>
+            <text variable="title" quotes="true"/>
             <text variable="title-short" font-style="italic"/>
             <group delimiter=" ">
-              <text variable="volume"></text>
+              <text variable="volume"/>
               <text macro="issued-year" prefix=" (" suffix=")"/>
             </group>
             <text variable="page"/>
             <text macro="citation-locator"/>
           </group>
-          <text macro="author-with-initials" prefix=" (" suffix=")"></text>
+          <text macro="author-with-initials" prefix=" (" suffix=")"/>
         </if>
         <else>
-       
           <group delimiter=", ">
             <group delimiter=" ">
               <text macro="author-short"/>
@@ -313,7 +319,7 @@
             </group>
             <text macro="citation-locator"/>
           </group>
-      </else>
+        </else>
       </choose>
     </layout>
   </citation>
@@ -323,13 +329,17 @@
       <key macro="issued-year" sort="ascending"/>
     </sort>
     <layout>
-      <choose><if type="book" match="any">
-        <choose><if variable="title-short" match="any">
-          <group suffix=". ">
-            <text variable="title-short"></text>
-          </group>
-        </if></choose>
-      </if></choose>
+      <choose>
+        <if type="book" match="any">
+          <choose>
+            <if variable="title-short" match="any">
+              <group suffix=". ">
+                <text variable="title-short"/>
+              </group>
+            </if>
+          </choose>
+        </if>
+      </choose>
       <group suffix=".">
         <text macro="author"/>
         <text macro="issued" prefix=" " suffix="."/>

--- a/hiob-ludolf-centre-for-ethiopian-studies-with-url-doi.csl
+++ b/hiob-ludolf-centre-for-ethiopian-studies-with-url-doi.csl
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" demote-non-dropping-particle="sort-only" default-locale="en-GB">
-  <!-- This style was edited with the Visual CSL Editor (http://editor.citationstyles.org/visualEditor/) -->
   <info>
     <title>Hiob Ludolf Centre for Ethiopian Studies (with URL/DOI)</title>
     <title-short>HLCES (Hamburg)</title-short>
@@ -21,7 +20,7 @@
     </contributor>
     <category citation-format="author-date"/>
     <category field="humanities"/>
-    <updated>2016-09-10T19:36:18+00:00</updated>
+    <updated>2017-10-02T08:36:15+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale xml:lang="en-GB">
@@ -71,6 +70,16 @@
       </substitute>
     </names>
   </macro>
+ <macro name="author-with-initials">
+    <names variable="author">
+      <name and="text" delimiter-precedes-et-al="never" initialize-with="." sort-separator=" "/>
+      <label form="short" text-case="lowercase" prefix=", " suffix=","/>
+      <substitute>
+        <names variable="editor"/>
+        <names variable="translator"/>
+      </substitute>
+    </names>
+  </macro>
   <macro name="author-short">
     <names variable="author">
       <name form="short" and="text" delimiter=", " initialize-with=". "/>
@@ -90,21 +99,24 @@
   </macro>
   <macro name="access">
     <choose>
-      <if match="any" variable="URL">
-        <group prefix=" (" suffix=")">
-          <text term="available at" suffix=" "/>
-          <text variable="URL" prefix="&lt;" suffix="&gt;"/>
-          <choose>
-            <if variable="accessed">
-              <text term="accessed" prefix=", "/>
-              <date variable="accessed">
-                <date-part name="day" form="numeric" prefix=" "/>
-                <date-part name="month" form="long" prefix=" "/>
-                <date-part name="year" prefix=" "/>
-              </date>
-            </if>
-          </choose>
-        </group>
+      <if type="webpage">
+        <choose>
+          <if match="any" variable="URL">
+            <group prefix=" " suffix="">
+              <text variable="URL" prefix="&lt;" suffix="&gt;"/>
+              <choose>
+                <if variable="accessed">
+                  <text term="accessed" prefix=", "/>
+                  <date variable="accessed">
+                    <date-part name="day" form="numeric" prefix=" "/>
+                    <date-part name="month" form="long" prefix=" "/>
+                    <date-part name="year" prefix=" "/>
+                  </date>
+                </if>
+                </choose>
+            </group>
+          </if>
+        </choose>
       </if>
     </choose>
     <choose>
@@ -118,10 +130,10 @@
   <macro name="title">
     <choose>
       <if type="report webpage" match="any">
-        <text variable="title" quotes="true"/>
-        <group prefix=" " suffix=" ">
+        <text variable="title" font-style="italic"/>
+        <group prefix=" (" suffix=") ">
           <text variable="genre"/>
-          <text variable="number" prefix=" No. "/>
+          <choose><if variable="number"><text variable="number" prefix=" No. "/></if></choose>
         </group>
       </if>
       <else-if type="bill book graphic legal_case legislation manuscript motion_picture report song speech webpage thesis" match="any">
@@ -135,13 +147,13 @@
   <macro name="publisher">
     <choose>
       <if type="thesis" match="any">
-        <group delimiter=", " prefix=", " suffix="">
-          <text variable="genre"/>
+        <group suffix="">
+          <text variable="genre" suffix=", "/>
           <group delimiter=": ">
             <text variable="publisher-place"/>
             <text variable="publisher"/>
           </group>
-          <date date-parts="year" form="text" variable="issued"/>
+          <date date-parts="year" form="text" variable="issued" prefix=" (" suffix=")"/>
         </group>
       </if>
       <else>
@@ -198,15 +210,16 @@
   </macro>
   <macro name="issued">
     <choose>
-      <if variable="issued">
+      <if type="webpage" match="none">
+        <choose><if variable="issued">
         <date variable="issued">
           <date-part name="year"/>
         </date>
       </if>
-      <else>
+          <else>
         <text term="no date" form="short"/>
-      </else>
-    </choose>
+      </else></choose></if>
+      </choose>
   </macro>
   <macro name="issued-year">
     <choose>
@@ -277,13 +290,31 @@
       <key macro="issued-year"/>
     </sort>
     <layout delimiter="; ">
-      <group delimiter=", ">
-        <group delimiter=" ">
-          <text macro="author-short"/>
-          <text macro="issued-year"/>
-        </group>
-        <text macro="citation-locator"/>
-      </group>
+      <choose>
+        <if type="entry-encyclopedia">
+          <group delimiter=", ">
+            <text variable="title" quotes="true"></text>
+            <text variable="title-short" font-style="italic"/>
+            <group delimiter=" ">
+              <text variable="volume"></text>
+              <text macro="issued-year" prefix=" (" suffix=")"/>
+            </group>
+            <text variable="page"/>
+            <text macro="citation-locator"/>
+          </group>
+          <text macro="author-with-initials" prefix=" (" suffix=")"></text>
+        </if>
+        <else>
+       
+          <group delimiter=", ">
+            <group delimiter=" ">
+              <text macro="author-short"/>
+              <text macro="issued-year"/>
+            </group>
+            <text macro="citation-locator"/>
+          </group>
+      </else>
+      </choose>
     </layout>
   </citation>
   <bibliography entry-spacing="1" line-spacing="1" hanging-indent="true">
@@ -292,6 +323,13 @@
       <key macro="issued-year" sort="ascending"/>
     </sort>
     <layout>
+      <choose><if type="book" match="any">
+        <choose><if variable="title-short" match="any">
+          <group suffix=". ">
+            <text variable="title-short"></text>
+          </group>
+        </if></choose>
+      </if></choose>
       <group suffix=".">
         <text macro="author"/>
         <text macro="issued" prefix=" " suffix="."/>

--- a/hiob-ludolf-centre-for-ethiopian-studies.csl
+++ b/hiob-ludolf-centre-for-ethiopian-studies.csl
@@ -20,7 +20,7 @@
     </contributor>
     <category citation-format="author-date"/>
     <category field="humanities"/>
-    <updated>2016-09-10T19:36:18+00:00</updated>
+    <updated>2017-10-02T08:36:15+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale xml:lang="en-GB">
@@ -70,6 +70,16 @@
       </substitute>
     </names>
   </macro>
+  <macro name="author-with-initials">
+    <names variable="author">
+      <name and="text" delimiter-precedes-et-al="never" initialize-with="." sort-separator=" "/>
+      <label form="short" text-case="lowercase" prefix=", " suffix=","/>
+      <substitute>
+        <names variable="editor"/>
+        <names variable="translator"/>
+      </substitute>
+    </names>
+  </macro>
   <macro name="author-short">
     <names variable="author">
       <name form="short" and="text" delimiter=", " initialize-with=". "/>
@@ -92,8 +102,7 @@
       <if type="webpage">
         <choose>
           <if match="any" variable="URL">
-            <group prefix=" (" suffix=")">
-              <text term="available at" suffix=" "/>
+            <group prefix=" " suffix="">
               <text variable="URL" prefix="&lt;" suffix="&gt;"/>
               <choose>
                 <if variable="accessed">
@@ -114,10 +123,10 @@
   <macro name="title">
     <choose>
       <if type="report webpage" match="any">
-        <text variable="title" quotes="true"/>
-        <group prefix=" " suffix=" ">
+        <text variable="title" font-style="italic"/>
+        <group prefix=" (" suffix=") ">
           <text variable="genre"/>
-          <text variable="number" prefix=" No. "/>
+          <choose><if variable="number"><text variable="number" prefix=" No. "/></if></choose>
         </group>
       </if>
       <else-if type="bill book graphic legal_case legislation manuscript motion_picture report song speech webpage thesis" match="any">
@@ -131,13 +140,13 @@
   <macro name="publisher">
     <choose>
       <if type="thesis" match="any">
-        <group delimiter=", " prefix=", " suffix="">
-          <text variable="genre"/>
+        <group suffix="">
+          <text variable="genre" suffix=", "/>
           <group delimiter=": ">
             <text variable="publisher-place"/>
             <text variable="publisher"/>
           </group>
-          <date date-parts="year" form="text" variable="issued"/>
+          <date date-parts="year" form="text" variable="issued" prefix=" (" suffix=")"/>
         </group>
       </if>
       <else>
@@ -194,15 +203,16 @@
   </macro>
   <macro name="issued">
     <choose>
-      <if variable="issued">
+      <if type="webpage" match="none">
+        <choose><if variable="issued">
         <date variable="issued">
           <date-part name="year"/>
         </date>
       </if>
-      <else>
+          <else>
         <text term="no date" form="short"/>
-      </else>
-    </choose>
+      </else></choose></if>
+      </choose>
   </macro>
   <macro name="issued-year">
     <choose>
@@ -273,13 +283,31 @@
       <key macro="issued-year"/>
     </sort>
     <layout delimiter="; ">
-      <group delimiter=", ">
-        <group delimiter=" ">
-          <text macro="author-short"/>
-          <text macro="issued-year"/>
-        </group>
-        <text macro="citation-locator"/>
-      </group>
+      <choose>
+        <if type="entry-encyclopedia">
+          <group delimiter=", ">
+            <text variable="title" quotes="true"></text>
+            <text variable="title-short" font-style="italic"/>
+            <group delimiter=" ">
+              <text variable="volume"></text>
+              <text macro="issued-year" prefix=" (" suffix=")"/>
+            </group>
+            <text variable="page"/>
+            <text macro="citation-locator"/>
+          </group>
+          <text macro="author-with-initials" prefix=" (" suffix=")"></text>
+        </if>
+        <else>
+       
+          <group delimiter=", ">
+            <group delimiter=" ">
+              <text macro="author-short"/>
+              <text macro="issued-year"/>
+            </group>
+            <text macro="citation-locator"/>
+          </group>
+      </else>
+      </choose>
     </layout>
   </citation>
   <bibliography entry-spacing="1" line-spacing="1" hanging-indent="true">
@@ -288,6 +316,13 @@
       <key macro="issued-year" sort="ascending"/>
     </sort>
     <layout>
+      <choose><if type="book" match="any">
+        <choose><if variable="title-short" match="any">
+          <group suffix=". ">
+            <text variable="title-short"></text>
+          </group>
+        </if></choose>
+      </if></choose>
       <group suffix=".">
         <text macro="author"/>
         <text macro="issued" prefix=" " suffix="."/>

--- a/hiob-ludolf-centre-for-ethiopian-studies.csl
+++ b/hiob-ludolf-centre-for-ethiopian-studies.csl
@@ -126,7 +126,11 @@
         <text variable="title" font-style="italic"/>
         <group prefix=" (" suffix=") ">
           <text variable="genre"/>
-          <choose><if variable="number"><text variable="number" prefix=" No. "/></if></choose>
+          <choose>
+            <if variable="number">
+              <text variable="number" prefix=" No. "/>
+            </if>
+          </choose>
         </group>
       </if>
       <else-if type="bill book graphic legal_case legislation manuscript motion_picture report song speech webpage thesis" match="any">
@@ -204,15 +208,18 @@
   <macro name="issued">
     <choose>
       <if type="webpage" match="none">
-        <choose><if variable="issued">
-        <date variable="issued">
-          <date-part name="year"/>
-        </date>
-      </if>
+        <choose>
+          <if variable="issued">
+            <date variable="issued">
+              <date-part name="year"/>
+            </date>
+          </if>
           <else>
-        <text term="no date" form="short"/>
-      </else></choose></if>
-      </choose>
+            <text term="no date" form="short"/>
+          </else>
+        </choose>
+      </if>
+    </choose>
   </macro>
   <macro name="issued-year">
     <choose>
@@ -286,19 +293,18 @@
       <choose>
         <if type="entry-encyclopedia">
           <group delimiter=", ">
-            <text variable="title" quotes="true"></text>
+            <text variable="title" quotes="true"/>
             <text variable="title-short" font-style="italic"/>
             <group delimiter=" ">
-              <text variable="volume"></text>
+              <text variable="volume"/>
               <text macro="issued-year" prefix=" (" suffix=")"/>
             </group>
             <text variable="page"/>
             <text macro="citation-locator"/>
           </group>
-          <text macro="author-with-initials" prefix=" (" suffix=")"></text>
+          <text macro="author-with-initials" prefix=" (" suffix=")"/>
         </if>
         <else>
-       
           <group delimiter=", ">
             <group delimiter=" ">
               <text macro="author-short"/>
@@ -306,7 +312,7 @@
             </group>
             <text macro="citation-locator"/>
           </group>
-      </else>
+        </else>
       </choose>
     </layout>
   </citation>
@@ -316,13 +322,17 @@
       <key macro="issued-year" sort="ascending"/>
     </sort>
     <layout>
-      <choose><if type="book" match="any">
-        <choose><if variable="title-short" match="any">
-          <group suffix=". ">
-            <text variable="title-short"></text>
-          </group>
-        </if></choose>
-      </if></choose>
+      <choose>
+        <if type="book" match="any">
+          <choose>
+            <if variable="title-short" match="any">
+              <group suffix=". ">
+                <text variable="title-short"/>
+              </group>
+            </if>
+          </choose>
+        </if>
+      </choose>
       <group suffix=".">
         <text macro="author"/>
         <text macro="issued" prefix=" " suffix="."/>


### PR DESCRIPTION
The Aethiopica guidelines have been revised and updated extensively, after the last approval with improvement of the styles, highlighting some remaining issues.
- I added a `choose` element in the `citation` to have an entirely different citation for the Encyclopaedia articles, which must be ‘Mikaʾel Sǝḥul’, _EAe_, III (2007), 962b–964b (J. Abbink) instead of Abbink 2007. This was done until now by hand...
- I corrected an extra white space which was occurring between the end of the title and the publisher section for type thesis and added brackets. 
before I had Meckelburg, A. 2008. _Ethnische Gewalt in Süd-West Äthiopien: Konflikte, Akteure, Perzeptionen_ , Magisterarbeit, Universität Hamburg 2008. now the updated style correctly produces
Meckelburg, A. 2008. _Ethnische Gewalt in Süd-West Äthiopien: Konflikte, Akteure, Perzeptionen_, Magisterarbeit, Universität Hamburg (2008).
- I updated the style for webpage from
‘The Bibliographical Society’ website n.d. (see <http://www.bibsoc.org.uk>, accessed 1 October 2004).
to the desired
The Bibliographical Society (website) <http://www.bibsoc.org.uk>, accessed 1 October 2004.
- in `bibliography` I have added a condition to add a short title for cases like the Coptic Encyclopaedia record for the whole work, which must be printed in the bibliogrpahy as follows
CE. Aziz S. Atiya, ed., _The Coptic Encyclopedia_, I–VIII, (New York: Macmillan Publishing Company, 1991).

