### PR TITLE
Update methods-of-information-in-medicine.csl

### DIFF
--- a/methods-of-information-in-medicine.csl
+++ b/methods-of-information-in-medicine.csl
@@ -4,7 +4,8 @@
     <title>Methods of Information in Medicine</title>
     <id>http://www.zotero.org/styles/methods-of-information-in-medicine</id>
     <link href="http://www.zotero.org/styles/methods-of-information-in-medicine" rel="self"/>
-    <link href="http://www.schattauer.de/fileadmin/assets/zeitschriften/methods/Instruction_to_Authors.pdf" rel="documentation"/>
+    <link href="https://www.thieme.com/books-main/clinical-informatics/product/4439-methods-of-information-in-medicine" rel="documentation"/>
+    <link href="https://www.thieme.com/media/ita/Methods_authors_instructions.pdf" rel="documentation"/>
     <author>
       <name>Sebastian Karcher</name>
     </author>
@@ -12,21 +13,25 @@
       <name>Michael Berkowitz</name>
       <email>mberkowi@gmu.edu</email>
     </contributor>
+    <contributor>
+      <name>Patrick O'Brien</name>
+    </contributor>
     <category citation-format="numeric"/>
     <category field="medicine"/>
     <issn>0026-1270</issn>
-    <updated>2012-09-27T22:06:38+00:00</updated>
+    <updated>2020-06-05T09:29:34+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale xml:lang="en">
     <terms>
       <term name="no date" form="long">date unknown</term>
+      <term name="presented at">paper presented at</term>
     </terms>
   </locale>
   <macro name="author">
-    <names variable="author" suffix=". ">
+    <names variable="author">
       <name sort-separator=" " initialize-with="" name-as-sort-order="all" delimiter=", " delimiter-precedes-last="always"/>
-      <label form="long" prefix=", " suffix="."/>
+      <label form="short" prefix=", " suffix="."/>
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
@@ -36,23 +41,24 @@
   <macro name="editor">
     <names variable="editor">
       <name sort-separator=" " initialize-with="" name-as-sort-order="all" delimiter=", " delimiter-precedes-last="always"/>
-      <label form="long" prefix=", " suffix=". "/>
+      <label form="short" prefix=", " suffix=". "/>
     </names>
   </macro>
   <macro name="publisher">
-    <text variable="publisher-place" suffix=": "/>
-    <text variable="publisher" suffix="; "/>
-    <text macro="date"/>
+    <group delimiter="; ">
+      <group delimiter=": ">
+        <text variable="publisher-place"/>
+        <text variable="publisher"/>
+      </group>
+      <text macro="date"/>
+    </group>
   </macro>
   <macro name="date">
     <choose>
       <if variable="issued">
         <choose>
-          <if type="article-journal">
-            <date variable="issued">
-              <date-part name="year"/>
-              <date-part name="month" form="short" prefix=" " strip-periods="true"/>
-            </date>
+          <if type="report paper-conference" match="any">
+            <date form="text" date-parts="year-month-day" variable="issued"/>
           </if>
           <else>
             <date variable="issued">
@@ -67,19 +73,26 @@
     </choose>
   </macro>
   <macro name="access">
-    <text variable="URL" suffix=". "/>
-    <group delimiter=" ">
-      <text term="accessed" text-case="capitalize-first"/>
-      <date variable="accessed">
-        <date-part name="year"/>
-        <date-part name="month" form="numeric" prefix="-"/>
-        <date-part name="day" prefix="-"/>
-      </date>
-    </group>
+    <choose>
+      <if type="webpage post post-weblog" match="any">
+        <group delimiter=". ">
+          <text variable="URL"/>
+          <group delimiter=" ">
+            <text term="accessed" text-case="capitalize-first"/>
+            <date form="text" variable="accessed"/>
+          </group>
+        </group>
+      </if>
+    </choose>
   </macro>
   <macro name="title">
     <group delimiter=" ">
       <text variable="title"/>
+      <choose>
+        <if type="thesis" match="any">
+          <text variable="genre" prefix="[" suffix="]"/>
+        </if>
+      </choose>
     </group>
   </macro>
   <macro name="edition">
