### PR TITLE
Update harvard-university-for-the-creative-arts.csl

### DIFF
--- a/harvard-university-for-the-creative-arts.csl
+++ b/harvard-university-for-the-creative-arts.csl
@@ -14,7 +14,7 @@
     <category citation-format="author-date"/>
     <category field="generic-base"/>
     <summary>University for the Creative Arts Harvard style</summary>
-    <updated>2017-06-24T11:51:19+00:00</updated>
+    <updated>2018-03-15T10:51:40+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale>
@@ -39,7 +39,7 @@
               <label form="short" plural="never" text-case="lowercase" prefix=" (" suffix=")"/>
               <et-al font-style="italic"/>
             </names>
-            <text variable="title"/>
+            <text variable="title" font-style="italic"/>
           </substitute>
         </names>
       </else>
@@ -162,10 +162,17 @@
     </choose>
   </macro>
   <macro name="edition-no">
-    <group delimiter=" " prefix="(" suffix=")">
-      <number variable="edition" form="ordinal"/>
-      <text term="edition" form="short"/>
-    </group>
+    <choose>
+      <if match="any" is-numeric="edition">
+        <group delimiter=" " prefix="(" suffix=")">
+          <number variable="edition" form="ordinal"/>
+          <text term="edition" form="short"/>
+        </group>
+      </if>
+      <else>
+        <text variable="edition" prefix="(" suffix=")"/>
+      </else>
+    </choose>
   </macro>
   <macro name="translator">
     <names variable="translator">
@@ -214,7 +221,7 @@
       <else-if type="report entry-dictionary entry-encyclopedia motion_picture chapter speech song paper-conference article-journal book" match="all" variable="URL">
         <text variable="publisher-place"/>
       </else-if>
-      <else-if type="manuscript" match="any"/>
+      <else-if type="manuscript map" match="any"/>
       <else>
         <text value="s.l." prefix="(" suffix=")"/>
       </else>
@@ -350,7 +357,7 @@
       </if>
       <else-if type="book chapter paper-conference entry-dictionary entry-encyclopedia motion_picture report manuscript article bill map song" match="any">
         <group>
-          <text variable="event" suffix=" "/>
+          <text variable="event" suffix=". "/>
           <group delimiter=":" suffix=".">
             <text macro="publisher-place"/>
             <text macro="publisher"/>


### PR DESCRIPTION
Improved handling of editions, if the data contains words and not just a number. Fix a couple of minor problems: Adds missing full stop after conference event field. Titles appearing at the start of references when there is no author are now in italics.