### PR TITLE
Remove et-al settings from american-chemical-society.csl

### DIFF
--- a/american-chemical-society.csl
+++ b/american-chemical-society.csl
@@ -145,7 +145,7 @@
       <text variable="citation-number"/>
     </layout>
   </citation>
-  <bibliography second-field-align="flush" entry-spacing="0" et-al-min="11" et-al-use-first="10">
+  <bibliography second-field-align="flush" entry-spacing="0">
     <layout suffix=".">
       <text variable="citation-number" prefix="(" suffix=") "/>
       <text macro="author" suffix=" "/>

--- a/american-chemical-society.csl
+++ b/american-chemical-society.csl
@@ -5,7 +5,7 @@
     <title-short>ACS</title-short>
     <id>http://www.zotero.org/styles/american-chemical-society</id>
     <link href="http://www.zotero.org/styles/american-chemical-society" rel="self"/>
-    <link href="http://pubs.acs.org/doi/pdf/10.1021/bk-2006-STYG.ch014" rel="documentation"/>
+    <link href="https://pubs.acs.org/doi/pdf/10.1021/bk-2006-STYG.ch014" rel="documentation"/>
     <author>
       <name>Julian Onions</name>
       <email>julian.onions@gmail.com</email>
@@ -20,7 +20,7 @@
     <category citation-format="numeric"/>
     <category field="chemistry"/>
     <summary>The American Chemical Society style</summary>
-    <updated>2018-12-30T12:00:00+00:00</updated>
+    <updated>2020-03-10T12:00:00+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale xml:lang="en">


### PR DESCRIPTION
As discussed here. Remove et-al from acs.csl. https://forums.zotero.org/discussion/comment/333791/#Comment_333791

Editors are coming back to writers again and again that they don't want any et-al in papers.