### PR TITLE
Update fachhochschule-vorarlberg-author-date.csl

### DIFF
--- a/fachhochschule-vorarlberg-author-date.csl
+++ b/fachhochschule-vorarlberg-author-date.csl
@@ -29,7 +29,7 @@
     <category citation-format="author-date"/>
     <category field="generic-base"/>
     <summary>Citation Style of the University of Applied Sciences Vorarlberg/Austria, based on A Harvard author-date style variant, mostly german</summary>
-    <updated>2018-02-24T16:00:00+00:00</updated>
+    <updated>2018-11-06T18:00:00+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale xml:lang="de">
@@ -385,8 +385,10 @@
   </macro>
   <citation et-al-min="4" et-al-use-first="1" et-al-subsequent-min="4" et-al-subsequent-use-first="1" disambiguate-add-year-suffix="true" disambiguate-add-names="true" disambiguate-add-givenname="true" collapse="year">
     <layout prefix="(" suffix=")" delimiter="; ">
-      <text macro="author-short"/>
-      <text macro="year-date" prefix=" "/>
+      <group delimiter=" ">
+        <text macro="author-short"/>
+        <text macro="year-date"/>
+      </group>
       <choose>
         <if variable="locator">
           <text term="page" form="short" prefix=", " suffix=" "/>


### PR DESCRIPTION
Fixed problem if author is repressed, then there is a blank space before the year in the citation for example ( 2019), which should be (2019)