### PR TITLE
Update ruhr-universitat-bochum-lehrstuhl-fur-industrial-sales-and-ser…

### DIFF
--- a/ruhr-universitat-bochum-lehrstuhl-fur-industrial-sales-and-service-engineering.csl
+++ b/ruhr-universitat-bochum-lehrstuhl-fur-industrial-sales-and-service-engineering.csl
@@ -12,16 +12,16 @@
       <email>sebastian.knop@rub.de</email>
     </author>
     <category citation-format="author-date"/>
-    <updated>2018-10-01T11:33:00+01:00</updated>
+    <updated>2019-05-16T09:04:20+01:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
-  <locale xml:lang="de-DE">
+  <locale xml:lang="de">
     <terms>
       <term name="et-al">et al.</term>
       <term name="retrieved">abgerufen am</term>
     </terms>
   </locale>
-  <locale xml:lang="en-US">
+  <locale xml:lang="en">
     <terms>
       <term name="ordinal">ᵗʰ</term>
       <term name="ordinal-01">ˢᵗ</term>
@@ -37,8 +37,8 @@
   <macro name="container-contributors">
     <choose>
       <if type="chapter paper-conference" match="any">
-        <names variable="editor translator" delimiter=", ">
-          <name and="text" initialize-with=". " delimiter=", "/>
+        <names variable="editor translator">
+          <name and="text"sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="never"/>
           <label form="short" prefix=" (" suffix=")"/>
         </names>
       </if>
@@ -48,7 +48,7 @@
     <choose>
       <if type="chapter paper-conference" match="none">
         <names variable="editor translator" delimiter=", " prefix=" (" suffix=")">
-          <name and="text" initialize-with=". " delimiter=", "/>
+          <name and="text" initialize-with=". " delimiter=", " delimiter-precedes-last="never"/>
           <label form="short" prefix=", "/>
         </names>
       </if>
@@ -234,7 +234,7 @@
       <text variable="container-title" font-style="italic"/>
     </group>
   </macro>
-  <citation et-al-min="3" et-al-use-first="1" disambiguate-add-year-suffix="true" disambiguate-add-names="true" disambiguate-add-givenname="true" givenname-disambiguation-rule="by-cite" collapse="year">
+  <citation et-al-min="3" et-al-use-first="1" disambiguate-add-year-suffix="true" disambiguate-add-names="false" disambiguate-add-givenname="true" givenname-disambiguation-rule="primary-name" collapse="year">
     <sort>
       <key macro="author"/>
       <key macro="issued-year"/>


### PR DESCRIPTION
There are some minor issues in the current version. 

This new version:
- changes the delimiter before last editor name.
- changes disambiguation from adding a further given name to year suffix.