### PR TITLE
New version of Infoclio styles

### DIFF
--- a/infoclio-de.csl
+++ b/infoclio-de.csl
@@ -36,6 +36,7 @@
       <term name="letter">Schreiben</term>
       <term name="number-of-volumes" form="short">Bd.</term>
       <term name="no date" form="short">o. D.</term>
+      <term name="edition">Ausgabe</term>
     </terms>
   </locale>
   <citation>

--- a/infoclio-de.csl
+++ b/infoclio-de.csl
@@ -280,6 +280,13 @@
           </if>
         </choose>
       </else-if>
+      <else-if type="dataset">
+        <choose>
+          <if variable="version">
+            <text variable="version"/>
+          </if>
+        </choose>
+      </else-if>
     </choose>
   </macro>
   <macro name="alt-publisher">

--- a/infoclio-de.csl
+++ b/infoclio-de.csl
@@ -415,7 +415,7 @@
   <macro name="url-web-documents-only">
     <choose>
       <if type="webpage post post-weblog" match="any">
-        <text macro="url"/>
+        <text macro="url-or-doi"/>
       </if>
     </choose>
   </macro>
@@ -424,34 +424,34 @@
       <if type="webpage post post-weblog" match="none">
         <choose>
           <if variable="DOI URL" match="any">
-            <group delimiter=" ">
-              <text term="online" text-case="capitalize-first" suffix=": "/>
-              <choose>
-                <if variable="DOI">
-                  <group delimiter=", ">
-                    <group delimiter="">
-                      <text value="&lt;"/>
-                      <text variable="DOI" prefix="https://doi.org/"/>
-                      <text value="&gt;"/>
-                    </group>
-                    <text macro="accessed"/>
-                  </group>
-                </if>
-                <else-if variable="URL">
-                  <text macro="url"/>
-                </else-if>
-              </choose>
+            <group delimiter=": ">
+              <text term="online" text-case="capitalize-first"/>
+              <text macro="url-or-doi"/>
             </group>
           </if>
         </choose>
       </if>
     </choose>
   </macro>
-  <macro name="url">
-    <group delimiter=", ">
-      <text variable="URL" prefix="&lt;" suffix="&gt;"/>
-      <text macro="accessed"/>
-    </group>
+  <macro name="url-or-doi">
+    <choose>
+      <if variable="DOI">
+        <group delimiter=", ">
+          <group delimiter="">
+            <text value="&lt;"/>
+            <text variable="DOI" prefix="https://doi.org/"/>
+            <text value="&gt;"/>
+          </group>
+          <text macro="accessed"/>
+        </group>
+      </if>
+      <else-if variable="URL">
+        <group delimiter=", ">
+          <text variable="URL" prefix="&lt;" suffix="&gt;"/>
+          <text macro="accessed"/>
+        </group>
+      </else-if>
+    </choose>
   </macro>
   <macro name="accessed">
     <group delimiter=": ">

--- a/infoclio-de.csl
+++ b/infoclio-de.csl
@@ -416,10 +416,7 @@
                       <text variable="DOI" prefix="https://doi.org/"/>
                       <text value="&gt;"/>
                     </group>
-                    <group delimiter=" ">
-                      <text term="accessed"/>
-                      <date variable="accessed" form="numeric" date-parts="year-month-day"/>
-                    </group>
+                    <text macro="accessed"/>
                   </group>
                 </if>
                 <else-if variable="URL">
@@ -435,10 +432,13 @@
   <macro name="url">
     <group delimiter=", ">
       <text variable="URL" prefix="&lt;" suffix="&gt;"/>
-      <group delimiter=": ">
-        <text term="accessed"/>
-        <date variable="accessed" form="numeric" date-parts="year-month-day"/>
-      </group>
+      <text macro="accessed"/>
+    </group>
+  </macro>
+  <macro name="accessed">
+    <group delimiter=": ">
+      <text term="accessed"/>
+      <date variable="accessed" form="numeric" date-parts="year-month-day"/>
     </group>
   </macro>
 </style>

--- a/infoclio-de.csl
+++ b/infoclio-de.csl
@@ -96,6 +96,7 @@
           <date variable="original-date" form="text" prefix="[" suffix="]"/>
           <text macro="book-series"/>
         </group>
