### PR TITLE
Update equine-veterinary-education.csl

### DIFF
--- a/equine-veterinary-education.csl
+++ b/equine-veterinary-education.csl
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<style class="in-text" version="1.0" delimiter-precedes-last="never" default-locale="en-GB" xmlns="http://purl.org/net/xbiblio/csl">
+<style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" delimiter-precedes-last="never" default-locale="en-GB">
   <info>
     <title>Equine Veterinary Education</title>
     <title-short>EVE</title-short>

--- a/equine-veterinary-education.csl
+++ b/equine-veterinary-education.csl
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
-<style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" default-locale="en-GB">
+<style class="in-text" version="1.0" delimiter-precedes-last="never" default-locale="en-GB" xmlns="http://purl.org/net/xbiblio/csl">
   <info>
     <title>Equine Veterinary Education</title>
     <title-short>EVE</title-short>
     <id>http://www.zotero.org/styles/equine-veterinary-education</id>
     <link href="http://www.zotero.org/styles/equine-veterinary-education" rel="self"/>
     <link href="http://www.zotero.org/styles/bmj" rel="template"/>
-    <link href="http://onlinelibrary.wiley.com/journal/10.1001/(ISSN)2042-3292/homepage/ForAuthors.html" rel="documentation"/>
+    <link href="https://beva.onlinelibrary.wiley.com/hub/journal/20423292/homepage/forauthors.html" rel="documentation"/>
     <author>
       <name>Charles Parnot</name>
       <email>charles.parnot@gmail.com</email>
@@ -15,21 +15,14 @@
     <contributor>
       <name>Patrick O'Brien</name>
     </contributor>
-    <category citation-format="numeric"/>
+    <category citation-format="author-date"/>
     <category field="biology"/>
     <category field="medicine"/>
     <issn>0957-7734</issn>
     <eissn>2042-3292</eissn>
-    <updated>2020-04-06T12:50:28+00:00</updated>
+    <updated>2020-04-07T14:27:20+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
-  <locale>
-    <terms>
-      <term name="and">and</term>
-      <term name="et-al">and others</term>
-      <term name="in">in</term>
-    </terms>
-  </locale>
   <macro name="author">
     <names variable="author">
       <name initialize-with="." name-as-sort-order="all">
@@ -92,14 +85,56 @@
       </else>
     </choose>
   </macro>
+  <macro name="point-locators">
+    <group>
+      <choose>
+        <if locator="page" match="none">
+          <label variable="locator" form="short" suffix=" "/>
+        </if>
+      </choose>
+      <text variable="locator"/>
+    </group>
+  </macro>
+  <macro name="contributors-short">
+    <names variable="author">
+      <name form="short" and="text" delimiter=", "/>
+      <et-al font-style="italic"/>
+      <substitute>
+        <names variable="editor"/>
+        <names variable="translator"/>
+        <text macro="title"/>
+      </substitute>
+    </names>
+  </macro>
+  <macro name="date-reference">
+    <choose>
+      <if variable="issued">
+        <date variable="issued">
+          <date-part name="year"/>
+        </date>
+      </if>
+      <else>
+        <text term="no date" form="short"/>
+      </else>
+    </choose>
+  </macro>
   <citation et-al-min="3" et-al-use-first="1" disambiguate-add-year-suffix="true" disambiguate-add-names="true" disambiguate-add-givenname="true">
-    <layout delimiter=", " prefix="[" suffix="]">
-      <text variable="citation-number"/>
+    <sort>
+      <key variable="issued" sort="ascending"/>
+      <key macro="author"/>
+    </sort>
+    <layout prefix="(" suffix=")" delimiter=", ">
+      <group delimiter=":">
+        <group delimiter=" ">
+          <text macro="contributors-short"/>
+          <text macro="date-reference"/>
+        </group>
+        <text macro="point-locators"/>
+      </group>
     </layout>
   </citation>
-  <bibliography and="text" et-al-min="12" et-al-use-first="6" second-field-align="flush">
+  <bibliography and="text" et-al-min="12" et-al-use-first="6">
     <layout>
-      <text variable="citation-number" suffix=". "/>
       <group delimiter=" " suffix=".">
         <text macro="author"/>
         <date variable="issued" prefix="(" suffix=")">


### PR DESCRIPTION
To undo #4674 
I mixed up the journals. equine-veterinary-journal.csl (which we have) has a numeric style. equinve-veterinary-education.csl has an author-date style that has the bibliographic style as evj.csl otherwise.

via https://forums.zotero.org/discussion/82337/help-amending-citation-presets-please#latest