### PR TITLE
Update annales.csl

### DIFF
--- a/annales.csl
+++ b/annales.csl
@@ -9,15 +9,18 @@
       <name>Franziska Heimburger</name>
       <email>zotero@franziska.fr</email>
     </author>
+    <contributor>
+      <name>Nicolas Barreyre</name>
+    </contributor>
     <category citation-format="note"/>
     <category field="social_science"/>
     <issn>0395-2649</issn>
-    <updated>2013-08-29T04:18:55+00:00</updated>
+    <updated>2019-02-01T00:59:23+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale xml:lang="fr">
     <terms>
-      <term name="ordinal-01">ère</term>
+      <term name="ordinal-01">re</term>
       <term name="ordinal-02">e</term>
       <term name="ordinal-03">e</term>
       <term name="ordinal-04">e</term>
@@ -166,7 +169,7 @@
           <group delimiter=", ">
             <text variable="page"/>
             <group delimiter="&#8239;">
-              <label variable="locator" form="short"/>
+              <label variable="locator" form="short" prefix="ici "/>
               <text variable="locator"/>
             </group>
           </group>
@@ -224,41 +227,26 @@
       <else-if type="article-journal article-magazine" match="any">
         <group font-style="normal">
           <choose>
+          	<if variable="volume issue">
+          	  <text variable="volume" prefix=" "/>
+          	  <text variable="issue" prefix="-"/>
+          	</if>
+          	<else-if variable="volume">  
+          	  <text variable="volume" prefix=" "/>
+          	</else-if> 
+          	<else-if variable="issue">  
+              <text variable="issue" prefix=" "/>
+          	</else-if>
+          </choose>
+          <choose>
             <if variable="issued">
-              <date variable="issued">
-                <date-part name="year"/>
+              <date variable="issued" prefix=", ">
+                <date-part name="year" />
               </date>
-              <text macro="volume" prefix=", "/>
             </if>
-            <else>
-              <text macro="volume" text-case="capitalize-first"/>
-            </else>
           </choose>
         </group>
       </else-if>
-    </choose>
-    <text macro="issue" prefix=", "/>
-  </macro>
-  <macro name="volume">
-    <choose>
-      <if is-numeric="volume">
-        <text term="volume" form="short" suffix=".&#160;"/>
-        <text variable="volume"/>
-      </if>
-      <else>
-        <text variable="volume"/>
-      </else>
-    </choose>
-  </macro>
-  <macro name="issue">
-    <choose>
-      <if is-numeric="issue">
-        <text term="issue" form="short" suffix="&#160;"/>
-        <text variable="issue"/>
-      </if>
-      <else>
-        <text variable="issue"/>
-      </else>
     </choose>
   </macro>
   <citation>
@@ -287,7 +275,14 @@
                 <text variable="title" text-case="capitalize-first" form="short" quotes="true" font-style="normal"/>
               </else>
             </choose>
-            <text term="cited" font-style="italic" suffix="."/>
+            <choose>
+			  <if type="article-journal article-magazine article-newspaper chapter paper-conference" match="any">
+				<text value="art. cit"/>
+			  </if>
+			  <else>
+				<text value="op. cit" font-style="italic"/>
+			  </else>
+			</choose>
             <group delimiter="&#8239;">
               <label variable="locator" form="short"/>
               <text variable="locator"/>

--- a/annales.csl
+++ b/annales.csl
@@ -15,6 +15,7 @@
     <category citation-format="note"/>
     <category field="social_science"/>
     <issn>0395-2649</issn>
+    <eissn>1953-8146</eissn>
     <updated>2019-02-01T00:59:23+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
@@ -57,8 +58,7 @@
   </macro>
   <macro name="editor">
     <names variable="editor">
-      <name form="long" and="text" delimiter-precedes-last="never" sort-separator=" " font-style="normal">
-      </name>
+      <name form="long" and="text" delimiter-precedes-last="never" sort-separator=" " font-style="normal"/>
       <label form="short" prefix="&#160;(" suffix=".)"/>
     </names>
   </macro>
@@ -227,21 +227,21 @@
       <else-if type="article-journal article-magazine" match="any">
         <group font-style="normal">
           <choose>
-          	<if variable="volume issue">
-          	  <text variable="volume" prefix=" "/>
-          	  <text variable="issue" prefix="-"/>
-          	</if>
-          	<else-if variable="volume">  
-          	  <text variable="volume" prefix=" "/>
-          	</else-if> 
-          	<else-if variable="issue">  
+            <if variable="volume issue">
+              <text variable="volume" prefix=" "/>
+              <text variable="issue" prefix="-"/>
+            </if>
+            <else-if variable="volume">
+              <text variable="volume" prefix=" "/>
+            </else-if>
+            <else-if variable="issue">
               <text variable="issue" prefix=" "/>
-          	</else-if>
+            </else-if>
           </choose>
           <choose>
             <if variable="issued">
               <date variable="issued" prefix=", ">
-                <date-part name="year" />
+                <date-part name="year"/>
               </date>
             </if>
           </choose>
@@ -276,13 +276,13 @@
               </else>
             </choose>
             <choose>
-			  <if type="article-journal article-magazine article-newspaper chapter paper-conference" match="any">
-				<text value="art. cit"/>
-			  </if>
-			  <else>
-				<text value="op. cit" font-style="italic"/>
-			  </else>
-			</choose>
+              <if type="article-journal article-magazine article-newspaper chapter paper-conference" match="any">
+                <text value="art. cit"/>
+              </if>
+              <else>
+                <text value="op. cit" font-style="italic"/>
+              </else>
+            </choose>
             <group delimiter="&#8239;">
               <label variable="locator" form="short"/>
               <text variable="locator"/>


### PR DESCRIPTION
Made a few changes that correspond to the updated style that Annales is now using:
- corrected for articles: year comes after volume and issue
- updated: volume and issue for articles now noted "XX-X"
- updated: cited pages for articles (full citation) is: "ici p."
- updated: for subsequent citations, after the short title, "op. cit." is used for books but "art. cit." is used for articles.