### PR TITLE
New version of Infoclio styles

### DIFF
--- a/infoclio-de.csl
+++ b/infoclio-de.csl
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <style xmlns="http://purl.org/net/xbiblio/csl" class="note" default-locale="de-CH" version="1.0" name-delimiter="; " delimiter-precedes-last="always" delimiter-precedes-et-al="never">
   <info>
-    <title>Infoclio (German - Switzerland)</title>
+    <title>infoclio.ch (German - Switzerland)</title>
     <id>http://www.zotero.org/styles/infoclio-de</id>
     <link href="http://www.zotero.org/styles/infoclio-de" rel="self"/>
     <link href="http://www.zotero.org/styles/infoclio-fr-smallcaps" rel="template"/>
@@ -25,7 +25,7 @@
     <category citation-format="note"/>
     <category field="history"/>
     <category field="social_science"/>
-    <updated>2015-08-28T15:05:38+02:00</updated>
+    <updated>2018-03-27T11:58:13+02:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale xml:lang="de">
@@ -159,7 +159,7 @@
           <name et-al-min="2" et-al-use-first="1"/>
         </names>
       </else-if>
-      <else-if type="report song broadcast motion_picture                      webpage post post-weblog" match="any">
+      <else-if type="report song broadcast motion_picture webpage post post-weblog" match="any">
         <!-- these types have either collection-title or container-title -->
         <text variable="collection-title"/>
         <text variable="container-title"/>
@@ -168,7 +168,7 @@
   </macro>
   <macro name="in">
     <choose>
-      <if type="chapter paper-conference                 entry-encyclopedia entry-dictionary                 article-magazine article-newspaper article-journal" match="any">
+      <if type="chapter paper-conference entry-encyclopedia entry-dictionary article-magazine article-newspaper article-journal" match="any">
         <text term="in"/>
       </if>
     </choose>
@@ -189,10 +189,10 @@
   </macro>
   <macro name="container-information">
     <choose>
-      <if type="chapter paper-conference                 entry-encyclopedia entry-dictionary                 article-newspaper article-magazine article-journal" match="any">
+      <if type="chapter paper-conference entry-encyclopedia entry-dictionary article-newspaper article-magazine article-journal" match="any">
         <text variable="container-title"/>
       </if>
-      <else-if type="report song broadcast motion_picture                      webpage post post-weblog" match="any">
+      <else-if type="report song broadcast motion_picture webpage post post-weblog" match="any">
         <group delimiter=", ">
           <text variable="genre"/>
           <!-- these types have either collection-title or container-title -->
@@ -217,7 +217,7 @@
   </macro>
   <macro name="volumes">
     <choose>
-      <if type="book chapter                 entry-encyclopedia entry-dictionary                 song motion_picture" match="any">
+      <if type="book chapter entry-encyclopedia entry-dictionary song motion_picture" match="any">
         <group delimiter=" / ">
           <group delimiter="&#160;">
             <label variable="volume" form="short"/>
@@ -283,7 +283,7 @@
   </macro>
   <macro name="alt-publisher">
     <choose>
-      <if type="book chapter                 paper-conference                 entry-dictionary entry-encyclopedia" match="none">
+      <if type="book chapter paper-conference entry-dictionary entry-encyclopedia" match="none">
         <!-- university for theses,
              institution for reports,
              label for songs,
@@ -324,7 +324,7 @@
           </else>
         </choose>
       </if>
-      <else-if type="article-journal article-newspaper article-magazine                      graphic entry-encyclopedia entry-dictionary                      report speech interview                      manuscript personal_communication" match="any">
+      <else-if type="article-journal article-newspaper article-magazine graphic entry-encyclopedia entry-dictionary report speech interview manuscript personal_communication" match="any">
         <choose>
           <if variable="issued">
             <date variable="issued" form="numeric" date-parts="year-month-day"/>
@@ -360,7 +360,7 @@
   </macro>
   <macro name="book-series">
     <choose>
-      <if type="book chapter paper-conference                 entry-dictionary entry-encyclopedia" match="any">
+      <if type="book chapter paper-conference entry-dictionary entry-encyclopedia" match="any">
         <group prefix="(" suffix=")" delimiter=" ">
           <text variable="collection-title"/>
           <choose>
