### PR TITLE
Align harvard-university-of-bath.csl with current guidance

### DIFF
--- a/harvard-university-of-bath.csl
+++ b/harvard-university-of-bath.csl
@@ -90,7 +90,7 @@
   <macro name="archive">
     <choose>
       <if type="graphic">
-        <text variable="archive-place" prefix="At: " suffix=". " />
+        <text variable="archive-place" prefix="At: " suffix=". "/>
         <text variable="archive"/>
       </if>
       <else>
@@ -362,7 +362,7 @@
                   </if>
                   <else>
                     <text variable="collection-title"/>
-                    <group delimiter="–">
+                    <group delimiter="&#8211;">
                       <text variable="volume"/>
                       <text variable="page"/>
                     </group>
@@ -416,8 +416,7 @@
         </else>
       </choose>
       <choose>
-        <if type="legislation legal_case" match="any">
-        </if>
+        <if type="legislation legal_case" match="any"></if>
         <else-if type="book motion_picture musical_score song" match="any">
           <group prefix=" " suffix="." delimiter=" ">
             <text macro="title"/>
@@ -499,7 +498,7 @@
                 <text macro="publisher"/>
                 <choose>
                   <if variable="number">
-                      <text macro="series-genre" prefix="(" suffix=")"/>
+                    <text macro="series-genre" prefix="(" suffix=")"/>
                   </if>
                 </choose>
               </group>
@@ -509,7 +508,7 @@
                 <text macro="publisher"/>
                 <choose>
                   <if variable="number">
-                      <text macro="series-genre" prefix="(" suffix=")"/>
+                    <text macro="series-genre" prefix="(" suffix=")"/>
                   </if>
                 </choose>
               </group>

--- a/harvard-university-of-bath.csl
+++ b/harvard-university-of-bath.csl
@@ -19,19 +19,15 @@
     <category citation-format="author-date"/>
     <category field="generic-base"/>
     <summary>Adaptation of Harvard referencing style used at the University of Bath.</summary>
-    <updated>2019-02-06T18:00:00+00:00</updated>
-    <rights license="https://creativecommons.org/licenses/by-sa/4.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 4.0 International License</rights>
+    <updated>2019-02-06T18:40:00+00:00</updated>
+    <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale xml:lang="en">
     <terms>
       <term name="available at">available from</term>
       <term name="version" form="short">v.</term>
       <term name="translator" form="short">trans.</term>
-      <term name="legal-chapter" form="long">
-        <single>chapter</single>
-        <multiple>chapters</multiple>
-      </term>
-      <term name="legal-chapter" form="short">
+      <term name="chapter" form="short">
         <single>c.</single>
         <multiple>cc.</multiple>
       </term>
@@ -44,9 +40,6 @@
       <name and="text" delimiter-precedes-last="never" initialize-with="."/>
       <label form="short" prefix=", " text-case="lowercase"/>
     </names>
-  </macro>
-  <macro name="anon">
-    <text term="anonymous" form="short" text-case="capitalize-first" strip-periods="true"/>
   </macro>
   <macro name="author">
     <names variable="author">
@@ -308,7 +301,7 @@
                     <text variable="collection-title"/>
                     <group delimiter="/">
                       <number variable="volume"/>
-                      <number variable="page"/>
+                      <text variable="page"/>
                     </group>
                   </group>
                 </group>
@@ -319,17 +312,20 @@
                     <group prefix=" (" suffix=")" delimiter=", ">
                       <text variable="collection-title"/>
                       <group>
-                        <term name="legal-chapter" form="short"/>
+                        <text term="chapter" form="short"/>
                         <number variable="chapter-number"/>
                       </group>
                     </group>
                   </if>
                   <else>
-                    <number variable="chapter-number" prefix=", c."/>
+                    <group prefix=", ">
+                      <text term="chapter" form="short"/>
+                      <number variable="chapter-number"/>
+                    </group>
                   </else>
                 </choose>
                 <group prefix=", ">
-                  <term name="number" form="short" text-case="capitalize-first"/>
+                  <text term="number" form="short" text-case="capitalize-first"/>
                   <number variable="number"/>
                 </group>
                 <choose>

