### PR TITLE
Update and correction to universite-de-montreal-apa.csl

### DIFF
--- a/universite-de-montreal-apa.csl
+++ b/universite-de-montreal-apa.csl
@@ -1,516 +1,515 @@
 <?xml version="1.0" encoding="utf-8"?>
 <style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" demote-non-dropping-particle="never" default-locale="fr-CA">
-	<info>
-		<title>Université de Montréal - APA (French - Canada)</title>
-		<title-short>UdeM APA FR</title-short>
-		<id>http://www.zotero.org/styles/universite-de-montreal-apa</id>
-		<link href="http://www.zotero.org/styles/universite-de-montreal-apa" rel="self"/>
-		<link href="http://www.zotero.org/styles/apa" rel="template"/>
-		<link href="http://guides.bib.umontreal.ca/disciplines/20-Citer-selon-les-normes-de-l-APA" rel="documentation"/>
-		<author>
-			<name>Florian Martin-Bariteau</name>
-			<email>f.martin-bariteau@umontreal.ca</email>
-			<uri>http://f-mb.org/</uri>
-		</author>
-		<contributor>
-			<name>Mathieu Brisson</name>
-			<email>mathieu.brisson@cegeplimoilou.ca</email>
-			<uri/>
-		</contributor>
-		<contributor>
-			<name>Marc Julien</name>
-			<email>marc.julien@cegeplimoilou.ca</email>
-			<uri/>
-		</contributor>
-		<category citation-format="author-date"/>
-		<category field="psychology"/>
-		<category field="generic-base"/>
-		<summary>Adaptation en français canadien des normes de citation de l'APA (6e édition) basée sur le guide des Bibliothèques de l'Université de Montréal.</summary>
-		<updated>2019-08-14T05:14:01+00:00</updated>
-		<rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
-	</info>
-	<locale>
-		<terms>
-			<term name="editor" form="short">dir.</term>
-			<term name="editortranslator" form="short">dir. et trad.</term>
-			<term name="translator" form="short">trad.</term>
-			<term name="no date" form="short">s. d.</term>
-			<term name="retrieved">repéré</term>
-			<term name="from">à</term>
-			<term name="presented at">communication présentée au</term>
-			<term name="page" form="short">p.</term>
-		</terms>
-	</locale>
-	<macro name="container-contributors">
-		<choose>
-			<if type="chapter paper-conference" match="any">
-				<names variable="editor translator" delimiter=", " suffix=", ">
-					<name and="text" initialize-with=". " delimiter=", " delimiter-precedes-last="never"/>
-					<et-al font-style="italic"/>
-					<label form="short" prefix=" (" suffix=")"/>
-				</names>
-			</if>
-		</choose>
-	</macro>
-	<macro name="secondary-contributors">
-		<choose>
-			<if type="article-journal chapter paper-conference" match="none">
-				<names variable="editor translator" delimiter=", ">
-					<label form="verb" suffix=" "/>
-					<name and="text" initialize-with=". " delimiter=", " delimiter-precedes-last="never"/>
-					<et-al font-style="italic"/>
-				</names>
-			</if>
-		</choose>
-	</macro>
-	<macro name="author">
-		<names variable="author">
-			<name name-as-sort-order="all" and="text" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="never"/>
-			<et-al font-style="italic"/>
-			<label form="short" prefix=" (" suffix=")"/>
-			<substitute>
-				<names variable="editor"/>
-				<names variable="translator"/>
-				<choose>
-					<if type="report">
-						<text variable="publisher"/>
-						<text macro="title"/>
-					</if>
-					<else>
-						<text macro="title"/>
-					</else>
-				</choose>
-			</substitute>
-		</names>
-	</macro>
-	<macro name="author-short">
-		<names variable="author">
-			<name form="short" and="text" delimiter=", " initialize-with=". " delimiter-precedes-last="never"/>
-			<substitute>
-				<names variable="editor"/>
-				<names variable="translator"/>
-				<choose>
-					<if type="report">
-						<text variable="publisher"/>
-						<text variable="title" form="short" font-style="italic"/>
-					</if>
-					<else-if type="bill book graphic legal_case legislation motion_picture song" match="any">
-						<text variable="title" form="short" font-style="italic"/>
-					</else-if>
-					<else>
-						<text variable="title" form="short" quotes="true"/>
-					</else>
-				</choose>
-			</substitute>
-		</names>
-	</macro>
-	<macro name="access">
-		<choose>
-			<if type="thesis">
-				<choose>
-					<if variable="archive" match="any">
-						<group>
-							<text term="retrieved" text-case="capitalize-first" suffix=" "/>
-							<text term="from" suffix=" "/>
-							<text variable="archive" suffix="."/>
-							<text variable="archive_location" prefix=" (" suffix=")"/>
-						</group>
-					</if>
-					<else>
-						<group>
-							<text term="retrieved" text-case="capitalize-first" suffix=" "/>
-							<text term="from" suffix=" "/>
-							<text variable="URL"/>
-						</group>
-					</else>
-				</choose>
-			</if>
-			<else>
-				<choose>
-					<if variable="DOI">
-						<text variable="DOI" prefix="doi:"/>
-					</if>
-					<else>
-						<group>
-							<text term="retrieved" text-case="capitalize-first" suffix=" "/>
-							<choose>
-								<if type="post">
-									<date variable="accessed" form="text" prefix="le " suffix=" "/>
-								</if>
-							</choose>
-							<text term="from" suffix=" "/>
-							<text variable="URL"/>
-						</group>
-					</else>
-				</choose>
-			</else>
-		</choose>
-	</macro>
-	<macro name="title">
-		<choose>
-			<if type="thesis" match="any">
-				<text variable="title" font-style="italic"/>
-				<group prefix=" (" suffix=")" delimiter=", ">
-					<text variable="genre"/>
-					<text variable="medium"/>
-					<choose>
-						<if variable="URL" match="any">
-							<text variable="publisher"/>
-							<text variable="publisher-place"/>
-						</if>
-					</choose>
-				</group>
-			</if>
-			<else-if type="report" match="any">
-				<text variable="title" font-style="italic"/>
-				<group prefix=" (" suffix=")" delimiter=" ">
-					<text variable="genre" prefix=" [" suffix="]" text-case="capitalize-first"/>
-					<text variable="medium" prefix=" [" suffix="]" text-case="capitalize-first"/>
-					<choose>
-						<if variable="number" match="any">
-							<text term="issue" form="short"/>
-							<text variable="number"/>
-						</if>
-					</choose>
-				</group>
-			</else-if>
-			<else-if type="book graphic motion_picture report song manuscript speech" match="any">
-				<!---This is a hack until we have a computer program type -->
-				<choose>
-					<if variable="version">
-						<group delimiter=" ">
-							<text variable="title"/>
-							<text variable="genre" prefix=" [" suffix="]" text-case="capitalize-first"/>
-							<text variable="medium" prefix=" [" suffix="]" text-case="capitalize-first"/>
-							<group delimiter=" " prefix="(" suffix=")">
-								<text term="version"/>
-								<text variable="version"/>
-							</group>
-						</group>
-					</if>
-					<else>
-						<text variable="title" font-style="italic"/>
-						<text variable="genre" prefix=" [" suffix="]" text-case="capitalize-first"/>
-						<text variable="medium" prefix=" [" suffix="]" text-case="capitalize-first"/>
-					</else>
-				</choose>
-			</else-if>
-			<else-if type="paper-conference">
-				<text variable="title"  font-style="italic"/>
-				<text variable="genre" prefix=" [" suffix="]" text-case="capitalize-first"/>
-				<text variable="medium" prefix=" [" suffix="]" text-case="capitalize-first"/>
-			</else-if>
-			<else>
-				<text variable="title"/>
-				<text variable="genre" prefix=" [" suffix="]" text-case="capitalize-first"/>
-				<text variable="medium" prefix=" [" suffix="]" text-case="capitalize-first"/>
-			</else>
-		</choose>
-	</macro>
-	<macro name="publisher">
-		<choose>
-			<if type="report" match="any">
-				<group delimiter=" : ">
-					<text variable="publisher-place"/>
-					<text variable="publisher"/>
-				</group>
-			</if>
-			<else-if type="thesis" match="any">
-				<choose>
-					<if variable="URL archive" match="none">
-						<group delimiter=", ">
-							<text variable="publisher"/>
-							<text variable="publisher-place"/>
-						</group>
-					</if>
-				</choose>
-			</else-if>
-			<else>
-				<group delimiter=", ">
-					<choose>
-						<if type="article-journal article-magazine paper-conference" match="none">
-							<group delimiter=" : ">
-								<text variable="publisher-place"/>
-								<text variable="publisher"/>
-							</group>
-						</if>
-					</choose>
-				</group>
-			</else>
-		</choose>
-	</macro>
-	<macro name="event">
-		<choose>
-			<if variable="container-title" match="none">
-				<choose>
-					<if variable="event">
-						<choose>
-							<if variable="genre" match="none">
-								<text term="presented at" text-case="capitalize-first" suffix=" "/>
-								<text variable="event"/>
-							</if>
-							<else>
-								<group delimiter=" ">
-									<text variable="genre" text-case="capitalize-first"/>
-									<text term="presented at"/>
-									<text variable="event"/>
-								</group>
-							</else>
-						</choose>
-					</if>
-				</choose>
-			</if>
-		</choose>
-	</macro>
-	<macro name="issued">
-		<choose>
-			<if type="bill legal_case legislation" match="none">
-				<choose>
-					<if variable="issued">
-						<group prefix=" (" suffix=")">
-							<date variable="issued">
-								<date-part name="year"/>
-							</date>
-							<text variable="year-suffix"/>
-							<choose>
-								<if type="article-journal bill book chapter graphic legal_case legislation motion_picture paper-conference report song" match="none">
-									<date variable="issued" prefix=",">
-										<date-part prefix=" " name="day"/>
-										<date-part prefix=" " name="month"/>
-									</date>
-								</if>
-							</choose>
-						</group>
-					</if>
-					<else>
-						<group prefix=" (" suffix=")">
-							<text term="no date" form="short"/>
-							<text variable="year-suffix" prefix="-"/>
-						</group>
-					</else>
-				</choose>
-			</if>
-		</choose>
-	</macro>
-	<macro name="issued-sort">
-		<choose>
-			<if type="article-journal bill book chapter graphic legal_case legislation motion_picture paper-conference report song" match="none">
-				<date variable="issued">
-					<date-part name="year"/>
-					<date-part name="month"/>
-					<date-part name="day"/>
-				</date>
-			</if>
-			<else>
-				<date variable="issued">
-					<date-part name="year"/>
-				</date>
-			</else>
-		</choose>
-	</macro>
-	<macro name="issued-year">
-		<choose>
-			<if variable="issued">
-				<date variable="issued">
-					<date-part name="year"/>
-				</date>
-				<text variable="year-suffix"/>
-			</if>
-			<else>
-				<text term="no date" form="short"/>
-				<text variable="year-suffix" prefix="-"/>
-			</else>
-		</choose>
-	</macro>
-	<macro name="edition">
-		<choose>
-			<if is-numeric="edition">
-				<group delimiter=" ">
-					<number variable="edition" form="ordinal"/>
-					<text term="edition" form="short"/>
-				</group>
-			</if>
-			<else>
-				<text variable="edition"/>
-			</else>
-		</choose>
-	</macro>
-	<macro name="locators">
-		<choose>
-			<if type="article-journal article-magazine" match="any">
-				<group prefix=", " delimiter=", ">
-					<group>
-						<text variable="volume" font-style="italic"/>
-						<text variable="issue" prefix="(" suffix=")"/>
-					</group>
-					<text variable="page"/>
-				</group>
-			</if>
-			<else-if type="article-newspaper">
-				<group delimiter=" " prefix=", ">
-					<label variable="page" form="short"/>
-					<text variable="page"/>
-				</group>
-			</else-if>
-			<else-if type="book graphic motion_picture report song chapter paper-conference" match="any">
-				<group prefix=" (" suffix=")" delimiter="; ">
-					<group delimiter=", ">
-						<text macro="edition"/>
-						<group>
-							<text term="volume" form="short" plural="true" suffix=" "/>
-							<number variable="number-of-volumes" form="numeric" prefix="1-"/>
-						</group>
-						<group>
-							<text term="volume" form="short" suffix=" "/>
-							<number variable="volume" form="numeric"/>
-						</group>
-						<group>
-							<label variable="page" form="short" suffix=" "/>
-							<text variable="page"/>
-						</group>
-					</group>
-					<text macro="secondary-contributors"/>
-				</group>
-			</else-if>
-			<else-if type="legal_case">
-				<group prefix=" (" suffix=")" delimiter=" ">
-					<text variable="authority"/>
-					<date variable="issued" form="text"/>
-				</group>
-			</else-if>
-			<else-if type="bill legislation" match="any">
-				<date variable="issued" prefix=" (" suffix=")">
-					<date-part name="year"/>
-				</date>
-			</else-if>
-		</choose>
-	</macro>
-	<macro name="citation-locator">
-		<group>
-			<choose>
-				<if locator="chapter">
-					<label variable="locator" form="short"/>
-				</if>
-				<else>
-					<label variable="locator" form="short"/>
-				</else>
-			</choose>
-			<text variable="locator" prefix=" "/>
-		</group>
-	</macro>
-	<macro name="container">
-		<group>
-			<choose>
-				<if type="chapter entry-encyclopedia" match="any">
-					<text term="in" text-case="capitalize-first" suffix=" "/>
-				</if>
-			</choose>
-			<text macro="container-contributors"/>
-			<choose>
-				<if type="paper-conference">
-					<text value="Communication présentée au "/>
-					<text macro="container-title"/>
-					<text variable="publisher-place" prefix=", "/>
-				</if>
-				<else>
-					<text macro="container-title"/>
-				</else>
-			</choose>
-			<choose>
-				<if type="entry-encyclopedia">
-					<text variable="volume" prefix=" (Vol. " suffix="," />
-					<text variable="page" prefix="  p. " suffix=")" />
-				</if>
-			</choose>
-		</group>
-		<choose>
-			<if type="manuscript">
-				<text value="Document inédit"/>
-			</if>
-		</choose>
-	</macro>
-	<macro name="container-title">
-		<choose>
-			<if type="article article-journal article-magazine article-newspaper" match="any">
-				<text variable="container-title" font-style="italic" text-case="title"/>
-			</if>
-			<else-if type="manuscript">
-			</else-if>
-			<else-if type="paper-conference">
-				<text variable="container-title" text-case="title"/>
-			</else-if>
-			<else-if type="bill legal_case legislation" match="none">
-				<text variable="container-title" font-style="italic"/>
-			</else-if>
-			<else>
-				<group delimiter=" " prefix=", ">
-					<choose>
-						<if variable="container-title">
-							<text variable="volume"/>
-							<text variable="container-title"/>
-							<group delimiter=" ">
-								<!--change to label variable="section" as that becomes available -->
-								<text term="section" form="symbol"/>
-								<text variable="section"/>
-							</group>
-							<text variable="page"/>
-						</if>
-						<else>
-							<choose>
-								<if type="legal_case">
-									<text term="issue" form="short"/>
-									<text variable="number"/>
-								</if>
-								<else>
-									<text term="issue" form="short"/>
-									<text variable="number"/>
-									<group delimiter=" ">
-										<!--change to label variable="section" as that becomes available -->
-										<text term="section" form="symbol"/>
-										<text variable="section"/>
-									</group>
-								</else>
-							</choose>
-						</else>
-					</choose>
-				</group>
-			</else>
-		</choose>
-	</macro>
-	<citation et-al-min="6" et-al-use-first="1" et-al-subsequent-min="3" et-al-subsequent-use-first="1" disambiguate-add-year-suffix="true" disambiguate-add-names="true" disambiguate-add-givenname="true" collapse="year" givenname-disambiguation-rule="primary-name">
-		<sort>
-			<key macro="author"/>
-			<key macro="issued-sort"/>
-		</sort>
-		<layout prefix="(" suffix=")" delimiter="; ">
-			<group delimiter=", ">
-				<text macro="author-short"/>
-				<text macro="issued-year"/>
-				<text macro="citation-locator"/>
-			</group>
-		</layout>
-	</citation>
-	<bibliography hanging-indent="true" et-al-min="8" et-al-use-first="6" et-al-use-last="true" entry-spacing="0" line-spacing="2">
-		<sort>
-			<key macro="author"/>
-			<key macro="issued-sort" sort="ascending"/>
-			<key macro="title"/>
-		</sort>
-		<layout>
-			<group suffix=".">
-				<group delimiter=". ">
-					<text macro="author"/>
-					<text macro="issued"/>
-					<text macro="title" prefix=" "/>
-					<text macro="container"/>
-				</group>
-				<text macro="locators"/>
-				<group delimiter=", " prefix=". ">
-					<text macro="event"/>
-					<text macro="publisher"/>
-				</group>
-			</group>
-			<text macro="access" prefix=" "/>
-		</layout>
-	</bibliography>
+  <info>
+    <title>Université de Montréal - APA (French - Canada)</title>
+    <title-short>UdeM APA FR</title-short>
+    <id>http://www.zotero.org/styles/universite-de-montreal-apa</id>
+    <link href="http://www.zotero.org/styles/universite-de-montreal-apa" rel="self"/>
+    <link href="http://www.zotero.org/styles/apa" rel="template"/>
+    <link href="http://guides.bib.umontreal.ca/disciplines/20-Citer-selon-les-normes-de-l-APA" rel="documentation"/>
+    <author>
+      <name>Florian Martin-Bariteau</name>
+      <email>f.martin-bariteau@umontreal.ca</email>
+      <uri>http://f-mb.org/</uri>
+    </author>
+    <contributor>
+      <name>Mathieu Brisson</name>
+      <email>mathieu.brisson@cegeplimoilou.ca</email>
+      <uri/>
+    </contributor>
+    <contributor>
+      <name>Marc Julien</name>
+      <email>marc.julien@cegeplimoilou.ca</email>
+      <uri/>
+    </contributor>
+    <category citation-format="author-date"/>
+    <category field="psychology"/>
+    <category field="generic-base"/>
+    <summary>Adaptation en français canadien des normes de citation de l'APA (6e édition) basée sur le guide des Bibliothèques de l'Université de Montréal.</summary>
+    <updated>2019-08-14T05:14:01+00:00</updated>
+    <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
+  </info>
+  <locale>
+    <terms>
+      <term name="editor" form="short">dir.</term>
+      <term name="editortranslator" form="short">dir. et trad.</term>
+      <term name="translator" form="short">trad.</term>
+      <term name="no date" form="short">s. d.</term>
+      <term name="retrieved">repéré</term>
+      <term name="from">à</term>
+      <term name="presented at">communication présentée au</term>
+      <term name="page" form="short">p.</term>
+    </terms>
+  </locale>
+  <macro name="container-contributors">
+    <choose>
+      <if type="chapter paper-conference" match="any">
+        <names variable="editor translator" delimiter=", " suffix=", ">
+          <name and="text" initialize-with=". " delimiter=", " delimiter-precedes-last="never"/>
+          <et-al font-style="italic"/>
+          <label form="short" prefix=" (" suffix=")"/>
+        </names>
+      </if>
+    </choose>
+  </macro>
+  <macro name="secondary-contributors">
+    <choose>
+      <if type="article-journal chapter paper-conference" match="none">
+        <names variable="editor translator" delimiter=", ">
+          <label form="verb" suffix=" "/>
+          <name and="text" initialize-with=". " delimiter=", " delimiter-precedes-last="never"/>
+          <et-al font-style="italic"/>
+        </names>
+      </if>
+    </choose>
+  </macro>
+  <macro name="author">
+    <names variable="author">
+      <name name-as-sort-order="all" and="text" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="never"/>
+      <et-al font-style="italic"/>
+      <label form="short" prefix=" (" suffix=")"/>
+      <substitute>
+        <names variable="editor"/>
+        <names variable="translator"/>
+        <choose>
+          <if type="report">
+            <text variable="publisher"/>
+            <text macro="title"/>
+          </if>
+          <else>
+            <text macro="title"/>
+          </else>
+        </choose>
+      </substitute>
+    </names>
+  </macro>
+  <macro name="author-short">
+    <names variable="author">
+      <name form="short" and="text" delimiter=", " initialize-with=". " delimiter-precedes-last="never"/>
+      <substitute>
+        <names variable="editor"/>
+        <names variable="translator"/>
+        <choose>
+          <if type="report">
+            <text variable="publisher"/>
+            <text variable="title" form="short" font-style="italic"/>
+          </if>
+          <else-if type="bill book graphic legal_case legislation motion_picture song" match="any">
+            <text variable="title" form="short" font-style="italic"/>
+          </else-if>
+          <else>
+            <text variable="title" form="short" quotes="true"/>
+          </else>
+        </choose>
+      </substitute>
+    </names>
+  </macro>
+  <macro name="access">
+    <choose>
+      <if type="thesis">
+        <choose>
+          <if variable="archive" match="any">
+            <group>
+              <text term="retrieved" text-case="capitalize-first" suffix=" "/>
+              <text term="from" suffix=" "/>
+              <text variable="archive" suffix="."/>
+              <text variable="archive_location" prefix=" (" suffix=")"/>
+            </group>
+          </if>
+          <else>
+            <group>
+              <text term="retrieved" text-case="capitalize-first" suffix=" "/>
+              <text term="from" suffix=" "/>
+              <text variable="URL"/>
+            </group>
+          </else>
+        </choose>
+      </if>
+      <else>
+        <choose>
+          <if variable="DOI">
+            <text variable="DOI" prefix="doi:"/>
+          </if>
+          <else>
+            <group>
+              <text term="retrieved" text-case="capitalize-first" suffix=" "/>
+              <choose>
+                <if type="post">
+                  <date variable="accessed" form="text" prefix="le " suffix=" "/>
+                </if>
+              </choose>
+              <text term="from" suffix=" "/>
+              <text variable="URL"/>
+            </group>
+          </else>
+        </choose>
+      </else>
+    </choose>
+  </macro>
+  <macro name="title">
+    <choose>
+      <if type="thesis" match="any">
+        <text variable="title" font-style="italic"/>
+        <group prefix=" (" suffix=")" delimiter=", ">
+          <text variable="genre"/>
+          <text variable="medium"/>
+          <choose>
+            <if variable="URL" match="any">
+              <text variable="publisher"/>
+              <text variable="publisher-place"/>
+            </if>
+          </choose>
+        </group>
+      </if>
+      <else-if type="report" match="any">
+        <text variable="title" font-style="italic"/>
+        <group prefix=" (" suffix=")" delimiter=" ">
+          <text variable="genre" prefix=" [" suffix="]" text-case="capitalize-first"/>
+          <text variable="medium" prefix=" [" suffix="]" text-case="capitalize-first"/>
+          <choose>
+            <if variable="number" match="any">
+              <text term="issue" form="short"/>
+              <text variable="number"/>
+            </if>
+          </choose>
+        </group>
+      </else-if>
+      <else-if type="book graphic motion_picture report song manuscript speech" match="any">
+        <!---This is a hack until we have a computer program type -->
+        <choose>
+          <if variable="version">
+            <group delimiter=" ">
+              <text variable="title"/>
+              <text variable="genre" prefix=" [" suffix="]" text-case="capitalize-first"/>
+              <text variable="medium" prefix=" [" suffix="]" text-case="capitalize-first"/>
+              <group delimiter=" " prefix="(" suffix=")">
+                <text term="version"/>
+                <text variable="version"/>
+              </group>
+            </group>
+          </if>
+          <else>
+            <text variable="title" font-style="italic"/>
+            <text variable="genre" prefix=" [" suffix="]" text-case="capitalize-first"/>
+            <text variable="medium" prefix=" [" suffix="]" text-case="capitalize-first"/>
+          </else>
+        </choose>
+      </else-if>
+      <else-if type="paper-conference">
+        <text variable="title" font-style="italic"/>
+        <text variable="genre" prefix=" [" suffix="]" text-case="capitalize-first"/>
+        <text variable="medium" prefix=" [" suffix="]" text-case="capitalize-first"/>
+      </else-if>
+      <else>
+        <text variable="title"/>
+        <text variable="genre" prefix=" [" suffix="]" text-case="capitalize-first"/>
+        <text variable="medium" prefix=" [" suffix="]" text-case="capitalize-first"/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="publisher">
+    <choose>
+      <if type="report" match="any">
+        <group delimiter=" : ">
+          <text variable="publisher-place"/>
+          <text variable="publisher"/>
+        </group>
+      </if>
+      <else-if type="thesis" match="any">
+        <choose>
+          <if variable="URL archive" match="none">
+            <group delimiter=", ">
+              <text variable="publisher"/>
+              <text variable="publisher-place"/>
+            </group>
+          </if>
+        </choose>
+      </else-if>
+      <else>
+        <group delimiter=", ">
+          <choose>
+            <if type="article-journal article-magazine paper-conference" match="none">
+              <group delimiter=" : ">
+                <text variable="publisher-place"/>
+                <text variable="publisher"/>
+              </group>
+            </if>
+          </choose>
+        </group>
+      </else>
+    </choose>
+  </macro>
+  <macro name="event">
+    <choose>
+      <if variable="container-title" match="none">
+        <choose>
+          <if variable="event">
+            <choose>
+              <if variable="genre" match="none">
+                <text term="presented at" text-case="capitalize-first" suffix=" "/>
+                <text variable="event"/>
+              </if>
+              <else>
+                <group delimiter=" ">
+                  <text variable="genre" text-case="capitalize-first"/>
+                  <text term="presented at"/>
+                  <text variable="event"/>
+                </group>
+              </else>
+            </choose>
+          </if>
+        </choose>
+      </if>
+    </choose>
+  </macro>
+  <macro name="issued">
+    <choose>
+      <if type="bill legal_case legislation" match="none">
+        <choose>
+          <if variable="issued">
+            <group prefix=" (" suffix=")">
+              <date variable="issued">
+                <date-part name="year"/>
+              </date>
+              <text variable="year-suffix"/>
+              <choose>
+                <if type="article-journal bill book chapter graphic legal_case legislation motion_picture paper-conference report song" match="none">
+                  <date variable="issued" prefix=",">
+                    <date-part prefix=" " name="day"/>
+                    <date-part prefix=" " name="month"/>
+                  </date>
+                </if>
+              </choose>
+            </group>
+          </if>
+          <else>
+            <group prefix=" (" suffix=")">
+              <text term="no date" form="short"/>
+              <text variable="year-suffix" prefix="-"/>
+            </group>
+          </else>
+        </choose>
+      </if>
+    </choose>
+  </macro>
+  <macro name="issued-sort">
+    <choose>
+      <if type="article-journal bill book chapter graphic legal_case legislation motion_picture paper-conference report song" match="none">
+        <date variable="issued">
+          <date-part name="year"/>
+          <date-part name="month"/>
+          <date-part name="day"/>
+        </date>
+      </if>
+      <else>
+        <date variable="issued">
+          <date-part name="year"/>
+        </date>
+      </else>
+    </choose>
+  </macro>
+  <macro name="issued-year">
+    <choose>
+      <if variable="issued">
+        <date variable="issued">
+          <date-part name="year"/>
+        </date>
+        <text variable="year-suffix"/>
+      </if>
+      <else>
+        <text term="no date" form="short"/>
+        <text variable="year-suffix" prefix="-"/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="edition">
+    <choose>
+      <if is-numeric="edition">
+        <group delimiter=" ">
+          <number variable="edition" form="ordinal"/>
+          <text term="edition" form="short"/>
+        </group>
+      </if>
+      <else>
+        <text variable="edition"/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="locators">
+    <choose>
+      <if type="article-journal article-magazine" match="any">
+        <group prefix=", " delimiter=", ">
+          <group>
+            <text variable="volume" font-style="italic"/>
+            <text variable="issue" prefix="(" suffix=")"/>
+          </group>
+          <text variable="page"/>
+        </group>
+      </if>
+      <else-if type="article-newspaper">
+        <group delimiter=" " prefix=", ">
+          <label variable="page" form="short"/>
+          <text variable="page"/>
+        </group>
+      </else-if>
+      <else-if type="book graphic motion_picture report song chapter paper-conference" match="any">
+        <group prefix=" (" suffix=")" delimiter="; ">
+          <group delimiter=", ">
+            <text macro="edition"/>
+            <group>
+              <text term="volume" form="short" plural="true" suffix=" "/>
+              <number variable="number-of-volumes" form="numeric" prefix="1-"/>
+            </group>
+            <group>
+              <text term="volume" form="short" suffix=" "/>
+              <number variable="volume" form="numeric"/>
+            </group>
+            <group>
+              <label variable="page" form="short" suffix=" "/>
+              <text variable="page"/>
+            </group>
+          </group>
+          <text macro="secondary-contributors"/>
+        </group>
+      </else-if>
+      <else-if type="legal_case">
+        <group prefix=" (" suffix=")" delimiter=" ">
+          <text variable="authority"/>
+          <date variable="issued" form="text"/>
+        </group>
+      </else-if>
+      <else-if type="bill legislation" match="any">
+        <date variable="issued" prefix=" (" suffix=")">
+          <date-part name="year"/>
+        </date>
+      </else-if>
+    </choose>
+  </macro>
+  <macro name="citation-locator">
+    <group>
+      <choose>
+        <if locator="chapter">
+          <label variable="locator" form="short"/>
+        </if>
+        <else>
+          <label variable="locator" form="short"/>
+        </else>
+      </choose>
+      <text variable="locator" prefix=" "/>
+    </group>
+  </macro>
+  <macro name="container">
+    <group>
+      <choose>
+        <if type="chapter entry-encyclopedia" match="any">
+          <text term="in" text-case="capitalize-first" suffix=" "/>
+        </if>
+      </choose>
+      <text macro="container-contributors"/>
+      <choose>
+        <if type="paper-conference">
+          <text value="Communication présentée au "/>
+          <text macro="container-title"/>
+          <text variable="publisher-place" prefix=", "/>
+        </if>
+        <else>
+          <text macro="container-title"/>
+        </else>
+      </choose>
+      <choose>
+        <if type="entry-encyclopedia">
+          <text variable="volume" prefix=" (Vol. " suffix=","/>
+          <text variable="page" prefix="  p. " suffix=")"/>
+        </if>
+      </choose>
+    </group>
+    <choose>
+      <if type="manuscript">
+        <text value="Document inédit"/>
+      </if>
+    </choose>
+  </macro>
+  <macro name="container-title">
+    <choose>
+      <if type="article article-journal article-magazine article-newspaper" match="any">
+        <text variable="container-title" font-style="italic" text-case="title"/>
+      </if>
+      <else-if type="manuscript"></else-if>
+      <else-if type="paper-conference">
+        <text variable="container-title" text-case="title"/>
+      </else-if>
+      <else-if type="bill legal_case legislation" match="none">
+        <text variable="container-title" font-style="italic"/>
+      </else-if>
+      <else>
+        <group delimiter=" " prefix=", ">
+          <choose>
+            <if variable="container-title">
+              <text variable="volume"/>
+              <text variable="container-title"/>
+              <group delimiter=" ">
+                <!--change to label variable="section" as that becomes available -->
+                <text term="section" form="symbol"/>
+                <text variable="section"/>
+              </group>
+              <text variable="page"/>
+            </if>
+            <else>
+              <choose>
+                <if type="legal_case">
+                  <text term="issue" form="short"/>
+                  <text variable="number"/>
+                </if>
+                <else>
+                  <text term="issue" form="short"/>
+                  <text variable="number"/>
+                  <group delimiter=" ">
+                    <!--change to label variable="section" as that becomes available -->
+                    <text term="section" form="symbol"/>
+                    <text variable="section"/>
+                  </group>
+                </else>
+              </choose>
+            </else>
+          </choose>
+        </group>
+      </else>
+    </choose>
+  </macro>
+  <citation et-al-min="6" et-al-use-first="1" et-al-subsequent-min="3" et-al-subsequent-use-first="1" disambiguate-add-year-suffix="true" disambiguate-add-names="true" disambiguate-add-givenname="true" collapse="year" givenname-disambiguation-rule="primary-name">
+    <sort>
+      <key macro="author"/>
+      <key macro="issued-sort"/>
+    </sort>
+    <layout prefix="(" suffix=")" delimiter="; ">
+      <group delimiter=", ">
+        <text macro="author-short"/>
+        <text macro="issued-year"/>
+        <text macro="citation-locator"/>
+      </group>
+    </layout>
+  </citation>
+  <bibliography hanging-indent="true" et-al-min="8" et-al-use-first="6" et-al-use-last="true" entry-spacing="0" line-spacing="2">
+    <sort>
+      <key macro="author"/>
+      <key macro="issued-sort" sort="ascending"/>
+      <key macro="title"/>
+    </sort>
+    <layout>
+      <group suffix=".">
+        <group delimiter=". ">
+          <text macro="author"/>
+          <text macro="issued"/>
+          <text macro="title" prefix=" "/>
+          <text macro="container"/>
+        </group>
+        <text macro="locators"/>
+        <group delimiter=", " prefix=". ">
+          <text macro="event"/>
+          <text macro="publisher"/>
+        </group>
+      </group>
+      <text macro="access" prefix=" "/>
+    </layout>
+  </bibliography>
 </style>

