### PR TITLE
Updates to the-geological-society-of-london.csl

### DIFF
--- a/the-geological-society-of-london.csl
+++ b/the-geological-society-of-london.csl
@@ -5,7 +5,7 @@
     <id>http://www.zotero.org/styles/the-geological-society-of-london</id>
     <link href="http://www.zotero.org/styles/the-geological-society-of-london" rel="self"/>
     <link href="http://www.zotero.org/styles/antarctic-science" rel="template"/>
-    <link href="https://www.geolsoc.org.uk/author_instructions" rel="documentation"/>
+    <link href="https://www.geolsoc.org.uk/~/media/Files/GSL/shared/pdfs/Publications/AuthorInfo_Text.pdf" rel="documentation"/>
     <author>
       <name>Sebastian Karcher</name>
     </author>
@@ -32,10 +32,7 @@
   <macro name="author">
     <names variable="author">
       <name name-as-sort-order="all" and="symbol" sort-separator=", " initialize-with="." delimiter-precedes-last="never" delimiter=", ">
-        <name-part name="family" font-variant="small-caps"/>
-        <name-part name="given" font-variant="small-caps"/>
       </name>
-      <et-al font-variant="small-caps"/>
       <label form="short" prefix=" (" suffix=")"/>
       <substitute>
         <names variable="editor"/>
@@ -66,10 +63,10 @@
   <macro name="access">
     <choose>
       <if variable="DOI" match="any">
-        <text variable="DOI" prefix=", doi: "/>
+        <text variable="DOI" prefix=", https://doi.org/"/>
       </if>
       <else-if variable="URL" type="webpage" match="all">
-        <text variable="URL" prefix=". World Wide Web Address: "/>
+        <text variable="URL"/>
       </else-if>
     </choose>
   </macro>

--- a/the-geological-society-of-london.csl
+++ b/the-geological-society-of-london.csl
@@ -31,8 +31,7 @@
   </macro>
   <macro name="author">
     <names variable="author">
-      <name name-as-sort-order="all" and="symbol" sort-separator=", " initialize-with="." delimiter-precedes-last="never" delimiter=", ">
-      </name>
+      <name name-as-sort-order="all" and="symbol" sort-separator=", " initialize-with="." delimiter-precedes-last="never" delimiter=", "/>
       <label form="short" prefix=" (" suffix=")"/>
       <substitute>
         <names variable="editor"/>


### PR DESCRIPTION
Updates made by Geological Society of London (publisher)

Changed
```<link href="https://www.geolsoc.org.uk/author_instructions" rel="documentation"/>```
To 
```<link href="https://www.geolsoc.org.uk/~/media/Files/GSL/shared/pdfs/Publications/AuthorInfo_Text.pdf"/>```

Changed
```<category field="geography"/>```
To
```<category field="geology"/>```

Changed
```<summary>Parent style for the Journals published by The Geological Society (London); details taken from sample</summary>```
To 
```<summary>Parent style for the publications published by The Geological Society (London); details taken from sample</summary>```

Removed reference to small caps. Changed 
```<macro name="author">
    <names variable="author">
      <name name-as-sort-order="all" and="symbol" sort-separator=", " initialize-with="." delimiter-precedes-last="never" delimiter=", ">
        <name-part name="family" font-variant="small-caps"/>
        <name-part name="given" font-variant="small-caps"/>
      </name>
      <et-al font-variant="small-caps"/>
      <label form="short" prefix=" (" suffix=")"/>
      <substitute>
        <names variable="editor"/>
        <names variable="translator"/>
        <text macro="title"/>
      </substitute>
    </names>
  </macro>```
To

```<macro name="author">
    <names variable="author">
      <name name-as-sort-order="all" and="symbol" sort-separator=", " initialize-with="." delimiter-precedes-last="never" delimiter=", ">
      </name>
      <label form="short" prefix=" (" suffix=")"/>
      <substitute>
        <names variable="editor"/>
        <names variable="translator"/>
        <text macro="title"/>
      </substitute>
    </names>
  </macro>```

Changed
```<text variable="DOI" prefix=", doi: "/>```
To
```<text variable="DOI" prefix=", https://doi.org/"/>```

Changed
```<text variable="URL" prefix=". World Wide Web Address: "/>```
To
```<text variable="URL"/>```
