### PR TITLE
 Update masarykova-univerzita-pravnicka-fakulta.csl

### DIFF
--- a/masarykova-univerzita-pravnicka-fakulta.csl
+++ b/masarykova-univerzita-pravnicka-fakulta.csl
@@ -14,14 +14,14 @@
     <category citation-format="note"/>
     <category field="law"/>
     <summary>Masaryk University, Faculty of Law</summary>
-    <updated>2020-05-13T10:00:00+00:00</updated>
+    <updated>2020-05-14T10:00:00+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale xml:lang="cs">
     <terms>
       <term name="accessed" form="short">cit.</term>
       <term name="editor" form="short">
-        <single>ed</single>
+        <single>ed.</single>
         <multiple>eds</multiple>
       </term>
     </terms>
@@ -266,14 +266,20 @@
   <macro name="issued">
     <choose>
       <if type="article-journal article-magazine article-newspaper" match="any">
-        <date variable="issued">
-          <date-part name="year" range-delimiter="&#8211;"/>
-        </date>
         <choose>
-          <if variable="volume">
-            <text prefix=", " term="volume" form="short" suffix=". "/>
-            <text variable="volume"/>
+          <if variable="issued" match="any">
+            <date variable="issued">
+              <date-part name="year" range-delimiter="&#8211;"/>
+            </date>
           </if>
+          <else>
+            <choose>
+              <if variable="volume">
+                <text term="volume" form="short" suffix=". "/>
+                <text variable="volume"/>
+              </if>
+            </choose>
+          </else>
         </choose>
         <choose>
           <if variable="issue">

--- a/masarykova-univerzita-pravnicka-fakulta.csl
+++ b/masarykova-univerzita-pravnicka-fakulta.csl
@@ -44,14 +44,14 @@
     <choose>
       <if variable="author">
         <names variable="author">
-          <name name-as-sort-order="all" sort-separator=", " delimiter=", " initialize-with=". ">
+          <name name-as-sort-order="all" sort-separator=",&#160;" delimiter=", " initialize-with=". ">
             <name-part name="family" text-case="capitalize-first"/>
           </name>
         </names>
       </if>
       <else-if variable="editor">
         <names variable="editor">
-          <name name-as-sort-order="all" sort-separator=", " delimiter=", " initialize-with=". ">
+          <name name-as-sort-order="all" sort-separator=",&#160;" delimiter=", " initialize-with=". ">
             <name-part name="family" text-case="capitalize-first"/>
           </name>
           <label prefix=" (" form="short" plural="contextual" suffix=")."/>
@@ -63,14 +63,14 @@
     <choose>
       <if variable="author">
         <names variable="author">
-          <name name-as-sort-order="all" sort-separator=", " delimiter=", " initialize-with=". ">
+          <name name-as-sort-order="all" sort-separator=",&#160;" delimiter=", " initialize-with=". ">
             <name-part name="family" text-case="capitalize-first"/>
           </name>
         </names>
       </if>
       <else-if variable="editor">
         <names variable="editor">
-          <name name-as-sort-order="all" sort-separator=", " delimiter=", " initialize-with=". ">
+          <name name-as-sort-order="all" sort-separator=",&#160;" delimiter=", " initialize-with=". ">
             <name-part name="family" text-case="capitalize-first"/>
           </name>
           <label prefix=" (" form="short" plural="contextual" suffix=")."/>
@@ -82,14 +82,14 @@
     <choose>
       <if variable="author">
         <names variable="author">
-          <name name-as-sort-order="all" sort-separator=", " delimiter=", " initialize-with=". " form="short">
+          <name name-as-sort-order="all" sort-separator=",&#160;" delimiter=", " initialize-with=". " form="short">
             <name-part name="family" text-case="capitalize-first"/>
           </name>
         </names>
       </if>
       <else-if variable="editor">
         <names variable="editor">
-          <name name-as-sort-order="all" sort-separator=", " delimiter=", " initialize-with=". ">
+          <name name-as-sort-order="all" sort-separator=",&#160;" delimiter=", " initialize-with=". ">
             <name-part name="family" text-case="capitalize-first"/>
           </name>
           <label prefix=" (" form="short" plural="contextual" suffix=")."/>
