### PR TITLE
Fixes #4648

### DIFF
--- a/associacao-brasileira-de-normas-tecnicas.csl
+++ b/associacao-brasileira-de-normas-tecnicas.csl
@@ -200,8 +200,7 @@ autores, exceto em arquivos do tipo 'artigo de jornal, artigo de revista, artigo
           <if variable="publisher-place">
             <text variable="publisher-place" suffix=": "/>
           </if>
-          <else-if type="entry-encyclopedia">
-        </else-if>
+          <else-if type="entry-encyclopedia"></else-if>
           <else>
             <text value="[s.l.] "/>
           </else>

--- a/associacao-brasileira-de-normas-tecnicas.csl
+++ b/associacao-brasileira-de-normas-tecnicas.csl
@@ -106,9 +106,8 @@ tendo as inicias separadas por ponto.-->
   <!--A macro 'translator' e responsavel por mostrar os nomes dos tradutores, serao apresentados SOBRENOME, INICIAIS PRENOMES
 tendo as inicias separadas por ponto. -->
   <macro name="translator">
-    <text value="Traducao "/>
     <names variable="translator" delimiter="; ">
-      <name delimiter="; " sort-separator=" " delimiter-precedes-last="always">
+      <name delimiter="; " sort-separator=" " delimiter-precedes-last="always" prefix="Tradução: ">
         <name-part name="given" text-case="capitalize-first"/>
         <name-part name="family" text-case="capitalize-first"/>
       </name>


### PR DESCRIPTION
Moved the "Tradução: " heading to the prefix field in the <name> tag.