### PR TITLE
Update and rename associacao-brasileira-de-normas-tecnicas-ufjf.csl t…

### DIFF
--- a/renamed-styles.json
+++ b/renamed-styles.json
@@ -39,6 +39,7 @@
     "apsa": "american-political-science-association",
     "archives-of-dermatology": "jama-dermatology",
     "asa": "american-sociological-association",
+    "associacao-brasileira-de-normas-tecnicas-ufjf": "universidade-federal-de-juiz-de-fora",
     "australian-law-journal": "the-australian-law-journal",
     "automated-experimentation": "biomed-central",
     "bba-biochimica-et-biophysica-acta": "biochimica-et-biophysica-acta",

--- a/ufjf.csl
+++ b/ufjf.csl
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <style xmlns="http://purl.org/net/xbiblio/csl" version="1.0" class="in-text" default-locale="pt-BR" demote-non-dropping-particle="never">
   <info>
-    <title>Universidade Federal de Juiz de Fora - ABNT (Portuguese - Brazil)</title>
-    <title-short>ABNT-UFJF</title-short>
-    <id>http://www.zotero.org/styles/associacao-brasileira-de-normas-tecnicas-ufjf</id>
-    <link href="http://www.zotero.org/styles/associacao-brasileira-de-normas-tecnicas-ufjf" rel="self"/>
+    <title>Universidade Federal de Juiz de Fora (Portuguese - Brazil)</title>
+    <title-short>UFJF</title-short>
+    <id>http://www.zotero.org/styles/ufjf</id>
+    <link href="http://www.zotero.org/styles/ufjf" rel="self"/>
     <link href="http://www.zotero.org/styles/associacao-brasileira-de-normas-tecnicas-ufmg-face-full" rel="template"/>
     <!--Manual de referência ABNT: SOUSA, Vânia Pinheiro de. Manual para Elaboração de Trabalhos Acadêmicos. Juiz de Fora: UFJF, 2008.-->
     <link href="www.ufjf.br/engenhariadeproducao/files/2010/05/manual_para_elaboracao_TCC.pdf" rel="documentation"/>

--- a/universidade-federal-de-juiz-de-fora.csl
+++ b/universidade-federal-de-juiz-de-fora.csl
@@ -3,8 +3,8 @@
   <info>
     <title>Universidade Federal de Juiz de Fora (Portuguese - Brazil)</title>
     <title-short>UFJF</title-short>
-    <id>http://www.zotero.org/styles/ufjf</id>
-    <link href="http://www.zotero.org/styles/ufjf" rel="self"/>
+    <id>http://www.zotero.org/styles/universidade-federal-de-juiz-de-fora</id>
+    <link href="http://www.zotero.org/styles/universidade-federal-de-juiz-de-fora" rel="self"/>
     <link href="http://www.zotero.org/styles/associacao-brasileira-de-normas-tecnicas-ufmg-face-full" rel="template"/>
     <!--Manual de referência ABNT: SOUSA, Vânia Pinheiro de. Manual para Elaboração de Trabalhos Acadêmicos. Juiz de Fora: UFJF, 2008.-->
     <link href="www.ufjf.br/engenhariadeproducao/files/2010/05/manual_para_elaboracao_TCC.pdf" rel="documentation"/>
@@ -26,8 +26,7 @@
     </contributor>
     <category citation-format="author-date"/>
     <category field="generic-base"/>
-    <summary>The Brazilian standard style</summary>
-    <updated>2014-04-18T23:40:21+00:00</updated>
+    <updated>2018-05-01T12:00:00+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale xml:lang="pt-BR">


### PR DESCRIPTION
…o ufjf.csl

I am the person who first uploaded this style in the repository, but I was using another email back then. We needed to change the title of the style because it was causing confusion amongst many others styles that already has "associação brasileira de normas tecnicas" in their titles.