--- a/harvard-university-of-bath.csl
+++ b/harvard-university-of-bath.csl
@@ -6,20 +6,42 @@
     <id>http://www.zotero.org/styles/harvard-university-of-bath</id>
     <link href="http://www.zotero.org/styles/harvard-university-of-bath" rel="self"/>
     <link href="http://www.zotero.org/styles/harvard-bournemouth-university" rel="template"/>
-    <link href="http://www.bath.ac.uk/library/infoskills/referencing-plagiarism/harvard-bath-style.html" rel="documentation"/>
+    <link href="https://library.bath.ac.uk/referencing/harvard-bath" rel="documentation"/>
+    <link href="https://github.com/alex-ball/bathbib/" rel="documentation"/>
     <author>
       <name>Rob Fuller</name>
       <email>rob.fuller1@gmail.com</email>
     </author>
+    <author>
+      <name>Alex Ball</name>
+      <email>ab318@bath.ac.uk</email>
+    </author>
     <category citation-format="author-date"/>
     <category field="generic-base"/>
-    <summary>Adaptation of Harvard referencing style used at the University of Bath. This template has been developed by a student: it is not an official template provided by the university.</summary>
-    <updated>2016-11-28T13:05:27+00:00</updated>
-    <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
+    <summary>Adaptation of Harvard referencing style used at the University of Bath.</summary>
+    <updated>2019-02-06T18:00:00+00:00</updated>
+    <rights license="https://creativecommons.org/licenses/by-sa/4.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 4.0 International License</rights>
   </info>
+  <locale xml:lang="en">
+    <terms>
+      <term name="available at">available from</term>
+      <term name="version" form="short">v.</term>
+      <term name="translator" form="short">trans.</term>
+      <term name="legal-chapter" form="long">
+        <single>chapter</single>
+        <multiple>chapters</multiple>
+      </term>
+      <term name="legal-chapter" form="short">
+        <single>c.</single>
+        <multiple>cc.</multiple>
+      </term>
+      <term name="number" form="long">number</term>
+      <term name="number" form="short">no.</term>
+    </terms>
+  </locale>
   <macro name="editor">
-    <names variable="editor" delimiter=", ">
-      <name and="symbol" initialize-with=". " delimiter=", "/>
+    <names variable="editor">
+      <name and="text" delimiter-precedes-last="never" initialize-with="."/>
       <label form="short" prefix=", " text-case="lowercase"/>
     </names>
   </macro>
@@ -28,29 +50,39 @@
   </macro>
   <macro name="author">
     <names variable="author">
-      <name and="text" initialize-with="." name-as-sort-order="all"/>
+      <name and="text" delimiter-precedes-last="never" initialize-with="." name-as-sort-order="all"/>
       <label form="short" prefix=" " text-case="lowercase"/>
       <substitute>
-        <names variable="editor"/>
-        <text macro="anon"/>
+        <names variable="editor">
+          <name and="text" delimiter-precedes-last="never" initialize-with="." name-as-sort-order="all"/>
+          <label form="short" prefix=", " text-case="lowercase"/>
+        </names>
+        <text macro="title"/>
       </substitute>
     </names>
   </macro>
   <macro name="author-short">
     <names variable="author">
-      <name form="short" and="text" delimiter-precedes-last="never" initialize-with=". "/>
+      <name form="short" and="text" delimiter-precedes-last="never" initialize-with="."/>
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <text macro="anon"/>
+        <text macro="title-short"/>
       </substitute>
     </names>
   </macro>
   <macro name="access">
     <choose>
-      <if variable="URL">
-        <text value="Available from:" suffix=" "/>
-        <text variable="URL"/>
+      <if variable="URL DOI" match="any">
+        <text term="available at" text-case="capitalize-first" suffix=": "/>
+        <choose>
+          <if variable="DOI">
+            <text variable="DOI" prefix="https://doi.org/"/>
+          </if>
+          <else>
+            <text variable="URL"/>
+          </else>
+        </choose>
         <group prefix=" [" suffix="]">
           <text term="accessed" text-case="capitalize-first" suffix=" "/>
           <date variable="accessed">
@@ -62,19 +94,99 @@
       </if>
     </choose>
   </macro>
