### PR TITLE
Update universite-laval-departement-des-sciences-historiques.csl

### DIFF
--- a/universite-laval-departement-des-sciences-historiques.csl
+++ b/universite-laval-departement-des-sciences-historiques.csl
@@ -140,9 +140,9 @@
   </macro>
   <macro name="locators">
     <group delimiter=", ">
-      <text variable="volume" />
+      <text variable="volume"/>
       <group>
-        <text variable="issue" />
+        <text variable="issue"/>
         <choose>
           <if match="any" variable="volume issue">
             <text macro="year-date" prefix=" (" suffix=")"/>

--- a/universite-laval-departement-des-sciences-historiques.csl
+++ b/universite-laval-departement-des-sciences-historiques.csl
@@ -7,7 +7,7 @@
     <link href="http://www.hst.ulaval.ca/services-et-ressources/guides-pedagogiques/" rel="documentation"/>
     <author>
       <name>Charles Mercier-Paquin</name>
-      <email>charles.mercier-paquin.1@ulaval.ca</email>
+      <email>charles.mercier.paquin@gmail.com</email>
     </author>
     <category citation-format="note"/>
     <category field="history"/>
@@ -140,9 +140,9 @@
   </macro>
   <macro name="locators">
     <group delimiter=", ">
-      <text variable="volume" prefix="vol. "/>
+      <text variable="volume" />
       <group>
-        <text variable="issue" prefix="n° "/>
+        <text variable="issue" />
         <choose>
           <if match="any" variable="volume issue">
             <text macro="year-date" prefix=" (" suffix=")"/>


### PR DESCRIPTION
-Changed my email address, as I do not use the previous one anymore. 
-Removed both "vol. " and "n° ", as requested by the department's Director of 2nd and 3rd grade in history and stated in the department's documentation under "Article dans une revue" (although it was confirmed to me that there should be a space between the first comma and the issue number, which does not appear in the documentation itself).