### PR TITLE
update apa style: no publisher place for book, only publisher name

### DIFF
--- a/apa.csl
+++ b/apa.csl
@@ -834,6 +834,12 @@
           <text macro="archive"/>
         </group>
       </else-if>
+      <else-if type="book" match="any">
+        <group delimiter=". ">
+          <text variable="publisher"/>
+          <text macro="archive"/>
+        </group>
+      </else-if>
       <else-if type="article-journal article-magazine article-newspaper" match="any">
         <text macro="archive"/>
       </else-if>


### PR DESCRIPTION
https://apastyle.apa.org/style-grammar-guidelines/references/examples#whole
states that a whole book should have no publisher place