### PR TITLE
More type fixes

### DIFF
--- a/american-journal-of-science.csl
+++ b/american-journal-of-science.csl
@@ -87,7 +87,7 @@
         </date>
       </group>
       <choose>
-        <if type="report ">
+        <if type="report">
           <group prefix=" " delimiter=", ">
             <group delimiter=" ">
               <text variable="title" suffix=":"/>

--- a/budownictwo-i-architektura-pl.csl
+++ b/budownictwo-i-architektura-pl.csl
@@ -139,7 +139,7 @@
           <date-part name="year" form="long"/>
         </date>
       </if>
-      <else-if type=" bill book chapter graphic legal_case legislation motion_picture paper-conference song thesis" match="any">
+      <else-if type="bill book chapter graphic legal_case legislation motion_picture paper-conference song thesis" match="any">
         <date variable="issued">
           <date-part name="year" form="long"/>
         </date>

--- a/clio-medica.csl
+++ b/clio-medica.csl
@@ -603,7 +603,7 @@
           <text macro="issued"/>
         </group>
       </else-if>
-      <else-if type="speech " match="any">
+      <else-if type="speech" match="any">
         <group prefix=", ">
           <text variable="genre" suffix=" "/>
           <text macro="event"/>

--- a/din-1505-2-alphanumeric.csl
+++ b/din-1505-2-alphanumeric.csl
@@ -302,7 +302,7 @@
           <date prefix=", " variable="issued" form="numeric" date-parts="year"/>
           <text prefix=". &#8212;&#160;" variable="note"/>
         </else-if>
-        <else-if type="webpage post post-weblog " match="any">
+        <else-if type="webpage post post-weblog" match="any">
           <text prefix=" " macro="title" suffix=". " font-style="italic"/>
           <text prefix="URL " variable="URL"/>
           <text prefix=". - " macro="access"/>

--- a/din-1505-2-numeric-alphabetical.csl
+++ b/din-1505-2-numeric-alphabetical.csl
@@ -296,7 +296,7 @@
           <date prefix=", " variable="issued" form="numeric" date-parts="year"/>
           <text prefix=". &#8212;&#160;" variable="note"/>
         </else-if>
-        <else-if type="webpage post post-weblog " match="any">
+        <else-if type="webpage post post-weblog" match="any">
           <text prefix=" " macro="title" suffix=". " font-style="italic"/>
           <text prefix="URL " variable="URL"/>
           <text prefix=". - " macro="access"/>

--- a/din-1505-2-numeric.csl
+++ b/din-1505-2-numeric.csl
@@ -282,7 +282,7 @@
           <date prefix=", " variable="issued" form="numeric" date-parts="year"/>
           <text prefix=". &#8212;&#160;" variable="note"/>
         </else-if>
-        <else-if type="webpage post post-weblog " match="any">
+        <else-if type="webpage post post-weblog" match="any">
           <text prefix=" " macro="title" suffix=". " font-style="italic"/>
           <text prefix="URL " variable="URL"/>
           <text prefix=". - " macro="access"/>

--- a/din-1505-2.csl
+++ b/din-1505-2.csl
@@ -354,7 +354,7 @@
           <text macro="bibliography-year" prefix=", "/>
           <text prefix=". &#8212;&#160;" variable="note"/>
         </else-if>
-        <else-if type="webpage post post-weblog " match="any">
+        <else-if type="webpage post post-weblog" match="any">
           <text prefix=" " macro="title" suffix=". " font-style="italic"/>
           <text prefix="URL " variable="URL"/>
           <text prefix=". - " macro="access"/>

--- a/economic-geology.csl
+++ b/economic-geology.csl
@@ -90,7 +90,7 @@
         </date>
       </group>
       <choose>
-        <if type="report ">
+        <if type="report">
           <group prefix=" " delimiter=", ">
             <group delimiter=" ">
               <text variable="title" suffix=":"/>

