### PR TITLE
Update universite-laval-departement-des-sciences-historiques.csl

### DIFF
--- a/universite-laval-departement-des-sciences-historiques.csl
+++ b/universite-laval-departement-des-sciences-historiques.csl
@@ -58,7 +58,7 @@
     <choose>
       <if variable="URL">
         <choose>
-          <if type="webpage article-newspaper broadcast figure graphic post post-weblog song" match="any">
+          <if type="article-journal article-newspaper broadcast entry-encyclopedia figure graphic motion_picture patent post post-weblog song webpage" match="any">
             <text variable="URL"/>
             <text macro="accessed-date"/>
           </if>
@@ -69,7 +69,7 @@
   <macro name="accessed-date">
     <choose>
       <if variable="URL">
-        <group delimiter=" ">
+        <group prefix=", " delimiter=" ">
           <text value="consulté le"/>
           <date variable="accessed">
             <date-part name="day" suffix=" "/>


### PR DESCRIPTION
-Added the prefix ", " before the accessed-date element. It prevents a situation like this : "www.website.comconsulté le 15 mai 2018" and becomes "www.website.com, consulté le 15 mai 2018"
-Added multiple types that should show a URL if locator is filled