### PR TITLE
Update polish-legal.csl

### DIFF
--- a/polish-legal.csl
+++ b/polish-legal.csl
@@ -12,7 +12,7 @@
     <category citation-format="note"/>
     <category field="law"/>
     <summary>A style for legal citations in Poland.</summary>
-    <updated>2018-07-06T08:12:22+01:00</updated>
+    <updated>2018-07-30T16:43:00+02:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale xml:lang="pl">
@@ -29,6 +29,7 @@
       <term name="month-10" gender="masculine">października</term>
       <term name="month-11" gender="masculine">listopada</term>
       <term name="month-12" gender="masculine">grudnia</term>
+      <term name="section" form="long">teza</term>
     </terms>
   </locale>
   <macro name="editor-translator">
@@ -99,12 +100,21 @@
       <text variable="volume"/>
     </group>
   </macro>
-  <macro name="locator">
-    <!-- Numer strony. -->
-    <group delimiter=" ">
-      <label variable="locator" form="short" suffix="."/>
-      <text variable="locator"/>
-    </group>
+  <macro name="locator"> <!-- Numer strony. -->
+    <choose>
+      <if locator="section">
+        <group delimiter=" ">
+          <label variable="locator" form="long"/>
+          <text variable="locator"/>
+        </group>  
+      </if>
+      <else>
+          <group delimiter=" ">
+          <label variable="locator" form="short" suffix="."/>
+          <text variable="locator"/>
+        </group>
+      </else>
+    </choose>
   </macro>
   <!-- Poniżej makra dla poszczególnych typów -->
   <macro name="container">

--- a/polish-legal.csl
+++ b/polish-legal.csl
@@ -29,7 +29,7 @@
       <term name="month-10" gender="masculine">października</term>
       <term name="month-11" gender="masculine">listopada</term>
       <term name="month-12" gender="masculine">grudnia</term>
-      <term name="section" form="long">teza</term>
+      <term name="section" form="short">teza</term>
     </terms>
   </locale>
   <macro name="editor-translator">
@@ -102,20 +102,10 @@
   </macro>
   <macro name="locator">
     <!-- Numer strony. -->
-    <choose>
-      <if locator="section">
-        <group delimiter=" ">
-          <label variable="locator" form="long"/>
-          <text variable="locator"/>
-        </group>
-      </if>
-      <else>
-        <group delimiter=" ">
-          <label variable="locator" form="short" suffix="."/>
-          <text variable="locator"/>
-        </group>
-      </else>
-    </choose>
+    <group delimiter=" ">
+      <label variable="locator" form="short"/>
+      <text variable="locator"/>
+    </group>
   </macro>
   <!-- Poniżej makra dla poszczególnych typów -->
   <macro name="container">

--- a/polish-legal.csl
+++ b/polish-legal.csl
@@ -100,16 +100,17 @@
       <text variable="volume"/>
     </group>
   </macro>
-  <macro name="locator"> <!-- Numer strony. -->
+  <macro name="locator">
+    <!-- Numer strony. -->
     <choose>
       <if locator="section">
         <group delimiter=" ">
           <label variable="locator" form="long"/>
           <text variable="locator"/>
-        </group>  
+        </group>
       </if>
       <else>
-          <group delimiter=" ">
+        <group delimiter=" ">
           <label variable="locator" form="short" suffix="."/>
           <text variable="locator"/>
         </group>


### PR DESCRIPTION
Replaces "section" with "thesis" (PL: "teza") as is customary for citing legal commentaries.