### PR TITLE
Update acta-palaeontologica-polonica.csl

### DIFF
--- a/acta-palaeontologica-polonica.csl
+++ b/acta-palaeontologica-polonica.csl
@@ -19,13 +19,13 @@
   </info>
   <macro name="author">
     <names variable="author" suffix=".">
-      <name sort-separator=", " initialize-with=". " and="text" name-as-sort-order="all" delimiter=", " delimiter-precedes-last="never" form="long">
+      <name sort-separator=", " initialize-with="." and="text" name-as-sort-order="all" delimiter=", " delimiter-precedes-last="never" form="long">
       </name>
     </names>
   </macro>
   <macro name="editor">
     <names variable="editor">
-      <name sort-separator=", " initialize-with=". " and="text" name-as-sort-order="all" delimiter=", " delimiter-precedes-last="never">
+      <name sort-separator=", " initialize-with="." and="text" name-as-sort-order="all" delimiter=", " delimiter-precedes-last="never">
       </name>
       <label form="short" prefix=" (" suffix=".)"/>
     </names>


### PR DESCRIPTION
The space between the initials of author's names was deleted.
i.e.: 'Clemmensen, L. B.' is now corrected to 'Clemmensen, L.B."