### PR TITLE
Create hochschule-pforzheim-fakultat-wirtschaft-und-recht.csl

### DIFF
--- a/hochschule-pforzheim-fakultat-fur-wirtschaft-und-recht.csl
+++ b/hochschule-pforzheim-fakultat-fur-wirtschaft-und-recht.csl
@@ -6,6 +6,7 @@
     <link href="http://www.zotero.org/styles/hochschule-pforzheim-fakultat-fur-wirtschaft-und-recht" rel="self"/>
     <link href="http://www.zotero.org/styles/arachne" rel="template"/>
     <link href="https://businesspf.hs-pforzheim.de/" rel="documentation"/>
+    <link href="https://forums.zotero.org/discussion/69757/autor-jahr-seite-kurzzitierweise-in-fussnote" rel="documentation"/>
     <author>
       <name>Patrick O'Brien</name>
     </author>

--- a/hochschule-pforzheim-fakultat-fur-wirtschaft-und-recht.csl
+++ b/hochschule-pforzheim-fakultat-fur-wirtschaft-und-recht.csl
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <style xmlns="http://purl.org/net/xbiblio/csl" class="note" version="1.0" demote-non-dropping-particle="sort-only" default-locale="de-DE">
   <info>
-    <title>Hochhschule Pforzheim - Fakultät Wirtschaft &amp; Recht (German)</title>
-    <id>http://www.zotero.org/styles/hochschule-pforzheim-fakultat-wirtschaft-und-recht</id>
-    <link href="http://www.zotero.org/styles/hochschule-pforzheim-fakultat-wirtschaft-und-recht" rel="self"/>
+    <title>Hochschule Pforzheim - Fakultät für Wirtschaft und Recht (German)</title>
+    <id>http://www.zotero.org/styles/hochschule-pforzheim-fakultat-fur-wirtschaft-und-recht</id>
+    <link href="http://www.zotero.org/styles/hochschule-pforzheim-fakultat-fur-wirtschaft-und-recht" rel="self"/>
     <link href="http://www.zotero.org/styles/arachne" rel="template"/>
-    <link href="http://www.dearge.de/arachne/" rel="documentation"/>
+    <link href="https://businesspf.hs-pforzheim.de/" rel="documentation"/>
     <author>
       <name>Patrick O'Brien</name>
     </author>

--- a/hochschule-pforzheim-fakultat-wirtschaft-und-recht.csl
+++ b/hochschule-pforzheim-fakultat-wirtschaft-und-recht.csl
@@ -11,7 +11,6 @@
     </author>
     <category citation-format="author-date"/>
     <category field="law"/>
-    <issn>1613-2688</issn>
     <updated>2018-01-09T10:05:13+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>

--- a/hochschule-pforzheim-fakultat-wirtschaft-und-recht.csl
+++ b/hochschule-pforzheim-fakultat-wirtschaft-und-recht.csl
@@ -11,7 +11,7 @@
     </author>
     <category citation-format="note"/>
     <category field="law"/>
-    <updated>2018-01-09T16:07:21+00:00</updated>
+    <updated>2018-01-09T16:32:10+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale xml:lang="de-DE">
@@ -41,7 +41,7 @@
   </macro>
   <macro name="author-short">
     <names variable="author">
-      <name form="short" and="symbol" delimiter=", " delimiter-precedes-last="never" initialize-with=". "/>
+      <name form="short" delimiter="; " delimiter-precedes-last="never" initialize-with=". "/>
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
@@ -137,7 +137,7 @@
       </else>
     </choose>
   </macro>
-  <citation et-al-min="3" et-al-use-first="1" disambiguate-add-year-suffix="true" collapse="year-suffix" givenname-disambiguation-rule="primary-name">
+  <citation et-al-min="4" et-al-use-first="3" disambiguate-add-year-suffix="true" givenname-disambiguation-rule="primary-name" collapse="year-suffix">
     <sort>
       <key macro="author-short"/>
       <key macro="year-date"/>