@@ -403,29 +403,33 @@
   </macro>
   <macro name="url-non-web-documents">
     <choose>
-      <if variable="DOI">
-        <text term="online" text-case="capitalize-first" suffix=": "/>
-        <group delimiter=", ">
-          <text variable="source"/>
-          <group delimiter=": ">
-            <text value="DOI"/>
-            <text variable="DOI"/>
-          </group>
-        </group>
-      </if>
-      <else-if variable="URL">
+      <if type="webpage post post-weblog" match="none">
         <choose>
-          <if type="webpage post post-weblog" match="none">
+          <if variable="DOI URL" match="any">
             <group delimiter=" ">
               <text term="online" text-case="capitalize-first" suffix=": "/>
-              <group delimiter=", ">
-                <text variable="source"/>
-                <text macro="url"/>
-              </group>
+              <choose>
+                <if variable="DOI">
+                  <group delimiter=", ">
+                    <group delimiter="">
+                      <text value="&lt;"/>
+                      <text variable="DOI" prefix="https://doi.org/"/>
+                      <text value="&gt;"/>
+                    </group>
+                    <group delimiter=" ">
+                      <text term="accessed"/>
+                      <date variable="accessed" form="numeric" date-parts="year-month-day"/>
+                    </group>
+                  </group>
+                </if>
+                <else-if variable="URL">
+                  <text macro="url"/>
+                </else-if>
+              </choose>
             </group>
           </if>
         </choose>
-      </else-if>
+      </if>
     </choose>
   </macro>
   <macro name="url">

--- a/infoclio-fr-nocaps.csl
+++ b/infoclio-fr-nocaps.csl
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <style xmlns="http://purl.org/net/xbiblio/csl" class="note" default-locale="fr-FR" version="1.0" delimiter-precedes-last="never" delimiter-precedes-et-al="never" and="text">
   <info>
-    <title>Infoclio (sans majuscules, French)</title>
+    <title>infoclio.ch (sans majuscules, French)</title>
     <id>http://www.zotero.org/styles/infoclio-fr-nocaps</id>
     <link href="http://www.zotero.org/styles/infoclio-fr-nocaps" rel="self"/>
     <link href="http://www.zotero.org/styles/infoclio-fr-smallcaps" rel="template"/>
@@ -25,7 +25,7 @@
     <category citation-format="note"/>
     <category field="history"/>
     <category field="social_science"/>
-    <updated>2015-08-28T15:07:44+02:00</updated>
+    <updated>2018-03-27T11:58:06+02:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale xml:lang="fr">
@@ -42,7 +42,7 @@
       </term>
       <term name="editor" form="short">
         <single>éd.</single>
-        <multiple>éds</multiple>
+        <multiple>éds.</multiple>
       </term>
       <term name="interviewer" form="verb">entretien réalisé par</term>
       <term name="letter">courrier</term>
@@ -126,7 +126,6 @@
     <names variable="author">
       <name sort-separator=" " name-as-sort-order="all" et-al-min="4" et-al-use-first="3"/>
       <label form="short" prefix="&#160;(" suffix=")"/>
-      <et-al font-style="italic"/>
       <substitute>
         <names variable="editor"/>
         <names variable="composer"/>
@@ -138,7 +137,6 @@
     <names variable="author">
       <name form="short" et-al-min="4" et-al-use-first="1"/>
       <label form="short" prefix="&#160;(" suffix=")"/>
-      <et-al font-style="italic"/>
       <substitute>
         <names variable="editor"/>
         <names variable="composer"/>
@@ -151,7 +149,7 @@
       <if type="book thesis graphic" match="any">
         <text variable="title" font-style="italic"/>
       </if>
-      <else-if type="article                      article-magazine article-newspaper article-journal                      entry entry-dictionary entry-encyclopedia                      report chapter paper-conference                      post post-weblog webpage                      song broadcast" match="any">
+      <else-if type="article article-magazine article-newspaper article-journal entry entry-dictionary entry-encyclopedia report chapter paper-conference post post-weblog webpage song broadcast" match="any">
         <text variable="title" quotes="true"/>
       </else-if>
       <else-if type="motion_picture">
