### PR TITLE
Create materials-express.csl

### DIFF
--- a/materials-express.csl
+++ b/materials-express.csl
@@ -1,0 +1,177 @@
+<?xml version="1.0" encoding="utf-8"?>
+<style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" demote-non-dropping-particle="sort-only" default-locale="en-US">
+  <info>
+    <title>Materials Express</title>
+    <id>http://www.zotero.org/styles/materials-express</id>
+    <link href="http://www.zotero.org/styles/materials-express" rel="self"/>
+    <link href="http://www.zotero.org/styles/journal-of-materials-research" rel="template"/>
+    <link href="http://www.aspbs.com/mex/inst-auth_mex.htm" rel="documentation"/>
+    <author>
+      <name>Patrick O'Brien</name>
+    </author>
+    <category citation-format="numeric"/>
+    <category field="physics"/>
+    <issn>2158-5849</issn>
+    <eissn>2158-5857</eissn>
+    <updated>2019-12-11T13:04:24+00:00</updated>
+    <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
+  </info>
+  <macro name="author">
+    <names variable="author">
+      <name delimiter=", " initialize-with=". " and="text"/>
+      <label prefix=", "/>
+      <substitute>
+        <names variable="editor"/>
+        <names variable="translator"/>
+      </substitute>
+    </names>
+  </macro>
+  <macro name="editor">
+    <names variable="editor">
+      <label form="verb" suffix=" "/>
+      <name delimiter=", " initialize-with=". " and="text"/>
+    </names>
+  </macro>
+  <macro name="year-date">
+    <choose>
+      <if variable="issued">
+        <date variable="issued">
+          <date-part name="year"/>
+        </date>
+      </if>
+      <else>
+        <text term="no date" form="short"/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="day-date">
+    <choose>
+      <if variable="issued">
+        <date variable="issued">
+          <date-part name="day" suffix=" "/>
+          <date-part name="month" form="long" suffix=" "/>
+          <date-part name="year"/>
+        </date>
+      </if>
+      <else>
+        <text term="no date" form="short"/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="publisher">
+    <group delimiter=", ">
+      <text variable="publisher"/>
+      <text variable="publisher-place" text-case="title"/>
+    </group>
+  </macro>
+  <macro name="edition">
+    <choose>
+      <if is-numeric="edition">
+        <group delimiter=" ">
+          <number variable="edition" form="ordinal"/>
+          <text term="edition" form="short"/>
+        </group>
+      </if>
+      <else>
+        <text variable="edition"/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="title">
+    <choose>
+      <if type="bill book graphic legal_case legislation motion_picture song" match="any">
+        <text variable="title" font-style="italic"/>
+      </if>
+      <else>
+        <text variable="title"/>
+      </else>
+    </choose>
+  </macro>
+  <citation collapse="citation-number">
+    <sort>
+      <key variable="citation-number"/>
+    </sort>
+    <layout vertical-align="sup" delimiter="," prefix="(" suffix=")">
+      <text variable="citation-number"/>
+    </layout>
+  </citation>
+  <bibliography entry-spacing="0" second-field-align="flush">
+    <layout suffix=".">
+      <text variable="citation-number" font-weight="bold" suffix="."/>
+      <text macro="author" suffix="; "/>
+      <choose>
+        <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
+          <group delimiter=" ">
+            <group delimiter=", ">
+              <text macro="title" text-case="title"/>
+              <text macro="edition"/>
+            </group>
+            <group delimiter=", ">
+              <text macro="publisher"/>
+              <group delimiter=" ">
+                <label variable="page" form="short"/>
+                <text variable="page"/>
+              </group>
+            </group>
+          </group>
+        </if>
+        <else-if type="chapter paper-conference" match="any">
+          <group delimiter=" ">
+            <text term="in"/>
+            <group delimiter=", ">
+              <text variable="container-title" form="short" text-case="title" font-style="italic"/>
+              <text macro="editor"/>
+              <text macro="edition"/>
+            </group>
+            <group delimiter=", ">
+              <text macro="publisher"/>
+              <group delimiter=" ">
+                <label variable="page" form="short"/>
+                <text variable="page"/>
+              </group>
+            </group>
+          </group>
+        </else-if>
+        <else-if type="patent">
+          <group delimiter=" ">
+            <text variable="number"/>
+            <text macro="day-date" prefix="(" suffix=")"/>
+          </group>
+        </else-if>
+        <else-if type="thesis">
+          <group delimiter=", ">
+            <text variable="title" text-case="title"/>
+            <text variable="genre"/>
+            <text variable="publisher"/>
+            <text macro="year-date"/>
+          </group>
+        </else-if>
+        <else-if type="article-journal review" match="any">
+          <group delimiter="; ">
+            <text macro="title"/>
+            <group delimiter=" ">
+              <text variable="container-title" form="short" font-style="italic"/>
+              <group delimiter=", ">
+                <text variable="volume" font-weight="normal"/>
+                <text variable="page-first"/>
+              </group>
+              <text macro="year-date" font-weight="bold" prefix="(" suffix=")"/>
+            </group>
+          </group>
+        </else-if>
+        <else>
+          <group delimiter=" ">
+            <text variable="container-title" font-style="italic" form="short" text-case="title"/>
+            <group delimiter=", ">
+              <text variable="volume" font-weight="bold"/>
+              <group delimiter=" ">
+                <text variable="page-first" form="short"/>
+                <text macro="year-date" prefix="(" suffix=")"/>
+              </group>
+            </group>
+          </group>
+        </else>
+      </choose>
+    </layout>
+  </bibliography>
+</style>

