### PR TITLE
Correct Acta Palaeontologica Polonica in-text citation format

### DIFF
--- a/acta-palaeontologica-polonica.csl
+++ b/acta-palaeontologica-polonica.csl
@@ -10,26 +10,22 @@
       <name>Martin R. Smith</name>
       <email>martins@gmail.com</email>
     </author>
-    <contributor>
-      <name>Benjamin C. Moon</name>
-      <email>benjamin.c.moon@bristol.ac.uk</email>
-    </contributor>
     <category citation-format="author-date"/>
     <category field="biology"/>
     <issn>0567-7920</issn>
     <eissn>1732-2421</eissn>
-    <updated>2020-03-30T14:52:58+01:00</updated>
+    <updated>2012-09-27T22:06:38+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <macro name="author">
     <names variable="author" suffix=".">
-      <name sort-separator=", " initialize-with="." and="text" name-as-sort-order="all" delimiter=", " delimiter-precedes-last="never" form="long">
+      <name sort-separator=", " initialize-with=". " and="text" name-as-sort-order="all" delimiter=", " delimiter-precedes-last="never" form="long">
       </name>
     </names>
   </macro>
   <macro name="editor">
     <names variable="editor">
-      <name sort-separator=", " initialize-with="." and="text" name-as-sort-order="all" delimiter=", " delimiter-precedes-last="never">
+      <name sort-separator=", " initialize-with=". " and="text" name-as-sort-order="all" delimiter=", " delimiter-precedes-last="never">
       </name>
       <label form="short" prefix=" (" suffix=".)"/>
     </names>
@@ -75,6 +71,29 @@
       <text variable="publisher-place"/>
     </group>
   </macro>
+  <macro name="container-title">
+    <choose>
+      <if variable="edition">
+        <text variable="container-title"/>
+      </if>
+      <else>
+        <text variable="container-title" suffix="."/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="edition">
+    <choose>
+      <if is-numeric="edition">
+        <group delimiter=" ">
+          <number variable="edition" form="ordinal"/>
+          <text term="edition" form="short" suffix="." strip-periods="true"/>
+        </group>
+      </if>
+      <else>
+        <text variable="edition" suffix="."/>
+      </else>
+    </choose>
+  </macro>
   <citation et-al-min="3" et-al-use-first="1" disambiguate-add-year-suffix="true" disambiguate-add-names="false" disambiguate-add-givenname="false" collapse="year-suffix" year-suffix-delimiter=", ">
     <sort>
       <key macro="year-date"/>
@@ -85,10 +104,8 @@
         <text macro="author-short"/>
         <text macro="year-date"/>
       </group>
+      <text variable="locator"/>
       <text variable="year-suffix" font-style="italic"/>
-      <group prefix=": ">
-        <text variable="locator"/>
-      </group>
     </layout>
   </citation>
   <bibliography entry-spacing="0" hanging-indent="true">
@@ -181,7 +198,7 @@
             </group>
           </else-if>
           <else-if type="webpage" match="any">
-            <group>
+            <group delimiter="">
               <text variable="title" font-style="italic" suffix=". "/>
               <text variable="container-title" form="long" suffix=". "/>
               <text variable="URL" prefix="Downloaded from " suffix=" "/>

--- a/acta-palaeontologica-polonica.csl
+++ b/acta-palaeontologica-polonica.csl
@@ -10,22 +10,26 @@
       <name>Martin R. Smith</name>
       <email>martins@gmail.com</email>
     </author>
+    <contributor>
+      <name>Benjamin C. Moon</name>
+      <email>benjamin.c.moon@bristol.ac.uk</email>
+    </contributor>
     <category citation-format="author-date"/>
     <category field="biology"/>
     <issn>0567-7920</issn>
     <eissn>1732-2421</eissn>
-    <updated>2012-09-27T22:06:38+00:00</updated>
+    <updated>2020-03-30T14:52:58+01:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <macro name="author">
     <names variable="author" suffix=".">
-      <name sort-separator=", " initialize-with=". " and="text" name-as-sort-order="all" delimiter=", " delimiter-precedes-last="never" form="long">
+      <name sort-separator=", " initialize-with="." and="text" name-as-sort-order="all" delimiter=", " delimiter-precedes-last="never" form="long">
       </name>
     </names>
   </macro>
   <macro name="editor">
     <names variable="editor">
