### PR TITLE
CMoS: month and year instead of exact date for journal articles

### DIFF
--- a/chicago-fullnote-bibliography-16th-edition.csl
+++ b/chicago-fullnote-bibliography-16th-edition.csl
@@ -727,9 +727,19 @@
     <choose>
       <if variable="issued">
         <choose>
-          <if type="graphic report" match="any">
-            <date variable="issued" form="text"/>
+          <if type="article-journal" match="any">
+            <choose>
+              <if variable="volume issue" match="all">
+                <date variable="issued" form="text" date-parts="year-month"/>
+              </if>
+              <else>
+                <date variable="issued" form="numeric" date-parts="year"/>
+              </else>
+            </choose>
           </if>
+          <else-if type="graphic report" match="any">
+            <date variable="issued" form="text"/>
+          </else-if>
           <else-if type="legal_case">
             <group delimiter=" ">
               <text variable="authority"/>

--- a/chicago-fullnote-bibliography-fr.csl
+++ b/chicago-fullnote-bibliography-fr.csl
@@ -642,9 +642,19 @@
     <choose>
       <if variable="issued">
         <choose>
-          <if type="graphic report" match="any">
-            <date variable="issued" form="text"/>
+          <if type="article-journal" match="any">
+            <choose>
+              <if variable="volume issue" match="all">
+                <date variable="issued" form="text" date-parts="year-month"/>
+              </if>
+              <else>
+                <date variable="issued" form="numeric" date-parts="year"/>
+              </else>
+            </choose>
           </if>
+          <else-if type="graphic report" match="any">
+            <date variable="issued" form="text"/>
+          </else-if>
           <else-if type="legal_case">
             <group delimiter=" ">
               <text variable="authority"/>

--- a/chicago-fullnote-bibliography-with-ibid.csl
+++ b/chicago-fullnote-bibliography-with-ibid.csl
@@ -755,9 +755,19 @@
     <choose>
       <if variable="issued">
         <choose>
-          <if type="graphic report" match="any">
-            <date variable="issued" form="text"/>
+          <if type="article-journal" match="any">
+            <choose>
+              <if variable="volume issue" match="all">
+                <date variable="issued" form="text" date-parts="year-month"/>
+              </if>
+              <else>
+                <date variable="issued" form="numeric" date-parts="year"/>
+              </else>
+            </choose>
           </if>
+          <else-if type="graphic report" match="any">
+            <date variable="issued" form="text"/>
+          </else-if>
           <else-if type="legal_case">
             <group delimiter=" ">
               <text variable="authority"/>

--- a/chicago-fullnote-bibliography.csl
+++ b/chicago-fullnote-bibliography.csl
@@ -770,7 +770,7 @@
               </choose>
             </group>
           </if>
-          <if type="legal_case">
+          <else-if type="legal_case">
             <group delimiter=" ">
               <text variable="authority"/>
               <choose>
@@ -783,7 +783,7 @@
                 </else>
               </choose>
             </group>
-          </if>
+          </else-if>
           <else-if type="book bill chapter  legislation motion_picture paper-conference song thesis" match="any">
             <choose>
               <if is-uncertain-date="issued">

--- a/chicago-fullnote-bibliography.csl
+++ b/chicago-fullnote-bibliography.csl
@@ -782,7 +782,7 @@
               </choose>
             </group>
           </else-if>
-          <else-if type="book bill chapter  legislation motion_picture paper-conference song thesis" match="any">
+          <else-if type="book bill chapter legislation motion_picture paper-conference song thesis" match="any">
             <choose>
               <if is-uncertain-date="issued">
                 <date variable="issued" form="numeric" date-parts="year" prefix="[" suffix="?]"/>

--- a/chicago-fullnote-bibliography.csl
+++ b/chicago-fullnote-bibliography.csl
@@ -759,16 +759,14 @@
       <if variable="issued">
         <choose>
           <if type="article-journal" match="any">
