### PR TITLE
Update unified-style-linguistics.csl

### DIFF
--- a/unified-style-linguistics.csl
+++ b/unified-style-linguistics.csl
@@ -1,389 +1,388 @@
 <?xml version="1.0" encoding="utf-8"?>
-<style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0"
-    demote-non-dropping-particle="display-and-sort" default-locale="en-US">
-    <info>
-        <title>Unified style sheet for linguistics journals</title>
-        <id>http://www.zotero.org/styles/unified-style-linguistics</id>
-        <link href="http://www.zotero.org/styles/unified-style-linguistics" rel="self"/>
-        <link href="https://www.linguisticsociety.org/sites/default/files/style-sheet_0.pdf" rel="documentation"/>
-        <author>
-            <name>Mark Dingemanse</name>
-            <email>mark.dingemanse@mpi.nl</email>
-        </author>
-        <contributor>
-            <name>Sebastian Karcher</name>
-        </contributor>
-        <contributor>
-            <name>Frank Bennett</name>
-        </contributor>
-        <contributor>
-            <name>Arash Zeini</name>
-        </contributor>
-        <category citation-format="author-date"/>
-        <category field="linguistics"/>
-        <summary>Unified Style Sheet for Linguistics</summary>
-        <updated>2018-05-10T17:57:00+00:00</updated>
-        <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
-    </info>
-    <locale>
-        <terms>
-            <term name="editor" form="verb-short">ed.</term>
-            <term name="translator" form="verb-short">trans.</term>
-        </terms>
-    </locale>
-    <macro name="secondary-contributors">
-        <choose>
-            <if type="chapter paper-conference" match="none">
-                <group delimiter=". ">
-                    <choose>
-                        <if variable="author">
-                            <names variable="editor">
-                                <label form="verb-short" prefix=" (" text-case="capitalize-first" suffix=") "/>
-                                <name and="symbol" delimiter=", " delimiter-precedes-last="never"/>
-                            </names>
-                        </if>
-                    </choose>
-                    <choose>
-                        <if variable="author editor" match="any">
-                            <names variable="translator">
-                                <label form="verb-short" prefix=" (" text-case="capitalize-first" suffix=") "/>
-                                <name and="symbol" delimiter=", " delimiter-precedes-last="never"/>
-                            </names>
-                        </if>
-                        <else>
-                            <names variable="editor">
-                                <label form="short" suffix=")" prefix="("/>
-                                <name and="symbol" delimiter=", " delimiter-precedes-last="never"/>
-                            </names>
-                        </else>
-                    </choose>
-                </group>
-            </if>
-        </choose>
-    </macro>
-    <macro name="container-contributors">
-        <choose>
-            <if type="chapter paper-conference" match="any">
-                <text term="in" text-case="capitalize-first" suffix=" "/>
-                <group delimiter=", ">
-                    <choose>
-                        <if variable="author">
-                            <names variable="editor">
-                                <name and="symbol" delimiter=", " delimiter-precedes-last="never"/>
-                                <label form="short" suffix=")" prefix=" ("/>
-                            </names>
-                        </if>
-                    </choose>
-                    <choose>
-                        <if variable="author editor" match="any">
-                            <names variable="translator">
-                                <label form="verb-short" prefix=" " suffix=" "/>
-                                <name and="symbol" delimiter=", " delimiter-precedes-last="never"/>
-                            </names>
-                        </if>
-                    </choose>
-                </group>
-            </if>
-        </choose>
-    </macro>
-    <macro name="editor">
-        <names variable="editor">
-            <name name-as-sort-order="first" and="symbol" sort-separator=", " delimiter=", " delimiter-precedes-last="never"/>
-            <label form="short" prefix=" (" suffix=")."/>
-        </names>
-    </macro>
-    <macro name="translator">
-        <names variable="translator">
-            <name name-as-sort-order="first" and="symbol" sort-separator=", " delimiter=", " delimiter-precedes-last="never"/>
-            <label form="verb-short" prefix=" (" suffix=")."/>
-        </names>
-    </macro>
-    <macro name="recipient">
-        <choose>
-            <if type="personal_communication">
-                <choose>
-                    <if variable="genre">
-                        <text variable="genre" text-case="capitalize-first"/>
-                    </if>
-                    <else>
-                        <text term="letter" text-case="capitalize-first"/>
-                    </else>
-                </choose>
-            </if>
-        </choose>
-        <names variable="recipient" delimiter=", ">
-            <label form="verb" prefix=" " suffix=" "/>
-            <name and="symbol" delimiter=", " delimiter-precedes-last="never"/>
-        </names>
-    </macro>
-    <macro name="contributors">
-        <names variable="author">
-            <name and="symbol" name-as-sort-order="first" sort-separator=", " delimiter=", " delimiter-precedes-last="never"/>
-            <label form="short" prefix=", " suffix=" "/>
-            <substitute>
-                <text macro="editor"/>
-                <text macro="translator"/>
-            </substitute>
-        </names>
-        <text macro="recipient"/>
-    </macro>
-    <macro name="contributors-short">
-        <names variable="author">
-            <name form="short" and="symbol" delimiter=", " delimiter-precedes-last="never"/>
-            <substitute>
-                <names variable="editor"/>
-                <names variable="translator"/>
-            </substitute>
-        </names>
-    </macro>
-    <macro name="interviewer">
-        <names variable="interviewer" delimiter=", ">
-            <label form="verb" text-case="capitalize-first" suffix=" "/>
-            <name and="symbol" delimiter=", " delimiter-precedes-last="never"/>
-        </names>
-    </macro>
-    <macro name="archive">
+<style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" demote-non-dropping-particle="display-and-sort" default-locale="en-US">
+  <info>
+    <title>Unified style sheet for linguistics journals</title>
+    <id>http://www.zotero.org/styles/unified-style-linguistics</id>
+    <link href="http://www.zotero.org/styles/unified-style-linguistics" rel="self"/>
+    <link href="https://www.linguisticsociety.org/sites/default/files/style-sheet_0.pdf" rel="documentation"/>
+    <author>
+      <name>Mark Dingemanse</name>
+      <email>mark.dingemanse@mpi.nl</email>
+    </author>
+    <contributor>
+      <name>Sebastian Karcher</name>
+    </contributor>
+    <contributor>
+      <name>Frank Bennett</name>
+    </contributor>
+    <contributor>
+      <name>Arash Zeini</name>
+    </contributor>
+    <category citation-format="author-date"/>
+    <category field="linguistics"/>
+    <summary>Unified Style Sheet for Linguistics</summary>
+    <updated>2018-05-10T17:57:00+00:00</updated>
+    <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
+  </info>
+  <locale>
+    <terms>
+      <term name="editor" form="verb-short">ed.</term>
+      <term name="translator" form="verb-short">trans.</term>
+    </terms>
+  </locale>
+  <macro name="secondary-contributors">
+    <choose>
+      <if type="chapter paper-conference" match="none">
         <group delimiter=". ">
