### PR TITLE
Update university-of-bradford-harvard.csl

### DIFF
--- a/university-of-bradford-harvard.csl
+++ b/university-of-bradford-harvard.csl
@@ -11,6 +11,11 @@
       <name>Diego Zaccariotto</name>
       <email>d.zaccariotto@bradford.ac.uk</email>
     </author>
+    <contributor>
+      <name>Gregory Goltsov</name>
+      <email>gregory@goltsov.info</email>
+      <uri>http://www.mendeley.com/profiles/gregory-goltsov</uri>
+    </contributor>
     <category citation-format="author-date"/>
     <category field="generic-base"/>
     <summary>The Bradford version of the Harvard author-date style (based on University of Abertay Dundee style from Gregory Goltsov)</summary>

--- a/university-of-bradford-harvard.csl
+++ b/university-of-bradford-harvard.csl
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" demote-non-dropping-particle="sort-only" default-locale="en-GB">
-  <!-- This style was edited with the Visual CSL Editor (http://editor.citationstyles.org/visualEditor/) -->
+  <!-- This style was edited with the Visual CSL Editor (https://editor.citationstyles.org/visualEditor/) -->
   <info>
     <title>University of Bradford - Harvard</title>
     <id>http://www.zotero.org/styles/university-of-bradford-harvard</id>
@@ -11,15 +11,10 @@
       <name>Diego Zaccariotto</name>
       <email>d.zaccariotto@bradford.ac.uk</email>
     </author>
-    <contributor>
-      <name>Gregory Goltsov</name>
-      <email>gregory@goltsov.info</email>
-      <uri>http://www.mendeley.com/profiles/gregory-goltsov</uri>
-    </contributor>
     <category citation-format="author-date"/>
     <category field="generic-base"/>
     <summary>The Bradford version of the Harvard author-date style (based on University of Abertay Dundee style from Gregory Goltsov)</summary>
-    <updated>2018-10-29T10:24:55+00:00</updated>
+    <updated>2019-05-24T14:31:50+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale xml:lang="en-GB">
@@ -37,7 +32,7 @@
           <text term="in"/>
         </if>
       </choose>
-      <names variable="editor" delimiter=", " suffix=",">
+      <names variable="editor" delimiter=", " suffix=".">
         <name and="symbol" initialize-with="" delimiter=", " delimiter-precedes-last="never"/>
         <label prefix=" (" suffix=")"/>
       </names>
@@ -58,7 +53,7 @@
   </macro>
   <macro name="author-short">
     <names variable="author">
-      <name form="short" and="text" delimiter-precedes-last="never" initialize-with=". "/>
+      <name form="short" and="text" delimiter-precedes-last="never" et-al-min="3" et-al-use-first="1" initialize-with=". "/>
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
@@ -72,14 +67,14 @@
         <text variable="title" font-style="italic"/>
       </if>
       <else>
-        <text variable="title"/>
+        <text variable="title" suffix="."/>
       </else>
     </choose>
   </macro>
   <macro name="publisher">
     <group delimiter=", ">
-      <text variable="publisher"/>
       <text variable="publisher-place"/>
+      <text variable="publisher"/>
     </group>
   </macro>
   <macro name="year-date">
@@ -97,7 +92,7 @@
   <macro name="locators-journal">
     <choose>
       <if type="article-journal article-magazine" match="any">
-        <group delimiter=", ">
+        <group delimiter=" " suffix=",">
           <text variable="volume" strip-periods="false"/>
           <text variable="issue" prefix="(" suffix=")"/>
         </group>
@@ -134,14 +129,14 @@
       <if type="post post-weblog webpage" match="any">
         <choose>
           <if variable="URL">
-            <text value="viewed"/>
+            <text variable="URL" suffix=" "/>
+            <text value="Accessed"/>
             <group prefix=" " delimiter=", ">
               <date variable="accessed" delimiter=" ">
                 <date-part name="day"/>
                 <date-part name="month" suffix=","/>
                 <date-part name="year"/>
               </date>
-              <text variable="URL" prefix="&lt;" suffix="&gt;"/>
             </group>
           </if>
         </choose>
@@ -151,14 +146,19 @@
   <citation et-al-min="4" et-al-use-first="1" disambiguate-add-year-suffix="true" disambiguate-add-names="true" disambiguate-add-givenname="true" collapse="year" givenname-disambiguation-rule="by-cite">
     <layout prefix="(" suffix=")" delimiter="; ">
       <group delimiter=", ">
-        <group delimiter=" ">
-          <text macro="author-short"/>
+        <group>
+          <text macro="author-short" suffix=" "/>
           <choose>
             <if type="personal_communication" match="any">
               <text value="pers. comm."/>
             </if>
           </choose>
           <text macro="year-date"/>
+          <choose>
+            <if match="any" locator="page">
+              <text variable="locator" prefix=": "/>
+            </if>
+          </choose>
         </group>
         <group delimiter=" ">
           <label variable="locator" plural="never" form="short"/>
@@ -173,7 +173,7 @@
       <key variable="title"/>
     </sort>
     <layout suffix=".">
-      <group delimiter=", ">
+      <group delimiter=" ">
         <group delimiter=" ">
           <text macro="author"/>
           <text macro="year-date" prefix="(" suffix=")"/>


### PR DESCRIPTION
Requesting an update of this style based on the changes described below to better comply to the Harvard style used at Bradford as per https://www.bradford.ac.uk/library/find-out-about/endnote/endnoteweb.pdf and https://www.bradford.ac.uk/library/find-out-about/referencing/Guide-to-referencing-using-the-Harvard-System--November-2017.pdf

Changes:
Fixed general delimiter(from ", " to " ")
Changed order of publisher and place of publication.
For web pages and articles: changed "viewed" to "Accessed" and removed extra separators ("< > and ,").
For journal-articles: fixed the format of Volume/issue.
Enabled "et al." for three or more authors (citations).
Added page number in citations where page(s) are added as locator.