--- a/environmental-values.csl
+++ b/environmental-values.csl
@@ -244,7 +244,7 @@
             <text variable="page" prefix=":"/>
           </group>
         </else-if>
-        <else-if type="speech report paper-conference " match="any">
+        <else-if type="speech report paper-conference" match="any">
           <choose>
             <if variable="event">
               <text variable="event" suffix=". "/>

--- a/escuela-nacional-de-antropologia-e-historia-full-note.csl
+++ b/escuela-nacional-de-antropologia-e-historia-full-note.csl
@@ -480,12 +480,12 @@
               <if disambiguate="true">
                 <text macro="title-short" prefix=". "/>
                 <choose>
-                  <if type="article-journal article-magazine article-newspaper " match="none">
+                  <if type="article-journal article-magazine article-newspaper" match="none">
                     <text macro="locators-title" suffix=""/>
                   </if>
                 </choose>
                 <choose>
-                  <if type="article-journal article-magazine article-newspaper " match="any">
+                  <if type="article-journal article-magazine article-newspaper" match="any">
                     <text value="art.&#160;cit." prefix=", "/>
                   </if>
                   <else>
@@ -495,7 +495,7 @@
               </if>
               <else>
                 <choose>
-                  <if type="article-journal article-magazine article-newspaper " match="any">
+                  <if type="article-journal article-magazine article-newspaper" match="any">
                     <text value="art.&#160;cit." prefix=", "/>
                   </if>
                   <else>

--- a/escuela-nacional-de-antropologia-e-historia-short-note.csl
+++ b/escuela-nacional-de-antropologia-e-historia-short-note.csl
@@ -487,12 +487,12 @@
               <if disambiguate="true">
                 <text macro="title-short" prefix=". "/>
                 <choose>
-                  <if type="article-journal article-magazine article-newspaper " match="none">
+                  <if type="article-journal article-magazine article-newspaper" match="none">
                     <text macro="locators-title" suffix=""/>
                   </if>
                 </choose>
                 <choose>
-                  <if type="article-journal article-magazine article-newspaper " match="any">
+                  <if type="article-journal article-magazine article-newspaper" match="any">
                     <text value="art.&#160;cit." prefix=", "/>
                   </if>
                   <else>
@@ -502,7 +502,7 @@
               </if>
               <else>
                 <choose>
-                  <if type="article-journal article-magazine article-newspaper " match="any">
+                  <if type="article-journal article-magazine article-newspaper" match="any">
                     <text value="art.&#160;cit." prefix=", "/>
                   </if>
                   <else>

--- a/evidence-based-complementary-and-alternative-medicine.csl
+++ b/evidence-based-complementary-and-alternative-medicine.csl
@@ -50,7 +50,7 @@
           <date-part name="year" form="long"/>
         </date>
       </if>
-      <else-if type=" bill book chapter graphic legal_case legislation motion_picture paper-conference song thesis" match="any">
+      <else-if type="bill book chapter graphic legal_case legislation motion_picture paper-conference song thesis" match="any">
         <date variable="issued">
           <date-part name="year" form="long"/>
         </date>
@@ -109,7 +109,7 @@
   </macro>
   <macro name="publisher">
     <choose>
-      <if type=" bill book chapter graphic legal_case legislation motion_picture paper-conference song" match="any">
+      <if type="bill book chapter graphic legal_case legislation motion_picture paper-conference song" match="any">
         <group delimiter=": ">
           <text variable="publisher-place"/>
           <text variable="publisher"/>

--- a/harvard-bournemouth-university.csl
+++ b/harvard-bournemouth-university.csl
@@ -272,14 +272,14 @@
           <text variable="page"/>
         </group>
       </if>
-      <else-if type=" article-newspaper" match="any">
+      <else-if type="article-newspaper" match="any">
         <date variable="issued" prefix=", " form="text"/>
         <group delimiter=" " prefix=", ">
           <label variable="page" form="short"/>
           <text variable="page"/>
         </group>
       </else-if>
