### PR TITLE
Change DOI format Springer styles

### DIFF
--- a/springer-basic-author-date-no-et-al.csl
+++ b/springer-basic-author-date-no-et-al.csl
@@ -149,7 +149,7 @@
                     <text variable="volume" suffix=":"/>
                     <text variable="page"/>
                   </group>
-                  <text prefix=". doi: " variable="DOI"/>
+                  <text prefix=". https://doi.org/" variable="DOI"/>
                 </group>
               </group>
             </if>
@@ -159,7 +159,7 @@
        J Mol Med. doi:10.1007/s001090000086     -->
               <group prefix=". " delimiter=". ">
                 <text variable="container-title" form="short" strip-periods="true"/>
-                <text prefix="doi: " variable="DOI"/>
+                <text prefix="https://doi.org/" variable="DOI"/>
               </group>
             </else>
           </choose>

--- a/springer-basic-author-date-no-et-al.csl
+++ b/springer-basic-author-date-no-et-al.csl
@@ -19,7 +19,7 @@
     <category citation-format="author-date"/>
     <category field="generic-base"/>
     <summary>Springer Author Date Style for the disciplines Medicine, Biomedicine, Life Sciences, Chemistry, Geosciences, Computer Science, Engineering, Economics. This style is based on Harvard style and recommendations of the Council of Biology Editors.</summary>
-    <updated>2015-03-07T12:00:00+00:00</updated>
+    <updated>2019-09-25T12:00:00+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale>

--- a/springer-basic-author-date.csl
+++ b/springer-basic-author-date.csl
@@ -19,7 +19,7 @@
     <category citation-format="author-date"/>
     <category field="generic-base"/>
     <summary>Springer Author Date Style for the disciplines Medicine, Biomedicine, Life Sciences, Chemistry, Geosciences, Computer Science, Engineering, Economics. This style is based on Harvard style and recommendations of the Council of Biology Editors.</summary>
-    <updated>2015-03-07T12:00:00+00:00</updated>
+    <updated>2019-09-25T12:00:00+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale>
@@ -160,7 +160,7 @@
                     <text variable="page"/>
                   </group>
                 </group>
-                <text prefix="doi: " variable="DOI"/>
+                <text prefix="https://doi.org/" variable="DOI"/>
               </group>
             </if>
             <else>
@@ -169,7 +169,7 @@
        J Mol Med. doi:10.1007/s001090000086     -->
               <group prefix=". " delimiter=". ">
                 <text variable="container-title" form="short" strip-periods="true"/>
-                <text prefix="doi: " variable="DOI"/>
+                <text prefix="https://doi.org/" variable="DOI"/>
               </group>
             </else>
           </choose>

--- a/springer-basic-brackets-no-et-al.csl
+++ b/springer-basic-brackets-no-et-al.csl
@@ -17,7 +17,7 @@
     <category citation-format="numeric"/>
     <category field="generic-base"/>
     <summary>Springer Numbered Style for the disciplines Medicine, Biomedicine, Life Sciences, Chemistry, Geosciences, Computer Science, Engineering, Economics. This style is based on Harvard style and recommendations of the Council of Biology Editors.</summary>
-    <updated>2013-05-10T12:00:00+00:00</updated>
+    <updated>2019-09-25T12:00:00+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <macro name="author">
@@ -121,7 +121,7 @@
                     <text variable="volume" suffix=":"/>
                     <text variable="page"/>
                   </group>
-                  <text prefix=". doi: " variable="DOI"/>
+                  <text prefix=". https://doi.org/" variable="DOI"/>
                 </group>
               </group>
             </if>
@@ -131,7 +131,7 @@
        J Mol Med. doi:10.1007/s001090000086     -->
               <group prefix=". " delimiter=". ">
                 <text variable="container-title" form="short" strip-periods="true"/>
-                <text prefix="doi: " variable="DOI"/>
+                <text prefix="https://doi.org/" variable="DOI"/>
               </group>
             </else>
           </choose>

--- a/springer-basic-note.csl
+++ b/springer-basic-note.csl
@@ -142,14 +142,14 @@
                       <text variable="volume" suffix=":"/>
                       <text variable="page"/>
                     </group>
-                    <text prefix=". doi: " variable="DOI"/>
+                    <text prefix=". https://doi.org/" variable="DOI"/>
                   </group>
                 </group>
               </if>
               <else>
                 <group prefix=". " delimiter=". ">
                   <text variable="container-title" form="short" strip-periods="true"/>
