### PR TITLE
Update wiesbaden-business-school.csl

### DIFF
--- a/wiesbaden-business-school.csl
+++ b/wiesbaden-business-school.csl
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <style xmlns="http://purl.org/net/xbiblio/csl" class="note" version="1.0" demote-non-dropping-particle="sort-only">
-    <!-- Polyglot; journal publishes in English and German. -->
+  <!-- Polyglot; journal publishes in English and German -->
   <info>
     <title>Wiesbaden Business School</title>
     <id>http://www.zotero.org/styles/wiesbaden-business-school</id>

--- a/wiesbaden-business-school.csl
+++ b/wiesbaden-business-school.csl
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <style xmlns="http://purl.org/net/xbiblio/csl" class="note" version="1.0" demote-non-dropping-particle="sort-only">
-  <!-- Polyglot; journal publishes in English and German. -->
+    <!-- Polyglot; journal publishes in English and German. -->
   <info>
     <title>Wiesbaden Business School</title>
     <id>http://www.zotero.org/styles/wiesbaden-business-school</id>
@@ -13,7 +13,7 @@
     </author>
     <category citation-format="note"/>
     <category field="humanities"/>
-    <updated>2019-07-23T10:55:31+00:00</updated>
+    <updated>2019-07-23T11:09:27+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale xml:lang="de">
@@ -133,8 +133,17 @@
         <text variable="title" suffix=", "/>
       </group>
       <choose>
-        <if type="webpage post-weblog">
-          <text variable="container-title"/>
+        <if type="webpage post-weblog post" match="any">
+          <group delimiter=", ">
+            <text variable="container-title"/>
+            <group delimiter=" ">
+              <group delimiter=": ">
+                <text term="in"/>
+                <text variable="URL"/>
+              </group>
+              <text macro="accessed" prefix="(" suffix=")"/>
+            </group>
+          </group>
         </if>
         <else-if type="speech" match="any">
           <text variable="publisher-place" prefix=", "/>
@@ -176,17 +185,6 @@
             <text macro="publisher"/>
           </group>
         </else>
-      </choose>
-      <choose>
-        <if type="webpage post-weblog">
-          <group delimiter=" " prefix=", ">
-            <group delimiter=": ">
-              <text term="in"/>
-              <text variable="URL"/>
-            </group>
-            <text macro="accessed" prefix="(" suffix=")"/>
-          </group>
-        </if>
       </choose>
     </layout>
   </bibliography>

--- a/wiesbaden-business-school.csl
+++ b/wiesbaden-business-school.csl
@@ -2,12 +2,12 @@
 <style xmlns="http://purl.org/net/xbiblio/csl" class="note" version="1.0" demote-non-dropping-particle="sort-only">
   <!-- Polyglot; journal publishes in English and German. -->
   <info>
-    <link href="https://www.hs-rm.de/fileadmin/Home/Fachbereiche/Wiesbaden_Business_School/Studiengaenge/International_Management__M.A._/Leitfaden_Thesis_IM_en.pdf"/>
     <title>Wiesbaden Business School</title>
     <id>http://www.zotero.org/styles/wiesbaden-business-school</id>
     <link href="http://www.zotero.org/styles/wiesbaden-business-school" rel="self"/>
     <link href="http://www.zotero.org/styles/universitat-zu-koln-seminar-fur-abwl-und-finanzierungslehre" rel="template"/>
     <link href="https://www.hs-rm.de/fileadmin/user_upload/Leitfaden_Thesis_IBA.pdf" rel="documentation"/>
+    <link href="https://www.hs-rm.de/fileadmin/Home/Fachbereiche/Wiesbaden_Business_School/Studiengaenge/International_Management__M.A._/Leitfaden_Thesis_IM_en.pdf" rel="documentation"/>
     <author>
       <name>Patrick O'Brien, PhD</name>
     </author>

--- a/wiesbaden-business-school.csl
+++ b/wiesbaden-business-school.csl
@@ -1,7 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
-<style xmlns="http://purl.org/net/xbiblio/csl" class="note" version="1.0" demote-non-dropping-particle="sort-only" default-locale="de-DE">
+<style xmlns="http://purl.org/net/xbiblio/csl" class="note" version="1.0" demote-non-dropping-particle="sort-only">
+  <!-- Polyglot; journal publishes in English and German. -->
   <info>
