### PR TITLE
Sbl2 updates

### DIFF
--- a/society-of-biblical-literature-fullnote-bibliography.csl
+++ b/society-of-biblical-literature-fullnote-bibliography.csl
@@ -596,6 +596,16 @@
       <else-if type="article-journal">
         <text variable="locator" prefix=": "/>
       </else-if>
+      <else-if type="entry-dictionary entry-encyclopedia">
+        <choose>
+          <if position="first" variable="volume" match="all">
+            <text macro="point-locators-subsequent" prefix=" "/><!--SBL 6.3.6 prefers space in first entry before vol info.-->
+          </if>
+          <else>
+            <text macro="point-locators-subsequent" prefix=", "/><!--SBL 6.3.6 prefers comma in subsequent entries before vol info.-->
+          </else>
+        </choose>
+      </else-if>
       <else>
         <text macro="point-locators-subsequent" prefix=", "/>
       </else>

--- a/society-of-biblical-literature-fullnote-bibliography.csl
+++ b/society-of-biblical-literature-fullnote-bibliography.csl
@@ -34,8 +34,8 @@
       <term name="translator" form="short">trans.</term>
       <term name="editortranslator" form="verb">edited and translated by</term>
       <term name="collection-editor">
-          <single>ed.</single>
-          <multiple>eds.</multiple>
+        <single>ed.</single>
+        <multiple>eds.</multiple>
       </term>
       <term name="collection-editor" form="verb">edited by</term>
     </terms>
@@ -98,7 +98,8 @@
     </names>
   </macro>
   <macro name="collection-editor">
-    <group delimiter=", " prefix=". "><!--TODO: Refactor? Bib uses prefix whereas CSL style prefers groups with delimeters.-->
+    <group delimiter=", " prefix=". ">
+      <!--TODO: Refactor? Bib uses prefix whereas CSL style prefers groups with delimeters.-->
       <names variable="collection-editor" delimiter=", ">
         <label form="verb" prefix=" " text-case="capitalize-first" suffix=" "/>
         <name and="text" delimiter=", "/>
@@ -334,19 +335,21 @@
   <macro name="collection-title">
     <choose>
       <if variable="volume number-of-volumes" match="any">
-      <!-- Presence of Volume info indicates multivolume work rather than series -->
-          <choose>
-            <!--This section required here rather than in title-note because the group delimiter inserts an unneeded comma otherwise-->
-            <if type="chapter" variable="container-title" match="all"> <!--Filter SBL 6.2.23-->
-            </if>
-            <else-if type="chapter" variable="collection-title" match="all"> <!--Filter SBL 6.2.22-->
-              <group>
-                <text term="volume" form="short" suffix=" "/>
-                <number variable="volume" form="numeric"/>
-                <text value=" of "/>
-              </group>
-            </else-if>
-          </choose>
+        <!-- Presence of Volume info indicates multivolume work rather than series -->
+        <choose>
+          <!--This section required here rather than in title-note because the group delimiter inserts an unneeded comma otherwise-->
+          <if type="chapter" variable="container-title" match="all">
+            <!--Filter SBL 6.2.23-->
+          </if>
+          <else-if type="chapter" variable="collection-title" match="all">
+            <!--Filter SBL 6.2.22-->
+            <group>
+              <text term="volume" form="short" suffix=" "/>
+              <number variable="volume" form="numeric"/>
+              <text value=" of "/>
+            </group>
+          </else-if>
+        </choose>
         <text variable="collection-title" form="short" text-case="title" font-style="italic"/>
         <text variable="collection-number" prefix=" "/>
       </if>
@@ -359,17 +362,17 @@
   <macro name="collection-title-note">
     <choose>
       <if variable="volume number-of-volumes" match="any">
-      <!-- Presence of Volume info indicates multivolume work rather than series -->
-          <choose>
-            <!-- This section required here rather than in title-note because the group delimiter inserts an unneeded comma otherwise-->
-            <if type="chapter paper-conference" match="any">
-              <choose>
-                <if variable="container-title" match="none">
-                  <text term="in" suffix=" "/>
-                </if>
-              </choose>
-            </if>
-          </choose>
+        <!-- Presence of Volume info indicates multivolume work rather than series -->
+        <choose>
+          <!-- This section required here rather than in title-note because the group delimiter inserts an unneeded comma otherwise-->
+          <if type="chapter paper-conference" match="any">
+            <choose>
+              <if variable="container-title" match="none">
+                <text term="in" suffix=" "/>
+              </if>
+            </choose>
+          </if>
+        </choose>
         <text variable="collection-title" form="short" text-case="title" font-style="italic"/>
         <text variable="collection-number" prefix=" "/>
       </if>
