### PR TITLE
jcn-no-parenthesis.csl

### DIFF
--- a/jcn-no-parenthesis.csl
+++ b/jcn-no-parenthesis.csl
@@ -3,13 +3,11 @@
   <info>
     <title>The Journal of Comparative Neurology (without parentheses)</title>
     <id>http://www.zotero.org/styles/jcn-no-parenthesis.csl</id>
-    <link href="http://www.zotero.org/styles/jcn-no-parenthesis.csl" rel="self"/>
+    <link href="http://www.zotero.org/styles/jcn-no-parenthesis" rel="self"/>
     <link href="http://onlinelibrary.wiley.com/journal/10.1002/(ISSN)1096-9861/homepage/ForAuthors.html" rel="documentation"/>
     <category citation-format="author-date"/>
     <category field="science"/>
-    <issn>0021-9967</issn>
-    <eissn>1096-9861</eissn>
-    <summary>Style for The Journal of Comparative Neurology</summary>
+    <summary>Modified style for The Journal of Comparative Neurology</summary>
     <updated>2014-08-28T01:36:46+00:00</updated>
     <link href="http://www.zotero.org/styles/the-journal-of-comparative-neurology" rel="template"/>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>

--- a/jcn-no-parenthesis.csl
+++ b/jcn-no-parenthesis.csl
@@ -2,7 +2,7 @@
 <style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" demote-non-dropping-particle="sort-only" default-locale="en-US">
   <info>
     <title>The Journal of Comparative Neurology (without parentheses)</title>
-    <id>http://www.zotero.org/styles/jcn-no-parenthesis.csl</id>
+    <id>http://www.zotero.org/styles/jcn-no-parenthesis</id>
     <link href="http://www.zotero.org/styles/jcn-no-parenthesis" rel="self"/>
     <link href="http://onlinelibrary.wiley.com/journal/10.1002/(ISSN)1096-9861/homepage/ForAuthors.html" rel="documentation"/>
     <category citation-format="author-date"/>

