### PR TITLE
Update harvard-university-of-bath.csl

### DIFF
--- a/harvard-university-of-bath.csl
+++ b/harvard-university-of-bath.csl
@@ -420,8 +420,7 @@
         </else>
       </choose>
       <choose>
-        <if type="legislation legal_case" match="any">
-        </if>
+        <if type="legislation legal_case" match="any"></if>
         <else-if type="book motion_picture musical_score song speech" match="any">
           <group prefix=" " suffix="." delimiter=" ">
             <text macro="title"/>
@@ -500,7 +499,7 @@
             <text macro="editor"/>
             <choose>
               <if variable="number">
-                  <text macro="series-genre" prefix="(" suffix=")"/>
+                <text macro="series-genre" prefix="(" suffix=")"/>
               </if>
             </choose>
             <text macro="publisher"/>

--- a/harvard-university-of-bath.csl
+++ b/harvard-university-of-bath.csl
@@ -527,7 +527,7 @@
           <group prefix=" " delimiter=" ">
             <choose>
               <if variable="editor">
-                <text term="in" text-case="capitalize-first" suffix=": "/>
+                <text term="in" text-case="capitalize-first" suffix=":"/>
                 <text macro="editor" suffix="."/>
               </if>
             </choose>

--- a/harvard-university-of-bath.csl
+++ b/harvard-university-of-bath.csl
@@ -527,7 +527,7 @@
           <group prefix=" " delimiter=" ">
             <choose>
               <if variable="editor">
-                <text term="in" text-case="capitalize-first" suffix=":"/>
+                <text term="in" text-case="capitalize-first" suffix=": "/>
                 <text macro="editor" suffix="."/>
               </if>
             </choose>

--- a/harvard-university-of-bath.csl
+++ b/harvard-university-of-bath.csl
@@ -94,7 +94,7 @@
   <macro name="archive">
     <choose>
       <if type="graphic">
-        <text variable="archive-place" prefix="At: " suffix=". " />
+        <text variable="archive-place" prefix="At: " suffix=". "/>
         <text variable="archive"/>
       </if>
       <else>
@@ -366,7 +366,7 @@
                   </if>
                   <else>
                     <text variable="collection-title"/>
-                    <group delimiter="–">
+                    <group delimiter="&#8211;">
                       <text variable="volume"/>
                       <text variable="page"/>
                     </group>

--- a/harvard-university-of-bath.csl
+++ b/harvard-university-of-bath.csl
@@ -19,20 +19,24 @@
     <category citation-format="author-date"/>
     <category field="generic-base"/>
     <summary>Adaptation of Harvard referencing style used at the University of Bath.</summary>
-    <updated>2019-02-06T18:40:00+00:00</updated>
+    <updated>2019-07-10T17:00:00+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale xml:lang="en">
     <terms>
       <term name="available at">available from</term>
-      <term name="version" form="short">v.</term>
-      <term name="translator" form="short">trans.</term>
       <term name="chapter" form="short">
         <single>c.</single>
         <multiple>cc.</multiple>
       </term>
+      <term name="editor" form="short">
+        <single>ed.</single>
+        <multiple>eds</multiple>
+      </term>
       <term name="number" form="long">number</term>
       <term name="number" form="short">no.</term>
+      <term name="translator" form="short">trans.</term>
+      <term name="version" form="short">v.</term>
     </terms>
   </locale>
   <macro name="editor">
@@ -90,7 +94,7 @@
   <macro name="archive">
     <choose>
       <if type="graphic">
-        <text variable="archive-place" prefix="At: " suffix=". "/>
+        <text variable="archive-place" prefix="At: " suffix=". " />
         <text variable="archive"/>
       </if>
       <else>
@@ -120,7 +124,7 @@
   </macro>
   <macro name="title">
     <choose>
-      <if type="bill broadcast book dataset graphic legal_case map motion_picture musical_score patent report song webpage thesis" match="any">
+      <if type="bill broadcast book dataset graphic legal_case map motion_picture musical_score patent report song speech webpage thesis" match="any">
         <text variable="title" font-style="italic"/>
       </if>
       <else-if type="legislation">
@@ -174,7 +178,7 @@
   <macro name="translator">
     <names variable="translator" prefix="(" suffix=")">
       <name and="text" delimiter-precedes-last="never" initialize-with="."/>
-      <label form="short" prefix=". " text-case="capitalize-first"/>
+      <label form="short" prefix=", " text-case="capitalize-first"/>
     </names>
   </macro>
   <macro name="online">
