### PR TITLE
Multilingual support, cite encycl. & dict, URL ...

### DIFF
--- a/deutsches-archaologisches-institut.csl
+++ b/deutsches-archaologisches-institut.csl
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <style class="in-text" version="1.0" delimiter-precedes-et-al="never" demote-non-dropping-particle="sort-only" xmlns="http://purl.org/net/xbiblio/csl">
   <!-- This style was edited with the Visual CSL Editor (http://editor.citationstyles.org/visualEditor/) -->
   <info>
@@ -19,7 +19,7 @@
     <category citation-format="author-date"/>
     <category field="anthropology"/>
     <summary>New author-date style meant to meet citation specifications provided by DAI</summary>
-    <updated>2018-03-07T19:57:06+00:00</updated>
+    <updated>2018-04-03T15:14:50+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale xml:lang="en">
@@ -60,7 +60,7 @@
             <if variable="editor author" match="all">
               <names variable="editor translator" prefix=", ">
                 <label form="verb-short" suffix=" "/>
-                <name delimiter=" &#8211; " initialize-with="."/>
+                <name delimiter=" – " initialize-with="."/>
               </names>
             </if>
           </choose>
@@ -76,11 +76,11 @@
             <if variable="editor container-title" match="any">
               <text term="in" prefix=", " suffix=": "/>
               <names variable="editor">
-                <name delimiter=" &#8211; " delimiter-precedes-et-al="never" delimiter-precedes-last="always" initialize-with="."/>
+                <name delimiter=" – " delimiter-precedes-et-al="never" delimiter-precedes-last="always" initialize-with="."/>
                 <label form="short" prefix=" (" suffix=")" strip-periods="false"/>
               </names>
               <names variable="container-author">
-                <name delimiter=" &#8211; " delimiter-precedes-et-al="never" delimiter-precedes-last="always" initialize-with="."/>
+                <name delimiter=" – " delimiter-precedes-et-al="never" delimiter-precedes-last="always" initialize-with="."/>
               </names>
               <text macro="collection-title"/>
             </if>
@@ -102,7 +102,7 @@
   </macro>
   <macro name="editor">
     <names variable="editor">
-      <name delimiter=" &#8211; " delimiter-precedes-et-al="never" delimiter-precedes-last="always" initialize-with=". "/>
+      <name delimiter=" – " delimiter-precedes-et-al="never" delimiter-precedes-last="always" initialize-with=". "/>
       <label form="short" prefix=" (" suffix=")"/>
     </names>
   </macro>
@@ -113,7 +113,7 @@
           <if match="none" variable="editor">
             <names variable="translator" prefix=", ">
               <label form="verb-short" suffix=" "/>
-              <name delimiter=" &#8211; " delimiter-precedes-et-al="never" delimiter-precedes-last="always" initialize-with="."/>
+              <name delimiter=" – " delimiter-precedes-et-al="never" delimiter-precedes-last="always" initialize-with="."/>
             </names>
           </if>
         </choose>
@@ -124,7 +124,7 @@
     <choose>
       <if variable="author">
         <names variable="author">
-          <name delimiter=" &#8211; " delimiter-precedes-et-al="never" delimiter-precedes-last="always" initialize-with=". "/>
+          <name delimiter=" – " delimiter-precedes-et-al="never" delimiter-precedes-last="always" initialize-with=". "/>
         </names>
       </if>
       <else-if variable="editor">
@@ -145,12 +145,12 @@
     <choose>
       <if variable="author">
         <names variable="author">
-          <name form="short" delimiter=" &#8211; " et-al-min="3" et-al-use-first="1"/>
+          <name form="short" delimiter=" – " et-al-min="3" et-al-use-first="1"/>
         </names>
       </if>
       <else-if variable="editor">
         <names variable="editor">
-          <name form="short" delimiter=" &#8211; " et-al-min="3" et-al-use-first="1"/>
+          <name form="short" delimiter=" – " et-al-min="3" et-al-use-first="1"/>
         </names>
       </else-if>
       <else>
@@ -167,14 +167,14 @@
           </if>
           <else>
             <names variable="author">
-              <name form="short" delimiter=" &#8211; " et-al-min="3" et-al-use-first="1"/>
+              <name form="short" delimiter=" – " et-al-min="3" et-al-use-first="1"/>
             </names>
           </else>
         </choose>
       </if>
       <else-if variable="editor">
         <names variable="editor">
-          <name form="short" delimiter=" &#8211; " delimiter-precedes-last="always" et-al-min="3" et-al-use-first="1"/>
+          <name form="short" delimiter=" – " delimiter-precedes-last="always" et-al-min="3" et-al-use-first="1"/>
         </names>
       </else-if>
       <else>
@@ -275,11 +275,7 @@
               <text variable="publisher-place"/>
             </else>
           </choose>
-          <choose>
-            <if match="none" is-uncertain-date="issued">
-              <text macro="date" prefix=" "/>
-            </if>
-          </choose>
+          <text macro="date" prefix=" "/>
         </group>
       </if>
     </choose>
@@ -342,8 +338,7 @@
   <macro name="url">
     <choose>
       <if match="any" variable="URL">
-        <text value=", "/>
-        <group display="block">
+        <group display="block" prefix=",&amp;#10;">
           <text variable="URL" text-case="lowercase" prefix="&lt;" suffix="&gt;"/>
           <choose>
             <if match="none" is-uncertain-date="accessed">
@@ -357,8 +352,7 @@
   <macro name="doi">
     <choose>
       <if match="any" variable="DOI">
-        <text value=", "/>
-        <group display="block">
+        <group display="block" prefix=",&amp;#10;">
           <text value="doi: " font-variant="small-caps"/>
           <text variable="DOI"/>
         </group>
@@ -370,7 +364,7 @@
       <if match="any" variable="reviewed-author">
         <text term="reviewed-author" form="verb" prefix=", " suffix=" "/>
         <names variable="reviewed-author">
-          <name delimiter=" &#8211; " delimiter-precedes-et-al="never" delimiter-precedes-last="always" initialize-with="."/>
+          <name delimiter=" – " delimiter-precedes-et-al="never" delimiter-precedes-last="always" initialize-with="."/>
         </names>
         <text variable="reviewed-title" prefix=", "/>
       </if>
@@ -453,8 +447,7 @@
             <text macro="series"/>
             <choose>
               <if type="article article-journal article-magazine article-newspaper" match="none">
-                <text macro="translator"/>
-                <text value=" "/>
+                <text macro="translator" suffix=" "/>
               </if>
             </choose>
             <text macro="edition"/>

--- a/deutsches-archaologisches-institut.csl
+++ b/deutsches-archaologisches-institut.csl
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <style class="in-text" version="1.0" delimiter-precedes-et-al="never" initialize-with="." names-delimiter=" &#8211; " demote-non-dropping-particle="sort-only" xmlns="http://purl.org/net/xbiblio/csl">
+  <!-- This style was edited with the Visual CSL Editor (http://editor.citationstyles.org/visualEditor/) -->
   <info>
     <title>Deutsches Archäologisches Institut</title>
     <title-short>DAI</title-short>
@@ -18,7 +19,7 @@
     <category citation-format="author-date"/>
     <category field="anthropology"/>
     <summary>New author-date style meant to meet citation specifications provided by DAI</summary>
-    <updated>2018-03-07T19:33:24+00:00</updated>
+    <updated>2018-03-07T19:57:06+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale xml:lang="en">
@@ -87,7 +88,7 @@
         </group>
       </if>
       <else-if type="article article-journal article-magazine article-newspaper" match="any">
-        <text macro="translated"/>
+        <text macro="translator"/>
         <choose>
           <if match="any" variable="container-title-short">
             <text variable="container-title-short" prefix=", "/>
@@ -99,13 +100,6 @@
       </else-if>
     </choose>
   </macro>
-  <macro name="anon">
-    <choose>
-      <if variable="author editor translator" match="none">
-        <text term="anonymous" form="short" text-case="capitalize-first" strip-periods="false"/>
-      </if>
-    </choose>
-  </macro>
   <macro name="editor">
     <names variable="editor">
       <name delimiter=" &#8211; " delimiter-precedes-et-al="never" delimiter-precedes-last="always" initialize-with=". "/>
@@ -113,28 +107,18 @@
     </names>
   </macro>
   <macro name="translator">
-    <names variable="translator">
-      <name delimiter=" &#8211; " delimiter-precedes-et-al="never" delimiter-precedes-last="always" initialize-with=". "/>
-      <label form="verb-short" strip-periods="false" prefix=", "/>
-    </names>
-  </macro>
-  <macro name="recipient">
     <choose>
-      <if type="personal_communication">
+      <if match="any" variable="translator">
         <choose>
-          <if variable="genre">
-            <text variable="genre" text-case="capitalize-first"/>
+          <if match="none" variable="editor">
+            <names variable="translator" prefix=", ">
+              <label form="verb-short" suffix=" "/>
+              <name delimiter=" &#8211; " delimiter-precedes-et-al="never" delimiter-precedes-last="always" initialize-with="."/>
+            </names>
           </if>
-          <else>
-            <text term="letter" text-case="capitalize-first"/>
-          </else>
         </choose>
       </if>
     </choose>
-    <names variable="recipient" delimiter=", ">
-      <label form="verb" prefix=" " text-case="lowercase" suffix=" "/>
-      <name and="text" delimiter=", "/>
-    </names>
   </macro>
   <macro name="contributors">
     <choose>
@@ -260,16 +244,6 @@
         <text variable="page" prefix=", "/>
       </else-if>
     </choose>
-  </macro>
-  <macro name="point-locators">
-    <group>
-      <choose>
-        <if locator="page" match="none">
-          <label variable="locator" form="short" suffix=" "/>
-        </if>
-      </choose>
-      <text variable="locator"/>
-    </group>
   </macro>
   <macro name="date">
     <date variable="issued">
@@ -441,20 +415,6 @@
       </if>
     </choose>
   </macro>
-  <macro name="translated">
-    <choose>
-      <if match="any" variable="translator">
-        <choose>
-          <if match="none" variable="editor">
-            <names variable="translator" prefix=", ">
-              <label form="verb-short" suffix=" "/>
-              <name delimiter=" &#8211; " delimiter-precedes-et-al="never" delimiter-precedes-last="always" initialize-with="."/>
-            </names>
-          </if>
-        </choose>
-      </if>
-    </choose>
-  </macro>
   <citation et-al-min="3" et-al-use-first="1" disambiguate-add-year-suffix="true">
     <sort>
       <key variable="issued"/>
@@ -495,7 +455,7 @@
             <text macro="series"/>
             <choose>
               <if type="article article-journal article-magazine article-newspaper" match="none">
-                <text macro="translated"/>
+                <text macro="translator"/>
                 <text value=" "/>
               </if>
             </choose>

--- a/deutsches-archaologisches-institut.csl
+++ b/deutsches-archaologisches-institut.csl
@@ -1,8 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
-<style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" delimiter-precedes-et-al="never" initialize-with="." demote-non-dropping-particle="sort-only" default-locale="de-DE">
-  <!-- This style was edited with the Visual CSL Editor (http://editor.citationstyles.org/visualEditor/#) -->
+<style class="in-text" version="1.0" delimiter-precedes-et-al="never" initialize-with="." names-delimiter=" &#8211; " demote-non-dropping-particle="sort-only" xmlns="http://purl.org/net/xbiblio/csl">
   <info>
-    <title>Deutsches Archäologisches Institut (German)</title>
+    <title>Deutsches Archäologisches Institut</title>
     <title-short>DAI</title-short>
     <id>http://www.zotero.org/styles/deutsches-archaologisches-institut</id>
     <link href="http://www.zotero.org/styles/deutsches-archaologisches-institut" rel="self"/>
@@ -19,26 +18,48 @@
     <category citation-format="author-date"/>
     <category field="anthropology"/>
     <summary>New author-date style meant to meet citation specifications provided by DAI</summary>
-    <updated>2016-10-25T15:48:55+00:00</updated>
+    <updated>2018-03-07T19:33:24+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
+  <locale xml:lang="en">
+    <terms>
+      <term name="reviewed-author" form="verb">rev. of</term>
+      <term name="presented at">talk</term>
+    </terms>
+  </locale>
+  <locale xml:lang="de">
+    <terms>
+      <term name="reviewed-author" form="verb">Rez. zu</term>
+      <term name="presented at">Vortrag</term>
+    </terms>
+  </locale>
+  <locale xml:lang="it">
+    <terms>
+      <term name="reviewed-author" form="verb">recens. di</term>
+      <term name="presented at">presentazione</term>
+    </terms>
+  </locale>
+  <locale xml:lang="fr">
+    <terms>
+      <term name="reviewed-author" form="verb">rec. de</term>
+      <term name="presented at">conférence</term>
+    </terms>
+  </locale>
+  <locale xml:lang="es">
+    <terms>
+      <term name="reviewed-author" form="verb">recensión de</term>
+      <term name="presented at">conferencia</term>
+    </terms>
+  </locale>
   <macro name="secondary-contributors">
     <choose>
       <if type="chapter paper-conference" match="none">
         <group delimiter=". ">
           <choose>
-            <if variable="author">
-              <names variable="editor">
-                <name delimiter=" &#8211; " initialize-with=". "/>
-                <label form="short" strip-periods="true" prefix=" (" suffix=")"/>
-              </names>
-            </if>
-          </choose>
-          <choose>
-            <if variable="author editor" match="any">
-              <names variable="translator">
-                <name and="text" initialize-with="."/>
-                <label form="verb" text-case="capitalize-first" suffix=" "/>
+            <if variable="editor author" match="all">
+              <names variable="editor translator" prefix=", ">
+                <label form="verb-short" suffix=" "/>
+                <name delimiter=" &#8211; " initialize-with="."/>
               </names>
             </if>
           </choose>
@@ -57,13 +78,24 @@
                 <name delimiter=" &#8211; " delimiter-precedes-et-al="never" delimiter-precedes-last="always" initialize-with="."/>
                 <label form="short" prefix=" (" suffix=")" strip-periods="false"/>
               </names>
-              <text macro="collection-title" prefix=", "/>
+              <names variable="container-author">
+                <name delimiter=" &#8211; " delimiter-precedes-et-al="never" delimiter-precedes-last="always" initialize-with="."/>
+              </names>
+              <text macro="collection-title"/>
             </if>
           </choose>
         </group>
       </if>
       <else-if type="article article-journal article-magazine article-newspaper" match="any">
-        <text variable="container-title" prefix=", "/>
+        <text macro="translated"/>
+        <choose>
+          <if match="any" variable="container-title-short">
+            <text variable="container-title-short" prefix=", "/>
+          </if>
+          <else>
+            <text variable="container-title" prefix=", "/>
+          </else>
+        </choose>
       </else-if>
     </choose>
   </macro>
@@ -77,13 +109,13 @@
   <macro name="editor">
     <names variable="editor">
       <name delimiter=" &#8211; " delimiter-precedes-et-al="never" delimiter-precedes-last="always" initialize-with=". "/>
-      <label form="short" prefix=" (" suffix=")" strip-periods="false"/>
+      <label form="short" strip-periods="false" prefix=" (" suffix=")"/>
     </names>
   </macro>
   <macro name="translator">
     <names variable="translator">
       <name delimiter=" &#8211; " delimiter-precedes-et-al="never" delimiter-precedes-last="always" initialize-with=". "/>
-      <label form="verb-short" prefix=", " suffix="." strip-periods="false"/>
+      <label form="verb-short" strip-periods="false" prefix=", "/>
     </names>
   </macro>
   <macro name="recipient">
@@ -109,19 +141,20 @@
       <if variable="author">
         <names variable="author">
           <name delimiter=" &#8211; " delimiter-precedes-et-al="never" delimiter-precedes-last="always" initialize-with=". "/>
-          <label form="short" text-case="lowercase" strip-periods="false"/>
         </names>
       </if>
       <else-if variable="editor">
         <text macro="editor"/>
       </else-if>
-      <else-if variable="translator">
-        <text macro="translator"/>
-      </else-if>
-      <else>
-        <text macro="anon"/>
-        <text macro="recipient"/>
-      </else>
+    </choose>
+    <choose>
+      <if match="any" variable="title">
+        <choose>
+          <if match="any" variable="editor author">
+            <text value=", "/>
+          </if>
+        </choose>
+      </if>
     </choose>
   </macro>
   <macro name="contributors-short-citation">
@@ -136,31 +169,32 @@
           <name form="short" delimiter=" &#8211; " et-al-min="3" et-al-use-first="1"/>
         </names>
       </else-if>
-      <else-if variable="translator">
-        <names variable="translator"/>
-      </else-if>
       <else>
-        <text macro="anon"/>
+        <text variable="title-short"/>
       </else>
     </choose>
   </macro>
   <macro name="contributors-short-biblio">
     <choose>
       <if variable="author">
-        <names variable="author">
-          <name form="short" delimiter=" &#8211; " et-al-min="3" et-al-use-first="1"/>
-        </names>
+        <choose>
+          <if match="any" variable="title-short">
+            <text variable="title-short"/>
+          </if>
+          <else>
+            <names variable="author">
+              <name form="short" delimiter=" &#8211; " et-al-min="3" et-al-use-first="1"/>
+            </names>
+          </else>
+        </choose>
       </if>
       <else-if variable="editor">
         <names variable="editor">
           <name form="short" delimiter=" &#8211; " delimiter-precedes-last="always" et-al-min="3" et-al-use-first="1"/>
         </names>
       </else-if>
-      <else-if variable="translator">
-        <names variable="translator"/>
-      </else-if>
       <else>
-        <text macro="anon"/>
+        <text variable="title-short"/>
       </else>
     </choose>
   </macro>
@@ -174,10 +208,11 @@
         </choose>
       </if>
       <else-if type="bill book graphic legal_case motion_picture report song thesis" match="any">
-        <text variable="title" strip-periods="true"/>
+        <text variable="title" strip-periods="false"/>
+        <text variable="volume" prefix=" "/>
       </else-if>
       <else>
-        <text variable="title" strip-periods="true" quotes="false"/>
+        <text variable="title" strip-periods="false" quotes="false"/>
       </else>
     </choose>
   </macro>
@@ -188,9 +223,6 @@
           <if is-numeric="edition">
             <text variable="edition" vertical-align="sup" prefix=" "/>
           </if>
-          <else>
-            <text value=" "/>
-          </else>
         </choose>
       </if>
     </choose>
@@ -198,17 +230,9 @@
   <macro name="locators">
     <choose>
       <if type="article-journal">
-        <text variable="volume" prefix=" "/>
-        <text variable="issue" prefix=":"/>
+        <number prefix=" " variable="volume"/>
+        <text variable="issue" prefix=", "/>
       </if>
-      <else-if type="bill book graphic legal_case motion_picture report song" match="any">
-        <group prefix=". " delimiter=". ">
-          <group>
-            <text term="volume" form="short" text-case="capitalize-first"/>
-            <text variable="volume" form="short" prefix=" " suffix=""/>
-          </group>
-        </group>
-      </else-if>
     </choose>
   </macro>
   <macro name="locators-chapter">
@@ -254,9 +278,35 @@
   </macro>
   <macro name="place-date">
     <choose>
-      <if type="book thesis chapter" match="any">
-        <text variable="publisher-place" prefix="(" suffix=" "/>
-        <text macro="date" suffix=")"/>
+      <if type="book thesis chapter paper-conference" match="any">
+        <choose>
+          <if match="none" variable="edition">
+            <text value=" "/>
+          </if>
+        </choose>
+        <group prefix="(" suffix=")">
+          <choose>
+            <if type="thesis" match="any">
+              <text variable="genre" suffix=" "/>
+              <text variable="publisher"/>
+            </if>
+            <else>
+              <choose>
+                <if match="any" variable="original-date original-publisher-place">
+                  <text variable="original-publisher-place"/>
+                  <date date-parts="year" form="text" variable="original-date" prefix=" "/>
+                  <text value="; "/>
+                </if>
+              </choose>
+              <text variable="publisher-place"/>
+            </else>
+          </choose>
+          <choose>
+            <if match="none" is-uncertain-date="issued">
+              <text macro="date" prefix=" "/>
+            </if>
+          </choose>
+        </group>
       </if>
     </choose>
   </macro>
@@ -274,42 +324,134 @@
     </date>
   </macro>
   <macro name="collection-title">
-    <text variable="container-title" strip-periods="true"/>
+    <choose>
+      <if match="any" variable="editor container-author">
+        <text value=","/>
+      </if>
+    </choose>
+    <text variable="container-title" strip-periods="false" prefix=" "/>
+    <text variable="volume" prefix=" "/>
   </macro>
   <macro name="event">
-    <group>
-      <text term="presented at" suffix=" "/>
-      <text variable="event"/>
-    </group>
+    <text term="presented at" suffix=" "/>
+    <date form="text" variable="issued" suffix=", "/>
+    <text variable="event-place" suffix=". "/>
+    <text variable="event"/>
   </macro>
   <macro name="issue">
     <choose>
-      <if type="speech">
+      <if type="speech" match="any">
         <group prefix=" " delimiter=", ">
           <text macro="event"/>
-          <text macro="day-month"/>
-          <text variable="event-place"/>
         </group>
       </if>
+      <else-if type="paper-conference" match="any">
+        <text variable="event" prefix=" "/>
+        <date form="text" variable="event-date" prefix=" "/>
+      </else-if>
       <else-if type="article-newspaper article-magazine" match="any">
         <text macro="day-month" prefix=", "/>
       </else-if>
-      <else>
-        <group delimiter=", ">
-          <choose>
-            <if type="thesis">
-              <text variable="genre" text-case="capitalize-first"/>
-            </if>
-          </choose>
-        </group>
-      </else>
     </choose>
   </macro>
   <macro name="series">
     <choose>
       <if match="any" variable="collection-title">
-        <text variable="collection-title" strip-periods="true" prefix=", "/>
+        <text variable="collection-title" strip-periods="false" prefix=", "/>
         <text variable="collection-number" prefix=" "/>
+      </if>
+    </choose>
+    <choose>
+      <if type="paper-conference" match="any">
+        <text variable="volume" prefix=" "/>
+      </if>
+    </choose>
+  </macro>
+  <macro name="url">
+    <choose>
+      <if match="any" variable="URL">
+        <text value=", "/>
+        <group display="block">
+          <text variable="URL" text-case="lowercase" prefix="&lt;" suffix="&gt;"/>
+          <choose>
+            <if match="none" is-uncertain-date="accessed">
+              <date form="text" variable="accessed" prefix=" (" suffix=")"/>
+            </if>
+          </choose>
+        </group>
+      </if>
+    </choose>
+  </macro>
+  <macro name="doi">
+    <choose>
+      <if match="any" variable="DOI">
+        <text value=", "/>
+        <group display="block">
+          <text value="doi: " font-variant="small-caps"/>
+          <text variable="DOI" font-variant="normal"/>
+        </group>
+      </if>
+    </choose>
+  </macro>
+  <macro name="review">
+    <choose>
+      <if match="any" variable="reviewed-author">
+        <text term="reviewed-author" form="verb" prefix=", " suffix=" "/>
+        <names variable="reviewed-author">
+          <name delimiter=" &#8211; " delimiter-precedes-et-al="never" delimiter-precedes-last="always" initialize-with="."/>
+        </names>
+        <text variable="reviewed-title" prefix=", "/>
+      </if>
+    </choose>
+  </macro>
+  <macro name="encyclopedia-article">
+    <text variable="container-title"/>
+    <number prefix=" " variable="volume"/>
+    <choose>
+      <if match="none" is-uncertain-date="issued">
+        <date date-parts="year" form="text" variable="issued" prefix=" (" suffix=")"/>
+      </if>
+    </choose>
+    <text variable="page" prefix=" "/>
+    <group>
+      <choose>
+        <if match="any" variable="title">
+          <text term="sub verbo" form="short" prefix=" " suffix=" "/>
+          <text variable="title"/>
+        </if>
+      </choose>
+    </group>
+    <text variable="edition" prefix=" [" suffix="]"/>
+    <choose>
+      <if match="any" variable="author">
+        <group prefix=" (" suffix=")">
+          <names variable="author"/>
+        </group>
+      </if>
+    </choose>
+  </macro>
+  <macro name="webpage-date">
+    <choose>
+      <if type="webpage" match="any">
+        <choose>
+          <if match="none" is-uncertain-date="issued">
+            <date date-parts="year" form="text" variable="issued" prefix=", "/>
+          </if>
+        </choose>
+      </if>
+    </choose>
+  </macro>
+  <macro name="translated">
+    <choose>
+      <if match="any" variable="translator">
+        <choose>
+          <if match="none" variable="editor">
+            <names variable="translator" prefix=", ">
+              <label form="verb-short" suffix=" "/>
+              <name delimiter=" &#8211; " delimiter-precedes-et-al="never" delimiter-precedes-last="always" initialize-with="."/>
+            </names>
+          </if>
+        </choose>
       </if>
     </choose>
   </macro>
@@ -324,13 +466,12 @@
           <text macro="contributors-short-citation"/>
           <text macro="date"/>
         </group>
-        <text macro="point-locators"/>
       </group>
     </layout>
   </citation>
   <bibliography hanging-indent="false" line-spacing="1" entry-spacing="0">
     <sort>
-      <key macro="contributors"/>
+      <key macro="contributors-short-biblio"/>
       <key variable="issued"/>
     </sort>
     <layout>
@@ -339,18 +480,35 @@
         <text macro="date"/>
       </group>
       <group>
-        <text macro="contributors" suffix=", "/>
-        <text macro="title" strip-periods="true"/>
-        <text macro="secondary-contributors"/>
-        <text macro="short-container-contributors"/>
-        <text macro="locators"/>
-        <text macro="issue"/>
-        <text macro="series"/>
-        <text macro="edition"/>
-        <text macro="place-date"/>
-        <text macro="journal-date"/>
-        <text macro="locators-chapter"/>
-        <text macro="locators-article"/>
+        <choose>
+          <if type="entry-encyclopedia entry-dictionary" match="any">
+            <text macro="encyclopedia-article"/>
+          </if>
+          <else>
+            <text macro="contributors"/>
+            <text macro="title" strip-periods="false"/>
+            <text macro="secondary-contributors"/>
+            <text macro="review"/>
+            <text macro="short-container-contributors"/>
+            <text macro="locators"/>
+            <text macro="issue"/>
+            <text macro="series"/>
+            <choose>
+              <if type="article article-journal article-magazine article-newspaper" match="none">
+                <text macro="translated"/>
+                <text value=" "/>
+              </if>
+            </choose>
+            <text macro="edition"/>
+            <text macro="webpage-date"/>
+            <text macro="place-date"/>
+            <text macro="journal-date"/>
+            <text macro="locators-chapter"/>
+            <text macro="locators-article"/>
+          </else>
+        </choose>
+        <text macro="url"/>
+        <text macro="doi"/>
       </group>
     </layout>
   </bibliography>

--- a/deutsches-archaologisches-institut.csl
+++ b/deutsches-archaologisches-institut.csl
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<style class="in-text" version="1.0" delimiter-precedes-et-al="never" initialize-with="." names-delimiter=" &#8211; " demote-non-dropping-particle="sort-only" xmlns="http://purl.org/net/xbiblio/csl">
+<style class="in-text" version="1.0" delimiter-precedes-et-al="never" demote-non-dropping-particle="sort-only" xmlns="http://purl.org/net/xbiblio/csl">
   <!-- This style was edited with the Visual CSL Editor (http://editor.citationstyles.org/visualEditor/) -->
   <info>
     <title>Deutsches Archäologisches Institut</title>
@@ -103,7 +103,7 @@
   <macro name="editor">
     <names variable="editor">
       <name delimiter=" &#8211; " delimiter-precedes-et-al="never" delimiter-precedes-last="always" initialize-with=". "/>
-      <label form="short" strip-periods="false" prefix=" (" suffix=")"/>
+      <label form="short" prefix=" (" suffix=")"/>
     </names>
   </macro>
   <macro name="translator">
@@ -192,11 +192,11 @@
         </choose>
       </if>
       <else-if type="bill book graphic legal_case motion_picture report song thesis" match="any">
-        <text variable="title" strip-periods="false"/>
+        <text variable="title"/>
         <text variable="volume" prefix=" "/>
       </else-if>
       <else>
-        <text variable="title" strip-periods="false" quotes="false"/>
+        <text variable="title"/>
       </else>
     </choose>
   </macro>
@@ -303,7 +303,7 @@
         <text value=","/>
       </if>
     </choose>
-    <text variable="container-title" strip-periods="false" prefix=" "/>
+    <text variable="container-title" sprefix=" "/>
     <text variable="volume" prefix=" "/>
   </macro>
   <macro name="event">
@@ -315,9 +315,7 @@
   <macro name="issue">
     <choose>
       <if type="speech" match="any">
-        <group prefix=" " delimiter=", ">
-          <text macro="event"/>
-        </group>
+        <text macro="event" prefix=" "/>
       </if>
       <else-if type="paper-conference" match="any">
         <text variable="event" prefix=" "/>
@@ -331,7 +329,7 @@
   <macro name="series">
     <choose>
       <if match="any" variable="collection-title">
-        <text variable="collection-title" strip-periods="false" prefix=", "/>
+        <text variable="collection-title" prefix=", "/>
         <text variable="collection-number" prefix=" "/>
       </if>
     </choose>
@@ -362,7 +360,7 @@
         <text value=", "/>
         <group display="block">
           <text value="doi: " font-variant="small-caps"/>
-          <text variable="DOI" font-variant="normal"/>
+          <text variable="DOI"/>
         </group>
       </if>
     </choose>

--- a/deutsches-archaologisches-institut.csl
+++ b/deutsches-archaologisches-institut.csl
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <style class="in-text" version="1.0" delimiter-precedes-et-al="never" demote-non-dropping-particle="sort-only" xmlns="http://purl.org/net/xbiblio/csl">
   <!-- This style was edited with the Visual CSL Editor (http://editor.citationstyles.org/visualEditor/) -->
   <info>
@@ -60,7 +60,7 @@
             <if variable="editor author" match="all">
               <names variable="editor translator" prefix=", ">
                 <label form="verb-short" suffix=" "/>
-                <name delimiter=" – " initialize-with="."/>
+                <name delimiter=" &#8211; " initialize-with="."/>
               </names>
             </if>
           </choose>
@@ -76,11 +76,11 @@
             <if variable="editor container-title" match="any">
               <text term="in" prefix=", " suffix=": "/>
               <names variable="editor">
-                <name delimiter=" – " delimiter-precedes-et-al="never" delimiter-precedes-last="always" initialize-with="."/>
+                <name delimiter=" &#8211; " delimiter-precedes-et-al="never" delimiter-precedes-last="always" initialize-with="."/>
                 <label form="short" prefix=" (" suffix=")" strip-periods="false"/>
               </names>
               <names variable="container-author">
-                <name delimiter=" – " delimiter-precedes-et-al="never" delimiter-precedes-last="always" initialize-with="."/>
+                <name delimiter=" &#8211; " delimiter-precedes-et-al="never" delimiter-precedes-last="always" initialize-with="."/>
               </names>
               <text macro="collection-title"/>
             </if>
@@ -102,7 +102,7 @@
   </macro>
   <macro name="editor">
     <names variable="editor">
-      <name delimiter=" – " delimiter-precedes-et-al="never" delimiter-precedes-last="always" initialize-with=". "/>
+      <name delimiter=" &#8211; " delimiter-precedes-et-al="never" delimiter-precedes-last="always" initialize-with=". "/>
       <label form="short" prefix=" (" suffix=")"/>
     </names>
   </macro>
@@ -113,7 +113,7 @@
           <if match="none" variable="editor">
             <names variable="translator" prefix=", ">
               <label form="verb-short" suffix=" "/>
-              <name delimiter=" – " delimiter-precedes-et-al="never" delimiter-precedes-last="always" initialize-with="."/>
+              <name delimiter=" &#8211; " delimiter-precedes-et-al="never" delimiter-precedes-last="always" initialize-with="."/>
             </names>
           </if>
         </choose>
@@ -124,7 +124,7 @@
     <choose>
       <if variable="author">
         <names variable="author">
-          <name delimiter=" – " delimiter-precedes-et-al="never" delimiter-precedes-last="always" initialize-with=". "/>
+          <name delimiter=" &#8211; " delimiter-precedes-et-al="never" delimiter-precedes-last="always" initialize-with=". "/>
         </names>
       </if>
       <else-if variable="editor">
@@ -145,12 +145,12 @@
     <choose>
       <if variable="author">
         <names variable="author">
-          <name form="short" delimiter=" – " et-al-min="3" et-al-use-first="1"/>
+          <name form="short" delimiter=" &#8211; " et-al-min="3" et-al-use-first="1"/>
         </names>
       </if>
       <else-if variable="editor">
         <names variable="editor">
-          <name form="short" delimiter=" – " et-al-min="3" et-al-use-first="1"/>
+          <name form="short" delimiter=" &#8211; " et-al-min="3" et-al-use-first="1"/>
         </names>
       </else-if>
       <else>
@@ -167,14 +167,14 @@
           </if>
           <else>
             <names variable="author">
-              <name form="short" delimiter=" – " et-al-min="3" et-al-use-first="1"/>
+              <name form="short" delimiter=" &#8211; " et-al-min="3" et-al-use-first="1"/>
             </names>
           </else>
         </choose>
       </if>
       <else-if variable="editor">
         <names variable="editor">
-          <name form="short" delimiter=" – " delimiter-precedes-last="always" et-al-min="3" et-al-use-first="1"/>
+          <name form="short" delimiter=" &#8211; " delimiter-precedes-last="always" et-al-min="3" et-al-use-first="1"/>
         </names>
       </else-if>
       <else>
@@ -364,7 +364,7 @@
       <if match="any" variable="reviewed-author">
         <text term="reviewed-author" form="verb" prefix=", " suffix=" "/>
         <names variable="reviewed-author">
-          <name delimiter=" – " delimiter-precedes-et-al="never" delimiter-precedes-last="always" initialize-with="."/>
+          <name delimiter=" &#8211; " delimiter-precedes-et-al="never" delimiter-precedes-last="always" initialize-with="."/>
         </names>
         <text variable="reviewed-title" prefix=", "/>
       </if>

--- a/deutsches-archaologisches-institut.csl
+++ b/deutsches-archaologisches-institut.csl
@@ -303,7 +303,7 @@
         <text value=","/>
       </if>
     </choose>
-    <text variable="container-title" sprefix=" "/>
+    <text variable="container-title" prefix=" "/>
     <text variable="volume" prefix=" "/>
   </macro>
   <macro name="event">


### PR DESCRIPTION
Extensive changes in CSL to allow for use in multiple languages (esp. EN, DE, IT, FR and ES) with some custom locale. Added citation of Encyclopedia Article and Dictionary Entry. Added display of URLs and DOIs (line break with display block is not working properly). Added event and event date for conference papers. Added translators. Added review. Enforce use of Journal abbreviations if present. Added Presentation. Enhanced citation of Thesis. Ancient Authors: using short title as a work around (until a custom item type will be introduced in Zotero)