### PR TITLE
Update pravnik.csl, masarykova-univerzita-pravnicka-fakulta.csl and iso690-full-note-cs.csl

### DIFF
--- a/iso690-full-note-cs.csl
+++ b/iso690-full-note-cs.csl
@@ -2,26 +2,19 @@
 <style xmlns="http://purl.org/net/xbiblio/csl" version="1.0" class="note" demote-non-dropping-particle="sort-only" default-locale="cs-CZ">
   <info>
     <title>ISO-690 (full note, Czech)</title>
-    <!--UPOZORNĚNÍ: 
-      1. ČSN ISO 690 jako takový vyžaduje uvádět místo vydání a název nakladatelství i u článků v časopisech. V praxi toto není dodržováno, ani interpretace normy to nedoporučuje a Zotero (5.0) tyto kategorie u časopiseckých článků ani standardně nepodporuje.
-      Je však možnost tyto údaje v článcích uvést, a to pokud v kolonce extras uvedete: 
-      {:publisher: Jméno nakladatelství} 
-      {:publisher-place: Místo vydání}
-      2. Pro zobrazování internetové adresy při citování elektronických periodik je potřeba tuto funkci zapnout, a to v Zotero -> Předvolby (Preferences) -> Citování (Cite) -> Styly (Styles).
-      3. Zotero 5.0 zatím nepodporuje zobrazení rozsahu dvou dat vydání, např 1950 &#8211; 1975. Je však možné do Zotera zadat například 1950zzz1975 a při konečné úpravě vložit " &#8211; " namísto "zzz". (Rozsah by se sice měl podle Ústavu pro jazyk český uvádět s pomlčkou bez mezery, ale dokumentace jej zrovna u dat vydání uvádí s mezerou.)-->
     <id>http://www.zotero.org/styles/iso690-full-note-cs</id>
     <link href="http://www.zotero.org/styles/iso690-full-note-cs" rel="self"/>
     <link href="http://www.zotero.org/styles/iso690-full-note-sk" rel="template"/>
     <link href="https://www.citace.com/CSN-ISO-690.pdf" rel="documentation"/>
     <author>
       <name>Oldrich Tristan Florian</name>
-      <email>oldrich(dot)florian(at)gmail.com</email>
+      <email>oldrich.florian@gmail.com</email>
       <uri>http://otristan.com</uri>
     </author>
     <category citation-format="note"/>
     <category field="law"/>
     <summary>Czech ISO-690, full note.</summary>
-    <updated>2019-12-30T16:03:24+00:00</updated>
+    <updated>2020-04-13T10:00:00+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale xml:lang="cs">
@@ -245,13 +238,7 @@
   </macro>
   <macro name="issued">
     <choose>
-      <if type="book chapter paper-conference" match="any">
-        <text prefix=" " macro="publisher" suffix=", "/>
-        <date variable="issued">
-          <date-part name="year" range-delimiter=" &#8211; "/>
-        </date>
-      </if>
-      <else-if type="article-journal article-magazine article-newspaper" match="any">
+      <if type="article-journal article-magazine article-newspaper" match="any">
         <date variable="issued">
           <date-part name="year" range-delimiter=" &#8211; "/>
         </date>
@@ -267,7 +254,13 @@
             <text variable="issue"/>
           </if>
         </choose>
-      </else-if>
+      </if>
+      <else>
+        <text prefix=" " macro="publisher" suffix=", "/>
+        <date variable="issued">
+          <date-part name="year" range-delimiter=" &#8211; "/>
+        </date>
+      </else>
     </choose>
   </macro>
   <macro name="citation-locator">
@@ -356,34 +349,7 @@
         </else-if>
         <else>
           <choose>
-            <if type="book thesis manuscript report" match="any">
-              <text macro="contributors-long" suffix=". "/>
-              <text macro="title-long" font-style="italic"/>
-              <choose>
-                <if variable="accessed DOI URL" match="any">
-                  <text prefix=" " macro="medium"/>
-                  <text prefix=". " macro="issued"/>
-                  <text prefix=", " macro="citation-locator"/>
-                  <text prefix=" " macro="quoted"/>
-                  <text prefix=". " macro="identifier"/>
-                </if>
-                <else-if variable="issued" match="none">
-                  <text prefix=" " macro="medium"/>
-                  <choose>
-                    <if variable="publisher publisher-place" match="any">
-                      <text prefix=". " macro="publisher"/>
-                    </if>
-                  </choose>
-                  <text prefix=", " macro="citation-locator" suffix="."/>
-                </else-if>
-                <else>
-                  <text prefix=" " macro="medium"/>
-                  <text prefix=". " macro="issued"/>
-                  <text prefix=", " macro="citation-locator" suffix="."/>
-                </else>
-              </choose>
-            </if>
-            <else-if type="chapter entry entry-dictionary entry-encyclopedia" match="any">
+            <if type="chapter entry entry-dictionary entry-encyclopedia" match="any">
               <text macro="contributors-long" suffix=". "/>
               <text macro="title-long" suffix=". "/>
               <text macro="container"/>
