### PR TITLE
Update university-of-bradford-harvard.csl

### DIFF
--- a/university-of-bradford-harvard.csl
+++ b/university-of-bradford-harvard.csl
@@ -19,7 +19,7 @@
     <category citation-format="author-date"/>
     <category field="generic-base"/>
     <summary>The Bradford version of the Harvard author-date style (based on University of Abertay Dundee style from Gregory Goltsov)</summary>
-    <updated>2019-05-24T14:31:50+00:00</updated>
+    <updated>2019-06-02T09:03:39+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale xml:lang="en-GB">
@@ -37,7 +37,7 @@
           <text term="in"/>
         </if>
       </choose>
-      <names variable="editor" delimiter=", " suffix=".">
+      <names variable="editor" delimiter=", " suffix=", ">
         <name and="symbol" initialize-with="" delimiter=", " delimiter-precedes-last="never"/>
         <label prefix=" (" suffix=")"/>
       </names>
@@ -58,7 +58,7 @@
   </macro>
   <macro name="author-short">
     <names variable="author">
-      <name form="short" and="text" delimiter-precedes-last="never" et-al-min="3" et-al-use-first="1" initialize-with=". "/>
+      <name form="short" and="text" delimiter-precedes-last="never" initialize-with=". "/>
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
@@ -68,18 +68,25 @@
   </macro>
   <macro name="title">
     <choose>
-      <if type="bill book graphic legal_case legislation motion_picture report song thesis webpage" match="any">
-        <text variable="title" font-style="italic"/>
+      <if type="bill book graphic legal_case legislation motion_picture report song thesis webpage post post-weblog" match="any">
+        <text variable="title" font-style="italic" suffix=". "/>
       </if>
       <else>
-        <text variable="title" suffix="."/>
+        <text variable="title" suffix=". "/>
       </else>
     </choose>
   </macro>
   <macro name="publisher">
-    <group delimiter=", ">
-      <text variable="publisher-place"/>
-      <text variable="publisher"/>
+    <group>
+      <text variable="publisher-place" suffix=": "/>
+      <choose>
+        <if type="chapter" match="any">
+          <text variable="publisher" suffix=". "/>
+        </if>
+        <else>
+          <text variable="publisher"/>
+        </else>
+      </choose>
     </group>
   </macro>
   <macro name="year-date">
@@ -97,7 +104,7 @@
   <macro name="locators-journal">
     <choose>
       <if type="article-journal article-magazine" match="any">
-        <group delimiter=" " suffix=",">
+        <group delimiter=" " suffix=", ">
           <text variable="volume" strip-periods="false"/>
           <text variable="issue" prefix="(" suffix=")"/>
         </group>
@@ -112,16 +119,15 @@
   </macro>
   <macro name="pages">
     <group delimiter=" ">
-      <label variable="page" form="short"/>
       <text variable="page"/>
     </group>
   </macro>
   <macro name="edition">
     <choose>
-      <if is-numeric="edition">
-        <group delimiter=" ">
+      <if variable="edition">
+        <group delimiter=" " suffix=". ">
           <number variable="edition" form="ordinal"/>
-          <text term="edition" form="short" strip-periods="true"/>
+          <text term="edition" text-case="capitalize-first" strip-periods="true"/>
         </group>
       </if>
       <else>
@@ -139,7 +145,7 @@
             <group prefix=" " delimiter=", ">
               <date variable="accessed" delimiter=" ">
                 <date-part name="day"/>
-                <date-part name="month" suffix=","/>
+                <date-part name="month"/>
                 <date-part name="year"/>
               </date>
             </group>
@@ -148,11 +154,11 @@
       </if>
     </choose>
   </macro>
-  <citation et-al-min="4" et-al-use-first="1" disambiguate-add-year-suffix="true" disambiguate-add-names="true" disambiguate-add-givenname="true" collapse="year" givenname-disambiguation-rule="by-cite">
+  <citation et-al-min="3" et-al-use-first="1" disambiguate-add-names="true" disambiguate-add-givenname="true" disambiguate-add-year-suffix="true" collapse="year">
     <layout prefix="(" suffix=")" delimiter="; ">
       <group delimiter=", ">
