### PR TITLE
APA: switch volume label to volume term for non-numeric volumes

### DIFF
--- a/apa-annotated-bibliography.csl
+++ b/apa-annotated-bibliography.csl
@@ -425,7 +425,7 @@
                   <choose>
                     <if is-numeric="volume" match="none">
                       <group delimiter=" ">
-                        <label variable="volume" form="short" text-case="capitalize-first"/>
+                        <text term="volume" form="short" text-case="capitalize-first"/>
                         <text variable="volume"/>
                       </group>
                     </if>
@@ -444,7 +444,7 @@
               <choose>
                 <if is-numeric="volume" match="none">
                   <group delimiter=" ">
-                    <label variable="volume" form="short" text-case="capitalize-first"/>
+                    <text term="volume" form="short" text-case="capitalize-first"/>
                     <text variable="volume"/>
                   </group>
                 </if>
@@ -1287,7 +1287,7 @@
               <choose>
                 <if is-numeric="volume" match="none">
                   <group delimiter=" ">
-                    <label variable="volume" form="short" text-case="capitalize-first"/>
+                    <text term="volume" form="short" text-case="capitalize-first"/>
                     <text variable="volume"/>
                   </group>
                 </if>

--- a/apa-cv.csl
+++ b/apa-cv.csl
@@ -313,7 +313,7 @@
                   <choose>
                     <if is-numeric="volume" match="none">
                       <group delimiter=" ">
-                        <label variable="volume" form="short" text-case="capitalize-first"/>
+                        <text term="volume" form="short" text-case="capitalize-first"/>
                         <text variable="volume"/>
                       </group>
                     </if>
@@ -332,7 +332,7 @@
               <choose>
                 <if is-numeric="volume" match="none">
                   <group delimiter=" ">
-                    <label variable="volume" form="short" text-case="capitalize-first"/>
+                    <text term="volume" form="short" text-case="capitalize-first"/>
                     <text variable="volume"/>
                   </group>
                 </if>
@@ -1034,7 +1034,7 @@
               <choose>
                 <if is-numeric="volume" match="none">
                   <group delimiter=" ">
-                    <label variable="volume" form="short" text-case="capitalize-first"/>
+                    <text term="volume" form="short" text-case="capitalize-first"/>
                     <text variable="volume"/>
                   </group>
                 </if>

--- a/apa-no-ampersand.csl
+++ b/apa-no-ampersand.csl
@@ -425,7 +425,7 @@
                   <choose>
                     <if is-numeric="volume" match="none">
                       <group delimiter=" ">
-                        <label variable="volume" form="short" text-case="capitalize-first"/>
+                        <text term="volume" form="short" text-case="capitalize-first"/>
                         <text variable="volume"/>
                       </group>
                     </if>
@@ -444,7 +444,7 @@
               <choose>
                 <if is-numeric="volume" match="none">
                   <group delimiter=" ">
-                    <label variable="volume" form="short" text-case="capitalize-first"/>
+                    <text term="volume" form="short" text-case="capitalize-first"/>
                     <text variable="volume"/>
                   </group>
                 </if>
@@ -1287,7 +1287,7 @@
               <choose>
                 <if is-numeric="volume" match="none">
                   <group delimiter=" ">
-                    <label variable="volume" form="short" text-case="capitalize-first"/>
+                    <text term="volume" form="short" text-case="capitalize-first"/>
                     <text variable="volume"/>
                   </group>
                 </if>

--- a/apa-single-spaced.csl
+++ b/apa-single-spaced.csl
@@ -425,7 +425,7 @@
                   <choose>
                     <if is-numeric="volume" match="none">
                       <group delimiter=" ">
-                        <label variable="volume" form="short" text-case="capitalize-first"/>
+                        <text term="volume" form="short" text-case="capitalize-first"/>
                         <text variable="volume"/>
                       </group>
                     </if>
@@ -444,7 +444,7 @@
               <choose>
                 <if is-numeric="volume" match="none">
                   <group delimiter=" ">
-                    <label variable="volume" form="short" text-case="capitalize-first"/>
+                    <text term="volume" form="short" text-case="capitalize-first"/>
                     <text variable="volume"/>
                   </group>
                 </if>
@@ -1287,7 +1287,7 @@
               <choose>
                 <if is-numeric="volume" match="none">
                   <group delimiter=" ">
-                    <label variable="volume" form="short" text-case="capitalize-first"/>
+                    <text term="volume" form="short" text-case="capitalize-first"/>
                     <text variable="volume"/>
                   </group>
                 </if>

--- a/apa-with-abstract.csl
+++ b/apa-with-abstract.csl
@@ -425,7 +425,7 @@
                   <choose>
                     <if is-numeric="volume" match="none">
                       <group delimiter=" ">
-                        <label variable="volume" form="short" text-case="capitalize-first"/>
+                        <text term="volume" form="short" text-case="capitalize-first"/>
                         <text variable="volume"/>
                       </group>
                     </if>
@@ -444,7 +444,7 @@
               <choose>
                 <if is-numeric="volume" match="none">
                   <group delimiter=" ">
-                    <label variable="volume" form="short" text-case="capitalize-first"/>
+                    <text term="volume" form="short" text-case="capitalize-first"/>
                     <text variable="volume"/>
                   </group>
                 </if>
@@ -1287,7 +1287,7 @@
               <choose>
                 <if is-numeric="volume" match="none">
                   <group delimiter=" ">
-                    <label variable="volume" form="short" text-case="capitalize-first"/>
+                    <text term="volume" form="short" text-case="capitalize-first"/>
                     <text variable="volume"/>
                   </group>
                 </if>

--- a/apa.csl
+++ b/apa.csl
@@ -425,7 +425,7 @@
                   <choose>
                     <if is-numeric="volume" match="none">
                       <group delimiter=" ">
-                        <label variable="volume" form="short" text-case="capitalize-first"/>
+                        <text term="volume" form="short" text-case="capitalize-first"/>
                         <text variable="volume"/>
                       </group>
                     </if>
@@ -444,7 +444,7 @@
               <choose>
                 <if is-numeric="volume" match="none">
                   <group delimiter=" ">
-                    <label variable="volume" form="short" text-case="capitalize-first"/>
+                    <text term="volume" form="short" text-case="capitalize-first"/>
                     <text variable="volume"/>
                   </group>
                 </if>
@@ -1287,7 +1287,7 @@
               <choose>
                 <if is-numeric="volume" match="none">
                   <group delimiter=" ">
-                    <label variable="volume" form="short" text-case="capitalize-first"/>
+                    <text term="volume" form="short" text-case="capitalize-first"/>
                     <text variable="volume"/>
                   </group>
                 </if>


### PR DESCRIPTION
Accomodate some undesirable behavior in citeproc-js: https://github.com/Juris-M/citeproc-js/issues/124

If the non-numeric pluralization behavior for `label` changes in citeproc-js (or when volume-title is incorporated), we can change this back.