@@ -401,15 +367,29 @@
                       <text prefix=". " macro="publisher"/>
                     </if>
                   </choose>
-                  <text prefix=", " macro="citation-locator" suffix="."/>
+                  <choose>
+                    <if variable="locator" match="none">
+                      <text value="."/>
+                    </if>
+                    <else>
+                      <text prefix=", " macro="citation-locator" suffix="."/>
+                    </else>
+                  </choose>
                 </else-if>
                 <else>
                   <text prefix=". " macro="issued"/>
                   <text prefix=", sv. " variable="volume"/>
-                  <text prefix=", " macro="citation-locator" suffix="."/>
+                  <choose>
+                    <if variable="locator" match="none">
+                      <text value="."/>
+                    </if>
+                    <else>
+                      <text prefix=", " macro="citation-locator" suffix="."/>
+                    </else>
+                  </choose>
                 </else>
               </choose>
-            </else-if>
+            </if>
             <else-if type="article-magazine article-newspaper webpage" match="any">
               <text macro="contributors-long" suffix=". "/>
               <text macro="title-long" suffix=". "/>
@@ -423,7 +403,14 @@
                 </if>
                 <else>
                   <text prefix=". " macro="issued"/>
-                  <text prefix=", " macro="citation-locator" suffix="."/>
+                  <choose>
+                    <if variable="locator" match="none">
+                      <text value="."/>
+                    </if>
+                    <else>
+                      <text prefix=", " macro="citation-locator" suffix="."/>
+                    </else>
+                  </choose>
                 </else>
               </choose>
             </else-if>
@@ -447,10 +434,58 @@
                   <text prefix=". " macro="identifier"/>
                 </if>
                 <else>
-                  <text prefix=", " macro="citation-locator" suffix="."/>
+                  <choose>
+                    <if variable="locator" match="none">
+                      <text value="."/>
+                    </if>
+                    <else>
+                      <text prefix=", " macro="citation-locator" suffix="."/>
+                    </else>
+                  </choose>
                 </else>
               </choose>
             </else-if>
+            <else>
+              <text macro="contributors-long" suffix=". "/>
+              <text macro="title-long" font-style="italic"/>
+              <choose>
+                <if variable="accessed DOI URL" match="any">
+                  <text prefix=" " macro="medium"/>
+                  <text prefix=". " macro="issued"/>
+                  <text prefix=", " macro="citation-locator"/>
+                  <text prefix=" " macro="quoted"/>
+                  <text prefix=". " macro="identifier"/>
+                </if>
+                <else-if variable="issued" match="none">
+                  <text prefix=" " macro="medium"/>
+                  <choose>
+                    <if variable="publisher publisher-place" match="any">
+                      <text prefix=". " macro="publisher"/>
+                    </if>
+                  </choose>
+                  <choose>
+                    <if variable="locator" match="none">
+                      <text value="."/>
+                    </if>
+                    <else>
+                      <text prefix=", " macro="citation-locator" suffix="."/>
+                    </else>
+                  </choose>
+                </else-if>
+                <else>
+                  <text prefix=" " macro="medium"/>
+                  <text prefix=". " macro="issued"/>
+                  <choose>
+                    <if variable="locator" match="none">
+                      <text value="."/>
+                    </if>
+                    <else>
+                      <text prefix=", " macro="citation-locator" suffix="."/>
+                    </else>
+                  </choose>
+                </else>
+              </choose>
+            </else>
           </choose>
         </else>
       </choose>
@@ -463,43 +498,7 @@
     </sort>
     <layout>
       <choose>