-        <group>
-          <text macro="author-short" suffix=" "/>
+        <group delimiter=" ">
+          <text macro="author-short"/>
           <choose>
             <if type="personal_communication" match="any">
               <text value="pers. comm."/>
@@ -161,33 +167,34 @@
           <text macro="year-date"/>
           <choose>
             <if match="any" locator="page">
-              <text variable="locator" prefix=": "/>
+              <text variable="locator" vertical-align="baseline" prefix=": "/>
             </if>
           </choose>
-        </group>
-        <group delimiter=" ">
-          <label variable="locator" plural="never" form="short"/>
-          <text variable="page" form="short"/>
         </group>
       </group>
     </layout>
   </citation>
-  <bibliography hanging-indent="true">
+  <bibliography entry-spacing="0" hanging-indent="true">
     <sort>
       <key macro="author"/>
       <key variable="title"/>
     </sort>
     <layout suffix=".">
-      <group delimiter=" ">
-        <group delimiter=" ">
+      <group>
+        <group delimiter=" " suffix=" ">
           <text macro="author"/>
+          <group delimiter=" ">
+            <text macro="editor"/>
+          </group>
           <text macro="year-date" prefix="(" suffix=")"/>
         </group>
         <text macro="title"/>
-        <group delimiter=" ">
-          <text macro="editor"/>
-          <text variable="container-title" font-style="italic"/>
-        </group>
+        <choose>
+          <if type="post post-weblog webpage" match="any"/>
+          <else>
+            <text variable="container-title" font-style="italic" suffix=" "/>
+          </else>
+        </choose>
         <text macro="locators-journal"/>
         <text macro="edition"/>
         <text variable="genre"/>

--- a/university-of-bradford-harvard.csl
+++ b/university-of-bradford-harvard.csl
@@ -61,7 +61,6 @@
       <name form="short" and="text" delimiter-precedes-last="never" initialize-with=". "/>
       <substitute>
         <names variable="editor"/>
-        <names variable="translator"/>
         <text macro="anon"/>
       </substitute>
     </names>
@@ -105,7 +104,7 @@
     <choose>
       <if type="article-journal article-magazine" match="any">
         <group delimiter=" " suffix=", ">
-          <text variable="volume" strip-periods="false"/>
+          <text variable="volume"/>
           <text variable="issue" prefix="(" suffix=")"/>
         </group>
       </if>
@@ -141,7 +140,7 @@
         <choose>
           <if variable="URL">
             <text variable="URL" suffix=" "/>
-            <text value="Accessed"/>
+            <text term="accessed" text-case="capitalize-first"/>
             <group prefix=" " delimiter=", ">
               <date variable="accessed" delimiter=" ">
                 <date-part name="day"/>
@@ -167,7 +166,7 @@
           <text macro="year-date"/>
           <choose>
             <if match="any" locator="page">
-              <text variable="locator" vertical-align="baseline" prefix=": "/>
+              <text variable="locator" prefix=": "/>
             </if>
           </choose>
         </group>
@@ -183,9 +182,7 @@
       <group>
         <group delimiter=" " suffix=" ">
           <text macro="author"/>
-          <group delimiter=" ">
-            <text macro="editor"/>
-          </group>
+          <text macro="editor"/>
           <text macro="year-date" prefix="(" suffix=")"/>
         </group>
         <text macro="title"/>


### PR DESCRIPTION
Changed the following after further revision to fix the below as per: https://www.bradford.ac.uk/library/find-out-about/referencing/Guide-to-referencing-using-the-Harvard-System--November-2017.pdf

Inline citation: 
- removed page number(s)
- Added page locator (if present).

Bibliography:
- The ", " delimiter after each group was not correct. Replaced with " " and added ". " after titles and ", " after volume/issue of journals.
- Removed the "p./pp." label before page number(s).
- Changed the format of place and publisher as "Place: Publisher".
- Set the space between bibliography lines to "0" as per the EndNote style provided by the university.
- Set italic for the title if publication is post or post-weblog.
- Fixed the separator between publisher and pages for chapters.
- Fixed date and url order for post post-weblog, and websites.
- Reverted back to "Accessed" for access date on post post-weblog, and websites. (There are contrasting directions between the brief citation guide and the full reference. The guidelines from the full reference was used here as it's the same used on EndNote's style from the university)