--- a/jcn-no-parenthesis.csl
+++ b/jcn-no-parenthesis.csl
@@ -1,0 +1,157 @@
+<?xml version="1.0" encoding="utf-8"?>
+<style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" demote-non-dropping-particle="sort-only" default-locale="en-US">
+  <info>
+    <title>The Journal of Comparative Neurology (without parentheses)</title>
+    <id>http://www.zotero.org/styles/jcn-no-parenthesis.csl</id>
+    <link href="http://www.zotero.org/styles/jcn-no-parenthesis.csl" rel="self"/>
+    <link href="http://onlinelibrary.wiley.com/journal/10.1002/(ISSN)1096-9861/homepage/ForAuthors.html" rel="documentation"/>
+    <category citation-format="author-date"/>
+    <category field="science"/>
+    <issn>0021-9967</issn>
+    <eissn>1096-9861</eissn>
+    <summary>Style for The Journal of Comparative Neurology</summary>
+    <updated>2014-08-28T01:36:46+00:00</updated>
+    <link href="http://www.zotero.org/styles/the-journal-of-comparative-neurology" rel="template"/>
+    <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
+  </info>
+  <macro name="editor">
+    <names variable="editor">
+      <name name-as-sort-order="all" sort-separator=" " initialize-with="" delimiter=", " delimiter-precedes-last="always"/>
+      <label form="long" prefix=", " suffix="."/>
+    </names>
+  </macro>
+  <macro name="anon">
+    <text term="anonymous" form="short" text-case="capitalize-first" strip-periods="true"/>
+  </macro>
+  <macro name="author">
+    <group suffix=".">
+      <names variable="author">
+        <name name-as-sort-order="all" sort-separator=" " initialize-with="" delimiter=", " delimiter-precedes-last="always"/>
+        <label form="short" prefix=" " strip-periods="true"/>
+        <substitute>
+          <names variable="editor"/>
+          <text macro="anon"/>
+        </substitute>
+      </names>
+    </group>
+  </macro>
+  <macro name="author-short">
+    <names variable="author">
+      <name form="short" and="text" delimiter=", " initialize-with="."/>
+      <substitute>
+        <names variable="editor"/>
+        <names variable="translator"/>
+        <text macro="anon"/>
+      </substitute>
+    </names>
+  </macro>
+  <macro name="access">
+    <group>
+      <text value="Available from:" suffix=" "/>
+      <text variable="URL"/>
+    </group>
+  </macro>
+  <macro name="title">
+    <text variable="title"/>
+  </macro>
+  <macro name="locator">
+    <label variable="locator" form="short" strip-periods="true"/>
+    <text variable="locator" prefix=" "/>
+  </macro>
+  <macro name="publisher">
+    <group delimiter=": ">
+      <text variable="publisher-place"/>
+      <text variable="publisher"/>
+    </group>
+  </macro>
+  <macro name="pages">
+    <text variable="page" prefix="p "/>
+  </macro>
+  <macro name="journal">
+    <text variable="container-title" form="short" strip-periods="true"/>
+    <choose>
+      <if variable="URL">
+        <text term="internet" prefix=" [" suffix="]" text-case="capitalize-first"/>
+      </if>
+    </choose>
+  </macro>
+  <macro name="edition">
+    <choose>
+      <if is-numeric="edition">
+        <group delimiter=" ">
+          <number variable="edition" form="ordinal"/>
+          <text term="edition" form="short"/>
+        </group>
+      </if>
+      <else>
+        <text variable="edition" suffix="."/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="year-issued">
+    <date variable="issued">
+      <date-part name="year"/>
+    </date>
+  </macro>
+  <citation et-al-min="3" et-al-use-first="1" disambiguate-add-year-suffix="true" collapse="year-suffix">
+    <sort>
+      <key macro="year-issued"/>
+      <key macro="author-short"/>
+    </sort>
+    <layout prefix="" suffix="" delimiter="; ">
+      <group delimiter=", ">
+        <text macro="author-short"/>
+        <date variable="issued" delimiter=" ">
+          <date-part name="year"/>
+        </date>
+        <text macro="locator"/>
+      </group>
+    </layout>
+  </citation>
+  <bibliography hanging-indent="true" et-al-min="99" et-al-use-first="98">
+    <sort>
+      <key macro="author"/>
+      <key macro="year-issued"/>
+    </sort>
+    <layout>
+      <text macro="author"/>
+      <date variable="issued" prefix=" " suffix=".">
+        <date-part name="year"/>
+      </date>
+      <text macro="title" prefix=" " suffix="."/>
+      <choose>
+        <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
+          <group prefix=" " suffix="." delimiter=" ">
+            <text macro="edition"/>
+            <text macro="editor" prefix="(" suffix=")"/>
+          </group>
+          <text prefix=" " suffix="." macro="publisher"/>
+        </if>
+        <else-if type="chapter paper-conference" match="any">
+          <group prefix=" " delimiter=" ">
+            <text term="in" text-case="capitalize-first" suffix=":"/>
+            <text macro="editor"/>
+            <text variable="container-title" suffix="."/>
+            <text variable="volume" prefix="Vol. " suffix="."/>
+            <text macro="edition"/>
+            <text variable="collection-title" suffix="."/>
+            <group suffix=".">
+              <text macro="publisher"/>
+              <group suffix="." prefix=". " delimiter=". ">
+                <text macro="pages"/>
+              </group>
+            </group>
+          </group>
+        </else-if>
+        <else>
+          <group prefix=" " suffix=".">
+            <text macro="journal"/>
+            <text variable="volume" prefix=" "/>
+            <text variable="page" prefix=":"/>
+          </group>
+        </else>
+      </choose>
+      <text prefix=" " macro="access"/>
+    </layout>
+  </bibliography>
+</style>


### PR DESCRIPTION
Modified Journal of Compartive Neurology citation style. Without the parentheses so it can be more customisable within the text.