### PR TITLE
Create storie-e-linguaggi.csl

### DIFF
--- a/storie-e-linguaggi.csl
+++ b/storie-e-linguaggi.csl
@@ -1,0 +1,201 @@
+<?xml version="1.0" encoding="utf-8"?>
+<style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" default-locale="it-IT" version="1.0" demote-non-dropping-particle="sort-only">
+  <info>
+    <title>Storie e linguaggi</title>
+    <id>http://www.zotero.org/styles/storie-e-linguaggi</id>
+    <link href="http://www.zotero.org/styles/storie-e-linguaggi" rel="self"/>
+    <link href="http://www.zotero.org/styles/communication-et-langages" rel="template"/>
+    <link href="http://ojs.webster.it/SeL/about" rel="documentation"/>
+    <author>
+      <name>Paolo Monella</name>
+      <email>paolo.monella@unipa.it</email>
+    </author>
+    <category citation-format="author-date"/>
+    <category field="humanities"/>
+    <issn>2421-7344</issn>
+    <summary>Style created for journal Storie e Linguaggi http://ojs.webster.it/SeL/about by Paolo Monellla on April 27, 2019, by adapting the "Communication et Langages style" from http://www.zotero.org/styles/communication-et-langages by Pierre-Carl Langlais, pierrecarl.langlais@gmail.com.</summary>
+    <updated>2019-04-27T19:12:02+00:00</updated>
+    <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
+  </info>
+  <locale xml:lang="it-IT">
+    <terms>
+      <term name="page" form="short">
+        <single>p.</single>
+        <multiple>pp.</multiple>
+      </term>
+      <term name="et-al">et alii</term>
+    </terms>
+  </locale>
+  <macro name="editor">
+    <names variable="editor" delimiter=" ">
+      <name form="long" and="text" delimiter-precedes-last="never" sort-separator=" " font-style="normal"/>
+      <label form="short" prefix=" (" suffix=")"/>
+      <et-al term="and others" font-style="italic"/>
+    </names>
+  </macro>
+  <macro name="author">
+    <names variable="author">
+      <name and="text" sort-separator=" " delimiter=", " delimiter-precedes-last="never"/>
+      <label form="short" prefix=" " text-case="lowercase"/>
+      <substitute>
+        <names variable="editor"/>
+        <names variable="translator"/>
+        <text variable="title"/>
+      </substitute>
+    </names>
+  </macro>
+  <macro name="author-short">
+    <names variable="author">
+      <name form="short" and="text" delimiter=", " delimiter-precedes-last="never" initialize-with=". "/>
+      <et-al term="et-al" font-style="italic"/>
+      <substitute>
+        <names variable="editor"/>
+        <names variable="translator"/>
+        <text variable="title"/>
+      </substitute>
+    </names>
+  </macro>
+  <macro name="access">
+    <choose>
+      <if variable="URL">
+        <group delimiter=" ">
+          <text value="URL:"/>
+          <text variable="URL"/>
+          <group prefix="[" suffix="]">
+            <text term="accessed" text-case="capitalize-first" suffix=": "/>
+            <date variable="accessed">
+              <date-part name="day" suffix=" "/>
+              <date-part name="month" suffix=" "/>
+              <date-part name="year"/>
+            </date>
+          </group>
+        </group>
+      </if>
+    </choose>
+  </macro>
+  <macro name="title">
+    <choose>
+      <if type="bill book graphic legal_case legislation motion_picture report song thesis" match="any">
+        <text variable="title" font-style="italic"/>
+      </if>
+      <else>
+        <text variable="title"/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="publisher">
+    <group delimiter=", ">
+      <text variable="publisher-place"/>
+      <text variable="publisher"/>
+    </group>
+  </macro>
+  <macro name="year-date">
+    <group prefix=" ">
+      <choose>
+        <if variable="issued">
+          <date variable="issued">
+            <date-part name="year"/>
+          </date>
+        </if>
+        <else>
+          <text term="no date" form="short"/>
+        </else>
+      </choose>
+    </group>
+  </macro>
+  <macro name="edition">
+    <choose>
+      <if is-numeric="edition">
+        <group delimiter=" ">
+          <number variable="edition" form="ordinal"/>
+          <text term="edition" form="short"/>
+        </group>
+      </if>
+      <else>
+        <text variable="edition" suffix="."/>
+      </else>
+    </choose>
+  </macro>
+  <citation et-al-min="1" et-al-use-first="1" disambiguate-add-year-suffix="true" disambiguate-add-names="true" disambiguate-add-givenname="true" collapse="year">
+    <layout delimiter="; ">
+      <group delimiter="">
+        <group delimiter="">
+          <text macro="author-short"/>
+          <text macro="year-date"/>
+        </group>
+        <text variable="locator"/>
+      </group>
+    </layout>
+  </citation>
+  <bibliography hanging-indent="true" et-al-min="6" et-al-use-first="1">
+    <sort>
+      <key macro="author"/>
+      <key variable="title"/>
+    </sort>
+    <layout>
+      <group delimiter="" suffix=" = ">
+        <group delimiter="">
+          <text macro="author-short"/>
+          <text macro="year-date"/>
+        </group>
+        <text variable="locator"/>
+      </group>
+      <text macro="author" suffix=","/>
+      <choose>
+        <if type="bill book graphic legal_case legislation motion_picture report song thesis" match="any">
+          <group prefix=" " delimiter=" ">
+            <text macro="title" suffix=","/>
+            <text variable="genre" suffix=","/>
+            <text macro="edition"/>
+            <text macro="editor"/>
+          </group>
+          <text prefix=" " macro="publisher"/>
+          <date variable="issued" prefix=", " suffix=".">
+            <date-part name="year"/>
+          </date>
+        </if>
+        <else-if type="chapter inproceedings incollection paper-conference" match="any">
+          <group prefix=" " suffix="">
+            <text macro="title" prefix="“" suffix="”"/>
+          </group>
+          <text value=", in"/>
+          <group prefix=" " delimiter=" ">
+            <text macro="editor" suffix=","/>
+            <text variable="container-title" font-style="italic" suffix=","/>
+            <group suffix=".">
+              <text macro="publisher"/>
+              <date variable="issued" prefix=", " suffix=",">
+                <date-part name="year"/>
+              </date>
+              <group prefix=", ">
+                <label variable="page" form="short" suffix=" "/>
+                <text variable="page"/>
+              </group>
+            </group>
+          </group>
+        </else-if>
+        <else>
+          <group prefix=" " delimiter=" " suffix=",">
+            <text macro="title" prefix="“" suffix="”"/>
+            <text macro="editor"/>
+          </group>
+          <group prefix=" " suffix=".">
+            <text variable="container-title" font-style="italic"/>
+            <group prefix=", ">
+              <text variable="volume"/>
+              <text variable="issue" prefix="(" suffix=")"/>
+            </group>
+            <date variable="issued" prefix=", ">
+              <date-part name="year"/>
+            </date>
+            <group prefix=", ">
+              <label variable="page" form="short" suffix=" "/>
+              <text variable="page"/>
+            </group>
+          </group>
+        </else>
+      </choose>
+      <text prefix=" " macro="access" suffix="."/>
+    </layout>
+  </bibliography>
+</style>

