### PR TITLE
add line break trick to bibtex.csl

### DIFF
--- a/bibtex.csl
+++ b/bibtex.csl
@@ -143,7 +143,7 @@
     </sort>
     <layout>
       <text macro="zotero2bibtexType" prefix=" @"/>
-      <group prefix="{" suffix=" }" delimiter=", ">
+      <group prefix="{&#10; " suffix="&#10;}" delimiter=", &#10;">
         <text macro="citeKey"/>
         <text variable="publisher-place" prefix=" place={" suffix="}"/>
         <!--Fix This-->


### PR DESCRIPTION
In general, Citation Style Language do not support line break. So, the generated bibliography via "BibTeX generic citation style" is always mixed all keys together. 
But I found an answer from https://forums.zotero.org/discussion/comment/124644/#Comment_124644. And follow the mleoking's answer, I tested the code and it's worked.
Thus, I want to add this trick to repository and make it available for all users.