### PR TITLE
Update chapter-title for foerster-geisteswissenschaft.csl

### DIFF
--- a/foerster-geisteswissenschaft.csl
+++ b/foerster-geisteswissenschaft.csl
@@ -419,7 +419,7 @@ CONTAINER (Sammelband oder Zeitschrift ...)
         <!-- 1. Container-Beitragende -->
         <text macro="container-contributors" suffix=": "/>
         <!-- Container-Titel -->
-        <text variable="container-title" form="short" font-style="italic"/>
+        <text variable="container-title" font-style="italic"/>
         <!-- Ggf. wird der Band ausgegeben. -->
         <choose>
           <if variable="volume">


### PR DESCRIPTION
via https://forums.zotero.org/discussion/83952/buchtitel-wird-von-zotero-in-der-fussnote-zusammengekuerzt

@saschafoerster 
Hallo Sascha,

Ein User hat im Forum geraded einen "Fehler" aufgezeigt. Buchkapitel haben container-title mit form="short" formatiert. Ist das so gewollt oder nur ein Versehen?
Hab hier einen PR gemacht, um das auszubessern. Danke für dein Feedback.