### PR TITLE
Changed et-al-min to 3 at first use

### DIFF
--- a/journal-of-management-studies.csl
+++ b/journal-of-management-studies.csl
@@ -197,7 +197,7 @@
       <text variable="locator" prefix=" "/>
     </group>
   </macro>
-  <citation et-al-min="6" et-al-use-first="1" et-al-subsequent-min="3" et-al-subsequent-use-first="1" disambiguate-add-year-suffix="true" disambiguate-add-names="true" disambiguate-add-givenname="true" collapse="year">
+  <citation et-al-min="3" et-al-use-first="1" et-al-subsequent-min="3" et-al-subsequent-use-first="1" disambiguate-add-year-suffix="true" disambiguate-add-names="true" disambiguate-add-givenname="true" collapse="year">
     <sort>
       <key macro="author"/>
       <key variable="issued"/>


### PR DESCRIPTION
JMS leaves this pretty ambiguous. If et al starts right away and at how many authors is not defined in their style guide. However, it was pointed out to me that all other articles in JMS use et al right away, at the 3rd author, so that's what I changed the style to.