### PR TITLE
Fix for conditions with multiple type values without match="any"

### DIFF
--- a/anabases.csl
+++ b/anabases.csl
@@ -123,7 +123,7 @@
   </macro>
   <macro name="year-date">
     <choose>
-      <if type="webpage post-weblog">
+      <if type="webpage post-weblog" match="any">
         <text term="online" suffix=" "/>
         <date variable="issued" form="text"/>
       </if>

--- a/annals-of-joint.csl
+++ b/annals-of-joint.csl
@@ -68,7 +68,7 @@
   </macro>
   <macro name="access">
     <choose>
-      <if type="webpage post-weblog">
+      <if type="webpage post-weblog" match="any">
         <choose>
           <if variable="URL">
             <text variable="URL"/>

--- a/associacao-brasileira-de-normas-tecnicas-unirio-eipp.csl
+++ b/associacao-brasileira-de-normas-tecnicas-unirio-eipp.csl
@@ -215,7 +215,7 @@
   </macro>
   <macro name="genre">
     <choose>
-      <if type="paper-conference thesis report">
+      <if type="paper-conference thesis report" match="any">
         <text variable="genre"/>
       </if>
     </choose>

--- a/cambridge-university-press-numeric.csl
+++ b/cambridge-university-press-numeric.csl
@@ -68,7 +68,7 @@
   </macro>
   <macro name="access">
     <choose>
-      <if type="webpage post-weblog">
+      <if type="webpage post-weblog" match="any">
         <text variable="URL"/>
         <group prefix=" (" suffix=")" delimiter=" ">
           <text term="accessed"/>

--- a/centre-de-recherche-sur-les-civilisations-de-l-asie-orientale.csl
+++ b/centre-de-recherche-sur-les-civilisations-de-l-asie-orientale.csl
@@ -341,7 +341,7 @@
           </else>
         </choose>
       </if>
-      <else-if type="article-journal article-magazine">
+      <else-if type="article-journal article-magazine" match="any">
         <group delimiter="" font-style="normal">
           <group delimiter="/">
             <group delimiter=" ">

--- a/chimia.csl
+++ b/chimia.csl
@@ -85,7 +85,7 @@
   <!-- pages -->
   <macro name="pages">
     <choose>
-      <if type="chapter paper-conference">
+      <if type="chapter paper-conference" match="any">
         <label variable="page" form="short" suffix=" "/>
         <text variable="page-first"/>
       </if>
@@ -144,7 +144,7 @@
   <macro name="volume">
     <group delimiter=" ">
       <choose>
-        <if type="chapter paper-conference">
+        <if type="chapter paper-conference" match="any">
           <text term="volume" form="short" text-case="capitalize-first"/>
         </if>
       </choose>

--- a/college-montmorency.csl
+++ b/college-montmorency.csl
@@ -184,7 +184,7 @@
       <else-if type="bill">
         <text variable="locator" prefix="art.&#160;"/>
       </else-if>
-      <else-if type="broadcast interview motion_picture song speech">
+      <else-if type="broadcast interview motion_picture song speech" match="any">
         <text variable="locator"/>
       </else-if>
       <else>

--- a/cultivos-tropicales.csl
+++ b/cultivos-tropicales.csl
@@ -320,7 +320,7 @@
             <text macro="isbn"/>
           </group>
         </if>
-        <else-if type="article-journal article-magazine article-newspaper">
+        <else-if type="article-journal article-magazine article-newspaper" match="any">
           <group suffix=", ">
             <text macro="responsability"/>
             <text macro="title"/>
@@ -401,7 +401,7 @@
             <text macro="page"/>
           </group>
         </else-if>
-        <else-if type="legislation legal_case">
+        <else-if type="legislation legal_case" match="any">
           <group suffix=", ">
             <text macro="responsability"/>
             <text macro="title"/>

--- a/current-gene-therapy.csl
+++ b/current-gene-therapy.csl
@@ -54,7 +54,7 @@
   </macro>
   <macro name="title">
     <choose>
