### PR TITLE
Update to la-trobe-university-harvard

### DIFF
--- a/la-trobe-university-harvard.csl
+++ b/la-trobe-university-harvard.csl
@@ -517,11 +517,11 @@
     <layout prefix="(" suffix=")" delimiter="; ">
       <group delimiter=" ">
         <text macro="author-short"/>
+        <text macro="citeissued"/>
         <group delimiter=" ">
           <label variable="locator" form="short"/>
           <text variable="locator"/>
         </group>
-        <text macro="citeissued"/>
       </group>
     </layout>
   </citation>


### PR DESCRIPTION
The locator within the in-text citation was moved to the end.