### PR TITLE
Fix date parts for original date

### DIFF
--- a/apa-annotated-bibliography.csl
+++ b/apa-annotated-bibliography.csl
@@ -299,6 +299,7 @@
             <text variable="genre" text-case="capitalize-first"/>
           </if>
           <else>
+            <!-- This should be localized -->
             <text value="Data set"/>
           </else>
         </choose>
@@ -446,7 +447,9 @@
     <choose>
       <if variable="issued">
         <group delimiter="/">
-          <date variable="original-date" form="text"/>
+          <date variable="original-date">
+            <date-part name="year"/>
+          </date>
           <group>
             <date variable="issued">
               <date-part name="year"/>
@@ -649,12 +652,31 @@
   </macro>
   <macro name="original-date">
     <choose>
-      <if variable="original-date">
-        <group prefix="(" suffix=")" delimiter=" ">
-          <!---This should be localized-->
-          <text value="Original work published"/>
-          <date variable="original-date" form="text"/>
-        </group>
+      <if type="bill legal_case legislation" match="none">
+        <choose>
+          <if variable="original-date">
+            <group prefix=" (" suffix=")" delimiter=" ">
+              <!---This should be localized-->
+              <text value="Original work published"/>
+              <choose>
+                <if type="speech" match="any">
+                  <date variable="original-date" delimiter=" ">
+                    <date-part name="month"/>
+                    <date-part name="year"/>
+                  </date>
+                </if>
+                <else-if type="article-journal bill book chapter graphic legal_case legislation motion_picture paper-conference report song dataset" match="none">
+                  <date variable="original-date" form="text"/>
+                </else-if>
+                <else>
+                  <date variable="original-date">
+                    <date-part name="year"/>
+                  </date>
+                </else>
+              </choose>
+            </group>
+          </if>
+        </choose>
       </if>
     </choose>
   </macro>

--- a/apa-cv.csl
+++ b/apa-cv.csl
@@ -299,6 +299,7 @@
             <text variable="genre" text-case="capitalize-first"/>
           </if>
           <else>
+            <!-- This should be localized -->
             <text value="Data set"/>
           </else>
         </choose>
@@ -446,7 +447,9 @@
     <choose>
       <if variable="issued">
         <group delimiter="/">
-          <date variable="original-date" form="text"/>
+          <date variable="original-date">
+            <date-part name="year"/>
+          </date>
           <group>
             <date variable="issued">
               <date-part name="year"/>
@@ -649,12 +652,31 @@
   </macro>
   <macro name="original-date">
     <choose>
-      <if variable="original-date">
-        <group prefix="(" suffix=")" delimiter=" ">
-          <!---This should be localized-->
-          <text value="Original work published"/>
-          <date variable="original-date" form="text"/>
-        </group>
+      <if type="bill legal_case legislation" match="none">
+        <choose>
+          <if variable="original-date">
+            <group prefix=" (" suffix=")" delimiter=" ">
+              <!---This should be localized-->
+              <text value="Original work published"/>
+              <choose>
+                <if type="speech" match="any">
+                  <date variable="original-date" delimiter=" ">
+                    <date-part name="month"/>
+                    <date-part name="year"/>
+                  </date>
+                </if>
+                <else-if type="article-journal bill book chapter graphic legal_case legislation motion_picture paper-conference report song dataset" match="none">
+                  <date variable="original-date" form="text"/>
+                </else-if>
+                <else>
+                  <date variable="original-date">
+                    <date-part name="year"/>
+                  </date>
+                </else>
+              </choose>
+            </group>
+          </if>
+        </choose>
       </if>
     </choose>
   </macro>

--- a/apa-no-ampersand.csl
+++ b/apa-no-ampersand.csl
@@ -299,6 +299,7 @@
             <text variable="genre" text-case="capitalize-first"/>
           </if>
           <else>
+            <!-- This should be localized -->
             <text value="Data set"/>
           </else>
         </choose>
@@ -446,7 +447,9 @@
     <choose>
       <if variable="issued">
         <group delimiter="/">
-          <date variable="original-date" form="text"/>
+          <date variable="original-date">
+            <date-part name="year"/>
+          </date>
           <group>
             <date variable="issued">
               <date-part name="year"/>