-      <if type="entry-dictionary entry-encyclopedia">
+      <if type="entry-dictionary entry-encyclopedia" match="any">
         <choose>
           <if variable="author">
             <text variable="title"/>

--- a/de-buck.csl
+++ b/de-buck.csl
@@ -130,7 +130,7 @@
         <text variable="title" font-style="italic"/>
       </if>
       <else-if type="manuscript"/>
-      <else-if type="thesis speech article">
+      <else-if type="thesis speech article" match="any">
         <text variable="title"/>
       </else-if>
       <else>
@@ -470,7 +470,7 @@
           <text variable="archive_location"/>
         </group>
       </else-if>
-      <else-if type="thesis speech article">
+      <else-if type="thesis speech article" match="any">
         <text variable="title" form="short"/>
       </else-if>
       <else>

--- a/documents-d-archeologie-francaise.csl
+++ b/documents-d-archeologie-francaise.csl
@@ -218,7 +218,7 @@
         <text variable="title" font-style="italic"/>
         <text variable="number" prefix=", "/>
       </else-if>
-      <else-if type="article-journal speech article-magazine article-newspaper post-weblog post">
+      <else-if type="article-journal speech article-magazine article-newspaper post-weblog post" match="any">
         <group delimiter=", ">
           <text variable="title" quotes="true"/>
           <text variable="container-title" form="short" font-style="italic"/>

--- a/edward-elgar-business-and-social-sciences.csl
+++ b/edward-elgar-business-and-social-sciences.csl
@@ -23,7 +23,7 @@
   <!-- Note: Patents and legal citations not currently supported -->
   <macro name="conditionalusetitle">
     <choose>
-      <if type="article-newspaper article-magazine">
+      <if type="article-newspaper article-magazine" match="any">
         <text variable="container-title"/>
       </if>
       <else>

--- a/elementa.csl
+++ b/elementa.csl
@@ -175,7 +175,7 @@
       <if type="chapter">
         <text variable="container-title" font-style="italic" text-case="title"/>
       </if>
-      <else-if type="article-magazine article-newspaper">
+      <else-if type="article-magazine article-newspaper" match="any">
         <text variable="container-title" font-style="italic"/>
       </else-if>
       <else-if type="article-journal">
@@ -241,7 +241,7 @@
       <choose>
         <if variable="volume issue page" match="none">
           <choose>
-            <if type="article-journal review review-book">
+            <if type="article-journal review review-book" match="any">
               <text term="in press" prefix=", "/>
             </if>
           </choose>

--- a/ens-de-lyon-centre-d-ingenierie-documentaire.csl
+++ b/ens-de-lyon-centre-d-ingenierie-documentaire.csl
@@ -518,7 +518,7 @@
       </choose>
       <!-- type/genre -->
       <choose>
-        <if type="thesis manuscript personal_communication speech motion_picture">
+        <if type="thesis manuscript personal_communication speech motion_picture" match="any">
           <text variable="genre"/>
         </if>
       </choose>

--- a/escuela-nacional-de-antropologia-e-historia-author-date.csl
+++ b/escuela-nacional-de-antropologia-e-historia-author-date.csl
@@ -314,7 +314,7 @@
   <!-- Título del contenedor -->
   <macro name="container-title">
     <choose>
-      <if type="chapter paper-conference">
+      <if type="chapter paper-conference" match="any">
         <text term="in" text-case="lowercase" prefix=", " suffix=" "/>
       </if>
     </choose>
@@ -453,7 +453,7 @@
       <else-if type="legal_case">
         <text variable="authority" prefix=". "/>
       </else-if>
-      <else-if type="speech paper-conference">
+      <else-if type="speech paper-conference" match="any">
         <group prefix=", " delimiter=". ">
           <text macro="event"/>
           <text macro="day-month"/>