+        <text macro="newspaper-edition"/>
         <text macro="artwork-description"/>
         <text macro="archive-location"/>
         <text macro="pages"/>
@@ -369,6 +370,23 @@
             </if>
           </choose>
         </group>
+      </if>
+    </choose>
+  </macro>
+  <macro name="newspaper-edition">
+    <choose>
+      <if type="article-newspaper">
+        <choose>
+          <if is-numeric="edition">
+            <group delimiter="&#160;">
+              <number variable="edition" form="ordinal"/>
+              <label variable="edition"/>
+            </group>
+          </if>
+          <else>
+            <text variable="edition"/>
+          </else>
+        </choose>
       </if>
     </choose>
   </macro>

--- a/infoclio-de.csl
+++ b/infoclio-de.csl
@@ -414,14 +414,14 @@
   </macro>
   <macro name="url-web-documents-only">
     <choose>
-      <if type="webpage post post-weblog" match="any">
+      <if type="webpage post post-weblog dataset" match="any">
         <text macro="url-or-doi"/>
       </if>
     </choose>
   </macro>
   <macro name="url-non-web-documents">
     <choose>
-      <if type="webpage post post-weblog" match="none">
+      <if type="webpage post post-weblog dataset" match="none">
         <choose>
           <if variable="DOI URL" match="any">
             <group delimiter=": ">

--- a/infoclio-fr-nocaps.csl
+++ b/infoclio-fr-nocaps.csl
@@ -344,6 +344,13 @@
           </if>
         </choose>
       </else-if>
+      <else-if type="dataset">
+        <choose>
+          <if variable="version">
+            <text variable="version"/>
+          </if>
+        </choose>
+      </else-if>
     </choose>
   </macro>
   <macro name="alt-publisher">

--- a/infoclio-fr-nocaps.csl
+++ b/infoclio-fr-nocaps.csl
@@ -105,6 +105,7 @@
           <date variable="original-date" form="text" prefix="[" suffix="]"/>
           <text macro="book-series"/>
         </group>
+        <text macro="newspaper-edition"/>
         <text macro="artwork-description"/>
         <text macro="archive-location"/>
         <text macro="pages"/>
@@ -451,6 +452,23 @@
             </if>
           </choose>
         </group>
+      </if>
+    </choose>
+  </macro>
+  <macro name="newspaper-edition">
+    <choose>
+      <if type="article-newspaper">
+        <choose>
+          <if is-numeric="edition">
+            <group delimiter="&#160;">
+              <number variable="edition" form="ordinal"/>
+              <label variable="edition"/>
+            </group>
+          </if>
+          <else>
+            <text variable="edition"/>
+          </else>
+        </choose>
       </if>
     </choose>
   </macro>

--- a/infoclio-fr-nocaps.csl
+++ b/infoclio-fr-nocaps.csl
@@ -150,7 +150,7 @@
       <if type="book thesis graphic" match="any">
         <text variable="title" font-style="italic"/>
       </if>
-      <else-if type="article article-magazine article-newspaper article-journal entry entry-dictionary entry-encyclopedia report chapter paper-conference post post-weblog webpage song broadcast" match="any">
+      <else-if type="article article-magazine article-newspaper article-journal entry entry-dictionary entry-encyclopedia report chapter paper-conference post post-weblog webpage song broadcast dataset" match="any">
         <text variable="title" quotes="true"/>
       </else-if>
       <else-if type="motion_picture">
@@ -175,7 +175,7 @@
           <if type="book thesis graphic" match="any">
             <text variable="title" font-style="italic" form="short"/>
           </if>
-          <else-if type="article article-magazine article-newspaper article-journal entry entry-dictionary entry-encyclopedia report chapter paper-conference post post-weblog webpage song broadcast" match="any">
+          <else-if type="article article-magazine article-newspaper article-journal entry entry-dictionary entry-encyclopedia report chapter paper-conference post post-weblog webpage song broadcast dataset" match="any">
             <text variable="title" quotes="true" form="short"/>
           </else-if>
           <else-if type="motion_picture">
@@ -496,14 +496,14 @@
   </macro>
   <macro name="url-web-documents-only">
     <choose>