--- a/hochschule-pforzheim-fakultat-wirtschaft-und-recht.csl
+++ b/hochschule-pforzheim-fakultat-wirtschaft-und-recht.csl
@@ -1,0 +1,239 @@
+<?xml version="1.0" encoding="utf-8"?>
+<style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" demote-non-dropping-particle="sort-only" default-locale="de-DE">
+  <info>
+    <title>Hochhschule Pforzheim - Fakultät Wirtschaft &amp; Recht (German)</title>
+    <id>http://www.zotero.org/styles/hochschule-pforzheim-fakultat-wirtschaft-und-recht</id>
+    <link href="http://www.zotero.org/styles/hochschule-pforzheim-fakultat-wirtschaft-und-recht" rel="self"/>
+    <link href="http://www.zotero.org/styles/arachne" rel="template"/>
+    <link href="http://www.dearge.de/arachne/" rel="documentation"/>
+    <author>
+      <name>Bastian Drolshagen</name>
+    </author>
+    <category citation-format="author-date"/>
+    <category field="law"/>
+    <issn>1613-2688</issn>
+    <updated>2018-01-09T10:05:13+00:00</updated>
+    <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
+  </info>
+  <locale xml:lang="de-DE">
+    <terms>
+      <term name="anonymous" form="short">o.V.</term>
+      <term name="accessed">Zugriff</term>
+    </terms>
+  </locale>
+  <macro name="editor">
+    <names variable="editor" delimiter=", ">
+      <name and="text" initialize-with=". " delimiter=", "/>
+      <label form="short" prefix=" (" text-case="capitalize-first" suffix=")" strip-periods="true"/>
+    </names>
+  </macro>
+  <macro name="anon">
+    <text term="anonymous" form="short" text-case="capitalize-first" strip-periods="false"/>
+  </macro>
+  <macro name="author">
+    <names variable="author">
+      <name and="symbol" delimiter-precedes-last="never" et-al-min="3" et-al-use-first="2" initialize-with="." name-as-sort-order="first"/>
+      <et-al font-style="italic"/>
+      <label form="short" text-case="capitalize-first" prefix=" (" suffix=")"/>
+      <substitute>
+        <names variable="editor"/>
+        <text macro="anon"/>
+      </substitute>
+    </names>
+  </macro>
+  <macro name="author-short">
+    <names variable="author">
+      <name form="short" and="symbol" delimiter=", " delimiter-precedes-last="never" initialize-with=". "/>
+      <et-al font-style="italic"/>
+      <substitute>
+        <names variable="editor"/>
+        <names variable="translator"/>
+        <text macro="anon"/>
+      </substitute>
+    </names>
+  </macro>
+  <macro name="access">
+    <choose>
+      <if type="webpage post-weblog" match="any">
+        <choose>
+          <if variable="URL">
+            <group delimiter=" ">
+              <text variable="URL" prefix="Available from: "/>
+              <group delimiter=": " prefix="(" suffix=")">
+                <text term="accessed"/>
+                <date variable="accessed" form="text"/>
+              </group>
+            </group>
+          </if>
+        </choose>
+      </if>
+    </choose>
+  </macro>
+  <macro name="title">
+    <choose>
+      <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
+        <text variable="title" font-style="normal"/>
+      </if>
+      <else>
+        <text variable="title" quotes="false"/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="legal_case">
+    <group prefix=" " delimiter=" ">
+      <text variable="volume"/>
+      <text variable="container-title"/>
+    </group>
+    <text variable="authority" prefix=" (" suffix=")"/>
+  </macro>
+  <macro name="publisher">
+    <choose>
+      <if type="thesis" match="none">
+        <group delimiter=", ">
+          <text variable="publisher-place"/>
+          <text variable="publisher"/>
+        </group>
+        <text variable="genre" prefix=". "/>
+      </if>
+      <else>
+        <group delimiter=". ">
+          <text variable="genre"/>
+          <text variable="publisher"/>
+        </group>
+      </else>
+    </choose>
+  </macro>
+  <macro name="year-date">
+    <choose>
+      <if variable="issued">
+        <group>
+          <date variable="issued" prefix="(" suffix=")">
+            <date-part name="year"/>
+          </date>
+        </group>
+      </if>
+      <else>
+        <text term="no date" form="short"/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="edition">
+    <choose>
+      <if is-numeric="edition">
+        <group delimiter=" ">
+          <number variable="edition" form="ordinal"/>
+          <text term="edition" form="short"/>
+        </group>
+      </if>
+      <else>
+        <text variable="issue" suffix=":"/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="locator">
+    <choose>
+      <if locator="page">
+        <group>
+          <label plural="never" text-case="capitalize-first" variable="page" form="short"/>
+          <text variable="locator"/>
+        </group>
+      </if>
+      <else>
+        <group delimiter=" ">
+          <label variable="locator" form="short"/>
+          <text variable="locator"/>
+        </group>
+      </else>
+    </choose>
+  </macro>
+  <citation et-al-min="3" et-al-use-first="1" disambiguate-add-year-suffix="true" collapse="year-suffix" givenname-disambiguation-rule="primary-name">
+    <sort>
+      <key macro="author-short"/>
+      <key macro="year-date"/>
+    </sort>
+    <layout delimiter="; ">
+      <group delimiter=", ">
+        <group delimiter=" ">
+          <text macro="author-short"/>
+          <text macro="year-date"/>
+        </group>
+        <text macro="locator"/>
+      </group>
+    </layout>
+  </citation>
+  <bibliography hanging-indent="true">
+    <sort>
+      <key macro="author"/>
+      <key macro="year-date"/>
+      <key variable="title"/>
+    </sort>
+    <layout suffix=" ">
+      <text macro="author" suffix=" "/>
+      <date variable="issued">
+        <date-part name="year" prefix="(" suffix="):"/>
+      </date>
+      <choose>
+        <if type="book" match="any">
+          <text macro="legal_case"/>
+          <group prefix=" " delimiter=" ">
+            <text macro="title" suffix="."/>
+            <text macro="edition"/>
+            <text macro="editor" suffix="."/>
+          </group>
+          <group prefix=" " suffix="." delimiter=", ">
+            <text macro="publisher"/>
+            <text variable="page" prefix=" " suffix=" pp"/>
+          </group>
+        </if>
+        <else-if type="chapter paper-conference" match="any">
+          <text macro="title" prefix=" " suffix="."/>
+          <group prefix=" In: " delimiter=" ">
+            <text macro="editor" suffix=","/>
+            <text variable="container-title" font-style="italic" suffix="."/>
+            <text variable="collection-title" suffix="."/>
+            <group suffix=".">
+              <text macro="publisher"/>
+              <group prefix=", pp. " delimiter=" " suffix=".">
+                <text variable="page"/>
+              </group>
+            </group>
+          </group>
+        </else-if>
+        <else-if type="bill graphic legal_case legislation manuscript motion_picture report song thesis" match="any">
+          <text macro="legal_case"/>
+          <group prefix=" " delimiter=" ">
+            <text macro="title" suffix="."/>
+            <text macro="edition"/>
+            <text macro="editor" suffix="."/>
+          </group>
+          <group prefix=" " delimiter=", ">
+            <text macro="publisher"/>
+            <text variable="page" prefix=" " suffix="pp."/>
+          </group>
+        </else-if>
+        <else-if type="webpage post-weblog" match="any">
+          <group delimiter=", " suffix=".">
+            <text macro="title"/>
+            <text variable="container-title"/>
+          </group>
+        </else-if>
+        <else>
+          <group prefix=" " delimiter=" " suffix=".">
+            <text macro="title"/>
+            <text macro="editor"/>
+          </group>
+          <group delimiter=": " prefix=" " suffix=".">
+            <text term="in" text-case="capitalize-first"/>
+            <group delimiter=", " prefix=" ">
+              <text variable="container-title" font-style="normal"/>
+              <text variable="volume" font-weight="normal"/>
+              <text variable="issue" form="short"/>
+              <text variable="page" suffix="."/>
+            </group>
+          </group>
+        </else>
+      </choose>
+      <text prefix=" " macro="access" suffix="."/>
+    </layout>
+  </bibliography>
+</style>