-      <else-if type="bill  book graphic legal_case legislation map motion_picture report song thesis" match="any">
+      <else-if type="bill book graphic legal_case legislation map motion_picture report song thesis" match="any">
         <group delimiter=", " prefix=". ">
           <text macro="event"/>
           <text macro="publisher"/>

--- a/harvard-edge-hill-university.csl
+++ b/harvard-edge-hill-university.csl
@@ -303,7 +303,7 @@
           </group>
         </group>
       </if>
-      <else-if type=" article-newspaper post-weblog" match="any">
+      <else-if type="article-newspaper post-weblog" match="any">
         <group delimiter=". " prefix=". ">
           <date variable="issued" delimiter=" ">
             <date-part name="day"/>

--- a/harvard-falmouth-university.csl
+++ b/harvard-falmouth-university.csl
@@ -354,7 +354,7 @@
           <text variable="page"/>
         </group>
       </if>
-      <else-if type=" article-newspaper" match="any">
+      <else-if type="article-newspaper" match="any">
         <date variable="issued" delimiter=" " prefix=", ">
           <date-part name="day"/>
           <date-part name="month" form="short" strip-periods="true"/>
@@ -362,7 +362,7 @@
         <text macro="online" prefix=" "/>
         <text variable="page" prefix=", "/>
       </else-if>
-      <else-if type="bill  book graphic legal_case legislation motion_picture report song thesis" match="any">
+      <else-if type="bill book graphic legal_case legislation motion_picture report song thesis" match="any">
         <group delimiter=", " prefix=". ">
           <text macro="event"/>
           <text macro="publisher"/>

--- a/harvard-robert-gordon-university.csl
+++ b/harvard-robert-gordon-university.csl
@@ -368,7 +368,7 @@
         </group>
         <text macro="online" prefix=". "/>
       </if>
-      <else-if type=" article-newspaper" match="any">
+      <else-if type="article-newspaper" match="any">
         <date variable="issued" delimiter=" " prefix=", ">
           <date-part name="day"/>
           <date-part name="month" form="short" strip-periods="true"/>
@@ -376,7 +376,7 @@
         <text macro="online" prefix=" "/>
         <text variable="page" prefix=", "/>
       </else-if>
-      <else-if type="bill  book graphic legal_case legislation motion_picture report song thesis" match="any">
+      <else-if type="bill book graphic legal_case legislation motion_picture report song thesis" match="any">
         <group delimiter=", " prefix=". ">
           <text macro="event"/>
           <text macro="publisher"/>
@@ -388,7 +388,7 @@
           <date variable="issued" form="text"/>
         </group>
       </else-if>
-      <else-if type=" speech" match="any">
+      <else-if type="speech" match="any">
         <group delimiter=", " prefix=". ">
           <text macro="event"/>
         </group>

--- a/harvard-southampton-solent-university.csl
+++ b/harvard-southampton-solent-university.csl
@@ -291,7 +291,7 @@
           <text variable="page"/>
         </group>
       </if>
-      <else-if type=" article-newspaper" match="any">
+      <else-if type="article-newspaper" match="any">
         <date variable="issued" delimiter=" " prefix=", ">
           <date-part name="day"/>
           <date-part name="month" form="short" strip-periods="true"/>

--- a/harvard-university-of-the-west-of-scotland.csl
+++ b/harvard-university-of-the-west-of-scotland.csl
@@ -308,14 +308,14 @@
           </group>
         </group>
       </if>
-      <else-if type=" article-newspaper" match="any">
+      <else-if type="article-newspaper" match="any">
         <date variable="issued" prefix=", " form="text"/>
         <group delimiter="" prefix=", ">
           <label variable="page" form="short"/>
           <text variable="page"/>
         </group>
       </else-if>
-      <else-if type="bill  book graphic legal_case legislation map motion_picture report song thesis" match="any">
+      <else-if type="bill book graphic legal_case legislation map motion_picture report song thesis" match="any">
         <group delimiter=", " prefix=". ">
           <text macro="event"/>
           <text macro="publisher"/>

