### PR TITLE
Update institut-francais-darcheologie-orientale.csl

### DIFF
--- a/institut-francais-darcheologie-orientale.csl
+++ b/institut-francais-darcheologie-orientale.csl
@@ -1,337 +1,579 @@
 <?xml version="1.0" encoding="utf-8"?>
-<style xmlns="http://purl.org/net/xbiblio/csl" version="1.0" class="note" demote-non-dropping-particle="sort-only" page-range-format="expanded">
+<style class="note" version="1.0" et-al-use-first="1" et-al-subsequent-min="3" initialize-with="." page-range-format="expanded" demote-non-dropping-particle="sort-only" default-locale="fr-FR" xmlns="http://purl.org/net/xbiblio/csl">
+  <!-- This style was edited with the Visual CSL Editor (https://editor.citationstyles.org/visualEditor/) -->
   <info>
-    <title>Institut français d'archéologie orientale</title>
-    <title-short>IFAO</title-short>
-    <id>http://www.zotero.org/styles/institut-francais-darcheologie-orientale</id>
-    <link href="http://www.zotero.org/styles/institut-francais-darcheologie-orientale" rel="self"/>
-    <link href="http://www.zotero.org/styles/gallia" rel="template"/>
-    <link href="https://www.ifao.egnet.net/publications/publier/normes-ed/" rel="documentation"/>
+    <title>Institut français d'archéologie orientale (Français)</title>
+    <title-short>IFAO (FR)</title-short>
+    <id>http://www.zotero.org/styles/institut-francais-darcheologie-orientale-fr</id>
+    <link href="http://www.zotero.org/styles/institut-francais-darcheologie-orientale-fr" rel="self"/>
+    <link href="https://www.ifao.egnet.net/uploads/publications/normes/IFAO_publications_normes_bibliographiques_pub_egypto_2020_fr.pdf" rel="documentation"/>
     <author>
-      <name>Alexandre Vincent</name>
-      <email>alexandre.vincent@univ-poitiers.fr</email>
+      <name>Nicolas Souchon</name>
+      <email>souchon.nicolas.ns@gmail.com</email>
     </author>
-    <author>
-      <name>Nicolas Monteix</name>
-      <email>nicolas.monteix@univ-rouen.fr</email>
-    </author>
-    <category citation-format="note"/>
-    <category field="history"/>
-    <category field="anthropology"/>
-    <summary>Author-date style for IFAO series</summary>
-    <updated>2020-04-29T00:53:29+00:00</updated>
+    <summary>Feuille de style pour les publications d'archéologie et d'égyptologie de l'Institut français d'archéologie orientale</summary>
+    <updated>2020-06-14T11:57:11+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale xml:lang="fr">
     <terms>
-      <term name="editor" form="short">éd.</term>
-      <term name="accessed">consulté le</term>
+      <term name="no date" form="short">s.d.</term>
+      <term name="sub verbo" form="short">s.v.</term>
     </terms>
   </locale>
-  <locale xml:lang="en">
-    <style-options punctuation-in-quote="false"/>
-    <terms>
-      <term name="translator" form="short">trans.</term>
-      <term name="open-quote">“</term>
-      <term name="close-quote">”</term>
-      <term name="open-inner-quote">‘</term>
-      <term name="close-inner-quote">’</term>
-    </terms>
-  </locale>
-  <macro name="volume">
-    <text variable="volume"/>
-  </macro>
-  <macro name="book">
-    <group delimiter=", ">
-      <text macro="title" font-style="italic"/>
-      <text macro="genre"/>
-      <text macro="volume"/>
-      <text macro="edition"/>
-      <text macro="collection"/>
-      <text macro="publisher"/>
-      <text macro="year-date"/>
-    </group>
-  </macro>
-  <macro name="genre">
+  <macro name="title">
     <choose>
-      <if type="book chapter" variable="genre">
-        <group delimiter=", ">
-          <text variable="genre"/>
-          <text variable="event-place"/>
-          <date variable="event-date" form="text"/>
-        </group>
+      <if type="book thesis" match="any">
+        <text variable="title" font-style="italic"/>
       </if>
+      <else>
+        <text variable="title" quotes="true"/>
+      </else>
     </choose>
   </macro>
-  <macro name="URL">
-    <group delimiter=", ">
-      <text variable="URL"/>
-      <text macro="access"/>
-    </group>
+  <macro name="title-short">
+    <text variable="title-short" font-style="italic"/>
   </macro>
-  <macro name="archive">
-    <group delimiter=", ">
-      <text variable="genre"/>
-      <text variable="archive"/>
-      <text variable="archive_location"/>
-      <text variable="call-number"/>
-    </group>
+  <macro name="container-title">
+    <text variable="container-title" form="short" font-style="italic"/>
   </macro>
-  <macro name="page-num">
-    <group delimiter="&#160;">
-      <text variable="number-of-pages"/>
-      <text term="page" form="short"/>
-    </group>
+  <macro name="collection-title">
+    <text variable="collection-title" form="short"/>
   </macro>
   <macro name="author">
-    <names variable="author" delimiter=", ">
-      <name font-variant="normal" initialize-with="." sort-separator=" "/>
+    <names variable="author">
+      <name delimiter="&amp;#44;&amp;#160;" initialize-with=".">
+        <name-part name="given"/>
+        <name-part name="family"/>
+      </name>
     </names>
   </macro>
-  <macro name="editor-translator">
-    <names variable="translator" delimiter=", ">
-      <name name-as-sort-order="all" sort-separator=" " initialize-with="." delimiter=", "/>
-      <label form="short" suffix=")" prefix=" ("/>
-      <substitute>
-        <text macro="editor"/>
-      </substitute>
+  <macro name="author-short">
+    <names variable="author">
+      <name form="short" font-variant="small-caps" et-al-min="3" et-al-use-first="1">
+        <name-part name="family"/>
+      </name>
+      <et-al font-style="italic"/>
     </names>
   </macro>
   <macro name="editor">
-    <names variable="editor" font-variant="normal" delimiter=", ">
-      <name font-variant="normal" initialize-with="." sort-separator=" "/>
-      <label form="short" text-case="lowercase" font-variant="normal" prefix=" (" suffix=")"/>
+    <names variable="editor">
+      <name delimiter="&amp;#44;&amp;#160;" initialize-with=".">
+        <name-part name="given"/>
+        <name-part name="family"/>
+      </name>
+      <label form="short" plural="never" prefix="&amp;#160;&amp;#40;" suffix="&amp;#41;"/>
       <substitute>
         <text macro="container-author"/>
       </substitute>
     </names>
   </macro>
-  <macro name="container-author">
-    <names variable="container-author" delimiter=", ">
-      <name font-variant="normal" initialize-with="." name-as-sort-order="all" sort-separator=" "/>
-      <et-al font-style="italic" font-variant="normal"/>
+  <macro name="translator">
+    <names variable="translator">
+      <name delimiter="&amp;#44;&amp;#160;" initialize-with=".">
+        <name-part name="given" font-variant="small-caps"/>
+        <name-part name="family" font-variant="small-caps"/>
+      </name>
+      <label form="short" plural="never" prefix="&amp;#160;&amp;#40;" suffix="&amp;#41;"/>
     </names>
   </macro>
-  <macro name="pages">
-    <group>
-      <text variable="page" prefix="p.&#160;"/>
-    </group>
-  </macro>
-  <macro name="author-short">
-    <choose>
-      <if variable="author">
-        <names variable="author">
-          <name form="short" delimiter=", " et-al-min="4" et-al-use-first="1" font-variant="small-caps"/>
-          <et-al font-variant="normal" font-style="italic"/>
-        </names>
-      </if>
-      <else-if variable="editor">
-        <names variable="editor">
-          <name form="short" delimiter=", " et-al-min="4" et-al-use-first="1" font-variant="small-caps"/>
-          <label form="short" text-case="lowercase" font-variant="normal" prefix=" (" suffix=")"/>
-        </names>
-      </else-if>
-      <else>
-        <text variable="title-short" font-variant="small-caps"/>
-      </else>
-    </choose>
-    <text macro="year-date" prefix=" "/>
-  </macro>
-  <macro name="access">
-    <group delimiter=" ">
-      <text term="accessed"/>
-      <date variable="accessed" delimiter=" ">
-        <date-part name="day"/>
-        <date-part name="month"/>
-        <date-part name="year"/>
-      </date>
-    </group>
-  </macro>
-  <macro name="collection">
-    <group delimiter=" ">
-      <text variable="collection-title"/>
-      <text variable="collection-number"/>
-    </group>
-  </macro>
-  <macro name="title">
-    <text variable="title" text-case="title"/>
-  </macro>
   <macro name="publisher">
-    <group delimiter=", ">
-      <text variable="publisher-place"/>
-    </group>
+    <text variable="publisher" text-case="capitalize-first"/>
   </macro>
-  <macro name="year-date">
+  <macro name="publisher-place">
     <choose>
-      <if variable="issued">
-        <date variable="issued">
-          <date-part name="year"/>
-        </date>
+      <if match="any" variable="publisher-place">
+        <text variable="publisher-place" text-case="capitalize-first"/>
       </if>
       <else>
-        <text term="no date" form="short"/>
+        <text value="[s.l.]"/>
       </else>
     </choose>
+  </macro>
+  <macro name="archive">
+    <text variable="archive" text-case="capitalize-first"/>
+  </macro>
+  <macro name="archive-location">
+    <text variable="archive_location" text-case="lowercase"/>
+  </macro>
+  <macro name="collection-number">
+    <number variable="collection-number"/>
+  </macro>
+  <macro name="volume">
+    <choose>
+      <if match="any" is-numeric="volume">
+        <number text-case="uppercase" variable="volume" form="roman"/>
+      </if>
+      <else-if match="none" is-numeric="volume">
+        <text variable="volume"/>
+      </else-if>
+    </choose>
+  </macro>
+  <macro name="genre">
+    <text variable="genre" text-case="lowercase"/>
+  </macro>
+  <macro name="pages">
+    <group delimiter="&amp;#160;">
+      <choose>
+        <if match="any" is-numeric="page">
+          <text value="p."/>
+        </if>
+      </choose>
+      <text variable="page"/>
+    </group>
+  </macro>
+  <macro name="accessed">
+    <group delimiter="&amp;#160;">
+      <text term="accessed" text-case="lowercase"/>
+      <date form="text" variable="accessed"/>
+    </group>
+  </macro>
+  <macro name="issued-year-month-day">
+    <choose>
+      <if match="any" variable="issued">
+        <date form="text" date-parts="year-month-day" variable="issued"/>
+      </if>
+      <else>
+        <text term="no date" form="short" text-case="lowercase" prefix="[" suffix="]"/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="issued-year">
+    <choose>
+      <if match="any" variable="issued">
+        <date date-parts="year" form="text" variable="issued"/>
+      </if>
+      <else>
+        <text term="no date" form="short" prefix="[" suffix="]"/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="original-date">
+    <date date-parts="year" form="text" variable="original-date"/>
+  </macro>
+  <macro name="URL">
+    <text variable="URL"/>
   </macro>
   <macro name="edition">
-    <group delimiter=", ">
-      <date variable="original-date">
-        <date-part name="year"/>
-      </date>
-      <choose>
-        <if is-numeric="edition">
-          <group delimiter=" ">
-            <number variable="edition" form="ordinal"/>
-            <text term="edition" form="short" text-case="lowercase"/>
-          </group>
-        </if>
-        <else>
-          <text variable="edition"/>
-        </else>
-      </choose>
+    <group delimiter="&amp;#160;" prefix="&amp;#40;" suffix="&amp;#41;">
+      <number variable="edition" form="ordinal"/>
+      <label variable="edition" form="short"/>
     </group>
   </macro>
-  <citation et-al-min="4" et-al-use-first="1" disambiguate-add-year-suffix="true">
+  <macro name="sort">
+    <choose>
+      <if match="any" variable="author">
+        <text macro="author"/>
+      </if>
+      <else-if match="any" variable="editor">
+        <text macro="editor"/>
+      </else-if>
+      <else-if type="webpage" match="all" variable="container-title">
+        <text macro="container-title"/>
+      </else-if>
+      <else>
+        <text macro="title"/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="locator">
+    <group delimiter="&amp;#160;">
+      <label plural="never" variable="locator" form="short"/>
+      <text variable="locator"/>
+    </group>
+  </macro>
+  <macro name="editor-short">
+    <names variable="editor">
+      <name form="short" font-variant="normal" et-al-min="3" et-al-use-first="1">
+        <name-part name="family" font-variant="small-caps"/>
+      </name>
+      <et-al font-style="italic"/>
+      <label form="short" plural="never" prefix="&amp;#160;&amp;#40;" suffix="&amp;#41;"/>
+    </names>
+  </macro>
+  <macro name="status">
+    <text term="forthcoming"/>
+  </macro>
+  <macro name="event-place">
+    <text variable="event-place"/>
+  </macro>
+  <macro name="event-date">
+    <date form="text" variable="event-date"/>
+  </macro>
+  <macro name="citation">
+    <choose>
+      <if match="any" variable="title-short">
+        <text macro="title-short"/>
+      </if>
+      <else-if match="any" variable="author">
+        <group delimiter="&amp;#160;">
+          <text macro="author-short"/>
+          <choose>
+            <if match="any" variable="original-date">
+              <group delimiter="&amp;#160;">
+                <text macro="original-date"/>
+                <group delimiter="&amp;#160;" prefix="&amp;#40;" suffix="&amp;#41;">
+                  <text term="edition" form="short"/>
+                  <text macro="issued-year"/>
+                </group>
+              </group>
+            </if>
+            <else-if match="any" variable="status">
+              <group>
+                <text macro="status" prefix="&amp;#40;" suffix="&amp;#41;"/>
+                <text macro="year-suffix"/>
+              </group>
+            </else-if>
+            <else>
+              <group>
+                <text macro="issued-year"/>
+                <text macro="year-suffix"/>
+              </group>
+            </else>
+          </choose>
+        </group>
+      </else-if>
+      <else-if match="any" variable="editor">
+        <group delimiter="&amp;#160;">
+          <text macro="editor-short"/>
+          <choose>
+            <if match="any" variable="original-date">
+              <group delimiter="&amp;#160;">
+                <text macro="original-date"/>
+                <group delimiter="&amp;#160;" prefix="&amp;#40;" suffix="&amp;#41;">
+                  <text term="edition" form="short"/>
+                  <text macro="issued-year"/>
+                </group>
+              </group>
+            </if>
+            <else-if match="any" variable="status">
+              <group>
+                <text macro="status" prefix="&amp;#40;" suffix="&amp;#41;"/>
+                <text macro="year-suffix"/>
+              </group>
+            </else-if>
+            <else>
+              <group>
+                <text macro="issued-year"/>
+              </group>
+              <text macro="year-suffix"/>
+            </else>
+          </choose>
+        </group>
+      </else-if>
+      <else-if type="entry-dictionary entry-encyclopedia" match="any">
+        <group delimiter="&amp;#160;">
+          <text macro="container-title"/>
+          <text macro="volume"/>
+        </group>
+        <group delimiter="&amp;#160;" prefix="&amp;#44;&amp;#160;">
+          <text term="sub verbo" form="short" font-style="italic"/>
+          <text macro="title"/>
+        </group>
+      </else-if>
+      <else>
+        <choose>
+          <if type="webpage" match="any">
+            <text macro="container-title"/>
+          </if>
+          <else>
+            <text macro="title"/>
+          </else>
+        </choose>
+      </else>
+    </choose>
+  </macro>
+  <macro name="container-author">
+    <names variable="container-author">
+      <name initialize-with=".">
+        <name-part name="given" font-variant="small-caps"/>
+        <name-part name="family" font-variant="small-caps"/>
+      </name>
+      <label/>
+      <et-al font-style="italic"/>
+    </names>
+  </macro>
+  <macro name="year-suffix">
+    <text variable="year-suffix"/>
+  </macro>
+  <macro name="note">
+    <text variable="note"/>
+  </macro>
+  <citation name-delimiter="&amp;#044;&amp;#160;" disambiguate-add-givenname="true" disambiguate-add-year-suffix="true" givenname-disambiguation-rule="all-names">
     <sort>
-      <key variable="issued"/>
+      <key macro="sort"/>
     </sort>
-    <layout delimiter="&#160;; ">
-      <text macro="author-short"/>
-      <group prefix=", " font-variant="normal">
-        <label variable="locator" form="short" suffix=".&#160;"/>
-        <text variable="locator"/>
-      </group>
+    <layout delimiter="&amp;#160;&amp;#59;&amp;#160;" suffix="&amp;#46;">
+      <text macro="citation"/>
+      <text macro="locator" prefix="&amp;#44;&amp;#160;"/>
     </layout>
   </citation>
   <bibliography>
     <sort>
-      <key macro="author-short"/>
+      <key macro="sort"/>
       <key variable="issued"/>
-      <key variable="page-first"/>
-      <key variable="title"/>
     </sort>
-    <layout suffix=".">
+    <layout suffix="&amp;#46;">
       <group display="block">
-        <text macro="author-short" suffix="&#9;"/>
+        <text macro="citation"/>
       </group>
-      <group display="left-margin">
+      <group display="left-margin" delimiter="&amp;#44;&amp;#160;">
         <choose>
-          <if match="any" variable="author">
-            <text macro="author" suffix=", "/>
-          </if>
-          <else-if match="none" variable="author">
-            <text macro="editor" suffix=", "/>
-          </else-if>
-        </choose>
-        <choose>
-          <if type="thesis report">
-            <group delimiter=", ">
-              <text macro="title" font-style="italic"/>
-              <text variable="genre"/>
-              <text variable="publisher"/>
-              <text variable="publisher-place"/>
+          <if type="book" match="any">
+            <group delimiter="&amp;#44;&amp;#160;">
+              <choose>
+                <if match="any" variable="author">
+                  <text macro="author"/>
+                </if>
+                <else>
+                  <text macro="editor"/>
+                </else>
+              </choose>
+              <group delimiter="&amp;#160;">
+                <text macro="title" font-style="normal"/>
+                <text macro="volume"/>
+                <text macro="original-date" prefix="&amp;#40;" suffix="&amp;#41;"/>
+              </group>
+              <text macro="translator"/>
+              <choose>
+                <if match="any" variable="genre">
+                  <group delimiter="&amp;#44;&amp;#160;">
+                    <text macro="genre"/>
+                    <text macro="event-place"/>
+                    <text macro="event-date"/>
+                  </group>
+                </if>
+              </choose>
+              <text macro="note"/>
+              <group delimiter="&amp;#160;">
+                <text macro="collection-title"/>
+                <text macro="collection-number"/>
+              </group>
+              <choose>
+                <if match="none" variable="publisher-place issued">
+                  <text value="s.l.n.d." prefix="&amp;#91;" suffix="&amp;#93;"/>
+                </if>
+                <else>
+                  <text macro="publisher-place"/>
+                  <choose>
+                    <if match="any" variable="status">
+                      <text macro="status"/>
+                    </if>
+                    <else>
+                      <group delimiter="&amp;#160;">
+                        <text macro="issued-year"/>
+                        <text macro="edition"/>
+                      </group>
+                    </else>
+                  </choose>
+                </else>
+              </choose>
             </group>
           </if>
-          <else-if type="entry-dictionary entry-encyclopedia">
-            <group delimiter=", ">
-              <group delimiter=" ">
-                <text variable="container-title" font-style="italic" text-case="title" form="short"/>
-                <text variable="volume"/>
+          <else-if type="article-journal article-magazine article-newspaper article" match="any">
+            <group delimiter="&amp;#44;&amp;#160;">
+              <text macro="author"/>
+              <text macro="title" quotes="false"/>
+              <group delimiter="&amp;#160;">
+                <text macro="container-title"/>
+                <group delimiter="&amp;#47;">
+                  <number variable="volume"/>
+                  <number variable="issue"/>
+                </group>
               </group>
-              <text macro="year-date"/>
-              <group delimiter="&#160;">
-                <text term="column" form="short"/>
-                <text variable="page"/>
-              </group>
-              <group delimiter="&#160;">
-                <text term="sub verbo" form="short" font-style="italic"/>
-                <text macro="title" quotes="true"/>
-              </group>
-            </group>
-          </else-if>
-          <else-if type="webpage article-journal article-magazine article-newspaper broadcast personal_communication article" match="any">
-            <group delimiter=", ">
-              <text macro="title" quotes="true"/>
-              <text macro="edition"/>
-              <text variable="container-title" font-style="italic" text-case="title"/>
-              <text macro="volume"/>
-              <text variable="issue"/>
-              <text macro="year-date"/>
+              <choose>
+                <if match="any" variable="status">
+                  <text macro="status"/>
+                </if>
+                <else>
+                  <text macro="issued-year-month-day"/>
+                </else>
+              </choose>
               <text macro="pages"/>
             </group>
-          </else-if>
-          <else-if type="book">
-            <choose>
-              <if variable="author">
-                <choose>
-                  <if variable="editor translator" match="none">
-                    <text macro="book"/>
-                  </if>
-                  <else>
-                    <group delimiter=", ">
-                      <text macro="title" font-style="italic"/>
-                      <text macro="edition"/>
-                      <text macro="editor-translator"/>
-                      <text macro="collection"/>
-                      <text macro="publisher"/>
-                      <text macro="year-date"/>
-                    </group>
-                  </else>
-                </choose>
-              </if>
-              <else>
-                <text macro="book"/>
-              </else>
-            </choose>
           </else-if>
           <else-if type="chapter paper-conference" match="any">
-            <group delimiter=", ">
-              <group delimiter=" ">
-                <text macro="title" quotes="true"/>
+            <group delimiter="&amp;#44;&amp;#160;">
+              <text macro="author"/>
+              <group delimiter="&amp;#160;">
+                <text macro="title" quotes="false"/>
                 <choose>
-                  <if variable="editor container-author" match="any">
-                    <group>
-                      <text value="in" font-style="italic" suffix=" "/>
-                      <text macro="editor" suffix=", "/>
-                      <text variable="container-title" font-style="italic" text-case="title"/>
+                  <if match="any" variable="editor container-author">
+                    <group delimiter="&amp;#160;">
+                      <text term="in" font-style="italic"/>
+                      <text macro="editor" suffix="&amp;#44;"/>
+                      <text macro="container-title"/>
+                      <text macro="volume"/>
+                      <text macro="original-date" prefix="&amp;#40;" suffix="&amp;#41;"/>
                     </group>
                   </if>
                   <else>
-                    <group>
-                      <text value="in" suffix=" "/>
-                      <text variable="container-title" font-style="italic" text-case="title"/>
+                    <group delimiter="&amp;#160;">
+                      <text term="in"/>
+                      <text macro="container-title"/>
+                      <text macro="volume"/>
+                      <text macro="original-date" prefix="&amp;#40;" suffix="&amp;#41;"/>
                     </group>
                   </else>
                 </choose>
               </group>
-              <text macro="volume"/>
-              <text macro="genre"/>
-              <text macro="edition"/>
-              <text macro="collection"/>
-              <text macro="publisher"/>
-              <text macro="year-date"/>
+              <choose>
+                <if match="any" variable="genre">
+                  <group delimiter="&amp;#44;&amp;#160;">
+                    <text macro="genre"/>
+                    <text macro="event-place"/>
+                    <text macro="event-date"/>
+                  </group>
+                </if>
+              </choose>
+              <text macro="note"/>
+              <group delimiter="&amp;#160;">
+                <text macro="collection-title"/>
+                <text macro="collection-number"/>
+              </group>
+              <choose>
+                <if match="none" variable="publisher-place issued">
+                  <text value="s.l.n.d." prefix="&amp;#91;" suffix="&amp;#93;"/>
+                </if>
+                <else>
+                  <text macro="publisher-place"/>
+                  <choose>
+                    <if match="any" variable="status">
+                      <text macro="status"/>
+                    </if>
+                    <else>
+                      <text macro="issued-year"/>
+                    </else>
+                  </choose>
+                </else>
+              </choose>
               <text macro="pages"/>
+              <text macro="container-author"/>
             </group>
           </else-if>
-          <else-if type="manuscript map graphic">
-            <group delimiter=", ">
-              <text macro="title" quotes="true"/>
-              <text macro="archive"/>
-              <text macro="page-num"/>
-            </group>
-          </else-if>
-          <else>
-            <group delimiter=", ">
-              <text macro="title" font-style="italic"/>
+          <else-if type="manuscript" match="any">
+            <group delimiter="&amp;#44;&amp;#160;">
+              <text macro="author"/>
+              <group delimiter="&amp;#160;">
+                <text macro="title" quotes="false"/>
+                <text macro="issued-year" prefix="&amp;#40;" suffix="&amp;#41;"/>
+              </group>
               <text macro="genre"/>
-              <text macro="collection"/>
-              <text variable="publisher"/>
-              <text macro="publisher"/>
-              <text macro="year-date"/>
+              <text macro="archive"/>
+              <text macro="archive-location"/>
             </group>
-          </else>
+          </else-if>
+          <else-if type="entry-dictionary entry-encyclopedia" match="any">
+            <group delimiter="&amp;#44;&amp;#160;">
+              <text macro="author"/>
+              <group delimiter="&amp;#160;">
+                <text macro="container-title"/>
+                <text macro="volume"/>
+              </group>
+              <choose>
+                <if match="any" variable="status">
+                  <text macro="status"/>
+                </if>
+                <else>
+                  <text macro="issued-year"/>
+                </else>
+              </choose>
+              <text macro="pages"/>
+              <group delimiter="&amp;#160;">
+                <text term="sub verbo" form="short" font-style="italic"/>
+                <text macro="title"/>
+              </group>
+            </group>
+          </else-if>
+          <else-if type="thesis" match="any">
+            <group delimiter="&amp;#44;&amp;#160;">
+              <text macro="author"/>
+              <text macro="title"/>
+              <text macro="genre"/>
+              <text macro="publisher"/>
+              <text macro="issued-year"/>
+            </group>
+          </else-if>
+          <else-if type="report" match="any">
+            <group delimiter="&amp;#44;&amp;#160;">
+              <text macro="author"/>
+              <text macro="title" quotes="false"/>
+              <text macro="genre"/>
+              <text macro="publisher"/>
+              <text macro="publisher-place"/>
+              <text macro="issued-year"/>
+            </group>
+          </else-if>
+          <else-if type="webpage" match="any">
+            <group delimiter="&amp;#44;&amp;#160;">
+              <text macro="author"/>
+              <text macro="container-title"/>
+              <group delimiter="&amp;#160;">
+                <text macro="genre"/>
+                <text term="online"/>
+              </group>
+              <text macro="URL"/>
+              <choose>
+                <if match="any" variable="issued">
+                  <group delimiter="&amp;#160;">
+                    <text value="version du"/>
+                    <text macro="issued-year-month-day"/>
+                  </group>
+                </if>
+              </choose>
+              <text macro="accessed"/>
+            </group>
+          </else-if>
+          <else-if type="post-weblog" match="any">
+            <group delimiter="&amp;#44;&amp;#160;">
+              <text macro="author"/>
+              <group delimiter="&amp;#160;">
+                <text macro="title" quotes="false"/>
+                <text term="in" font-style="normal"/>
+                <text macro="container-title"/>
+              </group>
+              <group delimiter="&amp;#160;">
+                <text macro="genre"/>
+                <text term="online"/>
+              </group>
+              <text macro="URL"/>
+              <group delimiter="&amp;#160;">
+                <text value="publié le"/>
+                <text macro="issued-year-month-day"/>
+              </group>
+              <text macro="accessed"/>
+            </group>
+          </else-if>
         </choose>
-        <text macro="URL" prefix=", "/>
+        <choose>
+          <if match="any" variable="URL">
+            <choose>
+              <if type="webpage post-weblog" match="none">
+                <group delimiter="&amp;#160;">
+                  <choose>
+                    <if type="book" match="any">
+                      <text value="livre"/>
+                    </if>
+                    <else-if type="article-journal chapter entry-dictionary entry-encyclopedia article article-magazine article-newspaper paper-conference" match="any">
+                      <text value="article"/>
+                    </else-if>
+                    <else-if type="thesis" match="any">
+                      <text macro="genre"/>
+                    </else-if>
+                    <else>
+                      <text value="document"/>
+                    </else>
+                  </choose>
+                  <text term="online"/>
+                  <text term="at"/>
+                  <text macro="archive"/>
+                </group>
+                <text macro="URL"/>
+                <text macro="accessed"/>
+              </if>
+            </choose>
+          </if>
+        </choose>
       </group>
     </layout>
   </bibliography>

--- a/institut-francais-darcheologie-orientale.csl
+++ b/institut-francais-darcheologie-orientale.csl
@@ -5,7 +5,7 @@
     <title>Institut français d'archéologie orientale (Français)</title>
     <title-short>IFAO (FR)</title-short>
     <id>http://www.zotero.org/styles/institut-francais-darcheologie-orientale-fr</id>
-    <link href="http://www.zotero.org/styles/institut-francais-darcheologie-orientale-fr" rel="self"/>
+    <link href="http://www.zotero.org/styles/institut-francais-darcheologie-orientale" rel="self"/>
     <link href="https://www.ifao.egnet.net/uploads/publications/normes/IFAO_publications_normes_bibliographiques_pub_egypto_2020_fr.pdf" rel="documentation"/>
     <author>
       <name>Nicolas Souchon</name>

--- a/institut-francais-darcheologie-orientale.csl
+++ b/institut-francais-darcheologie-orientale.csl
@@ -11,6 +11,8 @@
       <name>Nicolas Souchon</name>
       <email>souchon.nicolas.ns@gmail.com</email>
     </author>
+    <category citation-format="note"/>
+    <category field="history"/>
     <summary>Feuille de style pour les publications d'archéologie et d'égyptologie de l'Institut français d'archéologie orientale</summary>
     <updated>2020-06-14T11:57:11+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>

--- a/institut-francais-darcheologie-orientale.csl
+++ b/institut-francais-darcheologie-orientale.csl
@@ -44,7 +44,7 @@
   </macro>
   <macro name="author">
     <names variable="author">
-      <name delimiter="&amp;#44;&amp;#160;" initialize-with=".">
+      <name delimiter=", " initialize-with=".">
         <name-part name="given"/>
         <name-part name="family"/>
       </name>
@@ -60,11 +60,11 @@
   </macro>
   <macro name="editor">
     <names variable="editor">
-      <name delimiter="&amp;#44;&amp;#160;" initialize-with=".">
+      <name delimiter=", " initialize-with=".">
         <name-part name="given"/>
         <name-part name="family"/>
       </name>
-      <label form="short" plural="never" prefix="&amp;#160;&amp;#40;" suffix="&amp;#41;"/>
+      <label form="short" plural="never" prefix=" (" suffix=")"/>
       <substitute>
         <text macro="container-author"/>
       </substitute>
@@ -72,11 +72,11 @@
   </macro>
   <macro name="translator">
     <names variable="translator">
-      <name delimiter="&amp;#44;&amp;#160;" initialize-with=".">
+      <name delimiter=", " initialize-with=".">
         <name-part name="given" font-variant="small-caps"/>
         <name-part name="family" font-variant="small-caps"/>
       </name>
-      <label form="short" plural="never" prefix="&amp;#160;&amp;#40;" suffix="&amp;#41;"/>
+      <label form="short" plural="never" prefix=" (" suffix=")"/>
     </names>
   </macro>
   <macro name="publisher">
@@ -115,7 +115,7 @@
     <text variable="genre" text-case="lowercase"/>
   </macro>
   <macro name="pages">
-    <group delimiter="&amp;#160;">
+    <group delimiter="&#160;">
       <choose>
         <if match="any" is-numeric="page">
           <text value="p."/>
@@ -125,7 +125,7 @@
     </group>
   </macro>
   <macro name="accessed">
-    <group delimiter="&amp;#160;">
+    <group delimiter="&#160;">
       <text term="accessed" text-case="lowercase"/>
       <date form="text" variable="accessed"/>
     </group>
@@ -157,7 +157,7 @@
     <text variable="URL"/>
   </macro>
   <macro name="edition">
-    <group delimiter="&amp;#160;" prefix="&amp;#40;" suffix="&amp;#41;">
+    <group delimiter="&#160;" prefix="(" suffix=")">
       <number variable="edition" form="ordinal"/>
       <label variable="edition" form="short"/>
     </group>
@@ -179,7 +179,7 @@
     </choose>
   </macro>
   <macro name="locator">
-    <group delimiter="&amp;#160;">
+    <group delimiter="&#160;">
       <label plural="never" variable="locator" form="short"/>
       <text variable="locator"/>
     </group>
@@ -190,7 +190,7 @@
         <name-part name="family" font-variant="small-caps"/>
       </name>
       <et-al font-style="italic"/>
-      <label form="short" plural="never" prefix="&amp;#160;&amp;#40;" suffix="&amp;#41;"/>
+      <label form="short" plural="never" prefix="&#160;(" suffix=")"/>
     </names>
   </macro>
   <macro name="status">
@@ -208,13 +208,13 @@
         <text macro="title-short"/>
       </if>
       <else-if match="any" variable="author">
-        <group delimiter="&amp;#160;">
+        <group delimiter="&#160;">
           <text macro="author-short"/>
           <choose>
             <if match="any" variable="original-date">
-              <group delimiter="&amp;#160;">
+              <group delimiter="&#160;">
                 <text macro="original-date"/>
-                <group delimiter="&amp;#160;" prefix="&amp;#40;" suffix="&amp;#41;">
+                <group delimiter="&#160;" prefix="(" suffix=")">
                   <text term="edition" form="short"/>
                   <text macro="issued-year"/>
                 </group>
@@ -222,7 +222,7 @@
             </if>
             <else-if match="any" variable="status">
               <group>
-                <text macro="status" prefix="&amp;#40;" suffix="&amp;#41;"/>
+                <text macro="status" prefix="(" suffix=")"/>
                 <text macro="year-suffix"/>
               </group>
             </else-if>
@@ -236,13 +236,13 @@
         </group>
       </else-if>
       <else-if match="any" variable="editor">
-        <group delimiter="&amp;#160;">
+        <group delimiter="&#160;">
           <text macro="editor-short"/>
           <choose>
             <if match="any" variable="original-date">
-              <group delimiter="&amp;#160;">
+              <group delimiter="&#160;">
                 <text macro="original-date"/>
-                <group delimiter="&amp;#160;" prefix="&amp;#40;" suffix="&amp;#41;">
+                <group delimiter="&#160;" prefix="(" suffix=")">
                   <text term="edition" form="short"/>
                   <text macro="issued-year"/>
                 </group>
@@ -250,7 +250,7 @@
             </if>
             <else-if match="any" variable="status">
               <group>
-                <text macro="status" prefix="&amp;#40;" suffix="&amp;#41;"/>
+                <text macro="status" prefix="(" suffix=")"/>
                 <text macro="year-suffix"/>
               </group>
             </else-if>
@@ -264,11 +264,11 @@
         </group>
       </else-if>
       <else-if type="entry-dictionary entry-encyclopedia" match="any">
-        <group delimiter="&amp;#160;">
+        <group delimiter="&#160;">
           <text macro="container-title"/>
           <text macro="volume"/>
         </group>
-        <group delimiter="&amp;#160;" prefix="&amp;#44;&amp;#160;">
+        <group delimiter="&#160;" prefix=", ">
           <text term="sub verbo" form="short" font-style="italic"/>
           <text macro="title"/>
         </group>
@@ -301,13 +301,13 @@
   <macro name="note">
     <text variable="note"/>
   </macro>
-  <citation name-delimiter="&amp;#044;&amp;#160;" disambiguate-add-givenname="true" disambiguate-add-year-suffix="true" givenname-disambiguation-rule="all-names">
+  <citation name-delimiter=", " disambiguate-add-givenname="true" disambiguate-add-year-suffix="true" givenname-disambiguation-rule="all-names">
     <sort>
       <key macro="sort"/>
     </sort>
-    <layout delimiter="&amp;#160;&amp;#59;&amp;#160;" suffix="&amp;#46;">
+    <layout delimiter="&#160;; " suffix=".">
       <text macro="citation"/>
-      <text macro="locator" prefix="&amp;#44;&amp;#160;"/>
+      <text macro="locator" prefix=", "/>
     </layout>
   </citation>
   <bibliography>
@@ -315,14 +315,14 @@
       <key macro="sort"/>
       <key variable="issued"/>
     </sort>
-    <layout suffix="&amp;#46;">
+    <layout suffix=".">
       <group display="block">
         <text macro="citation"/>
       </group>
-      <group display="left-margin" delimiter="&amp;#44;&amp;#160;">
+      <group display="left-margin" delimiter=", ">
         <choose>
           <if type="book" match="any">
-            <group delimiter="&amp;#44;&amp;#160;">
+            <group delimiter=", ">
               <choose>
                 <if match="any" variable="author">
                   <text macro="author"/>
@@ -331,15 +331,15 @@
                   <text macro="editor"/>
                 </else>
               </choose>
-              <group delimiter="&amp;#160;">
+              <group delimiter="&#160;">
                 <text macro="title" font-style="normal"/>
                 <text macro="volume"/>
-                <text macro="original-date" prefix="&amp;#40;" suffix="&amp;#41;"/>
+                <text macro="original-date" prefix="(" suffix=")"/>
               </group>
               <text macro="translator"/>
               <choose>
                 <if match="any" variable="genre">
-                  <group delimiter="&amp;#44;&amp;#160;">
+                  <group delimiter=", ">
                     <text macro="genre"/>
                     <text macro="event-place"/>
                     <text macro="event-date"/>
@@ -347,13 +347,13 @@
                 </if>
               </choose>
               <text macro="note"/>
-              <group delimiter="&amp;#160;">
+              <group delimiter="&#160;">
                 <text macro="collection-title"/>
                 <text macro="collection-number"/>
               </group>
               <choose>
                 <if match="none" variable="publisher-place issued">
-                  <text value="s.l.n.d." prefix="&amp;#91;" suffix="&amp;#93;"/>
+                  <text value="s.l.n.d." prefix="[" suffix="]"/>
                 </if>
                 <else>
                   <text macro="publisher-place"/>
@@ -362,7 +362,7 @@
                       <text macro="status"/>
                     </if>
                     <else>
-                      <group delimiter="&amp;#160;">
+                      <group delimiter="&#160;">
                         <text macro="issued-year"/>
                         <text macro="edition"/>
                       </group>
@@ -373,12 +373,12 @@
             </group>
           </if>
           <else-if type="article-journal article-magazine article-newspaper article" match="any">
-            <group delimiter="&amp;#44;&amp;#160;">
+            <group delimiter=", ">
               <text macro="author"/>
               <text macro="title" quotes="false"/>
-              <group delimiter="&amp;#160;">
+              <group delimiter="&#160;">
                 <text macro="container-title"/>
-                <group delimiter="&amp;#47;">
+                <group delimiter="/">
                   <number variable="volume"/>
                   <number variable="issue"/>
                 </group>
@@ -395,33 +395,33 @@
             </group>
           </else-if>
           <else-if type="chapter paper-conference" match="any">
-            <group delimiter="&amp;#44;&amp;#160;">
+            <group delimiter=", ">
               <text macro="author"/>
-              <group delimiter="&amp;#160;">
+              <group delimiter="&#160;">
                 <text macro="title" quotes="false"/>
                 <choose>
                   <if match="any" variable="editor container-author">
-                    <group delimiter="&amp;#160;">
+                    <group delimiter="&#160;">
                       <text term="in" font-style="italic"/>
-                      <text macro="editor" suffix="&amp;#44;"/>
+                      <text macro="editor" suffix=","/>
                       <text macro="container-title"/>
                       <text macro="volume"/>
-                      <text macro="original-date" prefix="&amp;#40;" suffix="&amp;#41;"/>
+                      <text macro="original-date" prefix="(" suffix=")"/>
                     </group>
                   </if>
                   <else>
-                    <group delimiter="&amp;#160;">
+                    <group delimiter="&#160;">
                       <text term="in"/>
                       <text macro="container-title"/>
                       <text macro="volume"/>
-                      <text macro="original-date" prefix="&amp;#40;" suffix="&amp;#41;"/>
+                      <text macro="original-date" prefix="(" suffix=")"/>
                     </group>
                   </else>
                 </choose>
               </group>
               <choose>
                 <if match="any" variable="genre">
-                  <group delimiter="&amp;#44;&amp;#160;">
+                  <group delimiter=", ">
                     <text macro="genre"/>
                     <text macro="event-place"/>
                     <text macro="event-date"/>
@@ -429,13 +429,13 @@
                 </if>
               </choose>
               <text macro="note"/>
-              <group delimiter="&amp;#160;">
+              <group delimiter="&#160;">
                 <text macro="collection-title"/>
                 <text macro="collection-number"/>
               </group>
               <choose>
                 <if match="none" variable="publisher-place issued">
-                  <text value="s.l.n.d." prefix="&amp;#91;" suffix="&amp;#93;"/>
+                  <text value="s.l.n.d." prefix="[" suffix="]"/>
                 </if>
                 <else>
                   <text macro="publisher-place"/>
@@ -454,11 +454,11 @@
             </group>
           </else-if>
           <else-if type="manuscript" match="any">
-            <group delimiter="&amp;#44;&amp;#160;">
+            <group delimiter=", ">
               <text macro="author"/>
-              <group delimiter="&amp;#160;">
+              <group delimiter="&#160;">
                 <text macro="title" quotes="false"/>
-                <text macro="issued-year" prefix="&amp;#40;" suffix="&amp;#41;"/>
+                <text macro="issued-year" prefix="(" suffix=")"/>
               </group>
               <text macro="genre"/>
               <text macro="archive"/>
@@ -466,9 +466,9 @@
             </group>
           </else-if>
           <else-if type="entry-dictionary entry-encyclopedia" match="any">
-            <group delimiter="&amp;#44;&amp;#160;">
+            <group delimiter=", ">
               <text macro="author"/>
-              <group delimiter="&amp;#160;">
+              <group delimiter="&#160;">
                 <text macro="container-title"/>
                 <text macro="volume"/>
               </group>
@@ -481,14 +481,14 @@
                 </else>
               </choose>
               <text macro="pages"/>
-              <group delimiter="&amp;#160;">
+              <group delimiter="&#160;">
                 <text term="sub verbo" form="short" font-style="italic"/>
                 <text macro="title"/>
               </group>
             </group>
           </else-if>
           <else-if type="thesis" match="any">
-            <group delimiter="&amp;#44;&amp;#160;">
+            <group delimiter=", ">
               <text macro="author"/>
               <text macro="title"/>
               <text macro="genre"/>
@@ -497,7 +497,7 @@
             </group>
           </else-if>
           <else-if type="report" match="any">
-            <group delimiter="&amp;#44;&amp;#160;">
+            <group delimiter=", ">
               <text macro="author"/>
               <text macro="title" quotes="false"/>
               <text macro="genre"/>
@@ -507,17 +507,17 @@
             </group>
           </else-if>
           <else-if type="webpage" match="any">
-            <group delimiter="&amp;#44;&amp;#160;">
+            <group delimiter=", ">
               <text macro="author"/>
               <text macro="container-title"/>
-              <group delimiter="&amp;#160;">
+              <group delimiter="&#160;">
                 <text macro="genre"/>
                 <text term="online"/>
               </group>
               <text macro="URL"/>
               <choose>
                 <if match="any" variable="issued">
-                  <group delimiter="&amp;#160;">
+                  <group delimiter="&#160;">
                     <text value="version du"/>
                     <text macro="issued-year-month-day"/>
                   </group>
@@ -527,19 +527,19 @@
             </group>
           </else-if>
           <else-if type="post-weblog" match="any">
-            <group delimiter="&amp;#44;&amp;#160;">
+            <group delimiter=", ">
               <text macro="author"/>
-              <group delimiter="&amp;#160;">
+              <group delimiter="&#160;">
                 <text macro="title" quotes="false"/>
                 <text term="in" font-style="normal"/>
                 <text macro="container-title"/>
               </group>
-              <group delimiter="&amp;#160;">
+              <group delimiter="&#160;">
                 <text macro="genre"/>
                 <text term="online"/>
               </group>
               <text macro="URL"/>
-              <group delimiter="&amp;#160;">
+              <group delimiter="&#160;">
                 <text value="publié le"/>
                 <text macro="issued-year-month-day"/>
               </group>
@@ -551,7 +551,7 @@
           <if match="any" variable="URL">
             <choose>
               <if type="webpage post-weblog" match="none">
-                <group delimiter="&amp;#160;">
+                <group delimiter="&#160;">
                   <choose>
                     <if type="book" match="any">
                       <text value="livre"/>

--- a/institut-francais-darcheologie-orientale.csl
+++ b/institut-francais-darcheologie-orientale.csl
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<style class="note" version="1.0" et-al-use-first="1" et-al-subsequent-min="3" initialize-with="." page-range-format="expanded" demote-non-dropping-particle="sort-only" default-locale="fr-FR" xmlns="http://purl.org/net/xbiblio/csl">
+<style class="note" version="1.0" et-al-use-first="1" et-al-min="3" initialize-with="." page-range-format="expanded" demote-non-dropping-particle="sort-only" default-locale="fr-FR" xmlns="http://purl.org/net/xbiblio/csl">
   <!-- This style was edited with the Visual CSL Editor (https://editor.citationstyles.org/visualEditor/) -->
   <info>
     <title>Institut français d'archéologie orientale (Français)</title>

--- a/institut-francais-darcheologie-orientale.csl
+++ b/institut-francais-darcheologie-orientale.csl
@@ -4,7 +4,7 @@
   <info>
     <title>Institut français d'archéologie orientale (Français)</title>
     <title-short>IFAO (FR)</title-short>
-    <id>http://www.zotero.org/styles/institut-francais-darcheologie-orientale-fr</id>
+    <id>http://www.zotero.org/styles/institut-francais-darcheologie-orientale</id>
     <link href="http://www.zotero.org/styles/institut-francais-darcheologie-orientale" rel="self"/>
     <link href="https://www.ifao.egnet.net/uploads/publications/normes/IFAO_publications_normes_bibliographiques_pub_egypto_2020_fr.pdf" rel="documentation"/>
     <author>

--- a/institut-francais-darcheologie-orientale.csl
+++ b/institut-francais-darcheologie-orientale.csl
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<style class="note" version="1.0" et-al-use-first="1" et-al-min="3" initialize-with="." page-range-format="expanded" demote-non-dropping-particle="sort-only" default-locale="fr-FR" xmlns="http://purl.org/net/xbiblio/csl">
+<style class="note" version="1.0" initialize-with="." page-range-format="expanded" demote-non-dropping-particle="sort-only" default-locale="fr-FR" xmlns="http://purl.org/net/xbiblio/csl">
   <!-- This style was edited with the Visual CSL Editor (https://editor.citationstyles.org/visualEditor/) -->
   <info>
     <title>Institut français d'archéologie orientale (Français)</title>
@@ -315,11 +315,11 @@
       <key macro="sort"/>
       <key variable="issued"/>
     </sort>
-    <layout suffix=".">
+    <layout>
       <group display="block">
         <text macro="citation"/>
       </group>
-      <group display="left-margin" delimiter=", ">
+      <group display="left-margin" delimiter=", " suffix=".">
         <choose>
           <if type="book" match="any">
             <group delimiter=", ">
@@ -356,18 +356,20 @@
                   <text value="s.l.n.d." prefix="[" suffix="]"/>
                 </if>
                 <else>
-                  <text macro="publisher-place"/>
-                  <choose>
-                    <if match="any" variable="status">
-                      <text macro="status"/>
-                    </if>
-                    <else>
-                      <group delimiter="&#160;">
-                        <text macro="issued-year"/>
-                        <text macro="edition"/>
-                      </group>
-                    </else>
-                  </choose>
+                  <group delimiter=", ">
+                    <text macro="publisher-place"/>
+                    <choose>
+                      <if match="any" variable="status">
+                        <text macro="status"/>
+                      </if>
+                      <else>
+                        <group delimiter="&#160;">
+                          <text macro="issued-year"/>
+                          <text macro="edition"/>
+                        </group>
+                      </else>
+                    </choose>
+                  </group>
                 </else>
               </choose>
             </group>
@@ -438,15 +440,20 @@
                   <text value="s.l.n.d." prefix="[" suffix="]"/>
                 </if>
                 <else>
-                  <text macro="publisher-place"/>
-                  <choose>
-                    <if match="any" variable="status">
-                      <text macro="status"/>
-                    </if>
-                    <else>
-                      <text macro="issued-year"/>
-                    </else>
-                  </choose>
+                  <group delimiter=", ">
+                    <text macro="publisher-place"/>
+                    <choose>
+                      <if match="any" variable="status">
+                        <text macro="status"/>
+                      </if>
+                      <else>
+                        <group delimiter="&#160;">
+                          <text macro="issued-year"/>
+                          <text macro="edition"/>
+                        </group>
+                      </else>
+                    </choose>
+                  </group>
                 </else>
               </choose>
               <text macro="pages"/>

--- a/institut-francais-darcheologie-orientale.csl
+++ b/institut-francais-darcheologie-orientale.csl
@@ -2,7 +2,7 @@
 <style xmlns="http://purl.org/net/xbiblio/csl" class="note" version="1.0" initialize-with="." page-range-format="expanded" demote-non-dropping-particle="sort-only" default-locale="fr-FR">
   <!-- This style was edited with the Visual CSL Editor (https://editor.citationstyles.org/visualEditor/) -->
   <info>
-    <title>Institut français d'archéologie orientale (Français)</title>
+    <title>Institut français d'archéologie orientale (French)</title>
     <title-short>IFAO (FR)</title-short>
     <id>http://www.zotero.org/styles/institut-francais-darcheologie-orientale</id>
     <link href="http://www.zotero.org/styles/institut-francais-darcheologie-orientale" rel="self"/>

--- a/institut-francais-darcheologie-orientale.csl
+++ b/institut-francais-darcheologie-orientale.csl
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<style class="note" version="1.0" initialize-with="." page-range-format="expanded" demote-non-dropping-particle="sort-only" default-locale="fr-FR" xmlns="http://purl.org/net/xbiblio/csl">
+<style xmlns="http://purl.org/net/xbiblio/csl" class="note" version="1.0" initialize-with="." page-range-format="expanded" demote-non-dropping-particle="sort-only" default-locale="fr-FR">
   <!-- This style was edited with the Visual CSL Editor (https://editor.citationstyles.org/visualEditor/) -->
   <info>
     <title>Institut français d'archéologie orientale (Français)</title>

--- a/institut-francais-darcheologie-orientale.csl
+++ b/institut-francais-darcheologie-orientale.csl
@@ -52,8 +52,8 @@
   </macro>
   <macro name="author-short">
     <names variable="author">
-      <name form="short" font-variant="small-caps" et-al-min="3" et-al-use-first="1">
-        <name-part name="family"/>
+      <name form="short" font-variant="normal" et-al-min="3" et-al-use-first="1">
+        <name-part name="family" font-variant="small-caps"/>
       </name>
       <et-al font-style="italic"/>
     </names>
@@ -200,7 +200,11 @@
     <text variable="event-place"/>
   </macro>
   <macro name="event-date">
-    <date form="text" variable="event-date"/>
+    <date delimiter=" " variable="event-date">
+      <date-part name="day"/>
+      <date-part name="month"/>
+      <date-part name="year" range-delimiter="-"/>
+    </date>
   </macro>
   <macro name="citation">
     <choose>


### PR DESCRIPTION
Replace institut-francais-darcheologie-orientale.csl by a new CSL style corresponding to the updated version of the Institute français d'archéologie orientale’s standards (available here: https://www.ifao.egnet.net/uploads/publications/normes/IFAO_publications_normes_bibliographiques_pub_egypto_2020_fr.pdf)