### PR TITLE
Create university-of-south-australia-2017-harvard.csl

### DIFF
--- a/university-of-south-australia-2017-harvard.csl
+++ b/university-of-south-australia-2017-harvard.csl
@@ -1,0 +1,335 @@
+<?xml version="1.0" encoding="utf-8"?>
+<style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" default-locale="en-GB" version="1.0" demote-non-dropping-particle="sort-only">
+  <!-- This style was edited with the Visual CSL Editor (http://editor.citationstyles.org/visualEditor/) -->
+  <info>
+    <title>University of South Australia 2017 - Harvard</title>
+    <title-short>Harvard-UniSA</title-short>
+	<id>http://www.zotero.org/styles/university-of-south-australia-2017-harvard</id>
+	<link href="http://www.zotero.org/styles/university-of-south-australia-2017-harvard" rel="self"/>
+	<link href="http://www.zotero.org/styles/university-of-south-australia-harvard-2013" rel="template"/>
+    <link href="https://lo.unisa.edu.au/pluginfile.php/1396048/mod_resource/content/1/HRG%20January%202017.pdf" rel="documentation"/>
+    <author>
+      <name>Lachlan Young</name>
+      <email>Lachlan.Young@unisa.edu.au</email>
+    </author>
+    <category citation-format="author-date"/>
+    <category field="generic-base"/>
+    <summary>University of South Australia citation style based on the January 2017 version of the style guide titled Harvard referencing guide UniSA</summary>
+    <updated>2018-08-20T03:25:46+00:00</updated>
+    <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
+  </info>
+  <locale xml:lang="en">
+    <terms>
+      <term name="editor" form="short">
+        <single>ed.</single>
+        <multiple>eds</multiple>
+      </term>
+      <term name="translator" form="short">
+        <single>trans.</single>
+        <multiple>trans</multiple>
+      </term>
+      <term name="director" form="short">
+        <single>dir.</single>
+        <multiple>dirs</multiple>
+      </term>
+      <term name="edition" form="short">edn</term>
+      <term name="volume" form="short">vol.</term>
+      <term name="issue" form="short">no.</term>
+      <term name="accessed" form="long">accessed</term>
+      <term name="retrieved" form="long">viewed</term>
+      <term name="open-quote">‘</term>
+      <term name="close-quote">’</term>
+      <term name="open-inner-quote">“</term>
+      <term name="close-inner-quote">”</term>
+    </terms>
+    <style-options punctuation-in-quote="false"/>
+  </locale>
+  <macro name="editor">
+    <choose>
+      <if variable="editor container-title" match="all">
+        <text term="in" suffix=" "/>
+      </if>
+    </choose>
+    <names variable="editor" delimiter=", ">
+      <name and="symbol" initialize-with="" delimiter=", " delimiter-precedes-last="never"/>
+      <label form="short" prefix=" (" suffix=")"/>
+    </names>
+  </macro>
+  <macro name="translator">
+    <names variable="translator" delimiter=", ">
+      <label form="short" suffix=" "/>
+      <name and="symbol" initialize-with="" delimiter=", " delimiter-precedes-last="never"/>
+    </names>
+  </macro>
+  <macro name="noauthor_editor">
+    <names variable="author">
+      <name/>
+      <substitute>
+        <names variable="editor">
+          <name name-as-sort-order="all" and="symbol" sort-separator=", " initialize-with="" delimiter=", " delimiter-precedes-last="never"/>
+          <label form="short" prefix=" (" suffix=")"/>
+        </names>
+      </substitute>
+    </names>
+  </macro>
+  <macro name="noauthor_title">
+    <choose>
+      <if type="article-newspaper">
+        <names variable="author">
+          <name/>
+          <substitute>
+            <text variable="container-title" font-style="italic"/>
+          </substitute>
+        </names>
+      </if>
+      <else>
+        <names variable="author">
+          <name/>
+          <substitute>
+            <text macro="title"/>
+          </substitute>
+        </names>
+      </else>
+    </choose>
+  </macro>
+  <macro name="author">
+    <names variable="author">
+      <name name-as-sort-order="all" and="symbol" sort-separator=", " initialize-with="" delimiter=", " delimiter-precedes-last="never"/>
+      <label form="short" prefix=" (" suffix=")" strip-periods="true"/>
+      <substitute>
+        <text macro="noauthor_editor"/>
+        <text macro="noauthor_title"/>
+      </substitute>
+    </names>
+    <choose>
+      <if type="motion_picture">
+        <choose>
+          <if variable="author">
+            <text term="director" form="short" prefix=" (" suffix=")"/>
+          </if>
+        </choose>
+      </if>
+    </choose>
+  </macro>
+  <macro name="author-short">
+    <names variable="author">
+      <label form="short" suffix=" " strip-periods="true"/>
+      <name form="short" name-as-sort-order="all" and="symbol" sort-separator=", " delimiter=", " delimiter-precedes-last="never" initialize-with=""/>
+      <substitute>
+        <names variable="editor"/>
+        <text macro="noauthor_title"/>
+      </substitute>
+    </names>
+  </macro>
+  <macro name="title">
+    <choose>
+      <if type="chapter paper-conference article-journal article-magazine article-newspaper broadcast interview manuscript map personal_communication speech thesis map post post-weblog" match="none">
+        <text variable="title" font-style="italic"/>
+      </if>
+      <else>
+        <text variable="title" quotes="true"/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="publisher-place">
+    <choose>
+      <if variable="container-title">
+        <choose>
+          <if type="article article-journal article-magazine article-newspaper" match="none">
+            <text variable="publisher-place"/>
+          </if>
+        </choose>
+      </if>
+      <else-if variable="event" match="none">
+        <text variable="publisher-place"/>
+      </else-if>
+    </choose>
+  </macro>
+  <macro name="year-date">
+    <choose>
+      <if variable="issued">
+        <choose>
+          <if type="legal_case" match="any">
+            <date form="text" variable="issued" prefix="(" suffix=")">
+              <date-part name="year"/>
+            </date>
+          </if>
+          <else>
+            <date variable="issued">
+              <date-part name="year"/>
+            </date>
+          </else>
+        </choose>
+      </if>
+      <else>
+        <text term="no date" form="short"/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="day-month-date">
+    <choose>
+      <if type="article-newspaper report post post-weblog song" match="any">
+        <date variable="issued">
+          <date-part name="day" form="numeric" suffix=" "/>
+          <date-part name="month" form="long"/>
+        </date>
+      </if>
+    </choose>
+  </macro>
+  <macro name="edition">
+    <choose>
+      <if is-numeric="edition">
+        <group delimiter=" ">
+          <number variable="edition" form="ordinal"/>
+          <text term="edition" form="short" strip-periods="true"/>
+        </group>
+      </if>
+      <else>
+        <text variable="edition"/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="format">
+    <choose>
+      <if type="song motion_picture" match="any">
+        <text variable="medium"/>
+      </if>
+      <else>
+        <text variable="genre"/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="container">
+    <choose>
+      <if type="chapter paper-conference" match="any">
+        <choose>
+          <if variable="container-title">
+            <choose>
+              <if variable="editor author" match="all"/>
+              <else>
+                <text term="in" suffix=" "/>
+              </else>
+            </choose>
+            <text variable="container-title" font-style="italic"/>
+          </if>
+          <else-if variable="event">
+            <text value="paper presented at "/>
+            <text variable="event"/>
+            <text variable="event-place" prefix=", "/>
+          </else-if>
+        </choose>
+      </if>
+      <else-if type="webpage">
+        <text variable="container-title"/>
+      </else-if>
+      <else>
+        <text variable="container-title" font-style="italic"/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="volume">
+    <group delimiter=" ">
+      <text term="volume" form="short"/>
+      <text variable="volume"/>
+    </group>
+  </macro>
+  <macro name="issue">
+    <group delimiter=" ">
+      <text term="issue" form="short"/>
+      <text variable="issue"/>
+    </group>
+  </macro>
+  <macro name="pages">
+    <label variable="page" form="short" suffix=" "/>
+    <text variable="page"/>
+  </macro>
+  <macro name="access">
+    <choose>
+      <if variable="URL accessed" match="all">
+        <choose>
+          <if type="song">
+            <text term="accessed"/>
+          </if>
+          <else>
+            <text term="retrieved"/>
+          </else>
+        </choose>
+        <date variable="accessed" prefix=" ">
+          <date-part name="day" form="numeric" suffix=" "/>
+          <date-part name="month" form="long" suffix=" "/>
+          <date-part name="year" form="long"/>
+        </date>
+        <text variable="URL" prefix=", &lt;" suffix="&gt;"/>
+      </if>
+    </choose>
+  </macro>
+  <macro name="publisher">
+    <choose>
+      <if type="article-journal article-magazine article-newspaper article" match="none">
+        <text variable="publisher"/>
+      </if>
+    </choose>
+  </macro>
+  <citation et-al-min="4" et-al-use-first="1" disambiguate-add-givenname="true" disambiguate-add-year-suffix="true" collapse="year">
+    <sort>
+      <key macro="author-short"/>
+      <key macro="year-date"/>
+    </sort>
+    <layout prefix="(" suffix=")" delimiter="; ">
+      <group delimiter=", ">
+        <group delimiter=" ">
+          <text macro="author-short"/>
+          <text macro="year-date"/>
+        </group>
+        <group>
+          <label variable="locator" suffix=" " form="short"/>
+          <text variable="locator"/>
+        </group>
+      </group>
+    </layout>
+  </citation>
+  <bibliography et-al-min="99" et-al-use-first="98" hanging-indent="false" entry-spacing="1" line-spacing="1" subsequent-author-substitute="―" subsequent-author-substitute-rule="complete-all">
+    <sort>
+      <key macro="author"/>
+      <key macro="year-date"/>
+      <key macro="title"/>
+    </sort>
+    <layout>
+      <choose>
+        <if type="personal_communication" match="none">
+          <text macro="author"/>
+          <group prefix=" " delimiter=", " suffix=".">
+            <text macro="year-date"/>
+            <text macro="title"/>
+            <text macro="editor"/>
+            <text macro="translator"/>
+            <text macro="format"/>
+            <choose>
+              <if type="legal_case" match="any">
+                <group delimiter=" ">
+                  <text variable="volume"/>
+                  <text variable="issue" prefix="(" suffix=")"/>
+                  <text variable="container-title" form="short"/>
+                  <text variable="page-first"/>
+                </group>
+              </if>
+              <else>
+                <text macro="container"/>
+                <text macro="edition"/>
+                <text variable="number"/>
+                <text macro="day-month-date"/>
+                <text macro="volume"/>
+                <text variable="collection-title"/>
+                <text macro="publisher"/>
+                <text macro="publisher-place"/>
+                <text macro="issue"/>
+                <text macro="pages"/>
+                <text macro="access"/>
+              </else>
+            </choose>
+          </group>
+        </if>
+      </choose>
+    </layout>
+  </bibliography>
+</style>

--- a/university-of-south-australia-2017-harvard.csl
+++ b/university-of-south-australia-2017-harvard.csl
@@ -4,9 +4,9 @@
   <info>
     <title>University of South Australia 2017 - Harvard</title>
     <title-short>Harvard-UniSA</title-short>
-	<id>http://www.zotero.org/styles/university-of-south-australia-2017-harvard</id>
-	<link href="http://www.zotero.org/styles/university-of-south-australia-2017-harvard" rel="self"/>
-	<link href="http://www.zotero.org/styles/university-of-south-australia-harvard-2013" rel="template"/>
+    <id>http://www.zotero.org/styles/university-of-south-australia-2017-harvard</id>
+    <link href="http://www.zotero.org/styles/university-of-south-australia-2017-harvard" rel="self"/>
+    <link href="http://www.zotero.org/styles/university-of-south-australia-harvard-2013" rel="template"/>
     <link href="https://lo.unisa.edu.au/pluginfile.php/1396048/mod_resource/content/1/HRG%20January%202017.pdf" rel="documentation"/>
     <author>
       <name>Lachlan Young</name>


### PR DESCRIPTION
There are existing styles for the University of South Australia institutional version of Harvard citation, from 2010 and 2013, but the most recent 2017 edition of the style has not been added.
This new style builds upon the 2013 version, with changes to the handling of publisher names and legal cases.