### PR TITLE
Update accessed field for Incluenza and Other Respiratory Diseases style

### DIFF
--- a/influenza-and-other-respiratory-viruses.csl
+++ b/influenza-and-other-respiratory-viruses.csl
@@ -14,7 +14,7 @@
     <category field="medicine"/>
     <issn>1750-2640</issn>
     <eissn>1750-2659</eissn>
-    <updated>2017-05-31T10:46:24+00:00</updated>
+    <updated>2018-06-29T19:02:03+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale xml:lang="en">
@@ -184,9 +184,9 @@
         </else-if>
         <else-if type="webpage post-weblog" match="any">
           <text term="available at" text-case="capitalize-first" prefix=" "/>
-          <text variable="URL" prefix=" "/>
-          <group delimiter=" " prefix="(" suffix=")">
-            <text term="cited"/>
+          <text variable="URL" prefix=" " suffix="."/>
+          <group delimiter=" " prefix=" " suffix=".">
+            <text term="accessed" text-case="sentence"/>
             <date form="text" variable="accessed"/>
           </group>
         </else-if>

--- a/influenza-and-other-respiratory-viruses.csl
+++ b/influenza-and-other-respiratory-viruses.csl
@@ -186,7 +186,7 @@
           <text term="available at" text-case="capitalize-first" prefix=" "/>
           <text variable="URL" prefix=" " suffix="."/>
           <group delimiter=" " prefix=" " suffix=".">
-            <text term="accessed" text-case="sentence"/>
+            <text term="accessed" text-case="capitalize-first"/>
             <date form="text" variable="accessed"/>
           </group>
         </else-if>


### PR DESCRIPTION
They are now using the more standard "Accessed" now, as opposed to "cited".