@@ -452,29 +455,32 @@
           <!--Repositioned Edition to proceed volume-->
           <text macro="edition-note"/>
           <choose>
-            <if variable="volume"><!--If volume-->
-                <choose>
-                    <if type="book" variable="collection-title" match="all"> <!--SBL 6.2.21-->
-                          <group>
-                            <text term="volume" form="short" suffix=" "/>
-                            <number variable="volume" form="numeric"/>
-                            <text value=" of"/>
-                          </group>
-                    </if>
-                    <else-if type="chapter" variable="container-title" match="all"> <!--SBL 6.2.23-->
-                          <group>
-                            <text term="volume" form="short" suffix=" "/>
-                            <number variable="volume" form="numeric"/>
-                            <text value=" of"/>
-                          </group>
-                    </else-if>
-                    <else-if variable="locator page" match="none">
-                      <group>
-                        <text term="volume" form="short" suffix=" "/>
-                        <number variable="volume" form="numeric"/>
-                      </group>
-                    </else-if>
-                  </choose>
+            <if variable="volume">
+              <!--If volume-->
+              <choose>
+                <if type="book" variable="collection-title" match="all">
+                  <!--SBL 6.2.21-->
+                  <group>
+                    <text term="volume" form="short" suffix=" "/>
+                    <number variable="volume" form="numeric"/>
+                    <text value=" of"/>
+                  </group>
+                </if>
+                <else-if type="chapter" variable="container-title" match="all">
+                  <!--SBL 6.2.23-->
+                  <group>
+                    <text term="volume" form="short" suffix=" "/>
+                    <number variable="volume" form="numeric"/>
+                    <text value=" of"/>
+                  </group>
+                </else-if>
+                <else-if variable="locator page" match="none">
+                  <group>
+                    <text term="volume" form="short" suffix=" "/>
+                    <number variable="volume" form="numeric"/>
+                  </group>
+                </else-if>
+              </choose>
             </if>
             <else>
               <group>
@@ -500,29 +506,32 @@
           <!--Repositioned Edition to proceed volume-->
           <text macro="edition"/>
           <choose>
-            <if variable="volume"><!--If volume-->
-                <choose>
-                    <if type="book" variable="collection-title" match="all"> <!--SBL 6.2.21-->
-                          <group>
-                            <text term="volume" form="short" text-case="capitalize-first" suffix=" "/>
-                            <number variable="volume" form="numeric"/>
-                            <text value=" of"/>
-                          </group>
-                    </if>
-                    <else-if type="chapter" variable="container-title" match="all"> <!--SBL 6.2.23-->
-                          <group>
-                            <text term="volume" form="short" text-case="capitalize-first" suffix=" "/>
-                            <number variable="volume" form="numeric"/>
-                            <text value=" of"/>
-                          </group>
-                    </else-if>
-                    <else-if variable="locator page" match="none">
-                      <group>
-                        <text term="volume" form="short" text-case="capitalize-first" suffix=" "/>
-                        <number variable="volume" form="numeric"/>
-                      </group>
-                    </else-if>
-                  </choose>
+            <if variable="volume">
+              <!--If volume-->
+              <choose>
+                <if type="book" variable="collection-title" match="all">
+                  <!--SBL 6.2.21-->
+                  <group>
+                    <text term="volume" form="short" text-case="capitalize-first" suffix=" "/>
+                    <number variable="volume" form="numeric"/>
+                    <text value=" of"/>
+                  </group>
+                </if>
+                <else-if type="chapter" variable="container-title" match="all">
+                  <!--SBL 6.2.23-->
+                  <group>
+                    <text term="volume" form="short" text-case="capitalize-first" suffix=" "/>
+                    <number variable="volume" form="numeric"/>
+                    <text value=" of"/>
+                  </group>
+                </else-if>
+                <else-if variable="locator page" match="none">
+                  <group>
+                    <text term="volume" form="short" text-case="capitalize-first" suffix=" "/>
+                    <number variable="volume" form="numeric"/>
+                  </group>
+                </else-if>
+              </choose>
             </if>
             <else>
               <group>
@@ -533,7 +542,6 @@
           </choose>
         </group>
       </else-if>
-
       <!-- Added dictionary and encyclopedia to properly display volume information TODO: Refactor?-->
       <else-if type="entry-dictionary entry-encyclopedia">
         <group prefix=". ">