+  <macro name="archive">
+    <choose>
+      <if type="graphic">
+        <text variable="archive-place" prefix="At: " suffix=". " />
+        <text variable="archive"/>
+      </if>
+      <else>
+        <text variable="archive" font-style="italic"/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="credits">
+    <group delimiter=". ">
+      <names variable="composer">
+        <label form="verb" text-case="capitalize-first" suffix=" "/>
+        <name and="text" delimiter-precedes-last="never" initialize="false" initialize-with="."/>
+      </names>
+      <names variable="director">
+        <label form="verb" text-case="capitalize-first" suffix=" "/>
+        <name and="text" delimiter-precedes-last="never" initialize="false" initialize-with="."/>
+      </names>
+      <names variable="interviewer">
+        <label form="verb" text-case="capitalize-first" suffix=" "/>
+        <name and="text" delimiter-precedes-last="never" initialize="false" initialize-with="."/>
+      </names>
+      <names variable="illustrator">
+        <label form="verb" text-case="capitalize-first" suffix=" "/>
+        <name and="text" delimiter-precedes-last="never" initialize="false" initialize-with="."/>
+      </names>
+    </group>
+  </macro>
   <macro name="title">
     <choose>
-      <if type="bill book graphic legal_case legislation motion_picture report song webpage thesis" match="any">
+      <if type="bill broadcast book dataset graphic legal_case map motion_picture musical_score patent report song webpage thesis" match="any">
         <text variable="title" font-style="italic"/>
       </if>
+      <else-if type="legislation">
+        <choose>
+          <if variable="container-title">
+            <text variable="title"/>
+          </if>
+          <else>
+            <text variable="title" font-style="italic"/>
+          </else>
+        </choose>
+      </else-if>
       <else>
         <text variable="title"/>
       </else>
     </choose>
+    <text variable="original-title" prefix=" [" suffix="]"/>
+    <group prefix=" (" suffix=")">
+      <text term="version" form="short"/>
+      <text variable="version"/>
+    </group>
+    <choose>
+      <if type="thesis motion_picture broadcast" match="any"/>
+      <else-if type="report" variable="number"/>
+      <else-if type="patent" variable="number"/>
+      <else>
+        <text variable="genre" prefix=" [" suffix="]"/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="title-short">
+    <choose>
+      <if type="bill broadcast book dataset graphic map motion_picture musical_score patent report song webpage thesis" match="any">
+        <text variable="title" font-style="italic"/>
+      </if>
+      <else-if type="legislation legal_case" match="any">
+        <choose>
+          <if variable="container-title">
+            <text variable="title"/>
+          </if>
+          <else>
+            <text variable="title" font-style="italic"/>
+          </else>
+        </choose>
+      </else-if>
+      <else>
+        <text variable="title-short"/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="translator">
+    <names variable="translator" prefix="(" suffix=")">
+      <name and="text" delimiter-precedes-last="never" initialize-with="."/>
+      <label form="short" prefix=". " text-case="capitalize-first"/>
+    </names>
   </macro>
   <macro name="online">
     <choose>
-      <if variable="URL" match="any">
+      <if variable="URL DOI" match="any">
         <text term="online" text-case="capitalize-first" prefix="[" suffix="]"/>
       </if>
     </choose>
@@ -88,9 +200,20 @@
   <macro name="year-date">
     <choose>
       <if variable="issued">
-        <date variable="issued">
-          <date-part name="year"/>
-        </date>
+        <choose>
+          <if type="post">
+            <date variable="issued">
+              <date-part name="day" suffix=" "/>
+              <date-part name="month" suffix=" "/>
+              <date-part name="year"/>
+            </date>
+          </if>
+          <else>
+            <date variable="issued">
+              <date-part name="year"/>
+            </date>
+          </else>
+        </choose>
       </if>
       <else>
         <text term="no date" form="short"/>
@@ -117,7 +240,20 @@
     <choose>
       <if variable="collection-title">
         <text variable="collection-title"/>
-        <text variable="number" prefix=" no. "/>
+        <text variable="number" prefix=", "/>
+      </if>
+    </choose>
+  </macro>
+  <macro name="series-genre">
+    <choose>
+      <if variable="collection-title genre number" match="any">
+        <group delimiter=", ">
+          <text variable="collection-title"/>
+          <group delimiter=" ">
+            <text variable="genre"/>
+            <text variable="number"/>
+          </group>
+        </group>
       </if>
     </choose>
   </macro>
