### PR TITLE
Create iso690-full-note-cs.csl

### DIFF
--- a/iso690-full-note-cs.csl
+++ b/iso690-full-note-cs.csl
@@ -1,0 +1,536 @@
+<?xml version="1.0" encoding="utf-8"?>
+<style xmlns="http://purl.org/net/xbiblio/csl" version="1.0" class="note" demote-non-dropping-particle="sort-only" default-locale="cs-CZ">
+  <info>
+    <title>ISO-690 (full note, Czech)</title>
+    <!--Informace o stylu:
+      Styl vytvořil původně Pavel Vilhan pro slovenský ISO 690 (iso690-full-note-sk), ale upravil Oldrich Tristan Florian k použití v českém akademickém prostředí.
+      Originally created by Pavel Vilhan for Slovak ISO 690 (iso690-full-note-sk). Edited by Oldrich Tristan Florian to match the Czech version. 
+      Problémem ISO 690 jako takového a stylů, které z něj vychází (například dosavadní citační směrnice Právnické fakulty MUNI) je v tom, že vyžadují místo vydání a vydavatelství i u odborných časopisů. Zotero však tuto možnost zatím (5.0) nepodporuje, jelikož se v ostatních relevantních stylech tento požadavek nenachází. -->
+    <!--UPOZORNENIA: 
+      1. Pre zobrazovanie internetovej adresy pri citovaní elektronických periodík je nutné zapnúť túto funkciu v programe Zotero>Predvoľby>Citovanie>Štýly zaškrtnutím políčka dole.
+      2. Zotero 5.0 zatiaľ nepodporuje zobrazenie rozsahu dátumov, napr. 1950 &#8211; 1975. Je však možné do Zotera zadať napr. 1950zzz1975 a pri finálnej úprave nahradiť "zzz" pomlčkou s medzerami: " &#8211; ".-->
+    <id>http://www.zotero.org/styles/iso690-full-note-cs</id>
+    <link href="http://www.zotero.org/styles/iso690-full-note-cs" rel="self"/>
+    <link href="" rel="documentation"/>
+    <author>
+      <name>Oldrich Tristan Florian</name>
+      <email>oldrich(dot)florian(at)gmail.com</email>
+      <uri>http://otristan.com</uri>
+    </author>
+    <author>
+      <name>Pavel Vilhan</name>
+      <email>Pavel(dot)Vilhan(at)frcth(dot)uniba(dot)sk</email>
+      <uri>http://www.kniznice.eu</uri>
+    </author>
+    <category citation-format="note"/>
+    <category field="law"/>
+    <summary>Czech ISO-690 with full note.</summary>
+    <updated>2019-11-12T16:03:24+00:00</updated>
+    <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
+  </info>
+  <locale xml:lang="cs">
+    <terms>
+      <term name="et-al">et al.</term>
+      <term name="editor" form="short">
+        <single>ed</single>
+        <multiple>eds</multiple>
+      </term>
+      <term name="in">in:</term>
+      <term name="page-range-delimiter">-</term>
+    </terms>
+  </locale>
+  <macro name="contributors-full">
+    <choose>
+      <if variable="author">
+        <names variable="author">
+          <name name-as-sort-order="all" sort-separator=", " delimiter=", " delimiter-precedes-last="always">
+            <name-part name="family" text-case="uppercase"/>
+          </name>
+        </names>
+      </if>
+      <else-if variable="editor">
+        <names variable="editor">
+          <name name-as-sort-order="all" sort-separator=", " delimiter=", " delimiter-precedes-last="always">
+            <name-part name="family" text-case="uppercase"/>
+          </name>
+          <label prefix=". " form="short" plural="contextual" suffix="."/>
+        </names>
+      </else-if>
+    </choose>
+  </macro>
+  <macro name="contributors-long">
+    <choose>
+      <if variable="author">
+        <names variable="author">
+          <name name-as-sort-order="all" initialize-with="." sort-separator=", " delimiter=", " delimiter-precedes-last="always">
+            <name-part name="family" text-case="uppercase"/>
+          </name>
+        </names>
+      </if>
+      <else-if variable="editor">
+        <names variable="editor">
+          <name name-as-sort-order="all" initialize-with="." sort-separator=", " delimiter=", " delimiter-precedes-last="always">
+            <name-part name="family" text-case="uppercase"/>
+          </name>
+          <label prefix=". " form="short" plural="contextual" suffix="."/>
+        </names>
+      </else-if>
+    </choose>
+  </macro>
+  <macro name="contributors-short">
+    <choose>
+      <if variable="author">
+        <names variable="author">
+          <name form="short" name-as-sort-order="all" initialize-with="." sort-separator=", " delimiter=", " delimiter-precedes-last="always">
+            <name-part name="family" text-case="uppercase"/>
+          </name>
+        </names>
+      </if>
+      <else-if variable="editor">
+        <names variable="editor">
+          <name form="short" name-as-sort-order="all" initialize-with="." sort-separator=", " delimiter=", " delimiter-precedes-last="always">
+            <name-part name="family" text-case="uppercase"/>
+          </name>
+          <label prefix=". " form="short" plural="contextual" suffix="."/>
+        </names>
+      </else-if>
+    </choose>
+  </macro>
+  <macro name="secondary-contributors">
+    <choose>
+      <if variable="author" type="book" match="all">
+        <names variable="editor translator" delimiter=", ">
+          <label form="verb-short" text-case="uppercase"/>
+          <name sort-separator=", " delimiter=", " delimiter-precedes-last="always"/>
+        </names>
+      </if>
+    </choose>
+  </macro>
+  <macro name="container-contributors">
+    <choose>
+      <if variable="container-author">
+        <names variable="container-author">
+          <name name-as-sort-order="all" initialize-with="." sort-separator=", " delimiter=", " delimiter-precedes-last="always">
+            <name-part name="family" text-case="uppercase"/>
+          </name>
+        </names>
+      </if>
+      <else>
+        <choose>
+          <if type="chapter paper-conference" match="any">
+            <names variable="editor">
+              <name name-as-sort-order="all" initialize-with="." sort-separator=", " delimiter=", " delimiter-precedes-last="always">
+                <name-part name="family" text-case="uppercase"/>
+              </name>
+              <label prefix=". " form="short" plural="contextual" suffix="."/>
+            </names>
+          </if>
+        </choose>
+      </else>
+    </choose>
+  </macro>
+  <macro name="container-contributors-full">
+    <choose>
+      <if variable="container-author">
+        <names variable="container-author">
+          <name name-as-sort-order="all" sort-separator=", " delimiter=", " delimiter-precedes-last="always">
+            <name-part name="family" text-case="uppercase"/>
+          </name>
+        </names>
+      </if>
+      <else>
+        <choose>
+          <if type="chapter paper-conference" match="any">
+            <names variable="editor">
+              <name name-as-sort-order="all" sort-separator=", " delimiter=", " delimiter-precedes-last="always">
+                <name-part name="family" text-case="uppercase"/>
+              </name>
+              <label prefix=". " form="short" plural="contextual" suffix="."/>
+            </names>
+          </if>
+        </choose>
+      </else>
+    </choose>
+  </macro>
+  <macro name="title-long">
+    <group delimiter=". ">
+      <text variable="title"/>
+      <text macro="secondary-contributors"/>
+    </group>
+  </macro>
+  <macro name="title-short">
+    <group delimiter=". ">
+      <text variable="title" form="short"/>
+    </group>
+  </macro>
+  <macro name="container">
+    <choose>
+      <if type="chapter entry entry-dictionary entry-encyclopedia webpage" match="any">
+        <text term="in" text-case="capitalize-first" suffix=" "/>
+        <text macro="container-contributors" suffix=" "/>
+        <choose>
+          <if variable="container-title">
+            <text variable="container-title" font-style="italic"/>
+            <text prefix=" " macro="medium"/>
+          </if>
+          <else-if variable="volume">
+            <text prefix=", " term="volume" form="short" suffix=". "/>
+            <text variable="volume"/>
+          </else-if>
+        </choose>
+      </if>
+      <else-if type="article-journal article-magazine article-newspaper" match="any">
+        <text term="in" text-case="capitalize-first" suffix=" "/>
+        <text variable="container-title" font-style="italic"/>
+        <text prefix=" " macro="medium"/>
+      </else-if>
+    </choose>
+  </macro>
+  <macro name="container-full">
+    <choose>
+      <if type="chapter entry entry-dictionary entry-encyclopedia webpage" match="any">
+        <text term="in" text-case="capitalize-first" suffix=" "/>
+        <text macro="container-contributors-full" suffix=" "/>
+        <choose>
+          <if variable="container-title">
+            <text variable="container-title" font-style="italic"/>
+            <text prefix=" " macro="medium"/>
+          </if>
+          <else-if variable="volume">
+            <text prefix=", " term="volume" form="short" suffix=". "/>
+            <text variable="volume"/>
+          </else-if>
+        </choose>
+      </if>
+      <else-if type="article-journal article-magazine article-newspaper" match="any">
+        <text term="in" text-case="capitalize-first" suffix=" "/>
+        <text variable="container-title" font-style="italic"/>
+        <text prefix=" " macro="medium"/>
+      </else-if>
+    </choose>
+  </macro>
+  <macro name="edition">
+    <choose>
+      <if variable="edition">
+        <text variable="edition" suffix="."/>
+        <text prefix=" " term="edition" form="short" suffix="."/>
+      </if>
+    </choose>
+  </macro>
+  <macro name="publisher-place">
+    <group delimiter="; ">
+      <choose>
+        <if variable="publisher-place accessed DOI URL" match="any">
+          <text variable="publisher-place"/>
+        </if>
+        <else>
+          <text value="[s.l.]"/>
+        </else>
+      </choose>
+    </group>
+  </macro>
+  <macro name="printers">
+    <group delimiter="; ">
+      <choose>
+        <if variable="publisher accessed DOI URL" match="any">
+          <text variable="publisher"/>
+        </if>
+        <else>
+          <text value="[s.n.]"/>
+        </else>
+      </choose>
+    </group>
+  </macro>
+  <macro name="publisher">
+    <group delimiter=": ">
+      <text macro="publisher-place"/>
+      <text macro="printers"/>
+    </group>
+  </macro>
+  <macro name="issued">
+    <choose>
+      <if type="book chapter paper-conference" match="any">
+        <text prefix=" " macro="publisher" suffix=", "/>
+        <date variable="issued">
+          <date-part name="year" range-delimiter=" &#8211; "/>
+        </date>
+      </if>
+      <else-if type="article-journal article-magazine article-newspaper" match="any">
+        <date variable="issued">
+          <date-part name="year" range-delimiter=" &#8211; "/>
+        </date>
+        <choose>
+          <if variable="volume">
+            <text prefix=", " term="volume" form="short" suffix=". "/>
+            <text variable="volume"/>
+          </if>
+        </choose>
+        <choose>
+          <if variable="issue">
+            <text prefix=", " term="issue" form="short" suffix=". "/>
+            <text variable="issue"/>
+          </if>
+        </choose>
+      </else-if>
+    </choose>
+  </macro>
+  <macro name="citation-locator">
+    <label variable="locator" form="short" suffix=". "/>
+    <text variable="locator"/>
+  </macro>
+  <macro name="collection">
+    <text variable="collection-title"/>
+    <text prefix=" " variable="collection-number"/>
+    <choose>
+      <if variable="collection-editor">
+        <text prefix=", " term="editor" form="verb-short" text-case="uppercase" suffix=" "/>
+      </if>
+    </choose>
+  </macro>
+  <macro name="ISBN">
+    <choose>
+      <if variable="ISBN">
+        <text variable="ISBN" prefix="ISBN "/>
+      </if>
+    </choose>
+  </macro>
+  <macro name="ISSN">
+    <choose>
+      <if variable="ISSN">
+        <text variable="ISSN" prefix="ISSN "/>
+      </if>
+    </choose>
+  </macro>
+  <macro name="identifier">
+    <group delimiter="; ">
+      <choose>
+        <if variable="DOI">
+          <text variable="DOI" prefix="DOI: "/>
+        </if>
+        <else>
+          <text variable="URL" prefix="Dostupné z: "/>
+        </else>
+      </choose>
+    </group>
+  </macro>
+  <macro name="medium">
+    <choose>
+      <if variable="accessed DOI URL" match="any">
+        <text term="online" prefix="[" suffix="]"/>
+      </if>
+      <else>
+        <text variable="archive" prefix="[" suffix="]"/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="quoted">
+    <group prefix="[cit. " suffix="]">
+      <date variable="accessed">
+        <date-part name="day" suffix="." form="numeric-leading-zeros"/>
+        <date-part name="month" suffix="." form="numeric-leading-zeros"/>
+        <date-part name="year"/>
+      </date>
+    </group>
+  </macro>
+  <citation et-al-min="4" et-al-use-first="1" disambiguate-add-names="true">
+    <layout delimiter="; ">
+      <choose>
+        <if position="subsequent">
+          <text macro="contributors-short" suffix=", "/>
+          <text macro="title-short"/>
+          <choose>
+            <if variable="locator">
+              <text prefix=", " macro="citation-locator" suffix="."/>
+            </if>
+            <else-if variable="accessed URL DOI" match="any">
+              <text term="online" prefix=" [" suffix="] "/>
+              <text macro="quoted"/>
+              <text prefix=". " macro="identifier"/>
+            </else-if>
+          </choose>
+        </if>
+        <else>
+          <choose>
+            <if type="book thesis manuscript report" match="any">
+              <text macro="contributors-long" suffix=". "/>
+              <text macro="title-long" font-style="italic"/>
+              <choose>
+                <if variable="accessed DOI URL" match="any">
+                  <text prefix=" " macro="medium"/>
+                  <text prefix=". " macro="issued"/>
+                  <text prefix=", " macro="citation-locator"/>
+                  <text prefix=" " macro="quoted"/>
+                  <text prefix=". " macro="identifier"/>
+                </if>
+                <else-if variable="issued" match="none">
+                  <text prefix=" " macro="medium"/>
+                  <choose>
+                    <if variable="publisher publisher-place" match="any">
+                      <text prefix=". " macro="publisher"/>
+                    </if>
+                  </choose>
+                  <text prefix=", " macro="citation-locator" suffix="."/>
+                </else-if>
+                <else>
+                  <text prefix=" " macro="medium"/>
+                  <text prefix=". " macro="issued"/>
+                  <text prefix=", " macro="citation-locator" suffix="."/>
+                </else>
+              </choose>
+            </if>
+            <else-if type="chapter entry entry-dictionary entry-encyclopedia" match="any">
+              <text macro="contributors-long" suffix=". "/>
+              <text macro="title-long" suffix=". "/>
+              <text macro="container"/>
+              <choose>
+                <if variable="accessed DOI URL" match="any">
+                  <text prefix=". " macro="issued"/>
+                  <text prefix=", sv. " variable="volume"/>
+                  <text prefix=", " macro="citation-locator"/>
+                  <text prefix=" " macro="quoted"/>
+                  <text prefix=". " macro="identifier"/>
+                </if>
+                <else-if variable="issued" match="none">
+                  <choose>
+                    <if variable="publisher publisher-place" match="any">
+                      <text prefix=". " macro="publisher"/>
+                    </if>
+                  </choose>
+                  <text prefix=", " macro="citation-locator" suffix="."/>
+                </else-if>
+                <else>
+                  <text prefix=". " macro="issued"/>
+                  <text prefix=", sv. " variable="volume"/>
+                  <text prefix=", " macro="citation-locator" suffix="."/>
+                </else>
+              </choose>
+            </else-if>
+            <else-if type="article-journal article-magazine article-newspaper webpage" match="any">
+              <text macro="contributors-long" suffix=". "/>
+              <text macro="title-long" suffix=". "/>
+              <text macro="container"/>
+              <choose>
+                <if variable="accessed DOI URL" match="any">
+                  <text prefix=". " macro="issued"/>
+                  <text prefix=", " macro="citation-locator"/>
+                  <text prefix=" " macro="quoted"/>
+                  <text prefix=". " macro="identifier"/>
+                </if>
+                <else>
+                  <text prefix=". " macro="issued"/>
+                  <text prefix=", " macro="citation-locator" suffix="."/>
+                </else>
+              </choose>
+            </else-if>
+          </choose>
+        </else>
+      </choose>
+    </layout>
+  </citation>
+  <bibliography et-al-min="4" et-al-use-first="1">
+    <sort>
+      <key macro="contributors-full" names-min="3" names-use-first="3"/>
+      <key macro="title-long"/>
+    </sort>
+    <layout>
+      <choose>
+        <if type="book thesis manuscript report" match="any">
+          <text macro="contributors-full" suffix=". "/>
+          <text macro="title-long" font-style="italic"/>
+          <choose>
+            <if variable="accessed DOI URL" match="any">
+              <text prefix=" " macro="medium"/>
+              <text prefix=". " macro="secondary-contributors"/>
+              <text prefix=". " macro="edition" suffix="."/>
+              <text prefix=". " macro="issued"/>
+              <text prefix=" " macro="quoted" suffix="."/>
+              <text prefix=". " macro="collection" suffix="."/>
+              <text prefix=". " variable="note" suffix="."/>
+              <text prefix=". " macro="ISBN" suffix="."/>
+              <text prefix=". " macro="identifier"/>
+            </if>
+            <else-if variable="issued" match="none">
+              <text prefix=" " macro="medium" suffix="."/>
+              <choose>
+                <if variable="publisher publisher-place" match="any">
+                  <text prefix=". " macro="publisher" suffix="."/>
+                </if>
+              </choose>
+              <text prefix=". " macro="collection" suffix="."/>
+              <text prefix=". " variable="note" suffix="."/>
+              <text prefix=". " macro="ISBN" suffix="."/>
+            </else-if>
+            <else>
+              <text prefix=" " macro="medium" suffix="."/>
+              <text prefix=". " macro="edition" suffix="."/>
+              <text prefix=". " macro="issued" suffix="."/>
+              <text prefix=". " macro="collection" suffix="."/>
+              <text prefix=". " variable="note" suffix="."/>
+              <text prefix=". " macro="ISBN" suffix="."/>
+            </else>
+          </choose>
+        </if>
+        <else-if type="chapter entry entry-dictionary entry-encyclopedia" match="any">
+          <text macro="contributors-full" suffix=". "/>
+          <text macro="title-long" suffix=". "/>
+          <text macro="container-full"/>
+          <choose>
+            <if variable="accessed DOI URL" match="any">
+              <text prefix=". " macro="edition"/>
+              <text prefix=". " macro="issued"/>
+              <text prefix=", sv. " variable="volume"/>
+              <text prefix=", s. " variable="page"/>
+              <text prefix=" " macro="quoted"/>
+              <text prefix=". " macro="collection" suffix="."/>
+              <text prefix=". " macro="ISBN" suffix="."/>
+              <text prefix=". " macro="identifier"/>
+            </if>
+            <else-if variable="issued" match="none">
+              <text prefix=". " macro="edition" suffix="."/>
+              <choose>
+                <if variable="publisher publisher-place" match="any">
+                  <text prefix=". " macro="publisher"/>
+                </if>
+              </choose>
+              <text prefix=". " macro="collection" suffix="."/>
+              <text prefix=". " variable="note" suffix="."/>
+              <text prefix=", sv. " variable="volume"/>
+              <text prefix=", s. " variable="page"/>
+              <text prefix=" " macro="quoted"/>
+              <text prefix=". " macro="collection" suffix="."/>
+              <text prefix=". " macro="ISBN" suffix="."/>
+            </else-if>
+            <else>
+              <text prefix=". " macro="edition"/>
+              <text prefix=". " macro="issued"/>
+              <text prefix=", sv. " variable="volume"/>
+              <text prefix=", s. " variable="page" suffix="."/>
+              <text prefix=". " macro="collection" suffix="."/>
+              <text prefix=". " macro="ISBN" suffix="."/>
+            </else>
+          </choose>
+        </else-if>
+        <else-if type="article-journal article-magazine article-newspaper webpage" match="any">
+          <text macro="contributors-full" suffix=". "/>
+          <text macro="title-long" suffix=". "/>
+          <text macro="container-full"/>
+          <text prefix=". " macro="issued"/>
+          <choose>
+            <if variable="accessed DOI URL" match="any">
+              <text prefix=", s. " variable="page"/>
+              <text prefix=" " macro="quoted"/>
+              <text prefix=". " variable="note" suffix="."/>
+              <text prefix=". " macro="ISSN" suffix="."/>
+              <text prefix=". " macro="identifier"/>
+            </if>
+            <else>
+              <text prefix=", s. " variable="page" suffix="."/>
+              <text prefix=". " variable="note" suffix="."/>
+              <text prefix=". " macro="ISSN" suffix="."/>
+            </else>
+          </choose>
+        </else-if>
+      </choose>
+    </layout>
+  </bibliography>
+</style>