@@ -638,16 +646,20 @@
         </if>
         <else-if variable="volume">
           <choose>
-            <if type="book" variable="collection-title" match="all"> <!--Filter SBL 6.2.21-->
+            <if type="book" variable="collection-title" match="all">
+              <!--Filter SBL 6.2.21-->
               <text variable="locator"/>
             </if>
-            <else-if type="chapter" variable="container-title" match="all"> <!--Filter SBL 6.2.23-->
+            <else-if type="chapter" variable="container-title" match="all">
+              <!--Filter SBL 6.2.23-->
               <text variable="locator"/>
             </else-if>
-            <else-if type="chapter" variable="collection-title" position="subsequent" match="all"> <!--Filter SBL 6.2.22-->
+            <else-if type="chapter" variable="collection-title" position="subsequent" match="all">
+              <!--Filter SBL 6.2.22-->
               <text variable="locator"/>
             </else-if>
-            <else-if type="article-journal"><!--Filter SBL 6.3.1-->
+            <else-if type="article-journal">
+              <!--Filter SBL 6.3.1-->
               <text variable="locator"/>
             </else-if>
             <else>
@@ -675,10 +687,12 @@
       <else-if type="entry-dictionary entry-encyclopedia">
         <choose>
           <if position="first" variable="volume" match="all">
-            <text macro="point-locators-subsequent" prefix=" "/><!--SBL 6.3.6 prefers space in first entry before vol info.-->
+            <text macro="point-locators-subsequent" prefix=" "/>
+            <!--SBL 6.3.6 prefers space in first entry before vol info.-->
           </if>
           <else>
-            <text macro="point-locators-subsequent" prefix=", "/><!--SBL 6.3.6 prefers comma in subsequent entries before vol info.-->
+            <text macro="point-locators-subsequent" prefix=", "/>
+            <!--SBL 6.3.6 prefers comma in subsequent entries before vol info.-->
           </else>
         </choose>
       </else-if>
@@ -696,19 +710,19 @@
         <choose>
           <if variable="volume">
             <choose>
-              <if type="chapter" variable="container-title" match="all"> <!--Filter SBL 6.2.23-->
+              <if type="chapter" variable="container-title" match="all">
+                <!--Filter SBL 6.2.23-->
                 <text variable="page" prefix=", "/>
               </if>
-              <else-if type="chapter" variable="collection-title" position="subsequent" match="all"> <!--Filter SBL 6.2.22-->
+              <else-if type="chapter" variable="collection-title" position="subsequent" match="all">
+                <!--Filter SBL 6.2.22-->
                 <text variable="page" prefix=", "/>
               </else-if>
-
               <else>
                 <number variable="volume" prefix=" " suffix=":"/>
                 <text variable="page"/>
               </else>
             </choose>
-
           </if>
           <else>
             <text variable="page" prefix=", "/>
@@ -836,20 +850,20 @@
       <group delimiter=" ">
         <text term="sub verbo" form="short"/>
         <text variable="title" text-case="title" quotes="true"/>
+      </group>
     </group>
-  </group>
   </macro>
   <macro name="signed-dictionary-note">
     <choose>
       <if position="subsequent">
-          <group delimiter=", ">
-            <text macro="contributors-short"/>
-            <choose>
-              <if position="ibid" match="none">
-                <!-- Excludes Title for ibid entries per CMS 14.34.-->
-                <text macro="title-short"/>
-              </if>
-            </choose>
+        <group delimiter=", ">
+          <text macro="contributors-short"/>
+          <choose>
+            <if position="ibid" match="none">
+              <!-- Excludes Title for ibid entries per CMS 14.34.-->
+              <text macro="title-short"/>
+            </if>
+          </choose>
           <text macro="point-locators-subsequent"/>
         </group>
       </if>
@@ -892,51 +906,51 @@
           </choose>
         </if>
         <!-- Not Lexicon/Dictionary/Encyclopedia -->
