### PR TITLE
Improve song, motion_picture and others

### DIFF
--- a/associacao-brasileira-de-normas-tecnicas.csl
+++ b/associacao-brasileira-de-normas-tecnicas.csl
@@ -36,15 +36,19 @@
       <name>Mario José</name>
       <email>gnumario [at-mark] gmail [dot-mark] com</email>
     </contributor>
+    <contributor>
+      <name>José de Mattos Neto</name>
+      <email>josepmneto [at-mark] gmail [dot-mark] com</email>
+    </contributor>
     <category citation-format="author-date"/>
     <category field="generic-base"/>
     <summary>The Brazilian Standard Style in accordance with ABNT-NBR 10520.2002 and ABNT-NBR 6023.2002</summary>
-    <updated>2013-05-01T03:53:13+00:00</updated>
+    <updated>2018-05-08T20:15:47+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale xml:lang="pt-BR">
     <terms>
-      <!--Abreviacoes meses "Forma Curta"-->
+      <!--Abreviações de meses "Forma Curta"-->
       <term name="month-01" form="short">jan.</term>
       <term name="month-02" form="short">fev.</term>
       <term name="month-03" form="short">mar.</term>
@@ -57,14 +61,14 @@
       <term name="month-10" form="short">out.</term>
       <term name="month-11" form="short">nov.</term>
       <term name="month-12" form="short">dez.</term>
-      <!--Os termos abaixo serao utilizados quando houverem nomes de editores. Apos a citacao dos nomes, eles irao aparecer entre parenteses.-->
+      <!--Os termos abaixo serão utilizados quando houver nomes de editores. Após a citação dos nomes, eles irão aparecer entre parênteses.-->
       <term name="editor" form="short">
         <single>ed</single>
         <multiple>eds</multiple>
       </term>
       <term name="container-author" form="short">
-        <single>ed</single>
-        <multiple>eds</multiple>
+        <single>org</single>
+        <multiple>org</multiple>
       </term>
       <term name="collection-editor" form="short">
         <single>ed</single>
@@ -72,15 +76,14 @@
       </term>
     </terms>
   </locale>
-  <!--A macro 'container-contribuitor' e responsavel por mostrar os nomes dos editores, serao apresentados SOBRENOME, INICIAIS PRENOMES 
-tendo as inicias separadas por ponto.-->
+  <!--A macro 'container-contributor' é responsável por mostrar os nomes dos editores, serão apresentados SOBRENOME, INICIAIS PRENOMES tendo as iniciais separadas por ponto.-->
   <macro name="container-contributors">
     <choose>
-      <if type="chapter">
+      <if match="any" type="chapter">
         <names variable="container-author" delimiter=", ">
           <name name-as-sort-order="all" sort-separator=", " initialize-with=". " delimiter="; " delimiter-precedes-last="always">
             <name-part name="family" text-case="uppercase"/>
-            <name-part name="given" text-case="uppercase"/>
+            <name-part name="given" text-case="capitalize-first"/>
           </name>
           <label form="short" prefix=" (" suffix=".). " text-case="capitalize-first"/>
           <substitute>
@@ -91,8 +94,7 @@ tendo as inicias separadas por ponto.-->
       </if>
     </choose>
   </macro>
-  <!--A macro 'secundary-contribuitor' e responsavel por mostrar os nomes dos organizadores, serao apresentados SOBRENOME, INICIAIS PRENOMES
-tendo as inicias separadas por ponto.-->
+  <!--A macro 'secundary-contributor' é responsável por mostrar os nomes dos organizadores, serão apresentados SOBRENOME, INICIAIS PRENOMES tendo as iniciais separadas por ponto.-->
   <macro name="secondary-contributors">
     <choose>
       <if type="chapter" match="none">
@@ -103,41 +105,47 @@ tendo as inicias separadas por ponto.-->
       </if>
     </choose>
   </macro>
-  <!--A macro 'translator' e responsavel por mostrar os nomes dos tradutores, serao apresentados SOBRENOME, INICIAIS PRENOMES
-tendo as inicias separadas por ponto. -->
+  <!--A macro 'translator' é responsável por mostrar os nomes dos tradutores, serão apresentados SOBRENOME, INICIAIS PRENOMES tendo as iniciais separadas por ponto. -->
   <macro name="translator">
-    <text value="Traducao "/>
-    <names variable="translator" delimiter="; ">
-      <name delimiter="; " sort-separator=" " delimiter-precedes-last="always">
-        <name-part name="given" text-case="capitalize-first"/>
-        <name-part name="family" text-case="capitalize-first"/>
-      </name>
-    </names>
+    <choose>
+      <if match="any" variable="translator">
+        <text value="Tradução: "/>
+        <names variable="translator" delimiter="; ">
+          <name delimiter="; " sort-separator=" " delimiter-precedes-last="always">
+            <name-part name="given" text-case="capitalize-first"/>
+            <name-part name="family" text-case="capitalize-first"/>
+          </name>
+        </names>
+      </if>
+    </choose>
   </macro>
-  <!--A macro 'author' e responsavel por mostrar os nomes dos autores na bibliografia, serao no formato SOBRENOME, INICIAIS PRENOMES, tendo 
-as inicias separadas por ponto. Quando houver mais de tres autores, somente o primeiro sera mostrado e no lugar dos outros
-aparecera a expess o 'et. al.'. Na regra da ABNT essa expressao deve aparecer em fonte normal-->
+  <!--A macro 'author' é responsável por mostrar os nomes dos autores na bibliografia, serão no formato SOBRENOME, INICIAIS PRENOMES, tendo as inicias separadas por ponto. Quando houver mais de três autores, somente o primeiro será mostrado e no lugar dos outros aparecerá a expressao 'et. al.'. Na regra da ABNT essa expressão deve aparecer em fonte normal-->
   <macro name="author">
     <names variable="author">
       <name name-as-sort-order="all" sort-separator=", " initialize-with=". " delimiter="; " delimiter-precedes-last="always">
         <name-part name="family" text-case="uppercase"/>
