### PR TITLE
Fix scale macro for din-1505-2

### DIFF
--- a/din-1505-2.csl
+++ b/din-1505-2.csl
@@ -210,10 +210,14 @@
     </group>
   </macro>
   <macro name="scale">
-    <group>
-      <text term="scale"/>
-      <text prefix=" " variable="scale"/>
-    </group>
+    <choose>
+      <if variable="scale">
+        <group>
+          <text term="scale"/>
+          <text prefix=" " variable="scale"/>
+        </group>
+      </if>
+    </choose>
   </macro>
   <macro name="recipient-show">
     <choose>


### PR DESCRIPTION
The contents of the "scale" macro were inserted no matter if there was any data on "scale". So while ```<text prefix=" " variable="scale"/>``` returned nothing, the unguarded ```<text term="scale"/>``` always inserted the German word "Maßstab" into my citations.
This patch request makes sure that the descriptive text is only inserted if there actually is some scale information present.