### PR TITLE
Encrypt Travis CI notification email addresses

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,22 +2,22 @@ dist: bionic
 language: ruby
 cache: bundler
 rvm:
-  - 2.6.5
+- 2.6.5
 install:
-  - bundle install --jobs=3 --retry=3 --path=${BUNDLE_PATH:-vendor/bundle}
-  - bundle update sheldon
+- bundle install --jobs=3 --retry=3 --path=${BUNDLE_PATH:-vendor/bundle}
+- bundle update sheldon
 notifications:
   email:
-    recipients:
-      - rintze.zelle@gmail.com
-      - karcher@u.northwestern.edu
     on_success: change
     on_failure: always
+    recipients:
+    - secure: Ko9SzcdByE/HOMP7s9ddTpRdqahnO5LJ1MGJWX/cmymQc8fDRMgP9jgI6D/G5Ntgo6uGUO+xkcV5mBbOAoI5v8U2GQ5nICDXHdQrX8kJzve9JDiQJOy0c17TYi3d7bBeS1bOhy7E0TxHRax2wWWxDhqz80GwSo9JAhQbcusR/1U=
+    - secure: Ov0xcwOVBSbc7uuCk0Qu+ILmh3HuFNa9PnfI363at9V3aG05oJHiTRseFXvfiHgK5663Wcytcl3DU+A2vYZSz7Y3ZGzcUzhlRBLMUfebncB2nAsX3NJsieJ6FoYlkRBZdzA2lzt3FVv99hebuZnU4OiANdnHFiLmFzeWRaPZfIQ=
   webhooks:
     urls:
-      - https://shelbot.herokuapp.com/build
-      - https://styles-update.zotero.org:8826/
-      - https://styles-update.zotero.org:8827/
+    - https://shelbot.herokuapp.com/build
+    - https://styles-update.zotero.org:8826/
+    - https://styles-update.zotero.org:8827/
     on_success: always
     on_failure: always
     on_start: never


### PR DESCRIPTION
Should prevent fork-spam (like https://travis-ci.org/winkhaing/styles/jobs/651061689/config).

Per https://github.com/quinoacomputing/quinoa/commit/8ec05f1b458904308778158d4bd5b1a8c3413990 and https://github.com/travis-ci/travis.rb#encrypt

Used:

```
$ travis encrypt "<email1>" --add notifications.email.recipients
$ travis encrypt "<email2>" --add notifications.email.recipients --append
```