### PR TITLE
[SBL] add editortranslator locale term for verb-short

### DIFF
--- a/society-of-biblical-literature-fullnote-bibliography.csl
+++ b/society-of-biblical-literature-fullnote-bibliography.csl
@@ -35,7 +35,7 @@
       <term name="editor" form="verb-short">ed.</term>
       <term name="translator" form="verb-short">trans.</term>
       <term name="translator" form="short">trans.</term>
-      <term name="editortranslator" form="verb">edited and translated by</term>
+      <term name="editortranslator" form="verb-short">ed. and trans.</term>
       <term name="collection-editor">
         <single>ed.</single>
         <multiple>eds.</multiple>
@@ -49,7 +49,7 @@
         <if variable="container-author reviewed-author" match="any">
           <group>
             <names variable="container-author reviewed-author" delimiter=", ">
-              <label form="verb-short"  suffix=" "/>
+              <label form="verb-short" suffix=" "/>
               <name and="text" delimiter=", "/>
             </names>
           </group>


### PR DESCRIPTION
Adding the verb-short term should wake up the name collapsing.

(Per https://forums.zotero.org/discussion/71632/ed-and-trans-in-sbl-style)