### PR TITLE
Change chinese-gb7714-* to fit the standard better.

### DIFF
--- a/chinese-gb7714-1987-numeric.csl
+++ b/chinese-gb7714-1987-numeric.csl
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" demote-non-dropping-particle="sort-only">
+<style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" demote-non-dropping-particle="sort-only" default-locale="zh-CN">
   <info>
     <title>Chinese Std GB/T 7714-1987 (numeric, Chinese)</title>
     <id>http://www.zotero.org/styles/chinese-gb7714-1987-numeric</id>

--- a/chinese-gb7714-1987-numeric.csl
+++ b/chinese-gb7714-1987-numeric.csl
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" demote-non-dropping-particle="sort-only" default-locale="zh-CN">
+<style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" demote-non-dropping-particle="sort-only">
   <info>
     <title>Chinese Std GB/T 7714-1987 (numeric, Chinese)</title>
     <id>http://www.zotero.org/styles/chinese-gb7714-1987-numeric</id>

--- a/chinese-gb7714-1987-numeric.csl
+++ b/chinese-gb7714-1987-numeric.csl
@@ -178,7 +178,7 @@
       <text variable="citation-number"/>
     </layout>
   </citation>
-  <bibliography et-al-min="3" et-al-use-first="1" second-field-align="flush" entry-spacing="0">
+  <bibliography et-al-min="4" et-al-use-first="3" second-field-align="flush" entry-spacing="0">
     <layout suffix=".">
       <text variable="citation-number" prefix="[" suffix="]"/>
       <text macro="author" suffix=". "/>

--- a/chinese-gb7714-2005-author-date.csl
+++ b/chinese-gb7714-2005-author-date.csl
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" demote-non-dropping-particle="sort-only" default-locale="zh-CN">
+<style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" demote-non-dropping-particle="sort-only">
   <info>
     <title>Chinese Std GB/T 7714-2005 (author-date, Chinese)</title>
     <id>http://www.zotero.org/styles/chinese-gb7714-2005-author-date</id>

--- a/chinese-gb7714-2005-author-date.csl
+++ b/chinese-gb7714-2005-author-date.csl
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" demote-non-dropping-particle="sort-only">
+<style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" demote-non-dropping-particle="sort-only" default-locale="zh-CN">
   <info>
     <title>Chinese Std GB/T 7714-2005 (author-date, Chinese)</title>
     <id>http://www.zotero.org/styles/chinese-gb7714-2005-author-date</id>

--- a/chinese-gb7714-2005-numeric.csl
+++ b/chinese-gb7714-2005-numeric.csl
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" demote-non-dropping-particle="sort-only">
+<style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" demote-non-dropping-particle="sort-only" default-locale="zh-CN">
   <info>
     <title>Chinese Std GB/T 7714-2005 (numeric, Chinese)</title>
     <id>http://www.zotero.org/styles/chinese-gb7714-2005-numeric</id>

--- a/chinese-gb7714-2005-numeric.csl
+++ b/chinese-gb7714-2005-numeric.csl
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" demote-non-dropping-particle="sort-only" default-locale="zh-CN">
+<style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" demote-non-dropping-particle="sort-only">
   <info>
     <title>Chinese Std GB/T 7714-2005 (numeric, Chinese)</title>
     <id>http://www.zotero.org/styles/chinese-gb7714-2005-numeric</id>

--- a/chinese-gb7714-2005-numeric.csl
+++ b/chinese-gb7714-2005-numeric.csl
@@ -189,7 +189,7 @@
       <text variable="citation-number"/>
     </layout>
   </citation>
-  <bibliography et-al-min="3" et-al-use-first="1" second-field-align="flush" entry-spacing="0">
+  <bibliography et-al-min="4" et-al-use-first="3" second-field-align="flush" entry-spacing="0">
     <layout suffix=".">
       <text variable="citation-number" prefix="[" suffix="]"/>
       <text macro="author" suffix=". "/>


### PR DESCRIPTION
I made two changes. 

First, and the most important, **et-al-use-first** is ought to be **3** according to the standard, then I changed **et-al-min** to **4** to fit it.

Second, I removed **default-locale** in files, since the standard specified strings such as "et al." should fit the native language of the original documents.

I'm not sure whether there is a proper way to process mixed-language references in the same thesis. So please tell me if I made anything wrong.