### PR TITLE
fix: remove space after opening parenthesis

### DIFF
--- a/le-tapuscrit-note.csl
+++ b/le-tapuscrit-note.csl
@@ -255,7 +255,7 @@
       </else-if>
       <else-if type="webpage post-weblog" match="any">
         <group delimiter=" " prefix="(" suffix=")">
-          <text value="consulté le">
+          <text value="consulté le"/>
           <date variable="accessed" form="text">
             <date-part name="day"/>
             <date-part name="month"/>

--- a/le-tapuscrit-note.csl
+++ b/le-tapuscrit-note.csl
@@ -255,7 +255,7 @@
       </else-if>
       <else-if type="webpage post-weblog" match="any">
         <group delimiter=" " prefix="(" suffix=")">
-          <text value="consulté le" suffix=" " prefix=""/>
+          <text value="consulté le">
           <date variable="accessed" form="text">
             <date-part name="day"/>
             <date-part name="month"/>

--- a/le-tapuscrit-note.csl
+++ b/le-tapuscrit-note.csl
@@ -255,7 +255,7 @@
       </else-if>
       <else-if type="webpage post-weblog" match="any">
         <group delimiter=" " prefix="(" suffix=")">
-          <text value="consulté le" suffix=" " prefix=" "/>
+          <text value="consulté le" suffix=" " prefix=""/>
           <date variable="accessed" form="text">
             <date-part name="day"/>
             <date-part name="month"/>


### PR DESCRIPTION
The style currently prints `( consulté le` for webpage and blog posts. I think it's much better without the extra space after the parenthesis.

Thanks a lot for an awesome and very useful `.csl`!