### PR TITLE
Update kidney-international.csl

### DIFF
--- a/kidney-international.csl
+++ b/kidney-international.csl
@@ -17,7 +17,7 @@
     <category field="medicine"/>
     <issn>0085-2538</issn>
     <eissn>1523-1755</eissn>
-    <updated>2012-09-27T22:06:38+00:00</updated>
+    <updated>2014-08-28T01:36:46+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <macro name="editor">
@@ -29,8 +29,7 @@
   <macro name="author">
     <group suffix=".">
       <names variable="author">
-        <name name-as-sort-order="all" sort-separator=" " initialize-with="" delimiter=", " delimiter-precedes-last="always" delimiter-precedes-et-al="never"/>
-        <et-al font-style="italic"/>
+        <name name-as-sort-order="all" sort-separator=" " initialize-with="" delimiter=", " delimiter-precedes-last="always" delimiter-precedes-et-al="always"/>
         <label form="short" prefix=" " strip-periods="true"/>
         <substitute>
           <names variable="editor"/>
@@ -76,7 +75,7 @@
       <text variable="citation-number"/>
     </layout>
   </citation>
-  <bibliography hanging-indent="false" et-al-min="4" et-al-use-first="3">
+  <bibliography hanging-indent="true" et-al-min="4" et-al-use-first="3">
     <layout>
       <text variable="citation-number" suffix=". "/>
       <text macro="author"/>
@@ -154,16 +153,16 @@
         <else>
           <text macro="editor" prefix=" " suffix="."/>
           <group prefix=" " suffix=".">
-            <text variable="container-title" font-style="italic" form="short"/>
+            <text variable="container-title" strip-periods="true" suffix="." font-style="italic" form="short"/>
             <group delimiter=";" prefix=" ">
               <date variable="issued">
                 <date-part name="year"/>
               </date>
               <group>
-                <text variable="volume" font-weight="bold" prefix=" "/>
+                <text variable="volume"  prefix=""/>
               </group>
             </group>
-            <text variable="page" prefix=": "/>
+            <text variable="page" prefix=":"/>
           </group>
         </else>
       </choose>


### PR DESCRIPTION
Updated to match bibliography style of recent Kidney International papers (as per pdf versions of articles). 

Changes made to original Kidney International format are:
- Stripped full stops (periods) in abbreviated journal titles
- Full stop added after journal title.
- Volume number no longer bold
- "et al" no longer italicised
- Comma delimiter added before "et al"
- Space between year, volume and page numbers removed
- Hanging indents added