-        <name-part name="given" text-case="uppercase"/>
+        <name-part name="given" text-case="capitalize-first"/>
       </name>
-      <label form="short" prefix=" (" suffix=".)" text-case="uppercase"/>
+      <label form="short" prefix=" (" suffix=".)" text-case="capitalize-first"/>
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <text macro="title"/>
+        <choose>
+          <!-- "IF" Evita duplicação de títulos em audiovisuais sem autor -->
+          <if match="none" type="motion_picture broadcast">
+            <text macro="title"/>
+          </if>
+        </choose>
       </substitute>
     </names>
   </macro>
-  <!--A macro 'author-short' e responsavel por mostrar os nomes dos autores na citacao (no meio do texto). Nela aparecera apenas o ultimo nome
-do autor. Na regra da ABNT o sobrenome deve aparecer com todas as letras em caixa alta-->
+  <!--A macro 'author-short' é responsável por mostrar os nomes dos autores na citação (no meio do texto). Nela aparecerá apenas o último nome do autor. Na regra da ABNT o sobrenome deve aparecer com todas as letras em caixa alta, mas não há restrição ao uso do versalete (small-caps), utilizado aqui-->
   <macro name="author-short">
     <names variable="author">
       <name form="short" name-as-sort-order="all" sort-separator=", " initialize-with=". " delimiter="; " delimiter-precedes-last="never">
-        <name-part name="family" text-case="uppercase"/>
-        <name-part name="given" text-case="uppercase"/>
+        <!-- <name-part name="family" text-case="uppercase"/> -->
+        <name-part name="family" text-case="lowercase" font-variant="small-caps"/>
+        <name-part name="given" text-case="capitalize-first"/>
       </name>
       <substitute>
         <names variable="editor"/>
@@ -153,120 +161,172 @@ do autor. Na regra da ABNT o sobrenome deve aparecer com todas as letras em caix
       </substitute>
     </names>
   </macro>
-  <!--A macro 'access' e utilizada em arquivos de paginas da web. Ela e responsavel por mostrar a URL do site pesquisado e a data do acesso-->
+  <!--A macro 'access' é utilizada em arquivos de páginas da web. Ela é responsável por mostrar a URL do site pesquisado e a data do acesso-->
   <macro name="access">
     <text variable="URL" prefix="Disponível em: &lt;" suffix="&gt;"/>
     <date variable="accessed" prefix=". Acesso em: ">
       <date-part name="day" suffix=" "/>
-      <date-part name="month" form="short" suffix=". " text-case="lowercase"/>
+      <date-part name="month" form="short" text-case="lowercase" suffix=" "/>
       <date-part name="year"/>
     </date>
   </macro>
-  <!--A macro 'title' e responsavel por mostrar o titulo principal do arquivo. Em todos os tipos ele aparecera em negrito logo apos os nomes dos
-autores, exceto em arquivos do tipo 'artigo de jornal, artigo de revista, artigo de periodico', nesses arquivos eles irao aparecer em fonte normal.-->
+  <!--A macro 'title' é responsável por mostrar o título principal do arquivo. Em todos os tipos ele aparecerá em negrito logo após os nomes dos autores, exceto em arquivos do tipo 'artigo de jornal, artigo de revista, artigo de periodico'; nesses arquivos eles irão aparecer em fonte normal.-->
   <macro name="title">
     <choose>
-      <if type="chapter bill" match="any">
-        <text variable="title"/>
+      <if type="chapter bill webpage post-weblog article-newspaper article-magazine article-journal motion_picture broadcast paper-conference speech" match="any">
+        <text variable="title" text-case="sentence"/>
       </if>
-      <else-if type="book thesis" match="any">
-        <text variable="title" font-weight="bold"/>
-      </else-if>
-      <else-if type="article-newspaper article-magazine article-journal" match="any">
-        <text variable="title"/>
+      <else-if match="any" type="entry-encyclopedia entry-dictionary">
+        <choose>
+          <if match="any" variable="author editor collection-editor translator">
+            <text variable="title" text-case="sentence"/>
+          </if>
+          <else>
+            <text variable="title" text-case="uppercase"/>
+          </else>
+        </choose>
       </else-if>
       <else>
-        <text variable="title" font-weight="bold"/>
+        <text variable="title" font-weight="bold" text-case="sentence"/>
       </else>
     </choose>
   </macro>
-  <!-- Titulo dos Anais-->
+  <!-- Macro de titulo do container (como p. ex. título dos Anais) -->
   <macro name="container-title">
+    <text variable="container-title" font-weight="bold"/>
+  </macro>
+  <!-- Macro com informações do container. Se houver um container-title, essa macro coloca a expressão "In:" (em fonte normal, como a ABNT pede), seguida dos autores do container, seguidos do título do container. -->
+  <macro name="container">
     <choose>
-      <if type="paper-conference" match="any">
-        <text variable="container-title" suffix=". "/>
-        <text value="Anais" font-weight="bold"/>
-        <text value="..."/>
+      <if match="any" variable="container-title">
+        <!-- In: -->
+        <text term="in" text-case="capitalize-first" suffix=": "/>
+        <group>
+          <!-- Nomes de editores -->
+          <text macro="container-contributors"/>
+          <text macro="secondary-contributors"/>
+          <text macro="container-title"/>
+        </group>
       </if>
