### PR TITLE
Updates in research-institute-for-nature-and-forest.csl

### DIFF
--- a/research-institute-for-nature-and-forest.csl
+++ b/research-institute-for-nature-and-forest.csl
@@ -93,7 +93,7 @@
     <choose>
       <if type="webpage">
         <group delimiter=" ">
-          <text value="URL"/>
+          <text value="URL" suffix=":"/>
           <text variable="URL"/>
           <group prefix="(" suffix=").">
             <text term="accessed" suffix=" "/>

--- a/research-institute-for-nature-and-forest.csl
+++ b/research-institute-for-nature-and-forest.csl
@@ -210,7 +210,7 @@
   </macro>
   <macro name="url">
     <choose>
-      <if type="webpage" match="none">
+      <if type="webpage" variable="DOI" match="none">
         <choose>
           <if match="any" variable="URL">
             <text value="URL" suffix=": "/>

--- a/research-institute-for-nature-and-forest.csl
+++ b/research-institute-for-nature-and-forest.csl
@@ -29,6 +29,7 @@
         <single>ed.</single>
         <multiple>eds.</multiple>
       </term>
+      <term name="edition" form="short">edn.</term>
       <term name="no date" form="short">s.d.</term>
     </terms>
   </locale>
@@ -40,6 +41,7 @@
         <single>ed.</single>
         <multiple>eds.</multiple>
       </term>
+      <term name="edition" form="short">ed.</term>
       <term name="no date" form="short">s.d.</term>
     </terms>
   </locale>
@@ -172,10 +174,10 @@
           <number variable="edition" form="ordinal"/>
         </if>
         <else>
-          <text variable="edition" suffix="."/>
+          <text variable="edition"/>
         </else>
       </choose>
-      <text value="ed"/>
+      <text term="edition" form="short"/>
     </group>
   </macro>
   <macro name="locators">

--- a/research-institute-for-nature-and-forest.csl
+++ b/research-institute-for-nature-and-forest.csl
@@ -219,12 +219,6 @@
           <text variable="page" prefix="p. "/>
         </group>
       </else-if>
-      <else-if type="report" match="any">
-        <group>
-          <text macro="publisher"/>
-          <text variable="page" suffix=" p "/>
-        </group>
-      </else-if>
       <else-if type="patent">
         <text variable="number"/>
       </else-if>

--- a/research-institute-for-nature-and-forest.csl
+++ b/research-institute-for-nature-and-forest.csl
@@ -19,7 +19,7 @@
     </contributor>
     <category citation-format="author-date"/>
     <category field="biology"/>
-    <updated>2020-08-05T00:00:00</updated>
+    <updated>2020-08-06T00:00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale xml:lang="en">

--- a/research-institute-for-nature-and-forest.csl
+++ b/research-institute-for-nature-and-forest.csl
@@ -25,12 +25,14 @@
   <locale xml:lang="en">
     <terms>
       <term name="in">In</term>
+      <term name="no date" form="short">s.d.</term>
     </terms>
   </locale>
   <locale xml:lang="nl">
     <terms>
       <term name="in">In</term>
       <term name="et-al">et al.</term>
+      <term name="no date" form="short">s.d.</term>
     </terms>
   </locale>
   <macro name="container">

--- a/research-institute-for-nature-and-forest.csl
+++ b/research-institute-for-nature-and-forest.csl
@@ -59,12 +59,15 @@
       <text variable="container-title"/>
       <text variable="collection-title"/>
       <choose>
-        <if variable="volume">
+        <if type="article-journal article-magazine article-newspaper" match="any">
+            <!-- show nothing -->
+        </if>
+        <else-if variable="volume">
           <group delimiter=" ">
             <text term="volume" form="short" text-case="capitalize-first"/>
             <number variable="volume"/>
           </group>  
-        </if>
+        </else-if>
         <else-if variable="collection-number">
           <group delimiter=" ">
             <text term="issue" form="short" text-case="capitalize-first"/>

--- a/research-institute-for-nature-and-forest.csl
+++ b/research-institute-for-nature-and-forest.csl
@@ -137,13 +137,13 @@
   </macro>
   <macro name="title">
     <choose>
-      <if type="bill book graphic legal_case legislation motion_picture song speech" match="any">
-        <text variable="title"/>
-        <text macro="edition" prefix=". "/>
-      </if>
-      <else-if type="webpage">
+      <if type="webpage">
         <text variable="title"/>
         <text value="WWW document" prefix=" [" suffix="]"/>
