### PR TITLE
ABNT style with small-caps and changes to song

### DIFF
--- a/associacao-brasileira-de-normas-tecnicas-small-caps.csl
+++ b/associacao-brasileira-de-normas-tecnicas-small-caps.csl
@@ -373,10 +373,6 @@
       </else-if>
     </choose>
   </macro>
-  <!--Resumo-->
-  <macro name="abstract">
-    <text variable="abstract"/>
-  </macro>
   <!--Mostra a ISBN-->
   <macro name="ISBN">
     <text variable="ISBN" prefix="ISBN "/>
@@ -482,8 +478,8 @@
             <text macro="translator"/>
             <text macro="edition"/>
             <text macro="publisher"/>
-            <!--Dados complementares "pagina, volume"-->
             <text macro="locators"/>
+            <text macro="ISBN"/>
             <text macro="access" suffix=". "/>
           </group>
         </else-if>
@@ -594,6 +590,7 @@
               <text macro="publisher"/>
             </group>
             <text macro="locators"/>
+            <text macro="ISBN"/>
             <text macro="genre"/>
             <text macro="access"/>
             <text macro="extra"/>
@@ -635,6 +632,7 @@
             <text macro="edition"/>
             <text macro="publisher"/>
             <text macro="locators"/>
+            <text macro="ISBN"/>
             <!--Tipo ou gênero-->
             <text macro="genre"/>
             <text variable="medium"/>
@@ -653,6 +651,7 @@
             <text macro="edition"/>
             <text macro="publisher"/>
             <text macro="locators"/>
+            <text macro="ISBN"/>
             <text macro="genre"/>
             <!-- Suporte (CD, DVD, partitura etc) -->
             <text variable="medium"/>