@@ -113,7 +113,7 @@
     <choose>
       <if variable="container-author">
         <names variable="container-author">
-          <name name-as-sort-order="all" sort-separator=", " delimiter=", " initialize-with=". ">
+          <name name-as-sort-order="all" sort-separator=",&#160;" delimiter=", " initialize-with=". ">
             <name-part name="family" text-case="capitalize-first"/>
           </name>
         </names>
@@ -122,7 +122,7 @@
         <choose>
           <if type="chapter paper-conference" match="any">
             <names variable="editor">
-              <name name-as-sort-order="all" sort-separator=", " delimiter=", " initialize-with=". ">
+              <name name-as-sort-order="all" sort-separator=",&#160;" delimiter=", " initialize-with=". ">
                 <name-part name="family" text-case="capitalize-first"/>
               </name>
               <label prefix=" (" form="short" plural="contextual" suffix=")."/>
@@ -136,7 +136,7 @@
     <choose>
       <if variable="container-author">
         <names variable="container-author">
-          <name name-as-sort-order="all" sort-separator=", " delimiter=", " initialize-with=". ">
+          <name name-as-sort-order="all" sort-separator=",&#160;" delimiter=", " initialize-with=". ">
             <name-part name="family" text-case="capitalize-first"/>
           </name>
         </names>
@@ -145,7 +145,7 @@
         <choose>
           <if type="chapter paper-conference" match="any">
             <names variable="editor">
-              <name name-as-sort-order="all" sort-separator=", " delimiter=", " initialize-with=". ">
+              <name name-as-sort-order="all" sort-separator=",&#160;" delimiter=", " initialize-with=". ">
                 <name-part name="family" text-case="capitalize-first"/>
               </name>
               <label prefix=" (" form="short" plural="contextual" suffix=")."/>
@@ -275,7 +275,7 @@
           <else>
             <choose>
               <if variable="volume">
-                <text term="volume" form="short" suffix=". "/>
+                <text term="volume" form="short" suffix="&#160;"/>
                 <text variable="volume"/>
               </if>
             </choose>
@@ -283,15 +283,15 @@
         </choose>
         <choose>
           <if variable="issue">
-            <text prefix=", " term="issue" form="short" suffix=". "/>
+            <text prefix=", " term="issue" form="short" suffix="&#160;"/>
             <text variable="issue"/>
           </if>
         </choose>
       </if>
       <else-if type="webpage" match="any">
         <date variable="issued">
-          <date-part name="day" suffix=". "/>
-          <date-part name="month" suffix=". " form="numeric"/>
+          <date-part name="day" suffix=".&#160;"/>
+          <date-part name="month" suffix=".&#160;" form="numeric"/>
           <date-part name="year"/>
         </date>
       </else-if>
@@ -309,7 +309,7 @@
     </choose>
   </macro>
   <macro name="citation-locator">
-    <label variable="locator" form="short" suffix=". "/>
+    <label variable="locator" form="short" suffix="&#160;"/>
     <text variable="locator"/>
   </macro>
   <macro name="collection">
@@ -343,10 +343,10 @@
   </macro>
   <macro name="quoted">
     <group prefix="[" suffix="]">
-      <text term="accessed" form="short" suffix=" "/>
+      <text term="accessed" form="short" suffix="&#160;"/>
       <date variable="accessed">
-        <date-part name="day" suffix=". "/>
-        <date-part name="month" suffix=". " form="numeric"/>
+        <date-part name="day" suffix=".&#160;"/>
+        <date-part name="month" suffix=".&#160;" form="numeric"/>
         <date-part name="year"/>
       </date>
     </group>

--- a/masarykova-univerzita-pravnicka-fakulta.csl
+++ b/masarykova-univerzita-pravnicka-fakulta.csl
@@ -14,7 +14,7 @@
     <category citation-format="note"/>
     <category field="law"/>
     <summary>Masaryk University, Faculty of Law</summary>