--- a/escuela-nacional-de-antropologia-e-historia-full-note.csl
+++ b/escuela-nacional-de-antropologia-e-historia-full-note.csl
@@ -308,7 +308,7 @@
   <!-- Título del contenedor -->
   <macro name="container-title">
     <choose>
-      <if type="chapter paper-conference">
+      <if type="chapter paper-conference" match="any">
         <text term="in" text-case="lowercase" prefix=", " suffix=" "/>
       </if>
     </choose>

--- a/escuela-nacional-de-antropologia-e-historia-short-note.csl
+++ b/escuela-nacional-de-antropologia-e-historia-short-note.csl
@@ -310,7 +310,7 @@
   <!-- Título del contenedor -->
   <macro name="container-title">
     <choose>
-      <if type="chapter paper-conference">
+      <if type="chapter paper-conference" match="any">
         <text term="in" text-case="lowercase" prefix=", " suffix=" "/>
       </if>
     </choose>

--- a/european-journal-of-microbiology-and-immunology.csl
+++ b/european-journal-of-microbiology-and-immunology.csl
@@ -131,7 +131,7 @@
             </choose>
           </group>
         </else-if>
-        <else-if type="webpage post-weblog">
+        <else-if type="webpage post-weblog" match="any">
           <group delimiter=", " prefix=": ">
             <text macro="title"/>
             <text variable="URL"/>

--- a/european-journal-of-ultrasound.csl
+++ b/european-journal-of-ultrasound.csl
@@ -55,7 +55,7 @@
   </macro>
   <macro name="title">
     <choose>
-      <if type="entry-dictionary entry-encyclopedia">
+      <if type="entry-dictionary entry-encyclopedia" match="any">
         <choose>
           <if variable="author">
             <text variable="title"/>
@@ -94,7 +94,7 @@
           </else>
         </choose>
       </if>
-      <else-if type="entry-encyclopedia" variable="author">
+      <else-if type="entry-encyclopedia" variable="author" match="any">
         <text macro="editor-container"/>
       </else-if>
       <else-if type="chapter">
@@ -116,7 +116,7 @@
       <if type="report">
         <text macro="online" prefix=" [" suffix="]"/>
       </if>
-      <else-if type="thesis" variable="genre">
+      <else-if type="thesis" variable="genre" match="any">
         <group delimiter=", ">
           <text variable="genre" prefix="[" suffix="]"/>
           <text macro="online" prefix="[" suffix="]"/>

--- a/fachhochschule-vorarlberg-author-date.csl
+++ b/fachhochschule-vorarlberg-author-date.csl
@@ -415,7 +415,7 @@
         </else>
       </choose>
       <choose>
-        <if type="post-weblog webpage">
+        <if type="post-weblog webpage" match="any">
           <text macro="container-title"/>
         </if>
         <else>
@@ -424,7 +424,7 @@
       </choose>
       <text macro="container-prefix"/>
       <choose>
-        <if type="post-weblog webpage">
+        <if type="post-weblog webpage" match="any">
           <text macro="title"/>
         </if>
         <else>

--- a/fachhochschule-vorarlberg-note.csl
+++ b/fachhochschule-vorarlberg-note.csl
@@ -414,7 +414,7 @@
         </else>
       </choose>
       <choose>
-        <if type="post-weblog webpage">
+        <if type="post-weblog webpage" match="any">
           <text macro="container-title"/>
         </if>
         <else>
@@ -423,7 +423,7 @@
       </choose>
       <text macro="container-prefix"/>
       <choose>
-        <if type="post-weblog webpage">
+        <if type="post-weblog webpage" match="any">
           <text macro="title"/>
         </if>
         <else>

--- a/harvard-university-for-the-creative-arts.csl
+++ b/harvard-university-for-the-creative-arts.csl
@@ -262,7 +262,7 @@
       <else-if type="patent">
         <text variable="number" suffix="."/>
       </else-if>
