### PR TITLE
Update university-of-south-australia-2017-harvard.csl

### DIFF
--- a/university-of-south-australia-2017-harvard.csl
+++ b/university-of-south-australia-2017-harvard.csl
@@ -15,7 +15,7 @@
     <category citation-format="author-date"/>
     <category field="generic-base"/>
     <summary>University of South Australia citation style based on the January 2017 version of the style guide titled Harvard referencing guide UniSA</summary>
-    <updated>2019-01-18T13:00:00+10:30</updated>
+    <updated>2019-03-12T13:00:00+10:30</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale xml:lang="en">
@@ -134,7 +134,7 @@
       </if>
       <else>
         <names variable="author">
-          <label form="short" suffix=" " strip-periods="true"/>
+          <label form="short" suffix=" "/>
           <name form="short" name-as-sort-order="all" and="symbol" sort-separator=", " delimiter=", " delimiter-precedes-last="never" initialize-with=""/>
           <substitute>
             <names variable="editor"/>
@@ -241,7 +241,7 @@
       <else-if type="webpage" match="any">
         <text variable="container-title"/>
       </else-if>
-      <else-if type="article article-journal article-magazine article-newspaper" match="any">
+	  <else-if type="article article-journal article-magazine article-newspaper" match="any">
         <text variable="container-title" font-style="italic" text-case="title"/>
       </else-if>
       <else>
@@ -282,7 +282,7 @@
           <date-part name="year" form="long"/>
         </date>
       </if>
-    </choose>
+	</choose>
   </macro>
   <macro name="access-link">
     <text variable="URL" prefix="&lt;" suffix="&gt;"/>
@@ -312,7 +312,7 @@
       </group>
     </layout>
   </citation>
-  <bibliography et-al-min="99" et-al-use-first="98" hanging-indent="false" entry-spacing="1" line-spacing="1" subsequent-author-substitute="―" subsequent-author-substitute-rule="complete-all">
+  <bibliography et-al-min="8" et-al-use-first="6" et-al-use-last="true" hanging-indent="false" entry-spacing="1" line-spacing="1" subsequent-author-substitute="―" subsequent-author-substitute-rule="complete-all">
     <sort>
       <key macro="author"/>
       <key macro="year-date"/>
@@ -357,23 +357,23 @@
                 </choose>
                 <text macro="issue"/>
                 <text macro="pages"/>
-                <choose>
-                  <if type="article-journal book chapter" match="none">
-                    <text macro="access-date"/>
-                    <text macro="access-link"/>
-                  </if>
-                </choose>
+				<choose>
+				  <if type="article-journal book chapter" match="none">
+					<text macro="access-date"/>
+					<text macro="access-link"/>
+				  </if>
+				</choose>
               </else>
             </choose>
           </group>
         </if>
-        <else-if type="legislation">
-          <group delimiter=" ">
-            <text macro="title"/>
-            <text macro="year-date" font-style="italic"/>
-            <text variable="jurisdiction" prefix="(" suffix=")"/>
-          </group>
-        </else-if>
+		<else-if type="legislation">
+		  <group delimiter=" ">
+		    <text macro="title"/>
+		    <text macro="year-date" font-style="italic"/>
+			<text variable="jurisdiction" prefix="(" suffix=")"/>
+		  </group>
+		</else-if>
       </choose>
     </layout>
   </bibliography>

--- a/university-of-south-australia-2017-harvard.csl
+++ b/university-of-south-australia-2017-harvard.csl
@@ -241,7 +241,7 @@
       <else-if type="webpage" match="any">
         <text variable="container-title"/>
       </else-if>
-	  <else-if type="article article-journal article-magazine article-newspaper" match="any">
+      <else-if type="article article-journal article-magazine article-newspaper" match="any">
         <text variable="container-title" font-style="italic" text-case="title"/>
       </else-if>
       <else>
@@ -282,7 +282,7 @@
           <date-part name="year" form="long"/>
         </date>
       </if>
-	</choose>
+    </choose>
   </macro>
   <macro name="access-link">
     <text variable="URL" prefix="&lt;" suffix="&gt;"/>
@@ -357,23 +357,23 @@
                 </choose>
                 <text macro="issue"/>
                 <text macro="pages"/>
-				<choose>
-				  <if type="article-journal book chapter" match="none">
-					<text macro="access-date"/>
-					<text macro="access-link"/>
-				  </if>
-				</choose>
+                <choose>
+                  <if type="article-journal book chapter" match="none">
+                    <text macro="access-date"/>
+                    <text macro="access-link"/>
+                  </if>
+                </choose>
               </else>
             </choose>
           </group>
         </if>
-		<else-if type="legislation">
-		  <group delimiter=" ">
-		    <text macro="title"/>
-		    <text macro="year-date" font-style="italic"/>
-			<text variable="jurisdiction" prefix="(" suffix=")"/>
-		  </group>
-		</else-if>
+        <else-if type="legislation">
+          <group delimiter=" ">
+            <text macro="title"/>
+            <text macro="year-date" font-style="italic"/>
+            <text variable="jurisdiction" prefix="(" suffix=")"/>
+          </group>
+        </else-if>
       </choose>
     </layout>
   </bibliography>


### PR DESCRIPTION
This change corrects the display of author labels (they should include periods if these are in the labels) and corrects the et-al limit for the number of authors that are included in the bibliography (the limit should be 7, after which the elllipsis > last author format is used, see http://www.library.unisa.edu.au/siteassets/pdfs-powerpoint-files/referencing-roadmap/referencingroadmapfaqs.pdf pg. 8).