### PR TITLE
Create eva-berlin-konferenz.csl

### DIFF
--- a/eva-berlin-konferenz.csl
+++ b/eva-berlin-konferenz.csl
@@ -1,0 +1,486 @@
+<?xml version="1.0" encoding="utf-8"?>
+<style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" demote-non-dropping-particle="never" default-locale="de-DE">
+  <info>
+    <title>EVA Berlin Konferenz (numeric)</title>
+    <id>http://www.zotero.org/styles/eva-berlin-konferenz</id>
+    <link rel="self" href="http://www.zotero.org/styles/eva-berlin-numeric"/>
+    <link href="https://forums.zotero.org/discussion/20342" rel="documentation"/>
+    <link href="https://www.eva-berlin.de/" rel="documentation"/>
+    <link href="http://www.zotero.org/styles/iso690-numeric-en" rel="template"/>
+    <author>
+      <name>Thomas Tunsch</name>
+      <email>thtbln@yahoo.de</email>
+      <uri>https://thtbln.solid.community/profile/card#me</uri>
+    </author>
+    <category citation-format="numeric"/>
+    <category field="generic-base"/>
+    <summary>Style based on ISO 690:2010(E), V1.1; adapted for EVA Berlin conference publication</summary>
+    <updated>2018-10-08T17:31:56+00:00</updated>
+    <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
+  </info>
+  <locale>
+    <terms>
+      <term name="no date">[o.J.]</term>
+      <term name="in">in</term>
+      <term name="online">online</term>
+      <term name="accessed">Online im Internet</term>
+      <term name="retrieved">URL</term>
+      <term name="from"/>
+      <term name="and">und</term>
+    </terms>
+  </locale>
+  <macro name="author">
+    <names variable="author">
+      <name and="text" name-as-sort-order="all" sort-separator=", " delimiter="; " delimiter-precedes-last="never">
+        <name-part name="family" text-case="capitalize-first"/>
+        <name-part name="given"/>
+      </name>
+    </names>
+  </macro>
+  <macro name="editor">
+    <names variable="editor">
+      <name and="text" name-as-sort-order="all" sort-separator=", " delimiter=", " delimiter-precedes-last="never">
+        <name-part name="family" text-case="capitalize-first"/>
+        <name-part name="given"/>
+      </name>
+      <label prefix=" (" form="short" suffix=".)"/>
+    </names>
+  </macro>
+  <macro name="translator">
+    <names variable="translator">
+      <name and="text" name-as-sort-order="all" sort-separator=", " delimiter=" " delimiter-precedes-last="never">
+        <name-part name="family" text-case="capitalize-first"/>
+        <name-part name="given"/>
+      </name>
+      <label prefix=" (" form="short" suffix=".)"/>
+    </names>
+  </macro>
+  <macro name="responsability">
+    <choose>
+      <if variable="author editor translator" match="any">
+        <choose>
+          <if variable="author">
+            <text macro="author"/>
+          </if>
+          <else-if variable="editor">
+            <text macro="editor"/>
+          </else-if>
+          <else>
+            <text macro="translator"/>
+          </else>
+        </choose>
+      </if>
+    </choose>
+  </macro>
+  <macro name="container-author">
+    <names variable="container-author">
+      <name and="text" name-as-sort-order="all" sort-separator=", " delimiter=", " delimiter-precedes-last="never">
+        <name-part name="family" text-case="capitalize-first"/>
+        <name-part name="given"/>
+      </name>
+    </names>
+  </macro>
+  <macro name="container-responsability">
+    <choose>
+      <if variable="container-author editor translator" match="any">
+        <choose>
+          <if variable="container-author">
+            <text macro="container-author"/>
+          </if>
+          <else-if variable="editor">
+            <text macro="editor"/>
+          </else-if>
+          <else>
+            <text macro="translator"/>
+          </else>
+        </choose>
+      </if>
+    </choose>
+  </macro>
+  <macro name="year-date">
+    <choose>
+      <if variable="issued">
+        <date variable="issued">
+          <date-part name="year" form="long"/>
+        </date>
+      </if>
+      <else>
+        <text term="no date"/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="title">
+    <choose>
+      <if type="book thesis map motion_picture song manuscript" match="any">
+        <text variable="title" font-style="italic"/>
+      </if>
+      <else-if type="paper-conference speech chapter article-journal article-magazine article-newspaper entry entry-dictionary entry-encyclopedia post-weblog post webpage broadcast" match="any">
+        <text variable="title" font-style="italic" suffix=", "/>
+        <choose>
+          <if type="chapter paper-conference entry-encyclopedia" match="any">
+            <text term="in" text-case="capitalize-first" suffix=": " font-style="normal"/>
+          </if>
+        </choose>
+        <choose>
+          <if variable="container-author editor translator" match="any">
+            <text macro="container-responsability"/>
+            <choose>
+              <if variable="container-title event" match="any">
+                <text value=", "/>
+              </if>
+            </choose>
+          </if>
+        </choose>
+        <choose>
+          <if variable="container-title">
+            <text variable="container-title" font-style="normal"/>
+          </if>
+          <else>
+            <text variable="event" font-style="normal"/>
+          </else>
+        </choose>
+      </else-if>
+      <else-if type="report">
+        <text variable="number" suffix=": "/>
+        <text variable="title" font-style="normal"/>
+      </else-if>
+      <else-if type="patent">
+        <text variable="title"/>
+      </else-if>
+      <else>
+        <text variable="title" font-style="italic"/>
+      </else>
+    </choose>
+    <choose>
+      <if variable="URL">
+        <text term="online" prefix=" [" suffix="]"/>
+      </if>
+    </choose>
+  </macro>
+  <macro name="number">
+    <text variable="number"/>
+  </macro>
+  <macro name="medium">
+    <text variable="medium" prefix=" [" suffix="]"/>
+  </macro>
+  <macro name="version">
+    <text variable="version"/>
+  </macro>
+  <macro name="genre">
+    <choose>
+      <if type="map">
+        <choose>
+          <if variable="genre">
+            <text variable="genre" prefix="[" suffix="]"/>
+          </if>
+          <else>
+            <text value="map" prefix="[" suffix="]"/>
+          </else>
+        </choose>
+      </if>
+      <else>
+        <text variable="genre"/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="date">
+    <choose>
+      <if variable="issued">
+        <date variable="issued">
+          <date-part name="day" suffix="."/>
+          <date-part name="month" form="numeric" suffix="."/>
+          <date-part name="year"/>
+        </date>
+      </if>
+    </choose>
+  </macro>
+  <macro name="edition">
+    <text variable="edition" form="long"/>
+  </macro>
+  <macro name="publisher-group">
+    <group delimiter=", ">
+      <text variable="publisher"/>
+      <text variable="publisher-place"/>
+    </group>
+  </macro>
+  <macro name="issue">
+    <group delimiter=", ">
+      <text variable="volume" prefix="Vol. "/>
+      <choose>
+        <if variable="volume">
+          <text variable="issue" prefix="no. "/>
+          <text variable="page" prefix="p. "/>
+        </if>
+        <else-if variable="issue">
+          <text variable="issue" prefix="No. "/>
+          <text variable="page" prefix="p. "/>
+        </else-if>
+        <else>
+          <text variable="page" prefix="P. "/>
+        </else>
+      </choose>
+    </group>
+  </macro>
+  <macro name="accessed">
+    <choose>
+      <if variable="URL">
+        <group prefix="" suffix=":">
+          <text term="accessed" text-case="capitalize-first"/>
+        </group>
+      </if>
+    </choose>
+  </macro>
+  <macro name="collection">
+    <group delimiter=", ">
+      <text variable="collection-title"/>
+      <text variable="collection-number"/>
+    </group>
+  </macro>
+  <macro name="page">
+    <choose>
+      <if type="book thesis manuscript" match="any">
+        <text variable="number-of-pages" suffix=" p"/>
+      </if>
+      <else-if type="chapter paper-conference article-newspaper" match="any">
+        <text variable="page" prefix="p. "/>
+      </else-if>
+      <else-if type="report patent" match="any">
+        <text variable="page" suffix=" p"/>
+      </else-if>
+    </choose>
+  </macro>
+  <macro name="isbn">
+    <text variable="ISBN" prefix="ISBN "/>
+  </macro>
+  <macro name="doi">
+    <text variable="DOI" prefix="DOI "/>
+  </macro>
+  <macro name="url">
+    <choose>
+      <if variable="URL">
+        <text variable="URL" suffix=" "/>
+        <group>
+          <text term="from" suffix=": "/>
+          <date variable="accessed">
+            <date-part name="day" prefix="("/>
+            <date-part name="month" form="numeric" prefix="."/>
+            <date-part name="year" prefix="." suffix="). "/>
+          </date>
+        </group>
+      </if>
+    </choose>
+  </macro>
+  <macro name="archive">
+    <group delimiter=": ">
+      <text variable="archive"/>
+      <text macro="archive_location"/>
+    </group>
+  </macro>
+  <macro name="archive_location">
+    <choose>
+      <if variable="archive_location">
+        <text variable="archive_location"/>
+      </if>
+      <else>
+        <text variable="call-number"/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="abstract">
+    <text variable="abstract"/>
+  </macro>
+  <macro name="note">
+    <text variable="note"/>
+  </macro>
+  <citation collapse="citation-number" after-collapse-delimiter="; ">
+    <sort>
+      <key variable="citation-number"/>
+    </sort>
+    <layout prefix="[" suffix="]" delimiter=", ">
+      <group delimiter=", ">
+        <text variable="citation-number"/>
+        <group>
+          <label variable="locator" suffix=". " form="short" strip-periods="true"/>
+          <text variable="locator"/>
+        </group>
+      </group>
+    </layout>
+  </citation>
+  <bibliography>
+    <sort>
+      <key variable="citation-number"/>
+    </sort>
+    <layout>
+      <text variable="citation-number" display="left-margin" prefix="[" suffix="] "/>
+      <choose>
+        <if type="book map" match="any">
+          <group display="right-inline">
+            <text macro="responsability" suffix=": "/>
+            <text macro="title" suffix=", "/>
+            <text macro="genre" suffix=", "/>
+            <text macro="edition" suffix=", "/>
+            <text macro="publisher-group" suffix=", "/>
+            <text macro="year-date" suffix=", "/>
+            <text macro="collection" suffix=", "/>
+            <text macro="accessed" suffix=" "/>
+            <text macro="isbn" suffix=". "/>
+            <text macro="url"/>
+          </group>
+        </if>
+        <else-if type="article-journal article-magazine" match="any">
+          <group display="right-inline">
+            <text macro="responsability" suffix=": "/>
+            <text macro="title" suffix=", "/>
+            <text macro="edition" suffix=", "/>
+            <text macro="date" suffix=", "/>
+            <text macro="issue" suffix=", "/>
+            <text macro="accessed" suffix=" "/>
+            <text macro="doi" suffix=", "/>
+            <text macro="url"/>
+          </group>
+        </else-if>
+        <else-if type="article-newspaper">
+          <group display="right-inline">
+            <text macro="responsability" suffix=": "/>
+            <text macro="title" suffix=", "/>
+            <text macro="edition" suffix=", "/>
+            <text macro="publisher-group" suffix=", "/>
+            <text macro="date" suffix=", "/>
+            <text macro="page" suffix=". "/>
+            <text macro="accessed" suffix=". "/>
+            <text macro="url"/>
+          </group>
+        </else-if>
+        <else-if type="chapter entry entry-dictionary entry-encyclopedia" match="any">
+          <group display="right-inline">
+            <text macro="responsability" suffix=": "/>
+            <text macro="title" font-style="normal" suffix=", "/>
+            <text macro="edition" suffix=". "/>
+            <text macro="publisher-group" suffix=", "/>
+            <text macro="year-date" prefix="" suffix=", "/>
+            <text macro="page" suffix=", "/>
+            <text macro="collection" suffix=", "/>
+            <text macro="isbn" suffix=". "/>
+            <text macro="accessed" suffix=". "/>
+            <text macro="url"/>
+          </group>
+        </else-if>
+        <else-if type="speech">
+          <group display="right-inline">
+            <text macro="responsability" suffix=": "/>
+            <text macro="title" suffix=", "/>
+            <text macro="genre" suffix=", "/>
+            <text macro="publisher-group" suffix=", "/>
+            <text macro="date" suffix=", "/>
+            <text macro="accessed" suffix=". "/>
+            <text macro="page" suffix=". "/>
+            <text macro="url"/>
+          </group>
+        </else-if>
+        <else-if type="paper-conference">
+          <group display="right-inline">
+            <text macro="responsability" suffix=": "/>
+            <text macro="title" suffix=". "/>
+            <text macro="genre" suffix=". "/>
+            <text macro="publisher-group" suffix=", "/>
+            <text macro="date" suffix=", "/>
+            <text macro="isbn" suffix=", "/>
+            <text macro="page" suffix=", "/>
+            <text macro="accessed" suffix=". "/>
+            <text macro="collection" suffix=". "/>
+            <text macro="url"/>
+          </group>
+        </else-if>
+        <else-if type="thesis">
+          <group display="right-inline">
+            <text macro="responsability" suffix=": "/>
+            <text macro="title" suffix=", "/>
+            <text macro="genre" suffix=", "/>
+            <text macro="publisher-group" suffix=", "/>
+            <text macro="year-date" suffix=", "/>
+            <text macro="accessed" suffix=". "/>
+            <text macro="url"/>
+          </group>
+        </else-if>
+        <else-if type="post-weblog post webpage" match="any">
+          <group display="right-inline">
+            <text macro="responsability" suffix=": "/>
+            <text macro="title" suffix=", "/>
+            <text macro="date" suffix=", "/>
+            <text macro="accessed" suffix=". "/>
+            <text macro="url"/>
+          </group>
+        </else-if>
+        <else-if type="broadcast motion_picture song" match="any">
+          <group display="right-inline">
+            <text macro="responsability" suffix=". "/>
+            <text macro="title" suffix=". "/>
+            <text macro="medium" suffix=". "/>
+            <text macro="publisher-group" suffix=", "/>
+            <text macro="date" suffix=". "/>
+            <text macro="accessed" suffix=". "/>
+            <text macro="collection" suffix=". "/>
+            <text macro="isbn" suffix=". "/>
+            <text macro="url"/>
+          </group>
+        </else-if>
+        <else-if type="report" match="any">
+          <group display="right-inline">
+            <text macro="responsability" suffix=". "/>
+            <text macro="title" suffix=". "/>
+            <text macro="genre" suffix=". "/>
+            <text macro="edition" suffix=". "/>
+            <text macro="publisher-group" suffix=", "/>
+            <text macro="year-date" suffix=". "/>
+            <text macro="accessed" suffix=". "/>
+            <text macro="collection" suffix=". "/>
+            <text macro="url"/>
+          </group>
+        </else-if>
+        <else-if type="manuscript" match="any">
+          <group display="right-inline">
+            <text macro="responsability" suffix=". "/>
+            <text macro="title" suffix=". "/>
+            <text macro="genre" suffix=". "/>
+            <text macro="edition" suffix=". "/>
+            <text macro="publisher-group" suffix=", "/>
+            <text macro="year-date" suffix=". "/>
+            <text macro="accessed" suffix=". "/>
+            <text macro="collection" suffix=". "/>
+            <text macro="url"/>
+          </group>
+        </else-if>
+        <else-if type="patent">
+          <group display="right-inline">
+            <text macro="responsability" suffix=". "/>
+            <text macro="title" suffix=". "/>
+            <text macro="number" suffix=". "/>
+            <text macro="date" suffix=". "/>
+            <text macro="publisher-group" suffix=". "/>
+            <text macro="accessed" suffix=". "/>
+            <text macro="collection" suffix=". "/>
+            <text macro="url"/>
+          </group>
+        </else-if>
+        <else>
+          <group display="right-inline">
+            <text macro="responsability" suffix=": "/>
+            <text macro="title" suffix=", "/>
+            <text macro="version" suffix=", "/>
+            <text macro="medium" suffix=", "/>
+            <text macro="genre" suffix=", "/>
+            <text macro="date" suffix=", "/>
+            <text macro="edition" suffix=", "/>
+            <text macro="publisher-group" suffix=". "/>
+            <text macro="number" suffix=". "/>
+            <text macro="accessed" suffix=". "/>
+            <text macro="collection" suffix=". "/>
+            <text macro="page" suffix=". "/>
+            <text macro="isbn" suffix=". "/>
+            <text macro="url"/>
+          </group>
+        </else>
+      </choose>
+    </layout>
+  </bibliography>
+</style>


### PR DESCRIPTION
Changed http://www.zotero.org/styles/iso690-numeric-en according to the requirements for the EVA Berlin Conference publication (https://www.eva-berlin.de/); no online style description available, only template: http://www.eva-berlin.de/wp-content/uploads/2018/10/EVA_Berlin_Template_Proceedings_dt_18-1.docx