### PR TITLE
Update chicago-author-date citation with collapse delimiter

### DIFF
--- a/chicago-author-date.csl
+++ b/chicago-author-date.csl
@@ -597,7 +597,7 @@
       </else>
     </choose>
   </macro>
-  <citation et-al-min="4" et-al-use-first="1" disambiguate-add-year-suffix="true" disambiguate-add-names="true" disambiguate-add-givenname="true" givenname-disambiguation-rule="primary-name" collapse="year">
+  <citation et-al-min="4" et-al-use-first="1" disambiguate-add-year-suffix="true" disambiguate-add-names="true" disambiguate-add-givenname="true" givenname-disambiguation-rule="primary-name" collapse="year" after-collapse-delimiter="; ">
     <layout prefix="(" suffix=")" delimiter="; ">
       <group delimiter=", ">
         <choose>


### PR DESCRIPTION
Include a semicolon as the delimiter for collapsed year citations. The use of the semicolon is consistent with non-collapsed citations. For example the current version creates (Schrijver 2015, 2018) whereas the proposed version creates (Schrijver 2015; 2018) which is consistent with the standard of (Doe 2011; Smith 2014).