### PR TITLE
Update american-medical-association.csl

### DIFF
--- a/american-medical-association.csl
+++ b/american-medical-association.csl
@@ -242,7 +242,7 @@
           </group>
         </else>
       </choose>
-      <text prefix=" " macro="access" suffix="."/>
+      <text prefix=" " macro="access" suffix=""/>
     </layout>
   </bibliography>
 </style>

--- a/american-medical-association.csl
+++ b/american-medical-association.csl
@@ -52,7 +52,7 @@
             <text variable="DOI"/>
           </if>
           <else-if variable="URL">
-            <group delimiter=". ">
+            <group delimiter=". " suffix=".">
               <text variable="URL"/>
               <choose>
                 <if type="webpage">
@@ -242,7 +242,7 @@
           </group>
         </else>
       </choose>
-      <text prefix=" " macro="access" suffix=""/>
+      <text prefix=" " macro="access"/>
     </layout>
   </bibliography>
 </style>


### PR DESCRIPTION
AMA has changed the handling of DOI´s- There is no period after a DOI anymore.
See here:
http://www.amamanualofstyle.com/page/updates;jsessionid=C9614A8B750AFA437F92204D8DF415AC#2016_09_01

I have used the editor to spot the period and simply deleted it. Hope this will be ok;-)
Feedback welcome!