### PR TITLE
Chicago fixes & add no-ibid variant

### DIFF
--- a/chicago-annotated-bibliography.csl
+++ b/chicago-annotated-bibliography.csl
@@ -516,10 +516,10 @@
       <if type="article-journal">
         <group delimiter=", ">
           <text macro="collection-title-journal"/>
-          <number variable="volume"/>
+          <text variable="volume"/>
           <group delimiter=" ">
             <text term="issue" form="short"/>
-            <number variable="issue"/>
+            <text variable="issue"/>
           </group>
         </group>
       </if>
@@ -637,10 +637,10 @@
       <if type="article-journal">
         <group delimiter=", ">
           <text macro="collection-title-journal"/>
-          <number variable="volume"/>
+          <text variable="volume"/>
           <group delimiter=" ">
             <text term="issue" form="short"/>
-            <number variable="issue"/>
+            <text variable="issue"/>
           </group>
         </group>
       </if>
@@ -837,7 +837,7 @@
         <choose>
           <if locator="page">
             <group delimiter=":">
-              <number variable="volume"/>
+              <text variable="volume"/>
               <text variable="locator"/>
             </group>
           </if>
@@ -955,7 +955,7 @@
           <else>
             <choose>
               <if variable="page">
-                <number variable="volume" suffix=":"/>
+                <text variable="volume" suffix=":"/>
                 <text variable="page"/>
               </if>
             </choose>
@@ -1041,10 +1041,9 @@
   </macro>
   <macro name="issue-note-join-with-comma">
     <choose>
-      <if type="graphic map" match="any"/>
-      <else-if type="article-journal bill legislation legal_case manuscript thesis" variable="event-place publisher-place publisher" match="none">
+      <if type="article-journal bill legislation legal_case manuscript speech thesis" variable="publisher-place publisher" match="none">
         <text macro="issue-note"/>
-      </else-if>
+      </if>
       <else-if type="article-newspaper">
         <text macro="issue-note"/>
       </else-if>
@@ -1094,6 +1093,8 @@
               <text variable="genre"/>
             </if>
           </choose>
+          <text variable="event"/>
+          <text variable="event-place"/>
           <text variable="publisher"/>
           <text macro="issued"/>
         </group>

--- a/chicago-fullnote-bibliography-short-title-subsequent.csl
+++ b/chicago-fullnote-bibliography-short-title-subsequent.csl
@@ -2,9 +2,9 @@
 <style xmlns="http://purl.org/net/xbiblio/csl" class="note" version="1.0" demote-non-dropping-particle="display-and-sort" page-range-format="chicago">
   <info>
     <title>Chicago Manual of Style 17th edition (full note, short title subsequent)</title>
-    <id>http://www.zotero.org/styles/chicago-fullnote-short-title-subsequent</id>
-    <link href="http://www.zotero.org/styles/chicago-fullnote-short-title-subsequent" rel="self"/>
-		<link href="http://www.zotero.org/styles/chicago-fullnote-bibliography" rel="template"/>
+    <id>http://www.zotero.org/styles/chicago-fullnote-bibliography-short-title-subsequent</id>
+    <link href="http://www.zotero.org/styles/chicago-fullnote-bibliography-short-title-subsequent" rel="self"/>
+    <link href="http://www.zotero.org/styles/chicago-fullnote-bibliography" rel="template"/>
     <link href="http://www.chicagomanualofstyle.org/tools_citationguide.html" rel="documentation"/>
     <author>
       <name>Julian Onions</name>
@@ -32,7 +32,7 @@
     <category citation-format="note"/>
     <category field="generic-base"/>
     <summary>Chicago format with full notes and bibliography</summary>
-    <updated>2017-10-12T12:00:00+00:00</updated>
+    <updated>2020-01-12T12:00:00+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale xml:lang="en">
@@ -1094,7 +1094,7 @@
               <text variable="genre"/>
             </if>
           </choose>
-	        <text variable="event"/>
+          <text variable="event"/>
           <text variable="event-place"/>
           <text variable="publisher"/>
           <text macro="issued"/>

--- a/chicago-fullnote-bibliography-with-ibid.csl
+++ b/chicago-fullnote-bibliography-with-ibid.csl
@@ -516,10 +516,10 @@
       <if type="article-journal">
         <group delimiter=", ">
           <text macro="collection-title-journal"/>