--- a/harvard-york-st-john-university.csl
+++ b/harvard-york-st-john-university.csl
@@ -185,7 +185,7 @@
   </macro>
   <macro name="container-jnl">
     <choose>
-      <if type="article-journal article-magazine article-newspaper " match="any">
+      <if type="article-journal article-magazine article-newspaper" match="any">
         <choose>
           <if variable="URL">
             <group suffix=",">

--- a/hochschule-munchen-fakultat-fur-angewandte-sozialwissenschaften.csl
+++ b/hochschule-munchen-fakultat-fur-angewandte-sozialwissenschaften.csl
@@ -253,7 +253,7 @@
           </group>
         </group>
       </if>
-      <else-if type=" article-newspaper" match="any">
+      <else-if type="article-newspaper" match="any">
         <group delimiter=", " prefix=", ">
           <group delimiter=" ">
             <group>

--- a/ieee-magnetics-letters.csl
+++ b/ieee-magnetics-letters.csl
@@ -100,7 +100,7 @@
   </macro>
   <macro name="publisher">
     <choose>
-      <if type=" bill book chapter graphic legal_case legislation motion_picture paper-conference song" match="any">
+      <if type="bill book chapter graphic legal_case legislation motion_picture paper-conference song" match="any">
         <group delimiter=": ">
           <text variable="publisher-place"/>
           <text variable="publisher"/>

--- a/ieee-transactions-on-medical-imaging.csl
+++ b/ieee-transactions-on-medical-imaging.csl
@@ -50,7 +50,7 @@
           <date-part name="year" form="long"/>
         </date>
       </if>
-      <else-if type=" bill book chapter graphic legal_case legislation motion_picture paper-conference song thesis" match="any">
+      <else-if type="bill book chapter graphic legal_case legislation motion_picture paper-conference song thesis" match="any">
         <date variable="issued">
           <date-part name="year" form="long"/>
         </date>
@@ -109,7 +109,7 @@
   </macro>
   <macro name="publisher">
     <choose>
-      <if type=" bill book chapter graphic legal_case legislation motion_picture paper-conference song" match="any">
+      <if type="bill book chapter graphic legal_case legislation motion_picture paper-conference song" match="any">
         <group delimiter=": ">
           <text variable="publisher-place"/>
           <text variable="publisher"/>

--- a/ieee-with-url.csl
+++ b/ieee-with-url.csl
@@ -64,7 +64,7 @@
           <date-part name="year" form="long"/>
         </date>
       </if>
-      <else-if type=" bill book chapter graphic legal_case legislation motion_picture paper-conference song thesis" match="any">
+      <else-if type="bill book chapter graphic legal_case legislation motion_picture paper-conference song thesis" match="any">
         <date variable="issued">
           <date-part name="year" form="long"/>
         </date>
@@ -124,7 +124,7 @@
   </macro>
   <macro name="publisher">
     <choose>
-      <if type=" bill book chapter graphic legal_case legislation motion_picture paper-conference song" match="any">
+      <if type="bill book chapter graphic legal_case legislation motion_picture paper-conference song" match="any">
         <group delimiter=": ">
           <text variable="publisher-place"/>
           <text variable="publisher"/>

--- a/ieee.csl
+++ b/ieee.csl
@@ -64,7 +64,7 @@
           <date-part name="year" form="long"/>
         </date>
       </if>
-      <else-if type=" bill book chapter graphic legal_case legislation motion_picture paper-conference song thesis" match="any">
+      <else-if type="bill book chapter graphic legal_case legislation motion_picture paper-conference song thesis" match="any">
         <date variable="issued">
           <date-part name="year" form="long"/>
         </date>
@@ -124,7 +124,7 @@
   </macro>
   <macro name="publisher">
     <choose>
-      <if type=" bill book chapter graphic legal_case legislation motion_picture paper-conference song" match="any">
+      <if type="bill book chapter graphic legal_case legislation motion_picture paper-conference song" match="any">
         <group delimiter=": ">
           <text variable="publisher-place"/>
           <text variable="publisher"/>

