### PR TITLE
Update universite-de-bordeaux-ecole-doctorale-de-droit.csl

### DIFF
--- a/universite-de-bordeaux-ecole-doctorale-de-droit.csl
+++ b/universite-de-bordeaux-ecole-doctorale-de-droit.csl
@@ -4,7 +4,7 @@
     <title>Université de Bordeaux - École doctorale de droit (French)</title>
     <id>http://www.zotero.org/styles/universite-de-bordeaux-ecole-doctorale-de-droit</id>
     <link href="http://www.zotero.org/styles/universite-de-bordeaux-ecole-doctorale-de-droit" rel="self"/>
-    <link href="http://weburfist.univ-bordeaux.fr/wp-content/uploads/2019/01/20190111-2e-%C3%A9d.-Citer-r%C3%A9f%C3%A9rences-bibliographiques-version-num%C3%A9rique.pdf" rel="documentation"/>
+    <link href="https://hal.archives-ouvertes.fr/hal-02151987" rel="documentation"/>
     <link href="https://documentation-style-csl-ed-droit-ubx.readthedocs.io" rel="documentation"/>
     <author>
       <name>Pierre Gravier</name>
@@ -16,7 +16,7 @@
     </author>
     <category citation-format="note"/>
     <category field="law"/>
-    <updated>2019-01-14T14:52:27+00:00</updated>
+    <updated>2019-04-03T15:47:26+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale xml:lang="fr">
@@ -46,12 +46,39 @@
       </substitute>
     </names>
   </macro>
-  <!-- Mise en forme du pays pour les normes juridiques -->
-  <macro name="bill-country">
+  <!-- Mise en forme du pays pour les normes juridiques, du tribunal pour la jurisprudence, de l'autorité émettrice pour les brevets -->
+  <macro name="authority">
     <choose>
       <if type="bill">
         <text variable="authority" text-case="uppercase"/>
       </if>
+      <else-if type="legal_case patent" match="any">
+        <text variable="authority"/>
+      </else-if>
+    </choose>
+  </macro>
+  <!-- Mise en forme de la date de décision et du numéro de requête pour la jurisprudence, du numéro pour les brevets -->
+  <macro name="case-patent-ref">
+    <choose>
+      <if type="legal_case" match="any">
+        <group delimiter=", ">
+          <date variable="issued" delimiter="&#160;">
+            <date-part name="day"/>
+            <date-part name="month"/>
+            <date-part name="year"/>
+          </date>
+          <group delimiter="&#160;">
+            <text term="issue" form="short"/>
+            <text variable="number"/>
+          </group>
+        </group>
+      </if>
+      <else-if type="patent" match="any">
+        <group delimiter="&#160;">
+          <text term="issue" form="short"/>
+          <text variable="number"/>
+        </group>
+      </else-if>
     </choose>
   </macro>
   <!-- Mise en forme des éditeurs scientifiques de colloque = livre sans auteur -->
@@ -116,7 +143,7 @@
       <label form="short" prefix=" (" suffix=".)"/>
     </names>
   </macro>
-  <!--Mise en forme des titres dans la bibliographie - pour les brevets inclut autorité émettrice et numéro, pour les entretiens oraux inclut l'interviewer et les autres informations concernant l'entretien -->
+  <!--Mise en forme des titres dans la bibliographie - pour les entretiens oraux inclut l'interviewer et les autres informations concernant l'entretien -->
   <macro name="title">
     <choose>
       <if type="book" match="any">
@@ -151,15 +178,8 @@
           </else>
         </choose>
       </else-if>
-      <else-if type="patent">
-        <group delimiter=", ">
-          <group delimiter=" ">
-            <text variable="authority" text-case="capitalize-first"/>
-            <text term="issue" form="short"/>
-            <text variable="number"/>
-          </group>
-          <text variable="title" text-case="capitalize-first" font-style="italic"/>
-        </group>
+      <else-if type="patent legal_case" match="any">
+        <text variable="title" font-style="italic"/>
       </else-if>
       <else-if type="personal_communication">
         <group delimiter=" ">
@@ -261,6 +281,14 @@
       <else-if type="paper-conference">
         <text variable="title" text-case="capitalize-first"/>
       </else-if>
+      <else-if type="legal_case" match="any">
+        <choose>
+          <if variable="title-short" match="none"/>
+          <else>
+            <text variable="title" form="short" font-style="italic"/>
+          </else>
+        </choose>
+      </else-if>
       <else>
         <text variable="title" form="short" text-case="capitalize-first" quotes="true"/>
       </else>
