### PR TITLE
Update weed-research.csl

### DIFF
--- a/weed-research.csl
+++ b/weed-research.csl
@@ -56,7 +56,7 @@
   </macro>
   <macro name="author-short">
     <names variable="author">
-      <name form="short" and="text" delimiter=", " initialize-with=". "/>
+      <name form="short" and="symbol" delimiter=", " initialize-with=". "/>
       <et-al font-style="italic"/>
       <substitute>
         <names variable="editor"/>


### PR DESCRIPTION
According to current Weed Research citation style, in in-text citations two authors should be separated by "&" and not by "and".