+      </if>
+      <else-if variable="container-title" match="none">
+        <text variable="title"/>
+        <text macro="edition" prefix=". "/>
       </else-if>
       <else>
         <text variable="title"/>

--- a/research-institute-for-nature-and-forest.csl
+++ b/research-institute-for-nature-and-forest.csl
@@ -48,11 +48,13 @@
   <macro name="container">
     <choose>
       <if type="chapter paper-conference" match="any">
-        <text term="in" suffix=": "/>
-        <names variable="editor translator" delimiter=", " suffix=". ">
-          <name and="symbol" delimiter-precedes-last="never" initialize-with="." name-as-sort-order="all" sort-separator=" "/>
-          <label text-case="lowercase" form="short" prefix=" (" suffix=")"/>
-        </names>
+        <group>
+          <text term="in" suffix=": "/>
+          <names variable="editor translator" delimiter=", " suffix=". ">
+            <name and="symbol" delimiter-precedes-last="never" initialize-with="." name-as-sort-order="all" sort-separator=" "/>
+            <label text-case="lowercase" form="short" prefix=" (" suffix=")"/>
+          </names>
+        </group>
       </if>
     </choose>
     <group delimiter=", ">

--- a/research-institute-for-nature-and-forest.csl
+++ b/research-institute-for-nature-and-forest.csl
@@ -222,6 +222,9 @@
       <else-if type="patent">
         <text variable="number"/>
       </else-if>
+      <else>
+        <text macro="publisher"/>
+      </else>
     </choose>
   </macro>
   <macro name="url">

--- a/research-institute-for-nature-and-forest.csl
+++ b/research-institute-for-nature-and-forest.csl
@@ -143,7 +143,7 @@
     <choose>
       <if type="bill book graphic legal_case legislation motion_picture song speech" match="any">
         <text variable="title"/>
-        <text macro="edition" prefix=", "/>
+        <text macro="edition" prefix=". "/>
       </if>
       <else-if type="webpage">
         <text variable="title"/>

--- a/research-institute-for-nature-and-forest.csl
+++ b/research-institute-for-nature-and-forest.csl
@@ -74,15 +74,11 @@
             <number variable="collection-number"/>
           </group>  
         </else-if>
-        <else-if type="report thesis" match="any">
-          <choose>
-            <if variable="number">
+        <else-if variable="number">
               <group delimiter=" ">
                 <text term="issue" form="short" text-case="capitalize-first"/>
                 <text variable="number"/>
               </group>  
-            </if>
-          </choose>
         </else-if>
       </choose>
       <choose>

--- a/research-institute-for-nature-and-forest.csl
+++ b/research-institute-for-nature-and-forest.csl
@@ -264,30 +264,26 @@
       <key macro="issued" sort="ascending"/>
     </sort>
     <layout>
-      <choose>
-        <if type="article-journal article-magazine article-newspaper" match="any">
-          <group suffix=".">
-            <text macro="author"/>
-            <text macro="issued" prefix=" (" suffix="). "/>
-                <group delimiter=" ">
-                  <text macro="title" suffix="."/>
-                  <text macro="container"/>
-                  <text macro="locators"/>
-                </group>
-          </group>
-        </if>
-        <else>
-          <group suffix=".">
-            <text macro="author"/>
-            <text macro="issued" prefix=" (" suffix="). "/>
-                <group delimiter=". ">
-                  <text macro="title"/>
-                  <text macro="container"/>
-                  <text macro="locators"/>
-                </group>
-          </group>
-        </else>
-      </choose>
+      <group suffix=".">
+        <text macro="author"/>
+        <text macro="issued" prefix=" (" suffix="). "/>
+        <choose>
+            <if type="article-journal article-magazine article-newspaper" match="any">
+                    <group delimiter=" ">
+                      <text macro="title" suffix="."/>
+                      <text macro="container"/>
+                      <text macro="locators"/>
+                    </group>
+            </if>
+            <else>
+                    <group delimiter=". ">
+                      <text macro="title"/>
+                      <text macro="container"/>
+                      <text macro="locators"/>
+                    </group>
+            </else>
+        </choose>
+      </group>
       <text macro="access" prefix=" " suffix="."/>
       <text macro="url" prefix=" " suffix="."/>
       <text macro="doi" prefix=" " suffix="."/>

