### PR TITLE
Update changes in Harvard-Stellenbosch

### DIFF
--- a/harvard-stellenbosch-university.csl
+++ b/harvard-stellenbosch-university.csl
@@ -277,10 +277,10 @@
           <else-if type="chapter paper-conference entry-encyclopedia entry-dictionary" match="any">
             <text macro="title"/>
             <group delimiter=" ">
-              <text term="in" text-case="capitalize-first"/>
+              <text term="in"/>
+               <text variable="container-title" font-style="italic"/>
               <text macro="book-details"/>
-              <text variable="container-title" font-style="italic"/>
-            </group>
+              </group>
             <text variable="page"/>
           </else-if>
           <else-if type="patent" match="any">

--- a/harvard-stellenbosch-university.csl
+++ b/harvard-stellenbosch-university.csl
@@ -278,9 +278,9 @@
             <text macro="title"/>
             <group delimiter=" ">
               <text term="in"/>
-               <text variable="container-title" font-style="italic"/>
+              <text variable="container-title" font-style="italic"/>
               <text macro="book-details"/>
-              </group>
+            </group>
             <text variable="page"/>
           </else-if>
           <else-if type="patent" match="any">


### PR DESCRIPTION
change `<text term="in" text-case="capitalize-first"/>` to `<text term="in"/>`

Also move `<text variable="container-title" font-style="italic"/>` above `<text macro="book-details"/>`

Book: Chapter, under editor 	

Blanton, L.L. 1994. Discourse, artefacts and the ozarks: Understanding academic literacy, in V. Zamel & R. Spack (eds.). Negotiating academic literacies: Teaching and learning across languages and cultures. New Jersey: Lawrence Erlbaum Associates. 235-319.

Note:

Use the appropriate abbreviation for one or more editors (English and Afrikaans examples):

One editor - (ed.)  - (red.)

More than one editor - (eds.) - (reds.)
	

The main implication is that texts should require interaction with the focus on negotiation of meaning within specific contexts (Blanton, 1994:237).

According to Blanton (1994:237), the main implication is that tests should require interaction with the focus on negotiation of meaning within specific contexts.