### PR TITLE
Update pravnik.csl, masarykova-univerzita-pravnicka-fakulta.csl, and iso690-full-note-cs.csl

### DIFF
--- a/dependent/the-lawyer-quarterly.csl
+++ b/dependent/the-lawyer-quarterly.csl
@@ -8,7 +8,9 @@
     <link href="https://tlq.ilaw.cas.cz/index.php/tlq/about/submissions#authorGuidelines" rel="documentation"/>
     <category citation-format="note"/>
     <category field="law"/>
-    <issn>1805-840X</issn>
+    <issn>1805-8396</issn>
+    <eissn>1805-840X</eissn>
+    <summary>Suitable for The Lawyer Quarterly - a journal published by the Institute of State and Law of the Czech Academy of Sciences.</summary>
     <updated>2020-05-25T10:00:00+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>

--- a/dependent/the-lawyer-quarterly.csl
+++ b/dependent/the-lawyer-quarterly.csl
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<style xmlns="http://purl.org/net/xbiblio/csl" version="1.0" default-locale="en-GB">
+  <info>
+    <title>The Lawyer Quarterly</title>
+    <id>http://www.zotero.org/styles/the-lawyer-quarterly</id>
+    <link href="http://www.zotero.org/styles/the-lawyer-quarterly" rel="self"/>
+    <link href="http://www.zotero.org/styles/pravnik" rel="independent-parent"/>
+    <link href="https://tlq.ilaw.cas.cz/index.php/tlq/about/submissions#authorGuidelines" rel="documentation"/>
+    <category citation-format="note"/>
+    <category field="law"/>
+    <issn>1805-840X</issn>
+    <updated>2020-05-25T10:00:00+00:00</updated>
+    <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
+  </info>
+</style>

--- a/iso690-full-note-cs.csl
+++ b/iso690-full-note-cs.csl
@@ -414,20 +414,13 @@
                 </else>
               </choose>
               <choose>
-                <if variable="accessed DOI URL" match="any">
+                <if variable="URL" match="any">
                   <text prefix=", " macro="citation-locator"/>
                   <text prefix=" " macro="quoted"/>
                   <text prefix=". " macro="identifier"/>
                 </if>
                 <else>
-                  <choose>
-                    <if variable="locator" match="none">
-                      <text value="."/>
-                    </if>
-                    <else>
-                      <text prefix=", " macro="citation-locator" suffix="."/>
-                    </else>
-                  </choose>
+                  <text macro="locator-or-period"/>
                 </else>
               </choose>
             </else-if>

--- a/iso690-full-note-cs.csl
+++ b/iso690-full-note-cs.csl
@@ -229,6 +229,11 @@
       <text macro="printers"/>
     </group>
   </macro>
+  <macro name="issued-year">
+    <date variable="issued">
+      <date-part name="year"/>
+    </date>
+  </macro>
   <macro name="issued">
     <choose>
       <if type="article-journal article-magazine article-newspaper" match="any">

--- a/iso690-full-note-cs.csl
+++ b/iso690-full-note-cs.csl
@@ -424,6 +424,14 @@
                 </else>
               </choose>
             </else-if>
+            <else-if type="thesis" match="any">
+              <text macro="contributors-long" suffix=". "/>
+              <text macro="title-long" font-style="italic"/>
+              <text prefix=". " macro="issued"/>
+              <text prefix=", " variable="genre"/>
+              <text prefix=", " variable="publisher"/>
+              <text macro="locator-or-period"/>
+            </else-if>
             <else>
               <text macro="contributors-long" suffix=". "/>
               <text macro="title-long" font-style="italic"/>

--- a/iso690-full-note-cs.csl
+++ b/iso690-full-note-cs.csl
@@ -168,7 +168,7 @@
   <macro name="container">
     <choose>
       <if type="chapter entry entry-dictionary entry-encyclopedia webpage" match="any">
-        <text term="in" text-case="capitalize-first" suffix=" "/>
+        <text term="in" text-case="capitalize-first" suffix=": "/>
         <text macro="container-contributors" suffix=" "/>
         <choose>
           <if variable="container-title">
@@ -190,7 +190,7 @@
   <macro name="container-full">
     <choose>
       <if type="chapter entry entry-dictionary entry-encyclopedia webpage" match="any">
-        <text term="in" text-case="capitalize-first" suffix=" "/>
+        <text term="in" text-case="capitalize-first" suffix=": "/>
         <text macro="container-contributors-full" suffix=" "/>
         <choose>
           <if variable="container-title">

--- a/iso690-full-note-cs.csl
+++ b/iso690-full-note-cs.csl
@@ -329,7 +329,8 @@
     </choose>
   </macro>
   <macro name="quoted">
-    <group prefix="[cit. " suffix="]">
+    <group prefix="[" suffix="]">
+      <text term="accessed" form="short" suffix="&#160;"/>
       <date variable="accessed">
         <date-part name="day" suffix="." form="numeric-leading-zeros"/>
         <date-part name="month" suffix="." form="numeric-leading-zeros"/>

--- a/iso690-full-note-cs.csl
+++ b/iso690-full-note-cs.csl
@@ -302,21 +302,23 @@
     </choose>
   </macro>
   <macro name="identifier">
-    <group delimiter="; ">
-      <choose>
-        <if variable="DOI">
-          <text variable="DOI" prefix="DOI: "/>
-        </if>
-        <else>
-          <text variable="URL" prefix="Dostupné z: "/>
-        </else>
-      </choose>
-    </group>
+    <choose>
+      <if variable="DOI">
+        <text variable="DOI" prefix="DOI: "/>
+      </if>
+      <else>
+        <text variable="URL" prefix="Dostupné z: "/>
+      </else>
+    </choose>
   </macro>
   <macro name="medium">
     <choose>
       <if variable="URL" match="any">
-        <text term="online" prefix="[" suffix="]"/>
+        <choose>
+          <if variable="DOI" match="none">
+            <text term="online" prefix="[" suffix="]"/>
+          </if>
+        </choose>
       </if>
       <else>
         <text variable="archive" prefix="[" suffix="]"/>
@@ -504,7 +506,6 @@
               </choose>
               <text prefix=". " macro="collection" suffix="."/>
               <text prefix=", " macro="page-range"/>
-              <text prefix=" " macro="quoted"/>
               <text prefix=". " macro="collection" suffix="."/>
               <text prefix=". " macro="ISBN" suffix="."/>
             </else-if>

--- a/iso690-full-note-cs.csl
+++ b/iso690-full-note-cs.csl
@@ -254,21 +254,33 @@
         </choose>
         <choose>
           <if variable="issue">
-            <text prefix=", " term="issue" form="short" suffix=". "/>
+            <text prefix=", " term="issue" form="short" suffix="&#160;"/>
             <text variable="issue"/>
           </if>
         </choose>
       </if>
+      <else-if type="webpage" match="any">
+        <date variable="issued">
+          <date-part name="day" suffix=".&#160;"/>
+          <date-part name="month" suffix=".&#160;" form="numeric"/>
+          <date-part name="year"/>
+        </date>
+      </else-if>
+      <else-if type="entry entry-dictionary entry-encyclopedia thesis" match="any">
+        <date variable="issued">
+          <date-part name="year" range-delimiter="&#8211;"/>
+        </date>
+      </else-if>
       <else>
         <text prefix=" " macro="publisher" suffix=", "/>
         <date variable="issued">
