### PR TITLE
updated gps-solutions.csl

### DIFF
--- a/dependent/gps-solutions.csl
+++ b/dependent/gps-solutions.csl
@@ -6,7 +6,7 @@
     <title-short>GPS Solut</title-short>
     <id>http://www.zotero.org/styles/gps-solutions</id>
     <link href="http://www.zotero.org/styles/gps-solutions" rel="self"/>
-    <link href="http://www.zotero.org/styles/springer-basic-author-date" rel="independent-parent"/>
+    <link href="http://www.zotero.org/styles/springer-basic-author-date-no-et-al" rel="independent-parent"/>
     <link href="http://www.springer.com/cda/content/document/cda_downloaddocument/Key_Style_Points_1.0.pdf" rel="documentation"/>
     <link href="http://www.springer.com/cda/content/document/cda_downloaddocument/manuscript-guidelines-1.0.pdf" rel="documentation"/>
     <category citation-format="author-date"/>


### PR DESCRIPTION
Author guidelines for GPS Solutions state: 
_"Ideally, the names of all authors should be provided."_
https://www.springer.com/journal/10291/submission-guidelines#Instructions%20for%20Authors_References
So, I've replaced Springer - Basic (author-date) for 
Springer - Basic (author-date, no "et al.").