### PR TITLE
chicago-fullnote-bibliography.csv: use reprint note if exists, cf. BibLaTeX 2.2.2 & CMoS 14.114

### DIFF
--- a/chicago-fullnote-bibliography.csl
+++ b/chicago-fullnote-bibliography.csl
@@ -729,22 +729,28 @@
   <macro name="reprint-note">
     <!--needs localization-->
     <choose>
-      <if variable="original-date issued" match="all">
+      <if variable="note" match="all">
+        <text variable="note"/>
+      </if>
+      <else-if variable="original-date issued" match="all">
         <choose>
           <!--for whatever reason in notes, when we have both original and new publishers, reprint doesn't appear-->
           <if variable="original-publisher original-publisher-place" match="none">
             <text value="repr."/>
           </if>
         </choose>
-      </if>
+      </else-if>
     </choose>
   </macro>
   <macro name="reprint">
     <!--needs localization-->
     <choose>
-      <if variable="original-date issued" match="all">
-        <text value="reprint" text-case="capitalize-first"/>
+      <if variable="note" match="all">
+        <text variable="note" text-case="capitalize-first"/>
       </if>
+      <else-if variable="original-date issued" match="all">
+        <text value="reprint" text-case="capitalize-first"/>
+      </else-if>
     </choose>
   </macro>
   <macro name="publisher">


### PR DESCRIPTION
## Expected Behavior

There should be a variable in chicago-fullnote-bibliography that inserts a user-generated reprint note.

## Actual Behavior

The CSL only writes "Reprint" or "rept." in certain special circumstances.

## Discussion

_Chicago Manual of Style_ (17th ed., CMoS) 14.114 allows free-text reprint descriptions, e.g.

> Emerson, Ralph Waldo. _Nature._ 1836. **Facsimile of the first edition, with an introduction by Jaroslav Pelikan.** Boston: Beacon Press, 1985.  (**bold** mine, p. 807)

or

> Fitzgerald, F. Scott. _The Great Gatsby._ New York: Scribner, 1925. **Reprinted with preface and notes by Matthew J. Bruccoli.** New York: Collier Books, 1992. [...] (**bold** mine, p. 807)

While the CSL standard suggests "note" is for commentary:

> (short) inline note giving additional item details (e.g. a concise summary or commentary) [link](https://docs.citationstyles.org/en/stable/specification.html#appendix-iv-variables)

The tradition inherited from BibLaTeX (and the crosswalks to CSL JSON) suggests that it's for:

> Miscellaneous bibliographic data which does not fit into any other field. The note field may be used to record bibliographic data in a free format. Publication facts such as “Reprint of the edition London 1831” are typical candidates for the note field. (Manual, 2.2.2) [link](https://www.ctan.org/pkg/biblatex)

I propose that we are to understand "a concise summary or commentary" as relating to the reprint preparation, thus restoring functionality present already in BibLaTeX.

In any case, I've edited my files locally, which solves my problem, but I thought someone else might find this useful too.

### Potential Side Effects

Zotero calls this variable "Extra" in its interface.  It too exports it to BibLaTeX "note", which suggests that the original purpose was enhanced publication info, but people could have used it in various weird ways that are as unpredictable as what "extra" might mean.

Respectfully submitted, open to tweaks/discussion/whatever