-          <date-part name="year" range-delimiter=" &#8211; "/>
+          <date-part name="year" range-delimiter="&#8211;"/>
         </date>
       </else>
     </choose>
   </macro>
   <macro name="citation-locator">
-    <label variable="locator" form="short" suffix=". "/>
+    <label variable="locator" form="short" suffix="&#160;"/>
     <text variable="locator"/>
   </macro>
   <macro name="collection">

--- a/iso690-full-note-cs.csl
+++ b/iso690-full-note-cs.csl
@@ -14,7 +14,7 @@
     <category citation-format="note"/>
     <category field="law"/>
     <summary>Czech ISO-690, full note.</summary>
-    <updated>2020-04-13T10:00:00+00:00</updated>
+    <updated>2020-05-25T10:00:00+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale xml:lang="cs">

--- a/iso690-full-note-cs.csl
+++ b/iso690-full-note-cs.csl
@@ -566,7 +566,14 @@
             </else>
           </choose>
         </else-if>
-        <else>
+        <else-if type="thesis" match="any">
+          <text macro="contributors-full" suffix=". "/>
+          <text macro="title-long" font-style="italic"/>
+          <text prefix=". " macro="issued"/>
+          <text prefix=", " variable="genre"/>
+          <text prefix=", " variable="publisher" suffix="."/>
+        </else-if>
+        <else-if type="bill legal_case legislation" match="none">
           <text macro="contributors-full" suffix=". "/>
           <text macro="title-long" font-style="italic"/>
           <choose>
@@ -599,7 +606,7 @@
               <text prefix=". " macro="ISBN" suffix="."/>
             </else>
           </choose>
-        </else>
+        </else-if>
       </choose>
     </layout>
   </bibliography>

--- a/iso690-full-note-cs.csl
+++ b/iso690-full-note-cs.csl
@@ -218,28 +218,10 @@
     </choose>
   </macro>
   <macro name="publisher-place">
-    <group delimiter="; ">
-      <choose>
-        <if variable="publisher-place accessed DOI URL" match="any">
-          <text variable="publisher-place"/>
-        </if>
-        <else>
-          <text value="[s.l.]"/>
-        </else>
-      </choose>
-    </group>
+    <text variable="publisher-place"/>
   </macro>
   <macro name="printers">
-    <group delimiter="; ">
-      <choose>
-        <if variable="publisher accessed DOI URL" match="any">
-          <text variable="publisher"/>
-        </if>
-        <else>
-          <text value="[s.n.]"/>
-        </else>
-      </choose>
-    </group>
+    <text variable="publisher"/>
   </macro>
   <macro name="publisher">
     <group delimiter=": ">

--- a/iso690-full-note-cs.csl
+++ b/iso690-full-note-cs.csl
@@ -436,7 +436,7 @@
               <text macro="contributors-long" suffix=". "/>
               <text macro="title-long" font-style="italic"/>
               <choose>
-                <if variable="accessed DOI URL" match="any">
+                <if variable="URL" match="any">
                   <text prefix=" " macro="medium"/>
                   <text prefix=". " macro="issued"/>
                   <text prefix=", " macro="citation-locator"/>
@@ -489,12 +489,12 @@
           <text macro="contributors-full" suffix=". "/>
           <text macro="title-long" suffix=". "/>
           <text macro="container-full"/>
+          <text prefix=". " variable="volume" text-case="capitalize-first"/>
           <choose>
-            <if variable="accessed DOI URL" match="any">
+            <if variable="URL" match="any">
               <text prefix=". " macro="edition"/>
               <text prefix=". " macro="issued"/>
-              <text prefix=", sv. " variable="volume"/>
-              <text prefix=", s. " variable="page"/>
+              <text prefix=", " macro="page-range"/>
               <text prefix=" " macro="quoted"/>
               <text prefix=". " macro="collection" suffix="."/>
               <text prefix=". " macro="ISBN" suffix="."/>
@@ -508,9 +508,7 @@
                 </if>
               </choose>
               <text prefix=". " macro="collection" suffix="."/>
-              <text prefix=". " variable="note" suffix="."/>
-              <text prefix=", sv. " variable="volume"/>
-              <text prefix=", s. " variable="page"/>
+              <text prefix=", " macro="page-range"/>
               <text prefix=" " macro="quoted"/>
               <text prefix=". " macro="collection" suffix="."/>
               <text prefix=". " macro="ISBN" suffix="."/>
@@ -518,8 +516,7 @@
             <else>
               <text prefix=". " macro="edition"/>
               <text prefix=". " macro="issued"/>
-              <text prefix=", sv. " variable="volume"/>
-              <text prefix=", s. " variable="page" suffix="."/>
+              <text prefix=", " macro="page-range" suffix="."/>
               <text prefix=". " macro="collection" suffix="."/>
               <text prefix=". " macro="ISBN" suffix="."/>
             </else>
@@ -531,16 +528,14 @@
           <text macro="container-full"/>
           <text prefix=". " macro="issued"/>
           <choose>
-            <if variable="accessed DOI URL" match="any">
-              <text prefix=", s. " variable="page"/>
+            <if variable="URL" match="any">
+              <text prefix=", " macro="page-range"/>
               <text prefix=" " macro="quoted"/>
-              <text prefix=". " variable="note" suffix="."/>
               <text prefix=". " macro="ISSN" suffix="."/>
               <text prefix=". " macro="identifier"/>
             </if>
             <else>
-              <text prefix=", s. " variable="page" suffix="."/>
-              <text prefix=". " variable="note" suffix="."/>
+              <text prefix=", " macro="page-range" suffix="."/>
               <text prefix=". " macro="ISSN" suffix="."/>
             </else>
           </choose>
@@ -559,16 +554,14 @@
             </else>
           </choose>
           <choose>
-            <if variable="accessed DOI URL" match="any">
-              <text prefix=", s. " variable="page"/>
+            <if variable="URL" match="any">
+              <text prefix=", " macro="page-range"/>
               <text prefix=" " macro="quoted"/>
-              <text prefix=". " variable="note" suffix="."/>
               <text prefix=". " macro="ISSN" suffix="."/>
               <text prefix=". " macro="identifier"/>
             </if>
             <else>
-              <text prefix=", s. " variable="page" suffix="."/>
-              <text prefix=". " variable="note" suffix="."/>
+              <text prefix=", " macro="page-range" suffix="."/>
               <text prefix=". " macro="ISSN" suffix="."/>
             </else>
           </choose>
@@ -577,7 +570,7 @@
           <text macro="contributors-full" suffix=". "/>
           <text macro="title-long" font-style="italic"/>
           <choose>
-            <if variable="accessed DOI URL" match="any">
+            <if variable="URL" match="any">
               <text prefix=" " macro="medium"/>
               <text prefix=". " macro="secondary-contributors"/>
               <text prefix=". " macro="edition" suffix="."/>
@@ -596,7 +589,6 @@
                 </if>
               </choose>
               <text prefix=". " macro="collection" suffix="."/>
-              <text prefix=". " variable="note" suffix="."/>
               <text prefix=". " macro="ISBN" suffix="."/>
             </else-if>
             <else>