-          <number variable="volume"/>
+          <text variable="volume"/>
           <group delimiter=" ">
             <text term="issue" form="short"/>
-            <number variable="issue"/>
+            <text variable="issue"/>
           </group>
         </group>
       </if>
@@ -637,10 +637,10 @@
       <if type="article-journal">
         <group delimiter=", ">
           <text macro="collection-title-journal"/>
-          <number variable="volume"/>
+          <text variable="volume"/>
           <group delimiter=" ">
             <text term="issue" form="short"/>
-            <number variable="issue"/>
+            <text variable="issue"/>
           </group>
         </group>
       </if>
@@ -837,7 +837,7 @@
         <choose>
           <if locator="page">
             <group delimiter=":">
-              <number variable="volume"/>
+              <text variable="volume"/>
               <text variable="locator"/>
             </group>
           </if>
@@ -955,7 +955,7 @@
           <else>
             <choose>
               <if variable="page">
-                <number variable="volume" suffix=":"/>
+                <text variable="volume" suffix=":"/>
                 <text variable="page"/>
               </if>
             </choose>
@@ -1041,10 +1041,9 @@
   </macro>
   <macro name="issue-note-join-with-comma">
     <choose>
-      <if type="graphic map" match="any"/>
-      <else-if type="article-journal bill legislation legal_case manuscript thesis" variable="event-place publisher-place publisher" match="none">
+      <if type="article-journal bill legislation legal_case manuscript speech thesis" variable="publisher-place publisher" match="none">
         <text macro="issue-note"/>
-      </else-if>
+      </if>
       <else-if type="article-newspaper">
         <text macro="issue-note"/>
       </else-if>
@@ -1094,6 +1093,8 @@
               <text variable="genre"/>
             </if>
           </choose>
+          <text variable="event"/>
+          <text variable="event-place"/>
           <text variable="publisher"/>
           <text macro="issued"/>
         </group>

--- a/chicago-fullnote-bibliography.csl
+++ b/chicago-fullnote-bibliography.csl
@@ -516,10 +516,10 @@
       <if type="article-journal">
         <group delimiter=", ">
           <text macro="collection-title-journal"/>
-          <number variable="volume"/>
+          <text variable="volume"/>
           <group delimiter=" ">
             <text term="issue" form="short"/>
-            <number variable="issue"/>
+            <text variable="issue"/>
           </group>
         </group>
       </if>
@@ -637,10 +637,10 @@
       <if type="article-journal">
         <group delimiter=", ">
           <text macro="collection-title-journal"/>
-          <number variable="volume"/>
+          <text variable="volume"/>
           <group delimiter=" ">
             <text term="issue" form="short"/>
-            <number variable="issue"/>
+            <text variable="issue"/>
           </group>
         </group>
       </if>
@@ -837,7 +837,7 @@
         <choose>
           <if locator="page">
             <group delimiter=":">
-              <number variable="volume"/>
+              <text variable="volume"/>
               <text variable="locator"/>
             </group>
           </if>
@@ -955,7 +955,7 @@
           <else>
             <choose>
               <if variable="page">
-                <number variable="volume" suffix=":"/>
+                <text variable="volume" suffix=":"/>
                 <text variable="page"/>
               </if>
             </choose>
@@ -1041,10 +1041,9 @@
   </macro>
   <macro name="issue-note-join-with-comma">
     <choose>
-      <if type="graphic map" match="any"/>
-      <else-if type="article-journal bill legislation legal_case manuscript thesis" variable="event-place publisher-place publisher" match="none">
+      <if type="article-journal bill legislation legal_case manuscript speech thesis" variable="publisher-place publisher" match="none">
         <text macro="issue-note"/>
-      </else-if>
+      </if>
       <else-if type="article-newspaper">
         <text macro="issue-note"/>
       </else-if>
@@ -1094,6 +1093,8 @@
               <text variable="genre"/>
             </if>
           </choose>
+          <text variable="event"/>
+          <text variable="event-place"/>
           <text variable="publisher"/>
           <text macro="issued"/>
         </group>

