### PR TITLE
Isolate calls to editor + translator, provide for collapse of verb form

### DIFF
--- a/society-of-biblical-literature-fullnote-bibliography.csl
+++ b/society-of-biblical-literature-fullnote-bibliography.csl
@@ -36,6 +36,7 @@
       <term name="translator" form="verb-short">trans.</term>
       <term name="translator" form="short">trans.</term>
       <term name="editortranslator" form="verb-short">ed. and trans.</term>
+      <term name="editortranslator" form="verb">edited and translated by</term>
       <term name="collection-editor">
         <single>ed.</single>
         <multiple>eds.</multiple>
@@ -43,57 +44,77 @@
       <term name="collection-editor" form="verb">edited by</term>
     </terms>
   </locale>
-  <macro name="editor-translator">
+  <macro name="editor-translator-verb-short-comma">
+    <names variable="editor translator" delimiter=", ">
+      <label form="verb-short" suffix=" "/>
+      <name and="text" delimiter=", "/>
+    </names>
+  </macro>
+  <macro name="editor-translator-verb-period">
+    <names variable="editor translator" delimiter=" ">
+      <label form="verb" text-case="capitalize-first" suffix=" "/>
+      <name and="text" delimiter=", "/>
+    </names>
+  </macro>
+  <macro name="editor-translator-verb-comma">
+    <names variable="editor translator" delimiter=", ">
+      <label form="verb" text-case="capitalize-first" suffix=" "/>
+      <name and="text" delimiter=", "/>
+    </names>
+  </macro>
+  <macro name="container-author-reviewed-author-and-editor-translator">
     <group delimiter=", ">
       <choose>
         <if variable="container-author reviewed-author" match="any">
-          <group>
-            <names variable="container-author reviewed-author" delimiter=", ">
-              <label form="verb-short" suffix=" "/>
-              <name and="text" delimiter=", "/>
-            </names>
-          </group>
+          <names variable="container-author reviewed-author" delimiter=", ">
+            <label form="verb-short" suffix=" "/>
+            <name and="text" delimiter=", "/>
+          </names>
         </if>
       </choose>
-      <names variable="editor translator" delimiter=", ">
-        <label form="verb-short" suffix=" "/>
-        <name and="text" delimiter=", "/>
-      </names>
+      <text macro="editor-translator-verb-short-comma"/>
     </group>
   </macro>
   <macro name="secondary-contributors-note">
     <choose>
       <if type="bill book chapter graphic legal_case legislation motion_picture paper-conference report song" match="none">
-        <text macro="editor-translator"/>
+        <text macro="container-author-reviewed-author-and-editor-translator"/>
       </if>
     </choose>
   </macro>
   <macro name="container-contributors-note">
     <choose>
       <if type="bill book chapter graphic legal_case legislation motion_picture paper-conference report song" match="any">
-        <names variable="editor translator container-author" delimiter=", ">
-          <label form="verb-short" suffix=" "/>
-          <name and="text" delimiter=", "/>
-        </names>
+        <group delimiter=", ">
+          <text macro="editor-translator-verb-short-comma"/>
+          <names variable="container-author">
+            <label form="verb-short" suffix=" "/>
+            <name and="text" delimiter=", "/>
+          </names>
+        </group>
       </if>
     </choose>
   </macro>
   <macro name="secondary-contributors">
     <choose>
       <if type="chapter paper-conference" match="none">
-        <names variable="editor translator container-author" delimiter=". ">
-          <label form="verb" prefix=" " text-case="capitalize-first" suffix=" "/>
-          <name and="text" delimiter=", "/>
-        </names>
+        <group delimiter=". " prefix=" ">
+          <text macro="editor-translator-verb-period"/>
+          <names variable="container-author">
+            <label form="verb" text-case="capitalize-first" suffix=" "/>
+            <name and="text" delimiter=", "/>
+          </names>
+        </group>
       </if>
     </choose>
   </macro>
   <macro name="container-contributors">
     <choose>
       <if type="chapter paper-conference" match="any">
-        <group delimiter=", ">
-          <names variable="editor translator container-author" delimiter=", ">
-            <label form="verb" prefix=" " text-case="capitalize-first" suffix=" "/>
+        <group delimiter=", " prefix=" ">
+          <text macro="editor-translator-verb-comma"/>
+          <names variable="container-author">
+            <label form="verb" text-case="capitalize-first" suffix=" "/>
             <name and="text" delimiter=", "/>
           </names>
         </group>


### PR DESCRIPTION
`editortranslator` collapse only works when editor and translator are the only two variables called on `cs:names`. This isolates them where they were mixed with other variables, preserving the original formatting. I've placed the three variants of the `editor translator` combination used in the style at the top. And I tested it this time!