-            <text variable="archive_location" text-case="capitalize-first"/>
-            <text variable="archive"/>
-            <text variable="archive-place"/>
-        </group>
-    </macro>
-    <macro name="access">
-        <group delimiter=". ">
-            <choose>
-                <if type="graphic report" match="any">
-                    <text macro="archive"/>
-                </if>
-                <else-if type="article-journal article-magazine article-newspaper bill book chapter graphic legal_case legislation motion_picture paper-conference report song thesis" match="none">
-                    <text macro="archive"/>
-                </else-if>
-            </choose>
-            <text variable="DOI" prefix="doi:"/>
-            <text variable="URL"/>
-        </group>
-        <group prefix=" (" suffix=")">
-            <date variable="accessed">
-                <date-part name="day" suffix=" "/>
-                <date-part name="month" suffix=", "/>
-                <date-part name="year"/>
-            </date>
-        </group>
-    </macro>
-    <macro name="title">
-        <choose>
-            <if variable="title" match="none">
-                <choose>
-                    <if type="personal_communication" match="none">
-                        <text variable="genre" text-case="capitalize-first"/>
-                    </if>
-                </choose>
+          <choose>
+            <if variable="author">
+              <names variable="editor">
+                <label form="verb-short" prefix=" (" text-case="capitalize-first" suffix=") "/>
+                <name and="symbol" delimiter=", " delimiter-precedes-last="never"/>
+              </names>
             </if>
-            <else-if type="book">
-                <choose>
-                    <if variable="collection-title">
-                        <group delimiter=" ">
-                            <text variable="title" font-style="italic"/>
-                            <text macro="collection-title"/>
-                        </group>
-                    </if>
-                    <else-if variable="collection-title" match="none">
-                        <text variable="title" font-style="italic"/>
-                    </else-if>
-                </choose>
-            </else-if>
-            <else-if type="bill graphic legal_case legislation motion_picture report song" match="any">
-                <text variable="title" font-style="italic"/>
-            </else-if>
+          </choose>
+          <choose>
+            <if variable="author editor" match="any">
+              <names variable="translator">
+                <label form="verb-short" prefix=" (" text-case="capitalize-first" suffix=") "/>
+                <name and="symbol" delimiter=", " delimiter-precedes-last="never"/>
+              </names>
+            </if>
             <else>
-                <text variable="title"/>
+              <names variable="editor">
+                <label form="short" suffix=")" prefix="("/>
+                <name and="symbol" delimiter=", " delimiter-precedes-last="never"/>
+              </names>
             </else>
-        </choose>
-    </macro>
-    <macro name="edition">
-        <choose>
-            <if type="bill book chapter graphic legal_case legislation motion_picture paper-conference report song" match="any">
-                <choose>
-                    <if is-numeric="edition">
-                        <group delimiter=" ">
-                            <number variable="edition" form="ordinal"/>
-                            <text term="edition" form="short"/>
-                        </group>
-                    </if>
-                    <else>
-                        <text variable="edition" suffix="."/>
-                    </else>
-                </choose>
-            </if>
-        </choose>
-    </macro>
-    <macro name="locators">
-        <choose>
-            <if type="article-journal">
-                <text variable="volume" prefix=" "/>
-                <text variable="issue" prefix="(" suffix=")."/>
-            </if>
-            <else-if type="bill book graphic legal_case legislation motion_picture report song" match="any">
-                <group prefix=". " delimiter=". ">
-                    <group>
-                        <text term="volume" form="short" text-case="capitalize-first" suffix=" "/>
-                        <number variable="volume" form="numeric"/>
-                    </group>
-                    <group>
-                        <number variable="number-of-volumes" form="numeric"/>
-                        <text term="volume" form="short" prefix=" " plural="true"/>
-                    </group>
-                </group>
-            </else-if>
-        </choose>
-    </macro>
-    <macro name="locators-chapter">
-        <choose>
-            <if type="chapter paper-conference" match="any">
-                <group delimiter=", ">
-                    <text variable="volume" prefix="vol. "/>
-                    <text variable="page"/>
-                </group>
-            </if>
-        </choose>
-    </macro>
-    <macro name="locators-article">
-        <choose>
-            <if type="article-newspaper">
-                <group prefix=", " delimiter=", ">
-                    <group delimiter=" ">
-                        <text variable="edition"/>
-                        <text term="edition"/>
-                    </group>
-                    <group>
-                        <text term="section" form="short" suffix=" "/>
-                        <text variable="section"/>
-                    </group>
-                </group>
-            </if>
-            <else-if type="article-journal">
-                <text variable="page" prefix=". "/>
-            </else-if>
-        </choose>
-    </macro>
-    <macro name="point-locators">
-        <group>
-            <choose>
-                <if locator="page" match="none">
-                    <label variable="locator" form="short" suffix=" "/>
-                </if>
-            </choose>
-            <text variable="locator"/>
+          </choose>
         </group>
-    </macro>
-    <macro name="container-title">
-        <text variable="container-title" font-style="italic"/>
-    </macro>
-    <macro name="publisher">
-        <group delimiter=": ">
-            <text variable="publisher-place"/>
-            <text variable="publisher"/>
-        </group>
-    </macro>
-    <macro name="date">
-        <date variable="issued">
-            <date-part name="year"/>
-        </date>
-    </macro>
-    <macro name="collection-title">
-        <group prefix="(" suffix=")">
-            <text variable="collection-title" text-case="title"/>
-            <text variable="collection-number" prefix=" "/>
-        </group>
-    </macro>
-    <macro name="event">
-        <group>
-            <text term="presented at" prefix="Paper " suffix=" "/>
-            <text variable="event"/>
-        </group>
-    </macro>
-    <macro name="description">
-        <group delimiter=". ">
-            <text macro="interviewer"/>
-            <text variable="medium" text-case="capitalize-first"/>
-        </group>
-        <choose>
-            <if variable="title" match="none"/>
-            <else-if type="thesis"/>
-            <else>
-                <text variable="genre" text-case="capitalize-first"/>
-            </else>
-        </choose>
-    </macro>
-    <macro name="issue">
-        <choose>
-            <if type="speech">
-                <group delimiter=", ">
-                    <text macro="event"/>
-                    <text variable="event-place"/>
-                </group>
+      </if>
+    </choose>
+  </macro>
+  <macro name="container-contributors">
+    <choose>
+      <if type="chapter paper-conference" match="any">
+        <text term="in" text-case="capitalize-first" suffix=" "/>
+        <group delimiter=", ">
+          <choose>
+            <if variable="author">
+              <names variable="editor">
+                <name and="symbol" delimiter=", " delimiter-precedes-last="never"/>
+                <label form="short" suffix=")" prefix=" ("/>
+              </names>
             </if>
-            <else-if type="thesis">
-                <group delimiter=" ">
-                    <text macro="publisher"/>
-                    <text variable="genre"/>
-                </group>
-            </else-if>
-            <else>
-                <group delimiter=", ">
-                    <text macro="publisher"/>
-                    <choose>
-                        <if type="manuscript">
-                            <text value="ms"/>
-                        </if>
-                    </choose>
-                </group>
-            </else>
+          </choose>
+          <choose>
+            <if variable="author editor" match="any">
+              <names variable="translator">
+                <label form="verb-short" prefix=" " suffix=" "/>
+                <name and="symbol" delimiter=", " delimiter-precedes-last="never"/>
+              </names>
+            </if>
+          </choose>
+        </group>
+      </if>
+    </choose>
+  </macro>
+  <macro name="editor">
+    <names variable="editor">
+      <name name-as-sort-order="first" and="symbol" sort-separator=", " delimiter=", " delimiter-precedes-last="never"/>
+      <label form="short" prefix=" (" suffix=")."/>
+    </names>
+  </macro>
+  <macro name="translator">
+    <names variable="translator">
+      <name name-as-sort-order="first" and="symbol" sort-separator=", " delimiter=", " delimiter-precedes-last="never"/>
+      <label form="verb-short" prefix=" (" suffix=")."/>
+    </names>
+  </macro>
+  <macro name="recipient">
+    <choose>
+      <if type="personal_communication">
+        <choose>
+          <if variable="genre">
+            <text variable="genre" text-case="capitalize-first"/>
+          </if>
+          <else>
+            <text term="letter" text-case="capitalize-first"/>
+          </else>
         </choose>
