### PR TITLE
Create minimal-grant-proposals.csl

### DIFF
--- a/minimal-grant-proposals.csl
+++ b/minimal-grant-proposals.csl
@@ -1,0 +1,91 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" demote-non-dropping-particle="sort-only" default-locale="en-GB">
+  <info>
+    <title>Minimal style for grant proposals</title>
+    <id>http://csl.mendeley.com/styles/20448741/minimal-grant-proposals</id>
+    <author>
+      <name>Anton Crombach</name>
+      <email>anton.crombach@gmail.com</email>
+    </author>
+    <contributor>
+      <name>Anton Crombach</name>
+      <uri>http://anton.cromba.ch/</uri>
+    </contributor>
+    <category citation-format="numeric"/>
+    <category field="science"/>
+    <category field="generic-base"/>
+    <updated>2016-02-05T14:26:52+00:00</updated>
+    <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
+  </info>
+  <macro name="author">
+    <names variable="author">
+      <name and="symbol" delimiter-precedes-last="never" et-al-min="2" initialize-with=". " name-as-sort-order="all"/>
+      <label form="short" prefix=", "/>
+      <et-al font-style="italic"/>
+    </names>
+  </macro>
+  <macro name="issuance">
+    <choose>
+      <if type="bill book graphic legal_case legislation motion_picture report song thesis chapter paper-conference" match="any">
+        <group delimiter=", " prefix="(" suffix=")">
+          <text variable="publisher" form="short"/>
+          <date variable="issued">
+            <date-part name="year"/>
+          </date>
+        </group>
+      </if>
+      <else>
+        <date variable="issued" prefix="(" suffix=")">
+          <date-part name="year"/>
+        </date>
+      </else>
+    </choose>
+  </macro>
+  <macro name="container-title">
+    <choose>
+      <if type="article-journal">
+        <text variable="container-title" font-style="italic" form="short"/>
+      </if>
+      <else>
+        <text variable="container-title" font-style="italic"/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="editor">
+    <choose>
+      <if type="chapter paper-conference" match="any">
+        <names variable="editor" prefix="(" suffix=")">
+          <label form="short" suffix=" "/>
+          <name and="symbol" delimiter-precedes-last="never" initialize-with=". " name-as-sort-order="all"/>
+        </names>
+      </if>
+    </choose>
+  </macro>
+  <citation collapse="citation-number">
+    <sort>
+      <key variable="citation-number"/>
+    </sort>
+    <layout vertical-align="sup" delimiter=",">
+      <text variable="citation-number"/>
+    </layout>
+  </citation>
+  <bibliography et-al-min="6" et-al-use-first="1" entry-spacing="0">
+    <layout>
+      <text variable="citation-number" font-weight="bold" suffix=" "/>
+      <group delimiter=" ">
+        <text macro="author" suffix="."/>
+        <choose>
+          <if type="chapter paper-conference" match="any">
+            <text term="in" form="long" plural="false"/>
+          </if>
+        </choose>
+        <text macro="container-title"/>
+        <text macro="editor"/>
+        <text variable="volume" form="short" font-weight="normal" suffix=","/>
+        <text variable="page" form="short"/>
+        <text macro="issuance"/>
+        <text macro="access"/>
+      </group>
+    </layout>
+  </bibliography>
+</style>

--- a/minimal-grant-proposals.csl
+++ b/minimal-grant-proposals.csl
@@ -21,7 +21,8 @@
   </info>
   <macro name="author">
     <names variable="author">
-      <name and="symbol" delimiter-precedes-last="never" et-al-min="2" initialize-with=". " name-as-sort-order="all"/>
+      <name and="symbol" delimiter-precedes-last="never" initialize-with=". " name-as-sort-order="all"/>
+      <!--<name and="symbol" delimiter-precedes-last="never" et-al-min="2" initialize-with=". " name-as-sort-order="all"/>-->
       <label form="short" prefix=", "/>
       <et-al font-style="italic"/>
     </names>
@@ -71,7 +72,7 @@
       <text variable="citation-number"/>
     </layout>
   </citation>
-  <bibliography et-al-min="6" et-al-use-first="1" entry-spacing="0">
+  <bibliography et-al-min="2" et-al-use-first="1" entry-spacing="0">
     <layout>
       <text variable="citation-number" font-weight="bold" suffix=" "/>
       <group delimiter=" ">

--- a/minimal-grant-proposals.csl
+++ b/minimal-grant-proposals.csl
@@ -2,7 +2,9 @@
 <style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" demote-non-dropping-particle="sort-only" default-locale="en-GB">
   <info>
     <title>Minimal style for grant proposals</title>
-    <id>http://csl.mendeley.com/styles/20448741/minimal-grant-proposals</id>
+    <!--<id>http://csl.mendeley.com/styles/20448741/minimal-grant-proposals</id>-->
+    <id>http://www.zotero.org/styles/minimal-grant-proposals</id>
+    <link href="http://www.zotero.org/styles/minimal-grant-proposals" rel="self"/>
     <author>
       <name>Anton Crombach</name>
       <email>anton.crombach@gmail.com</email>
@@ -14,7 +16,7 @@
     <category citation-format="numeric"/>
     <category field="science"/>
     <category field="generic-base"/>
-    <updated>2016-02-05T14:26:52+00:00</updated>
+    <updated>2018-08-30T11:17:00+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <macro name="author">
@@ -84,7 +86,7 @@
         <text variable="volume" form="short" font-weight="normal" suffix=","/>
         <text variable="page" form="short"/>
         <text macro="issuance"/>
-        <text macro="access"/>
+        <!--<text macro="access"/>-->
       </group>
     </layout>
   </bibliography>


### PR DESCRIPTION
A few years ago I created a bare-bones citation style for use in grant proposals. I made it available via Mendeley as I used their citation manager at the time. I regularly receive "thank you" comments from fellow scientists that use the style, and I think I could make their life even more comfortable if this citation style was also available in the Zotero style repository.

For some more info, please see http://anton.cromba.ch/2016/02/07/a-minimal-citation-stylefor-grant-proposals/