@@ -604,7 +596,6 @@
               <text prefix=". " macro="edition" suffix="."/>
               <text prefix=". " macro="issued" suffix="."/>
               <text prefix=". " macro="collection" suffix="."/>
-              <text prefix=". " variable="note" suffix="."/>
               <text prefix=". " macro="ISBN" suffix="."/>
             </else>
           </choose>

--- a/iso690-full-note-cs.csl
+++ b/iso690-full-note-cs.csl
@@ -304,7 +304,7 @@
         <text variable="DOI" prefix="DOI:&#160;"/>
       </if>
       <else>
-        <text term="available at" text-case="capitalize-first" suffix="&#160;"/>
+        <text term="available at" text-case="capitalize-first" suffix=":&#160;"/>
         <text variable="URL"/>
       </else>
     </choose>

--- a/iso690-full-note-cs.csl
+++ b/iso690-full-note-cs.csl
@@ -287,24 +287,25 @@
   <macro name="ISBN">
     <choose>
       <if variable="ISBN">
-        <text variable="ISBN" prefix="ISBN "/>
+        <text variable="ISBN" prefix="ISBN&#160;"/>
       </if>
     </choose>
   </macro>
   <macro name="ISSN">
     <choose>
       <if variable="ISSN">
-        <text variable="ISSN" prefix="ISSN "/>
+        <text variable="ISSN" prefix="ISSN&#160;"/>
       </if>
     </choose>
   </macro>
   <macro name="identifier">
     <choose>
       <if variable="DOI">
-        <text variable="DOI" prefix="DOI: "/>
+        <text variable="DOI" prefix="DOI:&#160;"/>
       </if>
       <else>
-        <text variable="URL" prefix="Dostupné z: "/>
+        <text term="available at" text-case="capitalize-first" suffix="&#160;"/>
+        <text variable="URL"/>
       </else>
     </choose>
   </macro>

--- a/iso690-full-note-cs.csl
+++ b/iso690-full-note-cs.csl
@@ -320,7 +320,7 @@
   </macro>
   <macro name="medium">
     <choose>
-      <if variable="accessed DOI URL" match="any">
+      <if variable="URL" match="any">
         <text term="online" prefix="[" suffix="]"/>
       </if>
       <else>

--- a/iso690-full-note-cs.csl
+++ b/iso690-full-note-cs.csl
@@ -232,15 +232,17 @@
   <macro name="issued">
     <choose>
       <if type="article-journal article-magazine article-newspaper" match="any">
-        <date variable="issued">
-          <date-part name="year" range-delimiter="&#8211;"/>
-        </date>
-        <choose>
-          <if variable="volume">
-            <text term="volume" form="short" suffix="&#160;"/>
-            <text variable="volume"/>
-          </if>
-        </choose>
+        <group delimiter=", ">
+          <date variable="issued">
+            <date-part name="year" range-delimiter="&#8211;"/>
+          </date>
+          <choose>
+            <if variable="volume">
+              <text term="volume" form="short" suffix="&#160;"/>
+              <text variable="volume"/>
+            </if>
+          </choose>
+        </group>
         <choose>
           <if variable="issue">
             <text prefix=", " term="issue" form="short" suffix="&#160;"/>

--- a/iso690-full-note-cs.csl
+++ b/iso690-full-note-cs.csl
@@ -19,13 +19,10 @@
   </info>
   <locale xml:lang="cs">
     <terms>
-      <term name="et-al">et al.</term>
       <term name="editor" form="short">
         <single>ed</single>
         <multiple>eds</multiple>
       </term>
-      <term name="in">in:</term>
-      <term name="page-range-delimiter">-</term>
     </terms>
   </locale>
   <macro name="contributors-full">

--- a/iso690-full-note-cs.csl
+++ b/iso690-full-note-cs.csl
@@ -353,16 +353,7 @@
         <else-if position="subsequent">
           <text macro="contributors-short" suffix=". "/>
           <text macro="title-short" font-style="italic"/>
-          <choose>
-            <if variable="locator">
-              <text prefix=", " macro="citation-locator" suffix="."/>
-            </if>
-            <else-if variable="accessed URL DOI" match="any">
-              <text term="online" prefix=" [" suffix="] "/>
-              <text macro="quoted"/>
-              <text prefix=". " macro="identifier"/>
-            </else-if>
-          </choose>
+          <text macro="locator-or-period"/>
         </else-if>
         <else>
           <choose>
@@ -370,10 +361,10 @@
               <text macro="contributors-long" suffix=". "/>
               <text macro="title-long" suffix=". "/>
               <text macro="container"/>
+              <text prefix=". " variable="volume" text-case="capitalize-first"/>
               <choose>
-                <if variable="accessed DOI URL" match="any">
+                <if variable="URL" match="any">
                   <text prefix=". " macro="issued"/>
-                  <text prefix=", sv. " variable="volume"/>
                   <text prefix=", " macro="citation-locator"/>
                   <text prefix=" " macro="quoted"/>
                   <text prefix=". " macro="identifier"/>
@@ -384,26 +375,11 @@
                       <text prefix=". " macro="publisher"/>
                     </if>
                   </choose>
-                  <choose>
-                    <if variable="locator" match="none">
-                      <text value="."/>
-                    </if>
-                    <else>
-                      <text prefix=", " macro="citation-locator" suffix="."/>
-                    </else>
-                  </choose>
+                  <text macro="locator-or-period"/>
                 </else-if>
                 <else>
                   <text prefix=". " macro="issued"/>
-                  <text prefix=", sv. " variable="volume"/>
-                  <choose>
-                    <if variable="locator" match="none">
-                      <text value="."/>
-                    </if>
-                    <else>
-                      <text prefix=", " macro="citation-locator" suffix="."/>
-                    </else>
-                  </choose>
+                  <text macro="locator-or-period"/>
                 </else>
               </choose>
             </if>

--- a/iso690-full-note-cs.csl
+++ b/iso690-full-note-cs.csl
@@ -229,11 +229,6 @@
       <text macro="printers"/>
     </group>
   </macro>
-  <macro name="issued-year">
-    <date variable="issued">
-      <date-part name="year"/>
-    </date>
-  </macro>
   <macro name="issued">
     <choose>
       <if type="article-journal article-magazine article-newspaper" match="any">

--- a/iso690-full-note-cs.csl
+++ b/iso690-full-note-cs.csl
@@ -19,6 +19,7 @@
   </info>
   <locale xml:lang="cs">
     <terms>
+      <term name="accessed" form="short">cit.</term>
       <term name="editor" form="short">
         <single>ed</single>
         <multiple>eds</multiple>

--- a/iso690-full-note-cs.csl
+++ b/iso690-full-note-cs.csl
@@ -232,20 +232,14 @@
   <macro name="issued">
     <choose>
       <if type="article-journal article-magazine article-newspaper" match="any">
+        <date variable="issued">
+          <date-part name="year" range-delimiter="&#8211;"/>
+        </date>
         <choose>
-          <if variable="issued" match="any">
-            <date variable="issued">
-              <date-part name="year" range-delimiter="&#8211;"/>
-            </date>
+          <if variable="volume">
+            <text term="volume" form="short" suffix="&#160;"/>
+            <text variable="volume"/>
           </if>
