### PR TITLE
Update University of Leeds Harvard style

### DIFF
--- a/harvard-university-of-leeds.csl
+++ b/harvard-university-of-leeds.csl
@@ -122,17 +122,24 @@
       </else>
     </choose>
   </macro>
+  <macro name="locator-with-label">
+    <choose>
+      <if locator="page">
+        <text macro="page"/>
+      </if>
+      <else>
+        <label variable="locator" form="short"/>
+        <text variable="locator" prefix=" "/>
+      </else>
+    </choose>
+  </macro>
   <citation et-al-min="3" et-al-use-first="1" disambiguate-add-year-suffix="true" disambiguate-add-names="true" disambiguate-add-givenname="true">
     <layout prefix="(" suffix=")" delimiter="; ">
       <group delimiter=" ">
         <group delimiter=", ">
           <text macro="author-short"/>
           <text macro="year-date"/>
-          <text macro="page"/>
-        </group>
-        <group>
-          <label variable="locator" form="short"/>
-          <text variable="locator" prefix=" "/>
+          <text macro="locator-with-label"/>
         </group>
       </group>
     </layout>
@@ -193,8 +200,7 @@
             <group suffix=".">
               <text macro="publisher" prefix=" "/>
               <group prefix=", ">
-                <label variable="page" form="short" suffix=" "/>
-                <text variable="page"/>
+                <text macro="page"/>
               </group>
             </group>
           </group>
@@ -217,9 +223,8 @@
               <text variable="volume" font-weight="bold"/>
               <text variable="issue" prefix="(" suffix=")"/>
             </group>
-            <group prefix=",">
-              <label variable="page" form="short"/>
-              <text variable="page"/>
+            <group prefix=", ">
+              <text macro="page"/>
             </group>
           </group>
         </else>

--- a/harvard-university-of-leeds.csl
+++ b/harvard-university-of-leeds.csl
@@ -20,7 +20,7 @@
     <category citation-format="author-date"/>
     <category field="generic-base"/>
     <summary>The Harvard author-date style</summary>
-    <updated>2018-03-06T11:17:34+00:00</updated>
+    <updated>2018-03-06T15:54:43+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <macro name="editor">
@@ -128,7 +128,7 @@
         <group delimiter=", ">
           <text macro="author-short"/>
           <text macro="year-date"/>
-		  <text macro="page"/>
+          <text macro="page"/>
         </group>
         <group>
           <label variable="locator" form="short"/>

--- a/harvard-university-of-leeds.csl
+++ b/harvard-university-of-leeds.csl
@@ -163,14 +163,14 @@
         </if>
         <else-if type="thesis" match="any">
           <text macro="title" prefix=" " suffix="."/>
+          <choose>
+            <if match="any" variable="URL">
+              <text term="online" text-case="capitalize-first" prefix="[" suffix="]"/>
+            </if>
+          </choose>
           <group prefix=" " delimiter=", " suffix=".">
             <text variable="genre"/>
             <text macro="publisher"/>
-            <choose>
-              <if match="any" variable="URL">
-                <text term="online" text-case="capitalize-first" prefix="[" suffix="]"/>
-              </if>
-            </choose>
           </group>
         </else-if>
         <else-if type="chapter paper-conference" match="any">

--- a/harvard-university-of-leeds.csl
+++ b/harvard-university-of-leeds.csl
@@ -70,7 +70,7 @@
   </macro>
   <macro name="title">
     <choose>
-      <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
+      <if type="bill book graphic legal_case legislation motion_picture report song thesis" match="any">
         <text variable="title" font-style="italic"/>
       </if>
       <else>
@@ -161,6 +161,18 @@
           </group>
           <text prefix=" " suffix="." macro="publisher"/>
         </if>
+        <else-if type="thesis" match="any">
+          <text macro="title" prefix=" " suffix="."/>
+          <group prefix=" " delimiter=", " suffix=".">
+            <text variable="genre"/>
+            <text macro="publisher"/>
+            <choose>
+              <if match="any" variable="URL">
+                <text term="online" text-case="capitalize-first" prefix="[" suffix="]"/>
+              </if>
+            </choose>
+          </group>
+        </else-if>
         <else-if type="chapter paper-conference" match="any">
           <text macro="title" prefix=" "/>
           <group prefix=" ">

--- a/harvard-university-of-leeds.csl
+++ b/harvard-university-of-leeds.csl
@@ -5,8 +5,7 @@
     <title>University of Leeds - Harvard</title>
     <id>http://www.zotero.org/styles/harvard-university-of-leeds</id>
     <link href="http://www.zotero.org/styles/harvard-university-of-leeds" rel="self"/>