@@ -315,6 +343,7 @@
           <text variable="container-title" form="short" font-style="italic"/>
         </group>
       </if>
+      <else-if type="legal_case" match="any"/>
       <else-if type="article-journal article-newspaper article-magazine" match="any">
         <group delimiter=", ">
           <text variable="container-title" form="short" font-style="italic"/>
@@ -398,7 +427,7 @@
       </else>
     </choose>
   </macro>
-  <!--Mise en forme de l'année + des numéros (norme juridique et articles) en bibliographie-->
+  <!--Mise en forme de l'année et des numéros pour les normes juridiques, les articles et la jurisprudence (volume et pages de recueil, références ECLI) en bibliographie-->
   <macro name="issued">
     <choose>
       <if type="webpage post-weblog" match="any">
@@ -478,6 +507,18 @@
           </group>
         </group>
       </else-if>
+      <else-if type="legal_case" match="any">
+        <group delimiter=", ">
+          <group delimiter="&#160;">
+            <text term="volume" form="short"/>
+            <group delimiter="-">
+              <text variable="volume"/>
+              <text variable="page"/>
+            </group>
+          </group>
+          <text variable="references"/>
+        </group>
+      </else-if>
       <else>
         <date variable="issued">
           <date-part name="year"/>
@@ -498,6 +539,7 @@
           <date-part name="year"/>
         </date>
       </else-if>
+      <else-if type="legal_case" match="any"/>
       <else>
         <date variable="issued">
           <date-part name="year"/>
@@ -591,45 +633,43 @@
       </if>
     </choose>
   </macro>
-  <!-- critère de tri primaire permettant de distinguer la liste de ressources et la biblbiographie - la liste de ressources est affichée en 2nd-->
+  <!-- Critère de tri primaire permettant de distinguer la liste de ressources et la biblbiographie - la liste de ressources est affichée en 2ème, la jurisprudence en 3ème-->
   <macro name="sort-key">
     <choose>
-      <if type="interview personal_communication post" match="none">
+      <if type="interview personal_communication post" match="any">
         <text value="2"/>
       </if>
+      <else-if type="legal_case" match="any">
+        <text value="3"/>
+      </else-if>
       <else>
         <text value="1"/>
       </else>
     </choose>
   </macro>
-  <citation et-al-min="4" et-al-use-first="3" et-al-subsequent-min="4" et-al-subsequent-use-first="3" near-note-distance="7">
+  <citation et-al-min="4" et-al-use-first="3" et-al-subsequent-min="4" et-al-subsequent-use-first="3" near-note-distance="3">
     <layout suffix="." delimiter=" ">
       <choose>
         <if position="ibid-with-locator">
           <group delimiter=", ">
             <text term="ibid" text-case="capitalize-first" font-style="italic" suffix="."/>
-            <group delimiter="&#160;">
-              <label variable="locator" form="short"/>
-              <text variable="locator"/>
-            </group>
+            <text macro="locator"/>
           </group>
         </if>
         <else-if position="ibid">
           <text term="ibid" text-case="capitalize-first" font-style="italic"/>
         </else-if>
-        <else-if position="near-note subsequent" match="any">
+        <else-if position="near-note" match="any">
           <group delimiter=", ">
             <text macro="author"/>
             <text term="cited" font-style="italic"/>
-            <group delimiter="&#160;">
-              <label variable="locator" form="short"/>
-              <text variable="locator"/>
-            </group>
+            <text macro="locator"/>
           </group>
         </else-if>
         <else>
           <group delimiter=", ">
-            <text macro="bill-country"/>
+            <text macro="authority"/>
+            <text macro="case-patent-ref"/>
             <text macro="author"/>
             <text macro="title-short"/>
             <text macro="container-title-short"/>
@@ -651,7 +691,8 @@
     </sort>
     <layout>
       <group delimiter=", " suffix=". ">
-        <text macro="bill-country"/>
+        <text macro="authority"/>
+        <text macro="case-patent-ref"/>
         <text macro="author"/>
         <text macro="title"/>
         <text macro="editor"/>


### PR DESCRIPTION
* updated documentation URL
* added support for legal_case
* side effect : code for patent cleaned
* simplified code in "citation" for "ibid-with-locator" and "near-note subsequent" positions : calling "locator" macro rather than repeating formatting instructions with a group
* corrected formatting for citations in "subsequent" position
* near-note-distance reduced to 3
:point_right:  documentation on readthedocs will be updated regarding legal_case and near-note-distance will as soon as this new version of the style will be made available