@@ -148,40 +284,281 @@
       <key variable="title"/>
     </sort>
     <layout>
-      <text macro="author" suffix=","/>
-      <date variable="issued" prefix=" " suffix=".">
-        <date-part name="year"/>
-      </date>
       <choose>
-        <if type="bill book graphic legal_case legislation motion_picture song" match="any">
-          <group prefix=" " suffix="." delimiter=". ">
+        <if type="legislation">
+          <group suffix=".">
+            <group delimiter=" ">
+              <text macro="author"/>
+              <choose>
+                <if variable="container-title">
+                  <text macro="year-date" prefix="[" suffix="]"/>
+                </if>
+                <else>
+                  <text macro="year-date" font-style="italic"/>
+                </else>
+              </choose>
+            </group>
+            <text macro="title" prefix=", "/>
+            <text macro="online" prefix=" "/>
+            <choose>
+              <if variable="container-title">
+                <group prefix=" " delimiter=" ">
+                  <text variable="container-title" font-style="italic"/>
+                  <group>
+                    <text variable="collection-title"/>
+                    <group delimiter="/">
+                      <number variable="volume"/>
+                      <number variable="page"/>
+                    </group>
+                  </group>
+                </group>
+              </if>
+              <else>
+                <choose>
+                  <if variable="collection-title">
+                    <group prefix=" (" suffix=")" delimiter=", ">
+                      <text variable="collection-title"/>
+                      <group>
+                        <term name="legal-chapter" form="short"/>
+                        <number variable="chapter-number"/>
+                      </group>
+                    </group>
+                  </if>
+                  <else>
+                    <number variable="chapter-number" prefix=", c."/>
+                  </else>
+                </choose>
+                <group prefix=", ">
+                  <term name="number" form="short" text-case="capitalize-first"/>
+                  <number variable="number"/>
+                </group>
+                <choose>
+                  <if variable="number">
+                    <text prefix=", " macro="publisher"/>
+                  </if>
+                  <else>
+                    <text prefix=". " macro="publisher"/>
+                  </else>
+                </choose>
+              </else>
+            </choose>
+          </group>
+        </if>
+        <else-if type="legal_case">
+          <choose>
+            <if variable="number">
+              <group suffix="." delimiter=" ">
+                <text macro="author"/>
+                <text variable="number" prefix="(" suffix=")"/>
+                <text macro="year-date" prefix="[" suffix="]"/>
+                <text macro="title"/>
+                <text macro="online"/>
+                <choose>
+                  <if variable="container-title">
+                    <text variable="container-title" font-style="italic"/>
+                    <group>
+                      <text variable="collection-title"/>
+                      <group delimiter="/">
+                        <text variable="volume"/>
+                        <text variable="page"/>
+                      </group>
+                    </group>
+                  </if>
+                  <else>
+                    <text variable="collection-title"/>
+                    <group delimiter="–">
+                      <text variable="volume"/>
+                      <text variable="page"/>
+                    </group>
+                  </else>
+                </choose>
+              </group>
+            </if>
+            <else>
+              <group suffix="." delimiter=". ">
+                <text macro="author"/>
+                <choose>
+                  <if variable="volume">
+                    <text macro="year-date" prefix="(" suffix=")"/>
+                  </if>
+                  <else>
+                    <text macro="year-date" prefix="[" suffix="]"/>
+                  </else>
+                </choose>
+                <group delimiter=" ">
+                  <text macro="title"/>
+                  <text macro="online"/>
+                </group>
+                <choose>
+                  <if variable="container-title">
+                    <group delimiter=" ">
+                      <text variable="container-title" font-style="italic"/>
+                      <group>
+                        <text variable="collection-title"/>
+                        <group delimiter="/">
+                          <text variable="volume"/>
+                          <text variable="page"/>
+                        </group>
+                      </group>
+                    </group>
+                  </if>
+                  <else>
+                    <text variable="volume"/>
+                    <group delimiter=" ">
+                      <text variable="collection-title"/>
+                      <text variable="page"/>
+                    </group>
+                  </else>
+                </choose>
+              </group>
+            </else>
+          </choose>
+        </else-if>
+        <else>
+          <text macro="author" suffix=","/>
+          <text macro="year-date" prefix=" " suffix="."/>
+        </else>
+      </choose>
+      <choose>
+        <if type="legislation legal_case" match="any">
+        </if>
+        <else-if type="book motion_picture musical_score song" match="any">
+          <group prefix=" " suffix="." delimiter=" ">
             <text macro="title"/>
