### PR TITLE
Create american-school-of-classical-studies-at-athens.csl

### DIFF
--- a/american-school-of-classical-studies-at-athens.csl
+++ b/american-school-of-classical-studies-at-athens.csl
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<style class="note" version="1.0" demote-non-dropping-particle="sort-only" default-locale="en-US" xmlns="http://purl.org/net/xbiblio/csl">
+<style xmlns="http://purl.org/net/xbiblio/csl" class="note" version="1.0" demote-non-dropping-particle="sort-only" default-locale="en-US">
   <info>
     <title>American School of Classical Studies at Athens</title>
     <title-short>ASCSA</title-short>

--- a/american-school-of-classical-studies-at-athens.csl
+++ b/american-school-of-classical-studies-at-athens.csl
@@ -6,7 +6,7 @@
     <id>http://www.zotero.org/styles/american-school-of-classical-studies-at-athens</id>
     <link href="http://www.zotero.org/styles/american-school-of-classical-studies-at-athens" rel="self"/>
     <link href="http://www.zotero.org/styles/ecology" rel="template"/>
-    <link href="http://athina.ascsa.edu.gr/pdf/uploads/Guidelines10-13.pdf" rel="documentation"/>
+    <link href="https://www.ascsa.edu.gr/uploads/media/Guidelines10-29-18.pdf" rel="documentation"/>
     <author>
       <name>Patrick O'Brien, PhD</name>
       <email>obrienpat86@gmail.com</email>