@@ -362,7 +366,7 @@
                   </if>
                   <else>
                     <text variable="collection-title"/>
-                    <group delimiter="&#8211;">
+                    <group delimiter="–">
                       <text variable="volume"/>
                       <text variable="page"/>
                     </group>
@@ -416,8 +420,9 @@
         </else>
       </choose>
       <choose>
-        <if type="legislation legal_case" match="any"/>
-        <else-if type="book motion_picture musical_score song" match="any">
+        <if type="legislation legal_case" match="any">
+        </if>
+        <else-if type="book motion_picture musical_score song speech" match="any">
           <group prefix=" " suffix="." delimiter=" ">
             <text macro="title"/>
             <text macro="online"/>
@@ -436,18 +441,20 @@
           </group>
           <text prefix=" " suffix="." macro="publisher"/>
         </else-if>
-        <else-if type="article-journal post" match="any">
+        <else-if type="article-journal" match="any">
           <group prefix=" " suffix="." delimiter=". ">
             <text macro="title"/>
           </group>
-          <group prefix=" " suffix=".">
-            <text variable="container-title" font-style="italic"/>
-            <text prefix=" " macro="online"/>
-            <group prefix=", ">
+          <group prefix=" " suffix="." delimiter=", ">
+            <group delimiter=" ">
+              <text variable="container-title" font-style="italic"/>
+              <text macro="online"/>
+            </group>
+            <group>
               <text variable="volume"/>
               <text variable="issue" prefix="(" suffix=")"/>
             </group>
-            <group prefix=", ">
+            <group>
               <label variable="page" form="short"/>
               <text variable="page"/>
             </group>
@@ -491,29 +498,13 @@
               </if>
             </choose>
             <text macro="editor"/>
+            <choose>
+              <if variable="number">
+                  <text macro="series-genre" prefix="(" suffix=")"/>
+              </if>
+            </choose>
+            <text macro="publisher"/>
           </group>
-          <choose>
-            <if type="report">
-              <group prefix=" " suffix="." delimiter=", ">
-                <text macro="publisher"/>
-                <choose>
-                  <if variable="number">
-                    <text macro="series-genre" prefix="(" suffix=")"/>
-                  </if>
-                </choose>
-              </group>
-            </if>
-            <else>
-              <group prefix=" " suffix="." delimiter=" ">
-                <text macro="publisher"/>
-                <choose>
-                  <if variable="number">
-                    <text macro="series-genre" prefix="(" suffix=")"/>
-                  </if>
-                </choose>
-              </group>
-            </else>
-          </choose>
           <choose>
             <if variable="archive">
               <group prefix=" " suffix="." delimiter=" ">
@@ -537,21 +528,19 @@
             <choose>
               <if variable="editor">
                 <text term="in" text-case="capitalize-first" suffix=":"/>
-                <text macro="editor"/>
+                <text macro="editor" suffix="."/>
               </if>
             </choose>
             <group suffix="." delimiter=", ">
               <text variable="container-title" font-style="italic"/>
               <text macro="online" prefix=" "/>
               <text variable="event"/>
-              <group delimiter=" ">
-                <date variable="event-date">
-                  <date-part name="day" suffix=" "/>
-                  <date-part name="month" suffix=" "/>
-                  <date-part name="year"/>
-                </date>
-                <text variable="event-place"/>
-              </group>
+              <date variable="event-date">
+                <date-part name="day" suffix=" "/>
+                <date-part name="month" suffix=" "/>
+                <date-part name="year"/>
+              </date>
+              <text variable="event-place"/>
             </group>
             <text variable="collection-title" suffix="."/>
             <group suffix="." delimiter=", ">
@@ -612,7 +601,7 @@
             <text macro="status"/>
             <text macro="editor"/>
           </group>
-          <group prefix=" " suffix=".">
+          <group prefix=" " suffix="." delimiter=", ">
             <choose>
               <if variable="container-title">
                 <group delimiter=" ">
@@ -621,11 +610,11 @@
                 </group>
               </if>
             </choose>
-            <group prefix=", ">
+            <group>
               <text variable="volume"/>
               <text variable="issue" prefix="(" suffix=")"/>
             </group>
-            <group prefix=", ">
+            <group>
               <label variable="page" form="short"/>
               <text variable="page"/>
             </group>


### PR DESCRIPTION
This update brings the style in line with the Summer 2019 update to the [Har­vard style](https://library.bath.ac.uk/referencing/harvard-bath) recommended by the University of Bath Library.