-      <if type="webpage post post-weblog" match="any">
+      <if type="webpage post post-weblog dataset" match="any">
         <text macro="url-or-doi"/>
       </if>
     </choose>
   </macro>
   <macro name="url-non-web-documents">
     <choose>
-      <if type="webpage post post-weblog" match="none">
+      <if type="webpage post post-weblog dataset" match="none">
         <choose>
           <if variable="DOI URL" match="any">
             <group delimiter=": ">

--- a/infoclio-fr-nocaps.csl
+++ b/infoclio-fr-nocaps.csl
@@ -498,10 +498,7 @@
                       <text variable="DOI" prefix="https://doi.org/"/>
                       <text value="&gt;"/>
                     </group>
-                    <group delimiter=" ">
-                      <text term="accessed"/>
-                      <date variable="accessed" form="numeric" date-parts="year-month-day"/>
-                    </group>
+                    <text macro="accessed"/>
                   </group>
                 </if>
                 <else-if variable="URL">
@@ -517,10 +514,13 @@
   <macro name="url">
     <group delimiter=", ">
       <text variable="URL" prefix="&lt;" suffix="&gt;"/>
-      <group delimiter=" ">
-        <text term="accessed"/>
-        <date variable="accessed" form="numeric" date-parts="year-month-day"/>
-      </group>
+      <text macro="accessed"/>
+    </group>
+  </macro>
+  <macro name="accessed">
+    <group delimiter=" ">
+      <text term="accessed"/>
+      <date variable="accessed" form="numeric" date-parts="year-month-day"/>
     </group>
   </macro>
 </style>

--- a/infoclio-fr-nocaps.csl
+++ b/infoclio-fr-nocaps.csl
@@ -497,7 +497,7 @@
   <macro name="url-web-documents-only">
     <choose>
       <if type="webpage post post-weblog" match="any">
-        <text macro="url"/>
+        <text macro="url-or-doi"/>
       </if>
     </choose>
   </macro>
@@ -506,34 +506,34 @@
       <if type="webpage post post-weblog" match="none">
         <choose>
           <if variable="DOI URL" match="any">
-            <group delimiter=" ">
-              <text term="online" text-case="capitalize-first" suffix=": "/>
-              <choose>
-                <if variable="DOI">
-                  <group delimiter=", ">
-                    <group delimiter="">
-                      <text value="&lt;"/>
-                      <text variable="DOI" prefix="https://doi.org/"/>
-                      <text value="&gt;"/>
-                    </group>
-                    <text macro="accessed"/>
-                  </group>
-                </if>
-                <else-if variable="URL">
-                  <text macro="url"/>
-                </else-if>
-              </choose>
+            <group delimiter=": ">
+              <text term="online" text-case="capitalize-first"/>
+              <text macro="url-or-doi"/>
             </group>
           </if>
         </choose>
       </if>
     </choose>
   </macro>
-  <macro name="url">
-    <group delimiter=", ">
-      <text variable="URL" prefix="&lt;" suffix="&gt;"/>
-      <text macro="accessed"/>
-    </group>
+  <macro name="url-or-doi">
+    <choose>
+      <if variable="DOI">
+        <group delimiter=", ">
+          <group delimiter="">
+            <text value="&lt;"/>
+            <text variable="DOI" prefix="https://doi.org/"/>
+            <text value="&gt;"/>
+          </group>
+          <text macro="accessed"/>
+        </group>
+      </if>
+      <else-if variable="URL">
+        <group delimiter=", ">
+          <text variable="URL" prefix="&lt;" suffix="&gt;"/>
+          <text macro="accessed"/>
+        </group>
+      </else-if>
+    </choose>
   </macro>
   <macro name="accessed">
     <group delimiter=" ">

--- a/infoclio-fr-smallcaps.csl
+++ b/infoclio-fr-smallcaps.csl
@@ -502,7 +502,7 @@
   <macro name="url-web-documents-only">
     <choose>
       <if type="webpage post post-weblog" match="any">
-        <text macro="url"/>
+        <text macro="url-or-doi"/>
       </if>
     </choose>
   </macro>
@@ -511,34 +511,34 @@
       <if type="webpage post post-weblog" match="none">
         <choose>
           <if variable="DOI URL" match="any">
