### PR TITLE
Create ieee-v11122018.csl

### DIFF
--- a/ieee-v11122018.csl
+++ b/ieee-v11122018.csl
@@ -139,7 +139,7 @@
   <macro name="doi-or-url">
     <choose>
       <if match="any" variable="DOI">
-        <text variable="DOI" form="short" text-case="lowercase" prefix="https://dx.doi.org/"/>
+        <text variable="DOI" form="short" text-case="lowercase" prefix="https://doi.org/"/>
       </if>
       <else>
         <date form="text" variable="accessed" prefix="Accessed: " suffix=". ">

--- a/ieee-v11122018.csl
+++ b/ieee-v11122018.csl
@@ -1,0 +1,263 @@
+<?xml version="1.0" encoding="utf-8"?>
+<style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" demote-non-dropping-particle="sort-only" default-locale="en">
+  <info>
+    <title>IEEE v11.12.2018</title>
+    <title-short>IEEE</title-short>
+    <id>http://www.zotero.org/styles/ieee-v11122018</id>
+    <link href="http://www.zotero.org/styles/ieee-v11122018" rel="self"/>
+    <link href="http://journals.ieeeauthorcenter.ieee.org/wp-content/uploads/sites/7/IEEE-Reference-Guide.pdf" rel="documentation"/>
+    <author>
+      <name>Michael Nickerson</name>
+      <email>nickersonm@ece.ucsb.edu</email>
+      <uri>https://orcid.org/0000-0002-2454-9079</uri>
+    </author>
+    <category citation-format="numeric"/>
+    <category field="engineering"/>
+    <summary>Attempts to conform to IEEE Reference Guide v11.12.2018, although the guide is not self-consistent.  Please contact author or submit pull request if nonconformity found.</summary>
+    <published>2019-04-30T12:00:00+07:00</published>
+    <updated>2019-04-29T22:24:05+00:00</updated>
+    <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
+  </info>
+  <locale xml:lang="en">
+    <terms>
+      <term name="chapter-number" form="short">ch.</term>
+      <term name="available at">available</term>
+      <term name="presented at" form="short">presented at</term>
+    </terms>
+  </locale>
+  <macro name="authors">
+    <names variable="author">
+      <name and="text" et-al-min="7" et-al-use-first="1" initialize-with=". "/>
+      <label form="short" text-case="capitalize-first" prefix=", "/>
+      <et-al font-style="italic"/>
+      <substitute>
+        <names variable="editor translator"/>
+      </substitute>
+    </names>
+  </macro>
+  <macro name="container-cite">
+    <choose>
+      <if match="any" variable="event">
+        <group delimiter=" ">
+          <text term="presented at" form="short"/>
+          <text variable="event" form="short"/>
+        </group>
+      </if>
+      <else-if type="book song motion_picture broadcast legislation legal_case chapter paper-conference" match="any">
+        <text variable="container-title" form="short" font-style="italic" prefix="in "/>
+      </else-if>
+      <else>
+        <text variable="container-title" form="short" font-style="italic"/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="title">
+    <choose>
+      <if type="patent report thesis personal_communication webpage article" match="any" variable="container-title event">
+        <group delimiter=", ">
+          <text variable="title" quotes="true"/>
+          <text macro="container-cite"/>
+        </group>
+      </if>
+      <else>
+        <text variable="title" font-style="italic"/>
+        <text variable="collection-title" prefix=" in "/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="pub-date">
+    <group prefix=", ">
+      <choose>
+        <if type="book chapter thesis" match="none">
+          <date variable="issued" suffix=" ">
+            <date-part name="month" form="short" strip-periods="false"/>
+          </date>
+        </if>
+      </choose>
+      <choose>
+        <if type="paper-conference personal_communication speech broadcast interview patent post post-weblog bill legislation" match="any">
+          <date variable="issued">
+            <date-part name="day" suffix=", "/>
+          </date>
+        </if>
+      </choose>
+      <date date-parts="year" form="numeric" variable="issued"/>
+    </group>
+  </macro>
+  <macro name="locator">
+    <group delimiter=", ">
+      <text macro="loc-issue"/>
+      <text macro="loc-chapter"/>
+      <text macro="loc-section"/>
+      <text macro="loc-pages"/>
+      <text macro="loc-authority-number"/>
+    </group>
+  </macro>
+  <macro name="loc-volume-edition">
+    <group delimiter=", ">
+      <choose>
+        <if match="any" variable="volume">
+          <group delimiter=" ">
+            <label variable="volume" form="short"/>
+            <number variable="volume"/>
+          </group>
+        </if>
+      </choose>
+      <choose>
+        <if match="any" is-numeric="edition">
+          <group delimiter=" ">
+            <number variable="edition" form="ordinal"/>
+            <label plural="never" variable="edition" form="short"/>
+          </group>
+        </if>
+        <else>
+          <text variable="edition"/>
+        </else>
+      </choose>
+    </group>
+  </macro>
+  <macro name="loc-issue">
+    <choose>
+      <if match="any" variable="issue">
+        <group delimiter=" ">
+          <label variable="issue" form="short"/>
+          <number variable="issue"/>
+        </group>
+      </if>
+    </choose>
+  </macro>
+  <macro name="loc-pages">
+    <choose>
+      <if match="any" variable="page">
+        <group delimiter=" ">
+          <label variable="page" form="short"/>
+          <text variable="page"/>
+        </group>
+      </if>
+    </choose>
+  </macro>
+  <macro name="doi-or-url">
+    <choose>
+      <if match="any" variable="DOI">
+        <text variable="DOI" form="short" text-case="lowercase" prefix="https://dx.doi.org/"/>
+      </if>
+      <else>
+        <date form="text" variable="accessed" prefix="Accessed: " suffix=". ">
+          <date-part name="month" form="short"/>
+        </date>
+        <text variable="URL" form="short" prefix="[Online]. Available: "/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="loc-chapter">
+    <choose>
+      <if match="any" variable="chapter-number">
+        <group delimiter=" ">
+          <label variable="chapter-number" form="short"/>
+          <text variable="chapter-number"/>
+        </group>
+      </if>
+    </choose>
+  </macro>
+  <macro name="loc-section">
+    <choose>
+      <if match="any" variable="section">
+        <group delimiter=" ">
+          <text term="section" form="short"/>
+          <text variable="section"/>
+        </group>
+      </if>
+    </choose>
+  </macro>
+  <macro name="loc-authority-number">
+    <choose>
+      <if match="any" variable="authority">
+        <text variable="authority" form="short"/>
+      </if>
+      <else-if match="any" variable="genre">
+        <text variable="genre" form="short"/>
+      </else-if>
+    </choose>
+    <choose>
+      <if type="patent" match="all">
+        <text variable="number" prefix=" Patent "/>
+      </if>
+      <else>
+        <text variable="number" prefix=" "/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="pub-values">
+    <choose>
+      <if type="report thesis" match="any">
+        <group delimiter=", ">
+          <text variable="publisher" form="short"/>
+          <text variable="publisher-place" form="short"/>
+        </group>
+      </if>
+      <else>
+        <group delimiter=": ">
+          <text variable="publisher-place"/>
+          <choose>
+            <if type="paper-conference" match="none">
+              <text variable="publisher"/>
+            </if>
+          </choose>
+        </group>
+      </else>
+    </choose>
+  </macro>
+  <citation collapse="citation-number">
+    <sort>
+      <key variable="citation-number"/>
+    </sort>
+    <layout delimiter=", ">
+      <group delimiter=", " prefix="[" suffix="]">
+        <text variable="citation-number"/>
+        <group>
+          <choose>
+            <if match="any" locator="page">
+              <label suffix=" " variable="locator" form="short"/>
+            </if>
+            <else>
+              <label text-case="capitalize-first" suffix=" " variable="locator" form="short"/>
+            </else>
+          </choose>
+          <text variable="locator"/>
+        </group>
+      </group>
+    </layout>
+  </citation>
+  <bibliography second-field-align="flush">
+    <layout>
+      <text variable="citation-number" prefix="[" suffix="]"/>
+      <text macro="authors"/>
+      <group suffix=".">
+        <text macro="title" prefix=", "/>
+        <text macro="loc-volume-edition" prefix=", "/>
+        <choose>
+          <if type="book chapter paper-conference report" match="none">
+            <text macro="locator" prefix=", "/>
+          </if>
+        </choose>
+        <names variable="editor" prefix=", ">
+          <name and="text" et-al-min="7" et-al-use-first="1" initialize-with=". "/>
+          <label form="short" text-case="capitalize-first" prefix=", "/>
+        </names>
+        <text macro="pub-values" prefix=", "/>
+        <choose>
+          <if type="report" match="any">
+            <text macro="locator" prefix=", "/>
+          </if>
+        </choose>
+        <text macro="pub-date"/>
+        <choose>
+          <if type="book chapter paper-conference" match="any">
+            <text macro="locator" prefix=", "/>
+          </if>
+        </choose>
+      </group>
+      <text macro="doi-or-url" prefix=" "/>
+    </layout>
+  </bibliography>
+</style>


### PR DESCRIPTION
[IEEE-Reference-Guide.pdf](https://github.com/citation-style-language/styles/files/3129408/IEEE-Reference-Guide.pdf)
An ab initio attempt to create a CSL that conforms to the IEEE Reference Guide v11.12.2018, although the guide is not self-consistent.

Known issues or nonconformities:
- Standards (guide p. 15) are cited as reports (guide p. 14) due to lack of discriminator.  Standard titles should be italicized instead of quoted.
- DOIs are included as resolver URLs for simplicity and standardization.
- Article numbers treated as pages.
- Manuals treated as books.
- Datasets, lectures, legislation not specifically handled.
- Book translations not handled.