--- a/american-school-of-classical-studies-at-athens.csl
+++ b/american-school-of-classical-studies-at-athens.csl
@@ -1,0 +1,256 @@
+<?xml version="1.0" encoding="utf-8"?>
+<style class="note" version="1.0" demote-non-dropping-particle="sort-only" default-locale="en-US" xmlns="http://purl.org/net/xbiblio/csl">
+  <info>
+    <title>American School of Classical Studies at Athens</title>
+    <title-short>ASCSA</title-short>
+    <id>http://www.zotero.org/styles/american-school-of-classical-studies-at-athens</id>
+    <link href="http://www.zotero.org/styles/american-school-of-classical-studies-at-athens" rel="self"/>
+    <link href="http://www.zotero.org/styles/ecology" rel="template"/>
+    <link href="http://athina.ascsa.edu.gr/pdf/uploads/Guidelines10-13.pdf" rel="documentation"/>
+    <author>
+      <name>Patrick O'Brien, PhD</name>
+      <email>obrienpat86@gmail.com</email>
+    </author>
+    <category citation-format="note"/>
+    <category field="history"/>
+    <summary>Reference style for ASCSA manuscripts and Hesperia journal articles.</summary>
+    <updated>2018-12-21T22:30:06+00:00</updated>
+    <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
+  </info>
+  <macro name="container-contributors">
+    <choose>
+      <if type="chapter paper-conference" match="any">
+        <names variable="editor translator" delimiter=", ">
+          <label form="short" plural="never" suffix=" "/>
+          <name and="text" initialize-with=". "/>
+        </names>
+      </if>
+    </choose>
+  </macro>
+  <macro name="secondary-contributors">
+    <choose>
+      <if type="chapter paper-conference" match="none">
+        <names variable="editor translator" delimiter=", ">
+          <label form="short" suffix=" "/>
+          <name and="text" initialize-with=". " delimiter=", "/>
+        </names>
+      </if>
+    </choose>
+  </macro>
+  <macro name="author">
+    <names variable="author">
+      <name and="text" delimiter-precedes-last="always" initialize-with=". " name-as-sort-order="first"/>
+      <label form="short" prefix=", "/>
+      <substitute>
+        <names variable="editor"/>
+        <names variable="translator"/>
+        <text variable="title"/>
+      </substitute>
+    </names>
+  </macro>
+  <macro name="author-short">
+    <names variable="author">
+      <name form="short" and="text" delimiter=", " initialize-with=". "/>
+      <label form="short" prefix=", "/>
+      <substitute>
+        <names variable="editor"/>
+        <names variable="translator"/>
+        <choose>
+          <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
+            <text variable="title" form="short" font-style="italic"/>
+          </if>
+          <else>
+            <text variable="title" form="short" quotes="true"/>
+          </else>
+        </choose>
+      </substitute>
+    </names>
+  </macro>
+  <macro name="access">
+    <choose>
+      <if type="webpage post-weblog" match="any">
+        <text variable="URL"/>
+      </if>
+    </choose>
+  </macro>
+  <macro name="publisher">
+    <group delimiter=", ">
+      <choose>
+        <if type="book" match="any">
+          <text variable="publisher-place" prefix=", "/>
+        </if>
+        <else-if type="thesis" match="any">
+          <text variable="publisher" prefix=" (diss. " suffix=")"/>
+        </else-if>
+      </choose>
+    </group>
+  </macro>
+  <macro name="issued">
+    <date variable="original-date">
+      <date-part name="year" prefix="[" suffix="] "/>
+    </date>
+    <choose>
+      <if variable="issued">
+        <group prefix=" " suffix=".">
+          <date variable="issued">
+            <date-part name="year"/>
+          </date>
+          <choose>
+            <if type="article-journal bill book chapter graphic legal_case legislation motion_picture paper-conference report song" match="none">
+              <date variable="issued">
+                <date-part prefix=", " name="month"/>
+                <date-part prefix=" " name="day"/>
+              </date>
+            </if>
+          </choose>
+        </group>
+      </if>
+      <else>
+        <text prefix=" (" term="no date" suffix=")." form="short"/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="issued-year">
+    <choose>
+      <if variable="issued">
+        <date variable="issued">
+          <date-part name="year"/>
+        </date>
+      </if>
+      <else>
+        <text term="no date" form="short"/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="edition">
+    <choose>
+      <if type="bill book chapter graphic legal_case legislation motion_picture paper-conference report song" match="any">
+        <choose>
+          <if is-numeric="edition">
+            <group delimiter=" ">
+              <number variable="edition" form="ordinal"/>
+              <text term="edition" form="short"/>
+            </group>
+          </if>
+          <else>
+            <text variable="edition" suffix="."/>
+          </else>
+        </choose>
+      </if>
+    </choose>
+  </macro>
+  <macro name="locators">
+    <choose>
+      <if type="article-journal article-magazine article-newspaper" match="any">
+        <group delimiter=" " prefix=", ">
+          <text variable="container-title" form="short" font-style="italic"/>
+          <group delimiter=", ">
+            <choose>
+              <if match="any" variable="volume">
+                <text variable="volume" prefix=" "/>
+              </if>
+              <else>
+                <text macro="issued-year"/>
+              </else>
+            </choose>
+            <text macro="page"/>
+          </group>
+        </group>
+      </if>
+      <else-if type="bill book graphic legal_case legislation motion_picture report song" match="any">
+        <group delimiter=", " prefix=", " suffix=",">
+          <text macro="edition"/>
+          <text macro="secondary-contributors"/>
+          <text variable="container-title"/>
+        </group>
+      </else-if>
+      <else-if type="chapter paper-conference" match="any">
+        <group delimiter=", " prefix=", ">
+          <group delimiter=", ">
+            <group delimiter=" ">
+              <text term="in" font-style="normal" suffix=" "/>
+              <text variable="container-title" font-style="italic"/>
+              <text macro="collection" prefix="(" suffix=")"/>
+            </group>
+            <text macro="container-contributors"/>
+          </group>
+          <text macro="volumes"/>
+          <text variable="publisher-place"/>
+          <text macro="page"/>
+        </group>
+      </else-if>
+    </choose>
+  </macro>
+  <macro name="citation-locator">
+    <group delimiter=" ">
+      <label variable="locator" form="short"/>
+      <text variable="locator"/>
+    </group>
+  </macro>
+  <macro name="page">
+    <group delimiter=" ">
+      <label variable="page" form="short"/>
+      <text variable="page"/>
+    </group>
+  </macro>
+  <macro name="title">
+    <choose>
+      <if type="book" match="any">
+        <text variable="title" text-case="title" font-style="italic"/>
+      </if>
+      <else-if type="thesis" match="any">
+        <text variable="title" quotes="true"/>
+      </else-if>
+      <else>
+        <text variable="title" text-case="title" quotes="true"/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="collection">
+    <group delimiter=" ">
+      <text variable="collection-title" font-style="italic"/>
+      <text variable="collection-number"/>
+    </group>
+  </macro>
+  <macro name="volumes">
+    <group delimiter=" ">
+      <text variable="number-of-volumes"/>
+      <label plural="always" variable="volume" form="short"/>
+    </group>
+  </macro>
+  <citation et-al-min="4" et-al-use-first="1" disambiguate-add-year-suffix="true" collapse="year">
+    <sort>
+      <key variable="issued"/>
+      <key macro="author"/>
+    </sort>
+    <layout delimiter="; ">
+      <group delimiter=", ">
+        <group delimiter=" ">
+          <text macro="author-short"/>
+          <text macro="issued-year"/>
+        </group>
+        <text macro="citation-locator"/>
+      </group>
+    </layout>
+  </citation>
+  <bibliography subsequent-author-substitute="&#8212;&#8212;&#8212;" entry-spacing="1" hanging-indent="true">
+    <sort>
+      <key macro="author"/>
+      <key variable="issued"/>
+    </sort>
+    <layout suffix=".">
+      <group delimiter=". ">
+        <text macro="author"/>
+        <text macro="issued" suffix=" "/>
+      </group>
+      <group delimiter=", ">
+        <text macro="title" quotes="false"/>
+      </group>
+      <text macro="locators"/>
+      <group delimiter=". ">
+        <text macro="publisher"/>
+        <text macro="access"/>
+      </group>
+    </layout>
+  </bibliography>
+</style>


### PR DESCRIPTION
This is the first version of the ASCSA style for Hesperia.
There is a custom abbreviations.json file to accompany this style. That file allows the use of the AJA (American Journal of Archaeology) abbreviations for [Journals and Book Series](https://www.ajaonline.org/submissions/abbreviations) (but not for Standard Reference Works). I don't know how to add that to this style.