### PR TITLE
Update metallurgical-and-materials-transactions-a.csl

### DIFF
--- a/metallurgical-and-materials-transactions-a.csl
+++ b/metallurgical-and-materials-transactions-a.csl
@@ -12,7 +12,7 @@
     <issn>1073-5623</issn>
     <eissn>1543-1940</eissn>
     <summary>Style for the Springer Metallurgical and Materials Transactrions</summary>
-    <updated>2017-04-12T22:42:45+00:00</updated>
+    <updated>2018-03-28T15:00:00+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <macro name="editor">
@@ -152,7 +152,7 @@
                 <text macro="pages"/>
               </if>
               <else>
-                <text variable="DOI" prefix=", DOI:"/>
+                <text variable="DOI" prefix="DOI:"/>
               </else>
             </choose>
           </group>


### PR DESCRIPTION
This patch removes an extra comma from article entries with no page reference. The comma is already provided by the enclosing `<group>`.