### PR TITLE
Create tagungsberichte-der-historischen-kommission-fur-ost-und-westpr…

### DIFF
--- a/tagungsberichte-der-historischen-kommission-fur-ost-und-westpreussische-landesforschung.csl
+++ b/tagungsberichte-der-historischen-kommission-fur-ost-und-westpreussische-landesforschung.csl
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <style xmlns="http://purl.org/net/xbiblio/csl" class="note" version="1.0" demote-non-dropping-particle="sort-only" default-locale="de-DE">
   <info>
-    <title>Tagungsberichte der Historischen Kommission für ost- und westpreußische Landesforschung</title>
+    <title>Tagungsberichte der Historischen Kommission für ost- und westpreußische Landesforschung (German)</title>
     <title-short>HiKo-OWP</title-short>
     <id>http://www.zotero.org/styles/tagungsberichte-der-historischen-kommission-fur-ost-und-westpreussische-landesforschung</id>
     <link href="http://www.zotero.org/styles/tagungsberichte-der-historischen-kommission-fur-ost-und-westpreussische-landesforschung" rel="self"/>

--- a/tagungsberichte-der-historischen-kommission-fur-ost-und-westpreussische-landesforschung.csl
+++ b/tagungsberichte-der-historischen-kommission-fur-ost-und-westpreussische-landesforschung.csl
@@ -3,9 +3,9 @@
   <info>
     <title>Tagungsberichte der Historischen Kommission für ost- und westpreußische Landesforschung</title>
     <title-short>HiKo-OWP</title-short>
-    <id>http://www.zotero.org/styles/tagungsberichte-der-historischen-kommission-fur-ost-und-westpreußische-landesforschung</id>
-    <link href="http://www.zotero.org/styles/tagungsberichte-der-historischen-kommission-fur-ost-und-westpreußische-landesforschung" rel="self"/>
-    <link href="https://www.zotero.org/styles/zeitschrift-fur-deutsche-philologie" rel="template"/>
+    <id>http://www.zotero.org/styles/tagungsberichte-der-historischen-kommission-fur-ost-und-westpreussische-landesforschung</id>
+    <link href="http://www.zotero.org/styles/tagungsberichte-der-historischen-kommission-fur-ost-und-westpreussische-landesforschung" rel="self"/>
+    <link href="http://www.zotero.org/styles/zeitschrift-fur-deutsche-philologie" rel="template"/>
     <link href="http://www.hiko-owp.eu/veroeffentlichungen/" rel="documentation"/>
     <author>
       <name>Rombert Stapel</name>

