### PR TITLE
Update zookeys.csl

### DIFF
--- a/zookeys.csl
+++ b/zookeys.csl
@@ -5,7 +5,7 @@
     <id>http://www.zotero.org/styles/zookeys</id>
     <link href="http://www.zotero.org/styles/zookeys" rel="self"/>
     <link href="http://www.zotero.org/styles/zootaxa" rel="template"/>
-    <link href="http://www.pensoft.net/journals/zookeys/about/Author%20Guidelines" rel="documentation"/>
+    <link href="https://zookeys.pensoft.net/about#CitationsandReferences" rel="documentation"/>
     <author>
       <name>Brian Stucky</name>
       <email>stuckyb@colorado.edu</email>
@@ -56,13 +56,18 @@
       </substitute>
     </names>
   </macro>
+  <macro name="authorcount">
+    <names variable="author">
+      <name form="count"/>
+    </names>
+  </macro>
   <macro name="access">
     <choose>
       <if type="legal_case" match="none">
         <choose>
           <if variable="DOI">
             <group delimiter=" ">
-              <text variable="DOI" prefix="doi: "/>
+              <text variable="DOI" prefix="https://doi.org/"/>
             </group>
           </if>
           <else-if variable="URL">
@@ -151,7 +156,7 @@
       </else>
     </choose>
   </macro>
-  <citation name-form="short" et-al-min="3" et-al-use-first="1" et-al-subsequent-min="3" et-al-subsequent-use-first="1" disambiguate-add-names="true" disambiguate-add-givenname="true" disambiguate-add-year-suffix="true" givenname-disambiguation-rule="primary-name" collapse="year">
+  <citation name-form="short" et-al-min="3" et-al-use-first="1" et-al-subsequent-min="3" et-al-subsequent-use-first="1" disambiguate-add-year-suffix="true" collapse="year">
     <sort>
       <key macro="year-date"/>
       <key macro="author-short"/>
@@ -168,7 +173,8 @@
   </citation>
   <bibliography hanging-indent="true">
     <sort>
-      <key macro="author"/>
+      <key macro="author" names-min="1" names-use-first="1"/>
+      <key macro="authorcount"/>
       <key macro="year-date"/>
       <key variable="title"/>
     </sort>
@@ -217,7 +223,7 @@
           </group>
         </else-if>
         <else>
-          <group prefix=" " delimiter=" " suffix=".">
+          <group prefix=" " delimiter=". " suffix=".">
             <text macro="title"/>
             <text macro="editor"/>
           </group>


### PR DESCRIPTION
Minor updates to match the current ZooKeys guidelines:
Citations should be disambiguated with e.g. 2019a, 2019b, not by adding names.
Bibliography sorted by first author, then number of authors, and only then year.

Also made minor changes to how the DOI and the editors are formatted. (The latter I'm unsure about. ZooKeys may not require that journal articles show the editors at all, one option would be to delete line 228:  <text macro="editor"/> )