### PR TITLE
Always print publisher in APA 6th edition

### DIFF
--- a/apa-6th-edition-no-ampersand.csl
+++ b/apa-6th-edition-no-ampersand.csl
@@ -503,19 +503,10 @@
                   <text variable="archive_location" prefix="(" suffix=")"/>
                 </group>
               </if>
-              <else>
-                <text macro="publisher" suffix="."/>
-              </else>
             </choose>
           </if>
-          <else>
-            <text macro="publisher" suffix="."/>
-          </else>
         </choose>
       </else-if>
-      <else>
-        <text macro="publisher" suffix="."/>
-      </else>
     </choose>
   </macro>
   <macro name="title">

--- a/apa-6th-edition-no-ampersand.csl
+++ b/apa-6th-edition-no-ampersand.csl
@@ -796,6 +796,25 @@
       </else>
     </choose>
   </macro>
+  <macro name="title-and-descriptions">
+    <group delimiter=" ">
+      <text macro="title"/>
+      <choose>
+        <if variable="title interviewer" type="interview" match="any">
+          <group delimiter=" ">
+            <text macro="description"/>
+            <text macro="format"/>
+          </group>
+        </if>
+        <else>
+          <group delimiter=" ">
+            <text macro="format"/>
+            <text macro="description"/>
+          </group>
+        </else>
+      </choose>
+    </group>
+  </macro>
   <macro name="archive">
     <group delimiter=". ">
       <group delimiter=", ">
@@ -1386,6 +1405,42 @@
       </else-if>
     </choose>
   </macro>
+  <!-- After 'source', APA also prints publication history (original publication, reprint info, retraction info) -->
+  <macro name="publication-history">
+    <choose>
+      <if type="patent" match="none">
+        <group prefix="(" suffix=")">
+          <choose>
+            <if variable="references">
+              <!-- This provides the option for more elaborate description 
+                   of publication history, such as full "reprinted" references
+                   (example 26) or retracted references -->
+              <text variable="references"/>
+            </if>
+            <else>
+              <group delimiter=" ">
+                <text macro="original-published"/>
+                <choose>
+                  <if is-uncertain-date="original-date">
+                    <group prefix="[" suffix="]" delimiter=" ">
+                      <text term="circa" form="short"/>
+                      <text macro="original-date"/>
+                    </group>
+                  </if>
+                  <else>
+                    <text macro="original-date"/>
+                  </else>
+                </choose>
+              </group>
+            </else>
+          </choose>
+        </group>
+      </if>
+      <else>
+        <text variable="references" prefix="(" suffix=")"/>
+      </else>
+    </choose>
+  </macro>
   <macro name="legal-cites">
     <choose>
       <if type="legal_case">
@@ -1492,57 +1547,28 @@
       <key macro="title"/>
     </sort>
     <layout>
-      <group suffix=".">
-        <group delimiter=". ">
+      <group delimiter=" ">
+        <group delimiter=". " suffix=".">
           <text macro="author"/>
           <choose>
             <if is-uncertain-date="issued">
-              <group prefix=" [" suffix="]" delimiter=" ">
+              <group prefix="[" suffix="]" delimiter=" ">
                 <text term="circa" form="short"/>
                 <text macro="issued"/>
               </group>
             </if>
             <else>
-              <text macro="issued" prefix=" (" suffix=")"/>
+              <text macro="issued" prefix="(" suffix=")"/>
             </else>
           </choose>
-          <group delimiter=" ">
-            <text macro="title"/>
-            <choose>
-              <if variable="title interviewer" type="interview" match="any">
-                <group delimiter=" ">
-                  <text macro="description"/>
-                  <text macro="format"/>
-                </group>
-              </if>
-              <else>
-                <group delimiter=" ">
-                  <text macro="format"/>
-                  <text macro="description"/>
-                </group>
-              </else>
-            </choose>
-          </group>
+          <text macro="title-and-descriptions"/>
           <text macro="container"/>