--- a/iso690-full-note-cs.csl
+++ b/iso690-full-note-cs.csl
@@ -5,7 +5,10 @@
     <!--Informace o stylu:
       Styl vytvořil původně Pavel Vilhan pro slovenský ISO 690 (iso690-full-note-sk), ale upravil Oldrich Tristan Florian k použití v českém akademickém prostředí.
       Originally created by Pavel Vilhan for Slovak ISO 690 (iso690-full-note-sk). Edited by Oldrich Tristan Florian to match the Czech version. 
-      Problémem ISO 690 jako takového a stylů, které z něj vychází (například dosavadní citační směrnice Právnické fakulty MUNI) je v tom, že vyžadují místo vydání a vydavatelství i u odborných časopisů. Zotero však tuto možnost zatím (5.0) nepodporuje, jelikož se v ostatních relevantních stylech tento požadavek nenachází. -->
+      ČSN ISO 690 jako takový vyžaduje uvádět místo vydání a název nakladatelství i u článků v časopisech. V praxi toto není dodržováno, ani interpretace normy to nedoporučuje a Zotero (5.0) tyto kategorie u časopiseckých článků ani standardně nepodporuje.
+      Je však možnost tyto údaje v článcích uvést, a to pokud v kolonce extras uvedete: 
+      {:publisher: Jméno nakladatelství} 
+      {:publisher-place: Místo vydání} -->
     <!--UPOZORNENIA: 
       1. Pre zobrazovanie internetovej adresy pri citovaní elektronických periodík je nutné zapnúť túto funkciu v programe Zotero>Predvoľby>Citovanie>Štýly zaškrtnutím políčka dole.
       2. Zotero 5.0 zatiaľ nepodporuje zobrazenie rozsahu dátumov, napr. 1950 &#8211; 1975. Je však možné do Zotera zadať napr. 1950zzz1975 a pri finálnej úprave nahradiť "zzz" pomlčkou s medzerami: " &#8211; ".-->
