### PR TITLE
SAGE Harvard

### DIFF
--- a/sage-harvard.csl
+++ b/sage-harvard.csl
@@ -144,6 +144,13 @@
       </if>
     </choose>
   </macro>
+  <macro name="genre">
+    <choose>
+      <if type="webpage post-weblog" match="none">
+        <text variable="genre"/>
+      </if>
+    </choose>
+  </macro>
   <macro name="pages">
     <choose>
       <if type="chapter" match="any">
@@ -210,7 +217,7 @@
             <text variable="container-title" font-style="italic"/>
           </group>
           <choose>
-            <if type="article-newspaper" match="any">
+            <if type="article-newspaper article-magazine" match="any">
               <date variable="issued">
                 <date-part name="day" suffix=" "/>
                 <date-part name="month" form="long"/>
@@ -242,6 +249,7 @@
       <key macro="author-count" names-min="3" names-use-first="3"/>
       <key macro="author" names-min="3" names-use-first="1"/>
       <key macro="year-date"/>
+      <key variable="citation-number" sort="ascending"/>
       <key variable="title"/>
     </sort>
     <layout suffix=".">
@@ -265,8 +273,12 @@
             </if>
           </choose>
           <group delimiter=", ">
-            <text variable="collection-title"/>
-            <text variable="genre"/>
+            <group delimiter=" ">
+              <text variable="collection-title"/>
+              <text variable="collection-number"/>
+              <text variable="number"/>
+            </group>
+            <text macro="genre"/>
             <text macro="published-date"/>
           </group>
           <text macro="publisher"/>

--- a/sage-harvard.csl
+++ b/sage-harvard.csl
@@ -232,6 +232,7 @@
     <sort>
       <key macro="author-short"/>
       <key macro="year-date"/>
+      <key variable="title"/>
     </sort>
     <layout prefix="(" suffix=")" delimiter="; ">
       <group delimiter=": ">
@@ -249,7 +250,6 @@
       <key macro="author-count" names-min="3" names-use-first="3"/>
       <key macro="author" names-min="3" names-use-first="1"/>
       <key macro="year-date"/>
-      <key variable="citation-number" sort="ascending"/>
       <key variable="title"/>
     </sort>
     <layout suffix=".">


### PR DESCRIPTION
More tweaks to SAGE-Harvard.csl

* suppress genre on websites. The connector often inserts a Website type of 'Text' into the database, which is not required in the output
* ensure numbers of reports etc are included
* sort order tweak addressing unexpected behaviour when two citations from the same author in the same year
* have magazines behave the same way as newspapers

Pretty much finished revising that paper, so this might be it now :)