+            <text macro="online"/>
+            <text macro="translator"/>
+          </group>
+          <group prefix=" " suffix="." delimiter=". ">
             <text macro="edition"/>
             <text macro="series"/>
+            <choose>
+              <if type="motion_picture">
+                <text variable="genre"/>
+              </if>
+            </choose>
             <text macro="editor"/>
+            <text macro="credits"/>
           </group>
           <text prefix=" " suffix="." macro="publisher"/>
-        </if>
-        <else-if type="report webpage" match="any">
+        </else-if>
+        <else-if type="article-journal post" match="any">
+          <group prefix=" " suffix="." delimiter=". ">
+            <text macro="title"/>
+          </group>
+          <group prefix=" " suffix=".">
+            <text variable="container-title" font-style="italic"/>
+            <text prefix=" " macro="online"/>
+            <group prefix=", ">
+              <text variable="volume"/>
+              <text variable="issue" prefix="(" suffix=")"/>
+            </group>
+            <group prefix=", ">
+              <label variable="page" form="short"/>
+              <text variable="page"/>
+            </group>
+          </group>
+        </else-if>
+        <else-if type="article-magazine article-newspaper" match="any">
+          <group prefix=" " suffix="." delimiter=". ">
+            <text macro="title"/>
+          </group>
+          <group prefix=" " suffix=".">
+            <text variable="container-title" font-style="italic"/>
+            <text prefix=" " macro="online"/>
+            <group prefix=", ">
+              <text variable="volume"/>
+              <text variable="issue" prefix="(" suffix=")"/>
+            </group>
+            <date variable="issued" prefix=", ">
+              <date-part name="day" suffix=" "/>
+              <date-part name="month"/>
+            </date>
+            <group prefix=", ">
+              <label variable="page" form="short"/>
+              <text variable="page"/>
+            </group>
+          </group>
+        </else-if>
+        <else-if type="bill report webpage" match="any">
+          <group prefix=" " suffix="." delimiter=" ">
+            <text macro="title"/>
+            <choose>
+              <if variable="archive" match="none">
+                <text macro="online"/>
+              </if>
+            </choose>
+          </group>
+          <group prefix=" " suffix="." delimiter=". ">
+            <text macro="edition"/>
+            <choose>
+              <if variable="number" match="none">
+                <text macro="series"/>
+              </if>
+            </choose>
+            <text macro="editor"/>
+          </group>
+          <choose>
+            <if type="report">
+              <group prefix=" " suffix="." delimiter=", ">
+                <text macro="publisher"/>
+                <choose>
+                  <if variable="number">
+                      <text macro="series-genre" prefix="(" suffix=")"/>
+                  </if>
+                </choose>
+              </group>
+            </if>
+            <else>
+              <group prefix=" " suffix="." delimiter=" ">
+                <text macro="publisher"/>
+                <choose>
+                  <if variable="number">
+                      <text macro="series-genre" prefix="(" suffix=")"/>
+                  </if>
+                </choose>
+              </group>
+            </else>
+          </choose>
+          <choose>
+            <if variable="archive">
+              <group prefix=" " suffix="." delimiter=" ">
+                <text macro="archive"/>
+                <text macro="online"/>
+              </group>
+            </if>
+          </choose>
+        </else-if>
+        <else-if type="patent" match="any">
           <group prefix=" " suffix="." delimiter=" ">
             <text macro="title"/>
             <text macro="online"/>
           </group>
-          <group prefix=" " suffix="." delimiter=". ">
-            <text macro="edition" suffix=". "/>
-            <text macro="series" suffix=". "/>
-            <text macro="editor" suffix=". "/>
-          </group>
-          <text prefix=" " suffix="." macro="publisher"/>
+          <text macro="series-genre" prefix=" " suffix="."/>
+          <text macro="publisher" prefix=" " suffix="."/>
         </else-if>
         <else-if type="chapter paper-conference" match="any">
           <text macro="title" prefix=" " suffix="."/>
           <group prefix=" " delimiter=" ">
