### PR TITLE
Update to better match RMIT Easy Cite

### DIFF
--- a/rmit-university-harvard.csl
+++ b/rmit-university-harvard.csl
@@ -113,9 +113,10 @@
   <macro name="presentation">
     <choose>
       <if type="speech">
-        <group delimiter=", "> <!-- suffix=", "> -->
+        <group delimiter=", ">
+          <!-- suffix=", "> -->
           <text variable="genre"/>
-            <!-- <text term="presented at"/> -->
+          <!-- <text term="presented at"/> -->
           <text variable="event"/>
           <text variable="event-place"/>
         </group>

--- a/rmit-university-harvard.csl
+++ b/rmit-university-harvard.csl
@@ -12,7 +12,7 @@
     </author>
     <category citation-format="author-date"/>
     <category field="generic-base"/>
-    <updated>2020-01-13T00:52:05+00:00</updated>
+    <updated>2020-04-13T04:40:00+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale xml:lang="en">
@@ -86,7 +86,7 @@
   </macro>
   <macro name="access">
     <choose>
-      <if variable="URL" type="webpage">
+      <if variable="URL" type="article-newspaper webpage speech">
         <group prefix=" " delimiter=", ">
           <date variable="accessed" prefix="viewed ">
             <date-part name="day" suffix=" "/>
@@ -95,6 +95,30 @@
           </date>
         </group>
         <text variable="URL" prefix=" &lt;" suffix="&gt;"/>
+      </if>
+    </choose>
+  </macro>
+  <macro name="newspaper-webpage">
+    <choose>
+      <if type="article-newspaper">
+        <group prefix=" " delimiter=", ">
+          <date variable="issued" prefix="">
+            <date-part name="day" suffix=" "/>
+            <date-part name="month" suffix=""/>
+          </date>
+        </group>
+      </if>
+    </choose>
+  </macro>
+  <macro name="presentation">
+    <choose>
+      <if type="speech">
+        <group delimiter=", "> <!-- suffix=", "> -->
+          <text variable="genre"/>
+            <!-- <text term="presented at"/> -->
+          <text variable="event"/>
+          <text variable="event-place"/>
+        </group>
       </if>
     </choose>
   </macro>
@@ -148,14 +172,14 @@
       </else>
     </choose>
   </macro>
-  <citation et-al-min="4" et-al-use-first="1" disambiguate-add-year-suffix="true" disambiguate-add-names="true" disambiguate-add-givenname="true" collapse="year">
+  <citation et-al-min="4" et-al-use-first="1" disambiguate-add-year-suffix="true" disambiguate-add-names="true" collapse="year">
     <layout prefix="(" suffix=")" delimiter="; ">
       <group delimiter=", ">
         <group delimiter=" ">
           <text macro="author-short"/>
           <text macro="year-date"/>
         </group>
-        <group>
+        <group delimiter=" ">
           <label variable="locator" form="short"/>
           <text variable="locator"/>
         </group>
@@ -210,6 +234,8 @@
           </group>
         </else>
       </choose>
+      <text prefix=", " macro="presentation"/>
+      <text prefix=", " macro="newspaper-webpage"/>
       <text prefix=", " macro="access"/>
     </layout>
   </bibliography>


### PR DESCRIPTION
Some citation types did not match the RMIT Easy Cite referencing tool recommendations.

Updated to fix:

1) In-citation page numbers were e.g. 'p.1' and 'pp.2-5', now corrected to 'p. 1' and 'pp. 2-5'
2) A newspaper article bibliography entry needs to have the date published, and if it was accessed online the date viewed and URL too.
3) If a lecture (type 'presentation' in Zotero, 'speech' in this CSL file) is cited, the bibliography needs to have the type of lecture, course code, university, date viewed, and URL if applicable.