--- a/research-institute-for-nature-and-forest.csl
+++ b/research-institute-for-nature-and-forest.csl
@@ -82,6 +82,11 @@
           </choose>
         </else-if>
       </choose>
+      <choose>
+        <if type="chapter paper-conference" match="any">
+          <text macro="edition"/>
+        </if>
+      </choose>
     </group>
   </macro>
   <macro name="author">

--- a/research-institute-for-nature-and-forest.csl
+++ b/research-institute-for-nature-and-forest.csl
@@ -38,7 +38,7 @@
       <if type="chapter paper-conference" match="any">
         <text term="in" prefix=". " suffix=": "/>
         <names variable="editor translator" delimiter=", " suffix=". ">
-          <name delimiter-precedes-last="always" initialize-with="." name-as-sort-order="all" sort-separator=" "/>
+          <name and="symbol" delimiter-precedes-last="never" initialize-with="." name-as-sort-order="all" sort-separator=" "/>
           <label text-case="lowercase" prefix=" (" suffix=")"/>
         </names>
         <group delimiter=", ">

--- a/research-institute-for-nature-and-forest.csl
+++ b/research-institute-for-nature-and-forest.csl
@@ -3,8 +3,8 @@
   <info>
     <title>Research Institute for Nature and Forest (Instituut voor Natuur- en Bosonderzoek)</title>
     <title-short>INBO</title-short>
-    <id>https://www.zotero.org/styles/research-institute-for-nature-and-forest</id>
-    <link href="https://www.zotero.org/styles/research-institute-for-nature-and-forest" rel="self"/>
+    <id>http://www.zotero.org/styles/research-institute-for-nature-and-forest</id>
+    <link href="http://www.zotero.org/styles/research-institute-for-nature-and-forest" rel="self"/>
     <author>
       <name>Maarten Stevens</name>
       <uri>https://www.mendeley.com/profiles/maarten-stevens/</uri>
@@ -20,7 +20,7 @@
     <category citation-format="author-date"/>
     <category field="biology"/>
     <updated>2019-08-01T00:00:00</updated>
-    <rights license="https://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
+    <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale xml:lang="en">
     <terms>

--- a/research-institute-for-nature-and-forest.csl
+++ b/research-institute-for-nature-and-forest.csl
@@ -55,9 +55,33 @@
         </names>
       </if>
     </choose>
-     <group delimiter=", ">
+    <group delimiter=", ">
       <text variable="container-title"/>
       <text variable="collection-title"/>
+      <choose>
+        <if variable="volume">
+          <group delimiter=" ">
+            <text term="volume" form="short" text-case="capitalize-first"/>
+            <number variable="volume"/>
+          </group>  
+        </if>
+        <else-if variable="collection-number">
+          <group delimiter=" ">
+            <text term="issue" form="short" text-case="capitalize-first"/>
+            <number variable="collection-number"/>
+          </group>  
+        </else-if>
+        <else-if type="report thesis" match="any">
+          <choose>
+            <if variable="number">
+              <group delimiter=" ">
+                <text term="issue" form="short" text-case="capitalize-first"/>
+                <text variable="number"/>
+              </group>  
+            </if>
+          </choose>
+        </else-if>
+      </choose>
     </group>
   </macro>
   <macro name="author">
@@ -109,17 +133,10 @@
   </macro>
   <macro name="title">
     <choose>
-      <if type="report thesis" match="any">
-        <text variable="title"/>
-        <group prefix=" (" suffix=")">
-          <text variable="genre"/>
-          <text variable="number" prefix=" No. "/>
-        </group>
-      </if>
-      <else-if type="bill book graphic legal_case legislation motion_picture song speech" match="any">
+      <if type="bill book graphic legal_case legislation motion_picture song speech" match="any">
         <text variable="title"/>
         <text macro="edition" prefix=", "/>
-      </else-if>
+      </if>
       <else-if type="webpage">
         <text variable="title"/>
         <text value="WWW Document" prefix=" [" suffix="]"/>

--- a/research-institute-for-nature-and-forest.csl
+++ b/research-institute-for-nature-and-forest.csl
@@ -53,18 +53,12 @@
           <name and="symbol" delimiter-precedes-last="never" initialize-with="." name-as-sort-order="all" sort-separator=" "/>
           <label text-case="lowercase" form="short" prefix=" (" suffix=")"/>
         </names>
