### PR TITLE
Update american-phytopathological-society.csl

### DIFF
--- a/american-phytopathological-society.csl
+++ b/american-phytopathological-society.csl
@@ -106,7 +106,7 @@
       </else>
     </choose>
   </macro>
-  <citation et-al-min="4" et-al-use-first="1" disambiguate-add-year-suffix="true" disambiguate-add-names="true" disambiguate-add-givenname="true" collapse="year">
+  <citation et-al-min="3" et-al-use-first="1" disambiguate-add-year-suffix="true" disambiguate-add-names="true" disambiguate-add-givenname="true" collapse="year">
     <layout prefix="(" suffix=")" delimiter="; ">
       <group delimiter=", ">
         <group delimiter=" ">


### PR DESCRIPTION
changed: use et al for first 3 authors insted of 4 (documentation https://forums.zotero.org/discussion/77104/new-american-phytopathology-citation)