-      <else>
-        <text variable="container-title" font-weight="bold"/>
-      </else>
     </choose>
   </macro>
-  <!--A macro 'publisher' e responsavel por mostrar o nome da editora responsavel pela publicacao-->
+  <!--A macro 'publisher' mostra lugar, editora e data. Artigos devem colocar o lugar no campo "Extra" do Zotero (campo CSL: "note"). Em palestra (speech), colocar promotor no campo "Extra" -->
   <macro name="publisher">
     <choose>
-      <if match="any" variable="publisher-place publisher">
+      <if type="paper-conference" match="none">
         <choose>
-          <if variable="publisher-place">
-            <text variable="publisher-place" suffix=": "/>
+          <if match="any" variable="publisher-place publisher issued note">
+            <choose>
+              <if variable="publisher-place">
+                <text variable="publisher-place" suffix=": "/>
+              </if>
+              <else>
+                <text value="[S.l.]: "/>
+              </else>
+            </choose>
+            <choose>
+              <if variable="publisher">
+                <text variable="publisher" suffix=", "/>
+              </if>
+              <else>
+                <choose>
+                  <if match="any" type="speech">
+                    <choose>
+                      <if variable="note">
+                        <text macro="extra" suffix=", "/>
+                      </if>
+                      <else>
+                        <text value="[s.n.]" suffix=", "/>
+                      </else>
+                    </choose>
+                  </if>
+                  <else>
+                    <text value="[s.n.]" suffix=", "/>
+                  </else>
+                </choose>
+              </else>
+            </choose>
+            <choose>
+              <if variable="issued">
+                <text macro="issued-year"/>
+              </if>
+              <else>
+                <text value="[s.d.]"/>
+              </else>
+            </choose>
           </if>
-          <else-if type="entry-encyclopedia">
-        </else-if>
           <else>
-            <text value="[s.l.] "/>
-          </else>
-        </choose>
-        <choose>
-          <if variable="publisher">
-            <text variable="publisher" suffix=", "/>
-            <text macro="issued"/>
-          </if>
-          <else>
-            <text value="[s.n.]"/>
+            <text value="[S.l: s.n., s.d.]"/>
           </else>
         </choose>
       </if>
-      <else>
-        <text value="[s.l: s.n.]"/>
-      </else>
     </choose>
   </macro>
-  <!--A macro 'event' sera utilizada em arquivos do tipo Evento/Conferencia. Ela e responsavel por mostrar o nome da conferencia, que tera formatacao
-em caixa alta. Utiliza-se antes do nome da conferencia a expressao "In". Segundo a regra da ABNT ela deve ser em fonte normal-->
+  <!-- A macro 'event' é utilizada em arquivos do tipo Evento/Conferência. Ela é responsavel por mostrar o nome da conferência, que tem formatação em caixa alta. Utiliza-se antes do nome da conferencia a expressao "In", em fonte normal (como a ABNT pede) -->
   <macro name="event">
     <choose>
       <if variable="event">
         <choose>
-          <if variable="genre" match="none">
-            <text term="in" text-case="capitalize-first" suffix=": "/>
-            <text variable="event" text-case="uppercase"/>
-          </if>
-          <else>
-            <group delimiter=" ">
-              <text variable="genre" text-case="capitalize-first"/>
-              <text term="presented at"/>
-              <text variable="event"/>
+          <!-- paper-conference -->
+          <if type="paper-conference" match="any">
+            <group delimiter=", " suffix=". ">
+              <group>
+                <text term="in" text-case="capitalize-first" suffix=": "/>
+                <text variable="event" text-case="uppercase"/>
+              </group>
+              <choose>
+                <if variable="collection-title">
+                  <text variable="collection-title" suffix=". "/>
+                </if>
+              </choose>
+              <text macro="issued-year"/>
+              <choose>
+                <if variable="publisher-place">
+                  <text variable="publisher-place"/>
+                </if>
+                <else>
+                  <text value="[S.l.] "/>
+                </else>
+              </choose>
             </group>
+            <text macro="container-title" suffix="…"/>
+          </if>
+          <!-- speech -->
+          <else>
+            <choose>
+              <if variable="genre" match="none">
+                <text term="in" text-case="capitalize-first" suffix=": "/>
+                <text variable="event" text-case="uppercase"/>
+              </if>
+              <else>
+                <group delimiter=" ">
+                  <text variable="genre" text-case="capitalize-first"/>
+                  <text term="presented at"/>
+                  <text variable="event" font-weight="bold"/>
+                </group>
+              </else>
+            </choose>
           </else>
         </choose>
       </if>
     </choose>
   </macro>
-  <!--A macro 'issued' e utilizada quando devemos mostrar a data completa exemplo: 03 mar. 2011.-->
+  <!--A macro 'issued' é utilizada quando devemos mostrar a data completa. Exemplo: 03 mar. 2011.-->
   <macro name="issued">
     <choose>
       <if variable="issued" match="any">
-        <group>
-          <choose>
-            <if type="book chapter" match="none">
-              <date variable="issued">
-                <date-part name="day" suffix=" "/>
-                <date-part name="month" form="short" suffix=" "/>
-              </date>
-            </if>
-          </choose>
-          <date variable="issued">
-            <date-part name="year"/>
-          </date>
-        </group>
+        <date variable="issued">
+          <date-part name="day" suffix=" "/>
+          <date-part name="month" form="short" suffix=" "/>
+          <date-part name="year"/>
+        </date>
       </if>
       <else>
         <text value="[s.d.]"/>
       </else>
     </choose>
   </macro>
