### PR TITLE
Update thieme-german.csl

### DIFF
--- a/thieme-german.csl
+++ b/thieme-german.csl
@@ -31,9 +31,6 @@
     <names suffix=". " variable="author">
       <name sort-separator=" " name-as-sort-order="all" initialize-with="" et-al-use-first="3" et-al-min="4" delimiter-precedes-last="always"/>
       <label prefix=" (" form="short" suffix=")"/>
-      <substitute>
-        <names variable="author"/>
-      </substitute>
     </names>
   </macro>
   <macro name="editor">

--- a/thieme-german.csl
+++ b/thieme-german.csl
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" demote-non-dropping-particle="sort-only" page-range-format="expanded" default-locale="de-DE">
-  <!-- This style was edited with the Visual CSL Editor (http://editor.citationstyles.org/visualEditor/) -->
+<style xmlns="http://purl.org/net/xbiblio/csl" version="1.0" demote-non-dropping-particle="sort-only" class="in-text" page-range-format="expanded" default-locale="de-DE">
+  <!-- This style was edited with the Visual CSL Editor (https://editor.citationstyles.org/visualEditor/) -->
   <info>
     <title>Thieme-German (German)</title>
     <id>http://www.zotero.org/styles/thieme-german</id>
@@ -24,22 +24,22 @@
     <category citation-format="numeric"/>
     <category field="medicine"/>
     <summary>Modified version of the "Vancouver Bracket" for Thieme Journals</summary>
-    <updated>2017-05-18T15:23:08+00:00</updated>
+    <updated>2020-06-30T08:44:34+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <macro name="author">
-    <names variable="author" suffix=". ">
-      <name sort-separator=" " initialize-with="" name-as-sort-order="all" delimiter=", " delimiter-precedes-last="always"/>
-      <label form="short" prefix=" (" suffix=")"/>
+    <names suffix=". " variable="author">
+      <name sort-separator=" " name-as-sort-order="all" initialize-with="" et-al-use-first="3" et-al-min="4" delimiter-precedes-last="always"/>
+      <label prefix=" (" form="short" suffix=")"/>
       <substitute>
-        <names variable="editor"/>
+        <names variable="author"/>
       </substitute>
     </names>
   </macro>
   <macro name="editor">
-    <names variable="editor" suffix=". ">
-      <name sort-separator=" " initialize-with="" name-as-sort-order="all" delimiter=", " delimiter-precedes-last="always"/>
-      <label form="short" prefix=" (" suffix=")"/>
+    <names suffix=". " variable="editor">
+      <name sort-separator=" " name-as-sort-order="all" initialize-with="" delimiter-precedes-last="always" delimiter=", "/>
+      <label prefix=" (" form="short" suffix=")"/>
     </names>
   </macro>
   <macro name="publisher">
@@ -62,7 +62,7 @@
     </group>
   </macro>
   <macro name="journal-title">
-    <text variable="container-title" form="short" strip-periods="true"/>
+    <text form="short" variable="container-title" strip-periods="true"/>
   </macro>
   <macro name="title">
     <text variable="title"/>
@@ -71,12 +71,12 @@
     <choose>
       <if is-numeric="edition">
         <group delimiter=" ">
-          <number variable="edition" form="ordinal"/>
-          <text term="edition" form="short"/>
+          <number form="ordinal" variable="edition"/>
+          <text form="short" term="edition"/>
         </group>
       </if>
       <else>
-        <text variable="edition" suffix="."/>
+        <text suffix="." variable="edition"/>
       </else>
     </choose>
   </macro>
@@ -89,8 +89,8 @@
     </layout>
   </citation>
   <bibliography second-field-align="flush">
-    <layout>
-      <text variable="citation-number" vertical-align="sup"/>
+    <layout vertical-align="baseline" font-variant="normal">
+      <text prefix="[" suffix="]" variable="citation-number" strip-periods="false" vertical-align="baseline" quotes="false" text-case="title"/>
       <text macro="author"/>
       <text macro="title" suffix=". "/>
       <choose>
@@ -102,22 +102,22 @@
         </if>
         <else-if type="chapter paper-conference" match="any">
           <group prefix=" " suffix=".">
-            <text term="in" suffix=": " text-case="capitalize-first"/>
+            <text suffix=": " term="in" text-case="capitalize-first"/>
             <text macro="editor"/>
             <text variable="container-title"/>
           </group>
-          <text macro="publisher" prefix=" "/>
-          <text variable="page" prefix=": "/>
+          <text prefix=" " macro="publisher"/>
+          <text prefix=": " variable="page"/>
         </else-if>
         <else>
           <group delimiter=" ">
             <text macro="journal-title"/>
-            <date variable="issued" suffix=";">
+            <date suffix=";" variable="issued">
               <date-part name="year"/>
             </date>
             <text variable="volume"/>
           </group>
-          <text variable="page" prefix=": "/>
+          <text prefix=": " variable="page"/>
         </else>
       </choose>
       <text macro="access"/>


### PR DESCRIPTION
Contributed by @SGoerlich from Thieme Group (via https://citationstyles.org/contact/).

> I am from the Publishing house Georg Thieme Verlag in Stuttgart, Germany.
We would like to replace the existing CSL style by a new one. ... We would like to use this file for all the journals just as we did in 2017. There were a few exceptions. You can check the records.

Follow-up of https://github.com/citation-style-language/styles/pull/2721.