-    </macro>
-    <citation et-al-min="4" et-al-use-first="1" disambiguate-add-year-suffix="true" disambiguate-add-names="true" disambiguate-add-givenname="true">
-        <layout prefix="(" suffix=")" delimiter="; ">
-            <group delimiter=":">
-                <group delimiter=" ">
-                    <text macro="contributors-short"/>
-                    <text macro="date"/>
-                </group>
-                <text macro="point-locators"/>
+      </if>
+    </choose>
+    <names variable="recipient" delimiter=", ">
+      <label form="verb" prefix=" " suffix=" "/>
+      <name and="symbol" delimiter=", " delimiter-precedes-last="never"/>
+    </names>
+  </macro>
+  <macro name="contributors">
+    <names variable="author">
+      <name and="symbol" name-as-sort-order="first" sort-separator=", " delimiter=", " delimiter-precedes-last="never"/>
+      <label form="short" prefix=", " suffix=" "/>
+      <substitute>
+        <text macro="editor"/>
+        <text macro="translator"/>
+      </substitute>
+    </names>
+    <text macro="recipient"/>
+  </macro>
+  <macro name="contributors-short">
+    <names variable="author">
+      <name form="short" and="symbol" delimiter=", " delimiter-precedes-last="never"/>
+      <substitute>
+        <names variable="editor"/>
+        <names variable="translator"/>
+      </substitute>
+    </names>
+  </macro>
+  <macro name="interviewer">
+    <names variable="interviewer" delimiter=", ">
+      <label form="verb" text-case="capitalize-first" suffix=" "/>
+      <name and="symbol" delimiter=", " delimiter-precedes-last="never"/>
+    </names>
+  </macro>
+  <macro name="archive">
+    <group delimiter=". ">
+      <text variable="archive_location" text-case="capitalize-first"/>
+      <text variable="archive"/>
+      <text variable="archive-place"/>
+    </group>
+  </macro>
+  <macro name="access">
+    <group delimiter=". ">
+      <choose>
+        <if type="graphic report" match="any">
+          <text macro="archive"/>
+        </if>
+        <else-if type="article-journal article-magazine article-newspaper bill book chapter graphic legal_case legislation motion_picture paper-conference report song thesis" match="none">
+          <text macro="archive"/>
+        </else-if>
+      </choose>
+      <text variable="DOI" prefix="doi:"/>
+      <text variable="URL"/>
+    </group>
+    <group prefix=" (" suffix=")">
+      <date variable="accessed">
+        <date-part name="day" suffix=" "/>
+        <date-part name="month" suffix=", "/>
+        <date-part name="year"/>
+      </date>
+    </group>
+  </macro>
+  <macro name="title">
+    <choose>
+      <if variable="title" match="none">
+        <choose>
+          <if type="personal_communication" match="none">
+            <text variable="genre" text-case="capitalize-first"/>
+          </if>
+        </choose>
+      </if>
+      <else-if type="book">
+        <choose>
+          <if variable="collection-title">
+            <group delimiter=" ">
+              <text variable="title" font-style="italic"/>
+              <text macro="collection-title"/>
             </group>
-        </layout>
-    </citation>
-    <bibliography et-al-min="11" et-al-use-first="7" entry-spacing="0">
-        <sort>
-            <key macro="contributors"/>
-            <key variable="issued"/>
-        </sort>
-        <layout suffix=".">
-            <group delimiter=". ">
-                <text macro="contributors"/>
-                <text macro="date"/>
-                <text macro="title"/>
-                <text macro="description"/>
-                <text macro="secondary-contributors"/>
-                <group>
-                    <group delimiter=". ">
-                        <group>
-                            <group delimiter=". ">
-                                <group delimiter=", ">
-                                    <text macro="container-contributors"/>
-                                    <text macro="container-title"/>
-                                    <text macro="locators-chapter"/>
-                                </group>
-                                <text macro="edition"/>
-                            </group>
-                            <text macro="locators"/>
-                        </group>
-                        <!-- <text macro="collection-title"/> -->
-                        <text macro="issue"/>
-                    </group>
-                    <text macro="locators-article"/>
-                </group>
-                <text macro="access"/>
+          </if>
+          <else-if variable="collection-title" match="none">
+            <text variable="title" font-style="italic"/>
+          </else-if>
+        </choose>
+      </else-if>
+      <else-if type="bill graphic legal_case legislation motion_picture report song" match="any">
+        <text variable="title" font-style="italic"/>
+      </else-if>
+      <else>
+        <text variable="title"/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="edition">
+    <choose>
+      <if type="bill book chapter graphic legal_case legislation motion_picture paper-conference report song" match="any">
+        <choose>
+          <if is-numeric="edition">
+            <group delimiter=" ">
+              <number variable="edition" form="ordinal"/>
+              <text term="edition" form="short"/>
             </group>