-  <!--A macro 'issued' e utilizada quando desejamos que apareca apenas o ano-->
+  <!-- A macro 'issued-year' é utilizada quando desejamos que apareça apenas o ano -->
   <macro name="issued-year">
     <choose>
       <if variable="issued" match="any">
@@ -279,10 +339,10 @@ em caixa alta. Utiliza-se antes do nome da conferencia a expressao "In". Segundo
       </else>
     </choose>
   </macro>
-  <!--A macro 'edition' e responsavel por mostrar o numero da edicao.-->
+  <!-- A macro 'edition' é responsável por mostrar o número da edição. -->
   <macro name="edition">
     <choose>
-      <!--Se for capitulo de livro aparecera somente o numero-->
+      <!--Se for capítulo de livro aparecerá somente o numero-->
       <if type="book chapter" match="any">
         <choose>
           <if is-numeric="edition">
@@ -292,17 +352,17 @@ em caixa alta. Utiliza-se antes do nome da conferencia a expressao "In". Segundo
             </group>
           </if>
           <else>
-            <!--Se for outro tipo de documento aparera o numero e depois a descricao "ed."-->
+            <!--Se for outro tipo de documento aparerá o número e depois a descrição "ed."-->
             <text variable="edition" suffix=" ed."/>
           </else>
         </choose>
       </if>
     </choose>
   </macro>
-  <!--A macro 'locators'tem como funcao mostrar os dados complementares do arquivo (paginas, secao, volume, etc)-->
+  <!--A macro 'locators' tem como função mostrar os dados complementares do arquivo (páginas, seção, volume, etc)-->
   <macro name="locators">
     <choose>
-      <!--Se for projeto de lei mostrara o dia, mes "forma curta", ano, secao "Sec." e pagina "p."-->
+      <!--Se for projeto de lei mostra o dia, mês "forma curta", ano, seção "Sec." e página "p."-->
       <if type="bill">
         <group prefix=". " delimiter=", ">
           <date variable="issued">
@@ -314,329 +374,303 @@ em caixa alta. Utiliza-se antes do nome da conferencia a expressao "In". Segundo
           <text variable="page" prefix="p. " suffix="."/>
         </group>
       </if>
-      <!--Se for artigos de jornal, revista, etc. Aparecera o volume "v.", edicao "n." e a pagina do artigo "p."-->
+      <!--Se for artigos de jornal, revista, etc. aparecerá o volume "v.", edição "n." e a página do artigo "p."-->
       <else-if match="any" type="article-journal article-magazine article-newspaper">
         <group delimiter=", ">
-          <group delimiter=", ">
-            <text variable="volume" prefix="v. "/>
-            <text variable="issue" prefix="n. "/>
-          </group>
+          <text variable="volume" prefix="v. "/>
+          <text variable="issue" prefix="n. "/>
           <text variable="page" prefix="p. "/>
         </group>
       </else-if>
-      <!--Se for capitulo de livro aparecera o volume "v." e a pagina "p."-->
-      <else-if match="any" type="book chapter">
+      <!--Se for capítulo de livro aparecerá o volume "v." e a página "p."-->
+      <else-if match="any" type="book chapter paper-conference speech entry-encyclopedia entry-dictionary">
         <group delimiter=", ">
-          <group>
-            <text variable="volume" prefix="v. "/>
-            <text variable="page" prefix="p. "/>
-          </group>
+          <text variable="volume" prefix="v. "/>
+          <text variable="page" prefix="p. "/>
         </group>
       </else-if>
     </choose>
   </macro>
-  <macro name="collection-title">
-    <text variable="collection-title"/>
-    <text variable="collection-number" prefix=" "/>
+  <!--Mostra a ISBN-->
+  <macro name="ISBN">
+    <text variable="ISBN" prefix="ISBN "/>
   </macro>
+  <!-- Título de coleção -->
+  <macro name="collection-title">
+    <group delimiter=", " suffix=".">
+      <group>
+        <text variable="collection-title"/>
+        <text variable="collection-number" prefix=" "/>
+      </group>
+      <choose>
+        <if type="song">
+          <text variable="volume" prefix="v. "/>
+        </if>
+      </choose>
+    </group>
+  </macro>
+  <!-- Anotações (campo "extra") -->
+  <macro name="extra">
+    <text variable="note"/>
+  </macro>
+  <!-- Tipo ou gênero -->
   <macro name="genre">
     <text variable="genre"/>
   </macro>
+  <!-- Lugar de publicação de jornal, revista ou periódico. Periódicos devem colocar a localidade no campo "Extra" do Zotero -->
+  <macro name="place">
+    <choose>
+      <if match="any" variable="publisher-place">
+        <text variable="publisher-place"/>
+      </if>
+      <else>
+        <choose>
+          <if match="any" type="article-magazine article-journal">
+            <text macro="extra"/>
+          </if>
+          <else>
+            <text value="[S.l.]"/>
+          </else>
+        </choose>
+      </else>
+    </choose>
+  </macro>
+  <!--Arquivo onde a referência se encontra. Lugar do arquivo: Nome do arquivo, localização da referência no arquivo. -->
+  <macro name="archive">
+    <group suffix=". ">
+      <text variable="archive-place" suffix=": "/>
+      <text variable="archive"/>
+      <text variable="archive_location" prefix=", "/>
+    </group>
+  </macro>
+  <!-- Número de páginas na citação -->
   <macro name="citation-locator">
     <group>
       <label variable="locator" form="short"/>
       <text variable="locator" prefix=" "/>
     </group>
   </macro>