-        <if type="book thesis manuscript report" match="any">
-          <text macro="contributors-full" suffix=". "/>
-          <text macro="title-long" font-style="italic"/>
-          <choose>
-            <if variable="accessed DOI URL" match="any">
-              <text prefix=" " macro="medium"/>
-              <text prefix=". " macro="secondary-contributors"/>
-              <text prefix=". " macro="edition" suffix="."/>
-              <text prefix=". " macro="issued"/>
-              <text prefix=" " macro="quoted" suffix="."/>
-              <text prefix=". " macro="collection" suffix="."/>
-              <text prefix=". " variable="note" suffix="."/>
-              <text prefix=". " macro="ISBN" suffix="."/>
-              <text prefix=". " macro="identifier"/>
-            </if>
-            <else-if variable="issued" match="none">
-              <text prefix=" " macro="medium" suffix="."/>
-              <choose>
-                <if variable="publisher publisher-place" match="any">
-                  <text prefix=". " macro="publisher" suffix="."/>
-                </if>
-              </choose>
-              <text prefix=". " macro="collection" suffix="."/>
-              <text prefix=". " variable="note" suffix="."/>
-              <text prefix=". " macro="ISBN" suffix="."/>
-            </else-if>
-            <else>
-              <text prefix=" " macro="medium" suffix="."/>
-              <text prefix=". " macro="edition" suffix="."/>
-              <text prefix=". " macro="issued" suffix="."/>
-              <text prefix=". " macro="collection" suffix="."/>
-              <text prefix=". " variable="note" suffix="."/>
-              <text prefix=". " macro="ISBN" suffix="."/>
-            </else>
-          </choose>
-        </if>
-        <else-if type="chapter entry entry-dictionary entry-encyclopedia" match="any">
+        <if type="chapter entry entry-dictionary entry-encyclopedia" match="any">
           <text macro="contributors-full" suffix=". "/>
           <text macro="title-long" suffix=". "/>
           <text macro="container-full"/>
@@ -538,7 +537,7 @@
               <text prefix=". " macro="ISBN" suffix="."/>
             </else>
           </choose>
-        </else-if>
+        </if>
         <else-if type="article-magazine article-newspaper webpage" match="any">
           <text macro="contributors-full" suffix=". "/>
           <text macro="title-long" suffix=". "/>
@@ -587,6 +586,42 @@
             </else>
           </choose>
         </else-if>
+        <else>
+          <text macro="contributors-full" suffix=". "/>
+          <text macro="title-long" font-style="italic"/>
+          <choose>
+            <if variable="accessed DOI URL" match="any">
+              <text prefix=" " macro="medium"/>
+              <text prefix=". " macro="secondary-contributors"/>
+              <text prefix=". " macro="edition" suffix="."/>
+              <text prefix=". " macro="issued"/>
+              <text prefix=" " macro="quoted" suffix="."/>
+              <text prefix=". " macro="collection" suffix="."/>
+              <text prefix=". " variable="note" suffix="."/>
+              <text prefix=". " macro="ISBN" suffix="."/>
+              <text prefix=". " macro="identifier"/>
+            </if>
+            <else-if variable="issued" match="none">
+              <text prefix=" " macro="medium" suffix="."/>
+              <choose>
+                <if variable="publisher publisher-place" match="any">
+                  <text prefix=". " macro="publisher" suffix="."/>
+                </if>
+              </choose>
+              <text prefix=". " macro="collection" suffix="."/>
+              <text prefix=". " variable="note" suffix="."/>
+              <text prefix=". " macro="ISBN" suffix="."/>
+            </else-if>
+            <else>
+              <text prefix=" " macro="medium" suffix="."/>
+              <text prefix=". " macro="edition" suffix="."/>
+              <text prefix=". " macro="issued" suffix="."/>
+              <text prefix=". " macro="collection" suffix="."/>
+              <text prefix=". " variable="note" suffix="."/>
+              <text prefix=". " macro="ISBN" suffix="."/>
+            </else>
+          </choose>
+        </else>
       </choose>
     </layout>
   </bibliography>

--- a/masarykova-univerzita-pravnicka-fakulta.csl
+++ b/masarykova-univerzita-pravnicka-fakulta.csl
@@ -14,7 +14,7 @@
     <category citation-format="note"/>
     <category field="law"/>
     <summary>Masaryk University, Faculty of Law</summary>
-    <updated>2020-04-11T10:00:00+00:00</updated>
+    <updated>2020-04-13T10:00:00+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale xml:lang="cs">
@@ -248,13 +248,7 @@
   </macro>
   <macro name="issued">
     <choose>
-      <if type="book chapter paper-conference" match="any">
-        <text prefix=" " macro="publisher" suffix=", "/>
-        <date variable="issued">
-          <date-part name="year" range-delimiter="&#8211;"/>
-        </date>
-      </if>
-      <else-if type="article-journal article-magazine article-newspaper" match="any">
+      <if type="article-journal article-magazine article-newspaper" match="any">
         <date variable="issued">
           <date-part name="year" range-delimiter="&#8211;"/>
         </date>
@@ -270,7 +264,7 @@
             <text variable="issue"/>
           </if>
         </choose>
-      </else-if>
+      </if>
       <else-if type="webpage" match="any">
         <date variable="issued">
           <date-part name="day" suffix=". "/>
@@ -278,7 +272,13 @@
           <date-part name="year"/>
         </date>
       </else-if>
+      <else-if type="entry entry-dictionary entry-encyclopedia thesis" match="any">
+        <date variable="issued">
+          <date-part name="year" range-delimiter="&#8211;"/>
+        </date>
+      </else-if>
       <else>
