### PR TITLE
Title case titles in mcgill-en.csl

### DIFF
--- a/mcgill-en.csl
+++ b/mcgill-en.csl
@@ -17,9 +17,13 @@
       <email>f.martin-bariteau@umontreal.ca</email>
       <uri>http://f-mb.github.io/cslegal/</uri>
     </contributor>
+    <contributor>
+      <name>William O'Hanley</name>
+      <email>me@wohanley.com</email>
+    </contributor>
     <category citation-format="note"/>
     <category field="law"/>
-    <updated>2014-06-28T19:23:00+00:00</updated>
+    <updated>2019-12-01T22:49:53+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale xml:lang="en">
@@ -143,7 +147,7 @@
 all the other tests should have been done... -->
   <macro name="render-chapter">
     <group delimiter=" ">
-      <text variable="title" quotes="true"/>
+      <text variable="title" quotes="true" text-case="title"/>
       <text term="in" form="short"/>
       <text macro="editor" strip-periods="true" suffix=","/>
       <text macro="container-title" font-style="italic"/>
@@ -155,7 +159,7 @@ all the other tests should have been done... -->
   </macro>
   <macro name="render-article-journal">
     <group delimiter=" ">
-      <text variable="title" quotes="true"/>
+      <text variable="title" quotes="true" text-case="title"/>
       <date form="text" variable="issued" date-parts="year" prefix="(" suffix=")"/>
       <group delimiter=":">
         <text variable="volume"/>
@@ -168,7 +172,7 @@ all the other tests should have been done... -->
   </macro>
   <macro name="render-book">
     <group delimiter=", ">
-      <text variable="title" font-style="italic"/>
+      <text variable="title" font-style="italic" text-case="title"/>
       <text macro="edition"/>
       <text macro="translator"/>
       <text macro="editor"/>
@@ -178,7 +182,7 @@ all the other tests should have been done... -->
   </macro>
   <macro name="render-report">
     <group delimiter=", ">
-      <text variable="title" font-style="italic"/>
+      <text variable="title" font-style="italic" text-case="title"/>
       <group delimiter=" ">
         <text variable="collection-title" strip-periods="true"/>
         <text macro="genre"/>
@@ -189,7 +193,7 @@ all the other tests should have been done... -->
   </macro>
   <macro name="render-thesis">
     <group delimiter=" ">
-      <text variable="title" font-style="italic"/>
+      <text variable="title" font-style="italic" text-case="title"/>
       <text macro="genre" prefix="(" suffix=","/>
       <text variable="publisher" suffix=","/>
       <date form="text" variable="issued" date-parts="year" suffix=") [unpublished]"/>
@@ -197,7 +201,7 @@ all the other tests should have been done... -->
   </macro>
   <macro name="render-article-newspaper">
     <group delimiter=" ">
-      <text variable="title" quotes="true" suffix=","/>
+      <text variable="title" quotes="true" suffix="," text-case="title"/>
       <text macro="container-title" font-style="italic"/>
       <text macro="issued-long" prefix="(" suffix=")"/>
       <text variable="page-first"/>
@@ -206,7 +210,7 @@ all the other tests should have been done... -->
   </macro>
   <macro name="render-article-magazine">
     <group delimiter=" ">
-      <text variable="title" quotes="true" suffix=","/>
+      <text variable="title" quotes="true" suffix="," text-case="title"/>
       <text macro="container-title" font-style="italic"/>
       <text macro="issued-long" prefix="(" suffix=")"/>
       <text variable="page-first"/>


### PR DESCRIPTION
I've been following the [convention](https://citationstyles.org/authors/#/titles-in-sentence-and-title-case) of storing titles in sentence case so that they can be converted when necessary. The McGill Guide says to print titles as they appear on the documents in question, enforcing neither title case nor sentence case. The result is that titles come out in sentence case, which is not how titles appear on most English documents. This pull request enforces title case instead, which is also not correct but is generally much closer for those following the convention.

I think this is probably not a good way to address this problem. I include the code changes only because I made them already for my own convenience and they make it clear what I mean - they probably shouldn't be merged. I would prefer to update the documentation that recommends the "store in sentence case" convention to make it clear that it will cause problems with styles like McGill that don't enforce any specific casing. I'm not sure how to propose such a change, and these changes might be useful as a band-aid, so here I am. If someone with more knowledge about this project knows how I ought to proceed and could give me some advice, I would appreciate it!