### PR TITLE
Updated the AMA base style to properly reference presentations

### DIFF
--- a/american-medical-association.csl
+++ b/american-medical-association.csl
@@ -220,17 +220,17 @@
           <text variable="container-title" prefix=" " suffix="."/>
         </else-if>
         <else-if type="speech">
-          <group>
+          <group delimiter=" ">
             <text variable="genre" prefix=" " suffix=" presented at:"/>
-            <text variable="event" prefix=" " suffix=";"/>
-              <group prefix=" " suffix=";">
-                <date variable="issued">
-                  <date-part name="month" suffix=" "/>
-                  <date-part name="day" suffix=", "/>
+            <text variable="event" suffix=";"/>
+              <group suffix=";">
+                <date delimiter=" " variable="issued">
+                  <date-part name="month"/>
+                  <date-part name="day" suffix=","/>
                   <date-part name="year"/>
                 </date>
               </group>
-            <text variable="event-place" prefix=" " suffix="."/>
+            <text variable="event-place" suffix="."/>
           </group>
         </else-if>
         <else>

--- a/american-medical-association.csl
+++ b/american-medical-association.csl
@@ -14,10 +14,14 @@
       <name>Christian Pietsch</name>
       <uri>http://purl.org/net/pietsch</uri>
     </contributor>
+    <contributor>
+      <name>Daniel W Chan</name>
+      <email>danwchan@protonmail.com</email>
+    </contributor>
     <category citation-format="numeric"/>
     <category field="medicine"/>
     <summary>The American Medical Association style as used in JAMA.</summary>
-    <updated>2012-09-30T23:10:36+00:00</updated>
+    <updated>2018-01-17T23:13:16-05:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale xml:lang="en">
@@ -214,6 +218,20 @@
         </else-if>
         <else-if type="webpage">
           <text variable="container-title" prefix=" " suffix="."/>
+        </else-if>
+        <else-if type="presentation ">
+          <group>
+            <text variable="presentationType" prefix=" " suffix="presented at:"/>
+            <text variable="meetingName" prefix=" " suffix=";"/>
+              <group prefix=" " suffix=";">
+                <date variable="issued">
+                  <date-part name="month" suffix=" "/>
+                  <date-part name="day" suffix=", "/>
+                  <date-part name="year"/>
+                </date>
+              </group>
+            <text variable="place" prefix=" " suffix="."/>
+          </group>
         </else-if>
         <else>
           <text macro="editor" prefix=" " suffix="."/>

--- a/american-medical-association.csl
+++ b/american-medical-association.csl
@@ -21,7 +21,7 @@
     <category citation-format="numeric"/>
     <category field="medicine"/>
     <summary>The American Medical Association style as used in JAMA.</summary>
-    <updated>2018-01-17T23:13:16-05:00</updated>
+    <updated>2018-01-18T23:11:17-05:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale xml:lang="en">
@@ -219,10 +219,10 @@
         <else-if type="webpage">
           <text variable="container-title" prefix=" " suffix="."/>
         </else-if>
-        <else-if type="presentation ">
+        <else-if type="speech">
           <group>
-            <text variable="presentationType" prefix=" " suffix="presented at:"/>
-            <text variable="meetingName" prefix=" " suffix=";"/>
+            <text variable="genre" prefix=" " suffix=" presented at:"/>
+            <text variable="event" prefix=" " suffix=";"/>
               <group prefix=" " suffix=";">
                 <date variable="issued">
                   <date-part name="month" suffix=" "/>
@@ -230,7 +230,7 @@
                   <date-part name="year"/>
                 </date>
               </group>
-            <text variable="place" prefix=" " suffix="."/>
+            <text variable="event-place" prefix=" " suffix="."/>
           </group>
         </else-if>
         <else>

--- a/american-medical-association.csl
+++ b/american-medical-association.csl
@@ -232,16 +232,7 @@
             </choose>
           </group>
           <group delimiter="; " prefix=" " suffix=".">
-            <group>
-            <choose>
-              <if variable="event">
-                <text variable="event"/>
-              </if>
-              <else>
-                <text term="an unnamed conference" text-case="capitalize-first"/>
-              </else>
-            </choose>
-            </group>
+            <text variable="event"/>
             <group>
               <date delimiter=" " variable="issued">
                 <date-part name="month"/>

--- a/american-medical-association.csl
+++ b/american-medical-association.csl
@@ -220,17 +220,36 @@
           <text variable="container-title" prefix=" " suffix="."/>
         </else-if>
         <else-if type="speech">
-          <group delimiter=" ">
-            <text variable="genre" prefix=" " suffix=" presented at:"/>
-            <text variable="event" suffix=";"/>
-              <group suffix=";">
-                <date delimiter=" " variable="issued">
-                  <date-part name="month"/>
-                  <date-part name="day" suffix=","/>
-                  <date-part name="year"/>
-                </date>
-              </group>
-            <text variable="event-place" suffix="."/>
+          <group prefix=" " suffix=":">
+            <choose>
+              <if variable="genre">
+                <text variable="genre" suffix=" "/>
+                <text term="presented at"/>
+              </if>
+              <else>
+                <text term="presented at" text-case="capitalize-first"/>
+              </else>
+            </choose>
+          </group>
+          <group delimiter="; " prefix=" " suffix=".">
+            <group>
+            <choose>
+              <if variable="event">
+                <text variable="event"/>
+              </if>
+              <else>
+                <text term="an unnamed conference" text-case="capitalize-first"/>
+              </else>
+            </choose>
+            </group>
+            <group>
+              <date delimiter=" " variable="issued">
+                <date-part name="month"/>
+                <date-part name="day" suffix=","/>
+                <date-part name="year"/>
+              </date>
+            </group>
+            <text variable="event-place"/>
           </group>
         </else-if>
         <else>

