### PR TITLE
Update fachhochschule-vorarlberg-author-date.csl

### DIFF
--- a/fachhochschule-vorarlberg-author-date.csl
+++ b/fachhochschule-vorarlberg-author-date.csl
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
-<style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" demote-non-dropping-particle="sort-only" default-locale="de-DE">
+<style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" demote-non-dropping-particle="sort-only">
   <info>
-    <title>Fachhochschule Vorarlberg (author-date, German)</title>
+    <title>Fachhochschule Vorarlberg (author-date, German, English)</title>
     <title-short>FHV Autor-Jahr</title-short>
     <id>http://www.zotero.org/styles/fachhochschule-vorarlberg-author-date</id>
     <link href="http://www.zotero.org/styles/fachhochschule-vorarlberg-author-date" rel="self"/>
@@ -29,11 +29,16 @@
     <category citation-format="author-date"/>
     <category field="generic-base"/>
     <summary>Citation Style of the University of Applied Sciences Vorarlberg/Austria, based on A Harvard author-date style variant, mostly german</summary>
-    <updated>2017-01-17T18:26:26+00:00</updated>
+    <updated>2017-11-29T18:00:00+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale xml:lang="de">
     <style-options punctuation-in-quote="true"/>
+    <date form="text">
+      <date-part name="day" form="numeric-leading-zeros" suffix="."/>
+      <date-part name="month" form="numeric-leading-zeros" suffix="."/>
+      <date-part name="year" form="long"/>
+    </date>
     <terms>
       <term name="accessed">Zugriff am</term>
       <term name="anonymous" form="short">o. A.</term>
@@ -46,17 +51,29 @@
       <term name="interview">Interview geführt von</term>
       <term name="interview" form="short">am</term>
       <term name="no date" form="short">o. J.</term>
+      <term name="page" form="short">S.</term>
     </terms>
   </locale>
   <locale xml:lang="en">
     <style-options punctuation-in-quote="true"/>
+    <date form="text">
+      <date-part name="day" form="numeric" suffix=" "/>
+      <date-part name="month" form="long" suffix=" "/>
+      <date-part name="year" form="long"/>
+    </date>
     <terms>
+      <term name="accessed">Accessed on</term>
       <term name="anonymous" form="short">n. a.</term>
-      <term name="et-al">et al.</term>
+      <term name="available at">Available at</term>
       <term name="collection-editor" form="short">Ed.</term>
       <term name="composer" form="short">Comp.</term>
       <term name="composer" form="long">Composer</term>
+      <term name="edition">Ed.</term>
+      <term name="et-al">et al.</term>
+      <term name="interview">Interview conducted by</term>
+      <term name="interview" form="short">on</term>
       <term name="no date" form="short">n. y.</term>
+      <term name="page" form="short">p.</term>
     </terms>
   </locale>
   <macro name="access">
@@ -78,11 +95,7 @@
     </choose>
     <group prefix=" (" delimiter=" " suffix=").">
       <text term="accessed" suffix=": "/>
-      <date variable="accessed">
-        <date-part name="day" form="numeric-leading-zeros" suffix="."/>
-        <date-part name="month" form="numeric-leading-zeros" suffix="."/>
-        <date-part name="year" form="long"/>
-      </date>
+      <date variable="accessed" form="text"/>
     </group>
   </macro>
   <macro name="anon">
@@ -219,7 +232,7 @@
         <choose>
           <if is-numeric="edition">
             <group delimiter=" ">
-              <number variable="edition" form="numeric" suffix=". "/>
+              <number variable="edition" form="ordinal" suffix=" "/>
               <text term="edition" suffix=". "/>
             </group>
           </if>
@@ -275,7 +288,7 @@
   <macro name="pages">
     <choose>
       <if variable="page">
-        <label variable="page" form="short" prefix=", " suffix=" "/>
+        <text term="page" form="short" prefix=", " suffix=" "/>
         <text variable="page" suffix=". "/>
       </if>
     </choose>
@@ -374,7 +387,12 @@
     <layout prefix="(" suffix=")" delimiter="; ">
       <text macro="author-short"/>
       <text macro="year-date" prefix=" "/>
-      <text variable="locator" prefix=", S. "/>
+      <choose>
+        <if variable="locator">
+          <text term="page" form="short" prefix=", " suffix=" "/>
+          <text variable="locator"/>
+        </if>
+      </choose>
     </layout>
   </citation>
   <bibliography hanging-indent="true" et-al-min="4" et-al-use-first="1">

--- a/fachhochschule-vorarlberg-author-date.csl
+++ b/fachhochschule-vorarlberg-author-date.csl
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" demote-non-dropping-particle="sort-only">
   <info>
-    <title>Fachhochschule Vorarlberg (author-date, German, English)</title>
+    <title>Fachhochschule Vorarlberg (author-date)</title>
     <title-short>FHV Autor-Jahr</title-short>
     <id>http://www.zotero.org/styles/fachhochschule-vorarlberg-author-date</id>
     <link href="http://www.zotero.org/styles/fachhochschule-vorarlberg-author-date" rel="self"/>


### PR DESCRIPTION
Added own terms for language en
Two new date forms (one for de and one for en)
Changed edition macro from numeric to ordinal
Added text term page instead of prefix S.
