### PR TITLE
Update universite-laval-departement-des-sciences-historiques.csl

### DIFF
--- a/universite-laval-departement-des-sciences-historiques.csl
+++ b/universite-laval-departement-des-sciences-historiques.csl
@@ -12,7 +12,7 @@
     <category citation-format="note"/>
     <category field="history"/>
     <summary>Le style bibliographique pour citation et références du Département des sciences historiques de l'Université Laval</summary>
-    <updated>2016-04-26T22:16:12+00:00</updated>
+    <updated>2017-10-14T07:50:27+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <macro name="author-bibliography">
@@ -190,7 +190,7 @@
     </choose>
   </macro>
   <citation et-al-min="4" et-al-use-first="1" disambiguate-add-year-suffix="true" disambiguate-add-names="true" disambiguate-add-givenname="true">
-    <layout delimiter=" ; ">
+    <layout delimiter=" ; " suffix=".">
       <choose>
         <if match="all" position="first">
           <group delimiter=", ">
@@ -208,30 +208,57 @@
               </else-if>
             </choose>
             <choose>
-              <if type="article article-journal article-magazine article-newspaper review" match="any">
-                <group delimiter=", ">
-                  <text macro="journal-title"/>
-                  <text macro="locators"/>
-                  <text macro="pages-citation"/>
-                </group>
+              <if match="all" locator="page">
+                <choose>
+                  <if type="article article-journal article-magazine article-newspaper review" match="any">
+                    <group delimiter=", ">
+                      <text macro="journal-title"/>
+                      <text macro="locators"/>
+                      <text macro="pages-citation"/>
+                    </group>
+                  </if>
+                  <else>
+                    <group delimiter=", ">
+                      <text macro="thesis"/>
+                      <text macro="publisher"/>
+                      <text macro="year-date"/>
+                      <text macro="pages-citation"/>
+                    </group>
+                  </else>
+                </choose>
               </if>
               <else>
-                <group delimiter=", ">
-                  <text macro="thesis"/>
-                  <text macro="publisher"/>
-                  <text macro="year-date"/>
-                  <text macro="pages-citation"/>
-                </group>
+                <choose>
+                  <if type="article article-journal article-magazine article-newspaper review" match="any">
+                    <group delimiter=", ">
+                      <text macro="journal-title"/>
+                      <text macro="locators"/>
+                      <text macro="pages-bibliography"/>
+                    </group>
+                  </if>
+                  <else>
+                    <group delimiter=", ">
+                      <text macro="thesis"/>
+                      <text macro="publisher"/>
+                      <text macro="year-date"/>
+                      <text macro="pages-bibliography"/>
+                    </group>
+                  </else>
+                </choose>
               </else>
             </choose>
             <text macro="access"/>
           </group>
         </if>
-        <else-if match="any" position="ibid ibid-with-locator">
+        <else-if match="all" position="ibid-with-locator">
           <group delimiter=", ">
             <text term="ibid" text-case="capitalize-first" font-style="italic" suffix="."/>
             <text macro="pages-citation"/>
           </group>
+        </else-if>
+        <else-if match="all" position="ibid" locator="page">
+              <text term="ibid" text-case="capitalize-first" font-style="italic" suffix="."/>
+              <text macro="pages-citation"/>
         </else-if>
         <else>
           <group delimiter=", ">

--- a/universite-laval-departement-des-sciences-historiques.csl
+++ b/universite-laval-departement-des-sciences-historiques.csl
@@ -257,8 +257,8 @@
           </group>
         </else-if>
         <else-if match="all" position="ibid" locator="page">
-              <text term="ibid" text-case="capitalize-first" font-style="italic" suffix="."/>
-              <text macro="pages-citation"/>
+          <text term="ibid" text-case="capitalize-first" font-style="italic" suffix="."/>
+          <text macro="pages-citation"/>
         </else-if>
         <else>
           <group delimiter=", ">


### PR DESCRIPTION
1. Added dot at the end of each cite group, as requested by the department. 
2. A cite can now have no locator and will display the full page range or number of pages as a reference. It implies that both op. cit. and ibid. have to be modified:
 - op. cit. are now also used for two subsequent cites without locator, as to prevent a situation where a cite group containing a cite without locator is followed by that single cite without locator and that it only shows "Ibid" without mention of which cite of the cite group is included in the ibid. This was confirmed by a member of the department as being acceptable.
 - op. cit. are now also used for subsequent cite without locator immediately following the same cite with a locator, as to prevent any confusion about the subsequent use of that locator.