### PR TITLE
Update harvard-university-for-the-creative-arts.csl

### DIFF
--- a/harvard-university-for-the-creative-arts.csl
+++ b/harvard-university-for-the-creative-arts.csl
@@ -14,7 +14,7 @@
     <category citation-format="author-date"/>
     <category field="generic-base"/>
     <summary>University for the Creative Arts Harvard style</summary>
-    <updated>2019-10-10T10:32:29+00:00</updated>
+    <updated>2019-10-14T08:17:05+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale>
@@ -34,7 +34,7 @@
           <label form="short" prefix=" "/>
           <et-al font-style="italic"/>
           <substitute>
-            <names variable="editor"/>
+            <text macro="editor"/>
             <text variable="title" font-style="italic"/>
           </substitute>
         </names>


### PR DESCRIPTION
Sorry to open a new pull request but when this was closed the other day when an edited book (not chapter) was referenced in a bibliography the ed. or eds. after the name was no longer within brackets.
It is producing this: 
Hancké, B. et al. eds. (2007) Beyond varieties of capitalism : Conflict, contradiction, and complementarities in the European economy. Oxford and New York: Oxford University Press.
When it should be this:
Hancké, B. et al. (eds.) (2007) Beyond varieties of capitalism : Conflict, contradiction, and complementarities in the European economy. Oxford and New York: Oxford University Press.
I use the visual editor and when I amended the names variable to the macro editor it fixed this issue.
Is this change ok, or is there a different way that it should be done?