@@ -99,38 +112,69 @@
     <sort>
       <key variable="citation-number"/>
     </sort>
-    <layout prefix="[" suffix="]" delimiter="; ">
+    <layout vertical-align="sup" delimiter="; ">
       <text variable="citation-number"/>
     </layout>
   </citation>
-  <bibliography>
-    <layout suffix=".">
-      <text variable="citation-number" suffix=". "/>
-      <text macro="author"/>
-      <text macro="title" suffix=". "/>
-      <choose>
-        <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
-          <text macro="edition" suffix=" "/>
-          <text macro="publisher" suffix="."/>
-        </if>
-        <else-if type="chapter paper-conference" match="any">
-          <group prefix=" " suffix=". ">
-            <text term="in" suffix=": " text-case="capitalize-first"/>
-            <text macro="editor"/>
-            <text variable="container-title"/>
-          </group>
-          <text macro="publisher" prefix=" "/>
-          <text variable="page" prefix=" p. " suffix="."/>
-        </else-if>
-        <else>
-          <text variable="container-title" suffix=" " form="short"/>
-          <text macro="date" suffix=";"/>
-          <text variable="volume"/>
-          <text variable="issue" prefix=" (" suffix=")"/>
-          <text variable="page" prefix=":" suffix="."/>
-        </else>
-      </choose>
-      <text macro="access" prefix=" "/>
+  <bibliography et-al-min="7" et-al-use-first="6" second-field-align="flush">
+    <layout>
+      <text variable="citation-number" suffix=" "/>
+      <group delimiter=". ">
+        <text macro="author"/>
+        <text macro="title"/>
+        <choose>
+          <if type="bill book graphic legal_case legislation motion_picture song thesis" match="any">
+            <group delimiter=". ">
+              <text macro="edition"/>
+              <text macro="publisher"/>
+            </group>
+          </if>
+          <else-if type="chapter" match="any">
+            <group prefix=" ">
+              <text term="in" suffix=": " text-case="capitalize-first"/>
+              <text macro="editor"/>
+              <text variable="container-title"/>
+              <group delimiter=":">
+                <group delimiter="; ">
+                  <text macro="publisher" prefix=" "/>
+                </group>
+                <text variable="page"/>
+              </group>
+            </group>
+          </else-if>
+          <else-if type="paper-conference" match="any">
+            <group delimiter="; ">
+              <group delimiter=": ">
+                <text term="presented at" text-case="capitalize-first"/>
+                <text variable="container-title"/>
+              </group>
+              <text macro="publisher"/>
+            </group>
+          </else-if>
+          <else-if type="report" match="any">
+            <group delimiter=". ">
+              <text macro="publisher"/>
+              <text variable="number"/>
+            </group>
+          </else-if>
+          <else>
+            <group delimiter=" ">
+              <text variable="container-title" form="short" strip-periods="true"/>
+              <group delimiter=";">
+                <text macro="date"/>
+                <group delimiter=":">
+                  <group>
+                    <text variable="volume"/>
+                    <text variable="issue" prefix="(" suffix=")"/>
+                  </group>
+                  <text variable="page"/>
+                </group>
+              </group>
+            </group>
+          </else>
+        </choose>
+        <text macro="access" prefix=" "/>
+      </group>
     </layout>
   </bibliography>
 </style>

--- a/methods-of-information-in-medicine.csl
+++ b/methods-of-information-in-medicine.csl
@@ -116,7 +116,7 @@
       <text variable="citation-number"/>
     </layout>
   </citation>
-  <bibliography et-al-min="7" et-al-use-first="6" second-field-align="flush">
+  <bibliography et-al-min="7" et-al-use-first="3" second-field-align="flush">
     <layout>
       <text variable="citation-number" suffix=" "/>
       <group delimiter=". ">


### PR DESCRIPTION
via https://forums.zotero.org/discussion/83519/style-error-methods-of-information-in-medicine

Switched to Thieme Verlag. thieme.csl doesn't fit. It is an AMA variant with lots of changes. I just modified the old style.