### PR TITLE
APA Fixes

### DIFF
--- a/apa-annotated-bibliography.csl
+++ b/apa-annotated-bibliography.csl
@@ -44,6 +44,11 @@
       <term name="translator" form="short">trans.</term>
     </terms>
   </locale>
+  <locale xml:lang="es">
+    <terms>
+      <term name="from">de</term>
+    </terms>
+  </locale>
   <macro name="container-contributors">
     <choose>
       <if type="chapter paper-conference entry-dictionary entry-encyclopedia" match="any">
@@ -333,7 +338,7 @@
       <else-if type="post-weblog webpage" match="none">
         <group delimiter=", ">
           <choose>
-            <if variable="event version" type="speech motion_picture" match="none">
+            <if variable="event version" type="speech dataset motion_picture" match="none">
               <!-- Including version is to avoid printing the programming language for computerProgram /-->
               <text variable="genre"/>
             </if>
@@ -679,7 +684,7 @@
   </macro>
   <citation et-al-min="6" et-al-use-first="1" et-al-subsequent-min="3" et-al-subsequent-use-first="1" disambiguate-add-year-suffix="true" disambiguate-add-names="true" disambiguate-add-givenname="true" collapse="year" givenname-disambiguation-rule="primary-name">
     <sort>
-      <key macro="author"/>
+      <key macro="author" names-min="8" names-use-first="6"/>
       <key macro="issued-sort"/>
     </sort>
     <layout prefix="(" suffix=")" delimiter="; ">

--- a/apa-cv.csl
+++ b/apa-cv.csl
@@ -48,6 +48,11 @@
       <term name="translator" form="short">trans.</term>
     </terms>
   </locale>
+  <locale xml:lang="es">
+    <terms>
+      <term name="from">de</term>
+    </terms>
+  </locale>
   <macro name="container-contributors">
     <choose>
       <if type="chapter paper-conference entry-dictionary entry-encyclopedia" match="any">
@@ -293,7 +298,7 @@
       <else-if type="post-weblog webpage" match="none">
         <group delimiter=", ">
           <choose>
-            <if variable="event version" type="speech motion_picture" match="none">
+            <if variable="event version" type="speech dataset motion_picture" match="none">
               <!-- Including version is to avoid printing the programming language for computerProgram /-->
               <text variable="genre"/>
             </if>

--- a/apa-no-doi-no-issue.csl
+++ b/apa-no-doi-no-issue.csl
@@ -44,6 +44,11 @@
       <term name="translator" form="short">trans.</term>
     </terms>
   </locale>
+  <locale xml:lang="es">
+    <terms>
+      <term name="from">de</term>
+    </terms>
+  </locale>
   <macro name="container-contributors">
     <choose>
       <if type="chapter paper-conference entry-dictionary entry-encyclopedia" match="any">
@@ -334,7 +339,7 @@
       <else-if type="post-weblog webpage" match="none">
         <group delimiter=", ">
           <choose>
-            <if variable="event version" type="speech motion_picture" match="none">
+            <if variable="event version" type="speech dataset motion_picture" match="none">
               <!-- Including version is to avoid printing the programming language for computerProgram /-->
               <text variable="genre"/>
             </if>
@@ -679,7 +684,7 @@
   </macro>
   <citation et-al-min="6" et-al-use-first="1" et-al-subsequent-min="3" et-al-subsequent-use-first="1" disambiguate-add-year-suffix="true" disambiguate-add-names="true" disambiguate-add-givenname="true" collapse="year" givenname-disambiguation-rule="primary-name">
     <sort>
-      <key macro="author"/>
+      <key macro="author" names-min="8" names-use-first="6"/>
       <key macro="issued-sort"/>
     </sort>
     <layout prefix="(" suffix=")" delimiter="; ">

--- a/apa-old-doi-prefix.csl
+++ b/apa-old-doi-prefix.csl
@@ -43,6 +43,11 @@
       <term name="translator" form="short">trans.</term>
     </terms>
   </locale>
