### PR TITLE
Move colon out of group for conference papers

### DIFF
--- a/elsevier-without-titles.csl
+++ b/elsevier-without-titles.csl
@@ -84,8 +84,8 @@
           </group>
         </if>
         <else-if type="chapter paper-conference" match="any">
+          <text term="in" suffix=": "/>
           <group delimiter=", ">
-            <text term="in" suffix=":"/>
             <text macro="editor"/>
             <text variable="container-title" form="short" text-case="title"/>
             <text macro="edition"/>


### PR DESCRIPTION
The term colon inside the group with ", " delimiter resulted in a wrong rendering, always "[...], in:, [...]" for conference papers, see citation 3 in the picture:

![image](https://user-images.githubusercontent.com/6943048/39801420-68489d0e-536b-11e8-8a60-3c83dfab5bf6.png)