-                  <text prefix="doi: " variable="DOI"/>
+                  <text prefix="https://doi.org/" variable="DOI"/>
                 </group>
               </else>
             </choose>

--- a/springer-basic-note.csl
+++ b/springer-basic-note.csl
@@ -142,8 +142,8 @@
                       <text variable="volume" suffix=":"/>
                       <text variable="page"/>
                     </group>
-                    <text prefix=". https://doi.org/" variable="DOI"/>
                   </group>
+                  <text prefix=". https://doi.org/" variable="DOI"/>
                 </group>
               </if>
               <else>

--- a/springer-basic-note.csl
+++ b/springer-basic-note.csl
@@ -18,7 +18,7 @@
     <category citation-format="note"/>
     <category field="law"/>
     <summary>Springer note style for law and related disciplines.</summary>
-    <updated>2018-01-26T11:21:15+00:00</updated>
+    <updated>2019-09-25T11:21:15+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale>

--- a/springer-fachzeitschriften-medizin-psychologie.csl
+++ b/springer-fachzeitschriften-medizin-psychologie.csl
@@ -15,7 +15,7 @@
     <category field="medicine"/>
     <category field="psychology"/>
     <summary>Springer Basic style (German, numeric, brackets, alphabetical) for Springer journals in medicine and psychology.</summary>
-    <updated>2015-01-17T17:55:52+00:00</updated>
+    <updated>2019-09-25T17:55:52+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale xml:lang="de">

--- a/springer-fachzeitschriften-medizin-psychologie.csl
+++ b/springer-fachzeitschriften-medizin-psychologie.csl
@@ -112,10 +112,10 @@
             </if>
             <else>
               <group>
-                <text variable="container-title" suffix=" " form="short" strip-periods="true"/>
-                <text variable="volume" suffix=":"/>
-                <text variable="page" suffix="."/>
-                <text prefix=" doi: " variable="DOI"/>
+                <text variable="container-title" form="short" strip-periods="true"/>
+                <text variable="volume" prefix=" "/>
+                <text variable="page" prefix=":"/>
+                <text prefix=". https://doi.org/" variable="DOI"/>
               </group>
             </else>
           </choose>
@@ -123,7 +123,7 @@
         <else-if variable="DOI">
           <group delimiter=". ">
             <text variable="container-title" form="short" strip-periods="true"/>
-            <text prefix="doi: " variable="DOI"/>
+            <text prefix="https://doi.org/" variable="DOI"/>
           </group>
         </else-if>
         <else-if type="bill book graphic legal_case legislation motion_picture report song" match="any">

--- a/springer-humanities-author-date.csl
+++ b/springer-humanities-author-date.csl
@@ -26,7 +26,7 @@
     <category field="generic-base"/>
     <category field="humanities"/>
     <summary>Style for Springer's humanities journals - the journals do look slightly different from each other, but this should work quite closely</summary>
-    <updated>2013-03-07T12:00:00+00:00</updated>
+    <updated>2019-09-25T12:00:00+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale>
@@ -145,7 +145,7 @@
           <text macro="archive"/>
         </else-if>
       </choose>
-      <text variable="DOI" prefix="doi:"/>
+      <text variable="DOI" prefix="https://doi.org/"/>
       <choose>
         <if variable="DOI issued" match="none">
           <choose>

--- a/springer-humanities-brackets.csl
+++ b/springer-humanities-brackets.csl
@@ -27,7 +27,7 @@
     <category field="generic-base"/>
     <category field="humanities"/>
     <summary>Style for Springer's humanities journals - the journals do look slightly different from each other, but this should work quite closely</summary>
-    <updated>2013-03-07T12:00:00+00:00</updated>
+    <updated>2019-09-25T12:00:00+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale>
@@ -136,7 +136,7 @@
           <text macro="archive"/>
         </else-if>
       </choose>
-      <text variable="DOI" prefix="doi:"/>
+      <text variable="DOI" prefix="https://doi.org/"/>
       <choose>
         <if variable="DOI issued" match="none">
           <choose>

--- a/springer-mathphys-author-date.csl
+++ b/springer-mathphys-author-date.csl
@@ -16,7 +16,7 @@
     <category field="generic-base"/>
     <category field="science"/>
     <summary>This style is used by a number of Springer publications.</summary>
-    <updated>2017-04-11T14:52:06+00:00</updated>
+    <updated>2019-09-25T14:52:06+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <macro name="author-short-in-citation">
@@ -96,7 +96,7 @@
     </group>
   </macro>
   <macro name="access">
