### PR TITLE
Remove duplicated issued in chicago (author-date)

### DIFF
--- a/chicago-author-date.csl
+++ b/chicago-author-date.csl
@@ -163,11 +163,6 @@
         </else-if>
       </choose>
       <choose>
-        <if type="webpage post-weblog" match="any">
-          <date variable="issued" form="text"/>
-        </if>
-      </choose>
-      <choose>
         <if variable="issued" match="none">
           <group delimiter=" ">
             <text term="accessed" text-case="capitalize-first"/>


### PR DESCRIPTION
`issued` is rendered twice for webpage and post-weblog. This change aligns Chicago (author-date) with Chicago (note) and (fullnote), where these lines have already been removed.

Reported https://forums.zotero.org/discussion/73102/duplicated-date#latest