### PR TITLE
Update university-of-bradford-harvard.csl

### DIFF
--- a/university-of-bradford-harvard.csl
+++ b/university-of-bradford-harvard.csl
@@ -18,7 +18,7 @@
     <category citation-format="author-date"/>
     <category field="generic-base"/>
     <summary>The Bradford version of the Harvard author-date style (based on University of Abertay Dundee style from Gregory Goltsov)</summary>
-    <updated>2018-11-24T08:45:52+00:00</updated>
+    <updated>2018-11-25T14:35:32+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale xml:lang="en-GB">
@@ -66,7 +66,14 @@
     </names>
   </macro>
   <macro name="title">
-    <text variable="title" text-case="capitalize-first" quotes="false" font-style="italic"/>
+    <choose>
+      <if type="article article-journal article-magazine article-newspaper" match="any">
+        <text variable="title" text-case="capitalize-first"/>
+      </if>
+      <else>
+        <text variable="title" text-case="capitalize-first" quotes="false" font-style="italic"/>
+      </else>
+    </choose>
   </macro>
   <macro name="publisher">
     <group delimiter=", ">

--- a/university-of-bradford-harvard.csl
+++ b/university-of-bradford-harvard.csl
@@ -5,16 +5,20 @@
     <title>University of Bradford - Harvard</title>
     <id>http://www.zotero.org/styles/university-of-bradford-harvard</id>
     <link href="http://www.zotero.org/styles/university-of-bradford-harvard" rel="self"/>
-    <link href="http://www.zotero.org/styles/harvard-university-of-abertay-dundee" rel="template"/>
     <link href="https://www.brad.ac.uk/library/find-out-about/referencing/" rel="documentation"/>
     <author>
       <name>Diego Zaccariotto</name>
       <email>d.zaccariotto@bradford.ac.uk</email>
     </author>
+    <contributor>
+      <name>Gregory Goltsov</name>
+      <email>gregory@goltsov.info</email>
+      <uri>http://www.mendeley.com/profiles/gregory-goltsov</uri>
+    </contributor>
     <category citation-format="author-date"/>
     <category field="generic-base"/>
     <summary>The Bradford version of the Harvard author-date style (based on University of Abertay Dundee style from Gregory Goltsov)</summary>
-    <updated>2018-09-21T15:58:19+00:00</updated>
+    <updated>2018-11-24T08:45:52+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale xml:lang="en-GB">
@@ -42,7 +46,7 @@
     <text term="anonymous" form="short" text-case="capitalize-first" strip-periods="true"/>
   </macro>
   <macro name="author">
-    <names variable="author">
+    <names variable="author" suffix=",">
       <name and="text" delimiter-precedes-last="never" initialize-with="" name-as-sort-order="all"/>
       <label form="short" prefix=" (" suffix=")"/>
       <substitute>
@@ -52,7 +56,7 @@
     </names>
   </macro>
   <macro name="author-short">
-    <names variable="author">
+    <names variable="author" suffix=",">
       <name form="short" and="text" delimiter-precedes-last="never" initialize-with=". "/>
       <substitute>
         <names variable="editor"/>
@@ -62,14 +66,7 @@
     </names>
   </macro>
   <macro name="title">
-    <choose>
-      <if type="bill book graphic legal_case legislation motion_picture report song thesis" match="any">
-        <text variable="title" form="long" text-case="capitalize-first" font-style="normal" font-variant="normal"/>
-      </if>
-      <else>
-        <text variable="title" form="long" quotes="false" font-style="normal"/>
-      </else>
-    </choose>
+    <text variable="title" text-case="capitalize-first" quotes="false" font-style="italic"/>
   </macro>
   <macro name="publisher">
     <group delimiter=", ">

--- a/university-of-bradford-harvard.csl
+++ b/university-of-bradford-harvard.csl
@@ -18,7 +18,7 @@
     <category citation-format="author-date"/>
     <category field="generic-base"/>
     <summary>The Bradford version of the Harvard author-date style (based on University of Abertay Dundee style from Gregory Goltsov)</summary>
-    <updated>2018-11-25T14:35:32+00:00</updated>
+    <updated>2018-11-25T15:18:16+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale xml:lang="en-GB">
@@ -160,8 +160,7 @@
           <text macro="year-date"/>
         </group>
         <group delimiter=" ">
-          <label variable="locator" plural="never" form="short"/>
-          <text variable="page" form="short"/>
+          <text macro="pages"/>
         </group>
       </group>
     </layout>


### PR DESCRIPTION
The original style submitted was not correctly setting the title in Italic in the bibliography as per the university requirements.

There were also a missing comma after the authors, both in the inline citations and in the bibliography.

Removed some choose tags that were causing wrong behaviours with different types of cited works.

This version would replace the previous pull request that was not yet approved.