### PR TITLE
Add the journal title to the style to print by default

### DIFF
--- a/american-statistical-association.csl
+++ b/american-statistical-association.csl
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" demote-non-dropping-particle="sort-only" default-locale="en-US">
   <info>
-    <title>American Statistical Association MOD</title>
-    <title-short>ASA-mod</title-short>
-    <id>http://www.zotero.org/styles/american-statistical-association-mod</id>
+    <title>American Statistical Association</title>
+    <title-short>ASA</title-short>
+    <id>http://www.zotero.org/styles/american-statistical-association</id>
     <link href="http://www.zotero.org/styles/american-statistical-association" rel="self"/>
     <link href="http://www.zotero.org/styles/american-society-of-civil-engineers" rel="template"/>
     <link href="http://amstat.tfjournals.com/asa-style-guide/" rel="documentation"/>
@@ -13,7 +13,7 @@
     <category citation-format="author-date"/>
     <category field="math"/>
     <summary>A style for the American Statistical Association used for all their journals.</summary>
-    <updated>2017-07-26T12:41:55+00:00</updated>
+    <updated>2018-04-18T12:41:55+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <macro name="container-contributors">

--- a/american-statistical-association.csl
+++ b/american-statistical-association.csl
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" demote-non-dropping-particle="sort-only" default-locale="en-US">
   <info>
-    <title>American Statistical Association</title>
-    <title-short>ASA</title-short>
-    <id>http://www.zotero.org/styles/american-statistical-association</id>
+    <title>American Statistical Association MOD</title>
+    <title-short>ASA-mod</title-short>
+    <id>http://www.zotero.org/styles/american-statistical-association-mod</id>
     <link href="http://www.zotero.org/styles/american-statistical-association" rel="self"/>
     <link href="http://www.zotero.org/styles/american-society-of-civil-engineers" rel="template"/>
     <link href="http://amstat.tfjournals.com/asa-style-guide/" rel="documentation"/>
@@ -143,6 +143,9 @@
           <text variable="container-title" font-style="italic"/>
         </group>
       </if>
+      <else>
+        <text variable="container-title" font-style="italic"/>
+      </else>
     </choose>
   </macro>
   <macro name="access">


### PR DESCRIPTION
The journal title (container-title) was not being printed in the default case. Added the else cause necessary to make this happen.