-      <else-if type="broadcast motion_picture">
+      <else-if type="broadcast motion_picture" match="any">
         <choose>
           <if match="any" variable="collection-title container-title">
             <text term="in" text-case="capitalize-first" suffix=": "/>

--- a/infoclio-de.csl
+++ b/infoclio-de.csl
@@ -396,7 +396,7 @@
   </macro>
   <macro name="url-web-documents-only">
     <choose>
-      <if type="webpage post post-weblog">
+      <if type="webpage post post-weblog" match="any">
         <text macro="url"/>
       </if>
     </choose>

--- a/infoclio-fr-nocaps.csl
+++ b/infoclio-fr-nocaps.csl
@@ -478,7 +478,7 @@
   </macro>
   <macro name="url-web-documents-only">
     <choose>
-      <if type="webpage post post-weblog">
+      <if type="webpage post post-weblog" match="any">
         <text macro="url"/>
       </if>
     </choose>

--- a/infoclio-fr-smallcaps.csl
+++ b/infoclio-fr-smallcaps.csl
@@ -483,7 +483,7 @@
   </macro>
   <macro name="url-web-documents-only">
     <choose>
-      <if type="webpage post post-weblog">
+      <if type="webpage post post-weblog" match="any">
         <text macro="url"/>
       </if>
     </choose>

--- a/international-journal-of-osteoarchaeology.csl
+++ b/international-journal-of-osteoarchaeology.csl
@@ -69,7 +69,7 @@
   </macro>
   <macro name="title">
     <choose>
-      <if type="book thesis">
+      <if type="book thesis" match="any">
         <text variable="title" font-style="italic"/>
       </if>
       <else>

--- a/journal-fur-kunstgeschichte.csl
+++ b/journal-fur-kunstgeschichte.csl
@@ -533,7 +533,7 @@
   </macro>
   <macro name="url-web-documents-only">
     <choose>
-      <if type="webpage post post-weblog">
+      <if type="webpage post post-weblog" match="any">
         <text macro="url"/>
       </if>
     </choose>

--- a/journal-of-environmental-science-and-health-part-b.csl
+++ b/journal-of-environmental-science-and-health-part-b.csl
@@ -116,7 +116,7 @@
             <date date-parts="year" form="text" variable="issued"/>
           </group>
         </else-if>
-        <else-if type="webpage post-weblog">
+        <else-if type="webpage post-weblog" match="any">
           <text variable="title" suffix=". "/>
           <text variable="URL" suffix=" "/>
           <group delimiter=" " prefix="(" suffix=")">

--- a/journal-of-management-studies.csl
+++ b/journal-of-management-studies.csl
@@ -101,7 +101,7 @@
   </macro>
   <macro name="publisher">
     <choose>
-      <if type="book chapter">
+      <if type="book chapter" match="any">
         <group delimiter=": " prefix=", ">
           <text variable="publisher-place"/>
           <text variable="publisher"/>

--- a/journal-of-molecular-recognition.csl
+++ b/journal-of-molecular-recognition.csl
@@ -49,7 +49,7 @@
           </if>
           <else-if variable="URL">
             <choose>
-              <if type="webpage post-weblog article-journal">
+              <if type="webpage post-weblog article-journal" match="any">
                 <group delimiter=". ">
                   <text variable="URL"/>
                   <group>

--- a/journal-of-political-philosophy.csl
+++ b/journal-of-political-philosophy.csl
@@ -279,7 +279,7 @@
       </choose>
     </group>
     <choose>
-      <if type="webpage post-weblog">
+      <if type="webpage post-weblog" match="any">
         <text variable="URL" prefix=" &lt;" suffix="&gt;"/>
         <group prefix=" [" suffix="]">
           <text term="accessed"/>

--- a/jurnal-pangan-dan-agroindustri.csl
+++ b/jurnal-pangan-dan-agroindustri.csl
@@ -74,7 +74,7 @@
   </macro>
   <macro name="access">
     <choose>
