### PR TITLE
APA: Use "et al." in Dutch

### DIFF
--- a/apa-6th-edition.csl
+++ b/apa-6th-edition.csl
@@ -41,9 +41,17 @@
         <multiple>eds. &amp; trans.</multiple>
       </term>
       <term name="translator" form="short">trans.</term>
-      <term name="interviewer" form="short">interviewer</term>
+      <term name="interviewer" form="short">
+        <single>interviewer</single>
+        <multiple>interviewers</multiple>
+      </term>
+      <term name="collection-editor" form="short">
+        <single>series ed.</single>
+        <multiple>series eds.</multiple>
+      </term>
       <term name="circa" form="short">ca.</term>
-      <term name="collection-editor" form="short">series ed.</term>
+      <term name="bc"> B.C.E.</term>
+      <term name="ad"> C.E.</term>
     </terms>
   </locale>
   <locale xml:lang="es">
@@ -62,6 +70,11 @@
     </terms>
   </locale>
   <locale xml:lang="nn">
+    <terms>
+      <term name="et-al">et al.</term>
+    </terms>
+  </locale>
+  <locale xml:lang="nl">
     <terms>
       <term name="et-al">et al.</term>
     </terms>

--- a/apa-annotated-bibliography.csl
+++ b/apa-annotated-bibliography.csl
@@ -63,6 +63,11 @@
       <term name="et-al">et al.</term>
     </terms>
   </locale>
+  <locale xml:lang="nl">
+    <terms>
+      <term name="et-al">et al.</term>
+    </terms>
+  </locale>
   <locale xml:lang="nn">
     <terms>
       <term name="et-al">et al.</term>

--- a/apa-cv.csl
+++ b/apa-cv.csl
@@ -63,6 +63,11 @@
       <term name="et-al">et al.</term>
     </terms>
   </locale>
+  <locale xml:lang="nl">
+    <terms>
+      <term name="et-al">et al.</term>
+    </terms>
+  </locale>
   <locale xml:lang="nn">
     <terms>
       <term name="et-al">et al.</term>

--- a/apa-no-ampersand.csl
+++ b/apa-no-ampersand.csl
@@ -63,6 +63,11 @@
       <term name="et-al">et al.</term>
     </terms>
   </locale>
+  <locale xml:lang="nl">
+    <terms>
+      <term name="et-al">et al.</term>
+    </terms>
+  </locale>
   <locale xml:lang="nn">
     <terms>
       <term name="et-al">et al.</term>

--- a/apa-no-doi-no-issue.csl
+++ b/apa-no-doi-no-issue.csl
@@ -42,9 +42,17 @@
         <multiple>eds. &amp; trans.</multiple>
       </term>
       <term name="translator" form="short">trans.</term>
-      <term name="interviewer" form="short">interviewer</term>
+      <term name="interviewer" form="short">
+        <single>interviewer</single>
+        <multiple>interviewers</multiple>
+      </term>
+      <term name="collection-editor" form="short">
+        <single>series ed.</single>
+        <multiple>series eds.</multiple>
+      </term>
       <term name="circa" form="short">ca.</term>
-      <term name="collection-editor" form="short">series ed.</term>
+      <term name="bc"> B.C.E.</term>
+      <term name="ad"> C.E.</term>
     </terms>
   </locale>
   <locale xml:lang="es">
@@ -63,6 +71,11 @@
     </terms>
   </locale>
   <locale xml:lang="nn">
+    <terms>
+      <term name="et-al">et al.</term>
+    </terms>
+  </locale>
+  <locale xml:lang="nl">
     <terms>
       <term name="et-al">et al.</term>
     </terms>

--- a/apa-old-doi-prefix.csl
+++ b/apa-old-doi-prefix.csl
@@ -42,9 +42,17 @@
         <multiple>eds. &amp; trans.</multiple>
       </term>
       <term name="translator" form="short">trans.</term>
-      <term name="interviewer" form="short">interviewer</term>
+      <term name="interviewer" form="short">
+        <single>interviewer</single>
+        <multiple>interviewers</multiple>
+      </term>
+      <term name="collection-editor" form="short">
+        <single>series ed.</single>
+        <multiple>series eds.</multiple>
+      </term>
       <term name="circa" form="short">ca.</term>
-      <term name="collection-editor" form="short">series ed.</term>
+      <term name="bc"> B.C.E.</term>
+      <term name="ad"> C.E.</term>
     </terms>
   </locale>
   <locale xml:lang="es">
@@ -63,6 +71,11 @@
     </terms>
   </locale>
   <locale xml:lang="nn">
+    <terms>
+      <term name="et-al">et al.</term>
+    </terms>
+  </locale>
+  <locale xml:lang="nl">
     <terms>
       <term name="et-al">et al.</term>
     </terms>

--- a/apa-single-spaced.csl
+++ b/apa-single-spaced.csl
@@ -63,6 +63,11 @@
       <term name="et-al">et al.</term>
     </terms>
   </locale>
+  <locale xml:lang="nl">
+    <terms>
+      <term name="et-al">et al.</term>
+    </terms>
+  </locale>
   <locale xml:lang="nn">
     <terms>
       <term name="et-al">et al.</term>

--- a/apa.csl
+++ b/apa.csl
@@ -63,6 +63,11 @@
       <term name="et-al">et al.</term>
     </terms>
   </locale>
+  <locale xml:lang="nl">
+    <terms>
+      <term name="et-al">et al.</term>
+    </terms>
+  </locale>
   <locale xml:lang="nn">
     <terms>
       <term name="et-al">et al.</term>


### PR DESCRIPTION
Also clean up the 6th edition locales a bit.

https://forums.zotero.org/discussion/80710/abriviation-of-et-alli#latest

Psychology journals currently publishing in Dutch seem mostly to use "et al." (e.g., https://dspace.library.uu.nl/bitstream/handle/1874/378701/GO_32_1_1.pdf?sequence=1), and several of the universities require Dutch-language theses to use "et al.".