### PR TITLE
Propagate from 5e36aa1 and 210399d (see #2266)

### DIFF
--- a/ieee-with-url.csl
+++ b/ieee-with-url.csl
@@ -28,7 +28,7 @@
     <category citation-format="numeric"/>
     <category field="engineering"/>
     <category field="generic-base"/>
-    <updated>2012-10-18T22:38:43+00:00</updated>
+    <updated>2017-11-14T12:30:00+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale xml:lang="en">
@@ -80,8 +80,9 @@
   </macro>
   <macro name="author">
     <names variable="author">
-      <name initialize-with=". " delimiter=", " and="text"/>
+      <name and="text" et-al-min="7" et-al-use-first="1" initialize-with=". "/>
       <label form="short" prefix=", " text-case="capitalize-first"/>
+      <et-al font-style="italic"/>
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>


### PR DESCRIPTION
ieee.csl has been updated but the changes have not been propagated to its derivative ieee-with-url.csl. This is a fix.