### PR TITLE
Correct bibtex type for conference papers

### DIFF
--- a/bibtex.csl
+++ b/bibtex.csl
@@ -23,7 +23,7 @@
       <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
         <text value="book"/>
       </if>
-      <else-if type="chapter paper-conference" match="any">
+      <else-if type="chapter" match="any">
         <text value="inbook"/>
       </else-if>
       <else-if type="article article-journal article-magazine article-newspaper" match="any">


### PR DESCRIPTION
The type paper-conference was used by mistake twice in the case distinction. Therefore, the correct bibtex mapping (inproceedings) was never chosen.