### PR TITLE
Update molecular-microbiology.csl

### DIFF
--- a/molecular-microbiology.csl
+++ b/molecular-microbiology.csl
@@ -121,7 +121,7 @@
       </else>
     </choose>
   </macro>
-  <citation et-al-min="3" et-al-use-first="1" disambiguate-add-year-suffix="true" disambiguate-add-names="false" disambiguate-add-givenname="true">
+  <citation et-al-min="3" et-al-use-first="1" disambiguate-add-year-suffix="true">
     <sort>
       <key variable="issued" sort="ascending"/>
       <key macro="author"/>

--- a/molecular-microbiology.csl
+++ b/molecular-microbiology.csl
@@ -15,7 +15,7 @@
     <category field="biology"/>
     <issn>0950-382X</issn>
     <eissn>1365-2958</eissn>
-    <updated>2012-09-13T07:21:04+00:00</updated>
+    <updated>2018-11-20T07:10:43+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale>
@@ -121,7 +121,7 @@
       </else>
     </choose>
   </macro>
-  <citation et-al-min="3" et-al-use-first="1" disambiguate-add-year-suffix="true" disambiguate-add-names="true" disambiguate-add-givenname="true">
+  <citation et-al-min="3" et-al-use-first="1" disambiguate-add-year-suffix="true" disambiguate-add-names="false" disambiguate-add-givenname="true">
     <sort>
       <key variable="issued" sort="ascending"/>
       <key macro="author"/>


### PR DESCRIPTION
Do not add names to disambiguate citations shortened with "et al." (disambiguate-add-names="false")

The [author guidelines](https://onlinelibrary.wiley.com/page/journal/13652958/homepage/ForAuthors.html) are not explicit about this, but during the review process I was asked to modify citations where a second author was shown for disambiguation.