### PR TITLE
first edition can be indicated with original-date

### DIFF
--- a/le-tapuscrit-note.csl
+++ b/le-tapuscrit-note.csl
@@ -13,7 +13,7 @@
     <category citation-format="note"/>
     <category field="social_science"/>
     <category field="generic-base"/>
-    <updated>2013-10-04T00:02:01+00:00</updated>
+    <updated>2018-03-04T23:30:10+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale xml:lang="fr">
@@ -22,7 +22,7 @@
       <term name="ordinal-02">e</term>
       <term name="ordinal-03">e</term>
       <term name="ordinal-04">e</term>
-      <term name="cited">op.&#160;cit.</term>
+      <term name="cited">op. cit.</term>
       <term name="page" form="short">
         <single>p.</single>
         <multiple>p.</multiple>
@@ -41,15 +41,13 @@
     <choose>
       <if variable="author">
         <names variable="author">
-          <name form="long" and="text" delimiter-precedes-last="never" sort-separator=" " font-style="normal">
-          </name>
+          <name form="long" and="text" delimiter-precedes-last="never" sort-separator=" " font-style="normal"/>
         </names>
       </if>
       <else-if variable="editor">
         <names variable="editor">
-          <name form="long" and="text" delimiter-precedes-last="never" sort-separator=" " font-style="normal">
-          </name>
-          <label form="short" prefix="&#160;(" suffix=".)"/>
+          <name form="long" and="text" delimiter-precedes-last="never" sort-separator=" " font-style="normal"/>
+          <label form="short" prefix=" (" suffix=".)"/>
         </names>
       </else-if>
     </choose>
@@ -68,7 +66,7 @@
           <name name-as-sort-order="all" form="long" and="text" delimiter-precedes-last="never" sort-separator=" " font-style="normal">
             <name-part name="family" font-variant="small-caps"/>
           </name>
-          <label form="short" prefix="&#160;(" suffix=".)"/>
+          <label form="short" prefix=" (" suffix=".)"/>
         </names>
       </else-if>
     </choose>
@@ -77,30 +75,26 @@
     <choose>
       <if variable="author">
         <names variable="author">
-          <name and="text" initialize="true" initialize-with="." delimiter-precedes-last="never" sort-separator=" " font-style="normal">
-          </name>
+          <name and="text" initialize="true" initialize-with="." delimiter-precedes-last="never" sort-separator=" " font-style="normal"/>
         </names>
       </if>
       <else-if variable="editor">
         <names variable="editor">
-          <name form="long" and="text" delimiter-precedes-last="never" sort-separator=" " font-style="normal">
-          </name>
-          <label form="short" prefix="&#160;(" suffix=".)"/>
+          <name form="long" and="text" delimiter-precedes-last="never" sort-separator=" " font-style="normal"/>
+          <label form="short" prefix=" (" suffix=".)"/>
         </names>
       </else-if>
     </choose>
   </macro>
   <macro name="editor">
     <names variable="editor">
-      <name form="long" and="text" delimiter-precedes-last="never" sort-separator=" " font-style="normal">
-      </name>
-      <label form="short" prefix="&#160;(" suffix=".)"/>
+      <name form="long" and="text" delimiter-precedes-last="never" sort-separator=" " font-style="normal"/>
+      <label form="short" prefix=" (" suffix=".)"/>
     </names>
   </macro>
   <macro name="translator">
     <names variable="translator">
-      <name form="long" and="text" delimiter-precedes-last="never" sort-separator=" " font-style="normal" prefix=" traduit par ">
-      </name>
+      <name form="long" and="text" delimiter-precedes-last="never" sort-separator=" " font-style="normal" prefix=" traduit par "/>
     </names>
   </macro>
   <macro name="title">
@@ -177,24 +171,38 @@
   <macro name="yearpage">
     <choose>
       <if type="bill book graphic legal_case motion_picture paper-conference manuscript report song thesis" match="any">
+        <choose>
+          <if match="any" variable="original-date">
+            <date form="text" variable="issued">
+              <date-part name="year"/>
+            </date>
+            <date form="text" variable="original-date" prefix=" [" suffix="], ">
+              <date-part name="year"/>
+            </date>
+          </if>
+        </choose>
         <group delimiter=", " font-style="normal">
-          <date variable="issued">
-            <date-part name="year"/>
-          </date>
+          <choose>
+            <if match="none" variable="original-date">
+              <date variable="issued">
+                <date-part name="year"/>
+              </date>
+            </if>
+          </choose>
           <group>
-            <text term="volume" form="short" suffix="."/>
+            <text term="volume" form="short" suffix=". "/>
             <text variable="number-of-volumes" prefix=". " suffix="/"/>
             <text variable="volume"/>
           </group>
           <choose>
             <if variable="locator" match="any">
-              <group delimiter="&#8239;">
+              <group delimiter=" ">
                 <label variable="locator" form="short"/>
                 <text variable="locator"/>
               </group>
             </if>
             <else-if variable="locator" match="none">
-              <text variable="number-of-pages" suffix="&#160;p"/>
+              <text variable="number-of-pages" suffix=" p"/>
             </else-if>
           </choose>
         </group>
@@ -211,7 +219,7 @@
           </group>
           <choose>
             <if variable="locator" match="any">
-              <group delimiter="&#8239;">
+              <group delimiter=" ">
                 <label variable="locator" form="short"/>
                 <text variable="locator"/>
               </group>
@@ -227,7 +235,7 @@
         <group delimiter=" " font-style="normal">
           <choose>
             <if variable="locator" match="any">
-              <group delimiter="&#8239;">
+              <group delimiter=" ">
                 <label variable="locator" form="short"/>
                 <text variable="locator"/>
               </group>
@@ -252,7 +260,7 @@
         <group delimiter=" " font-style="normal">
           <choose>
             <if variable="locator" match="any">
-              <group delimiter="&#8239;">
+              <group delimiter=" ">
                 <label variable="locator" form="short"/>
                 <text variable="locator"/>
               </group>
@@ -278,17 +286,31 @@
   <macro name="yearpage-bib">
     <choose>
       <if type="bill book graphic legal_case motion_picture paper-conference report song thesis" match="any">
-        <group delimiter=", ">
-          <group delimiter=", " font-style="normal">
+        <choose>
+          <if match="any" variable="original-date">
             <date variable="issued">
               <date-part name="year"/>
             </date>
+            <date variable="original-date" prefix=" [" suffix="], ">
+              <date-part name="year"/>
+            </date>
+          </if>
+        </choose>
+        <group delimiter=", ">
+          <group delimiter=", " font-style="normal">
+            <choose>
+              <if match="none" variable="original-date">
+                <date variable="issued">
+                  <date-part name="year"/>
+                </date>
+              </if>
+            </choose>
             <group>
-              <text term="volume" form="short" suffix="."/>
+              <text term="volume" form="short" suffix=". "/>
               <text variable="number-of-volumes" prefix=". " suffix="/"/>
               <text variable="volume"/>
             </group>
-            <text variable="number-of-pages" suffix="&#160;p"/>
+            <text variable="number-of-pages" suffix=" p"/>
           </group>
           <group>
             <label variable="locator" form="short"/>
@@ -308,7 +330,7 @@
           </group>
           <group>
             <label variable="page" form="short"/>
-            <text variable="page" prefix="&#160;"/>
+            <text variable="page" prefix=" "/>
           </group>
         </group>
       </else-if>
@@ -395,7 +417,7 @@
   <macro name="volume">
     <choose>
       <if is-numeric="volume">
-        <text term="volume" form="short" suffix=".&#160;"/>
+        <text term="volume" form="short" suffix=". "/>
         <text variable="volume"/>
       </if>
       <else>
@@ -406,7 +428,7 @@
   <macro name="issue">
     <choose>
       <if is-numeric="issue">
-        <text term="issue" form="short" suffix="&#160;"/>
+        <text term="issue" form="short" suffix=" "/>
         <text variable="issue"/>
       </if>
       <else>
@@ -415,10 +437,10 @@
     </choose>
   </macro>
   <macro name="collection">
-    <text variable="collection-title" quotes="true" prefix=" (coll.&#160;" suffix=")"/>
+    <text variable="collection-title" quotes="true" prefix=" (coll. " suffix=")"/>
   </macro>
   <citation et-al-min="4" et-al-use-first="1">
-    <layout suffix="." delimiter="&#160;; ">
+    <layout suffix="." delimiter=" ; ">
       <choose>
         <if position="ibid-with-locator">
           <group delimiter=", ">
@@ -442,7 +464,7 @@
                 <text value="art cit"/>
               </else>
             </choose>
-            <text variable="locator" prefix="p.&#160;"/>
+            <text variable="locator" prefix="p. "/>
           </group>
         </else-if>
         <else>


### PR DESCRIPTION
Added possibility for original publication date for books (yaml variable `original-date`) between [brackets].
Le style prend désormais en charge la date de première édition des livres (variable yaml `original-date`), rendue entre [crochets] après la date de publication.

See also [this issue](https://github.com/retorquere/zotero-better-bibtex/issues/922).

I also fixed a few little bugs having to do with nonbreaking spaces.
Quelques petites corrections aussi par rapport aux espaces insécables.