### PR TITLE
Create juristische-zitierweise-schweizer-stil.csl

### DIFF
--- a/juristische-zitierweise-schweizer-stil.csl
+++ b/juristische-zitierweise-schweizer-stil.csl
@@ -79,18 +79,6 @@
       </substitute>
     </names>
   </macro>
-  <macro name="locator-with-label">
-    <group delimiter=" ">
-      <label variable="locator" form="symbol"/>
-      <text variable="locator"/>
-    </group>
-  </macro>
-  <macro name="firstpage-locator">
-    <group delimiter=" ">
-      <text variable="page-first"/>
-      <text variable="locator" prefix="(" suffix=")"/>
-    </group>
-  </macro>
   <macro name="issued-without-zero">
     <date variable="issued">
       <date-part name="day" form="numeric" suffix="."/>

--- a/juristische-zitierweise-schweizer-stil.csl
+++ b/juristische-zitierweise-schweizer-stil.csl
@@ -1,0 +1,390 @@
+<?xml version="1.0" encoding="utf-8"?>
+<style xmlns="http://purl.org/net/xbiblio/csl" class="note" version="1.0" default-locale="de-DE">
+  <info>
+    <title>Juristische Zitierweise - Schweizer Stil (German)</title>
+    <id>http://www.zotero.org/styles/juristische-zitierweise-schweizer-stil</id>
+    <link href="http://www.zotero.org/styles/juristische-zitierweise-schweizer-stil" rel="self"/>
+    <author>
+      <name>Stephan Schlegel</name>
+      <email>stephan.schlegel@unibas.ch</email>
+    </author>
+    <category citation-format="note"/>
+    <category field="law"/>
+    <summary>This style is based on the "Juristische Zitierweise (Stüber)" style by Oliver Wolf and Philipp Zumstein (https://www.zotero.org/styles/juristische-zitierweise). 
+    The citation is adapted for the style of articles in Swiss law publications. It's similar to the style of the course book Ryser Büschi/Schlegel/Pflaum, Juristische Arbeiten 
+    erfolgreich schreiben und präsentieren, 2nd ed., Zurich 2017 (ISBN 978-3-7255-7612-8). Legal commentaries and handbooks should use publication type "entry-encyclopedia". 
+    See more details in the comments.
+    </summary>
+    <updated>2017-12-03T08:00:00+00:00</updated>
+    <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
+    <!-- 
+	Dissertationen:
+	Art: hier kann Diss.-Ort und Jahr angegeben werden, z.B. "Diss. Univ. Zürich, 2010"
+
+	Fall (für Entscheide):
+	Name des Falls: wenn angegeben werden alle and. Angaben nicht benutzt (z.B. für BGE, Fachzeitschriften), 
+	Nutzung z.B. "BGE 142 I 1"; leerlassen für unveröff. Entscheide
+	Zusammenfassung: "Urteil", "Beschluss"
+	Gericht: Abkürzung z.B. BGer, EGMR, OGer AG
+	Docket-Nr: Verfahrensnummer
+	Kurztitel: z.B. für Parteinamen beim EGMR
+	Extra: Parallelfundstelle z.B. in Fachzeitschrift wie "forumpoenale 2009, 2"
+    
+    Enzyklopädieartikel für Jur. Kommentare:
+    Einträge müssen pro Artikel erfolgen, wenn Herausgeber und Autoren; wenn Autoren Gesamtwerk + alle Art. bleibt Titel leer
+    Wenn nur Gesamtwerk in Bibliographie erscheinen soll, Werk zusätzlich in Sammlung aufnehmen und Bibliographie editieren 
+    
+    Titel: pro Art. ist Titel nur "Art. X"  
+    Herausgeber/Autor: Hrsg. erscheinen nur in Bibliographie, Autor nur in Fussnote, wenn Hrsg. existiert 
+    Titel der Enzyklopädie: Titel des Kommentars z.B. "Basler Kommentar zum ..."
+    Kurztitel: Abkürzung des Kommentars z.B. "BSK StGB"
+           
+    -->
+  </info>
+  <locale xml:lang="de-DE">
+    <terms>
+      <term name="accessed">besucht am</term>
+      <term name="editor">Hrsg.</term>
+      <term name="et-al">et al.</term>
+    </terms>
+  </locale>
+  <macro name="author">
+    <names variable="author">
+      <name delimiter="/" name-as-sort-order="all" sort-separator=" " form="long" font-style="normal" font-variant="small-caps"/>
+      <label form="short" prefix=" (" suffix=")"/>
+      <substitute>
+        <names variable="editor"/>
+      </substitute>
+    </names>
+  </macro>
+  <macro name="editor-author">
+    <names variable="editor">
+      <name delimiter="/" name-as-sort-order="all" sort-separator=" " form="long" font-style="normal" font-variant="small-caps"/>
+      <label form="short" prefix=" (" suffix=")"/>
+      <substitute>
+        <names variable="author"/>
+      </substitute>
+    </names>
+  </macro>
+  <macro name="author-note">
+    <names variable="author">
+      <name form="short" delimiter="/" et-al-min="4" et-al-use-first="1" name-as-sort-order="all" font-style="normal" font-variant="small-caps"/>
+    </names>
+  </macro>
+  <macro name="autor-editor-note">
+    <names variable="author">
+      <name form="short" delimiter="/" et-al-min="4" et-al-use-first="1" sort-separator="" font-style="normal" font-variant="small-caps"/>
+      <substitute>
+        <names variable="editor"/>
+      </substitute>
+    </names>
+  </macro>
+  <macro name="locator-with-label">
+    <group delimiter=" ">
+      <label variable="locator" form="symbol"/>
+      <text variable="locator"/>
+    </group>
+  </macro>
+  <macro name="firstpage-locator">
+    <group delimiter=" ">
+      <text variable="page-first"/>
+      <text variable="locator" prefix="(" suffix=")"/>
+    </group>
+  </macro>
+  <macro name="issued-without-zero">
+    <date variable="issued">
+      <date-part name="day" form="numeric" suffix="."/>
+      <date-part name="month" form="numeric" suffix="."/>
+      <date-part name="year" range-delimiter="/"/>
+    </date>
+  </macro>
+  <macro name="accessed-without-zero">
+    <date variable="accessed">
+      <date-part name="day" form="numeric" suffix="."/>
+      <date-part name="month" form="numeric" suffix="."/>
+      <date-part name="year" range-delimiter="/"/>
+    </date>
+  </macro>
+  <citation>
+    <layout delimiter="; " suffix=".">
+      <choose>
+        <if type="article-journal">
+          <group delimiter=", ">
+            <text macro="author-note"/>
+            <group delimiter=" ">
+              <text variable="container-title" form="short"/>
+              <choose>
+                <if match="any" variable="volume">
+                  <text variable="volume"/>
+                  <date date-parts="year" form="text" variable="issued" prefix=" (" suffix=")"/>
+                </if>
+                <else-if match="any" variable="issue">
+                  <group delimiter="">
+                    <text variable="issue"/>
+                    <date date-parts="year" form="text" variable="issued" prefix="/"/>
+                  </group>
+                </else-if>
+                <else>
+                  <date date-parts="year" form="text" variable="issued"/>
+                </else>
+              </choose>
+            </group>
+            <group delimiter=", ">
+              <text variable="page-first"/>
+              <text variable="locator"/>
+            </group>
+          </group>
+        </if>
+        <else-if type="book">
+          <group delimiter=", ">
+            <text macro="autor-editor-note"/>
+            <choose>
+              <if match="any" variable="title-short">
+                <text variable="title" form="short"/>
+              </if>
+            </choose>
+            <text variable="locator"/>
+          </group>
+        </else-if>
+        <else-if type="thesis">
+          <group delimiter=", ">
+            <text macro="autor-editor-note"/>
+            <choose>
+              <if match="any" variable="title-short">
+                <text variable="title" form="short"/>
+              </if>
+            </choose>
+            <text variable="locator"/>
+          </group>
+        </else-if>
+        <else-if type="chapter">
+          <group delimiter=", ">
+            <text macro="author-note"/>
+            <choose>
+              <if match="any" variable="title-short">
+                <text variable="title" form="short" prefix="in: "/>
+              </if>
+            </choose>
+            <text variable="locator"/>
+          </group>
+        </else-if>
+        <else-if type="entry-encyclopedia">
+          <text variable="title" suffix="-" form="short"/>
+          <text macro="author-note" suffix=", "/>
+          <text variable="title" form="long" suffix=" "/>
+          <text variable="locator"/>
+        </else-if>
+        <else-if type="legal_case" match="any">
+          <group delimiter=", ">
+            <choose>
+              <if match="any" variable="title">
+                <text variable="title"/>
+              </if>
+              <else>
+                <group delimiter=" ">
+                  <text variable="authority"/>
+                  <choose>
+                    <if match="any" variable="abstract">
+                      <text variable="number" suffix=", "/>
+                      <text variable="abstract"/>
+                    </if>
+                    <else>
+                      <text variable="number"/>
+                    </else>
+                  </choose>
+                  <text macro="issued-without-zero" prefix="v. "/>
+                  <text variable="title" form="short" font-style="italic" font-variant="normal" prefix="- "/>
+                </group>
+              </else>
+            </choose>
+            <text variable="locator"/>
+          </group>
+          <text variable="note" prefix=" "/>
+        </else-if>
+        <else>
+          <group delimiter=", ">
+            <text macro="author-note"/>
+            <text variable="title" form="short"/>
+            <text variable="locator"/>
+          </group>
+        </else>
+      </choose>
+    </layout>
+  </citation>
+  <bibliography subsequent-author-substitute="ders." line-spacing="1" hanging-indent="true">
+    <sort>
+      <key macro="author"/>
+      <key variable="issued"/>
+    </sort>
+    <layout suffix=".">
+      <choose>
+        <if type="article-journal">
+          <group delimiter=", ">
+            <text macro="author"/>
+            <text variable="title"/>
+            <group delimiter=" ">
+              <text variable="container-title" form="short" suffix=" "/>
+              <choose>
+                <if match="any" variable="volume">
+                  <text variable="volume"/>
+                  <group delimiter="">
+                    <!-- Hack, Klammer in Prefix in date würde zu [-->
+                    <text value="(" suffix=""/>
+                    <date date-parts="year" form="text" variable="issued"/>
+                    <text value=")" prefix=""/>
+                  </group>
+                </if>
+                <else-if match="any" variable="issue">
+                  <group delimiter="">
+                    <text variable="issue"/>
+                    <date date-parts="year" form="text" variable="issued" prefix="/"/>
+                  </group>
+                </else-if>
+                <else>
+                  <date date-parts="year" form="text" variable="issued"/>
+                </else>
+              </choose>
+            </group>
+            <text variable="page"/>
+          </group>
+        </if>
+        <else-if type="book">
+          <group delimiter=", ">
+            <text macro="author"/>
+            <text variable="title"/>
+            <text variable="edition" suffix=" Aufl."/>
+            <group delimiter=" ">
+              <text variable="publisher-place" suffix=" "/>
+              <date date-parts="year" form="text" variable="issued"/>
+            </group>
+          </group>
+          <choose>
+            <if match="any" variable="title-short">
+              <!-- Hack, Klammer in Prefix in autor-editor-note würde zu [-->
+              <text value=" (zit.: " suffix=""/>
+              <text macro="autor-editor-note" suffix=", "/>
+              <text variable="title" form="short" suffix=")"/>
+            </if>
+          </choose>
+        </else-if>
+        <else-if type="chapter">
+          <group delimiter=", ">
+            <text macro="author" font-variant="normal"/>
+            <text variable="title"/>
+            <group delimiter=":  ">
+              <text term="in"/>
+              <group delimiter=", ">
+                <names variable="editor" font-style="normal" font-variant="normal">
+                  <name delimiter="/" name-as-sort-order="all" sort-separator=", " form="long"/>
+                  <label form="short" prefix=" (" suffix=")"/>
+                </names>
+                <text variable="container-title"/>
+              </group>
+            </group>
+            <text variable="edition" suffix=" Aufl."/>
+            <group delimiter=" ">
+              <text variable="publisher-place"/>
+              <date date-parts="year" form="text" variable="issued"/>
+            </group>
+            <text variable="page"/>
+          </group>
+          <choose>
+            <if match="any" variable="title-short">
+              <!-- Hack, Klammer in Prefix in autor-editor-note würde zu [-->
+              <text value=" (zit.: " suffix=""/>
+              <text macro="autor-editor-note" suffix=", "/>
+              <text variable="title" form="short" prefix="in: " suffix=")"/>
+            </if>
+          </choose>
+        </else-if>
+        <else-if type="thesis">
+          <group delimiter=", ">
+            <text macro="author"/>
+            <text variable="title"/>
+            <group delimiter=" ">
+              <text variable="publisher-place"/>
+              <date date-parts="year" form="text" variable="issued"/>
+              <text variable="genre" prefix="= " suffix=""/>
+              <choose>
+                <if match="any" variable="title-short">
+                  <!-- Hack, Klammer in Prefix in autor-editor-note würde zu [-->
+                  <text value="(zit.: " suffix=""/>
+                  <text macro="autor-editor-note" suffix=", "/>
+                  <text variable="title" form="short" suffix=")"/>
+                </if>
+              </choose>
+            </group>
+          </group>
+        </else-if>
+        <else-if type="entry-encyclopedia">
+          <group delimiter=", ">
+            <text macro="author"/>
+            <choose>
+              <if variable="title" match ="all">
+                <text variable="title" prefix="Kommentierung zu "/>
+                <text macro="editor-author" prefix="in: "/>
+              </if>
+             </choose>
+             <text variable="container-title"/>
+             <text variable="edition" suffix=" Aufl."/>
+             <group delimiter="">
+               <text variable="publisher-place" suffix=" "/>
+               <date variable="issued" suffix=" ">
+                 <date-part name="year" form="long"/>
+               </date>
+               <!-- Hack, Klammer in Suffix in date würde zu [-->
+               <text value="(zit.: "/>
+               <text variable="title" form="short" suffix="-"/>
+               <text macro="author-note" suffix=", Art. ... N ..." font-style="normal" font-variant="normal"/>
+               <text value=")"/>
+              </group>
+            </group>
+        </else-if>
+        <else-if type="bill" match="all">
+          <group delimiter=", ">
+            <text variable="title"/>
+            <group delimiter=" ">
+              <text variable="container-title" form="short"/>
+              <text variable="volume"/>
+              <date date-parts="year" form="text" variable="issued" prefix="(" suffix=")"/>
+            </group>
+            <text variable="page"/>
+          </group>
+          <choose>
+            <if match="any" variable="title-short">
+              <!-- Hack, Klammer in Prefix in autor-editor-note würde zu [-->
+              <text value=" (zit.: " suffix=""/>
+              <text variable="title" form="short" suffix=")"/>
+            </if>
+          </choose>
+        </else-if>
+        <else-if type="webpage" match="any">
+          <group delimiter=", ">
+            <text macro="author"/>
+            <text variable="title"/>
+            <group delimiter=" ">
+              <text variable="URL" prefix="&lt;" suffix="&gt; "/>
+              <group delimiter=" " prefix="(" suffix=")">
+                <text term="accessed"/>
+                <text macro="accessed-without-zero"/>
+              </group>
+            </group>
+          </group>
+        </else-if>
+        <else>
+          <group delimiter=", ">
+            <text macro="author"/>
+            <text variable="title"/>
+            <group delimiter=" ">
+              <text variable="URL" prefix="&lt;" suffix="&gt; "/>
+              <group delimiter=" " prefix="(" suffix=")">
+                <text term="accessed"/>
+                <text macro="accessed-without-zero"/>
+              </group>
+            </group>
+          </group>
+        </else>
+      </choose>
+    </layout>
+  </bibliography>
+</style>

--- a/juristische-zitierweise-schweizer-stil.csl
+++ b/juristische-zitierweise-schweizer-stil.csl
@@ -2,8 +2,8 @@
 <style xmlns="http://purl.org/net/xbiblio/csl" class="note" version="1.0" default-locale="de-DE">
   <info>
     <title>Juristische Zitierweise Schweiz (Ryser Büschi/Schlegel/Pflaum)</title>
-    <id>http://www.zotero.org/styles/juristische-zitierweise-schweiz</id>
-    <link href="http://www.zotero.org/styles/juristische-zitierweise-schweiz" rel="self"/>
+    <id>http://www.zotero.org/styles/juristische-zitierweise-schweizer-stil</id>
+    <link href="http://www.zotero.org/styles/juristische-zitierweise-schweizer-stil" rel="self"/>
     <author>
       <name>Stephan Schlegel</name>
       <email>stephan.schlegel@unibas.ch</email>
@@ -13,13 +13,12 @@
     <summary>This style is based on the "Juristische Zitierweise (Stüber)" style by Oliver Wolf and Philipp Zumstein (https://www.zotero.org/styles/juristische-zitierweise). 
     The citation is adapted for the style of articles in Swiss law publications. It's similar to the style of the course book Ryser Büschi/Schlegel/Pflaum, Juristische Arbeiten 
     erfolgreich schreiben und präsentieren, 2nd ed., Zurich 2017 (ISBN 978-3-7255-7612-8). Legal Commentaries and handbooks should use publication type "entry-encyclopedia". 
-    See more details in the comments.
-    </summary>
+    See more details in the comments.</summary>
     <updated>2017-12-06T08:00:00+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
     <!-- 
-    Für alle Arten:
-    Kurztitel: wird als Referenz in Fussnoten verwendet
+	Für alle Arten:
+	Kurztitel: wird als Referenz in Fussnoten verwendet
     
 	Dissertationen:
 	Art: hier kann Diss.-Ort und Jahr angegeben werden, z.B. "Diss. Univ. Zürich, 2010"
@@ -33,14 +32,14 @@
 	Kurztitel: z.B. für Parteinamen beim EGMR
 	Extra: Parallelfundstelle z.B. in Fachzeitschrift wie "forumpoenale 2009, 2"
     
-    Enzyklopädieartikel für Jur. Kommentare:
-    Einträge müssen pro Artikel erfolgen, wenn Herausgeber und Autoren; wenn Autoren Gesamtwerk + alle Art. bleibt Titel leer
-    Wenn nur Gesamtwerk in Bibliographie erscheinen soll, Werk zusätzlich in Sammlung aufnehmen und Bibliographie editieren 
+	Enzyklopädieartikel für Jur. Kommentare:
+	Einträge müssen pro Artikel erfolgen, wenn Herausgeber und Autoren; wenn Autoren Gesamtwerk + alle Art. bleibt Titel leer
+	Wenn nur Gesamtwerk in Bibliographie erscheinen soll, Werk zusätzlich in Sammlung aufnehmen und Bibliographie editieren 
     
-    Titel: pro Art. ist Titel nur "Art. X"  
-    Herausgeber/Autor: Hrsg. erscheinen nur in Bibliographie, Autor nur in Fussnote, wenn Hrsg. existiert 
-    Titel der Enzyklopädie: Titel des Kommentars z.B. "Basler Kommentar zum ..."
-    Kurztitel: Abkürzung des Kommentars z.B. "BSK StGB"
+	Titel: pro Art. ist Titel nur "Art. X"  
+	Herausgeber/Autor: Hrsg. erscheinen nur in Bibliographie, Autor nur in Fussnote, wenn Hrsg. existiert 
+	Titel der Enzyklopädie: Titel des Kommentars z.B. "Basler Kommentar zum ..."
+	Kurztitel: Abkürzung des Kommentars z.B. "BSK StGB"
            
     -->
   </info>
@@ -83,7 +82,7 @@
     </names>
   </macro>
   <macro name="issued-date">
-	<date variable="issued" prefix="vom ">
+    <date variable="issued" prefix="vom ">
       <date-part name="day" suffix=". "/>
       <date-part name="month" form="long" suffix=" "/>
       <date-part name="year"/>
@@ -107,7 +106,7 @@
                 <text variable="title-short"/>
               </if>
             </choose>
-           <text variable="locator"/>
+            <text variable="locator"/>
           </group>
         </if>
         <else-if type="book">
@@ -168,16 +167,16 @@
                     </else>
                   </choose>
                   <group delimiter="">
-				  <text macro="issued-date" prefix="vom "/>
-                  <choose>
-                    <if match="any" variable="container-title">
-                      <text variable="container-title" prefix=", "/>
-                      <text variable="volume" prefix=" "/>
-                      <text variable="page" prefix=", "/>
-                     </if>
-                   </choose>                      
+                    <text macro="issued-date" prefix="vom "/>
+                    <choose>
+                      <if match="any" variable="container-title">
+                        <text variable="container-title" prefix=", "/>
+                        <text variable="volume" prefix=" "/>
+                        <text variable="page" prefix=", "/>
+                      </if>
+                    </choose>
                   </group>
-                 <text variable="title" form="short" font-style="italic" font-variant="normal" prefix="– "/>
+                  <text variable="title" form="short" font-style="italic" font-variant="normal" prefix="&#8211; "/>
                 </group>
               </else>
             </choose>
@@ -318,24 +317,24 @@
           <group delimiter=", ">
             <text macro="author"/>
             <choose>
-              <if variable="title" match ="all">
+              <if variable="title" match="all">
                 <text variable="title" prefix="Kommentierung zu "/>
                 <text macro="editor-author" prefix="in: "/>
               </if>
-             </choose>
-             <text variable="container-title"/>
-             <text variable="edition" suffix=" Aufl."/>
-             <group delimiter="">
-               <text variable="publisher-place" suffix=" "/>
-               <date variable="issued" suffix=" ">
-                 <date-part name="year" form="long"/>
-               </date>
-               <text value="(zit.: "/>
-               <text variable="title" form="short" suffix="-"/>
-               <text macro="author-note" suffix=", Art. ... N ..." font-style="normal" font-variant="normal"/>
-               <text value=")"/>
-              </group>
+            </choose>
+            <text variable="container-title"/>
+            <text variable="edition" suffix=" Aufl."/>
+            <group delimiter="">
+              <text variable="publisher-place" suffix=" "/>
+              <date variable="issued" suffix=" ">
+                <date-part name="year" form="long"/>
+              </date>
+              <text value="(zit.: "/>
+              <text variable="title" form="short" suffix="-"/>
+              <text macro="author-note" suffix=", Art. ... N ..." font-style="normal" font-variant="normal"/>
+              <text value=")"/>
             </group>
+          </group>
         </else-if>
         <else-if type="bill" match="all">
           <group delimiter=", ">
@@ -368,7 +367,7 @@
           </group>
         </else-if>
         <else-if type="legal_case" match="any">
-        <!-- kein Eintrag in Bibliographie -->
+          <!-- kein Eintrag in Bibliographie -->
         </else-if>
         <else>
           <group delimiter=", ">

--- a/juristische-zitierweise-schweizer-stil.csl
+++ b/juristische-zitierweise-schweizer-stil.csl
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <style xmlns="http://purl.org/net/xbiblio/csl" class="note" version="1.0" default-locale="de-DE">
   <info>
-    <title>Juristische Zitierweise Schweiz (Ryser Büschi/Schlegel/Pflaum)</title>
+    <title>Juristische Zitierweise Schweizer Stil (Ryser Büschi/Schlegel/Pflaum)</title>
     <id>http://www.zotero.org/styles/juristische-zitierweise-schweizer-stil</id>
     <link href="http://www.zotero.org/styles/juristische-zitierweise-schweizer-stil" rel="self"/>
     <author>

--- a/juristische-zitierweise-schweizer-stil.csl
+++ b/juristische-zitierweise-schweizer-stil.csl
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <style xmlns="http://purl.org/net/xbiblio/csl" class="note" version="1.0" default-locale="de-DE">
   <info>
-    <title>Juristische Zitierweise - Schweizer Stil (German)</title>
-    <id>http://www.zotero.org/styles/juristische-zitierweise-schweizer-stil</id>
-    <link href="http://www.zotero.org/styles/juristische-zitierweise-schweizer-stil" rel="self"/>
+    <title>Juristische Zitierweise Schweiz (Ryser Büschi/Schlegel/Pflaum)</title>
+    <id>http://www.zotero.org/styles/juristische-zitierweise-schweiz</id>
+    <link href="http://www.zotero.org/styles/juristische-zitierweise-schweiz" rel="self"/>
     <author>
       <name>Stephan Schlegel</name>
       <email>stephan.schlegel@unibas.ch</email>
@@ -12,12 +12,15 @@
     <category field="law"/>
     <summary>This style is based on the "Juristische Zitierweise (Stüber)" style by Oliver Wolf and Philipp Zumstein (https://www.zotero.org/styles/juristische-zitierweise). 
     The citation is adapted for the style of articles in Swiss law publications. It's similar to the style of the course book Ryser Büschi/Schlegel/Pflaum, Juristische Arbeiten 
-    erfolgreich schreiben und präsentieren, 2nd ed., Zurich 2017 (ISBN 978-3-7255-7612-8). Legal commentaries and handbooks should use publication type "entry-encyclopedia". 
+    erfolgreich schreiben und präsentieren, 2nd ed., Zurich 2017 (ISBN 978-3-7255-7612-8). Legal Commentaries and handbooks should use publication type "entry-encyclopedia". 
     See more details in the comments.
     </summary>
-    <updated>2017-12-03T08:00:00+00:00</updated>
+    <updated>2017-12-06T08:00:00+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
     <!-- 
+    Für alle Arten:
+    Kurztitel: wird als Referenz in Fussnoten verwendet
+    
 	Dissertationen:
 	Art: hier kann Diss.-Ort und Jahr angegeben werden, z.B. "Diss. Univ. Zürich, 2010"
 
@@ -71,7 +74,7 @@
       <name form="short" delimiter="/" et-al-min="4" et-al-use-first="1" name-as-sort-order="all" font-style="normal" font-variant="small-caps"/>
     </names>
   </macro>
-  <macro name="author-editor-note">
+  <macro name="autor-editor-note">
     <names variable="author">
       <name form="short" delimiter="/" et-al-min="4" et-al-use-first="1" sort-separator="" font-style="normal" font-variant="small-caps"/>
       <substitute>
@@ -79,18 +82,18 @@
       </substitute>
     </names>
   </macro>
-  <macro name="issued-without-zero">
-    <date variable="issued">
-      <date-part name="day" form="numeric" suffix="."/>
-      <date-part name="month" form="numeric" suffix="."/>
-      <date-part name="year" range-delimiter="/"/>
+  <macro name="issued-date">
+	<date variable="issued" prefix="vom ">
+      <date-part name="day" suffix=". "/>
+      <date-part name="month" form="long" suffix=" "/>
+      <date-part name="year"/>
     </date>
   </macro>
-  <macro name="accessed-without-zero">
+  <macro name="accessed-date">
     <date variable="accessed">
-      <date-part name="day" form="numeric" suffix="."/>
-      <date-part name="month" form="numeric" suffix="."/>
-      <date-part name="year" range-delimiter="/"/>
+      <date-part name="day" suffix=". "/>
+      <date-part name="month" form="long" suffix=" "/>
+      <date-part name="year"/>
     </date>
   </macro>
   <citation>
@@ -99,33 +102,17 @@
         <if type="article-journal">
           <group delimiter=", ">
             <text macro="author-note"/>
-            <group delimiter=" ">
-              <text variable="container-title" form="short"/>
-              <choose>
-                <if match="any" variable="volume">
-                  <text variable="volume"/>
-                  <date date-parts="year" form="text" variable="issued" prefix=" (" suffix=")"/>
-                </if>
-                <else-if match="any" variable="issue">
-                  <group delimiter="">
-                    <text variable="issue"/>
-                    <date date-parts="year" form="text" variable="issued" prefix="/"/>
-                  </group>
-                </else-if>
-                <else>
-                  <date date-parts="year" form="text" variable="issued"/>
-                </else>
-              </choose>
-            </group>
-            <group delimiter=", ">
-              <text variable="page-first"/>
-              <text variable="locator"/>
-            </group>
+            <choose>
+              <if match="any" variable="title-short">
+                <text variable="title-short"/>
+              </if>
+            </choose>
+           <text variable="locator"/>
           </group>
         </if>
         <else-if type="book">
           <group delimiter=", ">
-            <text macro="author-editor-note"/>
+            <text macro="autor-editor-note"/>
             <choose>
               <if match="any" variable="title-short">
                 <text variable="title" form="short"/>
@@ -136,7 +123,7 @@
         </else-if>
         <else-if type="thesis">
           <group delimiter=", ">
-            <text macro="author-editor-note"/>
+            <text macro="autor-editor-note"/>
             <choose>
               <if match="any" variable="title-short">
                 <text variable="title" form="short"/>
@@ -180,8 +167,17 @@
                       <text variable="number"/>
                     </else>
                   </choose>
-                  <text macro="issued-without-zero" prefix="v. "/>
-                  <text variable="title" form="short" font-style="italic" font-variant="normal" prefix="- "/>
+                  <group delimiter="">
+				  <text macro="issued-date" prefix="vom "/>
+                  <choose>
+                    <if match="any" variable="container-title">
+                      <text variable="container-title" prefix=", "/>
+                      <text variable="volume" prefix=" "/>
+                      <text variable="page" prefix=", "/>
+                     </if>
+                   </choose>                      
+                  </group>
+                 <text variable="title" form="short" font-style="italic" font-variant="normal" prefix="– "/>
                 </group>
               </else>
             </choose>
@@ -192,7 +188,7 @@
         <else>
           <group delimiter=", ">
             <text macro="author-note"/>
-            <text variable="title" form="short"/>
+            <text variable="title-short"/>
             <text variable="locator"/>
           </group>
         </else>
@@ -216,25 +212,42 @@
                 <if match="any" variable="volume">
                   <text variable="volume"/>
                   <group delimiter="">
-                    <!-- Hack, Klammer in Prefix in date würde zu [-->
                     <text value="(" suffix=""/>
                     <date date-parts="year" form="text" variable="issued"/>
                     <text value=")" prefix=""/>
+                    <text variable="page" prefix=" "/>
                   </group>
                 </if>
                 <else-if match="any" variable="issue">
                   <group delimiter="">
                     <text variable="issue"/>
                     <date date-parts="year" form="text" variable="issued" prefix="/"/>
+                    <text variable="page" prefix=", "/>
                   </group>
                 </else-if>
                 <else>
-                  <date date-parts="year" form="text" variable="issued"/>
+                  <group delimiter="">
+                    <date date-parts="year" form="text" variable="issued"/>
+                    <text variable="page" prefix=", "/>
+                  </group>
                 </else>
               </choose>
             </group>
-            <text variable="page"/>
           </group>
+          <group delimiter=" " prefix=", ">
+            <text variable="URL" prefix="&lt;" suffix="&gt; "/>
+            <group delimiter=" " prefix="(" suffix=")">
+              <text term="accessed"/>
+              <text macro="accessed-date"/>
+            </group>
+          </group>
+          <choose>
+            <if match="any" variable="title-short">
+              <text value=" (zit.: " suffix=""/>
+              <text macro="autor-editor-note" suffix=", "/>
+              <text variable="title" form="short" suffix=")"/>
+            </if>
+          </choose>
         </if>
         <else-if type="book">
           <group delimiter=", ">
@@ -248,9 +261,8 @@
           </group>
           <choose>
             <if match="any" variable="title-short">
-              <!-- Hack, Klammer in Prefix in author-editor-note würde zu [-->
               <text value=" (zit.: " suffix=""/>
-              <text macro="author-editor-note" suffix=", "/>
+              <text macro="autor-editor-note" suffix=", "/>
               <text variable="title" form="short" suffix=")"/>
             </if>
           </choose>
@@ -278,9 +290,8 @@
           </group>
           <choose>
             <if match="any" variable="title-short">
-              <!-- Hack, Klammer in Prefix in author-editor-note würde zu [-->
               <text value=" (zit.: " suffix=""/>
-              <text macro="author-editor-note" suffix=", "/>
+              <text macro="autor-editor-note" suffix=", "/>
               <text variable="title" form="short" prefix="in: " suffix=")"/>
             </if>
           </choose>
@@ -289,15 +300,14 @@
           <group delimiter=", ">
             <text macro="author"/>
             <text variable="title"/>
+            <text variable="genre"/>
             <group delimiter=" ">
               <text variable="publisher-place"/>
               <date date-parts="year" form="text" variable="issued"/>
-              <text variable="genre" prefix="= " suffix=""/>
               <choose>
                 <if match="any" variable="title-short">
-                  <!-- Hack, Klammer in Prefix in author-editor-note würde zu [-->
                   <text value="(zit.: " suffix=""/>
-                  <text macro="author-editor-note" suffix=", "/>
+                  <text macro="autor-editor-note" suffix=", "/>
                   <text variable="title" form="short" suffix=")"/>
                 </if>
               </choose>
@@ -320,7 +330,6 @@
                <date variable="issued" suffix=" ">
                  <date-part name="year" form="long"/>
                </date>
-               <!-- Hack, Klammer in Suffix in date würde zu [-->
                <text value="(zit.: "/>
                <text variable="title" form="short" suffix="-"/>
                <text macro="author-note" suffix=", Art. ... N ..." font-style="normal" font-variant="normal"/>
@@ -353,10 +362,13 @@
               <text variable="URL" prefix="&lt;" suffix="&gt; "/>
               <group delimiter=" " prefix="(" suffix=")">
                 <text term="accessed"/>
-                <text macro="accessed-without-zero"/>
+                <text macro="accessed-date"/>
               </group>
             </group>
           </group>
+        </else-if>
+        <else-if type="legal_case" match="any">
+        <!-- kein Eintrag in Bibliographie -->
         </else-if>
         <else>
           <group delimiter=", ">
@@ -366,7 +378,7 @@
               <text variable="URL" prefix="&lt;" suffix="&gt; "/>
               <group delimiter=" " prefix="(" suffix=")">
                 <text term="accessed"/>
-                <text macro="accessed-without-zero"/>
+                <text macro="accessed-date"/>
               </group>
             </group>
           </group>

--- a/juristische-zitierweise-schweizer-stil.csl
+++ b/juristische-zitierweise-schweizer-stil.csl
@@ -71,7 +71,7 @@
       <name form="short" delimiter="/" et-al-min="4" et-al-use-first="1" name-as-sort-order="all" font-style="normal" font-variant="small-caps"/>
     </names>
   </macro>
-  <macro name="autor-editor-note">
+  <macro name="author-editor-note">
     <names variable="author">
       <name form="short" delimiter="/" et-al-min="4" et-al-use-first="1" sort-separator="" font-style="normal" font-variant="small-caps"/>
       <substitute>
@@ -137,7 +137,7 @@
         </if>
         <else-if type="book">
           <group delimiter=", ">
-            <text macro="autor-editor-note"/>
+            <text macro="author-editor-note"/>
             <choose>
               <if match="any" variable="title-short">
                 <text variable="title" form="short"/>
@@ -148,7 +148,7 @@
         </else-if>
         <else-if type="thesis">
           <group delimiter=", ">
-            <text macro="autor-editor-note"/>
+            <text macro="author-editor-note"/>
             <choose>
               <if match="any" variable="title-short">
                 <text variable="title" form="short"/>
@@ -260,9 +260,9 @@
           </group>
           <choose>
             <if match="any" variable="title-short">
-              <!-- Hack, Klammer in Prefix in autor-editor-note würde zu [-->
+              <!-- Hack, Klammer in Prefix in author-editor-note würde zu [-->
               <text value=" (zit.: " suffix=""/>
-              <text macro="autor-editor-note" suffix=", "/>
+              <text macro="author-editor-note" suffix=", "/>
               <text variable="title" form="short" suffix=")"/>
             </if>
           </choose>
@@ -290,9 +290,9 @@
           </group>
           <choose>
             <if match="any" variable="title-short">
-              <!-- Hack, Klammer in Prefix in autor-editor-note würde zu [-->
+              <!-- Hack, Klammer in Prefix in author-editor-note würde zu [-->
               <text value=" (zit.: " suffix=""/>
-              <text macro="autor-editor-note" suffix=", "/>
+              <text macro="author-editor-note" suffix=", "/>
               <text variable="title" form="short" prefix="in: " suffix=")"/>
             </if>
           </choose>
@@ -307,9 +307,9 @@
               <text variable="genre" prefix="= " suffix=""/>
               <choose>
                 <if match="any" variable="title-short">
-                  <!-- Hack, Klammer in Prefix in autor-editor-note würde zu [-->
+                  <!-- Hack, Klammer in Prefix in author-editor-note würde zu [-->
                   <text value="(zit.: " suffix=""/>
-                  <text macro="autor-editor-note" suffix=", "/>
+                  <text macro="author-editor-note" suffix=", "/>
                   <text variable="title" form="short" suffix=")"/>
                 </if>
               </choose>
@@ -352,7 +352,6 @@
           </group>
           <choose>
             <if match="any" variable="title-short">
-              <!-- Hack, Klammer in Prefix in autor-editor-note würde zu [-->
               <text value=" (zit.: " suffix=""/>
               <text variable="title" form="short" suffix=")"/>
             </if>

--- a/juristische-zitierweise-schweizer.csl
+++ b/juristische-zitierweise-schweizer.csl
@@ -1,9 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <style xmlns="http://purl.org/net/xbiblio/csl" class="note" version="1.0" default-locale="de-DE">
   <info>
-    <title>Juristische Zitierweise Schweizer Stil (Ryser Büschi/Schlegel/Pflaum)</title>
-    <id>http://www.zotero.org/styles/juristische-zitierweise-schweizer-stil</id>
-    <link href="http://www.zotero.org/styles/juristische-zitierweise-schweizer-stil" rel="self"/>
+    <title>Juristische Zitierweise Schweizer (Ryser Büschi et al.) (German)</title>
+    <id>http://www.zotero.org/styles/juristische-zitierweise-schweizer</id>
+    <link href="http://www.zotero.org/styles/juristische-zitierweise-schweizer" rel="self"/>
+    <link href="http://www.zotero.org/styles/juristische-zitierweise" rel="template"/>
+    <link href="http://www.worldcat.org/oclc/1013162746" rel="documentation"/>
     <author>
       <name>Stephan Schlegel</name>
       <email>stephan.schlegel@unibas.ch</email>


### PR DESCRIPTION
This style is based on the "Juristische Zitierweise (Stüber)" style by Oliver Wolf and Philipp Zumstein (https://www.zotero.org/styles/juristische-zitierweise). The citation is adapted for the style of articles in Swiss law publications. It's similar to the style of the course book Ryser Büschi/Schlegel/Pflaum, Juristische Arbeiten erfolgreich schreiben und präsentieren, 2nd ed., Zurich 2017 (ISBN 978-3-7255-7612-8). Legal commentaries and handbooks should use publication type "entry-encyclopedia". 
See more details in the comments.