-            <group delimiter=" ">
-              <text term="online" text-case="capitalize-first" suffix=": "/>
-              <choose>
-                <if variable="DOI">
-                  <group delimiter=", ">
-                    <group delimiter="">
-                      <text value="&lt;"/>
-                      <text variable="DOI" prefix="https://doi.org/"/>
-                      <text value="&gt;"/>
-                    </group>
-                    <text macro="accessed"/>
-                  </group>
-                </if>
-                <else-if variable="URL">
-                  <text macro="url"/>
-                </else-if>
-              </choose>
+            <group delimiter=": ">
+              <text term="online" text-case="capitalize-first"/>
+              <text macro="url-or-doi"/>
             </group>
           </if>
         </choose>
       </if>
     </choose>
   </macro>
-  <macro name="url">
-    <group delimiter=", ">
-      <text variable="URL" prefix="&lt;" suffix="&gt;"/>
-      <text macro="accessed"/>
-    </group>
+  <macro name="url-or-doi">
+    <choose>
+      <if variable="DOI">
+        <group delimiter=", ">
+          <group delimiter="">
+            <text value="&lt;"/>
+            <text variable="DOI" prefix="https://doi.org/"/>
+            <text value="&gt;"/>
+          </group>
+          <text macro="accessed"/>
+        </group>
+      </if>
+      <else-if variable="URL">
+        <group delimiter=", ">
+          <text variable="URL" prefix="&lt;" suffix="&gt;"/>
+          <text macro="accessed"/>
+        </group>
+      </else-if>
+    </choose>
   </macro>
   <macro name="accessed">
     <group delimiter=" ">

--- a/infoclio-fr-smallcaps.csl
+++ b/infoclio-fr-smallcaps.csl
@@ -104,6 +104,7 @@
           <date variable="original-date" form="text" prefix="[" suffix="]"/>
           <text macro="book-series"/>
         </group>
+        <text macro="newspaper-edition"/>
         <text macro="artwork-description"/>
         <text macro="archive-location"/>
         <text macro="pages"/>
@@ -456,6 +457,23 @@
             </if>
           </choose>
         </group>
+      </if>
+    </choose>
+  </macro>
+  <macro name="newspaper-edition">
+    <choose>
+      <if type="article-newspaper">
+        <choose>
+          <if is-numeric="edition">
+            <group delimiter="&#160;">
+              <number variable="edition" form="ordinal"/>
+              <label variable="edition"/>
+            </group>
+          </if>
+          <else>
+            <text variable="edition"/>
+          </else>
+        </choose>
       </if>
     </choose>
   </macro>

--- a/infoclio-fr-smallcaps.csl
+++ b/infoclio-fr-smallcaps.csl
@@ -153,7 +153,7 @@
       <if type="book thesis graphic" match="any">
         <text variable="title" font-style="italic"/>
       </if>
-      <else-if type="article                      article-magazine article-newspaper article-journal                      entry entry-dictionary entry-encyclopedia                      report chapter paper-conference                      post post-weblog webpage                      song broadcast" match="any">
+      <else-if type="article article-magazine article-newspaper article-journal entry entry-dictionary entry-encyclopedia report chapter paper-conference post post-weblog webpage song broadcast" match="any">
         <text variable="title" quotes="true"/>
       </else-if>
       <else-if type="motion_picture">
@@ -178,7 +178,7 @@
           <if type="book thesis graphic" match="any">
             <text variable="title" font-style="italic" form="short"/>
           </if>
-          <else-if type="article                          article-magazine article-newspaper article-journal                          entry entry-dictionary entry-encyclopedia                          report chapter paper-conference                          post post-weblog webpage                          song broadcast" match="any">
+          <else-if type="article article-magazine article-newspaper article-journal entry entry-dictionary entry-encyclopedia report chapter paper-conference post post-weblog webpage song broadcast" match="any">
             <text variable="title" quotes="true" form="short"/>
           </else-if>
           <else-if type="motion_picture">
@@ -211,7 +211,7 @@
           <name et-al-min="3" et-al-use-first="1"/>
         </names>
       </else-if>
-      <else-if type="report song broadcast motion_picture                      webpage post post-weblog" match="any">
+      <else-if type="report song broadcast motion_picture webpage post post-weblog" match="any">
         <!-- these types have either collection-title or container-title -->
         <text variable="collection-title" font-style="italic"/>
         <text variable="container-title" font-style="italic"/>
