### PR TITLE
Fix et-al and indetation settings for mammalia.csl

### DIFF
--- a/mammalia.csl
+++ b/mammalia.csl
@@ -26,7 +26,6 @@
   <macro name="author">
     <names variable="author">
       <name and="text" initialize-with="." name-as-sort-order="first" sort-separator=" "/>
-      <et-al font-style="italic"/>
       <label form="short" prefix=" (" suffix=")" text-case="capitalize-first"/>
       <substitute>
         <names variable="editor"/>
@@ -38,7 +37,6 @@
   <macro name="author-short">
     <names variable="author">
       <name form="short" and="text" delimiter=", " initialize-with=". "/>
-      <et-al font-style="italic"/>
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
@@ -80,7 +78,7 @@
       </group>
     </layout>
   </citation>
-  <bibliography et-al-min="6" et-al-use-first="5" second-field-align="margin">
+  <bibliography et-al-min="4" et-al-use-first="1" second-field-align="margin">
     <sort>
       <key macro="author-short" names-min="1" names-use-first="1"/>
       <key variable="issued"/>

--- a/mammalia.csl
+++ b/mammalia.csl
@@ -14,7 +14,7 @@
     <category field="biology"/>
     <issn>0025-1461</issn>
     <eissn>1864-1547</eissn>
-    <updated>2020-04-19T12:35:46+00:00</updated>
+    <updated>2020-04-20T10:34:52+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <macro name="editor-translator">
@@ -78,62 +78,63 @@
       </group>
     </layout>
   </citation>
-  <bibliography et-al-min="4" et-al-use-first="1" second-field-align="margin">
+  <bibliography et-al-min="4" et-al-use-first="1">
     <sort>
-      <key macro="author-short" names-min="1" names-use-first="1"/>
-      <key variable="issued"/>
       <key macro="author"/>
+      <key variable="issued"/>
     </sort>
     <layout suffix=".">
-      <text macro="author"/>
-      <date date-parts="year" form="text" variable="issued" prefix=". "/>
-      <choose>
-        <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
-          <group suffix="." prefix=". ">
-            <text macro="title"/>
-            <text macro="editor-translator"/>
-          </group>
-          <text prefix=" " suffix="." macro="publisher"/>
-        </if>
-        <else-if type="chapter paper-conference" match="any">
-          <group delimiter=". " prefix=". ">
-            <text macro="title"/>
-            <group delimiter=" ">
-              <group delimiter=": ">
-                <text term="in" text-case="capitalize-first"/>
-                <names variable="editor translator" prefix="(" suffix=")">
-                  <name prefix=" " initialize-with=". " name-as-sort-order="all" sort-separator=" "/>
-                  <label form="short" prefix=", "/>
-                </names>
-              </group>
-              <group delimiter=", ">
-                <text variable="container-title"/>
-                <text variable="collection-title"/>
-              </group>
-            </group>
-            <text macro="publisher"/>
-            <group delimiter=" ">
-              <label variable="page" form="short"/>
-              <text variable="page"/>
-            </group>
-          </group>
-        </else-if>
-        <else>
-          <group delimiter=". " prefix=". ">
-            <group delimiter=", ">
+      <group delimiter=". ">
+        <text macro="author"/>
+        <date date-parts="year" form="text" variable="issued"/>
+        <choose>
+          <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
+            <group>
               <text macro="title"/>
               <text macro="editor-translator"/>
             </group>
-            <group delimiter=" ">
-              <text variable="container-title" form="short"/>
-              <group delimiter=": ">
-                <text variable="volume"/>
+            <text prefix=" " suffix="." macro="publisher"/>
+          </if>
+          <else-if type="chapter paper-conference" match="any">
+            <group delimiter=". ">
+              <text macro="title"/>
+              <group delimiter=" ">
+                <group delimiter=": ">
+                  <text term="in" text-case="capitalize-first"/>
+                  <names variable="editor translator" prefix="(" suffix=")">
+                    <name prefix=" " initialize-with=". " name-as-sort-order="all" sort-separator=" "/>
+                    <label form="short" prefix=", "/>
+                  </names>
+                </group>
+                <group delimiter=", ">
+                  <text variable="container-title"/>
+                  <text variable="collection-title"/>
+                </group>
+              </group>
+              <text macro="publisher"/>
+              <group delimiter=" ">
+                <label variable="page" form="short"/>
                 <text variable="page"/>
               </group>
             </group>
-          </group>
-        </else>
-      </choose>
+          </else-if>
+          <else>
+            <group delimiter=". ">
+              <group delimiter=", ">
+                <text macro="title"/>
+                <text macro="editor-translator"/>
+              </group>
+              <group delimiter=" ">
+                <text variable="container-title" form="short"/>
+                <group delimiter=": ">
+                  <text variable="volume"/>
+                  <text variable="page"/>
+                </group>
+              </group>
+            </group>
+          </else>
+        </choose>
+      </group>
     </layout>
   </bibliography>
 </style>

--- a/mammalia.csl
+++ b/mammalia.csl
@@ -78,7 +78,7 @@
       </group>
     </layout>
   </citation>
-  <bibliography et-al-min="4" et-al-use-first="1">
+  <bibliography>
     <sort>
       <key macro="author"/>
       <key variable="issued"/>


### PR DESCRIPTION
Remove italics for et al.
Change et-al settings: "If the reference consists of three or more author names, the first name is
followed by et al."

Fix indentation issues. (that weird author-short in the sort settings made it all odd. Hard to find that issue actually.)