### PR TITLE
Update Springer Note

### DIFF
--- a/springer-basic-note.csl
+++ b/springer-basic-note.csl
@@ -77,7 +77,7 @@
   </macro>
   <macro name="bibliography">
     <choose>
-      <!-- = Court, Name of the case (I included “Judgment of 27 June 1986" in the name itself), [Issue] Name of the jurisprudence journal, Number, para./paras. -->
+      <!-- = Court, Name of the case, Date, [Issue] Journal Title, Number, Locators -->
       <if type="legal_case">
         <group delimiter=", ">
           <text variable="authority"/>

--- a/springer-basic-note.csl
+++ b/springer-basic-note.csl
@@ -5,6 +5,7 @@
     <id>http://www.zotero.org/styles/springer-basic-note</id>
     <link href="http://www.zotero.org/styles/springer-basic-note" rel="self"/>
     <link href="http://www.zotero.org/styles/springer-basic-author-date" rel="template"/>
+    <link href="http://www.springer.com/cda/content/document/cda_downloaddocument/Key_Style_Points_1.0.pdf" rel="documentation"/>
     <link href="https://www.ligue.org/uploads/documents/Cycle%202017/Springer%20Instructions%20for%20Authors_%20Law.pdf" rel="documentation"/>
     <link href="https://doi.org/10.1007/978-981-10-6129-5_1" rel="documentation"/>
     <!-- Citations in published chapters differ from documentation - year is given in parentheses -->
@@ -75,6 +76,25 @@
     </date>
   </macro>
   <macro name="bibliography">
+    <choose>
+      <!-- = Court, Name of the case (I included “Judgment of 27 June 1986" in the name itself), [Issue] Name of the jurisprudence journal, Number, para./paras. -->
+      <if type="legal_case">
+        <group delimiter=", ">
+          <text variable="authority"/>
+          <text variable="title"/>
+          <date variable="issued" delimiter=" ">
+            <date-part name="day" prefix="Judgment of "/>
+            <date-part name="month" />
+            <date-part name="year"/>
+          </date>
+          <group delimiter=" ">
+            <text variable="volume" prefix="[" suffix="]"/>
+            <text variable="container-title" form="short" strip-periods="true"/>
+            <text variable="number"/>
+          </group>
+        </group>
+      </if>
+      <else>
     <group delimiter=" ">
       <text macro="author"/>
       <text macro="year-parenth"/>
@@ -139,7 +159,7 @@
           </else>
         </choose>
       </else-if>
-      <else-if type="bill book graphic legal_case legislation motion_picture report song" match="any">
+      <else-if type="bill book graphic legislation motion_picture report song" match="any">
         <!--    Book
              South J, Blass B (2001) The future of modern genomics. Blackwell, London    -->
         <group prefix=". " delimiter=", ">
@@ -158,7 +178,7 @@
           <text variable="URL"/>
           <date variable="accessed">
             <date-part prefix="Accessed " name="day" suffix=" "/>
-            <date-part name="month" form="short" suffix=" " strip-periods="true"/>
+            <date-part name="month" suffix=" "/>
             <date-part name="year"/>
           </date>
         </group>
@@ -183,7 +203,7 @@
       </else>
     </choose>
   </macro>
-  <citation et-al-min="3" et-al-use-first="1" disambiguate-add-year-suffix="true" collapse="year-suffix" cite-group-delimiter=", ">
+  <citation et-al-min="3" et-al-use-first="1" disambiguate-add-year-suffix="true">
     <sort>
       <key variable="issued"/>
       <key macro="author"/>


### PR DESCRIPTION
The requester heard back from the publisher. Springer says the only official style documentation is their Key Points file. I added a link to this file (also used in other Springer styles). Should I remove the other documentation link or retain it to describe what is actually published for legal/note publications?

Also fixed formatting for legal cases and removed citation collapsing (which doesn't make sense given that this is a note style).