--- a/international-journal-of-language-and-communication-disorders.csl
+++ b/international-journal-of-language-and-communication-disorders.csl
@@ -237,7 +237,7 @@
           <text variable="page"/>
         </group>
       </if>
-      <else-if type=" article-newspaper" match="any">
+      <else-if type="article-newspaper" match="any">
         <date variable="issued" delimiter=" " prefix=", ">
           <date-part name="day"/>
           <date-part name="month" form="short" strip-periods="true"/>
@@ -247,7 +247,7 @@
           <text variable="page"/>
         </group>
       </else-if>
-      <else-if type="bill  book graphic legal_case legislation motion_picture report song thesis" match="any">
+      <else-if type="bill book graphic legal_case legislation motion_picture report song thesis" match="any">
         <group delimiter=", " prefix=" ">
           <text macro="event"/>
           <text macro="publisher"/>

--- a/journal-of-computational-chemistry.csl
+++ b/journal-of-computational-chemistry.csl
@@ -19,7 +19,7 @@
   </info>
   <macro name="edition">
     <choose>
-      <if type="book paper-conference report " match="any">
+      <if type="book paper-conference report" match="any">
         <choose>
           <if is-numeric="edition">
             <group delimiter=" ">

--- a/limnology-and-oceanography.csl
+++ b/limnology-and-oceanography.csl
@@ -133,7 +133,7 @@
               <text macro="publisher"/>
             </group>
           </else-if>
-          <else-if type="report " match="any">
+          <else-if type="report" match="any">
             <group delimiter=" " suffix=".">
               <text macro="title" prefix=" " suffix="."/>
               <text variable="genre"/>

--- a/middle-east-critique.csl
+++ b/middle-east-critique.csl
@@ -311,7 +311,7 @@
       <if variable="page">
         <text variable="locator"/>
       </if>
-      <else-if type=" manuscript" match="any">
+      <else-if type="manuscript" match="any">
         <label variable="locator" form="short" suffix=" "/>
         <text variable="locator"/>
       </else-if>

--- a/navigation.csl
+++ b/navigation.csl
@@ -50,7 +50,7 @@
           <date-part name="year" form="long"/>
         </date>
       </if>
-      <else-if type=" bill book chapter graphic legal_case legislation motion_picture paper-conference song thesis" match="any">
+      <else-if type="bill book chapter graphic legal_case legislation motion_picture paper-conference song thesis" match="any">
         <date variable="issued">
           <date-part name="year" form="long"/>
         </date>
@@ -109,7 +109,7 @@
   </macro>
   <macro name="publisher">
     <choose>
-      <if type=" bill book chapter graphic legal_case legislation motion_picture paper-conference song" match="any">
+      <if type="bill book chapter graphic legal_case legislation motion_picture paper-conference song" match="any">
         <group delimiter=": ">
           <text variable="publisher-place"/>
           <text variable="publisher"/>

--- a/new-solutions.csl
+++ b/new-solutions.csl
@@ -90,7 +90,7 @@
   </macro>
   <macro name="publisher">
     <choose>
-      <if type=" bill book chapter graphic legal_case legislation motion_picture paper-conference song" match="any">
+      <if type="bill book chapter graphic legal_case legislation motion_picture paper-conference song" match="any">
         <text variable="publisher-place" suffix=": "/>
         <text variable="publisher"/>
       </if>

--- a/owbarth-verlag.csl
+++ b/owbarth-verlag.csl
@@ -287,7 +287,7 @@
           <date prefix=", " variable="issued" form="numeric" date-parts="year"/>
           <text prefix=". &#8212; " variable="note"/>
         </else-if>
-        <else-if type="webpage post post-weblog " match="any">
+        <else-if type="webpage post post-weblog" match="any">
           <text macro="title" font-style="normal" prefix=" " suffix=", "/>
           <text variable="URL" prefix="URL "/>
           <text macro="access" prefix=" "/>

