### PR TITLE
Update springer-basic-brackets-no-et-al-alphabetical.csl

### DIFF
--- a/springer-basic-brackets-no-et-al-alphabetical.csl
+++ b/springer-basic-brackets-no-et-al-alphabetical.csl
@@ -125,9 +125,9 @@
                   <text variable="container-title" form="short" strip-periods="true"/>
                   <group delimiter=":">
                     <text variable="volume" suffix=":"/>
-                    <text variable="page"/>
+                    <text variable="page" suffix="."/>
                   </group>
-                  <text prefix=". doi: " variable="DOI"/>
+                  <text prefix="doi: " variable="DOI"/>
                 </group>
               </group>
             </if>

--- a/springer-basic-brackets-no-et-al-alphabetical.csl
+++ b/springer-basic-brackets-no-et-al-alphabetical.csl
@@ -124,11 +124,11 @@
                 <group delimiter=" ">
                   <text variable="container-title" form="short" strip-periods="true"/>
                   <group delimiter=":">
-                    <text variable="volume" suffix=":"/>
-                    <text variable="page" suffix="."/>
+                    <text variable="volume"/>
+                    <text variable="page"/>
                   </group>
-                  <text prefix="doi: " variable="DOI"/>
                 </group>
+                <text prefix=". doi: " variable="DOI"/>
               </group>
             </if>
             <else>


### PR DESCRIPTION
Removes the space between page numbers and the dot before "doi:"