### PR TITLE
Create proceedings-of-the-joint-international-grassland-and-international-rangeland-congress-2021.csl

### DIFF
--- a/proceedings-of-the-international-grassland-conference-2020.csl
+++ b/proceedings-of-the-international-grassland-conference-2020.csl
@@ -1,0 +1,138 @@
+<?xml version="1.0" encoding="utf-8"?>
+<style class="in-text" version="1.0" page-range-format="expanded" default-locale="en-GB" xmlns="http://purl.org/net/xbiblio/csl">
+  <info>
+    <title>Proceedings of the International Grassland Conference 2020</title>
+    <title-short>IGC2020</title-short>
+    <id>http://www.zotero.org/styles/proceedings-of-the-international-grassland-conference-2020</id>
+    <link href="http://www.zotero.org/styles/proceedings-of-the-international-grassland-conference-2020" rel="self"/>
+    <link href="http://www.zotero.org/styles/boreal-environment-research" rel="template"/>
+    <link href="http://www.borenv.net/" rel="documentation"/>
+    <link href="http://2020kenya-igc-irc.rangelandcongress.org/wp-content/uploads/sites/6/2018/10/IGC-IRC-Paper-Template.docx" rel="documentation"/>
+    <author>
+      <name>Cristian Moreno</name>
+      <email>moreno.grassland@gmail.com</email>
+    </author>
+    <category citation-format="author-date"/>
+    <issn>0074-6185</issn>
+    <updated>2020-04-03T23:09:38+00:00</updated>
+    <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
+  </info>
+  <macro name="editor-translator">
+    <names variable="editor translator" delimiter=", ">
+      <name and="text" delimiter-precedes-last="never" initialize-with="." name-as-sort-order="all"/>
+      <et-al font-style="italic"/>
+      <label form="short" prefix=" (" suffix=")."/>
+    </names>
+  </macro>
+  <macro name="author">
+    <names variable="author">
+      <name and="text" delimiter-precedes-last="never" initialize-with="." name-as-sort-order="all"/>
+      <label form="short" prefix=" (" suffix=")"/>
+      <substitute>
+        <names variable="editor"/>
+        <names variable="translator"/>
+        <text macro="title"/>
+      </substitute>
+    </names>
+  </macro>
+  <macro name="author-short">
+    <names variable="author">
+      <name form="short" and="text" delimiter=", " initialize-with=". "/>
+      <et-al font-style="italic"/>
+      <substitute>
+        <names variable="editor"/>
+        <names variable="translator"/>
+        <choose>
+          <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
+            <text variable="title" form="short" font-style="italic"/>
+          </if>
+          <else>
+            <text variable="title" form="short" quotes="true"/>
+          </else>
+        </choose>
+      </substitute>
+    </names>
+  </macro>
+  <macro name="title">
+    <choose>
+      <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
+        <text variable="title" font-style="italic"/>
+      </if>
+      <else>
+        <text variable="title"/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="publisher">
+    <group delimiter=", ">
+      <text variable="publisher"/>
+      <text variable="publisher-place"/>
+    </group>
+  </macro>
+  <citation collapse="year-suffix" et-al-min="3" et-al-use-first="1" disambiguate-add-year-suffix="true" year-suffix-delimiter=", ">
+    <sort>
+      <key variable="issued"/>
+      <key macro="author-short"/>
+    </sort>
+    <layout prefix="(" suffix=")" delimiter="; ">
+      <group delimiter=" ">
+        <text macro="author-short"/>
+        <date variable="issued">
+          <date-part name="year"/>
+        </date>
+        <group>
+          <label variable="locator" form="short"/>
+          <text variable="locator" prefix=" "/>
+        </group>
+      </group>
+    </layout>
+  </citation>
+  <bibliography hanging-indent="true" et-al-min="99" et-al-use-first="98">
+    <sort>
+      <key macro="author-short"/>
+      <key variable="issued"/>
+    </sort>
+    <layout>
+      <text macro="author" suffix="."/>
+      <date variable="issued" prefix=" " suffix=".">
+        <date-part name="year"/>
+      </date>
+      <choose>
+        <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
+          <group suffix=".">
+            <text macro="title" prefix=" "/>
+            <text macro="editor-translator" prefix=" "/>
+          </group>
+          <text prefix=" " suffix="." macro="publisher"/>
+        </if>
+        <else-if type="chapter paper-conference" match="any">
+          <text macro="title" prefix=" "/>
+          <group prefix=".">
+            <group delimiter=" " prefix=" In: " suffix=".">
+              <text macro="editor-translator"/>
+              <text variable="container-title" font-style="italic" suffix="."/>
+              <text macro="publisher" prefix=" " suffix=","/>
+              <group delimiter=" ">
+                <label variable="page" form="short"/>
+                <text variable="page"/>
+              </group>
+            </group>
+          </group>
+        </else-if>
+        <else>
+          <group suffix=".">
+            <text macro="title" prefix=" "/>
+            <text macro="editor-translator" prefix=" "/>
+          </group>
+          <group prefix=" " suffix=".">
+            <text variable="container-title" form="short" font-style="italic"/>
+            <group prefix=" ">
+              <text variable="volume"/>
+            </group>
+            <text variable="page" prefix=": "/>
+          </group>
+        </else>
+      </choose>
+    </layout>
+  </bibliography>
+</style>