@@ -180,7 +183,6 @@
         </choose>
       </if>
       <else-if type="article-journal article-magazine article-newspaper" match="any">
-        <text term="in" text-case="capitalize-first" suffix=" "/>
         <text variable="container-title" font-style="italic"/>
         <text prefix=" " macro="medium"/>
       </else-if>
@@ -203,7 +205,6 @@
         </choose>
       </if>
       <else-if type="article-journal article-magazine article-newspaper" match="any">
-        <text term="in" text-case="capitalize-first" suffix=" "/>
         <text variable="container-title" font-style="italic"/>
         <text prefix=" " macro="medium"/>
       </else-if>
@@ -405,7 +406,7 @@
                 </else>
               </choose>
             </else-if>
-            <else-if type="article-journal article-magazine article-newspaper webpage" match="any">
+            <else-if type="article-magazine article-newspaper webpage" match="any">
               <text macro="contributors-long" suffix=". "/>
               <text macro="title-long" suffix=". "/>
               <text macro="container"/>
@@ -418,6 +419,30 @@
                 </if>
                 <else>
                   <text prefix=". " macro="issued"/>
+                  <text prefix=", " macro="citation-locator" suffix="."/>
+                </else>
+              </choose>
+            </else-if>
+            <else-if type="article-journal" match="any">
+              <text macro="contributors-long" suffix=". "/>
+              <text macro="title-long" suffix=". "/>
+              <text macro="container"/>
+              <choose>
+                <if variable="publisher publisher-place" match="any">
+                  <text prefix=". " macro="publisher"/>
+                  <text prefix=", " macro="issued"/>
+                </if>
+                <else>
+                  <text prefix=". " macro="issued"/>
+                </else>
+              </choose>
+              <choose>
+                <if variable="accessed DOI URL" match="any">
+                  <text prefix=", " macro="citation-locator"/>
+                  <text prefix=" " macro="quoted"/>
+                  <text prefix=". " macro="identifier"/>
+                </if>
+                <else>
                   <text prefix=", " macro="citation-locator" suffix="."/>
                 </else>
               </choose>
