### PR TITLE
Update queen-margaret-university-harvard.csl

### DIFF
--- a/queen-margaret-university-harvard.csl
+++ b/queen-margaret-university-harvard.csl
@@ -58,7 +58,7 @@
     <choose>
       <if type="motion_picture broadcast" match="none">
         <names variable="author">
-          <name font-variant="normal" and="text" initialize-with="." name-as-sort-order="all">
+          <name and="text" initialize-with="." name-as-sort-order="all">
             <name-part name="given" text-case="capitalize-all"/>
             <name-part name="family" text-case="capitalize-all"/>
           </name>
@@ -308,7 +308,7 @@
       </group>
     </layout>
   </citation>
-  <bibliography hanging-indent="true" entry-spacing="0" line-spacing="1">
+  <bibliography entry-spacing="0" line-spacing="1">
     <sort>
       <key macro="author"/>
       <key macro="issued" sort="ascending"/>

--- a/queen-margaret-university-harvard.csl
+++ b/queen-margaret-university-harvard.csl
@@ -59,8 +59,8 @@
       <if type="motion_picture broadcast" match="none">
         <names variable="author">
           <name and="text" initialize-with="." name-as-sort-order="all">
-            <name-part name="given" text-case="capitalize-all"/>
-            <name-part name="family" text-case="capitalize-all"/>
+            <name-part name="given" text-case="uppercase"/>
+            <name-part name="family" text-case="uppercase"/>
           </name>
           <label form="short" prefix=", "/>
           <substitute>


### PR DESCRIPTION
via https://forums.zotero.org/discussion/comment/344702/#Comment_344702
Not sure why the author names in the bibliography (author macro) are not in all caps. I thought that was just not shown in the editor due to a bug, but it seems not to show it.