### PR TITLE
Update to No Date abbreviation

### DIFF
--- a/apa-fr-provost.csl
+++ b/apa-fr-provost.csl
@@ -26,7 +26,7 @@
       </term>
       <term name="editortranslator" form="short">éd. &amp; trad.</term>
       <term name="translator" form="short">trad.</term>
-      <term name="no date" form="short">n.d.</term>
+      <term name="no date" form="short">s.d.</term>
       <term name="in">dans</term>
       <term name="retrieved">repéré</term>
       <term name="from">à</term>


### PR DESCRIPTION
I propose a small change to the abbreviation for "No date" from "n.d." to "s.d." whic is the correct format in french. The Provos Guideline does state that they use "n.d." but this is incorrect in french and all other APA-French versions guidelines that I could find use "s.d.". Since this style is used as a reference for many other APA-French style (e.g. Ecole-de-technologie-superieure-APA, UdeM, etc.), I propose the changes here. If it is impossible to change it here, could we make another APA-French style to which other styles could refer instead?