-    <updated>2020-04-18T10:00:00+00:00</updated>
+    <updated>2020-04-27T10:00:00+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale xml:lang="cs">
@@ -237,7 +237,7 @@
   <macro name="publisher-place">
     <group delimiter="; ">
       <choose>
-        <if variable="publisher-place accessed DOI URL" match="any">
+        <if variable="publisher-place URL" match="any">
           <text variable="publisher-place"/>
         </if>
       </choose>
@@ -246,7 +246,7 @@
   <macro name="printers">
     <group delimiter="; ">
       <choose>
-        <if variable="publisher accessed DOI URL" match="any">
+        <if variable="publisher URL" match="any">
           <text variable="publisher"/>
         </if>
       </choose>
@@ -318,12 +318,9 @@
   <macro name="identifier">
     <group delimiter="; ">
       <choose>
-        <if variable="DOI">
-          <text variable="DOI" prefix="doi: "/>
+        <if variable="URL">
+          <text variable="URL"/>
         </if>
-        <else>
-          <text variable="URL" prefix=""/>
-        </else>
       </choose>
     </group>
   </macro>
@@ -377,7 +374,7 @@
               <text macro="container"/>
               <text prefix=". " variable="volume" text-case="capitalize-first"/>
               <choose>
-                <if variable="accessed DOI URL" match="any">
+                <if variable="URL" match="any">
                   <text prefix=". " macro="issued"/>
                   <text prefix=", " macro="citation-locator"/>
                   <text prefix=" " macro="quoted"/>
@@ -410,7 +407,7 @@
               </choose>
               <text macro="container"/>
               <choose>
-                <if variable="accessed DOI URL" match="any">
+                <if variable="URL" match="any">
                   <text prefix=". " macro="issued"/>
                   <text prefix=", " macro="citation-locator"/>
                   <text prefix=" " macro="quoted"/>
@@ -428,7 +425,7 @@
               <text macro="container"/>
               <text prefix=". " macro="issued"/>
               <choose>
-                <if variable="accessed DOI URL" match="any">
+                <if variable="URL" match="any">
                   <text prefix=", " macro="citation-locator"/>
                   <text prefix=" " macro="quoted"/>
                   <text prefix=". " macro="identifier"/>
@@ -452,7 +449,7 @@
               <text macro="title-long" font-style="italic"/>
               <text prefix=" " macro="medium"/>
               <choose>
-                <if variable="accessed DOI URL" match="any">
+                <if variable="URL" match="any">
                   <text prefix=". " macro="issued"/>
                   <text prefix=", " macro="citation-locator"/>
                   <text prefix=" " macro="quoted"/>
@@ -504,7 +501,7 @@
           <text macro="container-full"/>
           <text prefix=". " variable="volume" text-case="capitalize-first"/>
           <choose>
-            <if variable="accessed DOI URL" match="any">
+            <if variable="URL" match="any">
               <text prefix=". " macro="edition"/>
               <text prefix=". " macro="issued"/>
               <text prefix=", " macro="page-range"/>
@@ -546,7 +543,7 @@
           <text macro="container-full"/>
           <text prefix=". " macro="issued"/>
           <choose>
-            <if variable="accessed DOI URL" match="any">
+            <if variable="URL" match="any">
               <text prefix=", " macro="page-range"/>
               <text prefix=" " macro="quoted"/>
               <text prefix=". " macro="identifier"/>
@@ -562,7 +559,7 @@
           <text macro="container-full"/>
           <text prefix=". " macro="issued"/>
           <choose>
-            <if variable="accessed DOI URL" match="any">
+            <if variable="URL" match="any">
               <text prefix=", " macro="page-range"/>
               <text prefix=" " macro="quoted"/>
               <text prefix=". " macro="identifier"/>
@@ -584,7 +581,7 @@
           <text macro="contributors-full" suffix=". "/>
           <text macro="title-long" font-style="italic"/>
           <choose>
