### PR TITLE
remove et-al from science.csl

### DIFF
--- a/science.csl
+++ b/science.csl
@@ -20,7 +20,7 @@
     <issn>0036-8075</issn>
     <eissn>1095-9203</eissn>
     <summary>The Science journal style.</summary>
-    <updated>2014-06-18T08:06:38+00:00</updated>
+    <updated>2019-07-02T08:06:38+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <macro name="editor">
@@ -120,7 +120,7 @@
       <text variable="citation-number" font-style="italic"/>
     </layout>
   </citation>
-  <bibliography et-al-min="6" et-al-use-first="1" second-field-align="flush">
+  <bibliography second-field-align="flush">
     <layout suffix=".">
       <text variable="citation-number" suffix=". "/>
       <group delimiter=", ">


### PR DESCRIPTION
via https://forums.zotero.org/discussion/78093/style-error-science-advances
also, see https://github.com/citation-style-language/styles/issues/3881