### PR TITLE
Mla8 support for interviewer

### DIFF
--- a/modern-language-association.csl
+++ b/modern-language-association.csl
@@ -42,6 +42,7 @@
       <name name-as-sort-order="first" and="text" delimiter-precedes-last="always" delimiter-precedes-et-al="always" initialize="false" initialize-with=". "/>
       <label form="long" prefix=", "/>
       <substitute>
+        <names variable="interviewer"/>
         <names variable="editor"/>
         <names variable="translator"/>
         <text macro="title-short"/>
@@ -53,6 +54,7 @@
       <names variable="author">
         <name form="short" initialize-with=". " and="text"/>
         <substitute>
+          <names variable="interviewer"/>
           <names variable="editor"/>
           <names variable="translator"/>
           <text macro="title-short"/>
@@ -91,13 +93,13 @@
   <macro name="other-contributors">
     <choose>
       <if variable="container-title" match="any">
-        <names variable="editor translator" delimiter=", ">
+        <names variable="interviewer editor translator" delimiter=", ">
           <label form="verb" suffix=" "/>
           <name and="text"/>
         </names>
       </if>
       <else>
-        <names variable="editor translator" delimiter=", ">
+        <names variable="interviewer editor translator" delimiter=", ">
           <label form="verb" suffix=" " text-case="capitalize-first"/>
           <name and="text"/>
         </names>

--- a/modern-language-association.csl
+++ b/modern-language-association.csl
@@ -42,7 +42,6 @@
       <name name-as-sort-order="first" and="text" delimiter-precedes-last="always" delimiter-precedes-et-al="always" initialize="false" initialize-with=". "/>
       <label form="long" prefix=", "/>
       <substitute>
-        <names variable="interviewer"/>
         <names variable="editor"/>
         <names variable="translator"/>
         <text macro="title-short"/>
@@ -54,7 +53,6 @@
       <names variable="author">
         <name form="short" initialize-with=". " and="text"/>
         <substitute>
-          <names variable="interviewer"/>
           <names variable="editor"/>
           <names variable="translator"/>
           <text macro="title-short"/>


### PR DESCRIPTION
The MLA 8 format did not include interviewer in the other-contributors section.  Added interviewer to the other contributors macro and with this change it appears to now match Purdue OWL's MLA8 guide for published interviews: https://owl.english.purdue.edu/owl/resource/747/09/