### PR TITLE
Fix redundant terms

### DIFF
--- a/acta-ophthalmologica.csl
+++ b/acta-ophthalmologica.csl
@@ -19,10 +19,7 @@
   </info>
   <locale xml:lang="en">
     <terms>
-      <term name="translator" form="short">
-        <single>trans.</single>
-        <multiple>trans.</multiple>
-      </term>
+      <term name="translator" form="short">trans.</term>
     </terms>
   </locale>
   <macro name="container-contributors">

--- a/acta-philosophica.csl
+++ b/acta-philosophica.csl
@@ -21,22 +21,10 @@
   </info>
   <locale xml:lang="it">
     <terms>
-      <term name="editor" form="verb">
-        <single>curato da</single>
-        <multiple>curato da</multiple>
-      </term>
-      <term name="editor" form="short">
-        <single>a cura di</single>
-        <multiple>a cura di</multiple>
-      </term>
-      <term name="collection-editor" form="verb">
-        <single>curato da</single>
-        <multiple>curato da</multiple>
-      </term>
-      <term name="collection-editor" form="short">
-        <single>a cura di</single>
-        <multiple>a cura di</multiple>
-      </term>
+      <term name="editor" form="verb">curato da</term>
+      <term name="editor" form="short">a cura di</term>
+      <term name="collection-editor" form="verb">curato da</term>
+      <term name="collection-editor" form="short">a cura di</term>
       <term name="translator" form="short">
         <single>trad.</single>
         <multiple>tradd.</multiple>
@@ -61,18 +49,12 @@
   </locale>
   <locale xml:lang="en">
     <terms>
-      <term name="collection-editor" form="verb">
-        <single>edited by</single>
-        <multiple>edited by</multiple>
-      </term>
+      <term name="collection-editor" form="verb">edited by</term>
       <term name="collection-editor" form="short">
         <single>ed.</single>
         <multiple>eds.</multiple>
       </term>
-      <term name="editor" form="verb">
-        <single>edited by</single>
-        <multiple>edited by</multiple>
-      </term>
+      <term name="editor" form="verb">edited by</term>
       <term name="editor" form="short">
         <single>ed.</single>
         <multiple>eds.</multiple>
@@ -91,18 +73,12 @@
   </locale>
   <locale xml:lang="es">
     <terms>
-      <term name="collection-editor" form="verb">
-        <single>edición a cargo de</single>
-        <multiple>edición a cargo de</multiple>
-      </term>
+      <term name="collection-editor" form="verb">edición a cargo de</term>
       <term name="collection-editor" form="short">
         <single>ed.</single>
         <multiple>eds.</multiple>
       </term>
-      <term name="editor" form="verb">
-        <single>edición a cargo de</single>
-        <multiple>edición a cargo de</multiple>
-      </term>
+      <term name="editor" form="verb">edición a cargo de</term>
       <term name="editor" form="short">
         <single>ed.</single>
         <multiple>eds.</multiple>
@@ -131,38 +107,14 @@
   </locale>
   <locale xml:lang="fr">
     <terms>
-      <term name="editor" form="verb">
-        <single>édité par</single>
-        <multiple>édité par</multiple>
-      </term>
-      <term name="editor" form="short">
-        <single>éd.</single>
-        <multiple>éd.</multiple>
-      </term>
-      <term name="collection-editor" form="verb">
-        <single>dirigé par</single>
-        <multiple>dirigé par</multiple>
-      </term>
-      <term name="collection-editor" form="short">
-        <single>dir.</single>
-        <multiple>dir.</multiple>
-      </term>
-      <term name="translator" form="short">
-        <single>trad.</single>
-        <multiple>trad.</multiple>
-      </term>
-      <term name="volume" form="short">
-        <single>Vol.</single>
-        <multiple>Vol.</multiple>
-      </term>
-      <term name="page" form="short">
-        <single>p.</single>
-        <multiple>p.</multiple>
-      </term>
-      <term name="paragraph" form="short">
-        <single>§</single>
-        <multiple>§</multiple>
-      </term>
+      <term name="editor" form="verb">édité par</term>
+      <term name="editor" form="short">éd.</term>
+      <term name="collection-editor" form="verb">dirigé par</term>
+      <term name="collection-editor" form="short">dir.</term>
+      <term name="translator" form="short">trad.</term>
+      <term name="volume" form="short">Vol.</term>
+      <term name="page" form="short">p.</term>
+      <term name="paragraph" form="short">§</term>
       <term name="in">dans</term>
       <term name="cited" form="short">op. cit.</term>
       <term name="accessed" form="long">consulté le</term>
@@ -171,34 +123,19 @@
   </locale>
   <locale xml:lang="de">
     <terms>
-      <term name="editor" form="verb">
-        <single>herausgegeben von</single>
-        <multiple>herausgegeben von</multiple>
-      </term>
+      <term name="editor" form="verb">herausgegeben von</term>
       <term name="editor" form="short">
         <single>Hg.</single>
         <multiple>Hgg.</multiple>
       </term>
-      <term name="collection-editor" form="verb">
-        <single>herausgegeben von</single>
-        <multiple>herausgegeben von</multiple>
-      </term>
+      <term name="collection-editor" form="verb">herausgegeben von</term>
       <term name="collection-editor" form="short">
         <single>Hg.</single>
         <multiple>Hgg.</multiple>
       </term>
-      <term name="translator" form="short">
-        <single>Übers.</single>
-        <multiple>Übers.</multiple>
-      </term>
-      <term name="volume" form="short">
-        <single>Bd.</single>
-        <multiple>Bd.</multiple>
-      </term>
-      <term name="page" form="short">
-        <single>S.</single>
-        <multiple>S.</multiple>
-      </term>
+      <term name="translator" form="short">Übers.</term>
+      <term name="volume" form="short">Bd.</term>
+      <term name="page" form="short">S.</term>
       <term name="paragraph" form="short">
         <single>§</single>
         <multiple>§§</multiple>

--- a/administrative-science-quarterly.csl
+++ b/administrative-science-quarterly.csl
@@ -19,10 +19,7 @@
   </info>
   <locale xml:lang="en">
     <terms>
-      <term name="translator" form="short">
-        <single>trans.</single>
-        <multiple>trans.</multiple>
-      </term>
+      <term name="translator" form="short">trans.</term>
     </terms>
   </locale>
   <macro name="container-contributors">

--- a/aix-marseille-universite-departement-d-etudes-asiatiques.csl
+++ b/aix-marseille-universite-departement-d-etudes-asiatiques.csl
@@ -23,14 +23,8 @@
       <term name="ordinal-03">e</term>
       <term name="ordinal-04">e</term>
       <term name="cited">op.&#160;cit.</term>
-      <term name="page" form="short">
-        <single>p.</single>
-        <multiple>p.</multiple>
-      </term>
-      <term name="editor" form="short">
-        <single>éd.</single>
-        <multiple>éd.</multiple>
-      </term>
+      <term name="page" form="short">p.</term>
+      <term name="editor" form="short">éd.</term>
     </terms>
   </locale>
   <macro name="author">

--- a/american-geophysical-union.csl
+++ b/american-geophysical-union.csl
@@ -45,10 +45,7 @@
         <single>ed. &amp; trans.</single>
         <multiple>eds. &amp; trans.</multiple>
       </term>
-      <term name="translator" form="short">
-        <single>trans.</single>
-        <multiple>trans.</multiple>
-      </term>
+      <term name="translator" form="short">trans.</term>
     </terms>
   </locale>
   <macro name="container-contributors">

--- a/american-mineralogist.csl
+++ b/american-mineralogist.csl
@@ -21,10 +21,7 @@
         <single>ed. &amp; trans.</single>
         <multiple>eds. &amp; trans.</multiple>
       </term>
-      <term name="translator" form="short">
-        <single>trans.</single>
-        <multiple>trans.</multiple>
-      </term>
+      <term name="translator" form="short">trans.</term>
     </terms>
   </locale>
   <macro name="container-contributors">

--- a/american-society-of-agricultural-and-biological-engineers.csl
+++ b/american-society-of-agricultural-and-biological-engineers.csl
@@ -22,10 +22,7 @@
         <single>ed. &amp; trans.</single>
         <multiple>eds. &amp; trans.</multiple>
       </term>
-      <term name="translator" form="short">
-        <single>trans.</single>
-        <multiple>trans.</multiple>
-      </term>
+      <term name="translator" form="short">trans.</term>
     </terms>
   </locale>
   <macro name="container-contributors">

--- a/anabases.csl
+++ b/anabases.csl
@@ -21,10 +21,7 @@
   </info>
   <locale xml:lang="fr">
     <terms>
-      <term name="editor" form="short">
-        <single>dir.</single>
-        <multiple>dir.</multiple>
-      </term>
+      <term name="editor" form="short">dir.</term>
       <term name="in">in</term>
       <term name="online">mis en ligne le</term>
       <term name="paragraph" form="short">§</term>

--- a/animal-conservation.csl
+++ b/animal-conservation.csl
@@ -22,10 +22,7 @@
         <single>ed. &amp; trans.</single>
         <multiple>eds. &amp; trans.</multiple>
       </term>
-      <term name="translator" form="short">
-        <single>trans.</single>
-        <multiple>trans.</multiple>
-      </term>
+      <term name="translator" form="short">trans.</term>
     </terms>
   </locale>
   <macro name="container-contributors">

--- a/annales.csl
+++ b/annales.csl
@@ -22,14 +22,8 @@
       <term name="ordinal-03">e</term>
       <term name="ordinal-04">e</term>
       <term name="cited">op.&#160;cit.</term>
-      <term name="page" form="short">
-        <single>p.</single>
-        <multiple>p.</multiple>
-      </term>
-      <term name="editor" form="short">
-        <single>dir.</single>
-        <multiple>dir.</multiple>
-      </term>
+      <term name="page" form="short">p.</term>
+      <term name="editor" form="short">dir.</term>
     </terms>
   </locale>
   <macro name="author">

--- a/antiquity.csl
+++ b/antiquity.csl
@@ -20,10 +20,7 @@
       <term name="editor" form="verb-short">ed.</term>
       <term name="container-author" form="verb">by</term>
       <term name="translator" form="verb-short">trans.</term>
-      <term name="editortranslator" form="verb">
-        <single>edited and translated by</single>
-        <multiple>edited and translated by</multiple>
-      </term>
+      <term name="editortranslator" form="verb">edited and translated by</term>
       <term name="translator" form="short">trans.</term>
     </terms>
   </locale>

--- a/apa-annotated-bibliography.csl
+++ b/apa-annotated-bibliography.csl
@@ -41,10 +41,7 @@
         <single>ed. &amp; trans.</single>
         <multiple>eds. &amp; trans.</multiple>
       </term>
-      <term name="translator" form="short">
-        <single>trans.</single>
-        <multiple>trans.</multiple>
-      </term>
+      <term name="translator" form="short">trans.</term>
     </terms>
   </locale>
   <macro name="container-contributors">

--- a/apa-cv.csl
+++ b/apa-cv.csl
@@ -41,10 +41,7 @@
         <single>ed. &amp; trans.</single>
         <multiple>eds. &amp; trans.</multiple>
       </term>
-      <term name="translator" form="short">
-        <single>trans.</single>
-        <multiple>trans.</multiple>
-      </term>
+      <term name="translator" form="short">trans.</term>
     </terms>
   </locale>
   <macro name="container-contributors">

--- a/apa-fr-provost.csl
+++ b/apa-fr-provost.csl
@@ -24,14 +24,8 @@
         <single>éd.</single>
         <multiple>éds</multiple>
       </term>
-      <term name="editortranslator" form="short">
-        <single>éd. &amp; trad.</single>
-        <multiple>éd. &amp; trad.</multiple>
-      </term>
-      <term name="translator" form="short">
-        <single>trad.</single>
-        <multiple>trad.</multiple>
-      </term>
+      <term name="editortranslator" form="short">éd. &amp; trad.</term>
+      <term name="translator" form="short">trad.</term>
       <term name="no date" form="short">n.d.</term>
       <term name="in">dans</term>
       <term name="retrieved">repéré</term>

--- a/apa-no-ampersand.csl
+++ b/apa-no-ampersand.csl
@@ -41,10 +41,7 @@
         <single>ed. &amp; trans.</single>
         <multiple>eds. &amp; trans.</multiple>
       </term>
-      <term name="translator" form="short">
-        <single>trans.</single>
-        <multiple>trans.</multiple>
-      </term>
+      <term name="translator" form="short">trans.</term>
     </terms>
   </locale>
   <macro name="container-contributors">

--- a/apa-no-doi-no-issue.csl
+++ b/apa-no-doi-no-issue.csl
@@ -41,10 +41,7 @@
         <single>ed. &amp; trans.</single>
         <multiple>eds. &amp; trans.</multiple>
       </term>
-      <term name="translator" form="short">
-        <single>trans.</single>
-        <multiple>trans.</multiple>
-      </term>
+      <term name="translator" form="short">trans.</term>
     </terms>
   </locale>
   <macro name="container-contributors">

--- a/apa-old-doi-prefix.csl
+++ b/apa-old-doi-prefix.csl
@@ -40,10 +40,7 @@
         <single>ed. &amp; trans.</single>
         <multiple>eds. &amp; trans.</multiple>
       </term>
-      <term name="translator" form="short">
-        <single>trans.</single>
-        <multiple>trans.</multiple>
-      </term>
+      <term name="translator" form="short">trans.</term>
     </terms>
   </locale>
   <macro name="container-contributors">

--- a/apa-single-spaced.csl
+++ b/apa-single-spaced.csl
@@ -41,10 +41,7 @@
         <single>ed. &amp; trans.</single>
         <multiple>eds. &amp; trans.</multiple>
       </term>
-      <term name="translator" form="short">
-        <single>trans.</single>
-        <multiple>trans.</multiple>
-      </term>
+      <term name="translator" form="short">trans.</term>
     </terms>
   </locale>
   <macro name="container-contributors">

--- a/apa-tr.csl
+++ b/apa-tr.csl
@@ -28,10 +28,7 @@
       <term name="retrieved">erişildi</term>
       <term name="from">adresinden</term>
       <term name="presented at">sunulmuş bildiri</term>
-      <term name="edition">
-        <single>basım</single>
-        <multiple>basım</multiple>
-      </term>
+      <term name="edition">basım</term>
       <term name="edition" form="short">bs.</term>
       <term name="page">
         <single>page</single>
@@ -41,18 +38,9 @@
         <single>s.</single>
         <multiple>ss.</multiple>
       </term>
-      <term name="volume" form="short">
-        <single>c.</single>
-        <multiple>c.</multiple>
-      </term>
-      <term name="translator" form="short">
-        <single>çev.</single>
-        <multiple>çev.</multiple>
-      </term>
-      <term name="editor" form="short">
-        <single>ed.</single>
-        <multiple>ed.</multiple>
-      </term>
+      <term name="volume" form="short">c.</term>
+      <term name="translator" form="short">çev.</term>
+      <term name="editor" form="short">ed.</term>
       <!-- ORDINALS -->
       <term name="ordinal-01">.</term>
       <term name="ordinal-02">.</term>

--- a/apa.csl
+++ b/apa.csl
@@ -40,10 +40,7 @@
         <single>ed. &amp; trans.</single>
         <multiple>eds. &amp; trans.</multiple>
       </term>
-      <term name="translator" form="short">
-        <single>trans.</single>
-        <multiple>trans.</multiple>
-      </term>
+      <term name="translator" form="short">trans.</term>
     </terms>
   </locale>
   <macro name="container-contributors">

--- a/aquitania.csl
+++ b/aquitania.csl
@@ -20,10 +20,7 @@
     <style-options punctuation-in-quote="false"/>
     <terms>
       <term name="cited">op. cit.</term>
-      <term name="editor" form="short">
-        <single>ed.</single>
-        <multiple>ed.</multiple>
-      </term>
+      <term name="editor" form="short">ed.</term>
       <term name="accessed">Consulté le </term>
       <term name="anonymous">anonyme</term>
       <term name="anonymous" form="short">anon.</term>

--- a/archeologie-medievale.csl
+++ b/archeologie-medievale.csl
@@ -19,10 +19,7 @@
   </info>
   <locale xml:lang="fr">
     <terms>
-      <term name="editor" form="short">
-        <single>dir.</single>
-        <multiple>dir.</multiple>
-      </term>
+      <term name="editor" form="short">dir.</term>
       <term name="in">dans</term>
       <term name="anonymous">anonyme</term>
       <term name="anonymous" form="short">anon.</term>

--- a/archeologies-et-sciences-de-lantiquite.csl
+++ b/archeologies-et-sciences-de-lantiquite.csl
@@ -22,10 +22,7 @@
       <term name="cited">op. cit.</term>
       <term name="issue">titre du fascicule </term>
       <term name="presented at">présentation à</term>
-      <term name="editor" form="short">
-        <single>dir.</single>
-        <multiple>dir.</multiple>
-      </term>
+      <term name="editor" form="short">dir.</term>
       <term name="accessed">Consultation: </term>
     </terms>
   </locale>

--- a/archivum-latinitatis-medii-aevi.csl
+++ b/archivum-latinitatis-medii-aevi.csl
@@ -25,10 +25,7 @@
       <term name="ordinal-03">e</term>
       <term name="ordinal-04">e</term>
       <term name="cited">op.&#160;cit.</term>
-      <term name="page" form="short">
-        <single>p.</single>
-        <multiple>p.</multiple>
-      </term>
+      <term name="page" form="short">p.</term>
       <term name="editor" form="verb-short">éd.</term>
     </terms>
   </locale>

--- a/arctic-antarctic-and-alpine-research.csl
+++ b/arctic-antarctic-and-alpine-research.csl
@@ -24,10 +24,7 @@
         <single>ed. &amp; trans.</single>
         <multiple>eds. &amp; trans.</multiple>
       </term>
-      <term name="translator" form="short">
-        <single>trans.</single>
-        <multiple>trans.</multiple>
-      </term>
+      <term name="translator" form="short">trans.</term>
     </terms>
   </locale>
   <macro name="container-contributors">

--- a/associacao-brasileira-de-normas-tecnicas-eceme.csl
+++ b/associacao-brasileira-de-normas-tecnicas-eceme.csl
@@ -52,18 +52,9 @@
       <term name="month-11" form="short">Nov</term>
       <term name="month-12" form="short">Dez</term>
       <term name="et-al"> e colab.</term>
-      <term name="editor" form="short">
-        <single>ed</single>
-        <multiple>ed</multiple>
-      </term>
-      <term name="editor" form="short">
-        <single>org</single>
-        <multiple>org</multiple>
-      </term>
-      <term name="collection-editor" form="short">
-        <single>org</single>
-        <multiple>org</multiple>
-      </term>
+      <term name="editor" form="short">ed</term>
+      <term name="editor" form="short">org</term>
+      <term name="collection-editor" form="short">org</term>
     </terms>
   </locale>
   <macro name="container-contributors">

--- a/associacao-brasileira-de-normas-tecnicas-instituto-meira-mattos.csl
+++ b/associacao-brasileira-de-normas-tecnicas-instituto-meira-mattos.csl
@@ -33,18 +33,9 @@
       <term name="month-11" form="short">Nov</term>
       <term name="month-12" form="short">Dez</term>
       <term name="et-al"> e colab.</term>
-      <term name="editor" form="short">
-        <single>ed</single>
-        <multiple>ed</multiple>
-      </term>
-      <term name="editor" form="short">
-        <single>org</single>
-        <multiple>org</multiple>
-      </term>
-      <term name="collection-editor" form="short">
-        <single>org</single>
-        <multiple>org</multiple>
-      </term>
+      <term name="editor" form="short">ed</term>
+      <term name="editor" form="short">org</term>
+      <term name="collection-editor" form="short">org</term>
     </terms>
   </locale>
   <macro name="container-contributors">

--- a/associacao-brasileira-de-normas-tecnicas-note.csl
+++ b/associacao-brasileira-de-normas-tecnicas-note.csl
@@ -61,40 +61,22 @@
         <single>coord.</single>
         <multiple>coords.</multiple>
       </term>
-      <term name="collection-editor" form="verb-short">
-        <single>coord.</single>
-        <multiple>coord.</multiple>
-      </term>
+      <term name="collection-editor" form="verb-short">coord.</term>
       <!-- tradutores (Translator) -->
       <term name="translator" form="short">
         <single>trad.</single>
         <multiple>trads.</multiple>
       </term>
-      <term name="translator" form="verb-short">
-        <single>trad.</single>
-        <multiple>trad.</multiple>
-      </term>
+      <term name="translator" form="verb-short">trad.</term>
       <!-- LOCALIZADORES -->
       <!-- volumes -->
-      <term name="volume" form="short">
-        <single>v.</single>
-        <multiple>v.</multiple>
-      </term>
+      <term name="volume" form="short">v.</term>
       <!--números de edição -->
-      <term name="issue" form="short">
-        <single>n.</single>
-        <multiple>n.</multiple>
-      </term>
+      <term name="issue" form="short">n.</term>
       <!-- páginas -->
-      <term name="page" form="short">
-        <single>p.</single>
-        <multiple>p.</multiple>
-      </term>
+      <term name="page" form="short">p.</term>
       <!-- capítulos -->
-      <term name="chapter" form="short">
-        <single>cap.</single>
-        <multiple>cap.</multiple>
-      </term>
+      <term name="chapter" form="short">cap.</term>
       <!-- MISC -->
       <term name="and">; </term>
       <term name="et-al">et al</term>

--- a/associacao-brasileira-de-normas-tecnicas-ufmg-face-full.csl
+++ b/associacao-brasileira-de-normas-tecnicas-ufmg-face-full.csl
@@ -47,18 +47,9 @@
       <term name="month-10" form="short">out.</term>
       <term name="month-11" form="short">nov.</term>
       <term name="month-12" form="short">dez.</term>
-      <term name="editor" form="short">
-        <single>ed</single>
-        <multiple>ed</multiple>
-      </term>
-      <term name="editor" form="short">
-        <single>org</single>
-        <multiple>org</multiple>
-      </term>
-      <term name="collection-editor" form="short">
-        <single>org</single>
-        <multiple>org</multiple>
-      </term>
+      <term name="editor" form="short">ed</term>
+      <term name="editor" form="short">org</term>
+      <term name="collection-editor" form="short">org</term>
     </terms>
   </locale>
   <macro name="container-contributors">

--- a/associacao-brasileira-de-normas-tecnicas-ufmg-face-initials.csl
+++ b/associacao-brasileira-de-normas-tecnicas-ufmg-face-initials.csl
@@ -46,18 +46,9 @@
       <term name="month-10" form="short">out.</term>
       <term name="month-11" form="short">nov.</term>
       <term name="month-12" form="short">dez.</term>
-      <term name="editor" form="short">
-        <single>ed</single>
-        <multiple>ed</multiple>
-      </term>
-      <term name="editor" form="short">
-        <single>org</single>
-        <multiple>org</multiple>
-      </term>
-      <term name="collection-editor" form="short">
-        <single>org</single>
-        <multiple>org</multiple>
-      </term>
+      <term name="editor" form="short">ed</term>
+      <term name="editor" form="short">org</term>
+      <term name="collection-editor" form="short">org</term>
     </terms>
   </locale>
   <macro name="container-contributors">

--- a/ausonius-editions.csl
+++ b/ausonius-editions.csl
@@ -17,14 +17,8 @@
   </info>
   <locale xml:lang="fr">
     <terms>
-      <term name="editor" form="short">
-        <single>éd.</single>
-        <multiple>éd.</multiple>
-      </term>
-      <term name="editortranslator" form="short">
-        <single>éd.</single>
-        <multiple>éd.</multiple>
-      </term>
+      <term name="editor" form="short">éd.</term>
+      <term name="editortranslator" form="short">éd.</term>
       <term name="in">dans</term>
       <term name="anonymous">anonyme</term>
       <term name="anonymous" form="short">anon.</term>

--- a/avian-pathology.csl
+++ b/avian-pathology.csl
@@ -19,10 +19,7 @@
   </info>
   <locale xml:lang="en">
     <terms>
-      <term name="translator" form="short">
-        <single>trans.</single>
-        <multiple>trans.</multiple>
-      </term>
+      <term name="translator" form="short">trans.</term>
     </terms>
   </locale>
   <macro name="container-contributors">

--- a/behaviour.csl
+++ b/behaviour.csl
@@ -23,10 +23,7 @@
         <single>ed. &amp; trans.</single>
         <multiple>eds. &amp; trans.</multiple>
       </term>
-      <term name="translator" form="short">
-        <single>trans.</single>
-        <multiple>trans.</multiple>
-      </term>
+      <term name="translator" form="short">trans.</term>
     </terms>
   </locale>
   <macro name="container-contributors">

--- a/bioarchaeology-of-the-near-east.csl
+++ b/bioarchaeology-of-the-near-east.csl
@@ -25,10 +25,7 @@
         <single>ed. &amp; trans.</single>
         <multiple>eds. &amp; trans.</multiple>
       </term>
-      <term name="translator" form="short">
-        <single>trans.</single>
-        <multiple>trans.</multiple>
-      </term>
+      <term name="translator" form="short">trans.</term>
     </terms>
   </locale>
   <macro name="container-contributors">

--- a/body-and-society.csl
+++ b/body-and-society.csl
@@ -20,10 +20,7 @@
   </info>
   <locale xml:lang="en-GB">
     <terms>
-      <term name="translator" form="short">
-        <single>trans.</single>
-        <multiple>trans.</multiple>
-      </term>
+      <term name="translator" form="short">trans.</term>
       <term name="editor" form="short">
         <single>ed.</single>
         <multiple>eds</multiple>

--- a/budownictwo-i-architektura-pl.csl
+++ b/budownictwo-i-architektura-pl.csl
@@ -25,30 +25,15 @@
       <term name="in">[w:]</term>
       <term name="and">i</term>
       <term name="and others">i inni</term>
-      <term name="page" form="short">
-        <single>s.</single>
-        <multiple>s.</multiple>
-      </term>
+      <term name="page" form="short">s.</term>
       <term name="edition" form="short">wyd.</term>
       <term name="et-al">et al.</term>
       <term name="chapter" form="short">rozdz.</term>
       <term name="issue" form="short">nr </term>
-      <term name="editor" form="short">
-        <single>red.</single>
-        <multiple>red.</multiple>
-      </term>
-      <term name="editorial-director" form="short">
-        <single>red.</single>
-        <multiple>red.</multiple>
-      </term>
-      <term name="translator" form="short">
-        <single>tłum.</single>
-        <multiple>tłum.</multiple>
-      </term>
-      <term name="editortranslator" form="short">
-        <single>red. &amp; tłum.</single>
-        <multiple>red. &amp; tłum.</multiple>
-      </term>
+      <term name="editor" form="short">red.</term>
+      <term name="editorial-director" form="short">red.</term>
+      <term name="translator" form="short">tłum.</term>
+      <term name="editortranslator" form="short">red. &amp; tłum.</term>
       <term name="container-author" form="verb-short">przez</term>
       <term name="editor" form="verb-short">pod. red.</term>
       <term name="editorial-director" form="verb-short">red.</term>

--- a/bulletin-de-la-societe-prehistorique-francaise.csl
+++ b/bulletin-de-la-societe-prehistorique-francaise.csl
@@ -20,10 +20,7 @@
   </info>
   <locale xml:lang="fr">
     <terms>
-      <term name="editor" form="short">
-        <single>dir</single>
-        <multiple>dir</multiple>
-      </term>
+      <term name="editor" form="short">dir</term>
     </terms>
   </locale>
   <macro name="editor">

--- a/business-ethics-a-european-review.csl
+++ b/business-ethics-a-european-review.csl
@@ -22,10 +22,7 @@
         <single>ed. &amp; trans.</single>
         <multiple>eds. &amp; trans.</multiple>
       </term>
-      <term name="translator" form="short">
-        <single>trans.</single>
-        <multiple>trans.</multiple>
-      </term>
+      <term name="translator" form="short">trans.</term>
     </terms>
   </locale>
   <macro name="container-contributors">

--- a/byzantine-and-modern-greek-studies.csl
+++ b/byzantine-and-modern-greek-studies.csl
@@ -24,18 +24,9 @@
   <locale xml:lang="en">
     <style-options punctuation-in-quote="false"/>
     <terms>
-      <term name="translator" form="short">
-        <single>trans.</single>
-        <multiple>trans.</multiple>
-      </term>
-      <term name="editortranslator" form="short">
-        <single>ed. and trans.</single>
-        <multiple>ed. and trans.</multiple>
-      </term>
-      <term name="chapter" form="short">
-        <single>c.</single>
-        <multiple>c.</multiple>
-      </term>
+      <term name="translator" form="short">trans.</term>
+      <term name="editortranslator" form="short">ed. and trans.</term>
+      <term name="chapter" form="short">c.</term>
       <term name="editor" form="short">
         <single>ed.</single>
         <multiple>eds</multiple>

--- a/cahiers-d-ethnomusicologie.csl
+++ b/cahiers-d-ethnomusicologie.csl
@@ -33,10 +33,7 @@
         <single>dir</single>
         <multiple>dirs.</multiple>
       </term>
-      <term name="page" form="short">
-        <single>p.</single>
-        <multiple>p.</multiple>
-      </term>
+      <term name="page" form="short">p.</term>
     </terms>
   </locale>
   <macro name="author">

--- a/cahiers-du-centre-gustave-glotz.csl
+++ b/cahiers-du-centre-gustave-glotz.csl
@@ -20,10 +20,7 @@
   </info>
   <locale xml:lang="fr">
     <terms>
-      <term name="editor" form="short">
-        <single>éd.</single>
-        <multiple>éd.</multiple>
-      </term>
+      <term name="editor" form="short">éd.</term>
       <term name="in">dans</term>
       <term name="anonymous">anonyme</term>
       <term name="anonymous" form="short">anon.</term>

--- a/cambridge-university-press-author-date.csl
+++ b/cambridge-university-press-author-date.csl
@@ -22,10 +22,7 @@
         <single>ed. &amp; trans.</single>
         <multiple>eds. &amp; trans.</multiple>
       </term>
-      <term name="translator" form="short">
-        <single>trans.</single>
-        <multiple>trans.</multiple>
-      </term>
+      <term name="translator" form="short">trans.</term>
     </terms>
   </locale>
   <macro name="container-contributors">

--- a/campus-adventiste-du-saleve-faculte-adventiste-de-theologie.csl
+++ b/campus-adventiste-du-saleve-faculte-adventiste-de-theologie.csl
@@ -30,14 +30,8 @@
   <locale xml:lang="fr">
     <terms>
       <term name="cited"/>
-      <term name="page" form="short">
-        <single>p.</single>
-        <multiple>p.</multiple>
-      </term>
-      <term name="editor" form="short">
-        <single>éd.</single>
-        <multiple>éd.</multiple>
-      </term>
+      <term name="page" form="short">p.</term>
+      <term name="editor" form="short">éd.</term>
       <term name="online">[en ligne]</term>
     </terms>
   </locale>

--- a/canadian-journal-of-economics.csl
+++ b/canadian-journal-of-economics.csl
@@ -23,10 +23,7 @@
       <term name="editor" form="verb-short">ed.</term>
       <term name="container-author" form="verb">by</term>
       <term name="translator" form="verb-short">trans.</term>
-      <term name="editortranslator" form="verb">
-        <single>edited and translated by</single>
-        <multiple>edited and translated by</multiple>
-      </term>
+      <term name="editortranslator" form="verb">edited and translated by</term>
       <term name="translator" form="short">trans.</term>
     </terms>
   </locale>

--- a/canadian-journal-of-physics.csl
+++ b/canadian-journal-of-physics.csl
@@ -20,10 +20,7 @@
   </info>
   <locale xml:lang="en">
     <terms>
-      <term name="editor" form="short">
-        <single>ed</single>
-        <multiple>ed</multiple>
-      </term>
+      <term name="editor" form="short">ed</term>
     </terms>
   </locale>
   <macro name="editor">

--- a/cath-lab-digest.csl
+++ b/cath-lab-digest.csl
@@ -18,10 +18,7 @@
   </info>
   <locale>
     <terms>
-      <term name="page" form="short">
-        <single>p</single>
-        <multiple>p</multiple>
-      </term>
+      <term name="page" form="short">p</term>
     </terms>
   </locale>
   <macro name="author">

--- a/centre-de-recherche-sur-les-civilisations-de-l-asie-orientale.csl
+++ b/centre-de-recherche-sur-les-civilisations-de-l-asie-orientale.csl
@@ -35,10 +35,7 @@
       <term name="ordinal-03">e</term>
       <term name="ordinal-04">e</term>
       <term name="cited">op. cit.</term>
-      <term name="page" form="short">
-        <single>p.</single>
-        <multiple>p.</multiple>
-      </term>
+      <term name="page" form="short">p.</term>
       <term name="editor" form="short">
         <single>éd.</single>
         <multiple>éds.</multiple>
@@ -51,10 +48,7 @@
         <single>éd. et trad. par</single>
         <multiple>éd. et trad par</multiple>
       </term>
-      <term name="editortranslator" form="verb">
-        <single>édité et traduit par</single>
-        <multiple>édité et traduit par</multiple>
-      </term>
+      <term name="editortranslator" form="verb">édité et traduit par</term>
     </terms>
   </locale>
   <macro name="author">

--- a/changer-d-epoque.csl
+++ b/changer-d-epoque.csl
@@ -20,10 +20,7 @@
   </info>
   <locale xml:lang="fr">
     <terms>
-      <term name="editor" form="short">
-        <single>dir.</single>
-        <multiple>dir.</multiple>
-      </term>
+      <term name="editor" form="short">dir.</term>
       <term name="in">dans</term>
       <term name="online">mis en ligne le</term>
       <term name="anonymous">anonyme</term>

--- a/chicago-annotated-bibliography.csl
+++ b/chicago-annotated-bibliography.csl
@@ -39,14 +39,8 @@
       <term name="editor" form="verb-short">ed.</term>
       <term name="translator" form="verb-short">trans.</term>
       <term name="translator" form="short">trans.</term>
-      <term name="editortranslator" form="verb-short">
-        <single>ed. and trans.</single>
-        <multiple>ed. and trans.</multiple>
-      </term>
-      <term name="editortranslator" form="verb">
-        <single>Edited and translated by</single>
-        <multiple>Edited and translated by</multiple>
-      </term>
+      <term name="editortranslator" form="verb-short">ed. and trans.</term>
+      <term name="editortranslator" form="verb">Edited and translated by</term>
       <term name="translator" form="short">trans.</term>
     </terms>
   </locale>

--- a/chicago-author-date-16th-edition.csl
+++ b/chicago-author-date-16th-edition.csl
@@ -32,10 +32,7 @@
       <term name="editor" form="verb-short">ed.</term>
       <term name="container-author" form="verb">by</term>
       <term name="translator" form="verb-short">trans.</term>
-      <term name="editortranslator" form="verb">
-        <single>edited and translated by</single>
-        <multiple>edited and translated by</multiple>
-      </term>
+      <term name="editortranslator" form="verb">edited and translated by</term>
       <term name="translator" form="short">trans.</term>
     </terms>
   </locale>

--- a/chicago-author-date-basque.csl
+++ b/chicago-author-date-basque.csl
@@ -61,10 +61,7 @@
         <single>aipamena</single>
         <multiple>aipamenak</multiple>
       </term>
-      <term name="reference" form="short">
-        <single>aip.</single>
-        <multiple>aip.</multiple>
-      </term>
+      <term name="reference" form="short">aip.</term>
       <term name="retrieved">berreskuratua</term>
       <!-- ANNO DOMINI; BEFORE CHRIST -->
       <term name="ad">K.a.</term>
@@ -189,34 +186,22 @@
       <term name="folio" form="short">or.</term>
       <term name="issue" form="short">zenb.</term>
       <term name="opus" form="short">op.</term>
-      <term name="page" form="short">
-        <single>or.</single>
-        <multiple>or.</multiple>
-      </term>
+      <term name="page" form="short">or.</term>
       <term name="paragraph" form="short">par.</term>
       <term name="part" form="short">zt.</term>
       <term name="section" form="short">atal.</term>
-      <term name="sub verbo" form="short">
-        <single>s.v.</single>
-        <multiple>s.v.</multiple>
-      </term>
+      <term name="sub verbo" form="short">s.v.</term>
       <term name="verse" form="short">
         <single>b.</single>
         <multiple>bb.</multiple>
       </term>
-      <term name="volume" form="short">
-        <single>libk.</single>
-        <multiple>libk.</multiple>
-      </term>
+      <term name="volume" form="short">libk.</term>
       <!-- SYMBOL LOCATOR FORMS -->
       <term name="paragraph" form="symbol">
         <single>¶</single>
         <multiple>¶¶</multiple>
       </term>
-      <term name="section" form="symbol">
-        <single>§</single>
-        <multiple>§</multiple>
-      </term>
+      <term name="section" form="symbol">§</term>
       <!-- LONG ROLE FORMS -->
       <term name="author">
         <single/>
@@ -243,22 +228,10 @@
         <single/>
         <multiple/>
       </term>
-      <term name="editor" form="short">
-        <single>arg.</single>
-        <multiple>arg.</multiple>
-      </term>
-      <term name="editorial-director" form="short">
-        <single>arg.</single>
-        <multiple>arg.</multiple>
-      </term>
-      <term name="translator" form="short">
-        <single>itzul.</single>
-        <multiple>itzul.</multiple>
-      </term>
-      <term name="editortranslator" form="short">
-        <single>arg. eta itzul.</single>
-        <multiple>arg. eta itzul.</multiple>
-      </term>
+      <term name="editor" form="short">arg.</term>
+      <term name="editorial-director" form="short">arg.</term>
+      <term name="translator" form="short">itzul.</term>
+      <term name="editortranslator" form="short">arg. eta itzul.</term>
       <!-- VERB ROLE FORMS -->
       <term name="editor" form="verb">-(e)k argitaratua</term>
       <term name="editorial-director" form="verb">-(e)k argitaratua</term>

--- a/chicago-author-date-de.csl
+++ b/chicago-author-date-de.csl
@@ -37,10 +37,7 @@
   </info>
   <locale xml:lang="de">
     <terms>
-      <term name="presented at">
-        <single>Gehalten auf</single>
-        <multiple>Gehalten auf</multiple>
-      </term>
+      <term name="presented at">Gehalten auf</term>
     </terms>
   </locale>
   <macro name="secondary-contributors">

--- a/chicago-author-date-fr.csl
+++ b/chicago-author-date-fr.csl
@@ -28,10 +28,7 @@
         <single>dir. et trad.</single>
         <multiple>dir. and trad.</multiple>
       </term>
-      <term name="editortranslator" form="verb">
-        <single>Sous la direction et traduit par</single>
-        <multiple>Sous la direction et traduit par</multiple>
-      </term>
+      <term name="editortranslator" form="verb">Sous la direction et traduit par</term>
       <term name="translator" form="verb-short">trad.</term>
       <term name="translator" form="short">trad.</term>
       <term name="translator" form="verb">traduit par</term>

--- a/chicago-author-date.csl
+++ b/chicago-author-date.csl
@@ -38,10 +38,7 @@
       <term name="editor" form="verb-short">ed.</term>
       <term name="container-author" form="verb">by</term>
       <term name="translator" form="verb-short">trans.</term>
-      <term name="editortranslator" form="verb">
-        <single>edited and translated by</single>
-        <multiple>edited and translated by</multiple>
-      </term>
+      <term name="editortranslator" form="verb">edited and translated by</term>
       <term name="translator" form="short">trans.</term>
     </terms>
   </locale>

--- a/chicago-fullnote-bibliography-16th-edition.csl
+++ b/chicago-fullnote-bibliography-16th-edition.csl
@@ -36,14 +36,8 @@
       <term name="editor" form="verb-short">ed.</term>
       <term name="translator" form="verb-short">trans.</term>
       <term name="translator" form="short">trans.</term>
-      <term name="editortranslator" form="verb-short">
-        <single>ed. and trans.</single>
-        <multiple>ed. and trans.</multiple>
-      </term>
-      <term name="editortranslator" form="verb">
-        <single>Edited and translated by</single>
-        <multiple>Edited and translated by</multiple>
-      </term>
+      <term name="editortranslator" form="verb-short">ed. and trans.</term>
+      <term name="editortranslator" form="verb">Edited and translated by</term>
       <term name="translator" form="short">trans.</term>
     </terms>
   </locale>

--- a/chicago-fullnote-bibliography-fr.csl
+++ b/chicago-fullnote-bibliography-fr.csl
@@ -28,10 +28,7 @@
         <single>dir. et trad.</single>
         <multiple>dir. and trad.</multiple>
       </term>
-      <term name="editortranslator" form="verb">
-        <single>Sous la direction et traduit par</single>
-        <multiple>Sous la direction et traduit par</multiple>
-      </term>
+      <term name="editortranslator" form="verb">Sous la direction et traduit par</term>
       <term name="translator" form="verb-short">trad.</term>
       <term name="translator" form="short">trad.</term>
       <term name="translator" form="verb">traduit par</term>

--- a/chicago-fullnote-bibliography-with-ibid.csl
+++ b/chicago-fullnote-bibliography-with-ibid.csl
@@ -36,14 +36,8 @@
       <term name="editor" form="verb-short">ed.</term>
       <term name="translator" form="verb-short">trans.</term>
       <term name="translator" form="short">trans.</term>
-      <term name="editortranslator" form="verb-short">
-        <single>ed. and trans.</single>
-        <multiple>ed. and trans.</multiple>
-      </term>
-      <term name="editortranslator" form="verb">
-        <single>Edited and translated by</single>
-        <multiple>Edited and translated by</multiple>
-      </term>
+      <term name="editortranslator" form="verb-short">ed. and trans.</term>
+      <term name="editortranslator" form="verb">Edited and translated by</term>
       <term name="translator" form="short">trans.</term>
     </terms>
   </locale>

--- a/chicago-fullnote-bibliography.csl
+++ b/chicago-fullnote-bibliography.csl
@@ -39,14 +39,8 @@
       <term name="editor" form="verb-short">ed.</term>
       <term name="translator" form="verb-short">trans.</term>
       <term name="translator" form="short">trans.</term>
-      <term name="editortranslator" form="verb-short">
-        <single>ed. and trans.</single>
-        <multiple>ed. and trans.</multiple>
-      </term>
-      <term name="editortranslator" form="verb">
-        <single>Edited and translated by</single>
-        <multiple>Edited and translated by</multiple>
-      </term>
+      <term name="editortranslator" form="verb-short">ed. and trans.</term>
+      <term name="editortranslator" form="verb">Edited and translated by</term>
       <term name="translator" form="short">trans.</term>
     </terms>
   </locale>

--- a/chicago-library-list.csl
+++ b/chicago-library-list.csl
@@ -39,14 +39,8 @@
       <term name="editor" form="verb-short">ed.</term>
       <term name="translator" form="verb-short">trans.</term>
       <term name="translator" form="short">trans.</term>
