### PR TITLE
Update gewerblicher-rechtsschutz-und-urheberrecht.csl

### DIFF
--- a/gewerblicher-rechtsschutz-und-urheberrecht.csl
+++ b/gewerblicher-rechtsschutz-und-urheberrecht.csl
@@ -126,7 +126,7 @@
           <text macro="autor-editor-note" suffix=", "/>
           <choose>
             <if match="none" position="first">
-              <group delimiter=" " prefix="(" suffix="), ">
+              <group delimiter=" " prefix="(" suffix=")">
                 <text value="o. Fn."/>
                 <text variable="first-reference-note-number"/>
               </group>
@@ -159,7 +159,7 @@
               <text macro="author-commentary" suffix=", "/>
               <choose>
                 <if match="none" position="first">
-                  <group delimiter=" " prefix="(" suffix="), ">
+                  <group delimiter=" " prefix="(" suffix=")">
                     <text value="o. Fn."/>
                     <text variable="first-reference-note-number"/>
                   </group>


### PR DESCRIPTION
The original style contained a bug: For books and encyclopaedia articles the abbreviated second citation would create a double comma between the reference and the page number (e.g.: "[1] Schwab, (o. Fn. 1), , S. 15."). This has been addressed by slightly modifying two lines. The abbreviated second citation now reads correctly (e.g. "[1] Schwab, (o. Fn. 1), S. 15."). There are no adverse consequences to the proposed changes.