@@ -221,13 +221,13 @@
   <macro name="op-cit">
     <group font-style="italic" delimiter="&#160;" suffix=".">
       <choose>
-        <if type="article                   article-magazine article-newspaper article-journal                   entry entry-dictionary entry-encyclopedia                   chapter paper-conference                   post post-weblog" match="any">
+        <if type="article article-magazine article-newspaper article-journal entry entry-dictionary entry-encyclopedia chapter paper-conference post post-weblog" match="any">
           <text value="art."/>
         </if>
-        <else-if type="manuscript personal_communication interview                        report webpage" match="any">
+        <else-if type="manuscript personal_communication interview report webpage" match="any">
           <text value="doc."/>
         </else-if>
-        <else-if type="book thesis graphic                        motion_picture song broadcast" match="any">
+        <else-if type="book thesis graphic motion_picture song broadcast" match="any">
           <text value="op."/>
         </else-if>
       </choose>
@@ -236,7 +236,7 @@
   </macro>
   <macro name="in">
     <choose>
-      <if type="chapter paper-conference                 entry-encyclopedia entry-dictionary" match="any">
+      <if type="chapter paper-conference entry-encyclopedia entry-dictionary" match="any">
         <text term="in"/>
       </if>
     </choose>
@@ -259,10 +259,10 @@
   </macro>
   <macro name="container-information">
     <choose>
-      <if type="chapter paper-conference                 entry-encyclopedia entry-dictionary                 article-newspaper article-magazine article-journal" match="any">
+      <if type="chapter paper-conference entry-encyclopedia entry-dictionary article-newspaper article-magazine article-journal" match="any">
         <text variable="container-title" font-style="italic"/>
       </if>
-      <else-if type="report song broadcast motion_picture                      webpage post post-weblog" match="any">
+      <else-if type="report song broadcast motion_picture webpage post post-weblog" match="any">
         <group delimiter=", ">
           <text variable="genre"/>
           <!-- these types have either collection-title or container-title -->
@@ -287,7 +287,7 @@
   </macro>
   <macro name="volumes">
     <choose>
-      <if type="book chapter                 entry-encyclopedia entry-dictionary                 song motion_picture" match="any">
+      <if type="book chapter entry-encyclopedia entry-dictionary song motion_picture" match="any">
         <group delimiter=" / ">
           <group delimiter="&#160;">
             <label variable="volume" form="short"/>
@@ -353,7 +353,7 @@
   </macro>
   <macro name="alt-publisher">
     <choose>
-      <if type="book chapter                 thesis report                 paper-conference                 entry-dictionary entry-encyclopedia" match="none">
+      <if type="book chapter thesis report paper-conference entry-dictionary entry-encyclopedia" match="none">
         <!--
              label for songs,
              distributor for films,
@@ -365,7 +365,7 @@
   </macro>
   <macro name="edition">
     <choose>
-      <if type="book chapter                 entry-dictionary entry-encyclopedia" match="any">
+      <if type="book chapter entry-dictionary entry-encyclopedia" match="any">
         <choose>
           <if is-numeric="edition">
             <group delimiter="&#160;">
@@ -395,7 +395,7 @@
   </macro>
   <macro name="publishing-house">
     <choose>
-      <if type="book chapter thesis report                 paper-conference                 entry-dictionary entry-encyclopedia" match="any">
+      <if type="book chapter thesis report paper-conference entry-dictionary entry-encyclopedia" match="any">
         <text variable="publisher"/>
       </if>
     </choose>
@@ -412,7 +412,7 @@
           </else>
         </choose>
       </if>
-      <else-if type="article-journal article-newspaper article-magazine                      graphic entry-encyclopedia entry-dictionary                      report speech interview                      manuscript personal_communication" match="any">
+      <else-if type="article-journal article-newspaper article-magazine graphic entry-encyclopedia entry-dictionary report speech interview manuscript personal_communication" match="any">
         <choose>
           <if variable="issued">
             <date variable="issued" form="numeric" date-parts="year-month-day"/>
@@ -448,7 +448,7 @@
   </macro>
   <macro name="book-series">
     <choose>
