### PR TITLE
always fetch latest sheldon

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,8 @@ cache: bundler
 rvm:
   - 2.6.3
 before_script:
-  - bundle --version
+  - bundle doctor
+  - bundle update sheldon
 notifications:
   email:
     recipients:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@ language: ruby
 cache: bundler
 rvm:
   - 2.6.3
+before_script:
+  - bundle update sheldon
 notifications:
   email:
     recipients:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,8 @@ language: ruby
 cache: bundler
 rvm:
   - 2.6.3
-before_script:
-  - bundle doctor
+install:
+  - bundle install --jobs=3 --retry=3 --path=${BUNDLE_PATH:-vendor/bundle}
   - bundle update sheldon
 notifications:
   email:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ cache: bundler
 rvm:
   - 2.6.3
 before_script:
-  - bundle update sheldon
+  - bundle --version
 notifications:
   email:
     recipients:


### PR DESCRIPTION
This always updates Sheldon before running the tests. This way, when Sheldon updates, only the Sheldon repo needs to be changed.