### PR TITLE
Use explicit year-suffix + minor code cleanup

### DIFF
--- a/deutsche-gesellschaft-fur-psychologie.csl
+++ b/deutsche-gesellschaft-fur-psychologie.csl
@@ -29,6 +29,11 @@
       <term name="et-al">et al.</term>
       <term name="retrieved">Zugriff am</term>
     </terms>
+    <date form="text">
+      <date-part name="year"/>
+      <date-part name="month" prefix=", "/>
+      <date-part name="day" prefix=" "/>
+    </date>
   </locale>
   <macro name="container-contributors">
     <choose>
@@ -173,38 +178,37 @@
     </choose>
   </macro>
   <macro name="issued">
-    <choose>
-      <if variable="issued">
-        <group prefix=" (" suffix=").">
-          <date variable="issued">
-            <date-part name="year"/>
-          </date>
+    <group prefix=" (" delimiter="-" suffix=").">
+      <choose>
+        <if variable="issued">
           <choose>
             <if type="bill book graphic legal_case motion_picture report song article-journal chapter paper-conference" match="none">
-              <date variable="issued">
-                <date-part prefix=", " name="month"/>
-                <date-part prefix=" " name="day"/>
-              </date>
+              <date variable="issued" form="text" date-parts="year-month-day"/>
             </if>
+            <else>
+              <date variable="issued" form="text" date-parts="year"/>
+            </else>
           </choose>
-        </group>
-      </if>
-      <else>
-        <text prefix=" (" term="no date" suffix=")." form="short"/>
-      </else>
-    </choose>
+        </if>
+        <else>
+          <text term="no date" form="short"/>
+        </else>
+      </choose>
+      <text variable="year-suffix"/>
+    </group>
   </macro>
   <macro name="issued-year">
-    <choose>
-      <if variable="issued">
-        <date variable="issued">
-          <date-part name="year"/>
-        </date>
-      </if>
-      <else>
-        <text term="no date" form="short"/>
-      </else>
-    </choose>
+    <group delimiter="-">
+      <choose>
+        <if variable="issued">
+          <date variable="issued" form="text" date-parts="year"/>
+        </if>
+        <else>
+          <text term="no date" form="short"/>
+        </else>
+      </choose>
+      <text variable="year-suffix"/>
+    </group>
   </macro>
   <macro name="edition">
     <choose>


### PR DESCRIPTION
The style Deutsche Gesellschaft für Psychologie (German) lacked an explicit year-suffix. This just adds it, and streamlines the date code a little. I haven't run it past the user for testing.

Issue was raised here:

https://forums.zotero.org/discussion/70521/disambiguation