### PR TITLE
removed spaces in harvard-gesellschaft-fur-bildung-und-forschung-in-e…

### DIFF
--- a/harvard-gesellschaft-fur-bildung-und-forschung-in-europa.csl
+++ b/harvard-gesellschaft-fur-bildung-und-forschung-in-europa.csl
@@ -30,10 +30,8 @@
         <multiple>Seiten</multiple>
       </term>
       <term name="page" form="short">S.</term>
-      <term name="editor">Herausgeber													<!--  HERAUSGEBER -->
-    </term>
-      <term name="editor" form="short">Hg.										<!--  HERAUSGEBER KURZ -->
-    </term>
+      <term name="editor">Herausgeber</term>
+      <term name="editor" form="short">Hg.</term>
       <term name="edition">
         <!--  AUFLAGE -->
         <single>Auflage</single>


### PR DESCRIPTION
## 🐞 Description

In the current version of harvard-gesellschaft-fur-bildung-und-forschung-in-europa.csl there are several tab characters and a line break after the constant "Hg.". Therefore the result of using this style looks like this:

## 🔥 Output

~~~~
HIS Hannover (Hg.
) 1919. Auswirkungen von hochschulfremden Publikationen auf Auswertungen.
~~~~

or 

~~~~
HIS Hannover (Hg.     ) 1919. Auswirkungen von hochschulfremden Publikationen auf Auswertungen.
~~~~

## 📝 Cause

The issue is caused by a comment in the csl file that was indented with tab characters and is followed by a new line within the &lt;term&gt; tag. 

This PR removes the additional whitespaces