+        <text prefix=" " macro="publisher" suffix=", "/>
         <date variable="issued">
           <date-part name="year" range-delimiter="&#8211;"/>
         </date>
@@ -355,59 +355,7 @@
         </else-if>
         <else>
           <choose>
-            <if type="book thesis manuscript report" match="any">
-              <text macro="contributors-long" suffix=". "/>
-              <text macro="title-long" font-style="italic"/>
-              <text prefix=" " macro="medium"/>
-              <choose>
-                <if type="thesis" match="any">
-                  <text prefix=". " macro="issued"/>
-                  <text prefix=", " variable="genre"/>
-                  <text prefix=", " variable="publisher"/>
-                  <choose>
-                    <if variable="locator" match="none">
-                      <text value="."/>
-                    </if>
-                    <else>
-                      <text prefix=", " macro="citation-locator" suffix="."/>
-                    </else>
-                  </choose>
-                </if>
-                <else-if variable="accessed DOI URL" match="any">
-                  <text prefix=". " macro="issued"/>
-                  <text prefix=", " macro="citation-locator"/>
-                  <text prefix=" " macro="quoted"/>
-                  <text prefix=". " macro="identifier" suffix="."/>
-                </else-if>
-                <else-if variable="issued" match="none">
-                  <choose>
-                    <if variable="publisher publisher-place" match="any">
-                      <text prefix=". " macro="publisher"/>
-                    </if>
-                  </choose>
-                  <choose>
-                    <if variable="locator" match="none">
-                      <text value="."/>
-                    </if>
-                    <else>
-                      <text prefix=", " macro="citation-locator" suffix="."/>
-                    </else>
-                  </choose>
-                </else-if>
-                <else>
-                  <text prefix=". " macro="issued"/>
-                  <choose>
-                    <if variable="locator" match="none">
-                      <text value="."/>
-                    </if>
-                    <else>
-                      <text prefix=", " macro="citation-locator" suffix="."/>
-                    </else>
-                  </choose>
-                </else>
-              </choose>
-            </if>
-            <else-if type="chapter entry entry-dictionary entry-encyclopedia" match="any">
+            <if type="chapter entry entry-dictionary entry-encyclopedia" match="any">
               <text macro="contributors-long" suffix=". "/>
               <text macro="title-long" suffix=". "/>
               <text macro="container"/>
@@ -425,7 +373,14 @@
                       <text prefix=". " macro="publisher"/>
                     </if>
                   </choose>
-                  <text prefix=", " macro="citation-locator" suffix="."/>
+                  <choose>
+                    <if variable="locator" match="none">
+                      <text value="."/>
+                    </if>
+                    <else>
+                      <text prefix=", " macro="citation-locator" suffix="."/>
+                    </else>
+                  </choose>
                 </else-if>
                 <else>
                   <text prefix=". " macro="issued"/>
@@ -440,7 +395,7 @@
                   </choose>
                 </else>
               </choose>
-            </else-if>
+            </if>
             <else-if type="article-magazine article-newspaper webpage" match="any">
               <text macro="contributors-long" suffix=". "/>
               <choose>
@@ -496,6 +451,58 @@
                 </else>
               </choose>
             </else-if>
+            <else>
+              <text macro="contributors-long" suffix=". "/>
+              <text macro="title-long" font-style="italic"/>
+              <text prefix=" " macro="medium"/>
+              <choose>
+                <if type="thesis" match="any">
+                  <text prefix=". " macro="issued"/>
+                  <text prefix=", " variable="genre"/>
+                  <text prefix=", " variable="publisher"/>
+                  <choose>
+                    <if variable="locator" match="none">
+                      <text value="."/>
+                    </if>
+                    <else>
+                      <text prefix=", " macro="citation-locator" suffix="."/>
+                    </else>
+                  </choose>
+                </if>
+                <else-if variable="accessed DOI URL" match="any">
+                  <text prefix=". " macro="issued"/>
+                  <text prefix=", " macro="citation-locator"/>
+                  <text prefix=" " macro="quoted"/>
+                  <text prefix=". " macro="identifier" suffix="."/>
+                </else-if>
+                <else-if variable="issued" match="none">
+                  <choose>
+                    <if variable="publisher publisher-place" match="any">
+                      <text prefix=". " macro="publisher"/>
+                    </if>
+                  </choose>
+                  <choose>
+                    <if variable="locator" match="none">
+                      <text value="."/>
+                    </if>
+                    <else>
+                      <text prefix=", " macro="citation-locator" suffix="."/>
+                    </else>
+                  </choose>
+                </else-if>
+                <else>
+                  <text prefix=". " macro="issued"/>
+                  <choose>
+                    <if variable="locator" match="none">
+                      <text value="."/>
+                    </if>
+                    <else>
+                      <text prefix=", " macro="citation-locator" suffix="."/>
+                    </else>
+                  </choose>
+                </else>
+              </choose>
+            </else>
           </choose>
         </else>
       </choose>
