### PR TITLE
Update cell-numeric-superscript.csl

### DIFF
--- a/cell-numeric-superscript.csl
+++ b/cell-numeric-superscript.csl
@@ -1,133 +1,130 @@
-<?xml version="1.0" encoding="utf-8"?>
 <style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" demote-non-dropping-particle="sort-only" default-locale="en-US">
-  <info>
-    <title>Cell journals (numeric, superscript)</title>
-    <id>http://www.zotero.org/styles/cell-numeric-superscript</id>
-    <link href="http://www.zotero.org/styles/cell-numeric-superscript" rel="self"/>
-    <link href="http://www.cell.com/chem/authors" rel="documentation"/>
-    <author>
-      <name>Sebastian Karcher</name>
-    </author>
-    <contributor>
-      <name>Julian Onions</name>
-      <email>julian.onions@gmail.com</email>
-    </contributor>
-    <category citation-format="numeric"/>
-    <category field="biology"/>
-    <summary>The style for Cell Journals using numerical citations in superscript, such as Chem</summary>
-    <updated>2016-07-28T09:56:00+00:00</updated>
-    <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
-  </info>
-  <macro name="editor">
-    <names variable="editor" delimiter=", ">
-      <name and="text" initialize-with=". " delimiter=", "/>
-      <label form="short" prefix=", "/>
-    </names>
-  </macro>
-  <macro name="author">
-    <names variable="author">
-      <name name-as-sort-order="all" and="text" sort-separator=", " initialize-with="." delimiter=", " delimiter-precedes-last="always"/>
-      <et-al font-style="italic"/>
-      <label form="short" prefix=" "/>
-      <substitute>
-        <names variable="editor"/>
-        <text variable="title"/>
-      </substitute>
-    </names>
-  </macro>
-  <macro name="access">
-    <choose>
-      <if variable="URL">
-        <text value="Available at:" suffix=" "/>
-        <text variable="URL"/>
-        <group prefix=" [" suffix="]">
-          <text term="accessed" text-case="capitalize-first" suffix=" "/>
-          <date variable="accessed">
-            <date-part name="month" suffix=" "/>
-            <date-part name="day" suffix=", "/>
-            <date-part name="year"/>
-          </date>
-        </group>
-      </if>
-    </choose>
-  </macro>
-  <macro name="title">
-    <text variable="title"/>
-  </macro>
-  <macro name="publisher">
-    <group prefix="(" delimiter=": " suffix=")">
-      <text variable="publisher-place"/>
-      <text variable="publisher"/>
-    </group>
-  </macro>
-  <macro name="edition">
-    <choose>
-      <if is-numeric="edition">
-        <group delimiter=" ">
-          <number variable="edition" form="ordinal"/>
-          <text term="edition" form="short"/>
-        </group>
-      </if>
-      <else>
-        <text variable="edition" suffix="."/>
-      </else>
-    </choose>
-  </macro>
-  <citation collapse="citation-number">
-    <sort>
-      <key variable="citation-number"/>
-    </sort>
-    <layout vertical-align="sup" delimiter=",">
-      <text variable="citation-number"/>
-    </layout>
-  </citation>
-  <bibliography et-al-min="11" et-al-use-first="10" second-field-align="flush">
-    <sort>
-      <key variable="citation-number"/>
-    </sort>
-    <layout suffix=".">
-      <text variable="citation-number" suffix="."/>
-      <text macro="author"/>
-      <date variable="issued" prefix=" (" suffix=").">
-        <date-part name="year"/>
-      </date>
-      <choose>
-        <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
-          <group delimiter=" " prefix=" ">
-            <text macro="title"/>
-            <text macro="edition"/>
-            <text macro="editor"/>
-            <text macro="publisher"/>
-          </group>
-        </if>
-        <else-if type="chapter paper-conference" match="any">
-          <group delimiter=" " prefix=" ">
-            <text macro="title" suffix="."/>
-            <text term="in" text-case="capitalize-first"/>
-            <text variable="container-title"/>
-            <text variable="collection-title" suffix="."/>
-          </group>
-          <text macro="editor" prefix=", "/>
-          <group suffix=".">
-            <text macro="publisher" prefix=" "/>
-            <group prefix=", ">
-              <label variable="page" suffix=" " form="short"/>
-              <text variable="page"/>
-            </group>
-          </group>
-        </else-if>
-        <else>
-          <text macro="title" prefix=" " suffix="."/>
-          <group delimiter=", " prefix=" " suffix=".">
-            <group delimiter=" ">
-              <text variable="container-title" form="short"/>
-              <text variable="volume" font-style="italic"/>
-            </group>
-            <text variable="page"/>
-          </group>
-        </else>
-      </choose>
-      <text prefix=" " macro="access"/>
-    </layout>
-  </bibliography>
+<info>
+<title>
+Cell journals (numeric, superscript)
+</title>
+<id>
+http://www.zotero.org/styles/cell-numeric-superscript
+</id>
+<link href="http://www.zotero.org/styles/cell-numeric-superscript" rel="self"/>
+<link href="http://www.cell.com/chem/authors" rel="documentation"/>
+<author>
+<name>Sebastian Karcher</name>
+</author>
+<contributor>
+<name>Julian Onions</name>
+<email>julian.onions@gmail.com</email>
+</contributor>
+<category citation-format="numeric"/>
+<category field="biology"/>
+<summary>
+The style for Cell Journals using numerical citations in superscript, such as Chem
+</summary>
+<updated>2019-10-29T19:17:19+00:00</updated>
+<rights license="http://creativecommons.org/licenses/by-sa/3.0/">
+This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License
+</rights>
+</info>
+<macro name="editor">
+<names variable="editor" delimiter=", ">
+<name and="text" initialize-with=". " delimiter=", "/>
+<label form="short" prefix=", "/>
+</names>
+</macro>
+<macro name="author">
+<names variable="author">
+<name name-as-sort-order="all" and="text" sort-separator=", " initialize-with="." delimiter=", " delimiter-precedes-last="always"/>
+<et-al font-style="italic"/>
+<label form="short" prefix=" "/>
+<substitute>
+<names variable="editor"/>
+<text variable="title"/>
+</substitute>
+</names>
+</macro>
+<macro name="access">
+<choose>
+<if variable="URL" type="webpage dataset entry-dictionary entry-encyclopedia post post-weblog">
+<text variable="URL"/>
+</if>
+</choose>
+</macro>
+<macro name="title">
+<text variable="title"/>
+</macro>
+<macro name="publisher">
+<group prefix="(" delimiter=": " suffix=")">
+<text variable="publisher"/>
+</group>
+</macro>
+<macro name="edition">
+<choose>
+<if is-numeric="edition">
+<group delimiter=" ">
+<number variable="edition" form="ordinal"/>
+<text term="edition" form="short"/>
+</group>
+</if>
+<else>
+<text variable="edition" suffix="."/>
+</else>
+</choose>
+</macro>
+<citation collapse="citation-number">
+<sort>
+<key variable="citation-number"/>
+</sort>
+<layout vertical-align="sup" delimiter=",">
+<text variable="citation-number"/>
+</layout>
+</citation>
+<bibliography et-al-min="11" et-al-use-first="10" second-field-align="flush">
+<sort>
+<key variable="citation-number"/>
+</sort>
+<layout suffix=".">
+<text variable="citation-number" suffix="."/>
+<text macro="author"/>
+<date variable="issued" prefix=" (" suffix=").">
+<date-part name="year"/>
+</date>
+<choose>
+<if type="bill book graphic legal_case legislation motion_picture report song" match="any">
+<group delimiter=" " prefix=" ">
+<text macro="title"/>
+<text macro="edition"/>
+<text macro="editor"/>
+<text macro="publisher"/>
+</group>
+</if>
+<else-if type="chapter paper-conference" match="any">
+<group delimiter=" " prefix=" ">
+<text macro="title" suffix="."/>
+<text term="in" text-case="capitalize-first"/>
+<text variable="container-title"/>
+<text variable="collection-title" suffix="."/>
+</group>
+<text macro="editor" prefix=", "/>
+<group suffix=".">
+<text macro="publisher" prefix=" "/>
+<group prefix=", ">
+<label variable="page" suffix=" " form="short"/>
+<text variable="page"/>
+</group>
+</group>
+</else-if>
+<else>
+<text macro="title" prefix=" " suffix="."/>
+<group delimiter=", " prefix=" " suffix=".">
+<group delimiter=" ">
+<text variable="container-title" form="short"/>
+<text variable="volume" font-style="italic"/>
+</group>
+<text variable="page"/>
+</group>
+</else>
+</choose>
+<text prefix=" " macro="access"/>
+</layout>
+</bibliography>
 </style>