-  <macro name="place">
-    <choose>
-      <if match="any" variable="publisher-place">
-        <text variable="publisher-place"/>
-      </if>
-    </choose>
-  </macro>
-  <macro name="archive">
-    <group>
-      <text variable="archive" prefix=" "/>
-    </group>
-  </macro>
-  <!--Citacao-->
-  <!--et al. aparece a partir de 04 autores-->
-  <citation et-al-min="4" et-al-use-first="1" collapse="year" disambiguate-add-year-suffix="true">
+  <!-- CITAÇÃO. "et al." aparece a partir de 4 autores. "desambiguate-add" serve para desambiguar nomes idênticos ou datas idênticas de mesmo autor. As referências são organizadas primeiro pelo nome de autor, depois pelo ano. A citação ocorre entre parênteses; o autor e a data são separados por vírgula, e uma referência e outra são separadas por ponto e vírgula. -->
+  <citation et-al-min="4" et-al-use-first="1" et-al-subsequent-min="4" et-al-subsequent-use-first="1" collapse="year-suffix-ranged" disambiguate-add-names="true" disambiguate-add-givenname="true" givenname-disambiguation-rule="primary-name" disambiguate-add-year-suffix="true">
     <sort>
       <key macro="author"/>
-      <!--Puxa o autor primeiro-->
       <key variable="issued"/>
-      <!--Depois o ano-->
     </sort>
     <layout prefix="(" suffix=")" delimiter="; ">
-      <!--Entre parenteses separando os autores com ponto-e-virgula-->
       <group>
         <text suffix=", " macro="author-short"/>
-        <!--Seperando os autores das datas usando virgula-->
         <text macro="issued-year"/>
         <text prefix=", " macro="citation-locator"/>
       </group>
     </layout>
   </citation>
-  <!--Bibliografia-->
-  <!--et al. aparece a partir de 04 autores-->
-  <bibliography hanging-indent="false" et-al-min="4" et-al-use-first="1" entry-spacing="1">
+  <!-- BIBLIOGRAFIA. "et al." aparece a partir de 4 autores. As referências são organizadas primeiro pelo nome de autor, depois pelo ano. -->
+  <bibliography hanging-indent="false" et-al-min="4" et-al-use-first="1" entry-spacing="1" subsequent-author-substitute="______." subsequent-author-substitute-rule="complete-all">
     <sort>
       <key macro="author"/>
-      <!--Puxa o autor primeiro-->
       <key variable="issued"/>
-      <!--Depois o ano-->
     </sort>
     <layout>
+      <!--livro, verbete de enciclopédia e outros estão no ELSE final-->
       <choose>
-        <!--Projeto de lei-->
+        <!-- Lei -->
         <if type="bill">
-          <group>
-            <text macro="author" suffix=". "/>
-            <!--autor-->
-            <text variable="number" suffix=". "/>
+          <group delimiter=". " suffix=". ">
+            <text macro="author"/>
             <!--Numero da lei-->
-            <text macro="title" suffix=". "/>
-            <!--Titulo-->
+            <text variable="number"/>
+            <text macro="title"/>
+            <!--Histórico em negrito-->
             <text variable="references" font-weight="bold"/>
-            <!--Historico em negrito-->
-            <text variable="note"/>
-            <!--Campo 'extra' caso queira colocar alguma observacao-->
-            <text macro="locators" suffix=". "/>
-            <!--Dados complementares "secao, pagina"-->
+            <text macro="extra" prefix=""/>
+            <!--Dados complementares "seção, página"-->
+            <text macro="locators"/>
           </group>
         </if>
-        <!--Mapa-->
-        <else-if type="map">
-          <group>
-            <text macro="author" suffix=". "/>
-            <!--autor-->
-            <text macro="title" suffix=", "/>
-            <!--Titulo-->
-            <text macro="issued" suffix=". "/>
-            <!--data-->
-            <text variable="note" suffix=". "/>
-            <!--Campo 'extra' caso queira colocar alguma observacao-->
-          </group>
-        </else-if>
-        <!--Livro-->
-        <else-if type="book">
-          <group>
-            <text macro="author" suffix=". "/>
-            <!--autor-->
-            <text macro="title" suffix=". "/>
-            <!--Titulo-->
-            <text macro="translator" suffix=". "/>
-            <!--Traducao-->
-            <text macro="edition" suffix=". "/>
-            <!--Edicao-->
-            <text macro="publisher" suffix=". "/>
-            <!--Local, data, etc-->
-            <text macro="locators"/>
-            <!--Dados complementares "pagina, volume"-->
-          </group>
-        </else-if>
-        <!--Conferencia-->
+        <!--Capítulo de livro (colocar a data original do capitulo no campo "Extra")-->
         <else-if type="chapter">
-          <group>
-            <text macro="author" suffix=". "/>
-            <!--autor-->
-            <text macro="title" suffix=". "/>
-            <!--Titulo-->
-            <text macro="secondary-contributors" suffix=". "/>
-            <text term="in" text-case="capitalize-first" suffix=": "/>
-            <!--In:-->
-            <text macro="container-contributors" suffix=". "/>
-            <!--Nomes de editores-->
-            <text macro="container-title" suffix=". "/>
-            <!--Titulo da conferencia-->
-            <text variable="collection-title" suffix=". "/>
-            <text macro="translator" suffix=". "/>
-            <!--Traducao-->
-            <text macro="edition" suffix=". "/>
-            <!--Edicao-->
-            <text macro="publisher" suffix=". "/>
-            <!--Local, data, etc-->
-            <text macro="locators" suffix=". "/>
-            <!--Dados complementares "pagina, volume"-->
+          <text macro="author" suffix=". "/>
+          <!--Campo 'extra': data original do capitulo entre colchetes-->
+          <text macro="extra" prefix="[" suffix="] "/>
+          <group delimiter=". " suffix=". ">
+            <text macro="title"/>
+            <text macro="container"/>
+            <text macro="collection-title"/>
+            <text macro="translator"/>
+            <text macro="edition"/>
+            <text macro="publisher"/>
+            <text macro="locators"/>
+            <text macro="ISBN"/>
+            <text macro="access" suffix=". "/>
           </group>
         </else-if>
