### PR TITLE
Update sodertorns-hogskola-harvard-ibid.csl

### DIFF
--- a/sodertorns-hogskola-harvard-ibid.csl
+++ b/sodertorns-hogskola-harvard-ibid.csl
@@ -1,6 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" demote-non-dropping-particle="sort-only">
-  <!-- This style was edited with the Visual CSL Editor (http://editor.citationstyles.org/visualEditor/) -->
+ <!-- 21 March 2019 -->
+  <!-- Fixed errors -->
+    <!-- 1. Parenthesis missing for editor -->
+    <!-- 2. Page text missing for book chapter -->
+    <!-- 3. Italics removed for "in" book chapter -->
   <info>
     <title>Södertörns högskola - Harvard (with Ibid.)</title>
     <title-short>SH - Harvard (Ibid.)</title-short>
@@ -16,7 +20,7 @@
     <category citation-format="author-date"/>
     <category field="generic-base"/>
     <summary>Södertörn Högskola Harvard (ibid)</summary>
-    <updated>2017-10-10T11:26:09+00:00</updated>
+    <updated>2018-03-31T04:01:14+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale xml:lang="sv">
@@ -161,11 +165,11 @@
   <macro name="container">
     <choose>
       <if type="chapter paper-conference" match="any">
-        <text term="in" text-case="capitalize-first" suffix=": " font-style="italic"/>
-        <group delimiter=". ">
+         <text term="in" text-case="capitalize-first" font-style="normal" suffix=": "/>
+        <group delimiter=" ">
           <names variable="editor translator" delimiter=", ">
-            <name sort-separator=", " initialize-with=". " and="text" delimiter=", " name-as-sort-order="all"/>
-            <label form="short" prefix=", "/>
+           <name and="symbol" initialize-with=". " name-as-sort-order="all"/>
+            <label form="short" prefix=", (" suffix=")"/>
           </names>
           <group delimiter=" ">
             <text variable="container-title" font-style="italic"/>
@@ -309,6 +313,7 @@
           <text macro="event"/>
           <text macro="publisher"/>
           <group>
+            <label suffix=" " variable="page" form="short"/>
             <text variable="page"/>
           </group>
         </group>


### PR DESCRIPTION
 <!-- 25 March 2019 -->
  <!-- Fixed errors -->
    <!-- 1. Parenthesis missing for editor -->
    <!-- 2. Page text missing for book chapter -->
    <!-- 3. Italics removed for "in" book chapter -->