### PR TITLE
[Frontiers journals] The inline citations should be sorted by year.

### DIFF
--- a/frontiers.csl
+++ b/frontiers.csl
@@ -102,8 +102,8 @@
   </macro>
   <citation et-al-min="3" et-al-use-first="1" disambiguate-add-year-suffix="true" collapse="year">
     <sort>
-      <key macro="author-short"/>
       <key macro="year-date"/>
+      <key macro="author-short"/>
     </sort>
     <layout prefix="(" suffix=")" delimiter="; ">
       <group delimiter=", ">


### PR DESCRIPTION
I am aware that inline citations order is different between EndNote and Zotero.

EndNote sort citations by year. (using [Frontiers Science Endnote Style](http://www.frontiersin.org/Design/ens/Frontiers-Science.ens) from [author guidelines](https://www.frontiersin.org/about/author-guidelines#References))

> (Kitchen et al., 2004; Shoichet, 2004; Irwin and Shoichet, 2016; Zhou et al., 2016; Wang et al., 2017; Lyu et al., 2019; Peng et al., 2019)

Zotero sort citations by author name. (using [frontiers-in-pharmacology.csl](https://www.zotero.org/styles/frontiers-in-pharmacology))

> (Irwin and Shoichet, 2016; Kitchen et al., 2004; Lyu et al., 2019; Peng et al., 2019; Shoichet, 2004; Wang et al., 2017; Zhou et al., 2016)

I have contact Frontiers Application Support to confirm that the inline citations should be sorted by year.

Here is a simple fix.

Thank you.