-    <link href="http://library.leeds.ac.uk/skills-referencing#activate-harvard_style" rel="documentation"/>
-    <link href="http://library.leeds.ac.uk/news/article/225/change_to_leeds_referencing_styles_in_201516" rel="documentation"/>
+    <link href="https://library.leeds.ac.uk/info/1402/referencing/50/leeds_harvard_introduction" rel="documentation"/>
     <author>
       <name>Julian Onions</name>
       <email>julian.onions@gmail.com</email>
@@ -14,15 +13,15 @@
     <contributor>
       <name>John Salter</name>
       <email>j.salter@leeds.ac.uk</email>
+      <uri>https://orcid.org/0000-0002-8611-8266</uri>
     </contributor>
     <contributor>
       <name>David Kane</name>
-      <email>fs15dmk@leeds.ac.uk</email>
     </contributor>
     <category citation-format="author-date"/>
     <category field="generic-base"/>
     <summary>The Harvard author-date style</summary>
-    <updated>2015-11-17T16:07:28+00:00</updated>
+    <updated>2018-03-06T07:03:18+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <macro name="editor">

--- a/harvard-university-of-leeds.csl
+++ b/harvard-university-of-leeds.csl
@@ -142,6 +142,9 @@
     </choose>
   </macro>
   <citation et-al-min="3" et-al-use-first="1" disambiguate-add-year-suffix="true" disambiguate-add-names="true" disambiguate-add-givenname="true">
+    <sort>
+      <key variable="issued"/>
+    </sort>
     <layout prefix="(" suffix=")" delimiter="; ">
       <group delimiter=" ">
         <group delimiter=", ">

--- a/harvard-university-of-leeds.csl
+++ b/harvard-university-of-leeds.csl
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" demote-non-dropping-particle="sort-only" default-locale="en-GB">
-  <!-- This style was edited with the Visual CSL Editor (http://editor.citationstyles.org/visualEditor/) -->
   <info>
     <title>University of Leeds - Harvard</title>
     <id>http://www.zotero.org/styles/harvard-university-of-leeds</id>
@@ -21,7 +20,7 @@
     <category citation-format="author-date"/>
     <category field="generic-base"/>
     <summary>The Harvard author-date style</summary>
-    <updated>2018-03-06T07:03:18+00:00</updated>
+    <updated>2018-03-06T11:17:34+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <macro name="editor">
@@ -112,12 +111,24 @@
       </else>
     </choose>
   </macro>
+  <macro name="page">
+    <choose>
+      <if is-numeric="page">
+        <label variable="page" form="short"/>
+        <text variable="page"/>
+      </if>
+      <else>
+        <text variable="page"/>
+      </else>
+    </choose>
+  </macro>
   <citation et-al-min="3" et-al-use-first="1" disambiguate-add-year-suffix="true" disambiguate-add-names="true" disambiguate-add-givenname="true">
     <layout prefix="(" suffix=")" delimiter="; ">
       <group delimiter=" ">
         <group delimiter=", ">
           <text macro="author-short"/>
           <text macro="year-date"/>
+		  <text macro="page"/>
         </group>
         <group>
           <label variable="locator" form="short"/>

--- a/harvard-university-of-leeds.csl
+++ b/harvard-university-of-leeds.csl
@@ -125,7 +125,15 @@
   <macro name="locator-with-label">
     <choose>
       <if locator="page">
-        <text macro="page"/>
+        <choose>
+          <if is-numeric="locator">
+            <label variable="locator" form="short"/>
+            <text variable="locator"/>
+          </if>
+          <else>
+            <text variable="locator"/>
+          </else>
+        </choose>
       </if>
       <else>
         <label variable="locator" form="short"/>


### PR DESCRIPTION
Hi, a few fixes:

- new URL for documentation
- fix for missing comma in citation list between date and locator
```diff
- (Jones, 2018 pp.12-34)
+(Jones, 2018, pp.12-34)
```
- fix to locator/pagination when value is a Roman numeral
```diff
- (Jones, 2018 p.xi)
+(Jones, 2018, xi)
```
- add qualification name to thesis type (see: https://forums.zotero.org/discussion/63455)
- italicise thesis title

File has been checked with the validator:
http://validator.citationstyles.org/?url=https%3A%2F%2Fraw.githubusercontent.com%2Fjesusbagpuss%2Fstyles%2Fpatch-1%2Fharvard-university-of-leeds.csl&version=1.0.1
