### PR TITLE
Add blog URL display to elsevier-harvard.csl

### DIFF
--- a/elsevier-harvard.csl
+++ b/elsevier-harvard.csl
@@ -94,7 +94,7 @@
       <if variable="DOI">
         <text variable="DOI" prefix="https://doi.org/"/>
       </if>
-      <else-if type="webpage">
+      <else-if type="webpage post-weblog" match="any">
         <group delimiter=" ">
           <text value="URL"/>
           <text variable="URL"/>


### PR DESCRIPTION
Add blogs to also display URL and access date.
As per guidelines:
"Web references
As a minimum, the full URL should be given and the date when the reference was last accessed. Any further information, if known (DOI, author names, dates, reference to a source publication, etc.), should also be given. Web references can be listed separately (e.g., after the reference list) under a different heading if desired, or can be included in the reference list."

As discussed here: https://forums.zotero.org/discussion/75547/style-error-brain-behavior-and-immunity#latest