### PR TITLE
Changes to match Taxon guidelines for authors

### DIFF
--- a/taxon.csl
+++ b/taxon.csl
@@ -18,7 +18,7 @@
     <category field="botany"/>
     <issn>0040-0262</issn>
     <eissn>1996-8175</eissn>
-    <updated>2018-05-22T00:59:23+00:00</updated>
+    <updated>2020-08-20T12:00:00+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale xml:lang="en">
@@ -573,7 +573,7 @@
         </group>
       </if>
     </choose>
-  </macro>    
+  </macro>
   <citation et-al-min="3" et-al-use-first="1" disambiguate-add-year-suffix="true" collapse="year" givenname-disambiguation-rule="primary-name">
     <sort>
       <key macro="issued-sort"/>

--- a/taxon.csl
+++ b/taxon.csl
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" demote-non-dropping-particle="never" default-locale="en-GB">
+<style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" demote-non-dropping-particle="never" default-locale="en-US">
   <info>
     <title>Taxon</title>
     <id>http://www.zotero.org/styles/taxon</id>
@@ -10,11 +10,15 @@
       <name>Patrick O'Brien, PhD</name>
       <email>obrienpat86@gmail.com</email>
     </author>
+    <contributor>
+      <name>Mark A. Garland</name>
+      <email>magarland@gmail.com</email>
+    </contributor>
     <category citation-format="author-date"/>
     <category field="botany"/>
     <issn>0040-0262</issn>
     <eissn>1996-8175</eissn>
-    <updated>2017-02-16T17:39:38+00:00</updated>
+    <updated>2018-05-22T00:59:23+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale xml:lang="en">
@@ -32,11 +36,11 @@
       <if type="chapter paper-conference entry-dictionary entry-encyclopedia" match="any">
         <group delimiter=", ">
           <names variable="container-author" delimiter=", ">
-            <name and="symbol" initialize-with=". " delimiter=", "/>
+            <name and="symbol" initialize-with="." delimiter=", "/>
             <label form="short" prefix=" (" text-case="title" suffix=")"/>
           </names>
           <names variable="editor translator" delimiter=", ">
-            <name and="symbol" initialize-with=". " delimiter=", "/>
+            <name and="symbol" initialize-with="." delimiter=", "/>
             <label form="short" prefix=" (" suffix=")"/>
           </names>
         </group>
@@ -48,11 +52,11 @@
       <if type="article-journal chapter paper-conference entry-dictionary entry-encyclopedia" match="none">
         <group delimiter=", " prefix=" ">
           <names variable="container-author" delimiter=", ">
-            <name and="symbol" initialize-with=". " delimiter=", "/>
+            <name and="symbol" initialize-with="." delimiter=", "/>
             <label form="short" prefix=", " text-case="title"/>
           </names>
           <names variable="editor translator" delimiter=", ">
-            <name and="symbol" initialize-with=". " delimiter=", "/>
+            <name and="symbol" initialize-with="." delimiter=", "/>
             <label form="short" prefix=", " text-case="title"/>
           </names>
         </group>
@@ -61,8 +65,8 @@
   </macro>
   <macro name="author">
     <names variable="author" font-weight="bold">
-      <name name-as-sort-order="all" and="symbol" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
-      <label form="short" prefix=" (" suffix=")" text-case="capitalize-first"/>
+      <name name-as-sort-order="all" and="symbol" sort-separator=", " initialize-with="." delimiter=", " delimiter-precedes-last="always"/>
+      <label form="short" prefix=" (" suffix=")" text-case="lowercase"/>
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
@@ -80,7 +84,7 @@
   </macro>
   <macro name="author-short">
     <names variable="author">
-      <name form="short" and="symbol" delimiter=", " initialize-with=". "/>
+      <name form="short" and="symbol" delimiter=", " initialize-with="."/>
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
@@ -146,9 +150,13 @@
               <if type="webpage">
                 <group delimiter=" ">
                   <text variable="URL"/>
-                  <group delimiter=" " prefix="(" suffix=")">
+                  <group delimiter=" " prefix="(" suffix="). ">
                     <text term="accessed"/>
-                    <date form="text" variable="accessed"/>
+                    <date variable="accessed" delimiter=" ">
+                      <date-part name="day"/>
+                      <date-part name="month" form="short" strip-periods="true"/>
+                      <date-part name="year"/>
+                    </date>
                   </group>
                 </group>
               </if>
