### PR TITLE
Update universite-de-bordeaux-ecole-doctorale-de-droit.csl

### DIFF
--- a/universite-de-bordeaux-ecole-doctorale-de-droit.csl
+++ b/universite-de-bordeaux-ecole-doctorale-de-droit.csl
@@ -16,7 +16,7 @@
     </author>
     <category citation-format="note"/>
     <category field="law"/>
-    <updated>2018-04-22T17:24:08+00:00</updated>
+    <updated>2019-01-14T14:52:27+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale xml:lang="fr">
@@ -119,7 +119,20 @@
   <!--Mise en forme des titres dans la bibliographie - pour les brevets inclut autorité émettrice et numéro, pour les entretiens oraux inclut l'interviewer et les autres informations concernant l'entretien -->
   <macro name="title">
     <choose>
-      <if type="book thesis" match="any">
+      <if type="book" match="any">
+        <choose>
+          <if variable="URL">
+            <group delimiter=" ">
+              <text variable="title" text-case="capitalize-first" font-style="italic"/>
+              <text term="online" prefix="[" suffix="]"/>
+            </group>
+          </if>
+          <else>
+            <text variable="title" text-case="capitalize-first" font-style="italic"/>
+          </else>
+        </choose>
+      </if>
+      <else-if type="thesis" match="any">
         <choose>
           <if variable="URL">
             <group delimiter=" ">
@@ -137,7 +150,7 @@
             <text variable="title" text-case="capitalize-first" font-style="italic"/>
           </else>
         </choose>
-      </if>
+      </else-if>
       <else-if type="patent">
         <group delimiter=", ">
           <group delimiter=" ">
@@ -197,7 +210,20 @@
   <!--Mise en forme des titres en note de bas de page - pour les entretiens oraux inclut l'interviewer et les autres informations concernant l'entretien-->
   <macro name="title-short">
     <choose>
-      <if type="book thesis " match="any">
+      <if type="book" match="any">
+        <choose>
+          <if variable="URL">
+            <group delimiter=" ">
+              <text variable="title" form="short" text-case="capitalize-first" font-style="italic"/>
+              <text term="online" prefix="[" suffix="]"/>
+            </group>
+          </if>
+          <else>
+            <text variable="title" form="short" text-case="capitalize-first" font-style="italic"/>
+          </else>
+        </choose>
+      </if>
+      <else-if type="thesis " match="any">
         <choose>
           <if variable="URL">
             <group delimiter=" ">
@@ -215,7 +241,7 @@
             <text variable="title" form="short" text-case="capitalize-first" font-style="italic"/>
           </else>
         </choose>
-      </if>
+      </else-if>
       <else-if type="article-journal article-newspaper article-magazine" match="any">
         <choose>
           <if variable="URL">


### PR DESCRIPTION
Tidied up macros `title` and `title-short` : text value "[microfiche]" is no longer displayed for books. The string "[microfiche]" should be inserted only for theses and does not apply to books.