### PR TITLE
Fix errors in Springer-SocPsych de locale

### DIFF
--- a/springer-socpsych-author-date.csl
+++ b/springer-socpsych-author-date.csl
@@ -40,8 +40,8 @@
   </locale>
   <locale xml:lang="de">
     <terms>
-      <term name="et-al">et al</term>
-      <term name="accessed" form="long">Zugegriffen:</term>
+      <term name="et-al">et al.</term>
+      <term name="accessed" form="long">zugegriffen:</term>
     </terms>
   </locale>
   <macro name="container-contributors">


### PR DESCRIPTION
https://forums.zotero.org/discussion/69160/style-error-publizistik

See uses of "et al." and "zugegriffen:" here:
https://link.springer.com/content/pdf/10.1007%2Fs11616-016-0308-2.pdf
https://link.springer.com/article/10.1007/s11616-016-0256-x

I'm not sure if specifying the de accessed like this in `locale` will override the `text-case` argument when `term="accessed"` is called in the style (will the colon will prevent case changes?), but I don't think it's much of a concern if not.