--- a/cell-numeric-superscript.csl
+++ b/cell-numeric-superscript.csl
@@ -37,7 +37,7 @@
   </macro>
   <macro name="access">
     <choose>
-      <if variable="URL" type="webpage dataset entry-dictionary entry-encyclopedia post post-weblog">
+      <if variable="URL" type="webpage dataset entry-dictionary entry-encyclopedia post post-weblog" match="any">
         <text variable="URL"/>
       </if>
     </choose>
@@ -46,9 +46,7 @@
     <text variable="title"/>
   </macro>
   <macro name="publisher">
-    <group prefix="(" delimiter=": " suffix=")">
-      <text variable="publisher"/>
-    </group>
+    <text variable="publisher" prefix="(" suffix=")"/>
   </macro>
   <macro name="edition">
     <choose>

--- a/cell-numeric-superscript.csl
+++ b/cell-numeric-superscript.csl
@@ -1,130 +1,123 @@
+<?xml version="1.0" encoding="utf-8"?>
 <style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" demote-non-dropping-particle="sort-only" default-locale="en-US">
-<info>
-<title>
-Cell journals (numeric, superscript)
-</title>
-<id>
-http://www.zotero.org/styles/cell-numeric-superscript
-</id>
-<link href="http://www.zotero.org/styles/cell-numeric-superscript" rel="self"/>
-<link href="http://www.cell.com/chem/authors" rel="documentation"/>
-<author>
-<name>Sebastian Karcher</name>
-</author>
-<contributor>
-<name>Julian Onions</name>
-<email>julian.onions@gmail.com</email>
-</contributor>
-<category citation-format="numeric"/>
-<category field="biology"/>
-<summary>
-The style for Cell Journals using numerical citations in superscript, such as Chem
-</summary>
-<updated>2019-10-29T19:17:19+00:00</updated>
-<rights license="http://creativecommons.org/licenses/by-sa/3.0/">
-This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License
-</rights>
-</info>
-<macro name="editor">
-<names variable="editor" delimiter=", ">
-<name and="text" initialize-with=". " delimiter=", "/>
-<label form="short" prefix=", "/>
-</names>
-</macro>
-<macro name="author">
-<names variable="author">
-<name name-as-sort-order="all" and="text" sort-separator=", " initialize-with="." delimiter=", " delimiter-precedes-last="always"/>
-<et-al font-style="italic"/>
-<label form="short" prefix=" "/>
-<substitute>
-<names variable="editor"/>
-<text variable="title"/>
-</substitute>
-</names>
-</macro>
-<macro name="access">
-<choose>
-<if variable="URL" type="webpage dataset entry-dictionary entry-encyclopedia post post-weblog">
-<text variable="URL"/>
-</if>
-</choose>
-</macro>
-<macro name="title">
-<text variable="title"/>
-</macro>
-<macro name="publisher">
-<group prefix="(" delimiter=": " suffix=")">
-<text variable="publisher"/>
-</group>
-</macro>
-<macro name="edition">
-<choose>
-<if is-numeric="edition">
-<group delimiter=" ">
-<number variable="edition" form="ordinal"/>
-<text term="edition" form="short"/>
-</group>
-</if>
-<else>
-<text variable="edition" suffix="."/>
-</else>
-</choose>
-</macro>
-<citation collapse="citation-number">
-<sort>
-<key variable="citation-number"/>
-</sort>
-<layout vertical-align="sup" delimiter=",">
-<text variable="citation-number"/>
-</layout>
-</citation>
-<bibliography et-al-min="11" et-al-use-first="10" second-field-align="flush">
-<sort>
-<key variable="citation-number"/>
-</sort>
-<layout suffix=".">
-<text variable="citation-number" suffix="."/>
-<text macro="author"/>
-<date variable="issued" prefix=" (" suffix=").">
-<date-part name="year"/>
-</date>
-<choose>
-<if type="bill book graphic legal_case legislation motion_picture report song" match="any">
-<group delimiter=" " prefix=" ">
-<text macro="title"/>
-<text macro="edition"/>
-<text macro="editor"/>
-<text macro="publisher"/>
-</group>
-</if>
-<else-if type="chapter paper-conference" match="any">
-<group delimiter=" " prefix=" ">
-<text macro="title" suffix="."/>
-<text term="in" text-case="capitalize-first"/>
-<text variable="container-title"/>
-<text variable="collection-title" suffix="."/>
-</group>
-<text macro="editor" prefix=", "/>
-<group suffix=".">
-<text macro="publisher" prefix=" "/>
-<group prefix=", ">
-<label variable="page" suffix=" " form="short"/>
-<text variable="page"/>
-</group>
-</group>
-</else-if>
-<else>
-<text macro="title" prefix=" " suffix="."/>
-<group delimiter=", " prefix=" " suffix=".">
-<group delimiter=" ">
-<text variable="container-title" form="short"/>
-<text variable="volume" font-style="italic"/>
-</group>
-<text variable="page"/>
-</group>
-</else>
-</choose>
-<text prefix=" " macro="access"/>
-</layout>
-</bibliography>
+  <info>
+    <title>Cell journals (numeric, superscript)</title>
+    <id>http://www.zotero.org/styles/cell-numeric-superscript</id>
+    <link href="http://www.zotero.org/styles/cell-numeric-superscript" rel="self"/>
+    <link href="http://www.cell.com/chem/authors" rel="documentation"/>
+    <author>
+      <name>Sebastian Karcher</name>
+    </author>
+    <contributor>
+      <name>Julian Onions</name>
+      <email>julian.onions@gmail.com</email>
+    </contributor>
+    <category citation-format="numeric"/>
+    <category field="biology"/>
+    <summary>The style for Cell Journals using numerical citations in superscript, such as Chem</summary>
+    <updated>2019-10-29T19:17:19+00:00</updated>
+    <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
+  </info>
+  <macro name="editor">
+    <names variable="editor" delimiter=", ">
+      <name and="text" initialize-with=". " delimiter=", "/>
+      <label form="short" prefix=", "/>
+    </names>
+  </macro>
+  <macro name="author">
+    <names variable="author">
+      <name name-as-sort-order="all" and="text" sort-separator=", " initialize-with="." delimiter=", " delimiter-precedes-last="always"/>
+      <et-al font-style="italic"/>
+      <label form="short" prefix=" "/>
+      <substitute>
+        <names variable="editor"/>
+        <text variable="title"/>
+      </substitute>
+    </names>
+  </macro>
+  <macro name="access">
+    <choose>
+      <if variable="URL" type="webpage dataset entry-dictionary entry-encyclopedia post post-weblog">
+        <text variable="URL"/>
+      </if>
+    </choose>
+  </macro>
+  <macro name="title">
+    <text variable="title"/>
+  </macro>
+  <macro name="publisher">
+    <group prefix="(" delimiter=": " suffix=")">
+      <text variable="publisher"/>
+    </group>
+  </macro>
+  <macro name="edition">
+    <choose>
+      <if is-numeric="edition">
+        <group delimiter=" ">
+          <number variable="edition" form="ordinal"/>
+          <text term="edition" form="short"/>
+        </group>
+      </if>
+      <else>
+        <text variable="edition" suffix="."/>
+      </else>
+    </choose>
+  </macro>
+  <citation collapse="citation-number">
+    <sort>
+      <key variable="citation-number"/>
+    </sort>
+    <layout vertical-align="sup" delimiter=",">
+      <text variable="citation-number"/>
+    </layout>
+  </citation>
+  <bibliography et-al-min="11" et-al-use-first="10" second-field-align="flush">
+    <sort>
+      <key variable="citation-number"/>
+    </sort>
+    <layout suffix=".">
+      <text variable="citation-number" suffix="."/>
+      <text macro="author"/>
+      <date variable="issued" prefix=" (" suffix=").">
+        <date-part name="year"/>
+      </date>
+      <choose>
+        <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
+          <group delimiter=" " prefix=" ">
+            <text macro="title"/>
+            <text macro="edition"/>
+            <text macro="editor"/>
+            <text macro="publisher"/>
+          </group>
+        </if>
+        <else-if type="chapter paper-conference" match="any">
+          <group delimiter=" " prefix=" ">
+            <text macro="title" suffix="."/>
+            <text term="in" text-case="capitalize-first"/>
+            <text variable="container-title"/>
+            <text variable="collection-title" suffix="."/>
+          </group>
+          <text macro="editor" prefix=", "/>
+          <group suffix=".">
+            <text macro="publisher" prefix=" "/>
+            <group prefix=", ">
+              <label variable="page" suffix=" " form="short"/>
+              <text variable="page"/>
+            </group>
+          </group>
+        </else-if>
+        <else>
+          <text macro="title" prefix=" " suffix="."/>
+          <group delimiter=", " prefix=" " suffix=".">
+            <group delimiter=" ">
+              <text variable="container-title" form="short"/>
+              <text variable="volume" font-style="italic"/>
+            </group>
+            <text variable="page"/>
+          </group>
+        </else>
+      </choose>
+      <text prefix=" " macro="access"/>
+    </layout>
+  </bibliography>
 </style>

--- a/cell-numeric-superscript.csl
+++ b/cell-numeric-superscript.csl
@@ -27,7 +27,6 @@
   <macro name="author">
     <names variable="author">
       <name name-as-sort-order="all" and="text" sort-separator=", " initialize-with="." delimiter=", " delimiter-precedes-last="always"/>
-      <et-al font-style="italic"/>
       <label form="short" prefix=" "/>
       <substitute>
         <names variable="editor"/>
@@ -37,8 +36,12 @@
   </macro>
   <macro name="access">
     <choose>
-      <if variable="URL" type="webpage dataset entry-dictionary entry-encyclopedia post post-weblog" match="any">
-        <text variable="URL"/>
+      <if variable="URL">
+        <choose>
+          <if type="webpage dataset entry-dictionary entry-encyclopedia post post-weblog" match="any">
+            <text variable="URL"/>
+          </if>
+        </choose>
       </if>
     </choose>
   </macro>


### PR DESCRIPTION
This update removes URLs from all non-webpage references, "Available at:" from all other URLs, access dates for all URLs, and publisher locations in accordance with Cell Press style.