@@ -508,47 +515,7 @@
     </sort>
     <layout>
       <choose>
-        <if type="book thesis manuscript report" match="any">
-          <text macro="contributors-full" suffix=". "/>
-          <text macro="title-long" font-style="italic"/>
-          <choose>
-            <if type="thesis" match="any">
-              <text prefix=" " macro="medium"/>
-              <text prefix=". " macro="issued"/>
-              <text prefix=", " variable="genre"/>
-              <text prefix=", " variable="publisher"/>
-              <text prefix=", " variable="number-of-pages" suffix=" s."/>
-            </if>
-            <else-if variable="accessed DOI URL" match="any">
-              <text prefix=" " macro="medium"/>
-              <text prefix=". " macro="secondary-contributors"/>
-              <text prefix=". " macro="edition" suffix="."/>
-              <text prefix=". " macro="issued"/>
-              <text prefix=" " macro="quoted" suffix="."/>
-              <text prefix=". " macro="collection" suffix="."/>
-              <text prefix=". " variable="note" suffix="."/>
-              <text prefix=". " macro="identifier" suffix="."/>
-            </else-if>
-            <else-if variable="issued" match="none">
-              <text prefix=" " macro="medium" suffix="."/>
-              <choose>
-                <if variable="publisher publisher-place" match="any">
-                  <text prefix=". " macro="publisher" suffix="."/>
-                </if>
-              </choose>
-              <text prefix=". " macro="collection" suffix="."/>
-              <text prefix=". " variable="note" suffix="."/>
-            </else-if>
-            <else>
-              <text prefix=" " macro="medium" suffix="."/>
-              <text prefix=". " macro="edition" suffix="."/>
-              <text prefix=". " macro="issued" suffix="."/>
-              <text prefix=". " macro="collection" suffix="."/>
-              <text prefix=". " variable="note" suffix="."/>
-            </else>
-          </choose>
-        </if>
-        <else-if type="chapter entry entry-dictionary entry-encyclopedia" match="any">
+        <if type="chapter entry entry-dictionary entry-encyclopedia" match="any">
           <text macro="contributors-full" suffix=". "/>
           <text macro="title-long" suffix=". "/>
           <text macro="container-full"/>
@@ -584,7 +551,7 @@
               <text prefix=". " macro="collection" suffix="."/>
             </else>
           </choose>
-        </else-if>
+        </if>
         <else-if type="article-magazine article-newspaper webpage" match="any">
           <text macro="contributors-full" suffix=". "/>
           <choose>
@@ -629,6 +596,46 @@
             </else>
           </choose>
         </else-if>
+        <else>
+          <text macro="contributors-full" suffix=". "/>
+          <text macro="title-long" font-style="italic"/>
+          <choose>
+            <if type="thesis" match="any">
+              <text prefix=" " macro="medium"/>
+              <text prefix=". " macro="issued"/>
+              <text prefix=", " variable="genre"/>
+              <text prefix=", " variable="publisher"/>
+              <text prefix=", " variable="number-of-pages" suffix=" s."/>
+            </if>
+            <else-if variable="accessed DOI URL" match="any">
+              <text prefix=" " macro="medium"/>
+              <text prefix=". " macro="secondary-contributors"/>
+              <text prefix=". " macro="edition" suffix="."/>
+              <text prefix=". " macro="issued"/>
+              <text prefix=" " macro="quoted" suffix="."/>
+              <text prefix=". " macro="collection" suffix="."/>
+              <text prefix=". " variable="note" suffix="."/>
+              <text prefix=". " macro="identifier" suffix="."/>
+            </else-if>
+            <else-if variable="issued" match="none">
+              <text prefix=" " macro="medium" suffix="."/>
+              <choose>
+                <if variable="publisher publisher-place" match="any">
+                  <text prefix=". " macro="publisher" suffix="."/>
+                </if>
+              </choose>
+              <text prefix=". " macro="collection" suffix="."/>
+              <text prefix=". " variable="note" suffix="."/>
+            </else-if>
+            <else>
+              <text prefix=" " macro="medium" suffix="."/>
+              <text prefix=". " macro="edition" suffix="."/>
+              <text prefix=". " macro="issued" suffix="."/>
+              <text prefix=". " macro="collection" suffix="."/>
+              <text prefix=". " variable="note" suffix="."/>
+            </else>
+          </choose>
+        </else>
       </choose>
     </layout>
   </bibliography>