@@ -510,11 +535,39 @@
             </else>
           </choose>
         </else-if>
-        <else-if type="article-journal article-magazine article-newspaper webpage" match="any">
+        <else-if type="article-magazine article-newspaper webpage" match="any">
           <text macro="contributors-full" suffix=". "/>
           <text macro="title-long" suffix=". "/>
           <text macro="container-full"/>
           <text prefix=". " macro="issued"/>
+          <choose>
+            <if variable="accessed DOI URL" match="any">
+              <text prefix=", s. " variable="page"/>
+              <text prefix=" " macro="quoted"/>
+              <text prefix=". " variable="note" suffix="."/>
+              <text prefix=". " macro="ISSN" suffix="."/>
+              <text prefix=". " macro="identifier"/>
+            </if>
+            <else>
+              <text prefix=", s. " variable="page" suffix="."/>
+              <text prefix=". " variable="note" suffix="."/>
+              <text prefix=". " macro="ISSN" suffix="."/>
+            </else>
+          </choose>
+        </else-if>
+        <else-if type="article-journal" match="any">
+          <text macro="contributors-full" suffix=". "/>
+          <text macro="title-long" suffix=". "/>
+          <text macro="container-full"/>
+          <choose>
+            <if variable="publisher publisher-place" match="any">
+              <text prefix=". " macro="publisher"/>
+              <text prefix=", " macro="issued"/>
+            </if>
+          <else>
+            <text prefix=". " macro="issued"/>
+          </else>
+          </choose>
           <choose>
             <if variable="accessed DOI URL" match="any">
               <text prefix=", s. " variable="page"/>

