### PR TITLE
Update journal-of-plant-nutrition-and-soil-science.csl

### DIFF
--- a/journal-of-plant-nutrition-and-soil-science.csl
+++ b/journal-of-plant-nutrition-and-soil-science.csl
@@ -55,9 +55,9 @@
   <macro name="author-short">
     <names variable="author">
       <name form="short" and="text" delimiter=", " initialize-with=". " font-style="italic">
-	<et-al font-style="normal" prefix=" "/>
         <name-part name="family" font-style="italic"/>
       </name>
+      <et-al font-style="normal"/>
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>

--- a/journal-of-plant-nutrition-and-soil-science.csl
+++ b/journal-of-plant-nutrition-and-soil-science.csl
@@ -14,7 +14,7 @@
     <category field="biology"/>
     <issn>1436-8730</issn>
     <eissn>1522-2624</eissn>
-    <updated>2017-11-01T22:34:35+00:00</updated>
+    <updated>2019-05-14T23:14:59+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <macro name="container">
@@ -53,8 +53,9 @@
     </names>
   </macro>
   <macro name="author-short">
-    <names variable="author" font-style="italic">
-      <name form="short" and="text" delimiter=", " initialize-with=". " font-style="normal">
+    <names variable="author">
+      <name form="short" and="text" delimiter=", " initialize-with=". " font-style="italic">
+	<et-al font-style="normal" prefix=" "/>
         <name-part name="family" font-style="italic"/>
       </name>
       <substitute>


### PR DESCRIPTION
According to the style guidelines of the journal (see https://wol-prod-cdn.literatumonline.com/pb-assets/assets/15222624/Instructions_for_Authors_August_2018-1533052683593_new-1541429205090.pdf), only author names should be in italic; "and" and "et al." go in normal font style.