-        </layout>
-    </bibliography>
+          </if>
+          <else>
+            <text variable="edition" suffix="."/>
+          </else>
+        </choose>
+      </if>
+    </choose>
+  </macro>
+  <macro name="locators">
+    <choose>
+      <if type="article-journal">
+        <text variable="volume" prefix=" "/>
+        <text variable="issue" prefix="(" suffix=")."/>
+      </if>
+      <else-if type="bill book graphic legal_case legislation motion_picture report song" match="any">
+        <group prefix=". " delimiter=". ">
+          <group>
+            <text term="volume" form="short" text-case="capitalize-first" suffix=" "/>
+            <number variable="volume" form="numeric"/>
+          </group>
+          <group>
+            <number variable="number-of-volumes" form="numeric"/>
+            <text term="volume" form="short" prefix=" " plural="true"/>
+          </group>
+        </group>
+      </else-if>
+    </choose>
+  </macro>
+  <macro name="locators-chapter">
+    <choose>
+      <if type="chapter paper-conference" match="any">
+        <group delimiter=", ">
+          <text variable="volume" prefix="vol. "/>
+          <text variable="page"/>
+        </group>
+      </if>
+    </choose>
+  </macro>
+  <macro name="locators-article">
+    <choose>
+      <if type="article-newspaper">
+        <group prefix=", " delimiter=", ">
+          <group delimiter=" ">
+            <text variable="edition"/>
+            <text term="edition"/>
+          </group>
+          <group>
+            <text term="section" form="short" suffix=" "/>
+            <text variable="section"/>
+          </group>
+        </group>
+      </if>
+      <else-if type="article-journal">
+        <text variable="page" prefix=". "/>
+      </else-if>
+    </choose>
+  </macro>
+  <macro name="point-locators">
+    <group>
+      <choose>
+        <if locator="page" match="none">
+          <label variable="locator" form="short" suffix=" "/>
+        </if>
+      </choose>
+      <text variable="locator"/>
+    </group>
+  </macro>
+  <macro name="container-title">
+    <text variable="container-title" font-style="italic"/>
+  </macro>
+  <macro name="publisher">
+    <group delimiter=": ">
+      <text variable="publisher-place"/>
+      <text variable="publisher"/>
+    </group>
+  </macro>
+  <macro name="date">
+    <date variable="issued">
+      <date-part name="year"/>
+    </date>
+  </macro>
+  <macro name="collection-title">
+    <group prefix="(" suffix=")">
+      <text variable="collection-title" text-case="title"/>
+      <text variable="collection-number" prefix=" "/>
+    </group>
+  </macro>
+  <macro name="event">
+    <group>
+      <text term="presented at" prefix="Paper " suffix=" "/>
+      <text variable="event"/>
+    </group>
+  </macro>
+  <macro name="description">
+    <group delimiter=". ">
+      <text macro="interviewer"/>
+      <text variable="medium" text-case="capitalize-first"/>
+    </group>
+    <choose>
+      <if variable="title" match="none"/>
+      <else-if type="thesis"/>
+      <else>
+        <text variable="genre" text-case="capitalize-first"/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="issue">
+    <choose>
+      <if type="speech">
+        <group delimiter=", ">
+          <text macro="event"/>
+          <text variable="event-place"/>
+        </group>
+      </if>
+      <else-if type="thesis">
+        <group delimiter=" ">
+          <text macro="publisher"/>
+          <text variable="genre"/>
+        </group>
+      </else-if>
+      <else>
+        <group delimiter=", ">
+          <text macro="publisher"/>
+          <choose>
+            <if type="manuscript">
+              <text value="ms"/>
+            </if>
+          </choose>
+        </group>
+      </else>
+    </choose>
+  </macro>
+  <citation et-al-min="4" et-al-use-first="1" disambiguate-add-year-suffix="true" disambiguate-add-names="true" disambiguate-add-givenname="true">
+    <layout prefix="(" suffix=")" delimiter="; ">
+      <group delimiter=":">
+        <group delimiter=" ">
+          <text macro="contributors-short"/>
+          <text macro="date"/>
+        </group>
+        <text macro="point-locators"/>
+      </group>
+    </layout>
+  </citation>
+  <bibliography et-al-min="11" et-al-use-first="7" entry-spacing="0">
+    <sort>
+      <key macro="contributors"/>
+      <key variable="issued"/>
+    </sort>
+    <layout suffix=".">
+      <group delimiter=". ">
+        <text macro="contributors"/>
+        <text macro="date"/>
+        <text macro="title"/>
+        <text macro="description"/>
+        <text macro="secondary-contributors"/>
+        <group>
+          <group delimiter=". ">
+            <group>
+              <group delimiter=". ">
+                <group delimiter=", ">
+                  <text macro="container-contributors"/>
+                  <text macro="container-title"/>
+                  <text macro="locators-chapter"/>
+                </group>
+                <text macro="edition"/>
+              </group>
+              <text macro="locators"/>
+            </group>
+            <!-- <text macro="collection-title"/> -->
+            <text macro="issue"/>
+          </group>
+          <text macro="locators-article"/>
+        </group>
+        <text macro="access"/>
+      </group>
+    </layout>
+  </bibliography>
 </style>

--- a/unified-style-linguistics.csl
+++ b/unified-style-linguistics.csl
@@ -179,17 +179,10 @@
         </choose>
       </if>
       <else-if type="book">
-        <choose>
-          <if variable="collection-title">
-            <group delimiter=" ">
-              <text variable="title" font-style="italic"/>
-              <text macro="collection-title"/>
-            </group>
-          </if>
-          <else-if variable="collection-title" match="none">
-            <text variable="title" font-style="italic"/>
-          </else-if>
-        </choose>
+        <group delimiter=" ">
+          <text variable="title" font-style="italic"/>
+          <text macro="collection-title"/>
+        </group>
       </else-if>
       <else-if type="bill graphic legal_case legislation motion_picture report song" match="any">
         <text variable="title" font-style="italic"/>
@@ -276,7 +269,10 @@
     </group>
   </macro>
   <macro name="container-title">
-    <text variable="container-title" font-style="italic"/>
+    <group delimiter=" ">
+      <text variable="container-title" font-style="italic"/>
+      <text macro="collection-title"/>
+    </group>
   </macro>
   <macro name="publisher">
     <group delimiter=": ">
@@ -290,10 +286,14 @@
     </date>
   </macro>
   <macro name="collection-title">
-    <group prefix="(" suffix=")">
-      <text variable="collection-title" text-case="title"/>
-      <text variable="collection-number" prefix=" "/>
-    </group>
+    <choose>
+      <if variable="collection-title">
+        <group prefix="(" suffix=")">
+          <text variable="collection-title" text-case="title"/>
+          <text variable="collection-number" prefix=" "/>
+        </group>
+      </if>
+    </choose>
   </macro>
   <macro name="event">
     <group>

--- a/unified-style-linguistics.csl
+++ b/unified-style-linguistics.csl
@@ -5,8 +5,7 @@
         <title>Unified style sheet for linguistics journals</title>
         <id>http://www.zotero.org/styles/unified-style-linguistics</id>
         <link href="http://www.zotero.org/styles/unified-style-linguistics" rel="self"/>
-        <link href="https://www.linguisticsociety.org/sites/default/files/style-sheet_0.pdf"
-            rel="documentation"/>
+        <link href="https://www.linguisticsociety.org/sites/default/files/style-sheet_0.pdf" rel="documentation"/>
         <author>
             <name>Mark Dingemanse</name>
             <email>mark.dingemanse@mpi.nl</email>
@@ -24,8 +23,7 @@
         <category field="linguistics"/>
         <summary>Unified Style Sheet for Linguistics</summary>
         <updated>2018-05-10T17:57:00+00:00</updated>
-        <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under
-            a Creative Commons Attribution-ShareAlike 3.0 License</rights>
+        <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
     </info>
     <locale>
         <terms>
@@ -40,8 +38,7 @@
                     <choose>
                         <if variable="author">
                             <names variable="editor">
-                                <label form="verb-short" prefix=" (" text-case="capitalize-first"
-                                    suffix=") "/>
+                                <label form="verb-short" prefix=" (" text-case="capitalize-first" suffix=") "/>
                                 <name and="symbol" delimiter=", " delimiter-precedes-last="never"/>
                             </names>
                         </if>
@@ -49,8 +46,7 @@
                     <choose>
                         <if variable="author editor" match="any">
                             <names variable="translator">
-                                <label form="verb-short" prefix=" (" text-case="capitalize-first"
-                                    suffix=") "/>
+                                <label form="verb-short" prefix=" (" text-case="capitalize-first" suffix=") "/>
                                 <name and="symbol" delimiter=", " delimiter-precedes-last="never"/>
                             </names>
                         </if>
@@ -92,15 +88,13 @@
     </macro>
     <macro name="editor">
         <names variable="editor">
-            <name name-as-sort-order="first" and="symbol" sort-separator=", " delimiter=", "
-                delimiter-precedes-last="never"/>
+            <name name-as-sort-order="first" and="symbol" sort-separator=", " delimiter=", " delimiter-precedes-last="never"/>
             <label form="short" prefix=" (" suffix=")."/>
         </names>
     </macro>
     <macro name="translator">
         <names variable="translator">