-            <else-if position="subsequent">
-                  <group delimiter=", ">
-                    <text macro="contributors-short"/>
-                    <!-- Implements conditional check to exclude title in ibid entries (see CMS 14.34) -->
-                    <choose>
-                      <if type="post-weblog">
-                        <text macro="title-short"/>
-                      </if>
-                      <else-if position="ibid" match="none">
-                        <text macro="title-short"/>
-                        <text macro="disambiguate-chapter"/>
-                      </else-if>
-                    </choose>
-                    <text macro="point-locators-subsequent"/>
-                  </group>
-            </else-if>
-            <else>
-              <group delimiter=", ">
-                <text macro="contributors-note"/>
-                <text macro="title-note"/>
-                <text macro="description-note"/>
-                <text macro="secondary-contributors-note"/>
-                <text macro="container-title-note"/>
-                <text macro="container-contributors-note"/>
-                <choose>
-                  <if variable="volume collection-title" match="all">
-                  <!--If Volume # and collection-title -->
-                      <group delimiter=" ">
-                      <!--Added group to prevent comma between vol # of...and collection-title-->
-                        <text macro="locators-note"/>
-                        <text macro="collection-title-note"/>
-                      </group>
-                  </if>
-                  <else>
-                    <text macro="locators-note"/>
-                    <text macro="collection-title-note"/>
-                  </else>
-                </choose>
-                <text macro="collection-editor-note"/>
-              </group>
-              <text macro="issue-note"/>
-              <text macro="locators-newspaper" prefix=", "/>
-              <text macro="point-locators"/>
-              <text macro="access-note" prefix=", "/>
-            </else>
+        <else-if position="subsequent">
+          <group delimiter=", ">
+            <text macro="contributors-short"/>
+            <!-- Implements conditional check to exclude title in ibid entries (see CMS 14.34) -->
+            <choose>
+              <if type="post-weblog">
+                <text macro="title-short"/>
+              </if>
+              <else-if position="ibid" match="none">
+                <text macro="title-short"/>
+                <text macro="disambiguate-chapter"/>
+              </else-if>
+            </choose>
+            <text macro="point-locators-subsequent"/>
+          </group>
+        </else-if>
+        <else>
+          <group delimiter=", ">
+            <text macro="contributors-note"/>
+            <text macro="title-note"/>
+            <text macro="description-note"/>
+            <text macro="secondary-contributors-note"/>
+            <text macro="container-title-note"/>
+            <text macro="container-contributors-note"/>
+            <choose>
+              <if variable="volume collection-title" match="all">
+                <!--If Volume # and collection-title -->
+                <group delimiter=" ">
+                  <!--Added group to prevent comma between vol # of...and collection-title-->
+                  <text macro="locators-note"/>
+                  <text macro="collection-title-note"/>
+                </group>
+              </if>
+              <else>
+                <text macro="locators-note"/>
+                <text macro="collection-title-note"/>
+              </else>
+            </choose>
+            <text macro="collection-editor-note"/>
+          </group>
+          <text macro="issue-note"/>
+          <text macro="locators-newspaper" prefix=", "/>
+          <text macro="point-locators"/>
+          <text macro="access-note" prefix=", "/>
+        </else>
       </choose>
     </layout>
   </citation>
@@ -962,30 +976,30 @@
         </if>
         <!-- Not Dictionary -->
         <else>
-            <group delimiter=". ">
-              <text macro="contributors"/>
-              <text macro="title"/>
-              <text macro="description"/>
-              <text macro="secondary-contributors"/>
-              <text macro="container-title"/>
-              <text macro="container-contributors"/>
-            </group>
-            <choose>
-              <if variable="volume collection-title" match="all">
+          <group delimiter=". ">
+            <text macro="contributors"/>
+            <text macro="title"/>
+            <text macro="description"/>
+            <text macro="secondary-contributors"/>
+            <text macro="container-title"/>
+            <text macro="container-contributors"/>
+          </group>
+          <choose>
+            <if variable="volume collection-title" match="all">
               <!--If Volume # and collection-title -->
-                  <text macro="locators"/>
-                  <text macro="collection-title" text-case="title" prefix=" "/>
-              </if>
-              <else>
-                <text macro="locators"/>
-                <text macro="collection-title" text-case="title" prefix=". "/>
-              </else>
-            </choose>
-            <text macro="collection-editor"/>
-            <text macro="issue"/>
-            <text macro="locators-newspaper" prefix=", "/>
-            <text macro="locators-journal"/>
-            <text macro="access" prefix=". "/>
+              <text macro="locators"/>
+              <text macro="collection-title" text-case="title" prefix=" "/>
+            </if>
+            <else>
+              <text macro="locators"/>
+              <text macro="collection-title" text-case="title" prefix=". "/>
+            </else>
+          </choose>
+          <text macro="collection-editor"/>
+          <text macro="issue"/>
+          <text macro="locators-newspaper" prefix=", "/>
+          <text macro="locators-journal"/>
+          <text macro="access" prefix=". "/>
         </else>
       </choose>
     </layout>

