### PR TITLE
Punctuation outside end quotes in uniwersytet-im-adama-mickiewicza-w-poznaniu-wydzial-anglistyki…

### DIFF
--- a/uniwersytet-im-adama-mickiewicza-w-poznaniu-wydzial-anglistyki.csl
+++ b/uniwersytet-im-adama-mickiewicza-w-poznaniu-wydzial-anglistyki.csl
@@ -21,6 +21,8 @@
   <!--CSL 1.0 specification says locale should override the terms below (PK 2010-02-27). Would the GB locale, which I tried earlier in 2010, be OK, and desirable for us now ?, PK 2012-02-04 -->
   <!--<locale xml:lang="en-GB" xmlns="http://purl.org/net/xbiblio/csl">-->
   <locale xml:lang="en">
+    <!-- Adding option below to force punctuation outside of closing quote; first tested on local copy of the style in Zotero editor, PK 2018-12-17 21:01 -->
+    <style-options punctuation-in-quote="false"/>
     <terms>
       <term name="no date" form="short">[n.d.]</term>
       <term name="in">in</term>


### PR DESCRIPTION
….csl

Adding a punctuation-in-quote style option to force punctuation outside the end quote sign - to provide fuller compatibility with the WA Stylesheet documentation at http://wa.amu.edu.pl/wa/stylesheet for, among others, book chapter and journal article entries in References / Bibliography lists.