-            <name name-as-sort-order="first" and="symbol" sort-separator=", " delimiter=", "
-                delimiter-precedes-last="never"/>
+            <name name-as-sort-order="first" and="symbol" sort-separator=", " delimiter=", " delimiter-precedes-last="never"/>
             <label form="verb-short" prefix=" (" suffix=")."/>
         </names>
     </macro>
@@ -124,8 +118,7 @@
     </macro>
     <macro name="contributors">
         <names variable="author">
-            <name and="symbol" name-as-sort-order="first" sort-separator=", " delimiter=", "
-                delimiter-precedes-last="never"/>
+            <name and="symbol" name-as-sort-order="first" sort-separator=", " delimiter=", " delimiter-precedes-last="never"/>
             <label form="short" prefix=", " suffix=" "/>
             <substitute>
                 <text macro="editor"/>
@@ -162,9 +155,7 @@
                 <if type="graphic report" match="any">
                     <text macro="archive"/>
                 </if>
-                <else-if
-                    type="article-journal article-magazine article-newspaper bill book chapter graphic legal_case legislation motion_picture paper-conference report song thesis"
-                    match="none">
+                <else-if type="article-journal article-magazine article-newspaper bill book chapter graphic legal_case legislation motion_picture paper-conference report song thesis" match="none">
                     <text macro="archive"/>
                 </else-if>
             </choose>
@@ -201,8 +192,7 @@
                     </else-if>
                 </choose>
             </else-if>
-            <else-if type="bill graphic legal_case legislation motion_picture report song"
-                match="any">
+            <else-if type="bill graphic legal_case legislation motion_picture report song" match="any">
                 <text variable="title" font-style="italic"/>
             </else-if>
             <else>
@@ -212,9 +202,7 @@
     </macro>
     <macro name="edition">
         <choose>
-            <if
-                type="bill book chapter graphic legal_case legislation motion_picture paper-conference report song"
-                match="any">
+            <if type="bill book chapter graphic legal_case legislation motion_picture paper-conference report song" match="any">
                 <choose>
                     <if is-numeric="edition">
                         <group delimiter=" ">
@@ -235,8 +223,7 @@
                 <text variable="volume" prefix=" "/>
                 <text variable="issue" prefix="(" suffix=")."/>
             </if>
-            <else-if type="bill book graphic legal_case legislation motion_picture report song"
-                match="any">
+            <else-if type="bill book graphic legal_case legislation motion_picture report song" match="any">
                 <group prefix=". " delimiter=". ">
                     <group>
                         <text term="volume" form="short" text-case="capitalize-first" suffix=" "/>
@@ -354,8 +341,7 @@
             </else>
         </choose>
     </macro>
-    <citation et-al-min="4" et-al-use-first="1" disambiguate-add-year-suffix="true"
-        disambiguate-add-names="true" disambiguate-add-givenname="true">
+    <citation et-al-min="4" et-al-use-first="1" disambiguate-add-year-suffix="true" disambiguate-add-names="true" disambiguate-add-givenname="true">
         <layout prefix="(" suffix=")" delimiter="; ">
             <group delimiter=":">
                 <group delimiter=" ">

--- a/unified-style-linguistics.csl
+++ b/unified-style-linguistics.csl
@@ -351,7 +351,7 @@
       </group>
     </layout>
   </citation>
-  <bibliography et-al-min="11" et-al-use-first="7" entry-spacing="0">
+  <bibliography hanging-indent="true" et-al-min="11" et-al-use-first="7" entry-spacing="0">
     <sort>
       <key macro="contributors"/>
       <key variable="issued"/>
@@ -376,7 +376,6 @@
               </group>
               <text macro="locators"/>
             </group>
-            <!-- <text macro="collection-title"/> -->
             <text macro="issue"/>
           </group>
           <text macro="locators-article"/>

--- a/unified-style-linguistics.csl
+++ b/unified-style-linguistics.csl
@@ -1,372 +1,403 @@
 <?xml version="1.0" encoding="utf-8"?>
-<style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" demote-non-dropping-particle="display-and-sort" default-locale="en-US">
-  <info>
-    <title>Unified style sheet for linguistics journals</title>
-    <id>http://www.zotero.org/styles/unified-style-linguistics</id>
-    <link href="http://www.zotero.org/styles/unified-style-linguistics" rel="self"/>
-    <link href="http://linguistlist.org/pubs/tocs/JournalUnifiedStyleSheet2007.pdf" rel="documentation"/>
-    <author>
-      <name>Mark Dingemanse</name>
-      <email>mark.dingemanse@mpi.nl</email>
-    </author>
-    <contributor>
-      <name>Sebastian Karcher</name>
-    </contributor>
-    <contributor>
-      <name>Frank Bennett</name>
-    </contributor>
-    <category citation-format="author-date"/>
-    <category field="linguistics"/>
-    <summary>Unified Style Sheet for Linguistics</summary>
-    <updated>2012-10-25T21:15:26+00:00</updated>
-    <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
-  </info>
-  <locale>
-    <terms>
-      <term name="editor" form="verb-short">ed.</term>
-      <term name="translator" form="verb-short">trans.</term>
-    </terms>
-  </locale>
-  <macro name="secondary-contributors">
-    <choose>
-      <if type="chapter paper-conference" match="none">
-        <group delimiter=". ">
-          <choose>
-            <if variable="author">
-              <names variable="editor">
-                <label form="verb-short" prefix=" (" text-case="capitalize-first" suffix=") "/>
-                <name and="symbol" delimiter=", " delimiter-precedes-last="never"/>
-              </names>
-            </if>
-          </choose>
-          <choose>
-            <if variable="author editor" match="any">
-              <names variable="translator">
-                <label form="verb-short" prefix=" (" text-case="capitalize-first" suffix=") "/>
-                <name and="symbol" delimiter=", " delimiter-precedes-last="never"/>
-              </names>
-            </if>
-            <else>
-              <names variable="editor">
-                <label form="short" suffix=")" prefix="("/>
-                <name and="symbol" delimiter=", " delimiter-precedes-last="never"/>
-              </names>
-            </else>
-          </choose>
-        </group>
-      </if>
-    </choose>
-  </macro>
-  <macro name="container-contributors">
-    <choose>
-      <if type="chapter paper-conference" match="any">
-        <text term="in" text-case="capitalize-first" suffix=" "/>
-        <group delimiter=", ">
-          <choose>
-            <if variable="author">
-              <names variable="editor">
-                <name and="symbol" delimiter=", " delimiter-precedes-last="never"/>
-                <label form="short" suffix=")" prefix=" ("/>
-              </names>
-            </if>
-          </choose>
-          <choose>
-            <if variable="author editor" match="any">
-              <names variable="translator">
-                <label form="verb-short" prefix=" " suffix=" "/>
-                <name and="symbol" delimiter=", " delimiter-precedes-last="never"/>
-              </names>
-            </if>
-          </choose>
-        </group>
-      </if>
-    </choose>
-  </macro>
-  <macro name="editor">
-    <names variable="editor">
-      <name name-as-sort-order="first" and="symbol" sort-separator=", " delimiter=", " delimiter-precedes-last="never"/>
-      <label form="short" prefix=" (" suffix=")."/>
-    </names>
-  </macro>
-  <macro name="translator">
-    <names variable="translator">
-      <name name-as-sort-order="first" and="symbol" sort-separator=", " delimiter=", " delimiter-precedes-last="never"/>
-      <label form="verb-short" prefix=" (" suffix=")."/>
-    </names>
-  </macro>
-  <macro name="recipient">
-    <choose>
-      <if type="personal_communication">
+<style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0"
+    demote-non-dropping-particle="display-and-sort" default-locale="en-US">
+    <info>
+        <title>Unified style sheet for linguistics journals</title>
+        <id>http://www.zotero.org/styles/unified-style-linguistics</id>
+        <link href="http://www.zotero.org/styles/unified-style-linguistics" rel="self"/>
+        <link href="https://www.linguisticsociety.org/sites/default/files/style-sheet_0.pdf"
+            rel="documentation"/>
+        <author>
+            <name>Mark Dingemanse</name>
+            <email>mark.dingemanse@mpi.nl</email>
+        </author>
+        <contributor>
+            <name>Sebastian Karcher</name>
+        </contributor>
+        <contributor>
+            <name>Frank Bennett</name>
+        </contributor>
+        <contributor>
+            <name>Arash Zeini</name>
+        </contributor>
+        <category citation-format="author-date"/>
+        <category field="linguistics"/>
+        <summary>Unified Style Sheet for Linguistics</summary>
+        <updated>2018-05-10T17:57:00+00:00</updated>
+        <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under
+            a Creative Commons Attribution-ShareAlike 3.0 License</rights>
+    </info>
+    <locale>
+        <terms>
+            <term name="editor" form="verb-short">ed.</term>
+            <term name="translator" form="verb-short">trans.</term>
+        </terms>
+    </locale>
+    <macro name="secondary-contributors">
         <choose>
