### PR TITLE
add missing cs:sort to cs:bibliography in universitat-bern-institut-fur-musikwissenschaft

### DIFF
--- a/universitat-bern-institut-fur-musikwissenschaft-note.csl
+++ b/universitat-bern-institut-fur-musikwissenschaft-note.csl
@@ -467,6 +467,9 @@
     </layout>
   </citation>
   <bibliography>
+    <sort>
+      <key macro="author_title-bibliography"/>
+    </sort>
     <layout suffix=".">
       <text macro="author_title-bibliography"/>
       <text macro="reference-publication-details"/>


### PR DESCRIPTION
@adam3smith This fixes the erroneous sorting reported at https://forums.zotero.org/discussion/comment/357476

I'm not sure if just using `<key macro="author_title-bibliography"/>` is a wise choice, or if using the content of that macro would have any benefits:

```xml
<sort>
  <key macro="primary-contributor"/>
  <key macro="title_volumes"/>
</sort>
```