@@ -176,7 +174,7 @@
           <if type="book thesis graphic" match="any">
             <text variable="title" font-style="italic" form="short"/>
           </if>
-          <else-if type="article                          article-magazine article-newspaper article-journal                          entry entry-dictionary entry-encyclopedia                          report chapter paper-conference                          post post-weblog webpage                          song broadcast" match="any">
+          <else-if type="article article-magazine article-newspaper article-journal entry entry-dictionary entry-encyclopedia report chapter paper-conference post post-weblog webpage song broadcast" match="any">
             <text variable="title" quotes="true" form="short"/>
           </else-if>
           <else-if type="motion_picture">
@@ -200,7 +198,6 @@
           <names variable="recipient">
             <label form="verb" prefix=" " suffix=" "/>
             <name et-al-min="3" et-al-use-first="1"/>
-            <et-al font-style="italic"/>
           </names>
         </group>
       </else-if>
@@ -208,10 +205,9 @@
         <names variable="interviewer" delimiter=", ">
           <label form="verb" prefix=" " suffix=" "/>
           <name et-al-min="3" et-al-use-first="1"/>
-          <et-al font-style="italic"/>
         </names>
       </else-if>
-      <else-if type="report song broadcast motion_picture                      webpage post post-weblog" match="any">
+      <else-if type="report song broadcast motion_picture webpage post post-weblog" match="any">
         <!-- these types have either collection-title or container-title -->
         <text variable="collection-title" font-style="italic"/>
         <text variable="container-title" font-style="italic"/>
@@ -221,13 +217,13 @@
   <macro name="op-cit">
     <group font-style="italic" delimiter="&#160;" suffix=".">
       <choose>
-        <if type="article                   article-magazine article-newspaper article-journal                   entry entry-dictionary entry-encyclopedia                   chapter paper-conference                   post post-weblog" match="any">
+        <if type="article article-magazine article-newspaper article-journal entry entry-dictionary entry-encyclopedia chapter paper-conference post post-weblog" match="any">
           <text value="art."/>
         </if>
-        <else-if type="manuscript personal_communication interview                        report webpage" match="any">
+        <else-if type="manuscript personal_communication interview report webpage" match="any">
           <text value="doc."/>
         </else-if>
-        <else-if type="book thesis graphic                        motion_picture song broadcast" match="any">
+        <else-if type="book thesis graphic motion_picture song broadcast" match="any">
           <text value="op."/>
         </else-if>
       </choose>
@@ -236,7 +232,7 @@
   </macro>
   <macro name="in">
     <choose>
-      <if type="chapter paper-conference                 entry-encyclopedia entry-dictionary" match="any">
+      <if type="chapter paper-conference entry-encyclopedia entry-dictionary" match="any">
         <text term="in"/>
       </if>
     </choose>
@@ -247,7 +243,6 @@
         <names variable="editor">
           <name sort-separator=" " name-as-sort-order="all" et-al-min="4" et-al-use-first="3"/>
           <label form="short" prefix="&#160;(" suffix=")"/>
-          <et-al font-style="italic"/>
           <substitute>
             <names variable="container-author"/>
             <names variable="collection-editor"/>
@@ -258,10 +253,10 @@
   </macro>
   <macro name="container-information">
     <choose>
-      <if type="chapter paper-conference                 entry-encyclopedia entry-dictionary                 article-newspaper article-magazine article-journal" match="any">
+      <if type="chapter paper-conference entry-encyclopedia entry-dictionary article-newspaper article-magazine article-journal" match="any">
         <text variable="container-title" font-style="italic"/>
       </if>
-      <else-if type="report song broadcast motion_picture                      webpage post post-weblog" match="any">
+      <else-if type="report song broadcast motion_picture webpage post post-weblog" match="any">
         <group delimiter=", ">
           <text variable="genre"/>
           <!-- these types have either collection-title or container-title -->
@@ -286,7 +281,7 @@
   </macro>
   <macro name="volumes">
     <choose>
-      <if type="book chapter                 entry-encyclopedia entry-dictionary                 song motion_picture" match="any">
+      <if type="book chapter entry-encyclopedia entry-dictionary song motion_picture" match="any">
         <group delimiter=" / ">
           <group delimiter="&#160;">
             <label variable="volume" form="short"/>