-          <else>
-            <choose>
-              <if variable="volume">
-                <text term="volume" form="short" suffix="&#160;"/>
-                <text variable="volume"/>
-              </if>
-            </choose>
-          </else>
         </choose>
         <choose>
           <if variable="issue">

--- a/iso690-full-note-cs.csl
+++ b/iso690-full-note-cs.csl
@@ -25,6 +25,20 @@
       </term>
     </terms>
   </locale>
+  <macro name="page-range">
+    <label variable="page" form="short" suffix=" "/>
+    <text variable="page"/>
+  </macro>
+  <macro name="locator-or-period">
+    <choose>
+      <if variable="locator" match="none">
+        <text value="."/>
+      </if>
+      <else>
+        <text prefix=", " macro="citation-locator" suffix="."/>
+      </else>
+    </choose>
+  </macro>
   <macro name="contributors-full">
     <choose>
       <if variable="author">

--- a/iso690-full-note-cs.csl
+++ b/iso690-full-note-cs.csl
@@ -322,14 +322,22 @@
     </choose>
   </macro>
   <macro name="quoted">
-    <group prefix="[" suffix="]">
-      <text term="accessed" form="short" suffix="&#160;"/>
-      <date variable="accessed">
-        <date-part name="day" suffix="." form="numeric-leading-zeros"/>
-        <date-part name="month" suffix="." form="numeric-leading-zeros"/>
-        <date-part name="year"/>
-      </date>
-    </group>
+    <choose>
+      <if variable="URL" match="any">
+        <choose>
+          <if variable="DOI" match="none">
+            <group prefix="[" suffix="]">
+              <text term="accessed" form="short" suffix="&#160;"/>
+              <date variable="accessed">
+                <date-part name="day" suffix="." form="numeric-leading-zeros"/>
+                <date-part name="month" suffix="." form="numeric-leading-zeros"/>
+                <date-part name="year"/>
+              </date>
+            </group>
+          </if>
+        </choose>
+      </if>
+    </choose>
   </macro>
   <citation et-al-min="4" et-al-use-first="1" disambiguate-add-names="true">
     <layout delimiter="; ">

--- a/iso690-full-note-cs.csl
+++ b/iso690-full-note-cs.csl
@@ -237,14 +237,20 @@
   <macro name="issued">
     <choose>
       <if type="article-journal article-magazine article-newspaper" match="any">
-        <date variable="issued">
-          <date-part name="year" range-delimiter=" &#8211; "/>
-        </date>
         <choose>
-          <if variable="volume">
-            <text prefix=", " term="volume" form="short" suffix=". "/>
-            <text variable="volume"/>
+          <if variable="issued" match="any">
+            <date variable="issued">
+              <date-part name="year" range-delimiter="&#8211;"/>
+            </date>
           </if>
+          <else>
+            <choose>
+              <if variable="volume">
+                <text term="volume" form="short" suffix="&#160;"/>
+                <text variable="volume"/>
+              </if>
+            </choose>
+          </else>
         </choose>
         <choose>
           <if variable="issue">

--- a/iso690-full-note-cs.csl
+++ b/iso690-full-note-cs.csl
@@ -584,7 +584,6 @@
               <text prefix=". " macro="issued"/>
               <text prefix=" " macro="quoted" suffix="."/>
               <text prefix=". " macro="collection" suffix="."/>
-              <text prefix=". " variable="note" suffix="."/>
               <text prefix=". " macro="ISBN" suffix="."/>
               <text prefix=". " macro="identifier"/>
             </if>

--- a/iso690-full-note-cs.csl
+++ b/iso690-full-note-cs.csl
@@ -388,7 +388,7 @@
               <text macro="title-long" suffix=". "/>
               <text macro="container"/>
               <choose>
-                <if variable="accessed DOI URL" match="any">
+                <if variable="URL" match="any">
                   <text prefix=". " macro="issued"/>
                   <text prefix=", " macro="citation-locator"/>
                   <text prefix=" " macro="quoted"/>
@@ -396,14 +396,7 @@
                 </if>
                 <else>
                   <text prefix=". " macro="issued"/>
-                  <choose>
-                    <if variable="locator" match="none">
-                      <text value="."/>
-                    </if>
-                    <else>
-                      <text prefix=", " macro="citation-locator" suffix="."/>
-                    </else>
-                  </choose>
+                  <text macro="locator-or-period"/>
                 </else>
               </choose>
             </else-if>

--- a/masarykova-univerzita-pravnicka-fakulta.csl
+++ b/masarykova-univerzita-pravnicka-fakulta.csl
@@ -14,7 +14,7 @@
     <category citation-format="note"/>
     <category field="law"/>
     <summary>Masaryk University, Faculty of Law</summary>
-    <updated>2020-05-14T10:00:00+00:00</updated>
+    <updated>2020-05-25T10:00:00+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale xml:lang="cs">
@@ -209,14 +209,6 @@
         <text variable="container-title" font-style="italic"/>
         <text prefix=" " macro="medium"/>
       </else-if>
-    </choose>
-  </macro>
-  <macro name="edition">
-    <choose>
-      <if variable="edition">
-        <text variable="edition" suffix="."/>
-        <text prefix=" " term="edition" form="short" suffix="."/>
-      </if>
     </choose>
   </macro>
   <macro name="publisher-place">
@@ -494,7 +486,6 @@
           <text prefix=". " variable="volume" text-case="capitalize-first"/>
           <choose>
             <if variable="URL" match="any">
-              <text prefix=". " macro="edition"/>
               <text prefix=". " macro="issued"/>
               <text prefix=", " macro="page-range"/>
               <text prefix=" " macro="quoted"/>
@@ -502,7 +493,6 @@
               <text prefix=". " macro="identifier"/>
             </if>
             <else-if variable="issued" match="none">
-              <text prefix=". " macro="edition" suffix="."/>
               <choose>
                 <if variable="publisher publisher-place" match="any">
                   <text prefix=". " macro="publisher"/>
@@ -514,7 +504,6 @@
               <text prefix=". " macro="collection" suffix="."/>
             </else-if>
             <else>
-              <text prefix=". " macro="edition"/>
               <text prefix=". " macro="issued"/>
               <text prefix=", " macro="page-range" suffix="."/>
               <text prefix=". " macro="collection" suffix="."/>
@@ -575,7 +564,6 @@
           <choose>
             <if variable="URL" match="any">
               <text prefix=" " macro="medium"/>
-              <text prefix=". " macro="edition" suffix="."/>
               <text prefix=". " macro="issued"/>
               <text prefix=" " macro="quoted" suffix="."/>
               <text prefix=". " macro="collection" suffix="."/>
@@ -592,7 +580,6 @@
             </else-if>
             <else>
               <text prefix=" " macro="medium" suffix="."/>
-              <text prefix=". " macro="edition" suffix="."/>
               <text prefix=". " macro="issued" suffix="."/>
               <text prefix=". " macro="collection" suffix="."/>
             </else>

--- a/pravnik.csl
+++ b/pravnik.csl
@@ -323,21 +323,12 @@
           </group>
         </if>
         <else-if position="ibid">
-          <text term="ibid" suffix="."/>
+          <text term="ibid"/>
         </else-if>
         <else-if position="subsequent">
           <text macro="contributors-short" suffix=". "/>
           <text macro="title-short" font-style="italic"/>
