### PR TITLE
Update service-medical-de-l-assurance-maladie.csl

### DIFF
--- a/service-medical-de-l-assurance-maladie.csl
+++ b/service-medical-de-l-assurance-maladie.csl
@@ -14,7 +14,7 @@
     <category citation-format="author-date"/>
     <category field="medicine"/>
     <summary>Adaptation pour Zotero de l'adaptation de la norme de Vancouver en vigeur au Service Médical de l'Assurance Maladie</summary>
-    <updated>2016-12-16T10:15:01+00:00</updated>
+    <updated>2017-07-03T03:48:18+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale>
@@ -46,6 +46,7 @@
     <names variable="author">
       <name delimiter-precedes-last="always" initialize-with="" name-as-sort-order="all" sort-separator=" "/>
       <label prefix=", "/>
+	  <et-al font-style="italic"/>
       <substitute>
         <names variable="editor collection-editor"/>
       </substitute>
@@ -59,6 +60,7 @@
   <macro name="auteur-court">
     <names variable="author">
       <name form="short" delimiter-precedes-last="never" initialize="false"/>
+	  <et-al font-style="italic"/>
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>

--- a/service-medical-de-l-assurance-maladie.csl
+++ b/service-medical-de-l-assurance-maladie.csl
@@ -46,7 +46,7 @@
     <names variable="author">
       <name delimiter-precedes-last="always" initialize-with="" name-as-sort-order="all" sort-separator=" "/>
       <label prefix=", "/>
-	  <et-al font-style="italic"/>
+      <et-al font-style="italic"/>
       <substitute>
         <names variable="editor collection-editor"/>
       </substitute>
@@ -60,7 +60,7 @@
   <macro name="auteur-court">
     <names variable="author">
       <name form="short" delimiter-precedes-last="never" initialize="false"/>
-	  <et-al font-style="italic"/>
+	    <et-al font-style="italic"/>
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>


### PR DESCRIPTION
Modification to "et-al.", now in italics, as per the style requirements.
Didn't see the possibility italicise "et al." at the time. Now corrected.