### PR TITLE
Update vodohospodarske-technicko-ekonomicke-informace.csl

### DIFF
--- a/vodohospodarske-technicko-ekonomicke-informace.csl
+++ b/vodohospodarske-technicko-ekonomicke-informace.csl
@@ -438,7 +438,7 @@
       </group>
     </layout>
   </citation>
-  <bibliography et-al-min="4" et-al-use-first="3" and="text">
+  <bibliography>
     <sort>
       <key variable="citation-number"/>
     </sort>


### PR DESCRIPTION
Use of "et al." is not defined in the guidance for authors for this journal. The journal uses ČSN ISO 690 standard, but the standard is not strict in this and use of "et al." is not mandatory (can be published all authors OR only first three and "et al."). Published articles used all authors so I prepare this change of style. Also, Zotero style for ČSN ISO 690 does not use "et al.".