--- a/chicago-fullnote-short-title-subsequent.csl
+++ b/chicago-fullnote-short-title-subsequent.csl
@@ -1,9 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <style xmlns="http://purl.org/net/xbiblio/csl" class="note" version="1.0" demote-non-dropping-particle="display-and-sort" page-range-format="chicago">
   <info>
-    <title>Chicago Manual of Style 17th edition (note)</title>
-    <id>http://www.zotero.org/styles/chicago-note-bibliography</id>
-    <link href="http://www.zotero.org/styles/chicago-note-bibliography" rel="self"/>
+    <title>Chicago Manual of Style 17th edition (full note, short title subsequent)</title>
+    <id>http://www.zotero.org/styles/chicago-fullnote-short-title-subsequent</id>
+    <link href="http://www.zotero.org/styles/chicago-fullnote-short-title-subsequent" rel="self"/>
+		<link href="http://www.zotero.org/styles/chicago-fullnote-bibliography" rel="template"/>
     <link href="http://www.chicagomanualofstyle.org/tools_citationguide.html" rel="documentation"/>
     <author>
       <name>Julian Onions</name>
@@ -30,7 +31,7 @@
     </contributor>
     <category citation-format="note"/>
     <category field="generic-base"/>
-    <summary>Chicago format with short notes and bibliography</summary>
+    <summary>Chicago format with full notes and bibliography</summary>
     <updated>2017-10-12T12:00:00+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
@@ -1093,7 +1094,7 @@
               <text variable="genre"/>
             </if>
           </choose>
-          <text variable="event"/>
+	        <text variable="event"/>
           <text variable="event-place"/>
           <text variable="publisher"/>
           <text macro="issued"/>
@@ -1312,28 +1313,7 @@
   <citation et-al-min="4" et-al-use-first="1" disambiguate-add-names="true">
     <layout suffix="." delimiter="; ">
       <choose>
-        <if position="ibid ibid-with-locator" match="any">
-          <group delimiter=", ">
-            <text macro="contributors-short"/>
-            <group delimiter=" ">
-              <group delimiter=", ">
-                <choose>
-                  <if variable="author editor translator" match="none">
-                    <text macro="title-short"/>
-                  </if>
-                </choose>
-                <text macro="case-locator-subsequent"/>
-              </group>
-              <text macro="case-pinpoint-subsequent"/>
-            </group>
-            <choose>
-              <if match="none" type="legal_case">
-                <text macro="point-locators-subsequent"/>
-              </if>
-            </choose>
-          </group>
-        </if>
-        <else>
+        <if position="subsequent">
           <group delimiter=", ">
             <text macro="contributors-short"/>
             <group delimiter=" ">
@@ -1350,6 +1330,40 @@
                 <text macro="point-locators-subsequent"/>
               </if>
             </choose>
+          </group>
+        </if>
+        <else>
+          <group delimiter=", ">
+            <group delimiter=": ">
+              <group delimiter=", ">
+                <group delimiter=" ">
+                  <group delimiter=", ">
+                    <group delimiter=" ">
+                      <group delimiter=", ">
+                        <group delimiter=", ">
+                          <text macro="contributors-note"/>
+                          <text macro="title-note"/>
+                          <text macro="issue-map-graphic"/>
+                        </group>
+                        <text macro="description-note"/>
+                        <text macro="secondary-contributors-note"/>
+                        <text macro="container-title-note"/>
+                        <text macro="container-contributors-note"/>
+                      </group>
+                      <text macro="locators-note-join-with-space"/>
+                    </group>
+                    <text macro="locators-note-join-with-comma"/>
+                    <text macro="collection-title"/>
+                    <text macro="issue-note-join-with-comma"/>
+                  </group>
+                  <text macro="issue-note-join-with-space"/>
+                </group>
+                <text macro="locators-newspaper"/>
+                <text macro="point-locators-join-with-comma"/>
+              </group>
+              <text macro="point-locators-join-with-colon"/>
+            </group>
+            <text macro="access-note"/>
           </group>
         </else>
       </choose>

--- a/chicago-library-list.csl
+++ b/chicago-library-list.csl
@@ -516,10 +516,10 @@
       <if type="article-journal">
         <group delimiter=", ">
           <text macro="collection-title-journal"/>
-          <number variable="volume"/>
+          <text variable="volume"/>
           <group delimiter=" ">
             <text term="issue" form="short"/>
