### PR TITLE
Properly support personal communications in APA

### DIFF
--- a/apa.csl
+++ b/apa.csl
@@ -44,6 +44,7 @@
         <single>trans.</single>
         <multiple>trans.</multiple>
       </term>
+      <term name="interview">personal communication</term>
     </terms>
   </locale>
   <macro name="container-contributors">
@@ -650,17 +651,38 @@
       </if>
     </choose>
   </macro>
+  <macro name="personal_communication">
+    <group delimiter=", ">
+      <names variable="author">
+        <name and="symbol" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
+      </names>
+      <text term="interview"/>
+      <date variable="issued">
+        <date-part name="month"/>
+        <date-part name="day" prefix=" "/>
+        <date-part name="year" prefix=", "/>
+      </date>
+      <text macro="citation-locator"/>
+    </group>
+  </macro>
   <citation et-al-min="6" et-al-use-first="1" et-al-subsequent-min="3" et-al-subsequent-use-first="1" disambiguate-add-year-suffix="true" disambiguate-add-names="true" disambiguate-add-givenname="true" collapse="year" givenname-disambiguation-rule="primary-name">
     <sort>
       <key macro="author"/>
       <key macro="issued-sort"/>
     </sort>
     <layout prefix="(" suffix=")" delimiter="; ">
-      <group delimiter=", ">
-        <text macro="author-short"/>
-        <text macro="issued-year"/>
-        <text macro="citation-locator"/>
-      </group>
+      <choose>
+        <if type="personal_communication interview">
+          <text macro="personal_communication"/>
+        </if>
+        <else>
+          <group delimiter=", ">
+            <text macro="author-short"/>
+            <text macro="issued-year"/>
+            <text macro="citation-locator"/>
+          </group>
+        </else>
+      </choose>
     </layout>
   </citation>
   <bibliography hanging-indent="true" et-al-min="8" et-al-use-first="6" et-al-use-last="true" entry-spacing="0" line-spacing="2">
@@ -670,22 +692,26 @@
       <key macro="title"/>
     </sort>
     <layout>
-      <group suffix=".">
-        <group delimiter=". ">
-          <text macro="author"/>
-          <text macro="issued"/>
-          <text macro="title-plus-extra"/>
-          <text macro="container"/>
-        </group>
-        <text macro="legal-cites"/>
-        <text macro="locators"/>
-        <group delimiter=", " prefix=". ">
-          <text macro="event"/>
-          <text macro="publisher"/>
-        </group>
-      </group>
-      <text macro="access" prefix=" "/>
-      <text macro="original-date" prefix=" "/>
+      <choose>
+        <if type="personal_communication interview" match="none">
+          <group suffix=".">
+            <group delimiter=". ">
+              <text macro="author"/>
+              <text macro="issued"/>
+              <text macro="title-plus-extra"/>
+              <text macro="container"/>
+            </group>
+            <text macro="legal-cites"/>
+            <text macro="locators"/>
+            <group delimiter=", " prefix=". ">
+              <text macro="event"/>
+              <text macro="publisher"/>
+            </group>
+          </group>
+          <text macro="access" prefix=" "/>
+          <text macro="original-date" prefix=" "/>
+        </if>
+      </choose>
     </layout>
   </bibliography>
 </style>


### PR DESCRIPTION
APA specifies that personal communications should be cited with a
unique in-text style and should be omitted from the bibliography. This
change supports that.

The in-text format is:
(J. P. Campbell, personal communication, August 16, 2010)

To get the “personal communication” term, I applied a locale to
“interview”, which fits conceptually and is not otherwise used in APA.
This could be changed if a “personal-communication” term is added in a
future CSL update (which has been suggested). If there is a better way
to do that, let me know.

If this works, I can make parallel changes to the other APA styles.