### PR TITLE
Update environmental-microbiology.csl

### DIFF
--- a/environmental-microbiology.csl
+++ b/environmental-microbiology.csl
@@ -29,7 +29,7 @@
   </info>
   <macro name="editor">
     <names variable="editor" delimiter=",">
-      <name name-as-sort-order="all" sort-separator="," and="text" initialize-with="." delimiter=", "/>
+      <name name-as-sort-order="all" sort-separator=", " and="text" initialize-with="." delimiter=", "/>
       <label form="short" prefix=" (" suffix=")" strip-periods="true"/>
     </names>
   </macro>
@@ -116,11 +116,11 @@
         </if>
         <else-if type="chapter paper-conference" match="any">
           <text macro="title" prefix=" " suffix="."/>
-          <group prefix=" " delimiter=", " suffix=".">
+          <group prefix=" " delimiter=" " suffix=".">
             <text term="in" text-case="capitalize-first"/>
+            <text variable="container-title" font-style="italic" suffix="."/>
+            <text variable="collection-title" suffix="."/>
             <text macro="editor"/>
-            <text variable="container-title" font-style="italic"/>
-            <text variable="collection-title" prefix=" " suffix="."/>
           </group>
           <group suffix=".">
             <text macro="publisher" prefix=" "/>


### PR DESCRIPTION
The style for the journal Environmental Microbiology is setting editors names before book title when citing a book chapter, e.g.

Mares, I. (2001) Firms and the welfare state: When, why, and how does social policy matter to employers? In, **Hall,P.A. and Soskice,D. (eds), Varieties of capitalism. The institutional foundations of comparative advantage.** New York: Oxford University Press, pp. 184–213.

while the reference should look based on the Author Guidelines (https://onlinelibrary.wiley.com/page/journal/14622920/homepage/ForAuthors.html) like this:

Finlay, B.I., Fenchel, T., and Embley, T.M. (1993) Methanogen endosymbiosis in anaerobic climates. In **_Trends in Microbial Ecology_. Guerrero, R., and Pedros-Alio, C. (eds).** Barcelona: Spanish Society for Microbiology, pp. 285-288.

In addition, there should be a space after editor last name comma and before first name abbreviations and after "In" should not come a comma.