-      <term name="editortranslator" form="verb-short">
-        <single>ed. and trans.</single>
-        <multiple>ed. and trans.</multiple>
-      </term>
-      <term name="editortranslator" form="verb">
-        <single>Edited and translated by</single>
-        <multiple>Edited and translated by</multiple>
-      </term>
+      <term name="editortranslator" form="verb-short">ed. and trans.</term>
+      <term name="editortranslator" form="verb">Edited and translated by</term>
       <term name="translator" form="short">trans.</term>
     </terms>
   </locale>

--- a/chicago-note-bibliography-16th-edition.csl
+++ b/chicago-note-bibliography-16th-edition.csl
@@ -36,14 +36,8 @@
       <term name="editor" form="verb-short">ed.</term>
       <term name="translator" form="verb-short">trans.</term>
       <term name="translator" form="short">trans.</term>
-      <term name="editortranslator" form="verb-short">
-        <single>ed. and trans.</single>
-        <multiple>ed. and trans.</multiple>
-      </term>
-      <term name="editortranslator" form="verb">
-        <single>Edited and translated by</single>
-        <multiple>Edited and translated by</multiple>
-      </term>
+      <term name="editortranslator" form="verb-short">ed. and trans.</term>
+      <term name="editortranslator" form="verb">Edited and translated by</term>
       <term name="translator" form="short">trans.</term>
     </terms>
   </locale>

--- a/chicago-note-bibliography-with-ibid.csl
+++ b/chicago-note-bibliography-with-ibid.csl
@@ -39,14 +39,8 @@
       <term name="editor" form="verb-short">ed.</term>
       <term name="translator" form="verb-short">trans.</term>
       <term name="translator" form="short">trans.</term>
-      <term name="editortranslator" form="verb-short">
-        <single>ed. and trans.</single>
-        <multiple>ed. and trans.</multiple>
-      </term>
-      <term name="editortranslator" form="verb">
-        <single>Edited and translated by</single>
-        <multiple>Edited and translated by</multiple>
-      </term>
+      <term name="editortranslator" form="verb-short">ed. and trans.</term>
+      <term name="editortranslator" form="verb">Edited and translated by</term>
       <term name="translator" form="short">trans.</term>
     </terms>
   </locale>

--- a/chicago-note-bibliography.csl
+++ b/chicago-note-bibliography.csl
@@ -39,14 +39,8 @@
       <term name="editor" form="verb-short">ed.</term>
       <term name="translator" form="verb-short">trans.</term>
       <term name="translator" form="short">trans.</term>
-      <term name="editortranslator" form="verb-short">
-        <single>ed. and trans.</single>
-        <multiple>ed. and trans.</multiple>
-      </term>
-      <term name="editortranslator" form="verb">
-        <single>Edited and translated by</single>
-        <multiple>Edited and translated by</multiple>
-      </term>
+      <term name="editortranslator" form="verb-short">ed. and trans.</term>
+      <term name="editortranslator" form="verb">Edited and translated by</term>
       <term name="translator" form="short">trans.</term>
     </terms>
   </locale>

--- a/chroniques-des-activites-archeologiques-de-l-ecole-francaise-de-rome.csl
+++ b/chroniques-des-activites-archeologiques-de-l-ecole-francaise-de-rome.csl
@@ -19,14 +19,8 @@
   </info>
   <locale xml:lang="fr">
     <terms>
-      <term name="editor" form="short">
-        <single>éd.</single>
-        <multiple>éd.</multiple>
-      </term>
-      <term name="editortranslator" form="short">
-        <single>éd.</single>
-        <multiple>éd.</multiple>
-      </term>
+      <term name="editor" form="short">éd.</term>
+      <term name="editortranslator" form="short">éd.</term>
       <term name="in">dans</term>
       <term name="anonymous">anonyme</term>
       <term name="anonymous" form="short">anon.</term>

--- a/civilta-italiana.csl
+++ b/civilta-italiana.csl
@@ -22,18 +22,9 @@
         <single> a cura di</single>
         <multiple>a cura di</multiple>
       </term>
-      <term name="editor" form="short">
-        <single>a cura di</single>
-        <multiple>a cura di</multiple>
-      </term>
-      <term name="collection-editor" form="verb">
-        <single>a cura di</single>
-        <multiple>a cura di</multiple>
-      </term>
-      <term name="collection-editor" form="short">
-        <single>a cura di</single>
-        <multiple>a cura di</multiple>
-      </term>
+      <term name="editor" form="short">a cura di</term>
+      <term name="collection-editor" form="verb">a cura di</term>
+      <term name="collection-editor" form="short">a cura di</term>
       <term name="translator" form="short">
         <single>trad.</single>
         <multiple>tradd.</multiple>

--- a/clio-medica.csl
+++ b/clio-medica.csl
@@ -38,10 +38,7 @@
         <single>ed.</single>
         <multiple>eds</multiple>
       </term>
-      <term name="translator" form="short">
-        <single>trans.</single>
-        <multiple>trans.</multiple>
-      </term>
+      <term name="translator" form="short">trans.</term>
       <term name="volume" form="short">
         <single>Vol.</single>
         <multiple>vols</multiple>

--- a/collection-de-l-ecole-francaise-de-rome-full-note.csl
+++ b/collection-de-l-ecole-francaise-de-rome-full-note.csl
@@ -20,10 +20,7 @@
   </info>
   <locale xml:lang="fr">
     <terms>
-      <term name="editor" form="short">
-        <single>dir.</single>
-        <multiple>dir.</multiple>
-      </term>
+      <term name="editor" form="short">dir.</term>
       <term name="paragraph">§</term>
       <term name="in">dans</term>
       <term name="online">mis en ligne le</term>

--- a/collection-de-l-ecole-francaise-de-rome-note.csl
+++ b/collection-de-l-ecole-francaise-de-rome-note.csl
@@ -20,10 +20,7 @@
   </info>
   <locale xml:lang="fr">
     <terms>
-      <term name="editor" form="short">
-        <single>dir.</single>
-        <multiple>dir.</multiple>
-      </term>
+      <term name="editor" form="short">dir.</term>
       <term name="paragraph">§</term>
       <term name="in">dans</term>
       <term name="online">mis en ligne le</term>

--- a/collection-du-centre-jean-berard.csl
+++ b/collection-du-centre-jean-berard.csl
@@ -19,10 +19,7 @@
   </info>
   <locale xml:lang="fr">
     <terms>
-      <term name="editor" form="short">
-        <single>dir.</single>
-        <multiple>dir.</multiple>
-      </term>
+      <term name="editor" form="short">dir.</term>
       <term name="in">dans</term>
       <term name="anonymous">anonyme</term>
       <term name="anonymous" form="short">anon.</term>

--- a/collections-electroniques-de-l-inha-author-date.csl
+++ b/collections-electroniques-de-l-inha-author-date.csl
@@ -20,10 +20,7 @@
   </info>
   <locale xml:lang="fr">
     <terms>
-      <term name="editor" form="short">
-        <single>éd.</single>
-        <multiple>éd.</multiple>
-      </term>
+      <term name="editor" form="short">éd.</term>
       <term name="in">dans</term>
       <term name="anonymous">anonyme</term>
       <term name="anonymous" form="short">anon.</term>

--- a/collections-electroniques-de-l-inha-full-note.csl
+++ b/collections-electroniques-de-l-inha-full-note.csl
@@ -21,10 +21,7 @@
   </info>
   <locale xml:lang="fr">
     <terms>
-      <term name="editor" form="short">
-        <single>éd.</single>
-        <multiple>éd.</multiple>
-      </term>
+      <term name="editor" form="short">éd.</term>
       <term name="in">dans</term>
       <term name="anonymous">anonyme</term>
       <term name="anonymous" form="short">anon.</term>

--- a/college-montmorency.csl
+++ b/college-montmorency.csl
@@ -38,14 +38,8 @@
       <term name="ordinal-01" gender-form="feminine" match="whole-number">&amp;lt;sup&amp;gt;ère&amp;lt;/sup&amp;gt;</term>
       <term name="ordinal-01" gender-form="masculine" match="whole-number">&amp;lt;sup&amp;gt;er&amp;lt;/sup&amp;gt;</term>
       <term name="cited">op.&#160;cit.</term>
-      <term name="page" form="short">
-        <single>p.</single>
-        <multiple>p.</multiple>
-      </term>
-      <term name="editor" form="short">
-        <single>dir.</single>
-        <multiple>dir.</multiple>
-      </term>
+      <term name="page" form="short">p.</term>
+      <term name="editor" form="short">dir.</term>
       <term name="section" form="short">
         <single>art. </single>
         <multiple>art.</multiple>

--- a/colorado-state-university-school-of-biomedical-engineering.csl
+++ b/colorado-state-university-school-of-biomedical-engineering.csl
@@ -23,11 +23,8 @@
         <single>ed. &amp; trans.</single>
         <multiple>eds. &amp; trans.</multiple>
       </term>
-      <term name="translator" form="short">
-        <single>trans.</single>
-        <multiple>trans.</multiple>
-      </term>
-      <term name="et-al"></term>
+      <term name="translator" form="short">trans.</term>
+      <term name="et-al"/>
     </terms>
   </locale>
   <macro name="container-contributors">

--- a/cultural-studies-of-science-education.csl
+++ b/cultural-studies-of-science-education.csl
@@ -27,10 +27,7 @@
         <single>ed. &amp; trans.</single>
         <multiple>eds. &amp; trans.</multiple>
       </term>
-      <term name="translator" form="short">
-        <single>trans.</single>
-        <multiple>trans.</multiple>
-      </term>
+      <term name="translator" form="short">trans.</term>
     </terms>
   </locale>
   <macro name="container-contributors">

--- a/de-buck.csl
+++ b/de-buck.csl
@@ -26,10 +26,7 @@
   <locale xml:lang="nl">
     <terms>
       <term name="et-al">e.a.</term>
-      <term name="editor" form="verb-short">
-        <single>ed.</single>
-        <multiple>ed.</multiple>
-      </term>
+      <term name="editor" form="verb-short">ed.</term>
       <term name="edition" form="short">druk</term>
       <term name="translator" form="verb-short">
         <single>vertaler</single>

--- a/development-and-change.csl
+++ b/development-and-change.csl
@@ -19,10 +19,7 @@
   </info>
   <locale xml:lang="en-GB">
     <terms>
-      <term name="translator" form="short">
-        <single>trans.</single>
-        <multiple>trans.</multiple>
-      </term>
+      <term name="translator" form="short">trans.</term>
       <term name="editor" form="short">
         <single>ed.</single>
         <multiple>eds</multiple>

--- a/documents-d-archeologie-francaise.csl
+++ b/documents-d-archeologie-francaise.csl
@@ -25,10 +25,7 @@
   </info>
   <locale>
     <terms>
-      <term name="collection-editor" form="short">
-        <single>dir.</single>
-        <multiple>dir.</multiple>
-      </term>
+      <term name="collection-editor" form="short">dir.</term>
       <term name="no date">[sans date]</term>
       <term name="in">in</term>
       <term name="online">en&#160;ligne</term>

--- a/early-medieval-europe.csl
+++ b/early-medieval-europe.csl
@@ -21,18 +21,9 @@
   <locale xml:lang="en">
     <style-options punctuation-in-quote="false"/>
     <terms>
-      <term name="translator" form="short">
-        <single>trans.</single>
-        <multiple>trans.</multiple>
-      </term>
-      <term name="editortranslator" form="short">
-        <single>ed. and trans.</single>
-        <multiple>ed. and trans.</multiple>
-      </term>
-      <term name="chapter" form="short">
-        <single>c.</single>
-        <multiple>c.</multiple>
-      </term>
+      <term name="translator" form="short">trans.</term>
+      <term name="editortranslator" form="short">ed. and trans.</term>
+      <term name="chapter" form="short">c.</term>
       <term name="open-quote">‘</term>
       <term name="close-quote">’</term>
       <term name="open-inner-quote">“</term>

--- a/ecclesial-practices.csl
+++ b/ecclesial-practices.csl
@@ -21,14 +21,8 @@
     <terms>
       <term name="editor" form="verb-short">ed.</term>
       <term name="translator" form="verb-short">trans.</term>
-      <term name="editortranslator" form="verb-short">
-        <single>ed. and trans.</single>
-        <multiple>ed. and trans.</multiple>
-      </term>
-      <term name="editortranslator" form="verb">
-        <single>Edited and translated by</single>
-        <multiple>Edited and translated by</multiple>
-      </term>
+      <term name="editortranslator" form="verb-short">ed. and trans.</term>
+      <term name="editortranslator" form="verb">Edited and translated by</term>
       <term name="translator" form="short">trans.</term>
     </terms>
   </locale>

--- a/ecole-pratique-des-hautes-etudes-sciences-historiques-et-philologiques.csl
+++ b/ecole-pratique-des-hautes-etudes-sciences-historiques-et-philologiques.csl
@@ -30,14 +30,8 @@
       <term name="ordinal-03">e</term>
       <term name="ordinal-04">e</term>
       <term name="cited">op. cit.</term>
-      <term name="page" form="short">
-        <single>p.</single>
-        <multiple>p.</multiple>
-      </term>
-      <term name="editor" form="short">
-        <single>éd.</single>
-        <multiple>éd.</multiple>
-      </term>
+      <term name="page" form="short">p.</term>
+      <term name="editor" form="short">éd.</term>
       <term name="in">dans</term>
     </terms>
   </locale>

--- a/ecology-of-freshwater-fish.csl
+++ b/ecology-of-freshwater-fish.csl
@@ -23,10 +23,7 @@
         <single>ed. &amp; trans.</single>
         <multiple>eds. &amp; trans.</multiple>
       </term>
-      <term name="translator" form="short">
-        <single>trans.</single>
-        <multiple>trans.</multiple>
-      </term>
+      <term name="translator" form="short">trans.</term>
     </terms>
   </locale>
   <macro name="container-contributors">

--- a/economie-et-statistique.csl
+++ b/economie-et-statistique.csl
@@ -20,10 +20,7 @@
   </info>
   <locale xml:lang="fr">
     <terms>
-      <term name="editor" form="short">
-        <single>dir.</single>
-        <multiple>dir.</multiple>
-      </term>
+      <term name="editor" form="short">dir.</term>
       <term name="page" form="short">pp.</term>
     </terms>
   </locale>

--- a/einaudi.csl
+++ b/einaudi.csl
@@ -24,10 +24,7 @@
         <single>p.</single>
         <multiple>pp.</multiple>
       </term>
-      <term name="editor" form="short">
-        <single>a cura di</single>
-        <multiple>a cura di</multiple>
-      </term>
+      <term name="editor" form="short">a cura di</term>
     </terms>
   </locale>
   <macro name="responsibility">

--- a/ens-de-lyon-centre-d-ingenierie-documentaire.csl
+++ b/ens-de-lyon-centre-d-ingenierie-documentaire.csl
@@ -24,18 +24,9 @@
   <locale xml:lang="fr">
     <terms>
       <term name="cited">op.&#160;cit.</term>
-      <term name="page" form="short">
-        <single>p.</single>
-        <multiple>p.</multiple>
-      </term>
-      <term name="editor" form="short">
-        <single>éd.</single>
-        <multiple>éd.</multiple>
-      </term>
-      <term name="translator" form="short">
-        <single>trad.</single>
-        <multiple>trad.</multiple>
-      </term>
+      <term name="page" form="short">p.</term>
+      <term name="editor" form="short">éd.</term>
+      <term name="translator" form="short">trad.</term>
       <term name="in">dans</term>
       <term name="et-al">et&#160;al.</term>
       <term name="page-range-delimiter">-</term>

--- a/entomologia-experimentalis-et-applicata.csl
+++ b/entomologia-experimentalis-et-applicata.csl
@@ -19,10 +19,7 @@
   <locale xml:lang="en">
     <terms>
       <term name="editor" form="verb-short">ed. by</term>
-      <term name="editor" form="short">
-        <single>ed. by </single>
-        <multiple>ed. by </multiple>
-      </term>
+      <term name="editor" form="short">ed. by </term>
     </terms>
   </locale>
   <macro name="editor-translator">

--- a/ephemerides-theologicae-lovanienses.csl
+++ b/ephemerides-theologicae-lovanienses.csl
@@ -53,10 +53,7 @@
         <multiple>Hgg.</multiple>
       </term>
       <term name="translator" form="short">trans.</term>
-      <term name="page" form="short">
-        <single>S.</single>
-        <multiple>S.</multiple>
-      </term>
+      <term name="page" form="short">S.</term>
       <term name="in">in</term>
     </terms>
   </locale>

--- a/ethics-book-reviews.csl
+++ b/ethics-book-reviews.csl
@@ -20,14 +20,8 @@
   </info>
   <locale xml:lang="en">
     <terms>
-      <term name="editortranslator" form="verb-short">
-        <single>trans. and ed.</single>
-        <multiple>trans. and ed.</multiple>
-      </term>
-      <term name="editortranslator" form="verb">
-        <single> Translated and edited by</single>
-        <multiple> Translated and edited by</multiple>
-      </term>
+      <term name="editortranslator" form="verb-short">trans. and ed.</term>
+      <term name="editortranslator" form="verb"> Translated and edited by</term>
       <term name="editor" form="verb-short">ed.</term>
       <term name="translator" form="verb-short">trans.</term>
     </terms>

--- a/ethnologie-francaise.csl
+++ b/ethnologie-francaise.csl
@@ -26,10 +26,7 @@
       <term name="accessed">consulté&#160;le</term>
       <term name="no date">sans date</term>
       <term name="translator" form="short">trad.</term>
