### PR TITLE
Update fachhochschule-vorarlberg-note.csl

### DIFF
--- a/fachhochschule-vorarlberg-note.csl
+++ b/fachhochschule-vorarlberg-note.csl
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
-<style xmlns="http://purl.org/net/xbiblio/csl" class="note" version="1.0" demote-non-dropping-particle="sort-only" default-locale="de-DE">
+<style xmlns="http://purl.org/net/xbiblio/csl" class="note" version="1.0" demote-non-dropping-particle="sort-only">
   <info>
-    <title>Fachhochschule Vorarlberg (note, German)</title>
+    <title>Fachhochschule Vorarlberg (note, German, English)</title>
     <id>http://www.zotero.org/styles/fachhochschule-vorarlberg-note</id>
     <link href="http://www.zotero.org/styles/fachhochschule-vorarlberg-note" rel="self"/>
     <link href="https://ilias.fhv.at/goto_ilias_fhv_at_fold_176959.html" rel="documentation"/>
@@ -28,11 +28,16 @@
     <category citation-format="note"/>
     <category field="generic-base"/>
     <summary>Citation Style of the University of Applied Sciences Vorarlberg/Austria, based on A Harvard author-date style variant, mostly german, footnote style</summary>
-    <updated>2017-01-19T23:59:00+00:00</updated>
+    <updated>2017-11-29T18:00:00+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale xml:lang="de">
     <style-options punctuation-in-quote="true"/>
+    <date form="text">
+      <date-part name="day" form="numeric-leading-zeros" suffix="."/>
+      <date-part name="month" form="numeric-leading-zeros" suffix="."/>
+      <date-part name="year" form="long"/>
+    </date>
     <terms>
       <term name="accessed">Zugriff am</term>
       <term name="anonymous" form="short">o. A.</term>
@@ -45,17 +50,29 @@
       <term name="interview">Interview geführt von</term>
       <term name="interview" form="short">am</term>
       <term name="no date" form="short">o. J.</term>
+      <term name="page" form="short">S.</term>
     </terms>
   </locale>
   <locale xml:lang="en">
     <style-options punctuation-in-quote="true"/>
+    <date form="text">
+      <date-part name="day" form="numeric" suffix=" "/>
+      <date-part name="month" form="long" suffix=" "/>
+      <date-part name="year" form="long"/>
+    </date>
     <terms>
+      <term name="accessed">Accessed on</term>
       <term name="anonymous" form="short">n. a.</term>
-      <term name="et-al">et al.</term>
+      <term name="available at">Available at</term>
       <term name="collection-editor" form="short">Ed.</term>
       <term name="composer" form="short">Comp.</term>
       <term name="composer" form="long">Composer</term>
+      <term name="edition">Ed.</term>
+      <term name="et-al">et al.</term>
+      <term name="interview">Interview conducted by</term>
+      <term name="interview" form="short">on</term>
       <term name="no date" form="short">n. y.</term>
+      <term name="page" form="short">p.</term>
     </terms>
   </locale>
   <macro name="access">
@@ -77,11 +94,7 @@
     </choose>
     <group prefix=" (" delimiter=" " suffix=").">
       <text term="accessed" suffix=": "/>
-      <date variable="accessed">
-        <date-part name="day" form="numeric-leading-zeros" suffix="."/>
-        <date-part name="month" form="numeric-leading-zeros" suffix="."/>
-        <date-part name="year" form="long"/>
-      </date>
+      <date variable="accessed" form="text"/>
     </group>
   </macro>
   <macro name="anon">
@@ -218,7 +231,7 @@
         <choose>
           <if is-numeric="edition">
             <group delimiter=" ">
-              <number variable="edition" form="numeric" suffix=". "/>
+              <number variable="edition" form="ordinal" suffix=" "/>
               <text term="edition" suffix=". "/>
             </group>
           </if>
@@ -370,10 +383,15 @@
     </choose>
   </macro>
   <citation et-al-min="4" et-al-use-first="1" et-al-subsequent-min="4" et-al-subsequent-use-first="1" disambiguate-add-year-suffix="true" disambiguate-add-names="true" disambiguate-add-givenname="true" collapse="year">
-    <layout prefix="" suffix="" delimiter="; ">
+    <layout prefix="(" suffix=")" delimiter="; ">
       <text macro="author-short"/>
       <text macro="year-date" prefix=" "/>
-      <text variable="locator" prefix=", S. "/>
+      <choose>
+        <if variable="locator">
+          <text term="page" form="short" prefix=", " suffix=" "/>
+          <text variable="locator"/>
+        </if>
+      </choose>
     </layout>
   </citation>
   <bibliography hanging-indent="true" et-al-min="4" et-al-use-first="1">

--- a/fachhochschule-vorarlberg-note.csl
+++ b/fachhochschule-vorarlberg-note.csl
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <style xmlns="http://purl.org/net/xbiblio/csl" class="note" version="1.0" demote-non-dropping-particle="sort-only">
   <info>
-    <title>Fachhochschule Vorarlberg (note, German, English)</title>
+    <title>Fachhochschule Vorarlberg (note)</title>
     <id>http://www.zotero.org/styles/fachhochschule-vorarlberg-note</id>
     <link href="http://www.zotero.org/styles/fachhochschule-vorarlberg-note" rel="self"/>
     <link href="https://ilias.fhv.at/goto_ilias_fhv_at_fold_176959.html" rel="documentation"/>


### PR DESCRIPTION
Added own terms for language en
Two new date forms
Changed edition macro from numeric to ordinal
Added text term page instead of prefix S.
