### PR TITLE
Update american-chemical-society.csl

### DIFF
--- a/american-chemical-society.csl
+++ b/american-chemical-society.csl
@@ -148,7 +148,10 @@
               <text macro="issued" font-weight="bold"/>
               <choose>
                 <if variable="volume">
-                  <text variable="volume" font-style="italic"/>
+                  <group delimiter=" ">
+                    <text variable="volume" font-style="italic"/>
+                    <text variable="issue" prefix="(" suffix=")"/>
+                  </group>
                 </if>
                 <else>
                   <group delimiter=" ">

--- a/american-chemical-society.csl
+++ b/american-chemical-society.csl
@@ -20,7 +20,7 @@
     <category citation-format="numeric"/>
     <category field="chemistry"/>
     <summary>The American Chemical Society style</summary>
-    <updated>2012-09-27T22:06:38+00:00</updated>
+    <updated>2018-12-30T12:00:00+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale xml:lang="en">
@@ -148,17 +148,14 @@
               <text macro="issued" font-weight="bold"/>
               <choose>
                 <if variable="volume">
-                  <group delimiter=" ">
-                    <text variable="volume" font-style="italic"/>
-                    <text variable="issue" prefix="(" suffix=")"/>
-                  </group>
+                  <text variable="volume" font-style="italic"/>
                 </if>
-                <else-if variable="issue">
+                <else>
                   <group delimiter=" ">
                     <text term="issue" form="short" text-case="capitalize-first"/>
                     <text variable="issue"/>
                   </group>
-                </else-if>
+                </else>
               </choose>
               <text variable="page"/>
             </group>


### PR DESCRIPTION
Closes https://github.com/citation-style-language/styles/issues/3439.

@adam3smith, please merge if this looks okay. The main change is removing the issue for journal articles, which don't seem to be requested by the ACS style guide. I also simplified an `else-if` into an `else`, since the group already acts as a conditional.

For the style guide, Table 14-2 on page 6 of the PDF has examples without issue numbers: https://pubs.acs.org/doi/pdf/10.1021/bk-2006-STYG.ch014

Also, an editor from ACS wrote to me last year:

> American Chemical Society is finally going to a standard ref style in submission of articles. ... The style we will be using is the standard article titles included style, for example:
> 
> Popa, I.; Berkovich, R.; Alegre-Cebollada, J.; Badilla, C. L.; Rivas-Pardo, J. A.; Taniguchi, Y.; Kawakami, M.; Fernandez, J. M. Nanomechanics of HaloTag Tethers. J. Am. Chem. Soc. 2013, 135, 12762–12771."