### PR TITLE
Update IEEE to use long Journal names

### DIFF
--- a/ieee.csl
+++ b/ieee.csl
@@ -34,7 +34,7 @@
     <category field="engineering"/>
     <category field="generic-base"/>
     <summary>IEEE style as per the 2018 guidelines, V 11.12.2018.</summary>
-    <updated>2019-12-20T09:14:19+00:00</updated>
+    <updated>2020-02-02T02:32:19+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale xml:lang="en">
@@ -251,7 +251,7 @@
         <if type="article-journal">
           <group delimiter=", ">
             <text macro="title"/>
-            <text variable="container-title" font-style="italic" form="short"/>
+            <text variable="container-title" font-style="italic"/>
             <text macro="locators"/>
             <text macro="page"/>
             <text macro="issued"/>


### PR DESCRIPTION
Page 13-14 of https://ieeeauthorcenter.ieee.org/wp-content/uploads/IEEE-Reference-Guide.pdf

> Virtual Journal
> II. Style—14
> Basic Format:
> Name(s) of Ed(s)., “Title of Issue,” in _Title of Journal_, Abbrev. month year. [Online]. Available: URL

Journal names should not be abbreviated