-      <if type="book chapter paper-conference                 entry-dictionary entry-encyclopedia" match="any">
+      <if type="book chapter paper-conference entry-dictionary entry-encyclopedia" match="any">
         <group prefix="(" suffix=")" delimiter=" ">
           <text variable="collection-title"/>
           <choose>

--- a/infoclio-fr-smallcaps.csl
+++ b/infoclio-fr-smallcaps.csl
@@ -349,6 +349,13 @@
           </if>
         </choose>
       </else-if>
+      <else-if type="dataset">
+        <choose>
+          <if variable="version">
+            <text variable="version"/>
+          </if>
+        </choose>
+      </else-if>
     </choose>
   </macro>
   <macro name="alt-publisher">

--- a/infoclio-fr-smallcaps.csl
+++ b/infoclio-fr-smallcaps.csl
@@ -153,7 +153,7 @@
       <if type="book thesis graphic" match="any">
         <text variable="title" font-style="italic"/>
       </if>
-      <else-if type="article article-magazine article-newspaper article-journal entry entry-dictionary entry-encyclopedia report chapter paper-conference post post-weblog webpage song broadcast" match="any">
+      <else-if type="article article-magazine article-newspaper article-journal entry entry-dictionary entry-encyclopedia report chapter paper-conference post post-weblog webpage song broadcast dataset" match="any">
         <text variable="title" quotes="true"/>
       </else-if>
       <else-if type="motion_picture">
@@ -178,7 +178,7 @@
           <if type="book thesis graphic" match="any">
             <text variable="title" font-style="italic" form="short"/>
           </if>
-          <else-if type="article article-magazine article-newspaper article-journal entry entry-dictionary entry-encyclopedia report chapter paper-conference post post-weblog webpage song broadcast" match="any">
+          <else-if type="article article-magazine article-newspaper article-journal entry entry-dictionary entry-encyclopedia report chapter paper-conference post post-weblog webpage song broadcast dataset" match="any">
             <text variable="title" quotes="true" form="short"/>
           </else-if>
           <else-if type="motion_picture">
@@ -501,14 +501,14 @@
   </macro>
   <macro name="url-web-documents-only">
     <choose>
-      <if type="webpage post post-weblog" match="any">
+      <if type="webpage post post-weblog dataset" match="any">
         <text macro="url-or-doi"/>
       </if>
     </choose>
   </macro>
   <macro name="url-non-web-documents">
     <choose>
-      <if type="webpage post post-weblog" match="none">
+      <if type="webpage post post-weblog dataset" match="none">
         <choose>
           <if variable="DOI URL" match="any">
             <group delimiter=": ">

--- a/infoclio-fr-smallcaps.csl
+++ b/infoclio-fr-smallcaps.csl
@@ -503,10 +503,7 @@
                       <text variable="DOI" prefix="https://doi.org/"/>
                       <text value="&gt;"/>
                     </group>
-                    <group delimiter=" ">
-                      <text term="accessed"/>
-                      <date variable="accessed" form="numeric" date-parts="year-month-day"/>
-                    </group>
+                    <text macro="accessed"/>
                   </group>
                 </if>
                 <else-if variable="URL">
@@ -522,10 +519,13 @@
   <macro name="url">
     <group delimiter=", ">
       <text variable="URL" prefix="&lt;" suffix="&gt;"/>
-      <group delimiter=" ">
-        <text term="accessed"/>
-        <date variable="accessed" form="numeric" date-parts="year-month-day"/>
-      </group>
+      <text macro="accessed"/>
+    </group>
+  </macro>
+  <macro name="accessed">
+    <group delimiter=" ">
+      <text term="accessed"/>
+      <date variable="accessed" form="numeric" date-parts="year-month-day"/>
     </group>
   </macro>
 </style>


### PR DESCRIPTION
This is an update to a custom style for history students in Switzerland. See #234 for the original pull request, and #3400 for the last update.

Changes:
- When given, DOIs are now always preferred to URLs, even for webpages, weblog posts and forum posts; a new macro ensures that DOIs and URLs are displayed in a consistent manner (in the last update, a bug had crept in)
- The edition field is displayed for newspaper articles (important for historians citing articles from an era with two or even three daily editions for some newspapers)
- Added support for datasets

I look forward to your feedback and take this opportunity to thank you for the time invested in this repository! :pray: 