@@ -186,7 +194,7 @@
                 <text variable="reviewed-title" font-style="italic" prefix="Review of "/>
                 <names variable="reviewed-author" delimiter=", ">
                   <label form="verb-short" suffix=" "/>
-                  <name and="symbol" initialize-with=". " delimiter=", "/>
+                  <name and="symbol" initialize-with="." delimiter=", "/>
                 </names>
               </group>
             </group>
@@ -196,7 +204,7 @@
               <text variable="title" font-style="italic" prefix="Review of "/>
               <names variable="reviewed-author" delimiter=", ">
                 <label form="verb-short" suffix=" "/>
-                <name and="symbol" initialize-with=". " delimiter=", "/>
+                <name and="symbol" initialize-with="." delimiter=", "/>
               </names>
             </group>
           </else>
@@ -414,7 +422,7 @@
   <macro name="locators">
     <choose>
       <if type="article-journal article-magazine" match="any">
-        <group delimiter=": " prefix=", ">
+        <group delimiter=": " prefix=" ">
           <group>
             <text variable="volume" font-style="normal"/>
           </group>
@@ -437,7 +445,7 @@
         </group>
       </else-if>
       <else-if type="book graphic motion_picture report song chapter paper-conference entry-encyclopedia entry-dictionary" match="any">
-        <group prefix=" (" suffix=")" delimiter=", ">
+        <group prefix=", " delimiter=", ">
           <choose>
             <if type="report" match="none">
               <text macro="edition"/>
@@ -446,13 +454,13 @@
           <choose>
             <if variable="volume" match="any">
               <group>
-                <text term="volume" form="short" text-case="capitalize-first" suffix=" "/>
+                <text term="volume" form="short" text-case="lowercase" suffix=" "/>
                 <number variable="volume" form="numeric"/>
               </group>
             </if>
             <else>
               <group>
-                <text term="volume" form="short" plural="true" text-case="capitalize-first" suffix=" "/>
+                <text term="volume" form="short" plural="true" text-case="lowercase" suffix=" "/>
                 <number variable="number-of-volumes" form="numeric" prefix="1&#8211;"/>
               </group>
             </else>
@@ -478,11 +486,11 @@
         <if locator="chapter">
           <label variable="locator" form="long" text-case="capitalize-first"/>
         </if>
-        <else>
-          <label variable="locator" form="short"/>
-        </else>
+        <else-if locator="page" match="none">
+          <label variable="locator" form="short" suffix=" "/>
+        </else-if>
       </choose>
-      <text variable="locator" prefix=" "/>
+      <text variable="locator"/>
     </group>
   </macro>
   <macro name="container">
@@ -556,15 +564,27 @@
       </if>
     </choose>
   </macro>
+  <macro name="series">
+    <choose>
+      <if type="book chapter">
+        <group delimiter=" ">
+          <text variable="collection-title" text-case="title"/>
+          <text variable="collection-number"/>
+        </group>
+      </if>
+    </choose>
+  </macro>    
   <citation et-al-min="3" et-al-use-first="1" disambiguate-add-year-suffix="true" collapse="year" givenname-disambiguation-rule="primary-name">
     <sort>
       <key macro="issued-sort"/>
       <key macro="author"/>
     </sort>
     <layout prefix="(" suffix=")" delimiter="; ">
-      <group delimiter=", ">
-        <text macro="author-short"/>
-        <text macro="issued-year"/>
+      <group delimiter=": ">
+        <group delimiter=", ">
+          <text macro="author-short"/>
+          <text macro="issued-year"/>
+        </group>
         <text macro="citation-locator"/>
       </group>
     </layout>
@@ -582,6 +602,7 @@
           <text macro="issued"/>
           <text macro="title-plus-extra"/>
           <text macro="container"/>
+          <text macro="series"/>
         </group>
         <text macro="legal-cites"/>
         <text macro="locators"/>


### PR DESCRIPTION
Add "series" macro
Remove spaces between authors' initials
Change (Ed.) and Vol. to lowercase
Remove parentheses around Vol.
Change accessed date format in webpage bibliography entries
Precede page numbers in citations with : instead of p., pp.