### PR TITLE
APA.csl - Change journal title case to capitalize-first

### DIFF
--- a/apa.csl
+++ b/apa.csl
@@ -1347,7 +1347,7 @@
   <macro name="container-title">
     <choose>
       <if type="article article-journal article-magazine article-newspaper dataset" match="any">
-        <text variable="container-title" font-style="italic" text-case="title"/>
+        <text variable="container-title" font-style="italic" text-case="capitalize-first"/>
       </if>
       <else-if type="paper-conference speech">
         <choose>


### PR DESCRIPTION
With the Container journal title case being "title", each word in journal titles (including conjunctions like And and Of) is capitalized. When your journal metadata is correct and it gets transformed on you, that can be quite vexing.

This pull changes the case to "capitalize-first" which better respects the existing value of the field.