+          <text macro="event"/>
+          <text macro="publisher"/>
         </group>
-        <text macro="event" prefix=". "/>
+        <text macro="access"/>
+        <text macro="publication-history"/>
       </group>
-      <text macro="access" prefix=" "/>
-      <choose>
-        <if is-uncertain-date="original-date">
-          <group prefix=" [" suffix="]" delimiter=" ">
-            <text macro="original-published"/>
-            <text term="circa" form="short"/>
-            <text macro="original-date"/>
-          </group>
-        </if>
-        <else-if variable="original-date">
-          <group prefix=" (" suffix=")" delimiter=" ">
-            <text macro="original-published"/>
-            <text macro="original-date"/>
-          </group>
-        </else-if>
-      </choose>
     </layout>
   </bibliography>
 </style>

--- a/apa-6th-edition.csl
+++ b/apa-6th-edition.csl
@@ -502,19 +502,10 @@
                   <text variable="archive_location" prefix="(" suffix=")"/>
                 </group>
               </if>
-              <else>
-                <text macro="publisher" suffix="."/>
-              </else>
             </choose>
           </if>
-          <else>
-            <text macro="publisher" suffix="."/>
-          </else>
         </choose>
       </else-if>
-      <else>
-        <text macro="publisher" suffix="."/>
-      </else>
     </choose>
   </macro>
   <macro name="title">

--- a/apa-6th-edition.csl
+++ b/apa-6th-edition.csl
@@ -795,6 +795,25 @@
       </else>
     </choose>
   </macro>
+  <macro name="title-and-descriptions">
+    <group delimiter=" ">
+      <text macro="title"/>
+      <choose>
+        <if variable="title interviewer" type="interview" match="any">
+          <group delimiter=" ">
+            <text macro="description"/>
+            <text macro="format"/>
+          </group>
+        </if>
+        <else>
+          <group delimiter=" ">
+            <text macro="format"/>
+            <text macro="description"/>
+          </group>
+        </else>
+      </choose>
+    </group>
+  </macro>
   <macro name="archive">
     <group delimiter=". ">
       <group delimiter=", ">
@@ -1385,6 +1404,42 @@
       </else-if>
     </choose>
   </macro>
+  <!-- After 'source', APA also prints publication history (original publication, reprint info, retraction info) -->
+  <macro name="publication-history">
+    <choose>
+      <if type="patent" match="none">
+        <group prefix="(" suffix=")">
+          <choose>
+            <if variable="references">
+              <!-- This provides the option for more elaborate description 
+                   of publication history, such as full "reprinted" references
+                   (example 26) or retracted references -->
+              <text variable="references"/>
+            </if>
+            <else>
+              <group delimiter=" ">
+                <text macro="original-published"/>
+                <choose>
+                  <if is-uncertain-date="original-date">
+                    <group prefix="[" suffix="]" delimiter=" ">
+                      <text term="circa" form="short"/>
+                      <text macro="original-date"/>
+                    </group>
+                  </if>
+                  <else>
+                    <text macro="original-date"/>
+                  </else>
+                </choose>
+              </group>
+            </else>
+          </choose>
+        </group>
+      </if>
+      <else>
+        <text variable="references" prefix="(" suffix=")"/>
+      </else>
+    </choose>
+  </macro>
   <macro name="legal-cites">
     <choose>
       <if type="legal_case">
@@ -1491,57 +1546,28 @@
       <key macro="title"/>
     </sort>
     <layout>
-      <group suffix=".">
-        <group delimiter=". ">
+      <group delimiter=" ">
+        <group delimiter=". " suffix=".">
           <text macro="author"/>
           <choose>
             <if is-uncertain-date="issued">
-              <group prefix=" [" suffix="]" delimiter=" ">
+              <group prefix="[" suffix="]" delimiter=" ">
                 <text term="circa" form="short"/>
                 <text macro="issued"/>
               </group>
             </if>
             <else>