--- a/iso690-full-note-cs.csl
+++ b/iso690-full-note-cs.csl
@@ -2,9 +2,6 @@
 <style xmlns="http://purl.org/net/xbiblio/csl" version="1.0" class="note" demote-non-dropping-particle="sort-only" default-locale="cs-CZ">
   <info>
     <title>ISO-690 (full note, Czech)</title>
-    <!--Informace o stylu:
-      Styl vytvořil původně Pavel Vilhan pro slovenský ISO 690 (iso690-full-note-sk). Upravil Oldrich Tristan Florian k použití v českém akademickém prostředí.
-      Originally created by Pavel Vilhan for Slovak ISO 690 (iso690-full-note-sk). Edited by Oldrich Tristan Florian to match the Czech version. -->
     <!--UPOZORNĚNÍ: 
       1. ČSN ISO 690 jako takový vyžaduje uvádět místo vydání a název nakladatelství i u článků v časopisech. V praxi toto není dodržováno, ani interpretace normy to nedoporučuje a Zotero (5.0) tyto kategorie u časopiseckých článků ani standardně nepodporuje.
       Je však možnost tyto údaje v článcích uvést, a to pokud v kolonce extras uvedete: 
@@ -20,11 +17,7 @@
       <email>oldrich(dot)florian(at)gmail.com</email>
       <uri>http://otristan.com</uri>
     </author>
