### PR TITLE
Disambiguation by add year suffix was not present - Added it to the s…

### DIFF
--- a/international-journal-of-spatial-data-infrastructures-research.csl
+++ b/international-journal-of-spatial-data-infrastructures-research.csl
@@ -154,7 +154,7 @@
       <label form="short" prefix=" (" text-case="title" suffix=")"/>
     </names>
   </macro>
-  <citation et-al-min="3" et-al-use-first="1" disambiguate-add-names="true" disambiguate-add-givenname="true" givenname-disambiguation-rule="primary-name">
+  <citation et-al-min="3" et-al-use-first="1" disambiguate-add-names="true" disambiguate-add-givenname="true" givenname-disambiguation-rule="primary-name" disambiguate-add-year-suffix="true">
     <layout prefix="(" suffix=")" delimiter="; ">
       <text macro="contributors-short"/>
       <text macro="issued" prefix=", "/>


### PR DESCRIPTION
…tyle

It was:
 <citation et-al-min="3" et-al-use-first="1" disambiguate-add-names="true" disambiguate-add-givenname="true" givenname-disambiguation-rule="primary-name">

Now is:  
<citation et-al-min="3" et-al-use-first="1" disambiguate-add-names="true" disambiguate-add-givenname="true" givenname-disambiguation-rule="primary-name" disambiguate-add-year-suffix="true">
disambiguate-add-year-suffix="true"