-          <choose>
-            <if variable="locator">
-              <text prefix=", " macro="citation-locator" suffix="."/>
-            </if>
-            <else-if variable="accessed URL DOI" match="any">
-              <text term="online" prefix=" [" suffix="] "/>
-              <text macro="quoted"/>
-              <text prefix=". " macro="identifier"/>
-            </else-if>
-          </choose>
+          <text macro="locator-or-period"/>
         </else-if>
         <else>
           <choose>
@@ -345,10 +336,10 @@
               <text macro="contributors-long" suffix=". "/>
               <text macro="title-long" suffix=". "/>
               <text macro="container"/>
+              <text prefix=". " variable="volume" text-case="capitalize-first"/>
               <choose>
-                <if variable="accessed DOI URL" match="any">
+                <if variable="URL" match="any">
                   <text prefix=". " macro="issued"/>
-                  <text prefix=", sv. " variable="volume"/>
                   <text prefix=", " macro="citation-locator"/>
                   <text prefix=" " macro="quoted"/>
                   <text prefix=". " macro="identifier"/>
@@ -359,26 +350,11 @@
                       <text prefix=". " macro="publisher"/>
                     </if>
                   </choose>
-                  <choose>
-                    <if variable="locator" match="none">
-                      <text value="."/>
-                    </if>
-                    <else>
-                      <text prefix=", " macro="citation-locator" suffix="."/>
-                    </else>
-                  </choose>
+                  <text macro="locator-or-period"/>
                 </else-if>
                 <else>
                   <text prefix=". " macro="issued"/>
-                  <text prefix=", sv. " variable="volume"/>
-                  <choose>
-                    <if variable="locator" match="none">
-                      <text value="."/>
-                    </if>
-                    <else>
-                      <text prefix=", " macro="citation-locator" suffix="."/>
-                    </else>
-                  </choose>
+                  <text macro="locator-or-period"/>
                 </else>
               </choose>
             </if>

--- a/pravnik.csl
+++ b/pravnik.csl
@@ -381,20 +381,13 @@
               <text macro="container"/>
               <text prefix=". " macro="issued"/>
               <choose>
-                <if variable="accessed DOI URL" match="any">
+                <if variable="URL" match="any">
                   <text prefix=", " macro="citation-locator"/>
                   <text prefix=" " macro="quoted"/>
                   <text prefix=". " macro="identifier"/>
                 </if>
                 <else>
-                  <choose>
-                    <if variable="locator" match="none">
-                      <text value="."/>
-                    </if>
-                    <else>
-                      <text prefix=", " macro="citation-locator" suffix="."/>
-                    </else>
-                  </choose>
+                  <text macro="locator-or-period"/>
                 </else>
               </choose>
             </else-if>

--- a/pravnik.csl
+++ b/pravnik.csl
@@ -363,7 +363,7 @@
               <text macro="title-long" suffix=". "/>
               <text macro="container"/>
               <choose>
-                <if variable="accessed DOI URL" match="any">
+                <if variable="URL" match="any">
                   <text prefix=". " macro="issued"/>
                   <text prefix=", " macro="citation-locator"/>
                   <text prefix=" " macro="quoted"/>
@@ -371,14 +371,7 @@
                 </if>
                 <else>
                   <text prefix=". " macro="issued"/>
-                  <choose>
-                    <if variable="locator" match="none">
-                      <text value="."/>
-                    </if>
-                    <else>
-                      <text prefix=", " macro="citation-locator" suffix="."/>
-                    </else>
-                  </choose>
+                  <text macro="locator-or-period"/>
                 </else>
               </choose>
             </else-if>

--- a/pravnik.csl
+++ b/pravnik.csl
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
-<style xmlns="http://purl.org/net/xbiblio/csl" version="1.0" class="note" demote-non-dropping-particle="sort-only" default-locale="cs-CZ">
+<style xmlns="http://purl.org/net/xbiblio/csl" version="1.0" class="note" demote-non-dropping-particle="sort-only">
   <info>
-    <title>Právník (Czech)</title>
+    <title>Právník</title>
     <id>http://www.zotero.org/styles/pravnik</id>
     <link href="http://www.zotero.org/styles/pravnik" rel="self"/>
     <link href="http://www.zotero.org/styles/iso690-full-note-cs" rel="template"/>
@@ -14,8 +14,8 @@
     <category citation-format="note"/>
     <category field="law"/>
     <issn>0231-6625</issn>
-    <summary>Czech ISO-690, full note, suitable for Pravnik - a journal published by the Institute of State and Law of the Czech Academy of Sciences.</summary>
-    <updated>2020-04-13T10:00:00+00:00</updated>
+    <summary>Suitable for Pravnik and The Lawyer Quarterly - journals published by the Institute of State and Law of the Czech Academy of Sciences.</summary>
+    <updated>2020-05-25T10:00:00+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale xml:lang="cs">

--- a/pravnik.csl
+++ b/pravnik.csl
@@ -280,21 +280,23 @@
     </choose>
   </macro>
   <macro name="identifier">
-    <group delimiter="; " suffix=".">
-      <choose>
-        <if variable="DOI">
-          <text variable="DOI" prefix="DOI: "/>
-        </if>
-        <else>
-          <text variable="URL" prefix="Dostupné z: &lt;" suffix="&gt;"/>
-        </else>
-      </choose>
-    </group>
+    <choose>
+      <if variable="DOI">
+        <text variable="DOI" prefix="DOI: "/>
+      </if>
+      <else>
+        <text variable="URL" prefix="Dostupné z: &lt;" suffix="&gt;"/>
+      </else>
+    </choose>
   </macro>
   <macro name="medium">
     <choose>
       <if variable="URL" match="any">
-        <text term="online" prefix="[" suffix="]"/>
+        <choose>
+          <if variable="DOI" match="none">
+            <text term="online" prefix="[" suffix="]"/>
+          </if>
+        </choose>
       </if>
     </choose>
   </macro>
@@ -471,7 +473,6 @@
               </choose>
               <text prefix=". " macro="collection" suffix="."/>
               <text prefix=", " macro="page-range"/>
-              <text prefix=" " macro="quoted"/>
               <text prefix=". " macro="collection" suffix="."/>
               <text prefix=". " macro="ISBN" suffix="."/>
             </else-if>

--- a/pravnik.csl
+++ b/pravnik.csl
@@ -153,7 +153,7 @@
   <macro name="container">
     <choose>
       <if type="chapter entry entry-dictionary entry-encyclopedia webpage" match="any">
-        <text term="in" text-case="capitalize-first" suffix=" "/>
+        <text term="in" text-case="capitalize-first" suffix=": "/>
         <text macro="container-contributors" suffix=" "/>
         <choose>
           <if variable="container-title">
@@ -175,7 +175,7 @@
   <macro name="container-full">
     <choose>
       <if type="chapter entry entry-dictionary entry-encyclopedia webpage" match="any">
-        <text term="in" text-case="capitalize-first" suffix=" "/>
+        <text term="in" text-case="capitalize-first" suffix=": "/>
         <text macro="container-contributors-full" suffix=" "/>
         <choose>
           <if variable="container-title">