-        <group delimiter=", ">
-          <text variable="container-title"/>
-          <text variable="collection-title"/>
-        </group>
       </if>
-      <else>
-        <group delimiter=", ">
-          <text variable="container-title"/>
-          <text variable="collection-title"/>
-        </group>
-      </else>
     </choose>
+     <group delimiter=", ">
+      <text variable="container-title"/>
+      <text variable="collection-title"/>
+    </group>
   </macro>
   <macro name="author">
     <names variable="author">

--- a/research-institute-for-nature-and-forest.csl
+++ b/research-institute-for-nature-and-forest.csl
@@ -128,7 +128,7 @@
           <text variable="number" prefix=" No. "/>
         </group>
       </if>
-      <else-if type="bill book graphic legal_case legislation motion_picture report song speech" match="any">
+      <else-if type="bill book graphic legal_case legislation motion_picture song speech" match="any">
         <text variable="title"/>
         <text macro="edition" prefix=", "/>
       </else-if>

--- a/research-institute-for-nature-and-forest.csl
+++ b/research-institute-for-nature-and-forest.csl
@@ -25,6 +25,10 @@
   <locale xml:lang="en">
     <terms>
       <term name="in">In</term>
+      <term name="editor" form="short">
+        <single>ed.</single>
+        <multiple>eds.</multiple>
+      </term>
       <term name="no date" form="short">s.d.</term>
     </terms>
   </locale>
@@ -32,6 +36,10 @@
     <terms>
       <term name="in">In</term>
       <term name="et-al">et al.</term>
+      <term name="editor" form="short">
+        <single>ed.</single>
+        <multiple>eds.</multiple>
+      </term>
       <term name="no date" form="short">s.d.</term>
     </terms>
   </locale>
@@ -41,7 +49,7 @@
         <text term="in" prefix=". " suffix=": "/>
         <names variable="editor translator" delimiter=", " suffix=". ">
           <name and="symbol" delimiter-precedes-last="never" initialize-with="." name-as-sort-order="all" sort-separator=" "/>
-          <label text-case="lowercase" prefix=" (" suffix=")"/>
+          <label text-case="lowercase" form="short" prefix=" (" suffix=")"/>
         </names>
         <group delimiter=", ">
           <text variable="container-title"/>
@@ -65,7 +73,7 @@
   <macro name="author">
     <names variable="author">
       <name and="symbol" delimiter-precedes-last="never" initialize-with="." name-as-sort-order="all" sort-separator=" "/>
-      <label form="short" prefix=" (" suffix=")" text-case="capitalize-first"/>
+      <label form="short" prefix=" (" suffix=")"/>
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>

--- a/research-institute-for-nature-and-forest.csl
+++ b/research-institute-for-nature-and-forest.csl
@@ -47,14 +47,16 @@
   </locale>
   <macro name="container">
     <choose>
-      <if type="chapter paper-conference" match="any">
-        <group>
-          <text term="in" suffix=": "/>
-          <names variable="editor translator" delimiter=", " suffix=". ">
-            <name and="symbol" delimiter-precedes-last="never" initialize-with="." name-as-sort-order="all" sort-separator=" "/>
-            <label text-case="lowercase" form="short" prefix=" (" suffix=")"/>
-          </names>
-        </group>
+      <if type="article-journal article-magazine article-newspaper" match="none">
+        <choose>
+          <if type="paper-conference" variable="container-title" match="any">
+            <text term="in" suffix=": "/>
+            <names variable="editor translator" delimiter=", " suffix=". ">
+              <name and="symbol" delimiter-precedes-last="never" initialize-with="." name-as-sort-order="all" sort-separator=" "/>
+              <label text-case="lowercase" form="short" prefix=" (" suffix=")"/>
+            </names>
+          </if>
+        </choose>
       </if>
     </choose>
     <group delimiter=", ">
@@ -84,7 +86,7 @@
         </else-if>
       </choose>
       <choose>
-        <if type="chapter paper-conference" match="any">
+        <if type="paper-conference" variable="container-title" match="any">
           <text macro="edition"/>
         </if>
       </choose>

