### PR TITLE
Correct et-al-min

### DIFF
--- a/harvard-coventry-university.csl
+++ b/harvard-coventry-university.csl
@@ -271,7 +271,7 @@
       </if>
     </choose>
   </macro>
-  <citation et-al-min="3" et-al-use-first="1" disambiguate-add-year-suffix="true" disambiguate-add-givenname="true" givenname-disambiguation-rule="by-cite" name-as-sort-order="all" collapse="year">
+  <citation et-al-min="4" et-al-use-first="1" disambiguate-add-year-suffix="true" disambiguate-add-givenname="true" givenname-disambiguation-rule="by-cite" name-as-sort-order="all" collapse="year">
     <layout prefix="(" suffix=")" delimiter=", ">
       <choose>
         <if locator="page">


### PR DESCRIPTION
Style guide is full list of names 'for up to three authors', so et-al-min needs to be 4