-              <text macro="issued" prefix=" (" suffix=")"/>
+              <text macro="issued" prefix="(" suffix=")"/>
             </else>
           </choose>
-          <group delimiter=" ">
-            <text macro="title"/>
-            <choose>
-              <if variable="title interviewer" type="interview" match="any">
-                <group delimiter=" ">
-                  <text macro="description"/>
-                  <text macro="format"/>
-                </group>
-              </if>
-              <else>
-                <group delimiter=" ">
-                  <text macro="format"/>
-                  <text macro="description"/>
-                </group>
-              </else>
-            </choose>
-          </group>
+          <text macro="title-and-descriptions"/>
           <text macro="container"/>
+          <text macro="event"/>
+          <text macro="publisher"/>
         </group>
-        <text macro="event" prefix=". "/>
+        <text macro="access"/>
+        <text macro="publication-history"/>
       </group>
-      <text macro="access" prefix=" "/>
-      <choose>
-        <if is-uncertain-date="original-date">
-          <group prefix=" [" suffix="]" delimiter=" ">
-            <text macro="original-published"/>
-            <text term="circa" form="short"/>
-            <text macro="original-date"/>
-          </group>
-        </if>
-        <else-if variable="original-date">
-          <group prefix=" (" suffix=")" delimiter=" ">
-            <text macro="original-published"/>
-            <text macro="original-date"/>
-          </group>
-        </else-if>
-      </choose>
     </layout>
   </bibliography>
 </style>

--- a/apa-no-doi-no-issue.csl
+++ b/apa-no-doi-no-issue.csl
@@ -810,6 +810,25 @@
       </else>
     </choose>
   </macro>
+  <macro name="title-and-descriptions">
+    <group delimiter=" ">
+      <text macro="title"/>
+      <choose>
+        <if variable="title interviewer" type="interview" match="any">
+          <group delimiter=" ">
+            <text macro="description"/>
+            <text macro="format"/>
+          </group>
+        </if>
+        <else>
+          <group delimiter=" ">
+            <text macro="format"/>
+            <text macro="description"/>
+          </group>
+        </else>
+      </choose>
+    </group>
+  </macro>
   <macro name="archive">
     <group delimiter=". ">
       <group delimiter=", ">
@@ -1407,6 +1426,42 @@
       </else-if>
     </choose>
   </macro>
+  <!-- After 'source', APA also prints publication history (original publication, reprint info, retraction info) -->
+  <macro name="publication-history">
+    <choose>
+      <if type="patent" match="none">
+        <group prefix="(" suffix=")">
+          <choose>
+            <if variable="references">
+              <!-- This provides the option for more elaborate description 
+                   of publication history, such as full "reprinted" references
+                   (example 26) or retracted references -->
+              <text variable="references"/>
+            </if>
+            <else>
+              <group delimiter=" ">
+                <text macro="original-published"/>
+                <choose>
+                  <if is-uncertain-date="original-date">
+                    <group prefix="[" suffix="]" delimiter=" ">
+                      <text term="circa" form="short"/>
+                      <text macro="original-date"/>
+                    </group>
+                  </if>
+                  <else>
+                    <text macro="original-date"/>
+                  </else>
+                </choose>
+              </group>
+            </else>
+          </choose>
+        </group>
+      </if>
+      <else>
+        <text variable="references" prefix="(" suffix=")"/>
+      </else>
+    </choose>
+  </macro>
   <macro name="legal-cites">
     <choose>
       <if type="legal_case">
@@ -1513,57 +1568,28 @@
       <key macro="title"/>
     </sort>
     <layout>
-      <group suffix=".">
-        <group delimiter=". ">
+      <group delimiter=" ">
+        <group delimiter=". " suffix=".">
           <text macro="author"/>
           <choose>
             <if is-uncertain-date="issued">