--- a/phyllomedusa.csl
+++ b/phyllomedusa.csl
@@ -142,7 +142,7 @@
               <text macro="publisher"/>
             </group>
           </else-if>
-          <else-if type="report " match="any">
+          <else-if type="report" match="any">
             <group delimiter=" " suffix=".">
               <text macro="title" prefix=" " suffix="."/>
               <text variable="genre"/>

--- a/r-and-d-management.csl
+++ b/r-and-d-management.csl
@@ -284,7 +284,7 @@
             <text variable="page" prefix=":"/>
           </group>
         </else-if>
-        <else-if type="speech report paper-conference " match="any">
+        <else-if type="speech report paper-conference" match="any">
           <choose>
             <if variable="event">
               <text variable="event" suffix=". "/>

--- a/revista-latinoamericana-de-metalurgia-y-materiales.csl
+++ b/revista-latinoamericana-de-metalurgia-y-materiales.csl
@@ -51,7 +51,7 @@
           <date-part name="year" form="long"/>
         </date>
       </if>
-      <else-if type=" bill book graphic legal_case legislation motion_picture paper-conference song thesis" match="any">
+      <else-if type="bill book graphic legal_case legislation motion_picture paper-conference song thesis" match="any">
         <date variable="issued">
           <date-part name="year" form="long"/>
         </date>
@@ -96,7 +96,7 @@
   </macro>
   <macro name="publisher">
     <choose>
-      <if type=" bill book chapter graphic legal_case legislation motion_picture paper-conference song" match="any">
+      <if type="bill book chapter graphic legal_case legislation motion_picture paper-conference song" match="any">
         <group delimiter=": ">
           <text variable="publisher-place"/>
           <text variable="publisher"/>

--- a/sodertorns-hogskola-harvard-ibid.csl
+++ b/sodertorns-hogskola-harvard-ibid.csl
@@ -109,17 +109,21 @@
   </macro>
   <macro name="access">
     <choose>
-      <if variable="URL" type="webpage post-weblog">
-        <group>
-          <text variable="URL"/>
-        </group>
-        <group prefix=" [" suffix="]" delimiter=" ">
-          <date variable="accessed" delimiter="-">
-            <date-part name="year"/>
-            <date-part name="month" form="numeric-leading-zeros" strip-periods="true"/>
-            <date-part name="day"/>
-          </date>
-        </group>
+      <if variable="URL">
+        <choose>
+          <if type="webpage post-weblog" match="any">
+            <group>
+              <text variable="URL"/>
+            </group>
+            <group prefix=" [" suffix="]" delimiter=" ">
+              <date variable="accessed" delimiter="-">
+                <date-part name="year"/>
+                <date-part name="month" form="numeric-leading-zeros" strip-periods="true"/>
+                <date-part name="day"/>
+              </date>
+            </group>
+          </if>
+        </choose>
       </if>
     </choose>
   </macro>

--- a/sodertorns-hogskola-harvard-ibid.csl
+++ b/sodertorns-hogskola-harvard-ibid.csl
@@ -282,7 +282,7 @@
           </group>
         </group>
       </if>
-      <else-if type=" article-newspaper" match="any">
+      <else-if type="article-newspaper" match="any">
         <date variable="issued" prefix=", " form="text"/>
         <group delimiter=" " prefix=", ">
           <label variable="page" form="short"/>

--- a/sodertorns-hogskola-harvard.csl
+++ b/sodertorns-hogskola-harvard.csl
@@ -109,17 +109,21 @@
   </macro>
   <macro name="access">
     <choose>