--- a/tagungsberichte-der-historischen-kommission-fur-ost-und-westpreußische-landesforschung.csl
+++ b/tagungsberichte-der-historischen-kommission-fur-ost-und-westpreußische-landesforschung.csl
@@ -1,0 +1,238 @@
+<?xml version="1.0" encoding="utf-8"?>
+<style xmlns="http://purl.org/net/xbiblio/csl" class="note" version="1.0" demote-non-dropping-particle="sort-only" default-locale="de-DE">
+  <info>
+    <title>Tagungsberichte der Historischen Kommission für ost- und westpreußische Landesforschung</title>
+    <title-short>HiKo-OWP</title-short>
+    <id>http://www.zotero.org/styles/tagungsberichte-der-historischen-kommission-fur-ost-und-westpreußische-landesforschung</id>
+    <link href="http://www.zotero.org/styles/tagungsberichte-der-historischen-kommission-fur-ost-und-westpreußische-landesforschung" rel="self"/>
+    <link href="https://www.zotero.org/styles/zeitschrift-fur-deutsche-philologie" rel="template"/>
+    <link href="http://www.hiko-owp.eu/veroeffentlichungen/" rel="documentation"/>
+    <author>
+      <name>Rombert Stapel</name>
+      <uri>http://twitter.com/rjstapel</uri>
+    </author>
+    <category citation-format="note"/>
+    <category field="humanities"/>
+    <category field="literature"/>
+    <updated>2020-04-12T17:42:14+00:00</updated>
+    <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
+  </info>
+  <locale xml:lang="de">
+    <terms>
+      <term name="editor" form="verb-short">Hg. v.</term>
+      <term name="translator" form="verb-short">Übers. v.</term>
+      <term name="editortranslator" form="verb-short">hg. &amp; übers. v.</term>
+    </terms>
+  </locale>
+  <macro name="author">
+    <names variable="author">
+      <name delimiter=" / " text-decoration="none" delimiter-precedes-last="always">
+        <name-part name="family" text-decoration="underline"/>
+      </name>
+    </names>
+  </macro>
+  <macro name="container-title">
+    <group delimiter=": ">
+      <text term="in" text-case="lowercase"/>
+      <choose>
+        <if type="entry-encyclopedia" match="all" variable="author editor">
+          <text value="Ders./Dies."/>
+        </if>
+      </choose>
+      <text variable="container-title"/>
+    </group>
+  </macro>
+  <macro name="editor">
+    <choose>
+      <if type="entry-encyclopedia" match="all" variable="author editor"/>
+      <else>
+        <names variable="editor translator" delimiter=", ">
+          <label form="verb-short" text-case="lowercase" suffix=" "/>
+          <name delimiter=" / " delimiter-precedes-last="always">
+            <name-part name="family" text-decoration="underline"/>
+          </name>
+        </names>
+      </else>
+    </choose>
+  </macro>
+  <macro name="volume-for-books">
+    <choose>
+      <if variable="volume">
+        <group delimiter=" ">
+          <text term="volume" form="short" prefix=" " text-case="capitalize-first"/>
+          <number text-case="capitalize-first" variable="volume"/>
+        </group>
+      </if>
+      <else>
+        <group>
+          <number variable="number-of-volumes" form="numeric"/>
+          <text term="volume" form="short" prefix=" " plural="true"/>
+        </group>
+      </else>
+    </choose>
+  </macro>
+  <macro name="point-locators-subsequent">
+    <label variable="locator" form="short"/>
+    <text variable="locator" prefix=" "/>
+  </macro>
+  <macro name="point-locators">
+    <choose>
+      <if variable="page">
+        <label variable="locator" form="short" prefix="hier: "/>
+        <text variable="locator" prefix=" "/>
+      </if>
+      <else>
+        <label variable="locator" form="short"/>
+        <text variable="locator" prefix=" "/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="pages">
+    <label variable="page" text-case="capitalize-first" form="short"/>
+    <text variable="page" prefix=" "/>
+  </macro>
+  <macro name="edition-if-unveraendert">
+    <choose>
+      <if match="any" is-numeric="edition">
+        <text variable="edition"/>
+      </if>
+    </choose>
+  </macro>
+  <macro name="edition-if-not-unveraendert">
+    <choose>
+      <if match="none" is-numeric="edition">
+        <text variable="edition"/>
+      </if>
+    </choose>
+  </macro>
+  <macro name="author-short">
+    <names variable="author" text-decoration="none">
+      <name delimiter=" / " form="short" text-decoration="none">
+        <name-part name="family" text-decoration="underline"/>
+      </name>
+    </names>
+  </macro>
+  <macro name="serie-with-number">
+    <group delimiter="">
+      <text variable="collection-title"/>
+      <text variable="collection-number" prefix=", Nr. "/>
+    </group>
+  </macro>
+  <macro name="url-with-date">
+    <group delimiter=" ">
+      <text variable="URL"/>
+      <date form="numeric" variable="accessed" prefix="[" suffix="]"/>
+    </group>
+  </macro>
+  <citation et-al-min="4" et-al-use-first="3" disambiguate-add-names="true">
+    <layout delimiter="; " suffix=".">
+      <choose>
+        <if position="ibid-with-locator">
+          <group delimiter=", ">
+            <text term="ibid"/>
+            <text macro="point-locators-subsequent"/>
+          </group>
+        </if>
+        <else-if position="ibid">
+          <text term="ibid"/>
+        </else-if>
+        <else-if position="subsequent">
+          <text macro="author-short" suffix=", "/>
+          <text variable="title" form="short"/>
+          <text variable="first-reference-note-number" prefix=" (wie Anm. " suffix=")"/>
+          <text macro="point-locators-subsequent" prefix=", "/>
+        </else-if>
+        <else>
+          <group delimiter=", ">
+            <group delimiter=", ">
+              <text macro="author"/>
+              <text variable="title"/>
+              <group delimiter=" ">
+                <text macro="container-title"/>
+                <choose>
+                  <if type="article article-journal article-magazine article-newspaper" match="any">
+                    <group delimiter="">
+                      <text variable="volume" prefix=" "/>
+                      <text variable="issue" prefix=","/>
+                      <date variable="issued">
+                        <date-part name="year" prefix=" (" suffix=")"/>
+                      </date>
+                    </group>
+                  </if>
+                  <else>
+                    <group delimiter=", ">
+                      <text macro="editor"/>
+                      <text macro="volume-for-books"/>
+                      <text macro="edition-if-not-unveraendert"/>
+                      <group delimiter=" ">
+                        <text variable="publisher-place"/>
+                        <group>
+                          <text macro="edition-if-unveraendert" vertical-align="sup"/>
+                          <date variable="issued">
+                            <date-part name="year"/>
+                          </date>
+                        </group>
+                        <text macro="serie-with-number" prefix="(" suffix=")"/>
+                      </group>
+                    </group>
+                  </else>
+                </choose>
+              </group>
+            </group>
+            <text macro="pages"/>
+            <text macro="point-locators"/>
+            <text macro="url-with-date"/>
+          </group>
+        </else>
+      </choose>
+    </layout>
+  </citation>
+  <bibliography subsequent-author-substitute="&#8212;  " entry-spacing="0" hanging-indent="true">
+    <sort>
+      <key macro="author"/>
+      <key variable="issued"/>
+    </sort>
+    <layout suffix=".">
+      <group delimiter=", ">
+        <names variable="author" delimiter=", ">
+          <name name-as-sort-order="all" delimiter=" / ">
+            <name-part name="family" text-decoration="underline"/>
+          </name>
+        </names>
+        <group delimiter=", ">
+          <text variable="title"/>
+          <text macro="container-title"/>
+          <choose>
+            <if type="article article-journal article-magazine article-newspaper" match="any">
+              <group delimiter="">
+                <text variable="volume" prefix=" "/>
+                <text variable="issue" prefix=","/>
+                <date variable="issued">
+                  <date-part name="year" prefix=" (" suffix=")"/>
+                </date>
+              </group>
+            </if>
+            <else>
+              <text macro="editor"/>
+              <text macro="volume-for-books"/>
+              <text macro="edition-if-not-unveraendert"/>
+              <group delimiter=" ">
+                <text variable="publisher-place"/>
+                <group>
+                  <text macro="edition-if-unveraendert" vertical-align="sup"/>
+                  <date variable="issued">
+                    <date-part name="year"/>
+                  </date>
+                </group>
+                <text macro="serie-with-number" prefix=" (" suffix=")"/>
+              </group>
+            </else>
+          </choose>
+          <text macro="pages"/>
+          <text macro="point-locators"/>
+          <text macro="url-with-date"/>
+        </group>
+      </group>
+    </layout>
+  </bibliography>
+</style>


### PR DESCRIPTION
…eußische-landesforschung.csl

Stylesheet for publications by the Historische Kommission für ost- und westpreußische Landesforschung (German), using CSL of 'Zeitschrift für deutsche Philologie' as a template. Actual documentation of stylesheet are not available online, but this CSL is based on my own copy I was sent as an author.