-    <text variable="DOI" prefix="doi:"/>
+    <text variable="DOI" prefix="https://doi.org/"/>
   </macro>
   <citation et-al-min="3" et-al-use-first="1" disambiguate-add-year-suffix="true">
     <sort>

--- a/springer-mathphys-brackets.csl
+++ b/springer-mathphys-brackets.csl
@@ -16,7 +16,7 @@
     <category field="generic-base"/>
     <category field="science"/>
     <summary>This style is used by a number of Springer publications.</summary>
-    <updated>2017-04-11T12:00:00+00:00</updated>
+    <updated>2019-09-25T12:00:00+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <macro name="author">
@@ -57,7 +57,7 @@
     </group>
   </macro>
   <macro name="access">
-    <text variable="DOI" prefix="doi:"/>
+    <text variable="DOI" prefix="https://doi.org/"/>
   </macro>
   <citation collapse="citation-number">
     <sort>

--- a/springer-socpsych-author-date.csl
+++ b/springer-socpsych-author-date.csl
@@ -18,7 +18,7 @@
     <category field="psychology"/>
     <category field="generic-base"/>
     <summary>This style corresponds to 'Springer SocPsych' in the pdf document 'Key Style Points' at this url</summary>
-    <updated>2015-07-09T20:48:24+00:00</updated>
+    <updated>2019-09-25T20:48:24+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale xml:lang="en">
@@ -125,7 +125,7 @@
       <else>
         <choose>
           <if variable="DOI">
-            <text variable="DOI" prefix="doi:"/>
+            <text variable="DOI" prefix="https://doi.org/"/>
           </if>
           <else>
             <group delimiter=". ">

--- a/springer-socpsych-brackets.csl
+++ b/springer-socpsych-brackets.csl
@@ -18,7 +18,7 @@
     <category citation-format="numeric"/>
     <category field="psychology"/>
     <category field="generic-base"/>
-    <updated>2013-05-10T12:00:00+00:00</updated>
+    <updated>2019-09-25T12:00:00+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale xml:lang="en">
@@ -93,7 +93,7 @@
       <else>
         <choose>
           <if variable="DOI">
-            <text variable="DOI" prefix="doi:"/>
+            <text variable="DOI" prefix="https://doi.org/"/>
           </if>
           <else>
             <choose>

--- a/springer-vancouver.csl
+++ b/springer-vancouver.csl
@@ -16,7 +16,7 @@
     <category citation-format="numeric"/>
     <category field="generic-base"/>
     <summary>Springer Vancouver style - like the author-date style, but numeric</summary>
-    <updated>2012-10-18T22:38:43+00:00</updated>
+    <updated>2019-09-25T22:38:43+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale xml:lang="en">
@@ -130,7 +130,7 @@
 	       J Mol Med. doi:10.1007/s001090000086     -->
           <group delimiter=". ">
             <text variable="container-title" form="short" strip-periods="true"/>
-            <text prefix="doi: " variable="DOI"/>
+            <text prefix="https://doi.org/" variable="DOI"/>
           </group>
         </else-if>
         <else-if type="bill book graphic legal_case legislation motion_picture report song" match="any">

--- a/springer-vs-author-date.csl
+++ b/springer-vs-author-date.csl
@@ -118,7 +118,7 @@
             <text variable="page"/>
           </if>
           <else>
-            <text variable="DOI" prefix="doi: "/>
+            <text variable="DOI" prefix="https://doi.org/"/>
           </else>
         </choose>
       </if>

--- a/springer-vs-author-date.csl
+++ b/springer-vs-author-date.csl
@@ -13,7 +13,7 @@
     <category citation-format="author-date"/>
     <category field="sociology"/>
     <summary>Style for Springer VS based on the KZfSS style, a CMoS variant.</summary>
-    <updated>2017-05-09T00:00:00+00:00</updated>
+    <updated>2019-09-25T00:00:00+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale xml:lang="de">


### PR DESCRIPTION
to close https://github.com/citation-style-language/styles/issues/3956

excluded from this PR:
- Sprinter LNCS (already had this fixed in Mar-2019)
- springer-imis-series-migrationsgesellschaften.csl
- springer-vancouver-author-date.csl (doesn't have DOI at all)
- springer-vancouver-brackets.csl (doesn't have DOI at all)
- springer-physics-brackets.csl (doesn't have DOI at all)
- springer-physics-author-date.csl (doesn't have DOI at all)