### PR TITLE
Fixed style for Acta Orthopaedica - month + removed access + URL

### DIFF
--- a/acta-orthopaedica.csl
+++ b/acta-orthopaedica.csl
@@ -65,26 +65,11 @@
       <text variable="publisher"/>
     </group>
   </macro>
-  <macro name="accessed-date">
-    <choose>
-      <if variable="URL">
-        <group prefix="[" suffix="]" delimiter=" ">
-          <text term="cited" text-case="lowercase"/>
-          <date variable="accessed" form="text"/>
-        </group>
-      </if>
-    </choose>
-  </macro>
   <macro name="container-title">
     <choose>
       <if type="article-journal article-magazine chapter paper-conference article-newspaper" match="any">
         <group suffix="." delimiter=" ">
           <text variable="container-title" form="short" strip-periods="true"/>
-          <choose>
-            <if variable="URL">
-              <text term="internet" prefix="[" suffix="]" text-case="capitalize-first"/>
-            </if>
-          </choose>
         </group>
         <text macro="edition" prefix=" "/>
       </if>
@@ -109,11 +94,6 @@
     <text variable="title"/>
     <choose>
       <if type="article-journal article-magazine chapter paper-conference article-newspaper" match="none">
-        <choose>
-          <if variable="URL">
-            <text term="internet" prefix=" [" suffix="]" text-case="capitalize-first"/>
-          </if>
-        </choose>
         <text macro="edition" prefix=". "/>
       </if>
     </choose>
@@ -141,7 +121,6 @@
       <if type="article-journal article-magazine article-newspaper" match="any">
         <group suffix=";" delimiter=" ">
           <date date-parts="year" form="text" variable="issued" />
-          <text macro="accessed-date"/>
         </group>
       </if>
       <else-if type="bill legislation" match="any">
@@ -166,7 +145,6 @@
           <date variable="issued">
             <date-part name="year"/>
           </date>
-          <text macro="accessed-date" prefix=" "/>
         </group>
       </else>
     </choose>

--- a/acta-orthopaedica.csl
+++ b/acta-orthopaedica.csl
@@ -140,7 +140,7 @@
     <choose>
       <if type="article-journal article-magazine article-newspaper" match="any">
         <group suffix=";" delimiter=" ">
-          <date variable="issued" form="text"/>
+          <date date-parts="year" form="text" variable="issued" />
           <text macro="accessed-date"/>
         </group>
       </if>


### PR DESCRIPTION
The Acta Orthopaedica doesn't require months in the reference list. They also don't use the access/URL parts. Checked with one of the editors.