### PR TITLE
don't merge: springer-humanities-author-date.csl

### DIFF
--- a/springer-humanities-author-date.csl
+++ b/springer-humanities-author-date.csl
@@ -22,11 +22,14 @@
       <email>charles.parnot@gmail.com</email>
       <uri>http://twitter.com/cparnot</uri>
     </contributor>
+    <contributor>
+      <name>Patrick O'Brien</name>
+    </contributor>
     <category citation-format="author-date"/>
     <category field="generic-base"/>
     <category field="humanities"/>
     <summary>Style for Springer's humanities journals - the journals do look slightly different from each other, but this should work quite closely</summary>
-    <updated>2019-09-25T12:00:00+00:00</updated>
+    <updated>2020-05-21T11:35:39+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale>
@@ -66,7 +69,7 @@
             <if variable="author">
               <names variable="container-author editor" delimiter=", ">
                 <label form="short" suffix=" " plural="never"/>
-                <name and="text" delimiter=", " initialize="false" initialize-with=". "/>
+                <name and="text" initialize-with="."/>
               </names>
             </if>
           </choose>
@@ -74,7 +77,7 @@
             <if variable="author editor" match="any">
               <names variable="translator">
                 <label form="short" plural="never" suffix=" "/>
-                <name and="text" delimiter=", "/>
+                <name and="text" initialize-with="."/>
               </names>
             </if>
           </choose>
@@ -102,7 +105,7 @@
   </macro>
   <macro name="contributors">
     <names variable="author">
-      <name and="text" name-as-sort-order="first" sort-separator=", " delimiter=", " delimiter-precedes-last="always"/>
+      <name and="text" delimiter-precedes-last="always" initialize-with="." name-as-sort-order="first"/>
       <label form="short" plural="never" prefix=", "/>
       <substitute>
         <names variable="editor"/>
@@ -224,7 +227,10 @@
   <macro name="locators">
     <choose>
       <if type="article-journal">
-        <text variable="volume" prefix=" "/>
+        <group delimiter=" ">
+          <text variable="volume" prefix=" "/>
+          <text variable="issue" prefix="(" suffix=")"/>
+        </group>
       </if>
       <else-if type="legal_case">
         <text variable="volume" prefix=", "/>
@@ -252,6 +258,15 @@
             </group>
           </if>
         </choose>
+      </else-if>
+      <else-if type="post post-weblog webpage" match="any">
+        <group delimiter=". " prefix=". ">
+          <text variable="URL"/>
+          <group delimiter=" ">
+            <text term="accessed" text-case="capitalize-first"/>
+            <date form="text" variable="accessed"/>
+          </group>
+        </group>
       </else-if>
     </choose>
   </macro>
@@ -398,7 +413,6 @@
         </group>
       </else>
     </choose>
-    <!--This is for computer programs only. Localization new to 1.0.1, so may be missing in many locales-->
     <group delimiter=" " prefix=" (" suffix=")">
       <text term="version"/>
       <text variable="version"/>


### PR DESCRIPTION
Update style to current formatting (early 2020). Several journals checked this is across the dependent styles.

- changes: initialise authors/editors
- add URL for online documents
- add issue to article-journal

Let's wait to see what the requestor says after checking some more journals.