-    <author>
-      <name>Pavel Vilhan</name>
-      <email>Pavel(dot)Vilhan(at)frcth(dot)uniba(dot)sk</email>
-      <uri>http://www.kniznice.eu</uri>
-    </author>
+    <link href="http://www.zotero.org/styles/iso690-full-note-sk" rel="template"/>
     <category citation-format="note"/>
     <category field="law"/>
     <summary>Czech ISO-690, full note.</summary>

--- a/iso690-full-note-cs.csl
+++ b/iso690-full-note-cs.csl
@@ -8,16 +8,16 @@
       {:publisher: Jméno nakladatelství} 
       {:publisher-place: Místo vydání}
       2. Pro zobrazování internetové adresy při citování elektronických periodik je potřeba tuto funkci zapnout, a to v Zotero -> Předvolby (Preferences) -> Citování (Cite) -> Styly (Styles).
-      3. Zotero 5.0 zatím nepodporuje zobrazení rozsahu dvou dat vydání, např 1950 – 1975. Je však možné do Zotera zadat například 1950zzz1975 a při konečné úpravě vložit " – " namísto "zzz". (Rozsah by se sice měl podle Ústavu pro jazyk český uvádět s pomlčkou bez mezery, ale dokumentace jej zrovna u dat vydání uvádí s mezerou.)-->
+      3. Zotero 5.0 zatím nepodporuje zobrazení rozsahu dvou dat vydání, např 1950 &#8211; 1975. Je však možné do Zotera zadat například 1950zzz1975 a při konečné úpravě vložit " &#8211; " namísto "zzz". (Rozsah by se sice měl podle Ústavu pro jazyk český uvádět s pomlčkou bez mezery, ale dokumentace jej zrovna u dat vydání uvádí s mezerou.)-->
     <id>http://www.zotero.org/styles/iso690-full-note-cs</id>
     <link href="http://www.zotero.org/styles/iso690-full-note-cs" rel="self"/>
