### PR TITLE
Update harvard-cite-them-right.csl

### DIFF
--- a/harvard-cite-them-right.csl
+++ b/harvard-cite-them-right.csl
@@ -164,7 +164,7 @@
           </group>
         </group>
       </else-if>
-      <else-if type="article-newspaper article-magazine" match="none">
+    <else-if type="article-journal article-newspaper article-magazine" match="none">
         <group delimiter=" ">
           <group delimiter=", ">
             <choose>


### PR DESCRIPTION
On advice from ExLibris our Library System vendor to fix a problem where the publisher is appearing in journal references, I have on their advice change line 167 from

`<else-if type="article-newspaper article-magazine" match="none">`

to

`<else-if type="article-journal article-newspaper article-magazine" match="none"> `

This should fix a major problem for our library.  Please can this be check and approved?

Thanks

Adam Edwards