--- a/universite-de-montreal-apa.csl
+++ b/universite-de-montreal-apa.csl
@@ -408,9 +408,13 @@
       <text macro="container-contributors"/>
       <choose>
         <if type="paper-conference">
-          <text value="Communication présentée au "/>
-          <text macro="container-title"/>
-          <text variable="publisher-place" prefix=", "/>
+          <group delimiter=", ">
+            <group delimiter=" ">
+              <text value="Communication présentée au"/>
+              <text macro="container-title"/>
+            </group>
+            <text variable="publisher-place"/>
+          </group>
         </if>
         <else>
           <text macro="container-title"/>
@@ -418,8 +422,10 @@
       </choose>
       <choose>
         <if type="entry-encyclopedia">
-          <text variable="volume" prefix=" (Vol. " suffix=","/>
-          <text variable="page" prefix="  p. " suffix=")"/>
+          <group prefix=" (" suffix=")" delimiter=", ">
+            <text variable="volume" prefix="Vol. "/>
+            <text variable="page" prefix="p. "/>
+          </group>
         </if>
       </choose>
     </group>

--- a/universite-de-montreal-apa.csl
+++ b/universite-de-montreal-apa.csl
@@ -1,482 +1,516 @@
 <?xml version="1.0" encoding="utf-8"?>
 <style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" demote-non-dropping-particle="never" default-locale="fr-CA">