@@ -649,12 +652,31 @@
   </macro>
   <macro name="original-date">
     <choose>
-      <if variable="original-date">
-        <group prefix="(" suffix=")" delimiter=" ">
-          <!---This should be localized-->
-          <text value="Original work published"/>
-          <date variable="original-date" form="text"/>
-        </group>
+      <if type="bill legal_case legislation" match="none">
+        <choose>
+          <if variable="original-date">
+            <group prefix=" (" suffix=")" delimiter=" ">
+              <!---This should be localized-->
+              <text value="Original work published"/>
+              <choose>
+                <if type="speech" match="any">
+                  <date variable="original-date" delimiter=" ">
+                    <date-part name="month"/>
+                    <date-part name="year"/>
+                  </date>
+                </if>
+                <else-if type="article-journal bill book chapter graphic legal_case legislation motion_picture paper-conference report song dataset" match="none">
+                  <date variable="original-date" form="text"/>
+                </else-if>
+                <else>
+                  <date variable="original-date">
+                    <date-part name="year"/>
+                  </date>
+                </else>
+              </choose>
+            </group>
+          </if>
+        </choose>
       </if>
     </choose>
   </macro>

--- a/apa-no-doi-no-issue.csl
+++ b/apa-no-doi-no-issue.csl
@@ -300,6 +300,7 @@
             <text variable="genre" text-case="capitalize-first"/>
           </if>
           <else>
+            <!-- This should be localized -->
             <text value="Data set"/>
           </else>
         </choose>
@@ -447,7 +448,9 @@
     <choose>
       <if variable="issued">
         <group delimiter="/">
-          <date variable="original-date" form="text"/>
+          <date variable="original-date">
+            <date-part name="year"/>
+          </date>
           <group>
             <date variable="issued">
               <date-part name="year"/>
@@ -649,12 +652,31 @@
   </macro>
   <macro name="original-date">
     <choose>
-      <if variable="original-date">
-        <group prefix="(" suffix=")" delimiter=" ">
-          <!---This should be localized-->
-          <text value="Original work published"/>
-          <date variable="original-date" form="text"/>
-        </group>
+      <if type="bill legal_case legislation" match="none">
+        <choose>
+          <if variable="original-date">
+            <group prefix=" (" suffix=")" delimiter=" ">
+              <!---This should be localized-->
+              <text value="Original work published"/>
+              <choose>
+                <if type="speech" match="any">
+                  <date variable="original-date" delimiter=" ">
+                    <date-part name="month"/>
+                    <date-part name="year"/>
+                  </date>
+                </if>
+                <else-if type="article-journal bill book chapter graphic legal_case legislation motion_picture paper-conference report song dataset" match="none">
+                  <date variable="original-date" form="text"/>
+                </else-if>
+                <else>
+                  <date variable="original-date">
+                    <date-part name="year"/>
+                  </date>
+                </else>
+              </choose>
+            </group>
+          </if>
+        </choose>
       </if>
     </choose>
   </macro>

--- a/apa-old-doi-prefix.csl
+++ b/apa-old-doi-prefix.csl
@@ -298,6 +298,7 @@
             <text variable="genre" text-case="capitalize-first"/>
           </if>
           <else>
+            <!-- This should be localized -->
             <text value="Data set"/>
           </else>
         </choose>
@@ -445,7 +446,9 @@
     <choose>
       <if variable="issued">
         <group delimiter="/">
-          <date variable="original-date" form="text"/>
+          <date variable="original-date">
+            <date-part name="year"/>
+          </date>
           <group>
             <date variable="issued">
               <date-part name="year"/>
@@ -648,12 +651,31 @@
   </macro>
   <macro name="original-date">
     <choose>
-      <if variable="original-date">
-        <group prefix="(" suffix=")" delimiter=" ">
-          <!---This should be localized-->
-          <text value="Original work published"/>
-          <date variable="original-date" form="text"/>
-        </group>
+      <if type="bill legal_case legislation" match="none">
+        <choose>
+          <if variable="original-date">
+            <group prefix=" (" suffix=")" delimiter=" ">
+              <!---This should be localized-->
+              <text value="Original work published"/>
+              <choose>
+                <if type="speech" match="any">
+                  <date variable="original-date" delimiter=" ">
+                    <date-part name="month"/>
+                    <date-part name="year"/>
+                  </date>
+                </if>
+                <else-if type="article-journal bill book chapter graphic legal_case legislation motion_picture paper-conference report song dataset" match="none">
+                  <date variable="original-date" form="text"/>
+                </else-if>
+                <else>
+                  <date variable="original-date">
+                    <date-part name="year"/>
+                  </date>
+                </else>
+              </choose>
+            </group>
+          </if>
+        </choose>
       </if>
     </choose>
   </macro>