--- a/pravnik.csl
+++ b/pravnik.csl
@@ -214,6 +214,11 @@
       <text macro="printers"/>
     </group>
   </macro>
+  <macro name="issued-year">
+    <date variable="issued">
+      <date-part name="year"/>
+    </date>
+  </macro>
   <macro name="issued">
     <choose>
       <if type="article-journal article-magazine article-newspaper" match="any">

--- a/pravnik.csl
+++ b/pravnik.csl
@@ -304,7 +304,8 @@
     </choose>
   </macro>
   <macro name="quoted">
-    <group prefix="[cit. " suffix="]">
+    <group prefix="[" suffix="]">
+      <text term="accessed" form="short" suffix="&#160;"/>
       <date variable="accessed">
         <date-part name="year" suffix="-"/>
         <date-part name="month" suffix="-" form="numeric-leading-zeros"/>

--- a/pravnik.csl
+++ b/pravnik.csl
@@ -215,7 +215,7 @@
     <choose>
       <if variable="edition">
         <text variable="edition" suffix="."/>
-        <text prefix=" " term="edition" form="short" suffix="."/>
+        <text prefix=" " term="edition" form="long"/>
       </if>
     </choose>
   </macro>

--- a/pravnik.csl
+++ b/pravnik.csl
@@ -217,15 +217,17 @@
   <macro name="issued">
     <choose>
       <if type="article-journal article-magazine article-newspaper" match="any">
-        <date variable="issued">
-          <date-part name="year" range-delimiter="&#8211;"/>
-        </date>
-        <choose>
-          <if variable="volume">
-            <text term="volume" form="short" suffix="&#160;"/>
-            <text variable="volume"/>
-          </if>
-        </choose>
+        <group delimiter=", ">
+          <date variable="issued">
+            <date-part name="year" range-delimiter="&#8211;"/>
+          </date>
+          <choose>
+            <if variable="volume">
+              <text term="volume" form="short" suffix="&#160;"/>
+              <text variable="volume"/>
+            </if>
+          </choose>
+        </group>
         <choose>
           <if variable="issue">
             <text prefix=", " term="issue" form="short" suffix="&#160;"/>

--- a/pravnik.csl
+++ b/pravnik.csl
@@ -217,20 +217,14 @@
   <macro name="issued">
     <choose>
       <if type="article-journal article-magazine article-newspaper" match="any">
+        <date variable="issued">
+          <date-part name="year" range-delimiter="&#8211;"/>
+        </date>
         <choose>
-          <if variable="issued" match="any">
-            <date variable="issued">
-              <date-part name="year" range-delimiter="&#8211;"/>
-            </date>
+          <if variable="volume">
+            <text term="volume" form="short" suffix="&#160;"/>
+            <text variable="volume"/>
           </if>
-          <else>
-            <choose>
-              <if variable="volume">
-                <text term="volume" form="short" suffix="&#160;"/>
-                <text variable="volume"/>
-              </if>
-            </choose>
-          </else>
         </choose>
         <choose>
           <if variable="issue">

--- a/pravnik.csl
+++ b/pravnik.csl
@@ -305,9 +305,9 @@
             <group prefix="[" suffix="]">
               <text term="accessed" form="short" suffix="&#160;"/>
               <date variable="accessed">
-                <date-part name="day" suffix="." form="numeric-leading-zeros"/>
-                <date-part name="month" suffix="." form="numeric-leading-zeros"/>
-                <date-part name="year"/>
+                <date-part name="year" suffix="-"/>
+                <date-part name="month" suffix="-" form="numeric-leading-zeros"/>
+                <date-part name="day" form="numeric-leading-zeros"/>
               </date>
             </group>
           </if>

--- a/pravnik.csl
+++ b/pravnik.csl
@@ -391,6 +391,14 @@
                 </else>
               </choose>
             </else-if>
+            <else-if type="thesis" match="any">
+              <text macro="contributors-long" suffix=". "/>
+              <text macro="title-long" font-style="italic"/>
+              <text prefix=". " macro="issued"/>
+              <text prefix=", " variable="genre"/>
+              <text prefix=", " variable="publisher"/>
+              <text macro="locator-or-period"/>
+            </else-if>
             <else>
               <text macro="contributors-long" suffix=". "/>
               <text macro="title-long" font-style="italic"/>

--- a/pravnik.csl
+++ b/pravnik.csl
@@ -203,22 +203,10 @@
     </choose>
   </macro>
   <macro name="publisher-place">
-    <group delimiter="; ">
-      <choose>
-        <if variable="publisher-place accessed DOI URL" match="any">
-          <text variable="publisher-place"/>
-        </if>
-      </choose>
-    </group>
+    <text variable="publisher-place"/>
   </macro>
   <macro name="printers">
-    <group delimiter="; ">
-      <choose>
-        <if variable="publisher accessed DOI URL" match="any">
-          <text variable="publisher"/>
-        </if>
-      </choose>
-    </group>
+    <text variable="publisher"/>
   </macro>
   <macro name="publisher">
     <group delimiter=": ">

--- a/pravnik.csl
+++ b/pravnik.csl
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
-<style xmlns="http://purl.org/net/xbiblio/csl" version="1.0" class="note" demote-non-dropping-particle="sort-only">
+<style xmlns="http://purl.org/net/xbiblio/csl" version="1.0" class="note" demote-non-dropping-particle="sort-only" default-locale="cs-CZ">
   <info>
-    <title>Právník</title>
+    <title>Právník (Czech)</title>
     <id>http://www.zotero.org/styles/pravnik</id>
     <link href="http://www.zotero.org/styles/pravnik" rel="self"/>
     <link href="http://www.zotero.org/styles/iso690-full-note-cs" rel="template"/>
@@ -14,7 +14,7 @@
     <category citation-format="note"/>
     <category field="law"/>
     <issn>0231-6625</issn>
-    <summary>Suitable for Pravnik and its English version The Lawyer Quarterly - journals published by the Institute of State and Law of the Czech Academy of Sciences.</summary>
+    <summary>Suitable for Právník - a journal published by the Institute of State and Law of the Czech Academy of Sciences.</summary>
     <updated>2020-05-25T10:00:00+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>

--- a/pravnik.csl
+++ b/pravnik.csl
@@ -145,14 +145,10 @@
     </choose>
   </macro>
   <macro name="title-long">
-    <group delimiter=". ">
-      <text variable="title"/>
-    </group>
+    <text variable="title"/>
   </macro>
   <macro name="title-short">
-    <group delimiter=". ">
-      <text variable="title" form="short"/>
-    </group>
+    <text variable="title" form="short"/>
   </macro>
   <macro name="container">
     <choose>

--- a/pravnik.csl
+++ b/pravnik.csl
@@ -14,7 +14,7 @@
     <category citation-format="note"/>
     <category field="law"/>
     <issn>0231-6625</issn>
-    <summary>Suitable for Pravnik and The Lawyer Quarterly - journals published by the Institute of State and Law of the Czech Academy of Sciences.</summary>
+    <summary>Suitable for Pravnik and its English version The Lawyer Quarterly - journals published by the Institute of State and Law of the Czech Academy of Sciences.</summary>
     <updated>2020-05-25T10:00:00+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>

