### PR TITLE
Update harvard-university-of-leeds.csl

### DIFF
--- a/harvard-university-of-leeds.csl
+++ b/harvard-university-of-leeds.csl
@@ -54,17 +54,21 @@
   </macro>
   <macro name="access">
     <choose>
-      <if variable="URL">
-        <group prefix=" [" suffix="]. ">
-          <text term="accessed" text-case="capitalize-first" suffix=" "/>
-          <date variable="accessed">
-            <date-part name="day" suffix=" "/>
-            <date-part name="month" suffix=" "/>
-            <date-part name="year"/>
-          </date>
-        </group>
-        <text value="Available from:" suffix=" "/>
-        <text variable="URL"/>
+      <if type="article article-journal article-magazine" match="none">
+        <choose>
+          <if variable="URL">
+            <group prefix=" [" suffix="]. ">
+              <text term="accessed" text-case="capitalize-first" suffix=" "/>
+              <date variable="accessed">
+                <date-part name="day" suffix=" "/>
+                <date-part name="month" suffix=" "/>
+                <date-part name="year"/>
+              </date>
+            </group>
+            <text value="Available from:" suffix=" "/>
+            <text variable="URL"/>
+          </if>
+        </choose>
       </if>
     </choose>
   </macro>
@@ -225,8 +229,12 @@
             <group delimiter=" ">
               <text variable="container-title" font-style="italic" suffix="."/>
               <choose>
-                <if match="any" variable="URL">
-                  <text term="online" text-case="capitalize-first" prefix="[" suffix="]"/>
+                <if type="article article-journal article-magazine" match="none">
+                  <choose>
+                    <if match="any" variable="URL">
+                      <text term="online" text-case="capitalize-first" prefix="[" suffix="]"/>
+                    </if>
+                  </choose>
                 </if>
               </choose>
             </group>


### PR DESCRIPTION
Fixes #3704 

No [Online] or access details for articles / journal articles / magazine articles.
Newspaper articles should retain those details.

From : https://library.leeds.ac.uk/referencing-examples/9/leeds-harvard:

 * Article / Journal Article: https://library.leeds.ac.uk/referencing-examples/9/leeds-harvard/11/journal-article
 * Magazine article defers to Journal Article 
 * Newspaper article retains [Online] and access information: https://library.leeds.ac.uk/referencing-examples/9/leeds-harvard/82/newspaper