### PR TITLE
Update harvard-university-of-bath.csl

### DIFF
--- a/harvard-university-of-bath.csl
+++ b/harvard-university-of-bath.csl
@@ -424,7 +424,11 @@
         <else-if type="book motion_picture musical_score song speech" match="any">
           <group prefix=" " suffix="." delimiter=" ">
             <text macro="title"/>
-            <text macro="online"/>
+            <choose>
+              <if variable="author editor" match="any">
+                <text macro="online"/>
+              </if>
+            </choose>
             <text macro="translator"/>
           </group>
           <group prefix=" " suffix="." delimiter=". ">
@@ -432,7 +436,14 @@
             <text macro="series"/>
             <choose>
               <if type="motion_picture">
-                <text variable="genre"/>
+                <group delimiter=" ">
+                  <text variable="genre"/>
+                  <choose>
+                    <if variable="author editor" match="none">
+                      <text macro="online"/>
+                    </if>
+                  </choose>
+                </group>
               </if>
             </choose>
             <text macro="editor"/>
@@ -574,10 +585,21 @@
         <else-if type="broadcast">
           <group prefix=" " suffix="." delimiter=" ">
             <text macro="title"/>
-            <text macro="online"/>
+            <choose>
+              <if variable="author editor" match="any">
+                <text macro="online"/>
+              </if>
+            </choose>
           </group>
           <text macro="series-genre" prefix=" " suffix="."/>
-          <text variable="medium" prefix=" " suffix="."/>
+          <group prefix=" " suffix="." delimiter=" ">
+            <text variable="medium"/>
+            <choose>
+              <if variable="author editor" match="none">
+                <text macro="online"/>
+              </if>
+            </choose>
+          </group>
           <group prefix=" " suffix="." delimiter=", ">
             <text macro="publisher"/>
             <date variable="issued">

--- a/harvard-university-of-bath.csl
+++ b/harvard-university-of-bath.csl
@@ -263,7 +263,7 @@
   <citation et-al-min="3" et-al-use-first="1" disambiguate-add-year-suffix="true" disambiguate-add-names="true" disambiguate-add-givenname="true">
     <layout prefix="(" suffix=")" delimiter="; ">
       <group delimiter=", ">
-        <group delimiter=" ">
+        <group delimiter=", ">
           <text macro="author-short"/>
           <text macro="year-date"/>
         </group>

--- a/harvard-university-of-bath.csl
+++ b/harvard-university-of-bath.csl
@@ -263,10 +263,8 @@
   <citation et-al-min="3" et-al-use-first="1" disambiguate-add-year-suffix="true" disambiguate-add-names="true" disambiguate-add-givenname="true">
     <layout prefix="(" suffix=")" delimiter="; ">
       <group delimiter=", ">
-        <group delimiter=", ">
-          <text macro="author-short"/>
-          <text macro="year-date"/>
-        </group>
+        <text macro="author-short"/>
+        <text macro="year-date"/>
         <group>
           <label variable="locator" form="short"/>
           <text variable="locator"/>
@@ -420,7 +418,7 @@
         </else>
       </choose>
       <choose>
-        <if type="legislation legal_case" match="any"></if>
+        <if type="legislation legal_case" match="any"/>
         <else-if type="book motion_picture musical_score song speech" match="any">
           <group prefix=" " suffix="." delimiter=" ">
             <text macro="title"/>

--- a/harvard-university-of-bath.csl
+++ b/harvard-university-of-bath.csl
@@ -19,7 +19,7 @@
     <category citation-format="author-date"/>
     <category field="generic-base"/>
     <summary>Adaptation of Harvard referencing style used at the University of Bath.</summary>
-    <updated>2019-07-10T17:00:00+00:00</updated>
+    <updated>2019-09-13T15:00:00+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale xml:lang="en">


### PR DESCRIPTION
Changes:

- Fix punctuation in parenthetical citations: there should be a comma between the author and year.
- If the title is at the head of the reference, the [Online] label is now shown after the genre of a motion picture or the medium of a broadcast.