--- a/research-institute-for-nature-and-forest.csl
+++ b/research-institute-for-nature-and-forest.csl
@@ -48,7 +48,7 @@
   <macro name="container">
     <choose>
       <if type="chapter paper-conference" match="any">
-        <text term="in" prefix=". " suffix=": "/>
+        <text term="in" suffix=": "/>
         <names variable="editor translator" delimiter=", " suffix=". ">
           <name and="symbol" delimiter-precedes-last="never" initialize-with="." name-as-sort-order="all" sort-separator=" "/>
           <label text-case="lowercase" form="short" prefix=" (" suffix=")"/>
@@ -59,7 +59,7 @@
         </group>
       </if>
       <else>
-        <group prefix=". " delimiter=", ">
+        <group delimiter=", ">
           <text variable="container-title"/>
           <text variable="collection-title"/>
         </group>
@@ -177,7 +177,7 @@
   <macro name="locators">
     <choose>
       <if type="article-journal article-magazine article-newspaper" match="any">
-        <group delimiter=": " prefix=" ">
+        <group delimiter=": ">
           <group>
             <text variable="volume"/>
             <choose>
@@ -190,14 +190,14 @@
         </group>
       </if>
       <else-if type="bill book graphic legal_case legislation motion_picture report song thesis" match="any">
-        <group delimiter=", " prefix=". ">
+        <group delimiter=", ">
           <text macro="event"/>
           <text macro="publisher"/>
           <text variable="number-of-pages" prefix=" " suffix=" p"/>
         </group>
       </else-if>
       <else-if type="chapter paper-conference" match="any">
-        <group delimiter=", " prefix=". ">
+        <group delimiter=", ">
           <text macro="event"/>
           <text macro="publisher"/>
           <text variable="page" prefix="p. "/>
@@ -210,7 +210,7 @@
         </group>
       </else-if>
       <else-if type="patent">
-        <text variable="number" prefix=". "/>
+        <text variable="number"/>
       </else-if>
     </choose>
   </macro>
@@ -259,7 +259,7 @@
       <group suffix=".">
         <text macro="author"/>
         <text macro="issued" prefix=" (" suffix="). "/>
-        <group>
+        <group delimiter=". ">
           <text macro="title"/>
           <text macro="container"/>
           <text macro="locators"/>

--- a/research-institute-for-nature-and-forest.csl
+++ b/research-institute-for-nature-and-forest.csl
@@ -9,13 +9,13 @@
       <name>Maarten Stevens</name>
       <uri>https://www.mendeley.com/profiles/maarten-stevens/</uri>
     </author>
+    <author>
+      <name>Floris Vanderhaeghe</name>
+      <email>floris.vanderhaeghe@inbo.be</email>
+    </author>
     <contributor>
       <name>Thierry Onkelinx</name>
       <uri>https://www.mendeley.com/profiles/thierry-onkelinx/</uri>
-    </contributor>
-    <contributor>
-      <name>Floris Vanderhaeghe</name>
-      <email>floris.vanderhaeghe@inbo.be</email>
     </contributor>
     <category citation-format="author-date"/>
     <category field="biology"/>

--- a/research-institute-for-nature-and-forest.csl
+++ b/research-institute-for-nature-and-forest.csl
@@ -121,7 +121,6 @@
     <choose>
       <if type="webpage">
         <group delimiter=" ">
-          <text value="URL" suffix=":"/>
           <text variable="URL"/>
           <group prefix="(" suffix=").">
             <text term="accessed" suffix=" "/>
@@ -231,7 +230,6 @@
       <if type="webpage" variable="DOI" match="none">
         <choose>
           <if match="any" variable="URL">
-            <text value="URL" suffix=": "/>
             <text variable="URL"/>
           </if>
         </choose>
@@ -241,7 +239,6 @@
   <macro name="doi">
     <choose>
       <if match="any" variable="DOI">
-        <text value="DOI:" suffix=" "/>
         <text variable="DOI" prefix="https://doi.org/"/>
       </if>
     </choose>

--- a/research-institute-for-nature-and-forest.csl
+++ b/research-institute-for-nature-and-forest.csl
@@ -58,12 +58,6 @@
           <text variable="collection-title"/>
         </group>
       </if>
-      <else-if type="bill book graphic legal_case legislation motion_picture report song" match="any">
-        <group prefix=". " delimiter=", ">
-          <text variable="container-title"/>
-          <text variable="collection-title"/>
-        </group>
-      </else-if>
       <else>
         <group prefix=". " delimiter=", ">
           <text variable="container-title"/>

