### PR TITLE
Update clinical-and-experimental-optometry.csl

### DIFF
--- a/dependent/clinical-and-experimental-optometry.csl
+++ b/dependent/clinical-and-experimental-optometry.csl
@@ -5,7 +5,7 @@
     <id>http://www.zotero.org/styles/clinical-and-experimental-optometry</id>
     <link href="http://www.zotero.org/styles/clinical-and-experimental-optometry" rel="self"/>
     <link href="http://www.zotero.org/styles/vancouver-superscript" rel="independent-parent"/>
-    <link href="http://www.blackwellpublishing.com/pdf/CXO_Author_Guidelines.pdf" rel="documentation"/>
+    <link href="https://onlinelibrary.wiley.com/page/journal/14440938/homepage/ForAuthors.html" rel="documentation"/>
     <category citation-format="numeric"/>
     <category field="medicine"/>
     <issn>0816-4622</issn>

--- a/dependent/clinical-and-experimental-optometry.csl
+++ b/dependent/clinical-and-experimental-optometry.csl
@@ -4,7 +4,7 @@
     <title>Clinical and Experimental Optometry</title>
     <id>http://www.zotero.org/styles/clinical-and-experimental-optometry</id>
     <link href="http://www.zotero.org/styles/clinical-and-experimental-optometry" rel="self"/>
-    <link href="http://www.zotero.org/styles/vancouver-superscript" rel="independent-parent"/>
+    <link href="http://www.zotero.org/styles/sage-vancouver" rel="independent-parent"/>
     <link href="https://onlinelibrary.wiley.com/page/journal/14440938/homepage/ForAuthors.html" rel="documentation"/>
     <category citation-format="numeric"/>
     <category field="medicine"/>


### PR DESCRIPTION
The citation style had a major upgrade in 2018 and this style is now obsolete. Please update as per the new guidelines https://onlinelibrary.wiley.com/page/journal/14440938/homepage/ForAuthors.html or use the current EndNote file for reference.