-            <text term="in" text-case="capitalize-first" suffix=":"/>
-            <text macro="editor"/>
-            <text variable="container-title" font-style="italic" suffix="."/>
+            <choose>
+              <if variable="editor">
+                <text term="in" text-case="capitalize-first" suffix=":"/>
+                <text macro="editor"/>
+              </if>
+            </choose>
+            <group suffix="." delimiter=", ">
+              <text variable="container-title" font-style="italic"/>
+              <text macro="online" prefix=" "/>
+              <text variable="event"/>
+              <group delimiter=" ">
+                <date variable="event-date">
+                  <date-part name="day" suffix=" "/>
+                  <date-part name="month" suffix=" "/>
+                  <date-part name="year"/>
+                </date>
+                <text variable="event-place"/>
+              </group>
+            </group>
             <text variable="collection-title" suffix="."/>
-            <text variable="event" suffix="."/>
             <group suffix="." delimiter=", ">
               <text macro="publisher" prefix=" "/>
               <text macro="pages"/>
@@ -195,10 +572,45 @@
             <text macro="publisher"/>
           </group>
         </else-if>
-        <else>
+        <else-if type="graphic map" match="any">
+          <group prefix=" " suffix="." delimiter=" ">
+            <group delimiter=", ">
+              <text macro="title"/>
+              <text variable="scale"/>
+            </group>
+            <text macro="online"/>
+          </group>
+          <group prefix=" " suffix="." delimiter=". ">
+            <text macro="edition"/>
+            <text macro="series"/>
+            <text macro="editor"/>
+          </group>
+          <text prefix=" " suffix="." macro="publisher"/>
+          <text prefix=" " suffix="." macro="archive"/>
+        </else-if>
+        <else-if type="broadcast">
           <group prefix=" " suffix="." delimiter=" ">
             <text macro="title"/>
             <text macro="online"/>
+          </group>
+          <text macro="series-genre" prefix=" " suffix="."/>
+          <text variable="medium" prefix=" " suffix="."/>
+          <group prefix=" " suffix="." delimiter=", ">
+            <text macro="publisher"/>
+            <date variable="issued">
+              <date-part name="day" suffix=" "/>
+              <date-part name="month"/>
+            </date>
+          </group>
+        </else-if>
+        <else>
+          <group prefix=" " suffix="." delimiter=" ">
+            <text macro="title"/>
+            <choose>
+              <if variable="container-title" match="none">
+                <text macro="online"/>
+              </if>
+            </choose>
           </group>
           <group prefix=" " suffix="." delimiter=". ">
             <text macro="series"/>
@@ -206,7 +618,14 @@
             <text macro="editor"/>
           </group>
           <group prefix=" " suffix=".">
-            <text variable="container-title" font-style="italic"/>
+            <choose>
+              <if variable="container-title">
+                <group delimiter=" ">
+                  <text variable="container-title" font-style="italic"/>
+                  <text macro="online"/>
+                </group>
+              </if>
+            </choose>
             <group prefix=", ">
               <text variable="volume"/>
               <text variable="issue" prefix="(" suffix=")"/>
@@ -216,9 +635,11 @@
               <text variable="page"/>
             </group>
           </group>
+          <text prefix=" " suffix="." macro="publisher"/>
         </else>
       </choose>
-      <text prefix=" " macro="access" suffix="."/>
+      <text variable="annote" prefix=" " suffix="."/>
+      <text macro="access" prefix=" " suffix="."/>
     </layout>
   </bibliography>
 </style>


### PR DESCRIPTION
These changes bring the style as near as possible into line with the current University of Bath guidance:
https://library.bath.ac.uk/referencing/harvard-bath.

The CSL-YAML database against which this style has been tested is available for inspection:
https://github.com/alex-ball/bathbib/blob/master/csl/bath-csl-test.yaml

Tips for using this style are available here:
https://github.com/alex-ball/bathbib

(NB. I am a librarian at the University of Bath and also maintain the LaTeX implementations of the style.)