### PR TITLE
Updated Transactions of the American Philological Association CSL

### DIFF
--- a/transactions-of-the-american-philological-association.csl
+++ b/transactions-of-the-american-philological-association.csl
@@ -20,6 +20,10 @@
       <name>Sebastian Karcher</name>
     </contributor>
     <contributor>
+      <name>Kenneth Mayer</name>
+      <email>ken.i.mayer@gmail.com</email>
+    </contributor>
+    <contributor>
       <name>Richard Karnesky</name>
       <email>karnesky+zotero@gmail.com</email>
       <uri>http://arc.nucapt.northwestern.edu/Richard_Karnesky</uri>
@@ -29,7 +33,7 @@
     <issn>0360-5949</issn>
     <eissn>1533-0699</eissn>
     <summary>The author-date variant of the Chicago style with TAPA modifications (colon before page, no parentheses)</summary>
-    <updated>2013-04-13T17:12:15+00:00</updated>
+    <updated>2017-11-07T13:37:33+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale>
@@ -66,12 +70,12 @@
   <macro name="container-contributors">
     <choose>
       <if type="chapter paper-conference" match="any">
-        <group prefix=", " delimiter=", ">
+        <group delimiter=", " suffix=", ">
           <choose>
             <if variable="author">
               <names variable="container-author editor" delimiter=", ">
-                <label form="verb" suffix=" " plural="never"/>
-                <name and="text" delimiter=", "/>
+                <name and="text" initialize-with="." name-as-sort-order="all"/>
+                <label form="short"/>
               </names>
             </if>
           </choose>
@@ -107,7 +111,7 @@
   </macro>
   <macro name="contributors">
     <names variable="author">
-      <name and="text" name-as-sort-order="first" sort-separator=", " delimiter=", " delimiter-precedes-last="always"/>
+      <name and="text" delimiter-precedes-last="always" initialize-with="." name-as-sort-order="all"/>
       <label form="short" plural="never" prefix=", "/>
       <substitute>
         <names variable="editor"/>
@@ -338,7 +342,8 @@
     </choose>
     <choose>
       <if type="legal_case" match="none">
-        <text variable="container-title" text-case="title" font-style="italic"/>
+        <text macro="container-contributors"/>
+        <text variable="container-title" form="short" text-case="title" font-style="italic"/>
       </if>
     </choose>
   </macro>
@@ -450,7 +455,7 @@
       </group>
     </layout>
   </citation>
-  <bibliography hanging-indent="true" et-al-min="11" et-al-use-first="7" subsequent-author-substitute="���" entry-spacing="0">
+  <bibliography hanging-indent="true" et-al-min="11" et-al-use-first="7" subsequent-author-substitute="&#8212;&#8212;&#8212;" entry-spacing="0">
     <sort>
       <key macro="contributors"/>
       <key variable="issued"/>
@@ -464,7 +469,6 @@
       <text macro="description"/>
       <text macro="secondary-contributors" prefix=". "/>
       <text macro="container-title" prefix=". "/>
-      <text macro="container-contributors"/>
       <text macro="edition"/>
       <text macro="locators-chapter"/>
       <text macro="locators"/>


### PR DESCRIPTION
This update *should* make the style more compatible with current TAPA guidelines
1) All authors and editors should have first and middle initials only, not full names
2) Book chapters and sections format should be  Last, F.M. "Chapter." In Editor, F. and Editor, S. eds., The Big Book...
3) The subsequent-author-substitute emdash characters (———) were not working in MSWord for me. So I'm trying to change them to "&#8212;&#8212;&#8212;" 
4) TAPA requires that all journals be cited using modifed versions of *L'Annee Philologique*'s abbreviations. Unfortunately, we can't put the list of abbreviations into the CSL, but this modification forces the short form of the journal names in the bibliography.