-      <name sort-separator=", " initialize-with=". " and="text" name-as-sort-order="all" delimiter=", " delimiter-precedes-last="never">
+      <name sort-separator=", " initialize-with="." and="text" name-as-sort-order="all" delimiter=", " delimiter-precedes-last="never">
       </name>
       <label form="short" prefix=" (" suffix=".)"/>
     </names>
@@ -71,29 +75,6 @@
       <text variable="publisher-place"/>
     </group>
   </macro>
-  <macro name="container-title">
-    <choose>
-      <if variable="edition">
-        <text variable="container-title"/>
-      </if>
-      <else>
-        <text variable="container-title" suffix="."/>
-      </else>
-    </choose>
-  </macro>
-  <macro name="edition">
-    <choose>
-      <if is-numeric="edition">
-        <group delimiter=" ">
-          <number variable="edition" form="ordinal"/>
-          <text term="edition" form="short" suffix="." strip-periods="true"/>
-        </group>
-      </if>
-      <else>
-        <text variable="edition" suffix="."/>
-      </else>
-    </choose>
-  </macro>
   <citation et-al-min="3" et-al-use-first="1" disambiguate-add-year-suffix="true" disambiguate-add-names="false" disambiguate-add-givenname="false" collapse="year-suffix" year-suffix-delimiter=", ">
     <sort>
       <key macro="year-date"/>
@@ -104,8 +85,10 @@
         <text macro="author-short"/>
         <text macro="year-date"/>
       </group>
-      <text variable="locator"/>
       <text variable="year-suffix" font-style="italic"/>
+      <group prefix=": ">
+        <text variable="locator"/>
+      </group>
     </layout>
   </citation>
   <bibliography entry-spacing="0" hanging-indent="true">
@@ -198,7 +181,7 @@
             </group>
           </else-if>
           <else-if type="webpage" match="any">
-            <group delimiter="">
+            <group>
               <text variable="title" font-style="italic" suffix=". "/>
               <text variable="container-title" form="long" suffix=". "/>
               <text variable="URL" prefix="Downloaded from " suffix=" "/>

--- a/acta-palaeontologica-polonica.csl
+++ b/acta-palaeontologica-polonica.csl
@@ -23,14 +23,12 @@
   </info>
   <macro name="author">
     <names variable="author" suffix=".">
-      <name sort-separator=", " initialize-with="." and="text" name-as-sort-order="all" delimiter=", " delimiter-precedes-last="never" form="long">
-      </name>
+      <name sort-separator=", " initialize-with="." and="text" name-as-sort-order="all" delimiter=", " delimiter-precedes-last="never" form="long"></name>
     </names>
   </macro>
   <macro name="editor">
     <names variable="editor">
-      <name sort-separator=", " initialize-with="." and="text" name-as-sort-order="all" delimiter=", " delimiter-precedes-last="never">
-      </name>
+      <name sort-separator=", " initialize-with="." and="text" name-as-sort-order="all" delimiter=", " delimiter-precedes-last="never"></name>
       <label form="short" prefix=" (" suffix=".)"/>
     </names>
   </macro>

--- a/acta-palaeontologica-polonica.csl
+++ b/acta-palaeontologica-polonica.csl
@@ -10,11 +10,15 @@
       <name>Martin R. Smith</name>
       <email>martins@gmail.com</email>
     </author>
+    <contributor>
+      <name>Benjamin C. Moon</name>
+      <email>benjamin.c.moon@bristol.ac.uk</email>
+    </contributor>
     <category citation-format="author-date"/>
     <category field="biology"/>
     <issn>0567-7920</issn>
     <eissn>1732-2421</eissn>
-    <updated>2012-09-27T22:06:38+00:00</updated>
+    <updated>2020-03-30T14:52:58+01:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <macro name="author">
@@ -81,8 +85,10 @@
         <text macro="author-short"/>
         <text macro="year-date"/>
       </group>
-      <text variable="locator"/>
       <text variable="year-suffix" font-style="italic"/>
+      <group prefix=": ">
+        <text variable="locator"/>
+      </group>
     </layout>
   </citation>
   <bibliography entry-spacing="0" hanging-indent="true">


### PR DESCRIPTION
Modifications to in-text citation style to correct rendering of year-suffix and page references:
e.g. (Abel 2010*a*, *b*)
(Abel 2010: 544)