### PR TITLE
Create uludag-universitesi-sosyal-bilimler-enstitusu-ilahiyat-fakultesi-full-note.csl

### DIFF
--- a/Sosyal Bilimler Enstitüsü (full note, ilahiyat, Turkish).csl
+++ b/Sosyal Bilimler Enstitüsü (full note, ilahiyat, Turkish).csl
@@ -1,0 +1,1437 @@
+<?xml version="1.0" encoding="utf-8"?>
+<style xmlns="http://purl.org/net/xbiblio/csl" class="note" version="1.0" delimiter-precedes-et-al="never" delimiter-precedes-last="always" et-al-min="4" et-al-use-first="1" page-range-format="chicago" default-locale="tr-TR">
+  <!-- This style was edited with the Visual CSL Editor (http://editor.citationstyles.org/visualEditor/) -->
+  <info>
+    <title>Uludağ Üniversitesi - Sosyal Bilimler Enstitüsü (full note, ilahiyat, Turkish)</title>
+    <id>http://www.zotero.org/styles/uludag-universitesi-sosyal-bilimler-enstitusu-full-note-ilahiyat</id>
+    <link href="http://www.zotero.org/styles/uludag-universitesi-sosyal-bilimler-enstitusu-full-note-ilahiyat" rel="self"></link>
+    <link href="http://www.zotero.org/styles/chicago-fullnote-bibliography" rel="template"/>
+    <link href="http://www.uludag.edu.tr/dosyalar/sosyalbilimler/2016%20Duyurular/SBE%20TEZ%20YAZ.%20KIL.(YEN%C4%B0)%2023.09.2016%20(1).pdf" xml:lang="tr" rel="documentation"/>
+    <author>
+      <name>Muhammet Tarakçı</name>
+      <email>muhammettarakci@gmail.com</email>
+    </author>
+    <category citation-format="note"/>
+    <category field="social_science"/>
+    <summary xml:lang="tr">Uludağ Üniversitesi Sosyal Bilimler Enstitüsü'nde yüksek lisans ve doktora tezi yazan öğrencilerimiz için tez yazım kılavuzuna uygun olarak hazırlanmıştır.</summary>
+    <updated>2017-10-01T08:59:49+00:00</updated>
+    <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
+  </info>
+  <locale xml:lang="tr">
+    <terms>
+      <term name="editor" form="verb-short">ed.</term>
+      <term name="translator" form="verb-short">çev.</term>
+      <term name="translator" form="short">çev.</term>
+      <term name="editortranslator" form="verb-short">
+        <single>ed. &amp; çev.</single>
+        <multiple>ed. &amp; çev.</multiple>
+      </term>
+      <term name="editortranslator" form="verb">
+        <single>ed. &amp; çev.</single>
+        <multiple>ed. &amp; çev.</multiple>
+      </term>
+      <term name="translator" form="short">çev.</term>
+      <term name="edition" form="short">bs.</term>
+      <term name="ibid">a.yer</term>
+      <term name="issue" form="short">sy.</term>
+      <term name="volume" form="short">c.</term>
+      <term name="number-of-volumes">cilt</term>
+      <term name="cited">a.g.e.</term>
+      <term name="et-al">v.dğr.</term>
+      <term name="et-al" form="short">v.dğr.</term>
+    </terms>
+  </locale>
+  <macro name="editor-translator">
+    <group delimiter=", ">
+      <group delimiter=" ">
+        <choose>
+          <if variable="container-author reviewed-author" match="any">
+            <group>
+              <names variable="container-author reviewed-author">
+                <label form="verb-short" text-case="lowercase" suffix=" "/>
+                <name delimiter-precedes-et-al="never" delimiter-precedes-last="always"/>
+              </names>
+            </group>
+          </if>
+        </choose>
+      </group>
+      <names variable="editor translator" delimiter=", " suffix=",">
+        <label form="verb-short" text-case="lowercase" suffix=" "/>
+        <name delimiter-precedes-et-al="never" delimiter-precedes-last="always"/>
+      </names>
+    </group>
+  </macro>
+  <macro name="secondary-contributors-note">
+    <choose>
+      <if type="chapter paper-conference" match="none">
+        <text macro="editor-translator"/>
+      </if>
+    </choose>
+  </macro>
+  <macro name="container-contributors-note">
+    <choose>
+      <if type="chapter paper-conference" match="any">
+        <text macro="editor-translator"/>
+      </if>
+    </choose>
+  </macro>
+  <macro name="secondary-contributors">
+    <choose>
+      <if type="chapter paper-conference" match="none">
+        <names variable="editor translator" delimiter=", ">
+          <label form="short" text-case="lowercase" suffix=" "/>
+          <name delimiter-precedes-et-al="never" delimiter-precedes-last="always"/>
+        </names>
+      </if>
+    </choose>
+  </macro>
+  <macro name="container-contributors">
+    <choose>
+      <if type="chapter paper-conference" match="any">
+        <group delimiter=", ">
+          <choose>
+            <if variable="author">
+              <choose>
+                <if variable="container-author" match="any">
+                  <names variable="container-author">
+                    <label form="verb-short" text-case="lowercase" suffix=" "/>
+                    <name delimiter-precedes-et-al="never" delimiter-precedes-last="always"/>
+                  </names>
+                </if>
+              </choose>
+              <choose>
+                <if variable="container-author author" match="all">
+                  <group delimiter=". ">
+                    <names variable="editor translator" delimiter=", ">
+                      <label form="short" suffix=" "/>
+                      <name delimiter-precedes-et-al="never" delimiter-precedes-last="always"/>
+                    </names>
+                  </group>
+                </if>
+                <else>
+                  <names variable="editor translator" delimiter=", ">
+                    <label form="short" text-case="lowercase" suffix=" "/>
+                    <name delimiter-precedes-et-al="never" delimiter-precedes-last="always"/>
+                  </names>
+                </else>
+              </choose>
+            </if>
+          </choose>
+        </group>
+      </if>
+    </choose>
+  </macro>
+  <macro name="recipient-note">
+    <names variable="recipient" delimiter=", ">
+      <label form="verb" text-case="lowercase" suffix=" "/>
+      <name delimiter-precedes-et-al="never" delimiter-precedes-last="always"/>
+    </names>
+  </macro>
+  <macro name="contributors-note">
+    <group delimiter=" ">
+      <names variable="author">
+        <name delimiter-precedes-et-al="never" delimiter-precedes-last="always"/>
+        <label form="short" prefix=" (" suffix=")"/>
+        <substitute>
+          <names variable="editor"/>
+          <names variable="translator"/>
+        </substitute>
+      </names>
+      <text macro="recipient-note"/>
+    </group>
+  </macro>
+  <macro name="editor">
+    <names variable="editor">
+      <name delimiter-precedes-et-al="never" delimiter-precedes-last="always" name-as-sort-order="first" sort-separator=" "/>
+      <label form="short" prefix=", (" suffix=")"/>
+    </names>
+  </macro>
+  <macro name="translator">
+    <names variable="translator">
+      <label form="verb-short" prefix=", "/>
+      <name delimiter-precedes-et-al="never" delimiter-precedes-last="always" name-as-sort-order="first"/>
+    </names>
+  </macro>
+  <macro name="recipient">
+    <group delimiter=" ">
+      <choose>
+        <if type="personal_communication">
+          <choose>
+            <if variable="genre">
+              <text variable="genre" text-case="capitalize-first"/>
+            </if>
+            <else>
+              <text term="letter" text-case="capitalize-first"/>
+            </else>
+          </choose>
+        </if>
+      </choose>
+      <text macro="recipient-note"/>
+    </group>
+  </macro>
+  <macro name="contributors">
+    <group delimiter=". ">
+      <names variable="author">
+        <name delimiter-precedes-et-al="never" delimiter-precedes-last="always" name-as-sort-order="first" sort-separator=" ">
+          <name-part name="family" text-case="uppercase"/>
+        </name>
+        <substitute>
+          <text macro="editor"/>
+          <text macro="translator"/>
+        </substitute>
+      </names>
+      <text macro="recipient"/>
+    </group>
+  </macro>
+  <macro name="recipient-short">
+    <names variable="recipient">
+      <label form="verb" text-case="lowercase" suffix=" "/>
+      <name form="short" delimiter-precedes-et-al="never" delimiter-precedes-last="always"/>
+    </names>
+  </macro>
+  <macro name="contributors-short">
+    <group delimiter=" ">
+      <names variable="author">
+        <name form="short" delimiter-precedes-et-al="never" delimiter-precedes-last="always"/>
+        <substitute>
+          <names variable="editor"/>
+          <names variable="translator"/>
+        </substitute>
+      </names>
+      <text macro="recipient-short"/>
+    </group>
+  </macro>
+  <macro name="contributors-sort">
+    <names variable="author">
+      <name delimiter-precedes-et-al="never" delimiter-precedes-last="always" name-as-sort-order="all"/>
+      <substitute>
+        <names variable="editor"/>
+        <names variable="translator"/>
+        <text macro="title"/>
+      </substitute>
+    </names>
+  </macro>
+  <macro name="interviewer-note">
+    <names variable="interviewer" delimiter=", ">
+      <label form="verb" text-case="lowercase" suffix=" "/>
+      <name delimiter-precedes-et-al="never" delimiter-precedes-last="always"/>
+    </names>
+  </macro>
+  <macro name="interviewer">
+    <names variable="interviewer" delimiter=", ">
+      <label form="verb" text-case="capitalize-first" suffix=" "/>
+      <name delimiter-precedes-et-al="never" delimiter-precedes-last="always"/>
+    </names>
+  </macro>
+  <macro name="title-note">
+    <choose>
+      <if variable="title" match="none">
+        <text variable="genre"/>
+      </if>
+      <else-if type="book graphic motion_picture song thesis manuscript" match="any">
+        <text variable="title" text-case="title" font-style="italic"/>
+        <group delimiter=" " prefix=", ">
+          <text term="version"/>
+          <text variable="version"/>
+        </group>
+      </else-if>
+      <else-if type="legal_case interview patent" match="any">
+        <text variable="title"/>
+      </else-if>
+      <else-if variable="reviewed-author">
+        <text variable="title" font-style="italic"/>
+      </else-if>
+      <else>
+        <text variable="title" text-case="title" quotes="true"/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="title">
+    <choose>
+      <if variable="title" match="none">
+        <choose>
+          <if type="personal_communication" match="none">
+            <text variable="genre" text-case="capitalize-first"/>
+          </if>
+        </choose>
+      </if>
+      <else-if type="book graphic motion_picture song thesis manuscript" match="any">
+        <text variable="title" text-case="title" font-style="italic"/>
+        <group delimiter=" " prefix=", ">
+          <number variable="number-of-volumes" form="numeric"/>
+          <text term="volume"/>
+        </group>
+        <group prefix=" (" suffix=")" delimiter=" ">
+          <text term="version"/>
+          <text variable="version"/>
+        </group>
+      </else-if>
+      <else-if variable="reviewed-author">
+        <group delimiter=", ">
+          <text variable="title" font-style="italic"/>
+          <names variable="reviewed-author">
+            <label form="verb-short" text-case="lowercase" suffix=" "/>
+            <name delimiter-precedes-et-al="never" delimiter-precedes-last="always"/>
+          </names>
+        </group>
+      </else-if>
+      <else-if type="bill legislation legal_case interview patent" match="any">
+        <text variable="title"/>
+      </else-if>
+      <else>
+        <text variable="title" text-case="title" quotes="true" suffix=","/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="title-short">
+    <choose>
+      <if variable="title" match="none">
+        <choose>
+          <if type="interview">
+            <text term="interview"/>
+          </if>
+          <else-if type="manuscript speech" match="any">
+            <text variable="genre" form="short"/>
+          </else-if>
+          <else-if type="personal_communication">
+            <text macro="issued"/>
+          </else-if>
+        </choose>
+      </if>
+      <else-if type="book graphic motion_picture song" match="any">
+        <text variable="title" text-case="title" form="short" font-style="italic"/>
+      </else-if>
+      <else-if type="legal_case" variable="title-short" match="all">
+        <text variable="title" font-style="italic" form="short"/>
+      </else-if>
+      <else-if type="patent interview" match="any">
+        <text variable="title" form="short"/>
+      </else-if>
+      <else-if type="legal_case bill legislation" match="any">
+        <text variable="title"/>
+      </else-if>
+      <else>
+        <text variable="title" text-case="title" form="short" quotes="true"/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="date-disambiguate">
+    <choose>
+      <if disambiguate="true">
+        <text macro="issued"/>
+      </if>
+    </choose>
+  </macro>
+  <macro name="description-note">
+    <group delimiter=", ">
+      <text macro="interviewer-note"/>
+      <text variable="medium"/>
+      <choose>
+        <if variable="title" match="none"/>
+        <else-if type="manuscript thesis speech" match="any"/>
+        <else-if type="patent">
+          <group delimiter=" ">
+            <text variable="authority"/>
+            <text variable="number"/>
+          </group>
+        </else-if>
+        <else>
+          <text variable="genre" suffix=","/>
+        </else>
+      </choose>
+    </group>
+  </macro>
+  <macro name="description">
+    <group delimiter=", ">
+      <group delimiter=". ">
+        <text macro="interviewer"/>
+        <text variable="medium" text-case="capitalize-first"/>
+      </group>
+      <choose>
+        <if variable="title" match="none"/>
+        <else-if type="thesis speech" match="any"/>
+        <else-if type="patent">
+          <group delimiter=" ">
+            <text variable="authority"/>
+            <text variable="number"/>
+          </group>
+        </else-if>
+        <else>
+          <text variable="genre" text-case="capitalize-first"/>
+        </else>
+      </choose>
+    </group>
+  </macro>
+  <macro name="container-title-note">
+    <group delimiter=" ">
+      <choose>
+        <if type="chapter paper-conference" match="any"/>
+      </choose>
+      <choose>
+        <if type="bill legislation legal_case" match="none">
+          <text variable="container-title" text-case="title" font-style="italic"/>
+        </if>
+      </choose>
+    </group>
+  </macro>
+  <macro name="container-title">
+    <group>
+      <choose>
+        <if type="chapter paper-conference" match="any"/>
+      </choose>
+      <choose>
+        <if type="bill legislation legal_case book" match="none">
+          <text variable="container-title" text-case="title" font-style="italic"/>
+          <group prefix=", ">
+            <choose>
+              <if match="any" variable="number-of-volumes">
+                <text variable="number-of-volumes"/>
+                <text term="number-of-volumes" prefix=" "/>
+              </if>
+            </choose>
+          </group>
+        </if>
+      </choose>
+    </group>
+  </macro>
+  <macro name="collection-title">
+    <choose>
+      <if match="none" type="article-journal">
+        <choose>
+          <if match="none" is-numeric="collection-number">
+            <group delimiter=", ">
+              <text variable="collection-title" text-case="title"/>
+              <text variable="collection-number"/>
+            </group>
+          </if>
+        </choose>
+      </if>
+    </choose>
+  </macro>
+  <macro name="collection-title-journal">
+    <choose>
+      <if type="article-journal">
+        <group delimiter=" ">
+          <text variable="collection-title"/>
+          <text variable="collection-number"/>
+        </group>
+      </if>
+    </choose>
+  </macro>
+  <macro name="edition-note">
+    <choose>
+      <if type="book chapter graphic motion_picture paper-conference report song" match="any">
+        <choose>
+          <if is-numeric="edition">
+            <group delimiter=" ">
+              <number variable="edition" form="ordinal"/>
+              <text term="edition" form="short" text-case="lowercase" suffix=","/>
+            </group>
+          </if>
+          <else>
+            <text variable="edition"/>
+          </else>
+        </choose>
+      </if>
+    </choose>
+  </macro>
+  <macro name="edition">
+    <choose>
+      <if type="book chapter graphic motion_picture paper-conference report song" match="any">
+        <choose>
+          <if is-numeric="edition">
+            <group delimiter=" ">
+              <number variable="edition" form="ordinal"/>
+              <text term="edition" form="short"/>
+            </group>
+          </if>
+          <else>
+            <text variable="edition" text-case="capitalize-first" suffix="."/>
+          </else>
+        </choose>
+      </if>
+    </choose>
+  </macro>
+  <macro name="locators-note-join-with-space">
+    <choose>
+      <if type="article-journal" variable="volume" match="all">
+        <choose>
+          <if match="none" variable="collection-title">
+            <text macro="locators-note"/>
+          </if>
+        </choose>
+      </if>
+    </choose>
+  </macro>
+  <macro name="locators-note-join-with-comma">
+    <choose>
+      <if type="article-journal" match="none">
+        <text macro="locators-note"/>
+      </if>
+      <else-if type="article-journal">
+        <choose>
+          <if variable="volume" match="none">
+            <text macro="locators-note"/>
+          </if>
+          <else-if match="any" variable="collection-title">
+            <text macro="locators-note"/>
+          </else-if>
+        </choose>
+      </else-if>
+    </choose>
+  </macro>
+  <macro name="locators-note">
+    <choose>
+      <if type="article-journal">
+        <group delimiter=", ">
+          <group>
+            <label plural="never" suffix=" " variable="volume" form="short"/>
+            <number variable="volume"/>
+          </group>
+          <text macro="collection-title-journal"/>
+          <group delimiter=" ">
+            <label plural="never" variable="issue" form="short"/>
+            <number variable="issue"/>
+          </group>
+        </group>
+      </if>
+      <else-if type="bill legislation legal_case" match="any">
+        <text macro="legal-cites"/>
+      </else-if>
+      <else-if type="book graphic motion_picture report song" match="any">
+        <group delimiter=", ">
+          <text macro="edition-note"/>
+        </group>
+      </else-if>
+    </choose>
+  </macro>
+  <macro name="legal-cites">
+    <choose>
+      <if type="legal_case" match="any">
+        <group delimiter=" ">
+          <choose>
+            <if variable="container-title">
+              <label plural="never" variable="volume" form="short"/>
+              <text variable="volume"/>
+              <text variable="container-title"/>
+              <group delimiter=" ">
+                <text term="section" form="symbol"/>
+                <text variable="section"/>
+              </group>
+              <text variable="page"/>
+            </if>
+            <else>
+              <text variable="number"/>
+            </else>
+          </choose>
+        </group>
+      </if>
+      <else-if type="bill legislation" match="any">
+        <group delimiter=", ">
+          <choose>
+            <if variable="number">
+              <text variable="number"/>
+              <group delimiter=" ">
+                <text term="section" form="symbol"/>
+                <text variable="section"/>
+              </group>
+              <group delimiter=" ">
+                <label plural="never" variable="volume" form="short"/>
+                <text variable="volume"/>
+                <text variable="container-title"/>
+                <text variable="page-first"/>
+              </group>
+            </if>
+            <else>
+              <group delimiter=" ">
+                <label plural="never" variable="volume" form="short"/>
+                <text variable="volume"/>
+                <text variable="container-title"/>
+                <text term="section" form="symbol"/>
+                <text variable="section"/>
+              </group>
+            </else>
+          </choose>
+        </group>
+      </else-if>
+    </choose>
+  </macro>
+  <macro name="locators-join-with-space">
+    <choose>
+      <if type="article-journal" variable="volume" match="all">
+        <choose>
+          <if match="none" variable="collection-title">
+            <text macro="locators"/>
+          </if>
+        </choose>
+      </if>
+    </choose>
+  </macro>
+  <macro name="locators-join-with-comma">
+    <choose>
+      <if type="bill chapter legislation legal_case paper-conference" match="any">
+        <text macro="locators"/>
+      </if>
+      <else-if type="article-journal">
+        <choose>
+          <if variable="volume" match="none">
+            <text macro="locators"/>
+          </if>
+          <else-if match="any" variable="collection-title">
+            <text macro="locators"/>
+          </else-if>
+        </choose>
+      </else-if>
+    </choose>
+  </macro>
+  <macro name="locators-join-with-period">
+    <choose>
+      <if type="bill legislation legal_case article-journal chapter paper-conference" match="none">
+        <text macro="locators"/>
+      </if>
+    </choose>
+  </macro>
+  <macro name="locators">
+    <choose>
+      <if type="article-journal">
+        <group delimiter=" ">
+          <text macro="collection-title-journal"/>
+          <label plural="never" variable="volume" form="short"/>
+          <number suffix="," variable="volume"/>
+          <group delimiter=" ">
+            <label plural="never" variable="issue" form="short"/>
+            <number variable="issue"/>
+          </group>
+        </group>
+      </if>
+      <else-if type="bill legislation legal_case" match="any">
+        <text macro="legal-cites"/>
+      </else-if>
+      <else-if type="book graphic motion_picture report song" match="any">
+        <group delimiter=", ">
+          <text macro="edition"/>
+        </group>
+      </else-if>
+      <else-if type="chapter paper-conference" match="any">
+        <group delimiter=". ">
+          <text macro="edition"/>
+          <choose>
+            <if variable="page" match="none">
+              <group delimiter=" ">
+                <label plural="never" variable="volume" form="short"/>
+                <number variable="volume" form="numeric"/>
+              </group>
+            </if>
+          </choose>
+        </group>
+      </else-if>
+    </choose>
+  </macro>
+  <macro name="locators-newspaper">
+    <choose>
+      <if type="article-newspaper">
+        <group delimiter=", ">
+          <group delimiter=" ">
+            <number variable="edition"/>
+            <text term="edition"/>
+          </group>
+          <group delimiter=" ">
+            <text term="section" form="short"/>
+            <text variable="section"/>
+          </group>
+        </group>
+      </if>
+    </choose>
+  </macro>
+  <macro name="event-note">
+    <choose>
+      <if match="none" variable="container-title">
+        <text variable="event"/>
+      </if>
+    </choose>
+  </macro>
+  <macro name="event">
+    <choose>
+      <if variable="title">
+        <group delimiter=" ">
+          <text variable="event"/>
+        </group>
+      </if>
+      <else>
+        <group delimiter=" ">
+          <text term="presented at" text-case="capitalize-first"/>
+          <text variable="event"/>
+        </group>
+      </else>
+    </choose>
+  </macro>
+  <macro name="originally-published">
+    <group delimiter=", ">
+      <group delimiter=", ">
+        <text variable="original-publisher-place"/>
+        <text variable="original-publisher"/>
+      </group>
+      <date variable="original-date" form="text" date-parts="year"/>
+    </group>
+  </macro>
+  <macro name="reprint-note">
+    <choose>
+      <if variable="original-date issued" match="all">
+        <choose>
+          <if variable="original-publisher original-publisher-place" match="none">
+            <text value="repr."/>
+          </if>
+        </choose>
+      </if>
+    </choose>
+  </macro>
+  <macro name="reprint">
+    <choose>
+      <if variable="original-date issued" match="all">
+        <text value="reprint" text-case="capitalize-first"/>
+      </if>
+    </choose>
+  </macro>
+  <macro name="publisher">
+    <choose>
+      <if type="thesis">
+        <group delimiter=": ">
+          <text variable="publisher-place"/>
+          <text variable="publisher"/>
+        </group>
+      </if>
+      <else-if type="speech">
+        <text variable="event-place"/>
+      </else-if>
+      <else>
+        <group delimiter=": ">
+          <text variable="publisher-place"/>
+          <text variable="publisher"/>
+        </group>
+      </else>
+    </choose>
+  </macro>
+  <macro name="issued">
+    <choose>
+      <if variable="issued">
+        <choose>
+          <if type="graphic report" match="any">
+            <date form="numeric" variable="issued"/>
+          </if>
+          <else-if type="legal_case">
+            <group delimiter=" ">
+              <text variable="authority"/>
+              <choose>
+                <if variable="container-title" match="any">
+                  <date variable="issued" form="numeric" date-parts="year"/>
+                </if>
+                <else>
+                  <date variable="issued" form="text"/>
+                </else>
+              </choose>
+            </group>
+          </else-if>
+          <else-if type="book bill chapter graphic legislation motion_picture paper-conference report song thesis" match="any">
+            <date variable="issued">
+              <date-part name="year"/>
+            </date>
+          </else-if>
+          <else-if type="patent">
+            <group delimiter=", ">
+              <group delimiter=" ">
+                <text value="filed"/>
+                <date variable="submitted" form="text"/>
+              </group>
+              <group delimiter=" ">
+                <choose>
+                  <if variable="issued submitted" match="all">
+                    <text term="and"/>
+                  </if>
+                </choose>
+                <date form="numeric" variable="issued" prefix="(" suffix=")"/>
+              </group>
+            </group>
+          </else-if>
+          <else-if type="article-newspaper article-magazine" match="any">
+            <date form="numeric" variable="issued" prefix="(" suffix=")"/>
+          </else-if>
+          <else-if type="article-journal" match="any">
+            <date date-parts="year" form="text" variable="issued"/>
+          </else-if>
+          <else-if type="manuscript" match="any">
+            <date form="text" date-parts="year-month-day" variable="issued">
+              <date-part name="year"/>
+            </date>
+          </else-if>
+          <else>
+            <date form="numeric" variable="issued"/>
+          </else>
+        </choose>
+      </if>
+      <else-if variable="status">
+        <text variable="status"/>
+      </else-if>
+      <else-if variable="accessed URL" match="all"/>
+      <else>
+        <text term="no date" form="short"/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="point-locators-subsequent">
+    <choose>
+      <if type="legal_case" variable="locator" match="all">
+        <choose>
+          <if locator="page">
+            <group>
+              <number suffix=", " variable="volume"/>
+              <label suffix=" " variable="locator" form="short"/>
+              <text variable="locator"/>
+            </group>
+          </if>
+          <else>
+            <group delimiter=" ">
+              <label variable="locator" form="short"/>
+              <text variable="locator"/>
+            </group>
+          </else>
+        </choose>
+      </if>
+      <else-if variable="locator">
+        <choose>
+          <if locator="page" match="none">
+            <group delimiter=" ">
+              <choose>
+                <if type="book graphic motion_picture report song" match="any">
+                  <choose>
+                    <if variable="volume">
+                      <group delimiter=", ">
+                        <group delimiter=" ">
+                          <text term="volume" form="short"/>
+                          <number variable="volume" form="numeric"/>
+                        </group>
+                        <label variable="locator" form="short"/>
+                      </group>
+                    </if>
+                    <else>
+                      <label variable="locator" form="short"/>
+                    </else>
+                  </choose>
+                </if>
+                <else>
+                  <label variable="locator" form="short"/>
+                </else>
+              </choose>
+              <text variable="locator"/>
+            </group>
+          </if>
+          <else-if type="book graphic motion_picture report song" match="any">
+            <group>
+              <number suffix=", " variable="volume"/>
+              <label suffix=" " variable="locator" form="short"/>
+              <text variable="locator"/>
+            </group>
+          </else-if>
+          <else>
+            <label suffix=" " variable="locator" form="short"/>
+            <text variable="locator"/>
+          </else>
+        </choose>
+      </else-if>
+      <else-if match="none" variable="locator">
+        <group>
+          <label suffix=" " variable="page" form="short"/>
+          <text variable="page"/>
+        </group>
+      </else-if>
+    </choose>
+  </macro>
+  <macro name="point-locators-join-with-colon">
+    <choose>
+      <if type="article-journal">
+        <choose>
+          <if variable="locator page" match="any">
+            <choose>
+              <if variable="volume issue" match="any">
+                <text macro="point-locators"/>
+              </if>
+            </choose>
+          </if>
+        </choose>
+      </if>
+    </choose>
+  </macro>
+  <macro name="point-locators-join-with-comma">
+    <choose>
+      <if type="article-journal" match="none">
+        <text macro="point-locators"/>
+      </if>
+      <else-if variable="volume issue" match="none">
+        <text macro="point-locators"/>
+      </else-if>
+    </choose>
+  </macro>
+  <macro name="point-locators">
+    <choose>
+      <if variable="locator" match="none">
+        <choose>
+          <if type="article-journal paper-conference" match="any">
+            <label suffix=" " variable="page" form="short"/>
+            <text variable="page"/>
+          </if>
+          <else-if type="chapter entry-dictionary entry-encyclopedia" match="any">
+            <group>
+              <choose>
+                <if variable="volume">
+                  <group delimiter=", ">
+                    <group delimiter=" ">
+                      <label plural="never" variable="volume" form="short"/>
+                      <text variable="volume"/>
+                    </group>
+                    <group delimiter=" ">
+                      <label variable="page" form="short"/>
+                      <text variable="page"/>
+                    </group>
+                  </group>
+                </if>
+                <else>
+                  <label suffix=" " variable="page" form="short"/>
+                  <text variable="page"/>
+                </else>
+              </choose>
+            </group>
+          </else-if>
+        </choose>
+      </if>
+      <else-if type="article-journal">
+        <group delimiter=" ">
+          <choose>
+            <if locator="page" match="none">
+              <label variable="locator" form="short" suffix=" "/>
+            </if>
+          </choose>
+          <label suffix=" " variable="locator" form="short"/>
+          <text variable="locator"/>
+        </group>
+      </else-if>
+      <else-if type="legal_case"/>
+      <else-if type="entry-dictionary chapter entry-encyclopedia paper-conference report" match="any">
+        <group>
+          <choose>
+            <if match="any" variable="volume">
+              <label plural="never" suffix=" " variable="volume" form="short"/>
+              <text variable="volume" suffix=", "/>
+            </if>
+          </choose>
+          <label suffix=" " variable="locator" form="short"/>
+          <text variable="locator"/>
+        </group>
+      </else-if>
+      <else>
+        <group delimiter=" ">
+          <choose>
+            <if locator="page" match="none">
+              <label variable="locator" form="short"/>
+            </if>
+            <else-if match="any" variable="volume">
+              <label plural="never" suffix=" " variable="volume" form="short"/>
+              <text variable="volume" suffix=","/>
+            </else-if>
+          </choose>
+          <label suffix=" " variable="locator" form="short"/>
+          <text variable="locator"/>
+        </group>
+      </else>
+    </choose>
+  </macro>
+  <macro name="locators-chapter">
+    <choose>
+      <if type="paper-conference" match="any">
+        <choose>
+          <if variable="author container-author" match="all"/>
+        </choose>
+      </if>
+    </choose>
+  </macro>
+  <macro name="locators-journal-join-with-colon">
+    <choose>
+      <if type="article-journal">
+        <choose>
+          <if variable="volume issue" match="any">
+            <group>
+              <label prefix=", " suffix=" " variable="page" form="short"/>
+              <text variable="page"/>
+            </group>
+          </if>
+        </choose>
+      </if>
+      <else-if type="entry-dictionary entry-encyclopedia" match="any">
+        <group>
+          <choose>
+            <if match="any" variable="volume">
+              <label plural="never" prefix=", " suffix=" " variable="volume" form="short"/>
+              <text variable="volume" suffix=", "/>
+            </if>
+          </choose>
+        </group>
+        <label suffix=" " variable="page" form="short"/>
+        <text variable="page"/>
+      </else-if>
+      <else-if type="chapter" match="any">
+        <group>
+          <choose>
+            <if match="any" variable="volume">
+              <label plural="never" prefix=", " suffix=" " variable="volume" form="short"/>
+              <text variable="volume"/>
+            </if>
+          </choose>
+        </group>
+        <label prefix=", " suffix=" " variable="page" form="short"/>
+        <text variable="page"/>
+      </else-if>
+      <else-if type="paper-conference" match="any">
+        <group>
+          <choose>
+            <if match="any" variable="volume">
+              <label plural="never" prefix=", " suffix=" " variable="volume" form="short"/>
+              <text variable="volume"/>
+            </if>
+          </choose>
+        </group>
+        <label prefix=", " suffix=" " variable="page" form="short"/>
+        <text variable="page"/>
+      </else-if>
+    </choose>
+  </macro>
+  <macro name="locators-journal-join-with-comma">
+    <choose>
+      <if type="article-journal">
+        <choose>
+          <if variable="volume issue" match="none">
+            <text variable="page"/>
+          </if>
+        </choose>
+      </if>
+    </choose>
+  </macro>
+  <macro name="archive-note">
+    <choose>
+      <if type="thesis">
+        <group delimiter=" ">
+          <text variable="archive"/>
+          <text variable="archive_location" prefix="(" suffix=")"/>
+        </group>
+      </if>
+      <else>
+        <group delimiter=", ">
+          <text variable="archive"/>
+          <text variable="archive_location"/>
+          <text variable="archive-place"/>
+          <text variable="call-number"/>
+        </group>
+      </else>
+    </choose>
+  </macro>
+  <macro name="archive">
+    <choose>
+      <if type="thesis">
+        <group delimiter=" ">
+          <text variable="archive"/>
+          <text variable="archive_location" prefix=", (" suffix=")"/>
+        </group>
+      </if>
+      <else>
+        <group delimiter=", " prefix=", ">
+          <text variable="archive"/>
+          <text variable="archive_location" text-case="capitalize-first"/>
+          <text variable="archive-place"/>
+          <text variable="call-number"/>
+        </group>
+      </else>
+    </choose>
+  </macro>
+  <macro name="issue-note-join-with-space">
+    <choose>
+      <if type="article-journal bill legislation legal_case manuscript thesis" variable="publisher-place publisher" match="any">
+        <choose>
+          <if type="article-newspaper" match="none">
+            <choose>
+              <if type="article-journal" match="none">
+                <text macro="issue-note"/>
+              </if>
+              <else-if variable="issue volume" match="any">
+                <text macro="issue-note"/>
+              </else-if>
+            </choose>
+          </if>
+        </choose>
+      </if>
+    </choose>
+  </macro>
+  <macro name="issue-note-join-with-comma">
+    <choose>
+      <if type="article-journal bill legislation legal_case manuscript thesis" variable="publisher-place publisher" match="none">
+        <text macro="issue-note"/>
+      </if>
+      <else-if type="article-newspaper">
+        <text macro="issue-note"/>
+      </else-if>
+      <else-if type="article-journal">
+        <choose>
+          <if variable="volume issue" match="none">
+            <text macro="issue-note"/>
+          </if>
+        </choose>
+      </else-if>
+    </choose>
+  </macro>
+  <macro name="issue-note">
+    <choose>
+      <if type="bill legislation legal_case" match="any">
+        <text macro="issued" prefix="(" suffix=")"/>
+      </if>
+      <else-if type="article-journal">
+        <choose>
+          <if variable="volume issue" match="any">
+            <text macro="issued" prefix="(" suffix=")"/>
+          </if>
+          <else>
+            <text macro="issued"/>
+          </else>
+        </choose>
+      </else-if>
+      <else-if type="article-newspaper">
+        <text macro="issued"/>
+      </else-if>
+      <else-if variable="publisher-place event-place publisher genre" match="any">
+        <group delimiter=", ">
+          <choose>
+            <if variable="title" match="none"/>
+            <else-if type="thesis" match="any">
+              <text variable="genre" prefix="(" suffix=" Tezi)"/>
+            </else-if>
+            <else-if type="manuscript speech" match="any">
+              <text variable="genre" prefix="(" suffix=")"/>
+            </else-if>
+          </choose>
+          <text macro="event-note"/>
+          <group delimiter="; ">
+            <text macro="originally-published"/>
+            <group delimiter=", ">
+              <text macro="reprint-note"/>
+              <text macro="publisher"/>
+            </group>
+          </group>
+          <text macro="issued"/>
+        </group>
+      </else-if>
+      <else>
+        <text macro="issued"/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="issue-join-with-space">
+    <choose>
+      <if type="article-journal" match="any">
+        <choose>
+          <if variable="issue volume" match="any">
+            <text macro="issue"/>
+          </if>
+        </choose>
+      </if>
+      <else-if type="bill legislation legal_case" match="any">
+        <text macro="issue"/>
+      </else-if>
+    </choose>
+  </macro>
+  <macro name="issue-join-with-period">
+    <choose>
+      <if type="article-journal bill legislation legal_case" match="none">
+        <choose>
+          <if type="speech" variable="publisher publisher-place" match="any">
+            <text macro="issue"/>
+          </if>
+        </choose>
+      </if>
+    </choose>
+  </macro>
+  <macro name="issue-join-with-comma">
+    <choose>
+      <if type="bill legislation legal_case" match="none">
+        <choose>
+          <if type="article-journal" match="none">
+            <choose>
+              <if type="speech" variable="publisher publisher-place" match="none">
+                <text macro="issue"/>
+              </if>
+            </choose>
+          </if>
+          <else-if variable="volume issue" match="none">
+            <text macro="issue"/>
+          </else-if>
+        </choose>
+      </if>
+    </choose>
+  </macro>
+  <macro name="issue">
+    <choose>
+      <if type="bill legislation legal_case" match="any">
+        <text macro="issued" prefix="(" suffix=")"/>
+      </if>
+      <else-if type="article-journal">
+        <choose>
+          <if variable="issue volume" match="any">
+            <text macro="issued" prefix="(" suffix=")"/>
+          </if>
+          <else>
+            <text macro="issued"/>
+          </else>
+        </choose>
+      </else-if>
+      <else-if type="speech">
+        <group delimiter=", ">
+          <group delimiter=", ">
+            <choose>
+              <if variable="title" match="none"/>
+              <else>
+                <text variable="genre" text-case="capitalize-first" prefix="(" suffix=")"/>
+              </else>
+            </choose>
+            <text macro="event"/>
+          </group>
+          <text variable="event-place"/>
+          <text macro="issued"/>
+        </group>
+      </else-if>
+      <else-if type="article-newspaper">
+        <text macro="issued"/>
+      </else-if>
+      <else-if variable="publisher-place publisher" match="any">
+        <group delimiter=", ">
+          <choose>
+            <if type="thesis">
+              <text variable="genre" text-case="title" prefix="(" suffix=" Tezi)"/>
+            </if>
+            <else-if match="none" variable="container-title">
+              <text variable="event"/>
+            </else-if>
+          </choose>
+          <group delimiter=". ">
+            <text macro="originally-published"/>
+            <group delimiter=", ">
+              <text macro="reprint"/>
+              <text macro="publisher"/>
+            </group>
+          </group>
+          <text macro="issued"/>
+        </group>
+      </else-if>
+      <else>
+        <text macro="issued"/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="access-note">
+    <group delimiter=", ">
+      <choose>
+        <if type="graphic report" match="any">
+          <text macro="archive-note"/>
+        </if>
+        <else-if type="article-journal bill book chapter legal_case legislation motion_picture paper-conference" match="none">
+          <text macro="archive-note"/>
+        </else-if>
+      </choose>
+      <choose>
+        <if variable="issued" match="none">
+          <group delimiter=" ">
+            <date form="numeric" variable="accessed" prefix="(" suffix=")"/>
+          </group>
+        </if>
+      </choose>
+      <choose>
+        <if type="legal_case book thesis" match="none">
+          <choose>
+            <if match="any" variable="DOI">
+              <text variable="DOI" prefix="doi:"/>
+            </if>
+            <else>
+              <text variable="URL"/>
+            </else>
+          </choose>
+        </if>
+      </choose>
+    </group>
+  </macro>
+  <macro name="access">
+    <group>
+      <choose>
+        <if type="graphic report" match="any">
+          <text macro="archive"/>
+        </if>
+        <else-if type="article-journal bill book chapter legal_case legislation motion_picture paper-conference" match="none">
+          <text macro="archive"/>
+        </else-if>
+      </choose>
+      <choose>
+        <if variable="issued" match="none">
+          <group delimiter=" ">
+            <date form="numeric" variable="accessed" prefix=" (" suffix=")"/>
+          </group>
+        </if>
+      </choose>
+      <choose>
+        <if type="legal_case book thesis" match="none">
+          <choose>
+            <if match="any" variable="DOI">
+              <text variable="DOI" prefix=", doi:"/>
+            </if>
+            <else>
+              <text variable="URL" prefix=", "/>
+            </else>
+          </choose>
+        </if>
+      </choose>
+    </group>
+  </macro>
+  <macro name="case-locator-subsequent">
+    <choose>
+      <if type="legal_case">
+        <group delimiter=" ">
+          <text variable="volume"/>
+          <text variable="container-title"/>
+        </group>
+      </if>
+    </choose>
+  </macro>
+  <macro name="case-pinpoint-subsequent">
+    <choose>
+      <if type="legal_case">
+        <group delimiter=" ">
+          <choose>
+            <if locator="page">
+              <text term="at"/>
+              <text variable="locator"/>
+            </if>
+            <else>
+              <label variable="locator"/>
+              <text variable="locator"/>
+            </else>
+          </choose>
+        </group>
+      </if>
+    </choose>
+  </macro>
+  <citation et-al-min="4" et-al-use-first="1" disambiguate-add-names="true">
+    <layout suffix="." delimiter="; ">
+      <choose>
+        <if position="ibid-with-locator">
+          <group delimiter=", ">
+            <text term="cited" text-case="lowercase"/>
+            <text macro="point-locators-subsequent"/>
+          </group>
+        </if>
+        <else-if position="ibid">
+          <text term="ibid" text-case="lowercase"/>
+        </else-if>
+        <else-if position="subsequent">
+          <group delimiter=", ">
+            <text macro="contributors-short"/>
+            <group delimiter=" ">
+              <group delimiter=", ">
+                <text macro="title-short"/>
+                <text macro="date-disambiguate"/>
+                <text macro="case-locator-subsequent"/>
+              </group>
+              <text macro="case-pinpoint-subsequent"/>
+            </group>
+            <choose>
+              <if match="none" type="legal_case">
+                <text macro="point-locators-subsequent"/>
+              </if>
+            </choose>
+          </group>
+        </else-if>
+        <else>
+          <group delimiter=", ">
+            <group delimiter=", ">
+              <group delimiter=", ">
+                <group delimiter=" ">
+                  <group delimiter=", ">
+                    <group delimiter=" ">
+                      <group delimiter=", ">
+                        <group delimiter=", ">
+                          <text macro="contributors-note"/>
+                          <text macro="title-note" suffix=","/>
+                        </group>
+                        <text macro="description-note"/>
+                        <text macro="container-title-note" suffix=","/>
+                        <text macro="secondary-contributors-note"/>
+                        <text macro="container-contributors-note"/>
+                      </group>
+                      <text macro="locators-note-join-with-space"/>
+                    </group>
+                    <text macro="locators-note-join-with-comma"/>
+                    <text macro="collection-title"/>
+                    <text macro="issue-note-join-with-comma"/>
+                  </group>
+                  <text macro="issue-note-join-with-space"/>
+                </group>
+                <text macro="locators-newspaper"/>
+                <text macro="point-locators-join-with-comma"/>
+              </group>
+              <text macro="point-locators-join-with-colon"/>
+            </group>
+            <text macro="access-note"/>
+          </group>
+        </else>
+      </choose>
+    </layout>
+  </citation>
+  <bibliography delimiter-precedes-et-al="never" delimiter-precedes-last="always" et-al-min="4" et-al-use-first="1" subsequent-author-substitute="———" entry-spacing="0" hanging-indent="true">
+    <sort>
+      <key macro="contributors-sort"/>
+      <key variable="title"/>
+      <key variable="genre"/>
+      <key variable="issued"/>
+    </sort>
+    <layout suffix=".">
+      <group>
+        <group>
+          <group delimiter=", ">
+            <group delimiter=" ">
+              <group delimiter=", ">
+                <group delimiter=" ">
+                  <group delimiter=", ">
+                    <group delimiter=", ">
+                      <group delimiter=", ">
+                        <text macro="contributors"/>
+                        <text macro="title"/>
+                      </group>
+                      <text macro="description"/>
+                      <group delimiter=", ">
+                        <text macro="container-title" suffix=","/>
+                        <text macro="secondary-contributors" suffix=","/>
+                        <text macro="container-contributors"/>
+                      </group>
+                      <text macro="locators-join-with-period"/>
+                    </group>
+                    <text macro="locators-join-with-comma"/>
+                    <text macro="locators-chapter"/>
+                  </group>
+                  <text macro="locators-join-with-space"/>
+                </group>
+                <text macro="collection-title"/>
+                <text macro="issue-join-with-period"/>
+              </group>
+              <text macro="issue-join-with-space"/>
+            </group>
+            <text macro="issue-join-with-comma"/>
+            <text macro="locators-journal-join-with-comma"/>
+            <text macro="locators-newspaper"/>
+          </group>
+          <text macro="locators-journal-join-with-colon"/>
+        </group>
+        <text macro="access"/>
+      </group>
+    </layout>
+  </bibliography>
+</style>

--- a/uludag-universitesi-sosyal-bilimler-enstitusu-ilahiyat-fakultesi-full-note.csl
+++ b/uludag-universitesi-sosyal-bilimler-enstitusu-ilahiyat-fakultesi-full-note.csl
@@ -3,8 +3,8 @@
   <!-- This style was edited with the Visual CSL Editor (http://editor.citationstyles.org/visualEditor/) -->
   <info>
     <title>Uludağ Üniversitesi - Sosyal Bilimler Enstitüsü (full note, ilahiyat, Turkish)</title>
-    <id>http://www.zotero.org/styles/uludag-universitesi-sosyal-bilimler-enstitusu-full-note-ilahiyat</id>
-    <link href="http://www.zotero.org/styles/uludag-universitesi-sosyal-bilimler-enstitusu-full-note-ilahiyat" rel="self"></link>
+    <id>http://www.zotero.org/styles/uludag-universitesi-sosyal-bilimler-enstitusu-ilahiyat-fakultesi-full-note</id>
+    <link href="http://www.zotero.org/styles/uludag-universitesi-sosyal-bilimler-enstitusu-ilahiyat-fakultesi-full-note" rel="self"></link>
     <link href="http://www.zotero.org/styles/chicago-fullnote-bibliography" rel="template"/>
     <link href="http://www.uludag.edu.tr/dosyalar/sosyalbilimler/2016%20Duyurular/SBE%20TEZ%20YAZ.%20KIL.(YEN%C4%B0)%2023.09.2016%20(1).pdf" xml:lang="tr" rel="documentation"/>
     <author>

--- a/uludag-universitesi-sosyal-bilimler-enstitusu-ilahiyat-fakultesi-full-note.csl
+++ b/uludag-universitesi-sosyal-bilimler-enstitusu-ilahiyat-fakultesi-full-note.csl
@@ -2,7 +2,7 @@
 <style xmlns="http://purl.org/net/xbiblio/csl" class="note" version="1.0" delimiter-precedes-et-al="never" delimiter-precedes-last="always" et-al-min="4" et-al-use-first="1" page-range-format="chicago" default-locale="tr-TR">
   <!-- This style was edited with the Visual CSL Editor (http://editor.citationstyles.org/visualEditor/) -->
   <info>
-    <title>Uludağ Üniversitesi - Sosyal Bilimler Enstitüsü (full note, ilahiyat, Turkish)</title>
+    <title>Uludağ Üniversitesi - Sosyal Bilimler Enstitüsü İlahiyat Fakültesi (full note, Turkish)</title>
     <id>http://www.zotero.org/styles/uludag-universitesi-sosyal-bilimler-enstitusu-ilahiyat-fakultesi-full-note</id>
     <link href="http://www.zotero.org/styles/uludag-universitesi-sosyal-bilimler-enstitusu-ilahiyat-fakultesi-full-note" rel="self"></link>
     <link href="http://www.zotero.org/styles/chicago-fullnote-bibliography" rel="template"/>

--- a/uludag-universitesi-sosyal-bilimler-enstitusu-ilahiyat-fakultesi-full-note.csl
+++ b/uludag-universitesi-sosyal-bilimler-enstitusu-ilahiyat-fakultesi-full-note.csl
@@ -4,7 +4,7 @@
   <info>
     <title>Uludağ Üniversitesi - Sosyal Bilimler Enstitüsü İlahiyat Fakültesi (full note, Turkish)</title>
     <id>http://www.zotero.org/styles/uludag-universitesi-sosyal-bilimler-enstitusu-ilahiyat-fakultesi-full-note</id>
-    <link href="http://www.zotero.org/styles/uludag-universitesi-sosyal-bilimler-enstitusu-ilahiyat-fakultesi-full-note" rel="self"></link>
+    <link href="http://www.zotero.org/styles/uludag-universitesi-sosyal-bilimler-enstitusu-ilahiyat-fakultesi-full-note" rel="self"/>
     <link href="http://www.zotero.org/styles/chicago-fullnote-bibliography" rel="template"/>
     <link href="http://www.uludag.edu.tr/dosyalar/sosyalbilimler/2016%20Duyurular/SBE%20TEZ%20YAZ.%20KIL.(YEN%C4%B0)%2023.09.2016%20(1).pdf" xml:lang="tr" rel="documentation"/>
     <author>
@@ -14,7 +14,7 @@
     <category citation-format="note"/>
     <category field="social_science"/>
     <summary xml:lang="tr">Uludağ Üniversitesi Sosyal Bilimler Enstitüsü'nde yüksek lisans ve doktora tezi yazan öğrencilerimiz için tez yazım kılavuzuna uygun olarak hazırlanmıştır.</summary>
-    <updated>2017-10-01T08:59:49+00:00</updated>
+    <updated>2017-10-09T21:05:58+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale xml:lang="tr">
@@ -783,10 +783,15 @@
         <choose>
           <if locator="page">
             <group>
-              <number suffix=", " variable="volume"/>
-              <label suffix=" " variable="locator" form="short"/>
-              <text variable="locator"/>
+              <choose>
+                <if match="any" variable="volume">
+                  <label plural="never" suffix=" " variable="volume" form="short"/>
+                  <number suffix=", " variable="volume"/>
+                </if>
+              </choose>
             </group>
+            <label suffix=" " variable="locator" form="short"/>
+            <text variable="locator"/>
           </if>
           <else>
             <group delimiter=" ">
@@ -806,7 +811,7 @@
                     <if variable="volume">
                       <group delimiter=", ">
                         <group delimiter=" ">
-                          <text term="volume" form="short"/>
+                          <text term="volume" form="short" suffix=" "/>
                           <number variable="volume" form="numeric"/>
                         </group>
                         <label variable="locator" form="short"/>
@@ -826,7 +831,12 @@
           </if>
           <else-if type="book graphic motion_picture report song" match="any">
             <group>
-              <number suffix=", " variable="volume"/>
+              <choose>
+                <if match="any" variable="volume">
+                  <label plural="never" suffix=" " variable="volume" form="short"/>
+                  <number suffix=", " variable="volume"/>
+                </if>
+              </choose>
               <label suffix=" " variable="locator" form="short"/>
               <text variable="locator"/>
             </group>

--- a/uludag-universitesi-sosyal-bilimler-enstitusu-ilahiyat-fakultesi-full-note.csl
+++ b/uludag-universitesi-sosyal-bilimler-enstitusu-ilahiyat-fakultesi-full-note.csl
@@ -2,7 +2,7 @@
 <style xmlns="http://purl.org/net/xbiblio/csl" class="note" version="1.0" delimiter-precedes-et-al="never" delimiter-precedes-last="always" et-al-min="4" et-al-use-first="1" page-range-format="chicago" default-locale="tr-TR">
   <!-- This style was edited with the Visual CSL Editor (http://editor.citationstyles.org/visualEditor/) -->
   <info>
-    <title>Uludağ Üniversitesi - Sosyal Bilimler Enstitüsü İlahiyat Fakültesi (full note, Turkish)</title>
+    <title>Uludağ Üniversitesi - Sosyal Bilimler Enstitüsü - İlahiyat Fakültesi (full note, Turkish)</title>
     <id>http://www.zotero.org/styles/uludag-universitesi-sosyal-bilimler-enstitusu-ilahiyat-fakultesi-full-note</id>
     <link href="http://www.zotero.org/styles/uludag-universitesi-sosyal-bilimler-enstitusu-ilahiyat-fakultesi-full-note" rel="self"/>
     <link href="http://www.zotero.org/styles/chicago-fullnote-bibliography" rel="template"/>
@@ -608,9 +608,7 @@
         <text macro="legal-cites"/>
       </else-if>
       <else-if type="book graphic motion_picture report song" match="any">
-        <group delimiter=", ">
-          <text macro="edition"/>
-        </group>
+        <text macro="edition"/>
       </else-if>
       <else-if type="chapter paper-conference" match="any">
         <group delimiter=". ">
@@ -653,9 +651,7 @@
   <macro name="event">
     <choose>
       <if variable="title">
-        <group delimiter=" ">
-          <text variable="event"/>
-        </group>
+        <text variable="event"/>
       </if>
       <else>
         <group delimiter=" ">
@@ -1396,7 +1392,7 @@
       </choose>
     </layout>
   </citation>
-  <bibliography delimiter-precedes-et-al="never" delimiter-precedes-last="always" et-al-min="4" et-al-use-first="1" subsequent-author-substitute="———" entry-spacing="0" hanging-indent="true">
+  <bibliography delimiter-precedes-et-al="never" delimiter-precedes-last="always" et-al-min="4" et-al-use-first="1" subsequent-author-substitute="&#8212;&#8212;&#8212;" entry-spacing="0" hanging-indent="true">
     <sort>
       <key macro="contributors-sort"/>
       <key variable="title"/>


### PR DESCRIPTION
Dear rmzelle,
I said before that there will be three styles for "Uludağ Üniversitesi Sosyal Bilimler Enstitüsü". 
However, two different approaches have appeared and Institute approved both. 

There is slight difference between "full note, Turkish" and "full note, ilahiyat, Turkish". 

The former uses "vd." for "et-al" while the latter uses "v.dğr."
And the former uses "s." for both "number" and single page, while the latter "sy." for number, and "s." for single page. 

Would you mind adding the fourth style to repository as "Uludağ Üniversitesi - Sosyal Bilimler Enstitüsü (full note, ilahiyat, Turkish)?