### PR TITLE
Fixes details for edited volumes in TAPA style

### DIFF
--- a/transactions-of-the-american-philological-association.csl
+++ b/transactions-of-the-american-philological-association.csl
@@ -28,12 +28,17 @@
       <email>karnesky+zotero@gmail.com</email>
       <uri>http://arc.nucapt.northwestern.edu/Richard_Karnesky</uri>
     </contributor>
+    <contributor>
+      <name>Patrick J. Burns</name>
+      <email>patrick@diyclassics.org</email>
+      <uri>https://diyclassics.github.io</uri>
+    </contributor>
     <category citation-format="author-date"/>
     <category field="linguistics"/>
     <issn>0360-5949</issn>
     <eissn>1533-0699</eissn>
     <summary>The author-date variant of the Chicago style with TAPA modifications (colon before page, no parentheses)</summary>
-    <updated>2017-11-07T13:37:33+00:00</updated>
+    <updated>2019-02-16T07:30:00+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale>
@@ -70,12 +75,12 @@
   <macro name="container-contributors">
     <choose>
       <if type="chapter paper-conference" match="any">
-        <group delimiter=", " suffix=", ">
+        <group delimiter=", " suffix=" ">
           <choose>
             <if variable="author">
               <names variable="container-author editor" delimiter=", ">
                 <name and="text" initialize-with="." name-as-sort-order="all"/>
-                <label form="short"/>
+                <label form="short" prefix=" "/>
               </names>
             </if>
           </choose>
@@ -270,7 +275,7 @@
       <if type="chapter paper-conference" match="any">
         <choose>
           <if variable="page">
-            <group prefix=", ">
+            <group prefix=". ">
               <text variable="volume" suffix=":"/>
               <text variable="page"/>
             </group>
@@ -470,11 +475,11 @@
       <text macro="secondary-contributors" prefix=". "/>
       <text macro="container-title" prefix=". "/>
       <text macro="edition"/>
-      <text macro="locators-chapter"/>
       <text macro="locators"/>
       <text macro="collection-title" prefix=". "/>
       <text macro="issue"/>
       <text macro="locators-article"/>
+      <text macro="locators-chapter"/>
       <text macro="access" prefix=". "/>
     </layout>
   </bibliography>


### PR DESCRIPTION
 - removes prefix ', ' from secondary-contributors label, i.e. 'ed.'
 - adds suffix ' ' to same
 - moves locators-chapter to correct position; changes prefix to '.'
 - updates contributor