--- a/proceedings-of-the-joint-international-grassland-and-international-rangeland-congress-2021.csl
+++ b/proceedings-of-the-joint-international-grassland-and-international-rangeland-congress-2021.csl
@@ -4,7 +4,7 @@
     <title>Proceedings of the Joint International Grassland & International Rangeland Congress 2021</title>
     <title-short>IGC2020</title-short>
     <id>http://www.zotero.org/styles/proceedings-of-the-joint-international-grassland-and-international-rangeland-congress-2021</id>
-    <link href="http://www.zotero.org/styles/proceedings-of-the-international-grassland-conference-2020" rel="self"/>
+    <link href="http://www.zotero.org/styles/proceedings-of-the-joint-international-grassland-and-international-rangeland-congress-2021" rel="self"/>
     <link href="http://www.zotero.org/styles/boreal-environment-research" rel="template"/>
     <link href="http://www.borenv.net/" rel="documentation"/>
     <link href="http://2020kenya-igc-irc.rangelandcongress.org/wp-content/uploads/sites/6/2018/10/IGC-IRC-Paper-Template.docx" rel="documentation"/>

--- a/proceedings-of-the-joint-international-grassland-and-international-rangeland-congress-2021.csl
+++ b/proceedings-of-the-joint-international-grassland-and-international-rangeland-congress-2021.csl
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <style class="in-text" version="1.0" page-range-format="expanded" default-locale="en-GB" xmlns="http://purl.org/net/xbiblio/csl">
   <info>
-    <title>Proceedings of the International Grassland Conference 2020</title>
+    <title>Proceedings of the Joint International Grassland & International Rangeland Congress 2021</title>
     <title-short>IGC2020</title-short>
-    <id>http://www.zotero.org/styles/proceedings-of-the-international-grassland-conference-2020</id>
+    <id>http://www.zotero.org/styles/proceedings-of-the-joint-international-grassland-and-international-rangeland-congress-2021</id>
     <link href="http://www.zotero.org/styles/proceedings-of-the-international-grassland-conference-2020" rel="self"/>
     <link href="http://www.zotero.org/styles/boreal-environment-research" rel="template"/>
     <link href="http://www.borenv.net/" rel="documentation"/>

--- a/proceedings-of-the-joint-international-grassland-and-international-rangeland-congress-2021.csl
+++ b/proceedings-of-the-joint-international-grassland-and-international-rangeland-congress-2021.csl
@@ -1,19 +1,18 @@
 <?xml version="1.0" encoding="utf-8"?>
-<style class="in-text" version="1.0" page-range-format="expanded" default-locale="en-GB" xmlns="http://purl.org/net/xbiblio/csl">
+<style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" page-range-format="expanded" default-locale="en-GB">
   <info>
-    <title>Proceedings of the Joint International Grassland and International Rangeland Congress 2021</title>
-    <title-short>IGC2020</title-short>
+    <title>Proceedings of the Joint International Grassland &amp; International Rangeland Congress 2021</title>
+    <title-short>IGC-IRC 2021</title-short>
     <id>http://www.zotero.org/styles/proceedings-of-the-joint-international-grassland-and-international-rangeland-congress-2021</id>
     <link href="http://www.zotero.org/styles/proceedings-of-the-joint-international-grassland-and-international-rangeland-congress-2021" rel="self"/>
     <link href="http://www.zotero.org/styles/boreal-environment-research" rel="template"/>
-    <link href="http://www.borenv.net/" rel="documentation"/>
     <link href="http://2020kenya-igc-irc.rangelandcongress.org/wp-content/uploads/sites/6/2018/10/IGC-IRC-Paper-Template.docx" rel="documentation"/>
     <author>
       <name>Cristian Moreno</name>
       <email>moreno.grassland@gmail.com</email>
     </author>
     <category citation-format="author-date"/>
-    <issn>0074-6185</issn>
+    <category field="geography"/>
     <updated>2020-04-03T23:09:38+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>

--- a/proceedings-of-the-joint-international-grassland-and-international-rangeland-congress-2021.csl
+++ b/proceedings-of-the-joint-international-grassland-and-international-rangeland-congress-2021.csl
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <style class="in-text" version="1.0" page-range-format="expanded" default-locale="en-GB" xmlns="http://purl.org/net/xbiblio/csl">
   <info>
-    <title>Proceedings of the Joint International Grassland & International Rangeland Congress 2021</title>
+    <title>Proceedings of the Joint International Grassland and International Rangeland Congress 2021</title>
     <title-short>IGC2020</title-short>
     <id>http://www.zotero.org/styles/proceedings-of-the-joint-international-grassland-and-international-rangeland-congress-2021</id>
     <link href="http://www.zotero.org/styles/proceedings-of-the-joint-international-grassland-and-international-rangeland-congress-2021" rel="self"/>


### PR DESCRIPTION
The International Grassland Congress 2020 received over a 1,000 abstracts that will need their corresponding papers. The organizers provided a file template with examples of citation. However, there were not a matching citation style in the repository. I created it by editing an existing one that matched 94%.