--- a/hochschule-pforzheim-fakultat-wirtschaft-und-recht.csl
+++ b/hochschule-pforzheim-fakultat-wirtschaft-und-recht.csl
@@ -11,7 +11,7 @@
     </author>
     <category citation-format="note"/>
     <category field="law"/>
-    <updated>2018-01-09T15:26:08+00:00</updated>
+    <updated>2018-01-09T16:07:21+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale xml:lang="de-DE">
@@ -31,7 +31,7 @@
   </macro>
   <macro name="author">
     <names variable="author">
-      <name delimiter="; " delimiter-precedes-last="never" et-al-min="3" et-al-use-first="2" name-as-sort-order="first"/>
+      <name delimiter="; " delimiter-precedes-last="never" name-as-sort-order="first"/>
       <label form="short" text-case="capitalize-first" prefix=" (" suffix=")"/>
       <substitute>
         <names variable="editor"/>
@@ -116,17 +116,10 @@
     </choose>
   </macro>
   <macro name="edition">
-    <choose>
-      <if is-numeric="edition">
-        <group delimiter=" ">
-          <number variable="edition" form="ordinal"/>
-          <text term="edition" form="short"/>
-        </group>
-      </if>
-      <else>
-        <text variable="issue" suffix=":"/>
-      </else>
-    </choose>
+    <group delimiter=" ">
+      <number variable="edition" form="ordinal"/>
+      <text term="edition" form="short"/>
+    </group>
   </macro>
   <macro name="locator">
     <choose>