--- a/society-of-biblical-literature-fullnote-bibliography.csl
+++ b/society-of-biblical-literature-fullnote-bibliography.csl
@@ -763,6 +763,32 @@
     </group>
   </group>
   </macro>
+  <macro name="signed-dictionary-note">
+    <choose>
+      <if position="subsequent">
+          <group delimiter=", ">
+            <text macro="contributors-short"/>
+            <choose>
+              <if position="ibid" match="none">
+                <!-- Excludes Title for ibid entries per CMS 14.34.-->
+                <text macro="title-short"/>
+              </if>
+            </choose>
+          <text macro="point-locators-subsequent"/>
+        </group>
+      </if>
+      <else>
+        <group delimiter="">
+          <group delimiter=", ">
+            <text macro="contributors-note"/>
+            <text macro="title-note"/>
+            <text macro="container-title-note"/>
+          </group>
+          <text macro="point-locators"/>
+        </group>
+      </else>
+    </choose>
+  </macro>
   <citation et-al-min="4" et-al-use-first="1" disambiguate-add-names="true">
     <layout suffix="." delimiter="; ">
       <choose>

--- a/society-of-biblical-literature-fullnote-bibliography.csl
+++ b/society-of-biblical-literature-fullnote-bibliography.csl
@@ -323,11 +323,11 @@
     </choose>
   </macro>
   <macro name="collection-title">
-    <text variable="collection-title" form="short"/>
+    <text variable="collection-title" form="short" text-case="title"/>
     <text variable="collection-number" prefix=" "/>
   </macro>
   <macro name="collection-title-note">
-    <text variable="collection-title" form="short"/>
+    <text variable="collection-title" form="short" text-case="title"/>
     <text variable="collection-number" prefix=" "/>
   </macro>
   <macro name="container-title">

--- a/society-of-biblical-literature-fullnote-bibliography.csl
+++ b/society-of-biblical-literature-fullnote-bibliography.csl
@@ -406,6 +406,8 @@
     <choose>
       <if type="bill book chapter graphic legal_case legislation motion_picture paper-conference report song" match="any">
         <group delimiter=", ">
+          <!--Repositioned Edition to proceed volume-->
+          <text macro="edition-note"/>
           <group>
             <text term="volume" form="short" suffix=" "/>
             <number variable="volume" form="numeric"/>
@@ -414,7 +416,7 @@
             <number variable="number-of-volumes" form="numeric"/>
             <text term="volume" form="short" prefix=" " plural="true"/>
           </group>
-          <text macro="edition-note"/>
+
         </group>
       </if>
     </choose>

--- a/society-of-biblical-literature-fullnote-bibliography.csl
+++ b/society-of-biblical-literature-fullnote-bibliography.csl
@@ -482,8 +482,8 @@
           </else-if>
           <else>
             <date variable="issued">
+              <date-part name="day" suffix=" "/>
               <date-part name="month" suffix=" "/>
-              <date-part name="day" suffix=", "/>
               <date-part name="year"/>
             </date>
           </else>

--- a/society-of-biblical-literature-fullnote-bibliography.csl
+++ b/society-of-biblical-literature-fullnote-bibliography.csl
@@ -749,6 +749,20 @@
       <text variable="URL"/>
     </group>
   </macro>
+  <macro name="unsigned-dictionary-note">
+    <group delimiter=", ">
+      <group>
+        <text variable="container-title" font-style="italic" text-case="uppercase"/>
+        <number variable="volume" prefix=" "/>
+        <text variable="collection-title" text-case="uppercase"/>
+        <text variable="collection-number" prefix=" "/>
+      </group>
+      <group delimiter=" ">
+        <text term="sub verbo" form="short"/>
+        <text variable="title" text-case="title" quotes="true"/>
+    </group>
+  </group>
+  </macro>
   <citation et-al-min="4" et-al-use-first="1" disambiguate-add-names="true">
     <layout suffix="." delimiter="; ">
       <choose>

--- a/society-of-biblical-literature-fullnote-bibliography.csl
+++ b/society-of-biblical-literature-fullnote-bibliography.csl
@@ -616,8 +616,28 @@
       <if type="article-journal">
         <text variable="page" prefix=": "/>
       </if>