-        <!--Artigo de revista, jornal, etc-->
-        <else-if type="article-newspaper article-magazine article-journal" match="any">
-          <group>
-            <text macro="author" suffix=". "/>
-            <!--Autor-->
-            <text macro="title" suffix=". "/>
+        <!--Artigo de revista ou periódico ou de jornal impresso ou digital-->
+        <else-if type="article-magazine article-journal article-newspaper" match="any">
+          <group delimiter=". " suffix=". ">
+            <text macro="author"/>
             <!--Titulo do artigo-->
-            <text macro="container-title" suffix=", "/>
-            <!--Titulo da publicacao-->
-            <text variable="collection-title" suffix=". "/>
-            <!--Titulo da serie-->
-            <text macro="edition" suffix=", "/>
-            <!--Edicao-->
-            <text macro="locators" suffix=", "/>
-            <!--Dados complementares "pagina, volume"-->
-            <text macro="issued" suffix=". "/>
-            <!--Data-->
-          </group>
-        </else-if>
-        <!--Tese-->
-        <else-if type="thesis">
-          <group>
-            <text macro="author" suffix=". "/>
-            <!--Autor-->
-            <text macro="title" suffix=". "/>
-            <!--Titulo-->
-            <text macro="genre" suffix="&#8212;"/>
-            <!--Tipo-->
-            <text macro="publisher" suffix="."/>
-            <!--Local, data, etc-->
-          </group>
-        </else-if>
-        <!-- Nao ha norma ABNT para manuscritos -->
-        <else-if type="manuscript">
-          <group>
-            <text macro="author" suffix=". "/>
-            <!--Autor-->
-            <text macro="title" suffix=". "/>
-            <!--Titulo-->
-            <text macro="edition" suffix=". "/>
-            <!--Edicao-->
-            <text macro="place" suffix=", "/>
-            <text macro="issued" suffix=". "/>
-            <!--Data-->
-            <text macro="access" suffix=". "/>
-            <!--URL, data do acesso-->
-            <text macro="archive" suffix=". "/>
-            <!--Arquive-->
-          </group>
-        </else-if>
-        <!--Pagina da WEB-->
-        <else-if type="webpage">
-          <group>
-            <text macro="author" suffix=". "/>
-            <!--Autor-->
-            <text macro="title" suffix=". "/>
-            <!--Titulo-->
-            <text macro="genre" suffix=". "/>
-            <text macro="access" suffix=". "/>
-            <!--URL, data do acesso-->
-          </group>
-        </else-if>
-        <!--Relatorio-->
-        <else-if type="report">
-          <group>
-            <text macro="author" suffix=". "/>
-            <!--Autor-->
             <text macro="title"/>
-            <!--Titulo-->
-            <text macro="container-contributors"/>
-            <!--Nomes de editores-->
-            <text macro="secondary-contributors"/>
-            <text macro="container-title"/>
             <!--Titulo da publicacao-->
-            <text variable="collection-title" prefix=": "/>
-            <text macro="locators"/>
-            <!--Dados complementares "pagina, volume"-->
-            <text macro="event"/>
-            <!--Nome do evento, conferencia-->
-            <text macro="publisher" prefix=". " suffix=". "/>
-            <!--Local, data, etc-->
-            <text macro="access" suffix="."/>
-            <!--URL, data do acesso-->
-          </group>
-        </else-if>
-        <!--Texto para Discussao (Verbete de Dicionario)-->
-        <else-if type="entry-dictionary">
-          <group>
-            <text macro="author" suffix=". "/>
-            <!--Autor-->
-            <text macro="title"/>
-            <!--Titulo-->
-            <text macro="container-contributors"/>
-            <!--Nomes de editores-->
-            <text macro="secondary-contributors"/>
             <text macro="container-title"/>
-            <!--Titulo da publicacao-->
-            <text variable="collection-title" prefix=": " suffix=". "/>
+            <group delimiter=", ">
+              <!-- Local, editor -->
+              <text macro="place"/>
+              <text macro="issued"/>
+            </group>
+            <!--Título da série-->
+            <text macro="collection-title"/>
+            <text macro="edition"/>
             <text macro="locators"/>
-            <!--Dados complementares "pagina, volume"-->
-            <text macro="event"/>
-            <!--Nome do evento, conferencia-->
-            <text macro="publisher" prefix=". " suffix=". "/>
-            <!--Local, data, etc-->
-            <text macro="collection-title" prefix="(Texto para discussao, n. " suffix=")."/>
             <text macro="access"/>
-            <!--URL, data do acesso-->
           </group>
         </else-if>
-        <!--Nota Tecnica (Verbete de Enciclopedia)-->
-        <else-if type="entry-encyclopedia">
-          <group>
-            <text macro="author" suffix=". "/>
-            <!--Autor-->
+        <!--Tese e dissertação-->
+        <else-if type="thesis">
+          <group delimiter=". " suffix=". ">
+            <text macro="author"/>
             <text macro="title"/>