--- a/hochschule-pforzheim-fakultat-wirtschaft-und-recht.csl
+++ b/hochschule-pforzheim-fakultat-wirtschaft-und-recht.csl
@@ -5,7 +5,7 @@
     <id>http://www.zotero.org/styles/hochschule-pforzheim-fakultat-wirtschaft-und-recht</id>
     <link href="http://www.zotero.org/styles/hochschule-pforzheim-fakultat-wirtschaft-und-recht" rel="self"/>
     <link href="http://www.zotero.org/styles/arachne" rel="template"/>
-    <link href="http://www.dearge.de/arachne/" rel="documentation"/>
+    <link href="https://github.com/citation-style-language/styles/pull/3251" rel="documentation"/>
     <author>
       <name>Bastian Drolshagen</name>
     </author>

--- a/hochschule-pforzheim-fakultat-wirtschaft-und-recht.csl
+++ b/hochschule-pforzheim-fakultat-wirtschaft-und-recht.csl
@@ -11,7 +11,7 @@
     </author>
     <category citation-format="note"/>
     <category field="law"/>
-    <updated>2018-01-09T13:44:47+00:00</updated>
+    <updated>2018-01-09T15:03:00+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale xml:lang="de-DE">
@@ -42,7 +42,6 @@
   <macro name="author-short">
     <names variable="author">
       <name form="short" and="symbol" delimiter=", " delimiter-precedes-last="never" initialize-with=". "/>
-      <et-al font-style="italic"/>
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
@@ -160,13 +159,13 @@
       </group>
     </layout>
   </citation>
-  <bibliography hanging-indent="true">
+  <bibliography et-al-min="4" et-al-use-first="3" hanging-indent="true">
     <sort>
       <key macro="author"/>
       <key macro="year-date"/>
       <key variable="title"/>
     </sort>
-    <layout suffix=" ">
+    <layout suffix=".">
       <group delimiter=" ">
         <group delimiter=": ">
           <group delimiter=" ">
@@ -190,15 +189,22 @@
                 </group>
               </if>
               <else-if type="chapter paper-conference" match="any">
