### PR TITLE
Update harvard-university-for-the-creative-arts.csl

### DIFF
--- a/harvard-university-for-the-creative-arts.csl
+++ b/harvard-university-for-the-creative-arts.csl
@@ -14,7 +14,7 @@
     <category citation-format="author-date"/>
     <category field="generic-base"/>
     <summary>University for the Creative Arts Harvard style</summary>
-    <updated>2018-03-15T10:51:40+00:00</updated>
+    <updated>2019-04-25T11:06:04+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale>
@@ -69,7 +69,12 @@
   <macro name="primary-title">
     <choose>
       <if type="chapter article-journal article-newspaper article-magazine paper-conference" match="any">
-        <text variable="title" prefix="'" suffix="'"/>
+        <text variable="title" prefix="'" suffix="' "/>
+        <choose>
+          <if match="any" variable="original-title">
+            <text variable="original-title" prefix="(" suffix=")"/>
+          </if>
+        </choose>
       </if>
       <else-if type="bill legal_case legislation motion_picture" match="any">
         <text variable="collection-number"/>
@@ -91,6 +96,11 @@
               <group delimiter=" ">
                 <text variable="title" font-style="italic" suffix="."/>
                 <choose>
+                  <if match="any" variable="original-title">
+                    <text variable="original-title" font-style="italic" prefix="(" suffix=")"/>
+                  </if>
+                </choose>
+                <choose>
                   <if match="any" variable="volume">
                     <text term="volume" form="short" text-case="capitalize-first"/>
                     <text variable="volume" text-case="uppercase" suffix="."/>
@@ -102,6 +112,7 @@
                     <if type="song" match="any">
                       <text term="in" text-case="capitalize-first"/>
                       <text variable="collection-title"/>
+                      <text variable="container-title"/>
                     </if>
                   </choose>
                 </group>
@@ -229,18 +240,13 @@
   </macro>
   <macro name="container">
     <choose>
-      <if type="entry-dictionary entry-encyclopedia paper-conference chapter" match="any">
+      <if type="entry-dictionary entry-encyclopedia paper-conference" match="any">
         <group>
           <text term="in" text-case="capitalize-first" suffix=": "/>
-          <names variable="editor" delimiter="." suffix=" ">
-            <name and="text" delimiter-precedes-last="never" et-al-min="3" et-al-use-first="1" initialize-with="." name-as-sort-order="all"/>
-            <label form="short" plural="never" text-case="lowercase" prefix=" (" suffix=")"/>
-            <et-al font-style="italic"/>
-          </names>
+          <text macro="editor"/>
           <group delimiter=", ">
             <group font-style="normal" font-variant="normal" delimiter=" ">
               <text variable="container-title" font-style="italic" suffix="."/>
-              <text variable="collection-title" font-style="italic"/>
               <group delimiter=" " suffix=".">
                 <text term="volume" form="short" text-case="capitalize-first"/>
                 <text variable="volume" text-case="uppercase"/>
@@ -272,9 +278,11 @@
       <else-if type="broadcast motion_picture" match="any">
         <choose>
           <if match="any" variable="collection-title container-title">
-            <text term="in" text-case="capitalize-first" suffix=": "/>
-            <text variable="collection-title" font-style="italic" suffix="."/>
-            <text variable="container-title" font-style="italic" suffix="."/>
+            <group suffix=" ">
+              <text term="in" text-case="capitalize-first" suffix=": "/>
+              <text variable="collection-title" font-style="italic" suffix="."/>
+              <text variable="container-title" font-style="italic" suffix="."/>
+            </group>
           </if>
         </choose>
         <names variable="author" prefix="Directed by ">
@@ -294,9 +302,15 @@
         <text variable="genre" prefix="[" suffix="]"/>
         <text variable="scale" prefix=" " suffix="."/>
       </else-if>
+      <else-if type="chapter" match="any">
+        <text term="in" text-case="capitalize-first" suffix=": "/>
+        <text macro="editor"/>
+        <text macro="translator"/>
+        <text variable="container-title" font-style="italic" suffix="."/>
+      </else-if>
       <else>
         <choose>
-          <if variable="volume issue page" match="any" type="article-newspaper">
+          <if variable="volume issue page" match="any" type="article-newspaper article-magazine">
             <text variable="container-title" font-style="italic" prefix="In: " suffix=" "/>
           </if>
         </choose>
@@ -421,8 +435,15 @@
       </else>
     </choose>
   </macro>
+  <macro name="editor">
+    <names variable="editor" delimiter="," suffix=" ">
+      <name and="text" delimiter-precedes-last="never" et-al-min="3" et-al-use-first="1" initialize-with="." name-as-sort-order="all"/>
+      <label form="short" prefix=" (" suffix=")"/>
+      <et-al font-style="italic"/>
+    </names>
+  </macro>
   <citation disambiguate-add-year-suffix="true" collapse="year-suffix" et-al-min="3" et-al-use-first="1">
-    <layout delimiter=";" prefix="(" suffix=")">
+    <layout delimiter="; " prefix="(" suffix=")">
       <group delimiter=":">
         <group delimiter=", ">
           <text macro="author-short"/>


### PR DESCRIPTION
Update and fix errors:
Add original title for books, websites, chapters, articles
Add Container Title for songs
Remove Collection Title from book chapters
Add macro for editor
Add missing space between container title and Director in broadcast
Add missing title for article-magazine
Add missing space where two sources are cited in in text citation