### PR TITLE
Correcting the 'and' separator for author-short

### DIFF
--- a/palaeontology.csl
+++ b/palaeontology.csl
@@ -39,7 +39,7 @@
   </macro>
   <macro name="author-short">
     <names variable="author">
-      <name form="short" and="text" delimiter=", " delimiter-precedes-last="never" initialize-with=". "/>
+      <name form="short" and="symbol" delimiter=", " delimiter-precedes-last="never" initialize-with=". "/>
       <et-al font-style="italic"/>
       <substitute>
         <names variable="editor"/>

--- a/palaeontology.csl
+++ b/palaeontology.csl
@@ -5,7 +5,7 @@
     <id>http://www.zotero.org/styles/palaeontology</id>
     <link href="http://www.zotero.org/styles/palaeontology" rel="self"/>
     <link href="http://www.zotero.org/styles/journal-of-vertebrate-paleontology" rel="template"/>
-    <link href="https://www.palass.org/publications/authors/instructions-authors-2012" rel="documentation"/>
+    <link href="https://www.palass.org/sites/default/files/media/publications/for_authors/ITA_2016_v1.pdf" rel="documentation"/>
     <author>
       <name>Benjamin C. Moon</name>
       <email>benjamin.moon@bristol.ac.uk</email>


### PR DESCRIPTION
The instructions for authors indicate that the author separator should be ampersand for in-text citations instead of the 'and'; conversely, it should be textual (and) for the references section (both for authors and editors). The proposed change in the tag  in L42 produces the desired output.