-                <text macro="title" prefix=" " suffix="."/>
-                <group prefix=" In: " delimiter=" ">
-                  <text macro="editor" suffix=","/>
-                  <text variable="container-title" font-style="italic" suffix="."/>
-                  <text variable="collection-title" suffix="."/>
-                  <group suffix=".">
-                    <text macro="publisher"/>
-                    <group prefix=", pp. " delimiter=" " suffix=".">
-                      <text variable="page"/>
+                <group delimiter=". ">
+                  <text macro="title" prefix=" " suffix="."/>
+                  <group delimiter=": ">
+                    <text term="in" text-case="capitalize-first"/>
+                    <group delimiter=" ">
+                      <text macro="editor" suffix=","/>
+                      <text variable="container-title" font-style="italic" suffix="."/>
+                      <text variable="collection-title" suffix="."/>
+                      <text macro="edition"/>
+                      <group delimiter=", ">
+                        <text macro="publisher"/>
+                        <group delimiter=" ">
+                          <label variable="page" form="short"/>
+                          <text variable="page"/>
+                        </group>
+                      </group>
                     </group>
                   </group>
                 </group>
@@ -212,7 +218,10 @@
                 </group>
                 <group prefix=" " delimiter=", ">
                   <text macro="publisher"/>
-                  <text variable="page" prefix=" " suffix="pp."/>
+                  <group delimiter=" ">
+                    <label variable="page" form="short"/>
+                    <text variable="page" prefix=" "/>
+                  </group>
                 </group>
               </else-if>
               <else-if type="webpage post-weblog" match="any">
@@ -226,13 +235,13 @@
                   <text macro="title"/>
                   <text macro="editor"/>
                 </group>
-                <group delimiter=": " prefix=" " suffix=".">
+                <group delimiter=": " prefix=" ">
                   <text term="in" text-case="capitalize-first"/>
                   <group delimiter=", " prefix=" ">
                     <text variable="container-title" font-style="normal"/>
                     <text variable="volume" font-weight="normal"/>
                     <text variable="issue" form="short"/>
-                    <text variable="page" suffix="."/>
+                    <text variable="page"/>
                   </group>
                 </group>
               </else>

--- a/hochschule-pforzheim-fakultat-wirtschaft-und-recht.csl
+++ b/hochschule-pforzheim-fakultat-wirtschaft-und-recht.csl
@@ -1,17 +1,17 @@
 <?xml version="1.0" encoding="utf-8"?>
-<style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" demote-non-dropping-particle="sort-only" default-locale="de-DE">
+<style xmlns="http://purl.org/net/xbiblio/csl" class="note" version="1.0" demote-non-dropping-particle="sort-only" default-locale="de-DE">
   <info>
     <title>Hochhschule Pforzheim - Fakultät Wirtschaft &amp; Recht (German)</title>
     <id>http://www.zotero.org/styles/hochschule-pforzheim-fakultat-wirtschaft-und-recht</id>
     <link href="http://www.zotero.org/styles/hochschule-pforzheim-fakultat-wirtschaft-und-recht" rel="self"/>
     <link href="http://www.zotero.org/styles/arachne" rel="template"/>
-    <link href="https://github.com/citation-style-language/styles/pull/3251" rel="documentation"/>
+    <link href="http://www.dearge.de/arachne/" rel="documentation"/>
     <author>
-      <name>Bastian Drolshagen</name>
+      <name>Patrick O'Brien</name>
     </author>
-    <category citation-format="author-date"/>
+    <category citation-format="note"/>
     <category field="law"/>
-    <updated>2018-01-09T10:05:13+00:00</updated>
+    <updated>2018-01-09T13:44:47+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale xml:lang="de-DE">
@@ -31,8 +31,7 @@
   </macro>
   <macro name="author">
     <names variable="author">
-      <name and="symbol" delimiter-precedes-last="never" et-al-min="3" et-al-use-first="2" initialize-with="." name-as-sort-order="first"/>
-      <et-al font-style="italic"/>
+      <name delimiter="; " delimiter-precedes-last="never" et-al-min="3" et-al-use-first="2" name-as-sort-order="first"/>
       <label form="short" text-case="capitalize-first" prefix=" (" suffix=")"/>
       <substitute>
         <names variable="editor"/>
@@ -57,7 +56,8 @@
         <choose>
           <if variable="URL">
             <group delimiter=" ">
-              <text variable="URL" prefix="Available from: "/>
+              <text term="available at" text-case="capitalize-first"/>
+              <text variable="URL"/>
               <group delimiter=": " prefix="(" suffix=")">
                 <text term="accessed"/>
                 <date variable="accessed" form="text"/>