+  <locale xml:lang="es">
+    <terms>
+      <term name="from">de</term>
+    </terms>
+  </locale>
   <macro name="container-contributors">
     <choose>
       <if type="chapter paper-conference entry-dictionary entry-encyclopedia" match="any">
@@ -332,7 +337,7 @@
       <else-if type="post-weblog webpage" match="none">
         <group delimiter=", ">
           <choose>
-            <if variable="event version" type="speech motion_picture" match="none">
+            <if variable="event version" type="speech dataset motion_picture" match="none">
               <!-- Including version is to avoid printing the programming language for computerProgram /-->
               <text variable="genre"/>
             </if>
@@ -678,7 +683,7 @@
   </macro>
   <citation et-al-min="6" et-al-use-first="1" et-al-subsequent-min="3" et-al-subsequent-use-first="1" disambiguate-add-year-suffix="true" disambiguate-add-names="true" disambiguate-add-givenname="true" collapse="year" givenname-disambiguation-rule="primary-name">
     <sort>
-      <key macro="author"/>
+      <key macro="author" names-min="8" names-use-first="6"/>
       <key macro="issued-sort"/>
     </sort>
     <layout prefix="(" suffix=")" delimiter="; ">

--- a/apa-single-spaced.csl
+++ b/apa-single-spaced.csl
@@ -44,6 +44,11 @@
       <term name="translator" form="short">trans.</term>
     </terms>
   </locale>
+  <locale xml:lang="es">
+    <terms>
+      <term name="from">de</term>
+    </terms>
+  </locale>
   <macro name="container-contributors">
     <choose>
       <if type="chapter paper-conference entry-dictionary entry-encyclopedia" match="any">
@@ -333,7 +338,7 @@
       <else-if type="post-weblog webpage" match="none">
         <group delimiter=", ">
           <choose>
-            <if variable="event version" type="speech motion_picture" match="none">
+            <if variable="event version" type="speech dataset motion_picture" match="none">
               <!-- Including version is to avoid printing the programming language for computerProgram /-->
               <text variable="genre"/>
             </if>
@@ -679,7 +684,7 @@
   </macro>
   <citation et-al-min="6" et-al-use-first="1" et-al-subsequent-min="3" et-al-subsequent-use-first="1" disambiguate-add-year-suffix="true" disambiguate-add-names="true" disambiguate-add-givenname="true" collapse="year" givenname-disambiguation-rule="primary-name">
     <sort>
-      <key macro="author"/>
+      <key macro="author" names-min="8" names-use-first="6"/>
       <key macro="issued-sort"/>
     </sort>
     <layout prefix="(" suffix=")" delimiter="; ">

--- a/apa.csl
+++ b/apa.csl
@@ -43,6 +43,11 @@
       <term name="translator" form="short">trans.</term>
     </terms>
   </locale>
+  <locale xml:lang="es">
+    <terms>
+      <term name="from">de</term>
+    </terms>
+  </locale>
   <macro name="container-contributors">
     <choose>
       <if type="chapter paper-conference entry-dictionary entry-encyclopedia" match="any">
@@ -678,7 +683,7 @@
   </macro>
   <citation et-al-min="6" et-al-use-first="1" et-al-subsequent-min="3" et-al-subsequent-use-first="1" disambiguate-add-year-suffix="true" disambiguate-add-names="true" disambiguate-add-givenname="true" collapse="year" givenname-disambiguation-rule="primary-name">
     <sort>
-      <key macro="author"/>
+      <key macro="author" names-min="8" names-use-first="6"/>
       <key macro="issued-sort"/>
     </sort>
     <layout prefix="(" suffix=")" delimiter="; ">


### PR DESCRIPTION
Fix Spanish "Retrieved from" and in-text author sorting.
(My original idea didn't work out because we're using "retrieved" and "from" split with the access date in the middle for webpages).