@@ -352,7 +347,7 @@
   </macro>
   <macro name="alt-publisher">
     <choose>
-      <if type="book chapter                 thesis report                 paper-conference                 entry-dictionary entry-encyclopedia" match="none">
+      <if type="book chapter thesis report paper-conference entry-dictionary entry-encyclopedia" match="none">
         <!--
              label for songs,
              distributor for films,
@@ -364,7 +359,7 @@
   </macro>
   <macro name="edition">
     <choose>
-      <if type="book chapter                 entry-dictionary entry-encyclopedia" match="any">
+      <if type="book chapter entry-dictionary entry-encyclopedia" match="any">
         <choose>
           <if is-numeric="edition">
             <group delimiter="&#160;">
@@ -394,7 +389,7 @@
   </macro>
   <macro name="publishing-house">
     <choose>
-      <if type="book chapter thesis report                 paper-conference                 entry-dictionary entry-encyclopedia" match="any">
+      <if type="book chapter thesis report paper-conference entry-dictionary entry-encyclopedia" match="any">
         <text variable="publisher"/>
       </if>
     </choose>
@@ -411,7 +406,7 @@
           </else>
         </choose>
       </if>
-      <else-if type="article-journal article-newspaper article-magazine                      graphic entry-encyclopedia entry-dictionary                      report speech interview                      manuscript personal_communication" match="any">
+      <else-if type="article-journal article-newspaper article-magazine graphic entry-encyclopedia entry-dictionary report speech interview manuscript personal_communication" match="any">
         <choose>
           <if variable="issued">
             <date variable="issued" form="numeric" date-parts="year-month-day"/>
@@ -447,7 +442,7 @@
   </macro>
   <macro name="book-series">
     <choose>
-      <if type="book chapter paper-conference                 entry-dictionary entry-encyclopedia" match="any">
+      <if type="book chapter paper-conference entry-dictionary entry-encyclopedia" match="any">
         <group prefix="(" suffix=")" delimiter=" ">
           <text variable="collection-title"/>
           <choose>
@@ -490,29 +485,33 @@
   </macro>
   <macro name="url-non-web-documents">
     <choose>
-      <if variable="DOI">
-        <text term="online" text-case="capitalize-first" suffix=": "/>
-        <group delimiter=", ">
-          <text variable="source"/>
-          <group delimiter=": ">
-            <text value="DOI"/>
-            <text variable="DOI"/>
-          </group>
-        </group>
-      </if>
-      <else-if variable="URL">
+      <if type="webpage post post-weblog" match="none">
         <choose>
-          <if type="webpage post post-weblog" match="none">
+          <if variable="DOI URL" match="any">
             <group delimiter=" ">
               <text term="online" text-case="capitalize-first" suffix=": "/>
-              <group delimiter=", ">
-                <text variable="source"/>
-                <text macro="url"/>
-              </group>
+              <choose>
+                <if variable="DOI">
+                  <group delimiter=", ">
+                    <group delimiter="">
+                      <text value="&lt;"/>
+                      <text variable="DOI" prefix="https://doi.org/"/>
+                      <text value="&gt;"/>
+                    </group>
+                    <group delimiter=" ">
+                      <text term="accessed"/>
+                      <date variable="accessed" form="numeric" date-parts="year-month-day"/>
+                    </group>
+                  </group>
+                </if>
+                <else-if variable="URL">
+                  <text macro="url"/>
+                </else-if>
+              </choose>
             </group>
           </if>
         </choose>
-      </else-if>
+      </if>
     </choose>
   </macro>
   <macro name="url">

--- a/infoclio-fr-smallcaps.csl
+++ b/infoclio-fr-smallcaps.csl
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <style xmlns="http://purl.org/net/xbiblio/csl" class="note" default-locale="fr-FR" version="1.0" delimiter-precedes-last="never" delimiter-precedes-et-al="never" and="text">
   <info>
-    <title>Infoclio (petites majuscules, French)</title>
+    <title>infoclio.ch (petites majuscules, French)</title>
     <id>http://www.zotero.org/styles/infoclio-fr-smallcaps</id>
     <link href="http://www.zotero.org/styles/infoclio-fr-smallcaps" rel="self"/>
     <link href="https://www.infoclio.ch/fr/node/138218" rel="documentation"/>