--- a/associacao-brasileira-de-normas-tecnicas-small-caps.csl
+++ b/associacao-brasileira-de-normas-tecnicas-small-caps.csl
@@ -1,0 +1,667 @@
+<?xml version="1.0" encoding="utf-8"?>
+<style xmlns="http://purl.org/net/xbiblio/csl" version="1.0" class="in-text" default-locale="pt-BR">
+  <info>
+    <title>Associação Brasileira de Normas Técnicas small-caps (Portuguese - Brazil)</title>
+    <title-short>ABNT-smcp</title-short>
+    <id>http://www.zotero.org/styles/associacao-brasileira-de-normas-tecnicas-small-caps</id>
+    <link href="http://www.zotero.org/styles/associacao-brasileira-de-normas-tecnicas-small-caps" rel="self"/>
+    <link href="http://www.zotero.org/styles/associacao-brasileira-de-normas-tecnicas" rel="template"/>
+    <contributor>
+      <name>José de Mattos Neto</name>
+      <email>josepmneto [at-mark] gmail [dot-mark] com</email>
+    </contributor>
+    <category citation-format="author-date"/>
+    <category field="generic-base"/>
+    <!--Um estilo em concordância com as normas da ABNT (ABNT-NBR 10520.2002 e ABNT-NBR 6023.2002, com nomes de autores nas citações em versalete (small-caps) e otimizações para gravações de áudio (que também podem ser usadas para partituras e semelhantes).-->
+    <summary>The Brazilian Standard Style in accordance with ABNT-NBR 10520.2002 and ABNT-NBR 6023.2002, names in citations in small-caps, and optimizations to song entries</summary>
+    <updated>2018-05-08T00:16:13+00:00</updated>
+    <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
+  </info>
+  <locale xml:lang="pt-BR">
+    <terms>
+      <!--Abreviações de meses "Forma Curta"-->
+      <term name="month-01" form="short">jan.</term>
+      <term name="month-02" form="short">fev.</term>
+      <term name="month-03" form="short">mar.</term>
+      <term name="month-04" form="short">abr.</term>
+      <term name="month-05" form="short">maio</term>
+      <term name="month-06" form="short">jun.</term>
+      <term name="month-07" form="short">jul.</term>
+      <term name="month-08" form="short">ago.</term>
+      <term name="month-09" form="short">set.</term>
+      <term name="month-10" form="short">out.</term>
+      <term name="month-11" form="short">nov.</term>
+      <term name="month-12" form="short">dez.</term>
+      <!--Os termos abaixo serão utilizados quando houver nomes de editores. Após a citação dos nomes, eles irão aparecer entre parênteses.-->
+      <term name="editor" form="short">
+        <single>org</single>
+        <multiple>org</multiple>
+      </term>
+      <term name="container-author" form="short">
+        <single>org</single>
+        <multiple>org</multiple>
+      </term>
+      <term name="collection-editor" form="short">
+        <single>org</single>
+        <multiple>org</multiple>
+      </term>
+    </terms>
+  </locale>
+  <!--A macro 'container-contributor' é responsável por mostrar os nomes dos editores, serão apresentados SOBRENOME, INICIAIS PRENOMES tendo as iniciais separadas por ponto.-->
+  <macro name="container-contributors">
+    <choose>
+      <if match="any" type="chapter">
+        <names variable="container-author" delimiter=", ">
+          <name name-as-sort-order="all" sort-separator=", " initialize-with=". " delimiter="; " delimiter-precedes-last="always">
+            <name-part name="family" text-case="uppercase"/>
+            <name-part name="given" text-case="capitalize-first"/>
+          </name>
+          <label form="short" prefix=" (" suffix=".). " text-case="capitalize-first"/>
+          <substitute>
+            <names variable="editor"/>
+            <names variable="collection-editor"/>
+          </substitute>
+        </names>
+      </if>
+    </choose>
+  </macro>
+  <!--A macro 'secundary-contributor' é responsável por mostrar os nomes dos organizadores, serão apresentados SOBRENOME, INICIAIS PRENOMES tendo as iniciais separadas por ponto.-->
+  <macro name="secondary-contributors">
+    <choose>
+      <if type="chapter" match="none">
+        <names variable="editor" delimiter="; " prefix=" (" suffix=")">
+          <name and="symbol" initialize-with=". " delimiter=", "/>
+          <label form="short" prefix=", " text-case="capitalize-first" suffix="."/>
+        </names>
+      </if>
+    </choose>
+  </macro>
+  <!--A macro 'translator' é responsável por mostrar os nomes dos tradutores, serão apresentados SOBRENOME, INICIAIS PRENOMES tendo as iniciais separadas por ponto. -->
+  <macro name="translator">
+    <choose>
+      <if match="any" variable="translator">
+        <text value="Tradução: "/>
+        <names variable="translator" delimiter="; ">
+          <name delimiter="; " sort-separator=" " delimiter-precedes-last="always">
+            <name-part name="given" text-case="capitalize-first"/>
+            <name-part name="family" text-case="capitalize-first"/>
+          </name>
+        </names>
+      </if>
+    </choose>
+  </macro>
+  <!--A macro 'author' é responsável por mostrar os nomes dos autores na bibliografia, serão no formato SOBRENOME, INICIAIS PRENOMES, tendo as inicias separadas por ponto. Quando houver mais de três autores, somente o primeiro será mostrado e no lugar dos outros aparecerá a expressao 'et. al.'. Na regra da ABNT essa expressão deve aparecer em fonte normal-->
+  <macro name="author">
+    <names variable="author">
+      <!--<name name-as-sort-order="all" sort-separator=", " initialize-with=". " delimiter="; " delimiter-precedes-last="always">-->
+      <name name-as-sort-order="all" sort-separator=", " delimiter="; " delimiter-precedes-last="always">
+        <name-part name="family" text-case="uppercase"/>
+        <!--<name-part name="given" text-case="capitalize-all" />-->
+        <name-part name="given" text-case="capitalize-first"/>
+      </name>
+      <label form="short" prefix=" (" suffix=".)" text-case="capitalize-first"/>
+      <substitute>
+        <names variable="editor"/>
+        <names variable="translator"/>
+        <choose>
+          <!-- "IF" Evita duplicação de títulos em audiovisuais sem autor -->
+          <if match="none" type="motion_picture broadcast">
+            <text macro="title"/>
+          </if>
+        </choose>
+      </substitute>
+    </names>
+  </macro>
+  <!--A macro 'author-short' é responsável por mostrar os nomes dos autores na citação (no meio do texto). Nela aparecerá apenas o último nome do autor. Na regra da ABNT o sobrenome deve aparecer com todas as letras em caixa alta, mas não há restrição ao uso do versalete (small-caps), utilizado aqui-->
+  <macro name="author-short">
+    <names variable="author">
+      <name form="short" name-as-sort-order="all" sort-separator=", " initialize-with=". " delimiter="; " delimiter-precedes-last="never">
+        <!-- <name-part name="family" text-case="uppercase"/> -->
+        <name-part name="family" text-case="lowercase" font-variant="small-caps"/>
+        <name-part name="given" text-case="capitalize-all"/>
+      </name>
+      <substitute>
+        <names variable="editor"/>
+        <names variable="translator"/>
+        <choose>
+          <if type="book">
+            <text variable="title" form="short"/>
+          </if>
+          <else>
+            <text variable="title" form="short" quotes="true"/>
+          </else>
+        </choose>
+      </substitute>
+    </names>
+  </macro>
+  <!--A macro 'access' é utilizada em arquivos de páginas da web. Ela é responsável por mostrar a URL do site pesquisado e a data do acesso-->
+  <macro name="access">
+    <text variable="URL" prefix="Disponível em: &lt;" suffix="&gt;"/>
+    <date variable="accessed" prefix=". Acesso em: ">
+      <date-part name="day" suffix=" "/>
+      <date-part name="month" form="short" suffix=". " text-case="lowercase" strip-periods="true"/>
+      <date-part name="year"/>
+    </date>
+  </macro>
+  <!--A macro 'title' é responsável por mostrar o título principal do arquivo. Em todos os tipos ele aparecerá em negrito logo após os nomes dos autores, exceto em arquivos do tipo 'artigo de jornal, artigo de revista, artigo de periodico'; nesses arquivos eles irão aparecer em fonte normal.-->
+  <macro name="title">
+    <choose>
+      <if type="chapter bill webpage post-weblog article-newspaper article-magazine article-journal motion_picture paper-conference speech" match="any">
+        <text variable="title"/>
+      </if>
+      <else-if match="any" type="entry-encyclopedia entry-dictionary">
+        <choose>
+          <if match="any" variable="author editor collection-editor translator">
+            <text variable="title"/>
+          </if>
+          <else>
+            <text variable="title" text-case="uppercase"/>
+          </else>
+        </choose>
+      </else-if>
+      <else>
+        <text variable="title" font-weight="bold"/>
+      </else>
+    </choose>
+  </macro>
+  <!-- Macro de titulo do container -->
+  <macro name="container-title">
+    <choose>
+      <if type="paper-conference speech" match="any">
+        <text variable="container-title"/>
+      </if>
+      <else>
+        <text variable="container-title" font-weight="bold"/>
+      </else>
+    </choose>
+  </macro>
+  <!-- Macro com informações do container. Se houver um container-title, essa macro coloca a expressão "In:" (em fonte normal, como a ABNT pede), seguida dos autores do container, seguidos do título do container. -->
+  <macro name="container">
+    <choose>
+      <if match="any" variable="container-title">
+        <!-- In: -->
+        <text term="in" text-case="capitalize-first" suffix=": "/>
+        <group>
+          <!-- Nomes de editores -->
+          <text macro="container-contributors"/>
+          <text macro="secondary-contributors"/>
+          <text macro="container-title"/>
+        </group>
+      </if>
+    </choose>
+  </macro>
+  <!--A macro 'publisher' mostra lugar, editora e data. Artigos devem colocar o lugar no campo "Extra" do Zotero (campo CSL: "note"). Em palestra (speech), colocar promotor no campo "Extra" -->
+  <macro name="publisher">
+    <choose>
+      <if type="paper-conference" match="none">
+        <choose>
+          <if match="any" variable="publisher-place publisher issued note">
+            <choose>
+              <if variable="publisher-place">
+                <text variable="publisher-place" suffix=": "/>
+              </if>
+              <else>
+                <text value="[S.l.]: "/>
+              </else>
+            </choose>
+            <choose>
+              <if variable="publisher">
+                <text variable="publisher" suffix=", "/>
+              </if>
+              <else>
+                <choose>
+                  <if match="any" type="speech">
+                    <choose>
+                      <if variable="note">
+                        <text macro="extra" suffix=", "/>
+                      </if>
+                    </choose>
+                  </if>
+                  <else>
+                    <text value="[s.n.]" suffix=", "/>
+                  </else>
+                </choose>
+              </else>
+            </choose>
+            <choose>
+              <if variable="issued">
+                <text macro="issued-year"/>
+              </if>
+              <else>
+                <text value="[s.d.]"/>
+              </else>
+            </choose>
+          </if>
+          <else>
+            <text value="[S.l: s.n., s.d.]"/>
+          </else>
+        </choose>
+      </if>
+    </choose>
+  </macro>
+  <!-- A macro 'event' é utilizada em arquivos do tipo Evento/Conferência. Ela é responsavel por mostrar o nome da conferência, que tem formatação em caixa alta. Utiliza-se antes do nome da conferencia a expressao "In", em fonte normal (como a ABNT pede) -->
+  <macro name="event">
+    <choose>
+      <if variable="event">
+        <choose>
+          <!-- paper-conference -->
+          <if type="paper-conference" match="any">
+            <group delimiter=", " suffix=". ">
+              <group>
+                <text term="in" text-case="capitalize-first" suffix=": "/>
+                <text variable="event" text-case="uppercase"/>
+              </group>
+              <choose>
+                <if variable="collection-title">
+                  <text variable="collection-title" suffix=". "/>
+                </if>
+              </choose>
+              <text macro="issued-year"/>
+              <choose>
+                <if variable="publisher-place">
+                  <text variable="publisher-place"/>
+                </if>
+                <else>
+                  <text prefix=", " value="[S.l.] "/>
+                </else>
+              </choose>
+            </group>
+            <text value="Anais" font-weight="bold"/>
+            <choose>
+              <if variable="URL">
+                <text value=" eletrônicos" font-weight="bold"/>
+              </if>
+            </choose>
+            <text value="…"/>
+          </if>
+          <!-- speech -->
+          <else>
+            <group suffix=". ">
+              <text term="in" text-case="capitalize-first" suffix=": "/>
+              <!-- "presented at" -->
+              <text variable="event" text-case="uppercase" suffix=". "/>
+              <text variable="genre" text-case="capitalize-first" suffix=". "/>
+            </group>
+          </else>
+        </choose>
+      </if>
+    </choose>
+  </macro>
+  <!--A macro 'issued' é utilizada quando devemos mostrar a data completa. Exemplo: 03 mar. 2011.-->
+  <macro name="issued">
+    <choose>
+      <if variable="issued" match="any">
+        <choose>
+          <if type="book chapter" match="none">
+            <date variable="issued">
+              <date-part name="day" suffix=" "/>
+              <date-part name="month" form="short" suffix=". " strip-periods="true"/>
+            </date>
+          </if>
+        </choose>
+        <date variable="issued">
+          <date-part name="year"/>
+        </date>
+      </if>
+      <else>
+        <text value="[s.d.]"/>
+      </else>
+    </choose>
+  </macro>
+  <!-- A macro 'issued-year' é utilizada quando desejamos que apareça apenas o ano -->
+  <macro name="issued-year">
+    <choose>
+      <if variable="issued" match="any">
+        <date variable="issued">
+          <date-part name="year"/>
+        </date>
+      </if>
+      <else>
+        <text value="[s.d.]"/>
+      </else>
+    </choose>
+  </macro>
+  <!-- A macro 'edition' é responsável por mostrar o número da edição. -->
+  <macro name="edition">
+    <choose>
+      <if type="book chapter" match="any">
+        <choose>
+          <if is-numeric="edition">
+            <group delimiter=" ">
+              <number variable="edition" form="numeric" suffix="."/>
+              <text term="edition" form="short" suffix="."/>
+            </group>
+          </if>
+          <else>
+            <text variable="edition"/>
+          </else>
+        </choose>
+      </if>
+    </choose>
+  </macro>
+  <!--A macro 'locators' tem como função mostrar os dados complementares do arquivo (páginas, seção, volume, etc)-->
+  <macro name="locators">
+    <choose>
+      <!--Se for projeto de lei mostra o dia, mês "forma curta", ano, seção "Sec." e página "p."-->
+      <if type="bill">
+        <group prefix=". " suffix="" delimiter=", ">
+          <date variable="issued">
+            <date-part name="day"/>
+            <date-part prefix=" " name="month" form="short"/>
+            <date-part prefix=" " name="year"/>
+          </date>
+          <text variable="section" prefix="Sec. "/>
+          <text variable="page" prefix="p. " suffix="."/>
+        </group>
+      </if>
+      <!--Se for artigos de jornal, revista, etc. aparecerá o volume "v.", edição "n." e a página do artigo "p."-->
+      <else-if match="any" type="article-journal article-magazine article-newspaper">
+        <group delimiter=", ">
+          <group delimiter=", ">
+            <text variable="volume" prefix="v. "/>
+            <text variable="issue" prefix="n. "/>
+          </group>
+          <text variable="page" prefix="p. "/>
+        </group>
+      </else-if>
+      <!--Se for capítulo de livro aparecera o volume "v." e a página "p."-->
+      <else-if match="any" type="book chapter paper-conference speech entry-encyclopedia entry-dictionary">
+        <group delimiter=", ">
+          <text variable="volume" prefix="V. "/>
+          <text variable="page" prefix="p. "/>
+        </group>
+      </else-if>
+    </choose>
+  </macro>
+  <!--Resumo-->
+  <macro name="abstract">
+    <text variable="abstract"/>
+  </macro>
+  <!--Mostra a ISBN-->
+  <macro name="ISBN">
+    <text variable="ISBN" prefix="ISBN "/>
+  </macro>
+  <!-- Título de coleção -->
+  <macro name="collection-title">
+    <group delimiter=", " suffix=".">
+      <text variable="collection-title"/>
+      <text variable="collection-number"/>
+      <choose>
+        <if type="song">
+          <text variable="volume" prefix="v. "/>
+        </if>
+      </choose>
+    </group>
+  </macro>
+  <!-- Anotações (campo "extra") -->
+  <macro name="extra">
+    <choose>
+      <!-- speech usa campo Extra para instituição ou editor -->
+      <if type="speech" match="none">
+        <text variable="note"/>
+      </if>
+    </choose>
+  </macro>
+  <!-- Tipo ou gênero -->
+  <macro name="genre">
+    <text variable="genre"/>
+  </macro>
+  <!-- Lugar de publicação de jornal, revista ou periódico. Periódicos devem colocar a localidade no campo "Extra" do Zotero -->
+  <macro name="place">
+    <choose>
+      <if match="any" variable="publisher-place">
+        <text variable="publisher-place"/>
+      </if>
+      <else>
+        <choose>
+          <if match="any" type="article-magazine article-journal">
+            <text macro="extra"/>
+          </if>
+          <else>
+            <text value="[S.l.]"/>
+          </else>
+        </choose>
+      </else>
+    </choose>
+  </macro>
+  <!-- Número de páginas na citação -->
+  <macro name="citation-locator">
+    <group>
+      <label variable="locator" form="short"/>
+      <text variable="locator" prefix=" "/>
+    </group>
+  </macro>
+  <!-- CITAÇÃO. "et al." aparece a partir de 4 autores. "desambiguate-add" serve para desambiguar nomes idênticos ou datas idênticas de mesmo autor. As referências são organizadas primeiro pelo nome de autor, depois pelo ano. A citação ocorre entre parênteses; o autor e a data são separados por vírgula, e uma referência e outra são separadas por ponto e vírgula. -->
+  <citation et-al-min="4" et-al-use-first="1" et-al-subsequent-min="4" et-al-subsequent-use-first="1" collapse="year-suffix-ranged" disambiguate-add-names="true" disambiguate-add-givenname="true" givenname-disambiguation-rule="primary-name" disambiguate-add-year-suffix="true">
+    <sort>
+      <key macro="author"/>
+      <key variable="issued"/>
+    </sort>
+    <layout prefix="(" suffix=")" delimiter="; ">
+      <group>
+        <text suffix=", " macro="author-short"/>
+        <text macro="issued-year"/>
+        <text prefix=", " macro="citation-locator"/>
+      </group>
+    </layout>
+  </citation>
+  <!-- BIBLIOGRAFIA. "et al." aparece a partir de 4 autores. As referências são organizadas primeiro pelo nome de autor, depois pelo ano. -->
+  <bibliography hanging-indent="false" et-al-min="4" et-al-use-first="1" entry-spacing="1" subsequent-author-substitute="______." subsequent-author-substitute-rule="complete-all">
+    <sort>
+      <key macro="author"/>
+      <key variable="issued"/>
+    </sort>
+    <layout>
+      <!--livro, verbete de enciclopédia e outros estão no ELSE final-->
+      <choose>
+        <!-- Lei -->
+        <if type="bill">
+          <group delimiter=". " suffix=". ">
+            <text macro="author"/>
+            <!--Numero da lei-->
+            <text variable="number"/>
+            <text macro="title"/>
+            <!--Histórico em negrito-->
+            <text variable="references" font-weight="bold"/>
+            <text macro="extra" prefix=""/>
+            <!--Dados complementares "seção, página"-->
+            <text macro="locators"/>
+          </group>
+        </if>
+        <!--Capítulo de livro (colocar a data original do capitulo no campo "Extra")-->
+        <else-if type="chapter">
+          <group delimiter=". " suffix=". ">
+            <text macro="author"/>
+            <group suffix=" ">
+              <!--Campo 'extra': data original do capitulo entre colchetes-->
+              <text macro="extra"/>
+            </group>
+            <text macro="title"/>
+            <text macro="container"/>
+            <text macro="collection-title"/>
+            <text macro="translator"/>
+            <text macro="edition"/>
+            <text macro="publisher"/>
+            <!--Dados complementares "pagina, volume"-->
+            <text macro="locators"/>
+            <text macro="access" suffix=". "/>
+          </group>
+        </else-if>
+        <!--Artigo de revista ou periódico ou de jornal impresso ou digital-->
+        <else-if type="article-magazine article-journal article-newspaper" match="any">
+          <group delimiter=". " suffix=". ">
+            <text macro="author"/>
+            <!--Titulo do artigo-->
+            <text macro="title"/>
+            <group>
+              <choose>
+                <if type="article-newspaper">
+                  <!--Titulo da publicacao-->
+                  <text macro="container-title"/>
+                  <!-- Local, editor -->
+                  <text macro="place"/>
+                </if>
+                <else>
+                  <text macro="place" suffix=": "/>
+                  <text macro="container-title" suffix=", "/>
+                </else>
+              </choose>
+              <text macro="issued"/>
+            </group>
+            <!--Título da série-->
+            <text macro="collection-title"/>
+            <text macro="edition"/>
+            <text macro="locators"/>
+            <text macro="access"/>
+          </group>
+        </else-if>
+        <!--Tese e dissertação-->
+        <else-if type="thesis">
+          <group delimiter=". " suffix=". ">
+            <text macro="author"/>
+            <text macro="title"/>
+            <!--Tipo (p. ex. Dissertação de Mestrado em Jornalismo)-->
+            <text macro="genre"/>
+            <text macro="edition"/>
+            <text macro="publisher" suffix="."/>
+            <text macro="access"/>
+          </group>
+        </else-if>
+        <!-- Manuscritos (não há norma ABNT) -->
+        <else-if type="manuscript">
+          <group delimiter=". " suffix=". ">
+            <text macro="author"/>
+            <text macro="title"/>
+            <text macro="edition"/>
+            <text macro="place"/>
+            <text macro="issued"/>
+            <text macro="access"/>
+            <text macro="genre"/>
+            <text macro="extra"/>
+          </group>
+        </else-if>
+        <!--Página da WEB-->
+        <else-if type="webpage post-weblog" match="any">
+          <group delimiter=". " suffix=". ">
+            <text macro="author"/>
+            <!--Título da página-->
+            <text macro="title"/>
+            <group delimiter=", ">
+              <!--Título do site-->
+              <text macro="container-title"/>
+              <!--Data-->
+              <text macro="issued"/>
+            </group>
+            <text macro="genre"/>
+            <text macro="extra"/>
+            <text macro="access"/>
+          </group>
+        </else-if>
+        <!--Relatório-->
+        <else-if type="report">
+          <group delimiter=". " suffix=". ">
+            <text macro="author"/>
+            <text macro="title"/>
+            <!--Nomes de editores-->
+            <text macro="container-contributors"/>
+            <text macro="secondary-contributors"/>
+            <!--Título da publicação-->
+            <text macro="container-title"/>
+            <text variable="collection-title"/>
+            <text macro="locators"/>
+            <!--Nome do evento, conferência-->
+            <text macro="event"/>
+            <text macro="publisher"/>
+            <text macro="access"/>
+            <text macro="extra"/>
+          </group>
+        </else-if>
+        <!--O tipo Zotero "Conferência" é igual ao tipo CSL "paper-conference", e o tipo "Apresentação" é igual ao tipo CSL "speech" (que tem campo CSL "genre") -->
+        <else-if type="paper-conference speech" match="any">
+          <group delimiter=". " suffix=". ">
+            <text macro="author"/>
+            <text macro="title"/>
+            <!--Nomes de editores-->
+            <text macro="container-contributors"/>
+            <text macro="secondary-contributors"/>
+            <!--Título da publicação-->
+            <text macro="container-title"/>
+            <text variable="collection-title"/>
+            <group delimiter=", " suffix=".">
+              <!--Nome do evento, conferência-->
+              <text macro="event"/>
+              <!--Editor-->
+              <text macro="publisher"/>
+            </group>
+            <text macro="locators"/>
+            <text macro="genre"/>
+            <text macro="access"/>
+            <text macro="extra"/>
+          </group>
+        </else-if>
+        <!-- Filmes e vídeos. Imperfeito. Só inclui diretor. Necessita mais trabalho. O campo "Extra" deve conter o local de produção -->
+        <else-if type="motion_picture broadcast" match="any">
+          <group delimiter=". " suffix=". ">
+            <text macro="title"/>
+            <text macro="author"/>
+            <!--Nomes de editores-->
+            <text macro="container-contributors"/>
+            <text macro="secondary-contributors"/>
+            <group>
+              <text macro="extra" suffix=": "/>
+              <text variable="publisher" suffix=", "/>
+              <text macro="issued"/>
+            </group>
+            <text macro="collection-title" font-weight="bold"/>
+            <!-- Suporte -->
+            <text variable="medium"/>
+            <!-- Tipo, gênero -->
+            <text macro="genre"/>
+            <text macro="locators"/>
+            <text macro="event"/>
+            <text macro="access"/>
+          </group>
+        </else-if>
+        <!--Gravação de áudio. Colocar no campo "Extra" compositorxs, intérpretes etc-->
+        <else-if type="song">
+          <group delimiter=". " suffix=". ">
+            <text macro="author"/>
+            <text macro="title"/>
+            <!--'Extra' para inserir compositorx, intérpretes etc-->
+            <text macro="extra"/>
+            <text macro="container"/>
+            <text macro="collection-title"/>
+            <text macro="translator"/>
+            <text macro="edition"/>
+            <text macro="publisher"/>
+            <text macro="locators"/>
+            <!--Tipo ou gênero-->
+            <text macro="genre"/>
+            <text variable="medium"/>
+            <!-- Suporte (CD, DVD, partitura etc) -->
+            <text macro="access"/>
+          </group>
+        </else-if>
+        <!-- Qualquer outra referência -->
+        <else>
+          <group delimiter=". " suffix=". ">
+            <text macro="author"/>
+            <text macro="title"/>
+            <text macro="container"/>
+            <text macro="collection-title"/>
+            <text macro="translator"/>
+            <text macro="edition"/>
+            <text macro="publisher"/>
+            <text macro="locators"/>
+            <text macro="genre"/>
+            <!-- Suporte (CD, DVD, partitura etc) -->
+            <text variable="medium"/>
+            <text macro="access"/>
+            <!--Campo 'extra' caso queira ou precise colocar alguma observação-->
+            <text macro="extra"/>
+          </group>
+        </else>
+      </choose>
+    </layout>
+  </bibliography>
+</style>


### PR DESCRIPTION
Optimization of ABNT (Brazilian Standards) style, with small-caps in author names (just in citations, not in bibliography), and improvements in song formatting (allowing it to be used also for sheet music).