--- a/pravnik.csl
+++ b/pravnik.csl
@@ -8,14 +8,14 @@
     <link href="https://www.ilaw.cas.cz/casopisy-a-knihy/casopisy/casopis-pravnik/pro-autory/pokyny-pro-autory-citace.html" rel="documentation"/>
     <author>
       <name>Oldrich Tristan Florian</name>
-      <email>oldrich(dot)florian(at)gmail.com</email>
+      <email>oldrich.florian@gmail.com</email>
       <uri>http://otristan.com</uri>
     </author>
     <category citation-format="note"/>
     <category field="law"/>
     <issn>0231-6625</issn>
-    <summary>Czech ISO-690, full note, suitable for Pravnik - a journal published by the Institute of State and Law of the Czech Academy of Sciences. UPOZORNĚNÍ: Pro zobrazování internetové adresy při citování elektronických periodik je potřeba tuto funkci zapnout, a to v Zotero -&gt; Předvolby (Preferences) -&gt; Citování (Cite) -&gt; Styly (Styles).</summary>
-    <updated>2020-04-11T10:00:00+00:00</updated>
+    <summary>Czech ISO-690, full note, suitable for Pravnik - a journal published by the Institute of State and Law of the Czech Academy of Sciences.</summary>
+    <updated>2020-04-13T10:00:00+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale xml:lang="cs">
@@ -214,9 +214,6 @@
         <if variable="publisher-place accessed DOI URL" match="any">
           <text variable="publisher-place"/>
         </if>
-        <else>
-          <text value="[s.l.]"/>
-        </else>
       </choose>
     </group>
   </macro>
@@ -226,9 +223,6 @@
         <if variable="publisher accessed DOI URL" match="any">
           <text variable="publisher"/>
         </if>
-        <else>
-          <text value="[s.n.]"/>
-        </else>
       </choose>
     </group>
   </macro>
@@ -240,13 +234,7 @@
   </macro>
   <macro name="issued">
     <choose>
-      <if type="book chapter paper-conference" match="any">
-        <text prefix=" " macro="publisher" suffix=", "/>
-        <date variable="issued">
-          <date-part name="year" range-delimiter=" &#8211; "/>
-        </date>
-      </if>
-      <else-if type="article-journal article-magazine article-newspaper" match="any">
+      <if type="article-journal article-magazine article-newspaper" match="any">
         <date variable="issued">
           <date-part name="year" range-delimiter=" &#8211; "/>
         </date>
@@ -262,7 +250,20 @@
             <text variable="issue"/>
           </if>
         </choose>
+      </if>
+      <else-if type="webpage" match="any">
+        <date variable="issued">
+          <date-part name="day" suffix=". "/>
+          <date-part name="month" suffix=". " form="numeric"/>
+          <date-part name="year"/>
+        </date>
       </else-if>
+      <else>
+        <text prefix=" " macro="publisher" suffix=", "/>
+        <date variable="issued">
+          <date-part name="year" range-delimiter=" &#8211; "/>
+        </date>
+      </else>
     </choose>
   </macro>
   <macro name="citation-locator">
@@ -344,7 +345,95 @@
         </else-if>
         <else>
           <choose>
-            <if type="book thesis manuscript report" match="any">
+            <if type="chapter entry entry-dictionary entry-encyclopedia" match="any">
+              <text macro="contributors-long" suffix=". "/>
+              <text macro="title-long" suffix=". "/>
+              <text macro="container"/>
+              <choose>
+                <if variable="accessed DOI URL" match="any">
+                  <text prefix=". " macro="issued"/>
+                  <text prefix=", sv. " variable="volume"/>
+                  <text prefix=", " macro="citation-locator"/>
+                  <text prefix=" " macro="quoted"/>
+                  <text prefix=". " macro="identifier"/>
+                </if>
+                <else-if variable="issued" match="none">
+                  <choose>
+                    <if variable="publisher publisher-place" match="any">
+                      <text prefix=". " macro="publisher"/>
+                    </if>
+                  </choose>
+                  <choose>
+                    <if variable="locator" match="none">
+                      <text value="."/>
+                    </if>
+                    <else>
+                      <text prefix=", " macro="citation-locator" suffix="."/>
+                    </else>
+                  </choose>
+                </else-if>
+                <else>
+                  <text prefix=". " macro="issued"/>
+                  <text prefix=", sv. " variable="volume"/>
+                  <choose>
+                    <if variable="locator" match="none">
+                      <text value="."/>
+                    </if>
+                    <else>
+                      <text prefix=", " macro="citation-locator" suffix="."/>
+                    </else>
+                  </choose>
+                </else>
+              </choose>
+            </if>
+            <else-if type="article-magazine article-newspaper webpage" match="any">
+              <text macro="contributors-long" suffix=". "/>
+              <text macro="title-long" suffix=". "/>
+              <text macro="container"/>
+              <choose>
+                <if variable="accessed DOI URL" match="any">
+                  <text prefix=". " macro="issued"/>
+                  <text prefix=", " macro="citation-locator"/>
+                  <text prefix=" " macro="quoted"/>
+                  <text prefix=". " macro="identifier"/>
+                </if>
+                <else>
+                  <text prefix=". " macro="issued"/>
+                  <choose>
+                    <if variable="locator" match="none">
+                      <text value="."/>
+                    </if>
+                    <else>
+                      <text prefix=", " macro="citation-locator" suffix="."/>
+                    </else>
+                  </choose>
+                </else>
+              </choose>
+            </else-if>
+            <else-if type="article-journal" match="any">
+              <text macro="contributors-long" suffix=". "/>
+              <text macro="title-long" suffix=". "/>
+              <text macro="container"/>
+              <text prefix=". " macro="issued"/>
+              <choose>
+                <if variable="accessed DOI URL" match="any">
+                  <text prefix=", " macro="citation-locator"/>
+                  <text prefix=" " macro="quoted"/>
+                  <text prefix=". " macro="identifier"/>
+                </if>
+                <else>
+                  <choose>
+                    <if variable="locator" match="none">
+                      <text value="."/>
+                    </if>
+                    <else>
+                      <text prefix=", " macro="citation-locator" suffix="."/>
+                    </else>
+                  </choose>
+                </else>
+              </choose>
+            </else-if>
+            <else>
               <text macro="contributors-long" suffix=". "/>
               <text macro="title-long" font-style="italic"/>
               <choose>