@@ -24,7 +24,7 @@
     <category citation-format="note"/>
     <category field="history"/>
     <category field="social_science"/>
-    <updated>2015-08-28T15:07:37+02:00</updated>
+    <updated>2018-03-27T11:57:56+02:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale xml:lang="fr">
@@ -41,7 +41,7 @@
       </term>
       <term name="editor" form="short">
         <single>éd.</single>
-        <multiple>éds</multiple>
+        <multiple>éds.</multiple>
       </term>
       <term name="interviewer" form="verb">entretien réalisé par</term>
       <term name="letter">courrier</term>
@@ -127,7 +127,6 @@
         <name-part name="family" font-variant="small-caps"/>
       </name>
       <label form="short" prefix="&#160;(" suffix=")"/>
-      <et-al font-style="italic"/>
       <substitute>
         <names variable="editor"/>
         <names variable="composer"/>
@@ -141,7 +140,6 @@
         <name-part name="family" font-variant="small-caps"/>
       </name>
       <label form="short" prefix="&#160;(" suffix=")"/>
-      <et-al font-style="italic"/>
       <substitute>
         <names variable="editor"/>
         <names variable="composer"/>
@@ -203,7 +201,6 @@
           <names variable="recipient">
             <label form="verb" prefix=" " suffix=" "/>
             <name et-al-min="3" et-al-use-first="1"/>
-            <et-al font-style="italic"/>
           </names>
         </group>
       </else-if>
@@ -211,7 +208,6 @@
         <names variable="interviewer" delimiter=", ">
           <label form="verb" prefix=" " suffix=" "/>
           <name et-al-min="3" et-al-use-first="1"/>
-          <et-al font-style="italic"/>
         </names>
       </else-if>
       <else-if type="report song broadcast motion_picture                      webpage post post-weblog" match="any">
@@ -252,7 +248,6 @@
             <name-part name="family" font-variant="small-caps"/>
           </name>
           <label form="short" prefix="&#160;(" suffix=")"/>
-          <et-al font-style="italic"/>
           <substitute>
             <names variable="container-author"/>
             <names variable="collection-editor"/>
@@ -495,29 +490,33 @@
   </macro>
   <macro name="url-non-web-documents">
     <choose>
-      <if variable="DOI">
-        <text term="online" text-case="capitalize-first" suffix=": "/>
-        <group delimiter=", ">
-          <text variable="source"/>
-          <group delimiter=": ">
-            <text value="DOI"/>
-            <text variable="DOI"/>
-          </group>
-        </group>
-      </if>
-      <else-if variable="URL">
+      <if type="webpage post post-weblog" match="none">
         <choose>
-          <if type="webpage post post-weblog" match="none">
+          <if variable="DOI URL" match="any">
             <group delimiter=" ">
               <text term="online" text-case="capitalize-first" suffix=": "/>
-              <group delimiter=", ">
-                <text variable="source"/>
-                <text macro="url"/>
-              </group>
+              <choose>
+                <if variable="DOI">
+                  <group delimiter=", ">
+                    <group delimiter="">
+                      <text value="&lt;"/>
+                      <text variable="DOI" prefix="https://doi.org/"/>
+                      <text value="&gt;"/>
+                    </group>
+                    <group delimiter=" ">
+                      <text term="accessed"/>
+                      <date variable="accessed" form="numeric" date-parts="year-month-day"/>
+                    </group>
+                  </group>
+                </if>
+                <else-if variable="URL">
+                  <text macro="url"/>
+                </else-if>
+              </choose>
             </group>
           </if>
         </choose>
-      </else-if>
+      </if>
     </choose>
   </macro>
   <macro name="url">


### PR DESCRIPTION
This is a small update to a custom style for history students in Switzerland. See #234 for the original pull request, and #1675 for the last update.

Changes:
- name is now infoclio.ch
- Show DOIs as full URLs
- French: make abbreviations (et al., éds.) consistent with documentation
- whitespace clean-up

Thank you for taking the time to maintain the styles.