### PR TITLE
Add iso690-numeric-brackets-no-abstract-en

### DIFF
--- a/iso690-numeric-brackets-no-abstract-en.csl
+++ b/iso690-numeric-brackets-no-abstract-en.csl
@@ -1,0 +1,487 @@
+<?xml version="1.0" encoding="utf-8"?>
+<style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" demote-non-dropping-particle="never" default-locale="en-US">
+  <info>
+    <title>ISO-690 (numeric, brackets, no abstract, English)</title>
+    <id>http://www.zotero.org/styles/iso690-numeric-brackets-no-abstract-en</id>
+    <link href="http://www.zotero.org/styles/iso690-numeric-brackets-no-abstract-en" rel="self"/>
+    <link href="http://www.zotero.org/styles/iso690-numeric-en" rel="template"/>
+    <link href="https://github.com/citation-style-language/styles/pull/3348" rel="documentation"/>
+    <author>
+      <name>Heidi Vanparys</name>
+      <email>heidi.vanparys@gmail.com</email>
+    </author>
+    <category citation-format="numeric"/>
+    <category field="generic-base"/>
+    <summary>Style based on ISO 690:2010(E), V1.1</summary>
+    <updated>2018-02-20T22:45:00+01:00</updated>
+    <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
+  </info>
+  <locale>
+    <terms>
+      <term name="no date">[no date]</term>
+      <term name="in">in</term>
+      <term name="online">online</term>
+      <term name="accessed">accessed</term>
+      <term name="retrieved">Available</term>
+      <term name="from">from</term>
+    </terms>
+  </locale>
+  <macro name="author">
+    <names variable="author">
+      <name and="text" name-as-sort-order="all" sort-separator=", " delimiter=", " delimiter-precedes-last="never">
+        <name-part name="family" text-case="uppercase"/>
+        <name-part name="given"/>
+      </name>
+    </names>
+  </macro>
+  <macro name="editor">
+    <names variable="editor">
+      <name and="text" name-as-sort-order="all" sort-separator=", " delimiter=", " delimiter-precedes-last="never">
+        <name-part name="family" text-case="uppercase"/>
+        <name-part name="given"/>
+      </name>
+      <label prefix=" (" form="short" suffix=".)"/>
+    </names>
+  </macro>
+  <macro name="translator">
+    <names variable="translator">
+      <name and="text" name-as-sort-order="all" sort-separator=", " delimiter=", " delimiter-precedes-last="never">
+        <name-part name="family" text-case="uppercase"/>
+        <name-part name="given"/>
+      </name>
+      <label prefix=" (" form="short" suffix=".)"/>
+    </names>
+  </macro>
+  <macro name="responsability">
+    <choose>
+      <if variable="author editor translator" match="any">
+        <choose>
+          <if variable="author">
+            <text macro="author"/>
+          </if>
+          <else-if variable="editor">
+            <text macro="editor"/>
+          </else-if>
+          <else>
+            <text macro="translator"/>
+          </else>
+        </choose>
+      </if>
+    </choose>
+  </macro>
+  <macro name="container-author">
+    <names variable="container-author">
+      <name and="text" name-as-sort-order="all" sort-separator=", " delimiter=", " delimiter-precedes-last="never">
+        <name-part name="family" text-case="uppercase"/>
+        <name-part name="given"/>
+      </name>
+    </names>
+  </macro>
+  <macro name="container-responsability">
+    <choose>
+      <if variable="container-author editor translator" match="any">
+        <choose>
+          <if variable="container-author">
+            <text macro="container-author"/>
+          </if>
+          <else-if variable="editor">
+            <text macro="editor"/>
+          </else-if>
+          <else>
+            <text macro="translator"/>
+          </else>
+        </choose>
+      </if>
+    </choose>
+  </macro>
+  <macro name="year-date">
+    <choose>
+      <if variable="issued">
+        <date variable="issued">
+          <date-part name="year" form="long"/>
+        </date>
+      </if>
+      <else>
+        <text term="no date"/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="title">
+    <choose>
+      <if type="book thesis map motion_picture song manuscript" match="any">
+        <text variable="title" font-style="italic"/>
+      </if>
+      <else-if type="paper-conference speech chapter article-journal article-magazine article-newspaper entry entry-dictionary entry-encyclopedia post-weblog post webpage broadcast" match="any">
+        <text variable="title" suffix=". "/>
+        <choose>
+          <if type="chapter paper-conference" match="any">
+            <text term="in" text-case="capitalize-first" suffix="&#160;: "/>
+          </if>
+        </choose>
+        <choose>
+          <if variable="container-author editor translator" match="any">
+            <text macro="container-responsability"/>
+            <choose>
+              <if variable="container-title event" match="any">
+                <text value=", "/>
+              </if>
+            </choose>
+          </if>
+        </choose>
+        <choose>
+          <if variable="container-title">
+            <text variable="container-title" font-style="italic"/>
+          </if>
+          <else>
+            <text variable="event" font-style="italic"/>
+          </else>
+        </choose>
+      </else-if>
+      <else-if type="report">
+        <text variable="number" suffix=": "/>
+        <text variable="title" font-style="italic"/>
+      </else-if>
+      <else-if type="patent">
+        <text variable="title"/>
+      </else-if>
+      <else>
+        <text variable="title" font-style="italic"/>
+      </else>
+    </choose>
+    <choose>
+      <if variable="URL">
+        <text term="online" prefix=" [" suffix="]"/>
+      </if>
+    </choose>
+  </macro>
+  <macro name="number">
+    <text variable="number"/>
+  </macro>
+  <macro name="medium">
+    <text variable="medium" prefix=" [" suffix="]"/>
+  </macro>
+  <macro name="version">
+    <text variable="version"/>
+  </macro>
+  <macro name="genre">
+    <choose>
+      <if type="map">
+        <choose>
+          <if variable="genre">
+            <text variable="genre" prefix="[" suffix="]"/>
+          </if>
+          <else>
+            <text value="map" prefix="[" suffix="]"/>
+          </else>
+        </choose>
+      </if>
+      <else>
+        <text variable="genre"/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="date">
+    <choose>
+      <if variable="issued">
+        <date variable="issued">
+          <date-part name="day" suffix=" "/>
+          <date-part name="month" suffix=" "/>
+          <date-part name="year"/>
+        </date>
+      </if>
+    </choose>
+  </macro>
+  <macro name="edition">
+    <text variable="edition" form="long"/>
+  </macro>
+  <macro name="publisher-group">
+    <group delimiter="&#160;: ">
+      <text variable="publisher-place"/>
+      <text variable="publisher"/>
+    </group>
+  </macro>
+  <macro name="issue">
+    <group delimiter=", ">
+      <text variable="volume" prefix="Vol.&#160;"/>
+      <choose>
+        <if variable="volume">
+          <text variable="issue" prefix="no.&#160;"/>
+          <text variable="page" prefix="p.&#160;"/>
+        </if>
+        <else-if variable="issue">
+          <text variable="issue" prefix="No.&#160;"/>
+          <text variable="page" prefix="p.&#160;"/>
+        </else-if>
+        <else>
+          <text variable="page" prefix="P.&#160;"/>
+        </else>
+      </choose>
+    </group>
+  </macro>
+  <macro name="accessed">
+    <choose>
+      <if variable="URL">
+        <group prefix=" [" suffix="]">
+          <text term="accessed" text-case="capitalize-first"/>
+          <date variable="accessed">
+            <date-part name="day" prefix="&#160;"/>
+            <date-part name="month" prefix="&#160;"/>
+            <date-part name="year" prefix="&#160;"/>
+          </date>
+        </group>
+      </if>
+    </choose>
+  </macro>
+  <macro name="collection">
+    <group delimiter=", ">
+      <text variable="collection-title"/>
+      <text variable="collection-number"/>
+    </group>
+  </macro>
+  <macro name="page">
+    <choose>
+      <if type="book thesis manuscript" match="any">
+        <text variable="number-of-pages" suffix="&#160;p"/>
+      </if>
+      <else-if type="chapter paper-conference article-newspaper" match="any">
+        <text variable="page" prefix="p.&#160;"/>
+      </else-if>
+      <else-if type="report patent" match="any">
+        <text variable="page" suffix="&#160;p"/>
+      </else-if>
+    </choose>
+  </macro>
+  <macro name="isbn">
+    <text variable="ISBN" prefix="ISBN&#160;"/>
+  </macro>
+  <macro name="doi">
+    <text variable="DOI" prefix="DOI&#160;"/>
+  </macro>
+  <macro name="url">
+    <choose>
+      <if variable="URL">
+        <group>
+          <text term="retrieved" suffix=" " text-case="capitalize-first"/>
+          <text term="from" suffix=": "/>
+          <text variable="URL"/>
+        </group>
+      </if>
+    </choose>
+  </macro>
+  <macro name="archive">
+    <group delimiter=":&#160;">
+      <text variable="archive"/>
+      <text macro="archive_location"/>
+    </group>
+  </macro>
+  <macro name="archive_location">
+    <choose>
+      <if variable="archive_location">
+        <text variable="archive_location"/>
+      </if>
+      <else>
+        <text variable="call-number"/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="note">
+    <text variable="note"/>
+  </macro>
+  <citation collapse="citation-number" after-collapse-delimiter="; ">
+    <sort>
+      <key variable="citation-number"/>
+    </sort>
+    <layout prefix="[" suffix="]" delimiter=", ">
+      <group delimiter=", ">
+        <text variable="citation-number"/>
+        <group>
+          <label variable="locator" suffix=".&#160;" form="short" strip-periods="true"/>
+          <text variable="locator"/>
+        </group>
+      </group>
+    </layout>
+  </citation>
+  <bibliography>
+    <sort>
+      <key variable="citation-number"/>
+    </sort>
+    <layout>
+      <text variable="citation-number" display="left-margin" prefix="[" suffix="] "/>
+      <choose>
+        <if type="book map" match="any">
+          <group display="right-inline">
+            <text macro="responsability" suffix=". "/>
+            <text macro="title" suffix=". "/>
+            <text macro="genre" suffix=". "/>
+            <text macro="edition" suffix=". "/>
+            <text macro="publisher-group" suffix=", "/>
+            <text macro="year-date" suffix=". "/>
+            <text macro="accessed" suffix=". "/>
+            <text macro="collection" suffix=". "/>
+            <text macro="isbn" suffix=". "/>
+            <text macro="url"/>
+          </group>
+        </if>
+        <else-if type="article-journal article-magazine" match="any">
+          <group display="right-inline">
+            <text macro="responsability" suffix=". "/>
+            <text macro="title" suffix=". "/>
+            <text macro="edition" suffix=". "/>
+            <text macro="date" suffix=". "/>
+            <text macro="issue" suffix=". "/>
+            <text macro="accessed" suffix=". "/>
+            <text macro="doi" suffix=". "/>
+            <text macro="url"/>
+          </group>
+        </else-if>
+        <else-if type="article-newspaper">
+          <group display="right-inline">
+            <text macro="responsability" suffix=". "/>
+            <text macro="title" suffix=". "/>
+            <text macro="edition" suffix=". "/>
+            <text macro="publisher-group" suffix=", "/>
+            <text macro="date" suffix=". "/>
+            <text macro="page" suffix=". "/>
+            <text macro="accessed" suffix=". "/>
+            <text macro="url"/>
+          </group>
+        </else-if>
+        <else-if type="chapter entry entry-dictionary entry-encyclopedia" match="any">
+          <group display="right-inline">
+            <text macro="responsability" suffix=". "/>
+            <text macro="title" font-style="normal" suffix=". "/>
+            <text macro="edition" suffix=". "/>
+            <text macro="publisher-group" suffix=", "/>
+            <text macro="year-date" suffix=". "/>
+            <text macro="page" suffix=". "/>
+            <text macro="collection" suffix=". "/>
+            <text macro="accessed" suffix=". "/>
+            <text macro="isbn" suffix=". "/>
+            <text macro="url"/>
+          </group>
+        </else-if>
+        <else-if type="speech">
+          <group display="right-inline">
+            <text macro="responsability" suffix=". "/>
+            <text macro="title" suffix=". "/>
+            <text macro="genre" suffix=". "/>
+            <text macro="publisher-group" suffix=". "/>
+            <text macro="date" suffix=". "/>
+            <text macro="accessed" suffix=". "/>
+            <text macro="page" suffix=". "/>
+            <text macro="url"/>
+          </group>
+        </else-if>
+        <else-if type="paper-conference">
+          <group display="right-inline">
+            <text macro="responsability" suffix=". "/>
+            <text macro="title" suffix=". "/>
+            <text macro="genre" suffix=". "/>
+            <text macro="publisher-group" suffix=", "/>
+            <text macro="date" suffix=". "/>
+            <text macro="page" suffix=". "/>
+            <text macro="accessed" suffix=". "/>
+            <text macro="collection" suffix=". "/>
+            <text macro="isbn" suffix=". "/>
+            <text macro="url"/>
+          </group>
+        </else-if>
+        <else-if type="thesis">
+          <group display="right-inline">
+            <text macro="responsability" suffix=". "/>
+            <text macro="title" suffix=". "/>
+            <text macro="genre" suffix=". "/>
+            <text macro="publisher-group" suffix=", "/>
+            <text macro="year-date" suffix=". "/>
+            <text macro="accessed" suffix=". "/>
+            <text macro="url"/>
+          </group>
+        </else-if>
+        <else-if type="post-weblog post webpage" match="any">
+          <group display="right-inline">
+            <text macro="responsability" suffix=". "/>
+            <text macro="title" suffix=". "/>
+            <text macro="date" suffix=". "/>
+            <text macro="accessed" suffix=". "/>
+            <text macro="url"/>
+          </group>
+        </else-if>
+        <else-if type="broadcast motion_picture song" match="any">
+          <group display="right-inline">
+            <text macro="responsability" suffix=". "/>
+            <text macro="title" suffix=". "/>
+            <text macro="medium" suffix=". "/>
+            <text macro="publisher-group" suffix=", "/>
+            <text macro="date" suffix=". "/>
+            <text macro="accessed" suffix=". "/>
+            <text macro="collection" suffix=". "/>
+            <text macro="isbn" suffix=". "/>
+            <text macro="url"/>
+          </group>
+        </else-if>
+        <else-if type="report" match="any">
+          <group display="right-inline">
+            <text macro="responsability" suffix=". "/>
+            <text macro="title" suffix=". "/>
+            <text macro="genre" suffix=". "/>
+            <text macro="edition" suffix=". "/>
+            <text macro="publisher-group" suffix=", "/>
+            <text macro="year-date" suffix=". "/>
+            <text macro="accessed" suffix=". "/>
+            <text macro="collection" suffix=". "/>
+            <text macro="url"/>
+          </group>
+        </else-if>
+        <else-if type="manuscript" match="any">
+          <group display="right-inline">
+            <text macro="responsability" suffix=". "/>
+            <text macro="title" suffix=". "/>
+            <text macro="genre" suffix=". "/>
+            <text macro="edition" suffix=". "/>
+            <text macro="publisher-group" suffix=", "/>
+            <text macro="year-date" suffix=". "/>
+            <text macro="accessed" suffix=". "/>
+            <text macro="collection" suffix=". "/>
+            <text macro="url"/>
+          </group>
+        </else-if>
+        <else-if type="patent">
+          <group display="right-inline">
+            <text macro="responsability" suffix=". "/>
+            <text macro="title" suffix=". "/>
+            <text macro="number" suffix=". "/>
+            <text macro="date" suffix=". "/>
+            <text macro="publisher-group" suffix=". "/>
+            <text macro="accessed" suffix=". "/>
+            <text macro="collection" suffix=". "/>
+            <text macro="url"/>
+          </group>
+        </else-if>
+        <else>
+          <group display="right-inline">
+            <text macro="responsability" suffix=". "/>
+            <text macro="title" suffix=". "/>
+            <text macro="version" suffix=". "/>
+            <text macro="medium" suffix=". "/>
+            <text macro="genre" suffix=". "/>
+            <text macro="date" suffix=". "/>
+            <text macro="edition" suffix=". "/>
+            <text macro="publisher-group" suffix=". "/>
+            <text macro="number" suffix=". "/>
+            <text macro="accessed" suffix=". "/>
+            <text macro="collection" suffix=". "/>
+            <text macro="page" suffix=". "/>
+            <text macro="isbn" suffix=". "/>
+            <text macro="url"/>
+          </group>
+        </else>
+      </choose>
+      <group display="right-inline">
+        <text macro="archive"/>
+      </group>
+      <group display="right-inline">
+        <text macro="note"/>
+      </group>
+    </layout>
+  </bibliography>
+</style>

