### PR TITLE
Fixes for unified-style-sheet-for-linguistics.csl

### DIFF
--- a/unified-style-sheet-for-linguistics.csl
+++ b/unified-style-sheet-for-linguistics.csl
@@ -21,6 +21,9 @@
     <contributor>
       <name>Patrick O'Brien</name>
     </contributor>
+    <contributor>
+      <name>Brian Plimley</name>
+    </contributor>
     <category citation-format="author-date"/>
     <category field="linguistics"/>
     <updated>2018-07-31T12:25:01+00:00</updated>
@@ -30,6 +33,7 @@
     <terms>
       <term name="editor" form="verb-short">ed.</term>
       <term name="translator" form="verb-short">trans.</term>
+      <term name="edition" form="short">edn.</term>
     </terms>
   </locale>
   <macro name="secondary-contributors">

--- a/unified-style-sheet-for-linguistics.csl
+++ b/unified-style-sheet-for-linguistics.csl
@@ -26,7 +26,7 @@
     </contributor>
     <category citation-format="author-date"/>
     <category field="linguistics"/>
-    <updated>2018-07-31T12:25:01+00:00</updated>
+    <updated>2018-12-19T23:42:01+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale>
@@ -190,7 +190,7 @@
           <text macro="collection-title"/>
         </group>
       </else-if>
-      <else-if type="bill graphic legal_case legislation motion_picture report song" match="any">
+      <else-if type="bill graphic legal_case legislation motion_picture report song thesis" match="any">
         <text variable="title" font-style="italic"/>
       </else-if>
       <else>


### PR DESCRIPTION
Two simple corrections:

- Edition should be abbreviated "edn." as per the [style sheet](https://www.linguisticsociety.org/sites/default/files/style-sheet_0.pdf) bullet point 11
- Thesis title should be italicized as per the [style sheet](https://www.linguisticsociety.org/sites/default/files/style-sheet_0.pdf) bullet point 1 and style sheet example entries Stewart and Yu