-            <if variable="accessed DOI URL" match="any">
+            <if variable="URL" match="any">
               <text prefix=" " macro="medium"/>
               <text prefix=". " macro="secondary-contributors"/>
               <text prefix=". " macro="edition" suffix="."/>

--- a/masarykova-univerzita-pravnicka-fakulta.csl
+++ b/masarykova-univerzita-pravnicka-fakulta.csl
@@ -21,8 +21,8 @@
     <terms>
       <term name="accessed" form="short">cit.</term>
       <term name="editor" form="short">
-        <single>ed.</single>
-        <multiple>eds.</multiple>
+        <single>ed</single>
+        <multiple>eds</multiple>
       </term>
     </terms>
   </locale>

--- a/masarykova-univerzita-pravnicka-fakulta.csl
+++ b/masarykova-univerzita-pravnicka-fakulta.csl
@@ -14,7 +14,7 @@
     <category citation-format="note"/>
     <category field="law"/>
     <summary>Masaryk University, Faculty of Law</summary>
-    <updated>2020-04-27T10:00:00+00:00</updated>
+    <updated>2020-05-13T10:00:00+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale xml:lang="cs">
@@ -327,7 +327,11 @@
   <macro name="medium">
     <choose>
       <if variable="URL" match="any">
-        <text term="online" prefix="[" suffix="]"/>
+        <choose>
+          <if type="webpage">
+            <text term="online" prefix="[" suffix="]"/>
+          </if>
+        </choose>
       </if>
       <else>
         <text variable="archive" prefix="[" suffix="]"/>

--- a/masarykova-univerzita-pravnicka-fakulta.csl
+++ b/masarykova-univerzita-pravnicka-fakulta.csl
@@ -360,7 +360,7 @@
           <text macro="contributors-short" suffix=". "/>
           <text macro="title-short" font-style="italic"/>
           <choose>
-          	<if variable="author" match="none">
+            <if variable="author" match="none">
               <text prefix=", " macro="issued-year"/>
             </if>
           </choose>
@@ -577,7 +577,7 @@
           <text prefix=", " variable="genre"/>
           <text prefix=", " variable="publisher" suffix="."/>
         </else-if>
-        <else>
+        <else-if type="bill legal_case legislation" match="none">
           <text macro="contributors-full" suffix=". "/>
           <text macro="title-long" font-style="italic"/>
           <choose>
@@ -606,7 +606,7 @@
               <text prefix=". " macro="collection" suffix="."/>
             </else>
           </choose>
-        </else>
+        </else-if>
       </choose>
     </layout>
   </bibliography>

--- a/masarykova-univerzita-pravnicka-fakulta.csl
+++ b/masarykova-univerzita-pravnicka-fakulta.csl
@@ -258,6 +258,11 @@
       <text macro="printers"/>
     </group>
   </macro>
+  <macro name="issued-year">
+    <date variable="issued">
+      <date-part name="year"/>
+    </date>
+  </macro>
   <macro name="issued">
     <choose>
       <if type="article-journal article-magazine article-newspaper" match="any">
@@ -324,7 +329,7 @@
   </macro>
   <macro name="medium">
     <choose>
-      <if variable="accessed DOI URL" match="any">
+      <if variable="URL" match="any">
         <text term="online" prefix="[" suffix="]"/>
       </if>
       <else>
@@ -334,7 +339,7 @@
   </macro>
   <macro name="quoted">
     <group prefix="[" suffix="]">
-      <text term="accessed" form="short" suffix=". "/>
+      <text term="accessed" form="short" suffix=" "/>
       <date variable="accessed">
         <date-part name="day" suffix=". "/>
         <date-part name="month" suffix=". " form="numeric"/>
@@ -357,6 +362,11 @@
         <else-if position="subsequent">
           <text macro="contributors-short" suffix=". "/>
           <text macro="title-short" font-style="italic"/>
+          <choose>
+          	<if variable="author" match="none">
+              <text prefix=", " macro="issued-year"/>
+            </if>
+          </choose>
           <text macro="locator-or-period"/>
         </else-if>
         <else>
@@ -371,7 +381,7 @@
                   <text prefix=". " macro="issued"/>
                   <text prefix=", " macro="citation-locator"/>
                   <text prefix=" " macro="quoted"/>