-      <if type="webpage post-weblog">
+      <if type="webpage post-weblog" match="any">
         <text variable="URL"/>
       </if>
     </choose>
@@ -92,7 +92,7 @@
         <text variable="title"/>
         <text macro="edition" prefix=", "/>
       </else-if>
-      <else-if type="webpage post-weblog">
+      <else-if type="webpage post-weblog" match="any">
         <text variable="title"/>
       </else-if>
       <else>

--- a/microbial-cell.csl
+++ b/microbial-cell.csl
@@ -84,7 +84,7 @@
         <text macro="title"/>
       </group>
       <choose>
-        <if type="chapter paper-conference">
+        <if type="chapter paper-conference" match="any">
           <group delimiter=" " suffix=". ">
             <text term="in" text-case="capitalize-first" suffix=":"/>
             <names variable="editor">

--- a/mis-quarterly.csl
+++ b/mis-quarterly.csl
@@ -256,7 +256,7 @@
       <else>
         <text variable="URL"/>
         <choose>
-          <if type="post post-weblog webpage manuscript dataset">
+          <if type="post post-weblog webpage manuscript dataset" match="any">
             <group prefix=", " delimiter=" ">
               <text term="accessed"/>
               <date variable="accessed">

--- a/mondes-en-developpement.csl
+++ b/mondes-en-developpement.csl
@@ -221,7 +221,7 @@
             <text macro="number-of-pages"/>
           </group>
         </else-if>
-        <else-if type="chapter paper-conference" variable="container-title">
+        <else-if type="chapter paper-conference" variable="container-title" match="any">
           <text variable="title" quotes="false"/>
           <group prefix=", ">
             <text term="in" font-style="italic" suffix=" "/>

--- a/nehet.csl
+++ b/nehet.csl
@@ -224,7 +224,7 @@
               <text macro="year-date"/>
             </group>
           </if>
-          <else-if type="webpage post-weblog">
+          <else-if type="webpage post-weblog" match="any">
             <group delimiter=", ">
               <text macro="title" quotes="true"/>
               <text variable="container-title" font-style="italic"/>

--- a/padagogische-hochschule-fachhochschule-nordwestschweiz.csl
+++ b/padagogische-hochschule-fachhochschule-nordwestschweiz.csl
@@ -80,7 +80,7 @@
           <if type="entry entry-dictionary entry-encyclopedia broadcast" match="none">
             <text term="anonymous" text-case="capitalize-first"/>
           </if>
-          <else-if type="entry entry-dictionary entry-encyclopedia broadcast">
+          <else-if type="entry entry-dictionary entry-encyclopedia broadcast" match="any">
             <text variable="container-title" font-style="normal"/>
           </else-if>
         </choose>
@@ -183,7 +183,7 @@
           </if>
         </choose>
       </if>
-      <else-if type="entry entry-dictionary entry-encyclopedia">
+      <else-if type="entry entry-dictionary entry-encyclopedia" match="any">
         <text variable="title" font-style="normal"/>
       </else-if>
       <else>
@@ -277,7 +277,7 @@
         </group>
         <text variable="container-title" font-style="italic"/>
       </if>
-      <else-if type="article-journal article-newspaper post post-weblog webpage entry entry-dictionary entry-encyclopedia">
+      <else-if type="article-journal article-newspaper post post-weblog webpage entry entry-dictionary entry-encyclopedia" match="any">
         <group delimiter=": ">
           <text term="in" text-case="capitalize-first"/>
           <text variable="container-title" font-style="normal"/>
@@ -365,7 +365,7 @@
           <text macro="publisher"/>
           <!-- Datum ausgeben bei "broadcast" etc. -->
           <choose>
-            <if type="broadcast post-weblog">
+            <if type="broadcast post-weblog" match="any">
               <text macro="day-month-year"/>
             </if>
           </choose>

--- a/pest-management-science.csl
+++ b/pest-management-science.csl
@@ -76,7 +76,7 @@
   </macro>
   <macro name="access">
     <choose>