+    <link href="http://www.zotero.org/styles/iso690-full-note-sk" rel="template"/>
     <link href="https://www.citace.com/CSN-ISO-690.pdf" rel="documentation"/>
     <author>
       <name>Oldrich Tristan Florian</name>
       <email>oldrich(dot)florian(at)gmail.com</email>
       <uri>http://otristan.com</uri>
     </author>
-    <link href="http://www.zotero.org/styles/iso690-full-note-sk" rel="template"/>
     <category citation-format="note"/>
     <category field="law"/>
     <summary>Czech ISO-690, full note.</summary>
@@ -557,9 +557,9 @@
               <text prefix=". " macro="publisher"/>
               <text prefix=", " macro="issued"/>
             </if>
-          <else>
-            <text prefix=". " macro="issued"/>
-          </else>
+            <else>
+              <text prefix=". " macro="issued"/>
+            </else>
           </choose>
           <choose>
             <if variable="accessed DOI URL" match="any">

--- a/iso690-full-note-cs.csl
+++ b/iso690-full-note-cs.csl
@@ -3,18 +3,18 @@
   <info>
     <title>ISO-690 (full note, Czech)</title>
     <!--Informace o stylu:
-      Styl vytvořil původně Pavel Vilhan pro slovenský ISO 690 (iso690-full-note-sk), ale upravil Oldrich Tristan Florian k použití v českém akademickém prostředí.
-      Originally created by Pavel Vilhan for Slovak ISO 690 (iso690-full-note-sk). Edited by Oldrich Tristan Florian to match the Czech version. 
-      ČSN ISO 690 jako takový vyžaduje uvádět místo vydání a název nakladatelství i u článků v časopisech. V praxi toto není dodržováno, ani interpretace normy to nedoporučuje a Zotero (5.0) tyto kategorie u časopiseckých článků ani standardně nepodporuje.
+      Styl vytvořil původně Pavel Vilhan pro slovenský ISO 690 (iso690-full-note-sk). Upravil Oldrich Tristan Florian k použití v českém akademickém prostředí.
+      Originally created by Pavel Vilhan for Slovak ISO 690 (iso690-full-note-sk). Edited by Oldrich Tristan Florian to match the Czech version. -->
+    <!--UPOZORNĚNÍ: 
+      1. ČSN ISO 690 jako takový vyžaduje uvádět místo vydání a název nakladatelství i u článků v časopisech. V praxi toto není dodržováno, ani interpretace normy to nedoporučuje a Zotero (5.0) tyto kategorie u časopiseckých článků ani standardně nepodporuje.
       Je však možnost tyto údaje v článcích uvést, a to pokud v kolonce extras uvedete: 
       {:publisher: Jméno nakladatelství} 
