### PR TITLE
Update american-physiological-society.csl (change sorting)

### DIFF
--- a/american-physiological-society.csl
+++ b/american-physiological-society.csl
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" demote-non-dropping-particle="sort-only" default-locale="en-US">
+<style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" demote-non-dropping-particle="never" default-locale="en-US">
   <info>
     <title>American Physiological Society</title>
     <title-short>APS</title-short>


### PR DESCRIPTION
via https://forums.zotero.org/discussion/79133/style-error-american-physiological-society

set: demote-non-dropping-particle="never"