-      <if type="webpage post-weblog">
+      <if type="webpage post-weblog" match="any">
         <group delimiter=" ">
           <text variable="URL"/>
           <group delimiter=" " prefix="[" suffix="]">
@@ -138,7 +138,7 @@
       <text variable="citation-number"/>
       <text macro="author" suffix=", "/>
       <choose>
-        <if type="webpage post-weblog">
+        <if type="webpage post-weblog" match="any">
           <group delimiter=". ">
             <group delimiter=", ">
               <text macro="title"/>

--- a/plos.csl
+++ b/plos.csl
@@ -112,7 +112,7 @@
             <if type="article-journal">
               <text variable="container-title" form="short" strip-periods="true"/>
             </if>
-            <else-if type="post-weblog webpage">
+            <else-if type="post-weblog webpage" match="any">
               <group delimiter=" ">
                 <text term="in" text-case="capitalize-first" suffix=":"/>
                 <text variable="container-title"/>
@@ -168,7 +168,7 @@
         </choose>
         <text macro="edition" prefix=". "/>
       </if>
-      <else-if type="post-weblog webpage">
+      <else-if type="post-weblog webpage" match="any">
         <choose>
           <if variable="container-title" match="none">
             <text term="internet" prefix=" [" suffix="]" text-case="capitalize-first"/>
@@ -202,7 +202,7 @@
           <date variable="issued" form="text" date-parts="year"/>
         </group>
       </if>
-      <else-if type="article-magazine article-newspaper">
+      <else-if type="article-magazine article-newspaper" match="any">
         <date variable="issued" form="text"/>
       </else-if>
       <else-if type="bill legislation" match="any">
@@ -244,7 +244,7 @@
           <text variable="event-place"/>
         </group>
       </else-if>
-      <else-if type="post-weblog webpage">
+      <else-if type="post-weblog webpage" match="any">
         <date variable="issued" form="text"/>
         <text macro="accessed-date" prefix=" "/>
       </else-if>

--- a/prehospital-emergency-care.csl
+++ b/prehospital-emergency-care.csl
@@ -91,7 +91,7 @@
           <text term="forthcoming" text-case="capitalize-first" prefix="(" suffix=")"/>
         </group>
       </else-if>
-      <else-if type="webpage post-weblog">
+      <else-if type="webpage post-weblog" match="any">
         <group delimiter=" ">
           <group delimiter=" " suffix=".">
             <text term="available at" text-case="capitalize-first"/>

--- a/revista-latinoamericana-de-recursos-naturales.csl
+++ b/revista-latinoamericana-de-recursos-naturales.csl
@@ -176,7 +176,7 @@
   </macro>
   <macro name="publisher-place">
     <choose>
-      <if type="book paper-conference chapter entry-encyclopedia entry-dictionary entry post-weblog map patent legislation report thesis">
+      <if type="book paper-conference chapter entry-encyclopedia entry-dictionary entry post-weblog map patent legislation report thesis" match="any">
         <group delimiter=": ">
           <text variable="publisher-place"/>
           <text variable="publisher"/>
@@ -187,7 +187,7 @@
   </macro>
   <macro name="volume">
     <choose>
-      <if type="article-journal article-magazine">
+      <if type="article-journal article-magazine" match="any">
         <group>
           <text variable="volume"/>
           <text variable="issue" prefix="(" suffix=")"/>
@@ -350,7 +350,7 @@
             <text macro="accessed"/>
           </group>
         </if>
-        <else-if type="article-journal article-magazine article-newspaper post-weblog">
+        <else-if type="article-journal article-magazine article-newspaper post-weblog" match="any">
           <group suffix=". ">
             <text macro="author"/>
             <text macro="year-date"/>
@@ -370,7 +370,7 @@
             <text macro="accessed"/>
           </group>
         </else-if>