-              <group prefix=" [" suffix="]" delimiter=" ">
+              <group prefix="[" suffix="]" delimiter=" ">
                 <text term="circa" form="short"/>
                 <text macro="issued"/>
               </group>
             </if>
             <else>
-              <text macro="issued" prefix=" (" suffix=")"/>
+              <text macro="issued" prefix="(" suffix=")"/>
             </else>
           </choose>
-          <group delimiter=" ">
-            <text macro="title"/>
-            <choose>
-              <if variable="title interviewer" type="interview" match="any">
-                <group delimiter=" ">
-                  <text macro="description"/>
-                  <text macro="format"/>
-                </group>
-              </if>
-              <else>
-                <group delimiter=" ">
-                  <text macro="format"/>
-                  <text macro="description"/>
-                </group>
-              </else>
-            </choose>
-          </group>
+          <text macro="title-and-descriptions"/>
           <text macro="container"/>
+          <text macro="event"/>
+          <text macro="publisher"/>
         </group>
-        <text macro="event" prefix=". "/>
+        <text macro="access"/>
+        <text macro="publication-history"/>
       </group>
-      <text macro="access" prefix=" "/>
-      <choose>
-        <if is-uncertain-date="original-date">
-          <group prefix=" [" suffix="]" delimiter=" ">
-            <text macro="original-published"/>
-            <text term="circa" form="short"/>
-            <text macro="original-date"/>
-          </group>
-        </if>
-        <else-if variable="original-date">
-          <group prefix=" (" suffix=")" delimiter=" ">
-            <text macro="original-published"/>
-            <text macro="original-date"/>
-          </group>
-        </else-if>
-      </choose>
     </layout>
   </bibliography>
 </style>

--- a/apa-no-doi-no-issue.csl
+++ b/apa-no-doi-no-issue.csl
@@ -460,23 +460,15 @@
   </macro>
   <macro name="access">
     <choose>
-      <if type="bill legal_case legislation" match="any"/>
+      <if type="bill legal_case legislation" variable="page" match="any"/>
       <else-if type="article-journal article-magazine article-newspaper" match="any">
-        <choose>
-          <if variable="page"/>
-          <else>
-            <text macro="online-access"/>
-          </else>
-        </choose>
+        <text macro="online-access"/>
       </else-if>
       <else>
         <choose>
-          <if variable="publisher page" match="any">
-            <text macro="publisher" suffix="."/>
-          </if>
-          <else>
+          <if variable="publisher" match="none">
             <text macro="online-access"/>
-          </else>
+          </if>
         </choose>
       </else>
     </choose>

--- a/apa-no-doi-no-issue.csl
+++ b/apa-no-doi-no-issue.csl
@@ -517,19 +517,10 @@
                   <text variable="archive_location" prefix="(" suffix=")"/>
                 </group>
               </if>
-              <else>
-                <text macro="publisher" suffix="."/>
-              </else>
             </choose>
           </if>
-          <else>
-            <text macro="publisher" suffix="."/>
-          </else>
         </choose>
       </else-if>
-      <else>
-        <text macro="publisher" suffix="."/>
-      </else>
     </choose>
   </macro>
   <macro name="title">

--- a/apa-old-doi-prefix.csl
+++ b/apa-old-doi-prefix.csl
@@ -503,19 +503,10 @@
                   <text variable="archive_location" prefix="(" suffix=")"/>
                 </group>
               </if>
-              <else>
-                <text macro="publisher" suffix="."/>
-              </else>
             </choose>
           </if>
-          <else>
-            <text macro="publisher" suffix="."/>
-          </else>
         </choose>
       </else-if>
-      <else>
-        <text macro="publisher" suffix="."/>
-      </else>
     </choose>
   </macro>
   <macro name="title">

--- a/apa-old-doi-prefix.csl
+++ b/apa-old-doi-prefix.csl
@@ -796,6 +796,25 @@
       </else>
     </choose>
   </macro>
