### PR TITLE
apa.csl: title case for conference paper (@inproceeding booktitle)

### DIFF
--- a/apa.csl
+++ b/apa.csl
@@ -650,7 +650,7 @@
   </macro>
   <macro name="container-title">
     <choose>
-      <if type="article article-journal article-magazine article-newspaper" match="any">
+      <if type="article article-journal article-magazine article-newspaper paper-conference" match="any">
         <text variable="container-title" font-style="italic" text-case="title"/>
       </if>
       <else-if type="bill legal_case legislation" match="none">


### PR DESCRIPTION
The current apa.csl downcases the title of the proceedings, thus
requiring users to protect what is usually every word.  From the APA:

    Parsons, O. A., Pryzwansky, W. B., Weinstein, D. J., & Wiens, A. N.
     (1995). Taxonomy for psychology. In J. N. Reich, H. Sands, & A. N.
     Wiens (Eds.), Education and training beyond the doctoral degree:
     Proceedings of the American Psychological Association National
     Conference on Postdoctoral Education and Training in Psychology
     (pp. 45–50). Washington, DC: American Psychological Association.

  https://blog.apastyle.org/apastyle/2012/08/how-to-cite-materials-from-meetings-and-symposia.html

To obtain this one would currently need to protect case as in

  booktitle = {Proceedings of the {American} {Psychological} ...}

The more natural

  booktitle = {Proceedings of the American Psychological ...}

currently results in the title being lower case.  This commit provides
the desired behavior from either formatting.