-      <term name="editor" form="short">
-        <single>dir.</single>
-        <multiple>dir.</multiple>
-      </term>
+      <term name="editor" form="short">dir.</term>
       <term name="no date" form="short">[s.&#160;d.]</term>
     </terms>
   </locale>

--- a/ethnomusicology.csl
+++ b/ethnomusicology.csl
@@ -22,10 +22,7 @@
       <term name="editor" form="verb-short">ed.</term>
       <term name="container-author" form="verb">by</term>
       <term name="translator" form="verb-short">trans.</term>
-      <term name="editortranslator" form="verb">
-        <single>edited and translated by</single>
-        <multiple>edited and translated by</multiple>
-      </term>
+      <term name="editortranslator" form="verb">edited and translated by</term>
       <term name="translator" form="short">trans.</term>
     </terms>
   </locale>

--- a/european-journal-of-political-research.csl
+++ b/european-journal-of-political-research.csl
@@ -23,10 +23,7 @@
         <single>ed. &amp; trans.</single>
         <multiple>eds. &amp; trans.</multiple>
       </term>
-      <term name="translator" form="short">
-        <single>trans.</single>
-        <multiple>trans.</multiple>
-      </term>
+      <term name="translator" form="short">trans.</term>
     </terms>
   </locale>
   <macro name="container-contributors">

--- a/evolutionary-anthropology.csl
+++ b/evolutionary-anthropology.csl
@@ -22,20 +22,14 @@
     <terms>
       <term name="retrieved">available</term>
       <term name="section" form="short">sect.</term>
-      <term name="page" form="short">
-        <single>p</single>
-        <multiple>p</multiple>
-      </term>
+      <term name="page" form="short">p</term>
     </terms>
   </locale>
   <locale xml:lang="de">
     <terms>
       <term name="retrieved">verfügbar</term>
       <term name="from">unter</term>
-      <term name="page" form="short">
-        <single>p</single>
-        <multiple>p</multiple>
-      </term>
+      <term name="page" form="short">p</term>
     </terms>
   </locale>
   <macro name="author">

--- a/family-business-review.csl
+++ b/family-business-review.csl
@@ -24,10 +24,7 @@
         <single>ed. &amp; trans.</single>
         <multiple>eds. &amp; trans.</multiple>
       </term>
-      <term name="translator" form="short">
-        <single>trans.</single>
-        <multiple>trans.</multiple>
-      </term>
+      <term name="translator" form="short">trans.</term>
     </terms>
   </locale>
   <macro name="container-contributors">

--- a/feminist-economics.csl
+++ b/feminist-economics.csl
@@ -22,10 +22,7 @@
       <term name="editor" form="verb-short">ed.</term>
       <term name="container-author" form="verb">by</term>
       <term name="translator" form="verb-short">trans.</term>
-      <term name="editortranslator" form="verb">
-        <single>edited and translated by</single>
-        <multiple>edited and translated by</multiple>
-      </term>
+      <term name="editortranslator" form="verb">edited and translated by</term>
       <term name="translator" form="short">trans.</term>
     </terms>
   </locale>

--- a/ferdinand-porsche-fern-fachhochschule.csl
+++ b/ferdinand-porsche-fern-fachhochschule.csl
@@ -29,14 +29,8 @@
         <single>Abruf am</single>
         <multiple>Abrufe am</multiple>
       </term>
-      <term name="anonymous" form="short">
-        <single>o. V.</single>
-        <multiple>o. V.</multiple>
-      </term>
-      <term name="et-al" form="long">
-        <single>et al.</single>
-        <multiple>et al.</multiple>
-      </term>
+      <term name="anonymous" form="short">o. V.</term>
+      <term name="et-al" form="long">et al.</term>
       <term name="presented at" form="long">
         <single>vortrag auf der</single>
         <multiple>vorträge auf der</multiple>

--- a/fishery-bulletin.csl
+++ b/fishery-bulletin.csl
@@ -22,10 +22,7 @@
         <single>ed. &amp; trans.</single>
         <multiple>eds. &amp; trans.</multiple>
       </term>
-      <term name="translator" form="short">
-        <single>trans.</single>
-        <multiple>trans.</multiple>
-      </term>
+      <term name="translator" form="short">trans.</term>
     </terms>
   </locale>
   <macro name="container-contributors">

--- a/forum-qualitative-social-research.csl
+++ b/forum-qualitative-social-research.csl
@@ -24,10 +24,7 @@
         <single>ed. &amp; trans.</single>
         <multiple>eds. &amp; trans.</multiple>
       </term>
-      <term name="translator" form="short">
-        <single>trans.</single>
-        <multiple>trans.</multiple>
-      </term>
+      <term name="translator" form="short">trans.</term>
     </terms>
   </locale>
   <macro name="container-contributors">

--- a/french-politics.csl
+++ b/french-politics.csl
@@ -24,10 +24,7 @@
         <single>ed. &amp; trans.</single>
         <multiple>eds. &amp; trans.</multiple>
       </term>
-      <term name="translator" form="short">
-        <single>trans.</single>
-        <multiple>trans.</multiple>
-      </term>
+      <term name="translator" form="short">trans.</term>
     </terms>
   </locale>
   <macro name="container-contributors">

--- a/gallia.csl
+++ b/gallia.csl
@@ -20,10 +20,7 @@
   </info>
   <locale xml:lang="fr">
     <terms>
-      <term name="editor" form="short">
-        <single>dir.</single>
-        <multiple>dir.</multiple>
-      </term>
+      <term name="editor" form="short">dir.</term>
       <term name="in">dans</term>
       <term name="anonymous">anonyme</term>
       <term name="anonymous" form="short">anon.</term>

--- a/geoarchaeology.csl
+++ b/geoarchaeology.csl
@@ -23,10 +23,7 @@
         <single>ed. &amp; trans.</single>
         <multiple>eds. &amp; trans.</multiple>
       </term>
-      <term name="translator" form="short">
-        <single>trans.</single>
-        <multiple>trans.</multiple>
-      </term>
+      <term name="translator" form="short">trans.</term>
     </terms>
   </locale>
   <macro name="container-contributors">

--- a/glossa.csl
+++ b/glossa.csl
@@ -27,10 +27,7 @@
         <single>ed. &amp; trans.</single>
         <multiple>eds. &amp; trans.</multiple>
       </term>
-      <term name="translator" form="short">
-        <single>trans.</single>
-        <multiple>trans.</multiple>
-      </term>
+      <term name="translator" form="short">trans.</term>
     </terms>
   </locale>
   <macro name="container-contributors">

--- a/harvard-gesellschaft-fur-bildung-und-forschung-in-europa.csl
+++ b/harvard-gesellschaft-fur-bildung-und-forschung-in-europa.csl
@@ -29,11 +29,7 @@
         <single>Seite</single>
         <multiple>Seiten</multiple>
       </term>
-      <term name="page" form="short">
-        <!--  SEITE KURZ -->
-        <single>S.</single>
-        <multiple>S.</multiple>
-      </term>
+      <term name="page" form="short">S.</term>
       <term name="editor">Herausgeber													<!--  HERAUSGEBER -->
     </term>
       <term name="editor" form="short">Hg.										<!--  HERAUSGEBER KURZ -->

--- a/harvard-london-south-bank-university.csl
+++ b/harvard-london-south-bank-university.csl
@@ -30,10 +30,7 @@
         <single>ed. &amp; trans.</single>
         <multiple>eds. &amp; trans.</multiple>
       </term>
-      <term name="translator" form="short">
-        <single>trans.</single>
-        <multiple>trans.</multiple>
-      </term>
+      <term name="translator" form="short">trans.</term>
     </terms>
   </locale>
   <macro name="container-contributors">

--- a/harvard-theologisches-seminar-adelshofen.csl
+++ b/harvard-theologisches-seminar-adelshofen.csl
@@ -24,10 +24,7 @@
         <single>Seite</single>
         <multiple>Seiten</multiple>
       </term>
-      <term name="page" form="short">
-        <single>S.</single>
-        <multiple>S.</multiple>
-      </term>
+      <term name="page" form="short">S.</term>
       <term name="editor">Herausgeber</term>
       <term name="editor" form="short">Hg.</term>
       <term name="edition">

--- a/harvard-university-of-exeter-geography.csl
+++ b/harvard-university-of-exeter-geography.csl
@@ -21,10 +21,7 @@
         <single>ed. &amp; trans.</single>
         <multiple>eds. &amp; trans.</multiple>
       </term>
-      <term name="translator" form="short">
-        <single>trans.</single>
-        <multiple>trans.</multiple>
-      </term>
+      <term name="translator" form="short">trans.</term>
     </terms>
   </locale>
   <macro name="container-contributors">

--- a/haute-ecole-pedagogique-fribourg.csl
+++ b/haute-ecole-pedagogique-fribourg.csl
@@ -27,10 +27,7 @@
         <single>ed. &amp; trad.</single>
         <multiple>eds. &amp; trad.</multiple>
       </term>
-      <term name="translator" form="short">
-        <single>trad.</single>
-        <multiple>trad.</multiple>
-      </term>
+      <term name="translator" form="short">trad.</term>
       <term name="page" form="short">
         <single>p.</single>
         <multiple>pp.</multiple>

--- a/henoch.csl
+++ b/henoch.csl
@@ -17,18 +17,9 @@
   </info>
   <locale xml:lang="en">
     <terms>
-      <term name="translator" form="short">
-        <single>trans.</single>
-        <multiple>trans.</multiple>
-      </term>
-      <term name="editortranslator" form="short">
-        <single>ed. and trans.</single>
-        <multiple>ed. and trans.</multiple>
-      </term>
-      <term name="chapter" form="short">
-        <single>c.</single>
-        <multiple>c.</multiple>
-      </term>
+      <term name="translator" form="short">trans.</term>
+      <term name="editortranslator" form="short">ed. and trans.</term>
+      <term name="chapter" form="short">c.</term>
     </terms>
   </locale>
   <macro name="author">

--- a/histoire-at-politique.csl
+++ b/histoire-at-politique.csl
@@ -22,14 +22,8 @@
       <term name="ordinal-03">e</term>
       <term name="ordinal-04">e</term>
       <term name="cited">op.&#160;cit.</term>
-      <term name="page" form="short">
-        <single>p.</single>
-        <multiple>p.</multiple>
-      </term>
-      <term name="editor" form="short">
-        <single>dir.</single>
-        <multiple>dir.</multiple>
-      </term>
+      <term name="page" form="short">p.</term>
+      <term name="editor" form="short">dir.</term>
     </terms>
   </locale>
   <macro name="author">

--- a/histoire-et-mesure.csl
+++ b/histoire-et-mesure.csl
@@ -23,14 +23,8 @@
       <term name="ordinal-03">e</term>
       <term name="ordinal-04">e</term>
       <term name="cited">op.&#160;cit.</term>
-      <term name="page" form="short">
-        <single>p.</single>
-        <multiple>p.</multiple>
-      </term>
-      <term name="editor" form="short">
-        <single>éd.</single>
-        <multiple>éd.</multiple>
-      </term>
+      <term name="page" form="short">p.</term>
+      <term name="editor" form="short">éd.</term>
     </terms>
   </locale>
   <macro name="author">

--- a/historical-social-research.csl
+++ b/historical-social-research.csl
@@ -28,10 +28,7 @@
       <term name="page-range-delimiter">-</term>
       <term name="container-author" form="verb">by</term>
       <term name="translator" form="verb-short">trans.</term>
-      <term name="editortranslator" form="verb">
-        <single>edited and translated by</single>
-        <multiple>edited and translated by</multiple>
-      </term>
+      <term name="editortranslator" form="verb">edited and translated by</term>
       <term name="translator" form="short">trans.</term>
     </terms>
   </locale>

--- a/history-australia.csl
+++ b/history-australia.csl
@@ -23,14 +23,8 @@
       <term name="editor" form="verb-short">ed.</term>
       <term name="translator" form="verb-short">trans.</term>
       <term name="translator" form="short">trans.</term>
-      <term name="editortranslator" form="verb-short">
-        <single>ed. and trans.</single>
-        <multiple>ed. and trans.</multiple>
-      </term>
-      <term name="editortranslator" form="verb">
-        <single>Edited and translated by</single>
-        <multiple>Edited and translated by</multiple>
-      </term>
+      <term name="editortranslator" form="verb-short">ed. and trans.</term>
+      <term name="editortranslator" form="verb">Edited and translated by</term>
       <term name="translator" form="short">trans.</term>
     </terms>
   </locale>

--- a/hochschule-fur-wirtschaft-und-recht-berlin.csl
+++ b/hochschule-fur-wirtschaft-und-recht-berlin.csl
@@ -22,19 +22,10 @@
       <term name="retrieved">zugegriffen am</term>
       <term name="accessed">abgerufen am</term>
       <term name="ibid">ebenda</term>
-      <term name="page" form="short">
-        <single>S.</single>
-        <multiple>S.</multiple>
-      </term>
-      <term name="section" form="short">
-        <single>Abs.</single>
-        <multiple>Abs.</multiple>
-      </term>
+      <term name="page" form="short">S.</term>
+      <term name="section" form="short">Abs.</term>
       <term name="editor" form="verb-short">hrsg. von</term>
-      <term name="editor" form="short">
-        <single>(Hrsg.)</single>
-        <multiple>(Hrsg.)</multiple>
-      </term>
+      <term name="editor" form="short">(Hrsg.)</term>
     </terms>
   </locale>
   <!--

--- a/iforest.csl
+++ b/iforest.csl
@@ -22,10 +22,7 @@
         <single>ed. &amp; trans.</single>
         <multiple>eds. &amp; trans.</multiple>
       </term>
-      <term name="translator" form="short">
-        <single>trans.</single>
-        <multiple>trans.</multiple>
-      </term>
+      <term name="translator" form="short">trans.</term>
     </terms>
   </locale>
   <macro name="container-contributors">

--- a/information-systems-journal.csl
+++ b/information-systems-journal.csl
@@ -24,10 +24,7 @@
         <single>ed. &amp; trans.</single>
         <multiple>eds. &amp; trans.</multiple>
       </term>
-      <term name="translator" form="short">
-        <single>trans.</single>
-        <multiple>trans.</multiple>
-      </term>
+      <term name="translator" form="short">trans.</term>
     </terms>
   </locale>
   <macro name="container-contributors">

--- a/institut-national-de-sante-publique-du-quebec-napp.csl
+++ b/institut-national-de-sante-publique-du-quebec-napp.csl
@@ -17,10 +17,7 @@
   </info>
   <locale xml:lang="fr-CA">
     <terms>
-      <term name="editor" form="short">
-        <single>dir.</single>
-        <multiple>dir.</multiple>
-      </term>
+      <term name="editor" form="short">dir.</term>
       <term name="et-al">et collab.</term>
     </terms>
   </locale>

--- a/institut-national-de-sante-publique-du-quebec-topo.csl
+++ b/institut-national-de-sante-publique-du-quebec-topo.csl
@@ -17,10 +17,7 @@
   </info>
   <locale xml:lang="fr-CA">
     <terms>
-      <term name="editor" form="short">
-        <single>dir.</single>
-        <multiple>dir.</multiple>
-      </term>
+      <term name="editor" form="short">dir.</term>
     </terms>
   </locale>
   <macro name="author">

--- a/institut-teknologi-bandung-tesis-magister.csl
+++ b/institut-teknologi-bandung-tesis-magister.csl
@@ -36,10 +36,7 @@
         <single>ed. &amp; trans.</single>
         <multiple>eds. &amp; trans.</multiple>
       </term>
-      <term name="translator" form="short">
-        <single>trans.</single>
-        <multiple>trans.</multiple>
-      </term>
+      <term name="translator" form="short">trans.</term>
       <term name="et-al">dkk.</term>
       <term name="retrieved">diperoleh</term>
       <term name="from">melalui</term>

--- a/institute-of-mathematical-statistics.csl
+++ b/institute-of-mathematical-statistics.csl
@@ -21,10 +21,7 @@
   <locale xml:lang="en">
     <terms>
       <term name="et-al">et al</term>
-      <term name="editor" form="short">
-        <single>ed</single>
-        <multiple>ed</multiple>
-      </term>
+      <term name="editor" form="short">ed</term>
     </terms>
   </locale>
   <macro name="editor">

--- a/institute-of-physics-harvard.csl
+++ b/institute-of-physics-harvard.csl
@@ -21,10 +21,7 @@
   <locale xml:lang="en">
     <terms>
       <term name="et-al">et al</term>
-      <term name="editor" form="short">
-        <single>ed</single>
-        <multiple>ed</multiple>
-      </term>
+      <term name="editor" form="short">ed</term>
     </terms>
   </locale>
   <macro name="editor">

--- a/institute-of-physics-numeric.csl
+++ b/institute-of-physics-numeric.csl
@@ -17,10 +17,7 @@
   <locale xml:lang="en">
     <terms>
       <term name="et-al">et al</term>
-      <term name="editor" form="short">
-        <single>ed</single>
-        <multiple>ed</multiple>
-      </term>
+      <term name="editor" form="short">ed</term>
     </terms>
   </locale>
   <macro name="editor">

--- a/international-journal-of-management-reviews.csl
+++ b/international-journal-of-management-reviews.csl
@@ -23,10 +23,7 @@
         <single>ed. &amp; trans.</single>
         <multiple>eds. &amp; trans.</multiple>
       </term>
-      <term name="translator" form="short">
-        <single>trans.</single>
-        <multiple>trans.</multiple>
-      </term>
+      <term name="translator" form="short">trans.</term>
     </terms>
   </locale>
   <macro name="container-contributors">

--- a/international-journal-of-simulation-modelling.csl
+++ b/international-journal-of-simulation-modelling.csl
@@ -22,10 +22,7 @@
         <single>ed. &amp; trans.</single>
         <multiple>eds. &amp; trans.</multiple>
       </term>
-      <term name="translator" form="short">
-        <single>trans.</single>
-        <multiple>trans.</multiple>
-      </term>
+      <term name="translator" form="short">trans.</term>
     </terms>
   </locale>
   <macro name="container-contributors">

--- a/international-journal-of-urban-and-regional-research.csl
+++ b/international-journal-of-urban-and-regional-research.csl
@@ -23,10 +23,7 @@
         <single>ed. &amp; trans.</single>
         <multiple>eds. &amp; trans.</multiple>
       </term>
-      <term name="translator" form="short">
-        <single>trans.</single>
-        <multiple>trans.</multiple>
-      </term>
+      <term name="translator" form="short">trans.</term>
     </terms>
   </locale>
   <macro name="container-contributors">

--- a/international-review-of-the-red-cross.csl
+++ b/international-review-of-the-red-cross.csl
@@ -24,18 +24,9 @@
   <locale xml:lang="en">
     <style-options punctuation-in-quote="false"/>
     <terms>
-      <term name="translator" form="short">
-        <single>trans.</single>
-        <multiple>trans.</multiple>
-      </term>
-      <term name="editortranslator" form="short">
-        <single>ed. and trans.</single>
-        <multiple>ed. and trans.</multiple>
-      </term>
-      <term name="chapter" form="short">
-        <single>c.</single>
-        <multiple>c.</multiple>
-      </term>
+      <term name="translator" form="short">trans.</term>
+      <term name="editortranslator" form="short">ed. and trans.</term>
+      <term name="chapter" form="short">c.</term>
     </terms>
   </locale>
   <macro name="author">

--- a/invisu.csl
+++ b/invisu.csl
@@ -36,10 +36,7 @@
         <single>vol.</single>
         <multiple>vols.</multiple>
       </term>
-      <term name="page" form="short">
-        <single>p.</single>
-        <multiple>p.</multiple>
-      </term>
+      <term name="page" form="short">p.</term>
       <term name="ibid">ibid</term>
       <term name="cited">op.&#160;cit.</term>
       <term name="edition" form="short">ed.</term>
@@ -59,10 +56,7 @@
         <single>cap.</single>
         <multiple>caps.</multiple>
       </term>
-      <term name="page" form="short">
-        <single>p.</single>
-        <multiple>p.</multiple>
-      </term>
+      <term name="page" form="short">p.</term>
       <term name="accessed">fecha de consulta</term>
       <term name="in">en</term>
       <term name="at">en</term>
@@ -76,22 +70,13 @@
       <term name="and">und</term>
       <term name="retrieved">zugegriffen am</term>
       <term name="ibid">ebd.</term>
-      <term name="section" form="short">
-        <single>Abs.</single>
-        <multiple>Abs.</multiple>
-      </term>
-      <term name="editor" form="short">
-        <single>Hrsg.</single>
-        <multiple>Hrsg.</multiple>
-      </term>
+      <term name="section" form="short">Abs.</term>
+      <term name="editor" form="short">Hrsg.</term>
     </terms>
   </locale>
   <locale xml:lang="en-US">
     <terms>
-      <term name="page" form="short">
-        <single>p.</single>
-        <multiple>p.</multiple>
-      </term>
+      <term name="page" form="short">p.</term>
       <term name="cited">op.&#160;cit.</term>
       <term name="issue">issue title</term>
       <term name="editor" form="short">

--- a/isnad.csl
+++ b/isnad.csl
@@ -38,14 +38,8 @@
       <term name="editor" form="verb-short">ed.</term>
       <term name="translator" form="verb-short">trans.</term>
       <term name="translator" form="short">trans.</term>
-      <term name="editortranslator" form="verb-short">
-        <single>ed. and trans.</single>
-        <multiple>ed. and trans.</multiple>
-      </term>
-      <term name="editortranslator" form="verb">
-        <single>Edited and translated by</single>
-        <multiple>Edited and translated by</multiple>
-      </term>
+      <term name="editortranslator" form="verb-short">ed. and trans.</term>
+      <term name="editortranslator" form="verb">Edited and translated by</term>
       <term name="translator" form="short">trans.</term>
       <term name="editorial-director">ed.</term>
       <term name="collection-editor">ed.</term>

--- a/iso690-author-date-fr-no-abstract.csl
+++ b/iso690-author-date-fr-no-abstract.csl
@@ -24,10 +24,7 @@
       <term name="accessed">consulté&#160;le</term>
       <term name="retrieved">disponible</term>
       <term name="from">à l'adresse</term>
-      <term name="page" form="short">
-        <single>p.</single>
-        <multiple>p.</multiple>
-      </term>
+      <term name="page" form="short">p.</term>
     </terms>
   </locale>
   <macro name="author">

--- a/iso690-note-fr.csl
+++ b/iso690-note-fr.csl
@@ -23,11 +23,7 @@
       <term name="online">en&#160;ligne</term>
       <term name="accessed">consulté&#160;le</term>
       <term name="available at">disponible à l'adresse</term>
-      <term name="editor" form="short">
-        <!-- Dir. (Sous la direction de) = most common term in french for editorial responsability of a collective work-->
-        <single>dir.</single>
-        <multiple>dir.</multiple>
-      </term>
+      <term name="editor" form="short">dir.</term>
     </terms>
   </locale>
   <macro name="author">

--- a/ithaque.csl
+++ b/ithaque.csl
@@ -24,15 +24,9 @@
       <term name="ordinal-03">&#7497;</term>
       <term name="ordinal-04">&#7497;</term>
       <term name="volume" form="short">vol.</term>
-      <term name="page" form="short">
-        <single>p.</single>
-        <multiple>p.</multiple>
-      </term>
+      <term name="page" form="short">p.</term>
       <term name="translator" form="verb">trad.</term>
-      <term name="editor" form="short">
-        <single> (dir.)</single>
-        <multiple> (dir.)</multiple>
-      </term>
+      <term name="editor" form="short"> (dir.)</term>
     </terms>
   </locale>
   <macro name="author-or-editor">

--- a/ius-ecclesiae.csl
+++ b/ius-ecclesiae.csl
@@ -22,22 +22,10 @@
   </info>
   <locale xml:lang="it">
     <terms>
-      <term name="editor" form="verb">
-        <single>curato da</single>
-        <multiple>curato da</multiple>
-      </term>
-      <term name="editor" form="short">
-        <single>a cura di</single>
-        <multiple>a cura di</multiple>
-      </term>
-      <term name="collection-editor" form="verb">
-        <single>curato da</single>
-        <multiple>curato da</multiple>
-      </term>
-      <term name="collection-editor" form="short">
-        <single>a cura di</single>
-        <multiple>a cura di</multiple>
-      </term>
+      <term name="editor" form="verb">curato da</term>
+      <term name="editor" form="short">a cura di</term>
+      <term name="collection-editor" form="verb">curato da</term>
+      <term name="collection-editor" form="short">a cura di</term>
       <term name="translator" form="short">
         <single>trad.</single>
         <multiple>tradd.</multiple>
@@ -62,18 +50,12 @@
   </locale>
   <locale xml:lang="en">
     <terms>
-      <term name="collection-editor" form="verb">
-        <single>edited by</single>
-        <multiple>edited by</multiple>
-      </term>
+      <term name="collection-editor" form="verb">edited by</term>
       <term name="collection-editor" form="short">
         <single>ed.</single>
         <multiple>eds.</multiple>
       </term>
-      <term name="editor" form="verb">
-        <single>edited by</single>
-        <multiple>edited by</multiple>
-      </term>
+      <term name="editor" form="verb">edited by</term>
       <term name="editor" form="short">
         <single>ed.</single>
         <multiple>eds.</multiple>
@@ -92,18 +74,12 @@
   </locale>
   <locale xml:lang="es">
     <terms>
-      <term name="collection-editor" form="verb">
-        <single>edición a cargo de</single>
-        <multiple>edición a cargo de</multiple>
-      </term>
+      <term name="collection-editor" form="verb">edición a cargo de</term>
       <term name="collection-editor" form="short">
         <single>ed.</single>
         <multiple>eds.</multiple>
       </term>
-      <term name="editor" form="verb">
-        <single>edición a cargo de</single>
-        <multiple>edición a cargo de</multiple>
-      </term>
+      <term name="editor" form="verb">edición a cargo de</term>
       <term name="editor" form="short">
         <single>ed.</single>
         <multiple>eds.</multiple>
@@ -132,38 +108,14 @@
   </locale>
   <locale xml:lang="fr">
     <terms>
-      <term name="editor" form="verb">
-        <single>édité par</single>
-        <multiple>édité par</multiple>
-      </term>
-      <term name="editor" form="short">
-        <single>éd.</single>
-        <multiple>éd.</multiple>
-      </term>
-      <term name="collection-editor" form="verb">
-        <single>dirigé par</single>
-        <multiple>dirigé par</multiple>
-      </term>
-      <term name="collection-editor" form="short">
-        <single>dir.</single>
-        <multiple>dir.</multiple>
-      </term>
-      <term name="translator" form="short">
-        <single>trad.</single>
-        <multiple>trad.</multiple>
-      </term>
-      <term name="volume" form="short">
-        <single>Vol.</single>
-        <multiple>Vol.</multiple>
-      </term>
-      <term name="page" form="short">
-        <single>p.</single>
-        <multiple>p.</multiple>
-      </term>
-      <term name="paragraph" form="short">
-        <single>§</single>
-        <multiple>§</multiple>
-      </term>
+      <term name="editor" form="verb">édité par</term>
+      <term name="editor" form="short">éd.</term>
+      <term name="collection-editor" form="verb">dirigé par</term>
+      <term name="collection-editor" form="short">dir.</term>
+      <term name="translator" form="short">trad.</term>
+      <term name="volume" form="short">Vol.</term>
+      <term name="page" form="short">p.</term>
+      <term name="paragraph" form="short">§</term>
       <term name="in">dans</term>
       <term name="cited" form="short">op. cit.</term>
       <term name="accessed" form="long">consulté le</term>
@@ -172,34 +124,19 @@
   </locale>
   <locale xml:lang="de">
     <terms>
-      <term name="editor" form="verb">
-        <single>herausgegeben von</single>
-        <multiple>herausgegeben von</multiple>
-      </term>
+      <term name="editor" form="verb">herausgegeben von</term>
       <term name="editor" form="short">
         <single>Hg.</single>
         <multiple>Hgg.</multiple>
       </term>
-      <term name="collection-editor" form="verb">
-        <single>herausgegeben von</single>
-        <multiple>herausgegeben von</multiple>
-      </term>
+      <term name="collection-editor" form="verb">herausgegeben von</term>
       <term name="collection-editor" form="short">
         <single>Hg.</single>
         <multiple>Hgg.</multiple>
       </term>
-      <term name="translator" form="short">
-        <single>Übers.</single>
-        <multiple>Übers.</multiple>
-      </term>
-      <term name="volume" form="short">
-        <single>Bd.</single>
-        <multiple>Bd.</multiple>
-      </term>
-      <term name="page" form="short">
-        <single>S.</single>
-        <multiple>S.</multiple>
-      </term>
+      <term name="translator" form="short">Übers.</term>
+      <term name="volume" form="short">Bd.</term>
+      <term name="page" form="short">S.</term>
       <term name="paragraph" form="short">
         <single>§</single>
         <multiple>§§</multiple>

--- a/jahrbuch-der-osterreichischen-byzantinischen-gesellschaft.csl
+++ b/jahrbuch-der-osterreichischen-byzantinischen-gesellschaft.csl
@@ -39,18 +39,9 @@
       <term name="folio" form="short">fol.</term>
       <term name="issue" form="short">iss</term>
       <term name="opus" form="short">op.</term>
-      <term name="editor" form="short">
-        <single>ed.</single>
-        <multiple>ed.</multiple>
-      </term>
-      <term name="editorial-director" form="short">
-        <single>ed.</single>
-        <multiple>ed.</multiple>
-      </term>
-      <term name="translator" form="short">
-        <single>trans.</single>
-        <multiple>trans.</multiple>
-      </term>
+      <term name="editor" form="short">ed.</term>
+      <term name="editorial-director" form="short">ed.</term>
+      <term name="translator" form="short">trans.</term>
       <!--DATE-->
       <term name="month-01">january</term>
       <term name="month-02">february</term>

--- a/journal-of-agricultural-and-applied-economics.csl
+++ b/journal-of-agricultural-and-applied-economics.csl
@@ -25,10 +25,7 @@
         <single>ed. &amp; trans.</single>
         <multiple>eds. &amp; trans.</multiple>
       </term>
-      <term name="translator" form="short">
-        <single>trans.</single>
-        <multiple>trans.</multiple>
-      </term>
+      <term name="translator" form="short">trans.</term>
     </terms>
   </locale>
   <macro name="container-contributors">

--- a/journal-of-animal-physiology-and-animal-nutrition.csl
+++ b/journal-of-animal-physiology-and-animal-nutrition.csl
@@ -19,14 +19,8 @@
   </info>
   <locale xml:lang="en">
     <terms>
-      <term name="translator" form="short">
-        <single>trans.</single>
-        <multiple>trans.</multiple>
-      </term>
-      <term name="edition" form="short">
-        <single>edn.</single>
-        <multiple>edn.</multiple>
-      </term>
+      <term name="translator" form="short">trans.</term>
+      <term name="edition" form="short">edn.</term>
     </terms>
   </locale>
   <macro name="container-contributors">

--- a/journal-of-business-logistics.csl
+++ b/journal-of-business-logistics.csl
@@ -23,10 +23,7 @@
       <term name="editor" form="verb-short">ed.</term>
       <term name="container-author" form="verb">by</term>
       <term name="translator" form="verb-short">trans.</term>
-      <term name="editortranslator" form="verb">
-        <single>edited and translated by</single>
-        <multiple>edited and translated by</multiple>
-      </term>
+      <term name="editortranslator" form="verb">edited and translated by</term>
       <term name="translator" form="short">trans.</term>
     </terms>
   </locale>

--- a/journal-of-interactive-marketing.csl
+++ b/journal-of-interactive-marketing.csl
@@ -31,10 +31,7 @@
       <term name="editor" form="verb-short">ed.</term>
       <term name="container-author" form="verb">by</term>
       <term name="translator" form="verb-short">trans.</term>
-      <term name="editortranslator" form="verb">
-        <single>edited and translated by</single>
-        <multiple>edited and translated by</multiple>
-      </term>
+      <term name="editortranslator" form="verb">edited and translated by</term>
       <term name="translator" form="short">trans.</term>
     </terms>
   </locale>

--- a/journal-of-management.csl
+++ b/journal-of-management.csl
@@ -20,10 +20,7 @@
   </info>
   <locale xml:lang="en">
     <terms>
-      <term name="translator" form="short">
-        <single>trans.</single>
-        <multiple>trans.</multiple>
-      </term>
+      <term name="translator" form="short">trans.</term>
     </terms>
   </locale>
   <macro name="container-contributors">

--- a/journal-of-music-technology-and-education.csl
+++ b/journal-of-music-technology-and-education.csl
@@ -24,10 +24,7 @@
         <single>ed. &amp; trans.</single>
         <multiple>eds. &amp; trans.</multiple>
       </term>
-      <term name="translator" form="short">
-        <single>trans.</single>
-        <multiple>trans.</multiple>
-      </term>
+      <term name="translator" form="short">trans.</term>
     </terms>
   </locale>
   <macro name="container-contributors">

--- a/journal-of-neurochemistry.csl
+++ b/journal-of-neurochemistry.csl
@@ -47,10 +47,7 @@
         <single>ed</single>
         <multiple>eds</multiple>
       </term>
-      <term name="translator" form="short">
-        <single>trans.</single>
-        <multiple>trans.</multiple>
-      </term>
+      <term name="translator" form="short">trans.</term>
       <!--DATE-->
       <term name="month-01">january</term>
       <term name="month-02">february</term>

--- a/journal-of-physical-therapy-science.csl
+++ b/journal-of-physical-therapy-science.csl
@@ -18,10 +18,7 @@
   </info>
   <locale xml:lang="en">
     <terms>
-      <term name="page" form="short">
-        <single>p</single>
-        <multiple>p</multiple>
-      </term>
+      <term name="page" form="short">p</term>
       <term name="number-of-pages" form="short">
         <single>p</single>
         <multiple>pp</multiple>

--- a/journal-of-psychiatric-and-mental-health-nursing.csl
+++ b/journal-of-psychiatric-and-mental-health-nursing.csl
@@ -22,10 +22,7 @@
         <single>ed. &amp; trans.</single>
         <multiple>eds. &amp; trans.</multiple>
       </term>
-      <term name="translator" form="short">
-        <single>trans.</single>
-        <multiple>trans.</multiple>
-      </term>
+      <term name="translator" form="short">trans.</term>
     </terms>
   </locale>
   <macro name="container-contributors">

--- a/journal-of-retailing.csl
+++ b/journal-of-retailing.csl
@@ -27,10 +27,7 @@
       <term name="editor" form="verb-short">ed.</term>
       <term name="container-author" form="verb">by</term>
       <term name="translator" form="verb-short">trans.</term>
-      <term name="editortranslator" form="verb">
-        <single>edited and translated by</single>
-        <multiple>edited and translated by</multiple>
-      </term>
+      <term name="editortranslator" form="verb">edited and translated by</term>
       <term name="translator" form="short">trans.</term>
     </terms>
   </locale>

--- a/journal-of-roman-archaeology-a.csl
+++ b/journal-of-roman-archaeology-a.csl
@@ -24,10 +24,7 @@
         <single>ed.</single>
         <multiple>edd.</multiple>
       </term>
-      <term name="edition" form="short">
-        <single>edn.</single>
-        <multiple>edn.</multiple>
-      </term>
+      <term name="edition" form="short">edn.</term>
     </terms>
   </locale>
   <macro name="editor">

--- a/journal-of-roman-archaeology-b.csl
+++ b/journal-of-roman-archaeology-b.csl
@@ -24,10 +24,7 @@
         <single>ed.</single>
         <multiple>edd.</multiple>
       </term>
-      <term name="edition" form="short">
-        <single>edn.</single>
-        <multiple>edn.</multiple>
-      </term>
+      <term name="edition" form="short">edn.</term>
       <term name="cited">supra</term>
     </terms>
   </locale>

--- a/journal-of-the-air-and-waste-management-association.csl
+++ b/journal-of-the-air-and-waste-management-association.csl
@@ -23,10 +23,7 @@
       <term name="editor" form="verb-short">ed.</term>
       <term name="container-author" form="verb">by</term>
       <term name="translator" form="verb-short">trans.</term>
-      <term name="editortranslator" form="verb">
-        <single>edited and translated by</single>
-        <multiple>edited and translated by</multiple>
-      </term>
+      <term name="editortranslator" form="verb">edited and translated by</term>
       <term name="translator" form="short">trans.</term>
     </terms>
   </locale>

--- a/journal-of-the-association-for-information-systems.csl
+++ b/journal-of-the-association-for-information-systems.csl
@@ -24,10 +24,7 @@
         <single>ed. &amp; trans.</single>
         <multiple>eds. &amp; trans.</multiple>
       </term>
-      <term name="translator" form="short">
-        <single>trans.</single>
-        <multiple>trans.</multiple>
-      </term>
+      <term name="translator" form="short">trans.</term>
     </terms>
   </locale>
   <macro name="container-contributors">

--- a/journal-of-the-history-of-collections.csl
+++ b/journal-of-the-history-of-collections.csl
@@ -20,18 +20,9 @@
   <locale xml:lang="en">
     <style-options punctuation-in-quote="false"/>
     <terms>
-      <term name="translator" form="short">
-        <single>trans.</single>
-        <multiple>trans.</multiple>
-      </term>
-      <term name="editortranslator" form="short">
-        <single>ed. and trans.</single>
-        <multiple>ed. and trans.</multiple>
-      </term>
-      <term name="chapter" form="short">
-        <single>c.</single>
-        <multiple>c.</multiple>
-      </term>
+      <term name="translator" form="short">trans.</term>
+      <term name="editortranslator" form="short">ed. and trans.</term>
+      <term name="chapter" form="short">c.</term>
       <term name="open-quote">‘</term>
       <term name="close-quote">’</term>
       <term name="open-inner-quote">“</term>

--- a/journal-of-the-marine-biological-association-of-the-united-kingdom.csl
+++ b/journal-of-the-marine-biological-association-of-the-united-kingdom.csl
@@ -24,10 +24,7 @@
         <single>ed. &amp; trans.</single>
         <multiple>eds. &amp; trans.</multiple>
       </term>
-      <term name="translator" form="short">
-        <single>trans.</single>
-        <multiple>trans.</multiple>
-      </term>
+      <term name="translator" form="short">trans.</term>
     </terms>
   </locale>
   <macro name="container-contributors">

--- a/journal-of-the-south-african-veterinary-association.csl
+++ b/journal-of-the-south-african-veterinary-association.csl
@@ -25,10 +25,7 @@
         <single>ed. &amp; trans.</single>
         <multiple>eds. &amp; trans.</multiple>
       </term>
-      <term name="translator" form="short">
-        <single>trans.</single>
-        <multiple>trans.</multiple>
-      </term>
+      <term name="translator" form="short">trans.</term>
       <term name="retrieved">viewed</term>
     </terms>
   </locale>

--- a/journal-of-the-warburg-and-courtauld-institutes.csl
+++ b/journal-of-the-warburg-and-courtauld-institutes.csl
@@ -21,14 +21,8 @@
     <style-options punctuation-in-quote="false"/>
     <terms>
       <term name="et-al">et al.</term>
-      <term name="editor" form="short">
-        <single>ed.</single>
-        <multiple>ed.</multiple>
-      </term>
-      <term name="collection-editor" form="short">
-        <single>ed.</single>
-        <multiple>ed.</multiple>
-      </term>
+      <term name="editor" form="short">ed.</term>
+      <term name="collection-editor" form="short">ed.</term>
       <term name="page-range-delimiter">-</term>
     </terms>
   </locale>

--- a/journal-of-universal-computer-science.csl
+++ b/journal-of-universal-computer-science.csl
@@ -25,10 +25,7 @@
         <single>ed. &amp; trans.</single>
         <multiple>eds. &amp; trans.</multiple>
       </term>
-      <term name="translator" form="short">
-        <single>trans.</single>
-        <multiple>trans.</multiple>
-      </term>
+      <term name="translator" form="short">trans.</term>
     </terms>
   </locale>
   <macro name="container-contributors">

--- a/journal-of-value-inquiry.csl
+++ b/journal-of-value-inquiry.csl
@@ -22,18 +22,9 @@
   <locale xml:lang="en">
     <style-options punctuation-in-quote="false"/>
     <terms>
-      <term name="translator" form="short">
-        <single>trans.</single>
-        <multiple>trans.</multiple>
-      </term>
-      <term name="editortranslator" form="short">
-        <single>ed. and trans.</single>
-        <multiple>ed. and trans.</multiple>
-      </term>
-      <term name="chapter" form="short">
-        <single>c.</single>
-        <multiple>c.</multiple>
-      </term>
+      <term name="translator" form="short">trans.</term>
+      <term name="editortranslator" form="short">ed. and trans.</term>
+      <term name="chapter" form="short">c.</term>
     </terms>
   </locale>
   <macro name="author">

--- a/journal-of-water-sanitation-and-hygiene-for-development.csl
+++ b/journal-of-water-sanitation-and-hygiene-for-development.csl
@@ -24,10 +24,7 @@
         <single>ed. &amp; trans.</single>
         <multiple>eds. &amp; trans.</multiple>
       </term>
-      <term name="translator" form="short">
-        <single>trans.</single>
-        <multiple>trans.</multiple>
-      </term>
+      <term name="translator" form="short">trans.</term>
     </terms>
   </locale>
   <macro name="container-contributors">

--- a/journal-on-efficiency-and-responsibility-in-education-and-science.csl
+++ b/journal-on-efficiency-and-responsibility-in-education-and-science.csl
@@ -29,10 +29,7 @@
         <single>ed. &amp; trans.</single>
         <multiple>eds. &amp; trans.</multiple>
       </term>
-      <term name="translator" form="short">
-        <single>trans.</single>
-        <multiple>trans.</multiple>
-      </term>
+      <term name="translator" form="short">trans.</term>
     </terms>
   </locale>
   <macro name="container-contributors">

--- a/journalistica.csl
+++ b/journalistica.csl
@@ -22,24 +22,12 @@
   </info>
   <locale xml:lang="da-DK">
     <terms>
-      <term name="editor" form="short">
-        <single>red.</single>
-        <multiple>red.</multiple>
-      </term>
-      <term name="editor">
-        <single>red.</single>
-        <multiple>red.</multiple>
-      </term>
+      <term name="editor" form="short">red.</term>
+      <term name="editor">red.</term>
       <term name="et-al">mfl.</term>
       <term name="and">og</term>
-      <term name="page" form="short">
-        <single>s.</single>
-        <multiple>s.</multiple>
-      </term>
-      <term name="page">
-        <single>s.</single>
-        <multiple>s.</multiple>
-      </term>
+      <term name="page" form="short">s.</term>
+      <term name="page">s.</term>
       <term name="month-01">januar</term>
       <term name="month-02">februar</term>
       <term name="month-03">marts</term>

--- a/kindheit-und-entwicklung.csl
+++ b/kindheit-und-entwicklung.csl
@@ -24,10 +24,7 @@
         <single>ed. &amp; trans.</single>
         <multiple>eds. &amp; trans.</multiple>
       </term>
-      <term name="translator" form="short">
-        <single>trans.</single>
-        <multiple>trans.</multiple>
-      </term>
+      <term name="translator" form="short">trans.</term>
     </terms>
   </locale>
   <macro name="container-contributors">

--- a/kth-royal-institute-of-technology-school-of-computer-science-and-communication-sv.csl
+++ b/kth-royal-institute-of-technology-school-of-computer-science-and-communication-sv.csl
@@ -24,22 +24,10 @@
       <date-part name="day" prefix="-"/>
     </date>
     <terms>
-      <term name="page" form="short">
-        <single>s.</single>
-        <multiple>s.</multiple>
-      </term>
-      <term name="editor" form="short">
-        <single>red.</single>
-        <multiple>red.</multiple>
-      </term>
-      <term name="editortranslator" form="verb-short">
-        <single>övers. och red.</single>
-        <multiple>övers. och red.</multiple>
-      </term>
-      <term name="editortranslator" form="verb">
-        <single>Översatt och redigerad av </single>
-        <multiple>Översatt och redigerad av </multiple>
-      </term>
+      <term name="page" form="short">s.</term>
+      <term name="editor" form="short">red.</term>
+      <term name="editortranslator" form="verb-short">övers. och red.</term>
+      <term name="editortranslator" form="verb">Översatt och redigerad av </term>
     </terms>
   </locale>
   <macro name="container">

--- a/latin-american-perspectives.csl
+++ b/latin-american-perspectives.csl
@@ -19,10 +19,7 @@
   </info>
   <locale xml:lang="en">
     <terms>
-      <term name="translator" form="short">
-        <single>trans.</single>
-        <multiple>trans.</multiple>
-      </term>
+      <term name="translator" form="short">trans.</term>
     </terms>
   </locale>
   <macro name="container-contributors">

--- a/le-mouvement-social.csl
+++ b/le-mouvement-social.csl
@@ -23,14 +23,8 @@
       <term name="ordinal-03">e</term>
       <term name="ordinal-04">e</term>
       <term name="cited">op.&#160;cit.</term>
-      <term name="page" form="short">
-        <single>p.</single>
-        <multiple>p.</multiple>
-      </term>
-      <term name="editor" form="short">
-        <single>dir.</single>
-        <multiple>dir.</multiple>
-      </term>
+      <term name="page" form="short">p.</term>
+      <term name="editor" form="short">dir.</term>
     </terms>
   </locale>
   <macro name="author">

--- a/le-tapuscrit-author-date.csl
+++ b/le-tapuscrit-author-date.csl
@@ -23,18 +23,12 @@
       <term name="ordinal-03">e</term>
       <term name="ordinal-04">e</term>
       <term name="cited">op.&#160;cit.</term>
-      <term name="page" form="short">
-        <single>p.</single>
-        <multiple>p.</multiple>
-      </term>
+      <term name="page" form="short">p.</term>
       <term name="editor" form="short">
         <single>ed.</single>
         <multiple>eds.</multiple>
       </term>
-      <term name="in">
-        <single>dans</single>
-        <multiple>dans</multiple>
-      </term>
+      <term name="in">dans</term>
     </terms>
   </locale>
   <macro name="contrib-court">

--- a/le-tapuscrit-note.csl
+++ b/le-tapuscrit-note.csl
@@ -23,18 +23,12 @@
       <term name="ordinal-03">e</term>
       <term name="ordinal-04">e</term>
       <term name="cited">op.&#160;cit.</term>
-      <term name="page" form="short">
-        <single>p.</single>
-        <multiple>p.</multiple>
-      </term>
+      <term name="page" form="short">p.</term>
       <term name="editor" form="short">
         <single>ed.</single>
         <multiple>eds.</multiple>
       </term>
-      <term name="in">
-        <single>dans</single>
-        <multiple>dans</multiple>
-      </term>
+      <term name="in">dans</term>
     </terms>
   </locale>
   <macro name="author">

--- a/maison-de-l-orient-et-de-la-mediterranee.csl
+++ b/maison-de-l-orient-et-de-la-mediterranee.csl
@@ -28,14 +28,8 @@
       <term name="accessed">consulté en</term>
       <term name="no date">sans date</term>
       <term name="translator" form="short">trad.</term>
-      <term name="editor" form="short">
-        <single>éd.</single>
-        <multiple>éd.</multiple>
-      </term>
-      <term name="edition" form="short">
-        <single>éd.</single>
-        <multiple>éd.</multiple>
-      </term>
+      <term name="editor" form="short">éd.</term>
+      <term name="edition" form="short">éd.</term>
       <term name="no date" form="short">(s.d.)</term>
       <term name="sub verbo" form="short">s.v.</term>
     </terms>

--- a/management-international.csl
+++ b/management-international.csl
@@ -22,10 +22,7 @@
       <term name="editor" form="verb-short">ed.</term>
       <term name="container-author" form="verb">by</term>
       <term name="translator" form="verb-short">trans.</term>
-      <term name="editortranslator" form="verb">
-        <single>edited and translated by</single>
-        <multiple>edited and translated by</multiple>
-      </term>
+      <term name="editortranslator" form="verb">edited and translated by</term>
       <term name="translator" form="short">trans.</term>
     </terms>
   </locale>

--- a/medical-history.csl
+++ b/medical-history.csl
@@ -33,10 +33,7 @@
         <single>(ed. and trans.)</single>
         <multiple>(eds and trans.)</multiple>
       </term>
-      <term name="translator" form="short">
-        <single>(trans.)</single>
-        <multiple>(trans.)</multiple>
-      </term>
+      <term name="translator" form="short">(trans.)</term>
       <term name="container-author" form="short">
         <single>(author)</single>
         <multiple>(authors)</multiple>

--- a/mediterranean-politics.csl
+++ b/mediterranean-politics.csl
@@ -23,10 +23,7 @@
         <single>ed. &amp; trans.</single>
         <multiple>eds. &amp; trans.</multiple>
       </term>
-      <term name="translator" form="short">
-        <single>trans.</single>
-        <multiple>trans.</multiple>
-      </term>
+      <term name="translator" form="short">trans.</term>
     </terms>
   </locale>
   <macro name="container-contributors">

--- a/mercatus-center.csl
+++ b/mercatus-center.csl
@@ -20,14 +20,8 @@
     <terms>
       <term name="editor" form="verb-short">ed.</term>
       <term name="translator" form="verb-short">trans.</term>
-      <term name="editortranslator" form="verb-short">
-        <single>ed. and trans.</single>
-        <multiple>ed. and trans.</multiple>
-      </term>
-      <term name="editortranslator" form="verb">
-        <single>Edited and translated by</single>
-        <multiple>Edited and translated by</multiple>
-      </term>
+      <term name="editortranslator" form="verb-short">ed. and trans.</term>
+      <term name="editortranslator" form="verb">Edited and translated by</term>
       <term name="translator" form="short">trans.</term>
     </terms>
   </locale>

--- a/methods-in-ecology-and-evolution.csl
+++ b/methods-in-ecology-and-evolution.csl
@@ -22,10 +22,7 @@
         <single>ed. &amp; trans.</single>
         <multiple>eds. &amp; trans.</multiple>
       </term>
-      <term name="translator" form="short">
-        <single>trans.</single>
-        <multiple>trans.</multiple>
-      </term>
+      <term name="translator" form="short">trans.</term>
     </terms>
   </locale>
   <macro name="container-contributors">

--- a/metropolitiques.csl
+++ b/metropolitiques.csl
@@ -23,18 +23,9 @@
       <term name="ordinal-03">e</term>
       <term name="ordinal-04">e</term>
       <term name="cited">op.&#160;cit.</term>
-      <term name="page" form="short">
-        <single>p.</single>
-        <multiple>p.</multiple>
-      </term>
-      <term name="issue" form="short">
-        <single>n°</single>
-        <multiple>n°</multiple>
-      </term>
-      <term name="editor" form="short">
-        <single>dir.</single>
-        <multiple>dir.</multiple>
-      </term>
+      <term name="page" form="short">p.</term>
+      <term name="issue" form="short">n°</term>
+      <term name="editor" form="short">dir.</term>
     </terms>
   </locale>
   <macro name="author">

--- a/molecular-oncology.csl
+++ b/molecular-oncology.csl
@@ -22,10 +22,7 @@
         <single>ed. &amp; trans.</single>
         <multiple>eds. &amp; trans.</multiple>
       </term>
-      <term name="translator" form="short">
-        <single>trans.</single>
-        <multiple>trans.</multiple>
-      </term>
+      <term name="translator" form="short">trans.</term>
     </terms>
   </locale>
   <macro name="container-contributors">

--- a/monash-university-harvard.csl
+++ b/monash-university-harvard.csl
@@ -21,10 +21,7 @@
         <single>ed. &amp; trans.</single>
         <multiple>eds. &amp; trans.</multiple>
       </term>
-      <term name="translator" form="short">
-        <single>trans.</single>
-        <multiple>trans.</multiple>
-      </term>
+      <term name="translator" form="short">trans.</term>
       <term name="edition" form="short">edn</term>
       <term name="accessed">viewed</term>
     </terms>

--- a/mondes-en-developpement.csl
+++ b/mondes-en-developpement.csl
@@ -33,10 +33,7 @@
         <multiple>dirs.</multiple>
       </term>
       <term name="in">in</term>
-      <term name="translator" form="short">
-        <single>trad.</single>
-        <multiple>trad.</multiple>
-      </term>
+      <term name="translator" form="short">trad.</term>
     </terms>
   </locale>
   <macro name="editor">

--- a/moorlands-college.csl
+++ b/moorlands-college.csl
@@ -18,14 +18,8 @@
   </info>
   <locale xml:lang="en">
     <terms>
-      <term name="editortranslator" form="verb-short">
-        <single>trans. and ed.</single>
-        <multiple>trans. and ed.</multiple>
-      </term>
-      <term name="editortranslator" form="verb">
-        <single>Translated and edited by</single>
-        <multiple>Translated and edited by</multiple>
-      </term>
+      <term name="editortranslator" form="verb-short">trans. and ed.</term>
+      <term name="editortranslator" form="verb">Translated and edited by</term>
       <term name="editor" form="verb-short">ed.</term>
       <term name="translator" form="verb-short">trans.</term>
     </terms>

--- a/nccr-mediality.csl
+++ b/nccr-mediality.csl
@@ -24,22 +24,10 @@
       <term name="open-inner-quote">›</term>
       <term name="close-inner-quote">‹</term>
       <term name="accessed">gesehen am</term>
-      <term name="editor" form="short">
-        <single>Hg</single>
-        <multiple>Hg</multiple>
-      </term>
-      <term name="editor" form="verb-short">
-        <single>Hg. v</single>
-        <multiple>Hg. v</multiple>
-      </term>
-      <term name="translator" form="short">
-        <single>Übers</single>
-        <multiple>Übers</multiple>
-      </term>
-      <term name="translator" form="verb-short">
-        <single>Übers. v</single>
-        <multiple>Übers. v</multiple>
-      </term>
+      <term name="editor" form="short">Hg</term>
+      <term name="editor" form="verb-short">Hg. v</term>
+      <term name="translator" form="short">Übers</term>
+      <term name="translator" form="verb-short">Übers. v</term>
       <term name="accessed">gesehen am</term>
       <term name="ordinal-01">.</term>
       <term name="ordinal-02">.</term>

--- a/nuclear-receptor-signaling.csl
+++ b/nuclear-receptor-signaling.csl
@@ -23,10 +23,7 @@
         <single>ed. &amp; trans.</single>
         <multiple>eds. &amp; trans.</multiple>
       </term>
-      <term name="translator" form="short">
-        <single>trans.</single>
-        <multiple>trans.</multiple>
-      </term>
+      <term name="translator" form="short">trans.</term>
     </terms>
   </locale>
   <macro name="container-contributors">

--- a/oecologia-australis.csl
+++ b/oecologia-australis.csl
@@ -35,10 +35,7 @@
         <single>ed. &amp; trans.</single>
         <multiple>eds. &amp; trans.</multiple>
       </term>
-      <term name="translator" form="short">
-        <single>trans.</single>
-        <multiple>trans.</multiple>
-      </term>
+      <term name="translator" form="short">trans.</term>
     </terms>
   </locale>
   <macro name="container-contributors">

--- a/oxford-studies-in-ancient-philosophy.csl
+++ b/oxford-studies-in-ancient-philosophy.csl
@@ -19,14 +19,8 @@
   </info>
   <locale xml:lang="en">
     <terms>
-      <term name="editortranslator" form="verb-short">
-        <single>trans. and ed.</single>
-        <multiple>trans. and ed.</multiple>
-      </term>
-      <term name="editortranslator" form="verb">
-        <single>Translated and edited by</single>
-        <multiple>Translated and edited by</multiple>
-      </term>
+      <term name="editortranslator" form="verb-short">trans. and ed.</term>
+      <term name="editortranslator" form="verb">Translated and edited by</term>
       <term name="editor" form="verb-short">ed.</term>
       <term name="translator" form="verb-short">trans.</term>
     </terms>

--- a/past-and-present.csl
+++ b/past-and-present.csl
@@ -22,10 +22,7 @@
         <single>fo.</single>
         <multiple>fos.</multiple>
       </term>
-      <term name="translator" form="short">
-        <single>trans.</single>
-        <multiple>trans.</multiple>
-      </term>
+      <term name="translator" form="short">trans.</term>
     </terms>
   </locale>
   <macro name="author">

--- a/perspectives-on-politics.csl
+++ b/perspectives-on-politics.csl
@@ -22,10 +22,7 @@
       <term name="editor" form="verb-short">ed.</term>
       <term name="container-author" form="verb">by</term>
       <term name="translator" form="verb-short">trans.</term>
-      <term name="editortranslator" form="verb">
-        <single>edited and translated by</single>
-        <multiple>edited and translated by</multiple>
-      </term>
+      <term name="editortranslator" form="verb">edited and translated by</term>
       <term name="translator" form="short">trans.</term>
     </terms>
   </locale>

--- a/philosophiques.csl
+++ b/philosophiques.csl
@@ -37,10 +37,7 @@
         <single>p.</single>
         <multiple>pp.</multiple>
       </term>
-      <term name="editor" form="short">
-        <single>dir.</single>
-        <multiple>dir.</multiple>
-      </term>
+      <term name="editor" form="short">dir.</term>
     </terms>
   </locale>
   <macro name="author-or-editor">

--- a/physiological-and-biochemical-zoology.csl
+++ b/physiological-and-biochemical-zoology.csl
@@ -19,10 +19,7 @@
   </info>
   <locale xml:lang="en">
     <terms>
-      <term name="translator" form="short">
-        <single>trans.</single>
-        <multiple>trans.</multiple>
-      </term>
+      <term name="translator" form="short">trans.</term>
     </terms>
   </locale>
   <macro name="container-contributors">

--- a/planning-practice-and-research.csl
+++ b/planning-practice-and-research.csl
@@ -23,10 +23,7 @@
         <single>ed. &amp; trans.</single>
         <multiple>eds. &amp; trans.</multiple>
       </term>
-      <term name="translator" form="short">
-        <single>trans.</single>
-        <multiple>trans.</multiple>
-      </term>
+      <term name="translator" form="short">trans.</term>
     </terms>
   </locale>
   <macro name="container-contributors">

--- a/political-studies.csl
+++ b/political-studies.csl
@@ -33,10 +33,7 @@
   <locale xml:lang="en">
     <style-options punctuation-in-quote="false"/>
     <terms>
-      <term name="translator" form="short">
-        <single>trans.</single>
-        <multiple>trans.</multiple>
-      </term>
+      <term name="translator" form="short">trans.</term>
       <term name="open-quote">‘</term>
       <term name="close-quote">’</term>
       <term name="open-inner-quote">“</term>

--- a/pontifical-biblical-institute.csl
+++ b/pontifical-biblical-institute.csl
@@ -21,14 +21,8 @@
     <terms>
       <term name="et-al">et al.</term>
       <term name="ibid">ibidem</term>
-      <term name="editor" form="short">
-        <single>ed.</single>
-        <multiple>ed.</multiple>
-      </term>
-      <term name="collection-editor" form="short">
-        <single>ed.</single>
-        <multiple>ed.</multiple>
-      </term>
+      <term name="editor" form="short">ed.</term>
+      <term name="collection-editor" form="short">ed.</term>
       <term name="page-range-delimiter">-</term>
     </terms>
   </locale>

--- a/pontifical-gregorian-university.csl
+++ b/pontifical-gregorian-university.csl
@@ -22,14 +22,8 @@
       <term name="ibid">Ibid.</term>
       <term name="in">in</term>
       <term name="accessed">accesso</term>
-      <term name="editor">
-        <single>ed.</single>
-        <multiple>ed.</multiple>
-      </term>
-      <term name="editor" form="short">
-        <single>ed.</single>
-        <multiple>ed.</multiple>
-      </term>
+      <term name="editor">ed.</term>
+      <term name="editor" form="short">ed.</term>
       <term name="page-range-delimiter">-</term>
     </terms>
   </locale>
@@ -39,14 +33,8 @@
       <term name="open-quote">«</term>
       <term name="close-quote">»</term>
       <term name="in">dans</term>
-      <term name="editor">
-        <single>éd.</single>
-        <multiple>éd.</multiple>
-      </term>
-      <term name="editor" form="short">
-        <single>éd.</single>
-        <multiple>éd.</multiple>
-      </term>
+      <term name="editor">éd.</term>
+      <term name="editor" form="short">éd.</term>
     </terms>
   </locale>
   <locale xml:lang="es">
@@ -58,14 +46,8 @@
   <locale xml:lang="de">
     <terms>
       <term name="accessed">Zugriff</term>
-      <term name="editor">
-        <single>Hg.</single>
-        <multiple>Hg.</multiple>
-      </term>
-      <term name="editor" form="short">
-        <single>Hg.</single>
-        <multiple>Hg.</multiple>
-      </term>
+      <term name="editor">Hg.</term>
+      <term name="editor" form="short">Hg.</term>
     </terms>
   </locale>
   <locale xml:lang="en">

--- a/population.csl
+++ b/population.csl
@@ -25,10 +25,7 @@
   </locale>
   <locale xml:lang="fr">
     <terms>
-      <term name="editor" form="short">
-        <single>dir.</single>
-        <multiple>dir.</multiple>
-      </term>
+      <term name="editor" form="short">dir.</term>
     </terms>
   </locale>
   <macro name="editor">

--- a/pour-reussir-note.csl
+++ b/pour-reussir-note.csl
@@ -23,14 +23,8 @@
       <term name="ordinal-03">e</term>
       <term name="ordinal-04">e</term>
       <term name="cited">op.&#160;cit.</term>
-      <term name="page" form="short">
-        <single>p.</single>
-        <multiple>p.</multiple>
-      </term>
-      <term name="editor" form="short">
-        <single>dir.</single>
-        <multiple>dir.</multiple>
-      </term>
+      <term name="page" form="short">p.</term>
+      <term name="editor" form="short">dir.</term>
     </terms>
   </locale>
   <macro name="author">

--- a/presses-universitaires-de-paris-nanterre.csl
+++ b/presses-universitaires-de-paris-nanterre.csl
@@ -26,22 +26,10 @@
       <term name="ordinal-03">e</term>
       <term name="ordinal-04">e</term>
       <term name="cited">op.&#160;cit.</term>
-      <term name="page" form="short">
-        <single>p.</single>
-        <multiple>p.</multiple>
-      </term>
-      <term name="editor" form="short">
-        <single>éd.</single>
-        <multiple>éd.</multiple>
-      </term>
-      <term name="container-author" form="short">
-        <single>dir.</single>
-        <multiple>dir.</multiple>
-      </term>
-      <term name="in">
-        <single>dans</single>
-        <multiple>dans</multiple>
-      </term>
+      <term name="page" form="short">p.</term>
+      <term name="editor" form="short">éd.</term>
+      <term name="container-author" form="short">dir.</term>
+      <term name="in">dans</term>
     </terms>
   </locale>
   <macro name="author">

--- a/presses-universitaires-de-rennes-archeologie-et-culture.csl
+++ b/presses-universitaires-de-rennes-archeologie-et-culture.csl
@@ -20,19 +20,10 @@
   <locale xml:lang="fr">
     <terms>
       <term name="cited">op.&#160;cit.</term>
-      <term name="page" form="short">
-        <single>p.</single>
-        <multiple>p.</multiple>
-      </term>
+      <term name="page" form="short">p.</term>
       <term name="in">dans</term>
-      <term name="editor" form="short">
-        <single>éd</single>
-        <multiple>éd</multiple>
-      </term>
-      <term name="collection-editor" form="short">
-        <single>dir.</single>
-        <multiple>dir.</multiple>
-      </term>
+      <term name="editor" form="short">éd</term>
+      <term name="collection-editor" form="short">dir.</term>
     </terms>
   </locale>
   <macro name="responsability">

--- a/presses-universitaires-de-rennes.csl
+++ b/presses-universitaires-de-rennes.csl
@@ -22,14 +22,8 @@
       <term name="ordinal-03">e</term>
       <term name="ordinal-04">e</term>
       <term name="cited">op.&#160;cit.</term>
-      <term name="page" form="short">
-        <single>p.</single>
-        <multiple>p.</multiple>
-      </term>
-      <term name="editor" form="short">
-        <single>dir.</single>
-        <multiple>dir.</multiple>
-      </term>
+      <term name="page" form="short">p.</term>
+      <term name="editor" form="short">dir.</term>
     </terms>
   </locale>
   <macro name="author">

--- a/quaderni-materialisti.csl
+++ b/quaderni-materialisti.csl
@@ -23,10 +23,7 @@
         <single>p.</single>
         <multiple>pp.</multiple>
       </term>
-      <term name="translator" form="verb-short">
-        <single>tr. it. di</single>
-        <multiple>tr. it. di</multiple>
-      </term>
+      <term name="translator" form="verb-short">tr. it. di</term>
       <term name="no date">s.d.</term>
       <term name="ibid" form="short">ivi</term>
       <term name="ibid" form="long">ibidem</term>

--- a/raffles-bulletin-of-zoology.csl
+++ b/raffles-bulletin-of-zoology.csl
@@ -24,10 +24,7 @@
         <single>ed. &amp; trans.</single>
         <multiple>eds. &amp; trans.</multiple>
       </term>
-      <term name="translator" form="short">
-        <single>trans.</single>
-        <multiple>trans.</multiple>
-      </term>
+      <term name="translator" form="short">trans.</term>
     </terms>
   </locale>
   <macro name="container-contributors">

--- a/revue-archeologique.csl
+++ b/revue-archeologique.csl
@@ -19,10 +19,7 @@
   </info>
   <locale xml:lang="fr">
     <terms>
-      <term name="editor" form="short">
-        <single>éd.</single>
-        <multiple>éd.</multiple>
-      </term>
+      <term name="editor" form="short">éd.</term>
       <term name="in">dans</term>
       <term name="online">en ligne</term>
       <term name="anonymous">anonyme</term>

--- a/revue-dhistoire-moderne-et-contemporaine.csl
+++ b/revue-dhistoire-moderne-et-contemporaine.csl
@@ -23,14 +23,8 @@
       <term name="ordinal-03">e</term>
       <term name="ordinal-04">e</term>
       <term name="cited">op.&#160;cit.</term>
-      <term name="page" form="short">
-        <single>p.</single>
-        <multiple>p.</multiple>
-      </term>
-      <term name="editor" form="short">
-        <single>éd.</single>
-        <multiple>éd.</multiple>
-      </term>
+      <term name="page" form="short">p.</term>
+      <term name="editor" form="short">éd.</term>
     </terms>
   </locale>
   <macro name="author">

--- a/science-and-technology-for-the-built-environment.csl
+++ b/science-and-technology-for-the-built-environment.csl
@@ -24,10 +24,7 @@
         <single>ed. &amp; trans.</single>
         <multiple>eds. &amp; trans.</multiple>
       </term>
-      <term name="translator" form="short">
-        <single>trans.</single>
-        <multiple>trans.</multiple>
-      </term>
+      <term name="translator" form="short">trans.</term>
     </terms>
   </locale>
   <macro name="container-contributors">

--- a/scientific-review-engineering-and-environmental-sciences.csl
+++ b/scientific-review-engineering-and-environmental-sciences.csl
@@ -27,10 +27,7 @@
         <single>ed. &amp; trans.</single>
         <multiple>eds. &amp; trans.</multiple>
       </term>
-      <term name="translator" form="short">
-        <single>trans.</single>
-        <multiple>trans.</multiple>
-      </term>
+      <term name="translator" form="short">trans.</term>
     </terms>
   </locale>
   <macro name="container-contributors">

--- a/sheffield-hallam-university-history.csl
+++ b/sheffield-hallam-university-history.csl
@@ -20,14 +20,8 @@
       <term name="edition" form="short">edn.</term>
       <term name="editor" form="verb-short">ed.</term>
       <term name="translator" form="verb-short">trans.</term>
-      <term name="editortranslator" form="verb-short">
-        <single>ed. and trans.</single>
-        <multiple>ed. and trans.</multiple>
-      </term>
-      <term name="editortranslator" form="verb">
-        <single>Edited and translated by</single>
-        <multiple>Edited and translated by</multiple>
-      </term>
+      <term name="editortranslator" form="verb-short">ed. and trans.</term>
+      <term name="editortranslator" form="verb">Edited and translated by</term>
       <term name="translator" form="short">trans.</term>
     </terms>
   </locale>

--- a/smithsonian-institution-scholarly-press-author-date.csl
+++ b/smithsonian-institution-scholarly-press-author-date.csl
@@ -22,10 +22,7 @@
         <single>ed. &amp; trans.</single>
         <multiple>eds. &amp; trans.</multiple>
       </term>
-      <term name="translator" form="short">
-        <single>trans.</single>
-        <multiple>trans.</multiple>
-      </term>
+      <term name="translator" form="short">trans.</term>
     </terms>
   </locale>
   <macro name="container-contributors">

--- a/smithsonian-institution-scholarly-press-botany.csl
+++ b/smithsonian-institution-scholarly-press-botany.csl
@@ -22,10 +22,7 @@
         <single>ed. &amp; trans.</single>
         <multiple>eds. &amp; trans.</multiple>
       </term>
-      <term name="translator" form="short">
-        <single>trans.</single>
-        <multiple>trans.</multiple>
-      </term>
+      <term name="translator" form="short">trans.</term>
     </terms>
   </locale>
   <macro name="container-contributors">

--- a/societe-archeologique-de-bordeaux.csl
+++ b/societe-archeologique-de-bordeaux.csl
@@ -18,10 +18,7 @@
   </info>
   <locale xml:lang="fr">
     <terms>
-      <term name="editor" form="short">
-        <single>dir.</single>
-        <multiple>dir.</multiple>
-      </term>
+      <term name="editor" form="short">dir.</term>
       <term name="in">dans</term>
       <term name="anonymous">anonyme</term>
       <term name="anonymous" form="short">anon.</term>

--- a/soziologie.csl
+++ b/soziologie.csl
@@ -23,10 +23,7 @@
     <terms>
       <term name="et-al">et al.</term>
       <term name="and">und</term>
-      <term name="editor" form="short">
-        <single>hg.</single>
-        <multiple>hg.</multiple>
-      </term>
+      <term name="editor" form="short">hg.</term>
     </terms>
   </locale>
   <macro name="container-contributors">

--- a/speculum.csl
+++ b/speculum.csl
@@ -24,14 +24,8 @@
       <term name="editor" form="verb-short">ed.</term>
       <term name="translator" form="verb-short">trans.</term>
       <term name="translator" form="short">trans.</term>
-      <term name="editortranslator" form="verb-short">
-        <single>ed. and trans.</single>
-        <multiple>ed. and trans.</multiple>
-      </term>
-      <term name="editortranslator" form="verb">
-        <single>Edited and translated by</single>
-        <multiple>Edited and translated by</multiple>
-      </term>
+      <term name="editortranslator" form="verb-short">ed. and trans.</term>
+      <term name="editortranslator" form="verb">Edited and translated by</term>
       <term name="translator" form="short">trans.</term>
     </terms>
   </locale>

--- a/springer-socpsych-author-date.csl
+++ b/springer-socpsych-author-date.csl
@@ -32,10 +32,7 @@
         <single>ed. &amp; trans.</single>
         <multiple>eds. &amp; trans.</multiple>
       </term>
-      <term name="translator" form="short">
-        <single>trans.</single>
-        <multiple>trans.</multiple>
-      </term>
+      <term name="translator" form="short">trans.</term>
     </terms>
   </locale>
   <locale xml:lang="de">

--- a/springer-socpsych-brackets.csl
+++ b/springer-socpsych-brackets.csl
@@ -27,10 +27,7 @@
         <single>ed. &amp; trans.</single>
         <multiple>eds. &amp; trans.</multiple>
       </term>
-      <term name="translator" form="short">
-        <single>trans.</single>
-        <multiple>trans.</multiple>
-      </term>
+      <term name="translator" form="short">trans.</term>
     </terms>
   </locale>
   <macro name="container-contributors">

--- a/stuttgart-media-university.csl
+++ b/stuttgart-media-university.csl
@@ -24,14 +24,8 @@
       <term name="retrieved">zugegriffen am</term>
       <term name="accessed">Zugriff:</term>
       <term name="ibid">ebenda</term>
-      <term name="page" form="short">
-        <single>S.</single>
-        <multiple>S.</multiple>
-      </term>
-      <term name="section" form="short">
-        <single>Abs.</single>
-        <multiple>Abs.</multiple>
-      </term>
+      <term name="page" form="short">S.</term>
+      <term name="section" form="short">Abs.</term>
     </terms>
   </locale>
   <!--

--- a/taxon.csl
+++ b/taxon.csl
@@ -23,10 +23,7 @@
         <single>ed. &amp; trans.</single>
         <multiple>eds. &amp; trans.</multiple>
       </term>
-      <term name="translator" form="short">
-        <single>trans.</single>
-        <multiple>trans.</multiple>
-      </term>
+      <term name="translator" form="short">trans.</term>
       <term name="et-al">&amp; al.</term>
     </terms>
   </locale>

--- a/taylor-and-francis-chicago-author-date.csl
+++ b/taylor-and-francis-chicago-author-date.csl
@@ -19,10 +19,7 @@
       <term name="editor" form="verb-short">ed.</term>
       <term name="container-author" form="verb">by</term>
       <term name="translator" form="verb-short">trans.</term>
-      <term name="editortranslator" form="verb">
-        <single>edited and translated by</single>
-        <multiple>edited and translated by</multiple>
-      </term>
+      <term name="editortranslator" form="verb">edited and translated by</term>
       <term name="translator" form="short">trans.</term>
     </terms>
   </locale>

--- a/technische-universitat-dresden-wirtschaftswissenschaften.csl
+++ b/technische-universitat-dresden-wirtschaftswissenschaften.csl
@@ -25,19 +25,10 @@
       <term name="retrieved">zugegriffen am</term>
       <term name="accessed">Stand</term>
       <term name="ibid">ebenda</term>
-      <term name="page" form="short">
-        <single>S.</single>
-        <multiple>S.</multiple>
-      </term>
-      <term name="section" form="short">
-        <single>Abs.</single>
-        <multiple>Abs.</multiple>
-      </term>
+      <term name="page" form="short">S.</term>
+      <term name="section" form="short">Abs.</term>
       <term name="editor" form="verb-short">hrsg. von</term>
-      <term name="editor" form="short">
-        <single>(Hrsg.)</single>
-        <multiple>(Hrsg.)</multiple>
-      </term>
+      <term name="editor" form="short">(Hrsg.)</term>
     </terms>
   </locale>
   <macro name="author">

--- a/technische-universitat-munchen-controlling.csl
+++ b/technische-universitat-munchen-controlling.csl
@@ -23,14 +23,8 @@
       <term name="and"> / </term>
       <term name="retrieved">zugegriffen am:</term>
       <term name="accessed">abgerufen am:</term>
-      <term name="page" form="short">
-        <single>S.</single>
-        <multiple>S.</multiple>
-      </term>
-      <term name="section" form="short">
-        <single>Abs.</single>
-        <multiple>Abs.</multiple>
-      </term>
+      <term name="page" form="short">S.</term>
+      <term name="section" form="short">Abs.</term>
       <term name="editor" form="verb-short">hrsg. von</term>
       <term name="editor" form="short">
         <single>Hrsg.</single>

--- a/technische-universitat-munchen-unternehmensfuhrung.csl
+++ b/technische-universitat-munchen-unternehmensfuhrung.csl
@@ -22,14 +22,8 @@
       <term name="et-al">et al.</term>
       <term name="retrieved">zugegriffen am:</term>
       <term name="accessed">abgerufen am:</term>
-      <term name="page" form="short">
-        <single>S.</single>
-        <multiple>S.</multiple>
-      </term>
-      <term name="section" form="short">
-        <single>Abs.</single>
-        <multiple>Abs.</multiple>
-      </term>
+      <term name="page" form="short">S.</term>
+      <term name="section" form="short">Abs.</term>
       <term name="editor" form="verb-short">hrsg. von</term>
       <term name="editor" form="short">
         <single>Hrsg.</single>

--- a/technische-universitat-wien.csl
+++ b/technische-universitat-wien.csl
@@ -22,19 +22,10 @@
       <term name="retrieved">zugegriffen am</term>
       <term name="accessed">abgerufen am</term>
       <term name="ibid">ebenda</term>
-      <term name="page" form="short">
-        <single>S.</single>
-        <multiple>S.</multiple>
-      </term>
-      <term name="section" form="short">
-        <single>Abs.</single>
-        <multiple>Abs.</multiple>
-      </term>
+      <term name="page" form="short">S.</term>
+      <term name="section" form="short">Abs.</term>
       <term name="editor" form="verb-short">hrsg. von</term>
-      <term name="editor" form="short">
-        <single>(Hrsg.)</single>
-        <multiple>(Hrsg.)</multiple>
-      </term>
+      <term name="editor" form="short">(Hrsg.)</term>
     </terms>
   </locale>
   <!--

--- a/tgm-wien-diplom.csl
+++ b/tgm-wien-diplom.csl
@@ -21,19 +21,10 @@
       <term name="retrieved">zugegriffen am</term>
       <term name="accessed">abgerufen am</term>
       <term name="ibid">ebenda</term>
-      <term name="page" form="short">
-        <single>S.</single>
-        <multiple>S.</multiple>
-      </term>
-      <term name="section" form="short">
-        <single>Abs.</single>
-        <multiple>Abs.</multiple>
-      </term>
+      <term name="page" form="short">S.</term>
+      <term name="section" form="short">Abs.</term>
       <term name="editor" form="verb-short">hrsg. von</term>
-      <term name="editor" form="short">
-        <single>(Hrsg.)</single>
-        <multiple>(Hrsg.)</multiple>
-      </term>
+      <term name="editor" form="short">(Hrsg.)</term>
     </terms>
   </locale>
   <!--

--- a/the-american-naturalist.csl
+++ b/the-american-naturalist.csl
@@ -20,10 +20,7 @@
   </info>
   <locale xml:lang="en">
     <terms>
-      <term name="translator" form="short">
-        <single>trans.</single>
-        <multiple>trans.</multiple>
-      </term>
+      <term name="translator" form="short">trans.</term>
     </terms>
   </locale>
   <macro name="container-contributors">

--- a/the-canadian-journal-of-psychiatry.csl
+++ b/the-canadian-journal-of-psychiatry.csl
@@ -21,10 +21,7 @@
   </info>
   <locale>
     <terms>
-      <term name="page" form="short">
-        <single>p</single>
-        <multiple>p</multiple>
-      </term>
+      <term name="page" form="short">p</term>
     </terms>
   </locale>
   <macro name="author">

--- a/the-hastings-center-report.csl
+++ b/the-hastings-center-report.csl
@@ -25,14 +25,8 @@
     <terms>
       <term name="editor" form="verb-short">ed.</term>
       <term name="translator" form="verb-short">trans.</term>
-      <term name="editortranslator" form="verb-short">
-        <single>ed. and trans.</single>
-        <multiple>ed. and trans.</multiple>
-      </term>
-      <term name="editortranslator" form="verb">
-        <single>Edited and translated by</single>
-        <multiple>Edited and translated by</multiple>
-      </term>
+      <term name="editortranslator" form="verb-short">ed. and trans.</term>
+      <term name="editortranslator" form="verb">Edited and translated by</term>
       <term name="translator" form="short">trans.</term>
     </terms>
   </locale>

--- a/the-journal-of-egyptian-archaeology.csl
+++ b/the-journal-of-egyptian-archaeology.csl
@@ -21,18 +21,9 @@
     <style-options punctuation-in-quote="false"/>
     <terms>
       <term name="edition" form="short">edn</term>
-      <term name="translator" form="short">
-        <single>trans.</single>
-        <multiple>trans.</multiple>
-      </term>
-      <term name="editortranslator" form="short">
-        <single>ed. and trans.</single>
-        <multiple>ed. and trans.</multiple>
-      </term>
-      <term name="chapter" form="short">
-        <single>c.</single>
-        <multiple>c.</multiple>
-      </term>
+      <term name="translator" form="short">trans.</term>
+      <term name="editortranslator" form="short">ed. and trans.</term>
+      <term name="chapter" form="short">c.</term>
       <term name="open-quote">‘</term>
       <term name="close-quote">’</term>
       <term name="open-inner-quote">“</term>

--- a/the-journal-of-hellenic-studies.csl
+++ b/the-journal-of-hellenic-studies.csl
@@ -26,10 +26,7 @@
         <single>ed.</single>
         <multiple>eds</multiple>
       </term>
-      <term name="translator" form="short">
-        <single>tr.</single>
-        <multiple>tr.</multiple>
-      </term>
+      <term name="translator" form="short">tr.</term>
       <term name="chapter" form="short">
         <single>chapter </single>
         <multiple>chapters </multiple>

--- a/the-journal-of-modern-history.csl
+++ b/the-journal-of-modern-history.csl
@@ -22,14 +22,8 @@
       <term name="editor" form="verb-short">ed.</term>
       <term name="translator" form="verb-short">trans.</term>
       <term name="translator" form="short">trans.</term>
-      <term name="editortranslator" form="verb-short">
-        <single>ed. and trans.</single>
-        <multiple>ed. and trans.</multiple>
-      </term>
-      <term name="editortranslator" form="verb">
-        <single>Edited and translated by</single>
-        <multiple>Edited and translated by</multiple>
-      </term>
+      <term name="editortranslator" form="verb-short">ed. and trans.</term>
+      <term name="editortranslator" form="verb">Edited and translated by</term>
       <term name="translator" form="short">trans.</term>
     </terms>
   </locale>

--- a/the-journal-of-parasitology.csl
+++ b/the-journal-of-parasitology.csl
@@ -19,10 +19,7 @@
   </info>
   <locale xml:lang="en">
     <terms>
-      <term name="page" form="short">
-        <single>p</single>
-        <multiple>p</multiple>
-      </term>
+      <term name="page" form="short">p</term>
     </terms>
   </locale>
   <macro name="container-contributors">

--- a/the-journal-of-the-acoustical-society-of-america.csl
+++ b/the-journal-of-the-acoustical-society-of-america.csl
@@ -25,10 +25,7 @@
   </info>
   <locale xml:lang="en">
     <terms>
-      <term name="translator" form="short">
-        <single>trans.</single>
-        <multiple>trans.</multiple>
-      </term>
+      <term name="translator" form="short">trans.</term>
     </terms>
   </locale>
   <macro name="container-contributors">

--- a/the-university-of-winchester-harvard.csl
+++ b/the-university-of-winchester-harvard.csl
@@ -22,10 +22,7 @@
         <single>ed. &amp; trans.</single>
         <multiple>eds. &amp; trans.</multiple>
       </term>
-      <term name="translator" form="short">
-        <single>trans.</single>
-        <multiple>trans.</multiple>
-      </term>
+      <term name="translator" form="short">trans.</term>
       <term name="edition" form="short">edn</term>
     </terms>
   </locale>

--- a/theory-culture-and-society.csl
+++ b/theory-culture-and-society.csl
@@ -34,10 +34,7 @@
   </info>
   <locale xml:lang="en-GB">
     <terms>
-      <term name="translator" form="short">
-        <single>trans.</single>
-        <multiple>trans.</multiple>
-      </term>
+      <term name="translator" form="short">trans.</term>
       <term name="editor" form="short">
         <single>ed.</single>
         <multiple>eds</multiple>

--- a/u-schylku-starozytnosci.csl
+++ b/u-schylku-starozytnosci.csl
@@ -39,22 +39,10 @@
       <term name="folio" form="short">fol.</term>
       <term name="issue" form="short">nr</term>
       <term name="opus" form="short">op.</term>
-      <term name="editor" form="short">
-        <single>red.</single>
-        <multiple>red.</multiple>
-      </term>
-      <term name="editorial-director" form="short">
-        <single>red.</single>
-        <multiple>red.</multiple>
-      </term>
-      <term name="translator" form="short">
-        <single>tłum.</single>
-        <multiple>tłum.</multiple>
-      </term>
-      <term name="editortranslator" form="short">
-        <single>red. &amp; tłum.</single>
-        <multiple>red. &amp; tłum.</multiple>
-      </term>
+      <term name="editor" form="short">red.</term>
+      <term name="editorial-director" form="short">red.</term>
+      <term name="translator" form="short">tłum.</term>
+      <term name="editortranslator" form="short">red. &amp; tłum.</term>
       <term name="container-author" form="verb-short">przez</term>
       <term name="editor" form="verb-short">wyd.</term>
       <term name="editorial-director" form="verb-short">wyd.</term>

--- a/uludag-universitesi-sosyal-bilimler-enstitusu-author-date.csl
+++ b/uludag-universitesi-sosyal-bilimler-enstitusu-author-date.csl
@@ -21,10 +21,7 @@
     <terms>
       <term name="editor" form="verb-short">ed.</term>
       <term name="translator" form="verb-short">çev.</term>
-      <term name="editortranslator" form="verb">
-        <single>ed. &amp; çev.</single>
-        <multiple>ed. &amp; çev.</multiple>
-      </term>
+      <term name="editortranslator" form="verb">ed. &amp; çev.</term>
       <term name="translator" form="short">çev.</term>
       <term name="edition" form="short">b.</term>
       <term name="volume" form="short">C.</term>

--- a/uludag-universitesi-sosyal-bilimler-enstitusu-full-note-with-ibid.csl
+++ b/uludag-universitesi-sosyal-bilimler-enstitusu-full-note-with-ibid.csl
@@ -22,14 +22,8 @@
       <term name="editor" form="verb-short">ed.</term>
       <term name="translator" form="verb-short">çev.</term>
       <term name="translator" form="short">çev.</term>
-      <term name="editortranslator" form="verb-short">
-        <single>ed. &amp; çev.</single>
-        <multiple>ed. &amp; çev.</multiple>
-      </term>
-      <term name="editortranslator" form="verb">
-        <single>ed. &amp; çev.</single>
-        <multiple>ed. &amp; çev.</multiple>
-      </term>
+      <term name="editortranslator" form="verb-short">ed. &amp; çev.</term>
+      <term name="editortranslator" form="verb">ed. &amp; çev.</term>
       <term name="translator" form="short">çev.</term>
       <term name="edition" form="short">b.</term>
       <term name="ibid">a.yer</term>

--- a/uludag-universitesi-sosyal-bilimler-enstitusu-full-note.csl
+++ b/uludag-universitesi-sosyal-bilimler-enstitusu-full-note.csl
@@ -22,14 +22,8 @@
       <term name="editor" form="verb-short">ed.</term>
       <term name="translator" form="verb-short">çev.</term>
       <term name="translator" form="short">çev.</term>
-      <term name="editortranslator" form="verb-short">
-        <single>ed. &amp; çev.</single>
-        <multiple>ed. &amp; çev.</multiple>
-      </term>
-      <term name="editortranslator" form="verb">
-        <single>ed. &amp; çev.</single>
-        <multiple>ed. &amp; çev.</multiple>
-      </term>
+      <term name="editortranslator" form="verb-short">ed. &amp; çev.</term>
+      <term name="editortranslator" form="verb">ed. &amp; çev.</term>
       <term name="translator" form="short">çev.</term>
       <term name="edition" form="short">b.</term>
       <term name="ibid">a.yer</term>

--- a/uludag-universitesi-sosyal-bilimler-enstitusu-ilahiyat-fakultesi-full-note-with-ibid.csl
+++ b/uludag-universitesi-sosyal-bilimler-enstitusu-ilahiyat-fakultesi-full-note-with-ibid.csl
@@ -22,14 +22,8 @@
       <term name="editor" form="verb-short">ed.</term>
       <term name="translator" form="verb-short">çev.</term>
       <term name="translator" form="short">çev.</term>
-      <term name="editortranslator" form="verb-short">
-        <single>ed. &amp; çev.</single>
-        <multiple>ed. &amp; çev.</multiple>
-      </term>
-      <term name="editortranslator" form="verb">
-        <single>ed. &amp; çev.</single>
-        <multiple>ed. &amp; çev.</multiple>
-      </term>
+      <term name="editortranslator" form="verb-short">ed. &amp; çev.</term>
+      <term name="editortranslator" form="verb">ed. &amp; çev.</term>
       <term name="translator" form="short">çev.</term>
       <term name="edition" form="short">bs.</term>
       <term name="ibid">a.yer</term>

--- a/uludag-universitesi-sosyal-bilimler-enstitusu-ilahiyat-fakultesi-full-note.csl
+++ b/uludag-universitesi-sosyal-bilimler-enstitusu-ilahiyat-fakultesi-full-note.csl
@@ -22,14 +22,8 @@
       <term name="editor" form="verb-short">ed.</term>
       <term name="translator" form="verb-short">çev.</term>
       <term name="translator" form="short">çev.</term>
-      <term name="editortranslator" form="verb-short">
-        <single>ed. &amp; çev.</single>
-        <multiple>ed. &amp; çev.</multiple>
-      </term>
-      <term name="editortranslator" form="verb">
-        <single>ed. &amp; çev.</single>
-        <multiple>ed. &amp; çev.</multiple>
-      </term>
+      <term name="editortranslator" form="verb-short">ed. &amp; çev.</term>
+      <term name="editortranslator" form="verb">ed. &amp; çev.</term>
       <term name="translator" form="short">çev.</term>
       <term name="edition" form="short">bs.</term>
       <term name="issue" form="short">sy.</term>

--- a/universidade-federal-de-juiz-de-fora.csl
+++ b/universidade-federal-de-juiz-de-fora.csl
@@ -51,10 +51,7 @@
         <single>org</single>
         <multiple>orgs</multiple>
       </term>
-      <term name="collection-editor" form="short">
-        <single>ed</single>
-        <multiple>ed</multiple>
-      </term>
+      <term name="collection-editor" form="short">ed</term>
     </terms>
   </locale>
   <macro name="container-contributors">

--- a/universitas-negeri-yogyakarta-program-pascasarjana.csl
+++ b/universitas-negeri-yogyakarta-program-pascasarjana.csl
@@ -24,10 +24,7 @@
         <single>ed. &amp; trans.</single>
         <multiple>eds. &amp; trans.</multiple>
       </term>
-      <term name="translator" form="short">
-        <single>trans.</single>
-        <multiple>trans.</multiple>
-      </term>
+      <term name="translator" form="short">trans.</term>
     </terms>
   </locale>
   <macro name="container-contributors">

--- a/universitat-freiburg-geschichte.csl
+++ b/universitat-freiburg-geschichte.csl
@@ -21,14 +21,8 @@
       <term name="retrieved">zugegriffen am</term>
       <term name="accessed">Zugriff:</term>
       <!--      <term name="ibid">ebenda</term> -->
-      <term name="page" form="short">
-        <single>S.</single>
-        <multiple>S.</multiple>
-      </term>
-      <term name="section" form="short">
-        <single>Abs.</single>
-        <multiple>Abs.</multiple>
-      </term>
+      <term name="page" form="short">S.</term>
+      <term name="section" form="short">Abs.</term>
       <term name="editor" form="verb-short">hg. von</term>
       <term name="editor" form="short">
         <single> (Hg.)</single>

--- a/universite-catholique-de-louvain-histoire.csl
+++ b/universite-catholique-de-louvain-histoire.csl
@@ -22,14 +22,8 @@
       <term name="ordinal-03">e</term>
       <term name="ordinal-04">e</term>
       <term name="cited">op. cit.</term>
-      <term name="page" form="short">
-        <single>p.</single>
-        <multiple>p.</multiple>
-      </term>
-      <term name="editor" form="short">
-        <single>éd.</single>
-        <multiple>éd.</multiple>
-      </term>
+      <term name="page" form="short">p.</term>
+      <term name="editor" form="short">éd.</term>
       <term name="in">dans</term>
       <term name="translator">traduit par </term>
       <term name="director">dirigée par </term>

--- a/universite-de-liege-droit.csl
+++ b/universite-de-liege-droit.csl
@@ -33,14 +33,8 @@
         <single>dir.</single>
         <multiple>dirs.</multiple>
       </term>
-      <term name="in">
-        <single>dans</single>
-        <multiple>dans</multiple>
-      </term>
-      <term name="edition" form="short">
-        <single>éd.</single>
-        <multiple>éd.</multiple>
-      </term>
+      <term name="in">dans</term>
+      <term name="edition" form="short">éd.</term>
       <term name="cited">op. cit.</term>
       <term name="ordinal-01">&#7497;</term>
       <term name="ordinal-02">&#7497;</term>

--- a/universite-de-liege-histoire.csl
+++ b/universite-de-liege-histoire.csl
@@ -26,14 +26,8 @@
       <term name="ordinal-03">e</term>
       <term name="ordinal-04">e</term>
       <term name="cited">op.&#160;cit.</term>
-      <term name="page" form="short">
-        <single>p.</single>
-        <multiple>p.</multiple>
-      </term>
-      <term name="editor" form="short">
-        <single>dir.</single>
-        <multiple>dir.</multiple>
-      </term>
+      <term name="page" form="short">p.</term>
+      <term name="editor" form="short">dir.</term>
     </terms>
   </locale>
   <macro name="author">

--- a/universite-de-sherbrooke-departement-de-geomatique.csl
+++ b/universite-de-sherbrooke-departement-de-geomatique.csl
@@ -22,10 +22,7 @@
       <term name="editor" form="short">dir.</term>
       <term name="in">In</term>
       <term name="no date" form="short">s.d.</term>
-      <term name="translator" form="short">
-        <single>trad.</single>
-        <multiple>trad.</multiple>
-      </term>
+      <term name="translator" form="short">trad.</term>
     </terms>
   </locale>
   <macro name="container-contributors">

--- a/universite-de-sherbrooke-faculte-d-education.csl
+++ b/universite-de-sherbrooke-faculte-d-education.csl
@@ -21,10 +21,7 @@
       <term name="editor" form="short">dir.</term>
       <term name="in">In</term>
       <term name="no date" form="short">s.d.</term>
-      <term name="translator" form="short">
-        <single>trad.</single>
-        <multiple>trad.</multiple>
-      </term>
+      <term name="translator" form="short">trad.</term>
     </terms>
   </locale>
   <macro name="container-contributors">

--- a/universite-du-quebec-a-montreal-departement-dhistoire.csl
+++ b/universite-du-quebec-a-montreal-departement-dhistoire.csl
@@ -25,14 +25,8 @@
       <term name="ordinal-03">e</term>
       <term name="ordinal-04">e</term>
       <term name="cited">op.&#160;cit.</term>
-      <term name="page" form="short">
-        <single>p.</single>
-        <multiple>p.</multiple>
-      </term>
-      <term name="editor" form="short">
-        <single>éd.</single>
-        <multiple>éd.</multiple>
-      </term>
+      <term name="page" form="short">p.</term>
+      <term name="editor" form="short">éd.</term>
     </terms>
   </locale>
   <macro name="author">

--- a/universite-du-quebec-a-montreal.csl
+++ b/universite-du-quebec-a-montreal.csl
@@ -31,18 +31,12 @@
     <terms>
       <term name="editortranslator" form="short">dir. et trad.</term>
       <term name="editor" form="short">dir.</term>
-      <term name="translator" form="short">
-        <single>trad.</single>
-        <multiple>trad.</multiple>
-      </term>
+      <term name="translator" form="short">trad.</term>
       <term name="no date" form="short">s. d.</term>
       <term name="in">Dans</term>
       <term name="retrieved">Récupéré de</term>
       <term name="presented at">Communication présentée à</term>
-      <term name="page" form="short">
-        <single>p.</single>
-        <multiple>p.</multiple>
-      </term>
+      <term name="page" form="short">p.</term>
       <term name="in press">sous presse</term>
       <term name="director" form="short">réal.</term>
       <term name="chapter" form="short">chap. </term>

--- a/universite-laval-faculte-de-theologie-et-de-sciences-religieuses.csl
+++ b/universite-laval-faculte-de-theologie-et-de-sciences-religieuses.csl
@@ -37,14 +37,8 @@
   </info>
   <locale xml:lang="fr">
     <terms>
-      <term name="editortranslator" form="verb-short">
-        <single>trans. and ed.</single>
-        <multiple>trans. and ed.</multiple>
-      </term>
-      <term name="editortranslator" form="verb">
-        <single> Translated and edited by</single>
-        <multiple> Translated and edited by</multiple>
-      </term>
+      <term name="editortranslator" form="verb-short">trans. and ed.</term>
+      <term name="editortranslator" form="verb"> Translated and edited by</term>
       <term name="editor" form="verb-short">ed.</term>
       <term name="translator" form="verb-short">trans.</term>
     </terms>

--- a/universite-libre-de-bruxelles-histoire.csl
+++ b/universite-libre-de-bruxelles-histoire.csl
@@ -27,10 +27,7 @@
         <single>éd.</single>
         <multiple>éds.</multiple>
       </term>
-      <term name="in">
-        <single>dans</single>
-        <multiple>dans</multiple>
-      </term>
+      <term name="in">dans</term>
       <term name="cited">op. cit.</term>
       <term name="ordinal-01">&#7497;</term>
       <term name="ordinal-02">&#7497;</term>

--- a/universiteit-utrecht-onderzoeksgids-geschiedenis.csl
+++ b/universiteit-utrecht-onderzoeksgids-geschiedenis.csl
@@ -21,10 +21,7 @@
   <locale xml:lang="nl">
     <terms>
       <term name="et-al">e.a.</term>
-      <term name="editor" form="short">
-        <single>ed.</single>
-        <multiple>ed.</multiple>
-      </term>
+      <term name="editor" form="short">ed.</term>
       <term name="edition" form="short">druk</term>
       <term name="volume" form="short">
         <single>dl.</single>

--- a/universitetet-i-oslo-rettsvitenskap.csl
+++ b/universitetet-i-oslo-rettsvitenskap.csl
@@ -21,16 +21,10 @@
       <term name="editor" form="verb-short">red.</term>
       <term name="translator" form="verb-short">overs.</term>
       <term name="translator" form="short">overs.</term>
-      <term name="editortranslator" form="verb-short">
-        <single>red. og overs.</single>
-        <multiple>red. og overs.</multiple>
-      </term>
-      <term name="editortranslator" form="verb">
-        <single>Redigert og oversatt av</single>
-        <multiple>Redigert og oversatt av</multiple>
-      </term>
+      <term name="editortranslator" form="verb-short">red. og overs.</term>
+      <term name="editortranslator" form="verb">Redigert og oversatt av</term>
       <term name="translator" form="short">overs.</term>
-      <term name="and others"></term>
+      <term name="and others"/>
       <term name="open-quote">"</term>
       <term name="close-quote">"</term>
       <term name="accessed">sitert</term>

--- a/university-college-dublin-school-of-history-and-archives.csl
+++ b/university-college-dublin-school-of-history-and-archives.csl
@@ -18,14 +18,8 @@
   </info>
   <locale xml:lang="en">
     <terms>
-      <term name="editortranslator" form="verb-short">
-        <single>trans. and ed.</single>
-        <multiple>trans. and ed.</multiple>
-      </term>
-      <term name="editortranslator" form="verb">
-        <single> Translated and edited by</single>
-        <multiple> Translated and edited by</multiple>
-      </term>
+      <term name="editortranslator" form="verb-short">trans. and ed.</term>
+      <term name="editortranslator" form="verb"> Translated and edited by</term>
       <term name="editor" form="verb-short">ed.</term>
       <term name="translator" form="verb-short">trans.</term>
     </terms>

--- a/university-college-lillebaelt-apa.csl
+++ b/university-college-lillebaelt-apa.csl
@@ -28,10 +28,7 @@
         <single>ed. and trans.</single>
         <multiple>eds. and trans.</multiple>
       </term>
-      <term name="translator" form="short">
-        <single>trans.</single>
-        <multiple>trans.</multiple>
-      </term>
+      <term name="translator" form="short">trans.</term>
     </terms>
   </locale>
   <macro name="container-contributors">

--- a/university-college-lillebaelt-vancouver.csl
+++ b/university-college-lillebaelt-vancouver.csl
@@ -19,10 +19,7 @@
       <term name="accessed">cited</term>
       <term name="available at">available from</term>
       <term name="no date">date unknown</term>
-      <term name="page" form="short">
-        <single>p.</single>
-        <multiple>p.</multiple>
-      </term>
+      <term name="page" form="short">p.</term>
     </terms>
   </locale>
   <!--                                                 CITATION MACRO -->

--- a/university-of-york-apa.csl
+++ b/university-of-york-apa.csl
@@ -19,10 +19,7 @@
         <single>ed. &amp; trans.</single>
         <multiple>eds. &amp; trans.</multiple>
       </term>
-      <term name="translator" form="short">
-        <single>trans.</single>
-        <multiple>trans.</multiple>
-      </term>
+      <term name="translator" form="short">trans.</term>
     </terms>
   </locale>
   <macro name="container-contributors">

--- a/university-of-york-chicago.csl
+++ b/university-of-york-chicago.csl
@@ -19,14 +19,8 @@
       <term name="editor" form="verb-short">ed.</term>
       <term name="translator" form="verb-short">trans.</term>
       <term name="translator" form="short">trans.</term>
-      <term name="editortranslator" form="verb-short">
-        <single>ed. and trans.</single>
-        <multiple>ed. and trans.</multiple>
-      </term>
-      <term name="editortranslator" form="verb">
-        <single>Edited and translated by</single>
-        <multiple>Edited and translated by</multiple>
-      </term>
+      <term name="editortranslator" form="verb-short">ed. and trans.</term>
+      <term name="editortranslator" form="verb">Edited and translated by</term>
       <term name="translator" form="short">trans.</term>
     </terms>
   </locale>

--- a/uppsala-universitet-historia.csl
+++ b/uppsala-universitet-historia.csl
@@ -24,10 +24,7 @@
         <single>ed. &amp; trans.</single>
         <multiple>eds. &amp; trans.</multiple>
       </term>
-      <term name="translator" form="short">
-        <single>trans.</single>
-        <multiple>trans.</multiple>
-      </term>
+      <term name="translator" form="short">trans.</term>
     </terms>
   </locale>
   <macro name="container-contributors">

--- a/uppsala-universitet-institutionen-for-biologisk-grundutbildning.csl
+++ b/uppsala-universitet-institutionen-for-biologisk-grundutbildning.csl
@@ -46,10 +46,7 @@
       <term name="ordinal-11">:e</term>
       <term name="ordinal-12">:e</term>
       <term name="accessed">hämtad</term>
-      <term name="page" form="short">
-        <single>s.</single>
-        <multiple>s.</multiple>
-      </term>
+      <term name="page" form="short">s.</term>
     </terms>
   </locale>
   <macro name="author-short">

--- a/vingtieme-siecle.csl
+++ b/vingtieme-siecle.csl
@@ -22,14 +22,8 @@
       <term name="ordinal-03">e</term>
       <term name="ordinal-04">e</term>
       <term name="cited">op.&#160;cit.</term>
-      <term name="page" form="short">
-        <single>p.</single>
-        <multiple>p.</multiple>
-      </term>
-      <term name="editor" form="short">
-        <single>dir.</single>
-        <multiple>dir.</multiple>
-      </term>
+      <term name="page" form="short">p.</term>
+      <term name="editor" form="short">dir.</term>
     </terms>
   </locale>
   <macro name="author">

--- a/vita-latina-auteurs-anciens.csl
+++ b/vita-latina-auteurs-anciens.csl
@@ -33,10 +33,7 @@ Remarques :
   <!-- INSTRUCTIONS DE FORMATAGE EN FRANCAIS -->
   <locale>
     <terms>
-      <term name="editor" form="short">
-        <single>éd.</single>
-        <multiple>éd.</multiple>
-      </term>
+      <term name="editor" form="short">éd.</term>
       <term name="translator" form="verb-short">trad.</term>
       <term name="in">dans</term>
       <term name="no date">pas de date</term>

--- a/vita-latina.csl
+++ b/vita-latina.csl
@@ -34,11 +34,7 @@ Remarques :
   <!-- INSTRUCTIONS DE FORMATAGE EN FRANCAIS -->
   <locale>
     <terms>
-      <term name="editor" form="short">
-        <single>dir.</single>
-        <multiple>dir.</multiple>
-        <!-- dir. diffère bien entendu de éd., mais Zotero ne permet pas de distinguer "directeur de publication" et "éditeur". -->
-      </term>
+      <term name="editor" form="short">dir.</term>
       <term name="translator" form="verb-short">trad.</term>
       <term name="in">dans</term>
       <term name="no date">pas de date</term>

--- a/water-sa.csl
+++ b/water-sa.csl
@@ -19,10 +19,7 @@
   </info>
   <locale xml:lang="en">
     <terms>
-      <term name="edition" form="short">
-        <single>edn</single>
-        <multiple>edn</multiple>
-      </term>
+      <term name="edition" form="short">edn</term>
       <term name="ordinal">ᵗʰ</term>
       <term name="ordinal-01">ˢᵗ</term>
       <term name="ordinal-02">ⁿᵈ</term>

--- a/wirtschaftsuniversitat-wien-author-date.csl
+++ b/wirtschaftsuniversitat-wien-author-date.csl
@@ -24,10 +24,7 @@
         <single>ed. &amp; trans.</single>
         <multiple>eds. &amp; trans.</multiple>
       </term>
-      <term name="translator" form="short">
-        <single>trans.</single>
-        <multiple>trans.</multiple>
-      </term>
+      <term name="translator" form="short">trans.</term>
       <term name="anonymous">No author</term>
       <!-- This should be term name="of" -->
       <term name="ad">of</term>
@@ -40,10 +37,7 @@
         <single>ed. &amp; trans.</single>
         <multiple>eds. &amp; trans.</multiple>
       </term>
-      <term name="translator" form="short">
-        <single>trans.</single>
-        <multiple>trans.</multiple>
-      </term>
+      <term name="translator" form="short">trans.</term>
       <term name="accessed">abgerufen am</term>
       <term name="ad">vom</term>
       <term name="et-al">et al.</term>

--- a/world-politcs.csl
+++ b/world-politcs.csl
@@ -22,10 +22,7 @@
       <term name="editor" form="verb-short">ed.</term>
       <term name="container-author" form="verb">by</term>
       <term name="translator" form="verb-short">trans.</term>
-      <term name="editortranslator" form="verb">
-        <single>edited and translated by</single>
-        <multiple>edited and translated by</multiple>
-      </term>
+      <term name="editortranslator" form="verb">edited and translated by</term>
       <term name="translator" form="short">trans.</term>
     </terms>
   </locale>

--- a/zeitschrift-fur-medienwissenschaft.csl
+++ b/zeitschrift-fur-medienwissenschaft.csl
@@ -37,22 +37,10 @@
     <terms>
       <term name="et-al">u.&#160;a.</term>
       <term name="accessed">gesehen am</term>
-      <term name="editor" form="short">
-        <single>Hg</single>
-        <multiple>Hg</multiple>
-      </term>
-      <term name="editor" form="verb-short">
-        <single>Hg.&#160;v</single>
-        <multiple>Hg.&#160;v</multiple>
-      </term>
-      <term name="translator" form="short">
-        <single>Übers</single>
-        <multiple>Übers</multiple>
-      </term>
-      <term name="translator" form="verb-short">
-        <single>Übers.&#160;v</single>
-        <multiple>Übers.&#160;v</multiple>
-      </term>
+      <term name="editor" form="short">Hg</term>
+      <term name="editor" form="verb-short">Hg.&#160;v</term>
+      <term name="translator" form="short">Übers</term>
+      <term name="translator" form="verb-short">Übers.&#160;v</term>
       <term name="accessed">gesehen am</term>
     </terms>
   </locale>

--- a/zeitschrift-fur-religionswissenschaft-note.csl
+++ b/zeitschrift-fur-religionswissenschaft-note.csl
@@ -24,14 +24,8 @@
     <terms>
       <term name="editor" form="verb-short">ed.</term>
       <term name="translator" form="verb-short">trans.</term>
-      <term name="editortranslator" form="verb-short">
-        <single>ed. and trans.</single>
-        <multiple>ed. and trans.</multiple>
-      </term>
-      <term name="editortranslator" form="verb">
-        <single>Edited and translated by</single>
-        <multiple>Edited and translated by</multiple>
-      </term>
+      <term name="editortranslator" form="verb-short">ed. and trans.</term>
+      <term name="editortranslator" form="verb">Edited and translated by</term>
       <term name="translator" form="short">trans.</term>
     </terms>
   </locale>


### PR DESCRIPTION
In reference to #3491, there are 253 styles in the repository with similarly redundant terms. This pull request fixes them all. Here is the node script used to apply the fix (installed in the top level of the repo and run from there, after fetching its dependencies from `npm`):
```
var fs = require('fs');
var xml = require('xmldom').DOMParser;
var xpath = require('xpath');
var enc = require('encode-decode');
var select = xpath.useNamespaces({"cs": "http://purl.org/net/xbiblio/csl"});

var ret = {};

function EntityFixer() {
    this.dat = {};
    var lurkers = {
        "&lt;": "{LESS-THAN}",
        "&gt;": "{GREATER-THAN}",
        "&nbsp;": "{NO-BREAK-SPACE}"
    }
    this.memo = function(txt) {
        for (key in lurkers) {
            var rex = new RegExp(key, "g");
            txt = txt.replace(rex, lurkers[key]);
        }
        var m = txt.match(/(\&\#[0-9]+;)/g);
        if (m) {
            for (var memo of m) {
                this.dat[memo] = enc.htmlDecode(memo);
            }
        }
        return txt;
    }
    this.dememo = function(txt) {
        for (var key in this.dat) {
            var rex = new RegExp(this.dat[key], "g");
            txt = txt.replace(rex, key);
        }
        for (key in lurkers) {
            var rex = new RegExp(lurkers[key], "g");
            txt = txt.replace(rex, key);
        }
        return txt;
    }
}



for (var fn of fs.readdirSync('.')) {
    var writeToFile = false;
    var entityFixer = new EntityFixer();
    if (fn.slice(-4) !== ".csl") continue;
    var txt = fs.readFileSync(fn).toString();
    txt = entityFixer.memo(txt);
    var doc = new xml().parseFromString(txt);
    var termNodes = select("//cs:locale/cs:terms/cs:term", doc);
    for (var termNode of termNodes) {
        var single = select(".//cs:single", termNode)[0];
        var multiple = select(".//cs:multiple", termNode)[0];
        if (single) {
            single = single.textContent ? single.textContent : false;
            multiple = multiple.textContent ? multiple.textContent : false;
            if (single && single === multiple) {
	            for (var i=0,ilen=termNode.childNodes.length;i<ilen;i++) {
	                termNode.removeChild(termNode.childNodes[0]);
	            }
                var textNode = doc.createTextNode(single);
	            termNode.appendChild(textNode);
	            writeToFile = true;
            }
        }
    }
    if (writeToFile) {
        txt = entityFixer.dememo(doc.toString());
        fs.writeFileSync(fn, txt + "\n");
    }
}
```