-            <group delimiter=" ">
-              <choose>
-                <if variable="volume issue" match="all">
-                  <date variable="issued" form="text" date-parts="year-month"/>
-                </if>
-                <else>
-                  <date variable="issued" form="numeric" date-parts="year"/>
-                </else>
-              </choose>
-            </group>
+            <choose>
+              <if variable="volume issue" match="all">
+                <date variable="issued" form="text" date-parts="year-month"/>
+              </if>
+              <else>
+                <date variable="issued" form="numeric" date-parts="year"/>
+              </else>
+            </choose>
           </if>
           <else-if type="legal_case">
             <group delimiter=" ">

--- a/chicago-fullnote-bibliography.csl
+++ b/chicago-fullnote-bibliography.csl
@@ -758,6 +758,18 @@
     <choose>
       <if variable="issued">
         <choose>
+          <if type="article-journal" match="any">
+            <group delimiter=" ">
+              <choose>
+                <if variable="volume issue" match="all">
+                  <date variable="issued" form="text" date-parts="year-month"/>
+                </if>
+                <else>
+                  <date variable="issued" form="numeric" date-parts="year"/>
+                </else>
+              </choose>
+            </group>
+          </if>
           <if type="legal_case">
             <group delimiter=" ">
               <text variable="authority"/>

--- a/chicago-note-bibliography-16th-edition.csl
+++ b/chicago-note-bibliography-16th-edition.csl
@@ -727,9 +727,19 @@
     <choose>
       <if variable="issued">
         <choose>
-          <if type="graphic report" match="any">
-            <date variable="issued" form="text"/>
+          <if type="article-journal" match="any">
+            <choose>
+              <if variable="volume issue" match="all">
+                <date variable="issued" form="text" date-parts="year-month"/>
+              </if>
+              <else>
+                <date variable="issued" form="numeric" date-parts="year"/>
+              </else>
+            </choose>
           </if>
+          <else-if type="graphic report" match="any">
+            <date variable="issued" form="text"/>
+          </else-if>
           <else-if type="legal_case">
             <group delimiter=" ">
               <text variable="authority"/>

--- a/chicago-note-bibliography-with-ibid.csl
+++ b/chicago-note-bibliography-with-ibid.csl
@@ -758,9 +758,19 @@
     <choose>
       <if variable="issued">
         <choose>
-          <if type="graphic report" match="any">
-            <date variable="issued" form="text"/>
+          <if type="article-journal" match="any">
+            <choose>
+              <if variable="volume issue" match="all">
+                <date variable="issued" form="text" date-parts="year-month"/>
+              </if>
+              <else>
+                <date variable="issued" form="numeric" date-parts="year"/>
+              </else>
+            </choose>
           </if>
+          <else-if type="graphic report" match="any">
+            <date variable="issued" form="text"/>
+          </else-if>
           <else-if type="legal_case">
             <group delimiter=" ">
               <text variable="authority"/>

--- a/chicago-note-bibliography.csl
+++ b/chicago-note-bibliography.csl
@@ -758,9 +758,19 @@
     <choose>
       <if variable="issued">
         <choose>
-          <if type="graphic report" match="any">
-            <date variable="issued" form="text"/>
+          <if type="article-journal" match="any">
+            <choose>
+              <if variable="volume issue" match="all">
+                <date variable="issued" form="text" date-parts="year-month"/>
+              </if>
+              <else>
+                <date variable="issued" form="numeric" date-parts="year"/>
+              </else>
+            </choose>
           </if>
+          <else-if type="graphic report" match="any">
+            <date variable="issued" form="text"/>
+          </else-if>
           <else-if type="legal_case">
             <group delimiter=" ">
               <text variable="authority"/>


### PR DESCRIPTION
As discussed [in the Zotero forum](https://forums.zotero.org/discussion/comment/317879/), the CMoS CSL currently gives the exact publication date for a journal article. This is permitted by the style guide, but in practice it is rarely done. Usually the month and year or the year alone is provided. This PR adopts the month-year style.