-            <number variable="issue"/>
+            <text variable="issue"/>
           </group>
         </group>
       </if>
@@ -637,10 +637,10 @@
       <if type="article-journal">
         <group delimiter=", ">
           <text macro="collection-title-journal"/>
-          <number variable="volume"/>
+          <text variable="volume"/>
           <group delimiter=" ">
             <text term="issue" form="short"/>
-            <number variable="issue"/>
+            <text variable="issue"/>
           </group>
         </group>
       </if>
@@ -837,7 +837,7 @@
         <choose>
           <if locator="page">
             <group delimiter=":">
-              <number variable="volume"/>
+              <text variable="volume"/>
               <text variable="locator"/>
             </group>
           </if>
@@ -955,7 +955,7 @@
           <else>
             <choose>
               <if variable="page">
-                <number variable="volume" suffix=":"/>
+                <text variable="volume" suffix=":"/>
                 <text variable="page"/>
               </if>
             </choose>
@@ -1041,10 +1041,9 @@
   </macro>
   <macro name="issue-note-join-with-comma">
     <choose>
-      <if type="graphic map" match="any"/>
-      <else-if type="article-journal bill legislation legal_case manuscript thesis" variable="event-place publisher-place publisher" match="none">
+      <if type="article-journal bill legislation legal_case manuscript speech thesis" variable="publisher-place publisher" match="none">
         <text macro="issue-note"/>
-      </else-if>
+      </if>
       <else-if type="article-newspaper">
         <text macro="issue-note"/>
       </else-if>
@@ -1094,6 +1093,8 @@
               <text variable="genre"/>
             </if>
           </choose>
+          <text variable="event"/>
+          <text variable="event-place"/>
           <text variable="publisher"/>
           <text macro="issued"/>
         </group>

--- a/chicago-note-bibliography-with-ibid.csl
+++ b/chicago-note-bibliography-with-ibid.csl
@@ -516,10 +516,10 @@
       <if type="article-journal">
         <group delimiter=", ">
           <text macro="collection-title-journal"/>
-          <number variable="volume"/>
+          <text variable="volume"/>
           <group delimiter=" ">
             <text term="issue" form="short"/>
-            <number variable="issue"/>
+            <text variable="issue"/>
           </group>
         </group>
       </if>
@@ -637,10 +637,10 @@
       <if type="article-journal">
         <group delimiter=", ">
           <text macro="collection-title-journal"/>
-          <number variable="volume"/>
+          <text variable="volume"/>
           <group delimiter=" ">
             <text term="issue" form="short"/>
-            <number variable="issue"/>
+            <text variable="issue"/>
           </group>
         </group>
       </if>
@@ -837,7 +837,7 @@
         <choose>
           <if locator="page">
             <group delimiter=":">
-              <number variable="volume"/>
+              <text variable="volume"/>
               <text variable="locator"/>
             </group>
           </if>
@@ -955,7 +955,7 @@
           <else>
             <choose>
               <if variable="page">
-                <number variable="volume" suffix=":"/>
+                <text variable="volume" suffix=":"/>
                 <text variable="page"/>
               </if>
             </choose>
@@ -1041,10 +1041,9 @@
   </macro>
   <macro name="issue-note-join-with-comma">
     <choose>
-      <if type="graphic map" match="any"/>
-      <else-if type="article-journal bill legislation legal_case manuscript thesis" variable="event-place publisher-place publisher" match="none">
+      <if type="article-journal bill legislation legal_case manuscript speech thesis" variable="publisher-place publisher" match="none">
         <text macro="issue-note"/>
-      </else-if>
+      </if>
       <else-if type="article-newspaper">
         <text macro="issue-note"/>
       </else-if>
@@ -1094,6 +1093,8 @@
               <text variable="genre"/>
             </if>
           </choose>
+          <text variable="event"/>
+          <text variable="event-place"/>
           <text variable="publisher"/>
           <text macro="issued"/>
         </group>


### PR DESCRIPTION
- add chicago-fullnote-short-title-subsequent, which behaves like the 
16th ed. no-ibid style, printing short titles on all subsequent 
citations, including in ibid position
- remove all `number variable` calls on issue and volume unless they 
specifically reference number properties (see #3243)
- Fix the issue with event and event place for presentations noted in 
#3243