### PR TITLE
Update fachhochschule-vorarlberg-note.csl

### DIFF
--- a/fachhochschule-vorarlberg-note.csl
+++ b/fachhochschule-vorarlberg-note.csl
@@ -28,7 +28,7 @@
     <category citation-format="note"/>
     <category field="generic-base"/>
     <summary>Citation Style of the University of Applied Sciences Vorarlberg/Austria, based on A Harvard author-date style variant, mostly german, footnote style</summary>
-    <updated>2018-11-06T18:00:00+00:00</updated>
+    <updated>2019-09-04T16:00:00+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale xml:lang="de">
@@ -268,7 +268,7 @@
         <date variable="issued">
           <date-part name="year" prefix="(" suffix=")"/>
         </date>
-        <text variable="issue" prefix=", H. "/>
+        <text variable="issue" prefix=", "/>
         <choose>
           <if variable="page">
             <text value=""/>
@@ -383,7 +383,7 @@
     </choose>
   </macro>
   <citation et-al-min="4" et-al-use-first="1" et-al-subsequent-min="4" et-al-subsequent-use-first="1" disambiguate-add-year-suffix="true" disambiguate-add-names="true" disambiguate-add-givenname="true" collapse="year">
-    <layout delimiter="; ">
+    <layout delimiter="; " suffix=".">
       <group delimiter=" ">
         <text macro="author-short"/>
         <text macro="year-date"/>


### PR DESCRIPTION
Removed "H." for journal articles. This change is necessary, because online magazines often have no booklet number but an article number and so the "H." does not fit for all cases.
The citation guidelines of this University of Applied Sciences require one point after each footnote.