-          <if variable="genre">
-            <text variable="genre" text-case="capitalize-first"/>
-          </if>
-          <else>
-            <text term="letter" text-case="capitalize-first"/>
-          </else>
-        </choose>
-      </if>
-    </choose>
-    <names variable="recipient" delimiter=", ">
-      <label form="verb" prefix=" " suffix=" "/>
-      <name and="symbol" delimiter=", " delimiter-precedes-last="never"/>
-    </names>
-  </macro>
-  <macro name="contributors">
-    <names variable="author">
-      <name and="symbol" name-as-sort-order="first" sort-separator=", " delimiter=", " delimiter-precedes-last="never"/>
-      <label form="short" prefix=", " suffix=" "/>
-      <substitute>
-        <text macro="editor"/>
-        <text macro="translator"/>
-      </substitute>
-    </names>
-    <text macro="recipient"/>
-  </macro>
-  <macro name="contributors-short">
-    <names variable="author">
-      <name form="short" and="symbol" delimiter=", " delimiter-precedes-last="never"/>
-      <substitute>
-        <names variable="editor"/>
-        <names variable="translator"/>
-      </substitute>
-    </names>
-  </macro>
-  <macro name="interviewer">
-    <names variable="interviewer" delimiter=", ">
-      <label form="verb" text-case="capitalize-first" suffix=" "/>
-      <name and="symbol" delimiter=", " delimiter-precedes-last="never"/>
-    </names>
-  </macro>
-  <macro name="archive">
-    <group delimiter=". ">
-      <text variable="archive_location" text-case="capitalize-first"/>
-      <text variable="archive"/>
-      <text variable="archive-place"/>
-    </group>
-  </macro>
-  <macro name="access">
-    <group delimiter=". ">
-      <choose>
-        <if type="graphic report" match="any">
-          <text macro="archive"/>
-        </if>
-        <else-if type="article-journal article-magazine article-newspaper bill book chapter graphic legal_case legislation motion_picture paper-conference report song thesis" match="none">
-          <text macro="archive"/>
-        </else-if>
-      </choose>
-      <text variable="DOI" prefix="doi:"/>
-      <text variable="URL"/>
-    </group>
-    <group prefix=" (" suffix=")">
-      <date variable="accessed">
-        <date-part name="day" suffix=" "/>
-        <date-part name="month" suffix=", "/>
-        <date-part name="year"/>
-      </date>
-    </group>
-  </macro>
-  <macro name="title">
-    <choose>
-      <if variable="title" match="none">
-        <choose>
-          <if type="personal_communication" match="none">
-            <text variable="genre" text-case="capitalize-first"/>
-          </if>
-        </choose>
-      </if>
-      <else-if type="bill book graphic legal_case legislation motion_picture report song" match="any">
-        <text variable="title" font-style="italic"/>
-      </else-if>
-      <else>
-        <text variable="title"/>
-      </else>
-    </choose>
-  </macro>
-  <macro name="edition">
-    <choose>
-      <if type="bill book chapter graphic legal_case legislation motion_picture paper-conference report song" match="any">
-        <choose>
-          <if is-numeric="edition">
-            <group delimiter=" ">
-              <number variable="edition" form="ordinal"/>
-              <text term="edition" form="short"/>
-            </group>
-          </if>
-          <else>
-            <text variable="edition" suffix="."/>
-          </else>
-        </choose>
-      </if>
-    </choose>
-  </macro>
-  <macro name="locators">
-    <choose>
-      <if type="article-journal">
-        <text variable="volume" prefix=" "/>
-        <text variable="issue" prefix="(" suffix=")."/>
-      </if>
-      <else-if type="bill book graphic legal_case legislation motion_picture report song" match="any">
-        <group prefix=". " delimiter=". ">
-          <group>
-            <text term="volume" form="short" text-case="capitalize-first" suffix=" "/>
-            <number variable="volume" form="numeric"/>
-          </group>
-          <group>
-            <number variable="number-of-volumes" form="numeric"/>
-            <text term="volume" form="short" prefix=" " plural="true"/>
-          </group>
-        </group>
-      </else-if>
-    </choose>
-  </macro>
-  <macro name="locators-chapter">
-    <choose>
-      <if type="chapter paper-conference" match="any">
-        <group delimiter=", ">
-          <text variable="volume" prefix="vol. "/>
-          <text variable="page"/>
-        </group>
-      </if>
-    </choose>
-  </macro>
-  <macro name="locators-article">
-    <choose>
-      <if type="article-newspaper">
-        <group prefix=", " delimiter=", ">
-          <group delimiter=" ">
-            <text variable="edition"/>
-            <text term="edition"/>
-          </group>
-          <group>
-            <text term="section" form="short" suffix=" "/>
-            <text variable="section"/>
-          </group>
-        </group>
-      </if>
-      <else-if type="article-journal">
-        <text variable="page" prefix=". "/>
-      </else-if>
-    </choose>
-  </macro>
-  <macro name="point-locators">
-    <group>
-      <choose>
-        <if locator="page" match="none">
-          <label variable="locator" form="short" suffix=" "/>
-        </if>
-      </choose>
-      <text variable="locator"/>
-    </group>
-  </macro>
-  <macro name="container-title">
-    <text variable="container-title" font-style="italic"/>
-  </macro>
-  <macro name="publisher">
-    <group delimiter=": ">
-      <text variable="publisher-place"/>
-      <text variable="publisher"/>
-    </group>
-  </macro>
-  <macro name="date">
-    <date variable="issued">
-      <date-part name="year"/>
-    </date>
-  </macro>
-  <macro name="collection-title">
-    <group prefix="(" suffix=")">
-      <text variable="collection-title" text-case="title"/>
-      <text variable="collection-number" prefix=" "/>
-    </group>
-  </macro>
-  <macro name="event">
-    <group>
-      <text term="presented at" prefix="Paper " suffix=" "/>
-      <text variable="event"/>
-    </group>
-  </macro>
-  <macro name="description">
-    <group delimiter=". ">
-      <text macro="interviewer"/>
-      <text variable="medium" text-case="capitalize-first"/>
-    </group>
-    <choose>
-      <if variable="title" match="none"/>
-      <else-if type="thesis"/>
-      <else>
-        <text variable="genre" text-case="capitalize-first"/>
-      </else>
-    </choose>
-  </macro>
-  <macro name="issue">
-    <choose>
-      <if type="speech">
-        <group delimiter=", ">
-          <text macro="event"/>
-          <text variable="event-place"/>
-        </group>
-      </if>
-      <else-if type="thesis">
-        <group delimiter=" ">
-          <text macro="publisher"/>
-          <text variable="genre"/>
-        </group>
-      </else-if>
-      <else>
-        <group delimiter=", ">
-          <text macro="publisher"/>
-          <choose>
-            <if type="manuscript">
-              <text value="ms"/>
-            </if>
-          </choose>
-        </group>
-      </else>
-    </choose>
-  </macro>
-  <citation et-al-min="4" et-al-use-first="1" disambiguate-add-year-suffix="true" disambiguate-add-names="true" disambiguate-add-givenname="true">
-    <layout prefix="(" suffix=")" delimiter="; ">
-      <group delimiter=":">
-        <group delimiter=" ">
-          <text macro="contributors-short"/>
-          <text macro="date"/>
-        </group>
-        <text macro="point-locators"/>
-      </group>
-    </layout>
-  </citation>
-  <bibliography hanging-indent="true" et-al-min="11" et-al-use-first="7" entry-spacing="0">
-    <sort>
-      <key macro="contributors"/>
-      <key variable="issued"/>
-    </sort>
-    <layout suffix=".">
-      <group delimiter=". ">
-        <text macro="contributors"/>
-        <text macro="date"/>
-        <text macro="title"/>
-        <text macro="description"/>
-        <text macro="secondary-contributors"/>
-        <group>
-          <group delimiter=". ">
-            <group>
-              <group delimiter=". ">
-                <group delimiter=", ">
-                  <text macro="container-contributors"/>
-                  <text macro="container-title"/>
-                  <text macro="locators-chapter"/>
+            <if type="chapter paper-conference" match="none">
+                <group delimiter=". ">
+                    <choose>
+                        <if variable="author">
+                            <names variable="editor">
+                                <label form="verb-short" prefix=" (" text-case="capitalize-first"
+                                    suffix=") "/>
+                                <name and="symbol" delimiter=", " delimiter-precedes-last="never"/>
+                            </names>
+                        </if>
+                    </choose>
+                    <choose>
+                        <if variable="author editor" match="any">
+                            <names variable="translator">
+                                <label form="verb-short" prefix=" (" text-case="capitalize-first"
+                                    suffix=") "/>
+                                <name and="symbol" delimiter=", " delimiter-precedes-last="never"/>
+                            </names>
+                        </if>
+                        <else>
+                            <names variable="editor">
+                                <label form="short" suffix=")" prefix="("/>
+                                <name and="symbol" delimiter=", " delimiter-precedes-last="never"/>
+                            </names>
+                        </else>
+                    </choose>
                 </group>
