### PR TITLE
Update elsevier-with-titles.csl

### DIFF
--- a/elsevier-with-titles.csl
+++ b/elsevier-with-titles.csl
@@ -18,12 +18,12 @@
     <category citation-format="numeric"/>
     <category field="generic-base"/>
     <summary>A style for many of Elsevier's journals that includes article titles in the reference list</summary>
-    <updated>2012-09-27T22:06:38+00:00</updated>
+    <updated>2019-10-08T22:06:38+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <macro name="author">
     <names variable="author">
-      <name initialize-with="." delimiter=", " delimiter-precedes-last="always"/>
+      <name initialize-with="." delimiter=", " delimiter-precedes-last="always" name-as-sort-order="all"/>
       <label form="short" prefix=", "/>
       <substitute>
         <names variable="editor"/>
@@ -33,7 +33,7 @@
   </macro>
   <macro name="editor">
     <names variable="editor">
-      <name initialize-with="." delimiter=", " delimiter-precedes-last="always"/>
+      <name initialize-with="." delimiter=", " delimiter-precedes-last="always" name-as-sort-order="all"/>
       <label form="short" prefix=" (" text-case="capitalize-first" suffix=")"/>
     </names>
   </macro>


### PR DESCRIPTION
via https://forums.zotero.org/discussion/79406/why-do-first-names-come-first-before-last-name-in-refense-list-fot-elsevier-style-with-numerics
Change to  name-as-sort-order="all" for authors/editors.

Confirmed in these papers: 
Journal of Hazardous Materials
   https://www.sciencedirect.com/science/article/pii/S0304389419309756
   https://www.sciencedirect.com/science/article/pii/S0304389419312373

However, I have checked a few other journals "Acta Austronautica", "Artificial Intelligence" and "Chemico-Biological Interactions" and none seem to have the new style. This PR will need some more research.