+  <macro name="title-and-descriptions">
+    <group delimiter=" ">
+      <text macro="title"/>
+      <choose>
+        <if variable="title interviewer" type="interview" match="any">
+          <group delimiter=" ">
+            <text macro="description"/>
+            <text macro="format"/>
+          </group>
+        </if>
+        <else>
+          <group delimiter=" ">
+            <text macro="format"/>
+            <text macro="description"/>
+          </group>
+        </else>
+      </choose>
+    </group>
+  </macro>
   <macro name="archive">
     <group delimiter=". ">
       <group delimiter=", ">
@@ -1386,6 +1405,42 @@
       </else-if>
     </choose>
   </macro>
+  <!-- After 'source', APA also prints publication history (original publication, reprint info, retraction info) -->
+  <macro name="publication-history">
+    <choose>
+      <if type="patent" match="none">
+        <group prefix="(" suffix=")">
+          <choose>
+            <if variable="references">
+              <!-- This provides the option for more elaborate description 
+                   of publication history, such as full "reprinted" references
+                   (example 26) or retracted references -->
+              <text variable="references"/>
+            </if>
+            <else>
+              <group delimiter=" ">
+                <text macro="original-published"/>
+                <choose>
+                  <if is-uncertain-date="original-date">
+                    <group prefix="[" suffix="]" delimiter=" ">
+                      <text term="circa" form="short"/>
+                      <text macro="original-date"/>
+                    </group>
+                  </if>
+                  <else>
+                    <text macro="original-date"/>
+                  </else>
+                </choose>
+              </group>
+            </else>
+          </choose>
+        </group>
+      </if>
+      <else>
+        <text variable="references" prefix="(" suffix=")"/>
+      </else>
+    </choose>
+  </macro>
   <macro name="legal-cites">
     <choose>
       <if type="legal_case">
@@ -1492,57 +1547,28 @@
       <key macro="title"/>
     </sort>
     <layout>
-      <group suffix=".">
-        <group delimiter=". ">
+      <group delimiter=" ">
+        <group delimiter=". " suffix=".">
           <text macro="author"/>
           <choose>
             <if is-uncertain-date="issued">
-              <group prefix=" [" suffix="]" delimiter=" ">
+              <group prefix="[" suffix="]" delimiter=" ">
                 <text term="circa" form="short"/>
                 <text macro="issued"/>
               </group>
             </if>
             <else>
-              <text macro="issued" prefix=" (" suffix=")"/>
+              <text macro="issued" prefix="(" suffix=")"/>
             </else>
           </choose>
-          <group delimiter=" ">
-            <text macro="title"/>
-            <choose>
-              <if variable="title interviewer" type="interview" match="any">
-                <group delimiter=" ">
-                  <text macro="description"/>
-                  <text macro="format"/>
-                </group>
-              </if>
-              <else>
-                <group delimiter=" ">
-                  <text macro="format"/>
-                  <text macro="description"/>
-                </group>
-              </else>
-            </choose>
-          </group>
+          <text macro="title-and-descriptions"/>
           <text macro="container"/>
+          <text macro="event"/>
+          <text macro="publisher"/>
         </group>
-        <text macro="event" prefix=". "/>
+        <text macro="access"/>
+        <text macro="publication-history"/>
       </group>
-      <text macro="access" prefix=" "/>
-      <choose>
-        <if is-uncertain-date="original-date">
-          <group prefix=" [" suffix="]" delimiter=" ">
-            <text macro="original-published"/>
-            <text term="circa" form="short"/>
-            <text macro="original-date"/>
-          </group>
-        </if>
-        <else-if variable="original-date">
-          <group prefix=" (" suffix=")" delimiter=" ">
-            <text macro="original-published"/>
-            <text macro="original-date"/>
-          </group>
-        </else-if>
-      </choose>
     </layout>
   </bibliography>
 </style>


### PR DESCRIPTION
Even though the manual says otherwise, I've found that journals (including APA) generally ask for publisher and place when working with APA 6.

Also backport some other features from APA 7.