-            <!--Titulo-->
-            <text variable="publisher-place" prefix=". " suffix=": "/>
-            <!--Local-->
-            <text variable="publisher" suffix=", "/>
-            <!--Editor-->
-            <text macro="issued" prefix=", " suffix=". (Nota técnica)."/>
-            <!--Data-->
+            <!--Tipo (p. ex. Dissertação de Mestrado em Jornalismo)-->
+            <text macro="genre"/>
+            <text macro="edition"/>
+            <text macro="publisher"/>
+            <text macro="locators"/>
+            <text macro="access"/>
           </group>
         </else-if>
-        <else-if type="paper-conference">
-          <text macro="author" suffix=". "/>
-          <!--Autor-->
-          <text macro="title" suffix=". "/>
-          <!--Titulo-->
-          <text macro="container-contributors"/>
-          <!--Nomes de editore-->
-          <text macro="secondary-contributors"/>
-          <text macro="container-title"/>
-          <!--Titulo da publicacao-->
-          <text variable="collection-title" prefix=": " suffix="."/>
-          <text macro="locators"/>
-          <!--Dados complementares "pagina, volume"-->
-          <group delimiter=". " prefix=". " suffix=". ">
+        <!-- Manuscritos (não há norma ABNT) -->
+        <else-if type="manuscript">
+          <group delimiter=". " suffix=". ">
+            <text macro="author"/>
+            <text macro="title"/>
+            <text macro="edition"/>
+            <text macro="place"/>
+            <text macro="issued"/>
+            <text macro="archive"/>
+            <text macro="genre"/>
+            <text macro="extra"/>
+            <text macro="access"/>
+          </group>
+        </else-if>
+        <!--Página da WEB-->
+        <else-if type="webpage post-weblog" match="any">
+          <group delimiter=". " suffix=". ">
+            <text macro="author"/>
+            <!--Título da página-->
+            <text macro="title"/>
+            <group delimiter=", ">
+              <!--Título do site-->
+              <text macro="container-title"/>
+              <!--Data-->
+              <text macro="issued"/>
+            </group>
+            <text macro="genre"/>
+            <text macro="extra"/>
+            <text macro="access"/>
+          </group>
+        </else-if>
+        <!--Relatório-->
+        <else-if type="report">
+          <group delimiter=". " suffix=". ">
+            <text macro="author"/>
+            <text macro="title"/>
+            <!--Nomes de editores-->
+            <text macro="container-contributors"/>
+            <text macro="secondary-contributors"/>
+            <!--Título da publicação-->
+            <text macro="container-title"/>
+            <text variable="collection-title"/>
+            <text macro="locators"/>
+            <!--Nome do evento, conferência-->
             <text macro="event"/>
-            <!--Nome do evento, conferencia-->
+            <text macro="publisher"/>
+            <text macro="extra"/>
+            <text macro="access"/>
           </group>
-          <text variable="publisher-place" suffix=": "/>
-          <!--Local-->
-          <text variable="publisher" suffix=", "/>
-          <!--Editor-->
-          <text macro="issued"/>
-          <!--Data-->
-          <text macro="access"/>
-          <!--URL, data do acesso-->
         </else-if>
+        <!--O tipo Zotero "Conferência" é igual ao tipo CSL "paper-conference", e o tipo "Apresentação" é igual ao tipo CSL "speech" (que tem campo CSL "genre") -->
+        <else-if type="paper-conference speech" match="any">
+          <group delimiter=". " suffix=". ">
+            <text macro="author"/>
+            <text macro="title"/>
+            <!--Nomes de editores-->
+            <text macro="container-contributors"/>
+            <text macro="secondary-contributors"/>
+            <group delimiter=", ">
+              <!--Nome do evento, conferência-->
+              <text macro="event"/>
+              <!--Editor-->
+              <text macro="publisher"/>
+            </group>
+            <text macro="locators"/>
+            <text macro="ISBN"/>
+            <text macro="genre"/>
+            <text macro="extra"/>
+            <text macro="access"/>
+          </group>
+        </else-if>
+        <!-- Filmes e vídeos. Imperfeito. Só inclui diretor. Necessita mais trabalho. O campo "Extra" deve conter o local de produção -->
+        <else-if type="motion_picture broadcast" match="any">
+          <group delimiter=". " suffix=". ">
+            <text macro="title"/>
+            <text macro="author"/>
+            <!--Nomes de editores-->
+            <text macro="container-contributors"/>
+            <text macro="secondary-contributors"/>
+            <group>
+              <text macro="extra" suffix=": "/>
+              <text variable="publisher" suffix=", "/>
+              <text macro="issued"/>
+            </group>
+            <text macro="collection-title" font-weight="bold"/>
+            <text macro="event"/>
+            <!-- Suporte -->
+            <text variable="medium"/>
+            <!-- Tipo, gênero -->
+            <text macro="genre"/>
+            <text macro="locators"/>
+            <text macro="access"/>
+          </group>
+        </else-if>
+        <!--Gravação de áudio. Colocar no campo "Extra" compositorxs, intérpretes etc-->
+        <else-if type="song">
+          <group delimiter=". " suffix=". ">
+            <text macro="author"/>
+            <text macro="title"/>
+            <!--'Extra' para inserir compositorx, intérpretes etc-->
+            <text macro="extra"/>
+            <text macro="container"/>
+            <text macro="collection-title"/>
+            <text macro="translator"/>
+            <text macro="edition"/>
+            <text macro="publisher"/>
+            <text macro="locators"/>
+            <text macro="ISBN"/>
+            <!--Tipo ou gênero-->
+            <text macro="genre"/>
+            <!-- Suporte (CD, DVD, partitura etc) -->
+            <text variable="medium"/>
+            <text macro="access"/>
+          </group>
+        </else-if>
+        <!-- Qualquer outra referência -->
         <else>
