### PR TITLE
remove space before in-text citation in le-tapuscrit-author-date.csl

### DIFF
--- a/le-tapuscrit-author-date.csl
+++ b/le-tapuscrit-author-date.csl
@@ -288,7 +288,7 @@
     <text variable="collection-title" quotes="true" prefix=" (coll.&#160;" suffix=")"/>
   </macro>
   <citation et-al-min="4" et-al-use-first="1" disambiguate-add-year-suffix="true" disambiguate-add-names="true" disambiguate-add-givenname="true" givenname-disambiguation-rule="primary-name">
-    <layout prefix="&#160;(" suffix=")" delimiter="; ">
+    <layout prefix="(" suffix=")" delimiter="; ">
       <choose>
         <if position="ibid-with-locator">
           <group delimiter=", ">


### PR DESCRIPTION
via https://forums.zotero.org/discussion/82514/personalized-style-space-added-before-the-quotation#latest

Not sure why there is a space there. If there is a reason for it, please close.