-                  <text prefix=". " macro="identifier" suffix="."/>
+                  <text prefix=". " macro="identifier"/>
                 </if>
                 <else-if variable="issued" match="none">
                   <choose>
@@ -404,7 +414,7 @@
                   <text prefix=". " macro="issued"/>
                   <text prefix=", " macro="citation-locator"/>
                   <text prefix=" " macro="quoted"/>
-                  <text prefix=". " macro="identifier" suffix="."/>
+                  <text prefix=". " macro="identifier"/>
                 </if>
                 <else>
                   <text prefix=". " macro="issued"/>
@@ -421,7 +431,7 @@
                 <if variable="accessed DOI URL" match="any">
                   <text prefix=", " macro="citation-locator"/>
                   <text prefix=" " macro="quoted"/>
-                  <text prefix=". " macro="identifier" suffix="."/>
+                  <text prefix=". " macro="identifier"/>
                 </if>
                 <else>
                   <text macro="locator-or-period"/>
@@ -446,7 +456,7 @@
                   <text prefix=". " macro="issued"/>
                   <text prefix=", " macro="citation-locator"/>
                   <text prefix=" " macro="quoted"/>
-                  <text prefix=". " macro="identifier" suffix="."/>
+                  <text prefix=". " macro="identifier"/>
                 </if>
                 <else-if variable="issued" match="none">
                   <choose>
@@ -500,7 +510,7 @@
               <text prefix=", " macro="page-range"/>
               <text prefix=" " macro="quoted"/>
               <text prefix=". " macro="collection" suffix="."/>
-              <text prefix=". " macro="identifier" suffix="."/>
+              <text prefix=". " macro="identifier"/>
             </if>
             <else-if variable="issued" match="none">
               <text prefix=". " macro="edition" suffix="."/>
@@ -539,7 +549,7 @@
             <if variable="accessed DOI URL" match="any">
               <text prefix=", " macro="page-range"/>
               <text prefix=" " macro="quoted"/>
-              <text prefix=". " macro="identifier" suffix="."/>
+              <text prefix=". " macro="identifier"/>
             </if>
             <else>
               <text prefix=", " macro="page-range" suffix="."/>
@@ -555,7 +565,7 @@
             <if variable="accessed DOI URL" match="any">
               <text prefix=", " macro="page-range"/>
               <text prefix=" " macro="quoted"/>
-              <text prefix=". " macro="identifier" suffix="."/>
+              <text prefix=". " macro="identifier"/>
             </if>
             <else>
               <text prefix=", " macro="page-range" suffix="."/>
@@ -581,7 +591,7 @@
               <text prefix=". " macro="issued"/>
               <text prefix=" " macro="quoted" suffix="."/>
               <text prefix=". " macro="collection" suffix="."/>
-              <text prefix=". " macro="identifier" suffix="."/>
+              <text prefix=". " macro="identifier"/>
             </if>
             <else-if variable="issued" match="none">
               <text prefix=" " macro="medium" suffix="."/>

--- a/masarykova-univerzita-pravnicka-fakulta.csl
+++ b/masarykova-univerzita-pravnicka-fakulta.csl
@@ -333,9 +333,6 @@
           </if>
         </choose>
       </if>
-      <else>
-        <text variable="archive" prefix="[" suffix="]"/>
-      </else>
     </choose>
   </macro>
   <macro name="quoted">


### PR DESCRIPTION
1. Added a year to subsequent citations when there is no author.
2. Although the examples suggest otherwise, cl. 9 odst. 1 tells us not to use the period at the end. of the link. The dean confirmed to me there should not be a period. Therefore, I have removed it.
3. Removed a dot from the suffix of accessed shortened term, since it is already included in some locales.
4. The dean told me that the shortened term for editors should be without a period. Therefore, I have updated it for the Czech locale.
5. Removed DOI since the documentation does not support it.
6. Excluded legal texts from the bibliography since the documentation says that they should not be included.
7. Show [online] only for webpages.