### PR TITLE
expand page ranges in bibliography

### DIFF
--- a/apa.csl
+++ b/apa.csl
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" demote-non-dropping-particle="never">
+<style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" demote-non-dropping-particle="never" page-range-format="expanded">
   <info>
     <title>American Psychological Association 6th edition</title>
     <title-short>APA</title-short>


### PR DESCRIPTION
APA requires full (non-abbreviated) page ranges (e.g., 512-518) instead of shortened ones (e.g., 512-8). Because the latter is used in many medical journals, you often get shortened ranges pulled from online archives and have to edit by hand. The new option handles that automatically (tested and works in Mendeley).