### PR TITLE
Update journal-of-developmental-and-behavioral-pediatrics.csl

### DIFF
--- a/dependent/journal-of-developmental-and-behavioral-pediatrics.csl
+++ b/dependent/journal-of-developmental-and-behavioral-pediatrics.csl
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <style xmlns="http://purl.org/net/xbiblio/csl" version="1.0" default-locale="en-US">
   <info>
-    <title>Journal of Developmental and Behavioral Pediatrics</title>
+    <title>Journal of Developmental &amp; Behavioral Pediatrics</title>
     <id>http://www.zotero.org/styles/journal-of-developmental-and-behavioral-pediatrics</id>
     <link href="http://www.zotero.org/styles/journal-of-developmental-and-behavioral-pediatrics" rel="self"/>
     <link href="http://www.zotero.org/styles/american-medical-association-no-url" rel="independent-parent"/>
-    <link href="https://onlinelibrary.wiley.com/page/journal/10970231/homepage/forauthors.html#ReferenceStyleandEndNote" rel="documentation"/>
+    <link href="https://journals.lww.com/jrnldbp/Pages/informationforauthors.aspx" rel="documentation"/>
     <category citation-format="numeric"/>
     <category field="medicine"/>
     <issn>0196-206X</issn>


### PR DESCRIPTION
Fix documentation link and use ampersand in title. Follow-up of #3932.