### PR TITLE
Mla8 2nd container not including source without a URL or DOI

### DIFF
--- a/modern-language-association.csl
+++ b/modern-language-association.csl
@@ -185,7 +185,15 @@
       </group>
       <choose>
         <if variable="source" match="none">
+<<<<<<< HEAD:modern-language-association.csl
           <text macro="URI"/>
+=======
+          <choose>
+            <if variable="URL DOI" match="any">
+              <text macro="URI"/>
+            </if>
+          </choose>
+>>>>>>> Fixed a problem where DOI's weren't being displayed because the tests around the calls to the URI macro only considered URL, not URL and DOI.:modern-language-association-8th-edition.csl
         </if>
       </choose>
     </group>
@@ -207,14 +215,10 @@
   <macro name="container2-location">
     <choose>
       <if variable="source">
-        <choose>
-          <if variable="DOI URL" match="any">
-            <group delimiter=", ">
-              <text variable="source" font-style="italic"/>
-              <text macro="URI"/>
-            </group>
-          </if>
-        </choose>
+        <group delimiter=", ">
+          <text variable="source" font-style="italic"/>
+          <text macro="URI"/>
+        </group>
       </if>
     </choose>
   </macro>

--- a/modern-language-association.csl
+++ b/modern-language-association.csl
@@ -169,6 +169,9 @@
       <else-if type="article-journal article-magazine" match="any">
         <date variable="issued" form="text" date-parts="year-month"/>
       </else-if>
+      <else-if type="webpage" match="any">
+        <date variable="issued" form="text"/>
+      </else-if>
       <else-if type="speech" match="none">
         <date variable="issued" form="text"/>
       </else-if>

--- a/modern-language-association.csl
+++ b/modern-language-association.csl
@@ -124,22 +124,26 @@
     <group delimiter=", ">
       <group>
         <choose>
-          <if variable="volume" match="any">
-            <choose>
-              <!--lowercase if we have a preceding element-->
-              <if variable="edition container-title" match="any">
-                <text term="volume" form="short"/>
-              </if>
-              <else-if variable="author editor" match="all">
-                <!--other contributors preceding the volume-->
-                <text term="volume" form="short"/>
-              </else-if>
-              <else>
-                <text term="volume" form="short" text-case="capitalize-first"/>
-              </else>
-            </choose>
-            <text variable="volume"/>
+          <!--lowercase if we have a preceding element-->
+          <if variable="edition container-title" match="any">
+            <group delimiter=" ">
+              <text term="volume" form="short"/>
+              <text variable="volume"/>
+            </group>
           </if>
+          <!--other contributors preceding the volume-->
+          <else-if variable="author editor" match="all">
+            <group delimiter=" ">
+              <text term="volume" form="short"/>
+              <text variable="volume"/>
+            </group>
+          </else-if>
+          <else>
+            <group delimiter=" ">
+              <text term="volume" form="short" text-case="capitalize-first"/>
+              <text variable="volume"/>
+            </group>
+          </else>
         </choose>
       </group>
       <group delimiter=" ">

--- a/modern-language-association.csl
+++ b/modern-language-association.csl
@@ -233,14 +233,19 @@
     </choose>
   </macro>
   <macro name="accessed">
-    <!--using accessed where we don't have an issued date; follows recommendation on p. 53 -->
     <choose>
-      <if variable="issued" match="none">
+      <if variable="URL DOI" match="any">
         <group delimiter=" ">
           <text term="accessed" text-case="capitalize-first"/>
           <date variable="accessed" form="text"/>
         </group>
       </if>
+      <else-if variable="issued" match="none">
+        <group delimiter=" ">
+          <text term="accessed" text-case="capitalize-first"/>
+          <date variable="accessed" form="text"/>
+        </group>
+      </else-if>
     </choose>
   </macro>
   <citation et-al-min="3" et-al-use-first="1" disambiguate-add-names="true" disambiguate-add-givenname="true">

--- a/modern-language-association.csl
+++ b/modern-language-association.csl
@@ -185,15 +185,11 @@
       </group>
       <choose>
         <if variable="source" match="none">
-<<<<<<< HEAD:modern-language-association.csl
-          <text macro="URI"/>
-=======
           <choose>
             <if variable="URL DOI" match="any">
               <text macro="URI"/>
             </if>
           </choose>
->>>>>>> Fixed a problem where DOI's weren't being displayed because the tests around the calls to the URI macro only considered URL, not URL and DOI.:modern-language-association-8th-edition.csl
         </if>
       </choose>
     </group>
@@ -217,7 +213,11 @@
       <if variable="source">
         <group delimiter=", ">
           <text variable="source" font-style="italic"/>
-          <text macro="URI"/>
+          <choose>
+            <if variable="DOI URL" match="any">
+              <text macro="URI"/>
+            </if>
+          </choose>
         </group>
       </if>
     </choose>

--- a/modern-language-association.csl
+++ b/modern-language-association.csl
@@ -124,26 +124,22 @@
     <group delimiter=", ">
       <group>
         <choose>
-          <!--lowercase if we have a preceding element-->
-          <if variable="edition container-title" match="any">
-            <group delimiter=" ">
-              <text term="volume" form="short"/>
-              <text variable="volume"/>
-            </group>
+          <if variable="volume" match="any">
+            <choose>
+              <!--lowercase if we have a preceding element-->
+              <if variable="edition container-title" match="any">
+                <text term="volume" form="short"/>
+              </if>
+              <else-if variable="author editor" match="all">
+                <!--other contributors preceding the volume-->
+                <text term="volume" form="short"/>
+              </else-if>
+              <else>
+                <text term="volume" form="short" text-case="capitalize-first"/>
+              </else>
+            </choose>
+            <text variable="volume"/>
           </if>
-          <!--other contributors preceding the volume-->
-          <else-if variable="author editor" match="all">
-            <group delimiter=" ">
-              <text term="volume" form="short"/>
-              <text variable="volume"/>
-            </group>
-          </else-if>
-          <else>
-            <group delimiter=" ">
-              <text term="volume" form="short" text-case="capitalize-first"/>
-              <text variable="volume"/>
-            </group>
-          </else>
         </choose>
       </group>
       <group delimiter=" ">


### PR DESCRIPTION
In MLA 8, found that the source variable was not being displayed (in the container2-location macro) unless a URL or DOI was also present.  Believe that it should always be shown.