-        <else-if type="paper-conference chapter entry-encyclopedia entry-dictionary entry">
+        <else-if type="paper-conference chapter entry-encyclopedia entry-dictionary entry" match="any">
           <group suffix=". ">
             <text macro="author"/>
             <text macro="year-date"/>

--- a/society-of-biblical-literature-fullnote-bibliography.csl
+++ b/society-of-biblical-literature-fullnote-bibliography.csl
@@ -545,7 +545,7 @@
         </group>
       </else-if>
       <!-- Added dictionary and encyclopedia to properly display volume information-->
-      <else-if type="entry-dictionary entry-encyclopedia">
+      <else-if type="entry-dictionary entry-encyclopedia" match="any">
         <group prefix=". ">
           <number variable="number-of-volumes" form="numeric"/>
           <text term="volume" form="short" prefix=" " plural="true"/>
@@ -683,7 +683,7 @@
       <else-if type="article-journal">
         <text variable="locator" prefix=": "/>
       </else-if>
-      <else-if type="entry-dictionary entry-encyclopedia">
+      <else-if type="entry-dictionary entry-encyclopedia" match="any">
         <choose>
           <if position="first" variable="volume" match="all">
             <text macro="point-locators-subsequent" prefix=" "/>

--- a/the-institution-of-engineering-and-technology.csl
+++ b/the-institution-of-engineering-and-technology.csl
@@ -134,7 +134,7 @@
             </group>
           </group>
         </else-if>
-        <else-if type="patent thesis">
+        <else-if type="patent thesis" match="any">
           <group delimiter=", " prefix=". ">
             <text variable="genre"/>
             <text variable="publisher"/>

--- a/triangle.csl
+++ b/triangle.csl
@@ -385,7 +385,7 @@
       </if>
       <else-if variable="URL">
         <choose>
-          <if type="webpage post-weblog">
+          <if type="webpage post-weblog" match="any">
             <text value="URL complète en biblio"/>
           </if>
           <else>
@@ -405,7 +405,7 @@
       </if>
       <else-if variable="URL">
         <choose>
-          <if type="webpage post-weblog">
+          <if type="webpage post-weblog" match="any">
             <group delimiter=" ">
               <group>
                 <date variable="accessed" form="text" suffix=", " prefix="consulté le "/>

--- a/uludag-universitesi-sosyal-bilimler-enstitusu-author-date.csl
+++ b/uludag-universitesi-sosyal-bilimler-enstitusu-author-date.csl
@@ -563,7 +563,7 @@
       <if type="legal_case">
         <text variable="authority" prefix=". "/>
       </if>
-      <else-if type="speech paper-conference">
+      <else-if type="speech paper-conference" match="any">
         <group delimiter=", " prefix=", ">
           <group delimiter=", ">
             <text variable="genre" text-case="capitalize-first" prefix="(" suffix=")"/>

--- a/universidad-autonoma-cidudad-juarez-estilo-latino-humanistico.csl
+++ b/universidad-autonoma-cidudad-juarez-estilo-latino-humanistico.csl
@@ -251,7 +251,7 @@
   </macro>
   <macro name="date-periodical">
     <choose>
-      <if type="article-journal article-magazine">
+      <if type="article-journal article-magazine" match="any">
         <date variable="issued" form="text" date-parts="year-month"/>
       </if>
       <else-if type="article-newspaper">

--- a/universite-de-liege-droit.csl
+++ b/universite-de-liege-droit.csl
@@ -242,7 +242,7 @@
   </macro>
   <macro name="volume-or-medium">
     <choose>
-      <if type="book thesis chapter paper-conference motion_picture">
+      <if type="book thesis chapter paper-conference motion_picture" match="any">
         <group delimiter=", ">
           <text variable="volume"/>
         </group>
@@ -477,7 +477,7 @@
               </else>
             </choose>
             <choose>
-              <if type="book thesis">
+              <if type="book thesis" match="any">
                 <group delimiter=", ">
                   <text variable="volume"/>
                 </group>