-  <info>
-    <title>Université de Montréal - APA (French - Canada)</title>
-    <title-short>UdeM APA FR</title-short>
-    <id>http://www.zotero.org/styles/universite-de-montreal-apa</id>
-    <link href="http://www.zotero.org/styles/universite-de-montreal-apa" rel="self"/>
-    <link href="http://www.zotero.org/styles/apa" rel="template"/>
-    <link href="http://guides.bib.umontreal.ca/disciplines/20-Citer-selon-les-normes-de-l-APA" rel="documentation"/>
-    <author>
-      <name>Florian Martin-Bariteau</name>
-      <email>f.martin-bariteau@umontreal.ca</email>
-      <uri>http://f-mb.org/</uri>
-    </author>
-    <category citation-format="author-date"/>
-    <category field="psychology"/>
-    <category field="generic-base"/>
-    <summary>Adaptation en français canadien des normes de citation de l'APA (6e édition) basée sur le guide des Bibliothèques de l'Université de Montréal.</summary>
-    <updated>2015-12-01T23:12:08+00:00</updated>
-    <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
-  </info>
-  <locale>
-    <terms>
-      <term name="editor" form="short">dir.</term>
-      <term name="editortranslator" form="short">dir. et trad.</term>
-      <term name="translator" form="short">trad.</term>
-      <term name="no date" form="short">s.d.</term>
-      <term name="retrieved">repéré</term>
-      <term name="from">à</term>
-      <term name="presented at">communication présentée au</term>
-      <term name="page" form="short">p.</term>
-    </terms>
-  </locale>
-  <macro name="container-contributors">
-    <choose>
-      <if type="chapter paper-conference" match="any">
-        <names variable="editor translator" delimiter=", " suffix=", ">
-          <name and="text" initialize-with=". " delimiter=", " delimiter-precedes-last="never"/>
-          <et-al font-style="italic"/>
-          <label form="short" prefix=" (" suffix=")"/>
-        </names>
-      </if>
-    </choose>
-  </macro>
-  <macro name="secondary-contributors">
-    <choose>
-      <if type="article-journal chapter paper-conference" match="none">
-        <names variable="editor translator" delimiter=", ">
-          <label form="verb" suffix=" "/>
-          <name and="text" initialize-with=". " delimiter=", " delimiter-precedes-last="never"/>
-          <et-al font-style="italic"/>
-        </names>
-      </if>
-    </choose>
-  </macro>
-  <macro name="author">
-    <names variable="author">
-      <name name-as-sort-order="all" and="text" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="never"/>
-      <et-al font-style="italic"/>
-      <label form="short" prefix=" (" suffix=")"/>
-      <substitute>
-        <names variable="editor"/>
-        <names variable="translator"/>
-        <choose>
-          <if type="report">
-            <text variable="publisher"/>
-            <text macro="title"/>
-          </if>
-          <else>
-            <text macro="title"/>
-          </else>
-        </choose>
-      </substitute>
-    </names>
-  </macro>
-  <macro name="author-short">
-    <names variable="author">
-      <name form="short" and="text" delimiter=", " initialize-with=". " delimiter-precedes-last="never"/>
-      <substitute>
-        <names variable="editor"/>
-        <names variable="translator"/>
-        <choose>
-          <if type="report">
-            <text variable="publisher"/>
-            <text variable="title" form="short" font-style="italic"/>
-          </if>
-          <else-if type="bill book graphic legal_case legislation motion_picture song" match="any">
-            <text variable="title" form="short" font-style="italic"/>
-          </else-if>
-          <else>
-            <text variable="title" form="short" quotes="true"/>
-          </else>
-        </choose>
-      </substitute>
-    </names>
-  </macro>
-  <macro name="access">
-    <choose>
-      <if type="thesis">
-        <choose>
-          <if variable="archive" match="any">
-            <group>
-              <text term="retrieved" text-case="capitalize-first" suffix=" "/>
-              <text term="from" suffix=" "/>
-              <text variable="archive" suffix="."/>
-              <text variable="archive_location" prefix=" (" suffix=")"/>
-            </group>
-          </if>
-          <else>
-            <group>
-              <text term="retrieved" text-case="capitalize-first" suffix=" "/>
-              <text term="from" suffix=" "/>
-              <text variable="URL"/>
-            </group>
-          </else>
-        </choose>
-      </if>
-      <else>
-        <choose>
-          <if variable="DOI">
-            <text variable="DOI" prefix="doi:"/>
-          </if>
-          <else>
-            <choose>
-              <if type="webpage">
-                <group delimiter=" ">
-                  <text term="retrieved" text-case="capitalize-first" suffix=" "/>
-                  <group>
-                    <date variable="accessed" form="text" suffix=", "/>
-                  </group>
-                  <text term="from"/>
-                  <text variable="URL"/>
-                </group>
-              </if>
-              <else>
-                <group>
-                  <text term="retrieved" text-case="capitalize-first" suffix=" "/>
-                  <text term="from" suffix=" "/>
-                  <text variable="URL"/>
-                </group>
-              </else>
-            </choose>
-          </else>
-        </choose>
-      </else>
-    </choose>
-  </macro>
-  <macro name="title">
-    <choose>
-      <if type="thesis" match="any">
-        <text variable="title" font-style="italic"/>
-        <group prefix=" (" suffix=")" delimiter=", ">
-          <text variable="genre"/>
-          <choose>
-            <if variable="URL" match="any">
-              <text variable="publisher"/>
-              <text variable="publisher-place"/>
-            </if>
-          </choose>
-        </group>
-      </if>
-      <else-if type="report" match="any">
-        <text variable="title" font-style="italic"/>
-        <group prefix=" (" suffix=")" delimiter=" ">
-          <text variable="genre"/>
-          <choose>
-            <if variable="number" match="any">
-              <text term="issue" form="short"/>
-              <text variable="number"/>
-            </if>
-          </choose>
-        </group>
-      </else-if>
-      <else-if type="book graphic motion_picture report song manuscript speech" match="any">
-        <!---This is a hack until we have a computer program type -->
-        <choose>
-          <if variable="version">
-            <group delimiter=" ">
-              <text variable="title"/>
-              <group delimiter=" " prefix="(" suffix=")">
-                <text term="version"/>
-                <text variable="version"/>
-              </group>
-            </group>
-          </if>
-          <else>
-            <text variable="title" font-style="italic"/>
-          </else>
-        </choose>
-      </else-if>
-      <else>
-        <text variable="title"/>
-      </else>
-    </choose>
-  </macro>
-  <macro name="publisher">
-    <choose>
-      <if type="report" match="any">
-        <group delimiter=" : ">
-          <text variable="publisher-place"/>
-          <text variable="publisher"/>
-        </group>
-      </if>
-      <else-if type="thesis" match="any">
-        <choose>
-          <if variable="URL archive" match="none">
-            <group delimiter=", ">
-              <text variable="publisher"/>
-              <text variable="publisher-place"/>
-            </group>
-          </if>
-        </choose>
-      </else-if>
-      <else>
-        <group delimiter=", ">
-          <choose>
-            <if variable="event" match="none">
-              <text variable="genre"/>
-            </if>
-          </choose>
-          <choose>
-            <if type="article-journal article-magazine" match="none">
-              <group delimiter=" : ">
-                <text variable="publisher-place"/>
-                <text variable="publisher"/>
-              </group>
-            </if>
-          </choose>
-        </group>
-      </else>
-    </choose>
-  </macro>
-  <macro name="event">
-    <choose>
-      <if variable="container-title" match="none">
-        <choose>
-          <if variable="event">
-            <choose>
-              <if variable="genre" match="none">
-                <text term="presented at" text-case="capitalize-first" suffix=" "/>
-                <text variable="event"/>
-              </if>
-              <else>
-                <group delimiter=" ">
-                  <text variable="genre" text-case="capitalize-first"/>
-                  <text term="presented at"/>
-                  <text variable="event"/>
-                </group>
-              </else>
-            </choose>
-          </if>
-        </choose>
-      </if>
-    </choose>
-  </macro>
-  <macro name="issued">
-    <choose>
-      <if type="bill legal_case legislation" match="none">
-        <choose>
-          <if variable="issued">
-            <group prefix=" (" suffix=")">
-              <date variable="issued">
-                <date-part name="year"/>
-              </date>
-              <text variable="year-suffix"/>
-              <choose>
-                <if type="article-journal bill book chapter graphic legal_case legislation motion_picture paper-conference report song" match="none">
-                  <date variable="issued" prefix=",">
-                    <date-part prefix=" " name="day"/>
-                    <date-part prefix=" " name="month"/>
-                  </date>
-                </if>
-              </choose>
-            </group>
-          </if>
-          <else>
-            <group prefix=" (" suffix=")">
-              <text term="no date" form="short"/>
-              <text variable="year-suffix" prefix="-"/>
-            </group>
-          </else>
-        </choose>
-      </if>
-    </choose>
-  </macro>
-  <macro name="issued-sort">
-    <choose>
-      <if type="article-journal bill book chapter graphic legal_case legislation motion_picture paper-conference report song" match="none">
-        <date variable="issued">
-          <date-part name="year"/>
-          <date-part name="month"/>
-          <date-part name="day"/>
-        </date>
-      </if>
-      <else>
-        <date variable="issued">
-          <date-part name="year"/>
-        </date>
-      </else>
-    </choose>
-  </macro>
-  <macro name="issued-year">
-    <choose>
-      <if variable="issued">
-        <date variable="issued">
-          <date-part name="year"/>
-        </date>
-        <text variable="year-suffix"/>
-      </if>
-      <else>
-        <text term="no date" form="short"/>
-        <text variable="year-suffix" prefix="-"/>
-      </else>
-    </choose>
-  </macro>
-  <macro name="edition">
-    <choose>
-      <if is-numeric="edition">
-        <group delimiter=" ">
-          <number variable="edition" form="ordinal"/>
-          <text term="edition" form="short"/>
-        </group>
-      </if>
-      <else>
-        <text variable="edition"/>
-      </else>
-    </choose>
-  </macro>
-  <macro name="locators">
-    <choose>
-      <if type="article-journal article-magazine" match="any">
-        <group prefix=", " delimiter=", ">
-          <group>
-            <text variable="volume" font-style="italic"/>
-            <text variable="issue" prefix="(" suffix=")"/>
-          </group>
-          <text variable="page"/>
-        </group>
-      </if>
-      <else-if type="article-newspaper">
-        <group delimiter=" " prefix=", ">
-          <label variable="page" form="short"/>
-          <text variable="page"/>
-        </group>
-      </else-if>
-      <else-if type="book graphic motion_picture report song chapter paper-conference" match="any">
-        <group prefix=" (" suffix=")" delimiter="; ">
-          <group delimiter=", ">
-            <text macro="edition"/>
-            <group>
-              <text term="volume" form="short" plural="true" suffix=" "/>
-              <number variable="number-of-volumes" form="numeric" prefix="1-"/>
-            </group>
-            <group>
-              <text term="volume" form="short" suffix=" "/>
-              <number variable="volume" form="numeric"/>
-            </group>
-            <group>
-              <label variable="page" form="short" suffix=" "/>
-              <text variable="page"/>
-            </group>
-          </group>
-          <text macro="secondary-contributors"/>
-        </group>
-      </else-if>
-      <else-if type="legal_case">
-        <group prefix=" (" suffix=")" delimiter=" ">
-          <text variable="authority"/>
-          <date variable="issued" form="text"/>
-        </group>
-      </else-if>
-      <else-if type="bill legislation" match="any">
-        <date variable="issued" prefix=" (" suffix=")">
-          <date-part name="year"/>
-        </date>
-      </else-if>
-    </choose>
-  </macro>
-  <macro name="citation-locator">
-    <group>
-      <choose>
-        <if locator="chapter">
-          <label variable="locator" form="short"/>
-        </if>
-        <else>
-          <label variable="locator" form="short"/>
-        </else>
-      </choose>
-      <text variable="locator" prefix=" "/>
-    </group>
-  </macro>
-  <macro name="container">
-    <group>
-      <choose>
-        <if type="chapter paper-conference entry-encyclopedia" match="any">
-          <text term="in" text-case="capitalize-first" suffix=" "/>
-        </if>
-      </choose>
-      <text macro="container-contributors"/>
-      <text macro="container-title"/>
-    </group>
-  </macro>
-  <macro name="container-title">
-    <choose>
-      <if type="article article-journal article-magazine article-newspaper" match="any">
-        <text variable="container-title" font-style="italic" text-case="title"/>
-      </if>
-      <else-if type="bill legal_case legislation" match="none">
-        <text variable="container-title" font-style="italic"/>
-      </else-if>
-      <else>
-        <group delimiter=" " prefix=", ">
-          <choose>
-            <if variable="container-title">
-              <text variable="volume"/>
-              <text variable="container-title"/>
-              <group delimiter=" ">
-                <!--change to label variable="section" as that becomes available -->
-                <text term="section" form="symbol"/>
-                <text variable="section"/>
-              </group>
-              <text variable="page"/>
-            </if>
-            <else>
-              <choose>
-                <if type="legal_case">
-                  <text term="issue" form="short"/>
-                  <text variable="number"/>
-                </if>
-                <else>
-                  <text term="issue" form="short"/>
-                  <text variable="number"/>
-                  <group delimiter=" ">
-                    <!--change to label variable="section" as that becomes available -->
-                    <text term="section" form="symbol"/>
-                    <text variable="section"/>
-                  </group>
-                </else>
-              </choose>
-            </else>
-          </choose>
-        </group>
-      </else>
-    </choose>
-  </macro>
-  <citation et-al-min="6" et-al-use-first="1" et-al-subsequent-min="3" et-al-subsequent-use-first="1" disambiguate-add-year-suffix="true" disambiguate-add-names="true" disambiguate-add-givenname="true" collapse="year" givenname-disambiguation-rule="primary-name">
-    <sort>
-      <key macro="author"/>
-      <key macro="issued-sort"/>
-    </sort>
-    <layout prefix="(" suffix=")" delimiter="; ">
-      <group delimiter=", ">
-        <text macro="author-short"/>
-        <text macro="issued-year"/>
-        <text macro="citation-locator"/>
-      </group>
-    </layout>
-  </citation>
-  <bibliography hanging-indent="true" et-al-min="8" et-al-use-first="6" et-al-use-last="true" entry-spacing="0" line-spacing="2">
-    <sort>
-      <key macro="author"/>
-      <key macro="issued-sort" sort="ascending"/>
-      <key macro="title"/>
-    </sort>
-    <layout>
-      <group suffix=".">
-        <group delimiter=". ">
-          <text macro="author"/>
-          <text macro="issued"/>
-          <text macro="title" prefix=" "/>
-          <text macro="container"/>
-        </group>
-        <text macro="locators"/>
-        <group delimiter=", " prefix=". ">
-          <text macro="event"/>
-          <text macro="publisher"/>
-        </group>
-      </group>
-      <text macro="access" prefix=" "/>
-    </layout>
-  </bibliography>
+	<info>
+		<title>Université de Montréal - APA (French - Canada)</title>
+		<title-short>UdeM APA FR</title-short>
+		<id>http://www.zotero.org/styles/universite-de-montreal-apa</id>
+		<link href="http://www.zotero.org/styles/universite-de-montreal-apa" rel="self"/>
+		<link href="http://www.zotero.org/styles/apa" rel="template"/>
+		<link href="http://guides.bib.umontreal.ca/disciplines/20-Citer-selon-les-normes-de-l-APA" rel="documentation"/>
+		<author>
+			<name>Florian Martin-Bariteau</name>
+			<email>f.martin-bariteau@umontreal.ca</email>
+			<uri>http://f-mb.org/</uri>
+		</author>
+		<contributor>
+			<name>Mathieu Brisson</name>
+			<email>mathieu.brisson@cegeplimoilou.ca</email>
+			<uri/>
+		</contributor>
+		<contributor>
+			<name>Marc Julien</name>
+			<email>marc.julien@cegeplimoilou.ca</email>
+			<uri/>
+		</contributor>
+		<category citation-format="author-date"/>
+		<category field="psychology"/>
+		<category field="generic-base"/>
+		<summary>Adaptation en français canadien des normes de citation de l'APA (6e édition) basée sur le guide des Bibliothèques de l'Université de Montréal.</summary>
+		<updated>2019-08-14T05:14:01+00:00</updated>
+		<rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
+	</info>
+	<locale>
+		<terms>
+			<term name="editor" form="short">dir.</term>
+			<term name="editortranslator" form="short">dir. et trad.</term>
+			<term name="translator" form="short">trad.</term>
+			<term name="no date" form="short">s. d.</term>
+			<term name="retrieved">repéré</term>
+			<term name="from">à</term>
+			<term name="presented at">communication présentée au</term>
+			<term name="page" form="short">p.</term>
+		</terms>
+	</locale>
+	<macro name="container-contributors">
+		<choose>
+			<if type="chapter paper-conference" match="any">
+				<names variable="editor translator" delimiter=", " suffix=", ">
+					<name and="text" initialize-with=". " delimiter=", " delimiter-precedes-last="never"/>
+					<et-al font-style="italic"/>
+					<label form="short" prefix=" (" suffix=")"/>
+				</names>
+			</if>
+		</choose>
+	</macro>
+	<macro name="secondary-contributors">
+		<choose>
+			<if type="article-journal chapter paper-conference" match="none">
+				<names variable="editor translator" delimiter=", ">
+					<label form="verb" suffix=" "/>
+					<name and="text" initialize-with=". " delimiter=", " delimiter-precedes-last="never"/>
+					<et-al font-style="italic"/>
+				</names>
+			</if>
+		</choose>
+	</macro>
+	<macro name="author">
+		<names variable="author">
+			<name name-as-sort-order="all" and="text" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="never"/>
+			<et-al font-style="italic"/>
+			<label form="short" prefix=" (" suffix=")"/>
+			<substitute>
+				<names variable="editor"/>
+				<names variable="translator"/>
+				<choose>
+					<if type="report">
+						<text variable="publisher"/>
+						<text macro="title"/>
+					</if>
+					<else>
+						<text macro="title"/>
+					</else>
+				</choose>
+			</substitute>
+		</names>
+	</macro>
+	<macro name="author-short">
+		<names variable="author">
+			<name form="short" and="text" delimiter=", " initialize-with=". " delimiter-precedes-last="never"/>
+			<substitute>
+				<names variable="editor"/>
+				<names variable="translator"/>
+				<choose>
+					<if type="report">
+						<text variable="publisher"/>
+						<text variable="title" form="short" font-style="italic"/>
+					</if>
+					<else-if type="bill book graphic legal_case legislation motion_picture song" match="any">
+						<text variable="title" form="short" font-style="italic"/>
+					</else-if>
+					<else>
+						<text variable="title" form="short" quotes="true"/>
+					</else>
+				</choose>
+			</substitute>
+		</names>
+	</macro>
+	<macro name="access">
+		<choose>
+			<if type="thesis">
+				<choose>
+					<if variable="archive" match="any">
+						<group>
+							<text term="retrieved" text-case="capitalize-first" suffix=" "/>
+							<text term="from" suffix=" "/>
+							<text variable="archive" suffix="."/>
+							<text variable="archive_location" prefix=" (" suffix=")"/>
+						</group>
+					</if>
+					<else>
+						<group>
+							<text term="retrieved" text-case="capitalize-first" suffix=" "/>
+							<text term="from" suffix=" "/>
+							<text variable="URL"/>
+						</group>
+					</else>
+				</choose>
+			</if>
+			<else>
+				<choose>
+					<if variable="DOI">
+						<text variable="DOI" prefix="doi:"/>
+					</if>
+					<else>
+						<group>
+							<text term="retrieved" text-case="capitalize-first" suffix=" "/>
+							<choose>
+								<if type="post">
+									<date variable="accessed" form="text" prefix="le " suffix=" "/>
+								</if>
+							</choose>
+							<text term="from" suffix=" "/>
+							<text variable="URL"/>
+						</group>
+					</else>
+				</choose>
+			</else>
+		</choose>
+	</macro>
+	<macro name="title">
+		<choose>
+			<if type="thesis" match="any">
+				<text variable="title" font-style="italic"/>
+				<group prefix=" (" suffix=")" delimiter=", ">
+					<text variable="genre"/>
+					<text variable="medium"/>
+					<choose>
+						<if variable="URL" match="any">
+							<text variable="publisher"/>
+							<text variable="publisher-place"/>
+						</if>
+					</choose>
+				</group>
+			</if>
+			<else-if type="report" match="any">
+				<text variable="title" font-style="italic"/>
+				<group prefix=" (" suffix=")" delimiter=" ">
+					<text variable="genre" prefix=" [" suffix="]" text-case="capitalize-first"/>
+					<text variable="medium" prefix=" [" suffix="]" text-case="capitalize-first"/>
+					<choose>
+						<if variable="number" match="any">
+							<text term="issue" form="short"/>
+							<text variable="number"/>
+						</if>
+					</choose>
+				</group>
+			</else-if>
+			<else-if type="book graphic motion_picture report song manuscript speech" match="any">
+				<!---This is a hack until we have a computer program type -->
+				<choose>
+					<if variable="version">
+						<group delimiter=" ">
+							<text variable="title"/>
+							<text variable="genre" prefix=" [" suffix="]" text-case="capitalize-first"/>
+							<text variable="medium" prefix=" [" suffix="]" text-case="capitalize-first"/>
+							<group delimiter=" " prefix="(" suffix=")">
+								<text term="version"/>
+								<text variable="version"/>
+							</group>
+						</group>
+					</if>
+					<else>
+						<text variable="title" font-style="italic"/>
+						<text variable="genre" prefix=" [" suffix="]" text-case="capitalize-first"/>
+						<text variable="medium" prefix=" [" suffix="]" text-case="capitalize-first"/>
+					</else>
+				</choose>
+			</else-if>
+			<else-if type="paper-conference">
+				<text variable="title"  font-style="italic"/>
+				<text variable="genre" prefix=" [" suffix="]" text-case="capitalize-first"/>
+				<text variable="medium" prefix=" [" suffix="]" text-case="capitalize-first"/>
+			</else-if>
+			<else>
+				<text variable="title"/>
+				<text variable="genre" prefix=" [" suffix="]" text-case="capitalize-first"/>
+				<text variable="medium" prefix=" [" suffix="]" text-case="capitalize-first"/>
+			</else>
+		</choose>
+	</macro>
+	<macro name="publisher">
+		<choose>
+			<if type="report" match="any">
+				<group delimiter=" : ">
+					<text variable="publisher-place"/>
+					<text variable="publisher"/>
+				</group>
+			</if>
+			<else-if type="thesis" match="any">
+				<choose>
+					<if variable="URL archive" match="none">
+						<group delimiter=", ">
+							<text variable="publisher"/>
+							<text variable="publisher-place"/>
+						</group>
+					</if>
+				</choose>
+			</else-if>
+			<else>
+				<group delimiter=", ">
+					<choose>
+						<if type="article-journal article-magazine paper-conference" match="none">
+							<group delimiter=" : ">
+								<text variable="publisher-place"/>
+								<text variable="publisher"/>
+							</group>
+						</if>
+					</choose>
+				</group>
+			</else>
+		</choose>
+	</macro>
+	<macro name="event">
+		<choose>
+			<if variable="container-title" match="none">
+				<choose>
+					<if variable="event">
+						<choose>
+							<if variable="genre" match="none">
+								<text term="presented at" text-case="capitalize-first" suffix=" "/>
+								<text variable="event"/>
+							</if>
+							<else>
+								<group delimiter=" ">
+									<text variable="genre" text-case="capitalize-first"/>
+									<text term="presented at"/>
+									<text variable="event"/>
+								</group>
+							</else>
+						</choose>
+					</if>
+				</choose>
+			</if>
+		</choose>
+	</macro>
+	<macro name="issued">
+		<choose>
+			<if type="bill legal_case legislation" match="none">
+				<choose>
+					<if variable="issued">
+						<group prefix=" (" suffix=")">
+							<date variable="issued">
+								<date-part name="year"/>
+							</date>
+							<text variable="year-suffix"/>
+							<choose>
+								<if type="article-journal bill book chapter graphic legal_case legislation motion_picture paper-conference report song" match="none">
+									<date variable="issued" prefix=",">
+										<date-part prefix=" " name="day"/>
+										<date-part prefix=" " name="month"/>
+									</date>
+								</if>
+							</choose>
+						</group>
+					</if>
+					<else>
+						<group prefix=" (" suffix=")">
+							<text term="no date" form="short"/>
+							<text variable="year-suffix" prefix="-"/>
+						</group>
+					</else>
+				</choose>
+			</if>
+		</choose>
+	</macro>
+	<macro name="issued-sort">
+		<choose>
+			<if type="article-journal bill book chapter graphic legal_case legislation motion_picture paper-conference report song" match="none">
+				<date variable="issued">
+					<date-part name="year"/>
+					<date-part name="month"/>
+					<date-part name="day"/>
+				</date>
+			</if>
+			<else>
+				<date variable="issued">
+					<date-part name="year"/>
+				</date>
+			</else>
+		</choose>
+	</macro>
+	<macro name="issued-year">
+		<choose>
+			<if variable="issued">
+				<date variable="issued">
+					<date-part name="year"/>
+				</date>
+				<text variable="year-suffix"/>
+			</if>
+			<else>
+				<text term="no date" form="short"/>
+				<text variable="year-suffix" prefix="-"/>
+			</else>
+		</choose>
+	</macro>
+	<macro name="edition">
+		<choose>
+			<if is-numeric="edition">
+				<group delimiter=" ">
+					<number variable="edition" form="ordinal"/>
+					<text term="edition" form="short"/>
+				</group>
+			</if>
+			<else>
+				<text variable="edition"/>
+			</else>
+		</choose>
+	</macro>
+	<macro name="locators">
+		<choose>
+			<if type="article-journal article-magazine" match="any">
+				<group prefix=", " delimiter=", ">
+					<group>
+						<text variable="volume" font-style="italic"/>
+						<text variable="issue" prefix="(" suffix=")"/>
+					</group>
+					<text variable="page"/>
+				</group>
+			</if>
+			<else-if type="article-newspaper">
+				<group delimiter=" " prefix=", ">
+					<label variable="page" form="short"/>
+					<text variable="page"/>
+				</group>
+			</else-if>
+			<else-if type="book graphic motion_picture report song chapter paper-conference" match="any">
+				<group prefix=" (" suffix=")" delimiter="; ">
+					<group delimiter=", ">
+						<text macro="edition"/>
+						<group>
+							<text term="volume" form="short" plural="true" suffix=" "/>
+							<number variable="number-of-volumes" form="numeric" prefix="1-"/>
+						</group>
+						<group>
+							<text term="volume" form="short" suffix=" "/>
+							<number variable="volume" form="numeric"/>
+						</group>
+						<group>
+							<label variable="page" form="short" suffix=" "/>
+							<text variable="page"/>
+						</group>
+					</group>
+					<text macro="secondary-contributors"/>
+				</group>
+			</else-if>
+			<else-if type="legal_case">
+				<group prefix=" (" suffix=")" delimiter=" ">
+					<text variable="authority"/>
+					<date variable="issued" form="text"/>
+				</group>
+			</else-if>
+			<else-if type="bill legislation" match="any">
+				<date variable="issued" prefix=" (" suffix=")">
+					<date-part name="year"/>
+				</date>
+			</else-if>
+		</choose>
+	</macro>
+	<macro name="citation-locator">
+		<group>
+			<choose>
+				<if locator="chapter">
+					<label variable="locator" form="short"/>
+				</if>
+				<else>
+					<label variable="locator" form="short"/>
+				</else>
+			</choose>
+			<text variable="locator" prefix=" "/>
+		</group>
+	</macro>
+	<macro name="container">
+		<group>
+			<choose>
+				<if type="chapter entry-encyclopedia" match="any">
+					<text term="in" text-case="capitalize-first" suffix=" "/>
+				</if>
+			</choose>
+			<text macro="container-contributors"/>
+			<choose>
+				<if type="paper-conference">
+					<text value="Communication présentée au "/>
+					<text macro="container-title"/>
+					<text variable="publisher-place" prefix=", "/>
+				</if>
+				<else>
+					<text macro="container-title"/>
+				</else>
+			</choose>
+			<choose>
+				<if type="entry-encyclopedia">
+					<text variable="volume" prefix=" (Vol. " suffix="," />
+					<text variable="page" prefix="  p. " suffix=")" />
+				</if>
+			</choose>
+		</group>
+		<choose>
+			<if type="manuscript">
+				<text value="Document inédit"/>
+			</if>
+		</choose>
+	</macro>
+	<macro name="container-title">
+		<choose>
+			<if type="article article-journal article-magazine article-newspaper" match="any">
+				<text variable="container-title" font-style="italic" text-case="title"/>
+			</if>
+			<else-if type="manuscript">
+			</else-if>
+			<else-if type="paper-conference">
+				<text variable="container-title" text-case="title"/>
+			</else-if>
+			<else-if type="bill legal_case legislation" match="none">
+				<text variable="container-title" font-style="italic"/>
+			</else-if>
+			<else>
+				<group delimiter=" " prefix=", ">
+					<choose>
+						<if variable="container-title">
+							<text variable="volume"/>
+							<text variable="container-title"/>
+							<group delimiter=" ">
+								<!--change to label variable="section" as that becomes available -->
+								<text term="section" form="symbol"/>
+								<text variable="section"/>
+							</group>
+							<text variable="page"/>
+						</if>
+						<else>
+							<choose>
+								<if type="legal_case">
+									<text term="issue" form="short"/>
+									<text variable="number"/>
+								</if>
+								<else>
+									<text term="issue" form="short"/>
+									<text variable="number"/>
+									<group delimiter=" ">
+										<!--change to label variable="section" as that becomes available -->
+										<text term="section" form="symbol"/>
+										<text variable="section"/>
+									</group>
+								</else>
+							</choose>
+						</else>
+					</choose>
+				</group>
+			</else>
+		</choose>
+	</macro>
+	<citation et-al-min="6" et-al-use-first="1" et-al-subsequent-min="3" et-al-subsequent-use-first="1" disambiguate-add-year-suffix="true" disambiguate-add-names="true" disambiguate-add-givenname="true" collapse="year" givenname-disambiguation-rule="primary-name">
+		<sort>
+			<key macro="author"/>
+			<key macro="issued-sort"/>
+		</sort>
+		<layout prefix="(" suffix=")" delimiter="; ">
+			<group delimiter=", ">
+				<text macro="author-short"/>
+				<text macro="issued-year"/>
+				<text macro="citation-locator"/>
+			</group>
+		</layout>
+	</citation>
+	<bibliography hanging-indent="true" et-al-min="8" et-al-use-first="6" et-al-use-last="true" entry-spacing="0" line-spacing="2">
+		<sort>
+			<key macro="author"/>
+			<key macro="issued-sort" sort="ascending"/>
+			<key macro="title"/>
+		</sort>
+		<layout>
+			<group suffix=".">
+				<group delimiter=". ">
+					<text macro="author"/>
+					<text macro="issued"/>
+					<text macro="title" prefix=" "/>
+					<text macro="container"/>
+				</group>
+				<text macro="locators"/>
+				<group delimiter=", " prefix=". ">
+					<text macro="event"/>
+					<text macro="publisher"/>
+				</group>
+			</group>
+			<text macro="access" prefix=" "/>
+		</layout>
+	</bibliography>
 </style>