--- a/apa-single-spaced.csl
+++ b/apa-single-spaced.csl
@@ -299,6 +299,7 @@
             <text variable="genre" text-case="capitalize-first"/>
           </if>
           <else>
+            <!-- This should be localized -->
             <text value="Data set"/>
           </else>
         </choose>
@@ -446,7 +447,9 @@
     <choose>
       <if variable="issued">
         <group delimiter="/">
-          <date variable="original-date" form="text"/>
+          <date variable="original-date">
+            <date-part name="year"/>
+          </date>
           <group>
             <date variable="issued">
               <date-part name="year"/>
@@ -649,12 +652,31 @@
   </macro>
   <macro name="original-date">
     <choose>
-      <if variable="original-date">
-        <group prefix="(" suffix=")" delimiter=" ">
-          <!---This should be localized-->
-          <text value="Original work published"/>
-          <date variable="original-date" form="text"/>
-        </group>
+      <if type="bill legal_case legislation" match="none">
+        <choose>
+          <if variable="original-date">
+            <group prefix=" (" suffix=")" delimiter=" ">
+              <!---This should be localized-->
+              <text value="Original work published"/>
+              <choose>
+                <if type="speech" match="any">
+                  <date variable="original-date" delimiter=" ">
+                    <date-part name="month"/>
+                    <date-part name="year"/>
+                  </date>
+                </if>
+                <else-if type="article-journal bill book chapter graphic legal_case legislation motion_picture paper-conference report song dataset" match="none">
+                  <date variable="original-date" form="text"/>
+                </else-if>
+                <else>
+                  <date variable="original-date">
+                    <date-part name="year"/>
+                  </date>
+                </else>
+              </choose>
+            </group>
+          </if>
+        </choose>
       </if>
     </choose>
   </macro>

--- a/apa.csl
+++ b/apa.csl
@@ -298,6 +298,7 @@
             <text variable="genre" text-case="capitalize-first"/>
           </if>
           <else>
+            <!-- This should be localized -->
             <text value="Data set"/>
           </else>
         </choose>
@@ -445,7 +446,9 @@
     <choose>
       <if variable="issued">
         <group delimiter="/">
-          <date variable="original-date" form="text"/>
+          <date variable="original-date">
+            <date-part name="year"/>
+          </date>
           <group>
             <date variable="issued">
               <date-part name="year"/>
@@ -648,12 +651,31 @@
   </macro>
   <macro name="original-date">
     <choose>
-      <if variable="original-date">
-        <group prefix="(" suffix=")" delimiter=" ">
-          <!---This should be localized-->
-          <text value="Original work published"/>
-          <date variable="original-date" form="text"/>
-        </group>
+      <if type="bill legal_case legislation" match="none">
+        <choose>
+          <if variable="original-date">
+            <group prefix=" (" suffix=")" delimiter=" ">
+              <!---This should be localized-->
+              <text value="Original work published"/>
+              <choose>
+                <if type="speech" match="any">
+                  <date variable="original-date" delimiter=" ">
+                    <date-part name="month"/>
+                    <date-part name="year"/>
+                  </date>
+                </if>
+                <else-if type="article-journal bill book chapter graphic legal_case legislation motion_picture paper-conference report song dataset" match="none">
+                  <date variable="original-date" form="text"/>
+                </else-if>
+                <else>
+                  <date variable="original-date">
+                    <date-part name="year"/>
+                  </date>
+                </else>
+              </choose>
+            </group>
+          </if>
+        </choose>
       </if>
     </choose>
   </macro>


### PR DESCRIPTION
To match rules for `issued` and published examples.

As an aside, in order to localize "Original work published", I think that three separate terms -- `original`, `work`, and `published` should be added. This would provide the most flexibility -- e.g., "Original version published", "Original edition published", "Original work presented at", etc.