@@ -362,75 +451,29 @@
                       <text prefix=". " macro="publisher"/>
                     </if>
                   </choose>
-                  <text prefix=", " macro="citation-locator" suffix="."/>
+                  <choose>
+                    <if variable="locator" match="none">
+                      <text value="."/>
+                    </if>
+                    <else>
+                      <text prefix=", " macro="citation-locator" suffix="."/>
+                    </else>
+                  </choose>
                 </else-if>
                 <else>
                   <text prefix=" " macro="medium"/>
                   <text prefix=". " macro="issued"/>
-                  <text prefix=", " macro="citation-locator" suffix="."/>
-                </else>
-              </choose>
-            </if>
-            <else-if type="chapter entry entry-dictionary entry-encyclopedia" match="any">
-              <text macro="contributors-long" suffix=". "/>
-              <text macro="title-long" suffix=". "/>
-              <text macro="container"/>
-              <choose>
-                <if variable="accessed DOI URL" match="any">
-                  <text prefix=". " macro="issued"/>
-                  <text prefix=", sv. " variable="volume"/>
-                  <text prefix=", " macro="citation-locator"/>
-                  <text prefix=" " macro="quoted"/>
-                  <text prefix=". " macro="identifier"/>
-                </if>
-                <else-if variable="issued" match="none">
                   <choose>
-                    <if variable="publisher publisher-place" match="any">
-                      <text prefix=". " macro="publisher"/>
+                    <if variable="locator" match="none">
+                      <text value="."/>
                     </if>
+                    <else>
+                      <text prefix=", " macro="citation-locator" suffix="."/>
+                    </else>
                   </choose>
-                  <text prefix=", " macro="citation-locator" suffix="."/>
-                </else-if>
-                <else>
-                  <text prefix=". " macro="issued"/>
-                  <text prefix=", sv. " variable="volume"/>
-                  <text prefix=", " macro="citation-locator" suffix="."/>
                 </else>
               </choose>
-            </else-if>
-            <else-if type="article-magazine article-newspaper webpage" match="any">
-              <text macro="contributors-long" suffix=". "/>
-              <text macro="title-long" suffix=". "/>
-              <text macro="container"/>
-              <choose>
-                <if variable="accessed DOI URL" match="any">
-                  <text prefix=". " macro="issued"/>
-                  <text prefix=", " macro="citation-locator"/>
-                  <text prefix=" " macro="quoted"/>
-                  <text prefix=". " macro="identifier"/>
-                </if>
-                <else>
-                  <text prefix=". " macro="issued"/>
-                  <text prefix=", " macro="citation-locator" suffix="."/>
-                </else>
-              </choose>
-            </else-if>
-            <else-if type="article-journal" match="any">
-              <text macro="contributors-long" suffix=". "/>
-              <text macro="title-long" suffix=". "/>
-              <text macro="container"/>
-              <text prefix=". " macro="issued"/>
-              <choose>
-                <if variable="accessed DOI URL" match="any">
-                  <text prefix=", " macro="citation-locator"/>
-                  <text prefix=" " macro="quoted"/>
-                  <text prefix=". " macro="identifier"/>
-                </if>
-                <else>
-                  <text prefix=", " macro="citation-locator" suffix="."/>
-                </else>
-              </choose>
-            </else-if>
+            </else>
           </choose>
         </else>
       </choose>
