### PR TITLE
Create chinese-research-writing.csl

### DIFF
--- a/chinese-research-writing.csl
+++ b/chinese-research-writing.csl
@@ -1,0 +1,2821 @@
+<?xml version="1.0" encoding="utf-8"?>
+<style xmlns="http://purl.org/net/xbiblio/csl" 
+  class="note" version="1.0" 
+  default-locale="en-US"
+  demote-non-dropping-particle="sort-only">
+
+  <info>
+    <title>Chinese Research Writing 3rd edition (full note)</title>
+    <id>http://www.zotero.org/styles/chinese-research-writing</id>
+
+    <link href="http://www.zotero.org/styles/chinese-research-writing" rel="self"/>
+    <!--
+    <link href="https://books.google.com.sg/books?id=1FzjDwAAQBAJ&dq=%E5%AD%A6%E6%9C%AF%E7%A0%94%E7%A9%B6%E4%B8%8E%E5%86%99%E4%BD%9C&source=gbs_navlinks_s" rel="documentation"/> -->
+
+    <!-- modified from Turabain -->
+    <link href="http://www.zotero.org/styles/turabian-fullnote-bibliography" rel="template"/>
+
+    <contributor>
+      <name>Daniel Owens</name>
+      <email>dcowens76@gmail.com</email>
+    </contributor>
+    <contributor>
+      <name>Wong Wing Kei</name>
+      <email>wingkei.wong@gmail.com</email>
+    </contributor>
+
+    <category citation-format="note"/>
+    <category field="history"/>
+
+    <summary>This supports both English and Chinese citation and bibliography. This is based on Turabian 8th style for English and complies with the Chinese citation format according to Chinese Research Writing 3rd edition. </summary>
+
+    <updated>2020-08-19T00:00:00+08:00</updated>
+
+    <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
+  </info>
+  
+
+<!-- =========================================================================================
+
+	  		UNOFFICIAL WORKAROUNDS
+
+	The following is a list of unofficical workarounds which are kinds of hack to 
+	provide special functionalities beyond the existing capabilities of Zotero app. 
+	They should be used with CAUTIONS. Other citation apps using CSL has not been 
+	tested and may have undesirable result. 
+	  
+	WARNING: The workarounds listed are not OFFICIALLY APPROVED and they may crash 
+	if the new version of Zotero app changes the use of the corresponding fields. 
+
+     +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+PROBLEM:	Citation of foreword as the special case of book section item
+
+KEYWORD:	FOREWORD_HACK (use this word to search through this file)
+
+FIELD USED:	genre (CSL), Genre (Zotero)
+
+EXTRA FIELD:	Genre: foreword
+
+DESCRIPTION:
+		The citation format requirement needs special handling for a 
+		particular case of Book Section, which is called Foreword or 
+		Introduction written by someone other than the book author. However, 
+		the current CSL cannot be able to identify this special case within 
+		the existing framework.
+
+SOLUTION:
+		we need an unused field to act as an indicator and we select genre 
+		to do this job. 
+
+		The modification consists of two phases, 
+		1) modify the code of this CSL to check the value of genre when the type
+		   is of "chapter" (ie. the item is of Book Section). 
+		   That is, an item will be regarded as foreword chapter 
+		   when type="chapter" and genre="foreword".
+
+		2) user adds the value to genre field in Zotero App. When the type is set to 
+	  	   Book Section, Zotero interface doesn't provide a way to see and modify
+		   the genre field. We need to add a line in the Extra field as
+		   "Genre: foreword" (no quotation mark typed). If there are something 
+	  	   already in the Extra field, please add the content on the next line. 
+
+	        NOTE: The user still has to fill the chapter title in Title field,
+		   e.g. Foreword / Introduction and this value will be shown in the 
+	 	   citation and bibliography. 
+
+DATE ADDED: 	2020/07/13 
+
+AUTHOR: 	Wong Wing Kei <wingkei.wong@gmail.com>
+
+     +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+PROBLEM: 	Citation of multivolumes book with individual titles
+
+KEYWORD:	MV_TITLES_HACK
+
+FIELD USED:	original-title (CSL), Original Title (Zotero)
+
+EXTRA FIELD:	Original Title: <title of the individual book> 
+
+DESCRIPTION:
+		For multivolume book with individual titles, the citation and bibliography 
+		show the name of the individual book after the volume no. And the subsequent
+		citation should also show the individual title as well. However, the current 
+		system cannot provide a suitable field for storing the individual book title.
+
+SOLUTION:
+		We employ a spare field called original-title (which is supposed to be used to
+		put the title of the book in original language if any). 
+
+		Two phases of modification,
+		1) modify the code to look for the content of original-title field when volume 
+		no. is to be rendered. If original-title != empty, put the title after the 
+		volume no. 
+	
+		2) user should input the individual book title in Extra field by adding a new 
+		line as follows, "Original Title: <title>" (<title>=the title 
+	 	without any quotation mark). 
+	
+		NOTE: The user still has to put the same title in "Short Title" field for 
+		the subsequent citation to be shown correctly. 
+
+DATE ADDED: 	2020/07/13
+	
+AUTHOR:		Wong Wing Kei <wingkei.wong@gmail.com>
+	  
+=============================================================================================== -->
+
+
+  <locale xml:lang="zh-TW">
+    <terms>
+      <term name="et-al">等</term>
+      <term name="in">於</term>
+      <term name="and">和</term>
+
+	      <!-- person -->
+      <term name="author" form="verb-short"></term>
+      <term name="author" form="short"></term>
+      <term name="editor" form="verb-short">編</term>
+      <term name="editor" form="short">編</term>
+      <term name="translator" form="verb-short">譯</term>
+      <term name="translator" form="short">譯</term>
+      <term name="editortranslator" form="verb-short">
+        <single>編輯及翻譯</single>
+        <multiple>編輯及翻譯</multiple>
+      </term>
+      <term name="editortranslator" form="verb">
+        <single>編輯及翻譯</single>
+        <multiple>編輯及翻譯</multiple>
+      </term>
+      <term name="reviewed-author" form="verb-short">評</term>
+      <term name="reviewed-author" form="short">評</term>
+      <term name="interviewer" form="verb">訪問</term>
+      <term name="recipient" form="verb">致</term>
+
+	      <!-- action -->
+      <term name="interview">訪問</term>
+      <term name="accessed">存取</term>
+      <term name="presented at">上發表之專文</term>
+
+	      <!-- punctuation -->
+      <term name="open-quote">“</term>
+      <term name="close-quote">”</term>
+      <term name="open-inner-quote">'</term>
+      <term name="close-inner-quote">'</term>
+
+	      <!-- locator -->
+      <term name="volume" form="short">卷</term>
+      <term name="edition" form="short">版</term>
+
+	      <!-- newly added -->
+      <term name="letter">電郵</term>
+      <term name="retrieved">上傳</term> <!-- we borrow this unused term as "posted" -->
+
+    </terms>
+  </locale>
+
+  <locale xml:lang="zh-CN">
+    <terms>
+      <term name="et-al">等</term>
+      <term name="in">于</term>
+      <term name="and">和</term>
+
+	      <!-- person -->
+      <term name="author" form="verb-short"></term>
+      <term name="author" form="short"></term>
+      <term name="editor" form="verb-short">编</term>
+      <term name="editor" form="short">编</term>
+      <term name="translator" form="verb-short">译</term>
+      <term name="translator" form="short">译</term>
+      <term name="editortranslator" form="verb-short">
+        <single>编辑及翻译</single>
+        <multiple>编辑及翻译</multiple>
+      </term>
+      <term name="editortranslator" form="verb">
+        <single>编辑及翻译</single>
+        <multiple>编辑及翻译</multiple>
+      </term>
+      <term name="reviewed-author" form="verb-short">评</term>
+      <term name="reviewed-author" form="short">评</term>
+      <term name="interviewer" form="verb">访问</term>
+      <term name="recipient" form="verb">致</term>
+
+	      <!-- action -->
+      <term name="interview">访问</term>
+      <term name="accessed">存取</term>
+      <term name="presented at">上发表之专文</term>
+
+	      <!-- punctuation -->
+      <term name="open-quote">“</term>
+      <term name="close-quote">”</term>
+      <term name="open-inner-quote">'</term>
+      <term name="close-inner-quote">'</term>
+
+	      <!-- locator -->
+      <term name="volume" form="short">卷</term>
+      <term name="edition" form="short">版</term>
+
+	      <!-- newly added -->
+      <term name="letter">电邮</term>
+      <term name="retrieved">上传</term>
+    </terms>
+  </locale>
+
+  <locale xml:lang="en">
+    <terms>
+	    <!-- person -->
+      <term name="editor" form="verb-short">ed.</term>
+      <term name="translator" form="verb-short">trans.</term>
+      <term name="translator" form="short">trans.</term>
+
+	      <!-- action -->
+      <term name="presented at">paper presented at</term>
+
+	      <!-- newly added -->
+      <term name="letter">e-mail message</term>
+      <term name="retrieved">posted</term>
+    </terms>
+  </locale>
+  
+  
+<!-- Editor-Translator   -->
+
+  <macro name="editor-translator">
+    <group delimiter=", ">
+      <choose>
+        <if variable="author">
+          <names variable="editor" delimiter=", ">
+            <label form="verb-short" suffix=" "/>
+            <name and="text" delimiter=", "/>
+          </names>
+          <choose>
+            <if variable="container-author">
+              <group>
+                <names variable="container-author">
+                  <label form="verb-short" prefix=" " suffix=" "/>
+                  <name and="text" delimiter=", "/>
+                </names>
+              </group>
+            </if>
+          </choose>
+        </if>
+      </choose>
+      <choose>
+        <if variable="author editor" match="any">
+          <names variable="translator" delimiter=", ">
+            <label form="verb-short" suffix=" "/>
+            <name and="text" delimiter=", "/>
+          </names>
+        </if>
+      </choose>
+    </group>
+  </macro>
+  
+  <macro name="editor-translator-zh">
+    <group delimiter="，">
+      <choose>
+        <if variable="author">
+          <!-- WK: add "和" between the editors -->
+          <names variable="editor" delimiter="，">
+            <name and="text" delimiter="、" delimiter-precedes-last="never"/>
+            <label form="verb-short" />
+          </names>
+          <choose>
+            <if variable="container-author">
+              <group>
+                <names variable="container-author">
+                  <!-- WK: need to localize for Chinese -->
+                  <name and="text" delimiter="、" delimiter-precedes-last="never"/>
+                  <label form="verb-short" prefix="" suffix=""/>
+                </names>
+              </group>
+            </if>
+          </choose>
+        </if>
+      </choose>
+      <choose>
+        <if variable="author editor" match="any">
+          <!-- WK: add "和" between the translators -->
+          <names variable="translator" delimiter="，" >
+            <name and="text" delimiter="、" delimiter-precedes-last="never"/>
+            <label form="verb-short" />
+          </names>
+        </if>
+      </choose>
+    </group>
+  </macro>
+
+<!-- Secondary Contributors -->
+
+  <macro name="secondary-contributors-note">
+    <choose>
+      <if type="entry-dictionary entry-encyclopedia chapter paper-conference" match="none">
+        <text macro="editor-translator"/>
+      </if>
+    </choose>
+  </macro>
+
+  <macro name="secondary-contributors-note-zh">
+    <choose>
+      <if type="entry-dictionary entry-encyclopedia chapter paper-conference" match="none">
+        <text macro="editor-translator-zh"/>
+      </if>
+    </choose>
+  </macro>
+
+<!--  container-contributors-note  -->
+
+  <macro name="container-contributors-note">
+    <choose>
+      <!-- do not show secondary contributors for dictionary entry in citation -->
+      <if type="chapter paper-conference" match="any">
+        <text macro="editor-translator"/>
+      </if>
+    </choose>
+  </macro>
+  
+    <macro name="container-contributors-note-zh">
+    <choose>
+      <!-- do not show secondary contributors for dictionary entry in citation -->
+      <if type="chapter paper-conference" match="any">
+        <text macro="editor-translator-zh"/>
+      </if>
+    </choose>
+  </macro>
+  
+<!--  secondary-contributors  -->
+  
+  <macro name="secondary-contributors">
+    <choose>
+      <if type="entry-dictionary entry-encyclopedia chapter paper-conference" match="none">
+        <group delimiter=". ">
+          <choose>
+            <if variable="author">
+              <names variable="editor" delimiter=". ">
+                <label form="verb" text-case="capitalize-first" suffix=" "/>
+                <name and="text" delimiter=", "/>
+              </names>
+            </if>
+          </choose>
+          <choose>
+            <if variable="author editor" match="any">
+              <names variable="translator" delimiter=". ">
+                <label form="verb" text-case="capitalize-first" suffix=" "/>
+                <name and="text" delimiter=", "/>
+              </names>
+            </if>
+          </choose>
+        </group>
+      </if>
+    </choose>
+  </macro>
+  
+  <macro name="secondary-contributors-zh">
+    <choose>
+      <if type="entry-dictionary entry-encyclopedia chapter paper-conference" match="none">
+        <group delimiter="。">
+          <choose>
+            <if variable="author">
+              <!-- WK: add "和" between the editors -->
+              <names variable="editor" delimiter="。">
+                <name and="text" delimiter="、" delimiter-precedes-last="never" />
+                <label form="verb-short" />
+              </names>
+            </if>
+          </choose>
+          <choose>
+            <if variable="author editor" match="any">
+              <!-- WK: add "和" between the translators -->
+              <names variable="translator" delimiter="。">
+                <name and="text" delimiter="、" delimiter-precedes-last="never" />
+                <label form="verb-short" />
+              </names>
+            </if>
+          </choose>
+        </group>
+      </if>
+    </choose>
+  </macro>
+  
+<!--   container-contributors -->
+  
+  <macro name="container-contributors">
+    <choose>
+      <if type="entry-dictionary entry-encyclopedia chapter paper-conference" match="any">
+        <group delimiter=", ">
+          <choose>
+            <if variable="author">
+              <names variable="editor" delimiter=", ">
+                <label form="verb" suffix=" "/>
+                <name and="text" delimiter=", "/>
+              </names>
+              <choose>
+                <if variable="container-author">
+                  <group>
+                    <names variable="container-author">
+                      <label form="verb-short" prefix=" " suffix=" "/>
+                      <name and="text" delimiter=", "/>
+                    </names>
+                  </group>
+                </if>
+              </choose>
+            </if>
+          </choose>
+          <choose>
+            <if variable="author editor" match="any">
+              <names variable="translator" delimiter=", ">
+                <label form="verb" suffix=" "/>
+                <name and="text" delimiter=", "/>
+              </names>
+            </if>
+          </choose>
+        </group>
+      </if>
+    </choose>
+  </macro>
+
+  <macro name="container-contributors-zh">
+    <choose>
+      <if type="entry-dictionary entry-encyclopedia chapter paper-conference" match="any">
+        <group delimiter="，">
+          <choose>
+            <if variable="author">
+              <!-- WK: add 和 between editors -->
+	      <names variable="editor" delimiter="。">
+                <name and="text" delimiter="、" delimiter-precedes-last="never" />
+                <label form="verb-short" />
+              </names>
+
+              <choose>
+                <if variable="container-author">
+                  <group>
+                    <!-- WK: need to localize for Chinese -->
+                    <names variable="container-author">
+                      <name and="text" delimiter="、" delimiter-precedes-last="never" />
+                      <label form="verb-short" prefix="" suffix=""/>
+                    </names>
+                  </group>
+                </if>
+              </choose>
+            </if>
+          </choose>
+          <choose>
+            <if variable="author editor" match="any">
+              <!-- WK: add 和 between editors -->
+	      <names variable="translator" delimiter="。">
+                <name and="text" delimiter="、" delimiter-precedes-last="never" />
+                <label form="verb-short" />
+              </names>
+            </if>
+          </choose>
+        </group>
+      </if>
+    </choose>
+  </macro>
+  
+<!--  recipient-note  -->
+  
+  <macro name="recipient-note">
+    <names variable="recipient" delimiter=", ">
+      <label form="verb" prefix=" " suffix=" "/> <!-- to -->
+      <name and="text" delimiter=", "/>
+    </names>
+  </macro>
+  
+  <macro name="recipient-note-zh">
+    <names variable="recipient" delimiter="，">
+      <label form="verb" prefix="" suffix=""/> <!-- 致 -->
+      <name and="text" delimiter="、"/>
+    </names>
+  </macro>
+  
+<!--  contributors-note  -->
+
+  <macro name="contributors-note">
+    <choose>
+      <!-- only show the author name of entry. If no author name, leave it blank -->
+      <if type="entry-dictionary entry-encyclopedia" match="any">
+         <names variable="author">
+           <name and="text" sort-separator=", " delimiter=", "/>
+           <label form="short" prefix=", "/>
+         </names>
+      </if>
+      <else>
+
+    <names variable="author">
+      <name and="text" sort-separator=", " delimiter=", "/>
+      <label form="short" prefix=", "/>
+      <substitute>
+        <names variable="editor"/>
+        <names variable="translator"/>
+      </substitute>
+    </names>
+
+    <!-- special handling for email -->
+    <choose>
+      <if type="personal_communication">
+        <choose>
+          <if variable="genre"> <!-- genre is used to identify as letter type -->
+	    <text macro="recipient-note"/>
+          </if>
+	  <!-- email -->
+          <else>
+	    <text term="letter" prefix=", "/>
+	    <text macro="recipient-note" prefix=" "/>
+          </else>
+        </choose>
+      </if>
+      <else>
+        <text macro="recipient-note"/>
+      </else>
+    </choose>
+
+      </else>
+    </choose>
+
+  </macro>
+  
+  <macro name="contributors-note-zh">
+    <choose>
+      <!-- only show the author name of entry. If no author name, leave it blank -->
+      <if type="entry-dictionary entry-encyclopedia" match="any">
+        <names variable="author">
+          <name and="text" sort-separator="，" delimiter="、"/> 
+          <label form="short" /> 
+        </names>
+      </if>
+      <else>
+
+    <names variable="author">
+      <name and="text" sort-separator="，" delimiter="、"/> 
+      <label form="short" /> 
+      <substitute>
+        <names variable="editor"/>
+        <names variable="translator"/>
+      </substitute>
+    </names>
+
+    <!-- special handling for email -->
+    <choose>
+      <if type="personal_communication">
+        <choose>
+          <if variable="genre"> <!-- genre is used to identify as letter type -->
+	    <text macro="recipient-note-zh"/>
+          </if>
+	  <!-- email -->
+          <else>
+	    <text macro="recipient-note-zh" prefix="，"/>
+	    <text term="letter" prefix="之"/>
+          </else>
+        </choose>
+      </if>
+      <else>
+        <text macro="recipient-note-zh"/>
+      </else>
+    </choose>
+
+      </else>
+    </choose>
+
+  </macro>
+  
+<!--  recipient  -->
+  
+  <macro name="recipient">
+    <choose>
+      <if type="personal_communication">
+        <choose>
+          <if variable="genre"> <!-- genre is used to identify as letter type -->
+            <text variable="genre" text-case="capitalize-first"/>
+          </if>
+	  <!-- email -->
+          <else>
+            <text term="letter" text-case="capitalize-first"/>
+          </else>
+        </choose>
+      </if>
+    </choose>
+    <text macro="recipient-note" prefix=" "/>
+  </macro>
+  
+  <macro name="recipient-zh">
+    <text macro="recipient-note-zh" prefix=""/>
+    <choose>
+      <if type="personal_communication">
+        <choose>
+          <if variable="genre"> <!-- genre is used to identify as letter type -->
+            <text variable="genre" text-case="capitalize-first"/>
+          </if>
+	  <!-- email -->
+          <else>
+            <text term="letter" text-case="capitalize-first"/>
+          </else>
+        </choose>
+      </if>
+    </choose>
+  </macro>
+  
+<!--  contributors  -->
+  
+  <macro name="contributors">
+    <names variable="author">
+      <name name-as-sort-order="first" and="text" sort-separator=", " delimiter=", " delimiter-precedes-last="always"/>
+      <label form="short" prefix=", "/>
+      <substitute>
+        <names variable="editor"/>
+        <names variable="translator"/>
+      </substitute>
+    </names>
+    <text macro="recipient" prefix=". "/>
+  </macro>
+  
+  <macro name="contributors-zh">
+    <names variable="author">
+      <!-- WK: need to change delimiter-precedes-last="never", 
+          so that the extra comma will not shown before the "and" preceding the last name -->
+      <name name-as-sort-order="first" and="text" sort-separator="，" delimiter="、" delimiter-precedes-last="never"/>
+      <label form="short" /> 
+      <substitute>
+        <names variable="editor"/>
+        <names variable="translator"/>
+      </substitute>
+    </names>
+    <text macro="recipient-zh" prefix="。"/>
+  </macro>
+  
+<!--  recipient-short  -->
+  
+  <macro name="recipient-short">
+    <names variable="recipient">
+      <label form="verb" prefix=" " suffix=" "/>
+      <name form="short" and="text" delimiter=", "/>
+    </names>
+  </macro>
+  
+  <!-- WK: TODO -->
+  <macro name="recipient-short-zh">
+    <names variable="recipient">
+      <label form="verb" prefix="" suffix=""/>
+      <name form="short" and="text" delimiter="、"/>
+    </names>
+  </macro>
+
+<!--  contributors-short  -->
+  
+  <macro name="contributors-short">
+    <choose>
+      <!-- only show author for dictionary entry. if no author, leave it blank -->
+      <if type="entry-dictionary entry-encyclopedia" match="any">
+        <names variable="author">
+          <name form="short" and="text" delimiter=", "/>
+        </names>
+      </if>
+      <else>
+
+    <names variable="author">
+      <name form="short" and="text" delimiter=", "/>
+      <substitute>
+        <names variable="editor"/>
+        <names variable="translator"/>
+      </substitute>
+    </names>
+
+    <!-- special handling for email -->
+    <choose>
+      <if type="personal_communication">
+        <choose>
+          <if variable="genre">	<!-- genre is used to identify as letter type -->
+	    <text macro="recipient-short"/>
+          </if>
+	  <!-- email -->
+	  <!-- do not add the recipient for short citation -->
+	  <!-- <else>
+	  </else> -->
+        </choose>
+      </if>
+      <else>
+        <text macro="recipient-short"/>
+      </else>
+    </choose>
+
+      </else>
+    </choose>
+	    
+  </macro>
+  
+  <macro name="contributors-short-zh">
+    <choose>
+      <!-- only show author for dictionary entry. if no author, leave it blank -->
+      <if type="entry-dictionary entry-encyclopedia" match="any">
+        <names variable="author">
+          <name form="short" and="text" delimiter="、"/>
+        </names>
+      </if>
+      <else>
+
+    <names variable="author">
+      <name form="short" and="text" delimiter="、"/>
+      <substitute>
+        <names variable="editor"/>
+        <names variable="translator"/>
+      </substitute>
+    </names>
+
+    <!-- special handling for email -->
+    <choose>
+      <if type="personal_communication">
+        <choose>
+          <if variable="genre"> <!-- genre is used to identify as letter type -->
+	    <text macro="recipient-short-zh"/>
+          </if>
+	  <!-- email -->
+	  <!-- do not add the recipient for short citation -->
+	  <!-- <else>
+	  </else> -->
+        </choose>
+      </if>
+      <else>
+        <text macro="recipient-short-zh"/>
+      </else>
+    </choose>
+
+      </else>
+    </choose>
+
+  </macro>
+  
+<!--  contributors-sort  -->
+  
+  <macro name="contributors-sort">
+    <names variable="author">
+      <name name-as-sort-order="all" and="text" sort-separator=", " delimiter=", " delimiter-precedes-last="always"/>
+      <substitute>
+        <names variable="editor"/>
+        <names variable="translator"/>
+      </substitute>
+    </names>
+  </macro>
+  
+  <macro name="contributors-sort-zh">
+    <names variable="author">
+      <name name-as-sort-order="all" and="text" sort-separator="，" delimiter="、" delimiter-precedes-last="always"/>
+      <substitute>
+        <names variable="editor"/>
+        <names variable="translator"/>
+      </substitute>
+    </names>
+  </macro>
+
+<!--  interviewer-note  -->
+  
+  <macro name="interviewer-note">
+    <names variable="interviewer" delimiter=", ">
+      <label form="verb" prefix=" " suffix=" "/>
+      <name and="text" delimiter=", "/>
+    </names>
+  </macro>
+  
+  <macro name="interviewer-note-zh">
+    <names variable="interviewer" delimiter="，" prefix="由">
+      <name and="text" delimiter="、"/>
+      <label form="verb" />
+    </names>
+  </macro>
+
+<!--  interviewer  -->
+  
+  <macro name="interviewer">
+    <names variable="interviewer" delimiter=", ">
+      <label form="verb" prefix=" " text-case="capitalize-first" suffix=" "/>
+      <name and="text" delimiter=", "/>
+    </names>
+  </macro>
+  
+  <macro name="interviewer-zh">
+    <names variable="interviewer" delimiter="，" prefix="由">
+      <name and="text" delimiter="、"/>
+      <label form="verb" />
+    </names>
+  </macro>
+  
+<!--  title-note  -->
+  
+  <macro name="title-note">
+    <choose>
+      <if variable="title" match="none">
+        <text variable="genre"/>
+      </if>
+      <else-if type="bill book graphic legal_case legislation motion_picture report song" match="any">
+        <text variable="title" font-style="italic" text-case="title"/>
+	
+	<!-- MV_TITLES_HACK Start -->
+	<!-- show volume no. and individual title after book title -->
+	<choose> 
+	  <if variable="original-title">
+            <group prefix=", " delimiter=", ">
+	      <group>
+                <text term="volume" form="short" suffix=" "/>
+                <number variable="volume" form="numeric"/>
+	      </group>
+              <text variable="original-title" font-style="italic" text-case="title"/>
+    	    </group>
+	  </if>
+	</choose>
+	<!-- MV_TITLES_HACK End -->
+
+      </else-if>
+      <!-- WK 20200706 modified: add book review handling, by using reviewed-author field -->
+      <else-if variable="reviewed-author">
+	<group delimiter=", " > 
+          <text variable="title" font-style="italic" text-case="title" prefix="review of "/>
+	  <names variable="reviewed-author">
+            <label form="verb" suffix=" "/>
+	    <name and="text" delimiter=", "/>
+	  </names>
+	</group>
+      </else-if>
+
+      <!-- FOREWORD_HACK Start -->
+      <else-if type="chapter">
+	<choose>
+	  <if variable="genre">	<!-- foreword chapter -->
+	    <!-- Do nothing. Leave the title be shown in container-title -->  
+	  </if>
+	  <else>		<!-- normal chapter -->
+	    <text variable="title" quotes="true" text-case="title"/>
+	  </else>
+	</choose>
+      </else-if>
+      <else>		<!-- normal chapter -->
+	<text variable="title" quotes="true" text-case="title"/>
+      </else>
+      <!-- FOREWORD_HACK End -->
+    </choose>
+  </macro>
+  
+  <macro name="title-note-zh">
+    <choose>
+      <if variable="title" match="none">
+        <text variable="genre"/>
+      </if>
+      <else-if type="bill book graphic legal_case legislation motion_picture report song" match="any">
+        <text variable="title"  prefix="《" suffix="》" text-case="sentence" />
+
+	<!-- MV_TITLES_HACK Start -->
+	<!-- show volume no. and individual title after book title -->
+	<choose> 
+	  <if variable="original-title">
+            <group prefix="，">
+              <text term="volume" form="short"/>
+              <number variable="volume" form="numeric"/>
+              <text variable="original-title" prefix="：《" suffix="》"/>
+    	    </group>
+	  </if>
+	</choose>
+	<!-- MV_TITLES_HACK End -->
+
+      </else-if>
+      <!-- WK 20200706 modified: add book review handling, by using reviewed-author field -->
+      <else-if variable="reviewed-author">
+	<group delimiter="，" > 
+	  <names variable="reviewed-author" >
+	    <label form="verb-short"/>
+	    <name and="text" delimiter="、"/>
+	  </names>
+          <text variable="title" prefix="《" suffix="》" text-case="sentence" />
+	</group>
+      </else-if>
+
+      <!-- FOREWORD_HACK Start -->
+      <else-if type="chapter">
+	<choose>
+	  <if variable="genre">	<!-- foreword chapter -->
+	    <!-- Do nothing. Leave the title be shown in container-title -->  
+	  </if>
+	  <else>		<!-- normal chapter -->
+	    <text variable="title" prefix="〈" suffix="〉" text-case="sentence" /> 
+	  </else>
+	</choose>
+      </else-if>
+      <else>		<!-- normal chapter -->
+	<text variable="title" prefix="〈" suffix="〉" text-case="sentence" /> 
+      </else>
+      <!-- FOREWORD_HACK End -->
+    </choose>
+  </macro>
+
+<!--  title  -->
+  
+  <macro name="title">
+    <choose>
+      <if variable="title" match="none">
+        <choose>
+          <if type="personal_communication" match="none">
+            <text variable="genre" text-case="capitalize-first"/>
+          </if>
+        </choose>
+      </if>
+      <else-if type="bill book graphic legal_case legislation motion_picture report song" match="any">
+        <text variable="title" font-style="italic" text-case="title"/>
+
+	<!-- MV_TITLES_HACK Start -->
+	<!-- show volume no. and individual title after book title -->
+	<choose>
+	  <if variable="original-title">
+            <group prefix=". " delimiter=", ">
+	      <group>
+                <text term="volume" form="short" text-case="capitalize-first" suffix=" "/>
+                <number variable="volume" form="numeric"/>
+	      </group>
+              <text variable="original-title" font-style="italic" text-case="title"/>
+    	    </group>
+	  </if>
+	</choose>
+	<!-- MV_TITLES_HACK End -->
+      </else-if>
+
+      <!-- WK 20200706 modified: add book review handling, by using reviewed-author field -->
+      <else-if variable="reviewed-author">
+	<group delimiter=", " > 
+          <text variable="title" font-style="italic" text-case="title" prefix="Review of "/>
+	  <names variable="reviewed-author">
+            <label form="verb" suffix=" "/>
+	    <name and="text" delimiter=", "/>
+	  </names>
+	</group>
+      </else-if>
+
+      <!-- FOREWORD_HACK Start -->
+      <else-if type="chapter">
+	<choose>
+	  <if variable="genre">	<!-- foreword chapter -->
+	    <!-- Do nothing. Leave the title be shown in container-title -->  
+	  </if>
+	  <else>		<!-- normal chapter -->
+	    <text variable="title" quotes="true" text-case="title"/>
+	  </else>
+	</choose>
+      </else-if>
+      <!-- FOREWORD_HACK End -->
+
+      <!-- when the dictionary entry has no author, don't show the entry-title -->
+      <else-if type="entry-dictionary entry-encyclopedia" match="any">
+	<choose>
+	  <if variable="author">
+	    <text variable="title" quotes="true" text-case="title"/>
+	  </if>
+	</choose>
+      </else-if>
+
+      <else>		
+	<text variable="title" quotes="true" text-case="title"/>
+      </else>
+    </choose>
+  </macro>
+  
+  <macro name="title-zh">
+    <choose>
+      <if variable="title" match="none">
+        <choose>
+          <if type="personal_communication" match="none">
+            <text variable="genre" />
+          </if>
+        </choose>
+      </if>
+      <else-if type="bill book graphic legal_case legislation motion_picture report song" match="any">
+        <text variable="title" prefix="《" suffix="》" text-case="sentence" />
+
+	<!-- MV_TITLES_HACK Start -->
+	<!-- show volume no. and individual title after book title -->
+	<choose>
+	  <if variable="original-title">
+            <group prefix="。">
+              <text term="volume" form="short"/>
+              <number variable="volume" form="numeric"/>
+              <text variable="original-title" prefix="：《" suffix="》"/>
+    	    </group>
+	  </if>
+	</choose>
+	<!-- MV_TITLES_HACK End -->
+      </else-if>
+
+      <!-- WK 20200706 modified: add book review handling, by using reviewed-author field -->
+      <else-if variable="reviewed-author">
+	<group delimiter="，" > 
+	  <names variable="reviewed-author" >
+	    <label form="verb-short"/>
+	    <name and="text" delimiter="、"/>
+	  </names>
+          <text variable="title" prefix="《" suffix="》" text-case="sentence" />
+	</group>
+      </else-if>
+
+      <!-- FOREWORD_HACK Start -->
+      <else-if type="chapter">
+	<choose>
+	  <if variable="genre">	<!-- foreword chapter -->
+	    <!-- Do nothing. Leave the title be shown in container-title -->  
+	  </if>
+	  <else>		<!-- normal chapter -->
+	    <text variable="title" prefix="〈" suffix="〉" text-case="sentence" /> 
+	  </else>
+	</choose>
+      </else-if>
+      <!-- FOREWORD_HACK End -->
+
+      <!-- when the dictionary entry has no author, don't show the entry-title -->
+      <else-if type="entry-dictionary entry-encyclopedia" match="any">
+	<choose>
+	  <if variable="author">
+	    <text variable="title" prefix="〈" suffix="〉" text-case="sentence" /> 
+	  </if>
+	</choose>
+      </else-if>
+
+      <else>
+	<text variable="title" prefix="〈" suffix="〉" text-case="sentence" /> 
+      </else>
+    </choose>
+  </macro>
+
+<!-- title-short -->
+  
+  <macro name="title-short">
+    <choose>
+      <if variable="title" match="none">
+        <choose>
+          <if type="interview">
+            <text term="interview"/>
+          </if>
+          <else-if type="manuscript speech" match="any">
+            <text variable="genre" form="short"/>
+          </else-if>
+          <else-if type="personal_communication">
+	    <choose>
+	      <if variable="genre">
+                <text macro="issued"/>
+	      </if>
+	      <!-- special handling for email -->
+	      <else>
+		<text term="letter"/>
+	      </else>
+	    </choose>
+          </else-if>
+        </choose>
+      </if>
+      <else-if type="bill book graphic legal_case legislation motion_picture report song" match="any">
+        <text variable="title" form="short" font-style="italic" text-case="title"/>
+      </else-if>
+      <!-- WK 20200706 modified: add book review handling, by using reviewed-author field -->
+      <else-if variable="reviewed-author">
+        <names variable="reviewed-author" prefix="review of ">
+	  <name form="short" and="text" delimiter=", "/>
+	</names>
+      </else-if>
+      <else>
+        <text variable="title" form="short" quotes="true" text-case="title"/>
+      </else>
+    </choose>
+  </macro>
+  
+  <macro name="title-short-zh">
+    <choose>
+      <if variable="title" match="none">
+        <choose>
+          <if type="interview">
+            <text term="interview"/>
+          </if>
+          <else-if type="manuscript speech" match="any">
+            <text variable="genre" form="short"/>
+          </else-if>
+          <else-if type="personal_communication">
+	    <choose>
+	      <if variable="genre">
+                <text macro="issued-zh"/>
+	      </if>
+	      <!-- special handling for email -->
+	      <else>
+		<text term="letter"/>
+	      </else>
+	    </choose>
+          </else-if>
+        </choose>
+      </if>
+      <else-if type="bill book graphic legal_case legislation motion_picture report song" match="any">
+        <text variable="title" form="short" prefix="《" suffix="》"/>
+      </else-if>
+      <!-- WK 20200706 modified: add book review handling, by using reviewed-author field -->
+      <else-if variable="reviewed-author">
+	<names variable="reviewed-author" >
+	  <label form="verb-short"/>
+	  <name and="text" delimiter="、"/>
+	</names>
+      </else-if>
+      <else>
+        <text variable="title" form="short" prefix="〈" suffix="〉"/>
+      </else>
+    </choose>
+  </macro>
+
+<!--  description-note  -->
+  
+  <macro name="description-note">
+    <group delimiter=", ">
+      <text macro="interviewer-note"/>
+      <text variable="medium"/>
+      <choose>
+        <if variable="title" match="none"/>
+        <else-if type="thesis speech" match="any"/>
+        <else>
+	  <!-- FOREWORD_HACK Start -->
+	    <choose>
+	      <if type="chapter">
+		<choose>
+		  <if variable="genre">	<!-- foreword chapter -->
+		    <!-- Do nothing. Leave the title be shown in container-title -->  
+		  </if>
+		  <else>		<!-- normal chapter -->
+                    <text variable="genre"/>
+		  </else>
+		</choose>
+	      </if>
+	      <else>		<!-- normal chapter -->
+                <text variable="genre"/>
+	      </else>
+	    </choose>
+	  <!-- FOREWORD_HACK End -->
+        </else>
+      </choose>
+    </group>
+  </macro>
+  
+  <macro name="description-note-zh">
+    <group delimiter="，">
+      <text macro="interviewer-note-zh"/>
+      <text variable="medium"/>
+      <choose>
+        <if variable="title" match="none"/>
+        <else-if type="thesis speech" match="any"/>
+        <else>
+	  <!-- FOREWORD_HACK Start -->
+	    <choose>
+	      <if type="chapter">
+		<choose>
+		  <if variable="genre">	<!-- foreword chapter -->
+		    <!-- Do nothing. Leave the title be shown in container-title -->  
+		  </if>
+		  <else>		<!-- normal chapter -->
+                    <text variable="genre"/>
+		  </else>
+		</choose>
+	      </if>
+	      <else>		<!-- normal chapter -->
+                <text variable="genre"/>
+	      </else>
+	    </choose>
+	  <!-- FOREWORD_HACK End -->
+        </else>
+      </choose>
+    </group>
+  </macro>
+
+<!-- description -->
+  
+  <macro name="description">
+    <group delimiter=", ">
+      <group delimiter=". ">
+        <text macro="interviewer"/>
+        <text variable="medium" text-case="capitalize-first"/>
+      </group>
+      <choose>
+        <if variable="title" match="none"/>
+        <else-if type="thesis speech" match="any"/>
+        <else>
+	  <!-- FOREWORD_HACK Start -->
+	    <choose>
+	      <if type="chapter">
+		<choose>
+		  <if variable="genre">	<!-- foreword chapter -->
+		    <!-- Do nothing. Leave the title be shown in container-title -->  
+		  </if>
+		  <else>		<!-- normal chapter -->
+                    <text variable="genre" text-case="capitalize-first"/>
+		  </else>
+		</choose>
+	      </if>
+	      <else>		<!-- normal chapter -->
+                <text variable="genre" text-case="capitalize-first"/>
+	      </else>
+	    </choose>
+	  <!-- FOREWORD_HACK End -->
+        </else>
+      </choose>
+    </group>
+  </macro>
+  
+  <macro name="description-zh">
+    <group delimiter="，">
+      <group delimiter="。">
+        <text macro="interviewer-zh"/>
+        <text variable="medium" />
+      </group>
+      <choose>
+        <if variable="title" match="none"/>
+        <else-if type="thesis speech" match="any"/>
+        <else>
+	  <!-- FOREWORD_HACK Start -->
+	    <choose>
+	      <if type="chapter">
+		<choose>
+		  <if variable="genre">	<!-- foreword chapter -->
+		    <!-- Do nothing. Leave the title be shown in container-title -->  
+		  </if>
+		  <else>		<!-- normal chapter -->
+                    <text variable="genre" />
+		  </else>
+		</choose>
+	      </if>
+	      <else>		<!-- normal chapter -->
+                <text variable="genre" />
+	      </else>
+	    </choose>
+	  <!-- FOREWORD_HACK End -->
+        </else>
+      </choose>
+    </group>
+  </macro>
+  
+<!-- container-title-note -->
+  
+  <macro name="container-title-note">
+
+    <!-- FOREWORD_HACK Start -->
+    <choose>
+      <if type="chapter">
+        <choose>
+	  <if variable="genre">	<!-- foreword chapter -->
+	    <text variable="title" text-case="lowercase" suffix=" to "/>
+	  </if>
+	  <else>		<!-- normal chapter -->
+            <text term="in" suffix=" "/>
+	  </else>
+	</choose>
+      </if>
+      <else-if type="paper-conference">
+        <text term="in" suffix=" "/>
+      </else-if>
+    </choose>
+    <!-- FOREWORD_HACK End -->
+
+    <choose>
+      <if type="legal_case" match="none">
+        <choose>
+	  <!-- WK 20200706: no italics for webpage title -->
+	  <if type="webpage">
+            <text variable="container-title"/>
+          </if>
+          <else-if type="article-journal article-magazine" match="any">
+            <text variable="container-title" font-style="italic"/>
+          </else-if>
+	  <else>
+            <!--title case every container title except webpage, magazines and journals-->
+            <text variable="container-title" font-style="italic" text-case="title"/>
+
+	    <!-- MV_TITLES_HACK Start -->
+	    <!-- show container book individual title for chapter type -->
+	    <choose> 
+	      <if type="chapter">
+	        <choose>
+	          <if variable="original-title">
+                    <group prefix=", " delimiter=", ">
+	              <group>
+                        <text term="volume" form="short" suffix=" "/>
+                        <number variable="volume" form="numeric"/>
+	              </group>
+                      <text variable="original-title" font-style="italic" text-case="title"/>
+    	            </group>
+	          </if>
+	        </choose>
+              </if>
+	    </choose>
+	    <!-- MV_TITLES_HACK End -->
+          </else>
+        </choose>
+      </if>
+    </choose>
+  </macro>
+  
+  <macro name="container-title-note-zh">
+
+    <!-- FOREWORD_HACK Start -->
+    <choose>
+      <if type="chapter">
+        <choose>
+	  <if variable="genre">	<!-- foreword chapter -->
+		  <!-- no nothing before the book title -->
+	  </if>
+	  <else>		<!-- normal chapter -->
+            <text term="in" />
+	  </else>
+	</choose>
+      </if>
+      <else-if type="paper-conference">
+        <text term="in" />
+      </else-if>
+    </choose>
+    <!-- FOREWORD_HACK End -->
+
+    <choose>
+      <if type="legal_case" match="none">
+        <choose>
+		<!-- WK 20200706: no book quotation mark for webpage title -->
+          <if type="webpage" >
+            <text variable="container-title" /> 
+          </if>
+          <else>
+            <text variable="container-title" prefix="《" suffix="》"/>
+
+	    <!-- MV_TITLES_HACK Start -->
+	    <!-- show container book individual title for chapter type -->
+	    <choose> 
+	      <if type="chapter">
+	        <choose> 
+	          <if variable="original-title">
+                    <group prefix="，">
+                      <text term="volume" form="short"/>
+                      <number variable="volume" form="numeric"/>
+                      <text variable="original-title" prefix="：《" suffix="》"/>
+    	            </group>
+	          </if>
+	        </choose>
+	      </if>
+            </choose>
+	    <!-- MV_TITLES_HACK End -->
+          </else>
+        </choose>
+      </if>
+    </choose>
+
+    <!-- FOREWORD_HACK Start -->
+    <choose>
+      <if type="chapter">
+	<choose>
+	  <if variable="genre">
+		  <!-- add the foreword after the book title -->
+	    <text variable="title" prefix="之"/>
+	  </if>
+        </choose>
+      </if>
+    </choose>
+    <!-- FOREWORD_HACK End -->
+
+  </macro>
+
+<!--  container-title  -->
+
+  <macro name="container-title">
+
+	  <!-- FOREWORD_HACK Start -->
+    <choose>
+      <if type="chapter">
+        <choose>
+	  <if variable="genre">	<!-- foreword chapter -->
+	    <text variable="title" text-case="capitalize-first" suffix=" to "/>
+	  </if>
+	  <else>		<!-- normal chapter -->
+            <text term="in" text-case="capitalize-first" suffix=" "/>
+	  </else>
+	</choose>
+      </if>
+      <else-if type="paper-conference">
+        <text term="in" text-case="capitalize-first" suffix=" "/>
+      </else-if>
+    </choose>
+	  <!-- FOREWORD_HACK End -->
+
+    <choose>
+      <if type="legal_case" match="none">
+        <choose>
+	  <!-- WK 20200706: no italics for webpage title -->
+	  <if type="webpage">
+            <text variable="container-title"/>
+          </if>
+          <else-if type="article-journal article-magazine" match="any">
+            <text variable="container-title" font-style="italic"/>
+          </else-if>
+	  <else>
+            <!--title case every container title except webpage, magazines and journals-->
+            <text variable="container-title" font-style="italic" text-case="title"/>
+
+	    <!-- MV_TITLES_HACK Start -->
+	    <!-- show book container individual title for chapter type -->
+	    <choose> 
+	      <if type="chapter">
+	        <choose>
+	          <if variable="original-title">
+                    <group prefix=", " delimiter=", ">
+	              <group>
+                        <text term="volume" form="short" text-case="capitalize-first" suffix=" "/>
+                        <number variable="volume" form="numeric"/>
+	              </group>
+                      <text variable="original-title" font-style="italic" text-case="title"/>
+    	            </group>
+	          </if>
+	        </choose>
+	      </if>
+            </choose>
+    	    <!-- MV_TITLES_HACK End -->
+
+          </else>
+        </choose>
+      </if>
+    </choose>
+  </macro>
+  
+  <macro name="container-title-zh">
+
+	  <!-- FOREWORD_HACK Start -->
+    <choose>
+      <if type="chapter">
+        <choose>
+	  <if variable="genre">	<!-- foreword chapter -->
+		  <!-- no nothing before the book title -->
+	  </if>
+	  <else>		<!-- normal chapter -->
+            <text term="in" />
+	  </else>
+	</choose>
+      </if>
+      <else-if type="paper-conference">
+        <text term="in" />
+      </else-if>
+    </choose>
+	  <!-- FOREWORD_HACK End -->
+
+    <choose>
+      <if type="legal_case" match="none">
+        <choose>
+		<!-- WK 20200706: no book quotation mark for webpage title -->
+	  <if type="webpage" >
+            <text variable="container-title" />
+          </if>
+          <else>
+            <text variable="container-title" prefix="《" suffix="》"/>
+
+	    <!-- MV_TITLES_HACK Start -->
+	    <!-- show book container individual title for chapter type -->
+	    <choose> 
+	      <if type="chapter">
+	        <choose>
+	          <if variable="original-title">
+                    <group prefix="，">
+                      <text term="volume" form="short"/>
+                      <number variable="volume" form="numeric"/>
+                      <text variable="original-title" prefix="：《" suffix="》"/>
+    	            </group>
+	          </if>
+	        </choose>
+	      </if>
+	    </choose>
+	    <!-- MV_TITLES_HACK End -->
+          </else>
+        </choose>
+      </if>
+    </choose>
+
+	  <!-- FOREWORD_HACK Start -->
+    <choose>
+      <if type="chapter">
+	<choose>
+	  <if variable="genre">
+		  <!-- add the foreword after the book title -->
+	    <text variable="title" prefix="之"/>
+	  </if>
+        </choose>
+      </if>
+    </choose>
+	  <!-- FOREWORD_HACK End -->
+  </macro>
+
+<!-- collection-title -->
+
+  <macro name="collection-title">
+    <text variable="collection-title"/>
+    <text variable="collection-number" prefix=" "/>
+  </macro>
+  
+  <macro name="collection-title-zh">
+    <text variable="collection-title"/>
+    <text variable="collection-number" prefix=""/>
+  </macro>
+  
+<!-- edition-note -->
+
+  <macro name="edition-note">
+    <choose>
+      <!-- show dictionary edition info -->
+      <if type="entry-dictionary entry-encyclopedia bill book chapter graphic legal_case legislation motion_picture paper-conference report song" match="any">
+        <choose>
+          <if is-numeric="edition">
+            <group delimiter=" ">
+              <number variable="edition" form="ordinal"/>
+              <text term="edition" form="short"/>
+            </group>
+          </if>
+          <else>
+            <text variable="edition" suffix="."/>
+          </else>
+        </choose>
+      </if>
+    </choose>
+  </macro>
+  
+  <macro name="edition-note-zh">
+    <choose>
+      <!-- show dictionary edition info -->
+      <if type="entry-dictionary entry-encyclopedia bill book chapter graphic legal_case legislation motion_picture paper-conference report song" match="any">
+        <choose>
+          <if is-numeric="edition">
+            <group delimiter="">
+              <!-- WK -->
+              <number variable="edition" form="ordinal" />
+              <text term="edition" form="short"/>
+            </group>
+          </if>
+          <else>
+            <text variable="edition" />
+          </else>
+        </choose>
+      </if>
+    </choose>
+  </macro>
+  
+<!-- edition -->
+
+  <macro name="edition">
+    <choose>
+      <!-- show dictionary edition info -->
+      <if type="entry-dictionary entry-encyclopedia bill book chapter graphic legal_case legislation motion_picture paper-conference report song" match="any">
+        <choose>
+          <if is-numeric="edition">
+            <group delimiter=" ">
+              <number variable="edition" form="ordinal"/>
+              <text term="edition" form="short"/>
+            </group>
+          </if>
+          <else>
+            <text variable="edition" text-case="capitalize-first" suffix="."/>
+          </else>
+        </choose>
+      </if>
+    </choose>
+  </macro>
+  
+  <macro name="edition-zh">
+    <choose>
+      <!-- show dictionary edition info -->
+      <if type="entry-dictionary entry-encyclopedia bill book chapter graphic legal_case legislation motion_picture paper-conference report song" match="any">
+        <choose>
+          <if is-numeric="edition">
+            <group delimiter="">
+              <!-- <number variable="edition" form="ordinal" suffix="版"/> -->
+              <number variable="edition" form="ordinal" />
+              <text term="edition" form="short"/>
+            </group>
+          </if>
+          <else>
+	  <!-- <text variable="edition" suffix="。"/> -->
+            <text variable="edition" />
+          </else>
+        </choose>
+      </if>
+    </choose>
+  </macro>
+
+<!--  locators-note  -->
+
+  <macro name="locators-note">
+    <choose>
+      <if type="article-journal article-magazine">
+        <text variable="volume" prefix=" "/>
+        <group prefix=", ">
+          <text term="issue" form="short" suffix=" "/>
+          <number variable="issue"/>
+        </group>
+      </if>
+      <else-if type="legal_case">
+        <text variable="volume" prefix=", "/>
+        <text variable="container-title" prefix=" "/>
+        <text variable="page" prefix=" "/>
+        <text variable="locator" prefix=", "/>
+      </else-if>
+
+      <else-if type="bill book chapter graphic legal_case legislation motion_picture paper-conference report song" match="any">
+        <group prefix=", " delimiter=", ">
+          <text macro="edition-note"/>
+          <group>
+	    <!-- MV_TITLES_HACK Start -->
+	    <!-- the volume no. is rendered in title-note macro -->
+	    <choose> 
+	      <if variable="original-title" match="none">
+                <text term="volume" form="short" suffix=" "/>
+                <number variable="volume" form="numeric"/>
+	      </if>
+	    </choose>
+	    <!-- MV_TITLES_HACK End -->
+          </group>
+
+	  <!-- WK: 20200706 modified -->
+	  <!-- previously, if the locator is none, number-of-volume will be shown 
+		 Now, we change it to show the number-of-volume in any case -->
+	  <!-- <choose>
+	      <if variable="locator" match="none"> -->
+          <group>
+            <number variable="number-of-volumes" form="numeric"/>
+            <text term="volume" form="short" prefix=" " plural="true"/>
+          </group>
+          <!-- </if> 
+	    </choose> -->
+        </group>
+      </else-if>
+      <else-if type="entry-dictionary entry-encyclopedia" match="any">
+        <group prefix=", " delimiter=", ">
+          <text macro="edition-note"/>
+        </group>
+      </else-if>
+    </choose>
+  </macro>
+  
+  <macro name="locators-note-zh">
+    <choose>
+      <if type="article-journal article-magazine">
+        <text variable="volume" prefix=""/>
+        <!-- WK: need to localize and clarify how the issue number is shown -->
+        <!--
+        <group prefix="，">
+          <number variable="issue"/>
+          <text term="issue" form="short" suffix=""/>
+        </group>
+        -->
+      </if>
+      <else-if type="legal_case">
+        <text variable="volume" prefix="，"/>
+        <text variable="container-title" prefix=""/>
+        <text variable="page" prefix=""/>
+        <text variable="locator" prefix="，"/>
+      </else-if>
+
+      <else-if type="bill book chapter graphic legal_case legislation motion_picture paper-conference report song" match="any">
+        <group prefix="，" delimiter="，">
+          <text macro="edition-note-zh"/>
+          <group>
+	    <!-- MV_TITLES_HACK Start -->
+	    <!-- the volume no. is rendered in title-note macro -->
+	    <choose>
+	      <if variable="original-title" match="none">
+                <text term="volume" form="short" />
+                <number variable="volume" form="numeric" />
+	      </if>
+	    </choose>
+	    <!-- MV_TITLES_HACK End -->
+          </group>
+
+	  <!-- WK: 20200706 modified -->
+	  <!-- previously, if the locator is none, number-of-volume will be shown 
+		 Now, we change it to show the number-of-volume in any case -->
+	  <!-- <choose>
+	     <if variable="locator" match="none"> -->
+          <group>
+            <number variable="number-of-volumes" form="numeric" prefix="共"/>
+            <text term="volume" form="short" />
+          </group>
+	  <!-- </if> 
+	  </choose>  -->
+        </group>
+      </else-if>
+      <else-if type="entry-dictionary entry-encyclopedia" match="any">
+        <group prefix="，" delimiter="，">
+          <text macro="edition-note-zh"/>
+        </group>
+      </else-if>
+    </choose>
+  </macro>
+  
+<!--  locators  -->
+  
+  <macro name="locators">
+    <choose>
+      <if type="article-journal article-magazine">
+        <text variable="volume" prefix=" "/>
+        <!-- WK: why was the issue number commented? --> 
+        <!-- <text variable="issue" prefix=", no. "/> -->
+      </if>
+
+      <else-if type="legal_case">
+        <text variable="volume" prefix=", "/>
+        <text variable="container-title" prefix=" "/>
+        <text variable="page" prefix=" "/>
+      </else-if>
+
+      <!-- show edition, volume ...etc info -->
+      <else-if type="bill book graphic legal_case legislation motion_picture report song" match="any">
+        <group prefix=". " delimiter=". ">
+          <text macro="edition"/>
+          <group>
+	    <!-- MV_TITLES_HACK Start -->
+	    <!-- the volume is rendered in title macro -->
+	    <choose> 
+	      <if variable="original-title" match="none">
+                <text term="volume" form="short" text-case="capitalize-first" suffix=" "/>
+                <number variable="volume" form="numeric"/>
+	      </if>
+	    </choose>
+	    <!-- MV_TITLES_HACK End -->
+          </group>
+          <group>
+            <number variable="number-of-volumes" form="numeric"/>
+            <text term="volume" form="short" prefix=" " plural="true"/>
+          </group>
+        </group>
+      </else-if>
+
+      <!-- special handling for dictionary entry -->
+      <else-if type="entry-dictionary entry-encyclopedia" match="any">
+        <group prefix=". " delimiter=". ">
+          <text macro="edition"/>
+
+	  <!-- no volume no. will be shown -->
+	  <!--
+          <group>
+	    <choose>
+	      <if variable="author">
+                 <text term="volume" form="short" text-case="capitalize-first" suffix=" "/>
+                 <number variable="volume" form="numeric"/>
+	      </if>
+            </choose>
+          </group>
+	  -->
+
+          <group>
+            <number variable="number-of-volumes" form="numeric"/>
+            <text term="volume" form="short" prefix=" " plural="true"/>
+          </group>
+        </group>
+      </else-if>
+
+      <else-if type="chapter paper-conference" match="any">
+        <group prefix=". " delimiter=". ">
+          <choose>
+            <if variable="page" match="none">
+              <group>
+                <text term="volume" form="short" text-case="capitalize-first" suffix=" "/>
+                <number variable="volume" form="numeric"/>
+              </group>
+            </if>
+          </choose>
+          <text macro="edition"/>
+        </group>
+      </else-if>
+    </choose>
+  </macro>
+    
+  <macro name="locators-zh">
+    <choose>
+      <if type="article-journal article-magazine">
+        <text variable="volume" prefix=""/>
+        <!-- WK: why was the issue number commented? --> 
+        <!-- <text variable="issue" prefix=", no. "/> -->
+      </if>
+
+      <else-if type="legal_case">
+        <text variable="volume" prefix="，"/>
+        <text variable="container-title" prefix=""/>
+        <text variable="page" prefix=""/>
+      </else-if>
+
+      <!-- show edition, volume ...etc info -->
+      <else-if type="bill book graphic legal_case legislation motion_picture report song" match="any">
+        <group prefix="。" delimiter="。">
+          <text macro="edition-zh"/>
+          <group>
+	    <!-- MV_TITLES_HACK Start -->
+	    <!-- the volume is rendered in title macro -->
+	    <choose> 
+	      <if variable="original-title" match="none">
+                <text term="volume" form="short" />
+                <number variable="volume" form="numeric" />
+	      </if>
+	    </choose>
+	    <!-- MV_TITLES_HACK End -->
+          </group>
+
+          <group>
+            <!-- WK -->
+            <number variable="number-of-volumes" form="numeric" prefix="共" />
+            <text term="volume" form="short" />
+          </group>
+        </group>
+      </else-if>
+
+      <!-- special handling for dictionary entry -->
+      <else-if type="entry-dictionary entry-encyclopedia" match="any">
+        <group prefix="。" delimiter="。">
+          <text macro="edition-zh"/>
+
+	  <!-- no volume no. will be shown -->
+	  <!--
+          <group>
+	    <choose>
+	      <if variable="author">
+                 <text term="volume" form="short" />
+                 <number variable="volume" form="numeric" />
+	      </if>
+            </choose>
+          </group>
+	  -->
+
+          <!-- WK -->
+          <group>
+            <number variable="number-of-volumes" form="numeric" prefix="共" />
+            <text term="volume" form="short" />
+          </group>
+        </group>
+	
+      </else-if>
+
+      <else-if type="chapter paper-conference" match="any">
+        <group prefix="。" delimiter="。">
+          <choose>
+            <if variable="page" match="none">
+              <group>
+                <!-- WK -->
+                <text term="volume" form="short" />
+                <number variable="volume" form="numeric" />
+              </group>
+            </if>
+          </choose>
+          <text macro="edition-zh"/>
+        </group>
+      </else-if>
+    </choose>
+  </macro>
+
+<!--  locators-newspaper  -->
+  
+  <macro name="locators-newspaper">
+    <choose>
+      <if type="article-newspaper">
+        <group delimiter=", ">
+          <group delimiter=" ">
+            <text variable="edition"/>
+            <text term="edition"/>
+          </group>
+          <group>
+            <text term="section" form="short" suffix=" "/>
+            <text variable="section"/>
+          </group>
+        </group>
+      </if>
+    </choose>
+  </macro>
+  
+  <macro name="locators-newspaper-zh">
+    <choose>
+      <if type="article-newspaper">
+        <group delimiter="，">
+          <group delimiter="">
+            <text variable="edition"/>
+            <text term="edition"/>
+          </group>
+          <group>
+            <text variable="section"/> <!-- ***How is this handled in Chinese? -->
+            <text term="section" form="short" suffix=""/> <!-- ***How is this handled in Chinese? -->
+          </group>
+        </group>
+      </if>
+    </choose>
+  </macro>
+  
+<!-- event   -->
+  <macro name="event-note">
+    <group>
+      <text term="presented at" text-case="lowercase" suffix=" "/>
+      <text variable="event"/>
+    </group>
+  </macro>
+  
+  <macro name="event-note-zh">
+    <group>
+      <text variable="event"/>
+      <text term="presented at" suffix=""/> 
+    </group>
+  </macro>
+
+  <macro name="event">
+    <group>
+      <text term="presented at" text-case="capitalize-first" suffix=" "/>
+      <text variable="event"/>
+    </group>
+  </macro>
+  
+  <macro name="event-zh">
+    <group>
+      <text variable="event"/>
+      <text term="presented at" suffix=""/>
+    </group>
+  </macro>
+
+<!--  publisher  -->
+  <macro name="publisher">
+    <choose>
+      <if type="thesis">
+        <text variable="publisher"/>
+      </if>
+      <else>
+        <group delimiter=": ">
+          <text variable="publisher-place"/>
+          <text variable="publisher"/>
+        </group>
+      </else>
+    </choose>
+  </macro>
+  
+  <macro name="publisher-zh">
+    <choose>
+      <if type="thesis">
+        <text variable="publisher"/>
+      </if>
+      <else>
+        <group delimiter="：">
+          <text variable="publisher-place"/>
+          <text variable="publisher"/>
+        </group>
+      </else>
+    </choose>
+  </macro>
+
+<!--  issued  -->
+
+  <macro name="issued">
+    <choose>
+      <if variable="issued">
+        <choose>
+          <if type="graphic report" match="any">
+            <date variable="issued">
+              <date-part name="month" suffix=" "/>
+              <date-part name="day" suffix=", "/>
+              <date-part name="year"/>
+            </date>
+          </if>
+          <else-if type="legal_case">
+            <text variable="authority" suffix=" "/>
+            <date variable="issued">
+              <date-part name="year"/>
+            </date>
+          </else-if>
+          <!-- WK: fix the problem of wrong year presentation of article-journal and entry-dictionary -->
+	  <!-- <else-if type="bill book chapter graphic legal_case legislation motion_picture paper-conference report song thesis" match="any"> -->
+          <else-if type="article-journal entry-dictionary entry-encyclopedia bill book chapter graphic legal_case legislation motion_picture report song thesis" match="any">
+            <date variable="issued">
+              <date-part name="year"/>
+            </date>
+          </else-if>
+          <else>
+            <date variable="issued">
+              <date-part name="month" suffix=" "/>
+              <date-part name="day" suffix=", "/>
+              <date-part name="year"/>
+            </date>
+          </else>
+        </choose>
+      </if>
+      <else>
+	<!-- a dirty fix using type of manuscript to handle meeting minute -->
+	<choose>
+	  <if type="manuscript" match="none">
+            <text term="no date" form="short"/>
+	  </if>
+	</choose>
+      </else>
+    </choose>
+  </macro>
+
+  <macro name="issued-zh">
+    <choose>
+      <if variable="issued">
+        <choose>
+          <if type="graphic report" match="any">
+            <!-- WK -->
+            <date variable="issued" >
+              <date-part name="year" suffix="年"/>
+              <date-part name="month" form="numeric" suffix="月"/>
+              <date-part name="day" suffix="日"/>
+            </date>
+          </if>
+          <else-if type="legal_case">
+            <text variable="authority" suffix=""/>
+            <date variable="issued">
+              <date-part name="year"/>
+            </date>
+          </else-if>
+          <!-- WK: fix the problem of wrong year presentation of article-journal and entry-dictionary -->
+          <!-- <else-if type="bill book chapter graphic legal_case legislation motion_picture paper-conference report song thesis" match="any"> -->
+          <else-if type="article-journal entry-dictionary entry-encyclopedia bill book chapter graphic legal_case legislation motion_picture report song thesis" match="any">
+	    <date variable="issued">
+	      <date-part name="year"/>
+	    </date>
+          </else-if>
+          <else>
+            <!-- WK -->
+            <date variable="issued" >
+              <date-part name="year" suffix="年"/>
+              <date-part name="month" form="numeric" suffix="月"/>
+              <date-part name="day" suffix="日"/>
+            </date>
+          </else>
+        </choose>
+      </if>
+      <else>
+	<!-- a dirty fix using type of manuscript to handle meeting minute -->
+	<choose>
+	  <if type="manuscript" match="none">
+            <text term="no date" form="short"/> 
+	  </if>
+	</choose>
+      </else>
+    </choose>
+  </macro>
+  
+<!--  point-locators-subsequent  -->
+
+  <macro name="point-locators-subsequent">
+    <group>
+      <choose>
+        <if locator="page" match="none">
+          <choose>
+            <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
+              <choose>
+                <if variable="volume">
+                  <group>
+                    <text term="volume" form="short" suffix=" "/>
+                    <number variable="volume" form="numeric"/>
+                    <label variable="locator" form="short" prefix=", " suffix=" "/>
+                  </group>
+                </if>
+                <else>
+                  <label variable="locator" form="short" suffix=" "/>
+                </else>
+              </choose>
+            </if>
+          </choose>
+        </if>
+        <else-if type="bill book graphic legal_case legislation motion_picture report song" match="any">
+	  <!-- MV_TITLES_HACK Start -->
+	  <!-- do not show volume no. if it has individual title -->
+	  <!-- <number variable="volume" form="numeric" suffix=":"/> -->
+	  <choose>
+	    <if variable="original-title" match="none">
+	      <number variable="volume" form="numeric" suffix=":"/> 
+	    </if>
+	  </choose>
+	  <!-- MV_TITLES_HACK End -->
+        </else-if>
+      </choose>
+      <text variable="locator"/>
+    </group>
+  </macro>
+
+  <macro name="point-locators-subsequent-zh">
+    <group>
+      <choose>
+        <if locator="page" match="none">
+          <choose>
+            <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
+              <choose>
+                <if variable="volume"> <!-- ***How is this handled in Chinese? -->
+                  <group>
+                    <text term="volume" form="short"/>
+                    <number variable="volume" form="numeric"/>
+                    <label variable="locator" form="short" prefix="，" suffix=""/>
+                  </group>
+                </if>
+                <else>
+                  <label variable="locator" form="short" suffix=""/>
+                </else>
+              </choose>
+            </if>
+          </choose>
+        </if>
+        <else-if type="bill book graphic legal_case legislation motion_picture report song" match="any">
+	  <!-- MV_TITLES_HACK Start -->
+	  <!-- do not show volume no. if it has individual title -->
+	  <!-- <number variable="volume" form="numeric" suffix=":"/> -->
+	  <choose>
+	    <if variable="original-title" match="none">
+	      <number variable="volume" form="numeric" suffix=":"/> 
+	    </if>
+	  </choose>
+	  <!-- MV_TITLES_HACK End -->
+        </else-if>
+      </choose>
+      <text variable="locator"/>
+    </group>
+  </macro>
+
+<!-- point-locators  -->
+
+  <macro name="point-locators">
+    <choose>
+      <if variable="locator" match="none">
+        <text macro="pages"/>
+      </if>
+      <else-if type="article-journal">
+        <text variable="locator" prefix=": "/>
+      </else-if>
+      <else-if type="legal_case"/>
+      <else>
+        <group prefix=", ">
+          <choose>
+            <if locator="page" match="none">
+              <label variable="locator" form="short" suffix=" "/>
+            </if>
+          </choose>
+          <text variable="locator"/>
+        </group>
+      </else>
+    </choose>
+  </macro>
+  
+  <macro name="point-locators-zh">
+    <choose>
+      <if variable="locator" match="none">
+        <text macro="pages-zh"/>
+      </if>
+      <else-if type="article-journal">
+        <text variable="locator" prefix="："/>
+      </else-if>
+      <else-if type="legal_case"/>
+      <else>
+        <group prefix="，">
+          <choose>
+            <if locator="page" match="none">
+              <label variable="locator" form="short" suffix=""/>
+            </if>
+          </choose>
+          <text variable="locator"/>
+        </group>
+      </else>
+    </choose>
+  </macro>  
+  
+<!--  pages  -->
+
+  <macro name="pages">
+    <choose>
+      <if type="article-journal">
+        <text variable="page" prefix=": "/>
+      </if>
+      <else-if type="chapter paper-conference article-magazine" match="any">
+        <text variable="page" prefix=", "/>
+      </else-if>
+    </choose>
+  </macro>
+
+  <macro name="pages-zh">
+    <choose>
+      <if type="article-journal">
+        <text variable="page" prefix="："/>
+      </if>
+      <else-if type="chapter paper-conference article-magazine" match="any">
+        <text variable="page" prefix="，"/>
+      </else-if>
+    </choose>
+  </macro>
+    
+<!--  locators-chapter  -->
+  
+  <macro name="locators-chapter">
+    <choose>
+      <!-- show dictionary entry page no. -->
+      <if type="chapter paper-conference" match="any">
+        <choose>
+          <if variable="page">
+	    <!-- MV_TITLES_HACK Start -->
+	    <!-- do not show volume no. if it has individual title -->
+	    <!--<text variable="volume" suffix=":"/>-->
+	    <!--<text variable="page"/>-->
+	    <choose>
+	      <if variable="original-title" match="none">
+                <text variable="volume" suffix=":"/>
+	      </if>
+	    </choose>
+            <text variable="page"/>
+	    <!-- MV_TITLES_HACK End -->
+          </if>
+        </choose>
+      </if>
+
+      <!-- show dictionary entry page no. if entry author exists -->
+      <else-if type="entry-dictionary entry-encyclopedia" match="any">
+        <choose>
+          <if variable="page">
+	    <choose>
+	      <if variable="author">
+                <text variable="volume" suffix=":"/>
+                <text variable="page"/>
+              </if>
+            </choose>
+          </if>
+        </choose>
+      </else-if>
+    </choose>
+  </macro>
+
+  <macro name="locators-chapter-zh">
+    <choose>
+      <if type="chapter paper-conference" match="any">
+        <choose>
+          <if variable="page">
+	    <!-- MV_TITLES_HACK Start -->
+	    <!-- do not show volume no. if it has individual title -->
+	    <!--<text variable="volume" suffix="："/>-->
+	    <!--<text variable="page"/>-->
+	    <choose>
+	      <if variable="original-title" match="none">
+                <text variable="volume" suffix=":"/>
+	      </if>
+	    </choose>
+            <text variable="page"/>
+	    <!-- MV_TITLES_HACK End -->
+          </if>
+        </choose>
+      </if>
+
+      <!-- show dictionary entry page no. if entry author exists -->
+      <else-if type="entry-dictionary entry-encyclopedia" match="any">
+        <choose>
+          <if variable="page">
+	    <choose>
+	      <if variable="author">
+	        <text variable="volume" suffix=":"/>
+                <text variable="page"/>
+              </if>
+            </choose>
+          </if>
+        </choose>
+      </else-if>
+    </choose>
+  </macro>  
+  
+<!--  locators-journal  -->
+
+  <macro name="locators-journal">
+    <choose>
+      <if type="article-journal">
+        <text variable="page" prefix=": "/>
+      </if>
+      <else-if type="article-magazine">
+        <text variable="page" prefix=", "/>
+      </else-if>      
+    </choose>
+  </macro>
+  
+  <macro name="locators-journal-zh">
+    <choose>
+      <if type="article-journal">
+        <text variable="page" prefix="："/>
+      </if>
+      <else-if type="article-magazine">
+        <text variable="page" prefix="，"/>
+      </else-if>      
+    </choose>
+  </macro>
+
+<!-- archive-note -->
+  
+  <macro name="archive-note">
+    <group delimiter=", ">
+      <text variable="archive_location"/>
+      <text variable="archive"/>
+      <text variable="archive-place"/>
+    </group>
+  </macro>
+  
+  <macro name="archive-note-zh">
+    <group delimiter="，">
+      <text variable="archive_location"/>
+      <text variable="archive"/>
+      <text variable="archive-place"/>
+    </group>
+  </macro>
+
+<!--  archive  -->
+  
+  <macro name="archive">
+    <group delimiter=". ">
+      <text variable="archive_location" text-case="capitalize-first"/>
+      <text variable="archive"/>
+      <text variable="archive-place"/>
+    </group>
+  </macro>
+  
+  <macro name="archive-zh">
+    <group delimiter="。">
+      <text variable="archive_location" text-case="capitalize-first"/>
+      <text variable="archive"/>
+      <text variable="archive-place"/>
+    </group>
+  </macro>  
+  
+<!--  issue-note  -->
+  
+  <macro name="issue-note">
+    <choose>
+      <if type="article-journal legal_case" match="any">
+        <text macro="issued" prefix=" (" suffix=")"/>
+      </if>
+      <else-if variable="publisher-place publisher" match="any">
+        <group prefix=" (" suffix=")" delimiter=", ">
+          <group delimiter=" ">
+            <choose>
+              <if variable="title" match="none"/>
+              <else-if type="thesis speech" match="any">
+                <text variable="genre" text-case="lowercase"/>
+              </else-if>
+            </choose>
+            <text macro="event-note"/>
+          </group>
+          <text macro="publisher"/>
+          <text macro="issued"/>
+        </group>
+      </else-if>
+      <else-if type="webpage" match="none">
+        <text macro="issued" prefix=", "/>
+      </else-if>
+    </choose>
+  </macro>
+  
+  <macro name="issue-note-zh">
+    <choose>
+      <if type="article-journal legal_case" match="any">
+        <!-- WK -->
+        <text macro="issued-zh" prefix="（" suffix="）"/>
+      </if>
+      <else-if variable="publisher-place publisher" match="any">
+        <group prefix="（" suffix="）" delimiter="，">
+          <group delimiter="">
+            <choose>
+              <if variable="title" match="none"/>
+              <else-if type="thesis speech" match="any">
+                <text variable="genre"/>
+              </else-if>
+            </choose>
+            <text macro="event-note-zh"/>
+          </group>
+          <text macro="publisher-zh"/>
+          <text macro="issued-zh"/>
+        </group>
+      </else-if>
+      <else-if type="webpage" match="none">
+        <!-- WK -->
+        <text macro="issued-zh" prefix="，"/>
+      </else-if>
+    </choose>
+  </macro>
+  
+<!--  issue  -->
+  
+  <macro name="issue">
+    <choose>
+      <if type="article-journal legal_case" match="any">
+        <text macro="issued" prefix=" (" suffix=")"/>
+      </if>
+      <else-if type="speech">
+        <choose>
+          <if variable="title" match="none"/>
+          <else>
+            <text variable="genre" text-case="capitalize-first" prefix=". "/>
+          </else>
+        </choose>
+        <text macro="event" prefix=" "/>
+        <text variable="event-place" prefix=", "/>
+        <text macro="issued" prefix=", "/>
+      </else-if>
+      <else-if variable="publisher-place publisher" match="any">
+        <group prefix=". " delimiter=", ">
+          <choose>
+            <if type="thesis">
+              <text variable="genre" text-case="capitalize-first"/>
+            </if>
+	    <!-- WK: 20200713: Add event in bibliography for conference paper -->
+	    <else-if type="paper-conference">
+              <text macro="event"/>
+	    </else-if>
+          </choose>
+          <text macro="publisher"/>
+          <text macro="issued"/>
+        </group>
+      </else-if>
+      <else-if type="webpage" match="none">
+        <text macro="issued" prefix=", "/>
+      </else-if>
+    </choose>
+  </macro>
+
+  <macro name="issue-zh">
+    <choose>
+      <if type="article-journal legal_case" match="any">
+        <text macro="issued-zh" prefix="（" suffix="）"/>
+      </if>
+      <else-if type="speech">
+        <choose>
+          <if variable="title" match="none"/>
+          <else>
+            <text variable="genre" text-case="capitalize-first" prefix="。"/>
+          </else>
+        </choose>
+        <text macro="event-zh"/>
+        <text variable="event-place" prefix="，"/>
+        <text macro="issued-zh" prefix="，"/>
+      </else-if>
+      <else-if variable="publisher-place publisher" match="any">
+        <group prefix="。" delimiter="，">
+          <choose>
+            <if type="thesis">
+              <text variable="genre" text-case="capitalize-first"/>
+            </if>
+	    <!-- WK: 20200713: Add event in bibliography for conference paper -->
+	    <else-if type="paper-conference">
+              <text macro="event-zh"/>
+	    </else-if>
+          </choose>
+          <text macro="publisher-zh"/>
+          <text macro="issued-zh"/>
+        </group>
+      </else-if>
+      <else-if type="webpage" match="none">
+        <text macro="issued-zh" prefix="，"/>
+      </else-if>
+    </choose>
+  </macro>
+
+<!-- access-note -->
+
+  <macro name="access-note">
+    <group delimiter=", ">
+      <choose>
+        <if type="graphic report" match="any">
+          <text macro="archive-note"/>
+        </if>
+        <else-if type="article-journal article-magazine article-newspaper bill book chapter graphic legal_case legislation motion_picture paper-conference report song thesis" match="none">
+          <text macro="archive-note"/>
+        </else-if>
+      </choose>
+      <choose>
+        <if type="legal_case" match="none">
+          <choose>
+            <if variable="URL">
+
+              <group delimiter=", ">
+                <choose>
+                  <if type="webpage">
+                    <group>
+                      <text term="retrieved" suffix=" "/>
+                      <date variable="issued">
+                        <date-part name="month" suffix=" "/>
+                        <date-part name="day" suffix=", "/>
+                        <date-part name="year"/>
+                      </date>
+                    </group>
+		    <group>
+                      <text term="accessed" suffix=" "/>
+                      <date variable="accessed">
+                        <date-part name="month" suffix=" "/>
+                        <date-part name="day" suffix=", "/>
+                        <date-part name="year"/>
+                      </date>
+		    </group>
+                  </if>
+                </choose>
+                <text variable="URL" />
+              </group>
+
+            </if>
+          </choose>
+        </if>
+      </choose>
+    </group>
+  </macro>
+  
+  <macro name="access-note-zh">
+    <group delimiter="，">
+      <choose>
+        <if type="graphic report" match="any">
+          <text macro="archive-note-zh"/>
+        </if>
+        <else-if type="article-journal article-magazine article-newspaper bill book chapter graphic legal_case legislation motion_picture paper-conference report song thesis" match="none">
+          <text macro="archive-note-zh"/>
+        </else-if>
+      </choose>
+      <choose>
+        <if type="legal_case" match="none">
+          <choose>
+            <if variable="URL">
+
+              <group delimiter="，">
+                <choose>
+                  <if type="webpage">
+		    <group>
+                      <date variable="issued">
+                        <date-part name="year" suffix="年"/>
+                        <date-part name="month" form="numeric" suffix="月"/>
+                        <date-part name="day" suffix="日"/>
+                      </date>
+                      <text term="retrieved" suffix=""/>
+	            </group>
+		    <group>
+                      <date variable="accessed">
+                        <date-part name="year" suffix="年"/>
+                        <date-part name="month" form="numeric" suffix="月"/>
+                        <date-part name="day" suffix="日"/>
+                      </date>
+                      <text term="accessed" suffix=""/>
+	            </group>
+                  </if>
+                </choose>
+                <text variable="URL"/>
+              </group>
+
+            </if>
+          </choose>
+        </if>
+      </choose>
+    </group>
+  </macro>
+
+<!-- access -->
+  
+  <macro name="access">
+    <group delimiter=". ">
+      <choose>
+        <if type="graphic report" match="any">
+          <text macro="archive"/>
+        </if>
+        <else-if type="article-journal article-magazine article-newspaper bill book chapter graphic legal_case legislation motion_picture paper-conference report song thesis" match="none">
+          <text macro="archive"/>
+        </else-if>
+      </choose>
+      <choose>
+        <if type="legal_case" match="none">
+          <choose>
+            <if variable="URL">
+		    
+              <group delimiter=". ">
+                <choose>
+                  <if type="webpage">
+		    <group>
+                      <text term="retrieved" suffix=" " text-case="capitalize-first"/>
+                      <date variable="issued">
+                        <date-part name="month" suffix=" "/>
+                        <date-part name="day" suffix=", "/>
+                        <date-part name="year"/>
+                      </date>
+	            </group>
+		    <group>
+                      <text term="accessed" suffix=" " text-case="capitalize-first"/>
+                      <date variable="accessed">
+                        <date-part name="month" suffix=" "/>
+                        <date-part name="day" suffix=", "/>
+                        <date-part name="year"/>
+                      </date>
+	            </group>
+                  </if>
+                </choose>
+                <text variable="URL"/>
+              </group>
+
+            </if>
+          </choose>
+        </if>
+      </choose>
+    </group>
+  </macro>
+
+  <macro name="access-zh">
+    <group delimiter="。">
+      <choose>
+        <if type="graphic report" match="any">
+          <text macro="archive-zh"/>
+        </if>
+        <else-if type="article-journal article-magazine article-newspaper bill book chapter graphic legal_case legislation motion_picture paper-conference report song thesis" match="none">
+          <text macro="archive-zh"/>
+        </else-if>
+      </choose>
+      <choose>
+        <if type="legal_case" match="none">
+          <choose>
+            <if variable="URL">
+
+              <group delimiter="。">
+                <choose>
+                  <if type="webpage">
+		    <group>
+                      <date variable="issued">
+                        <date-part name="year" suffix="年"/>
+                        <date-part name="month" form="numeric" suffix="月"/>
+                        <date-part name="day" suffix="日"/>
+                      </date>
+                      <text term="retrieved" suffix=""/>
+	            </group>
+		    <group>
+                      <date variable="accessed">
+                        <date-part name="year" suffix="年"/>
+                        <date-part name="month" form="numeric" suffix="月"/>
+                        <date-part name="day" suffix="日"/>
+                      </date>
+                      <text term="accessed" suffix=""/>
+	            </group>
+                  </if>
+                </choose>
+                <text variable="URL"/>
+              </group>
+
+            </if>
+          </choose>
+        </if>
+      </choose>
+    </group>
+  </macro>
+  
+<!--  Citations  -->
+  <macro name="chinese-citation" >
+    <choose>
+      <if position="ibid ibid-with-locator subsequent" match="any">
+        <group delimiter="，">
+          <text macro="contributors-short-zh"/>
+          <text macro="title-short-zh"/>
+          <text macro="point-locators-subsequent-zh"/>
+        </group>
+      </if>
+      <else>
+        <group delimiter="，">
+          <text macro="contributors-note-zh"/>
+          <text macro="title-note-zh"/>
+          <text macro="description-note-zh"/>
+          <text macro="secondary-contributors-note-zh"/>
+          <text macro="container-title-note-zh"/>
+          <text macro="container-contributors-note-zh"/>
+        </group>
+        <text macro="locators-note-zh"/>
+        <text macro="collection-title-zh" prefix="，"/>
+        <text macro="issue-note-zh"/>
+        <text macro="locators-newspaper-zh" prefix="，"/>
+        <text macro="point-locators-zh"/>
+        <text macro="access-note-zh" prefix="，"/>
+      </else>
+    </choose>
+  </macro>
+  
+  <citation et-al-min="4" et-al-use-first="1" disambiguate-add-names="true">
+
+    <!-- Chinese citation -->
+    <layout locale="zh-TW"  suffix="。" delimiter="；">
+      <text macro="chinese-citation" />
+    </layout>
+    <layout locale="zh-CN"  suffix="。" delimiter="；">
+      <text macro="chinese-citation" />
+    </layout>
+
+    <layout locale="zh-tw"  suffix="。" delimiter="；">
+      <text macro="chinese-citation" />
+    </layout>
+    <layout locale="zh-cn"  suffix="。" delimiter="；">
+      <text macro="chinese-citation" />
+    </layout>
+    <layout locale="zh"  suffix="。" delimiter="；">
+      <text macro="chinese-citation" />
+    </layout>
+    <layout locale="Chinese"  suffix="。" delimiter="；">
+      <text macro="chinese-citation" />
+    </layout>
+    <layout locale="chinese"  suffix="。" delimiter="；">
+      <text macro="chinese-citation" />
+    </layout>
+
+    <!-- English citation -->
+    <layout suffix="." delimiter="; ">
+      <choose>
+        <if position="ibid ibid-with-locator subsequent" match="any">
+          <group delimiter=", ">
+            <text macro="contributors-short"/>
+            <text macro="title-short"/>
+            <text macro="point-locators-subsequent"/>
+          </group>
+        </if>
+        <else>
+          <group delimiter=", ">
+            <text macro="contributors-note"/>
+            <text macro="title-note"/>
+            <text macro="description-note"/>
+            <text macro="secondary-contributors-note"/>
+            <text macro="container-title-note"/>
+            <text macro="container-contributors-note"/>
+          </group>
+          <text macro="locators-note"/>
+          <text macro="collection-title" prefix=", "/>
+          <text macro="issue-note"/>
+          <text macro="locators-newspaper" prefix=", "/>
+          <text macro="point-locators"/>
+          <text macro="access-note" prefix=", "/>
+        </else>
+      </choose>
+    </layout>
+
+  </citation>
+  
+  <!-- Bibliography -->
+  <macro name="chinese-bibliography" >
+    <group delimiter="。">
+      <text macro="contributors-zh"/>
+      <text macro="title-zh"/>
+      <text macro="description-zh"/>
+      <text macro="secondary-contributors-zh"/>
+
+      <group delimiter="，">
+        <text macro="container-title-zh"/>
+        <text macro="container-contributors-zh"/>
+        <text macro="locators-chapter-zh"/>
+      </group>
+    </group>
+
+    <text macro="locators-zh"/>
+    <text macro="collection-title-zh" prefix="。"/>
+    <text macro="issue-zh"/>
+    <text macro="locators-newspaper-zh" prefix="，"/>
+    <text macro="locators-journal-zh"/>
+    <text macro="access-zh" prefix="。"/>
+  </macro>
+
+  <bibliography 
+    hanging-indent="true" 
+    et-al-min="11" 
+    et-al-use-first="7" 
+    subsequent-author-substitute="&#8212;&#8212;&#8212;" 
+    entry-spacing="1">
+
+    <sort>
+      <key macro="contributors-sort"/>
+      <key variable="title"/>
+      <key variable="genre"/>
+      <key variable="issued"/>
+    </sort>
+
+    <!-- Chinese Bibliography Layout -->
+    <layout locale="zh-TW" suffix="。" >
+      <text macro="chinese-bibliography" />
+    </layout>   
+    <layout locale="zh-CN" suffix="。" >
+      <text macro="chinese-bibliography" />
+    </layout>   
+
+    <layout locale="zh-tw" suffix="。" >
+      <text macro="chinese-bibliography" />
+    </layout>   
+    <layout locale="zh-cn" suffix="。" >
+      <text macro="chinese-bibliography" />
+    </layout>   
+    <layout locale="zh" suffix="。" >
+      <text macro="chinese-bibliography" />
+    </layout>   
+    <layout locale="Chinese" suffix="。" >
+      <text macro="chinese-bibliography" />
+    </layout>   
+    <layout locale="chinese" suffix="。" >
+      <text macro="chinese-bibliography" />
+    </layout>   
+
+    
+    <!-- English Bibliography Layout -->
+    <layout suffix=".">
+      <group delimiter=". ">
+        <text macro="contributors"/>
+        <text macro="title"/>
+        <text macro="description"/>
+        <text macro="secondary-contributors"/>
+        <group delimiter=", ">
+          <text macro="container-title"/>
+          <text macro="container-contributors"/>
+          <text macro="locators-chapter"/>
+        </group>
+      </group>
+      <text macro="locators"/>
+      <text macro="collection-title" prefix=". "/>
+      <text macro="issue"/>
+      <text macro="locators-newspaper" prefix=", "/>
+      <text macro="locators-journal"/>
+      <text macro="access" prefix=". "/>
+    </layout>
+    
+  </bibliography>
+</style>


### PR DESCRIPTION
This CSL is modified on the basis of Turabian 8th full note CSL to support both English and Chinese citation at the same time. The English part basically follows the Turabian formatting standard. For the Chinese part, we comply with the Chinese formatting standard according to _A handbook for research writing : for biblical, theological, and pastoral ministry-related studies_ which is wildly used by Chinese academics in the field of theology. 

For the reference of the handbook, please visit the following link,  [https://www.sbc.edu.sg/sbc-publications/](url)