-      <else-if type="chapter paper-conference" match="any">
-        <text variable="page" prefix=", "/>
+      <else-if type="chapter paper-conference entry-dictionary entry-encyclopedia" match="any">
+        <choose>
+          <if variable="volume">
+            <choose>
+              <if type="chapter" variable="container-title" match="all"> <!--Filter SBL 6.2.23-->
+                <text variable="page" prefix=", "/>
+              </if>
+              <else-if type="chapter" variable="collection-title" position="subsequent" match="all"> <!--Filter SBL 6.2.22-->
+                <text variable="page" prefix=", "/>
+              </else-if>
+
+              <else>
+                <number variable="volume" prefix=" " suffix=":"/>
+                <text variable="page"/>
+              </else>
+            </choose>
+
+          </if>
+          <else>
+            <text variable="page" prefix=", "/>
+          </else>
+        </choose>
       </else-if>
     </choose>
   </macro>

--- a/society-of-biblical-literature-fullnote-bibliography.csl
+++ b/society-of-biblical-literature-fullnote-bibliography.csl
@@ -792,40 +792,65 @@
   <citation et-al-min="4" et-al-use-first="1" disambiguate-add-names="true">
     <layout suffix="." delimiter="; ">
       <choose>
-        <if position="ibid-with-locator">
-          <group delimiter=", ">
-            <text term="ibid"/>
-            <text macro="point-locators-subsequent"/>
-          </group>
+        <!-- Lexicon/Dictionary/Encyclopedia -->
+        <if type="entry-dictionary entry-encyclopedia" match="any">
+          <choose>
+            <if match="none" variable="author">
+              <!-- Unsigned Lexicon/Dictionary/Encyclopedia -->
+              <text macro="unsigned-dictionary-note"/>
+            </if>
+            <else>
+              <!-- Signed Lexicon/Dictionary/Encyclopedia -->
+              <text macro="signed-dictionary-note"/>
+            </else>
+          </choose>
         </if>
-        <else-if position="ibid">
-          <text term="ibid"/>
-        </else-if>
-        <else-if position="subsequent">
-          <group delimiter=", ">
-            <text macro="contributors-short"/>
-            <text macro="title-short"/>
-            <text macro="disambiguate-chapter"/>
-            <text macro="point-locators-subsequent"/>
-          </group>
-        </else-if>
-        <else>
-          <group delimiter=", ">
-            <text macro="contributors-note"/>
-            <text macro="title-note"/>
-            <text macro="description-note"/>
-            <text macro="secondary-contributors-note"/>
-            <text macro="container-title-note"/>
-            <text macro="container-contributors-note"/>
-            <text macro="locators-note"/>
-            <text macro="collection-title-note"/>
-            <text macro="collection-editor-note"/>
-          </group>
-          <text macro="issue-note"/>
-          <text macro="locators-newspaper" prefix=", "/>
-          <text macro="point-locators"/>
-          <text macro="access-note" prefix=", "/>
-        </else>
+        <!-- Not Lexicon/Dictionary/Encyclopedia -->
+            <else-if position="subsequent">
+                  <group delimiter=", ">
+                    <text macro="contributors-short"/>
+                    <!-- Implements conditional check to exclude title in ibid entries (see CMS 14.34) -->
+                    <choose>
+                      <if type="post-weblog">
+                        <text macro="title-short"/>
+                      </if>
+                      <else-if position="ibid" match="none">
+                        <text macro="title-short"/>
+                        <text macro="disambiguate-chapter"/>
+                      </else-if>
+                    </choose>
+                    <text macro="point-locators-subsequent"/>
+                  </group>
+            </else-if>
+            <else>
+              <group delimiter=", ">
+                <text macro="contributors-note"/>
+                <text macro="title-note"/>
+                <text macro="description-note"/>
+                <text macro="secondary-contributors-note"/>
+                <text macro="container-title-note"/>
+                <text macro="container-contributors-note"/>
+                <choose>
+                  <if variable="volume collection-title" match="all">
+                  <!--If Volume # and collection-title -->
+                      <group delimiter=" ">
+                      <!--Added group to prevent comma between vol # of...and collection-title-->
+                        <text macro="locators-note"/>
+                        <text macro="collection-title-note"/>
+                      </group>
+                  </if>
+                  <else>
+                    <text macro="locators-note"/>
+                    <text macro="collection-title-note"/>
+                  </else>
+                </choose>
+                <text macro="collection-editor-note"/>
+              </group>
+              <text macro="issue-note"/>
+              <text macro="locators-newspaper" prefix=", "/>
+              <text macro="point-locators"/>
+              <text macro="access-note" prefix=", "/>
+            </else>
       </choose>
     </layout>
   </citation>

