### PR TITLE
Updates to sage-harvard.csl to conform more closely with style guide

### DIFF
--- a/sage-harvard.csl
+++ b/sage-harvard.csl
@@ -12,7 +12,7 @@
     <category citation-format="author-date"/>
     <category field="generic-base"/>
     <summary>The SAGE Harvard author-date style</summary>
-    <updated>2012-09-27T22:06:38+00:00</updated>
+    <updated>2017-05-18T15:23:08+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale xml:lang="en-GB">
@@ -63,7 +63,7 @@
   <macro name="access">
     <choose>
       <if variable="URL">
-        <text value="Available from: "/>
+        <text value="Available at: "/>
         <text variable="URL"/>
         <group prefix=" (" delimiter=" " suffix=")">
           <text term="accessed"/>
@@ -78,7 +78,7 @@
   </macro>
   <macro name="title">
     <choose>
-      <if type="bill book graphic legal_case motion_picture report song" match="any">
+      <if type="bill book graphic legal_case motion_picture report song thesis" match="any">
         <text variable="title" font-style="italic"/>
       </if>
       <else>
@@ -86,11 +86,28 @@
       </else>
     </choose>
   </macro>
+  <macro name="container-title">
+    <choose>
+      <if type="webpage" match="none">
+        <text variable="container-title" font-style="italic"/>
+      </if>
+    </choose>
+  </macro>
   <macro name="publisher">
-    <group delimiter=": ">
-      <text variable="publisher-place"/>
-      <text variable="publisher"/>
-    </group>
+    <choose>
+      <if type="thesis" match="any">
+        <group delimiter=", ">
+          <text variable="publisher"/>
+          <text variable="publisher-place"/>
+        </group>
+      </if>
+      <else>
+        <group delimiter=": ">
+          <text variable="publisher-place"/>
+          <text variable="publisher"/>
+        </group>
+      </else>
+    </choose>    
   </macro>
   <macro name="year-date">
     <choose>
@@ -114,9 +131,9 @@
   </macro>
   <macro name="published-date">
     <choose>
-      <if type="article-newspaper">
+      <if type="article-newspaper report" match="any">
         <date variable="issued">
-          <date-part name="day" form="ordinal" suffix=" "/>
+          <date-part name="day" suffix=" "/>
           <date-part name="month" form="long"/>
         </date>
       </if>
@@ -126,7 +143,7 @@
     <choose>
       <if type="chapter paper-conference" match="any">
         <group delimiter=" " prefix=", ">
-          <label variable="page" form="short" suffix=" "/>
+          <label variable="page" form="short"/>
           <text variable="page"/>
         </group>
       </if>
@@ -150,7 +167,7 @@
   </macro>
   <macro name="container-prefix">
     <choose>
-      <if type="chapter paper-conference" match="any">
+      <if type="chapter paper-conference post-weblog" match="any">
         <text term="in" text-case="capitalize-first" suffix=": "/>
       </if>
     </choose>
@@ -187,7 +204,7 @@
         <text macro="container-prefix"/>
         <group delimiter=", ">
           <text macro="editor"/>
-          <text variable="container-title" font-style="italic"/>
+          <text macro="container-title" font-style="italic"/>
           <text variable="collection-title"/>
           <text variable="genre"/>
           <text macro="publisher"/>

--- a/sage-harvard.csl
+++ b/sage-harvard.csl
@@ -204,7 +204,7 @@
         <text macro="container-prefix"/>
         <group delimiter=", ">
           <text macro="editor"/>
-          <text macro="container-title" font-style="italic"/>
+          <text macro="container-title"/>
           <text variable="collection-title"/>
           <text variable="genre"/>
           <text macro="publisher"/>


### PR DESCRIPTION
This PR makes the following changes to sage-harvard.csl to conform more closely to the published style guide (https://uk.sagepub.com/sites/default/files/sage_harvard_reference_style_0.pdf).

* Website location should be 'Available at', not 'Available from'
* There is no indication in the style guide that website title should be included
* Thesis titles should be italic
* The place of publication of a thesis is formatted differently to other document types
* Blog titles should be preceded by 'In: '. (Note the style guide seems to indicate no italics, but as this is inconsistent with all other uses of In: I've assumed it's a typo and kept italics)
* Full dates are included for reports 