### PR TITLE
Update elsevier-x.csl styles with https://doi.org/ format

### DIFF
--- a/elsevier-vancouver-author-date.csl
+++ b/elsevier-vancouver-author-date.csl
@@ -12,7 +12,7 @@
     <category citation-format="author-date"/>
     <category field="generic-base"/>
     <summary>A style for some Elsevier journals, resembles Vancouver style, but using author-date format</summary>
-    <updated>2012-09-27T22:06:38+00:00</updated>
+    <updated>2019-10-15T22:06:38+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <macro name="author">

--- a/elsevier-vancouver-author-date.csl
+++ b/elsevier-vancouver-author-date.csl
@@ -75,7 +75,7 @@
   <macro name="access">
     <choose>
       <if variable="DOI">
-        <text variable="DOI" prefix="doi:"/>
+        <text variable="DOI" prefix="https://doi.org/"/>
       </if>
       <else-if type="webpage post-weblog" match="any">
         <choose>

--- a/elsevier-vancouver.csl
+++ b/elsevier-vancouver.csl
@@ -13,7 +13,7 @@
     <category citation-format="numeric"/>
     <category field="generic-base"/>
     <summary>A style for some Elsevier journals, resembles Vancouver style</summary>
-    <updated>2012-09-27T22:06:38+00:00</updated>
+    <updated>2019-10-15T22:06:38+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <macro name="author">

--- a/elsevier-vancouver.csl
+++ b/elsevier-vancouver.csl
@@ -65,7 +65,7 @@
   <macro name="access">
     <choose>
       <if variable="DOI">
-        <text variable="DOI" prefix="doi:"/>
+        <text variable="DOI" prefix="https://doi.org/"/>
       </if>
       <else-if type="webpage post-weblog" match="any">
         <choose>

--- a/elsevier-with-titles.csl
+++ b/elsevier-with-titles.csl
@@ -138,7 +138,7 @@
       </choose>
       <choose>
         <if variable="DOI">
-          <text variable="DOI" prefix=". doi:"/>
+          <text variable="DOI" prefix=". https://doi.org/"/>
         </if>
         <else>
           <text macro="access" prefix=". "/>

--- a/elsevier-with-titles.csl
+++ b/elsevier-with-titles.csl
@@ -18,7 +18,7 @@
     <category citation-format="numeric"/>
     <category field="generic-base"/>
     <summary>A style for many of Elsevier's journals that includes article titles in the reference list</summary>
-    <updated>2012-09-27T22:06:38+00:00</updated>
+    <updated>2019-10-15T22:06:38+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <macro name="author">


### PR DESCRIPTION
closes #4341
All elsevier styles were checked. Half of them either already had the new format or do not use DOI.