### PR TITLE
Reference disambiguation in JASA style

### DIFF
--- a/the-journal-of-the-acoustical-society-of-america.csl
+++ b/the-journal-of-the-acoustical-society-of-america.csl
@@ -142,7 +142,7 @@
     <choose>
       <if type="report thesis" match="any">
         <text variable="title" font-style="italic"/>
-        <group prefix=" (" suffix="), ">
+        <group prefix=" (" suffix="),">
           <text variable="genre"/>
           <text variable="number" prefix=" No. "/>
         </group>
@@ -154,7 +154,7 @@
         <text variable="title" font-style="italic" suffix=","/>
       </else-if>
       <else>
-        <text variable="title" quotes="true" strip-periods="true" suffix=","/>
+        <text variable="title" quotes="true" suffix=","/>
       </else>
     </choose>
   </macro>
@@ -368,30 +368,22 @@
     <layout>
       <group suffix="." delimiter=" ">
         <text macro="author"/>
-        <text font-weight="bold" prefix=" (" macro="issued-year" suffix=") "/>
-        <group delimiter=" ">
-          <text macro="title"/>
-          <group>
-            <text macro="container-contributors" prefix=" "/>
-            <text macro="secondary-contributors" prefix=" "/>
-            <group>
-              <text variable="container-title" form="short" prefix=" " suffix=","/>
-              <text variable="collection-title" prefix=" " suffix=","/>
-            </group>
-            <choose>
-              <if type="patent report thesis webpage" match="any">
-                <text macro="locators" suffix="."/>
-              </if>
-              <else>
-                <text macro="locators" prefix=" " suffix="."/>
-              </else>
-            </choose>
-          </group>
-        </group>
-        <group delimiter=", " prefix=". ">
-          <text macro="event"/>
-        </group>
+        <text font-weight="bold" prefix=" (" macro="issued-year" suffix=")."/>
+        <text macro="title"/>
+        <text macro="container-contributors"/>
+        <text macro="secondary-contributors"/>
+        <text variable="container-title" form="short" suffix=","/>
+        <text variable="collection-title" suffix=","/>
+        <choose>
+          <if type="patent report thesis webpage" match="any">
+            <text macro="locators" suffix="."/>
+          </if>
+          <else>
+            <text macro="locators" suffix="."/>
+          </else>
+        </choose>
       </group>
+      <text macro="event" prefix=". "/>
       <!-- if the access enabled, disable the URL in webpage locator section -->
       <text macro="access" prefix=". "/>
     </layout>

--- a/the-journal-of-the-acoustical-society-of-america.csl
+++ b/the-journal-of-the-acoustical-society-of-america.csl
@@ -395,7 +395,7 @@
     <layout>
       <group suffix="." delimiter=" ">
         <text macro="author"/>
-        <text macro="issued" suffix=" "/>
+        <text font-weight="bold" prefix=" (" macro="issued-year" suffix=") "/>
         <group delimiter=" ">
           <text macro="title"/>
           <group>

--- a/the-journal-of-the-acoustical-society-of-america.csl
+++ b/the-journal-of-the-acoustical-society-of-america.csl
@@ -204,33 +204,6 @@
       </if>
     </choose>
   </macro>
-  <macro name="issued">
-    <choose>
-      <if variable="issued">
-        <group prefix=" (" suffix=").">
-          <group font-weight="bold">
-            <date variable="issued">
-              <date-part name="year"/>
-            </date>
-            <choose>
-              <if type="article-journal bill book chapter graphic legal_case legislation motion_picture paper-conference report thesis song webpage patent" match="none">
-                <date variable="issued">
-                  <date-part prefix=", " name="month"/>
-                  <date-part prefix=" " name="day"/>
-                </date>
-              </if>
-            </choose>
-          </group>
-        </group>
-      </if>
-      <else>
-        <group prefix=" (" suffix=").">
-          <text term="no date" form="short"/>
-          <text variable="year-suffix" prefix="-"/>
-        </group>
-      </else>
-    </choose>
-  </macro>
   <macro name="issued-year">
     <choose>
       <if variable="issued">


### PR DESCRIPTION
Bug fix: References to several papers from the same author and one year get disambigued (Author 2018a, 2018b) in citations, but not in the bibliography (a, b missing there). Fixed this issue by changing the appropriate macros in the bibliography generator.