--- a/iso690-numeric-brackets-no-abstract-en.csl
+++ b/iso690-numeric-brackets-no-abstract-en.csl
@@ -5,7 +5,7 @@
     <id>http://www.zotero.org/styles/iso690-numeric-brackets-no-abstract-en</id>
     <link href="http://www.zotero.org/styles/iso690-numeric-brackets-no-abstract-en" rel="self"/>
     <link href="http://www.zotero.org/styles/iso690-numeric-en" rel="template"/>
-    <link href="https://github.com/citation-style-language/styles/pull/3348" rel="documentation"/>
+    <link href="https://www.iso.org/drafting-standards.html" rel="documentation"/>
     <author>
       <name>Heidi Vanparys</name>
       <email>heidi.vanparys@gmail.com</email>
@@ -13,7 +13,7 @@
     <category citation-format="numeric"/>
     <category field="generic-base"/>
     <summary>Style based on ISO 690:2010(E), V1.1</summary>
-    <updated>2018-02-20T22:45:00+01:00</updated>
+    <updated>2018-02-21T13:35:00+01:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale>
@@ -21,7 +21,7 @@
       <term name="no date">[no date]</term>
       <term name="in">in</term>
       <term name="online">online</term>
-      <term name="accessed">accessed</term>
+      <term name="accessed">viewed</term>
       <term name="retrieved">Available</term>
       <term name="from">from</term>
     </terms>


### PR DESCRIPTION
Add English ISO 690 style with square brackets (instead of round brackets) and no abstract. The style is based on iso690-numeric-en.