--- a/society-of-biblical-literature-fullnote-bibliography.csl
+++ b/society-of-biblical-literature-fullnote-bibliography.csl
@@ -33,6 +33,10 @@
       <term name="translator" form="verb-short">trans.</term>
       <term name="translator" form="short">trans.</term>
       <term name="editortranslator" form="verb">edited and translated by</term>
+      <term name="collection-editor">
+          <single>ed.</single>
+          <multiple>eds.</multiple>
+      </term>
     </terms>
   </locale>
   <macro name="editor-translator">
@@ -84,6 +88,12 @@
     <names variable="editor">
       <name and="text" sort-separator=", " delimiter=", "/>
       <label form="short" prefix=", "/>
+    </names>
+  </macro>
+  <macro name="collection-editor-note">
+    <names variable="collection-editor">
+      <label form="short" suffix=" "/>
+      <name and="text" sort-separator=", " delimiter=", "/>
     </names>
   </macro>
   <macro name="translator-note">
@@ -686,6 +696,7 @@
             <text macro="container-contributors-note"/>
             <text macro="locators-note"/>
             <text macro="collection-title-note"/>
+            <text macro="collection-editor-note"/>
           </group>
           <text macro="issue-note"/>
           <text macro="locators-newspaper" prefix=", "/>

--- a/society-of-biblical-literature-fullnote-bibliography.csl
+++ b/society-of-biblical-literature-fullnote-bibliography.csl
@@ -855,18 +855,20 @@
   </macro>
   <macro name="signed-dictionary-note">
     <choose>
-      <if position="subsequent">
+      <if position="ibid">
+        <!-- Excludes Title for ibid entries per CMS 14.34.-->
         <group delimiter=", ">
           <text macro="contributors-short"/>
-          <choose>
-            <if position="ibid" match="none">
-              <!-- Excludes Title for ibid entries per CMS 14.34.-->
-              <text macro="title-short"/>
-            </if>
-          </choose>
           <text macro="point-locators-subsequent"/>
         </group>
       </if>
+      <else-if position="subsequent">
+        <group delimiter=", ">
+          <text macro="contributors-short"/>
+          <text macro="title-short"/>
+          <text macro="point-locators-subsequent"/>
+        </group>
+      </else-if>
       <else>
         <group delimiter="">
           <group delimiter=", ">
@@ -906,19 +908,23 @@
           </choose>
         </if>
         <!-- Not Lexicon/Dictionary/Encyclopedia -->
-        <else-if position="subsequent">
+        <else-if position="ibid">
+          <!-- Implements conditional check to exclude title in ibid entries, except for blog posts (see CMS 14.34) -->
           <group delimiter=", ">
             <text macro="contributors-short"/>
-            <!-- Implements conditional check to exclude title in ibid entries (see CMS 14.34) -->
             <choose>
               <if type="post-weblog">
                 <text macro="title-short"/>
               </if>
-              <else-if position="ibid" match="none">
-                <text macro="title-short"/>
-                <text macro="disambiguate-chapter"/>
-              </else-if>
             </choose>
+            <text macro="point-locators-subsequent"/>
+          </group>
+        </else-if>
+        <else-if position="subsequent">
+          <group delimiter=", ">
+            <text macro="contributors-short"/>
+            <text macro="title-short"/>
+            <text macro="disambiguate-chapter"/>
             <text macro="point-locators-subsequent"/>
           </group>
         </else-if>

--- a/society-of-biblical-literature-fullnote-bibliography.csl
+++ b/society-of-biblical-literature-fullnote-bibliography.csl
@@ -408,15 +408,38 @@
         <group delimiter=", ">
           <!--Repositioned Edition to proceed volume-->
           <text macro="edition-note"/>
-          <group>
-            <text term="volume" form="short" suffix=" "/>
-            <number variable="volume" form="numeric"/>
-          </group>
-          <group>
-            <number variable="number-of-volumes" form="numeric"/>
-            <text term="volume" form="short" prefix=" " plural="true"/>
-          </group>
-
+          <choose>
+            <if variable="volume"><!--If volume-->
+                <choose>
+                    <if type="book" variable="collection-title" match="all"> <!--SBL 6.2.21-->
+                          <group>
+                            <text term="volume" form="short" suffix=" "/>
+                            <number variable="volume" form="numeric"/>
+                            <text value=" of"/>
+                          </group>
+                    </if>
+                    <else-if type="chapter" variable="container-title" match="all"> <!--SBL 6.2.23-->
+                          <group>
+                            <text term="volume" form="short" suffix=" "/>
+                            <number variable="volume" form="numeric"/>
+                            <text value=" of"/>
+                          </group>
+                    </else-if>
+                    <else-if variable="locator page" match="none">
+                      <group>
+                        <text term="volume" form="short" suffix=" "/>
+                        <number variable="volume" form="numeric"/>
+                      </group>
+                    </else-if>
+                  </choose>
+            </if>
+            <else>
+              <group>
+                <number variable="number-of-volumes" form="numeric"/>
+                <text term="volume" form="short" prefix=" " plural="true"/>
+              </group>
+            </else>
+          </choose>
         </group>
       </if>
     </choose>

