### PR TITLE
Update university-of-bradford-harvard.csl

### DIFF
--- a/university-of-bradford-harvard.csl
+++ b/university-of-bradford-harvard.csl
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" demote-non-dropping-particle="sort-only" default-locale="en-GB">
-  <!-- This style was edited with the Visual CSL Editor (https://editor.citationstyles.org/visualEditor/) -->
   <info>
     <title>University of Bradford - Harvard</title>
     <id>http://www.zotero.org/styles/university-of-bradford-harvard</id>
@@ -19,7 +18,7 @@
     <category citation-format="author-date"/>
     <category field="generic-base"/>
     <summary>The Bradford version of the Harvard author-date style (based on University of Abertay Dundee style from Gregory Goltsov)</summary>
-    <updated>2019-05-24T14:31:50+00:00</updated>
+    <updated>2019-05-29T13:23:27+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale xml:lang="en-GB">
@@ -37,7 +36,7 @@
           <text term="in"/>
         </if>
       </choose>
-      <names variable="editor" delimiter=", " suffix=".">
+      <names variable="editor" delimiter=", " suffix=", ">
         <name and="symbol" initialize-with="" delimiter=", " delimiter-precedes-last="never"/>
         <label prefix=" (" suffix=")"/>
       </names>
@@ -58,7 +57,7 @@
   </macro>
   <macro name="author-short">
     <names variable="author">
-      <name form="short" and="text" delimiter-precedes-last="never" et-al-min="3" et-al-use-first="1" initialize-with=". "/>
+      <name form="short" and="text" delimiter-precedes-last="never" initialize-with=". "/>
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
@@ -69,16 +68,16 @@
   <macro name="title">
     <choose>
       <if type="bill book graphic legal_case legislation motion_picture report song thesis webpage" match="any">
-        <text variable="title" font-style="italic"/>
+        <text variable="title" font-style="italic" suffix=". "/>
       </if>
       <else>
-        <text variable="title" suffix="."/>
+        <text variable="title" suffix=". "/>
       </else>
     </choose>
   </macro>
   <macro name="publisher">
-    <group delimiter=", ">
-      <text variable="publisher-place"/>
+    <group>
+      <text variable="publisher-place" suffix=": "/>
       <text variable="publisher"/>
     </group>
   </macro>
@@ -97,7 +96,7 @@
   <macro name="locators-journal">
     <choose>
       <if type="article-journal article-magazine" match="any">
-        <group delimiter=" " suffix=",">
+        <group delimiter=" " suffix=", ">
           <text variable="volume" strip-periods="false"/>
           <text variable="issue" prefix="(" suffix=")"/>
         </group>
@@ -112,16 +111,15 @@
   </macro>
   <macro name="pages">
     <group delimiter=" ">
-      <label variable="page" form="short"/>
       <text variable="page"/>
     </group>
   </macro>
   <macro name="edition">
     <choose>
-      <if is-numeric="edition">
-        <group delimiter=" ">
+      <if variable="edition">
+        <group delimiter=" " suffix=". ">
           <number variable="edition" form="ordinal"/>
-          <text term="edition" form="short" strip-periods="true"/>
+          <text term="edition" text-case="capitalize-first" strip-periods="true"/>
         </group>
       </if>
       <else>
@@ -134,14 +132,14 @@
       <if type="post post-weblog webpage" match="any">
         <choose>
           <if variable="URL">
-            <text variable="URL" suffix=" "/>
-            <text value="Accessed"/>
+            <text value="viewed"/>
             <group prefix=" " delimiter=", ">
               <date variable="accessed" delimiter=" ">
                 <date-part name="day"/>
                 <date-part name="month" suffix=","/>
                 <date-part name="year"/>
               </date>
+              <text variable="URL" prefix="&lt;" suffix="&gt;"/>
             </group>
           </if>
         </choose>
@@ -151,43 +149,34 @@
   <citation et-al-min="4" et-al-use-first="1" disambiguate-add-year-suffix="true" disambiguate-add-names="true" disambiguate-add-givenname="true" collapse="year" givenname-disambiguation-rule="by-cite">
     <layout prefix="(" suffix=")" delimiter="; ">
       <group delimiter=", ">
-        <group>
-          <text macro="author-short" suffix=" "/>
+        <group delimiter=" ">
+          <text macro="author-short"/>
           <choose>
             <if type="personal_communication" match="any">
               <text value="pers. comm."/>
             </if>
           </choose>
           <text macro="year-date"/>
-          <choose>
-            <if match="any" locator="page">
-              <text variable="locator" prefix=": "/>
-            </if>
-          </choose>
-        </group>
-        <group delimiter=" ">
-          <label variable="locator" plural="never" form="short"/>
-          <text variable="page" form="short"/>
         </group>
       </group>
     </layout>
   </citation>
-  <bibliography hanging-indent="true">
+  <bibliography entry-spacing="0" hanging-indent="true">
     <sort>
       <key macro="author"/>
       <key variable="title"/>
     </sort>
     <layout suffix=".">
-      <group delimiter=" ">
-        <group delimiter=" ">
+      <group>
+        <group delimiter=" " suffix=" ">
           <text macro="author"/>
+          <group delimiter=" ">
+            <text macro="editor"/>
+          </group>
           <text macro="year-date" prefix="(" suffix=")"/>
         </group>
         <text macro="title"/>
-        <group delimiter=" ">
-          <text macro="editor"/>
-          <text variable="container-title" font-style="italic"/>
-        </group>
+        <text variable="container-title" font-style="italic" suffix=" "/>
         <text macro="locators-journal"/>
         <text macro="edition"/>
         <text variable="genre"/>


### PR DESCRIPTION
Changed the following after further revision and feedback to fix the below as per: https://www.bradford.ac.uk/library/find-out-about/referencing/Guide-to-referencing-using-the-Harvard-System--November-2017.pdf

Inline citation: 
- removed page number(s)

Bibliography:
- The ", " delimiter after each group was not correct. Replaced with " " and added ". " after titles and ", " after volume/issue of journals.
- Removed the "p./pp." label before page number(s).
- Changed the format of place and publisher as "Place: Publisher".
- Set the space between bibliography lines to "0" as per the EndNote style provided by the university.