--- a/universite-de-sherbrooke-departement-de-geomatique.csl
+++ b/universite-de-sherbrooke-departement-de-geomatique.csl
@@ -336,7 +336,7 @@
           </date>
         </group>
       </else-if>
-      <else-if type="bill legislation">
+      <else-if type="bill legislation" match="any">
         <date variable="issued" prefix=" (" suffix=")">
           <date-part name="year"/>
         </date>

--- a/university-college-lillebaelt-apa.csl
+++ b/university-college-lillebaelt-apa.csl
@@ -346,7 +346,7 @@
   <macro name="issued-year">
     <!---                                                                                                                                                                              MACRO: issued-year -->
     <choose>
-      <if type="bill legal_case legislation">
+      <if type="bill legal_case legislation" match="any">
       </if>
       <else-if variable="issued">
         <group>

--- a/university-college-lillebaelt-vancouver.csl
+++ b/university-college-lillebaelt-vancouver.csl
@@ -61,7 +61,7 @@
   </macro>
   <macro name="title">
     <choose>
-      <if type="entry-dictionary entry-encyclopedia">
+      <if type="entry-dictionary entry-encyclopedia" match="any">
         <choose>
           <if variable="author">
             <text variable="title"/>

--- a/university-of-gothenburg-apa-swedish-legislations.csl
+++ b/university-of-gothenburg-apa-swedish-legislations.csl
@@ -232,7 +232,7 @@
         </choose>
       </else-if>
       <!--- Italizes title for "blog post", "webpage" and Zotero item type "statute" -->
-      <else-if type="post-weblog webpage">
+      <else-if type="post-weblog webpage" match="any">
         <text variable="title" font-style="italic"/>
       </else-if>
       <else-if type="legislation">

--- a/worlds-poultry-science-journal.csl
+++ b/worlds-poultry-science-journal.csl
@@ -74,7 +74,7 @@
   </macro>
   <macro name="access">
     <choose>
-      <if type="webpage report">
+      <if type="webpage report" match="any">
         <text variable="URL"/>
         <date form="text" variable="accessed" prefix=" (accessed " suffix=")"/>
       </if>

--- a/zeitschrift-fur-ostmitteleuropa-forschung.csl
+++ b/zeitschrift-fur-ostmitteleuropa-forschung.csl
@@ -275,7 +275,7 @@
   </macro>
   <macro name="access">
     <choose>
-      <if type="webpage post-weblog">
+      <if type="webpage post-weblog" match="any">
         <group delimiter=" ">
           <text variable="URL" prefix=", URL: "/>
           <date form="numeric" variable="accessed" prefix="(" suffix=")"/>


### PR DESCRIPTION
Fixes #3405

I found two other cases which are more difficult to fix. I didn't touch those as adding `match="any"` would perhaps not be what the authors of these styles meant. (Better to let them fix that IMO.)

Example [here](https://github.com/citation-style-language/styles/blob/8617a2b8fd3f7e0add85c6c75df1135d01c19aee/sodertorns-hogskola-harvard-ibid.csl#L112) and [here](https://github.com/citation-style-language/styles/blob/957c039ac5926df00c983e92e3166ff995d6083a/sodertorns-hogskola-harvard.csl#L112):

```xml
<if variable="URL" type="webpage post-weblog">
```

I also found these two other cases but I'm not entirely sure whether they are mistakes. (Just letting you know in case they are.)

In [university-college-lillebaelt-vancouver.csl](https://github.com/citation-style-language/styles/blob/5e38d2aabba638edabfb9603388ea3d425d63fd1/university-college-lillebaelt-vancouver.csl#L166):

```xml
<if type="legislation bill"/>
```

And in [uppsala-universitet-historia.csl](https://github.com/citation-style-language/styles/blob/8a1fc526de3e662520d93ce70dbce16b0cd259ce/uppsala-universitet-historia.csl#L328):

```xml
<if is-numeric="edition" type="book article"/>
```


