### PR TITLE
Fix Travis CI to Xenial; Ruby to pre-installed 2.5.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,8 @@
+dist: xenial
 language: ruby
 cache: bundler
 rvm:
-  - 2.6.3
+  - 2.5.3
 install:
   - bundle install --jobs=3 --retry=3 --path=${BUNDLE_PATH:-vendor/bundle}
   - bundle update sheldon

--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
-ruby '2.6.3'
+ruby '2.5.3'
 source 'https://rubygems.org'
 
 gem 'rake'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,12 +1,13 @@
 GIT
   remote: https://github.com/citation-style-language/Sheldon.git
-  revision: 7d83770802ef753448295f759bc4073543dba204
+  revision: 09d0daebe0b6c76ccf9963f86e2e966b28a3ef46
   specs:
-    sheldon (0.1.33)
+    sheldon (1.0.2)
       citeproc-ruby
       csl-styles
       diffy
       dotenv
+      nokogiri
       ostruct
       reverse_markdown
 
@@ -24,8 +25,8 @@ GEM
       csl (~> 1.0)
     diff-lcs (1.3)
     diffy (3.3.0)
-    dotenv (2.7.2)
-    fuubar (2.4.0)
+    dotenv (2.7.5)
+    fuubar (2.4.1)
       rspec-core (~> 3.0)
       ruby-progressbar (~> 1.4)
     mini_portile2 (2.4.0)
@@ -33,19 +34,19 @@ GEM
     nokogiri (1.10.3)
       mini_portile2 (~> 2.4.0)
     ostruct (0.1.0)
-    rake (12.3.2)
+    rake (12.3.3)
     reverse_markdown (1.1.0)
       nokogiri
     rspec (3.8.0)
       rspec-core (~> 3.8.0)
       rspec-expectations (~> 3.8.0)
       rspec-mocks (~> 3.8.0)
-    rspec-core (3.8.0)
+    rspec-core (3.8.2)
       rspec-support (~> 3.8.0)
     rspec-expectations (3.8.4)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.8.0)
-    rspec-mocks (3.8.0)
+    rspec-mocks (3.8.1)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.8.0)
     rspec-support (3.8.2)
@@ -63,7 +64,7 @@ DEPENDENCIES
   sheldon!
 
 RUBY VERSION
-   ruby 2.6.3p62
+   ruby 2.5.3p105
 
 BUNDLED WITH
-   1.17.2
+   1.17.3


### PR DESCRIPTION
Some of our recent Travis CI builds have started to run on Ubuntu Xenial 16.04 instead of Trusty (14.04), and failing (see e.g. https://travis-ci.org/citation-style-language/styles/builds/565790539).

This pull requests fixes our environment to Xenial, and updates the Gemfile.lock file. It also downgrades us to a pre-installed Ruby version to save about 20 seconds per Travis-CI build.

See also https://blog.travis-ci.com/2019-04-15-xenial-default-build-environment and https://docs.travis-ci.com/user/reference/xenial/#ruby-support.