--- a/research-institute-for-nature-and-forest.csl
+++ b/research-institute-for-nature-and-forest.csl
@@ -124,10 +124,7 @@
           <text variable="URL"/>
           <group prefix="(" suffix=").">
             <text term="accessed" suffix=" "/>
-            <date variable="accessed">
-              <date-part name="month" form="numeric" suffix="."/>
-              <date-part name="day" suffix="."/>
-              <date-part name="year" form="short"/>
+            <date variable="accessed" form="text">
             </date>
           </group>
         </group>

--- a/research-institute-for-nature-and-forest.csl
+++ b/research-institute-for-nature-and-forest.csl
@@ -272,15 +272,30 @@
       <key macro="issued" sort="ascending"/>
     </sort>
     <layout>
-      <group suffix=".">
-        <text macro="author"/>
-        <text macro="issued" prefix=" (" suffix="). "/>
-        <group delimiter=". ">
-          <text macro="title"/>
-          <text macro="container"/>
-          <text macro="locators"/>
-        </group>
-      </group>
+      <choose>
+        <if type="article-journal article-magazine article-newspaper" match="any">
+          <group suffix=".">
+            <text macro="author"/>
+            <text macro="issued" prefix=" (" suffix="). "/>
+                <group delimiter=" ">
+                  <text macro="title" suffix="."/>
+                  <text macro="container"/>
+                  <text macro="locators"/>
+                </group>
+          </group>
+        </if>
+        <else>
+          <group suffix=".">
+            <text macro="author"/>
+            <text macro="issued" prefix=" (" suffix="). "/>
+                <group delimiter=". ">
+                  <text macro="title"/>
+                  <text macro="container"/>
+                  <text macro="locators"/>
+                </group>
+          </group>
+        </else>
+      </choose>
       <text macro="access" prefix=" " suffix="."/>
       <text macro="url" prefix=" " suffix="."/>
       <text macro="doi" prefix=" " suffix="."/>

--- a/research-institute-for-nature-and-forest.csl
+++ b/research-institute-for-nature-and-forest.csl
@@ -3,15 +3,15 @@
   <info>
     <title>Research Institute for Nature and Forest (Instituut voor Natuur- en Bosonderzoek)</title>
     <title-short>INBO</title-short>
-    <id>http://www.zotero.org/styles/research-institute-for-nature-and-forest</id>
-    <link href="http://www.zotero.org/styles/research-institute-for-nature-and-forest" rel="self"/>
+    <id>https://www.zotero.org/styles/research-institute-for-nature-and-forest</id>
+    <link href="https://www.zotero.org/styles/research-institute-for-nature-and-forest" rel="self"/>
     <author>
       <name>Maarten Stevens</name>
-      <uri>http://www.mendeley.com/profiles/maarten-stevens/</uri>
+      <uri>https://www.mendeley.com/profiles/maarten-stevens/</uri>
     </author>
     <contributor>
       <name>Thierry Onkelinx</name>
-      <uri>http://www.mendeley.com/profiles/thierry-onkelinx/</uri>
+      <uri>https://www.mendeley.com/profiles/thierry-onkelinx/</uri>
     </contributor>
     <contributor>
       <name>Floris Vanderhaeghe</name>
@@ -20,7 +20,7 @@
     <category citation-format="author-date"/>
     <category field="biology"/>
     <updated>2019-08-01T00:00:00</updated>
-    <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
+    <rights license="https://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale xml:lang="en">
     <terms>

--- a/research-institute-for-nature-and-forest.csl
+++ b/research-institute-for-nature-and-forest.csl
@@ -209,7 +209,7 @@
           <text variable="number-of-pages" prefix=" " suffix=" p"/>
         </group>
       </else-if>
-      <else-if type="chapter paper-conference" match="any">
+      <else-if type="chapter paper-conference" variable="page" match="any">
         <group delimiter=", ">
           <text macro="event"/>
           <text macro="publisher"/>

--- a/research-institute-for-nature-and-forest.csl
+++ b/research-institute-for-nature-and-forest.csl
@@ -139,7 +139,7 @@
       </if>
       <else-if type="webpage">
         <text variable="title"/>