@@ -167,72 +167,80 @@
       <key variable="title"/>
     </sort>
     <layout suffix=" ">
-      <text macro="author" suffix=" "/>
-      <date variable="issued">
-        <date-part name="year" prefix="(" suffix="):"/>
-      </date>
-      <choose>
-        <if type="book" match="any">
-          <text macro="legal_case"/>
-          <group prefix=" " delimiter=" ">
-            <text macro="title" suffix="."/>
-            <text macro="edition"/>
-            <text macro="editor" suffix="."/>
+      <group delimiter=" ">
+        <group delimiter=": ">
+          <group delimiter=" ">
+            <text macro="author" suffix=" "/>
+            <date variable="issued" prefix="(" suffix=")">
+              <date-part name="year"/>
+            </date>
           </group>
-          <group prefix=" " suffix="." delimiter=", ">
-            <text macro="publisher"/>
-            <text variable="page" prefix=" " suffix=" pp"/>
+          <group>
+            <choose>
+              <if type="book" match="any">
+                <text macro="legal_case"/>
+                <group delimiter=" " prefix=" ">
+                  <text macro="title" suffix="."/>
+                  <text macro="edition" suffix=","/>
+                  <text macro="editor" suffix="."/>
+                </group>
+                <group prefix=" " suffix="." delimiter=", ">
+                  <text macro="publisher"/>
+                  <text variable="page" prefix=" " suffix=" pp"/>
+                </group>
+              </if>
+              <else-if type="chapter paper-conference" match="any">
+                <text macro="title" prefix=" " suffix="."/>
+                <group prefix=" In: " delimiter=" ">
+                  <text macro="editor" suffix=","/>
+                  <text variable="container-title" font-style="italic" suffix="."/>
+                  <text variable="collection-title" suffix="."/>
+                  <group suffix=".">
+                    <text macro="publisher"/>
+                    <group prefix=", pp. " delimiter=" " suffix=".">
+                      <text variable="page"/>
+                    </group>
+                  </group>
+                </group>
+              </else-if>
+              <else-if type="bill graphic legal_case legislation manuscript motion_picture report song thesis" match="any">
+                <text macro="legal_case"/>
+                <group prefix=" " delimiter=" ">
+                  <text macro="title" suffix="."/>
+                  <text macro="edition"/>
+                  <text macro="editor" suffix="."/>
+                </group>
+                <group prefix=" " delimiter=", ">
+                  <text macro="publisher"/>
+                  <text variable="page" prefix=" " suffix="pp."/>
+                </group>
+              </else-if>
+              <else-if type="webpage post-weblog" match="any">
+                <group delimiter=", " suffix=".">
+                  <text macro="title"/>
+                  <text variable="container-title"/>
+                </group>
+              </else-if>
+              <else>
+                <group prefix=" " delimiter=" " suffix=".">
+                  <text macro="title"/>
+                  <text macro="editor"/>
+                </group>
+                <group delimiter=": " prefix=" " suffix=".">
+                  <text term="in" text-case="capitalize-first"/>
+                  <group delimiter=", " prefix=" ">
+                    <text variable="container-title" font-style="normal"/>
+                    <text variable="volume" font-weight="normal"/>
+                    <text variable="issue" form="short"/>
+                    <text variable="page" suffix="."/>
+                  </group>
+                </group>
+              </else>
+            </choose>
           </group>