@@ -443,43 +486,7 @@
     </sort>
     <layout>
       <choose>
-        <if type="book thesis manuscript report" match="any">
-          <text macro="contributors-full" suffix=". "/>
-          <text macro="title-long" font-style="italic"/>
-          <choose>
-            <if variable="accessed DOI URL" match="any">
-              <text prefix=" " macro="medium"/>
-              <text prefix=". " macro="secondary-contributors"/>
-              <text prefix=". " macro="edition" suffix="."/>
-              <text prefix=". " macro="issued"/>
-              <text prefix=" " macro="quoted" suffix="."/>
-              <text prefix=". " macro="collection" suffix="."/>
-              <text prefix=". " variable="note" suffix="."/>
-              <text prefix=". " macro="ISBN" suffix="."/>
-              <text prefix=". " macro="identifier"/>
-            </if>
-            <else-if variable="issued" match="none">
-              <text prefix=" " macro="medium" suffix="."/>
-              <choose>
-                <if variable="publisher publisher-place" match="any">
-                  <text prefix=". " macro="publisher" suffix="."/>
-                </if>
-              </choose>
-              <text prefix=". " macro="collection" suffix="."/>
-              <text prefix=". " variable="note" suffix="."/>
-              <text prefix=". " macro="ISBN" suffix="."/>
-            </else-if>
-            <else>
-              <text prefix=" " macro="medium" suffix="."/>
-              <text prefix=". " macro="edition" suffix="."/>
-              <text prefix=". " macro="issued" suffix="."/>
-              <text prefix=". " macro="collection" suffix="."/>
-              <text prefix=". " variable="note" suffix="."/>
-              <text prefix=". " macro="ISBN" suffix="."/>
-            </else>
-          </choose>
-        </if>
-        <else-if type="chapter entry entry-dictionary entry-encyclopedia" match="any">
+        <if type="chapter entry entry-dictionary entry-encyclopedia" match="any">
           <text macro="contributors-full" suffix=". "/>
           <text macro="title-long" suffix=". "/>
           <text macro="container-full"/>
@@ -518,7 +525,7 @@
               <text prefix=". " macro="ISBN" suffix="."/>
             </else>
           </choose>
-        </else-if>
+        </if>
         <else-if type="article-magazine article-newspaper webpage article-journal" match="any">
           <text macro="contributors-full" suffix=". "/>
           <text macro="title-long" suffix=". "/>
@@ -537,6 +544,42 @@
             </else>
           </choose>
         </else-if>
+        <else>
+          <text macro="contributors-full" suffix=". "/>
+          <text macro="title-long" font-style="italic"/>
+          <choose>
+            <if variable="accessed DOI URL" match="any">
+              <text prefix=" " macro="medium"/>
+              <text prefix=". " macro="secondary-contributors"/>
+              <text prefix=". " macro="edition" suffix="."/>
+              <text prefix=". " macro="issued"/>
+              <text prefix=" " macro="quoted" suffix="."/>
+              <text prefix=". " macro="collection" suffix="."/>
+              <text prefix=". " variable="note" suffix="."/>
+              <text prefix=". " macro="ISBN" suffix="."/>
+              <text prefix=". " macro="identifier"/>
+            </if>
+            <else-if variable="issued" match="none">
+              <text prefix=" " macro="medium" suffix="."/>
+              <choose>
+                <if variable="publisher publisher-place" match="any">
+                  <text prefix=". " macro="publisher" suffix="."/>
+                </if>
+              </choose>
+              <text prefix=". " macro="collection" suffix="."/>
+              <text prefix=". " variable="note" suffix="."/>
+              <text prefix=". " macro="ISBN" suffix="."/>
+            </else-if>
+            <else>
+              <text prefix=" " macro="medium" suffix="."/>
+              <text prefix=". " macro="edition" suffix="."/>
+              <text prefix=". " macro="issued" suffix="."/>
+              <text prefix=". " macro="collection" suffix="."/>
+              <text prefix=". " variable="note" suffix="."/>
+              <text prefix=". " macro="ISBN" suffix="."/>
+            </else>
+          </choose>
+        </else>
       </choose>
     </layout>
   </bibliography>


### PR DESCRIPTION
Since "pravnik.csl" and "masarykova-univerzita-pravnicka-fakulta.csl" has "iso690-full-note-cs.csl" as a template, I am opening a pull request for all three of them. For "pravnik.csl" and "iso690-full-note-cs.csl", I made sure that it ends with "." even without a locator. At the top of that, for all the three styles, I made the book formatting as default (by moving it from if to else branch), which allows citing more item types.