### PR TITLE
Ibid update

### DIFF
--- a/society-of-biblical-literature-fullnote-bibliography.csl
+++ b/society-of-biblical-literature-fullnote-bibliography.csl
@@ -21,10 +21,13 @@
     <contributor>
       <name>Sebastian Karcher</name>
     </contributor>
+    <contributor>
+      <name>Tyler Mykkanen</name>
+    </contributor>
     <category citation-format="note"/>
     <category field="theology"/>
     <summary>Society of Biblical Literature format with full notes and bibliography</summary>
-    <updated>2016-11-30T13:46:46+00:00</updated>
+    <updated>2018-02-01T14:42:46+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale xml:lang="en-US">

--- a/society-of-biblical-literature-fullnote-bibliography.csl
+++ b/society-of-biblical-literature-fullnote-bibliography.csl
@@ -102,7 +102,6 @@
   </macro>
   <macro name="collection-editor">
     <group delimiter=", " prefix=". ">
-      <!--TODO: Refactor? Bib uses prefix whereas CSL style prefers groups with delimeters.-->
       <names variable="collection-editor" delimiter=", ">
         <label form="verb" prefix=" " text-case="capitalize-first" suffix=" "/>
         <name and="text" delimiter=", "/>
@@ -387,14 +386,14 @@
   </macro>
   <macro name="container-title">
     <choose>
-      <!-- Added dictionary and encyclopedia to get page and volume information TODO: Refactor as no longer needed?-->
+      <!-- Added dictionary and encyclopedia to get page and volume information-->
       <if type="chapter paper-conference entry-dictionary entry-encyclopedia" match="any">
         <group delimiter=" " suffix=" ">
           <label variable="page" form="long" text-case="capitalize-first"/>
           <text variable="page"/>
           <text term="in"/>
           <choose>
-            <!-- Added dictionary and encyclopedia to get volume information TODO: Refactor?-->
+            <!-- Added dictionary and encyclopedia to get volume information-->
             <if type="entry-dictionary entry-encyclopedia" match="any">
               <choose>
                 <if match="any" variable="volume">
@@ -545,7 +544,7 @@
           </choose>
         </group>
       </else-if>
-      <!-- Added dictionary and encyclopedia to properly display volume information TODO: Refactor?-->
+      <!-- Added dictionary and encyclopedia to properly display volume information-->
       <else-if type="entry-dictionary entry-encyclopedia">
         <group prefix=". ">
           <number variable="number-of-volumes" form="numeric"/>

--- a/society-of-biblical-literature-fullnote-bibliography.csl
+++ b/society-of-biblical-literature-fullnote-bibliography.csl
@@ -858,20 +858,13 @@
   </macro>
   <macro name="signed-dictionary-note">
     <choose>
-      <if position="ibid">
-        <!-- Excludes Title for ibid entries per CMS 14.34.-->
-        <group delimiter=", ">
-          <text macro="contributors-short"/>
-          <text macro="point-locators-subsequent"/>
-        </group>
-      </if>
-      <else-if position="subsequent">
+      <if position="subsequent">
         <group delimiter=", ">
           <text macro="contributors-short"/>
           <text macro="title-short"/>
           <text macro="point-locators-subsequent"/>
         </group>
-      </else-if>
+      </if>
       <else>
         <group delimiter="">
           <group delimiter=", ">
@@ -911,18 +904,6 @@
           </choose>
         </if>
         <!-- Not Lexicon/Dictionary/Encyclopedia -->
-        <else-if position="ibid">
-          <!-- Implements conditional check to exclude title in ibid entries, except for blog posts (see CMS 14.34) -->
-          <group delimiter=", ">
-            <text macro="contributors-short"/>
-            <choose>
-              <if type="post-weblog">
-                <text macro="title-short"/>
-              </if>
-            </choose>
-            <text macro="point-locators-subsequent"/>
-          </group>
-        </else-if>
         <else-if position="subsequent">
           <group delimiter=", ">
             <text macro="contributors-short"/>


### PR DESCRIPTION
1. Updates contributors

2. Removes stray TODO comments accidentally included in PR #3256 

3. Updates Ibid handling. SBL published new recommendations: https://sblhs2.com/2018/02/01/cms-update-ibid/  SBL will follow CMS by preferring short titles, but departs from CMS by using short titles for all subsequent entries. Therefore, checks to exclude short titles on ibid entries were removed.