-      <if variable="URL" type="webpage post-weblog">
-        <group>
-          <text variable="URL"/>
-        </group>
-        <group prefix=" [" suffix="]" delimiter=" ">
-          <date variable="accessed" delimiter="-">
-            <date-part name="year"/>
-            <date-part name="month" form="numeric-leading-zeros" strip-periods="true"/>
-            <date-part name="day"/>
-          </date>
-        </group>
+      <if variable="URL">
+        <choose>
+          <if type="webpage post-weblog" match="any">
+            <group>
+              <text variable="URL"/>
+            </group>
+            <group prefix=" [" suffix="]" delimiter=" ">
+              <date variable="accessed" delimiter="-">
+                <date-part name="year"/>
+                <date-part name="month" form="numeric-leading-zeros" strip-periods="true"/>
+                <date-part name="day"/>
+              </date>
+            </group>
+          </if>
+        </choose>
       </if>
     </choose>
   </macro>

--- a/sodertorns-hogskola-harvard.csl
+++ b/sodertorns-hogskola-harvard.csl
@@ -282,7 +282,7 @@
           </group>
         </group>
       </if>
-      <else-if type=" article-newspaper" match="any">
+      <else-if type="article-newspaper" match="any">
         <date variable="issued" prefix=", " form="text"/>
         <group delimiter=" " prefix=", ">
           <label variable="page" form="short"/>

--- a/taylor-and-francis-harvard-x.csl
+++ b/taylor-and-francis-harvard-x.csl
@@ -237,7 +237,7 @@
           <text variable="page"/>
         </group>
       </if>
-      <else-if type=" article-newspaper" match="any">
+      <else-if type="article-newspaper" match="any">
         <date variable="issued" delimiter=" " prefix=", ">
           <date-part name="day"/>
           <date-part name="month" form="short" strip-periods="true"/>
@@ -247,7 +247,7 @@
           <text variable="page"/>
         </group>
       </else-if>
-      <else-if type="bill  book graphic legal_case legislation motion_picture report song thesis" match="any">
+      <else-if type="bill book graphic legal_case legislation motion_picture report song thesis" match="any">
         <group delimiter=", " prefix=". ">
           <text macro="event"/>
           <text macro="publisher"/>

--- a/the-institute-of-electronics-information-and-communication-engineers.csl
+++ b/the-institute-of-electronics-information-and-communication-engineers.csl
@@ -44,7 +44,7 @@
           <date-part name="year" form="long"/>
         </date>
       </if>
-      <else-if type=" bill book chapter graphic legal_case legislation motion_picture paper-conference song thesis" match="any">
+      <else-if type="bill book chapter graphic legal_case legislation motion_picture paper-conference song thesis" match="any">
         <date variable="issued">
           <date-part name="year" form="long"/>
         </date>

--- a/the-journal-of-peasant-studies.csl
+++ b/the-journal-of-peasant-studies.csl
@@ -237,7 +237,7 @@
           <text variable="page"/>
         </group>
       </if>
-      <else-if type=" article-newspaper" match="any">
+      <else-if type="article-newspaper" match="any">
         <date variable="issued" delimiter=" " prefix=", ">
           <date-part name="day"/>
           <date-part name="month" form="short" strip-periods="true"/>

--- a/thomson-reuters-legal-tax-and-accounting-australia.csl
+++ b/thomson-reuters-legal-tax-and-accounting-australia.csl
@@ -165,7 +165,7 @@
   </macro>
   <macro name="date-parenthesis">
     <choose>
-      <if type="legal_case " match="any">
+      <if type="legal_case" match="any">
         <choose>
           <if variable="volume">
             <text macro="issued-year" prefix="(" suffix=")"/>

--- a/universiteit-utrecht-onderzoeksgids-geschiedenis.csl
+++ b/universiteit-utrecht-onderzoeksgids-geschiedenis.csl
@@ -291,7 +291,7 @@
       <else-if type="bill book graphic legal_case motion_picture report song thesis webpage" match="any">
         <text variable="locator" prefix=" "/>
       </else-if>
-      <else-if type=" manuscript" match="any">
+      <else-if type="manuscript" match="any">
         <label variable="locator" form="short" suffix=" "/>
         <text variable="locator"/>
       </else-if>
@@ -350,7 +350,7 @@
       <if variable="page">
         <text variable="locator"/>
       </if>