--- a/pravnik.csl
+++ b/pravnik.csl
@@ -20,14 +20,11 @@
   </info>
   <locale xml:lang="cs">
     <terms>
-      <term name="et-al">et al.</term>
       <term name="ibid">ibidem</term>
       <term name="editor" form="short">
         <single>ed.</single>
         <multiple>eds</multiple>
       </term>
-      <term name="in">In:</term>
-      <term name="page-range-delimiter">&#8211;</term>
     </terms>
   </locale>
   <macro name="contributors-full">

--- a/pravnik.csl
+++ b/pravnik.csl
@@ -239,22 +239,27 @@
         </choose>
         <choose>
           <if variable="issue">
-            <text prefix=", " term="issue" form="short" suffix=". "/>
+            <text prefix=", " term="issue" form="short" suffix="&#160;"/>
             <text variable="issue"/>
           </if>
         </choose>
       </if>
       <else-if type="webpage" match="any">
         <date variable="issued">
-          <date-part name="day" suffix=". "/>
-          <date-part name="month" suffix=". " form="numeric"/>
+          <date-part name="day" suffix=".&#160;"/>
+          <date-part name="month" suffix=".&#160;" form="numeric"/>
           <date-part name="year"/>
+        </date>
+      </else-if>
+      <else-if type="entry entry-dictionary entry-encyclopedia thesis" match="any">
+        <date variable="issued">
+          <date-part name="year" range-delimiter="&#8211;"/>
         </date>
       </else-if>
       <else>
         <text prefix=" " macro="publisher" suffix=", "/>
         <date variable="issued">
-          <date-part name="year" range-delimiter=" &#8211; "/>
+          <date-part name="year" range-delimiter="&#8211;"/>
         </date>
       </else>
     </choose>

--- a/pravnik.csl
+++ b/pravnik.csl
@@ -265,7 +265,7 @@
     </choose>
   </macro>
   <macro name="citation-locator">
-    <label variable="locator" form="short" suffix=". "/>
+    <label variable="locator" form="short" suffix="&#160;"/>
     <text variable="locator"/>
   </macro>
   <macro name="collection">
@@ -298,12 +298,9 @@
   </macro>
   <macro name="medium">
     <choose>
-      <if variable="accessed DOI URL" match="any">
+      <if variable="URL" match="any">
         <text term="online" prefix="[" suffix="]"/>
       </if>
-      <else>
-        <text variable="archive" prefix="[" suffix="]"/>
-      </else>
     </choose>
   </macro>
   <macro name="quoted">

--- a/pravnik.csl
+++ b/pravnik.csl
@@ -505,7 +505,14 @@
             </else>
           </choose>
         </else-if>
-        <else>
+        <else-if type="thesis" match="any">
+          <text macro="contributors-full" suffix=". "/>
+          <text macro="title-long" font-style="italic"/>
+          <text prefix=". " macro="issued"/>
+          <text prefix=", " variable="genre"/>
+          <text prefix=", " variable="publisher" suffix="."/>
+        </else-if>
+        <else-if type="bill legal_case legislation" match="none">
           <text macro="contributors-full" suffix=". "/>
           <text macro="title-long" font-style="italic"/>
           <choose>
@@ -536,7 +543,7 @@
               <text prefix=". " macro="ISBN" suffix="."/>
             </else>
           </choose>
-        </else>
+        </else-if>
       </choose>
     </layout>
   </bibliography>

--- a/pravnik.csl
+++ b/pravnik.csl
@@ -222,14 +222,20 @@
   <macro name="issued">
     <choose>
       <if type="article-journal article-magazine article-newspaper" match="any">
-        <date variable="issued">
-          <date-part name="year" range-delimiter=" &#8211; "/>
-        </date>
         <choose>
-          <if variable="volume">
-            <text prefix=", " term="volume" form="short" suffix=". "/>
-            <text variable="volume"/>
+          <if variable="issued" match="any">
+            <date variable="issued">
+              <date-part name="year" range-delimiter="&#8211;"/>
+            </date>
           </if>
+          <else>
+            <choose>
+              <if variable="volume">
+                <text term="volume" form="short" suffix="&#160;"/>
+                <text variable="volume"/>
+              </if>
+            </choose>
+          </else>
         </choose>
         <choose>
           <if variable="issue">

--- a/pravnik.csl
+++ b/pravnik.csl
@@ -27,6 +27,20 @@
       </term>
     </terms>
   </locale>
+  <macro name="page-range">
+    <label variable="page" form="short" suffix=" "/>
+    <text variable="page"/>
+  </macro>
+  <macro name="locator-or-period">
+    <choose>
+      <if variable="locator" match="none">
+        <text value="."/>
+      </if>
+      <else>
+        <text prefix=", " macro="citation-locator" suffix="."/>
+      </else>
+    </choose>
+  </macro>
   <macro name="contributors-full">
     <choose>
       <if variable="author">

--- a/pravnik.csl
+++ b/pravnik.csl
@@ -154,7 +154,7 @@
   <macro name="container">
     <choose>
       <if type="chapter entry entry-dictionary entry-encyclopedia webpage" match="any">
-        <text term="in" text-case="capitalize-first" suffix=": "/>
+        <text term="in" text-case="capitalize-first" suffix=":&#160;"/>
         <text macro="container-contributors" suffix=" "/>
         <choose>
           <if variable="container-title">
@@ -272,17 +272,18 @@
   <macro name="ISBN">
     <choose>
       <if variable="ISBN">
-        <text variable="ISBN" prefix="ISBN "/>
+        <text variable="ISBN" prefix="ISBN&#160;"/>
       </if>
     </choose>
   </macro>
   <macro name="identifier">
     <choose>
       <if variable="DOI">
-        <text variable="DOI" prefix="DOI: "/>
+        <text variable="DOI" prefix="DOI:&#160;"/>
       </if>
       <else>
-        <text variable="URL" prefix="Dostupné z: &lt;" suffix="&gt;"/>
+        <text term="available at" text-case="capitalize-first" suffix="&#160;"/>
+        <text variable="URL" prefix="&lt;" suffix="&gt;"/>
       </else>
     </choose>
   </macro>

--- a/pravnik.csl
+++ b/pravnik.csl
@@ -282,7 +282,7 @@
         <text variable="DOI" prefix="DOI:&#160;"/>
       </if>
       <else>
-        <text term="available at" text-case="capitalize-first" suffix="&#160;"/>
+        <text term="available at" text-case="capitalize-first" suffix=":&#160;"/>
         <text variable="URL" prefix="&lt;" suffix="&gt;"/>
       </else>
     </choose>

--- a/pravnik.csl
+++ b/pravnik.csl
@@ -20,6 +20,7 @@
   </info>
   <locale xml:lang="cs">
     <terms>
+      <term name="accessed" form="short">cit.</term>
       <term name="ibid">ibidem</term>
       <term name="editor" form="short">
         <single>ed.</single>

--- a/pravnik.csl
+++ b/pravnik.csl
@@ -214,11 +214,6 @@
       <text macro="printers"/>
     </group>
   </macro>
-  <macro name="issued-year">
-    <date variable="issued">
-      <date-part name="year"/>
-    </date>
-  </macro>
   <macro name="issued">
     <choose>
       <if type="article-journal article-magazine article-newspaper" match="any">