-                <text macro="edition"/>
-              </group>
-              <text macro="locators"/>
-            </group>
-            <text macro="collection-title"/>
-            <text macro="issue"/>
-          </group>
-          <text macro="locators-article"/>
+            </if>
+        </choose>
+    </macro>
+    <macro name="container-contributors">
+        <choose>
+            <if type="chapter paper-conference" match="any">
+                <text term="in" text-case="capitalize-first" suffix=" "/>
+                <group delimiter=", ">
+                    <choose>
+                        <if variable="author">
+                            <names variable="editor">
+                                <name and="symbol" delimiter=", " delimiter-precedes-last="never"/>
+                                <label form="short" suffix=")" prefix=" ("/>
+                            </names>
+                        </if>
+                    </choose>
+                    <choose>
+                        <if variable="author editor" match="any">
+                            <names variable="translator">
+                                <label form="verb-short" prefix=" " suffix=" "/>
+                                <name and="symbol" delimiter=", " delimiter-precedes-last="never"/>
+                            </names>
+                        </if>
+                    </choose>
+                </group>
+            </if>
+        </choose>
+    </macro>
+    <macro name="editor">
+        <names variable="editor">
+            <name name-as-sort-order="first" and="symbol" sort-separator=", " delimiter=", "
+                delimiter-precedes-last="never"/>
+            <label form="short" prefix=" (" suffix=")."/>
+        </names>
+    </macro>
+    <macro name="translator">
+        <names variable="translator">
+            <name name-as-sort-order="first" and="symbol" sort-separator=", " delimiter=", "
+                delimiter-precedes-last="never"/>
+            <label form="verb-short" prefix=" (" suffix=")."/>
+        </names>
+    </macro>
+    <macro name="recipient">
+        <choose>
+            <if type="personal_communication">
+                <choose>
+                    <if variable="genre">
+                        <text variable="genre" text-case="capitalize-first"/>
+                    </if>
+                    <else>
+                        <text term="letter" text-case="capitalize-first"/>
+                    </else>
+                </choose>
+            </if>
+        </choose>
+        <names variable="recipient" delimiter=", ">
+            <label form="verb" prefix=" " suffix=" "/>
+            <name and="symbol" delimiter=", " delimiter-precedes-last="never"/>
+        </names>
+    </macro>
+    <macro name="contributors">
+        <names variable="author">
+            <name and="symbol" name-as-sort-order="first" sort-separator=", " delimiter=", "
+                delimiter-precedes-last="never"/>
+            <label form="short" prefix=", " suffix=" "/>
+            <substitute>
+                <text macro="editor"/>
+                <text macro="translator"/>
+            </substitute>
+        </names>
+        <text macro="recipient"/>
+    </macro>
+    <macro name="contributors-short">
+        <names variable="author">
+            <name form="short" and="symbol" delimiter=", " delimiter-precedes-last="never"/>
+            <substitute>
+                <names variable="editor"/>
+                <names variable="translator"/>
+            </substitute>
+        </names>
+    </macro>
+    <macro name="interviewer">
+        <names variable="interviewer" delimiter=", ">
+            <label form="verb" text-case="capitalize-first" suffix=" "/>
+            <name and="symbol" delimiter=", " delimiter-precedes-last="never"/>
+        </names>
+    </macro>
+    <macro name="archive">
+        <group delimiter=". ">
+            <text variable="archive_location" text-case="capitalize-first"/>
+            <text variable="archive"/>
+            <text variable="archive-place"/>
         </group>