-        </if>
-        <else-if type="chapter paper-conference" match="any">
-          <text macro="title" prefix=" " suffix="."/>
-          <group prefix=" In: " delimiter=" ">
-            <text macro="editor" suffix=","/>
-            <text variable="container-title" font-style="italic" suffix="."/>
-            <text variable="collection-title" suffix="."/>
-            <group suffix=".">
-              <text macro="publisher"/>
-              <group prefix=", pp. " delimiter=" " suffix=".">
-                <text variable="page"/>
-              </group>
-            </group>
-          </group>
-        </else-if>
-        <else-if type="bill graphic legal_case legislation manuscript motion_picture report song thesis" match="any">
-          <text macro="legal_case"/>
-          <group prefix=" " delimiter=" ">
-            <text macro="title" suffix="."/>
-            <text macro="edition"/>
-            <text macro="editor" suffix="."/>
-          </group>
-          <group prefix=" " delimiter=", ">
-            <text macro="publisher"/>
-            <text variable="page" prefix=" " suffix="pp."/>
-          </group>
-        </else-if>
-        <else-if type="webpage post-weblog" match="any">
-          <group delimiter=", " suffix=".">
-            <text macro="title"/>
-            <text variable="container-title"/>
-          </group>
-        </else-if>
-        <else>
-          <group prefix=" " delimiter=" " suffix=".">
-            <text macro="title"/>
-            <text macro="editor"/>
-          </group>
-          <group delimiter=": " prefix=" " suffix=".">
-            <text term="in" text-case="capitalize-first"/>
-            <group delimiter=", " prefix=" ">
-              <text variable="container-title" font-style="normal"/>
-              <text variable="volume" font-weight="normal"/>
-              <text variable="issue" form="short"/>
-              <text variable="page" suffix="."/>
-            </group>
-          </group>
-        </else>
-      </choose>
-      <text prefix=" " macro="access" suffix="."/>
+        </group>
+        <text macro="access"/>
+      </group>
     </layout>
   </bibliography>
 </style>

--- a/hochschule-pforzheim-fakultat-wirtschaft-und-recht.csl
+++ b/hochschule-pforzheim-fakultat-wirtschaft-und-recht.csl
@@ -11,7 +11,7 @@
     </author>
     <category citation-format="note"/>
     <category field="law"/>
-    <updated>2018-01-09T15:03:00+00:00</updated>
+    <updated>2018-01-09T15:26:08+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale xml:lang="de-DE">
@@ -27,7 +27,7 @@
     </names>
   </macro>
   <macro name="anon">
-    <text term="anonymous" form="short" text-case="capitalize-first" strip-periods="false"/>
+    <text term="anonymous" form="short" strip-periods="false"/>
   </macro>
   <macro name="author">
     <names variable="author">


### PR DESCRIPTION
via https://forums.zotero.org/discussion/69757/autor-jahr-seite-kurzzitierweise-in-fussnote

Guidelines: Folgendes kann ich dir zu den Richtlinien sagen:
- Kurzzitierweise in der Fußnote: Name (Jahr), Seite.
im Literaturverzeichnis:
- bei Monographien: Name, Vorname des Autors (Jahr): Titel, evtl. Untertitel, ggf. Titel der Reihe in der die Monographie erschienen ist, Nummer der Auflage falls es nicht die 1. ist, Ort, Datum
- bei Sammelwerken: Name, Vorname des Herausgebers (mit Zusatz "Hrsg." in Klammern)(Jahr): Titel des Sammelwerks, falls nicht 1. Auflage dann Nummer der Auflage und entsprechende Zusätze; Erscheinigungsort
- bei Beiträgen in Sammelwerken: Nachname, Vorname des Autors (Jahr): Vollständiger Titel des Beitrages. Nachname, Name des Herausgebers (mit Zusatz "Hrsg." in Klammern): Titel des Sammelwerksfalls, falls nicht 1. Auflage dann Nummer der Auflage und entsprechende Zusätze; Erscheinigungsort, Seitenangaben des Beitrags
- bei Zeitschriften- und Zeitungsartikeln: Nachname, Vorname des Autors (Kurztitel:Erscheinungsjahr): Vollständiger Titel des Beitrags. In: Name der Zeitschrift, JAhrgang und Erscheinungsjahr, Nummer des Heftes, Seitenangaben des Beitrags
- bei Quellen aus dem Internet: Nachname, Vorname soweit Verfasser bekannt sonst Angabe o.V. (Jahr), Titel, Untertitel. URL (Zugriff: Datum)
Wenn es sich nur um einen html-Text handelt, dann sollte hier in der Kurzzitierweise statt der Jahreszahl in Klammern die Abkürzung "URL" stehen
  