### PR TITLE
Update harvard-stellenbosch-university.csl

### DIFF
--- a/harvard-stellenbosch-university.csl
+++ b/harvard-stellenbosch-university.csl
@@ -280,6 +280,7 @@
               <text term="in"/>
               <text variable="container-title" font-style="italic"/>
               <text macro="book-details"/>
+              <text macro="editor-translator"/>
             </group>
             <text variable="page"/>
           </else-if>


### PR DESCRIPTION
Add <text macro="editor-translator"/> to rearrange appearance of editors in book chapter reference
https://libguides.sun.ac.za/c.php?g=742962&p=5316902
Blanton, L.L. 1994. Discourse, artefacts and the ozarks: Understanding academic literacy, in V. Zamel & R. Spack (eds.). Negotiating academic literacies: Teaching and learning across languages and cultures. New Jersey: Lawrence Erlbaum Associates. 235-319.