--- a/universite-de-montreal-apa.csl
+++ b/universite-de-montreal-apa.csl
@@ -6,7 +6,7 @@
     <id>http://www.zotero.org/styles/universite-de-montreal-apa</id>
     <link href="http://www.zotero.org/styles/universite-de-montreal-apa" rel="self"/>
     <link href="http://www.zotero.org/styles/apa" rel="template"/>
-    <link href="http://guides.bib.umontreal.ca/disciplines/20-Citer-selon-les-normes-de-l-APA" rel="documentation"/>
+    <link href="https://bib.umontreal.ca/citer/apa" rel="documentation"/>
     <author>
       <name>Florian Martin-Bariteau</name>
       <email>f.martin-bariteau@umontreal.ca</email>
@@ -131,14 +131,14 @@
             <text variable="DOI" prefix="doi:"/>
           </if>
           <else>
-            <group>
-              <text term="retrieved" text-case="capitalize-first" suffix=" "/>
+            <group delimiter=" ">
+              <text term="retrieved" text-case="capitalize-first"/>
               <choose>
                 <if type="post">
-                  <date variable="accessed" form="text" prefix="le " suffix=" "/>
+                  <date variable="accessed" form="text" prefix="le "/>
                 </if>
               </choose>
-              <text term="from" suffix=" "/>
+              <text term="from"/>
               <text variable="URL"/>
             </group>
           </else>
@@ -434,7 +434,7 @@
       <if type="article article-journal article-magazine article-newspaper" match="any">
         <text variable="container-title" font-style="italic" text-case="title"/>
       </if>
-      <else-if type="manuscript"></else-if>
+      <else-if type="manuscript"/>
       <else-if type="paper-conference">
         <text variable="container-title" text-case="title"/>
       </else-if>


### PR DESCRIPTION
All changes are based on the APA style guide of the Bibliothèques de l’Université de Montréal :

https://bib.umontreal.ca/citer/apa

1- When using a document with no date, the abbreviation must be “s. d.”.
There is a space between “s.” and “d.” 


2- Item type : Web page (page web)
Accessed date should not appear (la date de consultation ne doit pas apparaître).


3- Item type : blog post (Billet de blogue)
The brackets [] for the Website type were missing (Les crochets carrés étaient manquant autour du type de site web).
 
4- Item type : TV broadcast (Émission de tv)
The format and the brackets [] were missing (le format et les crochets carrés étaient manquant).

5- Item type : Film (film)
The brackets [] for the genre were missing. Between the genre and the distributor, the comma has been change for a period. Between the title and the genre, the period has been removed. (Les crochets carrés étaient manquant autour du genre. La virgule entre le genre et le distributeur a été remplacée par un point. Le point entre le titre et le genre a été enlevé.)