-      {:publisher-place: Místo vydání} -->
-    <!--UPOZORNENIA: 
-      1. Pre zobrazovanie internetovej adresy pri citovaní elektronických periodík je nutné zapnúť túto funkciu v programe Zotero>Predvoľby>Citovanie>Štýly zaškrtnutím políčka dole.
-      2. Zotero 5.0 zatiaľ nepodporuje zobrazenie rozsahu dátumov, napr. 1950 &#8211; 1975. Je však možné do Zotera zadať napr. 1950zzz1975 a pri finálnej úprave nahradiť "zzz" pomlčkou s medzerami: " &#8211; ".-->
+      {:publisher-place: Místo vydání}
+      2. Pro zobrazování internetové adresy při citování elektronických periodik je potřeba tuto funkci zapnout, a to v Zotero -> Předvolby (Preferences) -> Citování (Cite) -> Styly (Styles).
+      3. Zotero 5.0 zatím nepodporuje zobrazení rozsahu dvou dat vydání, např 1950 – 1975. Je však možné do Zotera zadat například 1950zzz1975 a při konečné úpravě vložit " – " namísto "zzz". (Rozsah by se sice měl podle Ústavu pro jazyk český uvádět s pomlčkou bez mezery, ale dokumentace jej zrovna u dat vydání uvádí s mezerou.)-->
     <id>http://www.zotero.org/styles/iso690-full-note-cs</id>
     <link href="http://www.zotero.org/styles/iso690-full-note-cs" rel="self"/>
-    <link href="" rel="documentation"/>
+    <link href="https://www.citace.com/CSN-ISO-690.pdf" rel="documentation"/>
     <author>
       <name>Oldrich Tristan Florian</name>
       <email>oldrich(dot)florian(at)gmail.com</email>
@@ -27,8 +27,8 @@
     </author>
     <category citation-format="note"/>
     <category field="law"/>
-    <summary>Czech ISO-690 with full note.</summary>
-    <updated>2019-11-12T16:03:24+00:00</updated>
+    <summary>Czech ISO-690, full note.</summary>
+    <updated>2019-11-21T16:03:24+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale xml:lang="cs">


### PR DESCRIPTION
I edited the Slovak full-note ISO-690 (iso690-full-note-sk) to create a CSL for the Czech version of the style (ČSN ISO-690). The full-note ČSN ISO-690 style is commonly used by Czech legal journals, so that's the reason why I changed the category to law.