-        <text value="WWW Document" prefix=" [" suffix="]"/>
+        <text value="WWW document" prefix=" [" suffix="]"/>
       </else-if>
       <else>
         <text variable="title"/>

--- a/research-institute-for-nature-and-forest.csl
+++ b/research-institute-for-nature-and-forest.csl
@@ -19,7 +19,7 @@
     </contributor>
     <category citation-format="author-date"/>
     <category field="biology"/>
-    <updated>2019-08-01T00:00:00</updated>
+    <updated>2020-08-05T00:00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale xml:lang="en">

--- a/research-institute-for-nature-and-forest.csl
+++ b/research-institute-for-nature-and-forest.csl
@@ -202,7 +202,7 @@
         <group delimiter=", ">
           <text macro="event"/>
           <text macro="publisher"/>
-          <text variable="number-of-pages" prefix=" " suffix=" p"/>
+          <text variable="number-of-pages" suffix=" p"/>
         </group>
       </else-if>
       <else-if type="chapter paper-conference" variable="page" match="any">

--- a/research-institute-for-nature-and-forest.csl
+++ b/research-institute-for-nature-and-forest.csl
@@ -288,3 +288,4 @@
     </layout>
   </bibliography>
 </style>
+

--- a/research-institute-for-nature-and-forest.csl
+++ b/research-institute-for-nature-and-forest.csl
@@ -70,19 +70,19 @@
           <group delimiter=" ">
             <text term="volume" form="short" text-case="capitalize-first"/>
             <number variable="volume"/>
-          </group>  
+          </group>
         </else-if>
         <else-if variable="collection-number">
           <group delimiter=" ">
             <text term="issue" form="short" text-case="capitalize-first"/>
             <number variable="collection-number"/>
-          </group>  
+          </group>
         </else-if>
         <else-if variable="number">
               <group delimiter=" ">
                 <text term="issue" form="short" text-case="capitalize-first"/>
                 <text variable="number"/>
-              </group>  
+              </group>
         </else-if>
       </choose>
       <choose>

--- a/research-institute-for-nature-and-forest.csl
+++ b/research-institute-for-nature-and-forest.csl
@@ -24,14 +24,12 @@
   </info>
   <locale xml:lang="en">
     <terms>
-      <term name="in">In</term>
       <term name="edition" form="short">edn.</term>
       <term name="no date" form="short">s.d.</term>
     </terms>
   </locale>
   <locale xml:lang="nl">
     <terms>
-      <term name="in">In</term>
       <term name="et-al">et al.</term>
       <term name="editor" form="short">
         <single>ed.</single>
@@ -46,7 +44,7 @@
       <if type="article-journal article-magazine article-newspaper" match="none">
         <choose>
           <if type="paper-conference" variable="container-title" match="any">
-            <text term="in" suffix=": "/>
+            <text term="in" text-case="capitalize-first" suffix=": "/>
             <names variable="editor translator" delimiter=", " suffix=". ">
               <name and="symbol" delimiter-precedes-last="never" initialize-with="." name-as-sort-order="all" sort-separator=" "/>
               <label text-case="lowercase" form="short" prefix=" (" suffix=")"/>

--- a/research-institute-for-nature-and-forest.csl
+++ b/research-institute-for-nature-and-forest.csl
@@ -5,6 +5,7 @@
     <title-short>INBO</title-short>
     <id>http://www.zotero.org/styles/research-institute-for-nature-and-forest</id>
     <link href="http://www.zotero.org/styles/research-institute-for-nature-and-forest" rel="self"/>
+    <link href="https://inbomd-examples.netlify.app/citation_style/nl/index.html" rel="documentation"/>
     <author>
       <name>Maarten Stevens</name>
       <uri>https://www.mendeley.com/profiles/maarten-stevens/</uri>

--- a/research-institute-for-nature-and-forest.csl
+++ b/research-institute-for-nature-and-forest.csl
@@ -73,10 +73,10 @@
           </group>
         </else-if>
         <else-if variable="number">
-              <group delimiter=" ">
-                <text term="issue" form="short" text-case="capitalize-first"/>
-                <text variable="number"/>
-              </group>
+          <group delimiter=" ">
+            <text term="issue" form="short" text-case="capitalize-first"/>
+            <text variable="number"/>
+          </group>
         </else-if>
       </choose>
       <choose>