-      <else-if type=" manuscript" match="any">
+      <else-if type="manuscript" match="any">
         <label variable="locator" form="short" suffix=" "/>
         <text variable="locator"/>
       </else-if>

--- a/university-college-dublin-school-of-history-and-archives.csl
+++ b/university-college-dublin-school-of-history-and-archives.csl
@@ -722,7 +722,7 @@
         <if type="graphic report" match="any">
           <text macro="archive"/>
         </if>
-        <else-if type=" article-journal article-magazine article-newspaper bill book chapter graphic legal_case legislation motion_picture paper-conference report song" match="none">
+        <else-if type="article-journal article-magazine article-newspaper bill book chapter graphic legal_case legislation motion_picture paper-conference report song" match="none">
           <text macro="archive"/>
         </else-if>
       </choose>

--- a/university-college-lillebaelt-vancouver.csl
+++ b/university-college-lillebaelt-vancouver.csl
@@ -163,7 +163,7 @@
   </macro>
   <macro name="year">
     <choose>
-      <if type="legislation bill"/>
+      <if type="legislation bill" match="any"/>
       <else-if variable="issued accessed" match="none">
         <text term="no date" prefix="[" suffix="]"/>
       </else-if>

--- a/university-of-york-ieee.csl
+++ b/university-of-york-ieee.csl
@@ -45,7 +45,7 @@
           <date-part name="year" form="long"/>
         </date>
       </if>
-      <else-if type=" bill book chapter graphic legal_case legislation motion_picture paper-conference song thesis" match="any">
+      <else-if type="bill book chapter graphic legal_case legislation motion_picture paper-conference song thesis" match="any">
         <date variable="issued">
           <date-part name="year" form="long"/>
         </date>
@@ -112,7 +112,7 @@
   </macro>
   <macro name="publisher">
     <choose>
-      <if type=" bill book chapter graphic legal_case legislation motion_picture paper-conference song" match="any">
+      <if type="bill book chapter graphic legal_case legislation motion_picture paper-conference song" match="any">
         <group delimiter=": ">
           <text variable="publisher-place"/>
           <text variable="publisher"/>

--- a/uppsala-universitet-historia.csl
+++ b/uppsala-universitet-historia.csl
@@ -325,7 +325,11 @@
   </macro>
   <macro name="edition">
     <choose>
-      <if is-numeric="edition" type="book article"/>
+      <if is-numeric="edition">
+        <choose>
+          <if type="book article" match="any"/>
+        </choose>
+      </if>
       <else>
         <text variable="edition" form="short" text-case="lowercase" suffix="."/>
       </else>

--- a/zastosowania-komputerow-w-elektrotechnice.csl
+++ b/zastosowania-komputerow-w-elektrotechnice.csl
@@ -51,7 +51,7 @@
           <date-part name="year" form="long"/>
         </date>
       </if>
-      <else-if type=" bill book chapter graphic legal_case legislation motion_picture paper-conference song thesis" match="any">
+      <else-if type="bill book chapter graphic legal_case legislation motion_picture paper-conference song thesis" match="any">
         <date variable="issued">
           <date-part name="year" form="long"/>
         </date>
@@ -111,7 +111,7 @@
   </macro>
   <macro name="publisher">
     <choose>
-      <if type=" bill book chapter graphic legal_case legislation motion_picture paper-conference song" match="any">
+      <if type="bill book chapter graphic legal_case legislation motion_picture paper-conference song" match="any">
         <text variable="publisher-place"/>
       </if>
       <else>


### PR DESCRIPTION
Fixes a few additional issues mentioned in #3407 

```xml
<if variable="URL" type="webpage post-weblog">
<if type="legislation bill"/>
<if is-numeric="edition" type="book article"/>
```

I also took the liberty of cleaning up redundant whitespaces in some type attributes values.

Fixes are grouped in separate commits to make it easier to review and/or revert.

Let me know if that works @adam3smith 