### PR TITLE
Remove sudo: false from .travis.yml, update Ruby

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: xenial
 language: ruby
 cache: bundler
 rvm:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,3 @@
-sudo: false
 language: ruby
 cache: bundler
 rvm:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ dist: xenial
 language: ruby
 cache: bundler
 rvm:
-  - 2.5
+  - 2.5.3
 notifications:
   email:
     recipients:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,7 @@
-dist: xenial
 language: ruby
 cache: bundler
 rvm:
-  - 2.5.3
+  - 2.4.1
 notifications:
   email:
     recipients:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: ruby
 cache: bundler
 rvm:
-  - 2.4
+  - 2.5
 notifications:
   email:
     recipients:


### PR DESCRIPTION
Removing sudo: false is suggested by Travis CI in preparation of upcoming container > VM migration. See https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration