### PR TITLE
Create seed-science-and-technology.csl

### DIFF
--- a/seed-science-and-technology.csl
+++ b/seed-science-and-technology.csl
@@ -91,7 +91,7 @@
   </macro>
   <macro name="pages">
     <group delimiter=" ">
-      <label suffix=" " variable="page" form="short"/>
+      <label variable="page" form="short"/>
       <text variable="page"/>
     </group>
   </macro>
@@ -144,7 +144,6 @@
                   <name and="symbol" delimiter-precedes-last="never" initialize-with="."/>
                 </names>
               </group>
-              <group suffix="."/>
               <text macro="edition" prefix=", "/>
               <text macro="pages"/>
               <text macro="publisher" prefix=" "/>

--- a/seed-science-and-technology.csl
+++ b/seed-science-and-technology.csl
@@ -1,0 +1,184 @@
+<?xml version="1.0" encoding="utf-8"?>
+<style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" demote-non-dropping-particle="sort-only" default-locale="en-US">
+  <info>
+    <title>Seed Science and Technology</title>
+    <id>http://www.zotero.org/styles/seed-science-and-technology</id>
+    <link href="http://www.zotero.org/styles/seed-science-and-technology" rel="self"/>
+    <link href="http://www.zotero.org/styles/biometrics" rel="template"/>
+    <link href="https://www.seedtest.org/en/instructions-to-contributors-_content---1--1089.html" rel="documentation"/>
+    <author>
+      <name>Patrick O'Brien</name>
+      <email>citationstyler@gmail.com</email>
+    </author>
+    <category citation-format="author-date"/>
+    <category field="social_science"/>
+    <issn>0251-0952</issn>
+    <eissn>1819-5717</eissn>
+    <updated>2019-08-19T13:58:31+00:00</updated>
+    <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
+  </info>
+  <macro name="editor-translator">
+    <names variable="editor translator" prefix="(" suffix=")" delimiter=", ">
+      <label form="short" suffix=" " strip-periods="true"/>
+      <name and="text" initialize-with="" delimiter=", "/>
+    </names>
+  </macro>
+  <macro name="author">
+    <names variable="author">
+      <name name-as-sort-order="all" and="text" sort-separator=", " initialize-with="." delimiter=", " delimiter-precedes-last="never"/>
+      <label form="short" prefix=" (" suffix=")" strip-periods="true"/>
+      <substitute>
+        <names variable="editor"/>
+        <names variable="translator"/>
+        <text macro="title"/>
+      </substitute>
+    </names>
+  </macro>
+  <macro name="author-short">
+    <names variable="author">
+      <name form="short" and="text" delimiter=", " initialize-with=". " delimiter-precedes-last="never"/>
+      <et-al font-style="italic"/>
+      <substitute>
+        <names variable="editor"/>
+        <names variable="translator"/>
+        <choose>
+          <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
+            <text variable="title" form="short" font-style="italic"/>
+          </if>
+          <else>
+            <text variable="title" form="short" quotes="true"/>
+          </else>
+        </choose>
+      </substitute>
+    </names>
+  </macro>
+  <macro name="title">
+    <choose>
+      <if type="bill book graphic legal_case legislation motion_picture report song thesis" match="any">
+        <text variable="title" font-style="italic" text-case="title"/>
+      </if>
+      <else>
+        <text variable="title"/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="edition">
+    <choose>
+      <if is-numeric="edition">
+        <group delimiter=" ">
+          <number variable="edition" form="ordinal"/>
+          <text term="edition" form="short" strip-periods="true"/>
+        </group>
+      </if>
+      <else>
+        <text variable="edition"/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="publisher">
+    <group delimiter=", ">
+      <text variable="genre"/>
+      <text variable="publisher"/>
+      <text variable="publisher-place"/>
+    </group>
+  </macro>
+  <macro name="access">
+    <choose>
+      <if type="article-journal" match="any">
+        <text variable="DOI" prefix="https://doi.org/"/>
+      </if>
+    </choose>
+  </macro>
+  <macro name="pages">
+    <group delimiter=" ">
+      <label suffix=" " variable="page" form="short"/>
+      <text variable="page"/>
+    </group>
+  </macro>
+  <citation et-al-min="3" et-al-use-first="1" disambiguate-add-year-suffix="true" collapse="year-suffix">
+    <sort>
+      <key variable="issued"/>
+      <key variable="author"/>
+    </sort>
+    <layout prefix="(" suffix=")" delimiter="; ">
+      <group delimiter=", ">
+        <text macro="author-short"/>
+        <date variable="issued">
+          <date-part name="year"/>
+        </date>
+        <group>
+          <label variable="locator" form="short"/>
+          <text variable="locator" prefix=" "/>
+        </group>
+      </group>
+    </layout>
+  </citation>
+  <bibliography hanging-indent="true">
+    <sort>
+      <key macro="author-short"/>
+      <key variable="issued"/>
+    </sort>
+    <layout>
+      <text macro="author" suffix="."/>
+      <date variable="issued" prefix=" (" suffix=") ">
+        <date-part name="year"/>
+      </date>
+      <choose>
+        <if type="bill book graphic legal_case legislation motion_picture report song thesis" match="any">
+          <group suffix=".">
+            <text macro="title"/>
+            <text macro="edition" prefix=", "/>
+            <text macro="editor-translator" prefix=" "/>
+          </group>
+          <text prefix=" " suffix="." macro="publisher"/>
+        </if>
+        <else-if type="chapter paper-conference" match="any">
+          <group delimiter=". ">
+            <text macro="title" prefix=" "/>
+            <group delimiter=", ">
+              <group delimiter=" ">
+                <text term="in" text-case="capitalize-first"/>
+                <text variable="container-title" font-style="italic" prefix=" "/>
+                <names variable="editor translator" prefix="(" suffix=")">
+                  <label form="short" strip-periods="false" suffix=" "/>
+                  <name and="symbol" delimiter-precedes-last="never" initialize-with="."/>
+                </names>
+              </group>
+              <group suffix="."/>
+              <text macro="edition" prefix=", "/>
+              <text macro="pages"/>
+              <text macro="publisher" prefix=" "/>
+            </group>
+            <text variable="collection-title" prefix=" " suffix="."/>
+          </group>
+        </else-if>
+        <else-if type="webpage post post-weblog" match="any">
+          <group prefix=" " delimiter=". ">
+            <text variable="title"/>
+            <text macro="publisher"/>
+            <group prefix="URL ">
+              <text variable="URL" suffix=" "/>
+              <date variable="accessed" prefix="[accessed " suffix="]" delimiter=" ">
+                <date-part name="day"/>
+                <date-part name="month"/>
+                <date-part name="year"/>
+              </date>
+            </group>
+          </group>
+        </else-if>
+        <else>
+          <group delimiter=". ">
+            <text macro="title" prefix=" "/>
+            <text macro="editor-translator" prefix=" "/>
+          </group>
+          <group delimiter=", " prefix=" " suffix=".">
+            <text variable="container-title" font-style="italic"/>
+            <text variable="volume" font-weight="bold"/>
+            <text variable="page"/>
+          </group>
+        </else>
+      </choose>
+      <text macro="access" prefix=". "/>
+    </layout>
+  </bibliography>
+</style>

