### PR TITLE
Wrap cs:choose children of cs:substitute in cs:group element

### DIFF
--- a/academy-of-management-review.csl
+++ b/academy-of-management-review.csl
@@ -73,14 +73,16 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
-            <text variable="title" form="short" font-style="italic"/>
-          </if>
-          <else>
-            <text variable="title" form="short" quotes="true"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
+              <text variable="title" form="short" font-style="italic"/>
+            </if>
+            <else>
+              <text variable="title" form="short" quotes="true"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>

--- a/accident-analysis-and-prevention.csl
+++ b/accident-analysis-and-prevention.csl
@@ -60,14 +60,16 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
-            <text variable="title" form="short" font-style="italic"/>
-          </if>
-          <else>
-            <text variable="title" form="short" quotes="true"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
+              <text variable="title" form="short" font-style="italic"/>
+            </if>
+            <else>
+              <text variable="title" form="short" quotes="true"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>

--- a/acta-ophthalmologica.csl
+++ b/acta-ophthalmologica.csl
@@ -50,15 +50,17 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="report">
-            <text variable="publisher"/>
-            <text macro="title"/>
-          </if>
-          <else>
-            <text macro="title"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="report">
+              <text variable="publisher"/>
+              <text macro="title"/>
+            </if>
+            <else>
+              <text macro="title"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>
@@ -68,18 +70,20 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="report">
-            <text variable="publisher"/>
-            <text variable="title" form="short" font-style="italic"/>
-          </if>
-          <else-if type="bill book graphic legal_case legislation motion_picture song" match="any">
-            <text variable="title" form="short" font-style="italic"/>
-          </else-if>
-          <else>
-            <text variable="title" form="short" quotes="true"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="report">
+              <text variable="publisher"/>
+              <text variable="title" form="short" font-style="italic"/>
+            </if>
+            <else-if type="bill book graphic legal_case legislation motion_picture song" match="any">
+              <text variable="title" form="short" font-style="italic"/>
+            </else-if>
+            <else>
+              <text variable="title" form="short" quotes="true"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>

--- a/acta-pharmaceutica.csl
+++ b/acta-pharmaceutica.csl
@@ -53,15 +53,17 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="report">
-            <text variable="publisher"/>
-            <text macro="title"/>
-          </if>
-          <else>
-            <text macro="title"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="report">
+              <text variable="publisher"/>
+              <text macro="title"/>
+            </if>
+            <else>
+              <text macro="title"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>

--- a/acta-universitatis-agriculturae-et-silviculturae-mendelianae-brunensis.csl
+++ b/acta-universitatis-agriculturae-et-silviculturae-mendelianae-brunensis.csl
@@ -65,15 +65,17 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="report">
-            <text variable="publisher"/>
-            <text macro="title"/>
-          </if>
-          <else>
-            <text macro="title"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="report">
+              <text variable="publisher"/>
+              <text macro="title"/>
+            </if>
+            <else>
+              <text macro="title"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>
@@ -83,31 +85,33 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="report">
-            <text variable="publisher"/>
-            <text variable="title" form="short" font-style="italic"/>
-          </if>
-          <else-if type="legal_case">
-            <text variable="title" font-style="italic"/>
-          </else-if>
-          <else-if type="bill book graphic legislation motion_picture song" match="any">
-            <text variable="title" form="short" font-style="italic"/>
-          </else-if>
-          <else-if variable="reviewed-author">
-            <choose>
-              <if variable="reviewed-title" match="none">
-                <text variable="title" form="short" font-style="italic" prefix="Review of "/>
-              </if>
-              <else>
-                <text variable="title" form="short" quotes="true"/>
-              </else>
-            </choose>
-          </else-if>
-          <else>
-            <text variable="title" form="short" quotes="true"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="report">
+              <text variable="publisher"/>
+              <text variable="title" form="short" font-style="italic"/>
+            </if>
+            <else-if type="legal_case">
+              <text variable="title" font-style="italic"/>
+            </else-if>
+            <else-if type="bill book graphic legislation motion_picture song" match="any">
+              <text variable="title" form="short" font-style="italic"/>
+            </else-if>
+            <else-if variable="reviewed-author">
+              <choose>
+                <if variable="reviewed-title" match="none">
+                  <text variable="title" form="short" font-style="italic" prefix="Review of "/>
+                </if>
+                <else>
+                  <text variable="title" form="short" quotes="true"/>
+                </else>
+              </choose>
+            </else-if>
+            <else>
+              <text variable="title" form="short" quotes="true"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>
@@ -451,7 +455,7 @@
             <else>
               <group>
                 <text term="volume" form="short" plural="true" text-case="capitalize-first" suffix=" "/>
-                <number variable="number-of-volumes" form="numeric" prefix="1&#8211;"/>
+                <number variable="number-of-volumes" form="numeric" prefix="1–"/>
               </group>
             </else>
           </choose>

--- a/administrative-science-quarterly.csl
+++ b/administrative-science-quarterly.csl
@@ -56,15 +56,17 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="report">
-            <text variable="publisher"/>
-            <text macro="title"/>
-          </if>
-          <else>
-            <text macro="title"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="report">
+              <text variable="publisher"/>
+              <text macro="title"/>
+            </if>
+            <else>
+              <text macro="title"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>
@@ -74,18 +76,20 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="report">
-            <text variable="publisher"/>
-            <text variable="title" form="short"/>
-          </if>
-          <else-if type="bill book graphic legal_case legislation motion_picture song" match="any">
-            <text variable="title" form="short"/>
-          </else-if>
-          <else>
-            <text variable="title" form="short" quotes="true"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="report">
+              <text variable="publisher"/>
+              <text variable="title" form="short"/>
+            </if>
+            <else-if type="bill book graphic legal_case legislation motion_picture song" match="any">
+              <text variable="title" form="short"/>
+            </else-if>
+            <else>
+              <text variable="title" form="short" quotes="true"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>

--- a/aerosol-science-and-technology.csl
+++ b/aerosol-science-and-technology.csl
@@ -33,14 +33,16 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
-            <text variable="title" form="short" font-style="italic"/>
-          </if>
-          <else>
-            <text variable="title" form="short" quotes="true"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
+              <text variable="title" form="short" font-style="italic"/>
+            </if>
+            <else>
+              <text variable="title" form="short" quotes="true"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>

--- a/african-zoology.csl
+++ b/african-zoology.csl
@@ -58,14 +58,16 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="book" match="any">
-            <text variable="title" form="short" font-style="italic"/>
-          </if>
-          <else>
-            <text variable="title" form="short"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="book" match="any">
+              <text variable="title" form="short" font-style="italic"/>
+            </if>
+            <else>
+              <text variable="title" form="short"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>

--- a/alcoholism-clinical-and-experimental-research.csl
+++ b/alcoholism-clinical-and-experimental-research.csl
@@ -60,14 +60,16 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
-            <text variable="title" form="short" font-style="italic"/>
-          </if>
-          <else>
-            <text variable="title" form="short" quotes="true"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
+              <text variable="title" form="short" font-style="italic"/>
+            </if>
+            <else>
+              <text variable="title" form="short" quotes="true"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>

--- a/american-association-of-petroleum-geologists.csl
+++ b/american-association-of-petroleum-geologists.csl
@@ -36,14 +36,16 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
-            <text variable="title" form="short" font-style="italic"/>
-          </if>
-          <else>
-            <text variable="title" form="short" quotes="true"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
+              <text variable="title" form="short" font-style="italic"/>
+            </if>
+            <else>
+              <text variable="title" form="short" quotes="true"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>
@@ -118,7 +120,7 @@
       <if type="webpage">
         <choose>
           <if variable="URL">
-            <text variable="URL" prefix="&lt;" suffix="&gt;"/>
+            <text variable="URL" prefix="&lt;" suffix=">"/>
             <group prefix=" (" suffix=")" delimiter=" ">
               <text term="accessed"/>
               <date variable="accessed">

--- a/american-fisheries-society.csl
+++ b/american-fisheries-society.csl
@@ -52,14 +52,16 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
-            <text variable="title" form="short" font-style="italic"/>
-          </if>
-          <else>
-            <text variable="title" form="short" quotes="true"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
+              <text variable="title" form="short" font-style="italic"/>
+            </if>
+            <else>
+              <text variable="title" form="short" quotes="true"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>

--- a/american-geophysical-union.csl
+++ b/american-geophysical-union.csl
@@ -87,15 +87,17 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="report">
-            <text variable="publisher"/>
-            <text macro="title"/>
-          </if>
-          <else>
-            <text macro="title"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="report">
+              <text variable="publisher"/>
+              <text macro="title"/>
+            </if>
+            <else>
+              <text macro="title"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>
@@ -110,34 +112,36 @@
           <substitute>
             <names variable="editor"/>
             <names variable="translator"/>
-            <choose>
-              <if type="report">
-                <text variable="publisher"/>
-                <text variable="title" form="short" font-style="italic"/>
-              </if>
-              <else-if type="legal_case">
-                <text variable="title" font-style="italic"/>
-              </else-if>
-              <else-if type="book graphic  motion_picture song" match="any">
-                <text variable="title" form="short" font-style="italic"/>
-              </else-if>
-              <else-if type="bill legislation" match="any">
-                <text variable="title" form="short"/>
-              </else-if>
-              <else-if variable="reviewed-author">
-                <choose>
-                  <if variable="reviewed-title" match="none">
-                    <text variable="title" form="short" font-style="italic" prefix="Review of "/>
-                  </if>
-                  <else>
-                    <text variable="title" form="short" quotes="true"/>
-                  </else>
-                </choose>
-              </else-if>
-              <else>
-                <text variable="title" form="short" quotes="true"/>
-              </else>
-            </choose>
+            <group>
+              <choose>
+                <if type="report">
+                  <text variable="publisher"/>
+                  <text variable="title" form="short" font-style="italic"/>
+                </if>
+                <else-if type="legal_case">
+                  <text variable="title" font-style="italic"/>
+                </else-if>
+                <else-if type="book graphic  motion_picture song" match="any">
+                  <text variable="title" form="short" font-style="italic"/>
+                </else-if>
+                <else-if type="bill legislation" match="any">
+                  <text variable="title" form="short"/>
+                </else-if>
+                <else-if variable="reviewed-author">
+                  <choose>
+                    <if variable="reviewed-title" match="none">
+                      <text variable="title" form="short" font-style="italic" prefix="Review of "/>
+                    </if>
+                    <else>
+                      <text variable="title" form="short" quotes="true"/>
+                    </else>
+                  </choose>
+                </else-if>
+                <else>
+                  <text variable="title" form="short" quotes="true"/>
+                </else>
+              </choose>
+            </group>
           </substitute>
         </names>
       </else>
@@ -525,7 +529,7 @@
             <else>
               <group>
                 <text term="volume" form="short" plural="true" text-case="capitalize-first" suffix=" "/>
-                <number variable="number-of-volumes" form="numeric" prefix="1&#8211;"/>
+                <number variable="number-of-volumes" form="numeric" prefix="1–"/>
               </group>
             </else>
           </choose>

--- a/american-journal-of-enology-and-viticulture.csl
+++ b/american-journal-of-enology-and-viticulture.csl
@@ -46,14 +46,16 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="bill book graphic legal_case motion_picture report song" match="any">
-            <text variable="title" form="short"/>
-          </if>
-          <else>
-            <text variable="title" form="short" quotes="true"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="bill book graphic legal_case motion_picture report song" match="any">
+              <text variable="title" form="short"/>
+            </if>
+            <else>
+              <text variable="title" form="short" quotes="true"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>
@@ -63,14 +65,16 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="bill book graphic legal_case motion_picture report song" match="any">
-            <text variable="title" form="short"/>
-          </if>
-          <else>
-            <text variable="title" form="short" quotes="true"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="bill book graphic legal_case motion_picture report song" match="any">
+              <text variable="title" form="short"/>
+            </if>
+            <else>
+              <text variable="title" form="short" quotes="true"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>

--- a/american-marketing-association.csl
+++ b/american-marketing-association.csl
@@ -58,14 +58,16 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
-            <text variable="title" form="short" font-style="italic"/>
-          </if>
-          <else>
-            <text variable="title" form="short" quotes="true"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
+              <text variable="title" form="short" font-style="italic"/>
+            </if>
+            <else>
+              <text variable="title" form="short" quotes="true"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>
@@ -189,7 +191,7 @@
       </group>
     </layout>
   </citation>
-  <bibliography hanging-indent="true" entry-spacing="0" subsequent-author-substitute="&#8212;&#8212;&#8212;" subsequent-author-substitute-rule="partial-each">
+  <bibliography hanging-indent="true" entry-spacing="0" subsequent-author-substitute="———" subsequent-author-substitute-rule="partial-each">
     <sort>
       <key macro="author"/>
       <key variable="issued"/>

--- a/american-mineralogist.csl
+++ b/american-mineralogist.csl
@@ -52,15 +52,17 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="report">
-            <text variable="publisher"/>
-            <text macro="title"/>
-          </if>
-          <else>
-            <text macro="title"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="report">
+              <text variable="publisher"/>
+              <text macro="title"/>
+            </if>
+            <else>
+              <text macro="title"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>
@@ -70,18 +72,20 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="report">
-            <text variable="publisher"/>
-            <text variable="title" form="short"/>
-          </if>
-          <else-if type="bill book graphic legal_case legislation motion_picture song" match="any">
-            <text variable="title" form="short"/>
-          </else-if>
-          <else>
-            <text variable="title" form="short" quotes="true"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="report">
+              <text variable="publisher"/>
+              <text variable="title" form="short"/>
+            </if>
+            <else-if type="bill book graphic legal_case legislation motion_picture song" match="any">
+              <text variable="title" form="short"/>
+            </else-if>
+            <else>
+              <text variable="title" form="short" quotes="true"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>
@@ -339,7 +343,7 @@
       </group>
     </layout>
   </citation>
-  <bibliography et-al-min="11" et-al-use-first="10" hanging-indent="true" subsequent-author-substitute="&#8212;&#8212;&#8212;">
+  <bibliography et-al-min="11" et-al-use-first="10" hanging-indent="true" subsequent-author-substitute="———">
     <sort>
       <key macro="author" names-min="1" names-use-first="1"/>
       <key macro="author-count" names-min="3" names-use-first="3"/>

--- a/american-school-of-classical-studies-at-athens.csl
+++ b/american-school-of-classical-studies-at-athens.csl
@@ -55,14 +55,16 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
-            <text variable="title" form="short" font-style="italic"/>
-          </if>
-          <else>
-            <text variable="title" form="short" quotes="true"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
+              <text variable="title" form="short" font-style="italic"/>
+            </if>
+            <else>
+              <text variable="title" form="short" quotes="true"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>
@@ -233,7 +235,7 @@
       </group>
     </layout>
   </citation>
-  <bibliography subsequent-author-substitute="&#8212;&#8212;&#8212;" entry-spacing="1" hanging-indent="true">
+  <bibliography subsequent-author-substitute="———" entry-spacing="1" hanging-indent="true">
     <sort>
       <key macro="author"/>
       <key variable="issued"/>

--- a/american-society-of-agricultural-and-biological-engineers.csl
+++ b/american-society-of-agricultural-and-biological-engineers.csl
@@ -64,15 +64,17 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="report">
-            <text variable="publisher"/>
-            <text macro="title"/>
-          </if>
-          <else>
-            <text macro="title"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="report">
+              <text variable="publisher"/>
+              <text macro="title"/>
+            </if>
+            <else>
+              <text macro="title"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>
@@ -87,34 +89,36 @@
           <substitute>
             <names variable="editor"/>
             <names variable="translator"/>
-            <choose>
-              <if type="report">
-                <text variable="publisher"/>
-                <text variable="title" form="short" font-style="italic"/>
-              </if>
-              <else-if type="legal_case">
-                <text variable="title" font-style="italic"/>
-              </else-if>
-              <else-if type="book graphic  motion_picture song" match="any">
-                <text variable="title" form="short" font-style="italic"/>
-              </else-if>
-              <else-if type="bill legislation" match="any">
-                <text variable="title" form="short"/>
-              </else-if>
-              <else-if variable="reviewed-author">
-                <choose>
-                  <if variable="reviewed-title" match="none">
-                    <text variable="title" form="short" font-style="italic" prefix="Review of "/>
-                  </if>
-                  <else>
-                    <text variable="title" form="short" quotes="true"/>
-                  </else>
-                </choose>
-              </else-if>
-              <else>
-                <text variable="title" form="short" quotes="true"/>
-              </else>
-            </choose>
+            <group>
+              <choose>
+                <if type="report">
+                  <text variable="publisher"/>
+                  <text variable="title" form="short" font-style="italic"/>
+                </if>
+                <else-if type="legal_case">
+                  <text variable="title" font-style="italic"/>
+                </else-if>
+                <else-if type="book graphic  motion_picture song" match="any">
+                  <text variable="title" form="short" font-style="italic"/>
+                </else-if>
+                <else-if type="bill legislation" match="any">
+                  <text variable="title" form="short"/>
+                </else-if>
+                <else-if variable="reviewed-author">
+                  <choose>
+                    <if variable="reviewed-title" match="none">
+                      <text variable="title" form="short" font-style="italic" prefix="Review of "/>
+                    </if>
+                    <else>
+                      <text variable="title" form="short" quotes="true"/>
+                    </else>
+                  </choose>
+                </else-if>
+                <else>
+                  <text variable="title" form="short" quotes="true"/>
+                </else>
+              </choose>
+            </group>
           </substitute>
         </names>
       </else>
@@ -501,7 +505,7 @@
             <else>
               <group>
                 <text term="volume" form="short" plural="true" text-case="capitalize-first" suffix=" "/>
-                <number variable="number-of-volumes" form="numeric" prefix="1&#8211;"/>
+                <number variable="number-of-volumes" form="numeric" prefix="1–"/>
               </group>
             </else>
           </choose>

--- a/american-society-of-civil-engineers.csl
+++ b/american-society-of-civil-engineers.csl
@@ -54,14 +54,16 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
-            <text variable="title" form="short" font-style="italic"/>
-          </if>
-          <else>
-            <text variable="title" form="short" quotes="true"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
+              <text variable="title" form="short" font-style="italic"/>
+            </if>
+            <else>
+              <text variable="title" form="short" quotes="true"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>
@@ -123,7 +125,7 @@
         <text variable="page"/>
       </else-if>
       <else-if type="webpage">
-        <text variable="URL" prefix="&lt;" suffix="&gt;"/>
+        <text variable="URL" prefix="&lt;" suffix=">"/>
       </else-if>
     </choose>
   </macro>

--- a/american-sociological-association.csl
+++ b/american-sociological-association.csl
@@ -35,11 +35,13 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="report">
-            <text variable="publisher"/>
-          </if>
-        </choose>
+        <group>
+          <choose>
+            <if type="report">
+              <text variable="publisher"/>
+            </if>
+          </choose>
+        </group>
         <text macro="anon"/>
       </substitute>
     </names>
@@ -50,11 +52,13 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="report">
-            <text variable="publisher"/>
-          </if>
-        </choose>
+        <group>
+          <choose>
+            <if type="report">
+              <text variable="publisher"/>
+            </if>
+          </choose>
+        </group>
         <text macro="anon"/>
       </substitute>
     </names>

--- a/american-statistical-association.csl
+++ b/american-statistical-association.csl
@@ -53,14 +53,16 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
-            <text variable="title" form="short" font-style="italic"/>
-          </if>
-          <else>
-            <text variable="title" form="short" quotes="true"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
+              <text variable="title" form="short" font-style="italic"/>
+            </if>
+            <else>
+              <text variable="title" form="short" quotes="true"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>

--- a/animal-conservation.csl
+++ b/animal-conservation.csl
@@ -52,15 +52,17 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="report">
-            <text variable="publisher"/>
-            <text macro="title"/>
-          </if>
-          <else>
-            <text macro="title"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="report">
+              <text variable="publisher"/>
+              <text macro="title"/>
+            </if>
+            <else>
+              <text macro="title"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>
@@ -70,18 +72,20 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="report">
-            <text variable="publisher"/>
-            <text variable="title" form="short"/>
-          </if>
-          <else-if type="bill book graphic legal_case legislation motion_picture song" match="any">
-            <text variable="title" form="short"/>
-          </else-if>
-          <else>
-            <text variable="title" form="short" quotes="true"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="report">
+              <text variable="publisher"/>
+              <text variable="title" form="short"/>
+            </if>
+            <else-if type="bill book graphic legal_case legislation motion_picture song" match="any">
+              <text variable="title" form="short"/>
+            </else-if>
+            <else>
+              <text variable="title" form="short" quotes="true"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>

--- a/animal-welfare.csl
+++ b/animal-welfare.csl
@@ -53,14 +53,16 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
-            <text variable="title" form="short" font-style="italic"/>
-          </if>
-          <else>
-            <text variable="title" form="short" quotes="true"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
+              <text variable="title" form="short" font-style="italic"/>
+            </if>
+            <else>
+              <text variable="title" form="short" quotes="true"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>

--- a/animal.csl
+++ b/animal.csl
@@ -46,14 +46,16 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="bill book graphic legal_case legislation motion_picture report song thesis" match="any">
-            <text variable="title" form="short" font-style="italic"/>
-          </if>
-          <else>
-            <text variable="title" form="short" quotes="true"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="bill book graphic legal_case legislation motion_picture report song thesis" match="any">
+              <text variable="title" form="short" font-style="italic"/>
+            </if>
+            <else>
+              <text variable="title" form="short" quotes="true"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>

--- a/annals-of-botany.csl
+++ b/annals-of-botany.csl
@@ -41,14 +41,16 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
-            <text variable="title" form="short" font-style="italic"/>
-          </if>
-          <else>
-            <text variable="title" form="short" quotes="true"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
+              <text variable="title" form="short" font-style="italic"/>
+            </if>
+            <else>
+              <text variable="title" form="short" quotes="true"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>

--- a/apa-5th-edition.csl
+++ b/apa-5th-edition.csl
@@ -74,14 +74,16 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
-            <text variable="title" form="short" font-style="italic"/>
-          </if>
-          <else>
-            <text variable="title" form="short" quotes="true"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
+              <text variable="title" form="short" font-style="italic"/>
+            </if>
+            <else>
+              <text variable="title" form="short" quotes="true"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>

--- a/apa-annotated-bibliography.csl
+++ b/apa-annotated-bibliography.csl
@@ -266,39 +266,43 @@
               <name name-as-sort-order="all" and="symbol" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
               <label form="long" prefix=" (" suffix=")" text-case="title"/>
             </names>
-            <choose>
-              <if variable="container-title">
-                <choose>
-                  <if type="book entry entry-dictionary entry-encyclopedia">
-                    <text macro="title"/>
-                  </if>
-                  <else>
-                    <names variable="translator"/>
-                  </else>
-                </choose>
-                <names variable="translator">
-                  <name name-as-sort-order="all" and="symbol" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
+            <group>
+              <choose>
+                <if variable="container-title">
+                  <choose>
+                    <if type="book entry entry-dictionary entry-encyclopedia">
+                      <text macro="title"/>
+                    </if>
+                    <else>
+                      <names variable="translator"/>
+                    </else>
+                  </choose>
+                  <names variable="translator">
+                    <name name-as-sort-order="all" and="symbol" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
                     <label form="short" prefix=" (" suffix=")" text-case="title"/>
-                </names>
-              </if>
-            </choose>
+                  </names>
+                </if>
+              </choose>
+            </group>
             <names variable="editor translator" delimiter=", ">
               <name name-as-sort-order="all" and="symbol" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
-                <label form="short" prefix=" (" suffix=")" text-case="title"/>
+              <label form="short" prefix=" (" suffix=")" text-case="title"/>
             </names>
             <names variable="editorial-director">
               <name name-as-sort-order="all" and="symbol" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
-                <label form="short" prefix=" (" suffix=")" text-case="title"/>
+              <label form="short" prefix=" (" suffix=")" text-case="title"/>
             </names>
             <names variable="collection-editor">
               <name name-as-sort-order="all" and="symbol" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
-                <label form="short" prefix=" (" suffix=")" text-case="title"/>
+              <label form="short" prefix=" (" suffix=")" text-case="title"/>
             </names>
-            <choose>
-              <if type="report">
-                <text variable="publisher"/>
-              </if>
-            </choose>
+            <group>
+              <choose>
+                <if type="report">
+                  <text variable="publisher"/>
+                </if>
+              </choose>
+            </group>
             <group delimiter=" ">
               <text macro="title"/>
               <text macro="description"/>
@@ -337,14 +341,16 @@
               <substitute>
                 <names variable="editor"/>
                 <names variable="translator"/>
-                <choose>
-                  <if variable="container-title">
-                    <text variable="title" form="short" quotes="true"/>
-                  </if>
-                  <else>
-                    <text variable="title" form="short" font-style="italic"/>
-                  </else>
-                </choose>
+                <group>
+                  <choose>
+                    <if variable="container-title">
+                      <text variable="title" form="short" quotes="true"/>
+                    </if>
+                    <else>
+                      <text variable="title" form="short" font-style="italic"/>
+                    </else>
+                  </choose>
+                </group>
                 <text macro="format-short" prefix="[" suffix="]"/>
               </substitute>
             </names>
@@ -358,14 +364,16 @@
             <names variable="original-author"/>
             <names variable="author"/>
             <names variable="translator"/>
-             <choose>
-              <if variable="container-title">
-                <text variable="title" form="short" quotes="true"/>
-              </if>
-              <else>
-                <text variable="title" form="short" font-style="italic"/>
-              </else>
-            </choose>
+            <group>
+              <choose>
+                <if variable="container-title">
+                  <text variable="title" form="short" quotes="true"/>
+                </if>
+                <else>
+                  <text variable="title" form="short" font-style="italic"/>
+                </else>
+              </choose>
+            </group>
             <text macro="format-short" prefix="[" suffix="]"/>
           </substitute>
         </names>
@@ -377,41 +385,45 @@
             <names variable="illustrator"/>
             <names variable="composer"/>
             <names variable="director"/>
-            <choose>
-              <if variable="container-title">
-                <choose>
-                  <if type="book entry entry-dictionary entry-encyclopedia">
-                    <text variable="title" form="short" quotes="true"/>
-                  </if>
-                  <else>
-                    <names variable="translator"/>
-                  </else>
-                </choose>
-              </if>
-            </choose>
+            <group>
+              <choose>
+                <if variable="container-title">
+                  <choose>
+                    <if type="book entry entry-dictionary entry-encyclopedia">
+                      <text variable="title" form="short" quotes="true"/>
+                    </if>
+                    <else>
+                      <names variable="translator"/>
+                    </else>
+                  </choose>
+                </if>
+              </choose>
+            </group>
             <names variable="editor"/>
             <names variable="editorial-director"/>
             <names variable="translator"/>
-            <choose>
-              <if type="report" variable="publisher" match="all">
-                <text variable="publisher"/>
-              </if>
-              <else-if type="legal_case">
-                <text variable="title" font-style="italic"/>
-              </else-if>
-              <else-if type="bill legislation" match="any">
-                <text variable="title" form="short"/>
-              </else-if>
-              <else-if variable="reviewed-author" type="review review-book" match="any">
-                <text macro="format-short" prefix="[" suffix="]"/>
-              </else-if>
-              <else-if type="post post-weblog webpage" variable="container-title" match="any">
-                <text variable="title" form="short" quotes="true"/>
-              </else-if>
-              <else>
-                <text variable="title" form="short" font-style="italic"/>
-              </else>
-            </choose>
+            <group>
+              <choose>
+                <if type="report" variable="publisher" match="all">
+                  <text variable="publisher"/>
+                </if>
+                <else-if type="legal_case">
+                  <text variable="title" font-style="italic"/>
+                </else-if>
+                <else-if type="bill legislation" match="any">
+                  <text variable="title" form="short"/>
+                </else-if>
+                <else-if variable="reviewed-author" type="review review-book" match="any">
+                  <text macro="format-short" prefix="[" suffix="]"/>
+                </else-if>
+                <else-if type="post post-weblog webpage" variable="container-title" match="any">
+                  <text variable="title" form="short" quotes="true"/>
+                </else-if>
+                <else>
+                  <text variable="title" form="short" font-style="italic"/>
+                </else>
+              </choose>
+            </group>
             <text macro="format-short" prefix="[" suffix="]"/>
           </substitute>
         </names>
@@ -1145,7 +1157,7 @@
         <else>
           <group>
             <text term="volume" form="short" plural="true" text-case="capitalize-first" suffix=" "/>
-            <number variable="number-of-volumes" form="numeric" prefix="1&#8211;"/>
+            <number variable="number-of-volumes" form="numeric" prefix="1–"/>
           </group>
         </else>
       </choose>

--- a/apa-cv.csl
+++ b/apa-cv.csl
@@ -266,39 +266,43 @@
               <name name-as-sort-order="all" and="symbol" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
               <label form="long" prefix=" (" suffix=")" text-case="title"/>
             </names>
-            <choose>
-              <if variable="container-title">
-                <choose>
-                  <if type="book entry entry-dictionary entry-encyclopedia">
-                    <text macro="title"/>
-                  </if>
-                  <else>
-                    <names variable="translator"/>
-                  </else>
-                </choose>
-                <names variable="translator">
-                  <name name-as-sort-order="all" and="symbol" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
+            <group>
+              <choose>
+                <if variable="container-title">
+                  <choose>
+                    <if type="book entry entry-dictionary entry-encyclopedia">
+                      <text macro="title"/>
+                    </if>
+                    <else>
+                      <names variable="translator"/>
+                    </else>
+                  </choose>
+                  <names variable="translator">
+                    <name name-as-sort-order="all" and="symbol" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
                     <label form="short" prefix=" (" suffix=")" text-case="title"/>
-                </names>
-              </if>
-            </choose>
+                  </names>
+                </if>
+              </choose>
+            </group>
             <names variable="editor translator" delimiter=", ">
               <name name-as-sort-order="all" and="symbol" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
-                <label form="short" prefix=" (" suffix=")" text-case="title"/>
+              <label form="short" prefix=" (" suffix=")" text-case="title"/>
             </names>
             <names variable="editorial-director">
               <name name-as-sort-order="all" and="symbol" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
-                <label form="short" prefix=" (" suffix=")" text-case="title"/>
+              <label form="short" prefix=" (" suffix=")" text-case="title"/>
             </names>
             <names variable="collection-editor">
               <name name-as-sort-order="all" and="symbol" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
-                <label form="short" prefix=" (" suffix=")" text-case="title"/>
+              <label form="short" prefix=" (" suffix=")" text-case="title"/>
             </names>
-            <choose>
-              <if type="report">
-                <text variable="publisher"/>
-              </if>
-            </choose>
+            <group>
+              <choose>
+                <if type="report">
+                  <text variable="publisher"/>
+                </if>
+              </choose>
+            </group>
             <group delimiter=" ">
               <text macro="title"/>
               <text macro="description"/>
@@ -969,7 +973,7 @@
         <else>
           <group>
             <text term="volume" form="short" plural="true" text-case="capitalize-first" suffix=" "/>
-            <number variable="number-of-volumes" form="numeric" prefix="1&#8211;"/>
+            <number variable="number-of-volumes" form="numeric" prefix="1–"/>
           </group>
         </else>
       </choose>

--- a/apa-fr-provost.csl
+++ b/apa-fr-provost.csl
@@ -64,15 +64,17 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="report">
-            <text variable="publisher"/>
-            <text macro="title"/>
-          </if>
-          <else>
-            <text macro="title"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="report">
+              <text variable="publisher"/>
+              <text macro="title"/>
+            </if>
+            <else>
+              <text macro="title"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>
@@ -82,18 +84,20 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="report">
-            <text variable="publisher"/>
-            <text variable="title" font-style="italic"/>
-          </if>
-          <else-if type="bill book graphic legal_case legislation motion_picture song" match="any">
-            <text variable="title" font-style="italic"/>
-          </else-if>
-          <else>
-            <text variable="title" quotes="true"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="report">
+              <text variable="publisher"/>
+              <text variable="title" font-style="italic"/>
+            </if>
+            <else-if type="bill book graphic legal_case legislation motion_picture song" match="any">
+              <text variable="title" font-style="italic"/>
+            </else-if>
+            <else>
+              <text variable="title" quotes="true"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>
@@ -181,7 +185,7 @@
       </else-if>
       <else-if type="legislation">
         <text variable="title" font-style="italic"/>
-        <group prefix=" (" suffix=")" delimiter="&#160;; ">
+        <group prefix=" (" suffix=")" delimiter=" ; ">
           <text variable="number"/>
           <text variable="container-title"/>
         </group>
@@ -224,7 +228,7 @@
   <macro name="publisher">
     <choose>
       <if type="report" match="any">
-        <group delimiter="&#160;: ">
+        <group delimiter=" : ">
           <text variable="publisher-place"/>
           <text variable="publisher"/>
         </group>
@@ -247,7 +251,7 @@
           </choose>
           <choose>
             <if type="book chapter" match="any">
-              <group delimiter="&#160;: ">
+              <group delimiter=" : ">
                 <choose>
                   <if variable="publisher-place">
                     <text variable="publisher-place"/>
@@ -280,7 +284,7 @@
               </group>
             </else-if>
             <else-if type="article-journal article-magazine article-newspaper" match="none">
-              <group delimiter="&#160;: ">
+              <group delimiter=" : ">
                 <text variable="publisher-place"/>
                 <text variable="publisher"/>
               </group>
@@ -539,7 +543,7 @@
       <key macro="author"/>
       <key macro="issued-sort"/>
     </sort>
-    <layout prefix="(" suffix=")" delimiter="&#160;; ">
+    <layout prefix="(" suffix=")" delimiter=" ; ">
       <group delimiter=", ">
         <text macro="author-short"/>
         <text macro="issued-year"/>

--- a/apa-no-ampersand.csl
+++ b/apa-no-ampersand.csl
@@ -267,39 +267,43 @@
               <name name-as-sort-order="all" and="text" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
               <label form="long" prefix=" (" suffix=")" text-case="title"/>
             </names>
-            <choose>
-              <if variable="container-title">
-                <choose>
-                  <if type="book entry entry-dictionary entry-encyclopedia">
-                    <text macro="title"/>
-                  </if>
-                  <else>
-                    <names variable="translator"/>
-                  </else>
-                </choose>
-                <names variable="translator">
-                  <name name-as-sort-order="all" and="text" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
+            <group>
+              <choose>
+                <if variable="container-title">
+                  <choose>
+                    <if type="book entry entry-dictionary entry-encyclopedia">
+                      <text macro="title"/>
+                    </if>
+                    <else>
+                      <names variable="translator"/>
+                    </else>
+                  </choose>
+                  <names variable="translator">
+                    <name name-as-sort-order="all" and="text" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
                     <label form="short" prefix=" (" suffix=")" text-case="title"/>
-                </names>
-              </if>
-            </choose>
+                  </names>
+                </if>
+              </choose>
+            </group>
             <names variable="editor translator" delimiter=", ">
               <name name-as-sort-order="all" and="text" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
-                <label form="short" prefix=" (" suffix=")" text-case="title"/>
+              <label form="short" prefix=" (" suffix=")" text-case="title"/>
             </names>
             <names variable="editorial-director">
               <name name-as-sort-order="all" and="text" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
-                <label form="short" prefix=" (" suffix=")" text-case="title"/>
+              <label form="short" prefix=" (" suffix=")" text-case="title"/>
             </names>
             <names variable="collection-editor">
               <name name-as-sort-order="all" and="text" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
-                <label form="short" prefix=" (" suffix=")" text-case="title"/>
+              <label form="short" prefix=" (" suffix=")" text-case="title"/>
             </names>
-            <choose>
-              <if type="report">
-                <text variable="publisher"/>
-              </if>
-            </choose>
+            <group>
+              <choose>
+                <if type="report">
+                  <text variable="publisher"/>
+                </if>
+              </choose>
+            </group>
             <group delimiter=" ">
               <text macro="title"/>
               <text macro="description"/>
@@ -338,14 +342,16 @@
               <substitute>
                 <names variable="editor"/>
                 <names variable="translator"/>
-                <choose>
-                  <if variable="container-title">
-                    <text variable="title" form="short" quotes="true"/>
-                  </if>
-                  <else>
-                    <text variable="title" form="short" font-style="italic"/>
-                  </else>
-                </choose>
+                <group>
+                  <choose>
+                    <if variable="container-title">
+                      <text variable="title" form="short" quotes="true"/>
+                    </if>
+                    <else>
+                      <text variable="title" form="short" font-style="italic"/>
+                    </else>
+                  </choose>
+                </group>
                 <text macro="format-short" prefix="[" suffix="]"/>
               </substitute>
             </names>
@@ -359,14 +365,16 @@
             <names variable="original-author"/>
             <names variable="author"/>
             <names variable="translator"/>
-             <choose>
-              <if variable="container-title">
-                <text variable="title" form="short" quotes="true"/>
-              </if>
-              <else>
-                <text variable="title" form="short" font-style="italic"/>
-              </else>
-            </choose>
+            <group>
+              <choose>
+                <if variable="container-title">
+                  <text variable="title" form="short" quotes="true"/>
+                </if>
+                <else>
+                  <text variable="title" form="short" font-style="italic"/>
+                </else>
+              </choose>
+            </group>
             <text macro="format-short" prefix="[" suffix="]"/>
           </substitute>
         </names>
@@ -378,41 +386,45 @@
             <names variable="illustrator"/>
             <names variable="composer"/>
             <names variable="director"/>
-            <choose>
-              <if variable="container-title">
-                <choose>
-                  <if type="book entry entry-dictionary entry-encyclopedia">
-                    <text variable="title" form="short" quotes="true"/>
-                  </if>
-                  <else>
-                    <names variable="translator"/>
-                  </else>
-                </choose>
-              </if>
-            </choose>
+            <group>
+              <choose>
+                <if variable="container-title">
+                  <choose>
+                    <if type="book entry entry-dictionary entry-encyclopedia">
+                      <text variable="title" form="short" quotes="true"/>
+                    </if>
+                    <else>
+                      <names variable="translator"/>
+                    </else>
+                  </choose>
+                </if>
+              </choose>
+            </group>
             <names variable="editor"/>
             <names variable="editorial-director"/>
             <names variable="translator"/>
-            <choose>
-              <if type="report" variable="publisher" match="all">
-                <text variable="publisher"/>
-              </if>
-              <else-if type="legal_case">
-                <text variable="title" font-style="italic"/>
-              </else-if>
-              <else-if type="bill legislation" match="any">
-                <text variable="title" form="short"/>
-              </else-if>
-              <else-if variable="reviewed-author" type="review review-book" match="any">
-                <text macro="format-short" prefix="[" suffix="]"/>
-              </else-if>
-              <else-if type="post post-weblog webpage" variable="container-title" match="any">
-                <text variable="title" form="short" quotes="true"/>
-              </else-if>
-              <else>
-                <text variable="title" form="short" font-style="italic"/>
-              </else>
-            </choose>
+            <group>
+              <choose>
+                <if type="report" variable="publisher" match="all">
+                  <text variable="publisher"/>
+                </if>
+                <else-if type="legal_case">
+                  <text variable="title" font-style="italic"/>
+                </else-if>
+                <else-if type="bill legislation" match="any">
+                  <text variable="title" form="short"/>
+                </else-if>
+                <else-if variable="reviewed-author" type="review review-book" match="any">
+                  <text macro="format-short" prefix="[" suffix="]"/>
+                </else-if>
+                <else-if type="post post-weblog webpage" variable="container-title" match="any">
+                  <text variable="title" form="short" quotes="true"/>
+                </else-if>
+                <else>
+                  <text variable="title" form="short" font-style="italic"/>
+                </else>
+              </choose>
+            </group>
             <text macro="format-short" prefix="[" suffix="]"/>
           </substitute>
         </names>
@@ -1146,7 +1158,7 @@
         <else>
           <group>
             <text term="volume" form="short" plural="true" text-case="capitalize-first" suffix=" "/>
-            <number variable="number-of-volumes" form="numeric" prefix="1&#8211;"/>
+            <number variable="number-of-volumes" form="numeric" prefix="1–"/>
           </group>
         </else>
       </choose>

--- a/apa-no-doi-no-issue.csl
+++ b/apa-no-doi-no-issue.csl
@@ -266,39 +266,43 @@
               <name name-as-sort-order="all" and="symbol" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
               <label form="long" prefix=" (" suffix=")" text-case="title"/>
             </names>
-            <choose>
-              <if variable="container-title">
-                <choose>
-                  <if type="book entry entry-dictionary entry-encyclopedia">
-                    <text macro="title"/>
-                  </if>
-                  <else>
-                    <names variable="translator"/>
-                  </else>
-                </choose>
-                <names variable="translator">
-                  <name name-as-sort-order="all" and="symbol" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
+            <group>
+              <choose>
+                <if variable="container-title">
+                  <choose>
+                    <if type="book entry entry-dictionary entry-encyclopedia">
+                      <text macro="title"/>
+                    </if>
+                    <else>
+                      <names variable="translator"/>
+                    </else>
+                  </choose>
+                  <names variable="translator">
+                    <name name-as-sort-order="all" and="symbol" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
                     <label form="short" prefix=" (" suffix=")" text-case="title"/>
-                </names>
-              </if>
-            </choose>
+                  </names>
+                </if>
+              </choose>
+            </group>
             <names variable="editor translator" delimiter=", ">
               <name name-as-sort-order="all" and="symbol" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
-                <label form="short" prefix=" (" suffix=")" text-case="title"/>
+              <label form="short" prefix=" (" suffix=")" text-case="title"/>
             </names>
             <names variable="editorial-director">
               <name name-as-sort-order="all" and="symbol" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
-                <label form="short" prefix=" (" suffix=")" text-case="title"/>
+              <label form="short" prefix=" (" suffix=")" text-case="title"/>
             </names>
             <names variable="collection-editor">
               <name name-as-sort-order="all" and="symbol" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
-                <label form="short" prefix=" (" suffix=")" text-case="title"/>
+              <label form="short" prefix=" (" suffix=")" text-case="title"/>
             </names>
-            <choose>
-              <if type="report">
-                <text variable="publisher"/>
-              </if>
-            </choose>
+            <group>
+              <choose>
+                <if type="report">
+                  <text variable="publisher"/>
+                </if>
+              </choose>
+            </group>
             <group delimiter=" ">
               <text macro="title"/>
               <text macro="description"/>
@@ -337,14 +341,16 @@
               <substitute>
                 <names variable="editor"/>
                 <names variable="translator"/>
-                <choose>
-                  <if variable="container-title">
-                    <text variable="title" form="short" quotes="true"/>
-                  </if>
-                  <else>
-                    <text variable="title" form="short" font-style="italic"/>
-                  </else>
-                </choose>
+                <group>
+                  <choose>
+                    <if variable="container-title">
+                      <text variable="title" form="short" quotes="true"/>
+                    </if>
+                    <else>
+                      <text variable="title" form="short" font-style="italic"/>
+                    </else>
+                  </choose>
+                </group>
                 <text macro="format-short" prefix="[" suffix="]"/>
               </substitute>
             </names>
@@ -358,14 +364,16 @@
             <names variable="original-author"/>
             <names variable="author"/>
             <names variable="translator"/>
-             <choose>
-              <if variable="container-title">
-                <text variable="title" form="short" quotes="true"/>
-              </if>
-              <else>
-                <text variable="title" form="short" font-style="italic"/>
-              </else>
-            </choose>
+            <group>
+              <choose>
+                <if variable="container-title">
+                  <text variable="title" form="short" quotes="true"/>
+                </if>
+                <else>
+                  <text variable="title" form="short" font-style="italic"/>
+                </else>
+              </choose>
+            </group>
             <text macro="format-short" prefix="[" suffix="]"/>
           </substitute>
         </names>
@@ -377,41 +385,45 @@
             <names variable="illustrator"/>
             <names variable="composer"/>
             <names variable="director"/>
-            <choose>
-              <if variable="container-title">
-                <choose>
-                  <if type="book entry entry-dictionary entry-encyclopedia">
-                    <text variable="title" form="short" quotes="true"/>
-                  </if>
-                  <else>
-                    <names variable="translator"/>
-                  </else>
-                </choose>
-              </if>
-            </choose>
+            <group>
+              <choose>
+                <if variable="container-title">
+                  <choose>
+                    <if type="book entry entry-dictionary entry-encyclopedia">
+                      <text variable="title" form="short" quotes="true"/>
+                    </if>
+                    <else>
+                      <names variable="translator"/>
+                    </else>
+                  </choose>
+                </if>
+              </choose>
+            </group>
             <names variable="editor"/>
             <names variable="editorial-director"/>
             <names variable="translator"/>
-            <choose>
-              <if type="report" variable="publisher" match="all">
-                <text variable="publisher"/>
-              </if>
-              <else-if type="legal_case">
-                <text variable="title" font-style="italic"/>
-              </else-if>
-              <else-if type="bill legislation" match="any">
-                <text variable="title" form="short"/>
-              </else-if>
-              <else-if variable="reviewed-author" type="review review-book" match="any">
-                <text macro="format-short" prefix="[" suffix="]"/>
-              </else-if>
-              <else-if type="post post-weblog webpage" variable="container-title" match="any">
-                <text variable="title" form="short" quotes="true"/>
-              </else-if>
-              <else>
-                <text variable="title" form="short" font-style="italic"/>
-              </else>
-            </choose>
+            <group>
+              <choose>
+                <if type="report" variable="publisher" match="all">
+                  <text variable="publisher"/>
+                </if>
+                <else-if type="legal_case">
+                  <text variable="title" font-style="italic"/>
+                </else-if>
+                <else-if type="bill legislation" match="any">
+                  <text variable="title" form="short"/>
+                </else-if>
+                <else-if variable="reviewed-author" type="review review-book" match="any">
+                  <text macro="format-short" prefix="[" suffix="]"/>
+                </else-if>
+                <else-if type="post post-weblog webpage" variable="container-title" match="any">
+                  <text variable="title" form="short" quotes="true"/>
+                </else-if>
+                <else>
+                  <text variable="title" form="short" font-style="italic"/>
+                </else>
+              </choose>
+            </group>
             <text macro="format-short" prefix="[" suffix="]"/>
           </substitute>
         </names>
@@ -1166,7 +1178,7 @@
         <else>
           <group>
             <text term="volume" form="short" plural="true" text-case="capitalize-first" suffix=" "/>
-            <number variable="number-of-volumes" form="numeric" prefix="1&#8211;"/>
+            <number variable="number-of-volumes" form="numeric" prefix="1–"/>
           </group>
         </else>
       </choose>

--- a/apa-old-doi-prefix.csl
+++ b/apa-old-doi-prefix.csl
@@ -266,39 +266,43 @@
               <name name-as-sort-order="all" and="symbol" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
               <label form="long" prefix=" (" suffix=")" text-case="title"/>
             </names>
-            <choose>
-              <if variable="container-title">
-                <choose>
-                  <if type="book entry entry-dictionary entry-encyclopedia">
-                    <text macro="title"/>
-                  </if>
-                  <else>
-                    <names variable="translator"/>
-                  </else>
-                </choose>
-                <names variable="translator">
-                  <name name-as-sort-order="all" and="symbol" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
+            <group>
+              <choose>
+                <if variable="container-title">
+                  <choose>
+                    <if type="book entry entry-dictionary entry-encyclopedia">
+                      <text macro="title"/>
+                    </if>
+                    <else>
+                      <names variable="translator"/>
+                    </else>
+                  </choose>
+                  <names variable="translator">
+                    <name name-as-sort-order="all" and="symbol" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
                     <label form="short" prefix=" (" suffix=")" text-case="title"/>
-                </names>
-              </if>
-            </choose>
+                  </names>
+                </if>
+              </choose>
+            </group>
             <names variable="editor translator" delimiter=", ">
               <name name-as-sort-order="all" and="symbol" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
-                <label form="short" prefix=" (" suffix=")" text-case="title"/>
+              <label form="short" prefix=" (" suffix=")" text-case="title"/>
             </names>
             <names variable="editorial-director">
               <name name-as-sort-order="all" and="symbol" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
-                <label form="short" prefix=" (" suffix=")" text-case="title"/>
+              <label form="short" prefix=" (" suffix=")" text-case="title"/>
             </names>
             <names variable="collection-editor">
               <name name-as-sort-order="all" and="symbol" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
-                <label form="short" prefix=" (" suffix=")" text-case="title"/>
+              <label form="short" prefix=" (" suffix=")" text-case="title"/>
             </names>
-            <choose>
-              <if type="report">
-                <text variable="publisher"/>
-              </if>
-            </choose>
+            <group>
+              <choose>
+                <if type="report">
+                  <text variable="publisher"/>
+                </if>
+              </choose>
+            </group>
             <group delimiter=" ">
               <text macro="title"/>
               <text macro="description"/>
@@ -337,14 +341,16 @@
               <substitute>
                 <names variable="editor"/>
                 <names variable="translator"/>
-                <choose>
-                  <if variable="container-title">
-                    <text variable="title" form="short" quotes="true"/>
-                  </if>
-                  <else>
-                    <text variable="title" form="short" font-style="italic"/>
-                  </else>
-                </choose>
+                <group>
+                  <choose>
+                    <if variable="container-title">
+                      <text variable="title" form="short" quotes="true"/>
+                    </if>
+                    <else>
+                      <text variable="title" form="short" font-style="italic"/>
+                    </else>
+                  </choose>
+                </group>
                 <text macro="format-short" prefix="[" suffix="]"/>
               </substitute>
             </names>
@@ -358,14 +364,16 @@
             <names variable="original-author"/>
             <names variable="author"/>
             <names variable="translator"/>
-             <choose>
-              <if variable="container-title">
-                <text variable="title" form="short" quotes="true"/>
-              </if>
-              <else>
-                <text variable="title" form="short" font-style="italic"/>
-              </else>
-            </choose>
+            <group>
+              <choose>
+                <if variable="container-title">
+                  <text variable="title" form="short" quotes="true"/>
+                </if>
+                <else>
+                  <text variable="title" form="short" font-style="italic"/>
+                </else>
+              </choose>
+            </group>
             <text macro="format-short" prefix="[" suffix="]"/>
           </substitute>
         </names>
@@ -377,41 +385,45 @@
             <names variable="illustrator"/>
             <names variable="composer"/>
             <names variable="director"/>
-            <choose>
-              <if variable="container-title">
-                <choose>
-                  <if type="book entry entry-dictionary entry-encyclopedia">
-                    <text variable="title" form="short" quotes="true"/>
-                  </if>
-                  <else>
-                    <names variable="translator"/>
-                  </else>
-                </choose>
-              </if>
-            </choose>
+            <group>
+              <choose>
+                <if variable="container-title">
+                  <choose>
+                    <if type="book entry entry-dictionary entry-encyclopedia">
+                      <text variable="title" form="short" quotes="true"/>
+                    </if>
+                    <else>
+                      <names variable="translator"/>
+                    </else>
+                  </choose>
+                </if>
+              </choose>
+            </group>
             <names variable="editor"/>
             <names variable="editorial-director"/>
             <names variable="translator"/>
-            <choose>
-              <if type="report" variable="publisher" match="all">
-                <text variable="publisher"/>
-              </if>
-              <else-if type="legal_case">
-                <text variable="title" font-style="italic"/>
-              </else-if>
-              <else-if type="bill legislation" match="any">
-                <text variable="title" form="short"/>
-              </else-if>
-              <else-if variable="reviewed-author" type="review review-book" match="any">
-                <text macro="format-short" prefix="[" suffix="]"/>
-              </else-if>
-              <else-if type="post post-weblog webpage" variable="container-title" match="any">
-                <text variable="title" form="short" quotes="true"/>
-              </else-if>
-              <else>
-                <text variable="title" form="short" font-style="italic"/>
-              </else>
-            </choose>
+            <group>
+              <choose>
+                <if type="report" variable="publisher" match="all">
+                  <text variable="publisher"/>
+                </if>
+                <else-if type="legal_case">
+                  <text variable="title" font-style="italic"/>
+                </else-if>
+                <else-if type="bill legislation" match="any">
+                  <text variable="title" form="short"/>
+                </else-if>
+                <else-if variable="reviewed-author" type="review review-book" match="any">
+                  <text macro="format-short" prefix="[" suffix="]"/>
+                </else-if>
+                <else-if type="post post-weblog webpage" variable="container-title" match="any">
+                  <text variable="title" form="short" quotes="true"/>
+                </else-if>
+                <else>
+                  <text variable="title" form="short" font-style="italic"/>
+                </else>
+              </choose>
+            </group>
             <text macro="format-short" prefix="[" suffix="]"/>
           </substitute>
         </names>
@@ -1145,7 +1157,7 @@
         <else>
           <group>
             <text term="volume" form="short" plural="true" text-case="capitalize-first" suffix=" "/>
-            <number variable="number-of-volumes" form="numeric" prefix="1&#8211;"/>
+            <number variable="number-of-volumes" form="numeric" prefix="1–"/>
           </group>
         </else>
       </choose>

--- a/apa-single-spaced.csl
+++ b/apa-single-spaced.csl
@@ -266,22 +266,24 @@
               <name name-as-sort-order="all" and="symbol" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
               <label form="long" prefix=" (" suffix=")" text-case="title"/>
             </names>
-            <choose>
-              <if variable="container-title">
-                <choose>
-                  <if type="book entry entry-dictionary entry-encyclopedia">
-                    <text macro="title"/>
-                  </if>
-                  <else>
-                    <names variable="translator"/>
-                  </else>
-                </choose>
-                <names variable="translator">
-                  <name name-as-sort-order="all" and="symbol" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
-                  <label form="short" prefix=" (" suffix=")" text-case="title"/>
-                </names>
-              </if>
-            </choose>
+            <group>
+              <choose>
+                <if variable="container-title">
+                  <choose>
+                    <if type="book entry entry-dictionary entry-encyclopedia">
+                      <text macro="title"/>
+                    </if>
+                    <else>
+                      <names variable="translator"/>
+                    </else>
+                  </choose>
+                  <names variable="translator">
+                    <name name-as-sort-order="all" and="symbol" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
+                    <label form="short" prefix=" (" suffix=")" text-case="title"/>
+                  </names>
+                </if>
+              </choose>
+            </group>
             <names variable="editor translator" delimiter=", ">
               <name name-as-sort-order="all" and="symbol" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
               <label form="short" prefix=" (" suffix=")" text-case="title"/>
@@ -294,11 +296,13 @@
               <name name-as-sort-order="all" and="symbol" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
               <label form="short" prefix=" (" suffix=")" text-case="title"/>
             </names>
-            <choose>
-              <if type="report">
-                <text variable="publisher"/>
-              </if>
-            </choose>
+            <group>
+              <choose>
+                <if type="report">
+                  <text variable="publisher"/>
+                </if>
+              </choose>
+            </group>
             <group delimiter=" ">
               <text macro="title"/>
               <text macro="description"/>
@@ -337,14 +341,16 @@
               <substitute>
                 <names variable="editor"/>
                 <names variable="translator"/>
-                <choose>
-                  <if variable="container-title">
-                    <text variable="title" form="short" quotes="true"/>
-                  </if>
-                  <else>
-                    <text variable="title" form="short" font-style="italic"/>
-                  </else>
-                </choose>
+                <group>
+                  <choose>
+                    <if variable="container-title">
+                      <text variable="title" form="short" quotes="true"/>
+                    </if>
+                    <else>
+                      <text variable="title" form="short" font-style="italic"/>
+                    </else>
+                  </choose>
+                </group>
                 <text macro="format-short" prefix="[" suffix="]"/>
               </substitute>
             </names>
@@ -358,14 +364,16 @@
             <names variable="original-author"/>
             <names variable="author"/>
             <names variable="translator"/>
-            <choose>
-              <if variable="container-title">
-                <text variable="title" form="short" quotes="true"/>
-              </if>
-              <else>
-                <text variable="title" form="short" font-style="italic"/>
-              </else>
-            </choose>
+            <group>
+              <choose>
+                <if variable="container-title">
+                  <text variable="title" form="short" quotes="true"/>
+                </if>
+                <else>
+                  <text variable="title" form="short" font-style="italic"/>
+                </else>
+              </choose>
+            </group>
             <text macro="format-short" prefix="[" suffix="]"/>
           </substitute>
         </names>
@@ -377,41 +385,45 @@
             <names variable="illustrator"/>
             <names variable="composer"/>
             <names variable="director"/>
-            <choose>
-              <if variable="container-title">
-                <choose>
-                  <if type="book entry entry-dictionary entry-encyclopedia">
-                    <text variable="title" form="short" quotes="true"/>
-                  </if>
-                  <else>
-                    <names variable="translator"/>
-                  </else>
-                </choose>
-              </if>
-            </choose>
+            <group>
+              <choose>
+                <if variable="container-title">
+                  <choose>
+                    <if type="book entry entry-dictionary entry-encyclopedia">
+                      <text variable="title" form="short" quotes="true"/>
+                    </if>
+                    <else>
+                      <names variable="translator"/>
+                    </else>
+                  </choose>
+                </if>
+              </choose>
+            </group>
             <names variable="editor"/>
             <names variable="editorial-director"/>
             <names variable="translator"/>
-            <choose>
-              <if type="report" variable="publisher" match="all">
-                <text variable="publisher"/>
-              </if>
-              <else-if type="legal_case">
-                <text variable="title" font-style="italic"/>
-              </else-if>
-              <else-if type="bill legislation" match="any">
-                <text variable="title" form="short"/>
-              </else-if>
-              <else-if variable="reviewed-author" type="review review-book" match="any">
-                <text macro="format-short" prefix="[" suffix="]"/>
-              </else-if>
-              <else-if type="post post-weblog webpage" variable="container-title" match="any">
-                <text variable="title" form="short" quotes="true"/>
-              </else-if>
-              <else>
-                <text variable="title" form="short" font-style="italic"/>
-              </else>
-            </choose>
+            <group>
+              <choose>
+                <if type="report" variable="publisher" match="all">
+                  <text variable="publisher"/>
+                </if>
+                <else-if type="legal_case">
+                  <text variable="title" font-style="italic"/>
+                </else-if>
+                <else-if type="bill legislation" match="any">
+                  <text variable="title" form="short"/>
+                </else-if>
+                <else-if variable="reviewed-author" type="review review-book" match="any">
+                  <text macro="format-short" prefix="[" suffix="]"/>
+                </else-if>
+                <else-if type="post post-weblog webpage" variable="container-title" match="any">
+                  <text variable="title" form="short" quotes="true"/>
+                </else-if>
+                <else>
+                  <text variable="title" form="short" font-style="italic"/>
+                </else>
+              </choose>
+            </group>
             <text macro="format-short" prefix="[" suffix="]"/>
           </substitute>
         </names>
@@ -1145,7 +1157,7 @@
         <else>
           <group>
             <text term="volume" form="short" plural="true" text-case="capitalize-first" suffix=" "/>
-            <number variable="number-of-volumes" form="numeric" prefix="1&#8211;"/>
+            <number variable="number-of-volumes" form="numeric" prefix="1–"/>
           </group>
         </else>
       </choose>

--- a/apa-tr.csl
+++ b/apa-tr.csl
@@ -94,15 +94,17 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="report">
-            <text variable="publisher"/>
-            <text macro="title"/>
-          </if>
-          <else>
-            <text macro="title"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="report">
+              <text variable="publisher"/>
+              <text macro="title"/>
+            </if>
+            <else>
+              <text macro="title"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>
@@ -112,18 +114,20 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="report">
-            <text variable="publisher"/>
-            <text variable="title" form="short" font-style="italic"/>
-          </if>
-          <else-if type="bill book graphic legal_case legislation motion_picture song" match="any">
-            <text variable="title" form="short" font-style="italic"/>
-          </else-if>
-          <else>
-            <text variable="title" form="short" quotes="true"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="report">
+              <text variable="publisher"/>
+              <text variable="title" form="short" font-style="italic"/>
+            </if>
+            <else-if type="bill book graphic legal_case legislation motion_picture song" match="any">
+              <text variable="title" form="short" font-style="italic"/>
+            </else-if>
+            <else>
+              <text variable="title" form="short" quotes="true"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>

--- a/apa.csl
+++ b/apa.csl
@@ -265,39 +265,43 @@
               <name name-as-sort-order="all" and="symbol" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
               <label form="long" prefix=" (" suffix=")" text-case="title"/>
             </names>
-            <choose>
-              <if variable="container-title">
-                <choose>
-                  <if type="book entry entry-dictionary entry-encyclopedia">
-                    <text macro="title"/>
-                  </if>
-                  <else>
-                    <names variable="translator"/>
-                  </else>
-                </choose>
-                <names variable="translator">
-                  <name name-as-sort-order="all" and="symbol" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
+            <group>
+              <choose>
+                <if variable="container-title">
+                  <choose>
+                    <if type="book entry entry-dictionary entry-encyclopedia">
+                      <text macro="title"/>
+                    </if>
+                    <else>
+                      <names variable="translator"/>
+                    </else>
+                  </choose>
+                  <names variable="translator">
+                    <name name-as-sort-order="all" and="symbol" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
                     <label form="short" prefix=" (" suffix=")" text-case="title"/>
-                </names>
-              </if>
-            </choose>
+                  </names>
+                </if>
+              </choose>
+            </group>
             <names variable="editor translator" delimiter=", ">
               <name name-as-sort-order="all" and="symbol" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
-                <label form="short" prefix=" (" suffix=")" text-case="title"/>
+              <label form="short" prefix=" (" suffix=")" text-case="title"/>
             </names>
             <names variable="editorial-director">
               <name name-as-sort-order="all" and="symbol" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
-                <label form="short" prefix=" (" suffix=")" text-case="title"/>
+              <label form="short" prefix=" (" suffix=")" text-case="title"/>
             </names>
             <names variable="collection-editor">
               <name name-as-sort-order="all" and="symbol" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
-                <label form="short" prefix=" (" suffix=")" text-case="title"/>
+              <label form="short" prefix=" (" suffix=")" text-case="title"/>
             </names>
-            <choose>
-              <if type="report">
-                <text variable="publisher"/>
-              </if>
-            </choose>
+            <group>
+              <choose>
+                <if type="report">
+                  <text variable="publisher"/>
+                </if>
+              </choose>
+            </group>
             <group delimiter=" ">
               <text macro="title"/>
               <text macro="description"/>
@@ -336,14 +340,16 @@
               <substitute>
                 <names variable="editor"/>
                 <names variable="translator"/>
-                <choose>
-                  <if variable="container-title">
-                    <text variable="title" form="short" quotes="true"/>
-                  </if>
-                  <else>
-                    <text variable="title" form="short" font-style="italic"/>
-                  </else>
-                </choose>
+                <group>
+                  <choose>
+                    <if variable="container-title">
+                      <text variable="title" form="short" quotes="true"/>
+                    </if>
+                    <else>
+                      <text variable="title" form="short" font-style="italic"/>
+                    </else>
+                  </choose>
+                </group>
                 <text macro="format-short" prefix="[" suffix="]"/>
               </substitute>
             </names>
@@ -357,14 +363,16 @@
             <names variable="original-author"/>
             <names variable="author"/>
             <names variable="translator"/>
-             <choose>
-              <if variable="container-title">
-                <text variable="title" form="short" quotes="true"/>
-              </if>
-              <else>
-                <text variable="title" form="short" font-style="italic"/>
-              </else>
-            </choose>
+            <group>
+              <choose>
+                <if variable="container-title">
+                  <text variable="title" form="short" quotes="true"/>
+                </if>
+                <else>
+                  <text variable="title" form="short" font-style="italic"/>
+                </else>
+              </choose>
+            </group>
             <text macro="format-short" prefix="[" suffix="]"/>
           </substitute>
         </names>
@@ -376,41 +384,45 @@
             <names variable="illustrator"/>
             <names variable="composer"/>
             <names variable="director"/>
-            <choose>
-              <if variable="container-title">
-                <choose>
-                  <if type="book entry entry-dictionary entry-encyclopedia">
-                    <text variable="title" form="short" quotes="true"/>
-                  </if>
-                  <else>
-                    <names variable="translator"/>
-                  </else>
-                </choose>
-              </if>
-            </choose>
+            <group>
+              <choose>
+                <if variable="container-title">
+                  <choose>
+                    <if type="book entry entry-dictionary entry-encyclopedia">
+                      <text variable="title" form="short" quotes="true"/>
+                    </if>
+                    <else>
+                      <names variable="translator"/>
+                    </else>
+                  </choose>
+                </if>
+              </choose>
+            </group>
             <names variable="editor"/>
             <names variable="editorial-director"/>
             <names variable="translator"/>
-            <choose>
-              <if type="report" variable="publisher" match="all">
-                <text variable="publisher"/>
-              </if>
-              <else-if type="legal_case">
-                <text variable="title" font-style="italic"/>
-              </else-if>
-              <else-if type="bill legislation" match="any">
-                <text variable="title" form="short"/>
-              </else-if>
-              <else-if variable="reviewed-author" type="review review-book" match="any">
-                <text macro="format-short" prefix="[" suffix="]"/>
-              </else-if>
-              <else-if type="post post-weblog webpage" variable="container-title" match="any">
-                <text variable="title" form="short" quotes="true"/>
-              </else-if>
-              <else>
-                <text variable="title" form="short" font-style="italic"/>
-              </else>
-            </choose>
+            <group>
+              <choose>
+                <if type="report" variable="publisher" match="all">
+                  <text variable="publisher"/>
+                </if>
+                <else-if type="legal_case">
+                  <text variable="title" font-style="italic"/>
+                </else-if>
+                <else-if type="bill legislation" match="any">
+                  <text variable="title" form="short"/>
+                </else-if>
+                <else-if variable="reviewed-author" type="review review-book" match="any">
+                  <text macro="format-short" prefix="[" suffix="]"/>
+                </else-if>
+                <else-if type="post post-weblog webpage" variable="container-title" match="any">
+                  <text variable="title" form="short" quotes="true"/>
+                </else-if>
+                <else>
+                  <text variable="title" form="short" font-style="italic"/>
+                </else>
+              </choose>
+            </group>
             <text macro="format-short" prefix="[" suffix="]"/>
           </substitute>
         </names>
@@ -1144,7 +1156,7 @@
         <else>
           <group>
             <text term="volume" form="short" plural="true" text-case="capitalize-first" suffix=" "/>
-            <number variable="number-of-volumes" form="numeric" prefix="1&#8211;"/>
+            <number variable="number-of-volumes" form="numeric" prefix="1–"/>
           </group>
         </else>
       </choose>

--- a/applied-clay-science.csl
+++ b/applied-clay-science.csl
@@ -63,14 +63,16 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
-            <text variable="title" form="short" font-style="italic"/>
-          </if>
-          <else>
-            <text variable="title" form="short" quotes="true"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
+              <text variable="title" form="short" font-style="italic"/>
+            </if>
+            <else>
+              <text variable="title" form="short" quotes="true"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>

--- a/aquatic-conservation.csl
+++ b/aquatic-conservation.csl
@@ -43,14 +43,16 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="bill book graphic legal_case motion_picture report song" match="any">
-            <text variable="title" form="short" font-style="italic"/>
-          </if>
-          <else>
-            <text variable="title" form="short" quotes="true"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="bill book graphic legal_case motion_picture report song" match="any">
+              <text variable="title" form="short" font-style="italic"/>
+            </if>
+            <else>
+              <text variable="title" form="short" quotes="true"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>
@@ -60,14 +62,16 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="bill book graphic legal_case motion_picture report song" match="any">
-            <text variable="title" form="short" font-style="italic"/>
-          </if>
-          <else>
-            <text variable="title" form="short" quotes="true"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="bill book graphic legal_case motion_picture report song" match="any">
+              <text variable="title" form="short" font-style="italic"/>
+            </if>
+            <else>
+              <text variable="title" form="short" quotes="true"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>

--- a/aquatic-living-resources.csl
+++ b/aquatic-living-resources.csl
@@ -60,14 +60,16 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
-            <text variable="title" form="short" font-style="italic"/>
-          </if>
-          <else>
-            <text variable="title" form="short" quotes="true"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
+              <text variable="title" form="short" font-style="italic"/>
+            </if>
+            <else>
+              <text variable="title" form="short" quotes="true"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>

--- a/archeosciences.csl
+++ b/archeosciences.csl
@@ -28,7 +28,7 @@
       <term name="anonymous" form="short">anon.</term>
       <term name="accessed">consulté le</term>
       <term name="no date">sans date</term>
-      <term name="no date" form="short">s.&#160;d.</term>
+      <term name="no date" form="short">s. d.</term>
     </terms>
   </locale>
   <macro name="author">
@@ -54,14 +54,16 @@
       <name form="short" and="symbol" delimiter-precedes-last="never"/>
       <et-al font-style="italic"/>
       <substitute>
-        <choose>
-          <if match="any" variable="editor">
-            <text macro="editor-short"/>
-          </if>
-          <else>
-            <text term="anonymous" text-case="capitalize-first"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if match="any" variable="editor">
+              <text macro="editor-short"/>
+            </if>
+            <else>
+              <text term="anonymous" text-case="capitalize-first"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>
@@ -137,7 +139,7 @@
     <sort>
       <key variable="author"/>
     </sort>
-    <layout delimiter="&#160;; " prefix="(" suffix=")">
+    <layout delimiter=" ; " prefix="(" suffix=")">
       <group delimiter=", ">
         <text macro="author-short" font-variant="normal"/>
         <text macro="year-date"/>

--- a/arctic-antarctic-and-alpine-research.csl
+++ b/arctic-antarctic-and-alpine-research.csl
@@ -66,15 +66,17 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="report">
-            <text variable="publisher"/>
-            <text macro="title"/>
-          </if>
-          <else>
-            <text macro="title"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="report">
+              <text variable="publisher"/>
+              <text macro="title"/>
+            </if>
+            <else>
+              <text macro="title"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>
@@ -84,34 +86,36 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="report">
-            <text variable="publisher"/>
-            <text variable="title" form="short" font-style="italic"/>
-          </if>
-          <else-if type="legal_case">
-            <text variable="title" font-style="italic"/>
-          </else-if>
-          <else-if type="book graphic  motion_picture song" match="any">
-            <text variable="title" form="short" font-style="italic"/>
-          </else-if>
-          <else-if type="bill legislation" match="any">
-            <text variable="title" form="short"/>
-          </else-if>
-          <else-if variable="reviewed-author">
-            <choose>
-              <if variable="reviewed-title" match="none">
-                <text variable="title" form="short" font-style="italic" prefix="Review of "/>
-              </if>
-              <else>
-                <text variable="title" form="short" quotes="true"/>
-              </else>
-            </choose>
-          </else-if>
-          <else>
-            <text variable="title" form="short" quotes="false"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="report">
+              <text variable="publisher"/>
+              <text variable="title" form="short" font-style="italic"/>
+            </if>
+            <else-if type="legal_case">
+              <text variable="title" font-style="italic"/>
+            </else-if>
+            <else-if type="book graphic  motion_picture song" match="any">
+              <text variable="title" form="short" font-style="italic"/>
+            </else-if>
+            <else-if type="bill legislation" match="any">
+              <text variable="title" form="short"/>
+            </else-if>
+            <else-if variable="reviewed-author">
+              <choose>
+                <if variable="reviewed-title" match="none">
+                  <text variable="title" form="short" font-style="italic" prefix="Review of "/>
+                </if>
+                <else>
+                  <text variable="title" form="short" quotes="true"/>
+                </else>
+              </choose>
+            </else-if>
+            <else>
+              <text variable="title" form="short" quotes="false"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>
@@ -418,7 +422,7 @@
             <else>
               <group>
                 <text term="volume" form="short" plural="true" text-case="capitalize-first" suffix=" "/>
-                <number variable="number-of-volumes" form="numeric" prefix="1&#8211;"/>
+                <number variable="number-of-volumes" form="numeric" prefix="1–"/>
               </group>
             </else>
           </choose>
@@ -580,7 +584,7 @@
                   <group>
                     <date variable="accessed" form="text" suffix=", "/>
                   </group>
-                  <text variable="URL" prefix="&lt;" suffix="&gt;"/>
+                  <text variable="URL" prefix="&lt;" suffix=">"/>
                 </group>
               </if>
               <else>

--- a/arts-university-bournemouth.csl
+++ b/arts-university-bournemouth.csl
@@ -34,20 +34,22 @@
       <name name-as-sort-order="all" and="text" sort-separator=", " delimiter=", " delimiter-precedes-last="never" form="long" initialize-with="."/>
       <label form="short" prefix=" (" suffix=")"/>
       <substitute>
-        <choose>
-          <if type="webpage">
-            <text variable="container-title"/>
-            <group delimiter=": ">
-              <text term="available at" text-case="capitalize-first"/>
-              <text variable="URL"/>
-            </group>
-          </if>
-          <else>
-            <names variable="editor"/>
-            <names variable="director"/>
-            <text macro="anon"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="webpage">
+              <text variable="container-title"/>
+              <group delimiter=": ">
+                <text term="available at" text-case="capitalize-first"/>
+                <text variable="URL"/>
+              </group>
+            </if>
+            <else>
+              <names variable="editor"/>
+              <names variable="director"/>
+              <text macro="anon"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>
@@ -55,17 +57,19 @@
     <names variable="author">
       <name form="short" and="text" delimiter=", " delimiter-precedes-last="never" initialize-with=". "/>
       <substitute>
-        <choose>
-          <if type="webpage">
-            <text variable="container-title"/>
-          </if>
-          <else>
-            <names variable="editor"/>
-            <names variable="director"/>
-            <names variable="translator"/>
-            <text macro="anon"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="webpage">
+              <text variable="container-title"/>
+            </if>
+            <else>
+              <names variable="editor"/>
+              <names variable="director"/>
+              <names variable="translator"/>
+              <text macro="anon"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>

--- a/asa-cssa-sssa.csl
+++ b/asa-cssa-sssa.csl
@@ -55,14 +55,16 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
-            <text variable="title" form="short"/>
-          </if>
-          <else>
-            <text variable="title" form="short" quotes="true"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
+              <text variable="title" form="short"/>
+            </if>
+            <else>
+              <text variable="title" form="short" quotes="true"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>

--- a/asia-and-the-pacific-policy-studies.csl
+++ b/asia-and-the-pacific-policy-studies.csl
@@ -47,14 +47,16 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
-            <text variable="title" form="short" font-style="italic"/>
-          </if>
-          <else>
-            <text variable="title" form="short" quotes="true"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
+              <text variable="title" form="short" font-style="italic"/>
+            </if>
+            <else>
+              <text variable="title" form="short" quotes="true"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>

--- a/asia-pacific-journal-of-human-resources.csl
+++ b/asia-pacific-journal-of-human-resources.csl
@@ -68,15 +68,17 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="report">
-            <text variable="publisher"/>
-            <text macro="title"/>
-          </if>
-          <else>
-            <text macro="title"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="report">
+              <text variable="publisher"/>
+              <text macro="title"/>
+            </if>
+            <else>
+              <text macro="title"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>
@@ -86,31 +88,33 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="report">
-            <text variable="publisher"/>
-            <text variable="title" form="short" font-style="italic"/>
-          </if>
-          <else-if type="legal_case">
-            <text variable="title" font-style="italic"/>
-          </else-if>
-          <else-if type="bill book graphic legislation motion_picture song" match="any">
-            <text variable="title" form="short" font-style="italic"/>
-          </else-if>
-          <else-if variable="reviewed-author">
-            <choose>
-              <if variable="reviewed-title" match="none">
-                <text variable="title" form="short" font-style="italic" prefix="Review of "/>
-              </if>
-              <else>
-                <text variable="title" form="short" quotes="true"/>
-              </else>
-            </choose>
-          </else-if>
-          <else>
-            <text variable="title" form="short" quotes="true"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="report">
+              <text variable="publisher"/>
+              <text variable="title" form="short" font-style="italic"/>
+            </if>
+            <else-if type="legal_case">
+              <text variable="title" font-style="italic"/>
+            </else-if>
+            <else-if type="bill book graphic legislation motion_picture song" match="any">
+              <text variable="title" form="short" font-style="italic"/>
+            </else-if>
+            <else-if variable="reviewed-author">
+              <choose>
+                <if variable="reviewed-title" match="none">
+                  <text variable="title" form="short" font-style="italic" prefix="Review of "/>
+                </if>
+                <else>
+                  <text variable="title" form="short" quotes="true"/>
+                </else>
+              </choose>
+            </else-if>
+            <else>
+              <text variable="title" form="short" quotes="true"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>
@@ -439,7 +443,7 @@
             <else>
               <group>
                 <text term="volume" form="short" plural="true" text-case="capitalize-first" suffix=" "/>
-                <number variable="number-of-volumes" form="numeric" prefix="1&#8211;"/>
+                <number variable="number-of-volumes" form="numeric" prefix="1–"/>
               </group>
             </else>
           </choose>

--- a/associacao-brasileira-de-normas-tecnicas-eceme.csl
+++ b/associacao-brasileira-de-normas-tecnicas-eceme.csl
@@ -153,21 +153,23 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="book">
-            <text variable="title" form="short"/>
-          </if>
-          <else>
-            <text variable="title" form="short" quotes="true"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="book">
+              <text variable="title" form="short"/>
+            </if>
+            <else>
+              <text variable="title" form="short" quotes="true"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>
   <macro name="access">
     <choose>
       <if type="article-magazine article-journal" match="any">
-        <text variable="URL" prefix=". Disponível em: &lt;" suffix="&gt;"/>
+        <text variable="URL" prefix=". Disponível em: &lt;" suffix=">"/>
         <date variable="accessed" prefix=". Acesso em: ">
           <date-part name="day" suffix=" "/>
           <date-part name="month" form="short" suffix=" " text-case="lowercase"/>
@@ -175,7 +177,7 @@
         </date>
       </if>
       <else>
-        <text variable="URL" prefix="Disponível em: &lt;" suffix="&gt;"/>
+        <text variable="URL" prefix="Disponível em: &lt;" suffix=">"/>
         <date variable="accessed" prefix=". Acesso em: ">
           <date-part name="day" suffix=" "/>
           <date-part name="month" form="short" suffix=" " text-case="lowercase"/>
@@ -506,7 +508,7 @@
             <text macro="title" suffix=". "/>
             <text macro="issued-year" suffix=". "/>
             <text variable="number-of-pages" suffix=" f. "/>
-            <text variable="genre" suffix=" &#8211; "/>
+            <text variable="genre" suffix=" – "/>
             <text variable="publisher" suffix=", "/>
             <text variable="publisher-place" suffix=", "/>
             <text macro="issued-year" suffix=". "/>

--- a/associacao-brasileira-de-normas-tecnicas-instituto-meira-mattos.csl
+++ b/associacao-brasileira-de-normas-tecnicas-instituto-meira-mattos.csl
@@ -134,21 +134,23 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="book">
-            <text variable="title" form="short"/>
-          </if>
-          <else>
-            <text variable="title" form="short" quotes="true"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="book">
+              <text variable="title" form="short"/>
+            </if>
+            <else>
+              <text variable="title" form="short" quotes="true"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>
   <macro name="access">
     <choose>
       <if type="article-magazine article-journal" match="any">
-        <text variable="URL" prefix=". Disponível em: &lt;" suffix="&gt;"/>
+        <text variable="URL" prefix=". Disponível em: &lt;" suffix=">"/>
         <date variable="accessed" prefix=". Acesso em: ">
           <date-part name="day" suffix=" "/>
           <date-part name="month" form="short" suffix=" " text-case="lowercase"/>
@@ -156,7 +158,7 @@
         </date>
       </if>
       <else>
-        <text variable="URL" prefix="Disponível em: &lt;" suffix="&gt;"/>
+        <text variable="URL" prefix="Disponível em: &lt;" suffix=">"/>
         <date variable="accessed" prefix=". Acesso em: ">
           <date-part name="day" suffix=" "/>
           <date-part name="month" form="short" suffix=" " text-case="lowercase"/>
@@ -482,7 +484,7 @@
             <text macro="title" suffix=". "/>
             <text macro="issued-year" suffix=". "/>
             <text variable="number-of-pages" suffix=" f. "/>
-            <text variable="genre" suffix=" &#8211; "/>
+            <text variable="genre" suffix=" – "/>
             <text variable="publisher" suffix=", "/>
             <text variable="publisher-place" suffix=", "/>
             <text macro="issued-year" suffix=". "/>

--- a/associacao-brasileira-de-normas-tecnicas-ipea.csl
+++ b/associacao-brasileira-de-normas-tecnicas-ipea.csl
@@ -144,20 +144,22 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="book">
-            <text variable="title" form="short"/>
-          </if>
-          <else>
-            <text variable="title" form="short" quotes="true"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="book">
+              <text variable="title" form="short"/>
+            </if>
+            <else>
+              <text variable="title" form="short" quotes="true"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>
   <!--A macro 'access' e utilizada em arquivos de paginas da web. Ela e responsavel por mostrar a URL do site pesquisado e a data do acesso-->
   <macro name="access">
-    <text variable="URL" prefix="Disponível em: &lt;" suffix="&gt;"/>
+    <text variable="URL" prefix="Disponível em: &lt;" suffix=">"/>
     <date variable="accessed" prefix=". Acesso em: ">
       <date-part name="day" suffix=" "/>
       <date-part name="month" form="short" suffix=". " text-case="lowercase"/>

--- a/associacao-brasileira-de-normas-tecnicas-ufmg-face-full.csl
+++ b/associacao-brasileira-de-normas-tecnicas-ufmg-face-full.csl
@@ -150,21 +150,23 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="book">
-            <text variable="title" form="short"/>
-          </if>
-          <else>
-            <text variable="title" form="short" quotes="true"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="book">
+              <text variable="title" form="short"/>
+            </if>
+            <else>
+              <text variable="title" form="short" quotes="true"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>
   <macro name="access">
     <choose>
       <if type="article-magazine article-journal" match="any">
-        <text variable="URL" prefix=". Disponível em: &lt;" suffix="&gt;"/>
+        <text variable="URL" prefix=". Disponível em: &lt;" suffix=">"/>
         <date variable="accessed" prefix=". Acesso em: ">
           <date-part name="day" suffix=" "/>
           <date-part name="month" form="short" suffix=" " text-case="lowercase"/>
@@ -172,7 +174,7 @@
         </date>
       </if>
       <else>
-        <text variable="URL" prefix="Disponível em: &lt;" suffix="&gt;"/>
+        <text variable="URL" prefix="Disponível em: &lt;" suffix=">"/>
         <date variable="accessed" prefix=". Acesso em: ">
           <date-part name="day" suffix=" "/>
           <date-part name="month" form="short" suffix=" " text-case="lowercase"/>
@@ -503,7 +505,7 @@
             <text macro="title" suffix=". "/>
             <text macro="issued-year" suffix=". "/>
             <text variable="number-of-pages" suffix=" f. "/>
-            <text variable="genre" suffix=" &#8211; "/>
+            <text variable="genre" suffix=" – "/>
             <text variable="publisher" suffix=", "/>
             <text variable="publisher-place" suffix=", "/>
             <text macro="issued-year" suffix=". "/>

--- a/associacao-brasileira-de-normas-tecnicas-ufmg-face-initials.csl
+++ b/associacao-brasileira-de-normas-tecnicas-ufmg-face-initials.csl
@@ -149,21 +149,23 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="book">
-            <text variable="title" form="short"/>
-          </if>
-          <else>
-            <text variable="title" form="short" quotes="true"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="book">
+              <text variable="title" form="short"/>
+            </if>
+            <else>
+              <text variable="title" form="short" quotes="true"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>
   <macro name="access">
     <choose>
       <if type="article-magazine article-journal" match="any">
-        <text variable="URL" prefix=". Disponível em: &lt;" suffix="&gt;"/>
+        <text variable="URL" prefix=". Disponível em: &lt;" suffix=">"/>
         <date variable="accessed" prefix=". Acesso em: ">
           <date-part name="day" suffix=" "/>
           <date-part name="month" form="short" suffix=" " text-case="lowercase"/>
@@ -171,7 +173,7 @@
         </date>
       </if>
       <else>
-        <text variable="URL" prefix="Disponível em: &lt;" suffix="&gt;"/>
+        <text variable="URL" prefix="Disponível em: &lt;" suffix=">"/>
         <date variable="accessed" prefix=". Acesso em: ">
           <date-part name="day" suffix=" "/>
           <date-part name="month" form="short" suffix=" " text-case="lowercase"/>
@@ -502,7 +504,7 @@
             <text macro="title" suffix=". "/>
             <text macro="issued-year" suffix=". "/>
             <text variable="number-of-pages" suffix=" f. "/>
-            <text variable="genre" suffix=" &#8211; "/>
+            <text variable="genre" suffix=" – "/>
             <text variable="publisher" suffix=", "/>
             <text variable="publisher-place" suffix=", "/>
             <text macro="issued-year" suffix=". "/>

--- a/associacao-brasileira-de-normas-tecnicas-ufpr.csl
+++ b/associacao-brasileira-de-normas-tecnicas-ufpr.csl
@@ -64,19 +64,21 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
-            <text variable="title" form="short" font-weight="bold"/>
-          </if>
-          <else>
-            <text variable="title" form="short" quotes="true"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
+              <text variable="title" form="short" font-weight="bold"/>
+            </if>
+            <else>
+              <text variable="title" form="short" quotes="true"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>
   <macro name="access">
-    <text variable="URL" prefix="Disponível em: &lt;" suffix="&gt;. "/>
+    <text variable="URL" prefix="Disponível em: &lt;" suffix=">. "/>
     <date variable="accessed" prefix="Acesso em: ">
       <date-part name="day" suffix="/"/>
       <date-part name="month" form="numeric" suffix="/"/>

--- a/associacao-brasileira-de-normas-tecnicas-ufrgs-initials.csl
+++ b/associacao-brasileira-de-normas-tecnicas-ufrgs-initials.csl
@@ -122,19 +122,21 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="book">
-            <text variable="title" form="short"/>
-          </if>
-          <else>
-            <text variable="title" form="short" text-case="uppercase" quotes="false"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="book">
+              <text variable="title" form="short"/>
+            </if>
+            <else>
+              <text variable="title" form="short" text-case="uppercase" quotes="false"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>
   <macro name="access">
-    <text variable="URL" prefix=" Disponível em: &lt;" suffix="&gt;"/>
+    <text variable="URL" prefix=" Disponível em: &lt;" suffix=">"/>
     <date variable="accessed" prefix=". Acesso em: " suffix=".">
       <date-part name="day" suffix=" "/>
       <date-part name="month" form="short" suffix=". " text-case="lowercase"/>

--- a/associacao-brasileira-de-normas-tecnicas-ufrgs.csl
+++ b/associacao-brasileira-de-normas-tecnicas-ufrgs.csl
@@ -122,19 +122,21 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="book">
-            <text variable="title" form="short"/>
-          </if>
-          <else>
-            <text variable="title" form="short" text-case="uppercase" quotes="false"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="book">
+              <text variable="title" form="short"/>
+            </if>
+            <else>
+              <text variable="title" form="short" text-case="uppercase" quotes="false"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>
   <macro name="access">
-    <text variable="URL" prefix=" Disponível em: &lt;" suffix="&gt;"/>
+    <text variable="URL" prefix=" Disponível em: &lt;" suffix=">"/>
     <date variable="accessed" prefix=". Acesso em: " suffix=".">
       <date-part name="day" suffix=" "/>
       <date-part name="month" form="short" suffix=". " text-case="lowercase"/>

--- a/associacao-brasileira-de-normas-tecnicas-ufs.csl
+++ b/associacao-brasileira-de-normas-tecnicas-ufs.csl
@@ -122,20 +122,22 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="book">
-            <text variable="title" form="short"/>
-          </if>
-          <else>
-            <text variable="title" form="short" quotes="true"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="book">
+              <text variable="title" form="short"/>
+            </if>
+            <else>
+              <text variable="title" form="short" quotes="true"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>
   <!--A macro 'access' e utilizada em arquivos de paginas da web. Ela e responsavel por mostrar a URL do site pesquisado e a data do acesso-->
   <macro name="access">
-    <text variable="URL" prefix="Disponível em: &lt;" suffix="&gt;"/>
+    <text variable="URL" prefix="Disponível em: &lt;" suffix=">"/>
     <date variable="accessed" prefix=". Acesso em: ">
       <date-part name="day" suffix=" "/>
       <date-part name="month" form="short" suffix=". " text-case="lowercase"/>

--- a/associacao-brasileira-de-normas-tecnicas-usp-fmvz.csl
+++ b/associacao-brasileira-de-normas-tecnicas-usp-fmvz.csl
@@ -105,19 +105,21 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="book">
-            <text variable="title" form="short"/>
-          </if>
-          <else>
-            <text variable="title" form="short" quotes="true"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="book">
+              <text variable="title" form="short"/>
+            </if>
+            <else>
+              <text variable="title" form="short" quotes="true"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>
   <macro name="access">
-    <text variable="URL" prefix="Disponível em: &lt;" suffix="&gt;."/>
+    <text variable="URL" prefix="Disponível em: &lt;" suffix=">."/>
     <date variable="accessed" prefix=". Acesso em: " suffix=".">
       <date-part name="day" suffix=" "/>
       <date-part name="month" form="short" suffix=". " text-case="lowercase"/>

--- a/associacao-brasileira-de-normas-tecnicas.csl
+++ b/associacao-brasileira-de-normas-tecnicas.csl
@@ -142,20 +142,22 @@ do autor. Na regra da ABNT o sobrenome deve aparecer com todas as letras em caix
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="book">
-            <text variable="title" form="short"/>
-          </if>
-          <else>
-            <text variable="title" form="short" quotes="true"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="book">
+              <text variable="title" form="short"/>
+            </if>
+            <else>
+              <text variable="title" form="short" quotes="true"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>
   <!--A macro 'access' e utilizada em arquivos de paginas da web. Ela e responsavel por mostrar a URL do site pesquisado e a data do acesso-->
   <macro name="access">
-    <text variable="URL" prefix="Disponível em: &lt;" suffix="&gt;"/>
+    <text variable="URL" prefix="Disponível em: &lt;" suffix=">"/>
     <date variable="accessed" prefix=". Acesso em: ">
       <date-part name="day" suffix=" "/>
       <date-part name="month" form="short" suffix=". " text-case="lowercase"/>
@@ -202,7 +204,7 @@ autores, exceto em arquivos do tipo 'artigo de jornal, artigo de revista, artigo
             <text variable="publisher-place" suffix=": "/>
           </if>
           <else-if type="entry-encyclopedia">
-        </else-if>
+          </else-if>
           <else>
             <text value="[s.l.] "/>
           </else>
@@ -488,7 +490,7 @@ em caixa alta. Utiliza-se antes do nome da conferencia a expressao "In". Segundo
             <!--Autor-->
             <text macro="title" suffix=". "/>
             <!--Titulo-->
-            <text macro="genre" suffix="&#8212;"/>
+            <text macro="genre" suffix="—"/>
             <!--Tipo-->
             <text macro="publisher" suffix="."/>
             <!--Local, data, etc-->

--- a/associacao-nacional-de-pesquisa-e-ensino-em-transportes.csl
+++ b/associacao-nacional-de-pesquisa-e-ensino-em-transportes.csl
@@ -77,15 +77,17 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="report">
-            <text variable="publisher"/>
-            <text macro="title"/>
-          </if>
-          <else>
-            <text macro="title"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="report">
+              <text variable="publisher"/>
+              <text macro="title"/>
+            </if>
+            <else>
+              <text macro="title"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>
@@ -96,18 +98,20 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="report">
-            <text variable="publisher"/>
-            <text variable="title" form="short" font-style="italic"/>
-          </if>
-          <else-if type="bill book graphic legal_case legislation motion_picture song" match="any">
-            <text variable="title" form="short" font-style="italic"/>
-          </else-if>
-          <else>
-            <text variable="title" form="short" quotes="true"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="report">
+              <text variable="publisher"/>
+              <text variable="title" form="short" font-style="italic"/>
+            </if>
+            <else-if type="bill book graphic legal_case legislation motion_picture song" match="any">
+              <text variable="title" form="short" font-style="italic"/>
+            </else-if>
+            <else>
+              <text variable="title" form="short" quotes="true"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>

--- a/association-de-science-regionale-de-langue-francaise.csl
+++ b/association-de-science-regionale-de-langue-francaise.csl
@@ -69,15 +69,17 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="report">
-            <text variable="publisher"/>
-            <text macro="title"/>
-          </if>
-          <else>
-            <text macro="title"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="report">
+              <text variable="publisher"/>
+              <text macro="title"/>
+            </if>
+            <else>
+              <text macro="title"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>
@@ -88,18 +90,20 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="report">
-            <text variable="publisher"/>
-            <text variable="title" form="short" font-style="italic"/>
-          </if>
-          <else-if type="bill book graphic legal_case legislation motion_picture song" match="any">
-            <text variable="title" form="short" font-style="italic"/>
-          </else-if>
-          <else>
-            <text variable="title" form="short" quotes="true"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="report">
+              <text variable="publisher"/>
+              <text variable="title" form="short" font-style="italic"/>
+            </if>
+            <else-if type="bill book graphic legal_case legislation motion_picture song" match="any">
+              <text variable="title" form="short" font-style="italic"/>
+            </else-if>
+            <else>
+              <text variable="title" form="short" quotes="true"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>

--- a/australian-journal-of-grape-and-wine-research.csl
+++ b/australian-journal-of-grape-and-wine-research.csl
@@ -61,14 +61,16 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
-            <text variable="title" form="short" font-style="italic"/>
-          </if>
-          <else>
-            <text variable="title" form="short" quotes="true"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
+              <text variable="title" form="short" font-style="italic"/>
+            </if>
+            <else>
+              <text variable="title" form="short" quotes="true"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>

--- a/avian-conservation-and-ecology.csl
+++ b/avian-conservation-and-ecology.csl
@@ -53,14 +53,16 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
-            <text variable="title" form="short" font-style="italic"/>
-          </if>
-          <else>
-            <text variable="title" form="short" quotes="true"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
+              <text variable="title" form="short" font-style="italic"/>
+            </if>
+            <else>
+              <text variable="title" form="short" quotes="true"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>

--- a/avian-pathology.csl
+++ b/avian-pathology.csl
@@ -56,15 +56,17 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="report">
-            <text variable="publisher"/>
-            <text macro="title"/>
-          </if>
-          <else>
-            <text macro="title"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="report">
+              <text variable="publisher"/>
+              <text macro="title"/>
+            </if>
+            <else>
+              <text macro="title"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>
@@ -75,18 +77,20 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="report">
-            <text variable="publisher"/>
-            <text variable="title" form="short" font-style="italic"/>
-          </if>
-          <else-if type="bill book graphic legal_case legislation motion_picture song" match="any">
-            <text variable="title" form="short" font-style="italic"/>
-          </else-if>
-          <else>
-            <text variable="title" form="short" quotes="true"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="report">
+              <text variable="publisher"/>
+              <text variable="title" form="short" font-style="italic"/>
+            </if>
+            <else-if type="bill book graphic legal_case legislation motion_picture song" match="any">
+              <text variable="title" form="short" font-style="italic"/>
+            </else-if>
+            <else>
+              <text variable="title" form="short" quotes="true"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>

--- a/behaviour.csl
+++ b/behaviour.csl
@@ -53,15 +53,17 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="report">
-            <text variable="publisher"/>
-            <text macro="title"/>
-          </if>
-          <else>
-            <text macro="title"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="report">
+              <text variable="publisher"/>
+              <text macro="title"/>
+            </if>
+            <else>
+              <text macro="title"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>
@@ -71,18 +73,20 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="report">
-            <text variable="publisher"/>
-            <text variable="title" form="short"/>
-          </if>
-          <else-if type="bill book graphic legal_case legislation motion_picture song" match="any">
-            <text variable="title" form="short"/>
-          </else-if>
-          <else>
-            <text variable="title" form="short" quotes="true"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="report">
+              <text variable="publisher"/>
+              <text variable="title" form="short"/>
+            </if>
+            <else-if type="bill book graphic legal_case legislation motion_picture song" match="any">
+              <text variable="title" form="short"/>
+            </else-if>
+            <else>
+              <text variable="title" form="short" quotes="true"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>

--- a/berghahn-books-author-date-en-gb.csl
+++ b/berghahn-books-author-date-en-gb.csl
@@ -72,14 +72,16 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
-            <text variable="title" form="short" text-case="title" quotes="true" font-style="italic"/>
-          </if>
-          <else>
-            <text variable="title" form="short" quotes="true" text-case="title"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
+              <text variable="title" form="short" text-case="title" quotes="true" font-style="italic"/>
+            </if>
+            <else>
+              <text variable="title" form="short" quotes="true" text-case="title"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>

--- a/bibliotheque-universitaire-de-medecine-vancouver.csl
+++ b/bibliotheque-universitaire-de-medecine-vancouver.csl
@@ -51,14 +51,16 @@
       <name sort-separator=" " initialize-with="" name-as-sort-order="all" delimiter=", " delimiter-precedes-last="always"/>
       <label form="long" prefix=", "/>
       <substitute>
-        <choose>
-          <if type="chapter" match="none">
-            <names variable="editor collection-editor">
-              <name sort-separator=" " initialize-with="" name-as-sort-order="all" delimiter=", " delimiter-precedes-last="always"/>
-              <label form="long" prefix=", "/>
-            </names>
-          </if>
-        </choose>
+        <group>
+          <choose>
+            <if type="chapter" match="none">
+              <names variable="editor collection-editor">
+                <name sort-separator=" " initialize-with="" name-as-sort-order="all" delimiter=", " delimiter-precedes-last="always"/>
+                <label form="long" prefix=", "/>
+              </names>
+            </if>
+          </choose>
+        </group>
       </substitute>
     </names>
     <choose>

--- a/bibtex.csl
+++ b/bibtex.csl
@@ -58,14 +58,16 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
-            <text variable="title" form="short"/>
-          </if>
-          <else>
-            <text variable="title" form="short"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
+              <text variable="title" form="short"/>
+            </if>
+            <else>
+              <text variable="title" form="short"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>

--- a/biens-symboliques-symbolic-goods.csl
+++ b/biens-symboliques-symbolic-goods.csl
@@ -33,7 +33,7 @@
       <term name="editor" form="verb">édition établie par</term>
       <term name="translator" form="verb">traduit par</term>
       <term name="interviewer" form="verb">entretien réalisé par</term>
-      <term name="et-al"> et&#160;al.</term>
+      <term name="et-al"> et al.</term>
       <term name="page-range-delimiter">-</term>
       <term name="paragraph" form="short">§</term>
     </terms>
@@ -44,7 +44,7 @@
       <term name="editor" form="verb-short">ed. by</term>
       <term name="translator" form="verb">translated by</term>
       <term name="interviewer" form="verb">interview conducted by</term>
-      <term name="et-al">et&#160;al.</term>
+      <term name="et-al">et al.</term>
       <term name="page-range-delimiter">-</term>
       <term name="paragraph" form="short">§</term>
     </terms>
@@ -57,34 +57,36 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="report">
-            <text variable="publisher"/>
-            <text variable="title" form="short" font-style="italic"/>
-          </if>
-          <else-if type="legal_case">
-            <text variable="title" font-style="italic"/>
-          </else-if>
-          <else-if type="book graphic  motion_picture song" match="any">
-            <text variable="title" form="short" font-style="italic"/>
-          </else-if>
-          <else-if type="bill legislation" match="any">
-            <text variable="title" form="short"/>
-          </else-if>
-          <else-if variable="reviewed-author">
-            <choose>
-              <if variable="reviewed-title" match="none">
-                <text variable="title" form="short" font-style="italic" prefix="Review of "/>
-              </if>
-              <else>
-                <text variable="title" form="short" quotes="true"/>
-              </else>
-            </choose>
-          </else-if>
-          <else>
-            <text variable="title" form="short" quotes="true"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="report">
+              <text variable="publisher"/>
+              <text variable="title" form="short" font-style="italic"/>
+            </if>
+            <else-if type="legal_case">
+              <text variable="title" font-style="italic"/>
+            </else-if>
+            <else-if type="book graphic  motion_picture song" match="any">
+              <text variable="title" form="short" font-style="italic"/>
+            </else-if>
+            <else-if type="bill legislation" match="any">
+              <text variable="title" form="short"/>
+            </else-if>
+            <else-if variable="reviewed-author">
+              <choose>
+                <if variable="reviewed-title" match="none">
+                  <text variable="title" form="short" font-style="italic" prefix="Review of "/>
+                </if>
+                <else>
+                  <text variable="title" form="short" quotes="true"/>
+                </else>
+              </choose>
+            </else-if>
+            <else>
+              <text variable="title" form="short" quotes="true"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>
@@ -124,7 +126,7 @@
               <name-part name="family" font-variant="small-caps"/>
             </name>
             <et-al font-style="italic"/>
-            <label form="short" prefix="&#160;(" text-case="title" suffix=")"/>
+            <label form="short" prefix=" (" text-case="title" suffix=")"/>
           </names>
         </group>
       </if>
@@ -242,7 +244,7 @@
   </macro>
   <!-- MACRO ARCHIVE -->
   <macro name="archive">
-    <group prefix="Source&#160;: ">
+    <group prefix="Source : ">
       <text variable="archive"/>
       <text variable="archive_location" prefix=". "/>
     </group>
@@ -381,7 +383,7 @@
         </if>
         <else-if type="bill broadcast legislation report patent song" match="any">
           <group>
-            <text term="issue" form="short" prefix="" suffix="&#160;"/>
+            <text term="issue" form="short" prefix="" suffix=" "/>
             <text variable="number"/>
           </group>
         </else-if>
@@ -394,7 +396,7 @@
       <if type="bill book graphic legal_case motion_picture paper-conference manuscript report song thesis" match="any">
         <choose>
           <if is-numeric="number-of-volumes">
-            <text variable="number-of-volumes" prefix=" " suffix="&#160;"/>
+            <text variable="number-of-volumes" prefix=" " suffix=" "/>
             <text term="volume" form="short"/>
           </if>
           <else>
@@ -416,7 +418,7 @@
             <group>
               <choose>
                 <if is-numeric="collection-number">
-                  <text term="issue" form="short" suffix="&#160;"/>
+                  <text term="issue" form="short" suffix=" "/>
                   <text variable="collection-number"/>
                 </if>
                 <else-if type="report">
@@ -464,20 +466,20 @@
               <text variable="issue" prefix=" "/>
             </else>
           </choose>
-          <text variable="page" prefix="&#160;: "/>
+          <text variable="page" prefix=" : "/>
         </group>
       </if>
       <else-if type="chapter entry-encyclopedia entry-dictionary" match="any">
         <choose>
           <if is-numeric="volume">
-            <text term="volume" form="short" prefix=" " suffix=".&#160;"/>
+            <text term="volume" form="short" prefix=" " suffix=". "/>
             <text variable="volume"/>
           </if>
           <else>
             <text variable="volume"/>
           </else>
         </choose>
-        <text variable="page" prefix="&#160;: "/>
+        <text variable="page" prefix=" : "/>
       </else-if>
       <else-if type="article-newspaper">
         <group delimiter=" " prefix=", ">

--- a/bioarchaeology-of-the-near-east.csl
+++ b/bioarchaeology-of-the-near-east.csl
@@ -67,15 +67,17 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="report">
-            <text variable="publisher"/>
-            <text macro="title"/>
-          </if>
-          <else>
-            <text macro="title"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="report">
+              <text variable="publisher"/>
+              <text macro="title"/>
+            </if>
+            <else>
+              <text macro="title"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>
@@ -85,31 +87,33 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="report">
-            <text variable="publisher"/>
-            <text variable="title" form="short" font-style="italic"/>
-          </if>
-          <else-if type="legal_case">
-            <text variable="title" font-style="italic"/>
-          </else-if>
-          <else-if type="bill book graphic legislation motion_picture song" match="any">
-            <text variable="title" form="short" font-style="italic"/>
-          </else-if>
-          <else-if variable="reviewed-author">
-            <choose>
-              <if variable="reviewed-title" match="none">
-                <text variable="title" form="short" font-style="italic" prefix="Review of "/>
-              </if>
-              <else>
-                <text variable="title" form="short" quotes="true"/>
-              </else>
-            </choose>
-          </else-if>
-          <else>
-            <text variable="title" form="short" quotes="true"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="report">
+              <text variable="publisher"/>
+              <text variable="title" form="short" font-style="italic"/>
+            </if>
+            <else-if type="legal_case">
+              <text variable="title" font-style="italic"/>
+            </else-if>
+            <else-if type="bill book graphic legislation motion_picture song" match="any">
+              <text variable="title" form="short" font-style="italic"/>
+            </else-if>
+            <else-if variable="reviewed-author">
+              <choose>
+                <if variable="reviewed-title" match="none">
+                  <text variable="title" form="short" font-style="italic" prefix="Review of "/>
+                </if>
+                <else>
+                  <text variable="title" form="short" quotes="true"/>
+                </else>
+              </choose>
+            </else-if>
+            <else>
+              <text variable="title" form="short" quotes="true"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>
@@ -421,7 +425,7 @@
             <else>
               <group>
                 <text term="volume" form="short" plural="true" text-case="capitalize-first" suffix=" "/>
-                <number variable="number-of-volumes" form="numeric" prefix="1&#8211;"/>
+                <number variable="number-of-volumes" form="numeric" prefix="1–"/>
               </group>
             </else>
           </choose>

--- a/biological-journal-of-the-linnean-society.csl
+++ b/biological-journal-of-the-linnean-society.csl
@@ -43,14 +43,16 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
-            <text variable="title" form="short" font-style="italic"/>
-          </if>
-          <else>
-            <text variable="title" form="short" quotes="true"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
+              <text variable="title" form="short" font-style="italic"/>
+            </if>
+            <else>
+              <text variable="title" form="short" quotes="true"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>

--- a/biometrics.csl
+++ b/biometrics.csl
@@ -38,14 +38,16 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
-            <text variable="title" form="short" font-style="italic"/>
-          </if>
-          <else>
-            <text variable="title" form="short" quotes="true"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
+              <text variable="title" form="short" font-style="italic"/>
+            </if>
+            <else>
+              <text variable="title" form="short" quotes="true"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>

--- a/bioresources.csl
+++ b/bioresources.csl
@@ -55,14 +55,16 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
-            <text variable="title" form="short" font-style="italic"/>
-          </if>
-          <else>
-            <text variable="title" form="short" quotes="true"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
+              <text variable="title" form="short" font-style="italic"/>
+            </if>
+            <else>
+              <text variable="title" form="short" quotes="true"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>
@@ -124,7 +126,7 @@
         <text variable="page"/>
       </else-if>
       <else-if type="webpage">
-        <text variable="URL" prefix="&lt;" suffix="&gt;"/>
+        <text variable="URL" prefix="&lt;" suffix=">"/>
       </else-if>
     </choose>
   </macro>

--- a/boreal-environment-research.csl
+++ b/boreal-environment-research.csl
@@ -44,14 +44,16 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
-            <text variable="title" form="short" font-style="italic"/>
-          </if>
-          <else>
-            <text variable="title" form="short" quotes="true"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
+              <text variable="title" form="short" font-style="italic"/>
+            </if>
+            <else>
+              <text variable="title" form="short" quotes="true"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>

--- a/brain.csl
+++ b/brain.csl
@@ -27,14 +27,16 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
-            <text variable="title" form="short" font-style="italic"/>
-          </if>
-          <else>
-            <text variable="title" form="short" quotes="true"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
+              <text variable="title" form="short" font-style="italic"/>
+            </if>
+            <else>
+              <text variable="title" form="short" quotes="true"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>

--- a/british-journal-of-political-science.csl
+++ b/british-journal-of-political-science.csl
@@ -47,11 +47,13 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="report">
-            <text variable="publisher"/>
-          </if>
-        </choose>
+        <group>
+          <choose>
+            <if type="report">
+              <text variable="publisher"/>
+            </if>
+          </choose>
+        </group>
         <text macro="anon"/>
       </substitute>
     </names>
@@ -62,11 +64,13 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="report">
-            <text variable="publisher"/>
-          </if>
-        </choose>
+        <group>
+          <choose>
+            <if type="report">
+              <text variable="publisher"/>
+            </if>
+          </choose>
+        </group>
         <text macro="anon"/>
       </substitute>
     </names>

--- a/budownictwo-i-architektura-pl.csl
+++ b/budownictwo-i-architektura-pl.csl
@@ -146,15 +146,17 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="report">
-            <text variable="publisher"/>
-            <text macro="title"/>
-          </if>
-          <else>
-            <text macro="title"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="report">
+              <text variable="publisher"/>
+              <text macro="title"/>
+            </if>
+            <else>
+              <text macro="title"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>
@@ -300,7 +302,7 @@
     </layout>
   </citation>
   <!-- Bibliography -->
-  <bibliography hanging-indent="false" et-al-min="11" et-al-use-first="7" subsequent-author-substitute="&#8212;&#8212;&#8212;" entry-spacing="0">
+  <bibliography hanging-indent="false" et-al-min="11" et-al-use-first="7" subsequent-author-substitute="———" entry-spacing="0">
     <layout suffix=".">
       <!-- Citation Number -->
       <text variable="citation-number" prefix="[" suffix="] "/>

--- a/bulletin-of-the-seismological-society-of-america.csl
+++ b/bulletin-of-the-seismological-society-of-america.csl
@@ -34,14 +34,16 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
-            <text variable="title" form="short" font-style="italic"/>
-          </if>
-          <else>
-            <text variable="title" form="short" quotes="true"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
+              <text variable="title" form="short" font-style="italic"/>
+            </if>
+            <else>
+              <text variable="title" form="short" quotes="true"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>
@@ -119,7 +121,7 @@
       <if type="webpage post-weblog" match="any">
         <choose>
           <if variable="URL">
-            <text variable="URL" prefix=": &lt;" suffix="&gt;"/>
+            <text variable="URL" prefix=": &lt;" suffix=">"/>
             <group prefix=" (" suffix=")" delimiter=" ">
               <text term="accessed"/>
               <date variable="accessed">

--- a/bursa-uludag-universitesi-egitim-bilimleri-enstitusu.csl
+++ b/bursa-uludag-universitesi-egitim-bilimleri-enstitusu.csl
@@ -72,15 +72,17 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="report">
-            <text variable="publisher"/>
-            <text macro="title"/>
-          </if>
-          <else>
-            <text macro="title"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="report">
+              <text variable="publisher"/>
+              <text macro="title"/>
+            </if>
+            <else>
+              <text macro="title"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>
@@ -90,44 +92,46 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="report">
-            <text variable="publisher"/>
-            <text variable="title" form="short" font-style="italic"/>
-          </if>
-          <else-if type="legal_case">
-            <text variable="title" font-style="italic"/>
-          </else-if>
-          <else-if type="book graphic  motion_picture song review-book entry-encyclopedia" match="any">
-            <text variable="edition" form="short"/>
-            <text variable="title" form="short" font-style="italic"/>
-          </else-if>
-          <else-if type="bill legislation" match="any">
-            <text variable="title" form="short"/>
-          </else-if>
-          <else-if variable="reviewed-author">
-            <choose>
-              <if variable="reviewed-title" match="none">
-                <text variable="title" form="short" font-style="italic" prefix="Review of "/>
-              </if>
-              <else>
-                <text variable="title" form="short" quotes="true"/>
-              </else>
-            </choose>
-          </else-if>
-          <else-if type="thesis" match="any">
-            <text variable="title" suffix="(Yayınlanmamış tez)."/>
-          </else-if>
-          <else-if type="paper-conference" match="any">
-            <text value="" font-style="italic"/>
-          </else-if>
-          <else-if type="webpage" match="any">
-            <text term="accessed" suffix="tarihinde erişildi"/>
-          </else-if>
-          <else>
-            <text variable="title" form="short" quotes="true"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="report">
+              <text variable="publisher"/>
+              <text variable="title" form="short" font-style="italic"/>
+            </if>
+            <else-if type="legal_case">
+              <text variable="title" font-style="italic"/>
+            </else-if>
+            <else-if type="book graphic  motion_picture song review-book entry-encyclopedia" match="any">
+              <text variable="edition" form="short"/>
+              <text variable="title" form="short" font-style="italic"/>
+            </else-if>
+            <else-if type="bill legislation" match="any">
+              <text variable="title" form="short"/>
+            </else-if>
+            <else-if variable="reviewed-author">
+              <choose>
+                <if variable="reviewed-title" match="none">
+                  <text variable="title" form="short" font-style="italic" prefix="Review of "/>
+                </if>
+                <else>
+                  <text variable="title" form="short" quotes="true"/>
+                </else>
+              </choose>
+            </else-if>
+            <else-if type="thesis" match="any">
+              <text variable="title" suffix="(Yayınlanmamış tez)."/>
+            </else-if>
+            <else-if type="paper-conference" match="any">
+              <text value="" font-style="italic"/>
+            </else-if>
+            <else-if type="webpage" match="any">
+              <text term="accessed" suffix="tarihinde erişildi"/>
+            </else-if>
+            <else>
+              <text variable="title" form="short" quotes="true"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>
@@ -479,7 +483,7 @@
             <else>
               <group>
                 <text term="volume" form="short" plural="true" text-case="capitalize-first" suffix=" "/>
-                <number variable="number-of-volumes" form="numeric" prefix="1&#8211;"/>
+                <number variable="number-of-volumes" form="numeric" prefix="1–"/>
               </group>
             </else>
           </choose>

--- a/bursa-uludag-universitesi-fen-bilimleri-enstitusu.csl
+++ b/bursa-uludag-universitesi-fen-bilimleri-enstitusu.csl
@@ -97,15 +97,17 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="report">
-            <text variable="publisher"/>
-            <text macro="title"/>
-          </if>
-          <else>
-            <text macro="title"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="report">
+              <text variable="publisher"/>
+              <text macro="title"/>
+            </if>
+            <else>
+              <text macro="title"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>
@@ -120,35 +122,37 @@
           <substitute>
             <names variable="editor"/>
             <names variable="translator"/>
-            <choose>
-              <if type="report">
-                <text variable="publisher"/>
-                <text variable="title" form="short" font-style="normal"/>
-              </if>
-              <else-if type="legal_case">
-                <text variable="title" font-style="normal"/>
-              </else-if>
-              <else-if type="book graphic  motion_picture song" match="any">
-                <text variable="title" form="short" font-style="normal"/>
-              </else-if>
-              <else-if type="bill legislation" match="any">
-                <text variable="title" form="short"/>
-              </else-if>
-              <else-if variable="reviewed-author">
-                <choose>
-                  <if variable="reviewed-title" match="none">
-                    <text variable="title" form="short" font-style="normal" prefix="Review of "/>
-                  </if>
-                  <else>
-                    <text variable="title" form="short" quotes="false"/>
-                  </else>
-                </choose>
-              </else-if>
-              <else>
-                <text variable="title" form="short" quotes="false"/>
-                <text macro="issued"/>
-              </else>
-            </choose>
+            <group>
+              <choose>
+                <if type="report">
+                  <text variable="publisher"/>
+                  <text variable="title" form="short" font-style="normal"/>
+                </if>
+                <else-if type="legal_case">
+                  <text variable="title" font-style="normal"/>
+                </else-if>
+                <else-if type="book graphic  motion_picture song" match="any">
+                  <text variable="title" form="short" font-style="normal"/>
+                </else-if>
+                <else-if type="bill legislation" match="any">
+                  <text variable="title" form="short"/>
+                </else-if>
+                <else-if variable="reviewed-author">
+                  <choose>
+                    <if variable="reviewed-title" match="none">
+                      <text variable="title" form="short" font-style="normal" prefix="Review of "/>
+                    </if>
+                    <else>
+                      <text variable="title" form="short" quotes="false"/>
+                    </else>
+                  </choose>
+                </else-if>
+                <else>
+                  <text variable="title" form="short" quotes="false"/>
+                  <text macro="issued"/>
+                </else>
+              </choose>
+            </group>
           </substitute>
         </names>
       </else>

--- a/business-ethics-a-european-review.csl
+++ b/business-ethics-a-european-review.csl
@@ -52,15 +52,17 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="report">
-            <text variable="publisher"/>
-            <text macro="title"/>
-          </if>
-          <else>
-            <text macro="title"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="report">
+              <text variable="publisher"/>
+              <text macro="title"/>
+            </if>
+            <else>
+              <text macro="title"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>
@@ -70,21 +72,23 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="report">
-            <text variable="publisher"/>
-            <text variable="title" form="short" font-style="italic"/>
-          </if>
-          <else-if type="legal_case">
-            <text variable="title" font-style="italic"/>
-          </else-if>
-          <else-if type="bill book graphic legislation motion_picture song" match="any">
-            <text variable="title" form="short" font-style="italic"/>
-          </else-if>
-          <else>
-            <text variable="title" form="short" quotes="true"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="report">
+              <text variable="publisher"/>
+              <text variable="title" form="short" font-style="italic"/>
+            </if>
+            <else-if type="legal_case">
+              <text variable="title" font-style="italic"/>
+            </else-if>
+            <else-if type="bill book graphic legislation motion_picture song" match="any">
+              <text variable="title" form="short" font-style="italic"/>
+            </else-if>
+            <else>
+              <text variable="title" form="short" quotes="true"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>
@@ -379,7 +383,7 @@
             <else>
               <group>
                 <text term="volume" form="short" plural="true" text-case="capitalize-first" suffix=" "/>
-                <number variable="number-of-volumes" form="numeric" prefix="1&#8211;"/>
+                <number variable="number-of-volumes" form="numeric" prefix="1–"/>
               </group>
             </else>
           </choose>

--- a/cambridge-university-press-author-date.csl
+++ b/cambridge-university-press-author-date.csl
@@ -52,15 +52,17 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="report">
-            <text variable="publisher"/>
-            <text macro="title"/>
-          </if>
-          <else>
-            <text macro="title"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="report">
+              <text variable="publisher"/>
+              <text macro="title"/>
+            </if>
+            <else>
+              <text macro="title"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>
@@ -71,21 +73,23 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="report">
-            <text variable="publisher"/>
-            <text variable="title" form="short" font-style="italic"/>
-          </if>
-          <else-if type="legal_case">
-            <text variable="title" font-style="italic"/>
-          </else-if>
-          <else-if type="bill book graphic legislation motion_picture song" match="any">
-            <text variable="title" form="short" font-style="italic"/>
-          </else-if>
-          <else>
-            <text variable="title" form="short" quotes="true"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="report">
+              <text variable="publisher"/>
+              <text variable="title" form="short" font-style="italic"/>
+            </if>
+            <else-if type="legal_case">
+              <text variable="title" font-style="italic"/>
+            </else-if>
+            <else-if type="bill book graphic legislation motion_picture song" match="any">
+              <text variable="title" form="short" font-style="italic"/>
+            </else-if>
+            <else>
+              <text variable="title" form="short" quotes="true"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>
@@ -387,7 +391,7 @@
             <else>
               <group>
                 <text term="volume" form="short" plural="true" text-case="capitalize-first" suffix=" "/>
-                <number variable="number-of-volumes" form="numeric" prefix="1&#8211;"/>
+                <number variable="number-of-volumes" form="numeric" prefix="1–"/>
               </group>
             </else>
           </choose>

--- a/canadian-geotechnical-journal.csl
+++ b/canadian-geotechnical-journal.csl
@@ -61,14 +61,16 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
-            <text variable="title" form="short" font-style="italic"/>
-          </if>
-          <else>
-            <text variable="title" form="short" quotes="true"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
+              <text variable="title" form="short" font-style="italic"/>
+            </if>
+            <else>
+              <text variable="title" form="short" quotes="true"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>

--- a/canadian-journal-of-earth-sciences.csl
+++ b/canadian-journal-of-earth-sciences.csl
@@ -61,14 +61,16 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
-            <text variable="title" form="short" font-style="italic"/>
-          </if>
-          <else>
-            <text variable="title" form="short" quotes="true"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
+              <text variable="title" form="short" font-style="italic"/>
+            </if>
+            <else>
+              <text variable="title" form="short" quotes="true"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>

--- a/canadian-journal-of-fisheries-and-aquatic-sciences.csl
+++ b/canadian-journal-of-fisheries-and-aquatic-sciences.csl
@@ -56,14 +56,16 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
-            <text variable="title" form="short" font-style="italic"/>
-          </if>
-          <else>
-            <text variable="title" form="short" quotes="true"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
+              <text variable="title" form="short" font-style="italic"/>
+            </if>
+            <else>
+              <text variable="title" form="short" quotes="true"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>

--- a/canadian-journal-of-soil-science.csl
+++ b/canadian-journal-of-soil-science.csl
@@ -65,14 +65,16 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
-            <text variable="title" form="short" font-style="italic"/>
-          </if>
-          <else>
-            <text variable="title" form="short" quotes="true"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
+              <text variable="title" form="short" font-style="italic"/>
+            </if>
+            <else>
+              <text variable="title" form="short" quotes="true"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>

--- a/cerebral-cortex.csl
+++ b/cerebral-cortex.csl
@@ -63,14 +63,16 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
-            <text variable="title" form="short" font-style="italic"/>
-          </if>
-          <else>
-            <text variable="title" form="short" quotes="true"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
+              <text variable="title" form="short" font-style="italic"/>
+            </if>
+            <else>
+              <text variable="title" form="short" quotes="true"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>

--- a/ceska-zemedelska-univerzita-v-praze-fakulta-agrobiologie-potravinovych-a-prirodnich-zdroju.csl
+++ b/ceska-zemedelska-univerzita-v-praze-fakulta-agrobiologie-potravinovych-a-prirodnich-zdroju.csl
@@ -62,15 +62,17 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="report">
-            <text variable="publisher"/>
-            <text macro="title"/>
-          </if>
-          <else>
-            <text macro="title"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="report">
+              <text variable="publisher"/>
+              <text macro="title"/>
+            </if>
+            <else>
+              <text macro="title"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>
@@ -80,31 +82,33 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="report">
-            <text variable="publisher"/>
-            <text variable="title" form="short" font-style="italic"/>
-          </if>
-          <else-if type="legal_case">
-            <text variable="title" font-style="italic"/>
-          </else-if>
-          <else-if type="bill book graphic legislation motion_picture song" match="any">
-            <text variable="title" form="short" font-style="italic"/>
-          </else-if>
-          <else-if variable="reviewed-author">
-            <choose>
-              <if variable="reviewed-title" match="none">
-                <text variable="title" form="short" font-style="italic" prefix="Review of "/>
-              </if>
-              <else>
-                <text variable="title" form="short" quotes="true"/>
-              </else>
-            </choose>
-          </else-if>
-          <else>
-            <text variable="title" form="short" quotes="true"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="report">
+              <text variable="publisher"/>
+              <text variable="title" form="short" font-style="italic"/>
+            </if>
+            <else-if type="legal_case">
+              <text variable="title" font-style="italic"/>
+            </else-if>
+            <else-if type="bill book graphic legislation motion_picture song" match="any">
+              <text variable="title" form="short" font-style="italic"/>
+            </else-if>
+            <else-if variable="reviewed-author">
+              <choose>
+                <if variable="reviewed-title" match="none">
+                  <text variable="title" form="short" font-style="italic" prefix="Review of "/>
+                </if>
+                <else>
+                  <text variable="title" form="short" quotes="true"/>
+                </else>
+              </choose>
+            </else-if>
+            <else>
+              <text variable="title" form="short" quotes="true"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>
@@ -449,7 +453,7 @@
             <else>
               <group>
                 <text term="volume" form="short" plural="true" text-case="capitalize-first" suffix=" "/>
-                <number variable="number-of-volumes" form="numeric" prefix="1&#8211;"/>
+                <number variable="number-of-volumes" form="numeric" prefix="1–"/>
               </group>
             </else>
           </choose>

--- a/citizen-science-theory-and-practice.csl
+++ b/citizen-science-theory-and-practice.csl
@@ -47,11 +47,13 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="report" match="any">
-            <text variable="publisher"/>
-          </if>
-        </choose>
+        <group>
+          <choose>
+            <if type="report" match="any">
+              <text variable="publisher"/>
+            </if>
+          </choose>
+        </group>
         <text macro="anon"/>
       </substitute>
     </names>

--- a/cladistics.csl
+++ b/cladistics.csl
@@ -62,14 +62,16 @@
       <substitute>
         <names variable="editor" font-style="normal"/>
         <names variable="translator" font-style="normal"/>
-        <choose>
-          <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
-            <text variable="title" form="short" font-style="italic"/>
-          </if>
-          <else>
-            <text variable="title" form="short" quotes="true"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
+              <text variable="title" form="short" font-style="italic"/>
+            </if>
+            <else>
+              <text variable="title" form="short" quotes="true"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>

--- a/clinical-dysmorphology.csl
+++ b/clinical-dysmorphology.csl
@@ -41,14 +41,16 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
-            <text variable="title" form="short" font-style="italic"/>
-          </if>
-          <else>
-            <text variable="title" form="short" quotes="true"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
+              <text variable="title" form="short" font-style="italic"/>
+            </if>
+            <else>
+              <text variable="title" form="short" quotes="true"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>

--- a/colorado-state-university-school-of-biomedical-engineering.csl
+++ b/colorado-state-university-school-of-biomedical-engineering.csl
@@ -66,15 +66,17 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="report">
-            <text variable="publisher"/>
-            <text macro="title"/>
-          </if>
-          <else>
-            <text macro="title"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="report">
+              <text variable="publisher"/>
+              <text macro="title"/>
+            </if>
+            <else>
+              <text macro="title"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>
@@ -84,34 +86,36 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="report">
-            <text variable="publisher"/>
-            <text variable="title" form="short" font-style="italic"/>
-          </if>
-          <else-if type="legal_case">
-            <text variable="title" font-style="italic"/>
-          </else-if>
-          <else-if type="book graphic  motion_picture song" match="any">
-            <text variable="title" form="short" font-style="italic"/>
-          </else-if>
-          <else-if type="bill legislation" match="any">
-            <text variable="title" form="short"/>
-          </else-if>
-          <else-if variable="reviewed-author">
-            <choose>
-              <if variable="reviewed-title" match="none">
-                <text variable="title" form="short" font-style="italic" prefix="Review of "/>
-              </if>
-              <else>
-                <text variable="title" form="short" quotes="true"/>
-              </else>
-            </choose>
-          </else-if>
-          <else>
-            <text variable="title" form="short" quotes="true"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="report">
+              <text variable="publisher"/>
+              <text variable="title" form="short" font-style="italic"/>
+            </if>
+            <else-if type="legal_case">
+              <text variable="title" font-style="italic"/>
+            </else-if>
+            <else-if type="book graphic  motion_picture song" match="any">
+              <text variable="title" form="short" font-style="italic"/>
+            </else-if>
+            <else-if type="bill legislation" match="any">
+              <text variable="title" form="short"/>
+            </else-if>
+            <else-if variable="reviewed-author">
+              <choose>
+                <if variable="reviewed-title" match="none">
+                  <text variable="title" form="short" font-style="italic" prefix="Review of "/>
+                </if>
+                <else>
+                  <text variable="title" form="short" quotes="true"/>
+                </else>
+              </choose>
+            </else-if>
+            <else>
+              <text variable="title" form="short" quotes="true"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>
@@ -458,7 +462,7 @@
             <else>
               <group>
                 <text term="volume" form="short" plural="true" text-case="capitalize-first" suffix=" "/>
-                <number variable="number-of-volumes" form="numeric" prefix="1&#8211;"/>
+                <number variable="number-of-volumes" form="numeric" prefix="1–"/>
               </group>
             </else>
           </choose>

--- a/conservation-biology.csl
+++ b/conservation-biology.csl
@@ -62,14 +62,16 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
-            <text variable="title" form="short" font-style="italic"/>
-          </if>
-          <else>
-            <text variable="title" form="short" quotes="true"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
+              <text variable="title" form="short" font-style="italic"/>
+            </if>
+            <else>
+              <text variable="title" form="short" quotes="true"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>

--- a/conservation-letters.csl
+++ b/conservation-letters.csl
@@ -55,14 +55,16 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
-            <text variable="title" form="short" font-style="italic"/>
-          </if>
-          <else>
-            <text variable="title" form="short" quotes="true"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
+              <text variable="title" form="short" font-style="italic"/>
+            </if>
+            <else>
+              <text variable="title" form="short" quotes="true"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>

--- a/conservation-physiology.csl
+++ b/conservation-physiology.csl
@@ -57,14 +57,16 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
-            <text variable="title" form="short" font-style="italic"/>
-          </if>
-          <else>
-            <text variable="title" form="short"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
+              <text variable="title" form="short" font-style="italic"/>
+            </if>
+            <else>
+              <text variable="title" form="short"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>

--- a/creativity-and-innovation-management.csl
+++ b/creativity-and-innovation-management.csl
@@ -58,14 +58,16 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
-            <text variable="title" form="short" font-style="italic"/>
-          </if>
-          <else>
-            <text variable="title" form="short"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
+              <text variable="title" form="short" font-style="italic"/>
+            </if>
+            <else>
+              <text variable="title" form="short"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>

--- a/cultural-studies-of-science-education.csl
+++ b/cultural-studies-of-science-education.csl
@@ -69,15 +69,17 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="report">
-            <text variable="publisher"/>
-            <text macro="title"/>
-          </if>
-          <else>
-            <text macro="title"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="report">
+              <text variable="publisher"/>
+              <text macro="title"/>
+            </if>
+            <else>
+              <text macro="title"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>
@@ -87,31 +89,33 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="report">
-            <text variable="publisher"/>
-            <text variable="title" form="short" font-style="italic"/>
-          </if>
-          <else-if type="legal_case">
-            <text variable="title" font-style="italic"/>
-          </else-if>
-          <else-if type="bill book graphic legislation motion_picture song" match="any">
-            <text variable="title" form="short" font-style="italic"/>
-          </else-if>
-          <else-if variable="reviewed-author">
-            <choose>
-              <if variable="reviewed-title" match="none">
-                <text variable="title" form="short" font-style="italic" prefix="Review of "/>
-              </if>
-              <else>
-                <text variable="title" form="short" quotes="true"/>
-              </else>
-            </choose>
-          </else-if>
-          <else>
-            <text variable="title" form="short" quotes="true"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="report">
+              <text variable="publisher"/>
+              <text variable="title" form="short" font-style="italic"/>
+            </if>
+            <else-if type="legal_case">
+              <text variable="title" font-style="italic"/>
+            </else-if>
+            <else-if type="bill book graphic legislation motion_picture song" match="any">
+              <text variable="title" form="short" font-style="italic"/>
+            </else-if>
+            <else-if variable="reviewed-author">
+              <choose>
+                <if variable="reviewed-title" match="none">
+                  <text variable="title" form="short" font-style="italic" prefix="Review of "/>
+                </if>
+                <else>
+                  <text variable="title" form="short" quotes="true"/>
+                </else>
+              </choose>
+            </else-if>
+            <else>
+              <text variable="title" form="short" quotes="true"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>
@@ -441,7 +445,7 @@
             <else>
               <group>
                 <text term="volume" form="short" plural="true" text-case="capitalize-first" suffix=" "/>
-                <number variable="number-of-volumes" form="numeric" prefix="1&#8211;"/>
+                <number variable="number-of-volumes" form="numeric" prefix="1–"/>
               </group>
             </else>
           </choose>

--- a/cybium.csl
+++ b/cybium.csl
@@ -68,14 +68,16 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
-            <text variable="title" form="short" font-style="italic"/>
-          </if>
-          <else>
-            <text variable="title" form="short" quotes="true"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
+              <text variable="title" form="short" font-style="italic"/>
+            </if>
+            <else>
+              <text variable="title" form="short" quotes="true"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>

--- a/data-science-journal.csl
+++ b/data-science-journal.csl
@@ -62,14 +62,16 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
-            <text variable="title" form="short" font-style="italic"/>
-          </if>
-          <else>
-            <text variable="title" form="short"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
+              <text variable="title" form="short" font-style="italic"/>
+            </if>
+            <else>
+              <text variable="title" form="short"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>

--- a/de-buck.csl
+++ b/de-buck.csl
@@ -52,14 +52,16 @@
     <names variable="author" suffix=", ">
       <name name-as-sort-order="first" and="text" sort-separator=", " delimiter=", " delimiter-precedes-last="after-inverted-name" delimiter-precedes-et-al="after-inverted-name"/>
       <substitute>
-        <choose>
-          <if variable="container-title" match="none">
-            <names variable="editor" suffix=", ">
-              <name name-as-sort-order="first" and="text" delimiter=", " delimiter-precedes-last="after-inverted-name" delimiter-precedes-et-al="after-inverted-name"/>
-              <label form="verb-short" text-case="lowercase" prefix=" " suffix="." strip-periods="true"/>
-            </names>
-          </if>
-        </choose>
+        <group>
+          <choose>
+            <if variable="container-title" match="none">
+              <names variable="editor" suffix=", ">
+                <name name-as-sort-order="first" and="text" delimiter=", " delimiter-precedes-last="after-inverted-name" delimiter-precedes-et-al="after-inverted-name"/>
+                <label form="verb-short" text-case="lowercase" prefix=" " suffix="." strip-periods="true"/>
+              </names>
+            </if>
+          </choose>
+        </group>
         <names variable="translator" suffix=", ">
           <name name-as-sort-order="first" and="text" delimiter=", " delimiter-precedes-last="after-inverted-name" delimiter-precedes-et-al="after-inverted-name"/>
           <label form="verb-short" prefix=" (" suffix=")" text-case="lowercase" strip-periods="false"/>
@@ -96,14 +98,16 @@
         <names variable="author" suffix=", ">
           <name and="text" sort-separator=", " delimiter=", " delimiter-precedes-last="never"/>
           <substitute>
-            <choose>
-              <if variable="container-title" match="none">
-                <names variable="editor" suffix=", ">
-                  <name and="text" delimiter=", " delimiter-precedes-last="never"/>
-                  <label form="verb-short" text-case="lowercase" prefix=" " suffix="." strip-periods="true"/>
-                </names>
-              </if>
-            </choose>
+            <group>
+              <choose>
+                <if variable="container-title" match="none">
+                  <names variable="editor" suffix=", ">
+                    <name and="text" delimiter=", " delimiter-precedes-last="never"/>
+                    <label form="verb-short" text-case="lowercase" prefix=" " suffix="." strip-periods="true"/>
+                  </names>
+                </if>
+              </choose>
+            </group>
             <names variable="translator" suffix=", ">
               <name and="text" delimiter=", " delimiter-precedes-last="never"/>
               <label form="verb-short" text-case="lowercase" prefix=" " strip-periods="false"/>
@@ -270,16 +274,18 @@
             <name-part name="family" text-case="capitalize-first"/>
           </name>
           <substitute>
-            <choose>
-              <if variable="container-title" match="none">
-                <names variable="editor" suffix=", ">
-                  <name form="short" and="text" sort-separator=", " delimiter=", " delimiter-precedes-last="never">
-                    <name-part name="family" text-case="capitalize-first"/>
-                  </name>
-                  <label form="verb-short" prefix=" " suffix="." strip-periods="true"/>
-                </names>
-              </if>
-            </choose>
+            <group>
+              <choose>
+                <if variable="container-title" match="none">
+                  <names variable="editor" suffix=", ">
+                    <name form="short" and="text" sort-separator=", " delimiter=", " delimiter-precedes-last="never">
+                      <name-part name="family" text-case="capitalize-first"/>
+                    </name>
+                    <label form="verb-short" prefix=" " suffix="." strip-periods="true"/>
+                  </names>
+                </if>
+              </choose>
+            </group>
             <names variable="translator" suffix=", ">
               <name form="short" and="text" sort-separator=", " delimiter=", " delimiter-precedes-last="never">
                 <name-part name="family" text-case="capitalize-first"/>
@@ -442,10 +448,10 @@
     </group>
     <choose>
       <if variable="DOI">
-        <text variable="DOI" prefix=" &lt;doi:" suffix="&gt;"/>
+        <text variable="DOI" prefix=" &lt;doi:" suffix=">"/>
       </if>
       <else>
-        <text variable="URL" prefix=" &lt;" suffix="&gt;"/>
+        <text variable="URL" prefix=" &lt;" suffix=">"/>
         <group prefix=" [" suffix="]">
           <text term="accessed" text-case="lowercase"/>
           <date variable="accessed">

--- a/decision-sciences.csl
+++ b/decision-sciences.csl
@@ -36,11 +36,13 @@
       <name form="short" and="symbol" delimiter=", " initialize-with=". "/>
       <substitute>
         <names variable="editor"/>
-        <choose>
-          <if type="article-journal article-magazine article-newspaper paper-conference webpage" match="any">
-            <text variable="container-title"/>
-          </if>
-        </choose>
+        <group>
+          <choose>
+            <if type="article-journal article-magazine article-newspaper paper-conference webpage" match="any">
+              <text variable="container-title"/>
+            </if>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>

--- a/deutsche-gesellschaft-fur-psychologie.csl
+++ b/deutsche-gesellschaft-fur-psychologie.csl
@@ -73,14 +73,16 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="bill book graphic legal_case motion_picture report song" match="any">
-            <text variable="title" form="short" font-style="italic"/>
-          </if>
-          <else>
-            <text variable="title" form="short" quotes="true"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="bill book graphic legal_case motion_picture report song" match="any">
+              <text variable="title" form="short" font-style="italic"/>
+            </if>
+            <else>
+              <text variable="title" form="short" quotes="true"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>

--- a/developing-world-bioethics.csl
+++ b/developing-world-bioethics.csl
@@ -70,15 +70,17 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="report">
-            <text variable="publisher"/>
-            <text macro="title"/>
-          </if>
-          <else>
-            <text macro="title"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="report">
+              <text variable="publisher"/>
+              <text macro="title"/>
+            </if>
+            <else>
+              <text macro="title"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>
@@ -464,7 +466,7 @@
             <else>
               <group>
                 <text term="volume" form="short" plural="true" text-case="capitalize-first" suffix=" "/>
-                <number variable="number-of-volumes" form="numeric" prefix="1&#8211;"/>
+                <number variable="number-of-volumes" form="numeric" prefix="1–"/>
               </group>
             </else>
           </choose>

--- a/development-and-change.csl
+++ b/development-and-change.csl
@@ -70,14 +70,16 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
-            <text variable="title" form="short" font-style="italic" text-case="title"/>
-          </if>
-          <else>
-            <text variable="title" form="short" quotes="true" text-case="title"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
+              <text variable="title" form="short" font-style="italic" text-case="title"/>
+            </if>
+            <else>
+              <text variable="title" form="short" quotes="true" text-case="title"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>

--- a/development-policy-review.csl
+++ b/development-policy-review.csl
@@ -68,14 +68,16 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="article-newspaper article-magazine" match="any">
-            <text variable="container-title" text-case="title" font-style="italic"/>
-          </if>
-          <else>
-            <text macro="title"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="article-newspaper article-magazine" match="any">
+              <text variable="container-title" text-case="title" font-style="italic"/>
+            </if>
+            <else>
+              <text macro="title"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>
@@ -86,14 +88,16 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="article-newspaper article-magazine" match="any">
-            <text variable="container-title" text-case="title" font-style="italic"/>
-          </if>
-          <else>
-            <text macro="title"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="article-newspaper article-magazine" match="any">
+              <text variable="container-title" text-case="title" font-style="italic"/>
+            </if>
+            <else>
+              <text macro="title"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>

--- a/diatom-research.csl
+++ b/diatom-research.csl
@@ -56,14 +56,16 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
-            <text variable="title" form="short" font-style="italic"/>
-          </if>
-          <else>
-            <text variable="title" form="short" quotes="true"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
+              <text variable="title" form="short" font-style="italic"/>
+            </if>
+            <else>
+              <text variable="title" form="short" quotes="true"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>

--- a/die-bachelorarbeit-samac-et-al-in-text.csl
+++ b/die-bachelorarbeit-samac-et-al-in-text.csl
@@ -53,15 +53,17 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="report">
-            <text variable="publisher"/>
-            <text macro="title"/>
-          </if>
-          <else>
-            <text macro="title"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="report">
+              <text variable="publisher"/>
+              <text macro="title"/>
+            </if>
+            <else>
+              <text macro="title"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>
@@ -73,18 +75,20 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="report">
-            <text variable="publisher"/>
-            <text variable="title" form="short" font-style="italic"/>
-          </if>
-          <else-if type="bill book graphic legal_case legislation motion_picture song" match="any">
-            <text variable="title" form="short" font-style="italic"/>
-          </else-if>
-          <else>
-            <text variable="title" form="short" quotes="true"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="report">
+              <text variable="publisher"/>
+              <text variable="title" form="short" font-style="italic"/>
+            </if>
+            <else-if type="bill book graphic legal_case legislation motion_picture song" match="any">
+              <text variable="title" form="short" font-style="italic"/>
+            </else-if>
+            <else>
+              <text variable="title" form="short" quotes="true"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>

--- a/die-bachelorarbeit-samac-et-al-note.csl
+++ b/die-bachelorarbeit-samac-et-al-note.csl
@@ -53,15 +53,17 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="report">
-            <text variable="publisher"/>
-            <text macro="title"/>
-          </if>
-          <else>
-            <text macro="title"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="report">
+              <text variable="publisher"/>
+              <text macro="title"/>
+            </if>
+            <else>
+              <text macro="title"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>
@@ -73,18 +75,20 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="report">
-            <text variable="publisher"/>
-            <text variable="title" form="short" font-style="italic"/>
-          </if>
-          <else-if type="bill book graphic legal_case legislation motion_picture song" match="any">
-            <text variable="title" form="short" font-style="italic"/>
-          </else-if>
-          <else>
-            <text variable="title" form="short" quotes="true"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="report">
+              <text variable="publisher"/>
+              <text variable="title" form="short" font-style="italic"/>
+            </if>
+            <else-if type="bill book graphic legal_case legislation motion_picture song" match="any">
+              <text variable="title" form="short" font-style="italic"/>
+            </else-if>
+            <else>
+              <text variable="title" form="short" quotes="true"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>

--- a/din-1505-2.csl
+++ b/din-1505-2.csl
@@ -57,8 +57,8 @@
   </info>
   <locale xml:lang="de">
     <terms>
-      <term name="anonymous" form="short">o.&#160;A.</term>
-      <term name="no date" form="short">o.&#160;J.</term>
+      <term name="anonymous" form="short">o. A.</term>
+      <term name="no date" form="short">o. J.</term>
       <term name="collection-editor" form="short">Hrsg.</term>
       <term name="retrieved">abgerufen am</term>
       <term name="composer" form="short">Komp.</term>
@@ -98,13 +98,8 @@
       <!-- needed: Label should appear as suffix to EVERY name...!-->
     </names>
   </macro>
-  <!--  <macro name="contributor">
-    <names variable=" " delimiter=" ; ">
-    <name name-as-sort-order="all" sort-separator=", " initialize-with=". " delimiter=" ; "
-    delimiter-precedes-last="always" font-variant="small-caps"/>
-    <label form="short" prefix=" (" suffix=")"/>
-    </names>
-    </macro>-->
+  <!--  <macro name="contributor"><names variable=" " delimiter=" ; "><name name-as-sort-order="all" sort-separator=", " initialize-with=". " delimiter=" ; "
+    delimiter-precedes-last="always" font-variant="small-caps"/><label form="short" prefix=" (" suffix=")"/></names></macro>-->
   <macro name="translator">
     <names variable="translator" delimiter=" ; ">
       <name name-as-sort-order="all" sort-separator=", " initialize-with=". " delimiter=" ; " delimiter-precedes-last="always" font-variant="small-caps"/>
@@ -126,17 +121,19 @@
       <substitute>
         <names variable="editor" font-variant="small-caps"/>
         <names variable="translator" font-variant="small-caps"/>
-        <choose>
-          <if type="bill book graphic legal_case  motion_picture report song" match="any">
-            <text variable="title" form="short" font-style="italic"/>
-          </if>
-          <else-if type="bill legal_case legislation" match="any">
-            <text variable="title" form="short" font-style="normal"/>
-          </else-if>
-          <else>
-            <text variable="title" form="short" quotes="true"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="bill book graphic legal_case  motion_picture report song" match="any">
+              <text variable="title" form="short" font-style="italic"/>
+            </if>
+            <else-if type="bill legal_case legislation" match="any">
+              <text variable="title" form="short" font-style="normal"/>
+            </else-if>
+            <else>
+              <text variable="title" form="short" quotes="true"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>
@@ -154,7 +151,7 @@
   <macro name="title">
     <choose>
       <if type="bill legislation" match="any">
-        <group delimiter=" &#8212; ">
+        <group delimiter=" — ">
           <text variable="title-short" font-style="normal"/>
           <text variable="title"/>
         </group>
@@ -201,7 +198,7 @@
   <macro name="pages">
     <choose>
       <if type="chapter paper-conference article-journal" match="any">
-        <label variable="page" form="short" suffix="&#160;"/>
+        <label variable="page" form="short" suffix=" "/>
         <text variable="page"/>
       </if>
     </choose>
@@ -316,13 +313,13 @@
           <text prefix=". " macro="medium"/>
           <text prefix=". " macro="dimensions"/>
           <text prefix=". " variable="publisher-place"/>
-          <text prefix="&#160;: " variable="publisher"/>
+          <text prefix=" : " variable="publisher"/>
           <text macro="bibliography-year" prefix=", "/>
           <!-- " (1. Gesamttitel mit Zählung)"
             " (2. Gesamttitel mit Zählung)" -->
-          <text prefix=" &#8211;&#160;" macro="scale"/>
-          <text prefix=". &#8212;&#160;" variable="note"/>
-          <text prefix=" &#8212;&#160;ISBN&#160;" variable="ISBN"/>
+          <text prefix=" – " macro="scale"/>
+          <text prefix=". — " variable="note"/>
+          <text prefix=" — ISBN " variable="ISBN"/>
         </if>
         <!-- Tabelle 3 aus litverz.ps -->
         <else-if type="chapter paper-conference" match="any">
@@ -341,12 +338,12 @@
           <!-- <text prefix=" : " variable="title of volumes"/> what is this? -->
           <text prefix=". " macro="edition"/>
           <text prefix=". " variable="publisher-place"/>
-          <text prefix="&#160;: " variable="publisher"/>
+          <text prefix=" : " variable="publisher"/>
           <text macro="bibliography-year" prefix=", "/>
           <!-- " (1. Gesamttitel mit Zählung)"
             " (2. Gesamttitel mit Zählung)" -->
-          <text prefix=". &#8212;&#160;" variable="note"/>
-          <text prefix=" &#8212;&#160;ISBN&#160;" variable="ISBN"/>
+          <text prefix=". — " variable="note"/>
+          <text prefix=" — ISBN " variable="ISBN"/>
           <text prefix=", " macro="pages"/>
         </else-if>
         <!-- Tabelle 5 aus litverz.ps - Hochschulschriften
@@ -359,14 +356,14 @@
           <!-- <text prefix=", " variable="faculty"/> -->
           <text prefix=", " macro="genre"/>
           <text macro="bibliography-year" prefix=", "/>
-          <text prefix=". &#8212;&#160;" variable="note"/>
+          <text prefix=". — " variable="note"/>
         </else-if>
         <else-if type="webpage post post-weblog" match="any">
           <text prefix=" " macro="title" suffix=". " font-style="italic"/>
           <text prefix="URL " variable="URL"/>
           <text prefix=". - " macro="access"/>
-          <text prefix=". &#8212;&#160;" variable="container-title"/>
-          <text prefix=". &#8212;&#160;" variable="note"/>
+          <text prefix=". — " variable="container-title"/>
+          <text prefix=". — " variable="note"/>
         </else-if>
         <!-- Tabelle 2 aus litverz.ps UND -->
         <!-- Tabelle 4 aus litverz.ps - Schriften von Tagungen, Konferenzen, Symposien, ...-->
@@ -386,10 +383,10 @@
           <text prefix=". " variable="publisher-place"/>
           <text prefix=", " variable="publisher" form="long"/>
           <text macro="bibliography-year" prefix=" (" suffix=")"/>
-          <text prefix=", Nr.&#160;" variable="issue"/>
+          <text prefix=", Nr. " variable="issue"/>
           <text prefix=", " macro="pages"/>
-          <text prefix=". &#8212;&#160;" variable="note"/>
-          <text prefix=" &#8212;&#160;ISBN&#160;" variable="ISBN"/>
+          <text prefix=". — " variable="note"/>
+          <text prefix=" — ISBN " variable="ISBN"/>
         </else-if>
         <!-- keiner der oben genannten fälle -->
         <else>

--- a/discovery-medicine.csl
+++ b/discovery-medicine.csl
@@ -25,14 +25,16 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
-            <text variable="title" form="short" font-style="italic"/>
-          </if>
-          <else>
-            <text variable="title" form="short" quotes="true"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
+              <text variable="title" form="short" font-style="italic"/>
+            </if>
+            <else>
+              <text variable="title" form="short" quotes="true"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>

--- a/earthquake-spectra.csl
+++ b/earthquake-spectra.csl
@@ -56,14 +56,16 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
-            <text variable="title" form="short" font-style="italic"/>
-          </if>
-          <else>
-            <text variable="title" form="short" quotes="true"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
+              <text variable="title" form="short" font-style="italic"/>
+            </if>
+            <else>
+              <text variable="title" form="short" quotes="true"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>

--- a/ecole-de-technologie-superieure-apa.csl
+++ b/ecole-de-technologie-superieure-apa.csl
@@ -64,15 +64,17 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="report">
-            <text variable="publisher"/>
-            <text macro="title"/>
-          </if>
-          <else>
-            <text macro="title"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="report">
+              <text variable="publisher"/>
+              <text macro="title"/>
+            </if>
+            <else>
+              <text macro="title"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>
@@ -82,18 +84,20 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="report">
-            <text variable="publisher"/>
-            <text variable="title" font-style="italic"/>
-          </if>
-          <else-if type="bill book graphic legal_case legislation motion_picture song" match="any">
-            <text variable="title" font-style="italic"/>
-          </else-if>
-          <else>
-            <text variable="title" quotes="true"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="report">
+              <text variable="publisher"/>
+              <text variable="title" font-style="italic"/>
+            </if>
+            <else-if type="bill book graphic legal_case legislation motion_picture song" match="any">
+              <text variable="title" font-style="italic"/>
+            </else-if>
+            <else>
+              <text variable="title" quotes="true"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>
@@ -181,7 +185,7 @@
       </else-if>
       <else-if type="legislation">
         <text variable="title" font-style="italic"/>
-        <group prefix=" (" suffix=")" delimiter="&#160;; ">
+        <group prefix=" (" suffix=")" delimiter=" ; ">
           <text variable="number"/>
           <text variable="container-title"/>
         </group>
@@ -224,7 +228,7 @@
   <macro name="publisher">
     <choose>
       <if type="report" match="any">
-        <group delimiter="&#160;: ">
+        <group delimiter=" : ">
           <text variable="publisher-place"/>
           <text variable="publisher"/>
         </group>
@@ -247,7 +251,7 @@
           </choose>
           <choose>
             <if type="book chapter" match="any">
-              <group delimiter="&#160;: ">
+              <group delimiter=" : ">
                 <choose>
                   <if variable="publisher-place">
                     <text variable="publisher-place"/>
@@ -280,7 +284,7 @@
               </group>
             </else-if>
             <else-if type="article-journal article-magazine article-newspaper" match="none">
-              <group delimiter="&#160;: ">
+              <group delimiter=" : ">
                 <text variable="publisher-place"/>
                 <text variable="publisher"/>
               </group>
@@ -539,7 +543,7 @@
       <key macro="author"/>
       <key macro="issued-sort"/>
     </sort>
-    <layout prefix="(" suffix=")" delimiter="&#160;; ">
+    <layout prefix="(" suffix=")" delimiter=" ; ">
       <group delimiter=", ">
         <text macro="author-short"/>
         <text macro="issued-year"/>

--- a/ecological-entomology.csl
+++ b/ecological-entomology.csl
@@ -54,14 +54,16 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
-            <text variable="title" form="short" font-style="italic"/>
-          </if>
-          <else>
-            <text variable="title" form="short" quotes="true"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
+              <text variable="title" form="short" font-style="italic"/>
+            </if>
+            <else>
+              <text variable="title" form="short" quotes="true"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>

--- a/ecology-letters.csl
+++ b/ecology-letters.csl
@@ -58,14 +58,16 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
-            <text variable="title" form="short" font-style="italic"/>
-          </if>
-          <else>
-            <text variable="title" form="short" quotes="true"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
+              <text variable="title" form="short" font-style="italic"/>
+            </if>
+            <else>
+              <text variable="title" form="short" quotes="true"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>

--- a/ecology-of-freshwater-fish.csl
+++ b/ecology-of-freshwater-fish.csl
@@ -53,15 +53,17 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="report">
-            <text variable="publisher"/>
-            <text macro="title"/>
-          </if>
-          <else>
-            <text macro="title"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="report">
+              <text variable="publisher"/>
+              <text macro="title"/>
+            </if>
+            <else>
+              <text macro="title"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>
@@ -71,18 +73,20 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="report">
-            <text variable="publisher"/>
-            <text variable="title" form="short"/>
-          </if>
-          <else-if type="bill book graphic legal_case legislation motion_picture song" match="any">
-            <text variable="title" form="short"/>
-          </else-if>
-          <else>
-            <text variable="title" form="short" quotes="true"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="report">
+              <text variable="publisher"/>
+              <text variable="title" form="short"/>
+            </if>
+            <else-if type="bill book graphic legal_case legislation motion_picture song" match="any">
+              <text variable="title" form="short"/>
+            </else-if>
+            <else>
+              <text variable="title" form="short" quotes="true"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>

--- a/ecology.csl
+++ b/ecology.csl
@@ -53,14 +53,16 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
-            <text variable="title" form="short" font-style="italic"/>
-          </if>
-          <else>
-            <text variable="title" form="short" quotes="true"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
+              <text variable="title" form="short" font-style="italic"/>
+            </if>
+            <else>
+              <text variable="title" form="short" quotes="true"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>

--- a/economia-y-politica.csl
+++ b/economia-y-politica.csl
@@ -57,15 +57,17 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="report">
-            <text variable="publisher"/>
-            <text macro="title"/>
-          </if>
-          <else>
-            <text macro="title"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="report">
+              <text variable="publisher"/>
+              <text macro="title"/>
+            </if>
+            <else>
+              <text macro="title"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>
@@ -75,31 +77,33 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="report">
-            <text variable="publisher"/>
-            <text variable="title" form="short" font-style="italic"/>
-          </if>
-          <else-if type="legal_case">
-            <text variable="title" font-style="italic"/>
-          </else-if>
-          <else-if type="bill book graphic legislation motion_picture song" match="any">
-            <text variable="title" form="short" font-style="italic"/>
-          </else-if>
-          <else-if variable="reviewed-author">
-            <choose>
-              <if variable="reviewed-title" match="none">
-                <text variable="title" form="short" font-style="italic" prefix="Review of "/>
-              </if>
-              <else>
-                <text variable="title" form="short" quotes="true"/>
-              </else>
-            </choose>
-          </else-if>
-          <else>
-            <text variable="title" form="short" quotes="true"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="report">
+              <text variable="publisher"/>
+              <text variable="title" form="short" font-style="italic"/>
+            </if>
+            <else-if type="legal_case">
+              <text variable="title" font-style="italic"/>
+            </else-if>
+            <else-if type="bill book graphic legislation motion_picture song" match="any">
+              <text variable="title" form="short" font-style="italic"/>
+            </else-if>
+            <else-if variable="reviewed-author">
+              <choose>
+                <if variable="reviewed-title" match="none">
+                  <text variable="title" form="short" font-style="italic" prefix="Review of "/>
+                </if>
+                <else>
+                  <text variable="title" form="short" quotes="true"/>
+                </else>
+              </choose>
+            </else-if>
+            <else>
+              <text variable="title" form="short" quotes="true"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>

--- a/ecoscience.csl
+++ b/ecoscience.csl
@@ -52,14 +52,16 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
-            <text variable="title" form="short" font-style="italic"/>
-          </if>
-          <else>
-            <text variable="title" form="short" quotes="true"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
+              <text variable="title" form="short" font-style="italic"/>
+            </if>
+            <else>
+              <text variable="title" form="short" quotes="true"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>

--- a/elementa.csl
+++ b/elementa.csl
@@ -43,15 +43,17 @@
         <names variable="editor"/>
         <names variable="collection-editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="report">
-            <text variable="publisher"/>
-            <text macro="title"/>
-          </if>
-          <else>
-            <text macro="title"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="report">
+              <text variable="publisher"/>
+              <text macro="title"/>
+            </if>
+            <else>
+              <text macro="title"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>
@@ -62,15 +64,17 @@
         <names variable="editor"/>
         <names variable="collection-editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="report">
-            <text variable="publisher"/>
-            <text macro="title"/>
-          </if>
-          <else>
-            <text macro="title"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="report">
+              <text variable="publisher"/>
+              <text macro="title"/>
+            </if>
+            <else>
+              <text macro="title"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>

--- a/elife.csl
+++ b/elife.csl
@@ -65,14 +65,16 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
-            <text variable="title" form="short" font-style="italic"/>
-          </if>
-          <else>
-            <text variable="title" form="short" quotes="true"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
+              <text variable="title" form="short" font-style="italic"/>
+            </if>
+            <else>
+              <text variable="title" form="short" quotes="true"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>

--- a/elsevier-harvard-without-titles.csl
+++ b/elsevier-harvard-without-titles.csl
@@ -84,14 +84,16 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
-            <text variable="title" form="short" font-style="italic"/>
-          </if>
-          <else>
-            <text variable="title" form="short" quotes="true"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
+              <text variable="title" form="short" font-style="italic"/>
+            </if>
+            <else>
+              <text variable="title" form="short" quotes="true"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>

--- a/elsevier-harvard.csl
+++ b/elsevier-harvard.csl
@@ -78,14 +78,16 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
-            <text variable="title" form="short" font-style="italic"/>
-          </if>
-          <else>
-            <text variable="title" form="short" quotes="true"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
+              <text variable="title" form="short" font-style="italic"/>
+            </if>
+            <else>
+              <text variable="title" form="short" quotes="true"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>

--- a/elsevier-harvard2.csl
+++ b/elsevier-harvard2.csl
@@ -63,14 +63,16 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
-            <text variable="title" form="short" font-style="italic"/>
-          </if>
-          <else>
-            <text variable="title" form="short" quotes="true"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
+              <text variable="title" form="short" font-style="italic"/>
+            </if>
+            <else>
+              <text variable="title" form="short" quotes="true"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>

--- a/emerald-harvard.csl
+++ b/emerald-harvard.csl
@@ -64,11 +64,13 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="article-magazine article-newspaper entry entry-dictionary entry-encyclopedia" match="any">
-            <text variable="container-title" font-style="italic"/>
-          </if>
-        </choose>
+        <group>
+          <choose>
+            <if type="article-magazine article-newspaper entry entry-dictionary entry-encyclopedia" match="any">
+              <text variable="container-title" font-style="italic"/>
+            </if>
+          </choose>
+        </group>
         <text macro="title"/>
       </substitute>
     </names>
@@ -79,19 +81,23 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="article-magazine article-newspaper entry entry-dictionary entry-encyclopedia" match="any">
-            <text variable="container-title" font-style="italic"/>
-          </if>
-        </choose>
-        <choose>
-          <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
-            <text variable="title" form="short" font-style="italic" text-case="title"/>
-          </if>
-          <else>
-            <text variable="title" form="short" quotes="true"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="article-magazine article-newspaper entry entry-dictionary entry-encyclopedia" match="any">
+              <text variable="container-title" font-style="italic"/>
+            </if>
+          </choose>
+        </group>
+        <group>
+          <choose>
+            <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
+              <text variable="title" form="short" font-style="italic" text-case="title"/>
+            </if>
+            <else>
+              <text variable="title" form="short" quotes="true"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>

--- a/eneuro.csl
+++ b/eneuro.csl
@@ -61,14 +61,16 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
-            <text variable="title" form="short" font-style="italic"/>
-          </if>
-          <else>
-            <text variable="title" form="short" quotes="true"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
+              <text variable="title" form="short" font-style="italic"/>
+            </if>
+            <else>
+              <text variable="title" form="short" quotes="true"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>

--- a/entecho.csl
+++ b/entecho.csl
@@ -61,14 +61,16 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
-            <text variable="title" form="short" font-style="italic"/>
-          </if>
-          <else>
-            <text variable="title" form="short" quotes="true"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
+              <text variable="title" form="short" font-style="italic"/>
+            </if>
+            <else>
+              <text variable="title" form="short" quotes="true"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>

--- a/entomologia-experimentalis-et-applicata.csl
+++ b/entomologia-experimentalis-et-applicata.csl
@@ -58,14 +58,16 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
-            <text variable="title" form="short"/>
-          </if>
-          <else>
-            <text variable="title" form="short" quotes="true"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
+              <text variable="title" form="short"/>
+            </if>
+            <else>
+              <text variable="title" form="short" quotes="true"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>

--- a/entomological-society-of-america.csl
+++ b/entomological-society-of-america.csl
@@ -79,14 +79,16 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="bill book graphic legal_case motion_picture report song" match="any">
-            <text variable="title" form="short" font-style="italic"/>
-          </if>
-          <else>
-            <text variable="title" form="short" quotes="true"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="bill book graphic legal_case motion_picture report song" match="any">
+              <text variable="title" form="short" font-style="italic"/>
+            </if>
+            <else>
+              <text variable="title" form="short" quotes="true"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>

--- a/environmental-and-engineering-geoscience.csl
+++ b/environmental-and-engineering-geoscience.csl
@@ -43,14 +43,16 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
-            <text variable="title" form="short" font-style="italic"/>
-          </if>
-          <else>
-            <text variable="title" form="short" quotes="true"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
+              <text variable="title" form="short" font-style="italic"/>
+            </if>
+            <else>
+              <text variable="title" form="short" quotes="true"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>

--- a/environmental-chemistry.csl
+++ b/environmental-chemistry.csl
@@ -61,14 +61,16 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
-            <text variable="title" form="short" font-style="italic"/>
-          </if>
-          <else>
-            <text variable="title" form="short" quotes="true"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
+              <text variable="title" form="short" font-style="italic"/>
+            </if>
+            <else>
+              <text variable="title" form="short" quotes="true"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>

--- a/estudios-de-fonetica-experimental.csl
+++ b/estudios-de-fonetica-experimental.csl
@@ -76,14 +76,16 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="article-newspaper article-magazine" match="any">
-            <text variable="container-title" text-case="title" font-style="italic"/>
-          </if>
-          <else>
-            <text macro="title"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="article-newspaper article-magazine" match="any">
+              <text variable="container-title" text-case="title" font-style="italic"/>
+            </if>
+            <else>
+              <text macro="title"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>
@@ -94,14 +96,16 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="article-newspaper article-magazine" match="any">
-            <text variable="container-title" text-case="title" font-style="italic"/>
-          </if>
-          <else>
-            <text macro="title"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="article-newspaper article-magazine" match="any">
+              <text variable="container-title" text-case="title" font-style="italic"/>
+            </if>
+            <else>
+              <text macro="title"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>

--- a/european-journal-of-neuroscience.csl
+++ b/european-journal-of-neuroscience.csl
@@ -64,14 +64,16 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
-            <text variable="title" form="short" font-style="italic"/>
-          </if>
-          <else>
-            <text variable="title" form="short" quotes="true"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
+              <text variable="title" form="short" font-style="italic"/>
+            </if>
+            <else>
+              <text variable="title" form="short" quotes="true"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>

--- a/european-journal-of-political-research.csl
+++ b/european-journal-of-political-research.csl
@@ -53,15 +53,17 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="report">
-            <text variable="publisher"/>
-            <text macro="title"/>
-          </if>
-          <else>
-            <text macro="title"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="report">
+              <text variable="publisher"/>
+              <text macro="title"/>
+            </if>
+            <else>
+              <text macro="title"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>
@@ -71,18 +73,20 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="report">
-            <text variable="publisher"/>
-            <text variable="title" form="short" font-style="italic"/>
-          </if>
-          <else-if type="bill book graphic legal_case legislation motion_picture song" match="any">
-            <text variable="title" form="short" font-style="italic"/>
-          </else-if>
-          <else>
-            <text variable="title" form="short" quotes="true"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="report">
+              <text variable="publisher"/>
+              <text variable="title" form="short" font-style="italic"/>
+            </if>
+            <else-if type="bill book graphic legal_case legislation motion_picture song" match="any">
+              <text variable="title" form="short" font-style="italic"/>
+            </else-if>
+            <else>
+              <text variable="title" form="short" quotes="true"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>

--- a/european-journal-of-soil-science.csl
+++ b/european-journal-of-soil-science.csl
@@ -58,14 +58,16 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
-            <text variable="title" form="short"/>
-          </if>
-          <else>
-            <text variable="title" form="short" quotes="true"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
+              <text variable="title" form="short"/>
+            </if>
+            <else>
+              <text variable="title" form="short" quotes="true"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>

--- a/family-business-review.csl
+++ b/family-business-review.csl
@@ -66,15 +66,17 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="report">
-            <text variable="publisher"/>
-            <text macro="title"/>
-          </if>
-          <else>
-            <text macro="title"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="report">
+              <text variable="publisher"/>
+              <text macro="title"/>
+            </if>
+            <else>
+              <text macro="title"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>
@@ -84,31 +86,33 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="report">
-            <text variable="publisher"/>
-            <text variable="title" form="short" font-style="italic"/>
-          </if>
-          <else-if type="legal_case">
-            <text variable="title" font-style="italic"/>
-          </else-if>
-          <else-if type="bill book graphic legislation motion_picture song" match="any">
-            <text variable="title" form="short" font-style="italic"/>
-          </else-if>
-          <else-if variable="reviewed-author">
-            <choose>
-              <if variable="reviewed-title" match="none">
-                <text variable="title" form="short" font-style="italic" prefix="Review of "/>
-              </if>
-              <else>
-                <text variable="title" form="short" quotes="true"/>
-              </else>
-            </choose>
-          </else-if>
-          <else>
-            <text variable="title" form="short" quotes="true"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="report">
+              <text variable="publisher"/>
+              <text variable="title" form="short" font-style="italic"/>
+            </if>
+            <else-if type="legal_case">
+              <text variable="title" font-style="italic"/>
+            </else-if>
+            <else-if type="bill book graphic legislation motion_picture song" match="any">
+              <text variable="title" form="short" font-style="italic"/>
+            </else-if>
+            <else-if variable="reviewed-author">
+              <choose>
+                <if variable="reviewed-title" match="none">
+                  <text variable="title" form="short" font-style="italic" prefix="Review of "/>
+                </if>
+                <else>
+                  <text variable="title" form="short" quotes="true"/>
+                </else>
+              </choose>
+            </else-if>
+            <else>
+              <text variable="title" form="short" quotes="true"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>
@@ -441,7 +445,7 @@
             <else>
               <group>
                 <text term="volume" form="short" plural="true" text-case="capitalize-first" suffix=" "/>
-                <number variable="number-of-volumes" form="numeric" prefix="1&#8211;"/>
+                <number variable="number-of-volumes" form="numeric" prefix="1–"/>
               </group>
             </else>
           </choose>

--- a/fishery-bulletin.csl
+++ b/fishery-bulletin.csl
@@ -52,15 +52,17 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="report">
-            <text variable="publisher"/>
-            <text macro="title"/>
-          </if>
-          <else>
-            <text macro="title"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="report">
+              <text variable="publisher"/>
+              <text macro="title"/>
+            </if>
+            <else>
+              <text macro="title"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>
@@ -70,18 +72,20 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="report">
-            <text variable="publisher"/>
-            <text variable="title" form="short"/>
-          </if>
-          <else-if type="bill book graphic legal_case legislation motion_picture song" match="any">
-            <text variable="title" form="short"/>
-          </else-if>
-          <else>
-            <text variable="title" form="short" quotes="true"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="report">
+              <text variable="publisher"/>
+              <text variable="title" form="short"/>
+            </if>
+            <else-if type="bill book graphic legal_case legislation motion_picture song" match="any">
+              <text variable="title" form="short"/>
+            </else-if>
+            <else>
+              <text variable="title" form="short" quotes="true"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>

--- a/food-and-agriculture-organization-of-the-united-nations.csl
+++ b/food-and-agriculture-organization-of-the-united-nations.csl
@@ -66,15 +66,17 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <!-- Author in in-line citation for materials w/o author / editor / translator: If the type is not case, use Anonymous; use italic title for case. -->
-          <if match="none" type="legal_case">
-            <text macro="anonymous"/>
-          </if>
-          <else>
-            <text variable="title" font-style="italic"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <!-- Author in in-line citation for materials w/o author / editor / translator: If the type is not case, use Anonymous; use italic title for case. -->
+            <if match="none" type="legal_case">
+              <text macro="anonymous"/>
+            </if>
+            <else>
+              <text variable="title" font-style="italic"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>

--- a/forum-qualitative-social-research.csl
+++ b/forum-qualitative-social-research.csl
@@ -65,15 +65,17 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="report">
-            <text variable="publisher"/>
-            <text macro="title"/>
-          </if>
-          <else>
-            <text macro="title"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="report">
+              <text variable="publisher"/>
+              <text macro="title"/>
+            </if>
+            <else>
+              <text macro="title"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>
@@ -85,34 +87,36 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="report">
-            <text variable="publisher"/>
-            <text variable="title" form="short" font-style="italic"/>
-          </if>
-          <else-if type="legal_case">
-            <text variable="title" font-style="italic"/>
-          </else-if>
-          <else-if type="book graphic  motion_picture song" match="any">
-            <text variable="title" form="short" font-style="italic"/>
-          </else-if>
-          <else-if type="bill legislation" match="any">
-            <text variable="title" form="short"/>
-          </else-if>
-          <else-if variable="reviewed-author">
-            <choose>
-              <if variable="reviewed-title" match="none">
-                <text variable="title" form="short" font-style="italic" prefix="Review of "/>
-              </if>
-              <else>
-                <text variable="title" form="short" quotes="true"/>
-              </else>
-            </choose>
-          </else-if>
-          <else>
-            <text variable="title" form="short" quotes="true"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="report">
+              <text variable="publisher"/>
+              <text variable="title" form="short" font-style="italic"/>
+            </if>
+            <else-if type="legal_case">
+              <text variable="title" font-style="italic"/>
+            </else-if>
+            <else-if type="book graphic  motion_picture song" match="any">
+              <text variable="title" form="short" font-style="italic"/>
+            </else-if>
+            <else-if type="bill legislation" match="any">
+              <text variable="title" form="short"/>
+            </else-if>
+            <else-if variable="reviewed-author">
+              <choose>
+                <if variable="reviewed-title" match="none">
+                  <text variable="title" form="short" font-style="italic" prefix="Review of "/>
+                </if>
+                <else>
+                  <text variable="title" form="short" quotes="true"/>
+                </else>
+              </choose>
+            </else-if>
+            <else>
+              <text variable="title" form="short" quotes="true"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>
@@ -438,7 +442,7 @@
             <else>
               <group>
                 <text term="volume" form="short" plural="true" text-case="capitalize-first" suffix=" "/>
-                <number variable="number-of-volumes" form="numeric" prefix="1&#8211;"/>
+                <number variable="number-of-volumes" form="numeric" prefix="1–"/>
               </group>
             </else>
           </choose>

--- a/forum-qualitative-sozialforschung.csl
+++ b/forum-qualitative-sozialforschung.csl
@@ -68,15 +68,17 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="report">
-            <text variable="publisher"/>
-            <text macro="title"/>
-          </if>
-          <else>
-            <text macro="title"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="report">
+              <text variable="publisher"/>
+              <text macro="title"/>
+            </if>
+            <else>
+              <text macro="title"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>
@@ -88,34 +90,36 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="report">
-            <text variable="publisher"/>
-            <text variable="title" form="short" font-style="italic"/>
-          </if>
-          <else-if type="legal_case">
-            <text variable="title" font-style="italic"/>
-          </else-if>
-          <else-if type="book graphic  motion_picture song" match="any">
-            <text variable="title" form="short" font-style="italic"/>
-          </else-if>
-          <else-if type="bill legislation" match="any">
-            <text variable="title" form="short"/>
-          </else-if>
-          <else-if variable="reviewed-author">
-            <choose>
-              <if variable="reviewed-title" match="none">
-                <text variable="title" form="short" font-style="italic" prefix="Review of "/>
-              </if>
-              <else>
-                <text variable="title" form="short" quotes="true"/>
-              </else>
-            </choose>
-          </else-if>
-          <else>
-            <text variable="title" form="short" quotes="true"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="report">
+              <text variable="publisher"/>
+              <text variable="title" form="short" font-style="italic"/>
+            </if>
+            <else-if type="legal_case">
+              <text variable="title" font-style="italic"/>
+            </else-if>
+            <else-if type="book graphic  motion_picture song" match="any">
+              <text variable="title" form="short" font-style="italic"/>
+            </else-if>
+            <else-if type="bill legislation" match="any">
+              <text variable="title" form="short"/>
+            </else-if>
+            <else-if variable="reviewed-author">
+              <choose>
+                <if variable="reviewed-title" match="none">
+                  <text variable="title" form="short" font-style="italic" prefix="Review of "/>
+                </if>
+                <else>
+                  <text variable="title" form="short" quotes="true"/>
+                </else>
+              </choose>
+            </else-if>
+            <else>
+              <text variable="title" form="short" quotes="true"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>
@@ -438,7 +442,7 @@
             <else>
               <group>
                 <text term="volume" form="short" plural="true" text-case="capitalize-first" suffix=" "/>
-                <number variable="number-of-volumes" form="numeric" prefix="1&#8211;"/>
+                <number variable="number-of-volumes" form="numeric" prefix="1–"/>
               </group>
             </else>
           </choose>

--- a/french-politics.csl
+++ b/french-politics.csl
@@ -54,15 +54,17 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="report">
-            <text variable="publisher"/>
-            <text macro="title"/>
-          </if>
-          <else>
-            <text macro="title"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="report">
+              <text variable="publisher"/>
+              <text macro="title"/>
+            </if>
+            <else>
+              <text macro="title"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>
@@ -72,18 +74,20 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="report">
-            <text variable="publisher"/>
-            <text variable="title" form="short" font-style="italic"/>
-          </if>
-          <else-if type="bill book graphic legal_case legislation motion_picture song" match="any">
-            <text variable="title" form="short" font-style="italic"/>
-          </else-if>
-          <else>
-            <text variable="title" form="short" quotes="true"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="report">
+              <text variable="publisher"/>
+              <text variable="title" form="short" font-style="italic"/>
+            </if>
+            <else-if type="bill book graphic legal_case legislation motion_picture song" match="any">
+              <text variable="title" form="short" font-style="italic"/>
+            </else-if>
+            <else>
+              <text variable="title" form="short" quotes="true"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>

--- a/freshwater-crayfish.csl
+++ b/freshwater-crayfish.csl
@@ -44,14 +44,16 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
-            <text variable="title" form="short" font-style="italic"/>
-          </if>
-          <else>
-            <text variable="title" form="short" quotes="true"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
+              <text variable="title" form="short" font-style="italic"/>
+            </if>
+            <else>
+              <text variable="title" form="short" quotes="true"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>

--- a/freshwater-science.csl
+++ b/freshwater-science.csl
@@ -54,14 +54,16 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
-            <text variable="title" form="short" font-style="italic"/>
-          </if>
-          <else>
-            <text variable="title" form="short" quotes="true"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
+              <text variable="title" form="short" font-style="italic"/>
+            </if>
+            <else>
+              <text variable="title" form="short" quotes="true"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>

--- a/friedrich-schiller-universitat-jena-medizinische-fakultat.csl
+++ b/friedrich-schiller-universitat-jena-medizinische-fakultat.csl
@@ -44,14 +44,16 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="bill book graphic legal_case motion_picture report song" match="any">
-            <text variable="title" form="short"/>
-          </if>
-          <else>
-            <text variable="title" form="short" quotes="true"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="bill book graphic legal_case motion_picture report song" match="any">
+              <text variable="title" form="short"/>
+            </if>
+            <else>
+              <text variable="title" form="short" quotes="true"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>
@@ -61,14 +63,16 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="bill book graphic legal_case motion_picture report song" match="any">
-            <text variable="title" form="short"/>
-          </if>
-          <else>
-            <text variable="title" form="short" quotes="true"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="bill book graphic legal_case motion_picture report song" match="any">
+              <text variable="title" form="short"/>
+            </if>
+            <else>
+              <text variable="title" form="short" quotes="true"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>

--- a/frontiers-in-ecology-and-the-environment.csl
+++ b/frontiers-in-ecology-and-the-environment.csl
@@ -47,14 +47,16 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
-            <text variable="title" form="short"/>
-          </if>
-          <else>
-            <text variable="title" form="short" quotes="true"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
+              <text variable="title" form="short"/>
+            </if>
+            <else>
+              <text variable="title" form="short" quotes="true"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>

--- a/g-giappichelli-editore.csl
+++ b/g-giappichelli-editore.csl
@@ -61,15 +61,17 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="report">
-            <text variable="publisher"/>
-            <text macro="title"/>
-          </if>
-          <else>
-            <text macro="title"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="report">
+              <text variable="publisher"/>
+              <text macro="title"/>
+            </if>
+            <else>
+              <text macro="title"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>

--- a/g3.csl
+++ b/g3.csl
@@ -44,14 +44,16 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
-            <text variable="title" form="short" font-style="italic"/>
-          </if>
-          <else>
-            <text variable="title" form="short" quotes="true"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
+              <text variable="title" form="short" font-style="italic"/>
+            </if>
+            <else>
+              <text variable="title" form="short" quotes="true"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>

--- a/genes-brain-and-behavior.csl
+++ b/genes-brain-and-behavior.csl
@@ -52,14 +52,16 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
-            <text variable="title" form="short" font-style="italic"/>
-          </if>
-          <else>
-            <text variable="title" form="short" quotes="true"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
+              <text variable="title" form="short" font-style="italic"/>
+            </if>
+            <else>
+              <text variable="title" form="short" quotes="true"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>

--- a/genetics.csl
+++ b/genetics.csl
@@ -42,14 +42,16 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
-            <text variable="title" form="short" font-style="italic"/>
-          </if>
-          <else>
-            <text variable="title" form="short" quotes="true"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
+              <text variable="title" form="short" font-style="italic"/>
+            </if>
+            <else>
+              <text variable="title" form="short" quotes="true"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>

--- a/geoarchaeology.csl
+++ b/geoarchaeology.csl
@@ -53,15 +53,17 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="report">
-            <text variable="publisher"/>
-            <text macro="title"/>
-          </if>
-          <else>
-            <text macro="title"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="report">
+              <text variable="publisher"/>
+              <text macro="title"/>
+            </if>
+            <else>
+              <text macro="title"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>
@@ -71,18 +73,20 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="report">
-            <text variable="publisher"/>
-            <text variable="title" form="short"/>
-          </if>
-          <else-if type="bill book graphic legal_case legislation motion_picture song" match="any">
-            <text variable="title" form="short"/>
-          </else-if>
-          <else>
-            <text variable="title" form="short" quotes="true"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="report">
+              <text variable="publisher"/>
+              <text variable="title" form="short"/>
+            </if>
+            <else-if type="bill book graphic legal_case legislation motion_picture song" match="any">
+              <text variable="title" form="short"/>
+            </else-if>
+            <else>
+              <text variable="title" form="short" quotes="true"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>

--- a/geobiology.csl
+++ b/geobiology.csl
@@ -60,14 +60,16 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
-            <text variable="title" form="short" font-style="italic"/>
-          </if>
-          <else>
-            <text variable="title" form="short" quotes="true"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
+              <text variable="title" form="short" font-style="italic"/>
+            </if>
+            <else>
+              <text variable="title" form="short" quotes="true"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>

--- a/geochronometria.csl
+++ b/geochronometria.csl
@@ -39,14 +39,16 @@
         <names variable="editor"/>
         <names variable="translator"/>
         <text variable="container-title" font-style="italic"/>
-        <choose>
-          <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
-            <text variable="title" form="short" font-style="italic"/>
-          </if>
-          <else>
-            <text variable="title" form="short" quotes="true"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
+              <text variable="title" form="short" font-style="italic"/>
+            </if>
+            <else>
+              <text variable="title" form="short" quotes="true"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>

--- a/geographie-et-cultures.csl
+++ b/geographie-et-cultures.csl
@@ -50,15 +50,17 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="report">
-            <text variable="publisher"/>
-            <text macro="title"/>
-          </if>
-          <else>
-            <text macro="title"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="report">
+              <text variable="publisher"/>
+              <text macro="title"/>
+            </if>
+            <else>
+              <text macro="title"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>
@@ -68,21 +70,23 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="report">
-            <text variable="publisher"/>
-            <text variable="title" form="short" font-style="italic"/>
-          </if>
-          <else-if type="legal_case">
-            <text variable="title" font-style="italic"/>
-          </else-if>
-          <else-if type="bill book graphic legislation motion_picture song" match="any">
-            <text variable="title" form="short" font-style="italic"/>
-          </else-if>
-          <else>
-            <text variable="title" form="short" quotes="true"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="report">
+              <text variable="publisher"/>
+              <text variable="title" form="short" font-style="italic"/>
+            </if>
+            <else-if type="legal_case">
+              <text variable="title" font-style="italic"/>
+            </else-if>
+            <else-if type="bill book graphic legislation motion_picture song" match="any">
+              <text variable="title" form="short" font-style="italic"/>
+            </else-if>
+            <else>
+              <text variable="title" form="short" quotes="true"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>
@@ -390,7 +394,7 @@
             <else>
               <group>
                 <text term="volume" form="short" plural="true" text-case="capitalize-first" suffix=" "/>
-                <number variable="number-of-volumes" form="numeric" prefix="1&#8211;"/>
+                <number variable="number-of-volumes" form="numeric" prefix="1–"/>
               </group>
             </else>
           </choose>

--- a/geophysical-journal-international.csl
+++ b/geophysical-journal-international.csl
@@ -63,14 +63,16 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
-            <text variable="title" form="short" font-style="italic"/>
-          </if>
-          <else>
-            <text variable="title" form="short" quotes="true"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
+              <text variable="title" form="short" font-style="italic"/>
+            </if>
+            <else>
+              <text variable="title" form="short" quotes="true"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>

--- a/glossa.csl
+++ b/glossa.csl
@@ -69,15 +69,17 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="report">
-            <text variable="publisher"/>
-            <text macro="title"/>
-          </if>
-          <else>
-            <text macro="title"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="report">
+              <text variable="publisher"/>
+              <text macro="title"/>
+            </if>
+            <else>
+              <text macro="title"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>
@@ -87,34 +89,36 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="report">
-            <text variable="publisher"/>
-            <text variable="title" form="short" font-style="italic"/>
-          </if>
-          <else-if type="legal_case">
-            <text variable="title" font-style="italic"/>
-          </else-if>
-          <else-if type="book graphic  motion_picture song" match="any">
-            <text variable="title" form="short" font-style="italic"/>
-          </else-if>
-          <else-if type="bill legislation" match="any">
-            <text variable="title" form="short"/>
-          </else-if>
-          <else-if variable="reviewed-author">
-            <choose>
-              <if variable="reviewed-title" match="none">
-                <text variable="title" form="short" font-style="italic" prefix="Review of "/>
-              </if>
-              <else>
-                <text variable="title" form="short" quotes="true"/>
-              </else>
-            </choose>
-          </else-if>
-          <else>
-            <text variable="title" form="short" quotes="true"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="report">
+              <text variable="publisher"/>
+              <text variable="title" form="short" font-style="italic"/>
+            </if>
+            <else-if type="legal_case">
+              <text variable="title" font-style="italic"/>
+            </else-if>
+            <else-if type="book graphic  motion_picture song" match="any">
+              <text variable="title" form="short" font-style="italic"/>
+            </else-if>
+            <else-if type="bill legislation" match="any">
+              <text variable="title" form="short"/>
+            </else-if>
+            <else-if variable="reviewed-author">
+              <choose>
+                <if variable="reviewed-title" match="none">
+                  <text variable="title" form="short" font-style="italic" prefix="Review of "/>
+                </if>
+                <else>
+                  <text variable="title" form="short" quotes="true"/>
+                </else>
+              </choose>
+            </else-if>
+            <else>
+              <text variable="title" form="short" quotes="true"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>
@@ -464,7 +468,7 @@
             <else>
               <group>
                 <text term="volume" form="short" plural="true" text-case="capitalize-first" suffix=" "/>
-                <number variable="number-of-volumes" form="numeric" prefix="1&#8211;"/>
+                <number variable="number-of-volumes" form="numeric" prefix="1–"/>
               </group>
             </else>
           </choose>

--- a/government-and-opposition.csl
+++ b/government-and-opposition.csl
@@ -65,15 +65,17 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="report">
-            <text variable="publisher"/>
-            <text macro="title"/>
-          </if>
-          <else>
-            <text macro="title"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="report">
+              <text variable="publisher"/>
+              <text macro="title"/>
+            </if>
+            <else>
+              <text macro="title"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>
@@ -88,34 +90,36 @@
           <substitute>
             <names variable="editor"/>
             <names variable="translator"/>
-            <choose>
-              <if type="report">
-                <text variable="publisher"/>
-                <text variable="title" form="short" font-style="italic"/>
-              </if>
-              <else-if type="legal_case">
-                <text variable="title" font-style="italic"/>
-              </else-if>
-              <else-if type="book graphic  motion_picture song" match="any">
-                <text variable="title" form="short" font-style="italic"/>
-              </else-if>
-              <else-if type="bill legislation" match="any">
-                <text variable="title" form="short"/>
-              </else-if>
-              <else-if variable="reviewed-author">
-                <choose>
-                  <if variable="reviewed-title" match="none">
-                    <text variable="title" form="short" font-style="italic" prefix="Review of "/>
-                  </if>
-                  <else>
-                    <text variable="title" form="short" quotes="true"/>
-                  </else>
-                </choose>
-              </else-if>
-              <else>
-                <text variable="title" form="short" quotes="true"/>
-              </else>
-            </choose>
+            <group>
+              <choose>
+                <if type="report">
+                  <text variable="publisher"/>
+                  <text variable="title" form="short" font-style="italic"/>
+                </if>
+                <else-if type="legal_case">
+                  <text variable="title" font-style="italic"/>
+                </else-if>
+                <else-if type="book graphic  motion_picture song" match="any">
+                  <text variable="title" form="short" font-style="italic"/>
+                </else-if>
+                <else-if type="bill legislation" match="any">
+                  <text variable="title" form="short"/>
+                </else-if>
+                <else-if variable="reviewed-author">
+                  <choose>
+                    <if variable="reviewed-title" match="none">
+                      <text variable="title" form="short" font-style="italic" prefix="Review of "/>
+                    </if>
+                    <else>
+                      <text variable="title" form="short" quotes="true"/>
+                    </else>
+                  </choose>
+                </else-if>
+                <else>
+                  <text variable="title" form="short" quotes="true"/>
+                </else>
+              </choose>
+            </group>
           </substitute>
         </names>
       </else>
@@ -558,7 +562,7 @@
             <else>
               <group>
                 <text term="volume" form="short" plural="true" text-case="capitalize-first" suffix=" "/>
-                <number variable="number-of-volumes" form="numeric" prefix="1&#8211;"/>
+                <number variable="number-of-volumes" form="numeric" prefix="1–"/>
               </group>
             </else>
           </choose>

--- a/handbook-of-clinical-neurology.csl
+++ b/handbook-of-clinical-neurology.csl
@@ -62,14 +62,16 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
-            <text variable="title" form="short" font-style="italic"/>
-          </if>
-          <else>
-            <text variable="title" form="short" quotes="true"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
+              <text variable="title" form="short" font-style="italic"/>
+            </if>
+            <else>
+              <text variable="title" form="short" quotes="true"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>

--- a/harvard-cardiff-university.csl
+++ b/harvard-cardiff-university.csl
@@ -32,14 +32,16 @@
       <label form="short" prefix=" "/>
       <substitute>
         <names variable="editor"/>
-        <choose>
-          <if type="article-newspaper article-magazine" match="any">
-            <text variable="container-title"/>
-          </if>
-          <else>
-            <text macro="title"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="article-newspaper article-magazine" match="any">
+              <text variable="container-title"/>
+            </if>
+            <else>
+              <text macro="title"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>
@@ -49,14 +51,16 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="article-newspaper article-magazine" match="any">
-            <text variable="container-title" text-case="title" font-style="italic"/>
-          </if>
-          <else>
-            <text macro="title"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="article-newspaper article-magazine" match="any">
+              <text variable="container-title" text-case="title" font-style="italic"/>
+            </if>
+            <else>
+              <text macro="title"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>

--- a/harvard-cite-them-right.csl
+++ b/harvard-cite-them-right.csl
@@ -70,14 +70,16 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="article-newspaper article-magazine" match="any">
-            <text variable="container-title" text-case="title" font-style="italic"/>
-          </if>
-          <else>
-            <text macro="title"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="article-newspaper article-magazine" match="any">
+              <text variable="container-title" text-case="title" font-style="italic"/>
+            </if>
+            <else>
+              <text macro="title"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>
@@ -88,14 +90,16 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="article-newspaper article-magazine" match="any">
-            <text variable="container-title" text-case="title" font-style="italic"/>
-          </if>
-          <else>
-            <text macro="title"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="article-newspaper article-magazine" match="any">
+              <text variable="container-title" text-case="title" font-style="italic"/>
+            </if>
+            <else>
+              <text macro="title"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>

--- a/harvard-cranfield-university.csl
+++ b/harvard-cranfield-university.csl
@@ -48,11 +48,13 @@
       <name and="text" delimiter-precedes-last="never" initialize-with="." name-as-sort-order="all"/>
       <label form="short" prefix=" " text-case="lowercase"/>
       <substitute>
-        <choose>
-          <if type="chapter" match="any">
-            <text variable="publisher"/>
-          </if>
-        </choose>
+        <group>
+          <choose>
+            <if type="chapter" match="any">
+              <text variable="publisher"/>
+            </if>
+          </choose>
+        </group>
         <text macro="editor"/>
         <text macro="anon"/>
       </substitute>
@@ -63,14 +65,16 @@
       <name form="short" and="text" delimiter-precedes-last="never" et-al-min="4" et-al-use-first="1" initialize-with=". "/>
       <substitute>
         <names variable="translator"/>
-        <choose>
-          <if type="chapter" match="any">
-            <text variable="publisher"/>
-          </if>
-          <else>
-            <text macro="cite-editor"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="chapter" match="any">
+              <text variable="publisher"/>
+            </if>
+            <else>
+              <text macro="cite-editor"/>
+            </else>
+          </choose>
+        </group>
         <text macro="anon"/>
       </substitute>
     </names>

--- a/harvard-kings-college-london.csl
+++ b/harvard-kings-college-london.csl
@@ -44,14 +44,16 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
-            <text variable="title" form="short" font-style="italic"/>
-          </if>
-          <else>
-            <text variable="title" form="short" quotes="true"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
+              <text variable="title" form="short" font-style="italic"/>
+            </if>
+            <else>
+              <text variable="title" form="short" quotes="true"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>
@@ -202,14 +204,7 @@
             <text macro="online"/>
           </group>
           <!--
-	      <group prefix=" " delimiter=". " suffix=".">
-	      <date variable="issued">
-	      <date-part name="day" suffix=" "/>
-	      <date-part name="month" suffix=" "/>
-	      <date-part name="year"/>
-	      </date>
-	      <text variable="container-title"/>
-	      </group>
+	      <group prefix=" " delimiter=". " suffix="."><date variable="issued"><date-part name="day" suffix=" "/><date-part name="month" suffix=" "/><date-part name="year"/></date><text variable="container-title"/></group>
 	  -->
         </else-if>
         <else-if type="article-journal article-newspaper broadcast personal_communication thesis webpage" match="any">

--- a/harvard-limerick.csl
+++ b/harvard-limerick.csl
@@ -62,14 +62,16 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
-            <text variable="title" font-style="italic"/>
-          </if>
-          <else>
-            <text variable="title" quotes="true"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
+              <text variable="title" font-style="italic"/>
+            </if>
+            <else>
+              <text variable="title" quotes="true"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>

--- a/harvard-london-south-bank-university.csl
+++ b/harvard-london-south-bank-university.csl
@@ -65,15 +65,17 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="report">
-            <text variable="publisher"/>
-            <text macro="title"/>
-          </if>
-          <else>
-            <text macro="title"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="report">
+              <text variable="publisher"/>
+              <text macro="title"/>
+            </if>
+            <else>
+              <text macro="title"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>
@@ -84,18 +86,20 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="report">
-            <text variable="publisher"/>
-            <text variable="title" form="short" font-style="italic"/>
-          </if>
-          <else-if type="bill book graphic legal_case legislation motion_picture song" match="any">
-            <text variable="title" form="short" font-style="italic"/>
-          </else-if>
-          <else>
-            <text variable="title" form="short" quotes="false"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="report">
+              <text variable="publisher"/>
+              <text variable="title" form="short" font-style="italic"/>
+            </if>
+            <else-if type="bill book graphic legal_case legislation motion_picture song" match="any">
+              <text variable="title" form="short" font-style="italic"/>
+            </else-if>
+            <else>
+              <text variable="title" form="short" quotes="false"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>

--- a/harvard-manchester-metropolitan-university.csl
+++ b/harvard-manchester-metropolitan-university.csl
@@ -44,14 +44,16 @@
           <substitute>
             <names variable="editor"/>
             <names variable="translator"/>
-            <choose>
-              <if type="article-newspaper article-magazine" match="any">
-                <text variable="container-title" text-case="title"/>
-              </if>
-              <else>
-                <text macro="title"/>
-              </else>
-            </choose>
+            <group>
+              <choose>
+                <if type="article-newspaper article-magazine" match="any">
+                  <text variable="container-title" text-case="title"/>
+                </if>
+                <else>
+                  <text macro="title"/>
+                </else>
+              </choose>
+            </group>
           </substitute>
         </names>
       </else>
@@ -68,14 +70,16 @@
           <substitute>
             <names variable="editor"/>
             <names variable="translator"/>
-            <choose>
-              <if type="article-newspaper article-magazine" match="any">
-                <text variable="container-title" text-case="title"/>
-              </if>
-              <else>
-                <text macro="title"/>
-              </else>
-            </choose>
+            <group>
+              <choose>
+                <if type="article-newspaper article-magazine" match="any">
+                  <text variable="container-title" text-case="title"/>
+                </if>
+                <else>
+                  <text macro="title"/>
+                </else>
+              </choose>
+            </group>
           </substitute>
         </names>
       </else>

--- a/harvard-melbourne-polytechnic.csl
+++ b/harvard-melbourne-polytechnic.csl
@@ -33,14 +33,16 @@
       <label form="short" prefix=" (" suffix=")"/>
       <substitute>
         <names variable="editor"/>
-        <choose>
-          <if type="broadcast">
-            <text macro="title" font-style="italic"/>
-          </if>
-          <else>
-            <text macro="title"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="broadcast">
+              <text macro="title" font-style="italic"/>
+            </if>
+            <else>
+              <text macro="title"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>

--- a/harvard-newcastle-university.csl
+++ b/harvard-newcastle-university.csl
@@ -40,14 +40,16 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
-            <text variable="title" form="short" font-style="italic"/>
-          </if>
-          <else>
-            <text variable="title" form="short" quotes="true"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
+              <text variable="title" form="short" font-style="italic"/>
+            </if>
+            <else>
+              <text variable="title" form="short" quotes="true"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>

--- a/harvard-north-west-university.csl
+++ b/harvard-north-west-university.csl
@@ -61,14 +61,16 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="bill book graphic legal_case motion_picture report song" match="any">
-            <text variable="title" form="short" font-style="italic"/>
-          </if>
-          <else>
-            <text variable="title" form="short" quotes="true"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="bill book graphic legal_case motion_picture report song" match="any">
+              <text variable="title" form="short" font-style="italic"/>
+            </if>
+            <else>
+              <text variable="title" form="short" quotes="true"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>

--- a/harvard-pontificia-universidad-catolica-del-ecuador.csl
+++ b/harvard-pontificia-universidad-catolica-del-ecuador.csl
@@ -50,15 +50,17 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="report">
-            <text variable="publisher"/>
-            <text macro="title"/>
-          </if>
-          <else>
-            <text macro="title"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="report">
+              <text variable="publisher"/>
+              <text macro="title"/>
+            </if>
+            <else>
+              <text macro="title"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>
@@ -68,18 +70,20 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="report">
-            <text variable="publisher"/>
-            <text variable="title" form="short" font-style="italic"/>
-          </if>
-          <else-if type="bill book graphic legal_case legislation motion_picture song" match="any">
-            <text variable="title" form="short" font-style="italic"/>
-          </else-if>
-          <else>
-            <text variable="title" form="short" quotes="true"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="report">
+              <text variable="publisher"/>
+              <text variable="title" form="short" font-style="italic"/>
+            </if>
+            <else-if type="bill book graphic legal_case legislation motion_picture song" match="any">
+              <text variable="title" form="short" font-style="italic"/>
+            </else-if>
+            <else>
+              <text variable="title" form="short" quotes="true"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>
@@ -407,7 +411,7 @@
       <key macro="issued-sort"/>
     </sort>
     <layout prefix="(" suffix=")" delimiter="; ">
-      <group delimiter=":&#160;">
+      <group delimiter=": ">
         <group delimiter=", ">
           <text macro="author-short"/>
           <text macro="issued-year"/>

--- a/harvard-stellenbosch-university.csl
+++ b/harvard-stellenbosch-university.csl
@@ -50,14 +50,16 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="bill book graphic legal_case legislation motion_picture report song webpage" match="any">
-            <text variable="title" font-style="italic"/>
-          </if>
-          <else>
-            <text variable="title" quotes="true" text-case="capitalize-first"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="bill book graphic legal_case legislation motion_picture report song webpage" match="any">
+              <text variable="title" font-style="italic"/>
+            </if>
+            <else>
+              <text variable="title" quotes="true" text-case="capitalize-first"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>
@@ -68,14 +70,16 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
-            <text variable="title" form="short" font-style="italic"/>
-          </if>
-          <else>
-            <text variable="title" form="short" quotes="true" text-case="capitalize-first"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
+              <text variable="title" form="short" font-style="italic"/>
+            </if>
+            <else>
+              <text variable="title" form="short" quotes="true" text-case="capitalize-first"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>

--- a/harvard-the-university-of-sheffield-school-of-east-asian-studies.csl
+++ b/harvard-the-university-of-sheffield-school-of-east-asian-studies.csl
@@ -28,11 +28,13 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="article-journal article-magazine article-newspaper broadcast interview manuscript map patent personal_communication song speech thesis webpage" match="any">
-            <text variable="container-title"/>
-          </if>
-        </choose>
+        <group>
+          <choose>
+            <if type="article-journal article-magazine article-newspaper broadcast interview manuscript map patent personal_communication song speech thesis webpage" match="any">
+              <text variable="container-title"/>
+            </if>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>
@@ -42,14 +44,16 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
-            <text variable="title" form="short" font-style="italic"/>
-          </if>
-          <else>
-            <text variable="title" form="short" quotes="true"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
+              <text variable="title" form="short" font-style="italic"/>
+            </if>
+            <else>
+              <text variable="title" form="short" quotes="true"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>

--- a/harvard-the-university-of-sheffield-town-and-regional-planning.csl
+++ b/harvard-the-university-of-sheffield-town-and-regional-planning.csl
@@ -28,11 +28,13 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="article-journal article-magazine article-newspaper broadcast interview manuscript map patent personal_communication song speech thesis webpage" match="any">
-            <text variable="container-title"/>
-          </if>
-        </choose>
+        <group>
+          <choose>
+            <if type="article-journal article-magazine article-newspaper broadcast interview manuscript map patent personal_communication song speech thesis webpage" match="any">
+              <text variable="container-title"/>
+            </if>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>
@@ -42,14 +44,16 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
-            <text variable="title" form="short" font-style="italic"/>
-          </if>
-          <else>
-            <text variable="title" form="short" quotes="true"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
+              <text variable="title" form="short" font-style="italic"/>
+            </if>
+            <else>
+              <text variable="title" form="short" quotes="true"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>

--- a/harvard-university-of-birmingham.csl
+++ b/harvard-university-of-birmingham.csl
@@ -74,17 +74,19 @@
           <substitute>
             <text macro="editor"/>
             <!-- for anonymous works, use title -->
-            <choose>
-              <if type="webpage">
-                <text variable="title" font-style="italic"/>
-              </if>
-              <else-if variable="container-title">
-                <text variable="title" font-style="normal"/>
-              </else-if>
-              <else>
-                <text variable="title" font-style="italic"/>
-              </else>
-            </choose>
+            <group>
+              <choose>
+                <if type="webpage">
+                  <text variable="title" font-style="italic"/>
+                </if>
+                <else-if variable="container-title">
+                  <text variable="title" font-style="normal"/>
+                </else-if>
+                <else>
+                  <text variable="title" font-style="italic"/>
+                </else>
+              </choose>
+            </group>
           </substitute>
         </names>
       </else>

--- a/harvard-university-of-cape-town.csl
+++ b/harvard-university-of-cape-town.csl
@@ -51,14 +51,16 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="bill book graphic legal_case legislation motion_picture report song webpage" match="any">
-            <text variable="title" font-style="italic"/>
-          </if>
-          <else>
-            <text variable="title" quotes="true" text-case="capitalize-first"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="bill book graphic legal_case legislation motion_picture report song webpage" match="any">
+              <text variable="title" font-style="italic"/>
+            </if>
+            <else>
+              <text variable="title" quotes="true" text-case="capitalize-first"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>
@@ -68,15 +70,17 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
-            <!-- Note that webpage title is italicized in bibliography, but quoted in text -->
-            <text variable="title" form="short" font-style="italic"/>
-          </if>
-          <else>
-            <text variable="title" form="short" quotes="true" text-case="capitalize-first"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
+              <!-- Note that webpage title is italicized in bibliography, but quoted in text -->
+              <text variable="title" form="short" font-style="italic"/>
+            </if>
+            <else>
+              <text variable="title" form="short" quotes="true" text-case="capitalize-first"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>

--- a/harvard-university-of-exeter-geography.csl
+++ b/harvard-university-of-exeter-geography.csl
@@ -51,15 +51,17 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="report">
-            <text variable="publisher"/>
-            <text macro="title"/>
-          </if>
-          <else>
-            <text macro="title"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="report">
+              <text variable="publisher"/>
+              <text macro="title"/>
+            </if>
+            <else>
+              <text macro="title"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>
@@ -78,7 +80,7 @@
           <date-part name="month"/>
           <date-part name="year"/>
         </date>
-        <group prefix=" &lt;" suffix="&gt;" delimiter="">
+        <group prefix=" &lt;" suffix=">" delimiter="">
           <text variable="URL" suffix=". "/>
         </group>
       </else-if>
@@ -91,18 +93,20 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="report">
-            <text variable="publisher"/>
-            <text variable="title" form="short" font-style="italic"/>
-          </if>
-          <else-if type="bill book graphic legal_case legislation motion_picture song" match="any">
-            <text variable="title" form="short" font-style="italic"/>
-          </else-if>
-          <else>
-            <text variable="title" form="short" quotes="true"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="report">
+              <text variable="publisher"/>
+              <text variable="title" form="short" font-style="italic"/>
+            </if>
+            <else-if type="bill book graphic legal_case legislation motion_picture song" match="any">
+              <text variable="title" form="short" font-style="italic"/>
+            </else-if>
+            <else>
+              <text variable="title" form="short" quotes="true"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>

--- a/harvard-university-of-the-west-of-scotland.csl
+++ b/harvard-university-of-the-west-of-scotland.csl
@@ -27,14 +27,16 @@
           <substitute>
             <names variable="editor"/>
             <names variable="translator"/>
-            <choose>
-              <if type="webpage post-weblog" match="any">
-                <text variable="title" text-decoration="underline" suffix="."/>
-              </if>
-              <else>
-                <text macro="anon"/>
-              </else>
-            </choose>
+            <group>
+              <choose>
+                <if type="webpage post-weblog" match="any">
+                  <text variable="title" text-decoration="underline" suffix="."/>
+                </if>
+                <else>
+                  <text macro="anon"/>
+                </else>
+              </choose>
+            </group>
           </substitute>
         </names>
       </if>
@@ -70,14 +72,16 @@
           <substitute>
             <names variable="editor"/>
             <names variable="translator"/>
-            <choose>
-              <if type="webpage post-weblog" match="any">
-                <text variable="title"/>
-              </if>
-              <else>
-                <text macro="anon"/>
-              </else>
-            </choose>
+            <group>
+              <choose>
+                <if type="webpage post-weblog" match="any">
+                  <text variable="title"/>
+                </if>
+                <else>
+                  <text macro="anon"/>
+                </else>
+              </choose>
+            </group>
           </substitute>
         </names>
       </if>

--- a/haute-ecole-pedagogique-fribourg.csl
+++ b/haute-ecole-pedagogique-fribourg.csl
@@ -69,21 +69,25 @@
       <name name-as-sort-order="all" and="symbol" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
       <label form="short" prefix=" (" suffix=")" text-case="capitalize-first"/>
       <substitute>
-        <choose>
-          <if type="entry-dictionary entry-encyclopedia" match="none">
-            <names variable="editor"/>
-            <names variable="translator"/>
-          </if>
-        </choose>
-        <choose>
-          <if type="report">
-            <text variable="publisher"/>
-            <text macro="title-plus-extra"/>
-          </if>
-          <else>
-            <text macro="title-plus-extra"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="entry-dictionary entry-encyclopedia" match="none">
+              <names variable="editor"/>
+              <names variable="translator"/>
+            </if>
+          </choose>
+        </group>
+        <group>
+          <choose>
+            <if type="report">
+              <text variable="publisher"/>
+              <text macro="title-plus-extra"/>
+            </if>
+            <else>
+              <text macro="title-plus-extra"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>
@@ -91,45 +95,49 @@
     <names variable="author">
       <name form="short" and="symbol" delimiter=", " initialize-with=". "/>
       <substitute>
-        <choose>
-          <if type="entry-dictionary entry-encyclopedia" match="none">
-            <names variable="editor"/>
-            <names variable="translator"/>
-          </if>
-        </choose>
-        <choose>
-          <if type="report">
-            <text variable="publisher"/>
-            <text variable="title" form="short" font-style="italic"/>
-          </if>
-          <else-if type="legal_case">
-            <text variable="title" font-style="italic"/>
-          </else-if>
-          <else-if type="bill book graphic legislation motion_picture song" match="any">
-            <choose>
-              <if variable="version" type="book" match="all">
-                <!---This is a hack until we have a computer program type -->
-                <text variable="title" form="short" quotes="true"/>
-              </if>
-              <else>
-                <text variable="title" form="short" font-style="italic"/>
-              </else>
-            </choose>
-          </else-if>
-          <else-if variable="reviewed-author">
-            <choose>
-              <if variable="reviewed-title" match="none">
-                <text variable="title" form="short" font-style="italic" prefix="Recension de "/>
-              </if>
-              <else>
-                <text variable="title" form="short" quotes="true"/>
-              </else>
-            </choose>
-          </else-if>
-          <else>
-            <text variable="title" form="short" quotes="true"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="entry-dictionary entry-encyclopedia" match="none">
+              <names variable="editor"/>
+              <names variable="translator"/>
+            </if>
+          </choose>
+        </group>
+        <group>
+          <choose>
+            <if type="report">
+              <text variable="publisher"/>
+              <text variable="title" form="short" font-style="italic"/>
+            </if>
+            <else-if type="legal_case">
+              <text variable="title" font-style="italic"/>
+            </else-if>
+            <else-if type="bill book graphic legislation motion_picture song" match="any">
+              <choose>
+                <if variable="version" type="book" match="all">
+                  <!---This is a hack until we have a computer program type -->
+                  <text variable="title" form="short" quotes="true"/>
+                </if>
+                <else>
+                  <text variable="title" form="short" font-style="italic"/>
+                </else>
+              </choose>
+            </else-if>
+            <else-if variable="reviewed-author">
+              <choose>
+                <if variable="reviewed-title" match="none">
+                  <text variable="title" form="short" font-style="italic" prefix="Recension de "/>
+                </if>
+                <else>
+                  <text variable="title" form="short" quotes="true"/>
+                </else>
+              </choose>
+            </else-if>
+            <else>
+              <text variable="title" form="short" quotes="true"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>
@@ -522,13 +530,13 @@
                   <if variable="edition" match="none">
                     <group>
                       <text term="volume" form="short" plural="true" text-case="capitalize-first" suffix=" "/>
-                      <number variable="number-of-volumes" form="numeric" prefix="1&#8211;"/>
+                      <number variable="number-of-volumes" form="numeric" prefix="1–"/>
                     </group>
                   </if>
                   <else>
                     <group>
                       <text term="volume" form="short" plural="true" text-case="lowercase" suffix=" "/>
-                      <number variable="number-of-volumes" form="numeric" prefix="1&#8211;"/>
+                      <number variable="number-of-volumes" form="numeric" prefix="1–"/>
                     </group>
                   </else>
                 </choose>

--- a/health-and-social-care-in-the-community.csl
+++ b/health-and-social-care-in-the-community.csl
@@ -42,14 +42,16 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
-            <text variable="title" form="short" font-style="italic"/>
-          </if>
-          <else>
-            <text variable="title" form="short" quotes="true"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
+              <text variable="title" form="short" font-style="italic"/>
+            </if>
+            <else>
+              <text variable="title" form="short" quotes="true"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>

--- a/health-economics-policy-and-law.csl
+++ b/health-economics-policy-and-law.csl
@@ -45,14 +45,16 @@
         <names variable="editor"/>
         <names variable="translator"/>
         <text variable="container-title" font-style="italic"/>
-        <choose>
-          <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
-            <text variable="title" form="short" font-style="italic"/>
-          </if>
-          <else>
-            <text variable="title" form="short" quotes="true"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
+              <text variable="title" form="short" font-style="italic"/>
+            </if>
+            <else>
+              <text variable="title" form="short" quotes="true"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>

--- a/health-policy-and-planning.csl
+++ b/health-policy-and-planning.csl
@@ -41,14 +41,16 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="bill book graphic legal_case motion_picture report song" match="any">
-            <text variable="title" form="short" font-style="italic"/>
-          </if>
-          <else>
-            <text variable="title" form="short"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="bill book graphic legal_case motion_picture report song" match="any">
+              <text variable="title" form="short" font-style="italic"/>
+            </if>
+            <else>
+              <text variable="title" form="short"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>
@@ -58,14 +60,16 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="bill book graphic legal_case motion_picture report song" match="any">
-            <text variable="title" form="short" font-style="italic"/>
-          </if>
-          <else>
-            <text variable="title" form="short"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="bill book graphic legal_case motion_picture report song" match="any">
+              <text variable="title" form="short" font-style="italic"/>
+            </if>
+            <else>
+              <text variable="title" form="short"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>

--- a/heredity.csl
+++ b/heredity.csl
@@ -45,14 +45,16 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
-            <text variable="title" form="short" font-style="italic"/>
-          </if>
-          <else>
-            <text variable="title" form="short" quotes="true"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
+              <text variable="title" form="short" font-style="italic"/>
+            </if>
+            <else>
+              <text variable="title" form="short" quotes="true"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>

--- a/high-altitude-medicine-and-biology.csl
+++ b/high-altitude-medicine-and-biology.csl
@@ -25,14 +25,16 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
-            <text variable="title" form="short" font-style="italic"/>
-          </if>
-          <else>
-            <text variable="title" form="short" quotes="false"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
+              <text variable="title" form="short" font-style="italic"/>
+            </if>
+            <else>
+              <text variable="title" form="short" quotes="false"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>

--- a/hiob-ludolf-centre-for-ethiopian-studies-long-names.csl
+++ b/hiob-ludolf-centre-for-ethiopian-studies-long-names.csl
@@ -101,14 +101,16 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
-            <text variable="title" form="short" font-style="italic"/>
-          </if>
-          <else>
-            <text variable="title" form="short" quotes="false"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
+              <text variable="title" form="short" font-style="italic"/>
+            </if>
+            <else>
+              <text variable="title" form="short" quotes="false"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>
@@ -118,7 +120,7 @@
         <choose>
           <if match="any" variable="URL">
             <group prefix=" " suffix="">
-              <text variable="URL" prefix="&lt;" suffix="&gt;"/>
+              <text variable="URL" prefix="&lt;" suffix=">"/>
               <choose>
                 <if variable="accessed">
                   <text term="accessed" prefix=", "/>

--- a/hiob-ludolf-centre-for-ethiopian-studies-with-url-doi.csl
+++ b/hiob-ludolf-centre-for-ethiopian-studies-with-url-doi.csl
@@ -100,14 +100,16 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
-            <text variable="title" form="short" font-style="italic"/>
-          </if>
-          <else>
-            <text variable="title" form="short" quotes="false"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
+              <text variable="title" form="short" font-style="italic"/>
+            </if>
+            <else>
+              <text variable="title" form="short" quotes="false"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>
@@ -117,7 +119,7 @@
         <choose>
           <if match="any" variable="URL">
             <group prefix=" " suffix="">
-              <text variable="URL" prefix="&lt;" suffix="&gt;"/>
+              <text variable="URL" prefix="&lt;" suffix=">"/>
               <choose>
                 <if variable="accessed">
                   <text term="accessed" prefix=", "/>

--- a/hiob-ludolf-centre-for-ethiopian-studies.csl
+++ b/hiob-ludolf-centre-for-ethiopian-studies.csl
@@ -100,14 +100,16 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
-            <text variable="title" form="short" font-style="italic"/>
-          </if>
-          <else>
-            <text variable="title" form="short" quotes="false"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
+              <text variable="title" form="short" font-style="italic"/>
+            </if>
+            <else>
+              <text variable="title" form="short" quotes="false"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>
@@ -117,7 +119,7 @@
         <choose>
           <if match="any" variable="URL">
             <group prefix=" " suffix="">
-              <text variable="URL" prefix="&lt;" suffix="&gt;"/>
+              <text variable="URL" prefix="&lt;" suffix=">"/>
               <choose>
                 <if variable="accessed">
                   <text term="accessed" prefix=", "/>

--- a/history-of-the-human-sciences.csl
+++ b/history-of-the-human-sciences.csl
@@ -34,14 +34,16 @@
         <names variable="editor"/>
         <names variable="translator"/>
         <text variable="container-title" font-style="italic"/>
-        <choose>
-          <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
-            <text variable="title" form="short" font-style="italic"/>
-          </if>
-          <else>
-            <text variable="title" form="short" quotes="true"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
+              <text variable="title" form="short" font-style="italic"/>
+            </if>
+            <else>
+              <text variable="title" form="short" quotes="true"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>

--- a/hochschule-bonn-rhein-sieg.csl
+++ b/hochschule-bonn-rhein-sieg.csl
@@ -60,14 +60,16 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="bill book graphic legal_case motion_picture report song" match="any">
-            <text variable="title" form="short" font-style="italic"/>
-          </if>
-          <else>
-            <text variable="title" form="short" quotes="true"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="bill book graphic legal_case motion_picture report song" match="any">
+              <text variable="title" form="short" font-style="italic"/>
+            </if>
+            <else>
+              <text variable="title" form="short" quotes="true"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>

--- a/hochschule-munchen-fakultat-fur-angewandte-sozialwissenschaften.csl
+++ b/hochschule-munchen-fakultat-fur-angewandte-sozialwissenschaften.csl
@@ -95,14 +95,16 @@
           <substitute>
             <names variable="editor"/>
             <names variable="translator"/>
-            <choose>
-              <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
-                <text variable="title" form="short" font-style="italic"/>
-              </if>
-              <else>
-                <text variable="title" form="short"/>
-              </else>
-            </choose>
+            <group>
+              <choose>
+                <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
+                  <text variable="title" form="short" font-style="italic"/>
+                </if>
+                <else>
+                  <text variable="title" form="short"/>
+                </else>
+              </choose>
+            </group>
           </substitute>
         </names>
       </if>

--- a/human-reproduction.csl
+++ b/human-reproduction.csl
@@ -63,14 +63,16 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="book">
-            <text variable="title" form="short" font-style="italic"/>
-          </if>
-          <else>
-            <text variable="title" form="short" quotes="true"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="book">
+              <text variable="title" form="short" font-style="italic"/>
+            </if>
+            <else>
+              <text variable="title" form="short" quotes="true"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>

--- a/human-resource-management-journal.csl
+++ b/human-resource-management-journal.csl
@@ -56,14 +56,16 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
-            <text variable="title" form="short" font-style="italic"/>
-          </if>
-          <else>
-            <text variable="title" form="short" quotes="true"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
+              <text variable="title" form="short" font-style="italic"/>
+            </if>
+            <else>
+              <text variable="title" form="short" quotes="true"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>

--- a/humboldt-state-university-environmental-resources-engineering.csl
+++ b/humboldt-state-university-environmental-resources-engineering.csl
@@ -56,14 +56,16 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
-            <text variable="title" form="short" font-style="italic"/>
-          </if>
-          <else>
-            <text variable="title" form="short" quotes="true"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
+              <text variable="title" form="short" font-style="italic"/>
+            </if>
+            <else>
+              <text variable="title" form="short" quotes="true"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>
@@ -125,7 +127,7 @@
         <text variable="page"/>
       </else-if>
       <else-if type="webpage">
-        <text variable="URL" prefix="&lt;" suffix="&gt;"/>
+        <text variable="URL" prefix="&lt;" suffix=">"/>
       </else-if>
     </choose>
   </macro>

--- a/hydrobiologia.csl
+++ b/hydrobiologia.csl
@@ -37,14 +37,16 @@
         <names variable="editor"/>
         <names variable="translator"/>
         <text variable="container-title" font-style="normal"/>
-        <choose>
-          <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
-            <text variable="title" form="short" font-style="normal"/>
-          </if>
-          <else>
-            <text variable="title" form="short" quotes="true"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
+              <text variable="title" form="short" font-style="normal"/>
+            </if>
+            <else>
+              <text variable="title" form="short" quotes="true"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>

--- a/hydrological-processes.csl
+++ b/hydrological-processes.csl
@@ -50,14 +50,16 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="bill book graphic legal_case motion_picture report song" match="any">
-            <text variable="title" form="short" font-style="italic"/>
-          </if>
-          <else>
-            <text variable="title" form="short"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="bill book graphic legal_case motion_picture report song" match="any">
+              <text variable="title" form="short" font-style="italic"/>
+            </if>
+            <else>
+              <text variable="title" form="short"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>
@@ -67,14 +69,16 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="bill book graphic legal_case motion_picture report song" match="any">
-            <text variable="title" form="short" font-style="italic"/>
-          </if>
-          <else>
-            <text variable="title" form="short"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="bill book graphic legal_case motion_picture report song" match="any">
+              <text variable="title" form="short" font-style="italic"/>
+            </if>
+            <else>
+              <text variable="title" form="short"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>

--- a/hydrological-sciences-journal.csl
+++ b/hydrological-sciences-journal.csl
@@ -60,14 +60,16 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
-            <text variable="title" form="short" font-style="italic"/>
-          </if>
-          <else>
-            <text variable="title" form="short" quotes="true"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
+              <text variable="title" form="short" font-style="italic"/>
+            </if>
+            <else>
+              <text variable="title" form="short" quotes="true"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>

--- a/ices-journal-of-marine-science.csl
+++ b/ices-journal-of-marine-science.csl
@@ -71,14 +71,16 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
-            <text variable="title" form="short" font-style="italic"/>
-          </if>
-          <else>
-            <text variable="title" form="short" quotes="true"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
+              <text variable="title" form="short" font-style="italic"/>
+            </if>
+            <else>
+              <text variable="title" form="short" quotes="true"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>

--- a/idojaras-quarterly-journal-of-the-hungarian-meteorological-service.csl
+++ b/idojaras-quarterly-journal-of-the-hungarian-meteorological-service.csl
@@ -68,14 +68,16 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
-            <text variable="title" form="short" font-style="italic"/>
-          </if>
-          <else>
-            <text variable="title" form="short" quotes="true"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
+              <text variable="title" form="short" font-style="italic"/>
+            </if>
+            <else>
+              <text variable="title" form="short" quotes="true"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>

--- a/iforest.csl
+++ b/iforest.csl
@@ -64,15 +64,17 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="report">
-            <text variable="publisher"/>
-            <text macro="title"/>
-          </if>
-          <else>
-            <text macro="title"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="report">
+              <text variable="publisher"/>
+              <text macro="title"/>
+            </if>
+            <else>
+              <text macro="title"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>
@@ -82,34 +84,36 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="report">
-            <text variable="publisher"/>
-            <text variable="title" form="short" font-style="italic"/>
-          </if>
-          <else-if type="legal_case">
-            <text variable="title" font-style="italic"/>
-          </else-if>
-          <else-if type="book graphic  motion_picture song" match="any">
-            <text variable="title" form="short" font-style="italic"/>
-          </else-if>
-          <else-if type="bill legislation" match="any">
-            <text variable="title" form="short"/>
-          </else-if>
-          <else-if variable="reviewed-author">
-            <choose>
-              <if variable="reviewed-title" match="none">
-                <text variable="title" form="short" font-style="italic" prefix="Review of "/>
-              </if>
-              <else>
-                <text variable="title" form="short" quotes="true"/>
-              </else>
-            </choose>
-          </else-if>
-          <else>
-            <text variable="title" form="short" quotes="false"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="report">
+              <text variable="publisher"/>
+              <text variable="title" form="short" font-style="italic"/>
+            </if>
+            <else-if type="legal_case">
+              <text variable="title" font-style="italic"/>
+            </else-if>
+            <else-if type="book graphic  motion_picture song" match="any">
+              <text variable="title" form="short" font-style="italic"/>
+            </else-if>
+            <else-if type="bill legislation" match="any">
+              <text variable="title" form="short"/>
+            </else-if>
+            <else-if variable="reviewed-author">
+              <choose>
+                <if variable="reviewed-title" match="none">
+                  <text variable="title" form="short" font-style="italic" prefix="Review of "/>
+                </if>
+                <else>
+                  <text variable="title" form="short" quotes="true"/>
+                </else>
+              </choose>
+            </else-if>
+            <else>
+              <text variable="title" form="short" quotes="false"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>
@@ -446,7 +450,7 @@
             <else>
               <group>
                 <text term="volume" form="short" plural="true" text-case="capitalize-first" suffix=" "/>
-                <number variable="number-of-volumes" form="numeric" prefix="1&#8211;"/>
+                <number variable="number-of-volumes" form="numeric" prefix="1–"/>
               </group>
             </else>
           </choose>

--- a/indiana.csl
+++ b/indiana.csl
@@ -51,15 +51,17 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="report">
-            <text variable="publisher"/>
-            <text macro="title"/>
-          </if>
-          <else>
-            <text macro="title"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="report">
+              <text variable="publisher"/>
+              <text macro="title"/>
+            </if>
+            <else>
+              <text macro="title"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>
@@ -69,18 +71,20 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="report">
-            <text variable="publisher"/>
-            <text variable="title" form="short" font-style="italic"/>
-          </if>
-          <else-if type="bill book graphic legal_case legislation motion_picture song" match="any">
-            <text variable="title" form="short" font-style="italic"/>
-          </else-if>
-          <else>
-            <text variable="title" form="short" quotes="true"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="report">
+              <text variable="publisher"/>
+              <text variable="title" form="short" font-style="italic"/>
+            </if>
+            <else-if type="bill book graphic legal_case legislation motion_picture song" match="any">
+              <text variable="title" form="short" font-style="italic"/>
+            </else-if>
+            <else>
+              <text variable="title" form="short" quotes="true"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>
@@ -267,7 +271,7 @@
       </else-if>
       <else-if type="webpage post-weblog" match="any">
         <group delimiter=" ">
-          <text variable="URL" prefix=" &lt;" suffix="&gt;"/>
+          <text variable="URL" prefix=" &lt;" suffix=">"/>
           <date variable="accessed" prefix="(" suffix=")">
             <date-part name="day"/>
             <date-part name="month" prefix="." form="short" strip-periods="true"/>

--- a/information-systems-journal.csl
+++ b/information-systems-journal.csl
@@ -65,15 +65,17 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="report">
-            <text variable="publisher"/>
-            <text macro="title"/>
-          </if>
-          <else>
-            <text macro="title"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="report">
+              <text variable="publisher"/>
+              <text macro="title"/>
+            </if>
+            <else>
+              <text macro="title"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>
@@ -84,31 +86,33 @@
       <substitute>
         <names variable="editor" font-style="normal"/>
         <names variable="translator"/>
-        <choose>
-          <if type="report">
-            <text variable="publisher"/>
-            <text variable="title" form="short" font-style="italic"/>
-          </if>
-          <else-if type="legal_case">
-            <text variable="title" font-style="italic"/>
-          </else-if>
-          <else-if type="bill book graphic legislation motion_picture song" match="any">
-            <text variable="title" form="short" font-style="italic"/>
-          </else-if>
-          <else-if variable="reviewed-author">
-            <choose>
-              <if variable="reviewed-title" match="none">
-                <text variable="title" form="short" font-style="italic" prefix="Review of "/>
-              </if>
-              <else>
-                <text variable="title" form="short" quotes="true"/>
-              </else>
-            </choose>
-          </else-if>
-          <else>
-            <text variable="title" form="short" quotes="true"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="report">
+              <text variable="publisher"/>
+              <text variable="title" form="short" font-style="italic"/>
+            </if>
+            <else-if type="legal_case">
+              <text variable="title" font-style="italic"/>
+            </else-if>
+            <else-if type="bill book graphic legislation motion_picture song" match="any">
+              <text variable="title" form="short" font-style="italic"/>
+            </else-if>
+            <else-if variable="reviewed-author">
+              <choose>
+                <if variable="reviewed-title" match="none">
+                  <text variable="title" form="short" font-style="italic" prefix="Review of "/>
+                </if>
+                <else>
+                  <text variable="title" form="short" quotes="true"/>
+                </else>
+              </choose>
+            </else-if>
+            <else>
+              <text variable="title" form="short" quotes="true"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>
@@ -452,7 +456,7 @@
             <else>
               <group>
                 <text term="volume" form="short" plural="true" text-case="capitalize-first" suffix=" "/>
-                <number variable="number-of-volumes" form="numeric" prefix="1&#8211;"/>
+                <number variable="number-of-volumes" form="numeric" prefix="1–"/>
               </group>
             </else>
           </choose>

--- a/instap-academic-press.csl
+++ b/instap-academic-press.csl
@@ -81,14 +81,16 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
-            <text variable="title" form="short" font-style="italic"/>
-          </if>
-          <else>
-            <text variable="title" form="short" quotes="true"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
+              <text variable="title" form="short" font-style="italic"/>
+            </if>
+            <else>
+              <text variable="title" form="short" quotes="true"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>
@@ -302,7 +304,7 @@
       </group>
     </layout>
   </citation>
-  <bibliography subsequent-author-substitute="&#8212;&#8212;&#8212;" entry-spacing="1" hanging-indent="true">
+  <bibliography subsequent-author-substitute="———" entry-spacing="1" hanging-indent="true">
     <sort>
       <key macro="author"/>
       <key variable="issued"/>

--- a/institut-teknologi-bandung-sekolah-pascasarjana.csl
+++ b/institut-teknologi-bandung-sekolah-pascasarjana.csl
@@ -116,15 +116,17 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="report">
-            <text variable="publisher"/>
-            <text macro="title"/>
-          </if>
-          <else>
-            <text macro="title"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="report">
+              <text variable="publisher"/>
+              <text macro="title"/>
+            </if>
+            <else>
+              <text macro="title"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
     <choose>
@@ -147,34 +149,36 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="report">
-            <text variable="publisher"/>
-            <text variable="title" form="short" font-style="italic"/>
-          </if>
-          <else-if type="legal_case">
-            <text variable="title" font-style="italic"/>
-          </else-if>
-          <else-if type="bill book graphic legislation motion_picture song" match="any">
-            <text variable="title" form="short" font-style="italic"/>
-          </else-if>
-          <else-if variable="reviewed-author">
-            <choose>
-              <if variable="reviewed-title" match="none">
-                <text variable="title" form="short" font-style="italic" prefix="Review of "/>
-              </if>
-              <else>
-                <text variable="title" form="short" quotes="true"/>
-              </else>
-            </choose>
-          </else-if>
-          <else-if match="any" variable="container-title">
-            <text variable="container-title"/>
-          </else-if>
-          <else>
-            <text variable="title" form="short" quotes="true"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="report">
+              <text variable="publisher"/>
+              <text variable="title" form="short" font-style="italic"/>
+            </if>
+            <else-if type="legal_case">
+              <text variable="title" font-style="italic"/>
+            </else-if>
+            <else-if type="bill book graphic legislation motion_picture song" match="any">
+              <text variable="title" form="short" font-style="italic"/>
+            </else-if>
+            <else-if variable="reviewed-author">
+              <choose>
+                <if variable="reviewed-title" match="none">
+                  <text variable="title" form="short" font-style="italic" prefix="Review of "/>
+                </if>
+                <else>
+                  <text variable="title" form="short" quotes="true"/>
+                </else>
+              </choose>
+            </else-if>
+            <else-if match="any" variable="container-title">
+              <text variable="container-title"/>
+            </else-if>
+            <else>
+              <text variable="title" form="short" quotes="true"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>
@@ -554,7 +558,7 @@
             <else>
               <group>
                 <text term="volume" form="short" plural="true" text-case="capitalize-first" suffix=" "/>
-                <number variable="number-of-volumes" form="numeric" prefix="1&#8211;"/>
+                <number variable="number-of-volumes" form="numeric" prefix="1–"/>
               </group>
             </else>
           </choose>

--- a/institute-of-mathematics-and-its-applications.csl
+++ b/institute-of-mathematics-and-its-applications.csl
@@ -35,14 +35,16 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
-            <text variable="title" form="short" font-style="italic"/>
-          </if>
-          <else>
-            <text variable="title" form="short" quotes="true"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
+              <text variable="title" form="short" font-style="italic"/>
+            </if>
+            <else>
+              <text variable="title" form="short" quotes="true"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>

--- a/integrative-and-comparative-biology.csl
+++ b/integrative-and-comparative-biology.csl
@@ -62,14 +62,16 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
-            <text variable="title" form="short" font-style="italic"/>
-          </if>
-          <else>
-            <text variable="title" form="short" quotes="true"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
+              <text variable="title" form="short" font-style="italic"/>
+            </if>
+            <else>
+              <text variable="title" form="short" quotes="true"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>

--- a/international-biodeterioration-and-biodegradation.csl
+++ b/international-biodeterioration-and-biodegradation.csl
@@ -59,14 +59,16 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
-            <text variable="title" form="short" font-style="italic"/>
-          </if>
-          <else>
-            <text variable="title" form="short" quotes="true"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
+              <text variable="title" form="short" font-style="italic"/>
+            </if>
+            <else>
+              <text variable="title" form="short" quotes="true"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>

--- a/international-development-policy.csl
+++ b/international-development-policy.csl
@@ -52,14 +52,16 @@
       <et-al font-style="italic"/>
       <substitute>
         <names variable="editor"/>
-        <choose>
-          <if type="article-newspaper article-magazine" match="any">
-            <text variable="container-title" text-case="title" font-style="italic"/>
-          </if>
-          <else>
-            <text macro="title"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="article-newspaper article-magazine" match="any">
+              <text variable="container-title" text-case="title" font-style="italic"/>
+            </if>
+            <else>
+              <text macro="title"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>
@@ -69,14 +71,16 @@
       <et-al font-style="normal"/>
       <substitute>
         <names variable="editor"/>
-        <choose>
-          <if type="article-newspaper article-magazine" match="any">
-            <text variable="container-title" text-case="title" font-style="italic"/>
-          </if>
-          <else>
-            <text macro="title"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="article-newspaper article-magazine" match="any">
+              <text variable="container-title" text-case="title" font-style="italic"/>
+            </if>
+            <else>
+              <text macro="title"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>

--- a/international-energy-agency-organisation-for-economic-co-operation-and-development.csl
+++ b/international-energy-agency-organisation-for-economic-co-operation-and-development.csl
@@ -55,14 +55,16 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="bill book graphic legal_case motion_picture report song" match="any">
-            <text variable="title" form="short" font-style="italic"/>
-          </if>
-          <else>
-            <text variable="title" form="short" quotes="true"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="bill book graphic legal_case motion_picture report song" match="any">
+              <text variable="title" form="short" font-style="italic"/>
+            </if>
+            <else>
+              <text variable="title" form="short" quotes="true"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>

--- a/international-journal-of-climatology.csl
+++ b/international-journal-of-climatology.csl
@@ -38,14 +38,16 @@
         <names variable="editor"/>
         <names variable="translator"/>
         <text variable="container-title" font-style="italic"/>
-        <choose>
-          <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
-            <text variable="title" form="short" font-style="italic"/>
-          </if>
-          <else>
-            <text variable="title" form="short" quotes="true"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
+              <text variable="title" form="short" font-style="italic"/>
+            </if>
+            <else>
+              <text variable="title" form="short" quotes="true"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>

--- a/international-journal-of-food-science-and-technology.csl
+++ b/international-journal-of-food-science-and-technology.csl
@@ -55,14 +55,16 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
-            <text variable="title" form="short" font-style="italic"/>
-          </if>
-          <else>
-            <text variable="title" form="short" quotes="true"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
+              <text variable="title" form="short" font-style="italic"/>
+            </if>
+            <else>
+              <text variable="title" form="short" quotes="true"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>

--- a/international-journal-of-language-and-communication-disorders.csl
+++ b/international-journal-of-language-and-communication-disorders.csl
@@ -82,14 +82,16 @@
           <substitute>
             <names variable="editor"/>
             <names variable="translator"/>
-            <choose>
-              <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
-                <text variable="title" form="short" font-style="italic"/>
-              </if>
-              <else>
-                <text variable="title" form="short"/>
-              </else>
-            </choose>
+            <group>
+              <choose>
+                <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
+                  <text variable="title" form="short" font-style="italic"/>
+                </if>
+                <else>
+                  <text variable="title" form="short"/>
+                </else>
+              </choose>
+            </group>
           </substitute>
         </names>
       </if>

--- a/international-journal-of-management-reviews.csl
+++ b/international-journal-of-management-reviews.csl
@@ -56,15 +56,17 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="report">
-            <text variable="publisher"/>
-            <text macro="title"/>
-          </if>
-          <else>
-            <text macro="title"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="report">
+              <text variable="publisher"/>
+              <text macro="title"/>
+            </if>
+            <else>
+              <text macro="title"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>
@@ -75,18 +77,20 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="report">
-            <text variable="publisher"/>
-            <text variable="title" form="short" font-style="italic"/>
-          </if>
-          <else-if type="bill book graphic legal_case legislation motion_picture song" match="any">
-            <text variable="title" form="short" font-style="italic"/>
-          </else-if>
-          <else>
-            <text variable="title" form="short" quotes="false"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="report">
+              <text variable="publisher"/>
+              <text variable="title" form="short" font-style="italic"/>
+            </if>
+            <else-if type="bill book graphic legal_case legislation motion_picture song" match="any">
+              <text variable="title" form="short" font-style="italic"/>
+            </else-if>
+            <else>
+              <text variable="title" form="short" quotes="false"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>

--- a/international-journal-of-simulation-modelling.csl
+++ b/international-journal-of-simulation-modelling.csl
@@ -51,15 +51,17 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="report">
-            <text variable="publisher"/>
-            <text macro="title"/>
-          </if>
-          <else>
-            <text macro="title"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="report">
+              <text variable="publisher"/>
+              <text macro="title"/>
+            </if>
+            <else>
+              <text macro="title"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>

--- a/international-journal-of-urban-and-regional-research.csl
+++ b/international-journal-of-urban-and-regional-research.csl
@@ -53,15 +53,17 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="report">
-            <text variable="publisher"/>
-            <text macro="title"/>
-          </if>
-          <else>
-            <text macro="title"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="report">
+              <text variable="publisher"/>
+              <text macro="title"/>
+            </if>
+            <else>
+              <text macro="title"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>
@@ -96,18 +98,20 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="report">
-            <text variable="publisher"/>
-            <text variable="title" form="short" font-style="italic"/>
-          </if>
-          <else-if type="bill book graphic legal_case legislation motion_picture song" match="any">
-            <text variable="title" form="short" font-style="italic"/>
-          </else-if>
-          <else>
-            <text variable="title" form="short" quotes="true"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="report">
+              <text variable="publisher"/>
+              <text variable="title" form="short" font-style="italic"/>
+            </if>
+            <else-if type="bill book graphic legal_case legislation motion_picture song" match="any">
+              <text variable="title" form="short" font-style="italic"/>
+            </else-if>
+            <else>
+              <text variable="title" form="short" quotes="true"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>

--- a/international-journal-of-wildland-fire.csl
+++ b/international-journal-of-wildland-fire.csl
@@ -58,14 +58,16 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
-            <text variable="title" form="short"/>
-          </if>
-          <else>
-            <text variable="title" form="short" quotes="true"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
+              <text variable="title" form="short"/>
+            </if>
+            <else>
+              <text variable="title" form="short" quotes="true"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>

--- a/ipag-business-school-apa.csl
+++ b/ipag-business-school-apa.csl
@@ -66,15 +66,17 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="report">
-            <text variable="publisher"/>
-            <text macro="title"/>
-          </if>
-          <else>
-            <text macro="title"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="report">
+              <text variable="publisher"/>
+              <text macro="title"/>
+            </if>
+            <else>
+              <text macro="title"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>
@@ -89,34 +91,36 @@
           <substitute>
             <names variable="editor"/>
             <names variable="translator"/>
-            <choose>
-              <if type="report">
-                <text variable="publisher"/>
-                <text variable="title" form="short" font-style="italic"/>
-              </if>
-              <else-if type="legal_case">
-                <text variable="title" font-style="italic"/>
-              </else-if>
-              <else-if type="book graphic  motion_picture song" match="any">
-                <text variable="title" form="short" font-style="italic"/>
-              </else-if>
-              <else-if type="bill legislation" match="any">
-                <text variable="title" form="short"/>
-              </else-if>
-              <else-if variable="reviewed-author">
-                <choose>
-                  <if variable="reviewed-title" match="none">
-                    <text variable="title" form="short" font-style="italic" prefix="Review of "/>
-                  </if>
-                  <else>
-                    <text variable="title" form="short" quotes="true"/>
-                  </else>
-                </choose>
-              </else-if>
-              <else>
-                <text variable="title" form="short" quotes="true"/>
-              </else>
-            </choose>
+            <group>
+              <choose>
+                <if type="report">
+                  <text variable="publisher"/>
+                  <text variable="title" form="short" font-style="italic"/>
+                </if>
+                <else-if type="legal_case">
+                  <text variable="title" font-style="italic"/>
+                </else-if>
+                <else-if type="book graphic  motion_picture song" match="any">
+                  <text variable="title" form="short" font-style="italic"/>
+                </else-if>
+                <else-if type="bill legislation" match="any">
+                  <text variable="title" form="short"/>
+                </else-if>
+                <else-if variable="reviewed-author">
+                  <choose>
+                    <if variable="reviewed-title" match="none">
+                      <text variable="title" form="short" font-style="italic" prefix="Review of "/>
+                    </if>
+                    <else>
+                      <text variable="title" form="short" quotes="true"/>
+                    </else>
+                  </choose>
+                </else-if>
+                <else>
+                  <text variable="title" form="short" quotes="true"/>
+                </else>
+              </choose>
+            </group>
           </substitute>
         </names>
       </else>
@@ -565,7 +569,7 @@
             <else>
               <group>
                 <text term="volume" form="short" plural="true" text-case="capitalize-first" suffix=" "/>
-                <number variable="number-of-volumes" form="numeric" prefix="1&#8211;"/>
+                <number variable="number-of-volumes" form="numeric" prefix="1–"/>
               </group>
             </else>
           </choose>

--- a/johnson-matthey-technology-review.csl
+++ b/johnson-matthey-technology-review.csl
@@ -43,17 +43,19 @@
       <label suffix=" " form="short"/>
       <name delimiter=", " initialize-with=". " delimiter-precedes-last="never" and="text" et-al-min="100" et-al-use-first="99"/>
       <substitute>
-        <choose>
-          <if type="report">
-            <text variable="publisher"/>
-            <text macro="title"/>
-          </if>
-          <else>
-            <text macro="title"/>
-            <names variable="editor"/>
-            <names variable="translator"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="report">
+              <text variable="publisher"/>
+              <text macro="title"/>
+            </if>
+            <else>
+              <text macro="title"/>
+              <names variable="editor"/>
+              <names variable="translator"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>

--- a/journal-for-veterinary-medicine-biotechnology-and-biosafety.csl
+++ b/journal-for-veterinary-medicine-biotechnology-and-biosafety.csl
@@ -70,14 +70,16 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="article-newspaper article-magazine" match="any">
-            <text variable="container-title" text-case="title" font-style="italic"/>
-          </if>
-          <else>
-            <text macro="title"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="article-newspaper article-magazine" match="any">
+              <text variable="container-title" text-case="title" font-style="italic"/>
+            </if>
+            <else>
+              <text macro="title"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>
@@ -88,14 +90,16 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="article-newspaper article-magazine" match="any">
-            <text variable="container-title" text-case="title" font-style="italic"/>
-          </if>
-          <else>
-            <text macro="title"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="article-newspaper article-magazine" match="any">
+              <text variable="container-title" text-case="title" font-style="italic"/>
+            </if>
+            <else>
+              <text macro="title"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>

--- a/journal-of-agricultural-and-applied-economics.csl
+++ b/journal-of-agricultural-and-applied-economics.csl
@@ -67,15 +67,17 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="report">
-            <text variable="publisher"/>
-            <text macro="title"/>
-          </if>
-          <else>
-            <text macro="title"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="report">
+              <text variable="publisher"/>
+              <text macro="title"/>
+            </if>
+            <else>
+              <text macro="title"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>
@@ -90,34 +92,36 @@
           <substitute>
             <names variable="editor"/>
             <names variable="translator"/>
-            <choose>
-              <if type="report">
-                <text variable="publisher"/>
-                <text variable="title" form="short" font-style="italic"/>
-              </if>
-              <else-if type="legal_case">
-                <text variable="title" font-style="italic"/>
-              </else-if>
-              <else-if type="book graphic  motion_picture song" match="any">
-                <text variable="title" form="short" font-style="italic"/>
-              </else-if>
-              <else-if type="bill legislation" match="any">
-                <text variable="title" form="short"/>
-              </else-if>
-              <else-if variable="reviewed-author">
-                <choose>
-                  <if variable="reviewed-title" match="none">
-                    <text variable="title" form="short" font-style="italic" prefix="Review of "/>
-                  </if>
-                  <else>
-                    <text variable="title" form="short" quotes="true"/>
-                  </else>
-                </choose>
-              </else-if>
-              <else>
-                <text variable="title" form="short" quotes="true"/>
-              </else>
-            </choose>
+            <group>
+              <choose>
+                <if type="report">
+                  <text variable="publisher"/>
+                  <text variable="title" form="short" font-style="italic"/>
+                </if>
+                <else-if type="legal_case">
+                  <text variable="title" font-style="italic"/>
+                </else-if>
+                <else-if type="book graphic  motion_picture song" match="any">
+                  <text variable="title" form="short" font-style="italic"/>
+                </else-if>
+                <else-if type="bill legislation" match="any">
+                  <text variable="title" form="short"/>
+                </else-if>
+                <else-if variable="reviewed-author">
+                  <choose>
+                    <if variable="reviewed-title" match="none">
+                      <text variable="title" form="short" font-style="italic" prefix="Review of "/>
+                    </if>
+                    <else>
+                      <text variable="title" form="short" quotes="true"/>
+                    </else>
+                  </choose>
+                </else-if>
+                <else>
+                  <text variable="title" form="short" quotes="true"/>
+                </else>
+              </choose>
+            </group>
           </substitute>
         </names>
       </else>
@@ -473,7 +477,7 @@
             <else>
               <group>
                 <text term="volume" form="short" plural="true" text-case="capitalize-first" suffix=" "/>
-                <number variable="number-of-volumes" form="numeric" prefix="1&#8211;"/>
+                <number variable="number-of-volumes" form="numeric" prefix="1–"/>
               </group>
             </else>
           </choose>

--- a/journal-of-animal-physiology-and-animal-nutrition.csl
+++ b/journal-of-animal-physiology-and-animal-nutrition.csl
@@ -57,15 +57,17 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="report">
-            <text variable="publisher"/>
-            <text macro="title"/>
-          </if>
-          <else>
-            <text macro="title"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="report">
+              <text variable="publisher"/>
+              <text macro="title"/>
+            </if>
+            <else>
+              <text macro="title"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>
@@ -75,18 +77,20 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="report">
-            <text variable="publisher"/>
-            <text variable="title" form="short" font-style="italic"/>
-          </if>
-          <else-if type="bill book graphic legal_case motion_picture song" match="any">
-            <text variable="title" form="short" font-style="italic"/>
-          </else-if>
-          <else>
-            <text variable="title" form="short" quotes="true"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="report">
+              <text variable="publisher"/>
+              <text variable="title" form="short" font-style="italic"/>
+            </if>
+            <else-if type="bill book graphic legal_case motion_picture song" match="any">
+              <text variable="title" form="short" font-style="italic"/>
+            </else-if>
+            <else>
+              <text variable="title" form="short" quotes="true"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>

--- a/journal-of-applied-entomology.csl
+++ b/journal-of-applied-entomology.csl
@@ -70,14 +70,16 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
-            <text variable="title" form="short" font-style="italic"/>
-          </if>
-          <else>
-            <text variable="title" form="short" quotes="true"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
+              <text variable="title" form="short" font-style="italic"/>
+            </if>
+            <else>
+              <text variable="title" form="short" quotes="true"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>

--- a/journal-of-avian-biology.csl
+++ b/journal-of-avian-biology.csl
@@ -52,14 +52,16 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="book">
-            <text variable="title" form="short"/>
-          </if>
-          <else>
-            <text variable="title" form="short" quotes="true"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="book">
+              <text variable="title" form="short"/>
+            </if>
+            <else>
+              <text variable="title" form="short" quotes="true"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>

--- a/journal-of-comparative-pathology.csl
+++ b/journal-of-comparative-pathology.csl
@@ -45,14 +45,16 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="bill book graphic legal_case motion_picture report song" match="any">
-            <text variable="title" form="short" font-style="italic"/>
-          </if>
-          <else>
-            <text variable="title" form="short" quotes="true"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="bill book graphic legal_case motion_picture report song" match="any">
+              <text variable="title" form="short" font-style="italic"/>
+            </if>
+            <else>
+              <text variable="title" form="short" quotes="true"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>
@@ -62,14 +64,16 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="bill book graphic legal_case motion_picture report song" match="any">
-            <text variable="title" form="short" font-style="italic"/>
-          </if>
-          <else>
-            <text variable="title" form="short" quotes="true"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="bill book graphic legal_case motion_picture report song" match="any">
+              <text variable="title" form="short" font-style="italic"/>
+            </if>
+            <else>
+              <text variable="title" form="short" quotes="true"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>

--- a/journal-of-computer-applications-in-archaeology.csl
+++ b/journal-of-computer-applications-in-archaeology.csl
@@ -39,11 +39,13 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="report" match="any">
-            <text variable="publisher"/>
-          </if>
-        </choose>
+        <group>
+          <choose>
+            <if type="report" match="any">
+              <text variable="publisher"/>
+            </if>
+          </choose>
+        </group>
         <text macro="anon"/>
       </substitute>
     </names>
@@ -54,11 +56,13 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="report" match="any">
-            <text variable="publisher"/>
-          </if>
-        </choose>
+        <group>
+          <choose>
+            <if type="report" match="any">
+              <text variable="publisher"/>
+            </if>
+          </choose>
+        </group>
         <text macro="anon"/>
       </substitute>
     </names>

--- a/journal-of-experimental-botany.csl
+++ b/journal-of-experimental-botany.csl
@@ -42,14 +42,16 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
-            <text variable="title" form="short" font-style="italic"/>
-          </if>
-          <else>
-            <text variable="title" form="short" quotes="true"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
+              <text variable="title" form="short" font-style="italic"/>
+            </if>
+            <else>
+              <text variable="title" form="short" quotes="true"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>

--- a/journal-of-historical-linguistics.csl
+++ b/journal-of-historical-linguistics.csl
@@ -50,14 +50,16 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
-            <text variable="title" form="short" font-style="italic"/>
-          </if>
-          <else>
-            <text variable="title" form="short" quotes="true"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
+              <text variable="title" form="short" font-style="italic"/>
+            </if>
+            <else>
+              <text variable="title" form="short" quotes="true"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>

--- a/journal-of-human-evolution.csl
+++ b/journal-of-human-evolution.csl
@@ -59,14 +59,16 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
-            <text variable="title" form="short" font-style="italic"/>
-          </if>
-          <else>
-            <text variable="title" form="short" quotes="true"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
+              <text variable="title" form="short" font-style="italic"/>
+            </if>
+            <else>
+              <text variable="title" form="short" quotes="true"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>

--- a/journal-of-information-technology.csl
+++ b/journal-of-information-technology.csl
@@ -45,15 +45,17 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="report">
-            <text variable="publisher"/>
-            <text macro="title"/>
-          </if>
-          <else>
-            <text macro="title"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="report">
+              <text variable="publisher"/>
+              <text macro="title"/>
+            </if>
+            <else>
+              <text macro="title"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>
@@ -64,18 +66,20 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="report">
-            <text variable="publisher"/>
-            <text variable="title" form="short" font-style="italic"/>
-          </if>
-          <else-if type="bill book graphic legal_case legislation motion_picture song" match="any">
-            <text variable="title" form="short" font-style="italic"/>
-          </else-if>
-          <else>
-            <text variable="title" form="short" quotes="true"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="report">
+              <text variable="publisher"/>
+              <text variable="title" form="short" font-style="italic"/>
+            </if>
+            <else-if type="bill book graphic legal_case legislation motion_picture song" match="any">
+              <text variable="title" form="short" font-style="italic"/>
+            </else-if>
+            <else>
+              <text variable="title" form="short" quotes="true"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>

--- a/journal-of-international-business-studies.csl
+++ b/journal-of-international-business-studies.csl
@@ -57,14 +57,16 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
-            <text variable="title" form="short" font-style="italic"/>
-          </if>
-          <else>
-            <text variable="title" form="short" quotes="true"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
+              <text variable="title" form="short" font-style="italic"/>
+            </if>
+            <else>
+              <text variable="title" form="short" quotes="true"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>

--- a/journal-of-management-studies.csl
+++ b/journal-of-management-studies.csl
@@ -57,14 +57,16 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
-            <text variable="title" form="short" font-style="italic"/>
-          </if>
-          <else>
-            <text variable="title" form="short" quotes="true"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
+              <text variable="title" form="short" font-style="italic"/>
+            </if>
+            <else>
+              <text variable="title" form="short" quotes="true"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>

--- a/journal-of-management.csl
+++ b/journal-of-management.csl
@@ -57,15 +57,17 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="report">
-            <text variable="publisher"/>
-            <text macro="title"/>
-          </if>
-          <else>
-            <text macro="title"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="report">
+              <text variable="publisher"/>
+              <text macro="title"/>
+            </if>
+            <else>
+              <text macro="title"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>
@@ -75,18 +77,20 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="report">
-            <text variable="publisher"/>
-            <text variable="title" form="short" font-style="italic"/>
-          </if>
-          <else-if type="bill book graphic legal_case legislation motion_picture song" match="any">
-            <text variable="title" form="short" font-style="italic"/>
-          </else-if>
-          <else>
-            <text variable="title" form="short" quotes="true"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="report">
+              <text variable="publisher"/>
+              <text variable="title" form="short" font-style="italic"/>
+            </if>
+            <else-if type="bill book graphic legal_case legislation motion_picture song" match="any">
+              <text variable="title" form="short" font-style="italic"/>
+            </else-if>
+            <else>
+              <text variable="title" form="short" quotes="true"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>

--- a/journal-of-molecular-endocrinology.csl
+++ b/journal-of-molecular-endocrinology.csl
@@ -25,14 +25,16 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="book graphic legal_case motion_picture report song" match="any">
-            <text variable="title" form="short" font-style="italic"/>
-          </if>
-          <else>
-            <text variable="title" form="short" quotes="true"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="book graphic legal_case motion_picture report song" match="any">
+              <text variable="title" form="short" font-style="italic"/>
+            </if>
+            <else>
+              <text variable="title" form="short" quotes="true"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>
@@ -43,14 +45,16 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="book graphic legal_case motion_picture report song" match="any">
-            <text variable="title" form="short" font-style="italic"/>
-          </if>
-          <else>
-            <text variable="title" form="short" quotes="true"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="book graphic legal_case motion_picture report song" match="any">
+              <text variable="title" form="short" font-style="italic"/>
+            </if>
+            <else>
+              <text variable="title" form="short" quotes="true"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>

--- a/journal-of-music-technology-and-education.csl
+++ b/journal-of-music-technology-and-education.csl
@@ -66,15 +66,17 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="report">
-            <text variable="publisher"/>
-            <text macro="title"/>
-          </if>
-          <else>
-            <text macro="title"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="report">
+              <text variable="publisher"/>
+              <text macro="title"/>
+            </if>
+            <else>
+              <text macro="title"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>
@@ -84,31 +86,33 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="report">
-            <text variable="publisher"/>
-            <text variable="title" form="short" font-style="italic"/>
-          </if>
-          <else-if type="legal_case">
-            <text variable="title" font-style="italic"/>
-          </else-if>
-          <else-if type="bill book graphic legislation motion_picture song" match="any">
-            <text variable="title" form="short" font-style="italic"/>
-          </else-if>
-          <else-if variable="reviewed-author">
-            <choose>
-              <if variable="reviewed-title" match="none">
-                <text variable="title" form="short" font-style="italic" prefix="Review of "/>
-              </if>
-              <else>
-                <text variable="title" form="short" quotes="true"/>
-              </else>
-            </choose>
-          </else-if>
-          <else>
-            <text variable="title" form="short" quotes="true"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="report">
+              <text variable="publisher"/>
+              <text variable="title" form="short" font-style="italic"/>
+            </if>
+            <else-if type="legal_case">
+              <text variable="title" font-style="italic"/>
+            </else-if>
+            <else-if type="bill book graphic legislation motion_picture song" match="any">
+              <text variable="title" form="short" font-style="italic"/>
+            </else-if>
+            <else-if variable="reviewed-author">
+              <choose>
+                <if variable="reviewed-title" match="none">
+                  <text variable="title" form="short" font-style="italic" prefix="Review of "/>
+                </if>
+                <else>
+                  <text variable="title" form="short" quotes="true"/>
+                </else>
+              </choose>
+            </else-if>
+            <else>
+              <text variable="title" form="short" quotes="true"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>
@@ -438,7 +442,7 @@
             <else>
               <group>
                 <text term="volume" form="short" plural="true" text-case="capitalize-first" suffix=" "/>
-                <number variable="number-of-volumes" form="numeric" prefix="1&#8211;"/>
+                <number variable="number-of-volumes" form="numeric" prefix="1–"/>
               </group>
             </else>
           </choose>

--- a/journal-of-plant-ecology.csl
+++ b/journal-of-plant-ecology.csl
@@ -47,14 +47,16 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
-            <text variable="title" form="short" font-style="italic"/>
-          </if>
-          <else>
-            <text variable="title" form="short" quotes="true"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
+              <text variable="title" form="short" font-style="italic"/>
+            </if>
+            <else>
+              <text variable="title" form="short" quotes="true"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>

--- a/journal-of-plant-nutrition-and-soil-science.csl
+++ b/journal-of-plant-nutrition-and-soil-science.csl
@@ -61,14 +61,16 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
-            <text variable="title" form="short" font-style="italic"/>
-          </if>
-          <else>
-            <text variable="title" form="short" quotes="true"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
+              <text variable="title" form="short" font-style="italic"/>
+            </if>
+            <else>
+              <text variable="title" form="short" quotes="true"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>

--- a/journal-of-psychiatric-and-mental-health-nursing.csl
+++ b/journal-of-psychiatric-and-mental-health-nursing.csl
@@ -53,15 +53,17 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="report">
-            <text variable="publisher"/>
-            <text macro="title"/>
-          </if>
-          <else>
-            <text macro="title"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="report">
+              <text variable="publisher"/>
+              <text macro="title"/>
+            </if>
+            <else>
+              <text macro="title"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>
@@ -72,18 +74,20 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="report">
-            <text variable="publisher"/>
-            <text variable="title" form="short" font-style="italic"/>
-          </if>
-          <else-if type="bill book graphic legal_case legislation motion_picture song" match="any">
-            <text variable="title" form="short" font-style="italic"/>
-          </else-if>
-          <else>
-            <text variable="title" form="short" quotes="true"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="report">
+              <text variable="publisher"/>
+              <text variable="title" form="short" font-style="italic"/>
+            </if>
+            <else-if type="bill book graphic legal_case legislation motion_picture song" match="any">
+              <text variable="title" form="short" font-style="italic"/>
+            </else-if>
+            <else>
+              <text variable="title" form="short" quotes="true"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>

--- a/journal-of-small-animal-practice.csl
+++ b/journal-of-small-animal-practice.csl
@@ -65,14 +65,16 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
-            <text variable="title" form="short" font-style="italic"/>
-          </if>
-          <else>
-            <text variable="title" form="short" quotes="true"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
+              <text variable="title" form="short" font-style="italic"/>
+            </if>
+            <else>
+              <text variable="title" form="short" quotes="true"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>

--- a/journal-of-soil-and-water-conservation.csl
+++ b/journal-of-soil-and-water-conservation.csl
@@ -54,14 +54,16 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
-            <text variable="title" form="short" font-style="italic"/>
-          </if>
-          <else>
-            <text variable="title" form="short" quotes="true"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
+              <text variable="title" form="short" font-style="italic"/>
+            </if>
+            <else>
+              <text variable="title" form="short" quotes="true"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>

--- a/journal-of-studies-on-alcohol-and-drugs.csl
+++ b/journal-of-studies-on-alcohol-and-drugs.csl
@@ -65,14 +65,16 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
-            <text variable="title" form="short" font-style="italic"/>
-          </if>
-          <else>
-            <text variable="title" form="short" quotes="true"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
+              <text variable="title" form="short" font-style="italic"/>
+            </if>
+            <else>
+              <text variable="title" form="short" quotes="true"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>

--- a/journal-of-the-american-water-resources-association.csl
+++ b/journal-of-the-american-water-resources-association.csl
@@ -44,14 +44,16 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
-            <text variable="title" form="short" text-case="title"/>
-          </if>
-          <else>
-            <text variable="title" form="short" quotes="true" text-case="title"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
+              <text variable="title" form="short" text-case="title"/>
+            </if>
+            <else>
+              <text variable="title" form="short" quotes="true" text-case="title"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>

--- a/journal-of-the-association-for-information-systems.csl
+++ b/journal-of-the-association-for-information-systems.csl
@@ -54,15 +54,17 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="report">
-            <text variable="publisher"/>
-            <text macro="title"/>
-          </if>
-          <else>
-            <text macro="title"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="report">
+              <text variable="publisher"/>
+              <text macro="title"/>
+            </if>
+            <else>
+              <text macro="title"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>
@@ -72,18 +74,20 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="report">
-            <text variable="publisher"/>
-            <text variable="title" form="short" font-style="italic"/>
-          </if>
-          <else-if type="bill book graphic legal_case legislation motion_picture song" match="any">
-            <text variable="title" form="short" font-style="italic"/>
-          </else-if>
-          <else>
-            <text variable="title" form="short" quotes="true"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="report">
+              <text variable="publisher"/>
+              <text variable="title" form="short" font-style="italic"/>
+            </if>
+            <else-if type="bill book graphic legal_case legislation motion_picture song" match="any">
+              <text variable="title" form="short" font-style="italic"/>
+            </else-if>
+            <else>
+              <text variable="title" form="short" quotes="true"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>

--- a/journal-of-the-korean-society-of-civil-engineers.csl
+++ b/journal-of-the-korean-society-of-civil-engineers.csl
@@ -40,14 +40,16 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
-            <text variable="title" form="short" font-style="italic"/>
-          </if>
-          <else>
-            <text variable="title" form="short" quotes="true"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
+              <text variable="title" form="short" font-style="italic"/>
+            </if>
+            <else>
+              <text variable="title" form="short" quotes="true"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>

--- a/journal-of-the-marine-biological-association-of-the-united-kingdom.csl
+++ b/journal-of-the-marine-biological-association-of-the-united-kingdom.csl
@@ -66,15 +66,17 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="report">
-            <text variable="publisher"/>
-            <text macro="title"/>
-          </if>
-          <else>
-            <text macro="title"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="report">
+              <text variable="publisher"/>
+              <text macro="title"/>
+            </if>
+            <else>
+              <text macro="title"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>
@@ -85,34 +87,36 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="report">
-            <text variable="publisher"/>
-            <text variable="title" form="short" font-style="italic"/>
-          </if>
-          <else-if type="legal_case">
-            <text variable="title" font-style="italic"/>
-          </else-if>
-          <else-if type="book graphic  motion_picture song" match="any">
-            <text variable="title" form="short" font-style="italic"/>
-          </else-if>
-          <else-if type="bill legislation" match="any">
-            <text variable="title" form="short"/>
-          </else-if>
-          <else-if variable="reviewed-author">
-            <choose>
-              <if variable="reviewed-title" match="none">
-                <text variable="title" form="short" font-style="italic" prefix="Review of "/>
-              </if>
-              <else>
-                <text variable="title" form="short" quotes="true"/>
-              </else>
-            </choose>
-          </else-if>
-          <else>
-            <text variable="title" form="short" quotes="true"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="report">
+              <text variable="publisher"/>
+              <text variable="title" form="short" font-style="italic"/>
+            </if>
+            <else-if type="legal_case">
+              <text variable="title" font-style="italic"/>
+            </else-if>
+            <else-if type="book graphic  motion_picture song" match="any">
+              <text variable="title" form="short" font-style="italic"/>
+            </else-if>
+            <else-if type="bill legislation" match="any">
+              <text variable="title" form="short"/>
+            </else-if>
+            <else-if variable="reviewed-author">
+              <choose>
+                <if variable="reviewed-title" match="none">
+                  <text variable="title" form="short" font-style="italic" prefix="Review of "/>
+                </if>
+                <else>
+                  <text variable="title" form="short" quotes="true"/>
+                </else>
+              </choose>
+            </else-if>
+            <else>
+              <text variable="title" form="short" quotes="true"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>

--- a/journal-of-the-south-african-veterinary-association.csl
+++ b/journal-of-the-south-african-veterinary-association.csl
@@ -68,15 +68,17 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="report">
-            <text variable="publisher"/>
-            <text macro="title"/>
-          </if>
-          <else>
-            <text macro="title"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="report">
+              <text variable="publisher"/>
+              <text macro="title"/>
+            </if>
+            <else>
+              <text macro="title"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>
@@ -86,34 +88,36 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="report">
-            <text variable="publisher"/>
-            <text variable="title" form="short" font-style="italic"/>
-          </if>
-          <else-if type="legal_case">
-            <text variable="title" font-style="italic"/>
-          </else-if>
-          <else-if type="book graphic  motion_picture song" match="any">
-            <text variable="title" form="short" font-style="italic"/>
-          </else-if>
-          <else-if type="bill legislation" match="any">
-            <text variable="title" form="short"/>
-          </else-if>
-          <else-if variable="reviewed-author">
-            <choose>
-              <if variable="reviewed-title" match="none">
-                <text variable="title" form="short" font-style="italic" prefix="Review of "/>
-              </if>
-              <else>
-                <text variable="title" form="short" quotes="true"/>
-              </else>
-            </choose>
-          </else-if>
-          <else>
-            <text variable="title" form="short" quotes="true"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="report">
+              <text variable="publisher"/>
+              <text variable="title" form="short" font-style="italic"/>
+            </if>
+            <else-if type="legal_case">
+              <text variable="title" font-style="italic"/>
+            </else-if>
+            <else-if type="book graphic  motion_picture song" match="any">
+              <text variable="title" form="short" font-style="italic"/>
+            </else-if>
+            <else-if type="bill legislation" match="any">
+              <text variable="title" form="short"/>
+            </else-if>
+            <else-if variable="reviewed-author">
+              <choose>
+                <if variable="reviewed-title" match="none">
+                  <text variable="title" form="short" font-style="italic" prefix="Review of "/>
+                </if>
+                <else>
+                  <text variable="title" form="short" quotes="true"/>
+                </else>
+              </choose>
+            </else-if>
+            <else>
+              <text variable="title" form="short" quotes="true"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>
@@ -446,7 +450,7 @@
             <else>
               <group>
                 <text term="volume" form="short" plural="true" text-case="capitalize-first" suffix=" "/>
-                <number variable="number-of-volumes" form="numeric" prefix="1&#8211;"/>
+                <number variable="number-of-volumes" form="numeric" prefix="1–"/>
               </group>
             </else>
           </choose>

--- a/journal-of-tropical-ecology.csl
+++ b/journal-of-tropical-ecology.csl
@@ -60,14 +60,16 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
-            <text variable="title" form="short" font-style="italic"/>
-          </if>
-          <else>
-            <text variable="title" form="short" quotes="true"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
+              <text variable="title" form="short" font-style="italic"/>
+            </if>
+            <else>
+              <text variable="title" form="short" quotes="true"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>

--- a/journal-of-universal-computer-science.csl
+++ b/journal-of-universal-computer-science.csl
@@ -55,15 +55,17 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="report">
-            <text variable="publisher"/>
-            <text macro="title"/>
-          </if>
-          <else>
-            <text macro="title"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="report">
+              <text variable="publisher"/>
+              <text macro="title"/>
+            </if>
+            <else>
+              <text macro="title"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>
@@ -73,21 +75,23 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="report">
-            <text variable="publisher"/>
-            <text variable="title" form="short" font-style="italic"/>
-          </if>
-          <else-if type="legal_case">
-            <text variable="title" font-style="italic"/>
-          </else-if>
-          <else-if type="bill book graphic legislation motion_picture song" match="any">
-            <text variable="title" form="short" font-style="italic"/>
-          </else-if>
-          <else>
-            <text variable="title" form="short" quotes="true"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="report">
+              <text variable="publisher"/>
+              <text variable="title" form="short" font-style="italic"/>
+            </if>
+            <else-if type="legal_case">
+              <text variable="title" font-style="italic"/>
+            </else-if>
+            <else-if type="bill book graphic legislation motion_picture song" match="any">
+              <text variable="title" form="short" font-style="italic"/>
+            </else-if>
+            <else>
+              <text variable="title" form="short" quotes="true"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>
@@ -374,7 +378,7 @@
             <else>
               <group>
                 <text term="volume" form="short" plural="true" text-case="capitalize-first" suffix=" "/>
-                <number variable="number-of-volumes" form="numeric" prefix="1&#8211;"/>
+                <number variable="number-of-volumes" form="numeric" prefix="1–"/>
               </group>
             </else>
           </choose>

--- a/journal-of-vegetation-science.csl
+++ b/journal-of-vegetation-science.csl
@@ -45,14 +45,16 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
-            <text variable="title" form="short" font-style="italic"/>
-          </if>
-          <else>
-            <text variable="title" form="short" quotes="true"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
+              <text variable="title" form="short" font-style="italic"/>
+            </if>
+            <else>
+              <text variable="title" form="short" quotes="true"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>

--- a/journal-of-water-sanitation-and-hygiene-for-development.csl
+++ b/journal-of-water-sanitation-and-hygiene-for-development.csl
@@ -66,15 +66,17 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="report">
-            <text variable="publisher"/>
-            <text macro="title"/>
-          </if>
-          <else>
-            <text macro="title"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="report">
+              <text variable="publisher"/>
+              <text macro="title"/>
+            </if>
+            <else>
+              <text macro="title"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>
@@ -85,31 +87,33 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="report">
-            <text variable="publisher"/>
-            <text variable="title" form="short" font-style="italic"/>
-          </if>
-          <else-if type="legal_case">
-            <text variable="title" font-style="italic"/>
-          </else-if>
-          <else-if type="bill book graphic legislation motion_picture song" match="any">
-            <text variable="title" form="short" font-style="italic"/>
-          </else-if>
-          <else-if variable="reviewed-author">
-            <choose>
-              <if variable="reviewed-title" match="none">
-                <text variable="title" form="short" font-style="italic" prefix="Review of "/>
-              </if>
-              <else>
-                <text variable="title" form="short" quotes="true"/>
-              </else>
-            </choose>
-          </else-if>
-          <else>
-            <text variable="title" form="short" quotes="true"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="report">
+              <text variable="publisher"/>
+              <text variable="title" form="short" font-style="italic"/>
+            </if>
+            <else-if type="legal_case">
+              <text variable="title" font-style="italic"/>
+            </else-if>
+            <else-if type="bill book graphic legislation motion_picture song" match="any">
+              <text variable="title" form="short" font-style="italic"/>
+            </else-if>
+            <else-if variable="reviewed-author">
+              <choose>
+                <if variable="reviewed-title" match="none">
+                  <text variable="title" form="short" font-style="italic" prefix="Review of "/>
+                </if>
+                <else>
+                  <text variable="title" form="short" quotes="true"/>
+                </else>
+              </choose>
+            </else-if>
+            <else>
+              <text variable="title" form="short" quotes="true"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>
@@ -454,7 +458,7 @@
             <else>
               <group>
                 <text term="volume" form="short" plural="true" text-case="capitalize-first" suffix=" "/>
-                <number variable="number-of-volumes" form="numeric" prefix="1&#8211;"/>
+                <number variable="number-of-volumes" form="numeric" prefix="1–"/>
               </group>
             </else>
           </choose>

--- a/journal-of-wildlife-diseases.csl
+++ b/journal-of-wildlife-diseases.csl
@@ -62,14 +62,16 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
-            <text variable="title" form="short" font-style="italic"/>
-          </if>
-          <else>
-            <text variable="title" form="short" quotes="true"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
+              <text variable="title" form="short" font-style="italic"/>
+            </if>
+            <else>
+              <text variable="title" form="short" quotes="true"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>
@@ -182,7 +184,7 @@
       </group>
     </layout>
   </citation>
-  <bibliography hanging-indent="true" entry-spacing="0" line-spacing="2" subsequent-author-substitute="&#8212;&#8212;&#8212;" subsequent-author-substitute-rule="complete-each">
+  <bibliography hanging-indent="true" entry-spacing="0" line-spacing="2" subsequent-author-substitute="———" subsequent-author-substitute-rule="complete-each">
     <sort>
       <key macro="author"/>
       <key variable="issued"/>

--- a/journal-of-zoology.csl
+++ b/journal-of-zoology.csl
@@ -53,14 +53,16 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
-            <text variable="title" form="short" font-style="italic"/>
-          </if>
-          <else>
-            <text variable="title" form="short" quotes="true"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
+              <text variable="title" form="short" font-style="italic"/>
+            </if>
+            <else>
+              <text variable="title" form="short" quotes="true"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>

--- a/journal-on-efficiency-and-responsibility-in-education-and-science.csl
+++ b/journal-on-efficiency-and-responsibility-in-education-and-science.csl
@@ -74,15 +74,17 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="report">
-            <text variable="publisher"/>
-            <text macro="title"/>
-          </if>
-          <else>
-            <text macro="title"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="report">
+              <text variable="publisher"/>
+              <text macro="title"/>
+            </if>
+            <else>
+              <text macro="title"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>
@@ -92,34 +94,36 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="report">
-            <text variable="publisher"/>
-            <text variable="title" form="short" font-style="italic"/>
-          </if>
-          <else-if type="legal_case">
-            <text variable="title" font-style="italic"/>
-          </else-if>
-          <else-if type="book graphic  motion_picture song" match="any">
-            <text variable="title" form="short" font-style="italic"/>
-          </else-if>
-          <else-if type="bill legislation" match="any">
-            <text variable="title" form="short"/>
-          </else-if>
-          <else-if variable="reviewed-author">
-            <choose>
-              <if variable="reviewed-title" match="none">
-                <text variable="title" form="short" font-style="italic" prefix="Review of "/>
-              </if>
-              <else>
-                <text variable="title" form="short" quotes="true"/>
-              </else>
-            </choose>
-          </else-if>
-          <else>
-            <text variable="title" form="short" quotes="true"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="report">
+              <text variable="publisher"/>
+              <text variable="title" form="short" font-style="italic"/>
+            </if>
+            <else-if type="legal_case">
+              <text variable="title" font-style="italic"/>
+            </else-if>
+            <else-if type="book graphic  motion_picture song" match="any">
+              <text variable="title" form="short" font-style="italic"/>
+            </else-if>
+            <else-if type="bill legislation" match="any">
+              <text variable="title" form="short"/>
+            </else-if>
+            <else-if variable="reviewed-author">
+              <choose>
+                <if variable="reviewed-title" match="none">
+                  <text variable="title" form="short" font-style="italic" prefix="Review of "/>
+                </if>
+                <else>
+                  <text variable="title" form="short" quotes="true"/>
+                </else>
+              </choose>
+            </else-if>
+            <else>
+              <text variable="title" form="short" quotes="true"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>
@@ -469,7 +473,7 @@
             <else>
               <group>
                 <text term="volume" form="short" plural="true" text-case="capitalize-first" suffix=" "/>
-                <number variable="number-of-volumes" form="numeric" prefix="1&#8211;"/>
+                <number variable="number-of-volumes" form="numeric" prefix="1–"/>
               </group>
             </else>
           </choose>

--- a/jurnal-pangan-dan-agroindustri.csl
+++ b/jurnal-pangan-dan-agroindustri.csl
@@ -61,14 +61,16 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
-            <text variable="title" form="short" font-style="italic"/>
-          </if>
-          <else>
-            <text variable="title" form="short" quotes="true"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
+              <text variable="title" form="short" font-style="italic"/>
+            </if>
+            <else>
+              <text variable="title" form="short" quotes="true"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>

--- a/kindheit-und-entwicklung.csl
+++ b/kindheit-und-entwicklung.csl
@@ -54,15 +54,17 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="report">
-            <text variable="publisher"/>
-            <text macro="title"/>
-          </if>
-          <else>
-            <text macro="title"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="report">
+              <text variable="publisher"/>
+              <text macro="title"/>
+            </if>
+            <else>
+              <text macro="title"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>
@@ -72,18 +74,20 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="report">
-            <text variable="publisher"/>
-            <text variable="title" form="short" font-style="italic"/>
-          </if>
-          <else-if type="bill book graphic legal_case legislation motion_picture song" match="any">
-            <text variable="title" form="short" font-style="italic"/>
-          </else-if>
-          <else>
-            <text variable="title" form="short" quotes="true"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="report">
+              <text variable="publisher"/>
+              <text variable="title" form="short" font-style="italic"/>
+            </if>
+            <else-if type="bill book graphic legal_case legislation motion_picture song" match="any">
+              <text variable="title" form="short" font-style="italic"/>
+            </else-if>
+            <else>
+              <text variable="title" form="short" quotes="true"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>

--- a/ksce-journal-of-civil-engineering.csl
+++ b/ksce-journal-of-civil-engineering.csl
@@ -40,14 +40,16 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
-            <text variable="title" form="short" font-style="italic"/>
-          </if>
-          <else>
-            <text variable="title" form="short" quotes="true"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
+              <text variable="title" form="short" font-style="italic"/>
+            </if>
+            <else>
+              <text variable="title" form="short" quotes="true"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>

--- a/kth-royal-institute-of-technology-school-of-computer-science-and-communication-sv.csl
+++ b/kth-royal-institute-of-technology-school-of-computer-science-and-communication-sv.csl
@@ -92,14 +92,16 @@
           <substitute>
             <names variable="editor"/>
             <names variable="translator"/>
-            <choose>
-              <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
-                <text variable="title" form="short" font-style="italic"/>
-              </if>
-              <else>
-                <text variable="title" form="short"/>
-              </else>
-            </choose>
+            <group>
+              <choose>
+                <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
+                  <text variable="title" form="short" font-style="italic"/>
+                </if>
+                <else>
+                  <text variable="title" form="short"/>
+                </else>
+              </choose>
+            </group>
           </substitute>
         </names>
       </if>

--- a/kth-royal-institute-of-technology-school-of-computer-science-and-communication.csl
+++ b/kth-royal-institute-of-technology-school-of-computer-science-and-communication.csl
@@ -86,14 +86,16 @@
           <substitute>
             <names variable="editor"/>
             <names variable="translator"/>
-            <choose>
-              <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
-                <text variable="title" form="short" font-style="italic"/>
-              </if>
-              <else>
-                <text variable="title" form="short"/>
-              </else>
-            </choose>
+            <group>
+              <choose>
+                <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
+                  <text variable="title" form="short" font-style="italic"/>
+                </if>
+                <else>
+                  <text variable="title" form="short"/>
+                </else>
+              </choose>
+            </group>
           </substitute>
         </names>
       </if>

--- a/la-trobe-university-apa.csl
+++ b/la-trobe-university-apa.csl
@@ -63,15 +63,17 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="report">
-            <text variable="publisher"/>
-            <text macro="title"/>
-          </if>
-          <else>
-            <text macro="title"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="report">
+              <text variable="publisher"/>
+              <text macro="title"/>
+            </if>
+            <else>
+              <text macro="title"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>
@@ -86,34 +88,36 @@
           <substitute>
             <names variable="editor"/>
             <names variable="translator"/>
-            <choose>
-              <if type="report">
-                <text variable="publisher"/>
-                <text variable="title" form="short" font-style="italic"/>
-              </if>
-              <else-if type="legal_case">
-                <text variable="title" font-style="italic"/>
-              </else-if>
-              <else-if type="book graphic  motion_picture song" match="any">
-                <text variable="title" form="short" font-style="italic"/>
-              </else-if>
-              <else-if type="bill legislation" match="any">
-                <text variable="title" form="short"/>
-              </else-if>
-              <else-if variable="reviewed-author">
-                <choose>
-                  <if variable="reviewed-title" match="none">
-                    <text variable="title" form="short" font-style="italic" prefix="Review of "/>
-                  </if>
-                  <else>
-                    <text variable="title" form="short" quotes="true"/>
-                  </else>
-                </choose>
-              </else-if>
-              <else>
-                <text variable="title" form="short" quotes="true"/>
-              </else>
-            </choose>
+            <group>
+              <choose>
+                <if type="report">
+                  <text variable="publisher"/>
+                  <text variable="title" form="short" font-style="italic"/>
+                </if>
+                <else-if type="legal_case">
+                  <text variable="title" font-style="italic"/>
+                </else-if>
+                <else-if type="book graphic  motion_picture song" match="any">
+                  <text variable="title" form="short" font-style="italic"/>
+                </else-if>
+                <else-if type="bill legislation" match="any">
+                  <text variable="title" form="short"/>
+                </else-if>
+                <else-if variable="reviewed-author">
+                  <choose>
+                    <if variable="reviewed-title" match="none">
+                      <text variable="title" form="short" font-style="italic" prefix="Review of "/>
+                    </if>
+                    <else>
+                      <text variable="title" form="short" quotes="true"/>
+                    </else>
+                  </choose>
+                </else-if>
+                <else>
+                  <text variable="title" form="short" quotes="true"/>
+                </else>
+              </choose>
+            </group>
           </substitute>
         </names>
       </else>
@@ -598,7 +602,7 @@
             <else>
               <group>
                 <text term="volume" form="short" plural="true" text-case="capitalize-first" suffix=" "/>
-                <number variable="number-of-volumes" form="numeric" prefix="1&#8211;"/>
+                <number variable="number-of-volumes" form="numeric" prefix="1–"/>
               </group>
             </else>
           </choose>

--- a/la-trobe-university-harvard.csl
+++ b/la-trobe-university-harvard.csl
@@ -158,17 +158,19 @@
           <substitute>
             <names variable="editor"/>
             <names variable="translator"/>
-            <choose>
-              <if type="bill book graphic legal_case legislation motion_picture report" match="any">
-                <text variable="title" form="short" font-style="italic"/>
-              </if>
-              <else-if type="song" match="any">
-                <text variable="title"/>
-              </else-if>
-              <else>
-                <text variable="title" form="short" quotes="true"/>
-              </else>
-            </choose>
+            <group>
+              <choose>
+                <if type="bill book graphic legal_case legislation motion_picture report" match="any">
+                  <text variable="title" form="short" font-style="italic"/>
+                </if>
+                <else-if type="song" match="any">
+                  <text variable="title"/>
+                </else-if>
+                <else>
+                  <text variable="title" form="short" quotes="true"/>
+                </else>
+              </choose>
+            </group>
           </substitute>
         </names>
       </if>
@@ -181,7 +183,7 @@
     <choose>
       <if match="any" variable="URL">
         <group delimiter=", ">
-          <text variable="URL" prefix="&lt;" suffix="&gt;"/>
+          <text variable="URL" prefix="&lt;" suffix=">"/>
           <group delimiter=" ">
             <choose>
               <if type="report" match="any">

--- a/land-degradation-and-development.csl
+++ b/land-degradation-and-development.csl
@@ -37,14 +37,16 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
-            <text variable="title" form="short" font-style="italic"/>
-          </if>
-          <else>
-            <text variable="title" form="short" quotes="true"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
+              <text variable="title" form="short" font-style="italic"/>
+            </if>
+            <else>
+              <text variable="title" form="short" quotes="true"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>

--- a/latin-american-perspectives.csl
+++ b/latin-american-perspectives.csl
@@ -50,15 +50,17 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="report">
-            <text variable="publisher"/>
-            <text macro="title"/>
-          </if>
-          <else>
-            <text macro="title"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="report">
+              <text variable="publisher"/>
+              <text macro="title"/>
+            </if>
+            <else>
+              <text macro="title"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>
@@ -68,18 +70,20 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="report">
-            <text variable="publisher"/>
-            <text variable="title" form="short"/>
-          </if>
-          <else-if type="bill book graphic legal_case legislation motion_picture song" match="any">
-            <text variable="title" form="short"/>
-          </else-if>
-          <else>
-            <text variable="title" form="short" quotes="true"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="report">
+              <text variable="publisher"/>
+              <text variable="title" form="short"/>
+            </if>
+            <else-if type="bill book graphic legal_case legislation motion_picture song" match="any">
+              <text variable="title" form="short"/>
+            </else-if>
+            <else>
+              <text variable="title" form="short" quotes="true"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>

--- a/law-and-society-review.csl
+++ b/law-and-society-review.csl
@@ -57,14 +57,16 @@
           <substitute>
             <names variable="editor"/>
             <names variable="translator"/>
-            <choose>
-              <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
-                <text variable="title" form="short" font-style="italic"/>
-              </if>
-              <else>
-                <text variable="title" form="short" quotes="true"/>
-              </else>
-            </choose>
+            <group>
+              <choose>
+                <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
+                  <text variable="title" form="short" font-style="italic"/>
+                </if>
+                <else>
+                  <text variable="title" form="short" quotes="true"/>
+                </else>
+              </choose>
+            </group>
           </substitute>
         </names>
       </if>
@@ -226,7 +228,7 @@
       </group>
     </layout>
   </citation>
-  <bibliography hanging-indent="true" entry-spacing="0" et-al-min="3" et-al-use-first="1" subsequent-author-substitute="&#8212;&#8212;&#8212;">
+  <bibliography hanging-indent="true" entry-spacing="0" et-al-min="3" et-al-use-first="1" subsequent-author-substitute="———">
     <sort>
       <key macro="type-order"/>
       <key macro="author"/>

--- a/le-tapuscrit-author-date.csl
+++ b/le-tapuscrit-author-date.csl
@@ -22,7 +22,7 @@
       <term name="ordinal-02">e</term>
       <term name="ordinal-03">e</term>
       <term name="ordinal-04">e</term>
-      <term name="cited">op.&#160;cit.</term>
+      <term name="cited">op. cit.</term>
       <term name="page" form="short">p.</term>
       <term name="editor" form="short">
         <single>ed.</single>
@@ -34,18 +34,20 @@
   <macro name="contrib-court">
     <names variable="author">
       <name form="short" and="text" delimiter-precedes-last="never" sort-separator=" " font-style="normal"/>
-      <label form="short" prefix="&#160;(" suffix=".)"/>
+      <label form="short" prefix=" (" suffix=".)"/>
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="bill book graphic legal_case motion_picture report song thesis manuscript" match="any">
-            <text variable="title" form="short" font-style="italic"/>
-          </if>
-          <else>
-            <text variable="title" text-case="capitalize-first" form="short" quotes="true"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="bill book graphic legal_case motion_picture report song thesis manuscript" match="any">
+              <text variable="title" form="short" font-style="italic"/>
+            </if>
+            <else>
+              <text variable="title" text-case="capitalize-first" form="short" quotes="true"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>
@@ -54,7 +56,7 @@
       <name name-as-sort-order="all" form="long" and="text" delimiter-precedes-last="never" sort-separator=" " font-style="normal">
         <name-part name="family" font-variant="small-caps"/>
       </name>
-      <label form="short" prefix="&#160;(" suffix=".)"/>
+      <label form="short" prefix=" (" suffix=".)"/>
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
@@ -66,7 +68,7 @@
     <names variable="editor">
       <name form="long" and="text" delimiter-precedes-last="never" sort-separator=" " font-style="normal">
       </name>
-      <label form="short" prefix="&#160;(" suffix=".)"/>
+      <label form="short" prefix=" (" suffix=".)"/>
     </names>
   </macro>
   <macro name="translator">
@@ -161,7 +163,7 @@
               <text variable="number-of-volumes" prefix=". " suffix="/"/>
               <text variable="volume"/>
             </group>
-            <text variable="number-of-pages" suffix="&#160;p"/>
+            <text variable="number-of-pages" suffix=" p"/>
           </group>
           <group>
             <label variable="locator" form="short"/>
@@ -178,7 +180,7 @@
           </group>
           <group>
             <label variable="page" form="short"/>
-            <text variable="page" prefix="&#160;"/>
+            <text variable="page" prefix=" "/>
           </group>
         </group>
       </else-if>
@@ -265,7 +267,7 @@
   <macro name="volume">
     <choose>
       <if is-numeric="volume">
-        <text term="volume" form="short" suffix=".&#160;"/>
+        <text term="volume" form="short" suffix=". "/>
         <text variable="volume"/>
       </if>
       <else>
@@ -276,7 +278,7 @@
   <macro name="issue">
     <choose>
       <if is-numeric="issue">
-        <text term="issue" form="short" suffix="&#160;"/>
+        <text term="issue" form="short" suffix=" "/>
         <text variable="issue"/>
       </if>
       <else>
@@ -285,10 +287,10 @@
     </choose>
   </macro>
   <macro name="collection">
-    <text variable="collection-title" quotes="true" prefix=" (coll.&#160;" suffix=")"/>
+    <text variable="collection-title" quotes="true" prefix=" (coll. " suffix=")"/>
   </macro>
   <citation et-al-min="4" et-al-use-first="1" disambiguate-add-year-suffix="true" disambiguate-add-names="true" disambiguate-add-givenname="true" givenname-disambiguation-rule="primary-name">
-    <layout prefix="&#160;(" suffix=")" delimiter="; ">
+    <layout prefix=" (" suffix=")" delimiter="; ">
       <choose>
         <if position="ibid-with-locator">
           <group delimiter=", ">
@@ -305,7 +307,7 @@
             <text macro="year-short"/>
           </group>
           <group prefix=", ">
-            <label variable="locator" form="short" suffix="&#160;"/>
+            <label variable="locator" form="short" suffix=" "/>
             <text variable="locator"/>
           </group>
         </else>

--- a/letters-in-applied-microbiology.csl
+++ b/letters-in-applied-microbiology.csl
@@ -58,14 +58,16 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
-            <text variable="title" form="short" font-style="italic"/>
-          </if>
-          <else>
-            <text variable="title" form="short" quotes="true"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
+              <text variable="title" form="short" font-style="italic"/>
+            </if>
+            <else>
+              <text variable="title" form="short" quotes="true"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>

--- a/lettres-et-sciences-humaines-fr.csl
+++ b/lettres-et-sciences-humaines-fr.csl
@@ -25,10 +25,10 @@
       <term name="translator" form="verb-short">trad.</term>
       <term name="translator" form="short">traduction</term>
       <term name="interviewer" form="verb">entretien réalisé par</term>
-      <term name="in">in&#160;</term>
+      <term name="in">in </term>
       <term name="edition">édition</term>
       <term name="accessed">consulté le</term>
-      <term name="at">disponible sur&#160;:</term>
+      <term name="at">disponible sur :</term>
       <term name="et-al">[et al.]</term>
       <term name="ibid">ibidem</term>
     </terms>
@@ -40,17 +40,19 @@
       </name>
       <label form="short" prefix=", (" suffix=".)"/>
       <substitute>
-        <choose>
-          <if type="webpage">
-            <text macro="title"/>
-          </if>
-          <else>
-            <text macro="title" suffix=", "/>
-            <names variable="translator">
-              <name/>
-            </names>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="webpage">
+              <text macro="title"/>
+            </if>
+            <else>
+              <text macro="title" suffix=", "/>
+              <names variable="translator">
+                <name/>
+              </names>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>
@@ -174,13 +176,13 @@
     </date>
     <choose>
       <if variable="number-of-pages">
-        <text variable="number-of-pages" prefix=", " suffix="&#160;p."/>
+        <text variable="number-of-pages" prefix=", " suffix=" p."/>
       </if>
       <else>
         <choose>
           <if variable="number-of-volumes">
             <group>
-              <text variable="number-of-volumes" prefix=". " suffix="&#160;"/>
+              <text variable="number-of-volumes" prefix=". " suffix=" "/>
               <text term="volume" form="short" suffix="."/>
             </group>
           </if>
@@ -195,13 +197,13 @@
     </date>
     <choose>
       <if variable="number-of-pages">
-        <text variable="number-of-pages" prefix=", " suffix="&#160;p."/>
+        <text variable="number-of-pages" prefix=", " suffix=" p."/>
       </if>
       <else>
         <choose>
           <if variable="number-of-volumes">
             <group>
-              <text variable="number-of-volumes" prefix=". " suffix="&#160;"/>
+              <text variable="number-of-volumes" prefix=". " suffix=" "/>
               <text term="volume" form="short" suffix="."/>
             </group>
           </if>
@@ -218,13 +220,13 @@
     </date>
     <choose>
       <if variable="number-of-pages">
-        <text variable="number-of-pages" prefix=", " suffix="&#160;p."/>
+        <text variable="number-of-pages" prefix=", " suffix=" p."/>
       </if>
       <else>
         <choose>
           <if variable="number-of-volumes">
             <group>
-              <text variable="number-of-volumes" prefix=". " suffix="&#160;"/>
+              <text variable="number-of-volumes" prefix=". " suffix=" "/>
               <text term="volume" form="short" suffix="."/>
             </group>
           </if>
@@ -240,13 +242,13 @@
     </date>
     <choose>
       <if variable="number-of-pages">
-        <text variable="number-of-pages" prefix=", " suffix="&#160;p."/>
+        <text variable="number-of-pages" prefix=", " suffix=" p."/>
       </if>
       <else>
         <choose>
           <if variable="number-of-volumes">
             <group>
-              <text variable="number-of-volumes" prefix=". " suffix="&#160;"/>
+              <text variable="number-of-volumes" prefix=". " suffix=" "/>
               <text term="volume" form="short" suffix="."/>
             </group>
           </if>
@@ -257,7 +259,7 @@
   <macro name="volume">
     <choose>
       <if is-numeric="volume">
-        <text term="volume" form="short" suffix=".&#160;"/>
+        <text term="volume" form="short" suffix=". "/>
         <text variable="volume"/>
       </if>
       <else>
@@ -268,11 +270,11 @@
   <macro name="volume-issue">
     <choose>
       <if is-numeric="volume">
-        <text term="volume" form="short" suffix=".&#160;"/>
+        <text term="volume" form="short" suffix=". "/>
         <text variable="volume"/>
         <choose>
           <if variable="issue" match="any">
-            <text variable="issue" prefix="&#160;/&#160;"/>
+            <text variable="issue" prefix=" / "/>
           </if>
         </choose>
       </if>
@@ -332,7 +334,7 @@
                 <text macro="editor" text-case="capitalize-first"/>
                 <text macro="publisher-book-magazine-newspaper"/>
                 <text macro="collection"/>
-                <text variable="page" prefix="p.&#160;"/>
+                <text variable="page" prefix="p. "/>
               </group>
             </else-if>
             <else-if type="article-journal">
@@ -345,7 +347,7 @@
                 <text macro="editor" text-case="capitalize-first"/>
                 <text macro="publisher-book-journal"/>
                 <text macro="collection"/>
-                <text variable="page" prefix="p.&#160;"/>
+                <text variable="page" prefix="p. "/>
               </group>
             </else-if>
             <else-if type="webpage">
@@ -365,7 +367,7 @@
                 <text variable="edition" text-case="capitalize-first"/>
                 <text macro="publisher-book"/>
                 <text macro="collection"/>
-                <text variable="page" prefix="p.&#160;"/>
+                <text variable="page" prefix="p. "/>
               </group>
             </else-if>
             <else>
@@ -378,13 +380,13 @@
                 <text variable="edition" text-case="capitalize-first"/>
                 <text macro="publisher-book"/>
                 <text macro="collection"/>
-                <text variable="page" prefix="p.&#160;"/>
+                <text variable="page" prefix="p. "/>
               </group>
             </else>
           </choose>
           <group>
             <label variable="locator" form="short" prefix=", "/>
-            <text variable="locator" prefix="&#160;"/>
+            <text variable="locator" prefix=" "/>
           </group>
         </if>
         <else-if position="ibid-with-locator">
@@ -392,7 +394,7 @@
             <text term="ibid" form="long" font-style="italic" text-case="capitalize-first"/>
             <group>
               <label variable="locator" form="short" prefix=", "/>
-              <text variable="locator" prefix="&#160;"/>
+              <text variable="locator" prefix=" "/>
             </group>
           </group>
         </else-if>
@@ -402,11 +404,11 @@
         <else-if position="subsequent">
           <group>
             <text macro="contributors-notes" font-variant="normal" suffix=", "/>
-            <text value="op.&#160;cit." font-style="italic"/>
+            <text value="op. cit." font-style="italic"/>
           </group>
           <group>
             <label variable="locator" form="short" prefix=", "/>
-            <text variable="locator" prefix="&#160;"/>
+            <text variable="locator" prefix=" "/>
           </group>
         </else-if>
       </choose>
@@ -445,7 +447,7 @@
             <text variable="edition" text-case="capitalize-first"/>
             <text macro="publisher-book"/>
             <text macro="collection"/>
-            <text variable="page" prefix="p.&#160;"/>
+            <text variable="page" prefix="p. "/>
           </group>
         </else-if>
         <else-if type="article-magazine article-newspaper" match="any">
@@ -458,7 +460,7 @@
             <text macro="editor" text-case="capitalize-first"/>
             <text macro="publisher-book-magazine-newspaper"/>
             <text macro="collection"/>
-            <text variable="page" prefix="p.&#160;"/>
+            <text variable="page" prefix="p. "/>
           </group>
         </else-if>
         <else-if type="article-journal">
@@ -471,7 +473,7 @@
             <text macro="editor" text-case="capitalize-first"/>
             <text macro="publisher-book-journal"/>
             <text macro="collection"/>
-            <text variable="page" prefix="p.&#160;"/>
+            <text variable="page" prefix="p. "/>
           </group>
         </else-if>
         <else>
@@ -484,7 +486,7 @@
             <text macro="editor" text-case="capitalize-first"/>
             <text macro="publisher-book"/>
             <text macro="collection"/>
-            <text variable="page" prefix="p.&#160;"/>
+            <text variable="page" prefix="p. "/>
           </group>
         </else>
       </choose>

--- a/london-metropolitan-university-harvard.csl
+++ b/london-metropolitan-university-harvard.csl
@@ -66,14 +66,16 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="article-newspaper article-magazine" match="any">
-            <text variable="container-title" text-case="title" font-style="italic"/>
-          </if>
-          <else>
-            <text macro="title"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="article-newspaper article-magazine" match="any">
+              <text variable="container-title" text-case="title" font-style="italic"/>
+            </if>
+            <else>
+              <text macro="title"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>
@@ -84,14 +86,16 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="article-newspaper article-magazine" match="any">
-            <text variable="container-title" text-case="title" font-style="italic"/>
-          </if>
-          <else>
-            <text macro="title"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="article-newspaper article-magazine" match="any">
+              <text variable="container-title" text-case="title" font-style="italic"/>
+            </if>
+            <else>
+              <text macro="title"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>

--- a/mammal-review.csl
+++ b/mammal-review.csl
@@ -53,14 +53,16 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
-            <text variable="title" form="short" font-style="italic"/>
-          </if>
-          <else>
-            <text variable="title" form="short" quotes="true"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
+              <text variable="title" form="short" font-style="italic"/>
+            </if>
+            <else>
+              <text variable="title" form="short" quotes="true"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>

--- a/management-et-avenir.csl
+++ b/management-et-avenir.csl
@@ -50,15 +50,17 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="report">
-            <text variable="publisher"/>
-            <text macro="title"/>
-          </if>
-          <else>
-            <text macro="title"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="report">
+              <text variable="publisher"/>
+              <text macro="title"/>
+            </if>
+            <else>
+              <text macro="title"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>
@@ -68,21 +70,23 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="report">
-            <text variable="publisher"/>
-            <text variable="title" form="short" font-style="italic"/>
-          </if>
-          <else-if type="legal_case">
-            <text variable="title" font-style="italic"/>
-          </else-if>
-          <else-if type="bill book graphic legislation motion_picture song" match="any">
-            <text variable="title" form="short" font-style="italic"/>
-          </else-if>
-          <else>
-            <text variable="title" form="short" quotes="true"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="report">
+              <text variable="publisher"/>
+              <text variable="title" form="short" font-style="italic"/>
+            </if>
+            <else-if type="legal_case">
+              <text variable="title" font-style="italic"/>
+            </else-if>
+            <else-if type="bill book graphic legislation motion_picture song" match="any">
+              <text variable="title" form="short" font-style="italic"/>
+            </else-if>
+            <else>
+              <text variable="title" form="short" quotes="true"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>
@@ -390,7 +394,7 @@
             <else>
               <group>
                 <text term="volume" form="short" plural="true" text-case="capitalize-first" suffix=" "/>
-                <number variable="number-of-volumes" form="numeric" prefix="1&#8211;"/>
+                <number variable="number-of-volumes" form="numeric" prefix="1–"/>
               </group>
             </else>
           </choose>

--- a/marine-mammal-science.csl
+++ b/marine-mammal-science.csl
@@ -221,22 +221,24 @@
               <name name-as-sort-order="all" and="text" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
               <label form="long" prefix=" (" suffix=")" text-case="title"/>
             </names>
-            <choose>
-              <if variable="container-title">
-                <choose>
-                  <if type="book entry entry-dictionary entry-encyclopedia">
-                    <text macro="title"/>
-                  </if>
-                  <else>
-                    <names variable="translator"/>
-                  </else>
-                </choose>
-                <names variable="translator">
-                  <name name-as-sort-order="all" and="text" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
-                  <label form="short" prefix=" (" suffix=")" text-case="title"/>
-                </names>
-              </if>
-            </choose>
+            <group>
+              <choose>
+                <if variable="container-title">
+                  <choose>
+                    <if type="book entry entry-dictionary entry-encyclopedia">
+                      <text macro="title"/>
+                    </if>
+                    <else>
+                      <names variable="translator"/>
+                    </else>
+                  </choose>
+                  <names variable="translator">
+                    <name name-as-sort-order="all" and="text" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
+                    <label form="short" prefix=" (" suffix=")" text-case="title"/>
+                  </names>
+                </if>
+              </choose>
+            </group>
             <names variable="editor translator" delimiter=", ">
               <name name-as-sort-order="all" and="text" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
               <label form="short" prefix=" (" suffix=")" text-case="title"/>
@@ -249,11 +251,13 @@
               <name name-as-sort-order="all" and="text" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
               <label form="short" prefix=" (" suffix=")" text-case="title"/>
             </names>
-            <choose>
-              <if type="report">
-                <text variable="publisher"/>
-              </if>
-            </choose>
+            <group>
+              <choose>
+                <if type="report">
+                  <text variable="publisher"/>
+                </if>
+              </choose>
+            </group>
             <group delimiter=" ">
               <text macro="title"/>
               <text macro="description"/>
@@ -291,14 +295,16 @@
               <substitute>
                 <names variable="editor"/>
                 <names variable="translator"/>
-                <choose>
-                  <if variable="container-title">
-                    <text variable="title" form="short" quotes="true"/>
-                  </if>
-                  <else>
-                    <text variable="title" form="short" font-style="italic"/>
-                  </else>
-                </choose>
+                <group>
+                  <choose>
+                    <if variable="container-title">
+                      <text variable="title" form="short" quotes="true"/>
+                    </if>
+                    <else>
+                      <text variable="title" form="short" font-style="italic"/>
+                    </else>
+                  </choose>
+                </group>
                 <text macro="format-short" prefix="[" suffix="]"/>
               </substitute>
             </names>
@@ -312,14 +318,16 @@
             <names variable="original-author"/>
             <names variable="author"/>
             <names variable="translator"/>
-            <choose>
-              <if variable="container-title">
-                <text variable="title" form="short" quotes="true"/>
-              </if>
-              <else>
-                <text variable="title" form="short" font-style="italic"/>
-              </else>
-            </choose>
+            <group>
+              <choose>
+                <if variable="container-title">
+                  <text variable="title" form="short" quotes="true"/>
+                </if>
+                <else>
+                  <text variable="title" form="short" font-style="italic"/>
+                </else>
+              </choose>
+            </group>
             <text macro="format-short" prefix="[" suffix="]"/>
           </substitute>
         </names>
@@ -331,41 +339,45 @@
             <names variable="illustrator"/>
             <names variable="composer"/>
             <names variable="director"/>
-            <choose>
-              <if variable="container-title">
-                <choose>
-                  <if type="book entry entry-dictionary entry-encyclopedia">
-                    <text variable="title" form="short" quotes="true"/>
-                  </if>
-                  <else>
-                    <names variable="translator"/>
-                  </else>
-                </choose>
-              </if>
-            </choose>
+            <group>
+              <choose>
+                <if variable="container-title">
+                  <choose>
+                    <if type="book entry entry-dictionary entry-encyclopedia">
+                      <text variable="title" form="short" quotes="true"/>
+                    </if>
+                    <else>
+                      <names variable="translator"/>
+                    </else>
+                  </choose>
+                </if>
+              </choose>
+            </group>
             <names variable="editor"/>
             <names variable="editorial-director"/>
             <names variable="translator"/>
-            <choose>
-              <if type="report" variable="publisher" match="all">
-                <text variable="publisher"/>
-              </if>
-              <else-if type="legal_case">
-                <text variable="title" font-style="italic"/>
-              </else-if>
-              <else-if type="bill legislation" match="any">
-                <text variable="title" form="short"/>
-              </else-if>
-              <else-if variable="reviewed-author" type="review review-book" match="any">
-                <text macro="format-short" prefix="[" suffix="]"/>
-              </else-if>
-              <else-if type="post post-weblog webpage" variable="container-title" match="any">
-                <text variable="title" form="short" quotes="true"/>
-              </else-if>
-              <else>
-                <text variable="title" form="short" font-style="italic"/>
-              </else>
-            </choose>
+            <group>
+              <choose>
+                <if type="report" variable="publisher" match="all">
+                  <text variable="publisher"/>
+                </if>
+                <else-if type="legal_case">
+                  <text variable="title" font-style="italic"/>
+                </else-if>
+                <else-if type="bill legislation" match="any">
+                  <text variable="title" form="short"/>
+                </else-if>
+                <else-if variable="reviewed-author" type="review review-book" match="any">
+                  <text macro="format-short" prefix="[" suffix="]"/>
+                </else-if>
+                <else-if type="post post-weblog webpage" variable="container-title" match="any">
+                  <text variable="title" form="short" quotes="true"/>
+                </else-if>
+                <else>
+                  <text variable="title" form="short" font-style="italic"/>
+                </else>
+              </choose>
+            </group>
             <text macro="format-short" prefix="[" suffix="]"/>
           </substitute>
         </names>
@@ -1079,7 +1091,7 @@
         <else>
           <group>
             <text term="volume" form="short" plural="true" text-case="capitalize-first" suffix=" "/>
-            <number variable="number-of-volumes" form="numeric" prefix="1&#8211;"/>
+            <number variable="number-of-volumes" form="numeric" prefix="1–"/>
           </group>
         </else>
       </choose>

--- a/mediterranean-politics.csl
+++ b/mediterranean-politics.csl
@@ -65,15 +65,17 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="report">
-            <text variable="publisher"/>
-            <text macro="title"/>
-          </if>
-          <else>
-            <text macro="title"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="report">
+              <text variable="publisher"/>
+              <text macro="title"/>
+            </if>
+            <else>
+              <text macro="title"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>
@@ -83,34 +85,36 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="report">
-            <text variable="publisher"/>
-            <text variable="title" form="short" font-style="italic"/>
-          </if>
-          <else-if type="legal_case">
-            <text variable="title" font-style="italic"/>
-          </else-if>
-          <else-if type="book graphic  motion_picture song" match="any">
-            <text variable="title" form="short" font-style="italic"/>
-          </else-if>
-          <else-if type="bill legislation" match="any">
-            <text variable="title" form="short"/>
-          </else-if>
-          <else-if variable="reviewed-author">
-            <choose>
-              <if variable="reviewed-title" match="none">
-                <text variable="title" form="short" font-style="italic" prefix="Review of "/>
-              </if>
-              <else>
-                <text variable="title" form="short" quotes="true"/>
-              </else>
-            </choose>
-          </else-if>
-          <else>
-            <text variable="title" form="short" quotes="true"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="report">
+              <text variable="publisher"/>
+              <text variable="title" form="short" font-style="italic"/>
+            </if>
+            <else-if type="legal_case">
+              <text variable="title" font-style="italic"/>
+            </else-if>
+            <else-if type="book graphic  motion_picture song" match="any">
+              <text variable="title" form="short" font-style="italic"/>
+            </else-if>
+            <else-if type="bill legislation" match="any">
+              <text variable="title" form="short"/>
+            </else-if>
+            <else-if variable="reviewed-author">
+              <choose>
+                <if variable="reviewed-title" match="none">
+                  <text variable="title" form="short" font-style="italic" prefix="Review of "/>
+                </if>
+                <else>
+                  <text variable="title" form="short" quotes="true"/>
+                </else>
+              </choose>
+            </else-if>
+            <else>
+              <text variable="title" form="short" quotes="true"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>
@@ -446,7 +450,7 @@
             <else>
               <group>
                 <text term="volume" form="short" plural="true" text-case="capitalize-first" suffix=" "/>
-                <number variable="number-of-volumes" form="numeric" prefix="1&#8211;"/>
+                <number variable="number-of-volumes" form="numeric" prefix="1–"/>
               </group>
             </else>
           </choose>

--- a/memorias-do-instituto-oswaldo-cruz.csl
+++ b/memorias-do-instituto-oswaldo-cruz.csl
@@ -42,14 +42,16 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
-            <text variable="title" form="short" font-style="italic"/>
-          </if>
-          <else>
-            <text variable="title" form="short" quotes="true"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
+              <text variable="title" form="short" font-style="italic"/>
+            </if>
+            <else>
+              <text variable="title" form="short" quotes="true"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>

--- a/mercator-institut-fur-sprachforderung-und-deutsch-als-zweitsprache.csl
+++ b/mercator-institut-fur-sprachforderung-und-deutsch-als-zweitsprache.csl
@@ -19,7 +19,7 @@
   </info>
   <locale xml:lang="de">
     <terms>
-      <term name="page-range-delimiter">&#8211;</term>
+      <term name="page-range-delimiter">–</term>
       <term name="et-al">et al.</term>
       <term name="available at">Verfügbar unter</term>
       <term name="in press">im Druck</term>
@@ -53,14 +53,16 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="book bill review-book song" match="any">
-            <text variable="title" form="short" font-style="italic"/>
-          </if>
-          <else>
-            <text variable="title" form="short" quotes="true"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="book bill review-book song" match="any">
+              <text variable="title" form="short" font-style="italic"/>
+            </if>
+            <else>
+              <text variable="title" form="short" quotes="true"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>

--- a/meteorological-applications.csl
+++ b/meteorological-applications.csl
@@ -38,14 +38,16 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
-            <text variable="title" form="short" font-style="italic"/>
-          </if>
-          <else>
-            <text variable="title" form="short" quotes="true"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
+              <text variable="title" form="short" font-style="italic"/>
+            </if>
+            <else>
+              <text variable="title" form="short" quotes="true"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>

--- a/methods-in-ecology-and-evolution.csl
+++ b/methods-in-ecology-and-evolution.csl
@@ -64,15 +64,17 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="report">
-            <text variable="publisher"/>
-            <text macro="title"/>
-          </if>
-          <else>
-            <text macro="title"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="report">
+              <text variable="publisher"/>
+              <text macro="title"/>
+            </if>
+            <else>
+              <text macro="title"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>
@@ -82,34 +84,36 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="report">
-            <text variable="publisher"/>
-            <text variable="title" form="short" font-style="italic"/>
-          </if>
-          <else-if type="legal_case">
-            <text variable="title" font-style="italic"/>
-          </else-if>
-          <else-if type="book graphic  motion_picture song" match="any">
-            <text variable="title" form="short" font-style="italic"/>
-          </else-if>
-          <else-if type="bill legislation" match="any">
-            <text variable="title" form="short"/>
-          </else-if>
-          <else-if variable="reviewed-author">
-            <choose>
-              <if variable="reviewed-title" match="none">
-                <text variable="title" form="short" font-style="italic" prefix="Review of "/>
-              </if>
-              <else>
-                <text variable="title" form="short" quotes="true"/>
-              </else>
-            </choose>
-          </else-if>
-          <else>
-            <text variable="title" form="short" quotes="true"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="report">
+              <text variable="publisher"/>
+              <text variable="title" form="short" font-style="italic"/>
+            </if>
+            <else-if type="legal_case">
+              <text variable="title" font-style="italic"/>
+            </else-if>
+            <else-if type="book graphic  motion_picture song" match="any">
+              <text variable="title" form="short" font-style="italic"/>
+            </else-if>
+            <else-if type="bill legislation" match="any">
+              <text variable="title" form="short"/>
+            </else-if>
+            <else-if variable="reviewed-author">
+              <choose>
+                <if variable="reviewed-title" match="none">
+                  <text variable="title" form="short" font-style="italic" prefix="Review of "/>
+                </if>
+                <else>
+                  <text variable="title" form="short" quotes="true"/>
+                </else>
+              </choose>
+            </else-if>
+            <else>
+              <text variable="title" form="short" quotes="true"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>
@@ -456,7 +460,7 @@
             <else>
               <group>
                 <text term="volume" form="short" plural="true" text-case="capitalize-first" suffix=" "/>
-                <number variable="number-of-volumes" form="numeric" prefix="1&#8211;"/>
+                <number variable="number-of-volumes" form="numeric" prefix="1–"/>
               </group>
             </else>
           </choose>

--- a/mimesis-edizioni.csl
+++ b/mimesis-edizioni.csl
@@ -59,15 +59,17 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="report">
-            <text variable="publisher"/>
-            <text macro="title"/>
-          </if>
-          <else>
-            <text macro="title"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="report">
+              <text variable="publisher"/>
+              <text macro="title"/>
+            </if>
+            <else>
+              <text macro="title"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>

--- a/mind-and-language.csl
+++ b/mind-and-language.csl
@@ -68,14 +68,16 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="article-newspaper article-magazine" match="any">
-            <text variable="container-title" text-case="title" font-style="italic"/>
-          </if>
-          <else>
-            <text macro="title"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="article-newspaper article-magazine" match="any">
+              <text variable="container-title" text-case="title" font-style="italic"/>
+            </if>
+            <else>
+              <text macro="title"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>
@@ -86,14 +88,16 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="article-newspaper article-magazine" match="any">
-            <text variable="container-title" text-case="title" font-style="italic"/>
-          </if>
-          <else>
-            <text macro="title"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="article-newspaper article-magazine" match="any">
+              <text variable="container-title" text-case="title" font-style="italic"/>
+            </if>
+            <else>
+              <text macro="title"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>

--- a/mis-quarterly.csl
+++ b/mis-quarterly.csl
@@ -78,14 +78,16 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if variable="container-title" type="post-weblog webpage post report thesis" match="none">
-            <text variable="title" form="short" font-style="italic" text-case="title"/>
-          </if>
-          <else>
-            <text variable="title" form="short" quotes="true" text-case="title"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if variable="container-title" type="post-weblog webpage post report thesis" match="none">
+              <text variable="title" form="short" font-style="italic" text-case="title"/>
+            </if>
+            <else>
+              <text variable="title" form="short" quotes="true" text-case="title"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>

--- a/molecular-oncology.csl
+++ b/molecular-oncology.csl
@@ -64,15 +64,17 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="report">
-            <text variable="publisher"/>
-            <text macro="title"/>
-          </if>
-          <else>
-            <text macro="title"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="report">
+              <text variable="publisher"/>
+              <text macro="title"/>
+            </if>
+            <else>
+              <text macro="title"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>
@@ -83,34 +85,36 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="report">
-            <text variable="publisher"/>
-            <text variable="title" form="short" font-style="italic"/>
-          </if>
-          <else-if type="legal_case">
-            <text variable="title" font-style="italic"/>
-          </else-if>
-          <else-if type="book graphic  motion_picture song" match="any">
-            <text variable="title" form="short" font-style="italic"/>
-          </else-if>
-          <else-if type="bill legislation" match="any">
-            <text variable="title" form="short"/>
-          </else-if>
-          <else-if variable="reviewed-author">
-            <choose>
-              <if variable="reviewed-title" match="none">
-                <text variable="title" form="short" font-style="italic" prefix="Review of "/>
-              </if>
-              <else>
-                <text variable="title" form="short" quotes="true"/>
-              </else>
-            </choose>
-          </else-if>
-          <else>
-            <text variable="title" form="short" quotes="true"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="report">
+              <text variable="publisher"/>
+              <text variable="title" form="short" font-style="italic"/>
+            </if>
+            <else-if type="legal_case">
+              <text variable="title" font-style="italic"/>
+            </else-if>
+            <else-if type="book graphic  motion_picture song" match="any">
+              <text variable="title" form="short" font-style="italic"/>
+            </else-if>
+            <else-if type="bill legislation" match="any">
+              <text variable="title" form="short"/>
+            </else-if>
+            <else-if variable="reviewed-author">
+              <choose>
+                <if variable="reviewed-title" match="none">
+                  <text variable="title" form="short" font-style="italic" prefix="Review of "/>
+                </if>
+                <else>
+                  <text variable="title" form="short" quotes="true"/>
+                </else>
+              </choose>
+            </else-if>
+            <else>
+              <text variable="title" form="short" quotes="true"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>
@@ -436,7 +440,7 @@
             <else>
               <group>
                 <text term="volume" form="short" plural="true" text-case="capitalize-first" suffix=" "/>
-                <number variable="number-of-volumes" form="numeric" prefix="1&#8211;"/>
+                <number variable="number-of-volumes" form="numeric" prefix="1–"/>
               </group>
             </else>
           </choose>

--- a/monash-university-harvard.csl
+++ b/monash-university-harvard.csl
@@ -65,15 +65,17 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="report">
-            <text variable="publisher"/>
-            <text macro="title"/>
-          </if>
-          <else>
-            <text macro="title" font-style="italic"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="report">
+              <text variable="publisher"/>
+              <text macro="title"/>
+            </if>
+            <else>
+              <text macro="title" font-style="italic"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>
@@ -83,34 +85,36 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="report">
-            <text variable="publisher"/>
-            <text variable="title" form="short" font-style="italic"/>
-          </if>
-          <else-if type="legal_case">
-            <text variable="title" font-style="italic"/>
-          </else-if>
-          <else-if type="book graphic  motion_picture song" match="any">
-            <text variable="title" form="short" font-style="italic"/>
-          </else-if>
-          <else-if type="bill legislation" match="any">
-            <text variable="title" form="short"/>
-          </else-if>
-          <else-if variable="reviewed-author">
-            <choose>
-              <if variable="reviewed-title" match="none">
-                <text variable="title" form="short" font-style="italic" prefix="Review of "/>
-              </if>
-              <else>
-                <text variable="title" form="short" quotes="true"/>
-              </else>
-            </choose>
-          </else-if>
-          <else>
-            <text variable="title" form="short" quotes="false" font-style="italic"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="report">
+              <text variable="publisher"/>
+              <text variable="title" form="short" font-style="italic"/>
+            </if>
+            <else-if type="legal_case">
+              <text variable="title" font-style="italic"/>
+            </else-if>
+            <else-if type="book graphic  motion_picture song" match="any">
+              <text variable="title" form="short" font-style="italic"/>
+            </else-if>
+            <else-if type="bill legislation" match="any">
+              <text variable="title" form="short"/>
+            </else-if>
+            <else-if variable="reviewed-author">
+              <choose>
+                <if variable="reviewed-title" match="none">
+                  <text variable="title" form="short" font-style="italic" prefix="Review of "/>
+                </if>
+                <else>
+                  <text variable="title" form="short" quotes="true"/>
+                </else>
+              </choose>
+            </else-if>
+            <else>
+              <text variable="title" form="short" quotes="false" font-style="italic"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>
@@ -464,7 +468,7 @@
             <else>
               <group>
                 <text term="volume" form="short" plural="true" text-case="capitalize-first" suffix=" "/>
-                <number variable="number-of-volumes" form="numeric" prefix="1&#8211;"/>
+                <number variable="number-of-volumes" form="numeric" prefix="1–"/>
               </group>
             </else>
           </choose>

--- a/national-institute-of-technology-karnataka.csl
+++ b/national-institute-of-technology-karnataka.csl
@@ -55,14 +55,16 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
-            <text variable="title" form="short" font-style="italic"/>
-          </if>
-          <else>
-            <text variable="title" form="short" quotes="true"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
+              <text variable="title" form="short" font-style="italic"/>
+            </if>
+            <else>
+              <text variable="title" form="short" quotes="true"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>
@@ -157,7 +159,7 @@
         <text variable="page"/>
       </else-if>
       <else-if type="webpage">
-        <text variable="URL" prefix="&lt;" suffix="&gt;"/>
+        <text variable="URL" prefix="&lt;" suffix=">"/>
       </else-if>
     </choose>
   </macro>

--- a/national-university-of-singapore-department-of-geography-harvard.csl
+++ b/national-university-of-singapore-department-of-geography-harvard.csl
@@ -69,14 +69,16 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="article-newspaper article-magazine" match="any">
-            <text variable="container-title" text-case="title" font-style="italic"/>
-          </if>
-          <else>
-            <text macro="title"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="article-newspaper article-magazine" match="any">
+              <text variable="container-title" text-case="title" font-style="italic"/>
+            </if>
+            <else>
+              <text macro="title"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>
@@ -87,14 +89,16 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="article-newspaper article-magazine" match="any">
-            <text variable="container-title" text-case="title" font-style="italic"/>
-          </if>
-          <else>
-            <text macro="title"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="article-newspaper article-magazine" match="any">
+              <text variable="container-title" text-case="title" font-style="italic"/>
+            </if>
+            <else>
+              <text macro="title"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>

--- a/natures-sciences-societes.csl
+++ b/natures-sciences-societes.csl
@@ -63,14 +63,16 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="article-newspaper article-magazine" match="any">
-            <text variable="container-title" text-case="title" font-style="italic"/>
-          </if>
-          <else>
-            <text macro="title"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="article-newspaper article-magazine" match="any">
+              <text variable="container-title" text-case="title" font-style="italic"/>
+            </if>
+            <else>
+              <text macro="title"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>
@@ -81,14 +83,16 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="article-newspaper article-magazine" match="any">
-            <text variable="container-title" text-case="title" font-style="italic"/>
-          </if>
-          <else>
-            <text macro="title"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="article-newspaper article-magazine" match="any">
+              <text variable="container-title" text-case="title" font-style="italic"/>
+            </if>
+            <else>
+              <text macro="title"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>

--- a/new-phytologist.csl
+++ b/new-phytologist.csl
@@ -42,14 +42,16 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
-            <text variable="title" form="short" font-style="italic"/>
-          </if>
-          <else>
-            <text variable="title" form="short" quotes="true"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
+              <text variable="title" form="short" font-style="italic"/>
+            </if>
+            <else>
+              <text variable="title" form="short" quotes="true"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>

--- a/nordic-pulp-and-paper-research-journal.csl
+++ b/nordic-pulp-and-paper-research-journal.csl
@@ -56,14 +56,16 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
-            <text variable="title" form="short" font-style="italic"/>
-          </if>
-          <else>
-            <text variable="title" form="short" quotes="true"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
+              <text variable="title" form="short" font-style="italic"/>
+            </if>
+            <else>
+              <text variable="title" form="short" quotes="true"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>
@@ -125,7 +127,7 @@
         <text variable="page"/>
       </else-if>
       <else-if type="webpage">
-        <text variable="URL" prefix="&lt;" suffix="&gt;"/>
+        <text variable="URL" prefix="&lt;" suffix=">"/>
       </else-if>
     </choose>
   </macro>

--- a/norma-portuguesa-405.csl
+++ b/norma-portuguesa-405.csl
@@ -133,14 +133,16 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="bill book graphic legal_case legislation motion_picture song patent" match="any">
-            <text variable="title" form="short" font-style="italic" font-weight="normal"/>
-          </if>
-          <else>
-            <text variable="title" form="short" quotes="false" font-style="italic"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="bill book graphic legal_case legislation motion_picture song patent" match="any">
+              <text variable="title" form="short" font-style="italic" font-weight="normal"/>
+            </if>
+            <else>
+              <text variable="title" form="short" quotes="false" font-style="italic"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>
@@ -160,7 +162,7 @@
       <date-part name="month" form="short" suffix=". " text-case="lowercase"/>
       <date-part name="year" suffix="]. "/>
     </date>
-    <text variable="URL" prefix="Disponível em WWW:&lt;URL:" suffix="&gt;."/>
+    <text variable="URL" prefix="Disponível em WWW:&lt;URL:" suffix=">."/>
   </macro>
   <macro name="title">
     <group>

--- a/nuclear-receptor-signaling.csl
+++ b/nuclear-receptor-signaling.csl
@@ -64,15 +64,17 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="report">
-            <text variable="publisher"/>
-            <text macro="title"/>
-          </if>
-          <else>
-            <text macro="title"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="report">
+              <text variable="publisher"/>
+              <text macro="title"/>
+            </if>
+            <else>
+              <text macro="title"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>
@@ -83,31 +85,33 @@
       <substitute>
         <names variable="editor" font-style="normal"/>
         <names variable="translator"/>
-        <choose>
-          <if type="report">
-            <text variable="publisher"/>
-            <text variable="title" form="short" font-style="italic"/>
-          </if>
-          <else-if type="legal_case">
-            <text variable="title" font-style="italic"/>
-          </else-if>
-          <else-if type="bill book graphic legislation motion_picture song" match="any">
-            <text variable="title" form="short" font-style="italic"/>
-          </else-if>
-          <else-if variable="reviewed-author">
-            <choose>
-              <if variable="reviewed-title" match="none">
-                <text variable="title" form="short" font-style="italic" prefix="Review of "/>
-              </if>
-              <else>
-                <text variable="title" form="short" quotes="true"/>
-              </else>
-            </choose>
-          </else-if>
-          <else>
-            <text variable="title" form="short" quotes="true"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="report">
+              <text variable="publisher"/>
+              <text variable="title" form="short" font-style="italic"/>
+            </if>
+            <else-if type="legal_case">
+              <text variable="title" font-style="italic"/>
+            </else-if>
+            <else-if type="bill book graphic legislation motion_picture song" match="any">
+              <text variable="title" form="short" font-style="italic"/>
+            </else-if>
+            <else-if variable="reviewed-author">
+              <choose>
+                <if variable="reviewed-title" match="none">
+                  <text variable="title" form="short" font-style="italic" prefix="Review of "/>
+                </if>
+                <else>
+                  <text variable="title" form="short" quotes="true"/>
+                </else>
+              </choose>
+            </else-if>
+            <else>
+              <text variable="title" form="short" quotes="true"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>
@@ -449,7 +453,7 @@
             <else>
               <group>
                 <text term="volume" form="short" plural="true" text-case="capitalize-first" suffix=" "/>
-                <number variable="number-of-volumes" form="numeric" prefix="1&#8211;"/>
+                <number variable="number-of-volumes" form="numeric" prefix="1–"/>
               </group>
             </else>
           </choose>

--- a/obafemi-awolowo-university-faculty-of-technology.csl
+++ b/obafemi-awolowo-university-faculty-of-technology.csl
@@ -54,14 +54,16 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
-            <text variable="title" form="short" font-style="italic"/>
-          </if>
-          <else>
-            <text variable="title" form="short" quotes="true"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
+              <text variable="title" form="short" font-style="italic"/>
+            </if>
+            <else>
+              <text variable="title" form="short" quotes="true"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>

--- a/oecologia-australis.csl
+++ b/oecologia-australis.csl
@@ -73,15 +73,17 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="report">
-            <text variable="publisher"/>
-            <text macro="title"/>
-          </if>
-          <else>
-            <text macro="title"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="report">
+              <text variable="publisher"/>
+              <text macro="title"/>
+            </if>
+            <else>
+              <text macro="title"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>
@@ -92,31 +94,33 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="report">
-            <text variable="publisher"/>
-            <text variable="title" form="short" font-style="italic"/>
-          </if>
-          <else-if type="legal_case">
-            <text variable="title" font-style="italic"/>
-          </else-if>
-          <else-if type="bill book graphic legislation motion_picture song" match="any">
-            <text variable="title" form="short" font-style="italic"/>
-          </else-if>
-          <else-if variable="reviewed-author">
-            <choose>
-              <if variable="reviewed-title" match="none">
-                <text variable="title" form="short" font-style="italic" prefix="Review of "/>
-              </if>
-              <else>
-                <text variable="title" form="short" quotes="true"/>
-              </else>
-            </choose>
-          </else-if>
-          <else>
-            <text variable="title" form="short" quotes="true"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="report">
+              <text variable="publisher"/>
+              <text variable="title" form="short" font-style="italic"/>
+            </if>
+            <else-if type="legal_case">
+              <text variable="title" font-style="italic"/>
+            </else-if>
+            <else-if type="bill book graphic legislation motion_picture song" match="any">
+              <text variable="title" form="short" font-style="italic"/>
+            </else-if>
+            <else-if variable="reviewed-author">
+              <choose>
+                <if variable="reviewed-title" match="none">
+                  <text variable="title" form="short" font-style="italic" prefix="Review of "/>
+                </if>
+                <else>
+                  <text variable="title" form="short" quotes="true"/>
+                </else>
+              </choose>
+            </else-if>
+            <else>
+              <text variable="title" form="short" quotes="true"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>
@@ -472,7 +476,7 @@
             <else>
               <group>
                 <text term="volume" form="short" plural="true" text-case="capitalize-first" suffix=" "/>
-                <number variable="number-of-volumes" form="numeric" prefix="1&#8211;"/>
+                <number variable="number-of-volumes" form="numeric" prefix="1–"/>
               </group>
             </else>
           </choose>

--- a/oikos.csl
+++ b/oikos.csl
@@ -56,14 +56,16 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="book">
-            <text variable="title" form="short"/>
-          </if>
-          <else>
-            <text variable="title" form="short" quotes="true"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="book">
+              <text variable="title" form="short"/>
+            </if>
+            <else>
+              <text variable="title" form="short" quotes="true"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>

--- a/opuscula.csl
+++ b/opuscula.csl
@@ -62,14 +62,16 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
-            <text variable="title" form="short" font-style="italic"/>
-          </if>
-          <else>
-            <text variable="title" form="short" quotes="true"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
+              <text variable="title" form="short" font-style="italic"/>
+            </if>
+            <else>
+              <text variable="title" form="short" quotes="true"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>

--- a/oral-diseases.csl
+++ b/oral-diseases.csl
@@ -47,14 +47,16 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
-            <text variable="title" form="short" font-style="italic"/>
-          </if>
-          <else>
-            <text variable="title" form="short" quotes="true"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
+              <text variable="title" form="short" font-style="italic"/>
+            </if>
+            <else>
+              <text variable="title" form="short" quotes="true"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>

--- a/organic-geochemistry.csl
+++ b/organic-geochemistry.csl
@@ -57,14 +57,16 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
-            <text variable="title" form="short" font-style="italic"/>
-          </if>
-          <else>
-            <text variable="title" form="short" quotes="true"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
+              <text variable="title" form="short" font-style="italic"/>
+            </if>
+            <else>
+              <text variable="title" form="short" quotes="true"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>

--- a/owbarth-verlag.csl
+++ b/owbarth-verlag.csl
@@ -83,17 +83,19 @@
       <substitute>
         <names variable="editor" font-variant="small-caps"/>
         <names variable="translator" font-variant="small-caps"/>
-        <choose>
-          <if type="bill book graphic legal_case  motion_picture report song" match="any">
-            <text variable="title" form="short" font-style="italic"/>
-          </if>
-          <else-if type="bill legal_case legislation" match="any">
-            <text variable="title" form="short" font-style="normal"/>
-          </else-if>
-          <else>
-            <text variable="title" form="short" quotes="true"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="bill book graphic legal_case  motion_picture report song" match="any">
+              <text variable="title" form="short" font-style="italic"/>
+            </if>
+            <else-if type="bill legal_case legislation" match="any">
+              <text variable="title" form="short" font-style="normal"/>
+            </else-if>
+            <else>
+              <text variable="title" form="short" quotes="true"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>
@@ -110,7 +112,7 @@
   <macro name="title">
     <choose>
       <if type="bill legislation" match="any">
-        <group delimiter=" &#8212; ">
+        <group delimiter=" — ">
           <text variable="title-short" font-style="normal"/>
           <text variable="title"/>
         </group>
@@ -256,8 +258,8 @@
           <text prefix=". " macro="dimensions"/>
           <text variable="publisher-place" prefix=". "/>
           <date date-parts="year" form="numeric" variable="issued" prefix=", " suffix="."/>
-          <text prefix=" &#8211; " macro="scale"/>
-          <text prefix=". &#8212; " variable="note"/>
+          <text prefix=" – " macro="scale"/>
+          <text prefix=". — " variable="note"/>
         </if>
         <else-if type="chapter paper-conference" match="any">
           <text macro="title" prefix=" "/>
@@ -274,8 +276,8 @@
           <text prefix=". " variable="publisher-place"/>
           <text prefix=" : " variable="publisher"/>
           <date prefix=", " variable="issued" form="numeric" date-parts="year"/>
-          <text prefix=". &#8212; " variable="note"/>
-          <text prefix=" &#8212; ISBN " variable="ISBN"/>
+          <text prefix=". — " variable="note"/>
+          <text prefix=" — ISBN " variable="ISBN"/>
           <text prefix=", " macro="pages"/>
         </else-if>
         <else-if type="thesis" match="any">
@@ -285,14 +287,14 @@
           <text prefix=", " variable="publisher" form="long"/>
           <text prefix=", " macro="genre"/>
           <date prefix=", " variable="issued" form="numeric" date-parts="year"/>
-          <text prefix=". &#8212; " variable="note"/>
+          <text prefix=". — " variable="note"/>
         </else-if>
         <else-if type="webpage post post-weblog" match="any">
           <text macro="title" font-style="normal" prefix=" " suffix=", "/>
           <text variable="URL" prefix="URL "/>
           <text macro="access" prefix=" "/>
           <text variable="container-title" font-style="italic" prefix=" "/>
-          <text prefix=". &#8212; " variable="note"/>
+          <text prefix=". — " variable="note"/>
         </else-if>
         <else-if type="article article-journal article-magazine article-newspaper" match="any">
           <text variable="title" prefix=" »" suffix="«"/>
@@ -308,8 +310,8 @@
           <date form="text" variable="issued" prefix=" (" suffix=")"/>
           <text prefix=", Nr. " variable="issue"/>
           <text prefix=", " macro="pages"/>
-          <text prefix=". &#8212; " variable="note"/>
-          <text prefix=" &#8212; ISBN " variable="ISBN"/>
+          <text prefix=". — " variable="note"/>
+          <text prefix=" — ISBN " variable="ISBN"/>
         </else-if>
         <else>
           <group suffix=".">

--- a/oxford-university-press-humsoc.csl
+++ b/oxford-university-press-humsoc.csl
@@ -71,19 +71,21 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
-            <text variable="title" form="short" font-style="italic"/>
-          </if>
-          <else>
-            <text variable="title" form="short" quotes="true"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
+              <text variable="title" form="short" font-style="italic"/>
+            </if>
+            <else>
+              <text variable="title" form="short" quotes="true"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>
   <macro name="URL">
-    <group prefix="&lt;" suffix="&gt;">
+    <group prefix="&lt;" suffix=">">
       <text variable="URL"/>
     </group>
   </macro>
@@ -314,7 +316,7 @@
       </group>
     </layout>
   </citation>
-  <bibliography hanging-indent="true" et-al-min="8" et-al-use-first="7" entry-spacing="0" line-spacing="1" subsequent-author-substitute="&#8212;&#8212;">
+  <bibliography hanging-indent="true" et-al-min="8" et-al-use-first="7" entry-spacing="0" line-spacing="1" subsequent-author-substitute="——">
     <sort>
       <key macro="author"/>
       <key macro="issued-year" sort="ascending"/>

--- a/pakistani-veterinary-journal.csl
+++ b/pakistani-veterinary-journal.csl
@@ -26,14 +26,16 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
-            <text variable="title" form="short" font-style="italic"/>
-          </if>
-          <else>
-            <text variable="title" form="short"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
+              <text variable="title" form="short" font-style="italic"/>
+            </if>
+            <else>
+              <text variable="title" form="short"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>

--- a/palaeodiversity.csl
+++ b/palaeodiversity.csl
@@ -97,15 +97,17 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="report">
-            <text variable="publisher"/>
-            <text macro="title"/>
-          </if>
-          <else>
-            <text macro="title"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="report">
+              <text variable="publisher"/>
+              <text macro="title"/>
+            </if>
+            <else>
+              <text macro="title"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>
@@ -120,34 +122,36 @@
           <substitute>
             <names variable="editor" font-variant="small-caps"/>
             <names variable="translator" font-variant="small-caps"/>
-            <choose>
-              <if type="report">
-                <text variable="publisher"/>
-                <text variable="title" form="short" font-style="italic"/>
-              </if>
-              <else-if type="legal_case">
-                <text variable="title" font-style="italic"/>
-              </else-if>
-              <else-if type="book graphic  motion_picture song" match="any">
-                <text variable="title" form="short" font-style="italic"/>
-              </else-if>
-              <else-if type="bill legislation" match="any">
-                <text variable="title" form="short"/>
-              </else-if>
-              <else-if variable="reviewed-author">
-                <choose>
-                  <if variable="reviewed-title" match="none">
-                    <text variable="title" form="short" font-style="italic" prefix="Review of "/>
-                  </if>
-                  <else>
-                    <text variable="title" form="short" quotes="true"/>
-                  </else>
-                </choose>
-              </else-if>
-              <else>
-                <text variable="title" form="short" quotes="true"/>
-              </else>
-            </choose>
+            <group>
+              <choose>
+                <if type="report">
+                  <text variable="publisher"/>
+                  <text variable="title" form="short" font-style="italic"/>
+                </if>
+                <else-if type="legal_case">
+                  <text variable="title" font-style="italic"/>
+                </else-if>
+                <else-if type="book graphic  motion_picture song" match="any">
+                  <text variable="title" form="short" font-style="italic"/>
+                </else-if>
+                <else-if type="bill legislation" match="any">
+                  <text variable="title" form="short"/>
+                </else-if>
+                <else-if variable="reviewed-author">
+                  <choose>
+                    <if variable="reviewed-title" match="none">
+                      <text variable="title" form="short" font-style="italic" prefix="Review of "/>
+                    </if>
+                    <else>
+                      <text variable="title" form="short" quotes="true"/>
+                    </else>
+                  </choose>
+                </else-if>
+                <else>
+                  <text variable="title" form="short" quotes="true"/>
+                </else>
+              </choose>
+            </group>
           </substitute>
         </names>
       </else>
@@ -587,7 +591,7 @@
             <else>
               <group>
                 <text term="volume" form="short" plural="true" text-case="capitalize-first" suffix=" "/>
-                <number variable="number-of-volumes" form="numeric" prefix="1&#8211;"/>
+                <number variable="number-of-volumes" form="numeric" prefix="1–"/>
               </group>
             </else>
           </choose>
@@ -633,7 +637,7 @@
         <group>
           <choose>
             <if type="chapter paper-conference entry-encyclopedia" match="any">
-              <text term="in" text-case="capitalize-first" prefix="&#8211; " suffix=": "/>
+              <text term="in" text-case="capitalize-first" prefix="– " suffix=": "/>
             </if>
           </choose>
           <group delimiter=", ">
@@ -648,7 +652,7 @@
   <macro name="container-title">
     <choose>
       <if type="article article-journal article-magazine article-newspaper" match="any">
-        <text variable="container-title" text-case="title" font-style="normal" prefix="&#8211; "/>
+        <text variable="container-title" text-case="title" font-style="normal" prefix="– "/>
       </if>
       <else-if type="bill legal_case legislation" match="none">
         <text variable="container-title" font-style="italic"/>

--- a/palaeontologia-electronica.csl
+++ b/palaeontologia-electronica.csl
@@ -60,14 +60,16 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
-            <text variable="title" form="short" font-style="italic"/>
-          </if>
-          <else>
-            <text variable="title" form="short" quotes="true"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
+              <text variable="title" form="short" font-style="italic"/>
+            </if>
+            <else>
+              <text variable="title" form="short" quotes="true"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>

--- a/palaios.csl
+++ b/palaios.csl
@@ -42,14 +42,16 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
-            <text variable="title" form="short" font-style="italic"/>
-          </if>
-          <else>
-            <text variable="title" form="short" quotes="true"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
+              <text variable="title" form="short" font-style="italic"/>
+            </if>
+            <else>
+              <text variable="title" form="short" quotes="true"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>

--- a/peerj.csl
+++ b/peerj.csl
@@ -35,14 +35,16 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
-            <text variable="title" form="short" font-style="italic"/>
-          </if>
-          <else>
-            <text variable="title" form="short" quotes="true"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
+              <text variable="title" form="short" font-style="italic"/>
+            </if>
+            <else>
+              <text variable="title" form="short" quotes="true"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>

--- a/pesquisa-agropecuaria-brasileira.csl
+++ b/pesquisa-agropecuaria-brasileira.csl
@@ -116,20 +116,22 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="book">
-            <text variable="title" form="short"/>
-          </if>
-          <else>
-            <text variable="title" form="short" quotes="false"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="book">
+              <text variable="title" form="short"/>
+            </if>
+            <else>
+              <text variable="title" form="short" quotes="false"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>
   <!--A macro 'access' e utilizada em arquivos de paginas da web. Ela e responsavel por mostrar a URL do site pesquisado e a data do acesso -->
   <macro name="access">
-    <text variable="URL" prefix="Disponível em: &lt;" suffix="&gt;"/>
+    <text variable="URL" prefix="Disponível em: &lt;" suffix=">"/>
     <date variable="accessed" prefix=". Acesso em: ">
       <date-part name="day" suffix=" "/>
       <date-part name="month" form="short" suffix=". " text-case="lowercase"/>

--- a/philipps-universitat-marburg-note.csl
+++ b/philipps-universitat-marburg-note.csl
@@ -58,15 +58,17 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="report">
-            <text variable="publisher"/>
-            <text macro="title"/>
-          </if>
-          <else>
-            <text macro="title"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="report">
+              <text variable="publisher"/>
+              <text macro="title"/>
+            </if>
+            <else>
+              <text macro="title"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>
@@ -76,18 +78,20 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="report">
-            <text variable="publisher"/>
-            <text variable="title" form="short" font-style="italic"/>
-          </if>
-          <else-if type="bill book graphic legal_case legislation motion_picture song" match="any">
-            <text variable="title" form="short" font-style="italic"/>
-          </else-if>
-          <else>
-            <text variable="title" form="short" quotes="true"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="report">
+              <text variable="publisher"/>
+              <text variable="title" form="short" font-style="italic"/>
+            </if>
+            <else-if type="bill book graphic legal_case legislation motion_picture song" match="any">
+              <text variable="title" form="short" font-style="italic"/>
+            </else-if>
+            <else>
+              <text variable="title" form="short" quotes="true"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>

--- a/physiological-and-biochemical-zoology.csl
+++ b/physiological-and-biochemical-zoology.csl
@@ -58,15 +58,17 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="report">
-            <text variable="publisher"/>
-            <text macro="title"/>
-          </if>
-          <else>
-            <text macro="title"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="report">
+              <text variable="publisher"/>
+              <text macro="title"/>
+            </if>
+            <else>
+              <text macro="title"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>
@@ -76,18 +78,20 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="report">
-            <text variable="publisher"/>
-            <text variable="title" form="short" font-style="italic"/>
-          </if>
-          <else-if type="bill book graphic legal_case legislation motion_picture song" match="any">
-            <text variable="title" form="short" font-style="italic"/>
-          </else-if>
-          <else>
-            <text variable="title" form="short"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="report">
+              <text variable="publisher"/>
+              <text variable="title" form="short" font-style="italic"/>
+            </if>
+            <else-if type="bill book graphic legal_case legislation motion_picture song" match="any">
+              <text variable="title" form="short" font-style="italic"/>
+            </else-if>
+            <else>
+              <text variable="title" form="short"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>

--- a/planning-practice-and-research.csl
+++ b/planning-practice-and-research.csl
@@ -65,15 +65,17 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="report">
-            <text variable="publisher"/>
-            <text macro="title"/>
-          </if>
-          <else>
-            <text macro="title"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="report">
+              <text variable="publisher"/>
+              <text macro="title"/>
+            </if>
+            <else>
+              <text macro="title"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>
@@ -84,34 +86,36 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="report">
-            <text variable="publisher"/>
-            <text variable="title" form="short" font-style="italic"/>
-          </if>
-          <else-if type="legal_case">
-            <text variable="title" font-style="italic"/>
-          </else-if>
-          <else-if type="book graphic  motion_picture song" match="any">
-            <text variable="title" form="short" font-style="italic"/>
-          </else-if>
-          <else-if type="bill legislation" match="any">
-            <text variable="title" form="short"/>
-          </else-if>
-          <else-if variable="reviewed-author">
-            <choose>
-              <if variable="reviewed-title" match="none">
-                <text variable="title" form="short" font-style="italic" prefix="Review of "/>
-              </if>
-              <else>
-                <text variable="title" form="short" quotes="true"/>
-              </else>
-            </choose>
-          </else-if>
-          <else>
-            <text variable="title" form="short" quotes="true"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="report">
+              <text variable="publisher"/>
+              <text variable="title" form="short" font-style="italic"/>
+            </if>
+            <else-if type="legal_case">
+              <text variable="title" font-style="italic"/>
+            </else-if>
+            <else-if type="book graphic  motion_picture song" match="any">
+              <text variable="title" form="short" font-style="italic"/>
+            </else-if>
+            <else-if type="bill legislation" match="any">
+              <text variable="title" form="short"/>
+            </else-if>
+            <else-if variable="reviewed-author">
+              <choose>
+                <if variable="reviewed-title" match="none">
+                  <text variable="title" form="short" font-style="italic" prefix="Review of "/>
+                </if>
+                <else>
+                  <text variable="title" form="short" quotes="true"/>
+                </else>
+              </choose>
+            </else-if>
+            <else>
+              <text variable="title" form="short" quotes="true"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>
@@ -444,7 +448,7 @@
             <else>
               <group>
                 <text term="volume" form="short" plural="true" text-case="capitalize-first" suffix=" "/>
-                <number variable="number-of-volumes" form="numeric" prefix="1&#8211;"/>
+                <number variable="number-of-volumes" form="numeric" prefix="1–"/>
               </group>
             </else>
           </choose>

--- a/plant-and-cell-physiology.csl
+++ b/plant-and-cell-physiology.csl
@@ -68,14 +68,16 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
-            <text variable="title" form="short" font-style="italic"/>
-          </if>
-          <else>
-            <text variable="title" form="short" quotes="true"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
+              <text variable="title" form="short" font-style="italic"/>
+            </if>
+            <else>
+              <text variable="title" form="short" quotes="true"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>

--- a/plant-pathology.csl
+++ b/plant-pathology.csl
@@ -42,14 +42,16 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
-            <text variable="title" form="short" font-style="italic"/>
-          </if>
-          <else>
-            <text variable="title" form="short" quotes="true"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
+              <text variable="title" form="short" font-style="italic"/>
+            </if>
+            <else>
+              <text variable="title" form="short" quotes="true"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>

--- a/political-studies.csl
+++ b/political-studies.csl
@@ -78,14 +78,16 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
-            <text variable="title" form="short" font-style="italic"/>
-          </if>
-          <else>
-            <text variable="title"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
+              <text variable="title" form="short" font-style="italic"/>
+            </if>
+            <else>
+              <text variable="title"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>

--- a/population-space-and-place.csl
+++ b/population-space-and-place.csl
@@ -48,14 +48,16 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="bill book graphic legal_case motion_picture report song" match="any">
-            <text variable="title" form="short" font-style="italic"/>
-          </if>
-          <else>
-            <text variable="title" form="short"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="bill book graphic legal_case motion_picture report song" match="any">
+              <text variable="title" form="short" font-style="italic"/>
+            </if>
+            <else>
+              <text variable="title" form="short"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>
@@ -65,14 +67,16 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="bill book graphic legal_case motion_picture report song" match="any">
-            <text variable="title" form="short" font-style="italic"/>
-          </if>
-          <else>
-            <text variable="title" form="short"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="bill book graphic legal_case motion_picture report song" match="any">
+              <text variable="title" form="short" font-style="italic"/>
+            </if>
+            <else>
+              <text variable="title" form="short"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>

--- a/poultry-science.csl
+++ b/poultry-science.csl
@@ -57,14 +57,16 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
-            <text variable="title" form="short"/>
-          </if>
-          <else>
-            <text variable="title" form="short" quotes="true"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
+              <text variable="title" form="short"/>
+            </if>
+            <else>
+              <text variable="title" form="short" quotes="true"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>

--- a/preslia.csl
+++ b/preslia.csl
@@ -15,7 +15,7 @@
     <category field="biology"/>
     <category field="botany"/>
     <issn>0032-7786</issn>
-    <summary>Preslia is a peer-reviewed scientific journal publishing original research papers on plant systematics, morphology, phytogeography, ecology and vegetation science, with a geographical focus on central Europe. The journal was founded in 1914 and named in honour of brothers Jan Svatopluk Presl (1791&#8211;1849) and Karel Bořivoj Presl (1794&#8211;1852), outstanding Bohemian botanists. It is published quarterly by the Czech Botanical Society.</summary>
+    <summary>Preslia is a peer-reviewed scientific journal publishing original research papers on plant systematics, morphology, phytogeography, ecology and vegetation science, with a geographical focus on central Europe. The journal was founded in 1914 and named in honour of brothers Jan Svatopluk Presl (1791–1849) and Karel Bořivoj Presl (1794–1852), outstanding Bohemian botanists. It is published quarterly by the Czech Botanical Society.</summary>
     <updated>2013-11-25T16:12:28+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
@@ -47,14 +47,16 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
-            <text variable="title" form="short" font-style="normal"/>
-          </if>
-          <else>
-            <text variable="title" form="short" quotes="false"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
+              <text variable="title" form="short" font-style="normal"/>
+            </if>
+            <else>
+              <text variable="title" form="short" quotes="false"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>
@@ -70,7 +72,7 @@
   </macro>
   <macro name="publisher">
     <group delimiter=", ">
-      <text variable="publisher" prefix="&#8211; "/>
+      <text variable="publisher" prefix="– "/>
       <text variable="publisher-place"/>
     </group>
   </macro>
@@ -138,13 +140,13 @@
           <choose>
             <if variable="issue">
               <group delimiter=" " suffix=".">
-                <text variable="container-title" form="short" strip-periods="false" font-style="normal" prefix="&#8211; "/>
+                <text variable="container-title" form="short" strip-periods="false" font-style="normal" prefix="– "/>
                 <text variable="volume" font-style="normal" suffix=":"/>
                 <text variable="page" strip-periods="false"/>
               </group>
             </if>
             <else>
-              <text variable="container-title" form="short" font-style="normal" prefix="&#8211; " suffix="."/>
+              <text variable="container-title" form="short" font-style="normal" prefix="– " suffix="."/>
             </else>
           </choose>
         </else-if>

--- a/pure-and-applied-geophysics.csl
+++ b/pure-and-applied-geophysics.csl
@@ -68,15 +68,17 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="report">
-            <text variable="publisher"/>
-            <text macro="title"/>
-          </if>
-          <else>
-            <text macro="title"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="report">
+              <text variable="publisher"/>
+              <text macro="title"/>
+            </if>
+            <else>
+              <text macro="title"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>
@@ -91,34 +93,36 @@
           <substitute>
             <names variable="editor"/>
             <names variable="translator"/>
-            <choose>
-              <if type="report">
-                <text variable="publisher"/>
-                <text variable="title" form="short" font-style="italic"/>
-              </if>
-              <else-if type="legal_case">
-                <text variable="title" font-style="italic"/>
-              </else-if>
-              <else-if type="book graphic  motion_picture song" match="any">
-                <text variable="title" form="short" font-style="italic"/>
-              </else-if>
-              <else-if type="bill legislation" match="any">
-                <text variable="title" form="short"/>
-              </else-if>
-              <else-if variable="reviewed-author">
-                <choose>
-                  <if variable="reviewed-title" match="none">
-                    <text variable="title" form="short" font-style="italic" prefix="Review of "/>
-                  </if>
-                  <else>
-                    <text variable="title" form="short" quotes="true"/>
-                  </else>
-                </choose>
-              </else-if>
-              <else>
-                <text variable="title" form="short" quotes="true"/>
-              </else>
-            </choose>
+            <group>
+              <choose>
+                <if type="report">
+                  <text variable="publisher"/>
+                  <text variable="title" form="short" font-style="italic"/>
+                </if>
+                <else-if type="legal_case">
+                  <text variable="title" font-style="italic"/>
+                </else-if>
+                <else-if type="book graphic  motion_picture song" match="any">
+                  <text variable="title" form="short" font-style="italic"/>
+                </else-if>
+                <else-if type="bill legislation" match="any">
+                  <text variable="title" form="short"/>
+                </else-if>
+                <else-if variable="reviewed-author">
+                  <choose>
+                    <if variable="reviewed-title" match="none">
+                      <text variable="title" form="short" font-style="italic" prefix="Review of "/>
+                    </if>
+                    <else>
+                      <text variable="title" form="short" quotes="true"/>
+                    </else>
+                  </choose>
+                </else-if>
+                <else>
+                  <text variable="title" form="short" quotes="true"/>
+                </else>
+              </choose>
+            </group>
           </substitute>
         </names>
       </else>
@@ -498,7 +502,7 @@
             <else>
               <group>
                 <text term="volume" form="short" plural="true" text-case="capitalize-first" suffix=" "/>
-                <number variable="number-of-volumes" form="numeric" prefix="1&#8211;"/>
+                <number variable="number-of-volumes" form="numeric" prefix="1–"/>
               </group>
             </else>
           </choose>

--- a/raffles-bulletin-of-zoology.csl
+++ b/raffles-bulletin-of-zoology.csl
@@ -66,15 +66,17 @@
       <substitute>
         <names variable="editor" suffix="(ed)"/>
         <names variable="translator" suffix="(tr)"/>
-        <choose>
-          <if type="report">
-            <text variable="publisher"/>
-            <text macro="title"/>
-          </if>
-          <else>
-            <text macro="title"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="report">
+              <text variable="publisher"/>
+              <text macro="title"/>
+            </if>
+            <else>
+              <text macro="title"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>
@@ -89,34 +91,36 @@
           <substitute>
             <names variable="editor"/>
             <names variable="translator"/>
-            <choose>
-              <if type="report">
-                <text variable="publisher"/>
-                <text form="short" variable="title" font-style="italic"/>
-              </if>
-              <else-if type="legal_case">
-                <text variable="title" font-style="italic"/>
-              </else-if>
-              <else-if type="book graphic  motion_picture song" match="any">
-                <text form="short" variable="title" font-style="italic"/>
-              </else-if>
-              <else-if type="bill legislation" match="any">
-                <text form="short" variable="title"/>
-              </else-if>
-              <else-if variable="reviewed-author">
-                <choose>
-                  <if match="none" variable="reviewed-title">
-                    <text form="short" variable="title" prefix="Review of " font-style="italic"/>
-                  </if>
-                  <else>
-                    <text form="short" variable="title" quotes="true"/>
-                  </else>
-                </choose>
-              </else-if>
-              <else>
-                <text form="short" variable="title" quotes="true"/>
-              </else>
-            </choose>
+            <group>
+              <choose>
+                <if type="report">
+                  <text variable="publisher"/>
+                  <text form="short" variable="title" font-style="italic"/>
+                </if>
+                <else-if type="legal_case">
+                  <text variable="title" font-style="italic"/>
+                </else-if>
+                <else-if type="book graphic  motion_picture song" match="any">
+                  <text form="short" variable="title" font-style="italic"/>
+                </else-if>
+                <else-if type="bill legislation" match="any">
+                  <text form="short" variable="title"/>
+                </else-if>
+                <else-if variable="reviewed-author">
+                  <choose>
+                    <if match="none" variable="reviewed-title">
+                      <text form="short" variable="title" prefix="Review of " font-style="italic"/>
+                    </if>
+                    <else>
+                      <text form="short" variable="title" quotes="true"/>
+                    </else>
+                  </choose>
+                </else-if>
+                <else>
+                  <text form="short" variable="title" quotes="true"/>
+                </else>
+              </choose>
+            </group>
           </substitute>
         </names>
       </else>
@@ -469,7 +473,7 @@
             <else>
               <group>
                 <text form="short" text-case="capitalize-first" suffix=" " term="volume" plural="true"/>
-                <number form="numeric" variable="number-of-volumes" prefix="1&#8211;"/>
+                <number form="numeric" variable="number-of-volumes" prefix="1–"/>
               </group>
             </else>
           </choose>

--- a/renewable-agriculture-and-food-systems.csl
+++ b/renewable-agriculture-and-food-systems.csl
@@ -64,14 +64,16 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
-            <text variable="title" form="short" font-style="italic"/>
-          </if>
-          <else>
-            <text variable="title" form="short" quotes="false"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
+              <text variable="title" form="short" font-style="italic"/>
+            </if>
+            <else>
+              <text variable="title" form="short" quotes="false"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>

--- a/reproduction-fertility-and-development.csl
+++ b/reproduction-fertility-and-development.csl
@@ -60,14 +60,16 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
-            <text variable="title" form="short"/>
-          </if>
-          <else>
-            <text variable="title" form="short" quotes="true"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
+              <text variable="title" form="short"/>
+            </if>
+            <else>
+              <text variable="title" form="short" quotes="true"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>

--- a/reproduction.csl
+++ b/reproduction.csl
@@ -25,14 +25,16 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="book graphic legal_case motion_picture report song" match="any">
-            <text variable="title" form="short" font-style="italic"/>
-          </if>
-          <else>
-            <text variable="title" form="short" quotes="true"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="book graphic legal_case motion_picture report song" match="any">
+              <text variable="title" form="short" font-style="italic"/>
+            </if>
+            <else>
+              <text variable="title" form="short" quotes="true"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>
@@ -43,14 +45,16 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="book graphic legal_case motion_picture report song" match="any">
-            <text variable="title" form="short" font-style="italic"/>
-          </if>
-          <else>
-            <text variable="title" form="short" quotes="true"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="book graphic legal_case motion_picture report song" match="any">
+              <text variable="title" form="short" font-style="italic"/>
+            </if>
+            <else>
+              <text variable="title" form="short" quotes="true"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>

--- a/review-of-international-studies.csl
+++ b/review-of-international-studies.csl
@@ -50,11 +50,13 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="article-journal article-magazine article-newspaper broadcast interview manuscript map patent personal_communication song speech thesis webpage" match="any">
-            <text variable="container-title"/>
-          </if>
-        </choose>
+        <group>
+          <choose>
+            <if type="article-journal article-magazine article-newspaper broadcast interview manuscript map patent personal_communication song speech thesis webpage" match="any">
+              <text variable="container-title"/>
+            </if>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>
@@ -64,14 +66,16 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
-            <text variable="title" form="short"/>
-          </if>
-          <else>
-            <text variable="title" form="short" quotes="true"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
+              <text variable="title" form="short"/>
+            </if>
+            <else>
+              <text variable="title" form="short" quotes="true"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>

--- a/revista-de-biologia-tropical.csl
+++ b/revista-de-biologia-tropical.csl
@@ -62,14 +62,16 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
-            <text variable="title" form="short" font-style="italic"/>
-          </if>
-          <else>
-            <text variable="title" form="short" quotes="true"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
+              <text variable="title" form="short" font-style="italic"/>
+            </if>
+            <else>
+              <text variable="title" form="short" quotes="true"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>

--- a/revista-portuguesa-de-arqueologia.csl
+++ b/revista-portuguesa-de-arqueologia.csl
@@ -60,14 +60,16 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="book" match="any">
-            <text variable="title" form="short" font-style="italic"/>
-          </if>
-          <else>
-            <text variable="title" form="short"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="book" match="any">
+              <text variable="title" form="short" font-style="italic"/>
+            </if>
+            <else>
+              <text variable="title" form="short"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>

--- a/revue-d-elevage-et-de-medecine-veterinaire-des-pays-tropicaux.csl
+++ b/revue-d-elevage-et-de-medecine-veterinaire-des-pays-tropicaux.csl
@@ -74,14 +74,16 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
-            <text variable="title" form="short" font-style="italic"/>
-          </if>
-          <else>
-            <text variable="title" form="short" quotes="true"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
+              <text variable="title" form="short" font-style="italic"/>
+            </if>
+            <else>
+              <text variable="title" form="short" quotes="true"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>

--- a/revue-des-nouvelles-technologies-de-l-information.csl
+++ b/revue-des-nouvelles-technologies-de-l-information.csl
@@ -51,15 +51,17 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="report">
-            <text variable="publisher"/>
-            <text macro="title"/>
-          </if>
-          <else>
-            <text macro="title"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="report">
+              <text variable="publisher"/>
+              <text macro="title"/>
+            </if>
+            <else>
+              <text macro="title"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>
@@ -69,21 +71,23 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="report">
-            <text variable="publisher"/>
-            <text variable="title" form="short" font-style="italic"/>
-          </if>
-          <else-if type="legal_case">
-            <text variable="title" font-style="italic"/>
-          </else-if>
-          <else-if type="bill book graphic legislation motion_picture song" match="any">
-            <text variable="title" form="short" font-style="italic"/>
-          </else-if>
-          <else>
-            <text variable="title" form="short" quotes="true"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="report">
+              <text variable="publisher"/>
+              <text variable="title" form="short" font-style="italic"/>
+            </if>
+            <else-if type="legal_case">
+              <text variable="title" font-style="italic"/>
+            </else-if>
+            <else-if type="bill book graphic legislation motion_picture song" match="any">
+              <text variable="title" form="short" font-style="italic"/>
+            </else-if>
+            <else>
+              <text variable="title" form="short" quotes="true"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>

--- a/revue-europeenne-des-migrations-internationales.csl
+++ b/revue-europeenne-des-migrations-internationales.csl
@@ -47,14 +47,16 @@
           <substitute>
             <names variable="editor"/>
             <names variable="translator"/>
-            <choose>
-              <if type="article-newspaper article-magazine" match="any">
-                <text variable="container-title" text-case="title"/>
-              </if>
-              <else>
-                <text macro="title"/>
-              </else>
-            </choose>
+            <group>
+              <choose>
+                <if type="article-newspaper article-magazine" match="any">
+                  <text variable="container-title" text-case="title"/>
+                </if>
+                <else>
+                  <text macro="title"/>
+                </else>
+              </choose>
+            </group>
           </substitute>
         </names>
       </else>
@@ -71,14 +73,16 @@
           <substitute>
             <names variable="editor"/>
             <names variable="translator"/>
-            <choose>
-              <if type="article-newspaper article-magazine" match="any">
-                <text variable="container-title" text-case="title"/>
-              </if>
-              <else>
-                <text macro="title"/>
-              </else>
-            </choose>
+            <group>
+              <choose>
+                <if type="article-newspaper article-magazine" match="any">
+                  <text variable="container-title" text-case="title"/>
+                </if>
+                <else>
+                  <text macro="title"/>
+                </else>
+              </choose>
+            </group>
           </substitute>
         </names>
       </else>

--- a/rivista-italiana-di-paleontologia-e-stratigrafia.csl
+++ b/rivista-italiana-di-paleontologia-e-stratigrafia.csl
@@ -64,15 +64,17 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="report">
-            <text variable="publisher"/>
-            <text macro="title"/>
-          </if>
-          <else>
-            <text macro="title"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="report">
+              <text variable="publisher"/>
+              <text macro="title"/>
+            </if>
+            <else>
+              <text macro="title"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>
@@ -87,34 +89,36 @@
           <substitute>
             <names variable="editor"/>
             <names variable="translator"/>
-            <choose>
-              <if type="report">
-                <text variable="publisher"/>
-                <text variable="title" form="short" font-style="italic"/>
-              </if>
-              <else-if type="legal_case">
-                <text variable="title" font-style="italic"/>
-              </else-if>
-              <else-if type="book graphic  motion_picture song" match="any">
-                <text variable="title" form="short" font-style="italic"/>
-              </else-if>
-              <else-if type="bill legislation" match="any">
-                <text variable="title" form="short"/>
-              </else-if>
-              <else-if variable="reviewed-author">
-                <choose>
-                  <if variable="reviewed-title" match="none">
-                    <text variable="title" form="short" font-style="italic" prefix="Review of "/>
-                  </if>
-                  <else>
-                    <text variable="title" form="short" quotes="true"/>
-                  </else>
-                </choose>
-              </else-if>
-              <else>
-                <text variable="title" form="short" quotes="true"/>
-              </else>
-            </choose>
+            <group>
+              <choose>
+                <if type="report">
+                  <text variable="publisher"/>
+                  <text variable="title" form="short" font-style="italic"/>
+                </if>
+                <else-if type="legal_case">
+                  <text variable="title" font-style="italic"/>
+                </else-if>
+                <else-if type="book graphic  motion_picture song" match="any">
+                  <text variable="title" form="short" font-style="italic"/>
+                </else-if>
+                <else-if type="bill legislation" match="any">
+                  <text variable="title" form="short"/>
+                </else-if>
+                <else-if variable="reviewed-author">
+                  <choose>
+                    <if variable="reviewed-title" match="none">
+                      <text variable="title" form="short" font-style="italic" prefix="Review of "/>
+                    </if>
+                    <else>
+                      <text variable="title" form="short" quotes="true"/>
+                    </else>
+                  </choose>
+                </else-if>
+                <else>
+                  <text variable="title" form="short" quotes="true"/>
+                </else>
+              </choose>
+            </group>
           </substitute>
         </names>
       </else>
@@ -545,7 +549,7 @@
             <else>
               <group>
                 <text term="volume" form="short" plural="true" text-case="capitalize-first" suffix=" "/>
-                <number variable="number-of-volumes" form="numeric" prefix="1&#8211;"/>
+                <number variable="number-of-volumes" form="numeric" prefix="1–"/>
               </group>
             </else>
           </choose>

--- a/rose-school.csl
+++ b/rose-school.csl
@@ -56,14 +56,16 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
-            <text variable="title" form="short" font-style="italic"/>
-          </if>
-          <else>
-            <text variable="title" form="short" quotes="true"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
+              <text variable="title" form="short" font-style="italic"/>
+            </if>
+            <else>
+              <text variable="title" form="short" quotes="true"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>
@@ -131,7 +133,7 @@
         </group>
       </else-if>
       <else-if type="webpage">
-        <text variable="URL" prefix="&lt;" suffix="&gt;"/>
+        <text variable="URL" prefix="&lt;" suffix=">"/>
       </else-if>
     </choose>
   </macro>

--- a/ruhr-universitat-bochum-lehrstuhl-fur-industrial-sales-and-service-engineering.csl
+++ b/ruhr-universitat-bochum-lehrstuhl-fur-industrial-sales-and-service-engineering.csl
@@ -87,14 +87,16 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
-            <text variable="title" form="short" font-style="italic"/>
-          </if>
-          <else>
-            <text variable="title" form="short" quotes="true"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
+              <text variable="title" form="short" font-style="italic"/>
+            </if>
+            <else>
+              <text variable="title" form="short" quotes="true"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>

--- a/science-and-technology-for-the-built-environment.csl
+++ b/science-and-technology-for-the-built-environment.csl
@@ -66,15 +66,17 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="report">
-            <text variable="publisher"/>
-            <text macro="title"/>
-          </if>
-          <else>
-            <text macro="title"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="report">
+              <text variable="publisher"/>
+              <text macro="title"/>
+            </if>
+            <else>
+              <text macro="title"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>
@@ -84,31 +86,33 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="report">
-            <text variable="publisher"/>
-            <text variable="title" form="short" font-style="italic"/>
-          </if>
-          <else-if type="legal_case">
-            <text variable="title" font-style="italic"/>
-          </else-if>
-          <else-if type="bill book graphic legislation motion_picture song" match="any">
-            <text variable="title" form="short" font-style="italic"/>
-          </else-if>
-          <else-if variable="reviewed-author">
-            <choose>
-              <if variable="reviewed-title" match="none">
-                <text variable="title" form="short" font-style="italic" prefix="Review of "/>
-              </if>
-              <else>
-                <text variable="title" form="short" quotes="true"/>
-              </else>
-            </choose>
-          </else-if>
-          <else>
-            <text variable="title" form="short" quotes="true"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="report">
+              <text variable="publisher"/>
+              <text variable="title" form="short" font-style="italic"/>
+            </if>
+            <else-if type="legal_case">
+              <text variable="title" font-style="italic"/>
+            </else-if>
+            <else-if type="bill book graphic legislation motion_picture song" match="any">
+              <text variable="title" form="short" font-style="italic"/>
+            </else-if>
+            <else-if variable="reviewed-author">
+              <choose>
+                <if variable="reviewed-title" match="none">
+                  <text variable="title" form="short" font-style="italic" prefix="Review of "/>
+                </if>
+                <else>
+                  <text variable="title" form="short" quotes="true"/>
+                </else>
+              </choose>
+            </else-if>
+            <else>
+              <text variable="title" form="short" quotes="true"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>
@@ -401,7 +405,7 @@
             <else>
               <group>
                 <text term="volume" form="short" plural="true" text-case="capitalize-first" suffix=" "/>
-                <number variable="number-of-volumes" form="numeric" prefix="1&#8211;"/>
+                <number variable="number-of-volumes" form="numeric" prefix="1–"/>
               </group>
             </else>
           </choose>

--- a/scientific-review-engineering-and-environmental-sciences.csl
+++ b/scientific-review-engineering-and-environmental-sciences.csl
@@ -69,15 +69,17 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="report">
-            <text variable="publisher"/>
-            <text macro="title"/>
-          </if>
-          <else>
-            <text macro="title"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="report">
+              <text variable="publisher"/>
+              <text macro="title"/>
+            </if>
+            <else>
+              <text macro="title"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>
@@ -87,34 +89,36 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="report">
-            <text variable="publisher"/>
-            <text variable="title" form="short" font-style="italic"/>
-          </if>
-          <else-if type="legal_case">
-            <text variable="title" font-style="italic"/>
-          </else-if>
-          <else-if type="book graphic  motion_picture song" match="any">
-            <text variable="title" form="short" font-style="italic"/>
-          </else-if>
-          <else-if type="bill legislation" match="any">
-            <text variable="title" form="short"/>
-          </else-if>
-          <else-if variable="reviewed-author">
-            <choose>
-              <if variable="reviewed-title" match="none">
-                <text variable="title" form="short" font-style="italic" prefix="Review of "/>
-              </if>
-              <else>
-                <text variable="title" form="short" quotes="true"/>
-              </else>
-            </choose>
-          </else-if>
-          <else>
-            <text variable="title" form="short" quotes="true"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="report">
+              <text variable="publisher"/>
+              <text variable="title" form="short" font-style="italic"/>
+            </if>
+            <else-if type="legal_case">
+              <text variable="title" font-style="italic"/>
+            </else-if>
+            <else-if type="book graphic  motion_picture song" match="any">
+              <text variable="title" form="short" font-style="italic"/>
+            </else-if>
+            <else-if type="bill legislation" match="any">
+              <text variable="title" form="short"/>
+            </else-if>
+            <else-if variable="reviewed-author">
+              <choose>
+                <if variable="reviewed-title" match="none">
+                  <text variable="title" form="short" font-style="italic" prefix="Review of "/>
+                </if>
+                <else>
+                  <text variable="title" form="short" quotes="true"/>
+                </else>
+              </choose>
+            </else-if>
+            <else>
+              <text variable="title" form="short" quotes="true"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>
@@ -466,7 +470,7 @@
             <else>
               <group>
                 <text term="volume" form="short" plural="true" text-case="capitalize-first" suffix=" "/>
-                <number variable="number-of-volumes" form="numeric" prefix="1&#8211;"/>
+                <number variable="number-of-volumes" form="numeric" prefix="1–"/>
               </group>
             </else>
           </choose>

--- a/seismological-research-letters.csl
+++ b/seismological-research-letters.csl
@@ -37,14 +37,16 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
-            <text variable="title" form="short" font-style="italic"/>
-          </if>
-          <else>
-            <text variable="title" form="short" quotes="true"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
+              <text variable="title" form="short" font-style="italic"/>
+            </if>
+            <else>
+              <text variable="title" form="short" quotes="true"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>
@@ -114,7 +116,7 @@
       <if type="webpage">
         <choose>
           <if variable="URL">
-            <text variable="URL" prefix="&lt;" suffix="&gt;"/>
+            <text variable="URL" prefix="&lt;" suffix=">"/>
             <group prefix=" (" suffix=")" delimiter=" ">
               <text term="accessed"/>
               <date variable="accessed">

--- a/smithsonian-institution-scholarly-press-author-date.csl
+++ b/smithsonian-institution-scholarly-press-author-date.csl
@@ -64,15 +64,17 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="report">
-            <text variable="publisher"/>
-            <text macro="title"/>
-          </if>
-          <else>
-            <text macro="title"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="report">
+              <text variable="publisher"/>
+              <text macro="title"/>
+            </if>
+            <else>
+              <text macro="title"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>
@@ -82,34 +84,36 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="report">
-            <text variable="publisher"/>
-            <text variable="title" form="short" font-style="italic"/>
-          </if>
-          <else-if type="legal_case">
-            <text variable="title" font-style="italic"/>
-          </else-if>
-          <else-if type="book graphic  motion_picture song" match="any">
-            <text variable="title" form="short" font-style="italic"/>
-          </else-if>
-          <else-if type="bill legislation" match="any">
-            <text variable="title" form="short"/>
-          </else-if>
-          <else-if variable="reviewed-author">
-            <choose>
-              <if variable="reviewed-title" match="none">
-                <text variable="title" form="short" font-style="italic" prefix="Review of "/>
-              </if>
-              <else>
-                <text variable="title" form="short" quotes="true"/>
-              </else>
-            </choose>
-          </else-if>
-          <else>
-            <text variable="title" form="short" quotes="true"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="report">
+              <text variable="publisher"/>
+              <text variable="title" form="short" font-style="italic"/>
+            </if>
+            <else-if type="legal_case">
+              <text variable="title" font-style="italic"/>
+            </else-if>
+            <else-if type="book graphic  motion_picture song" match="any">
+              <text variable="title" form="short" font-style="italic"/>
+            </else-if>
+            <else-if type="bill legislation" match="any">
+              <text variable="title" form="short"/>
+            </else-if>
+            <else-if variable="reviewed-author">
+              <choose>
+                <if variable="reviewed-title" match="none">
+                  <text variable="title" form="short" font-style="italic" prefix="Review of "/>
+                </if>
+                <else>
+                  <text variable="title" form="short" quotes="true"/>
+                </else>
+              </choose>
+            </else-if>
+            <else>
+              <text variable="title" form="short" quotes="true"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>
@@ -456,7 +460,7 @@
             <else>
               <group>
                 <text term="volume" form="short" plural="true" text-case="capitalize-first" suffix=" "/>
-                <number variable="number-of-volumes" form="numeric" prefix="1&#8211;"/>
+                <number variable="number-of-volumes" form="numeric" prefix="1–"/>
               </group>
             </else>
           </choose>

--- a/smithsonian-institution-scholarly-press-botany.csl
+++ b/smithsonian-institution-scholarly-press-botany.csl
@@ -64,14 +64,16 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="report">
-            <text variable="publisher"/>
-          </if>
-          <else>
-            <text term="anonymous" text-case="capitalize-first" quotes="false"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="report">
+              <text variable="publisher"/>
+            </if>
+            <else>
+              <text term="anonymous" text-case="capitalize-first" quotes="false"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>
@@ -81,34 +83,36 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="report">
-            <text variable="publisher"/>
-            <text variable="title" form="short" font-style="italic"/>
-          </if>
-          <else-if type="legal_case">
-            <text variable="title" font-style="italic"/>
-          </else-if>
-          <else-if type="book graphic  motion_picture song" match="any">
-            <text variable="title" form="short" font-style="italic"/>
-          </else-if>
-          <else-if type="bill legislation" match="any">
-            <text variable="title" form="short"/>
-          </else-if>
-          <else-if variable="reviewed-author">
-            <choose>
-              <if variable="reviewed-title" match="none">
-                <text variable="title" form="short" font-style="italic" prefix="Review of "/>
-              </if>
-              <else>
-                <text variable="title" form="short" quotes="true"/>
-              </else>
-            </choose>
-          </else-if>
-          <else>
-            <text variable="title" form="short" quotes="true"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="report">
+              <text variable="publisher"/>
+              <text variable="title" form="short" font-style="italic"/>
+            </if>
+            <else-if type="legal_case">
+              <text variable="title" font-style="italic"/>
+            </else-if>
+            <else-if type="book graphic  motion_picture song" match="any">
+              <text variable="title" form="short" font-style="italic"/>
+            </else-if>
+            <else-if type="bill legislation" match="any">
+              <text variable="title" form="short"/>
+            </else-if>
+            <else-if variable="reviewed-author">
+              <choose>
+                <if variable="reviewed-title" match="none">
+                  <text variable="title" form="short" font-style="italic" prefix="Review of "/>
+                </if>
+                <else>
+                  <text variable="title" form="short" quotes="true"/>
+                </else>
+              </choose>
+            </else-if>
+            <else>
+              <text variable="title" form="short" quotes="true"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>
@@ -436,7 +440,7 @@
             <else>
               <group>
                 <text term="volume" form="short" plural="true" text-case="capitalize-first" suffix=" "/>
-                <number variable="number-of-volumes" form="numeric" prefix="1&#8211;"/>
+                <number variable="number-of-volumes" form="numeric" prefix="1–"/>
               </group>
             </else>
           </choose>

--- a/sociedade-brasileira-de-computacao.csl
+++ b/sociedade-brasileira-de-computacao.csl
@@ -107,14 +107,16 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="book">
-            <text variable="title" form="short"/>
-          </if>
-          <else>
-            <text variable="title" form="short" quotes="true"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="book">
+              <text variable="title" form="short"/>
+            </if>
+            <else>
+              <text variable="title" form="short" quotes="true"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>

--- a/sociology-of-health-and-illness.csl
+++ b/sociology-of-health-and-illness.csl
@@ -48,11 +48,13 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="report" match="any">
-            <text variable="publisher"/>
-          </if>
-        </choose>
+        <group>
+          <choose>
+            <if type="report" match="any">
+              <text variable="publisher"/>
+            </if>
+          </choose>
+        </group>
         <text macro="anon"/>
       </substitute>
     </names>

--- a/soil-biology-and-biochemistry.csl
+++ b/soil-biology-and-biochemistry.csl
@@ -59,14 +59,16 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
-            <text variable="title" form="short" font-style="italic"/>
-          </if>
-          <else>
-            <text variable="title" form="short" quotes="true"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
+              <text variable="title" form="short" font-style="italic"/>
+            </if>
+            <else>
+              <text variable="title" form="short" quotes="true"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>

--- a/south-african-journal-of-animal-science.csl
+++ b/south-african-journal-of-animal-science.csl
@@ -56,14 +56,16 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
-            <text variable="title" form="short"/>
-          </if>
-          <else>
-            <text variable="title" form="short" quotes="true"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
+              <text variable="title" form="short"/>
+            </if>
+            <else>
+              <text variable="title" form="short" quotes="true"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>

--- a/south-african-journal-of-enology-and-viticulture.csl
+++ b/south-african-journal-of-enology-and-viticulture.csl
@@ -56,14 +56,16 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="bill book graphic legal_case legislation motion_picture report song webpage" match="any">
-            <text variable="title" font-style="italic"/>
-          </if>
-          <else>
-            <text variable="title" quotes="true" text-case="capitalize-first"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="bill book graphic legal_case legislation motion_picture report song webpage" match="any">
+              <text variable="title" font-style="italic"/>
+            </if>
+            <else>
+              <text variable="title" quotes="true" text-case="capitalize-first"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>
@@ -74,14 +76,16 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
-            <text variable="title" form="short" font-style="italic"/>
-          </if>
-          <else>
-            <text variable="title" form="short" quotes="true" text-case="capitalize-first"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
+              <text variable="title" form="short" font-style="italic"/>
+            </if>
+            <else>
+              <text variable="title" form="short" quotes="true" text-case="capitalize-first"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>

--- a/south-african-journal-of-geology.csl
+++ b/south-african-journal-of-geology.csl
@@ -43,14 +43,16 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="bill book graphic legal_case legislation motion_picture report song thesis" match="any">
-            <text variable="title" form="short" font-style="italic"/>
-          </if>
-          <else>
-            <text variable="title" form="short" quotes="true"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="bill book graphic legal_case legislation motion_picture report song thesis" match="any">
+              <text variable="title" form="short" font-style="italic"/>
+            </if>
+            <else>
+              <text variable="title" form="short" quotes="true"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>

--- a/south-african-theological-seminary.csl
+++ b/south-african-theological-seminary.csl
@@ -51,14 +51,16 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="bill book graphic legal_case motion_picture report song" match="any">
-            <text variable="title" form="short"/>
-          </if>
-          <else>
-            <text variable="title" form="short" quotes="true"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="bill book graphic legal_case motion_picture report song" match="any">
+              <text variable="title" form="short"/>
+            </if>
+            <else>
+              <text variable="title" form="short" quotes="true"/>
+            </else>
+          </choose>
+        </group>
         <text variable="publisher"/>
       </substitute>
     </names>
@@ -69,14 +71,16 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="bill book graphic legal_case motion_picture report song" match="any">
-            <text variable="title" form="short"/>
-          </if>
-          <else>
-            <text variable="title" form="short" quotes="true"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="bill book graphic legal_case motion_picture report song" match="any">
+              <text variable="title" form="short"/>
+            </if>
+            <else>
+              <text variable="title" form="short" quotes="true"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>

--- a/soziologie.csl
+++ b/soziologie.csl
@@ -59,15 +59,17 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="report">
-            <text variable="publisher"/>
-            <text macro="title"/>
-          </if>
-          <else>
-            <text macro="title"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="report">
+              <text variable="publisher"/>
+              <text macro="title"/>
+            </if>
+            <else>
+              <text macro="title"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>
@@ -77,18 +79,20 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="report">
-            <text variable="publisher"/>
-            <text variable="title" form="short" font-style="italic"/>
-          </if>
-          <else-if type="bill book graphic legal_case legislation motion_picture song" match="any">
-            <text variable="title" form="short" font-style="italic"/>
-          </else-if>
-          <else>
-            <text variable="title" form="short" quotes="true"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="report">
+              <text variable="publisher"/>
+              <text variable="title" form="short" font-style="italic"/>
+            </if>
+            <else-if type="bill book graphic legal_case legislation motion_picture song" match="any">
+              <text variable="title" form="short" font-style="italic"/>
+            </else-if>
+            <else>
+              <text variable="title" form="short" quotes="true"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>

--- a/springer-socpsych-author-date.csl
+++ b/springer-socpsych-author-date.csl
@@ -68,15 +68,17 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="report">
-            <text variable="publisher"/>
-            <text macro="title"/>
-          </if>
-          <else>
-            <text macro="title"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="report">
+              <text variable="publisher"/>
+              <text macro="title"/>
+            </if>
+            <else>
+              <text macro="title"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>
@@ -86,18 +88,20 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="report">
-            <text variable="publisher"/>
-            <text variable="title" form="short" font-style="italic"/>
-          </if>
-          <else-if type="bill book graphic legal_case legislation motion_picture song" match="any">
-            <text variable="title" form="short" font-style="italic"/>
-          </else-if>
-          <else>
-            <text variable="title" form="short" quotes="true"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="report">
+              <text variable="publisher"/>
+              <text variable="title" form="short" font-style="italic"/>
+            </if>
+            <else-if type="bill book graphic legal_case legislation motion_picture song" match="any">
+              <text variable="title" form="short" font-style="italic"/>
+            </else-if>
+            <else>
+              <text variable="title" form="short" quotes="true"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>

--- a/springer-socpsych-brackets.csl
+++ b/springer-socpsych-brackets.csl
@@ -57,15 +57,17 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="report">
-            <text variable="publisher"/>
-            <text macro="title"/>
-          </if>
-          <else>
-            <text macro="title"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="report">
+              <text variable="publisher"/>
+              <text macro="title"/>
+            </if>
+            <else>
+              <text macro="title"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>

--- a/strategic-entrepreneurship-journal.csl
+++ b/strategic-entrepreneurship-journal.csl
@@ -46,14 +46,16 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="bill book graphic legal_case motion_picture report song" match="any">
-            <text variable="title" form="long" font-style="normal"/>
-          </if>
-          <else>
-            <text variable="title" form="long"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="bill book graphic legal_case motion_picture report song" match="any">
+              <text variable="title" form="long" font-style="normal"/>
+            </if>
+            <else>
+              <text variable="title" form="long"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>

--- a/strategic-management-journal.csl
+++ b/strategic-management-journal.csl
@@ -49,14 +49,16 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="bill book graphic legal_case motion_picture report song" match="any">
-            <text variable="title" form="short" font-style="italic"/>
-          </if>
-          <else>
-            <text variable="title" form="short"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="bill book graphic legal_case motion_picture report song" match="any">
+              <text variable="title" form="short" font-style="italic"/>
+            </if>
+            <else>
+              <text variable="title" form="short"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>

--- a/swiss-political-science-review.csl
+++ b/swiss-political-science-review.csl
@@ -78,14 +78,16 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
-            <text variable="title" form="short" font-style="italic" text-case="title"/>
-          </if>
-          <else>
-            <text variable="title" form="short" quotes="true" text-case="title"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
+              <text variable="title" form="short" font-style="italic" text-case="title"/>
+            </if>
+            <else>
+              <text variable="title" form="short" quotes="true" text-case="title"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>

--- a/taxon.csl
+++ b/taxon.csl
@@ -66,15 +66,17 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="report">
-            <text variable="publisher"/>
-            <text macro="title"/>
-          </if>
-          <else>
-            <text macro="title"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="report">
+              <text variable="publisher"/>
+              <text macro="title"/>
+            </if>
+            <else>
+              <text macro="title"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>
@@ -84,31 +86,33 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="report">
-            <text variable="publisher"/>
-            <text variable="title" form="short" font-style="italic"/>
-          </if>
-          <else-if type="legal_case">
-            <text variable="title" font-style="italic"/>
-          </else-if>
-          <else-if type="bill book graphic legislation motion_picture song" match="any">
-            <text variable="title" form="short" font-style="italic"/>
-          </else-if>
-          <else-if variable="reviewed-author">
-            <choose>
-              <if variable="reviewed-title" match="none">
-                <text variable="title" form="short" font-style="italic" prefix="Review of "/>
-              </if>
-              <else>
-                <text variable="title" form="short" quotes="true"/>
-              </else>
-            </choose>
-          </else-if>
-          <else>
-            <text variable="title" form="short" quotes="true"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="report">
+              <text variable="publisher"/>
+              <text variable="title" form="short" font-style="italic"/>
+            </if>
+            <else-if type="legal_case">
+              <text variable="title" font-style="italic"/>
+            </else-if>
+            <else-if type="bill book graphic legislation motion_picture song" match="any">
+              <text variable="title" form="short" font-style="italic"/>
+            </else-if>
+            <else-if variable="reviewed-author">
+              <choose>
+                <if variable="reviewed-title" match="none">
+                  <text variable="title" form="short" font-style="italic" prefix="Review of "/>
+                </if>
+                <else>
+                  <text variable="title" form="short" quotes="true"/>
+                </else>
+              </choose>
+            </else-if>
+            <else>
+              <text variable="title" form="short" quotes="true"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>
@@ -453,7 +457,7 @@
             <else>
               <group>
                 <text term="volume" form="short" plural="true" text-case="capitalize-first" suffix=" "/>
-                <number variable="number-of-volumes" form="numeric" prefix="1&#8211;"/>
+                <number variable="number-of-volumes" form="numeric" prefix="1–"/>
               </group>
             </else>
           </choose>

--- a/taylor-and-francis-harvard-x.csl
+++ b/taylor-and-francis-harvard-x.csl
@@ -82,14 +82,16 @@
           <substitute>
             <names variable="editor"/>
             <names variable="translator"/>
-            <choose>
-              <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
-                <text variable="title" form="short" font-style="italic"/>
-              </if>
-              <else>
-                <text variable="title" form="short"/>
-              </else>
-            </choose>
+            <group>
+              <choose>
+                <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
+                  <text variable="title" form="short" font-style="italic"/>
+                </if>
+                <else>
+                  <text variable="title" form="short"/>
+                </else>
+              </choose>
+            </group>
           </substitute>
         </names>
       </if>

--- a/technische-universitat-dresden-forstwissenschaft.csl
+++ b/technische-universitat-dresden-forstwissenschaft.csl
@@ -20,7 +20,7 @@
   </info>
   <locale xml:lang="de">
     <terms>
-      <term name="et-al" form="short">u.&#8239;a.</term>
+      <term name="et-al" form="short">u. a.</term>
     </terms>
   </locale>
   <macro name="container-contributors">
@@ -56,15 +56,17 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="report">
-            <text variable="publisher"/>
-            <text macro="title"/>
-          </if>
-          <else>
-            <text macro="title"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="report">
+              <text variable="publisher"/>
+              <text macro="title"/>
+            </if>
+            <else>
+              <text macro="title"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>
@@ -76,18 +78,20 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="report">
-            <text variable="publisher"/>
-            <text variable="title" form="short" font-style="normal"/>
-          </if>
-          <else-if type="bill book graphic legal_case legislation motion_picture song" match="any">
-            <text variable="title" form="short" font-style="normal"/>
-          </else-if>
-          <else>
-            <text variable="title" form="short" quotes="true"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="report">
+              <text variable="publisher"/>
+              <text variable="title" form="short" font-style="normal"/>
+            </if>
+            <else-if type="bill book graphic legal_case legislation motion_picture song" match="any">
+              <text variable="title" form="short" font-style="normal"/>
+            </else-if>
+            <else>
+              <text variable="title" form="short" quotes="true"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>

--- a/terra-nova.csl
+++ b/terra-nova.csl
@@ -41,14 +41,16 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
-            <text variable="title" form="short" font-style="italic"/>
-          </if>
-          <else>
-            <text variable="title" form="short" quotes="true"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
+              <text variable="title" form="short" font-style="italic"/>
+            </if>
+            <else>
+              <text variable="title" form="short" quotes="true"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>

--- a/the-american-naturalist.csl
+++ b/the-american-naturalist.csl
@@ -63,15 +63,17 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="report">
-            <text variable="publisher"/>
-            <text macro="title"/>
-          </if>
-          <else>
-            <text macro="title"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="report">
+              <text variable="publisher"/>
+              <text macro="title"/>
+            </if>
+            <else>
+              <text macro="title"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>
@@ -81,18 +83,20 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="report">
-            <text variable="publisher"/>
-            <text variable="title" form="short" font-style="italic"/>
-          </if>
-          <else-if type="bill book graphic legal_case legislation motion_picture song" match="any">
-            <text variable="title" form="short" font-style="italic"/>
-          </else-if>
-          <else>
-            <text variable="title" form="short"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="report">
+              <text variable="publisher"/>
+              <text variable="title" form="short" font-style="italic"/>
+            </if>
+            <else-if type="bill book graphic legal_case legislation motion_picture song" match="any">
+              <text variable="title" form="short" font-style="italic"/>
+            </else-if>
+            <else>
+              <text variable="title" form="short"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>
@@ -311,7 +315,7 @@
       </group>
     </layout>
   </citation>
-  <bibliography et-al-min="8" et-al-use-first="7" entry-spacing="0" subsequent-author-substitute="&#8212;&#8212;&#8212;">
+  <bibliography et-al-min="8" et-al-use-first="7" entry-spacing="0" subsequent-author-substitute="———">
     <sort>
       <key macro="author"/>
       <key macro="issued-year" sort="ascending"/>

--- a/the-botanical-review.csl
+++ b/the-botanical-review.csl
@@ -55,15 +55,17 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="report">
-            <text variable="publisher"/>
-            <text macro="title"/>
-          </if>
-          <else>
-            <text macro="title"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="report">
+              <text variable="publisher"/>
+              <text macro="title"/>
+            </if>
+            <else>
+              <text macro="title"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>
@@ -73,18 +75,20 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="report">
-            <text variable="publisher"/>
-            <text variable="title" form="short"/>
-          </if>
-          <else-if type="bill book graphic legal_case legislation motion_picture song" match="any">
-            <text variable="title" form="short"/>
-          </else-if>
-          <else>
-            <text variable="title" form="short" quotes="true"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="report">
+              <text variable="publisher"/>
+              <text variable="title" form="short"/>
+            </if>
+            <else-if type="bill book graphic legal_case legislation motion_picture song" match="any">
+              <text variable="title" form="short"/>
+            </else-if>
+            <else>
+              <text variable="title" form="short" quotes="true"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>

--- a/the-british-journal-for-the-philosophy-of-science.csl
+++ b/the-british-journal-for-the-philosophy-of-science.csl
@@ -54,15 +54,17 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="report">
-            <text variable="publisher"/>
-            <text macro="title"/>
-          </if>
-          <else>
-            <text macro="title"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="report">
+              <text variable="publisher"/>
+              <text macro="title"/>
+            </if>
+            <else>
+              <text macro="title"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>
@@ -73,18 +75,20 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="report">
-            <text variable="publisher"/>
-            <text variable="title" form="short"/>
-          </if>
-          <else-if type="bill book graphic legal_case legislation motion_picture song" match="any">
-            <text variable="title" form="short"/>
-          </else-if>
-          <else>
-            <text variable="title" form="short" quotes="true"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="report">
+              <text variable="publisher"/>
+              <text variable="title" form="short"/>
+            </if>
+            <else-if type="bill book graphic legal_case legislation motion_picture song" match="any">
+              <text variable="title" form="short"/>
+            </else-if>
+            <else>
+              <text variable="title" form="short" quotes="true"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>
@@ -259,7 +263,7 @@
     </choose>
   </macro>
   <macro name="access">
-    <text variable="URL" prefix="&lt;" suffix="&gt;"/>
+    <text variable="URL" prefix="&lt;" suffix=">"/>
   </macro>
   <macro name="citation-locator">
     <group>
@@ -337,7 +341,7 @@
       </group>
     </layout>
   </citation>
-  <bibliography subsequent-author-substitute="&#8212;&#8212;&#8212;" hanging-indent="true">
+  <bibliography subsequent-author-substitute="———" hanging-indent="true">
     <sort>
       <key macro="author" names-min="1" names-use-first="1"/>
       <key macro="issued-year" sort="ascending"/>

--- a/the-design-journal.csl
+++ b/the-design-journal.csl
@@ -44,15 +44,17 @@
         <names variable="translator"/>
         <text macro="anon"/>
         <names variable="translator"/>
-        <choose>
-          <if type="report">
-            <text variable="publisher"/>
-            <text macro="title"/>
-          </if>
-          <else>
-            <text macro="title"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="report">
+              <text variable="publisher"/>
+              <text macro="title"/>
+            </if>
+            <else>
+              <text macro="title"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>

--- a/the-geological-society-of-america.csl
+++ b/the-geological-society-of-america.csl
@@ -42,14 +42,16 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
-            <text variable="title" form="short" font-style="italic"/>
-          </if>
-          <else>
-            <text variable="title" form="short" quotes="true"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
+              <text variable="title" form="short" font-style="italic"/>
+            </if>
+            <else>
+              <text variable="title" form="short" quotes="true"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>

--- a/the-holocene.csl
+++ b/the-holocene.csl
@@ -37,14 +37,16 @@
         <names variable="editor"/>
         <names variable="translator"/>
         <text variable="container-title" font-style="italic"/>
-        <choose>
-          <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
-            <text variable="title" form="short" font-style="italic"/>
-          </if>
-          <else>
-            <text variable="title" form="short" quotes="true"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
+              <text variable="title" form="short" font-style="italic"/>
+            </if>
+            <else>
+              <text variable="title" form="short" quotes="true"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>

--- a/the-international-journal-of-psychoanalysis.csl
+++ b/the-international-journal-of-psychoanalysis.csl
@@ -59,14 +59,16 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="book">
-            <text variable="title" form="short" font-style="italic"/>
-          </if>
-          <else>
-            <text variable="title" form="short" quotes="true"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="book">
+              <text variable="title" form="short" font-style="italic"/>
+            </if>
+            <else>
+              <text variable="title" form="short" quotes="true"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>

--- a/the-journal-of-agricultural-science.csl
+++ b/the-journal-of-agricultural-science.csl
@@ -40,14 +40,16 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
-            <text variable="title" form="short" font-style="italic"/>
-          </if>
-          <else>
-            <text variable="title" form="short" quotes="true"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
+              <text variable="title" form="short" font-style="italic"/>
+            </if>
+            <else>
+              <text variable="title" form="short" quotes="true"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>

--- a/the-journal-of-nervous-and-mental-disease.csl
+++ b/the-journal-of-nervous-and-mental-disease.csl
@@ -55,14 +55,16 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
-            <text variable="title" form="short" font-style="italic"/>
-          </if>
-          <else>
-            <text variable="title" form="short"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
+              <text variable="title" form="short" font-style="italic"/>
+            </if>
+            <else>
+              <text variable="title" form="short"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>

--- a/the-journal-of-parasitology.csl
+++ b/the-journal-of-parasitology.csl
@@ -59,14 +59,16 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
-            <text variable="title" form="short" font-style="italic"/>
-          </if>
-          <else>
-            <text variable="title" form="short" quotes="true"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
+              <text variable="title" form="short" font-style="italic"/>
+            </if>
+            <else>
+              <text variable="title" form="short" quotes="true"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>

--- a/the-journal-of-peasant-studies.csl
+++ b/the-journal-of-peasant-studies.csl
@@ -82,14 +82,16 @@
           <substitute>
             <names variable="editor"/>
             <names variable="translator"/>
-            <choose>
-              <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
-                <text variable="title" form="short" font-style="italic"/>
-              </if>
-              <else>
-                <text variable="title" form="short"/>
-              </else>
-            </choose>
+            <group>
+              <choose>
+                <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
+                  <text variable="title" form="short" font-style="italic"/>
+                </if>
+                <else>
+                  <text variable="title" form="short"/>
+                </else>
+              </choose>
+            </group>
           </substitute>
         </names>
       </if>

--- a/the-journal-of-the-acoustical-society-of-america.csl
+++ b/the-journal-of-the-acoustical-society-of-america.csl
@@ -72,14 +72,16 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="bill book graphic legal_case legislation motion_picture report patent thesis song" match="any">
-            <text variable="title" form="short" font-style="italic"/>
-          </if>
-          <else>
-            <text variable="title" form="short" quotes="true"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="bill book graphic legal_case legislation motion_picture report patent thesis song" match="any">
+              <text variable="title" form="short" font-style="italic"/>
+            </if>
+            <else>
+              <text variable="title" form="short" quotes="true"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>

--- a/the-journal-of-the-torrey-botanical-society.csl
+++ b/the-journal-of-the-torrey-botanical-society.csl
@@ -58,14 +58,16 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
-            <text variable="title" form="short"/>
-          </if>
-          <else>
-            <text variable="title" form="short" quotes="true"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
+              <text variable="title" form="short"/>
+            </if>
+            <else>
+              <text variable="title" form="short" quotes="true"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>
@@ -82,7 +84,7 @@
           <group>
             <text term="from" suffix=" "/>
             <text variable="container-title" suffix=". "/>
-            <text variable="URL" prefix="&lt;" suffix="&gt;"/>
+            <text variable="URL" prefix="&lt;" suffix=">"/>
           </group>
         </group>
       </if>

--- a/the-lichenologist.csl
+++ b/the-lichenologist.csl
@@ -40,14 +40,16 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
-            <text variable="title" form="short" font-style="italic"/>
-          </if>
-          <else>
-            <text variable="title" form="short" quotes="true"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
+              <text variable="title" form="short" font-style="italic"/>
+            </if>
+            <else>
+              <text variable="title" form="short" quotes="true"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>

--- a/the-open-university-a251.csl
+++ b/the-open-university-a251.csl
@@ -46,14 +46,16 @@
           <substitute>
             <names variable="editor"/>
             <names variable="translator"/>
-            <choose>
-              <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
-                <text variable="title" form="short" font-style="italic"/>
-              </if>
-              <else>
-                <text variable="title" form="short"/>
-              </else>
-            </choose>
+            <group>
+              <choose>
+                <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
+                  <text variable="title" form="short" font-style="italic"/>
+                </if>
+                <else>
+                  <text variable="title" form="short"/>
+                </else>
+              </choose>
+            </group>
           </substitute>
         </names>
         <date variable="issued" prefix=", ">

--- a/the-open-university-harvard.csl
+++ b/the-open-university-harvard.csl
@@ -33,16 +33,18 @@
       <name name-as-sort-order="all" and="text" sort-separator=", " delimiter=", " delimiter-precedes-last="never" form="long" initialize-with=". "/>
       <label form="short" prefix=" (" suffix=")"/>
       <substitute>
-        <choose>
-          <if type="webpage">
-            <text variable="container-title"/>
-            <text variable="URL"/>
-          </if>
-          <else>
-            <names variable="editor"/>
-            <text macro="anon"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="webpage">
+              <text variable="container-title"/>
+              <text variable="URL"/>
+            </if>
+            <else>
+              <names variable="editor"/>
+              <text macro="anon"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>
@@ -50,17 +52,19 @@
     <names variable="author">
       <name form="short" and="text" delimiter=", " delimiter-precedes-last="never" initialize-with=". "/>
       <substitute>
-        <choose>
-          <if type="webpage">
-            <text variable="container-title"/>
-            <text variable="URL"/>
-          </if>
-          <else>
-            <names variable="editor"/>
-            <names variable="translator"/>
-            <text macro="anon"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="webpage">
+              <text variable="container-title"/>
+              <text variable="URL"/>
+            </if>
+            <else>
+              <names variable="editor"/>
+              <names variable="translator"/>
+              <text macro="anon"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>

--- a/the-university-of-winchester-harvard.csl
+++ b/the-university-of-winchester-harvard.csl
@@ -53,15 +53,17 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="report">
-            <text variable="publisher"/>
-            <text macro="title"/>
-          </if>
-          <else>
-            <text macro="title"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="report">
+              <text variable="publisher"/>
+              <text macro="title"/>
+            </if>
+            <else>
+              <text macro="title"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>
@@ -91,18 +93,20 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="report">
-            <text variable="publisher"/>
-            <text variable="title" form="short" font-style="italic"/>
-          </if>
-          <else-if type="bill book graphic legal_case legislation motion_picture song" match="any">
-            <text variable="title" form="short" font-style="italic"/>
-          </else-if>
-          <else>
-            <text variable="title" form="short" quotes="true"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="report">
+              <text variable="publisher"/>
+              <text variable="title" form="short" font-style="italic"/>
+            </if>
+            <else-if type="bill book graphic legal_case legislation motion_picture song" match="any">
+              <text variable="title" form="short" font-style="italic"/>
+            </else-if>
+            <else>
+              <text variable="title" form="short" quotes="true"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>

--- a/theory-culture-and-society.csl
+++ b/theory-culture-and-society.csl
@@ -89,14 +89,16 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
-            <text variable="title" form="short" font-style="italic" text-case="title"/>
-          </if>
-          <else>
-            <text variable="title" form="short" quotes="true" text-case="title"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
+              <text variable="title" form="short" font-style="italic" text-case="title"/>
+            </if>
+            <else>
+              <text variable="title" form="short" quotes="true" text-case="title"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>

--- a/transboundary-and-emerging-diseases.csl
+++ b/transboundary-and-emerging-diseases.csl
@@ -55,15 +55,17 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="report">
-            <text variable="publisher"/>
-            <text macro="title"/>
-          </if>
-          <else>
-            <text macro="title"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="report">
+              <text variable="publisher"/>
+              <text macro="title"/>
+            </if>
+            <else>
+              <text macro="title"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>
@@ -73,18 +75,20 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="report">
-            <text variable="publisher"/>
-            <text variable="title" form="short" font-style="italic"/>
-          </if>
-          <else-if type="bill book graphic legal_case legislation motion_picture song" match="any">
-            <text variable="title" form="short" font-style="italic"/>
-          </else-if>
-          <else>
-            <text variable="title" form="short" quotes="true"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="report">
+              <text variable="publisher"/>
+              <text variable="title" form="short" font-style="italic"/>
+            </if>
+            <else-if type="bill book graphic legal_case legislation motion_picture song" match="any">
+              <text variable="title" form="short" font-style="italic"/>
+            </else-if>
+            <else>
+              <text variable="title" form="short" quotes="true"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>

--- a/transport.csl
+++ b/transport.csl
@@ -48,11 +48,13 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="report" match="any">
-            <text variable="publisher"/>
-          </if>
-        </choose>
+        <group>
+          <choose>
+            <if type="report" match="any">
+              <text variable="publisher"/>
+            </if>
+          </choose>
+        </group>
         <text macro="anon"/>
       </substitute>
     </names>

--- a/turkiye-bilimsel-ve-teknolojik-arastirma-kurumu.csl
+++ b/turkiye-bilimsel-ve-teknolojik-arastirma-kurumu.csl
@@ -70,15 +70,17 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="report">
-            <text variable="publisher"/>
-            <text macro="title"/>
-          </if>
-          <else>
-            <text macro="title"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="report">
+              <text variable="publisher"/>
+              <text macro="title"/>
+            </if>
+            <else>
+              <text macro="title"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>
@@ -93,34 +95,36 @@
           <substitute>
             <names variable="editor"/>
             <names variable="translator"/>
-            <choose>
-              <if type="report">
-                <text variable="publisher"/>
-                <text variable="title" form="short" font-style="italic"/>
-              </if>
-              <else-if type="legal_case">
-                <text variable="title" font-style="italic"/>
-              </else-if>
-              <else-if type="book graphic  motion_picture song" match="any">
-                <text variable="title" form="short" font-style="italic"/>
-              </else-if>
-              <else-if type="bill legislation" match="any">
-                <text variable="title" form="short"/>
-              </else-if>
-              <else-if variable="reviewed-author">
-                <choose>
-                  <if variable="reviewed-title" match="none">
-                    <text variable="title" form="short" font-style="italic" prefix="Review of "/>
-                  </if>
-                  <else>
-                    <text variable="title" form="short" quotes="true"/>
-                  </else>
-                </choose>
-              </else-if>
-              <else>
-                <text variable="title" form="short" quotes="true"/>
-              </else>
-            </choose>
+            <group>
+              <choose>
+                <if type="report">
+                  <text variable="publisher"/>
+                  <text variable="title" form="short" font-style="italic"/>
+                </if>
+                <else-if type="legal_case">
+                  <text variable="title" font-style="italic"/>
+                </else-if>
+                <else-if type="book graphic  motion_picture song" match="any">
+                  <text variable="title" form="short" font-style="italic"/>
+                </else-if>
+                <else-if type="bill legislation" match="any">
+                  <text variable="title" form="short"/>
+                </else-if>
+                <else-if variable="reviewed-author">
+                  <choose>
+                    <if variable="reviewed-title" match="none">
+                      <text variable="title" form="short" font-style="italic" prefix="Review of "/>
+                    </if>
+                    <else>
+                      <text variable="title" form="short" quotes="true"/>
+                    </else>
+                  </choose>
+                </else-if>
+                <else>
+                  <text variable="title" form="short" quotes="true"/>
+                </else>
+              </choose>
+            </group>
           </substitute>
         </names>
       </else>
@@ -560,7 +564,7 @@
             <else>
               <group>
                 <text term="volume" form="short" plural="true" text-case="capitalize-first" suffix=" "/>
-                <number variable="number-of-volumes" form="numeric" prefix="1&#8211;"/>
+                <number variable="number-of-volumes" form="numeric" prefix="1–"/>
               </group>
             </else>
           </choose>

--- a/united-nations-framework-convention-on-climate-change.csl
+++ b/united-nations-framework-convention-on-climate-change.csl
@@ -36,14 +36,16 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
-            <text variable="title" form="short" font-style="italic"/>
-          </if>
-          <else>
-            <text variable="title" form="short" quotes="true"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
+              <text variable="title" form="short" font-style="italic"/>
+            </if>
+            <else>
+              <text variable="title" form="short" quotes="true"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>

--- a/universidad-autonoma-cidudad-juarez-estilo-latino-humanistico.csl
+++ b/universidad-autonoma-cidudad-juarez-estilo-latino-humanistico.csl
@@ -33,11 +33,13 @@
       <label form="short" prefix=" (" suffix=")"/>
       <et-al font-style="italic"/>
       <substitute>
-        <choose>
-          <if type="entry-encyclopedia" match="none">
-            <text macro="editor-note"/>
-          </if>
-        </choose>
+        <group>
+          <choose>
+            <if type="entry-encyclopedia" match="none">
+              <text macro="editor-note"/>
+            </if>
+          </choose>
+        </group>
         <text macro="title"/>
       </substitute>
     </names>
@@ -55,11 +57,13 @@
       <label form="short" prefix=" (" suffix=")"/>
       <et-al font-style="italic"/>
       <substitute>
-        <choose>
-          <if type="entry-encyclopedia" match="none">
-            <text macro="editor"/>
-          </if>
-        </choose>
+        <group>
+          <choose>
+            <if type="entry-encyclopedia" match="none">
+              <text macro="editor"/>
+            </if>
+          </choose>
+        </group>
         <text macro="title"/>
       </substitute>
     </names>

--- a/universidad-de-leon-harvard.csl
+++ b/universidad-de-leon-harvard.csl
@@ -67,14 +67,16 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="article-newspaper article-magazine" match="any">
-            <text variable="container-title" text-case="title" font-style="italic"/>
-          </if>
-          <else>
-            <text macro="title"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="article-newspaper article-magazine" match="any">
+              <text variable="container-title" text-case="title" font-style="italic"/>
+            </if>
+            <else>
+              <text macro="title"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>
@@ -85,14 +87,16 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="article-newspaper article-magazine" match="any">
-            <text variable="container-title" text-case="title" font-style="italic"/>
-          </if>
-          <else>
-            <text macro="title"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="article-newspaper article-magazine" match="any">
+              <text variable="container-title" text-case="title" font-style="italic"/>
+            </if>
+            <else>
+              <text macro="title"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>

--- a/universidade-de-sao-paulo-instituto-de-matematica-e-estatistica.csl
+++ b/universidade-de-sao-paulo-instituto-de-matematica-e-estatistica.csl
@@ -32,14 +32,16 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
-            <text variable="title" form="short" font-style="italic"/>
-          </if>
-          <else>
-            <text variable="title" form="short" quotes="true"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
+              <text variable="title" form="short" font-style="italic"/>
+            </if>
+            <else>
+              <text variable="title" form="short" quotes="true"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>
@@ -49,14 +51,16 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
-            <text variable="title" form="short" font-style="italic"/>
-          </if>
-          <else>
-            <text variable="title" form="short" quotes="true"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
+              <text variable="title" form="short" font-style="italic"/>
+            </if>
+            <else>
+              <text variable="title" form="short" quotes="true"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>

--- a/universidade-estadual-do-oeste-do-parana-programa-institucional-de-bolsas-de-iniciacao-cientifica.csl
+++ b/universidade-estadual-do-oeste-do-parana-programa-institucional-de-bolsas-de-iniciacao-cientifica.csl
@@ -77,14 +77,16 @@
         <names variable="editor"/>
         <names variable="translator"/>
         <text variable="container-title" font-style="italic" font-weight="normal"/>
-        <choose>
-          <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
-            <text variable="title" form="short" font-style="italic"/>
-          </if>
-          <else>
-            <text variable="title" form="short" quotes="true"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
+              <text variable="title" form="short" font-style="italic"/>
+            </if>
+            <else>
+              <text variable="title" form="short" quotes="true"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>

--- a/universidade-estadual-paulista-campus-de-dracena-abnt.csl
+++ b/universidade-estadual-paulista-campus-de-dracena-abnt.csl
@@ -104,19 +104,21 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="book">
-            <text variable="title" form="short"/>
-          </if>
-          <else>
-            <text variable="title" form="short" text-case="uppercase" quotes="false"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="book">
+              <text variable="title" form="short"/>
+            </if>
+            <else>
+              <text variable="title" form="short" text-case="uppercase" quotes="false"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>
   <macro name="access">
-    <text variable="URL" prefix=" Disponível em: &lt;" suffix="&gt;"/>
+    <text variable="URL" prefix=" Disponível em: &lt;" suffix=">"/>
     <date variable="accessed" prefix=". Acesso em: " suffix=".">
       <date-part name="day" suffix=" "/>
       <date-part name="month" form="short" suffix=". " text-case="lowercase"/>

--- a/universidade-federal-de-juiz-de-fora.csl
+++ b/universidade-federal-de-juiz-de-fora.csl
@@ -199,21 +199,23 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="book">
-            <text variable="title" form="short"/>
-          </if>
-          <else>
-            <text variable="title" form="short" quotes="true"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="book">
+              <text variable="title" form="short"/>
+            </if>
+            <else>
+              <text variable="title" form="short" quotes="true"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>
   <macro name="access">
     <choose>
       <if type="article-magazine article-journal" match="any">
-        <text variable="URL" prefix=". Disponível em: &lt;" suffix="&gt;"/>
+        <text variable="URL" prefix=". Disponível em: &lt;" suffix=">"/>
         <date variable="accessed" prefix=". Acesso em: ">
           <date-part name="day" suffix=" "/>
           <date-part name="month" form="short" suffix=" " text-case="lowercase"/>
@@ -221,7 +223,7 @@
         </date>
       </if>
       <else>
-        <text variable="URL" prefix="Disponível em: &lt;" suffix="&gt;"/>
+        <text variable="URL" prefix="Disponível em: &lt;" suffix=">"/>
         <date variable="accessed" prefix=". Acesso em: ">
           <date-part name="day" suffix=" "/>
           <date-part name="month" form="short" suffix=" " text-case="lowercase"/>
@@ -573,7 +575,7 @@
           <group>
             <text macro="author" suffix=". "/>
             <text macro="title" suffix=". "/>
-            <text variable="genre" suffix=" &#8211; "/>
+            <text variable="genre" suffix=" – "/>
             <text variable="publisher" suffix=", "/>
             <text variable="publisher-place" suffix=", "/>
             <text macro="issued-year" suffix=". "/>

--- a/universidade-federal-do-espirito-santo-abnt-initials.csl
+++ b/universidade-federal-do-espirito-santo-abnt-initials.csl
@@ -181,21 +181,23 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="book">
-            <text variable="title" form="short"/>
-          </if>
-          <else>
-            <text variable="title" form="short" quotes="true"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="book">
+              <text variable="title" form="short"/>
+            </if>
+            <else>
+              <text variable="title" form="short" quotes="true"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>
   <macro name="access">
     <choose>
       <if type="article-magazine article-journal" match="any">
-        <text variable="URL" prefix=". Disponível em: &lt;" suffix="&gt;"/>
+        <text variable="URL" prefix=". Disponível em: &lt;" suffix=">"/>
         <date variable="accessed" prefix=". Acesso em: ">
           <date-part name="day" suffix=" "/>
           <date-part name="month" form="short" suffix=" " text-case="lowercase"/>
@@ -203,7 +205,7 @@
         </date>
       </if>
       <else>
-        <text variable="URL" prefix="Disponível em: &lt;" suffix="&gt;"/>
+        <text variable="URL" prefix="Disponível em: &lt;" suffix=">"/>
         <date variable="accessed" prefix=". Acesso em: ">
           <date-part name="day" suffix=" "/>
           <date-part name="month" form="short" suffix=" " text-case="lowercase"/>
@@ -529,7 +531,7 @@
             <text macro="title" text-case="title" suffix=". "/>
             <text macro="issued-year" suffix=". "/>
             <text variable="number-of-pages" suffix=" f. "/>
-            <text variable="genre" suffix="&#8211;"/>
+            <text variable="genre" suffix="–"/>
             <text variable="publisher" suffix=", "/>
             <text variable="publisher-place" suffix=", "/>
             <text macro="issued-year" suffix=". "/>

--- a/universidade-federal-do-espirito-santo-abnt.csl
+++ b/universidade-federal-do-espirito-santo-abnt.csl
@@ -181,21 +181,23 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="book">
-            <text variable="title" form="short"/>
-          </if>
-          <else>
-            <text variable="title" form="short" quotes="true"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="book">
+              <text variable="title" form="short"/>
+            </if>
+            <else>
+              <text variable="title" form="short" quotes="true"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>
   <macro name="access">
     <choose>
       <if type="article-magazine article-journal" match="any">
-        <text variable="URL" prefix=". Disponível em: &lt;" suffix="&gt;"/>
+        <text variable="URL" prefix=". Disponível em: &lt;" suffix=">"/>
         <date variable="accessed" prefix=". Acesso em: ">
           <date-part name="day" suffix=" "/>
           <date-part name="month" form="short" suffix=" " text-case="lowercase"/>
@@ -203,7 +205,7 @@
         </date>
       </if>
       <else>
-        <text variable="URL" prefix="Disponível em: &lt;" suffix="&gt;"/>
+        <text variable="URL" prefix="Disponível em: &lt;" suffix=">"/>
         <date variable="accessed" prefix=". Acesso em: ">
           <date-part name="day" suffix=" "/>
           <date-part name="month" form="short" suffix=" " text-case="lowercase"/>
@@ -529,7 +531,7 @@
             <text macro="title" text-case="title" suffix=". "/>
             <text macro="issued-year" suffix=". "/>
             <text variable="number-of-pages" suffix=" f. "/>
-            <text variable="genre" suffix=" &#8211; "/>
+            <text variable="genre" suffix=" – "/>
             <text variable="publisher" suffix=", "/>
             <text variable="publisher-place" suffix=", "/>
             <text macro="issued-year" suffix=". "/>

--- a/universitas-negeri-yogyakarta-program-pascasarjana.csl
+++ b/universitas-negeri-yogyakarta-program-pascasarjana.csl
@@ -66,15 +66,17 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="report">
-            <text variable="publisher"/>
-            <text macro="title"/>
-          </if>
-          <else>
-            <text macro="title"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="report">
+              <text variable="publisher"/>
+              <text macro="title"/>
+            </if>
+            <else>
+              <text macro="title"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>
@@ -84,34 +86,36 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="report">
-            <text variable="publisher"/>
-            <text variable="title" form="short" font-style="italic"/>
-          </if>
-          <else-if type="legal_case">
-            <text variable="title" font-style="italic"/>
-          </else-if>
-          <else-if type="book graphic  motion_picture song" match="any">
-            <text variable="title" form="short" font-style="italic"/>
-          </else-if>
-          <else-if type="bill legislation" match="any">
-            <text variable="title" form="short"/>
-          </else-if>
-          <else-if variable="reviewed-author">
-            <choose>
-              <if variable="reviewed-title" match="none">
-                <text variable="title" form="short" font-style="italic" prefix="Review of "/>
-              </if>
-              <else>
-                <text variable="title" form="short" quotes="true"/>
-              </else>
-            </choose>
-          </else-if>
-          <else>
-            <text variable="title" form="short"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="report">
+              <text variable="publisher"/>
+              <text variable="title" form="short" font-style="italic"/>
+            </if>
+            <else-if type="legal_case">
+              <text variable="title" font-style="italic"/>
+            </else-if>
+            <else-if type="book graphic  motion_picture song" match="any">
+              <text variable="title" form="short" font-style="italic"/>
+            </else-if>
+            <else-if type="bill legislation" match="any">
+              <text variable="title" form="short"/>
+            </else-if>
+            <else-if variable="reviewed-author">
+              <choose>
+                <if variable="reviewed-title" match="none">
+                  <text variable="title" form="short" font-style="italic" prefix="Review of "/>
+                </if>
+                <else>
+                  <text variable="title" form="short" quotes="true"/>
+                </else>
+              </choose>
+            </else-if>
+            <else>
+              <text variable="title" form="short"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>
@@ -458,7 +462,7 @@
             <else>
               <group>
                 <text term="volume" form="short" plural="true" text-case="capitalize-first" suffix=" "/>
-                <number variable="number-of-volumes" form="numeric" prefix="1&#8211;"/>
+                <number variable="number-of-volumes" form="numeric" prefix="1–"/>
               </group>
             </else>
           </choose>

--- a/universitat-basel-deutsche-sprachwissenschaft.csl
+++ b/universitat-basel-deutsche-sprachwissenschaft.csl
@@ -98,34 +98,36 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="report">
-            <text variable="publisher"/>
-            <text variable="title" form="short" font-style="italic"/>
-          </if>
-          <else-if type="legal_case">
-            <text variable="title" font-style="italic"/>
-          </else-if>
-          <else-if type="book graphic  motion_picture song" match="any">
-            <text variable="title" form="short" font-style="italic"/>
-          </else-if>
-          <else-if type="bill legislation" match="any">
-            <text variable="title" form="short"/>
-          </else-if>
-          <else-if variable="reviewed-author">
-            <choose>
-              <if variable="reviewed-title" match="none">
-                <text variable="title" form="short" font-style="italic" prefix="Review of "/>
-              </if>
-              <else>
-                <text variable="title" form="short" quotes="true"/>
-              </else>
-            </choose>
-          </else-if>
-          <else>
-            <text variable="title" form="short" quotes="true"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="report">
+              <text variable="publisher"/>
+              <text variable="title" form="short" font-style="italic"/>
+            </if>
+            <else-if type="legal_case">
+              <text variable="title" font-style="italic"/>
+            </else-if>
+            <else-if type="book graphic  motion_picture song" match="any">
+              <text variable="title" form="short" font-style="italic"/>
+            </else-if>
+            <else-if type="bill legislation" match="any">
+              <text variable="title" form="short"/>
+            </else-if>
+            <else-if variable="reviewed-author">
+              <choose>
+                <if variable="reviewed-title" match="none">
+                  <text variable="title" form="short" font-style="italic" prefix="Review of "/>
+                </if>
+                <else>
+                  <text variable="title" form="short" quotes="true"/>
+                </else>
+              </choose>
+            </else-if>
+            <else>
+              <text variable="title" form="short" quotes="true"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>
@@ -472,7 +474,7 @@
             <else>
               <group>
                 <text term="volume" form="short" plural="true" text-case="capitalize-first" suffix=" "/>
-                <number variable="number-of-volumes" form="numeric" prefix="1&#8211;"/>
+                <number variable="number-of-volumes" form="numeric" prefix="1–"/>
               </group>
             </else>
           </choose>

--- a/universitat-bremen-lehrstuhl-fur-innovatives-markenmanagement.csl
+++ b/universitat-bremen-lehrstuhl-fur-innovatives-markenmanagement.csl
@@ -59,15 +59,17 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="report">
-            <text variable="publisher"/>
-            <text macro="title"/>
-          </if>
-          <else>
-            <text macro="title"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="report">
+              <text variable="publisher"/>
+              <text macro="title"/>
+            </if>
+            <else>
+              <text macro="title"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>
@@ -79,34 +81,36 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="report">
-            <text variable="publisher"/>
-            <text variable="title" form="short" font-style="italic"/>
-          </if>
-          <else-if type="legal_case">
-            <text variable="title" font-style="italic"/>
-          </else-if>
-          <else-if type="book graphic  motion_picture song" match="any">
-            <text variable="title" form="short" font-style="italic"/>
-          </else-if>
-          <else-if type="bill legislation" match="any">
-            <text variable="title" form="short"/>
-          </else-if>
-          <else-if variable="reviewed-author">
-            <choose>
-              <if variable="reviewed-title" match="none">
-                <text variable="title" form="short" font-style="italic" prefix="Review of "/>
-              </if>
-              <else>
-                <text term="anonymous" form="short" quotes="true"/>
-              </else>
-            </choose>
-          </else-if>
-          <else>
-            <text variable="title" form="short" quotes="true"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="report">
+              <text variable="publisher"/>
+              <text variable="title" form="short" font-style="italic"/>
+            </if>
+            <else-if type="legal_case">
+              <text variable="title" font-style="italic"/>
+            </else-if>
+            <else-if type="book graphic  motion_picture song" match="any">
+              <text variable="title" form="short" font-style="italic"/>
+            </else-if>
+            <else-if type="bill legislation" match="any">
+              <text variable="title" form="short"/>
+            </else-if>
+            <else-if variable="reviewed-author">
+              <choose>
+                <if variable="reviewed-title" match="none">
+                  <text variable="title" form="short" font-style="italic" prefix="Review of "/>
+                </if>
+                <else>
+                  <text term="anonymous" form="short" quotes="true"/>
+                </else>
+              </choose>
+            </else-if>
+            <else>
+              <text variable="title" form="short" quotes="true"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>
@@ -438,7 +442,7 @@
             <else>
               <group>
                 <text term="volume" form="short" plural="true" text-case="capitalize-first" suffix=" "/>
-                <number variable="number-of-volumes" form="numeric" prefix="1&#8211;"/>
+                <number variable="number-of-volumes" form="numeric" prefix="1–"/>
               </group>
             </else>
           </choose>

--- a/universitatsmedizin-gottingen.csl
+++ b/universitatsmedizin-gottingen.csl
@@ -29,14 +29,16 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="report">
-            <text variable="title" form="short"/>
-          </if>
-          <else>
-            <text variable="title"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="report">
+              <text variable="title" form="short"/>
+            </if>
+            <else>
+              <text variable="title"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>

--- a/universite-de-montreal-apa.csl
+++ b/universite-de-montreal-apa.csl
@@ -61,15 +61,17 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="report">
-            <text variable="publisher"/>
-            <text macro="title"/>
-          </if>
-          <else>
-            <text macro="title"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="report">
+              <text variable="publisher"/>
+              <text macro="title"/>
+            </if>
+            <else>
+              <text macro="title"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>
@@ -79,18 +81,20 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="report">
-            <text variable="publisher"/>
-            <text variable="title" form="short" font-style="italic"/>
-          </if>
-          <else-if type="bill book graphic legal_case legislation motion_picture song" match="any">
-            <text variable="title" form="short" font-style="italic"/>
-          </else-if>
-          <else>
-            <text variable="title" form="short" quotes="true"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="report">
+              <text variable="publisher"/>
+              <text variable="title" form="short" font-style="italic"/>
+            </if>
+            <else-if type="bill book graphic legal_case legislation motion_picture song" match="any">
+              <text variable="title" form="short" font-style="italic"/>
+            </else-if>
+            <else>
+              <text variable="title" form="short" quotes="true"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>

--- a/universite-de-sherbrooke-departement-de-geomatique.csl
+++ b/universite-de-sherbrooke-departement-de-geomatique.csl
@@ -59,15 +59,17 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="report">
-            <text variable="publisher"/>
-            <text macro="title"/>
-          </if>
-          <else>
-            <text macro="title"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="report">
+              <text variable="publisher"/>
+              <text macro="title"/>
+            </if>
+            <else>
+              <text macro="title"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>
@@ -78,77 +80,25 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="report">
-            <text variable="publisher"/>
-            <text variable="title" form="short" font-style="italic"/>
-          </if>
-          <else-if type="bill book graphic legal_case legislation motion_picture song" match="any">
-            <text variable="title" form="short" font-style="italic"/>
-          </else-if>
-          <else>
-            <text variable="title" form="short" quotes="true"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="report">
+              <text variable="publisher"/>
+              <text variable="title" form="short" font-style="italic"/>
+            </if>
+            <else-if type="bill book graphic legal_case legislation motion_picture song" match="any">
+              <text variable="title" form="short" font-style="italic"/>
+            </else-if>
+            <else>
+              <text variable="title" form="short" quotes="true"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>
   <!-- Unused macro; commented to pass the Travis CI test -->
-  <!--<macro name="access">
-    <choose>
-      <if type="thesis">
-        <choose>
-          <if variable="archive" match="any">
-            <group>
-              <text term="retrieved" text-case="capitalize-first" suffix=" "/>
-              <text term="from" suffix=" "/>
-              <text variable="archive" suffix="."/>
-              <text variable="archive_location" prefix=" (" suffix=")"/>
-            </group>
-          </if>
-          <else>
-            <group>
-              <text term="retrieved" text-case="capitalize-first" suffix=" "/>
-              <text term="from" suffix=" "/>
-              <text variable="URL"/>
-            </group>
-          </else>
-        </choose>
-      </if>
-      <else>
-        <choose>
-          <if variable="DOI">
-            <text variable="DOI" prefix="doi:"/>
-          </if>
-          <else>
-            <choose>
-              <if type="webpage">
-                <group>
-                  <text term="from" prefix="Site téléaccessible " suffix=" &lt;"/>
-                  <text variable="URL" suffix="&gt;. "/>
-                  <text term="retrieved" text-case="capitalize-first" suffix=" le "/>
-                  <group>
-                    <date variable="accessed" suffix=". ">
-                      <date-part name="day" suffix=" "/>
-                      <date-part name="month" suffix=" "/>
-                      <date-part name="year"/>
-                    </date>
-                  </group>
-                </group>
-              </if>
-              <else>
-                <group>
-                  <text term="retrieved" text-case="capitalize-first" suffix=" "/>
-                  <text term="from" suffix=" "/>
-                  <text variable="URL"/>
-                </group>
-              </else>
-            </choose>
-          </else>
-        </choose>
-      </else>
-    </choose>
-  </macro>-->
+  <!--<macro name="access"><choose><if type="thesis"><choose><if variable="archive" match="any"><group><text term="retrieved" text-case="capitalize-first" suffix=" "/><text term="from" suffix=" "/><text variable="archive" suffix="."/><text variable="archive_location" prefix=" (" suffix=")"/></group></if><else><group><text term="retrieved" text-case="capitalize-first" suffix=" "/><text term="from" suffix=" "/><text variable="URL"/></group></else></choose></if><else><choose><if variable="DOI"><text variable="DOI" prefix="doi:"/></if><else><choose><if type="webpage"><group><text term="from" prefix="Site téléaccessible " suffix=" &lt;"/><text variable="URL" suffix="&gt;. "/><text term="retrieved" text-case="capitalize-first" suffix=" le "/><group><date variable="accessed" suffix=". "><date-part name="day" suffix=" "/><date-part name="month" suffix=" "/><date-part name="year"/></date></group></group></if><else><group><text term="retrieved" text-case="capitalize-first" suffix=" "/><text term="from" suffix=" "/><text variable="URL"/></group></else></choose></else></choose></else></choose></macro>-->
   <macro name="title">
     <choose>
       <if type="report thesis" match="any">
@@ -199,25 +149,7 @@
     </choose>
   </macro>
   <!-- Unused macro; commented to pass the Travis CI test -->
-  <!--<macro name="event">
-    <choose>
-      <if variable="event">
-        <choose>
-          <if variable="genre" match="none">
-            <text term="presented at" text-case="capitalize-first" suffix=" "/>
-            <text variable="event"/>
-          </if>
-          <else>
-            <group delimiter=" ">
-              <text variable="genre" text-case="capitalize-first"/>
-              <text term="presented at"/>
-              <text variable="event"/>
-            </group>
-          </else>
-        </choose>
-      </if>
-    </choose>
-  </macro>-->
+  <!--<macro name="event"><choose><if variable="event"><choose><if variable="genre" match="none"><text term="presented at" text-case="capitalize-first" suffix=" "/><text variable="event"/></if><else><group delimiter=" "><text variable="genre" text-case="capitalize-first"/><text term="presented at"/><text variable="event"/></group></else></choose></if></choose></macro>-->
   <macro name="issued">
     <choose>
       <if type="bill legal_case legislation" match="none">
@@ -228,14 +160,7 @@
                 <date-part name="year"/>
               </date>
               <text variable="year-suffix"/>
-              <!--choose>
-                <if type="article-journal bill book chapter graphic legal_case legislation motion_picture paper-conference report song" match="none">
-                  <date variable="issued">
-                    <date-part prefix=", " name="month"/>
-                    <date-part prefix=" " name="day"/>
-                  </date>
-                </if>
-              </choose-->
+              <!--choose><if type="article-journal bill book chapter graphic legal_case legislation motion_picture paper-conference report song" match="none"><date variable="issued"><date-part prefix=", " name="month"/><date-part prefix=" " name="day"/></date></if></choose-->
             </group>
           </if>
           <else>

--- a/universite-de-sherbrooke-faculte-d-education.csl
+++ b/universite-de-sherbrooke-faculte-d-education.csl
@@ -58,15 +58,17 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="report">
-            <text variable="publisher"/>
-            <text macro="title"/>
-          </if>
-          <else>
-            <text macro="title"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="report">
+              <text variable="publisher"/>
+              <text macro="title"/>
+            </if>
+            <else>
+              <text macro="title"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>
@@ -76,18 +78,20 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="report">
-            <text variable="publisher"/>
-            <text variable="title" form="short" font-style="italic"/>
-          </if>
-          <else-if type="bill book graphic legal_case legislation motion_picture song" match="any">
-            <text variable="title" form="short" font-style="italic"/>
-          </else-if>
-          <else>
-            <text variable="title" form="short" quotes="true"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="report">
+              <text variable="publisher"/>
+              <text variable="title" form="short" font-style="italic"/>
+            </if>
+            <else-if type="bill book graphic legal_case legislation motion_picture song" match="any">
+              <text variable="title" form="short" font-style="italic"/>
+            </else-if>
+            <else>
+              <text variable="title" form="short" quotes="true"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>
@@ -122,7 +126,7 @@
               <if type="webpage">
                 <group>
                   <text term="from" prefix="Site téléaccessible " suffix=" &lt;"/>
-                  <text variable="URL" suffix="&gt;. "/>
+                  <text variable="URL" suffix=">. "/>
                   <text term="retrieved" text-case="capitalize-first" suffix=" le "/>
                   <group>
                     <date variable="accessed" suffix=". ">
@@ -166,7 +170,7 @@
   <macro name="publisher">
     <choose>
       <if type="report" match="any">
-        <group delimiter="&#160;: ">
+        <group delimiter=" : ">
           <text variable="publisher-place"/>
           <text variable="publisher"/>
         </group>
@@ -186,7 +190,7 @@
           </choose>
           <choose>
             <if type="article-journal article-magazine" match="none">
-              <group delimiter="&#160;: ">
+              <group delimiter=" : ">
                 <text variable="publisher-place"/>
                 <text variable="publisher"/>
               </group>

--- a/universite-du-quebec-a-montreal-etudes-litteraires-et-semiologie.csl
+++ b/universite-du-quebec-a-montreal-etudes-litteraires-et-semiologie.csl
@@ -26,10 +26,10 @@
       <term name="translator" form="verb-short">trad. par</term>
       <term name="translator" form="short">traduction</term>
       <term name="interviewer" form="verb">entretien réalisé par</term>
-      <term name="in">dans&#160;</term>
+      <term name="in">dans </term>
       <term name="edition">édition</term>
       <term name="accessed">consulté le</term>
-      <term name="at">disponible sur&#160;:</term>
+      <term name="at">disponible sur :</term>
       <term name="et-al">et al.</term>
       <term name="ibid" form="short">ibid</term>
       <term name="issue" form="short">nᵒ</term>
@@ -50,15 +50,17 @@
             <name-part name="family"/>
           </name>
           <substitute>
-            <choose>
-              <if type="webpage">
-                <text macro="title"/>
-              </if>
-              <else>
-                <text macro="editor"/>
-                <text macro="title"/>
-              </else>
-            </choose>
+            <group>
+              <choose>
+                <if type="webpage">
+                  <text macro="title"/>
+                </if>
+                <else>
+                  <text macro="editor"/>
+                  <text macro="title"/>
+                </else>
+              </choose>
+            </group>
           </substitute>
         </names>
       </else>
@@ -75,15 +77,17 @@
         <names variable="author composer">
           <name and="text" delimiter-precedes-last="never" et-al-min="4" et-al-use-first="3" initialize="false"/>
           <substitute>
-            <choose>
-              <if type="webpage">
-                <text macro="title"/>
-              </if>
-              <else>
-                <text macro="editor-notes"/>
-                <text macro="title"/>
-              </else>
-            </choose>
+            <group>
+              <choose>
+                <if type="webpage">
+                  <text macro="title"/>
+                </if>
+                <else>
+                  <text macro="editor-notes"/>
+                  <text macro="title"/>
+                </else>
+              </choose>
+            </group>
           </substitute>
         </names>
       </else>
@@ -173,10 +177,10 @@
           <text term="online" text-case="lowercase"/>
           <choose>
             <if match="any" variable="URL">
-              <text variable="URL" prefix="&lt;" suffix="&gt;"/>
+              <text variable="URL" prefix="&lt;" suffix=">"/>
             </if>
             <else>
-              <text variable="DOI" prefix="&lt;doi: " suffix="&gt;"/>
+              <text variable="DOI" prefix="&lt;doi: " suffix=">"/>
             </else>
           </choose>
         </group>
@@ -526,7 +530,7 @@
                 <text value="loc. cit." font-style="italic"/>
               </if>
               <else-if type="book report thesis chapter entry-encyclopedia entry-dictionary" match="any">
-                <text value="op.&#160;cit." font-style="italic"/>
+                <text value="op. cit." font-style="italic"/>
               </else-if>
               <else>
                 <text macro="short-title"/>
@@ -538,7 +542,7 @@
       </choose>
     </layout>
   </citation>
-  <bibliography delimiter-precedes-last="never" et-al-min="11" et-al-use-first="7" initialize="false" subsequent-author-substitute="&#8212;&#8212;&#8212;" hanging-indent="true">
+  <bibliography delimiter-precedes-last="never" et-al-min="11" et-al-use-first="7" initialize="false" subsequent-author-substitute="———" hanging-indent="true">
     <sort>
       <key macro="contributors-sort"/>
       <key variable="issued"/>

--- a/universite-du-quebec-a-montreal.csl
+++ b/universite-du-quebec-a-montreal.csl
@@ -52,9 +52,9 @@
         <multiple>éditions</multiple>
       </term>
       <term name="edition" form="short">éd.</term>
-      <term name="ordinal">&#7497;</term>
-      <term name="ordinal-01" gender-form="feminine" match="whole-number">ʳ&#7497;</term>
-      <term name="ordinal-01" gender-form="masculine" match="whole-number">&#7497;ʳ</term>
+      <term name="ordinal">ᵉ</term>
+      <term name="ordinal-01" gender-form="feminine" match="whole-number">ʳᵉ</term>
+      <term name="ordinal-01" gender-form="masculine" match="whole-number">ᵉʳ</term>
       <term name="number-of-volumes" form="short"> vol.</term>
       <term name="number">Numéro</term>
       <term name="circa" form="short">ca</term>
@@ -97,25 +97,29 @@
           <name and="text" delimiter-precedes-last="never" et-al-use-last="true" initialize-with=". " name-as-sort-order="all"/>
           <label form="short" prefix=" (" suffix=")"/>
           <substitute>
-            <choose>
-              <if type="entry-dictionary entry-encyclopedia webpage manuscript legislation legal_case bill treaty article map article-journal article-magazine article-newspaper" match="any">
-                <text macro="title"/>
-              </if>
-              <else-if type="book" match="any">
-                <names variable="editor"/>
-                <text macro="title" font-style="italic"/>
-              </else-if>
-              <else>
-                <names variable="editor"/>
-                <names variable="translator"/>
-              </else>
-            </choose>
-            <choose>
-              <if type="report">
-                <text variable="publisher"/>
-                <text variable="title" font-style="italic" suffix="."/>
-              </if>
-            </choose>
+            <group>
+              <choose>
+                <if type="entry-dictionary entry-encyclopedia webpage manuscript legislation legal_case bill treaty article map article-journal article-magazine article-newspaper" match="any">
+                  <text macro="title"/>
+                </if>
+                <else-if type="book" match="any">
+                  <names variable="editor"/>
+                  <text macro="title" font-style="italic"/>
+                </else-if>
+                <else>
+                  <names variable="editor"/>
+                  <names variable="translator"/>
+                </else>
+              </choose>
+            </group>
+            <group>
+              <choose>
+                <if type="report">
+                  <text variable="publisher"/>
+                  <text variable="title" font-style="italic" suffix="."/>
+                </if>
+              </choose>
+            </group>
           </substitute>
         </names>
       </else>
@@ -141,15 +145,17 @@
           <substitute>
             <names variable="editor"/>
             <names variable="translator"/>
-            <choose>
-              <if type="report">
-                <text variable="publisher"/>
-                <text variable="title" font-style="italic"/>
-              </if>
-              <else>
-                <text variable="title" font-style="italic"/>
-              </else>
-            </choose>
+            <group>
+              <choose>
+                <if type="report">
+                  <text variable="publisher"/>
+                  <text variable="title" font-style="italic"/>
+                </if>
+                <else>
+                  <text variable="title" font-style="italic"/>
+                </else>
+              </choose>
+            </group>
           </substitute>
         </names>
       </else>

--- a/universiti-kebangsaan-malaysia.csl
+++ b/universiti-kebangsaan-malaysia.csl
@@ -81,14 +81,16 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
-            <text variable="title" form="short" font-style="italic"/>
-          </if>
-          <else>
-            <text variable="title" form="short" quotes="true"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
+              <text variable="title" form="short" font-style="italic"/>
+            </if>
+            <else>
+              <text variable="title" form="short" quotes="true"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>

--- a/university-college-lillebaelt-apa.csl
+++ b/university-college-lillebaelt-apa.csl
@@ -70,11 +70,13 @@
           <label form="short" prefix=" (" suffix=")." text-case="capitalize-first"/>
           <substitute>
             <names variable="editor"/>
-            <choose>
-              <if type="report">
-                <text variable="publisher"/>
-              </if>
-            </choose>
+            <group>
+              <choose>
+                <if type="report">
+                  <text variable="publisher"/>
+                </if>
+              </choose>
+            </group>
             <text macro="title"/>
           </substitute>
         </names>
@@ -118,27 +120,31 @@
         <names variable="author">
           <name form="short"/>
           <substitute>
-            <choose>
-              <if type="entry-dictionary entry-encyclopedia chapter" match="none">
-                <names variable="editor"/>
-                <names variable="translator"/>
-              </if>
-            </choose>
-            <choose>
-              <if type="report">
-                <text variable="publisher"/>
-                <text variable="title" form="short" font-style="italic"/>
-              </if>
-              <else-if type="legal_case">
-                <text variable="title" font-style="italic"/>
-              </else-if>
-              <else-if type="book graphic motion_picture song webpage" match="any">
-                <text variable="title" form="short" font-style="italic"/>
-              </else-if>
-              <else>
-                <text variable="title" form="short" quotes="true"/>
-              </else>
-            </choose>
+            <group>
+              <choose>
+                <if type="entry-dictionary entry-encyclopedia chapter" match="none">
+                  <names variable="editor"/>
+                  <names variable="translator"/>
+                </if>
+              </choose>
+            </group>
+            <group>
+              <choose>
+                <if type="report">
+                  <text variable="publisher"/>
+                  <text variable="title" form="short" font-style="italic"/>
+                </if>
+                <else-if type="legal_case">
+                  <text variable="title" font-style="italic"/>
+                </else-if>
+                <else-if type="book graphic motion_picture song webpage" match="any">
+                  <text variable="title" form="short" font-style="italic"/>
+                </else-if>
+                <else>
+                  <text variable="title" form="short" quotes="true"/>
+                </else>
+              </choose>
+            </group>
           </substitute>
         </names>
       </else>

--- a/university-of-gothenburg-apa-swedish-legislations.csl
+++ b/university-of-gothenburg-apa-swedish-legislations.csl
@@ -68,15 +68,17 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="report">
-            <text variable="publisher"/>
-            <text macro="title"/>
-          </if>
-          <else>
-            <text macro="title"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="report">
+              <text variable="publisher"/>
+              <text macro="title"/>
+            </if>
+            <else>
+              <text macro="title"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>
@@ -92,35 +94,37 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="report">
-            <text variable="publisher"/>
-            <text variable="title" form="short" font-style="italic"/>
-          </if>
-          <else-if type="legal_case">
-            <text variable="title" font-style="italic"/>
-          </else-if>
-          <else-if type="book graphic  motion_picture song" match="any">
-            <text variable="title" form="short" font-style="italic"/>
-          </else-if>
-          <else-if type="legislation"/>
-          <else-if type="bill" match="any">
-            <text variable="title" form="short" font-style="italic"/>
-          </else-if>
-          <else-if variable="reviewed-author">
-            <choose>
-              <if variable="reviewed-title" match="none">
-                <text variable="title" form="short" font-style="italic" prefix="Review of "/>
-              </if>
-              <else>
-                <text variable="title" form="short" quotes="true"/>
-              </else>
-            </choose>
-          </else-if>
-          <else>
-            <text variable="title" form="short" quotes="true"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="report">
+              <text variable="publisher"/>
+              <text variable="title" form="short" font-style="italic"/>
+            </if>
+            <else-if type="legal_case">
+              <text variable="title" font-style="italic"/>
+            </else-if>
+            <else-if type="book graphic  motion_picture song" match="any">
+              <text variable="title" form="short" font-style="italic"/>
+            </else-if>
+            <else-if type="legislation"/>
+            <else-if type="bill" match="any">
+              <text variable="title" form="short" font-style="italic"/>
+            </else-if>
+            <else-if variable="reviewed-author">
+              <choose>
+                <if variable="reviewed-title" match="none">
+                  <text variable="title" form="short" font-style="italic" prefix="Review of "/>
+                </if>
+                <else>
+                  <text variable="title" form="short" quotes="true"/>
+                </else>
+              </choose>
+            </else-if>
+            <else>
+              <text variable="title" form="short" quotes="true"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>
@@ -512,7 +516,7 @@
             <else>
               <group>
                 <text term="volume" form="short" plural="true" text-case="capitalize-first" suffix=" "/>
-                <number variable="number-of-volumes" form="numeric" prefix="1&#8211;"/>
+                <number variable="number-of-volumes" form="numeric" prefix="1–"/>
               </group>
             </else>
           </choose>

--- a/university-of-lincoln-harvard.csl
+++ b/university-of-lincoln-harvard.csl
@@ -48,14 +48,16 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
-            <text variable="title" form="short" font-style="italic"/>
-          </if>
-          <else>
-            <text variable="title" form="short" quotes="false"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
+              <text variable="title" form="short" font-style="italic"/>
+            </if>
+            <else>
+              <text variable="title" form="short" quotes="false"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>

--- a/university-of-south-africa-harvard.csl
+++ b/university-of-south-africa-harvard.csl
@@ -51,14 +51,16 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="bill book graphic legal_case legislation motion_picture report song webpage" match="any">
-            <text variable="title" font-style="italic"/>
-          </if>
-          <else>
-            <text variable="title" quotes="true" text-case="capitalize-first"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="bill book graphic legal_case legislation motion_picture report song webpage" match="any">
+              <text variable="title" font-style="italic"/>
+            </if>
+            <else>
+              <text variable="title" quotes="true" text-case="capitalize-first"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>
@@ -68,14 +70,16 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
-            <text variable="title" form="short" font-style="italic"/>
-          </if>
-          <else>
-            <text variable="title" form="short" quotes="true" text-case="capitalize-first"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
+              <text variable="title" form="short" font-style="italic"/>
+            </if>
+            <else>
+              <text variable="title" form="short" quotes="true" text-case="capitalize-first"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>

--- a/university-of-york-apa.csl
+++ b/university-of-york-apa.csl
@@ -76,15 +76,17 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="report">
-            <text variable="publisher"/>
-            <text macro="title"/>
-          </if>
-          <else>
-            <text macro="title"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="report">
+              <text variable="publisher"/>
+              <text macro="title"/>
+            </if>
+            <else>
+              <text macro="title"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>
@@ -94,34 +96,36 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="report">
-            <text variable="publisher"/>
-            <text variable="title" form="short" font-style="italic"/>
-          </if>
-          <else-if type="legal_case">
-            <text variable="title" font-style="italic"/>
-          </else-if>
-          <else-if type="book graphic  motion_picture song" match="any">
-            <text variable="title" form="short" font-style="italic"/>
-          </else-if>
-          <else-if type="bill legislation" match="any">
-            <text variable="title" form="short"/>
-          </else-if>
-          <else-if variable="reviewed-author">
-            <choose>
-              <if variable="reviewed-title" match="none">
-                <text variable="title" form="short" font-style="italic" prefix="Review of "/>
-              </if>
-              <else>
-                <text variable="title" form="short" quotes="true"/>
-              </else>
-            </choose>
-          </else-if>
-          <else>
-            <text variable="title" form="short" quotes="true"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="report">
+              <text variable="publisher"/>
+              <text variable="title" form="short" font-style="italic"/>
+            </if>
+            <else-if type="legal_case">
+              <text variable="title" font-style="italic"/>
+            </else-if>
+            <else-if type="book graphic  motion_picture song" match="any">
+              <text variable="title" form="short" font-style="italic"/>
+            </else-if>
+            <else-if type="bill legislation" match="any">
+              <text variable="title" form="short"/>
+            </else-if>
+            <else-if variable="reviewed-author">
+              <choose>
+                <if variable="reviewed-title" match="none">
+                  <text variable="title" form="short" font-style="italic" prefix="Review of "/>
+                </if>
+                <else>
+                  <text variable="title" form="short" quotes="true"/>
+                </else>
+              </choose>
+            </else-if>
+            <else>
+              <text variable="title" form="short" quotes="true"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>
@@ -526,7 +530,7 @@
             <else>
               <group>
                 <text term="volume" form="short" plural="true" text-case="capitalize-first" suffix=" "/>
-                <number variable="number-of-volumes" form="numeric" prefix="1&#8211;"/>
+                <number variable="number-of-volumes" form="numeric" prefix="1–"/>
               </group>
             </else>
           </choose>

--- a/univerza-na-primorskem-fakulteta-za-vede-o-zdravju-apa.csl
+++ b/univerza-na-primorskem-fakulteta-za-vede-o-zdravju-apa.csl
@@ -65,15 +65,17 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="report">
-            <text variable="publisher"/>
-            <text macro="title"/>
-          </if>
-          <else>
-            <text macro="title"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="report">
+              <text variable="publisher"/>
+              <text macro="title"/>
+            </if>
+            <else>
+              <text macro="title"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>
@@ -83,34 +85,36 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="report">
-            <text variable="publisher"/>
-            <text variable="title" form="short" font-style="italic"/>
-          </if>
-          <else-if type="legal_case">
-            <text variable="title" font-style="italic"/>
-          </else-if>
-          <else-if type="book graphic  motion_picture song" match="any">
-            <text variable="title" form="short" font-style="italic"/>
-          </else-if>
-          <else-if type="bill legislation" match="any">
-            <text variable="title" form="short"/>
-          </else-if>
-          <else-if variable="reviewed-author">
-            <choose>
-              <if variable="reviewed-title" match="none">
-                <text variable="title" form="short" font-style="italic" prefix="Review of "/>
-              </if>
-              <else>
-                <text variable="title" form="short" quotes="true"/>
-              </else>
-            </choose>
-          </else-if>
-          <else>
-            <text variable="title" form="short" quotes="true"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="report">
+              <text variable="publisher"/>
+              <text variable="title" form="short" font-style="italic"/>
+            </if>
+            <else-if type="legal_case">
+              <text variable="title" font-style="italic"/>
+            </else-if>
+            <else-if type="book graphic  motion_picture song" match="any">
+              <text variable="title" form="short" font-style="italic"/>
+            </else-if>
+            <else-if type="bill legislation" match="any">
+              <text variable="title" form="short"/>
+            </else-if>
+            <else-if variable="reviewed-author">
+              <choose>
+                <if variable="reviewed-title" match="none">
+                  <text variable="title" form="short" font-style="italic" prefix="Review of "/>
+                </if>
+                <else>
+                  <text variable="title" form="short" quotes="true"/>
+                </else>
+              </choose>
+            </else-if>
+            <else>
+              <text variable="title" form="short" quotes="true"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>
@@ -457,7 +461,7 @@
             <else>
               <group>
                 <text term="volume" form="short" plural="true" text-case="capitalize-first" suffix=" "/>
-                <number variable="number-of-volumes" form="numeric" prefix="1&#8211;"/>
+                <number variable="number-of-volumes" form="numeric" prefix="1–"/>
               </group>
             </else>
           </choose>

--- a/uppsala-universitet-historia.csl
+++ b/uppsala-universitet-historia.csl
@@ -54,15 +54,17 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="report">
-            <text variable="publisher"/>
-            <text macro="title"/>
-          </if>
-          <else>
-            <text macro="title"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="report">
+              <text variable="publisher"/>
+              <text macro="title"/>
+            </if>
+            <else>
+              <text macro="title"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>
@@ -72,27 +74,29 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="report">
-            <group delimiter=" ">
-              <text variable="title" form="short" font-style="normal"/>
-            </group>
-          </if>
-          <else-if type="bill book graphic legislation motion_picture song" match="any">
-            <text variable="title" form="short" font-style="italic"/>
-          </else-if>
-          <else-if match="any" type="broadcast">
-            <group delimiter=", ">
-              <text variable="container-title" quotes="true" font-style="italic"/>
-              <text variable="publisher"/>
-              <date form="text" date-parts="year-month-day" variable="issued">
-                <date-part name="day"/>
-                <date-part name="month" form="short"/>
-                <date-part name="year"/>
-              </date>
-            </group>
-          </else-if>
-        </choose>
+        <group>
+          <choose>
+            <if type="report">
+              <group delimiter=" ">
+                <text variable="title" form="short" font-style="normal"/>
+              </group>
+            </if>
+            <else-if type="bill book graphic legislation motion_picture song" match="any">
+              <text variable="title" form="short" font-style="italic"/>
+            </else-if>
+            <else-if match="any" type="broadcast">
+              <group delimiter=", ">
+                <text variable="container-title" quotes="true" font-style="italic"/>
+                <text variable="publisher"/>
+                <date form="text" date-parts="year-month-day" variable="issued">
+                  <date-part name="day"/>
+                  <date-part name="month" form="short"/>
+                  <date-part name="year"/>
+                </date>
+              </group>
+            </else-if>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>

--- a/urban-geography.csl
+++ b/urban-geography.csl
@@ -34,11 +34,13 @@
       <name form="short" and="symbol" delimiter=", " initialize-with=". "/>
       <substitute>
         <names variable="editor"/>
-        <choose>
-          <if type="article-journal article-magazine article-newspaper paper-conference webpage" match="any">
-            <text variable="container-title"/>
-          </if>
-        </choose>
+        <group>
+          <choose>
+            <if type="article-journal article-magazine article-newspaper paper-conference webpage" match="any">
+              <text variable="container-title"/>
+            </if>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>

--- a/urban-studies.csl
+++ b/urban-studies.csl
@@ -30,11 +30,13 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="article-journal article-magazine article-newspaper broadcast interview manuscript map patent personal_communication song speech thesis webpage" match="any">
-            <text variable="container-title"/>
-          </if>
-        </choose>
+        <group>
+          <choose>
+            <if type="article-journal article-magazine article-newspaper broadcast interview manuscript map patent personal_communication song speech thesis webpage" match="any">
+              <text variable="container-title"/>
+            </if>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>
@@ -44,14 +46,16 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
-            <text variable="title" form="short" font-style="italic"/>
-          </if>
-          <else>
-            <text variable="title" form="short" quotes="true"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
+              <text variable="title" form="short" font-style="italic"/>
+            </if>
+            <else>
+              <text variable="title" form="short" quotes="true"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>

--- a/usda-forest-service-pacific-northwest-research-station.csl
+++ b/usda-forest-service-pacific-northwest-research-station.csl
@@ -88,17 +88,19 @@
           <label form="short" prefix=" " strip-periods="false"/>
           <substitute>
             <text macro="editor"/>
-            <choose>
-              <if type="webpage">
-                <text variable="title"/>
-              </if>
-              <else-if variable="container-title">
-                <text variable="title"/>
-              </else-if>
-              <else>
-                <text variable="title"/>
-              </else>
-            </choose>
+            <group>
+              <choose>
+                <if type="webpage">
+                  <text variable="title"/>
+                </if>
+                <else-if variable="container-title">
+                  <text variable="title"/>
+                </else-if>
+                <else>
+                  <text variable="title"/>
+                </else>
+              </choose>
+            </group>
           </substitute>
         </names>
       </else>

--- a/utah-geological-survey.csl
+++ b/utah-geological-survey.csl
@@ -41,14 +41,16 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="bill book graphic legal_case legislation motion_picture report song thesis" match="any">
-            <text variable="title" form="short" font-style="italic"/>
-          </if>
-          <else>
-            <text variable="title" form="short" quotes="true"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="bill book graphic legal_case legislation motion_picture report song thesis" match="any">
+              <text variable="title" form="short" font-style="italic"/>
+            </if>
+            <else>
+              <text variable="title" form="short" quotes="true"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>
@@ -139,7 +141,7 @@
               <et-al term="and others"/>
               <label prefix=", "/>
             </names>
-            <text variable="event" prefix=" " suffix=" &#8211;"/>
+            <text variable="event" prefix=" " suffix=" –"/>
             <text variable="container-title" prefix=" " suffix=":"/>
             <group suffix=".">
               <text macro="publisher" prefix=" "/>

--- a/vancouver-fr-ca.csl
+++ b/vancouver-fr-ca.csl
@@ -47,14 +47,16 @@
       <name sort-separator=" " initialize-with="" name-as-sort-order="all" delimiter=", " delimiter-precedes-last="always"/>
       <label form="long" prefix=", "/>
       <substitute>
-        <choose>
-          <if type="chapter" match="none">
-            <names variable="editor">
-              <name sort-separator=" " initialize-with="" name-as-sort-order="all" delimiter=", " delimiter-precedes-last="always"/>
-              <label form="long" prefix=", "/>
-            </names>
-          </if>
-        </choose>
+        <group>
+          <choose>
+            <if type="chapter" match="none">
+              <names variable="editor">
+                <name sort-separator=" " initialize-with="" name-as-sort-order="all" delimiter=", " delimiter-precedes-last="always"/>
+                <label form="long" prefix=", "/>
+              </names>
+            </if>
+          </choose>
+        </group>
       </substitute>
     </names>
     <choose>

--- a/veterinary-microbiology.csl
+++ b/veterinary-microbiology.csl
@@ -61,14 +61,16 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
-            <text variable="title" form="short" font-style="italic"/>
-          </if>
-          <else>
-            <text variable="title" form="short" quotes="true"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
+              <text variable="title" form="short" font-style="italic"/>
+            </if>
+            <else>
+              <text variable="title" form="short" quotes="true"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>

--- a/wader-study.csl
+++ b/wader-study.csl
@@ -23,15 +23,17 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="report">
-            <text variable="publisher"/>
-            <text macro="title"/>
-          </if>
-          <else>
-            <text macro="title"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="report">
+              <text variable="publisher"/>
+              <text macro="title"/>
+            </if>
+            <else>
+              <text macro="title"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>
@@ -42,31 +44,33 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="report">
-            <text variable="publisher"/>
-            <text variable="title" form="short" font-style="italic"/>
-          </if>
-          <else-if type="legal_case">
-            <text variable="title" font-style="italic"/>
-          </else-if>
-          <else-if type="bill book graphic legislation motion_picture song" match="any">
-            <text variable="title" form="short" font-style="italic"/>
-          </else-if>
-          <else-if variable="reviewed-author">
-            <choose>
-              <if variable="reviewed-title" match="none">
-                <text variable="title" form="short" font-style="italic" prefix="Review of "/>
-              </if>
-              <else>
-                <text variable="title" form="short"/>
-              </else>
-            </choose>
-          </else-if>
-          <else>
-            <text variable="title" form="short"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="report">
+              <text variable="publisher"/>
+              <text variable="title" form="short" font-style="italic"/>
+            </if>
+            <else-if type="legal_case">
+              <text variable="title" font-style="italic"/>
+            </else-if>
+            <else-if type="bill book graphic legislation motion_picture song" match="any">
+              <text variable="title" form="short" font-style="italic"/>
+            </else-if>
+            <else-if variable="reviewed-author">
+              <choose>
+                <if variable="reviewed-title" match="none">
+                  <text variable="title" form="short" font-style="italic" prefix="Review of "/>
+                </if>
+                <else>
+                  <text variable="title" form="short"/>
+                </else>
+              </choose>
+            </else-if>
+            <else>
+              <text variable="title" form="short"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>

--- a/water-alternatives.csl
+++ b/water-alternatives.csl
@@ -201,14 +201,16 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="bill book graphic legal_case legislation motion_picture song" match="any">
-            <text variable="title" form="short"/>
-          </if>
-          <else>
-            <text variable="container-title" form="short"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="bill book graphic legal_case legislation motion_picture song" match="any">
+              <text variable="title" form="short"/>
+            </if>
+            <else>
+              <text variable="container-title" form="short"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>

--- a/water-environment-research.csl
+++ b/water-environment-research.csl
@@ -59,14 +59,16 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
-            <text variable="title" form="short" font-style="italic"/>
-          </if>
-          <else>
-            <text variable="title" form="short" quotes="true"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
+              <text variable="title" form="short" font-style="italic"/>
+            </if>
+            <else>
+              <text variable="title" form="short" quotes="true"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>

--- a/water-science-and-technology.csl
+++ b/water-science-and-technology.csl
@@ -41,14 +41,16 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
-            <text variable="title" form="short" font-style="italic"/>
-          </if>
-          <else>
-            <text variable="title" form="short"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
+              <text variable="title" form="short" font-style="italic"/>
+            </if>
+            <else>
+              <text variable="title" form="short"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>

--- a/weed-science-society-of-america.csl
+++ b/weed-science-society-of-america.csl
@@ -52,14 +52,16 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
-            <text variable="title" form="short" font-style="italic"/>
-          </if>
-          <else>
-            <text variable="title" form="short" quotes="true"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
+              <text variable="title" form="short" font-style="italic"/>
+            </if>
+            <else>
+              <text variable="title" form="short" quotes="true"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>

--- a/wirtschaftsuniversitat-wien-author-date.csl
+++ b/wirtschaftsuniversitat-wien-author-date.csl
@@ -95,33 +95,35 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="report">
-            <text variable="publisher"/>
-            <text variable="title" form="short" font-style="italic"/>
-          </if>
-          <else-if type="legal_case">
-            <text variable="title" font-style="italic"/>
-          </else-if>
-          <else-if type="bill book graphic legislation motion_picture song" match="any">
-            <text variable="title" form="short" font-style="italic"/>
-          </else-if>
-          <else-if variable="reviewed-author">
-            <choose>
-              <if variable="reviewed-title" match="none">
-                <text variable="title" form="short" font-style="italic" prefix="Review of "/>
-              </if>
-              <else>
-                <text variable="title" form="short" quotes="true"/>
-              </else>
-            </choose>
-          </else-if>
-          <else>
-            <group>
-              <text term="anonymous"/>
-            </group>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="report">
+              <text variable="publisher"/>
+              <text variable="title" form="short" font-style="italic"/>
+            </if>
+            <else-if type="legal_case">
+              <text variable="title" font-style="italic"/>
+            </else-if>
+            <else-if type="bill book graphic legislation motion_picture song" match="any">
+              <text variable="title" form="short" font-style="italic"/>
+            </else-if>
+            <else-if variable="reviewed-author">
+              <choose>
+                <if variable="reviewed-title" match="none">
+                  <text variable="title" form="short" font-style="italic" prefix="Review of "/>
+                </if>
+                <else>
+                  <text variable="title" form="short" quotes="true"/>
+                </else>
+              </choose>
+            </else-if>
+            <else>
+              <group>
+                <text term="anonymous"/>
+              </group>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>
@@ -484,7 +486,7 @@
             <else>
               <group>
                 <text term="volume" form="short" plural="true" text-case="capitalize-first" suffix=" "/>
-                <number variable="number-of-volumes" form="numeric" prefix="1&#8211;"/>
+                <number variable="number-of-volumes" form="numeric" prefix="1–"/>
               </group>
             </else>
           </choose>

--- a/wirtschaftsuniversitat-wien-interdisziplinares-institut-fur-verhaltenswissenschaftlich-orientiertes-management.csl
+++ b/wirtschaftsuniversitat-wien-interdisziplinares-institut-fur-verhaltenswissenschaftlich-orientiertes-management.csl
@@ -82,33 +82,35 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="report">
-            <text variable="publisher"/>
-            <text variable="title" form="short" font-style="italic"/>
-          </if>
-          <else-if type="legal_case">
-            <text variable="title" font-style="italic"/>
-          </else-if>
-          <else-if type="bill book graphic legislation motion_picture song" match="any">
-            <text variable="title" form="short" font-style="italic"/>
-          </else-if>
-          <else-if variable="reviewed-author">
-            <choose>
-              <if variable="reviewed-title" match="none">
-                <text variable="title" form="short" font-style="italic" prefix="Review of "/>
-              </if>
-              <else>
-                <text variable="title" form="short" quotes="true"/>
-              </else>
-            </choose>
-          </else-if>
-          <else>
-            <group>
-              <text term="anonymous"/>
-            </group>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="report">
+              <text variable="publisher"/>
+              <text variable="title" form="short" font-style="italic"/>
+            </if>
+            <else-if type="legal_case">
+              <text variable="title" font-style="italic"/>
+            </else-if>
+            <else-if type="bill book graphic legislation motion_picture song" match="any">
+              <text variable="title" form="short" font-style="italic"/>
+            </else-if>
+            <else-if variable="reviewed-author">
+              <choose>
+                <if variable="reviewed-title" match="none">
+                  <text variable="title" form="short" font-style="italic" prefix="Review of "/>
+                </if>
+                <else>
+                  <text variable="title" form="short" quotes="true"/>
+                </else>
+              </choose>
+            </else-if>
+            <else>
+              <group>
+                <text term="anonymous"/>
+              </group>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>
@@ -407,7 +409,7 @@
             <else>
               <group>
                 <text term="volume" form="short" plural="true" text-case="capitalize-first" suffix=" "/>
-                <number variable="number-of-volumes" form="numeric" prefix="1&#8211;"/>
+                <number variable="number-of-volumes" form="numeric" prefix="1–"/>
               </group>
             </else>
           </choose>

--- a/world-politcs.csl
+++ b/world-politcs.csl
@@ -81,14 +81,16 @@
         <substitute>
           <names variable="editor"/>
           <names variable="translator"/>
-          <choose>
-            <if type="article-magazine article-newspaper" match="any">
-              <text macro="container-title"/>
-            </if>
-            <else>
-              <text macro="title"/>
-            </else>
-          </choose>
+          <group>
+            <choose>
+              <if type="article-magazine article-newspaper" match="any">
+                <text macro="container-title"/>
+              </if>
+              <else>
+                <text macro="title"/>
+              </else>
+            </choose>
+          </group>
         </substitute>
       </names>
       <text macro="recipient"/>
@@ -100,14 +102,16 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="article-magazine article-newspaper" match="any">
-            <text macro="container-title"/>
-          </if>
-          <else>
-            <text macro="title"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="article-magazine article-newspaper" match="any">
+              <text macro="container-title"/>
+            </if>
+            <else>
+              <text macro="title"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>
@@ -404,7 +408,7 @@
       </group>
     </layout>
   </citation>
-  <bibliography hanging-indent="true" et-al-min="11" et-al-use-first="7" subsequent-author-substitute="&#8212;&#8212;&#8212;" entry-spacing="0">
+  <bibliography hanging-indent="true" et-al-min="11" et-al-use-first="7" subsequent-author-substitute="———" entry-spacing="0">
     <sort>
       <key macro="contributors"/>
       <key variable="issued"/>

--- a/worlds-poultry-science-journal.csl
+++ b/worlds-poultry-science-journal.csl
@@ -61,14 +61,16 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
-            <text variable="title" form="short" font-style="italic"/>
-          </if>
-          <else>
-            <text variable="title" form="short" quotes="true"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
+              <text variable="title" form="short" font-style="italic"/>
+            </if>
+            <else>
+              <text variable="title" form="short" quotes="true"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>

--- a/zeitschrift-fur-kunstgeschichte.csl
+++ b/zeitschrift-fur-kunstgeschichte.csl
@@ -43,11 +43,13 @@
     <names variable="author">
       <name form="short" delimiter="/" and="text" delimiter-precedes-et-al="never"/>
       <substitute>
-        <choose>
-          <if type="entry-encyclopedia" match="none">
-            <names variable="editor"/>
-          </if>
-        </choose>
+        <group>
+          <choose>
+            <if type="entry-encyclopedia" match="none">
+              <names variable="editor"/>
+            </if>
+          </choose>
+        </group>
         <text variable="title" form="short"/>
       </substitute>
     </names>
@@ -57,11 +59,13 @@
       <name and="text" delimiter-precedes-et-al="never" delimiter-precedes-last="never"/>
       <label form="short" prefix=" (" suffix=")"/>
       <substitute>
-        <choose>
-          <if type="entry-encyclopedia" match="none">
-            <names variable="editor"/>
-          </if>
-        </choose>
+        <group>
+          <choose>
+            <if type="entry-encyclopedia" match="none">
+              <names variable="editor"/>
+            </if>
+          </choose>
+        </group>
         <text variable="title"/>
       </substitute>
     </names>
@@ -71,11 +75,13 @@
       <name and="text" delimiter-precedes-et-al="never" delimiter-precedes-last="never" name-as-sort-order="first"/>
       <label form="short" prefix=" (" suffix=")"/>
       <substitute>
-        <choose>
-          <if type="entry-encyclopedia" match="none">
-            <names variable="editor"/>
-          </if>
-        </choose>
+        <group>
+          <choose>
+            <if type="entry-encyclopedia" match="none">
+              <names variable="editor"/>
+            </if>
+          </choose>
+        </group>
         <text variable="title"/>
       </substitute>
     </names>
@@ -259,7 +265,7 @@
       </choose>
     </layout>
   </citation>
-  <bibliography et-al-min="3" et-al-use-first="1" subsequent-author-substitute="&#8212;&#8212;&#8212;" entry-spacing="0" hanging-indent="true">
+  <bibliography et-al-min="3" et-al-use-first="1" subsequent-author-substitute="———" entry-spacing="0" hanging-indent="true">
     <sort>
       <key macro="author-bibliography"/>
       <key macro="year-date"/>

--- a/zeitschrift-fur-padagogik.csl
+++ b/zeitschrift-fur-padagogik.csl
@@ -63,14 +63,16 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="bill book graphic legal_case motion_picture report song" match="any">
-            <text variable="title" form="short" font-style="italic"/>
-          </if>
-          <else>
-            <text variable="title" form="short" quotes="true"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="bill book graphic legal_case motion_picture report song" match="any">
+              <text variable="title" form="short" font-style="italic"/>
+            </if>
+            <else>
+              <text variable="title" form="short" quotes="true"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>

--- a/zeitschrift-fur-religionswissenschaft-author-date.csl
+++ b/zeitschrift-fur-religionswissenschaft-author-date.csl
@@ -43,11 +43,13 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="report">
-            <text variable="publisher"/>
-          </if>
-        </choose>
+        <group>
+          <choose>
+            <if type="report">
+              <text variable="publisher"/>
+            </if>
+          </choose>
+        </group>
         <text macro="anon"/>
       </substitute>
     </names>
@@ -58,11 +60,13 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="report">
-            <text variable="publisher"/>
-          </if>
-        </choose>
+        <group>
+          <choose>
+            <if type="report">
+              <text variable="publisher"/>
+            </if>
+          </choose>
+        </group>
         <text macro="anon"/>
       </substitute>
     </names>

--- a/zeitschrift-fur-soziologie.csl
+++ b/zeitschrift-fur-soziologie.csl
@@ -55,15 +55,17 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="report">
-            <text variable="publisher"/>
-            <text macro="title"/>
-          </if>
-          <else>
-            <text macro="title"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="report">
+              <text variable="publisher"/>
+              <text macro="title"/>
+            </if>
+            <else>
+              <text macro="title"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>
@@ -73,18 +75,20 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="report">
-            <text variable="publisher"/>
-            <text variable="title" form="short" font-style="italic"/>
-          </if>
-          <else-if type="bill book graphic legal_case legislation motion_picture song" match="any">
-            <text variable="title" form="short" font-style="italic"/>
-          </else-if>
-          <else>
-            <text variable="title" form="short" quotes="true"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="report">
+              <text variable="publisher"/>
+              <text variable="title" form="short" font-style="italic"/>
+            </if>
+            <else-if type="bill book graphic legal_case legislation motion_picture song" match="any">
+              <text variable="title" form="short" font-style="italic"/>
+            </else-if>
+            <else>
+              <text variable="title" form="short" quotes="true"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>

--- a/zoological-journal-of-the-linnean-society.csl
+++ b/zoological-journal-of-the-linnean-society.csl
@@ -45,14 +45,16 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <choose>
-          <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
-            <text variable="title" form="short" font-style="italic"/>
-          </if>
-          <else>
-            <text variable="title" form="short" quotes="true"/>
-          </else>
-        </choose>
+        <group>
+          <choose>
+            <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
+              <text variable="title" form="short" font-style="italic"/>
+            </if>
+            <else>
+              <text variable="title" form="short" quotes="true"/>
+            </else>
+          </choose>
+        </group>
       </substitute>
     </names>
   </macro>


### PR DESCRIPTION
Not sure how this will be received, but for what it's worth. I tweaked the audit script quoted in https://github.com/citation-style-language/styles/issues/4178 a bit, and added `cs:group` wrappers to bare `cs:choose` children of `cs:substitute` everywhere. The group wrapper has no delimiter, but none would have been provided by the `cs:choose` parent anyway, so it should be okay. He said.