### PR TITLE
Update Juristische Zitierweise (Stüber)

### DIFF
--- a/juristische-zitierweise.csl
+++ b/juristische-zitierweise.csl
@@ -40,7 +40,7 @@
     </names>
   </macro>
   <macro name="locator-with-label">
-    <group delimiter="&amp;#160;">
+    <group delimiter="&#160;">
       <label variable="locator" form="symbol"/>
       <text variable="locator"/>
     </group>
@@ -112,7 +112,7 @@
             <text macro="author-note"/>
             <text macro="inbook"/>
             <group delimiter=" ">
-              <group delimiter="&amp;#160;">
+              <group delimiter="&#160;">
                 <text term="page" form="short"/>
                 <text variable="page-first"/>
               </group>

--- a/juristische-zitierweise.csl
+++ b/juristische-zitierweise.csl
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <style xmlns="http://purl.org/net/xbiblio/csl" version="1.0" class="note" default-locale="de-DE">
   <!-- This style was edited with the Visual CSL Editor (http://editor.citationstyles.org/visualEditor/) -->
   <info>

--- a/juristische-zitierweise.csl
+++ b/juristische-zitierweise.csl
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <style xmlns="http://purl.org/net/xbiblio/csl" version="1.0" class="note" default-locale="de-DE">
   <!-- This style was edited with the Visual CSL Editor (http://editor.citationstyles.org/visualEditor/) -->
   <info>
@@ -17,7 +17,7 @@
     <category citation-format="note"/>
     <category field="law"/>
     <summary>Juristische Zitierweise nach Stüber www.niederle-media.de/Zitieren.pdf</summary>
-    <updated>2017-01-29T14:33:14+00:00</updated>
+    <updated>2018-07-21T09:10:53+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale xml:lang="de-DE">
@@ -40,7 +40,7 @@
     </names>
   </macro>
   <macro name="locator-with-label">
-    <group delimiter=" ">
+    <group delimiter="&amp;#160;">
       <label variable="locator" form="symbol"/>
       <text variable="locator"/>
     </group>
@@ -60,7 +60,7 @@
         <names variable="editor">
           <name form="short" delimiter="/" initialize-with=""/>
         </names>
-        <text variable="title"/>
+        <text variable="container-title" form="short"/>
       </group>
     </group>
   </macro>
@@ -111,14 +111,22 @@
           <group delimiter=", ">
             <text macro="author-note"/>
             <text macro="inbook"/>
-            <text macro="locator-with-label"/>
+            <group delimiter=" ">
+              <group delimiter="&amp;#160;">
+                <text term="page" form="short"/>
+                <text variable="page-first"/>
+              </group>
+              <text variable="locator" prefix="(" suffix=")"/>
+            </group>
           </group>
         </else-if>
         <else-if type="entry-encyclopedia">
-          <text value="Bearbeiter," suffix=" " font-style="italic"/>
+          <text value="Bearbeiter," font-style="italic" suffix=" "/>
           <text value="in: "/>
-          <text variable="title" suffix=", " form="short"/>
-          <text variable="locator" suffix=". "/>
+          <group delimiter=", ">
+            <text variable="title" form="short"/>
+            <text variable="locator"/>
+          </group>
         </else-if>
         <else-if type="legal_case" match="any">
           <group delimiter=", ">
@@ -147,7 +155,7 @@
         <else>
           <group delimiter=", ">
             <text macro="author-note"/>
-            <text variable="title"/>
+            <text variable="title" form="short"/>
             <text macro="locator-with-label"/>
           </group>
         </else>
@@ -247,6 +255,7 @@
           <group delimiter=", ">
             <text macro="author"/>
             <text variable="title"/>
+            <date form="text" variable="issued" prefix="Stand: "/>
             <group delimiter=" ">
               <text variable="URL"/>
               <group delimiter=" " prefix="(" suffix=")">


### PR DESCRIPTION
- chapter: fix mismatched use of title instead of container-title
- chapter: add first page besides pages from locator, similar to journal article,
e.g. Knemeyer, in: von Mutius, FG für von Unruh, S. 209 (209).
- use non-breakable space between locator and label
- encyclopedia-aricles: fix problem when title is missing
- prefer short-title in footnote citations
- wegpage: add date in bibliography with prefix "Stand: "