6- Item type : Manuscript (Manuscrit)
We added the following at the end of the reference entry : Document inédit. (Ajout de la mention Document inédit.)

7- Item type : Encyclopedia article (article d’encyclopédie)
We added the volume and pages after the title between parenthesis (ajout du volume et des pages entre paranthèses après le titre).

8 –Item type : Artwork (Illustration)
We added the medium between brackets [] (ajout du support de l’illustration entre crochets carrés).

9- Item type : forum post (Message de forum)
We added brackets for the post type and the accessed date (ajout des crochets carrés pour le type d’article et de la date de consultation)

10- Item type : podcast (balado)
We added brackets and the file type (ajout des crochets carrés et du type de fichier).

11- Item type : Map (carte)
We added the brackets [] for the type. Between the type and the place, the comma has been change for a period. Between the title and the type, the period has been removed. (Les crochets carrés étaient manquant autour du type. La virgule entre le type et le lieu a été remplacée par un point. Le point entre le titre et le type a été enlevé.)

12- Item type : Video recording (Enregistrement vidéo)
We added brackets and the format (ajout des crochets carrés et du type du format).

13- Item type : Conference paper (Article de colloque)
We removed the italics for the proceedings title and put italics on the title. We change « Dans » before the proceedings title by « Communication présentée au ». We change the period for a comma after the proceedings title. (L’italique est maintenant au titre au lieu du titre du congrès. « Dans » a été changé pour « Communication présentée au ». Il y a maintenant une virgule et non un point après le titre du congrès).