--- a/seed-science-and-technology.csl
+++ b/seed-science-and-technology.csl
@@ -134,7 +134,7 @@
         </if>
         <else-if type="chapter paper-conference" match="any">
           <group delimiter=". ">
-            <text macro="title" prefix=" "/>
+            <text macro="title"/>
             <group delimiter=", ">
               <group delimiter=" ">
                 <text term="in" text-case="capitalize-first"/>
@@ -152,7 +152,7 @@
           </group>
         </else-if>
         <else-if type="webpage post post-weblog" match="any">
-          <group prefix=" " delimiter=". ">
+          <group delimiter=". ">
             <text variable="title"/>
             <text macro="publisher"/>
             <group prefix="URL ">
@@ -167,8 +167,8 @@
         </else-if>
         <else>
           <group delimiter=". ">
-            <text macro="title" prefix=" "/>
-            <text macro="editor-translator" prefix=" "/>
+            <text macro="title"/>
+            <text macro="editor-translator"/>
           </group>
           <group delimiter=", " prefix=" " suffix=".">
             <text variable="container-title" font-style="italic"/>

--- a/seed-science-and-technology.csl
+++ b/seed-science-and-technology.csl
@@ -14,7 +14,7 @@
     <category field="social_science"/>
     <issn>0251-0952</issn>
     <eissn>1819-5717</eissn>
-    <updated>2019-08-19T13:58:31+00:00</updated>
+    <updated>2019-08-20T07:57:02+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <macro name="editor-translator">
@@ -123,18 +123,17 @@
       <date variable="issued" prefix=" (" suffix=") ">
         <date-part name="year"/>
       </date>
+      <text macro="title" suffix="."/>
       <choose>
         <if type="bill book graphic legal_case legislation motion_picture report song thesis" match="any">
           <group suffix=".">
-            <text macro="title"/>
             <text macro="edition" prefix=", "/>
             <text macro="editor-translator" prefix=" "/>
           </group>
           <text prefix=" " suffix="." macro="publisher"/>
         </if>
         <else-if type="chapter paper-conference" match="any">
-          <group delimiter=". ">
-            <text macro="title"/>
+          <group delimiter=". " prefix=" " suffix=".">
             <group delimiter=", ">
               <group delimiter=" ">
                 <text term="in" text-case="capitalize-first"/>
@@ -153,7 +152,6 @@
         </else-if>
         <else-if type="webpage post post-weblog" match="any">
           <group delimiter=". ">
-            <text variable="title"/>
             <text macro="publisher"/>
             <group prefix="URL ">
               <text variable="URL" suffix=" "/>
@@ -167,7 +165,6 @@
         </else-if>
         <else>
           <group delimiter=". ">
-            <text macro="title"/>
             <text macro="editor-translator"/>
           </group>
           <group delimiter=", " prefix=" " suffix=".">


### PR DESCRIPTION
via https://forums.zotero.org/discussion/78390/style-request-seed-science-and-technology#latest

Question for @adam3smith:
You had made the template style (like many others). I see that you tend to program the space " " in front of every title macro for every item time instead of how I did it here, after the year (2007) suffix=" ". Is there any particular reason for that?
Also, the title usually is included in every item type, so why include it in every single item type and not before the conditional?

Campbell, J.L. and Pedersen, O.K. (2007) The varieties of capitalism and hybrid success Comparative Political Studies, 40, 307–332. https://doi.org/10.1177/0010414006286542