### PR TITLE
Update rmit-university-harvard.csl

### DIFF
--- a/rmit-university-harvard.csl
+++ b/rmit-university-harvard.csl
@@ -8,7 +8,7 @@
     <link href="https://www.lib.rmit.edu.au/easy-cite/" rel="documentation"/>
     <author>
       <name>Katie Finch</name>
-      <email>katie.finch@rmit.edu.au</email>
+      <email>library.systems@rmit.edu.au</email>
     </author>
     <category citation-format="author-date"/>
     <category field="generic-base"/>
@@ -87,14 +87,15 @@
   <macro name="access">
     <choose>
       <if variable="URL" type="article-newspaper webpage speech report">
+        <text value="viewed"/>
         <group prefix=" " delimiter=", ">
-          <date variable="accessed" prefix="viewed ">
+          <date variable="accessed" delimiter=" ">
             <date-part name="day" suffix=" "/>
             <date-part name="month" suffix=" "/>
             <date-part name="year" suffix=","/>
           </date>
+          <text variable="URL" prefix=" &lt;" suffix="&gt;"/>
         </group>
-        <text variable="URL" prefix=" &lt;" suffix="&gt;"/>
       </if>
     </choose>
   </macro>
@@ -206,10 +207,10 @@
       </date>
       <choose>
         <if type="bill book graphic legal_case legislation motion_picture report song thesis" match="any">
-          <group prefix=" " delimiter=" " suffix=",">
+          <group delimiter=" " prefix=" ">
             <text macro="title"/>
             <text macro="report-number"/>
-            <text macro="edition"/>
+            <text macro="edition" suffix=","/>
             <text macro="editor"/>
           </group>
           <text prefix=" " macro="publisher"/>


### PR DESCRIPTION
Amendments to correct an error of duplicate commas appearing in some systems (eg Ex Libris' Primo).