### PR TITLE
fix demote-non-dropping-particle for equine-veterinary-education.csl

### DIFF
--- a/equine-veterinary-education.csl
+++ b/equine-veterinary-education.csl
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" delimiter-precedes-last="never" default-locale="en-GB">
+<style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" demote-non-dropping-particle="sort-only" delimiter-precedes-last="never" default-locale="en-GB">
   <info>
     <title>Equine Veterinary Education</title>
     <title-short>EVE</title-short>
@@ -20,7 +20,7 @@
     <category field="medicine"/>
     <issn>0957-7734</issn>
     <eissn>2042-3292</eissn>
-    <updated>2020-04-07T14:27:20+00:00</updated>
+    <updated>2020-05-10T14:27:20+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <macro name="author">


### PR DESCRIPTION
via https://forums.zotero.org/discussion/83043/issues-with-prefixed-author-surname-in-equine-veterinary-education-format

checked via several papers.