### PR TITLE
Update fachhochschule-vorarlberg-author-date.csl

### DIFF
--- a/fachhochschule-vorarlberg-author-date.csl
+++ b/fachhochschule-vorarlberg-author-date.csl
@@ -29,7 +29,7 @@
     <category citation-format="author-date"/>
     <category field="generic-base"/>
     <summary>Citation Style of the University of Applied Sciences Vorarlberg/Austria, based on A Harvard author-date style variant, mostly german</summary>
-    <updated>2018-11-06T18:00:00+00:00</updated>
+    <updated>2019-09-04T16:00:00+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale xml:lang="de">
@@ -269,7 +269,7 @@
         <date variable="issued">
           <date-part name="year" prefix="(" suffix=")"/>
         </date>
-        <text variable="issue" prefix=", H. "/>
+        <text variable="issue" prefix=", "/>
         <choose>
           <if variable="page">
             <text value=""/>


### PR DESCRIPTION
Removed "H." for journal articles. This change is necessary, because online magazines often have no booklet number but an article number and so the "H." does not fit for all cases.