-          <text macro="author" suffix=". "/>
-          <!--Autor-->
-          <text macro="title"/>
-          <!--Titulo-->
-          <text macro="container-contributors"/>
-          <!--Nomes de editore-->
-          <text macro="secondary-contributors"/>
-          <text macro="container-title"/>
-          <!--Titulo da publicacao-->
-          <text variable="collection-title" prefix=": " suffix="."/>
-          <text macro="locators"/>
-          <!--Dados complementares "pagina, volume"-->
-          <group delimiter=". " prefix=". " suffix=". ">
-            <text macro="event"/>
-            <!--Nome do evento, conferencia-->
+          <group delimiter=". " suffix=". ">
+            <text macro="author"/>
+            <text macro="title"/>
+            <text macro="container"/>
+            <text macro="collection-title"/>
+            <text macro="translator"/>
+            <text macro="publisher"/>
+            <text macro="edition"/>
+            <text macro="locators"/>
+            <text macro="ISBN"/>
+            <text macro="genre"/>
+            <!-- Suporte (CD, DVD, partitura etc) -->
+            <text variable="medium"/>
+            <!--Campo 'extra' caso queira ou precise colocar alguma observação-->
+            <text macro="extra"/>
+            <text macro="access"/>
           </group>
-          <text variable="publisher-place"/>
-          <!--Local-->
-          <text variable="publisher" suffix=", "/>
-          <!--Editor-->
-          <text macro="issued" prefix=", " suffix=". "/>
-          <!--Data-->
-          <text macro="access"/>
-          <!--URL, data do acesso-->
         </else>
       </choose>
     </layout>

--- a/associacao-brasileira-de-normas-tecnicas.csl
+++ b/associacao-brasileira-de-normas-tecnicas.csl
@@ -174,12 +174,12 @@
   <macro name="title">
     <choose>
       <if type="chapter bill webpage post-weblog article-newspaper article-magazine article-journal motion_picture broadcast paper-conference speech" match="any">
-        <text variable="title" text-case="sentence"/>
+        <text variable="title" text-case="capitalize-first"/>
       </if>
       <else-if match="any" type="entry-encyclopedia entry-dictionary">
         <choose>
           <if match="any" variable="author editor collection-editor translator">
-            <text variable="title" text-case="sentence"/>
+            <text variable="title" text-case="capitalize-first"/>
           </if>
           <else>
             <text variable="title" text-case="uppercase"/>
@@ -187,7 +187,7 @@
         </choose>
       </else-if>
       <else>
-        <text variable="title" font-weight="bold" text-case="sentence"/>
+        <text variable="title" font-weight="bold" text-case="capitalize-first"/>
       </else>
     </choose>
   </macro>


### PR DESCRIPTION
### Macros
- `names` label set to `capitalize-first`: "(Org.)" instead of "(ORG.)"
- test if there's a translator in macro `translator`, to avoid text "Tradução: " to be put alone
- in `motion_picture` and `broadcast` types, don't substitute author by title, to avoid duplication
- family names in citations set to `small-caps`, instead of `capitalize-all`, to improve reading (see [this discussion](https://github.com/citation-style-language/styles/pull/3497)).
- given names in citations set to `capitalize-first`, to avoid uppercase in disambiguation cases
- refactoring in macro `title`, with `entry-encyclopedia` and `entry-dictionary` showing uppercase if there's no author.
- removed "Anais..." literal expression from `container-title` macro.
- new macro `container`, grouping `container-contributors`, `secondary-contributors` and `container-title`, preceded by expression "In:" (normal font) only if there's a `container-title`.
- corrected logic on `publisher` macro (for inexistent `issued` variable).
- in `speech` type, the promoter of the event is retrieved from `note` field (workaround for Zotero).
- in `paper-conference`, `issued-year` is before `publisher-place`.
- new macro `archive`, containing `archive-place`, `archive` and `archive_location` (see [CSL variables](http://docs.citationstyles.org/en/stable/specification.html#appendix-iv-variables)).

### Citation
- disambiguation rules: by name, by year suffix.

### Bibliography
- `subsequent-author-substitute` set to six underlines and point; `subsequent-author-substitute-rule` set to `complete-all`.
- `chapter`: original date can be set in `note` field, to be put between brackets after authors.
- `paper-conference`: `container-title`, which contains the name of the proceedings, is used instead of a literal value ("Anais..." previously).
- `manuscript`: use new macro `archive`.
- `webpage`, `post-weblog`: use `container-title` (site name), `issued` and `note` fields.
- `motion_picture`, `broadcast`: use `note` field to write production place.
- `song`: use `note` field to write artists (composers, singers, instrumentalists etc.). Using `medium` field, it's possible to use this type also for sheet music: just write e.g. "Partitura" (ptBR for "sheet music") in `medium` field and use `note` field to write instrumentation (e.g. "For oboe solo").
- `entry-dictionary`, `entry-encyclopedia`: removed specific declarations, since the only unique difference, a note in the end of reference, can be made using `note` field, already present in general reference declaration (last `else` statement).
- overall reordering of text fields, using this basic structure (except when ABNT asks for other order):
  - author
  - title
  - container info (container authors and title)
  - collection-title
  - translator
  - publisher (place, publisher and date)
  - edition and locators
  - minor info (ISBN, genre, medium, notes, access).