-    <title>Wiesbaden Business School (German)</title>
+    <link href="https://www.hs-rm.de/fileadmin/Home/Fachbereiche/Wiesbaden_Business_School/Studiengaenge/International_Management__M.A._/Leitfaden_Thesis_IM_en.pdf"/>
+    <title>Wiesbaden Business School</title>
     <id>http://www.zotero.org/styles/wiesbaden-business-school</id>
     <link href="http://www.zotero.org/styles/wiesbaden-business-school" rel="self"/>
     <link href="http://www.zotero.org/styles/universitat-zu-koln-seminar-fur-abwl-und-finanzierungslehre" rel="template"/>
@@ -11,7 +13,7 @@
     </author>
     <category citation-format="note"/>
     <category field="humanities"/>
-    <updated>2019-03-25T10:17:29+00:00</updated>
+    <updated>2019-07-23T10:55:31+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale xml:lang="de">
@@ -19,7 +21,7 @@
       <term name="et-al">et al.</term>
       <term name="volume" form="short">Jg.</term>
       <term name="retrieved">zugegriffen am</term>
-      <term name="anonymous">o.V.</term>
+      <term name="anonymous" form="short">o.V.</term>
       <term name="accessed">Zugriff am</term>
       <term name="section" form="short">
         <single>Abs.</single>
@@ -33,7 +35,8 @@
       <label form="short" prefix=" (" suffix=")"/>
       <substitute>
         <names variable="editor"/>
-        <text term="anonymous"/>
+        <text variable="authority"/>
+        <text term="anonymous" form="short"/>
       </substitute>
     </names>
   </macro>
@@ -87,7 +90,7 @@
   </macro>
   <macro name="pages">
     <group delimiter=" ">
-      <label strip-periods="false" variable="page" form="short"/>
+      <label plural="never" strip-periods="false" variable="page" form="short"/>
       <text variable="page"/>
     </group>
   </macro>
@@ -104,29 +107,16 @@
   </macro>
   <citation et-al-min="3" et-al-use-first="1" disambiguate-add-year-suffix="true">
     <layout delimiter="; " suffix=".">
-      <choose>
-        <if match="any" position="ibid-with-locator">
-          <group delimiter=", ">
-            <text term="ibid" form="short"/>
-            <text variable="locator"/>
-          </group>
-        </if>
-        <else-if match="any" position="ibid">
-          <text term="ibid" form="short"/>
-        </else-if>
-        <else>
-          <group delimiter=", ">
-            <group delimiter=" ">
-              <text macro="author-short"/>
-              <text macro="year-date" prefix="(" suffix=")"/>
-            </group>
-            <group delimiter=" ">
-              <label text-case="capitalize-first" variable="locator" form="short"/>
-              <text variable="locator"/>
-            </group>
-          </group>
-        </else>
-      </choose>
+      <group delimiter=", ">
+        <group delimiter=" ">
+          <text macro="author-short"/>
+          <text macro="year-date" prefix="(" suffix=")"/>
+        </group>
+        <group delimiter=" ">
+          <label text-case="capitalize-first" variable="locator" form="short"/>
+          <text variable="locator"/>
+        </group>
+      </group>
     </layout>
   </citation>
   <bibliography>
@@ -136,7 +126,7 @@
     </sort>
     <layout suffix=".">
       <group delimiter=": ">
-        <group>
+        <group font-weight="bold">
           <text macro="author"/>
           <text macro="year-date" prefix=" (" suffix=")"/>
         </group>
@@ -162,7 +152,7 @@
               <text variable="volume"/>
             </group>
             <group delimiter=" ">
-              <label variable="issue" form="short"/>
+              <label text-case="capitalize-first" variable="issue" form="short"/>
               <text variable="issue"/>
             </group>
             <text macro="pages"/>

--- a/wiesbaden-business-school.csl
+++ b/wiesbaden-business-school.csl
@@ -36,9 +36,12 @@
       <substitute>
         <names variable="editor"/>
         <text variable="authority"/>
-        <text term="anonymous" form="short"/>
+        <text macro="anonymous"/>
       </substitute>
     </names>
+  </macro>
+  <macro name="anonymous">
+    <text term="anonymous" form="short"/>
   </macro>
   <macro name="author-short">
     <names variable="author" delimiter=";">


### PR DESCRIPTION
As per: https://forums.zotero.org/discussion/comment/336542/#Comment_336542
- remove ibid
- change and adapt to polyglot style for both languages

Question:
Technically this style should show "o.V." for ohne Verfasser via "anonymous" for items without author, editor or an authority, right?
It doesn't do so on the VisualEditor for the Webpage item we have on there (CSL Search).