### PR TITLE
Fix for missing comma in last group, removal of DOI

### DIFF
--- a/german-council-of-economic-experts.csl
+++ b/german-council-of-economic-experts.csl
@@ -30,7 +30,7 @@
     <category citation-format="author-date"/>
     <category field="political_science"/>
     <summary>Style for the German Council of Economic Experts</summary>
-    <updated>2017-10-31T15:43:27+00:00</updated>
+    <updated>2018-09-24T18:00:00+02:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale xml:lang="de">

--- a/german-council-of-economic-experts.csl
+++ b/german-council-of-economic-experts.csl
@@ -221,7 +221,7 @@
         <group delimiter=", ">
           <text value="Rede"/>
           <text variable="event"/>
-          <text variable="event-place" suffix=", "/>
+          <text variable="event-place"/>
         </group>
       </else-if>
       <else-if type="paper-conference" match="any">
@@ -323,7 +323,7 @@
       <key macro="date" sort="descending"/>
     </sort>
     <layout suffix=".">
-      <group delimiter=", ">
+      <group delimiter=", " suffix=", ">
         <group delimiter=" ">
           <text macro="contributors-long"/>
           <text prefix="(" macro="date" suffix=")"/>

--- a/german-council-of-economic-experts.csl
+++ b/german-council-of-economic-experts.csl
@@ -221,7 +221,7 @@
         <group delimiter=", ">
           <text value="Rede"/>
           <text variable="event"/>
-          <text variable="event-place"/>
+          <text variable="event-place" suffix=", "/>
         </group>
       </else-if>
       <else-if type="paper-conference" match="any">

--- a/german-council-of-economic-experts.csl
+++ b/german-council-of-economic-experts.csl
@@ -8,10 +8,25 @@
     <link href="http://www.zotero.org/styles/sozialwissenschaften-heilmann" rel="template"/>
     <link href="https://www.sachverstaendigenrat-wirtschaft.de/fileadmin/dateiablage/Sonstiges/SVR_Styleguide_Literaturverzeichnis_Stand_16.03.2017.pdf" rel="documentation"/>
     <author>
+      <name>Waldemar Hamm</name>
+      <email>waldemar.hamm@destatis.de</email>
+      <uri>http://www.sachverstaendigenrat-wirtschaft.de/index.html</uri>
+    </author>
+    <contributor>
       <name>Chris-Gabriel Islam</name>
       <email>chris-gabriel.islam@destatis.de</email>
       <uri>http://www.sachverstaendigenrat-wirtschaft.de/index.html</uri>
-    </author>
+    </contributor>
+    <contributor>
+      <name>Lara Wiengarten</name>
+      <email>lara.wiengarten@destatis.de</email>
+      <uri>http://www.sachverstaendigenrat-wirtschaft.de/index.html</uri>
+    </contributor>
+    <contributor>
+      <name>Adina Ehm</name>
+      <email>adina.ehm@destatis.de</email>
+      <uri>http://www.sachverstaendigenrat-wirtschaft.de/index.html</uri>
+    </contributor>
     <category citation-format="author-date"/>
     <category field="political_science"/>
     <summary>Style for the German Council of Economic Experts</summary>

--- a/german-council-of-economic-experts.csl
+++ b/german-council-of-economic-experts.csl
@@ -323,20 +323,20 @@
       <key macro="date" sort="descending"/>
     </sort>
     <layout suffix=".">
-      <group delimiter=", " suffix=", ">
+      <group delimiter=", ">
         <group delimiter=" ">
           <text macro="contributors-long"/>
           <text prefix="(" macro="date" suffix=")"/>
         </group>
         <text macro="title"/>
         <text macro="container"/>
-      </group>
-      <group delimiter=", ">
-        <text macro="issued"/>
-        <text macro="pages"/>
-        <text macro="access"/>
-        <text macro="exact-date"/>
-        <text macro="mimeo"/>
+        <group delimiter=", ">
+          <text macro="issued"/>
+          <text macro="pages"/>
+          <text macro="access"/>
+          <text macro="exact-date"/>
+          <text macro="mimeo"/>
+        </group>
       </group>
     </layout>
   </bibliography>

--- a/german-council-of-economic-experts.csl
+++ b/german-council-of-economic-experts.csl
@@ -337,7 +337,6 @@
         <text macro="access"/>
         <text macro="exact-date"/>
         <text macro="mimeo"/>
-        <text prefix="doi:" variable="DOI"/>
       </group>
     </layout>
   </bibliography>


### PR DESCRIPTION
Hello everyone!
We realized that we had a missing comma in the last group, so we ended up with wrongly styled citations. Also we realized that we don't want DOI in our citation, so we removed it for now.

I hope everything is fine, the CSL was validated properly before the PR.