--- a/pravnik.csl
+++ b/pravnik.csl
@@ -98,18 +98,6 @@
       </else-if>
     </choose>
   </macro>
-  <macro name="secondary-contributors">
-    <choose>
-      <if variable="author" type="book" match="all">
-        <names variable="editor translator" delimiter=", ">
-          <label text-case="capitalize-first" suffix=" "/>
-          <name sort-separator=", " delimiter=", " delimiter-precedes-last="never" and="text">
-            <name-part name="family" text-case="uppercase"/>
-          </name>
-        </names>
-      </if>
-    </choose>
-  </macro>
   <macro name="container-contributors">
     <choose>
       <if variable="container-author">
@@ -159,7 +147,6 @@
   <macro name="title-long">
     <group delimiter=". ">
       <text variable="title"/>
-      <text macro="secondary-contributors" font-style="normal"/>
     </group>
   </macro>
   <macro name="title-short">
@@ -561,7 +548,6 @@
           <choose>
             <if variable="accessed DOI URL" match="any">
               <text prefix=" " macro="medium"/>
-              <text prefix=". " macro="secondary-contributors"/>
               <text prefix=". " macro="edition" suffix="."/>
               <text prefix=". " macro="issued"/>
               <text prefix=" " macro="quoted" suffix="."/>

--- a/pravnik.csl
+++ b/pravnik.csl
@@ -403,7 +403,7 @@
               <text macro="contributors-long" suffix=". "/>
               <text macro="title-long" font-style="italic"/>
               <choose>
-                <if variable="accessed DOI URL" match="any">
+                <if variable="URL" match="any">
                   <text prefix=" " macro="medium"/>
                   <text prefix=". " macro="issued"/>
                   <text prefix=", " macro="citation-locator"/>
@@ -456,12 +456,12 @@
           <text macro="contributors-full" suffix=". "/>
           <text macro="title-long" suffix=". "/>
           <text macro="container-full"/>
+          <text prefix=". " variable="volume" text-case="capitalize-first"/>
           <choose>
-            <if variable="accessed DOI URL" match="any">
+            <if variable="URL" match="any">
               <text prefix=". " macro="edition"/>
               <text prefix=". " macro="issued"/>
-              <text prefix=", sv. " variable="volume"/>
-              <text prefix=", s. " variable="page"/>
+              <text prefix=", " macro="page-range"/>
               <text prefix=" " macro="quoted"/>
               <text prefix=". " macro="collection" suffix="."/>
               <text prefix=". " macro="ISBN" suffix="."/>
@@ -475,9 +475,7 @@
                 </if>
               </choose>
               <text prefix=". " macro="collection" suffix="."/>
-              <text prefix=". " variable="note" suffix="."/>
-              <text prefix=", sv. " variable="volume"/>
-              <text prefix=", s. " variable="page"/>
+              <text prefix=", " macro="page-range"/>
               <text prefix=" " macro="quoted"/>
               <text prefix=". " macro="collection" suffix="."/>
               <text prefix=". " macro="ISBN" suffix="."/>
@@ -485,8 +483,7 @@
             <else>
               <text prefix=". " macro="edition"/>
               <text prefix=". " macro="issued"/>
-              <text prefix=", sv. " variable="volume"/>
-              <text prefix=", s. " variable="page" suffix="."/>
+              <text prefix=", " macro="page-range" suffix="."/>
               <text prefix=". " macro="collection" suffix="."/>
               <text prefix=". " macro="ISBN" suffix="."/>
             </else>
@@ -498,15 +495,13 @@
           <text macro="container-full"/>
           <text prefix=". " macro="issued"/>
           <choose>
-            <if variable="accessed DOI URL" match="any">
-              <text prefix=", s. " variable="page"/>
+            <if variable="URL" match="any">
+              <text prefix=", " macro="page-range"/>
               <text prefix=" " macro="quoted"/>
-              <text prefix=". " variable="note" suffix="."/>
               <text prefix=". " macro="identifier"/>
             </if>
             <else>
-              <text prefix=", s. " variable="page" suffix="."/>
-              <text prefix=". " variable="note" suffix="."/>
+              <text prefix=", " macro="page-range" suffix="."/>
             </else>
           </choose>
         </else-if>
@@ -514,13 +509,12 @@
           <text macro="contributors-full" suffix=". "/>
           <text macro="title-long" font-style="italic"/>
           <choose>
-            <if variable="accessed DOI URL" match="any">
+            <if variable="URL" match="any">
               <text prefix=" " macro="medium"/>
               <text prefix=". " macro="edition" suffix="."/>
               <text prefix=". " macro="issued"/>
               <text prefix=" " macro="quoted" suffix="."/>
               <text prefix=". " macro="collection" suffix="."/>
-              <text prefix=". " variable="note" suffix="."/>
               <text prefix=". " macro="ISBN" suffix="."/>
               <text prefix=". " macro="identifier"/>
             </if>
@@ -532,7 +526,6 @@
                 </if>
               </choose>
               <text prefix=". " macro="collection" suffix="."/>
-              <text prefix=". " variable="note" suffix="."/>
               <text prefix=". " macro="ISBN" suffix="."/>
             </else-if>
             <else>
@@ -540,7 +533,6 @@
               <text prefix=". " macro="edition" suffix="."/>
               <text prefix=". " macro="issued" suffix="."/>
               <text prefix=". " macro="collection" suffix="."/>
-              <text prefix=". " variable="note" suffix="."/>
               <text prefix=". " macro="ISBN" suffix="."/>
             </else>
           </choose>

--- a/pravnik.csl
+++ b/pravnik.csl
@@ -297,14 +297,22 @@
     </choose>
   </macro>
   <macro name="quoted">
-    <group prefix="[" suffix="]">
-      <text term="accessed" form="short" suffix="&#160;"/>
-      <date variable="accessed">
-        <date-part name="year" suffix="-"/>
-        <date-part name="month" suffix="-" form="numeric-leading-zeros"/>
-        <date-part name="day" form="numeric-leading-zeros"/>
-      </date>
-    </group>
+    <choose>
+      <if variable="URL" match="any">
+        <choose>
+          <if variable="DOI" match="none">
+            <group prefix="[" suffix="]">
+              <text term="accessed" form="short" suffix="&#160;"/>
+              <date variable="accessed">
+                <date-part name="day" suffix="." form="numeric-leading-zeros"/>
+                <date-part name="month" suffix="." form="numeric-leading-zeros"/>
+                <date-part name="year"/>
+              </date>
+            </group>
+          </if>
+        </choose>
+      </if>
+    </choose>
   </macro>
   <citation et-al-min="4" et-al-use-first="1" disambiguate-add-names="true">
     <layout delimiter="; ">


### PR DESCRIPTION
masarykova-univerzita-pravnicka-fakulta.csl
- removed edition since it is not supported

pravnik.csl
- removed default locale since it can be used for The Lawyer Quarterly too

pravnik.csl & iso690-full-note-cs.csl
- I have modified the code to prevent it from using hardcoded values (such as s. for pages) instead of locale terms
- I have removed notes
- I have added new macros to prevent the code repetition.
- added thesis support and removed legal texts from the bibliography
- Removed a dot from the suffix of accessed shortened term, since it is already included in some locales. 
- Show [online] only for webpages