### PR TITLE
Minor tweaks to bibliography

### DIFF
--- a/journal-of-management-studies.csl
+++ b/journal-of-management-studies.csl
@@ -71,7 +71,7 @@
   <macro name="access">
     <choose>
       <!-- <if variable="DOI">
-        <text variable="DOI" prefix=", doi: "/>
+      <!--   <text variable="DOI" prefix=", doi: "/>
       </if> -->
       <!-- <else> -->
         <group>

--- a/journal-of-management-studies.csl
+++ b/journal-of-management-studies.csl
@@ -69,25 +69,16 @@
     </names>
   </macro>
   <macro name="access">
-    <choose>
-      <!-- <if variable="DOI">
-      <!--   <text variable="DOI" prefix=", doi: "/>
-      </if> -->
-      <!-- <else> -->
-        <group>
-          <group>
-            <text term="available at" text-case="title" prefix=". " suffix=" "/>
-            <text variable="URL"/>
-            <text term="accessed" text-case="lowercase" prefix=" (" suffix=" "/>
-            <date variable="accessed" suffix=")">
-              <date-part name="day" suffix=" "/>
-              <date-part name="month" suffix=" "/>
-              <date-part name="year"/>
-            </date>
-          </group>
-        </group>
-      <!-- </else> -->
-    </choose>
+    <group>
+      <text term="available at" text-case="title" prefix=". " suffix=" "/>
+      <text variable="URL"/>
+      <text term="accessed" text-case="lowercase" prefix=" (" suffix=" "/>
+      <date variable="accessed" suffix=")">
+        <date-part name="day" suffix=" "/>
+        <date-part name="month" suffix=" "/>
+        <date-part name="year"/>
+      </date>
+    </group>
   </macro>
   <macro name="title">
     <choose>

--- a/journal-of-management-studies.csl
+++ b/journal-of-management-studies.csl
@@ -70,10 +70,10 @@
   </macro>
   <macro name="access">
     <choose>
-      <if variable="DOI">
+      <!-- <if variable="DOI">
         <text variable="DOI" prefix=", doi: "/>
-      </if>
-      <else>
+      </if> -->
+      <!-- <else> -->
         <group>
           <group>
             <text term="available at" text-case="title" prefix=". " suffix=" "/>
@@ -86,7 +86,7 @@
             </date>
           </group>
         </group>
-      </else>
+      <!-- </else> -->
     </choose>
   </macro>
   <macro name="title">
@@ -168,7 +168,7 @@
       <if type="article-journal article-magazine article-newspaper" match="any">
         <group prefix=", " delimiter=", ">
           <group>
-            <text variable="volume"/>
+            <text variable="volume" font-weight="bold"/>
           </group>
           <text variable="page"/>
         </group>
@@ -197,7 +197,7 @@
       <text variable="locator" prefix=" "/>
     </group>
   </macro>
-  <citation et-al-min="6" et-al-use-first="1" et-al-subsequent-min="3" et-al-subsequent-use-first="1" disambiguate-add-year-suffix="true" disambiguate-add-names="true" disambiguate-add-givenname="true" collapse="year">
+  <citation et-al-min="3" et-al-use-first="1" et-al-subsequent-min="3" et-al-subsequent-use-first="1" disambiguate-add-year-suffix="true" disambiguate-add-names="true" disambiguate-add-givenname="true" collapse="year">
     <sort>
       <key macro="author"/>
       <key variable="issued"/>


### PR DESCRIPTION
Journal volume should be bold (line 171), there shouldn't be a DOI (73-89), and the et al min should be 3. The latter I already added in a previous pull request. I cannot figure out how to pull from the master to my fork on the website... Sorry for that. I hope it's ok that way. 

I got the adjustments from the JMS Style Guide (http://www.blackwellpublishing.com/pdf/JMS_Prep_of_Manuscripts.pdf). There are still some minor elements that could be tweaked in the CSL file, but I found it easier to just do it by hand in the end. 