--- a/american-medical-association.csl
+++ b/american-medical-association.csl
@@ -21,7 +21,7 @@
     <category citation-format="numeric"/>
     <category field="medicine"/>
     <summary>The American Medical Association style as used in JAMA.</summary>
-    <updated>2018-01-18T11:17-05:00</updated>
+    <updated>2018-01-18T11:17:00-05:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale xml:lang="en">

--- a/society-for-american-archaeology.csl
+++ b/society-for-american-archaeology.csl
@@ -10,12 +10,15 @@
       <email>michael.barton@asu.edu</email>
     </author>
     <contributor>
+      <name>Patrick O'Brien</name>
+    </contributor>
+    <contributor>
       <name>Allison Grunwald</name>
       <email>agrunwa1@uwyo.edu</email>
     </contributor>
     <category citation-format="author-date"/>
     <category field="anthropology"/>
-    <updated>2012-10-25T21:15:26+00:00</updated>
+    <updated>2018-01-17T11:57:41+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale>
@@ -27,20 +30,10 @@
   <macro name="secondary-contributors">
     <choose>
       <if type="chapter paper-conference" match="none">
-        <group delimiter=". ">
-          <names variable="editor">
-            <label form="verb-short" prefix=" " text-case="capitalize-first" suffix=" "/>
-            <name and="text" delimiter=", "/>
-          </names>
-          <choose>
-            <if variable="author editor" match="any">
-              <names variable="translator">
-                <label form="verb-short" prefix=" " text-case="capitalize-first" suffix=" "/>
-                <name and="text" delimiter=", "/>
-              </names>
-            </if>
-          </choose>
-        </group>
+        <names variable="editor translator" delimiter=". ">
+          <label form="verb" prefix=" " text-case="capitalize-first" suffix=" "/>
+          <name and="text" delimiter=", "/>
+        </names>
       </if>
     </choose>
   </macro>
@@ -71,18 +64,6 @@
       </if>
     </choose>
   </macro>
-  <macro name="editor">
-    <names variable="editor">
-      <name name-as-sort-order="first" and="text" sort-separator=", " delimiter=", " delimiter-precedes-last="always"/>
-      <label form="long" prefix=" (" suffix=")."/>
-    </names>
-  </macro>
-  <macro name="translator">
-    <names variable="translator">
-      <name name-as-sort-order="first" and="text" sort-separator=", " delimiter=", " delimiter-precedes-last="always"/>
-      <label form="long" prefix=" (" suffix=")."/>
-    </names>
-  </macro>
   <macro name="recipient">
     <choose>
       <if type="personal_communication">
@@ -104,10 +85,10 @@
   <macro name="contributors">
     <names variable="author">
       <name and="text" name-as-sort-order="first" sort-separator=", " delimiter=", " delimiter-precedes-last="always"/>
-      <label form="verb-short" prefix=", "/>
+      <label prefix=" (" suffix=")"/>
       <substitute>
-        <text macro="editor"/>
-        <text macro="translator"/>
+        <names variable="editor"/>
+        <names variable="translator"/>
       </substitute>
     </names>
     <text macro="anon"/>
@@ -304,8 +285,7 @@
   </macro>
   <macro name="issue">
     <choose>
-      <if type="article-journal">
-      </if>
+      <if type="article-journal"/>
       <else-if type="speech">
         <group prefix=" " delimiter=", ">
           <text macro="event"/>
@@ -343,12 +323,16 @@
     <text macro="locators-article"/>
     <text macro="access" prefix=". "/>
   </macro>
+  <macro name="original-date">
+    <date date-parts="year" form="text" variable="original-date"/>
+  </macro>
   <citation et-al-min="3" et-al-use-first="1" disambiguate-add-year-suffix="true" disambiguate-add-names="true" disambiguate-add-givenname="false" collapse="year">
     <layout prefix="(" suffix=")" delimiter="; ">
       <group delimiter=":">
         <group delimiter=" ">
           <text macro="contributors-short"/>
           <text macro="date1"/>
+          <text macro="original-date"/>
         </group>
         <text macro="point-locators"/>
       </group>
@@ -359,12 +343,13 @@
       <key macro="contributors"/>
       <key variable="issued"/>
     </sort>
-    <layout suffix=".">
-      <group display="block">
+    <layout>
+      <group>
         <text macro="contributors"/>
       </group>
-      <group display="indent">
-        <text macro="date1" suffix="  "/>
+      <group display="indent" suffix=".">
+        <text macro="date1" suffix=" "/>
+        <text macro="original-date" prefix="[" suffix="] "/>
         <text macro="rest-of-bib"/>
       </group>
     </layout>


### PR DESCRIPTION
`speech` is the CSL type which seems most fitting for orally presented work at a conference. `genre` holds the type presented. The AMA style guide gives examples of types as "posters" or "papers". `event`, `event-place` and `date` hold the name, location and date of the conference.

an example of a properly rendered presentation from the AMA style guide:
> Greenspan A, Eerdekens M, Mahmoud R. Is there an increased rate of cerebrovascular events among dementia patients? Poster presented at: 24th Congress of the Collegium Internationale Neuro-Psychopharmacologicum (CINP); June 20–24, 2004; Paris, France.