### PR TITLE
Improve edition macro for din-1505-2

### DIFF
--- a/din-1505-2-alphanumeric.csl
+++ b/din-1505-2-alphanumeric.csl
@@ -168,10 +168,17 @@
     </group>
   </macro>
   <macro name="edition">
-    <group>
-      <number variable="edition" form="numeric" suffix=". "/>
-      <text term="edition" form="short" plural="false"/>
-    </group>
+    <choose>
+      <if is-numeric="edition">
+        <group delimiter=" ">
+          <number variable="edition" form="numeric" suffix=". "/>
+          <text term="edition" form="short" plural="false"/>
+        </group>
+      </if>
+      <else>
+        <text variable="edition" suffix="."/>
+      </else>
+    </choose>
   </macro>
   <macro name="pages">
     <choose>

--- a/din-1505-2-numeric-alphabetical.csl
+++ b/din-1505-2-numeric-alphabetical.csl
@@ -163,10 +163,17 @@
     </group>
   </macro>
   <macro name="edition">
-    <group>
-      <number variable="edition" form="numeric" suffix=". "/>
-      <text term="edition" form="short" plural="false"/>
-    </group>
+    <choose>
+      <if is-numeric="edition">
+        <group delimiter=" ">
+          <number variable="edition" form="numeric" suffix=". "/>
+          <text term="edition" form="short" plural="false"/>
+        </group>
+      </if>
+      <else>
+        <text variable="edition" suffix="."/>
+      </else>
+    </choose>
   </macro>
   <macro name="pages">
     <choose>

--- a/din-1505-2-numeric.csl
+++ b/din-1505-2-numeric.csl
@@ -153,10 +153,17 @@
     </group>
   </macro>
   <macro name="edition">
-    <group>
-      <number variable="edition" form="numeric" suffix=". "/>
-      <text term="edition" form="short" plural="false"/>
-    </group>
+    <choose>
+      <if is-numeric="edition">
+        <group delimiter=" ">
+          <number variable="edition" form="numeric" suffix=". "/>
+          <text term="edition" form="short" plural="false"/>
+        </group>
+      </if>
+      <else>
+        <text variable="edition" suffix="."/>
+      </else>
+    </choose>
   </macro>
   <macro name="pages">
     <choose>

--- a/din-1505-2.csl
+++ b/din-1505-2.csl
@@ -186,10 +186,17 @@
     </group>
   </macro>
   <macro name="edition">
-    <group>
-      <number variable="edition" form="numeric" suffix=". "/>
-      <text term="edition" form="short" plural="false"/>
-    </group>
+    <choose>
+      <if is-numeric="edition">
+        <group delimiter=" ">
+          <number variable="edition" form="numeric" suffix=". "/>
+          <text term="edition" form="short" plural="false"/>
+        </group>
+      </if>
+      <else>
+        <text variable="edition" suffix="."/>
+      </else>
+    </choose>
   </macro>
   <macro name="pages">
     <choose>


### PR DESCRIPTION
Almost any edition i encountered is either plain numeric or - if not - already contains some (abbreviated) form of the word "edition". So in most cases my German citations have edition statements ending in "... Aufl. Aufl.", with the latter occurrence provided by the <text/> element in the style.
Unfortunately, I have no statistical data to prove that this solution is better. 
But at least the modifications in this patch request are based on how the "edition" is formatted in vancouver.csl.