### PR TITLE
Create springer-imis-series-migrationsgesellschaften-english.csl

### DIFF
--- a/springer-imis-series-migrationsgesellschaften-english.csl
+++ b/springer-imis-series-migrationsgesellschaften-english.csl
@@ -1,0 +1,459 @@
+<?xml version="1.0" encoding="utf-8"?>
+<style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" demote-non-dropping-particle="sort-only" default-locale="en-US">
+  <!-- This style was edited with the Visual CSL Editor (https://editor.citationstyles.org/visualEditor/) -->
+  <info>
+    <title>Springer - IMIS Series Migrationsgesellschaften English</title>
+    <id>http://www.zotero.org/styles/springer-imis-series-migrationsgesellschaften-english</id>
+    <link href="http://www.zotero.org/styles/springer-imis-series-migrationsgesellschaften-english" rel="self"/>
+    <author>
+      <name>Sebastian Schrader (IMIS)</name>
+    </author>
+    <category citation-format="author-date"/>
+    <category field="generic-base"/>
+    <category field="humanities"/>
+    <summary>Style for Springer's IMIS Series</summary>
+    <updated>2019-08-21T09:29:26+00:00</updated>
+    <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
+  </info>
+  <locale>
+    <terms>
+      <term name="container-author" form="verb">by</term>
+    </terms>
+  </locale>
+  <macro name="secondary-contributors">
+    <choose>
+      <if type="chapter paper-conference" match="none">
+        <group delimiter=". ">
+          <choose>
+            <if variable="author">
+              <names variable="editor">
+                <label form="verb" text-case="capitalize-first" suffix=" "/>
+                <name and="text" delimiter=", "/>
+              </names>
+            </if>
+          </choose>
+          <choose>
+            <if variable="author editor" match="any">
+              <names variable="translator">
+                <label form="verb" text-case="capitalize-first" suffix=" "/>
+                <name and="text" delimiter=", "/>
+              </names>
+            </if>
+          </choose>
+        </group>
+      </if>
+    </choose>
+  </macro>
+  <macro name="container-contributors">
+    <choose>
+      <if type="chapter paper-conference" match="any">
+        <group prefix=", " delimiter=", ">
+          <choose>
+            <if variable="author">
+              <names variable="container-author editor" delimiter=", ">
+                <label form="short" suffix=" "/>
+                <name and="text" delimiter=", " initialize="false" initialize-with=". "/>
+              </names>
+            </if>
+          </choose>
+          <choose>
+            <if variable="author editor" match="any">
+              <names variable="translator">
+                <label form="short" plural="never" suffix=" "/>
+                <name and="text" delimiter=", "/>
+              </names>
+            </if>
+          </choose>
+        </group>
+      </if>
+    </choose>
+  </macro>
+  <macro name="recipient">
+    <choose>
+      <if type="personal_communication">
+        <choose>
+          <if variable="genre">
+            <text variable="genre" text-case="capitalize-first"/>
+          </if>
+          <else>
+            <text term="letter" text-case="capitalize-first"/>
+          </else>
+        </choose>
+      </if>
+    </choose>
+    <names variable="recipient" delimiter=", ">
+      <label form="verb" prefix=" " suffix=" "/>
+      <name and="text" delimiter=", "/>
+    </names>
+  </macro>
+  <macro name="contributors">
+    <names variable="author">
+      <name and="text" name-as-sort-order="first" sort-separator=", " delimiter=", " delimiter-precedes-last="always"/>
+      <label form="short" prefix=", "/>
+      <substitute>
+        <names variable="editor"/>
+        <names variable="translator"/>
+        <text macro="title"/>
+      </substitute>
+    </names>
+    <text macro="recipient"/>
+  </macro>
+  <macro name="contributors-short">
+    <names variable="author">
+      <name form="short" and="text" delimiter=", " initialize-with=". "/>
+      <substitute>
+        <names variable="editor"/>
+        <names variable="translator"/>
+        <text macro="title"/>
+      </substitute>
+    </names>
+  </macro>
+  <macro name="interviewer">
+    <names variable="interviewer" delimiter=", ">
+      <label form="verb" prefix=" " text-case="capitalize-first" suffix=" "/>
+      <name and="text" delimiter=", "/>
+    </names>
+  </macro>
+  <macro name="archive">
+    <group delimiter=". ">
+      <text variable="archive_location" text-case="capitalize-first"/>
+      <text variable="archive"/>
+      <text variable="archive-place"/>
+      <text variable="URL"/>
+    </group>
+  </macro>
+  <macro name="access">
+    <group delimiter=". ">
+      <choose>
+        <if type="graphic report" match="all">
+          <text macro="archive"/>
+        </if>
+        <else-if type="article-magazine article-newspaper bill book chapter graphic legal_case legislation motion_picture paper-conference report song thesis" match="none">
+          <text macro="archive"/>
+        </else-if>
+      </choose>
+      <text variable="DOI" prefix="doi: "/>
+      <choose>
+        <if variable="DOI" match="all">
+          <choose>
+            <if variable="URL" match="any" type="webpage">
+              <choose>
+                <if type="legal_case" match="all">
+                  <text variable="URL"/>
+                </if>
+              </choose>
+              <group delimiter=" ">
+                <text term="accessed" text-case="capitalize-first"/>
+                <date variable="accessed" delimiter=" ">
+                  <date-part name="day"/>
+                  <date-part name="month"/>
+                  <date-part name="year"/>
+                </date>
+              </group>
+            </if>
+          </choose>
+        </if>
+        <else-if variable="accessed">
+          <date delimiter=" " variable="accessed" prefix="Accessed ">
+            <date-part name="day"/>
+            <date-part name="month"/>
+            <date-part name="year"/>
+          </date>
+        </else-if>
+      </choose>
+    </group>
+    <choose>
+      <if type="webpage" match="any">
+        <text variable="abstract"/>
+      </if>
+    </choose>
+  </macro>
+  <macro name="title">
+    <choose>
+      <if variable="title" match="none">
+        <choose>
+          <if type="personal_communication" match="none">
+            <text variable="genre" text-case="capitalize-first"/>
+          </if>
+        </choose>
+      </if>
+      <else-if type="bill book graphic legal_case legislation motion_picture report song" match="any">
+        <text variable="title" font-style="italic"/>
+      </else-if>
+      <else>
+        <text variable="title"/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="edition">
+    <choose>
+      <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
+        <choose>
+          <if is-numeric="edition">
+            <group delimiter=" " prefix=". ">
+              <number variable="edition" form="ordinal"/>
+              <text term="edition" form="short"/>
+            </group>
+          </if>
+          <else>
+            <text variable="edition" prefix=". "/>
+          </else>
+        </choose>
+      </if>
+      <else-if type="chapter  paper-conference" match="any">
+        <choose>
+          <if is-numeric="edition">
+            <group delimiter=" " prefix=", ">
+              <number variable="edition" form="ordinal"/>
+              <text term="edition" form="short"/>
+            </group>
+          </if>
+          <else>
+            <text variable="edition" prefix=", "/>
+          </else>
+        </choose>
+      </else-if>
+    </choose>
+  </macro>
+  <macro name="locators">
+    <choose>
+      <if type="article-journal">
+        <text variable="volume" prefix=" "/>
+        <text variable="issue" prefix=" (" suffix=")"/>
+      </if>
+      <else-if type="legal_case">
+        <text variable="volume" prefix=", "/>
+        <text variable="container-title" prefix=" "/>
+        <text variable="page" prefix=" "/>
+      </else-if>
+      <else-if type="bill book graphic legal_case legislation motion_picture report song" match="any">
+        <group prefix=". " delimiter=". ">
+          <group>
+            <text term="volume" form="short" text-case="capitalize-first" suffix=" "/>
+            <number variable="volume" form="numeric"/>
+          </group>
+          <group>
+            <number variable="number-of-volumes" form="numeric"/>
+            <text term="volume" form="short" prefix=" " plural="true"/>
+          </group>
+        </group>
+      </else-if>
+      <else-if type="chapter paper-conference" match="any">
+        <choose>
+          <if variable="page" match="none">
+            <group prefix=". ">
+              <text term="volume" form="short" text-case="capitalize-first" suffix=" "/>
+              <number variable="volume" form="numeric"/>
+            </group>
+          </if>
+        </choose>
+      </else-if>
+      <else-if type="article-journal" match="any"/>
+    </choose>
+  </macro>
+  <macro name="locators-chapter">
+    <choose>
+      <if type="chapter paper-conference" match="any">
+        <choose>
+          <if variable="page">
+            <group prefix=", ">
+              <text variable="volume" prefix="Vol." suffix=". "/>
+              <text variable="page"/>
+            </group>
+          </if>
+        </choose>
+      </if>
+    </choose>
+  </macro>
+  <macro name="locators-article">
+    <choose>
+      <if type="article-newspaper">
+        <text variable="page" prefix=": "/>
+      </if>
+      <else-if type="article-journal" match="any">
+        <text variable="page" prefix=": "/>
+      </else-if>
+    </choose>
+  </macro>
+  <macro name="point-locators">
+    <choose>
+      <if variable="locator">
+        <choose>
+          <if locator="page" match="none">
+            <choose>
+              <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
+                <choose>
+                  <if variable="volume">
+                    <group>
+                      <text term="volume" form="short" suffix=" "/>
+                      <number variable="volume" form="numeric"/>
+                      <label variable="locator" form="short" prefix=", " suffix=" "/>
+                    </group>
+                  </if>
+                  <else>
+                    <label variable="locator" form="short" suffix=" "/>
+                  </else>
+                </choose>
+              </if>
+              <else>
+                <label variable="locator" form="short" suffix=" "/>
+              </else>
+            </choose>
+          </if>
+          <else-if type="bill book graphic legal_case legislation motion_picture report song" match="any">
+            <number variable="volume" form="numeric" suffix=":"/>
+          </else-if>
+        </choose>
+        <text variable="locator" prefix="p. "/>
+      </if>
+    </choose>
+  </macro>
+  <macro name="container-prefix">
+    <text term="in" text-case="capitalize-first"/>
+  </macro>
+  <macro name="container-title">
+    <choose>
+      <if type="chapter paper-conference" match="any">
+        <text macro="container-prefix" suffix=" "/>
+      </if>
+    </choose>
+    <choose>
+      <if type="legal_case" match="none">
+        <text variable="container-title" font-style="italic"/>
+      </if>
+    </choose>
+  </macro>
+  <macro name="publisher">
+    <group delimiter=": ">
+      <text variable="publisher-place"/>
+      <text variable="publisher"/>
+    </group>
+  </macro>
+  <macro name="date">
+    <choose>
+      <if variable="issued">
+        <date variable="issued">
+          <date-part name="year"/>
+        </date>
+      </if>
+      <else-if variable="accessed">
+        <date variable="accessed">
+          <date-part name="year"/>
+        </date>
+      </else-if>
+    </choose>
+  </macro>
+  <macro name="day-month">
+    <date variable="issued">
+      <date-part name="month"/>
+      <date-part name="day" prefix=" "/>
+    </date>
+  </macro>
+  <macro name="collection-title">
+    <text variable="collection-title" text-case="title"/>
+    <text variable="collection-number" prefix=" "/>
+  </macro>
+  <macro name="event">
+    <group>
+      <text term="presented at" suffix=" "/>
+      <text variable="event"/>
+    </group>
+  </macro>
+  <macro name="description">
+    <choose>
+      <if type="interview">
+        <group delimiter=". ">
+          <text macro="interviewer"/>
+          <text variable="medium" text-case="capitalize-first"/>
+        </group>
+      </if>
+      <else>
+        <text variable="medium" text-case="capitalize-first" prefix=". "/>
+      </else>
+    </choose>
+    <choose>
+      <if variable="title" match="none"/>
+      <else-if type="thesis"/>
+      <else>
+        <group delimiter=" " prefix=". ">
+          <text variable="genre" text-case="capitalize-first"/>
+          <choose>
+            <if type="report">
+              <text variable="number"/>
+            </if>
+          </choose>
+        </group>
+      </else>
+    </choose>
+    <group delimiter=" " prefix=" (" suffix=")">
+      <text term="version"/>
+      <text variable="version"/>
+    </group>
+  </macro>
+  <macro name="issue">
+    <choose>
+      <if type="legal_case">
+        <text variable="authority" prefix=". "/>
+      </if>
+      <else-if type="speech">
+        <group prefix=" " delimiter=", ">
+          <text macro="event"/>
+          <text macro="day-month"/>
+          <text variable="event-place"/>
+        </group>
+      </else-if>
+      <else-if type="article-newspaper article-magazine" match="any">
+        <text macro="day-month" prefix=", "/>
+      </else-if>
+      <else>
+        <group prefix=". " delimiter=", ">
+          <choose>
+            <if type="thesis">
+              <text variable="genre" text-case="capitalize-first"/>
+            </if>
+          </choose>
+          <text macro="publisher"/>
+        </group>
+      </else>
+    </choose>
+  </macro>
+  <citation et-al-min="3" et-al-use-first="1" disambiguate-add-year-suffix="true" disambiguate-add-names="true" disambiguate-add-givenname="true" givenname-disambiguation-rule="primary-name">
+    <sort>
+      <key macro="date"/>
+      <key macro="contributors-short"/>
+    </sort>
+    <layout prefix="(" suffix=")" delimiter="; ">
+      <group delimiter=", ">
+        <group delimiter=" ">
+          <text macro="contributors-short"/>
+          <text macro="date"/>
+        </group>
+        <text macro="point-locators"/>
+      </group>
+    </layout>
+  </citation>
+  <bibliography hanging-indent="true" et-al-min="11" et-al-use-first="7" entry-spacing="0">
+    <sort>
+      <key macro="contributors"/>
+      <key variable="issued"/>
+    </sort>
+    <layout suffix=".">
+      <group delimiter=". ">
+        <text macro="contributors"/>
+        <text macro="date"/>
+        <text macro="title"/>
+      </group>
+      <text macro="description"/>
+      <text macro="secondary-contributors" prefix=". "/>
+      <text macro="container-title" prefix=". "/>
+      <text macro="collection-title" prefix=". "/>
+      <text macro="container-contributors"/>
+      <text macro="edition"/>
+      <text macro="locators-chapter"/>
+      <text macro="locators"/>
+      <text macro="issue"/>
+      <text macro="locators-article"/>
+      <text macro="access" prefix=". "/>
+    </layout>
+  </bibliography>
+</style>

--- a/springer-imis-series-migrationsgesellschaften.csl
+++ b/springer-imis-series-migrationsgesellschaften.csl
@@ -2,9 +2,9 @@
 <style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" demote-non-dropping-particle="sort-only">
   <!-- This style was edited with the Visual CSL Editor (https://editor.citationstyles.org/visualEditor/) -->
   <info>
-    <title>Springer - IMIS Series Migrationsgesellschaften English</title>
-    <id>http://www.zotero.org/styles/springer-imis-series-migrationsgesellschaften-english</id>
-    <link href="http://www.zotero.org/styles/springer-imis-series-migrationsgesellschaften-english" rel="self"/>
+    <title>Springer - IMIS Series Migrationsgesellschaften</title>
+    <id>http://www.zotero.org/styles/springer-imis-series-migrationsgesellschaften</id>
+    <link href="http://www.zotero.org/styles/springer-imis-series-migrationsgesellschaften" rel="self"/>
     <author>
       <name>Sebastian Schrader (IMIS)</name>
     </author>

--- a/springer-imis-series-migrationsgesellschaften.csl
+++ b/springer-imis-series-migrationsgesellschaften.csl
@@ -2,9 +2,9 @@
 <style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" demote-non-dropping-particle="sort-only">
   <!-- This style was edited with the Visual CSL Editor (https://editor.citationstyles.org/visualEditor/) -->
   <info>
-    <title>Springer - IMIS Series Migrationsgesellschaften</title>
-    <id>http://www.zotero.org/styles/springer-imis-series-migrationsgesellschaften</id>
-    <link href="http://www.zotero.org/styles/springer-imis-series-migrationsgesellschaften" rel="self"/>
+    <title>Springer - IMIS Series Migrationsgesellschaften English</title>
+    <id>http://www.zotero.org/styles/springer-imis-series-migrationsgesellschaften-english</id>
+    <link href="http://www.zotero.org/styles/springer-imis-series-migrationsgesellschaften-english" rel="self"/>
     <author>
       <name>Sebastian Schrader (IMIS)</name>
     </author>
@@ -15,6 +15,11 @@
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale xml:lang="en">
+  <date form="text">
+    <date-part name="day"  suffix=" "/>
+    <date-part name="month" suffix=" "/>
+    <date-part name="year"/>
+  </date>
     <terms>
       <term name="container-author" form="verb">by</term>
     </terms>
@@ -155,7 +160,7 @@
         </if>
         <else-if variable="accessed">
           <group delimiter=" ">
-          <text term="accesses" text-case="capitalize-first"/>
+          <text term="accessed" text-case="capitalize-first"/>
                         <date variable="accessed" form="text" date-parts="year-month-day"/>
           </group>
         </else-if>

--- a/springer-imis-series-migrationsgesellschaften.csl
+++ b/springer-imis-series-migrationsgesellschaften.csl
@@ -1,25 +1,29 @@
 <?xml version="1.0" encoding="utf-8"?>
-<style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" demote-non-dropping-particle="sort-only" default-locale="en-US">
+<style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" demote-non-dropping-particle="sort-only">
   <!-- This style was edited with the Visual CSL Editor (https://editor.citationstyles.org/visualEditor/) -->
   <info>
-    <title>Springer - IMIS Series Migrationsgesellschaften English</title>
-    <id>http://www.zotero.org/styles/springer-imis-series-migrationsgesellschaften-english</id>
-    <link href="http://www.zotero.org/styles/springer-imis-series-migrationsgesellschaften-english" rel="self"/>
+    <title>Springer - IMIS Series Migrationsgesellschaften</title>
+    <id>http://www.zotero.org/styles/springer-imis-series-migrationsgesellschaften</id>
+    <link href="http://www.zotero.org/styles/springer-imis-series-migrationsgesellschaften" rel="self"/>
     <author>
       <name>Sebastian Schrader (IMIS)</name>
     </author>
     <category citation-format="author-date"/>
-    <category field="generic-base"/>
     <category field="humanities"/>
     <summary>Style for Springer's IMIS Series</summary>
     <updated>2019-08-21T09:29:26+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
-  <locale>
+  <locale xml:lang="en">
     <terms>
       <term name="container-author" form="verb">by</term>
     </terms>
   </locale>
+  <locale xml:lang="de">
+    <terms>
+      <term name="et-al">et al.</term>
+    </terms>
+  </locale>  
   <macro name="secondary-contributors">
     <choose>
       <if type="chapter paper-conference" match="none">
@@ -144,21 +148,16 @@
               </choose>
               <group delimiter=" ">
                 <text term="accessed" text-case="capitalize-first"/>
-                <date variable="accessed" delimiter=" ">
-                  <date-part name="day"/>
-                  <date-part name="month"/>
-                  <date-part name="year"/>
-                </date>
+                <date variable="accessed" form="text" date-parts="year-month-day"/>
               </group>
             </if>
           </choose>
         </if>
         <else-if variable="accessed">
-          <date delimiter=" " variable="accessed" prefix="Accessed ">
-            <date-part name="day"/>
-            <date-part name="month"/>
-            <date-part name="year"/>
-          </date>
+          <group delimiter=" ">
+          <text term="accesses" text-case="capitalize-first"/>
+                        <date variable="accessed" form="text" date-parts="year-month-day"/>
+          </group>
         </else-if>
       </choose>
     </group>
@@ -256,8 +255,11 @@
       <if type="chapter paper-conference" match="any">
         <choose>
           <if variable="page">
-            <group prefix=", ">
-              <text variable="volume" prefix="Vol." suffix=". "/>
+            <group prefix=", " delimiter=". ">
+              <group delimiter=" ">
+                     <text term="volume" form="short" text-case="capitalize-first"/>
+              <text variable="volume"/>
+            </group>
               <text variable="page"/>
             </group>
           </if>
@@ -267,12 +269,9 @@
   </macro>
   <macro name="locators-article">
     <choose>
-      <if type="article-newspaper">
+      <if type="article-newspaper article-journal" match="any">
         <text variable="page" prefix=": "/>
       </if>
-      <else-if type="article-journal" match="any">
-        <text variable="page" prefix=": "/>
-      </else-if>
     </choose>
   </macro>
   <macro name="point-locators">
@@ -304,7 +303,10 @@
             <number variable="volume" form="numeric" suffix=":"/>
           </else-if>
         </choose>
-        <text variable="locator" prefix="p. "/>
+        <group delimiter=" ">
+          <label variable="locator" form="short"/>
+        <text variable="locator"/>
+        </group>
       </if>
     </choose>
   </macro>

--- a/springer-imis-series-migrationsgesellschaften.csl
+++ b/springer-imis-series-migrationsgesellschaften.csl
@@ -15,11 +15,11 @@
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale xml:lang="en">
-  <date form="text">
-    <date-part name="day"  suffix=" "/>
-    <date-part name="month" suffix=" "/>
-    <date-part name="year"/>
-  </date>
+    <date form="text">
+      <date-part name="day" suffix=" "/>
+      <date-part name="month" suffix=" "/>
+      <date-part name="year"/>
+    </date>
     <terms>
       <term name="container-author" form="verb">by</term>
     </terms>
@@ -28,7 +28,7 @@
     <terms>
       <term name="et-al">et al.</term>
     </terms>
-  </locale>  
+  </locale>
   <macro name="secondary-contributors">
     <choose>
       <if type="chapter paper-conference" match="none">
@@ -160,17 +160,12 @@
         </if>
         <else-if variable="accessed">
           <group delimiter=" ">
-          <text term="accessed" text-case="capitalize-first"/>
-                        <date variable="accessed" form="text" date-parts="year-month-day"/>
+            <text term="accessed" text-case="capitalize-first"/>
+            <date variable="accessed" form="text" date-parts="year-month-day"/>
           </group>
         </else-if>
       </choose>
     </group>
-    <choose>
-      <if type="webpage" match="any">
-        <text variable="abstract"/>
-      </if>
-    </choose>
   </macro>
   <macro name="title">
     <choose>
@@ -262,9 +257,9 @@
           <if variable="page">
             <group prefix=", " delimiter=". ">
               <group delimiter=" ">
-                     <text term="volume" form="short" text-case="capitalize-first"/>
-              <text variable="volume"/>
-            </group>
+                <text term="volume" form="short" text-case="capitalize-first"/>
+                <text variable="volume"/>
+              </group>
               <text variable="page"/>
             </group>
           </if>
@@ -310,7 +305,7 @@
         </choose>
         <group delimiter=" ">
           <label variable="locator" form="short"/>
-        <text variable="locator"/>
+          <text variable="locator"/>
         </group>
       </if>
     </choose>


### PR DESCRIPTION
This stylesheet is for the ongoing book series 'Migrationsgesellschaften' at the Institute for Migration Research and Intercultural Studies at University Osnabrück, Germany. It is especially for the English-writing authors and should help to institutionalize the ongoing book series. The style fits the requirements of the publisher.