--- a/research-institute-for-nature-and-forest.csl
+++ b/research-institute-for-nature-and-forest.csl
@@ -25,10 +25,6 @@
   <locale xml:lang="en">
     <terms>
       <term name="in">In</term>
-      <term name="editor" form="short">
-        <single>ed.</single>
-        <multiple>eds.</multiple>
-      </term>
       <term name="edition" form="short">edn.</term>
       <term name="no date" form="short">s.d.</term>
     </terms>

--- a/research-institute-for-nature-and-forest.csl
+++ b/research-institute-for-nature-and-forest.csl
@@ -20,6 +20,8 @@
     </contributor>
     <category citation-format="author-date"/>
     <category field="biology"/>
+    <category field="botany"/>
+    <category field="zoology"/>
     <updated>2020-08-06T00:00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>

--- a/research-institute-for-nature-and-forest.csl
+++ b/research-institute-for-nature-and-forest.csl
@@ -125,8 +125,7 @@
           <text variable="URL"/>
           <group prefix="(" suffix=").">
             <text term="accessed" suffix=" "/>
-            <date variable="accessed" form="text">
-            </date>
+            <date variable="accessed" form="text"></date>
           </group>
         </group>
       </if>

--- a/research-institute-for-nature-and-forest.csl
+++ b/research-institute-for-nature-and-forest.csl
@@ -125,7 +125,7 @@
           <text variable="URL"/>
           <group prefix="(" suffix=").">
             <text term="accessed" suffix=" "/>
-            <date variable="accessed" form="text"></date>
+            <date variable="accessed" form="text"/>
           </group>
         </group>
       </if>

--- a/research-institute-for-nature-and-forest.csl
+++ b/research-institute-for-nature-and-forest.csl
@@ -61,7 +61,7 @@
       <text variable="collection-title"/>
       <choose>
         <if type="article-journal article-magazine article-newspaper" match="any">
-            <!-- show nothing -->
+          <!-- show nothing -->
         </if>
         <else-if variable="volume">
           <group delimiter=" ">
@@ -267,20 +267,20 @@
         <text macro="author"/>
         <text macro="issued" prefix=" (" suffix="). "/>
         <choose>
-            <if type="article-journal article-magazine article-newspaper" match="any">
-                    <group delimiter=" ">
-                      <text macro="title" suffix="."/>
-                      <text macro="container"/>
-                      <text macro="locators"/>
-                    </group>
-            </if>
-            <else>
-                    <group delimiter=". ">
-                      <text macro="title"/>
-                      <text macro="container"/>
-                      <text macro="locators"/>
-                    </group>
-            </else>
+          <if type="article-journal article-magazine article-newspaper" match="any">
+            <group delimiter=" ">
+              <text macro="title" suffix="."/>
+              <text macro="container"/>
+              <text macro="locators"/>
+            </group>
+          </if>
+          <else>
+            <group delimiter=". ">
+              <text macro="title"/>
+              <text macro="container"/>
+              <text macro="locators"/>
+            </group>
+          </else>
         </choose>
       </group>
       <text macro="access" prefix=" " suffix="."/>

--- a/research-institute-for-nature-and-forest.csl
+++ b/research-institute-for-nature-and-forest.csl
@@ -22,7 +22,7 @@
     <category field="biology"/>
     <category field="botany"/>
     <category field="zoology"/>
-    <updated>2020-08-06T00:00:00</updated>
+    <updated>2020-10-12T12:01:18+02:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale xml:lang="en">


### PR DESCRIPTION
Adjustments address the bibliography style:

- editors/translators: `and='symbol'`, drop `in` if these variables are missing
- omit redundant parts within macros
- lang-specific term for short form of `edition`
- better handling of 'Vol.' and 'No.', allowing lang-specific forms of 'No.' by using the `issue` term for this
- improvements for webpages
- better handling of URL & DOI: drop the prefixes and don't show URL when DOI is present
- show page variable for more types
- various other changes

These follow from tests with [a bib file](https://github.com/inbo/inbomd_examples/blob/3a721f9/source/INBOmd.bib), using both _citeproc-js_ and _pandoc-citeproc_ as CSL processors (the former as obtained after import in Zotero with Better BibTeX enabled).

More changes may come, therefore this is a **draft** PR (not yet approved _by us_ for merging). I already started it so that the tests would be run.