### PR TITLE
Update RMIT Harvard to match Easy Cite

### DIFF
--- a/rmit-university-harvard.csl
+++ b/rmit-university-harvard.csl
@@ -86,7 +86,7 @@
   </macro>
   <macro name="access">
     <choose>
-      <if variable="URL" type="article-newspaper webpage speech">
+      <if variable="URL" type="article-newspaper webpage speech report">
         <group prefix=" " delimiter=", ">
           <date variable="accessed" prefix="viewed ">
             <date-part name="day" suffix=" "/>


### PR DESCRIPTION
Easy Cite referencing tool states that a report with a URL and 'accessed' date should have these included in the bibliography