### PR TITLE
Update hochschule-fur-soziale-arbeit-fhnw.csl

### DIFF
--- a/hochschule-fur-soziale-arbeit-fhnw.csl
+++ b/hochschule-fur-soziale-arbeit-fhnw.csl
@@ -206,7 +206,7 @@
     </choose>
   </macro>
   <!--Layout der In-Line-Zitation -->
-  <citation disambiguate-add-year-suffix="true">
+  <citation disambiguate-add-year-suffix="true" disambiguate-add-names="true">
     <layout prefix="(" suffix=")" delimiter=", ">
       <choose>
         <if position="ibid-with-locator">


### PR DESCRIPTION
Zotero assigns lowercase letters for publications with several authors in the same year, even if they are not the same authors, e.g. here (both cases are obviously simply processed as 'Ludwig-Mayerhofer et al.):
- Ludwig-Mayerhofer, Wolfgang/Behrend, Olaf/Sondermann, Ariadne (Hg.) (2007a). Fallverstehen und Deutungsmacht. etc.
- Ludwig-Mayerhofer, Wolfgang/Dölemeyer, Anne/Sondermann, Ariadne (2007b). Die neue Staatlichkeit: etc.