### PR TITLE
Update pesquisa-agropecuaria-brasileira.csl

### DIFF
--- a/pesquisa-agropecuaria-brasileira.csl
+++ b/pesquisa-agropecuaria-brasileira.csl
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" et-al-min="3" et-al-use-first="1" default-locale="pt-BR" demote-non-dropping-particle="display-and-sort">
+<style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" default-locale="pt-BR" demote-non-dropping-particle="display-and-sort">
   <!-- This style was edited with the Visual CSL Editor (http://editor.citationstyles.org/visualEditor/) -->
   <info>
     <title>Pesquisa Agropecuária Brasileira (Portuguese - Brazil)</title>


### PR DESCRIPTION
A small mistake was made in the original submission. I only modified the <style xmlns> line excluding the et-al-min and et-al-use-first attributes, since the journal does not require et al for the references, only for the citations, and these attributes were generating et al in the references.