--- a/materials-express.csl
+++ b/materials-express.csl
@@ -13,7 +13,7 @@
     <category field="physics"/>
     <issn>2158-5849</issn>
     <eissn>2158-5857</eissn>
-    <updated>2019-12-11T13:04:24+00:00</updated>
+    <updated>2019-12-16T09:54:44+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <macro name="author">
@@ -59,10 +59,7 @@
     </choose>
   </macro>
   <macro name="publisher">
-    <group delimiter=", ">
-      <text variable="publisher"/>
-      <text variable="publisher-place" text-case="title"/>
-    </group>
+    <text variable="publisher"/>
   </macro>
   <macro name="edition">
     <choose>
@@ -87,21 +84,30 @@
       </else>
     </choose>
   </macro>
+  <macro name="pages">
+    <group delimiter=" ">
+      <label variable="page" form="short"/>
+      <text variable="page"/>
+    </group>
+  </macro>
   <citation collapse="citation-number">
     <sort>
       <key variable="citation-number"/>
     </sort>
-    <layout vertical-align="sup" delimiter="," prefix="(" suffix=")">
+    <layout vertical-align="baseline" delimiter="," prefix="[" suffix="]">
       <text variable="citation-number"/>
     </layout>
   </citation>
-  <bibliography entry-spacing="0" second-field-align="flush">
+  <bibliography delimiter-precedes-last="never" second-field-align="flush" entry-spacing="0">
     <layout suffix=".">
       <text variable="citation-number" font-weight="bold" suffix="."/>
-      <text macro="author" suffix="; "/>
+      <group delimiter=", ">
+        <text macro="author"/>
+        <text macro="year-date" font-weight="bold" suffix=". "/>
+      </group>
       <choose>
         <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
-          <group delimiter=" ">
+          <group delimiter=". ">
             <group delimiter=", ">
               <text macro="title" text-case="title"/>
               <text macro="edition"/>
@@ -116,19 +122,18 @@
           </group>
         </if>
         <else-if type="chapter paper-conference" match="any">
-          <group delimiter=" ">
-            <text term="in"/>
-            <group delimiter=", ">
-              <text variable="container-title" form="short" text-case="title" font-style="italic"/>
-              <text macro="editor"/>
-              <text macro="edition"/>
+          <group delimiter=", ">
+            <group delimiter=" ">
+              <text term="in"/>
+              <group delimiter=", ">
+                <text variable="container-title" form="short" text-case="title" font-style="italic"/>
+                <text macro="editor"/>
+                <text macro="edition"/>
+              </group>
             </group>
             <group delimiter=", ">
               <text macro="publisher"/>
-              <group delimiter=" ">
-                <label variable="page" form="short"/>
-                <text variable="page"/>
-              </group>
+              <text macro="pages"/>
             </group>
           </group>
         </else-if>
@@ -143,19 +148,18 @@
             <text variable="title" text-case="title"/>
             <text variable="genre"/>
             <text variable="publisher"/>
-            <text macro="year-date"/>
           </group>
         </else-if>
         <else-if type="article-journal review" match="any">
-          <group delimiter="; ">
+          <group delimiter=". ">
             <text macro="title"/>
-            <group delimiter=" ">
-              <text variable="container-title" form="short" font-style="italic"/>
-              <group delimiter=", ">
-                <text variable="volume" font-weight="normal"/>
-                <text variable="page-first"/>
+            <group delimiter=", ">
+              <text variable="container-title" font-style="italic"/>
+              <group>
+                <text variable="volume" font-style="italic" font-weight="normal"/>
+                <text variable="issue" prefix="(" suffix=")"/>
               </group>
-              <text macro="year-date" font-weight="bold" prefix="(" suffix=")"/>
+              <text macro="pages"/>
             </group>
           </group>
         </else-if>


### PR DESCRIPTION
via https://forums.zotero.org/discussion/80461/style-request-materials-express-harvard-referencing

Style does not follow guidelines. It's certainly a numeric style (and not an author-date style). Formatting in various papers checked, but it's all over the place.
https://scholar.google.es/scholar?hl=en&as_sdt=0%2C5&q=%22Materials+Express%22+-optical+2019&btnG=