-        <text macro="access"/>
-      </group>
-    </layout>
-  </bibliography>
+    </macro>
+    <macro name="access">
+        <group delimiter=". ">
+            <choose>
+                <if type="graphic report" match="any">
+                    <text macro="archive"/>
+                </if>
+                <else-if
+                    type="article-journal article-magazine article-newspaper bill book chapter graphic legal_case legislation motion_picture paper-conference report song thesis"
+                    match="none">
+                    <text macro="archive"/>
+                </else-if>
+            </choose>
+            <text variable="DOI" prefix="doi:"/>
+            <text variable="URL"/>
+        </group>
+        <group prefix=" (" suffix=")">
+            <date variable="accessed">
+                <date-part name="day" suffix=" "/>
+                <date-part name="month" suffix=", "/>
+                <date-part name="year"/>
+            </date>
+        </group>
+    </macro>
+    <macro name="title">
+        <choose>
+            <if variable="title" match="none">
+                <choose>
+                    <if type="personal_communication" match="none">
+                        <text variable="genre" text-case="capitalize-first"/>
+                    </if>
+                </choose>
+            </if>
+            <else-if type="book">
+                <choose>
+                    <if variable="collection-title">
+                        <group delimiter=" ">
+                            <text variable="title" font-style="italic"/>
+                            <text macro="collection-title"/>
+                        </group>
+                    </if>
+                    <else-if variable="collection-title" match="none">
+                        <text variable="title" font-style="italic"/>
+                    </else-if>
+                </choose>
+            </else-if>
+            <else-if type="bill graphic legal_case legislation motion_picture report song"
+                match="any">
+                <text variable="title" font-style="italic"/>
+            </else-if>
+            <else>
+                <text variable="title"/>
+            </else>
+        </choose>
+    </macro>
+    <macro name="edition">
+        <choose>
+            <if
+                type="bill book chapter graphic legal_case legislation motion_picture paper-conference report song"
+                match="any">
+                <choose>
+                    <if is-numeric="edition">
+                        <group delimiter=" ">
+                            <number variable="edition" form="ordinal"/>
+                            <text term="edition" form="short"/>
+                        </group>
+                    </if>
+                    <else>
+                        <text variable="edition" suffix="."/>
+                    </else>
+                </choose>
+            </if>
+        </choose>
+    </macro>
+    <macro name="locators">
+        <choose>
+            <if type="article-journal">
+                <text variable="volume" prefix=" "/>
+                <text variable="issue" prefix="(" suffix=")."/>
+            </if>
+            <else-if type="bill book graphic legal_case legislation motion_picture report song"
+                match="any">
+                <group prefix=". " delimiter=". ">
+                    <group>
+                        <text term="volume" form="short" text-case="capitalize-first" suffix=" "/>
+                        <number variable="volume" form="numeric"/>
+                    </group>
+                    <group>
+                        <number variable="number-of-volumes" form="numeric"/>
+                        <text term="volume" form="short" prefix=" " plural="true"/>
+                    </group>
+                </group>
+            </else-if>
+        </choose>
+    </macro>
+    <macro name="locators-chapter">
+        <choose>
+            <if type="chapter paper-conference" match="any">
+                <group delimiter=", ">
+                    <text variable="volume" prefix="vol. "/>
+                    <text variable="page"/>
+                </group>
+            </if>
+        </choose>
+    </macro>
+    <macro name="locators-article">
+        <choose>
+            <if type="article-newspaper">
+                <group prefix=", " delimiter=", ">
+                    <group delimiter=" ">
+                        <text variable="edition"/>
+                        <text term="edition"/>
+                    </group>
+                    <group>
+                        <text term="section" form="short" suffix=" "/>
+                        <text variable="section"/>
+                    </group>
+                </group>
+            </if>
+            <else-if type="article-journal">
+                <text variable="page" prefix=". "/>
+            </else-if>
+        </choose>
+    </macro>
+    <macro name="point-locators">
+        <group>
+            <choose>
+                <if locator="page" match="none">
+                    <label variable="locator" form="short" suffix=" "/>
+                </if>
+            </choose>
+            <text variable="locator"/>
+        </group>
+    </macro>
+    <macro name="container-title">
+        <text variable="container-title" font-style="italic"/>
+    </macro>
+    <macro name="publisher">
+        <group delimiter=": ">
+            <text variable="publisher-place"/>
+            <text variable="publisher"/>
+        </group>
+    </macro>
+    <macro name="date">
+        <date variable="issued">
+            <date-part name="year"/>
+        </date>
+    </macro>
+    <macro name="collection-title">
+        <group prefix="(" suffix=")">
+            <text variable="collection-title" text-case="title"/>
+            <text variable="collection-number" prefix=" "/>
+        </group>
+    </macro>
+    <macro name="event">
+        <group>
+            <text term="presented at" prefix="Paper " suffix=" "/>
+            <text variable="event"/>
+        </group>
+    </macro>
+    <macro name="description">
+        <group delimiter=". ">
+            <text macro="interviewer"/>
+            <text variable="medium" text-case="capitalize-first"/>
+        </group>
+        <choose>
+            <if variable="title" match="none"/>
+            <else-if type="thesis"/>
+            <else>
+                <text variable="genre" text-case="capitalize-first"/>
+            </else>
+        </choose>
+    </macro>
+    <macro name="issue">
+        <choose>
+            <if type="speech">
+                <group delimiter=", ">
+                    <text macro="event"/>
+                    <text variable="event-place"/>
+                </group>
+            </if>
+            <else-if type="thesis">
+                <group delimiter=" ">
+                    <text macro="publisher"/>
+                    <text variable="genre"/>
+                </group>
+            </else-if>
+            <else>
+                <group delimiter=", ">
+                    <text macro="publisher"/>
+                    <choose>
+                        <if type="manuscript">
+                            <text value="ms"/>
+                        </if>
+                    </choose>
+                </group>
+            </else>
+        </choose>
+    </macro>
+    <citation et-al-min="4" et-al-use-first="1" disambiguate-add-year-suffix="true"
+        disambiguate-add-names="true" disambiguate-add-givenname="true">
+        <layout prefix="(" suffix=")" delimiter="; ">
+            <group delimiter=":">
+                <group delimiter=" ">
+                    <text macro="contributors-short"/>
+                    <text macro="date"/>
+                </group>
+                <text macro="point-locators"/>
+            </group>
+        </layout>
+    </citation>
+    <bibliography et-al-min="11" et-al-use-first="7" entry-spacing="0">
+        <sort>
+            <key macro="contributors"/>
+            <key variable="issued"/>
+        </sort>
+        <layout suffix=".">
+            <group delimiter=". ">
+                <text macro="contributors"/>
+                <text macro="date"/>
+                <text macro="title"/>
+                <text macro="description"/>
+                <text macro="secondary-contributors"/>
+                <group>
+                    <group delimiter=". ">
+                        <group>
+                            <group delimiter=". ">
+                                <group delimiter=", ">
+                                    <text macro="container-contributors"/>
+                                    <text macro="container-title"/>
+                                    <text macro="locators-chapter"/>
+                                </group>
+                                <text macro="edition"/>
+                            </group>
+                            <text macro="locators"/>
+                        </group>
+                        <!-- <text macro="collection-title"/> -->
+                        <text macro="issue"/>
+                    </group>
+                    <text macro="locators-article"/>
+                </group>
+                <text macro="access"/>
+            </group>
+        </layout>
+    </bibliography>
 </style>


### PR DESCRIPTION
In books that are part of a series or collection, a period is inserted between book title and the series' title in the parentheses. I have fixed this following this discussion:
https://forums.zotero.org/discussion/71825/style-error-unified-style-sheet-for-linguistics-journals

I have also removed "hanging-indent" from `<bibliography>`, as it can cause problems while copy and pasting bibliographies.