### PR TITLE
Update german-council-of-economic-experts.csl

### DIFF
--- a/german-council-of-economic-experts.csl
+++ b/german-council-of-economic-experts.csl
@@ -285,7 +285,7 @@
       </if>
     </choose>
   </macro>
-  <citation et-al-min="3" et-al-use-first="1" et-al-subsequent-min="3" et-al-subsequent-use-first="1" disambiguate-add-names="true" disambiguate-add-year-suffix="true" collapse="year" year-suffix-delimiter=", ">
+  <citation et-al-min="3" et-al-use-first="1" et-al-subsequent-min="3" et-al-subsequent-use-first="1" disambiguate-add-givenname="true" disambiguate-add-year-suffix="true" collapse="year" year-suffix-delimiter=", ">
     <layout prefix="(" suffix=")" delimiter="; ">
       <text macro="contributors-short" suffix=", "/>
       <text macro="date"/>


### PR DESCRIPTION
There was a problem with the citation of literature with more than two authors with the same year. It is fixed now.