--- a/society-of-biblical-literature-fullnote-bibliography.csl
+++ b/society-of-biblical-literature-fullnote-bibliography.csl
@@ -327,8 +327,27 @@
     <text variable="collection-number" prefix=" "/>
   </macro>
   <macro name="collection-title-note">
-    <text variable="collection-title" form="short" text-case="title"/>
-    <text variable="collection-number" prefix=" "/>
+    <choose>
+      <if variable="volume number-of-volumes" match="any">
+      <!-- Presence of Volume info indicates multivolume work rather than series -->
+          <choose>
+            <!-- This section required here rather than in title-note because the group delimiter inserts an unneeded comma otherwise-->
+            <if type="chapter paper-conference" match="any">
+              <choose>
+                <if variable="container-title" match="none">
+                  <text term="in" suffix=" "/>
+                </if>
+              </choose>
+            </if>
+          </choose>
+        <text variable="collection-title" form="short" text-case="title" font-style="italic"/>
+        <text variable="collection-number" prefix=" "/>
+      </if>
+      <else>
+        <text variable="collection-title" form="short" text-case="title"/>
+        <text variable="collection-number" prefix=" "/>
+      </else>
+    </choose>
   </macro>
   <macro name="container-title">
     <choose>

--- a/society-of-biblical-literature-fullnote-bibliography.csl
+++ b/society-of-biblical-literature-fullnote-bibliography.csl
@@ -560,16 +560,25 @@
           </choose>
           <text variable="locator"/>
         </if>
-        <else-if variable="volume locator" position="subsequent" match="all">
+        <else-if variable="volume">
           <choose>
-            <if type="bill book graphic legal_case legislation motion_picture report song chapter paper-conference" match="any">
+            <if type="book" variable="collection-title" match="all"> <!--Filter SBL 6.2.21-->
+              <text variable="locator"/>
+            </if>
+            <else-if type="chapter" variable="container-title" match="all"> <!--Filter SBL 6.2.23-->
+              <text variable="locator"/>
+            </else-if>
+            <else-if type="chapter" variable="collection-title" position="subsequent" match="all"> <!--Filter SBL 6.2.22-->
+              <text variable="locator"/>
+            </else-if>
+            <else-if type="article-journal"><!--Filter SBL 6.3.1-->
+              <text variable="locator"/>
+            </else-if>
+            <else>
               <group delimiter=":">
                 <number variable="volume" form="numeric"/>
                 <text variable="locator"/>
               </group>
-            </if>
-            <else>
-              <text variable="locator"/>
             </else>
           </choose>
         </else-if>

--- a/society-of-biblical-literature-fullnote-bibliography.csl
+++ b/society-of-biblical-literature-fullnote-bibliography.csl
@@ -332,13 +332,10 @@
     </choose>
   </macro>
   <macro name="collection-title">
-    <!--TODO: Macro is identical to collection-title-note. Seperate macros not needed?-->
     <choose>
       <if variable="volume number-of-volumes" match="any">
       <!-- Presence of Volume info indicates multivolume work rather than series -->
           <choose>
-            <!--TODO: Is this needed? Creates double "in".-->
-            <!--TODO: Determine best location.-->
             <!--This section required here rather than in title-note because the group delimiter inserts an unneeded comma otherwise-->
             <if type="chapter" variable="container-title" match="all"> <!--Filter SBL 6.2.23-->
             </if>


### PR DESCRIPTION
Several updates to bring the style more in compliance with SBL 2.

Most significantly:
* Handling for signed and unsigned dictionary entries (SBL 6.3.6 & 6.3.7; also this series of posts: https://sblhs2.com/2017/03/28/citing-reference-works-1/)
* Handling for multivolume works (6.2.20-6.2.23)
* Using short titles rather than ibid per CMS 17 recommendations (CMS 14.34 specifically).

NB: Current changes should only affect footnote citations. Bibliography updates are coming once I get a chance to check the changes locally.