--- a/storie-e-linguaggi.csl
+++ b/storie-e-linguaggi.csl
@@ -116,7 +116,7 @@
       </else>
     </choose>
   </macro>
-  <citation et-al-min="1" et-al-use-first="1" disambiguate-add-year-suffix="true" disambiguate-add-names="true" disambiguate-add-givenname="true" collapse="year">
+  <citation et-al-min="2" et-al-use-first="1" disambiguate-add-year-suffix="true" disambiguate-add-names="true" disambiguate-add-givenname="true" collapse="year">
     <layout delimiter="; ">
       <group delimiter="">
         <group delimiter="">

--- a/storie-e-linguaggi.csl
+++ b/storie-e-linguaggi.csl
@@ -154,7 +154,7 @@
             <date-part name="year"/>
           </date>
         </if>
-        <else-if type="chapter inproceedings incollection paper-conference" match="any">
+        <else-if type="chapter paper-conference" match="any">
           <group prefix=" " suffix="">
             <text macro="title" prefix="“" suffix="”"/>
           </group>


### PR DESCRIPTION
I used [http://www.zotero.org/styles/communication-et-langages](communication-et-langages) as a model and edited it so it fits the citation conventions of Italian Humanities journal [Storie e Linguaggi. A Journal of the Humanities / Rivista di studi umanistici](http://ojs.webster.it/SeL/about). I had tried yesterday (April 27, 2019) to add this citation style, but apparently I failed: please be patient, I don't have much GitHub experience. The CSL I'm submitting does not validate in [https://validator.citationstyles.org/](your validator), but the offending line derives directly from my model style http://www.zotero.org/styles/communication-et-langages: I didn't edit it. All feedback welcome.
The offending line is 157:
`<else-if type="chapter inproceedings incollection paper-conference" match="any">`
triggering the following error:
`"Bad value “chapter inproceedings incollection paper-conference” for attribute “type” on element “else-if” from namespace “http://purl.org/net/xbiblio/csl”`