### PR TITLE
Major Update mcgill-fr.csl to 9th ed.

### DIFF
--- a/mcgill-fr.csl
+++ b/mcgill-fr.csl
@@ -1,12 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
-<style xmlns="http://purl.org/net/xbiblio/csl" class="note" version="1.0" default-locale="fr-CA">
+<style xmlns="http://purl.org/net/xbiblio/csl" version="1.0" class="note" default-locale="fr-CA">
   <info>
-    <title>Manuel canadien de la référence juridique 7e édition (Guide McGill, French - Canada)</title>
-    <title-short>Guide McGill FR v7</title-short>
+    <title>Manuel canadien de la référence juridique 9e édition (Guide McGill, French - Canada)</title>
     <id>http://www.zotero.org/styles/mcgill-fr</id>
     <link href="http://www.zotero.org/styles/mcgill-fr" rel="self"/>
-    <link href="http://f-mb.github.io/cslegal/" rel="documentation"/>
-    <link href="http://www.lawjournal.mcgill.ca/fr/text/22" rel="documentation"/>
+    <link href="https://lawjournal.mcgill.ca/cite-guide" rel="documentation"/>
     <author>
       <name>Philippe Tousignant</name>
       <email>philippe.tousignant@gmail.com</email>
@@ -19,25 +17,53 @@
       <email>f.martin-bariteau@umontreal.ca</email>
       <uri>http://f-mb.github.io/cslegal/</uri>
     </contributor>
-    <contributor>
+	<contributor>
       <name>Jean-Sebastien Sauve</name>
+    </contributor>
+    <contributor>
+      <name>Gareth Spanglett</name>
+      <email>gspanglett@gmail.com</email>
+      <uri>https://gspanglett.github.io</uri>
     </contributor>
     <category citation-format="note"/>
     <category field="law"/>
-    <summary>This style may require use of specific fields in the reference manager. More infos: http://f-mb.github.io/cslegal/
-      Ce style peut demander un usage particulier des champs du logiciel de gestion bibliographique. Plus d'infos: http://f-mb.github.io/cslegal/</summary>
-    <updated>2014-06-28T19:18:00+00:00</updated>
+    <updated>2020-10-07T23:45:43+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale xml:lang="fr">
+    <style-options punctuation-in-quote="false"/>
     <terms>
-      <term name="page" form="short">
-        <single>à la p</single>
-        <multiple>aux pp</multiple>
-      </term>
+      <term name="et-al">et al</term>
+      <term name="ordinal">&#x1D49;</term>
+	  <term name="ordinal-01">&#x02B3;&#x1D49;</term>
+      <term name="ordinal-02">&#x1D49;</term>
+	  <term name="page" form="short">
+        <single> à la p</single>
+        <multiple> aux pp</multiple>
+      </term>	  
+	  <term name="at" form="short">
+		<single>à la p</single>
+		<multiple>aux pp</multiple>
+	  </term>
       <term name="paragraph" form="short">
         <single>au para</single>
-        <multiple>aux paras</multiple>
+        <multiple>aux para</multiple>
+      </term>
+	  <term name="sub verbo" form="short">
+        <single>sub verbo</single>
+        <multiple>sub verbis</multiple>
+      </term>
+	  <term name="part" form="short">
+        <single>Art</single>
+        <multiple>Arts</multiple>
+      </term>			 
+      <term name="section" form="short">
+        <single>art</single>
+        <multiple>arts</multiple>
+      </term>
+      <term name="chapter" form="short">
+        <single>c</single>
+        <multiple>cs</multiple>
       </term>
       <term name="chapter" form="short">ch</term>
       <term name="editor" form="verb-short">dir</term>
@@ -45,137 +71,51 @@
       <term name="editor" form="verb">dir</term>
       <term name="translator" form="verb">traduit par</term>
       <term name="in">dans</term>
+	  
     </terms>
   </locale>
-  <macro name="contributors-note">
-    <names variable="author">
-      <name and="text" sort-separator=", " delimiter=", " delimiter-precedes-last="never"/>
-      <substitute>
-        <text macro="editor-note"/>
-        <text macro="translator-note"/>
-      </substitute>
-    </names>
-    <text macro="recipient-note"/>
-  </macro>
-  <macro name="editor-note">
-    <names variable="editor">
-      <name and="text" sort-separator=", " delimiter=", " delimiter-precedes-last="never"/>
-      <label form="short" prefix=", " strip-periods="true"/>
-    </names>
-  </macro>
-  <macro name="translator-note">
-    <names variable="translator">
-      <label form="verb" suffix=" " strip-periods="true"/>
-      <name and="text" sort-separator=", " delimiter=", " delimiter-precedes-last="never"/>
-    </names>
-  </macro>
-  <macro name="recipient-note">
-    <names variable="recipient" delimiter=", ">
-      <label form="verb" prefix=" " text-case="lowercase" suffix=" "/>
-      <name and="text" delimiter-precedes-last="never"/>
-    </names>
-  </macro>
-  <macro name="interviewer-note">
-    <names variable="interviewer" delimiter=", ">
-      <label form="verb" prefix=" " text-case="lowercase" suffix=" "/>
-      <name and="text" delimiter=", " delimiter-precedes-last="never"/>
-    </names>
-  </macro>
-  <macro name="contributors">
-    <names variable="author">
-      <name name-as-sort-order="first" and="text" sort-separator=", " delimiter=", " delimiter-precedes-last="never"/>
-      <substitute>
-        <text macro="editor"/>
-        <text macro="translator"/>
-      </substitute>
-    </names>
-    <text macro="recipient" prefix=". "/>
-  </macro>
   <macro name="editor">
     <names variable="editor">
-      <name name-as-sort-order="first" and="text" sort-separator=", " delimiter=", " delimiter-precedes-last="never"/>
+      <name and="symbol" delimiter-precedes-last="never"/>
+      <et-al term="et-al"/>
       <label form="short" prefix=", " strip-periods="true"/>
     </names>
   </macro>
   <macro name="translator">
     <names variable="translator">
-      <label form="verb-short" suffix=" " strip-periods="true"/>
-      <name and="text" sort-separator=", " delimiter=", " delimiter-precedes-last="never"/>
+      <label form="verb" suffix=" "/>
+      <name and="symbol"/>
     </names>
   </macro>
-  <macro name="recipient">
+  <macro name="container-title">
+    <text strip-periods="true" variable="container-title" form="short"/>
+  </macro>
+  <macro name="author-note">
+    <names variable="author">
+      <name and="symbol" delimiter-precedes-last="never"/>
+      <et-al term="et-al"/>
+      <substitute>
+        <text macro="editor"/>
+      </substitute>
+    </names>
+  </macro>
+  <macro name="author-bib">
+    <names variable="author">
+      <name name-as-sort-order="first" and="symbol" sort-separator=", " delimiter-precedes-last="never"/>
+      <et-al term="et-al"/>
+      <label form="short" prefix=", "/>
+      <substitute>
+        <names variable="editor"/>
+      </substitute>
+    </names>
+  </macro>
+  <macro name="internet-location">
     <choose>
-      <if type="personal_communication">
-        <choose>
-          <if variable="genre">
-            <text variable="genre" text-case="capitalize-first"/>
-          </if>
-          <else>
-            <text term="letter" text-case="capitalize-first"/>
-          </else>
-        </choose>
+      <if variable="URL">
+        <text term="online" prefix=", " suffix=": &lt;"/>
+        <text variable="URL" suffix="&gt;"/>
       </if>
     </choose>
-    <text macro="recipient-note" prefix=" "/>
-  </macro>
-  <macro name="contributors-short">
-    <names variable="author">
-      <name form="short" and="text" delimiter=", " delimiter-precedes-last="never"/>
-      <substitute>
-        <names variable="editor"/>
-        <names variable="translator"/>
-      </substitute>
-    </names>
-    <text macro="recipient-short"/>
-  </macro>
-  <macro name="recipient-short">
-    <names variable="recipient">
-      <label form="verb" prefix=" " text-case="lowercase" suffix=" "/>
-      <name form="short" and="text" delimiter=", " delimiter-precedes-last="never"/>
-    </names>
-  </macro>
-  <macro name="interviewer">
-    <names variable="interviewer" delimiter=", ">
-      <label form="verb" prefix=" " text-case="capitalize-first" suffix=" "/>
-      <name and="text" delimiter=", " delimiter-precedes-last="never"/>
-    </names>
-  </macro>
-  <macro name="contributors-sort">
-    <names variable="author">
-      <name name-as-sort-order="all" and="text" sort-separator=", " delimiter=", " delimiter-precedes-last="never"/>
-      <substitute>
-        <names variable="editor"/>
-        <names variable="translator"/>
-      </substitute>
-    </names>
-  </macro>
-  <macro name="description-note">
-    <group delimiter=", ">
-      <text macro="interviewer-note"/>
-      <text variable="medium"/>
-      <choose>
-        <if variable="title" match="none"/>
-        <else-if type="speech" match="any"/>
-        <else>
-          <text variable="genre"/>
-        </else>
-      </choose>
-    </group>
-  </macro>
-  <macro name="description">
-    <group delimiter=", ">
-      <group delimiter=". ">
-        <text macro="interviewer"/>
-        <text variable="medium" text-case="capitalize-first"/>
-      </group>
-      <choose>
-        <if variable="title" match="none"/>
-        <else-if type="speech" match="any"/>
-        <else>
-          <text variable="genre" text-case="capitalize-first"/>
-        </else>
-      </choose>
-    </group>
   </macro>
   <macro name="URL">
     <choose>
@@ -202,729 +142,33 @@
       </else-if>
     </choose>
   </macro>
-  <macro name="collection-title">
-    <text variable="collection-title" prefix="coll "/>
+
+  <macro name="genre">
+    <text variable="genre"/>
   </macro>
-  <macro name="collection-number">
-    <text variable="collection-number" prefix="n°"/>
+  <macro name="issued-long">
+    <date variable="issued" delimiter=" ">
+      <date-part name="day"/>
+      <date-part name="month" form="long"/>
+      <date-part name="year" form="long"/>
+    </date>
   </macro>
-  <macro name="issued-year">
-    <date variable="issued">
+  <macro name="submitted-long">
+    <date variable="submitted" delimiter=" ">
+      <date-part name="day"/>
+      <date-part name="month" form="long"/>
       <date-part name="year" form="long"/>
     </date>
   </macro>
   <macro name="edition">
-    <choose>
-      <if is-numeric="edition">
-        <group delimiter=" ">
-          <number variable="edition" form="ordinal"/>
-          <text term="edition" form="short" strip-periods="true"/>
-        </group>
-      </if>
-      <else>
-        <text variable="edition" text-case="capitalize-first"/>
-      </else>
-    </choose>
+    <number variable="edition" form="ordinal" text-case="lowercase" suffix=" "/>
+    <text term="edition" form="short" strip-periods="true"/>
   </macro>
-  <macro name="issued">
-    <date variable="issued" font-style="normal" font-weight="normal">
-      <date-part name="day" suffix=" "/>
-      <date-part name="month" suffix=" "/>
-      <date-part name="year"/>
-    </date>
-  </macro>
-  <macro name="editor-translator">
-    <group delimiter=", ">
-      <choose>
-        <if variable="author">
-          <names variable="editor" delimiter=", ">
-            <name and="text" delimiter=", " delimiter-precedes-last="never"/>
-            <label form="verb-short" text-case="lowercase" prefix=", " strip-periods="true"/>
-          </names>
-          <choose>
-            <if variable="container-author">
-              <group>
-                <names variable="container-author">
-                  <label form="verb-short" prefix=" " text-case="lowercase" suffix=" " strip-periods="true"/>
-                  <name and="text" delimiter=", " delimiter-precedes-last="never"/>
-                </names>
-              </group>
-            </if>
-          </choose>
-        </if>
-      </choose>
-      <choose>
-        <if variable="author editor" match="any">
-          <names variable="translator" delimiter=", ">
-            <label form="verb-short" text-case="lowercase" suffix=" " strip-periods="true"/>
-            <name and="text" delimiter=", " delimiter-precedes-last="never"/>
-          </names>
-        </if>
-      </choose>
-    </group>
-  </macro>
-  <macro name="secondary-contributors-note">
-    <choose>
-      <if type="chapter paper-conference" match="none">
-        <text macro="editor-translator"/>
-      </if>
-    </choose>
-  </macro>
-  <macro name="container-contributors-note">
-    <choose>
-      <if type="chapter paper-conference" match="any">
-        <text macro="editor-translator"/>
-      </if>
-    </choose>
-  </macro>
-  <macro name="secondary-contributors">
-    <choose>
-      <if type="chapter paper-conference" match="none">
-        <group delimiter=". ">
-          <choose>
-            <if variable="author">
-              <names variable="editor" delimiter=". ">
-                <label form="verb" text-case="capitalize-first" suffix=" "/>
-                <name and="text" delimiter=", " delimiter-precedes-last="never"/>
-              </names>
-            </if>
-          </choose>
-          <choose>
-            <if variable="author editor" match="any">
-              <names variable="translator" delimiter=". ">
-                <label form="verb" text-case="capitalize-first" suffix=" "/>
-                <name and="text" delimiter=", " delimiter-precedes-last="never"/>
-              </names>
-            </if>
-          </choose>
-        </group>
-      </if>
-    </choose>
-  </macro>
-  <macro name="container-contributors">
-    <choose>
-      <if type="chapter paper-conference" match="any">
-        <group delimiter=", ">
-          <choose>
-            <if variable="author">
-              <names variable="editor" delimiter=", ">
-                <name and="text" delimiter=", " delimiter-precedes-last="never"/>
-                <label form="verb" text-case="lowercase" prefix=", "/>
-              </names>
-              <choose>
-                <if variable="container-author">
-                  <group>
-                    <names variable="container-author">
-                      <label form="verb-short" prefix=" " text-case="lowercase" suffix=" " strip-periods="true"/>
-                      <name and="text" delimiter=", " delimiter-precedes-last="never"/>
-                    </names>
-                  </group>
-                </if>
-              </choose>
-            </if>
-          </choose>
-          <choose>
-            <if variable="author editor" match="any">
-              <names variable="translator" delimiter=", ">
-                <label form="verb" text-case="lowercase" suffix=" "/>
-                <name and="text" delimiter=", " delimiter-precedes-last="never"/>
-              </names>
-            </if>
-          </choose>
-        </group>
-      </if>
-    </choose>
-  </macro>
-  <macro name="title-chapter-special">
-    <choose>
-      <if variable="container-title" match="any">
-        <text variable="title" quotes="true"/>
-        <text term="in" text-case="lowercase" suffix=" " prefix=" "/>
-      </if>
-      <else>
-        <text variable="title" font-style="italic" suffix=", "/>
-      </else>
-    </choose>
-  </macro>
-  <macro name="container-title-note">
-    <choose>
-      <if type="bill legal_case legislation" match="none">
-        <text variable="container-title" font-style="italic"/>
-      </if>
-    </choose>
-  </macro>
-  <macro name="container-title">
-    <choose>
-      <if type="legal_case" match="none">
-        <text variable="container-title" font-style="italic"/>
-      </if>
-    </choose>
-  </macro>
-  <macro name="note-chapter">
-    <text macro="contributors-note" suffix=", " strip-periods="true"/>
-    <text macro="title-chapter-special"/>
-    <group delimiter=", ">
-      <text macro="secondary-contributors-note" strip-periods="true"/>
-      <text macro="container-contributors-note" strip-periods="true"/>
-      <text variable="container-title" font-style="italic"/>
-      <text macro="edition"/>
-      <text macro="translator"/>
-      <text variable="volume"/>
-      <text macro="collection-title"/>
-      <text macro="collection-number" strip-periods="true"/>
-      <text variable="publisher-place" strip-periods="true"/>
-      <text variable="publisher" strip-periods="true"/>
-      <text macro="issued-year"/>
-      <text variable="page"/>
-    </group>
-    <text macro="point-locators"/>
-    <text macro="URL"/>
-  </macro>
-  <macro name="chapter">
-    <group delimiter=". ">
-      <text macro="contributors"/>
-      <text macro="title-chapter-special"/>
-    </group>
-    <group delimiter=", ">
-      <text macro="secondary-contributors" strip-periods="true"/>
-      <text macro="container-contributors" strip-periods="true"/>
-      <text variable="container-title" font-style="italic"/>
-      <text macro="edition"/>
-      <text macro="translator"/>
-      <text variable="volume"/>
-      <text macro="collection-title"/>
-      <text macro="collection-number" strip-periods="true"/>
-      <text variable="publisher-place" strip-periods="true"/>
-      <text variable="publisher" strip-periods="true"/>
-      <text macro="issued-year"/>
-      <text variable="page"/>
-    </group>
-    <text macro="point-locators"/>
-    <text macro="URL"/>
-  </macro>
-  <macro name="note-thesis">
-    <group delimiter=", ">
-      <text macro="contributors-note" strip-periods="true"/>
-      <text variable="title" font-style="italic"/>
-      <text variable="genre"/>
-      <text variable="publisher" strip-periods="true"/>
-      <text macro="issued-year"/>
-    </group>
-    <text macro="point-locators"/>
-    <text macro="URL"/>
-  </macro>
-  <macro name="thesis">
-    <group delimiter=". ">
-      <text macro="contributors"/>
-      <group delimiter=", ">
-        <text variable="title" font-style="italic"/>
-        <text variable="genre"/>
-        <text variable="publisher" strip-periods="true"/>
-        <text macro="issued-year"/>
-      </group>
-    </group>
-    <text macro="URL"/>
-  </macro>
-  <macro name="note-bill">
-    <group delimiter=", ">
-      <text macro="contributors-note"/>
-      <choose>
-        <if variable="volume chapter-number" match="any">
-          <text variable="number" prefix="PL "/>
-        </if>
-      </choose>
-      <text variable="title" font-style="italic"/>
-      <choose>
-        <if variable="volume chapter-number" match="none">
-          <text variable="number"/>
-        </if>
-      </choose>
-      <choose>
-        <if variable="chapter-number">
-          <text variable="chapter-number" strip-periods="true"/>
-          <text variable="authority" strip-periods="true"/>
-        </if>
-        <else>
-          <text variable="volume"/>
-          <text variable="container-title" strip-periods="true"/>
-        </else>
-      </choose>
-      <text variable="section" strip-periods="true"/>
-      <text macro="issued" strip-periods="true"/>
-    </group>
-    <text macro="point-locators"/>
-    <text variable="references" prefix=" (" suffix=")"/>
-    <text variable="title-short" prefix=" [" suffix="]" font-style="italic"/>
-    <text macro="URL"/>
-  </macro>
-  <macro name="bill">
-    <group delimiter=", ">
-      <text macro="contributors" strip-periods="true"/>
-      <choose>
-        <if variable="volume chapter-number" match="any">
-          <text variable="number" prefix="PL "/>
-        </if>
-      </choose>
-      <text variable="title" font-style="italic"/>
-      <choose>
-        <if variable="volume chapter-number" match="none">
-          <text variable="number"/>
-        </if>
-      </choose>
-      <choose>
-        <if variable="chapter-number">
-          <text variable="chapter-number" strip-periods="true"/>
-          <text variable="authority" strip-periods="true"/>
-        </if>
-        <else>
-          <text variable="volume"/>
-          <text variable="container-title" strip-periods="true"/>
-        </else>
-      </choose>
-      <text variable="section" strip-periods="true"/>
-      <text macro="issued"/>
-    </group>
-    <text macro="URL"/>
-  </macro>
-  <macro name="legislation-note">
-    <group delimiter=", ">
-      <text macro="contributors-note" strip-periods="true"/>
-      <text variable="title" font-style="italic"/>
-      <choose>
-        <if variable="page">
-          <group delimiter=" ">
-            <text macro="issued-year" prefix=" (" suffix=")"/>
-            <text variable="section" strip-periods="true"/>
-            <text variable="container-title" strip-periods="true"/>
-            <text variable="page" strip-periods="true"/>
-          </group>
-          <text variable="number" strip-periods="true"/>
-        </if>
-        <else>
-          <text variable="container-title" strip-periods="true"/>
-          <text variable="section" strip-periods="true"/>
-          <text variable="number" strip-periods="true"/>
-          <text macro="issued"/>
-        </else>
-      </choose>
-    </group>
-    <text macro="point-locators"/>
-    <text variable="references" prefix=" (" suffix=")"/>
-    <text variable="title-short" prefix=" [" suffix="]"/>
-    <text macro="URL"/>
-  </macro>
-  <macro name="legislation-bib">
-    <group delimiter=", ">
-      <text macro="contributors" strip-periods="true"/>
-      <text variable="title" font-style="italic"/>
-      <choose>
-        <if variable="page">
-          <group delimiter=" ">
-            <text macro="issued-year" prefix=" (" suffix=")"/>
-            <text variable="section" strip-periods="true"/>
-            <text variable="container-title" strip-periods="true"/>
-            <text variable="page" strip-periods="true"/>
-          </group>
-          <text variable="number" strip-periods="true"/>
-        </if>
-        <else>
-          <text variable="container-title" strip-periods="true"/>
-          <text variable="section" strip-periods="true"/>
-          <text variable="number" strip-periods="true"/>
-          <text macro="issued"/>
-        </else>
-      </choose>
-    </group>
-    <text macro="URL"/>
-  </macro>
-  <macro name="note-book">
-    <group delimiter=", ">
-      <text macro="contributors-note" strip-periods="true"/>
-      <text variable="title" font-style="italic"/>
-      <text macro="edition"/>
-      <text macro="translator-note" strip-periods="true"/>
-      <text variable="genre" strip-periods="true"/>
-      <text variable="number" strip-periods="true"/>
-      <text variable="volume" strip-periods="true"/>
-      <text macro="collection-title" strip-periods="true"/>
-      <text macro="collection-number"/>
-      <text variable="publisher-place" strip-periods="true"/>
-      <text variable="publisher" strip-periods="true"/>
-      <text macro="issued-year"/>
-    </group>
-    <text macro="point-locators"/>
-    <text macro="URL"/>
-  </macro>
-  <macro name="book">
-    <group delimiter=". ">
-      <text macro="contributors"/>
-      <group delimiter=", ">
-        <text variable="title" font-style="italic"/>
-        <text macro="edition" strip-periods="true"/>
-        <text macro="translator" strip-periods="true"/>
-        <text variable="genre" strip-periods="true"/>
-        <text variable="number" strip-periods="true"/>
-        <text variable="volume" strip-periods="true"/>
-        <text macro="collection-title" strip-periods="true"/>
-        <text macro="collection-number" strip-periods="true"/>
-        <text variable="publisher-place" strip-periods="true"/>
-        <text variable="publisher" strip-periods="true"/>
-        <text macro="issued-year"/>
-      </group>
-    </group>
-    <text macro="URL"/>
-  </macro>
-  <macro name="note-article-newspaper">
-    <group delimiter=", ">
-      <text macro="contributors-note" strip-periods="true"/>
-      <text variable="title" quotes="true"/>
-      <choose>
-        <if type="webpage post post-weblog" match="none">
-          <text variable="container-title" font-style="italic"/>
-        </if>
-      </choose>
-      <group>
-        <text term="edition" form="short" suffix=" " strip-periods="true"/>
-        <text variable="edition" strip-periods="true"/>
-      </group>
-      <group>
-        <text term="section" form="short" suffix=" " strip-periods="true"/>
-        <text variable="section" strip-periods="true"/>
-      </group>
-    </group>
-    <text macro="issued" prefix=" (" suffix=")"/>
-    <text variable="page" prefix=" "/>
-    <text macro="point-locators"/>
-    <text macro="URL"/>
-  </macro>
-  <macro name="article-newspaper">
-    <group delimiter=". ">
-      <text macro="contributors"/>
-      <group delimiter=", ">
-        <text variable="title" quotes="true"/>
-        <choose>
-          <if type="webpage post post-weblog" match="none">
-            <text variable="container-title" font-style="italic"/>
-          </if>
-        </choose>
-        <group>
-          <text term="edition" form="short" suffix=" " strip-periods="true"/>
-          <text variable="edition" strip-periods="true"/>
-        </group>
-        <group>
-          <text term="section" form="short" suffix=" " strip-periods="true"/>
-          <text variable="section" strip-periods="true"/>
-        </group>
-      </group>
-    </group>
-    <text macro="issued" prefix=" (" suffix=")"/>
-    <text variable="page" prefix=" "/>
-    <text macro="URL"/>
-  </macro>
-  <macro name="note-article-magazine">
+  <macro name="series-info">
     <group delimiter=" ">
-      <text macro="contributors-note" suffix="," strip-periods="true"/>
-      <text variable="title" quotes="true" suffix=","/>
-      <text variable="container-title" font-style="italic"/>
-      <choose>
-        <if variable="volume" match="any">
-          <group delimiter=":">
-            <text variable="volume"/>
-            <number variable="issue"/>
-          </group>
-        </if>
-        <else>
-          <group>
-            <text term="issue" form="short" strip-periods="true"/>
-            <number variable="issue"/>
-          </group>
-        </else>
-      </choose>
-      <text macro="issued" prefix="(" suffix=")"/>
-      <text variable="page"/>
+      <text variable="collection-title" strip-periods="true"/>
+      <text variable="collection-number"/>
     </group>
-    <text macro="point-locators"/>
-    <text macro="URL"/>
-  </macro>
-  <macro name="article-magazine">
-    <group delimiter=". ">
-      <text macro="contributors"/>
-      <group delimiter=" ">
-        <text variable="title" quotes="true" suffix=","/>
-        <text variable="container-title" font-style="italic"/>
-        <choose>
-          <if variable="volume" match="any">
-            <group delimiter=":">
-              <text variable="volume"/>
-              <number variable="issue"/>
-            </group>
-          </if>
-          <else>
-            <group>
-              <text term="issue" form="short" strip-periods="true"/>
-              <number variable="issue"/>
-            </group>
-          </else>
-        </choose>
-        <text macro="issued" prefix="(" suffix=")"/>
-        <text variable="page"/>
-      </group>
-    </group>
-    <text macro="URL"/>
-  </macro>
-  <macro name="note-article-journal">
-    <group delimiter=" ">
-      <text macro="contributors-note" suffix="," strip-periods="true"/>
-      <text variable="title" quotes="true"/>
-      <choose>
-        <if variable="volume" match="none">
-          <text macro="issued-year" prefix="[" suffix="]"/>
-          <number variable="issue"/>
-        </if>
-        <else>
-          <text macro="issued-year" prefix="(" suffix=")"/>
-          <group delimiter=":">
-            <text variable="volume"/>
-            <number variable="issue"/>
-          </group>
-        </else>
-      </choose>
-      <text variable="container-title" form="short" strip-periods="true"/>
-      <text variable="page"/>
-    </group>
-    <text macro="point-locators"/>
-    <text macro="URL"/>
-  </macro>
-  <macro name="article-journal">
-    <group delimiter=". ">
-      <text macro="contributors"/>
-      <group delimiter=" ">
-        <text variable="title" quotes="true"/>
-        <choose>
-          <if variable="volume" match="none">
-            <text macro="issued-year" prefix="[" suffix="]"/>
-            <number variable="issue"/>
-          </if>
-          <else>
-            <text macro="issued-year" prefix="(" suffix=")"/>
-            <group delimiter=":">
-              <text variable="volume"/>
-              <number variable="issue"/>
-            </group>
-          </else>
-        </choose>
-        <text variable="container-title" form="short" strip-periods="true"/>
-        <text variable="page"/>
-      </group>
-    </group>
-    <text macro="URL"/>
-  </macro>
-  <macro name="note-case">
-    <choose>
-      <if variable="author">
-        <group delimiter=", ">
-          <text variable="authority" strip-periods="true"/>
-          <text macro="issued"/>
-          <text variable="number"/>
-          <group delimiter=" ">
-            <text variable="title" font-style="italic" strip-periods="true"/>
-            <text variable="references" prefix="(" suffix=")"/>
-          </group>
-          <text variable="container-title" strip-periods="true" font-style="italic"/>
-          <text variable="volume"/>
-          <text variable="page"/>
-          <text macro="point-locators"/>
-        </group>
-      </if>
-      <else-if variable="title" match="none">
-        <group delimiter=", ">
-          <text variable="authority" strip-periods="true"/>
-          <text macro="issued"/>
-          <text variable="number"/>
-          <group delimiter=" ">
-            <text variable="title" form="short" font-style="italic" strip-periods="true"/>
-            <text variable="references" prefix="(" suffix=")"/>
-          </group>
-          <text variable="container-title" strip-periods="true" font-style="italic"/>
-          <text variable="volume"/>
-          <text variable="page"/>
-          <text macro="point-locators"/>
-        </group>
-      </else-if>
-      <else>
-        <text variable="title" font-style="italic" suffix=", " strip-periods="true"/>
-        <choose>
-          <if variable="container-title" match="none">
-            <group delimiter=" ">
-              <text macro="issued-year"/>
-              <text variable="authority" strip-periods="true"/>
-              <text variable="page"/>
-            </group>
-          </if>
-          <else>
-            <text macro="issued-year" prefix=" [" suffix="] "/>
-            <text variable="volume" suffix=" "/>
-            <text variable="container-title" suffix=" " strip-periods="true"/>
-            <text variable="page"/>
-            <text variable="authority" prefix=" (" suffix=")" strip-periods="true"/>
-          </else>
-        </choose>
-        <text variable="references" prefix=" (" suffix=")"/>
-        <text macro="point-locators"/>
-        <text variable="title-short" prefix=" [" suffix="]" font-style="italic"/>
-      </else>
-    </choose>
-    <text macro="URL"/>
-  </macro>
-  <macro name="case">
-    <choose>
-      <if variable="author">
-        <group delimiter=", ">
-          <text variable="authority" strip-periods="true"/>
-          <text macro="issued"/>
-          <text variable="number"/>
-          <group delimiter=" ">
-            <text variable="title" font-style="italic" strip-periods="true"/>
-            <text variable="references" prefix="(" suffix=")"/>
-          </group>
-          <text variable="container-title" strip-periods="true" font-style="italic"/>
-          <text variable="volume"/>
-          <text variable="page"/>
-        </group>
-      </if>
-      <else-if variable="title" match="none">
-        <group delimiter=", ">
-          <text variable="authority" strip-periods="true"/>
-          <text macro="issued"/>
-          <text variable="number"/>
-          <group delimiter=" ">
-            <text variable="title" form="short" font-style="italic" strip-periods="true"/>
-            <text variable="references" prefix="(" suffix=")"/>
-          </group>
-          <text variable="container-title" strip-periods="true" font-style="italic"/>
-          <text variable="volume"/>
-          <text variable="page"/>
-        </group>
-      </else-if>
-      <else>
-        <text variable="title" font-style="italic" suffix=", " strip-periods="true"/>
-        <choose>
-          <if variable="container-title" match="none">
-            <text macro="issued-year" suffix=" "/>
-            <text variable="authority" suffix=" " strip-periods="true"/>
-            <text variable="page"/>
-          </if>
-          <else>
-            <text macro="issued-year" prefix=" [" suffix="] "/>
-            <text variable="volume" suffix=" "/>
-            <text variable="container-title" suffix=" " strip-periods="true"/>
-            <text variable="page"/>
-            <text variable="authority" prefix=" (" suffix=")" strip-periods="true"/>
-          </else>
-        </choose>
-        <text variable="references" prefix=" (" suffix=")"/>
-      </else>
-    </choose>
-    <text macro="URL"/>
-  </macro>
-  <macro name="entrydic-note">
-    <group delimiter=", ">
-      <text macro="contributors-note" strip-periods="true"/>
-      <text variable="container-title" font-style="italic"/>
-      <text macro="edition" strip-periods="true"/>
-      <text macro="translator-note" strip-periods="true"/>
-      <text variable="volume" strip-periods="true"/>
-      <text macro="collection-title" strip-periods="true"/>
-      <text macro="collection-number" strip-periods="true"/>
-      <text variable="publisher-place" strip-periods="true"/>
-      <text variable="publisher" strip-periods="true"/>
-      <text macro="issued-year"/>
-      <group delimiter=" ">
-        <text value="sub verbo" font-style="italic"/>
-        <text variable="title" quotes="true"/>
-      </group>
-    </group>
-    <text macro="point-locators"/>
-    <text macro="URL"/>
-  </macro>
-  <macro name="entrydic-bib">
-    <group delimiter=". ">
-      <text macro="contributors"/>
-      <group delimiter=", ">
-        <text variable="container-title" font-style="italic"/>
-        <text macro="edition" strip-periods="true"/>
-        <text macro="translator" strip-periods="true"/>
-        <text variable="volume" strip-periods="true"/>
-        <text macro="collection-title" strip-periods="true"/>
-        <text macro="collection-number" strip-periods="true"/>
-        <text variable="publisher-place" strip-periods="true"/>
-        <text variable="publisher" strip-periods="true"/>
-        <text macro="issued-year"/>
-      </group>
-    </group>
-    <text macro="URL"/>
-  </macro>
-  <macro name="entryencyclo-note">
-    <group delimiter=", ">
-      <text variable="container-title" font-style="italic" strip-periods="true"/>
-      <text variable="volume" font-style="italic" strip-periods="true"/>
-      <text macro="collection-title" strip-periods="true"/>
-      <text variable="collection-number" strip-periods="true"/>
-      <text macro="edition" strip-periods="true"/>
-      <text macro="translator-note" strip-periods="true"/>
-      <text variable="publisher-place" strip-periods="true"/>
-      <text variable="publisher" strip-periods="true"/>
-      <group delimiter=" ">
-        <text variable="page" strip-periods="true"/>
-        <text variable="title" quotes="true"/>
-        <text macro="contributors-note" prefix="par "/>
-      </group>
-    </group>
-    <text macro="point-locators"/>
-    <text macro="URL"/>
-  </macro>
-  <macro name="entryencyclo-bib">
-    <group delimiter=". ">
-      <text macro="contributors"/>
-      <group delimiter=", ">
-        <group delimiter=" ">
-          <text variable="page" strip-periods="true"/>
-          <text variable="title" quotes="true"/>
-        </group>
-        <text variable="container-title" font-style="italic" strip-periods="true"/>
-        <text variable="volume" font-style="italic" strip-periods="true"/>
-        <text macro="collection-title" strip-periods="true"/>
-        <text variable="collection-number" strip-periods="true"/>
-        <text macro="edition" strip-periods="true"/>
-        <text macro="translator-note" strip-periods="true"/>
-        <text variable="publisher-place" strip-periods="true"/>
-        <text variable="publisher" strip-periods="true"/>
-      </group>
-    </group>
-    <text macro="URL"/>
-  </macro>
-  <macro name="point-locators">
-    <choose>
-      <if variable="locator" match="any">
-        <choose>
-          <if locator="page paragraph" match="any">
-            <label variable="locator" prefix=" " suffix="&#160;" form="short" strip-periods="true"/>
-            <text variable="locator"/>
-          </if>
-          <else-if locator="sub-verbo" match="any">
-            <label variable="locator" prefix=", " suffix="&#160;" form="long" font-style="italic"/>
-            <text variable="locator" quotes="true"/>
-          </else-if>
-          <else-if type="legislation bill" locator="section" match="all">
-            <text variable="locator" prefix=", art&#160;"/>
-          </else-if>
-          <else>
-            <label variable="locator" prefix=", " suffix="&#160;" form="short" strip-periods="true"/>
-            <text variable="locator"/>
-          </else>
-        </choose>
-      </if>
-    </choose>
   </macro>
   <macro name="sort-by-type">
     <choose>
@@ -934,10 +178,10 @@
       <else-if type="legal_case">
         <text value="2"/>
       </else-if>
-      <else-if type="book thesis entry-dictionary" match="any">
-        <text value="3" font-weight="normal"/>
+      <else-if type="book thesis" match="any">
+        <text value="3"/>
       </else-if>
-      <else-if type="chapter article-journal entry-encyclopedia" match="any">
+      <else-if type="article-journal chapter article-newspaper article-magazine" match="any">
         <text value="4"/>
       </else-if>
       <else>
@@ -945,185 +189,565 @@
       </else>
     </choose>
   </macro>
-  <citation et-al-min="4" et-al-use-first="1" disambiguate-add-names="true" delimiter-precedes-et-al="never">
-    <layout suffix="." delimiter="; ">
+  <!-- the 'rendering' macros mostly check if called from w/i bibliography so that author gets printed
+    right. Only actually need to check for 'first' because w/i cite
+all the other tests should have been done... -->
+  <macro name="render-chapter">
+    <group delimiter=" ">
+      <text variable="title" quotes="true"/>
+      <text term="in" form="short"/>
+      <text macro="editor" strip-periods="true" suffix=","/>
+      <text macro="container-title" font-style="italic"/>
+    </group>
+    <text macro="series-info" prefix=" "/>
+    <text macro="edition" prefix=", "/>
+    <text macro="publisher-place-year"/>
+    <text variable="page-first" prefix=" "/>
+  </macro>
+  <macro name="render-dictionary">
+    <group delimiter=", ">
+      <text macro="editor" strip-periods="true" suffix=","/>
+      <text variable="title" font-style="italic"/>
+    </group>
+    <text macro="series-info" prefix=" "/>
+    <text macro="edition" prefix=", "/>
+    <text macro="publisher-place-year"/>
+    <text variable="page-first" prefix=" "/>     
+  </macro>
+  <macro name="render-encyclopedia">
+    <group delimiter=" ">
+      <text variable="title" quotes="true"/>
+      <text term="in" form="short"/>
+      <text macro="editor" strip-periods="true" suffix=","/>
+      <text macro="container-title" font-style="italic"/>
+    </group>
+    <text macro="series-info" prefix=" "/>
+    <text macro="edition" prefix=", "/>
+    <text macro="publisher-place-year"/>
+    <text variable="page-first" prefix=" "/>    
+														 
+																				  
+  </macro>
+  <macro name="render-article-journal">
+    <group delimiter=" ">
+      <text variable="title" quotes="true"/>
+      <date form="text" variable="issued" date-parts="year" prefix="(" suffix=")"/>
+      <group delimiter=":">
+        <text variable="volume"/>
+        <text variable="issue"/>
+      </group>
+      <text macro="container-title"/>
+      <text variable="collection-title" prefix="(" suffix=") "/>
+      <text variable="page"/>
+    </group>
+    <text macro="internet-location"/>
+  </macro>
+  <macro name="render-book">
+    <group delimiter=", ">
+      <text variable="title" font-style="italic"/>
+      <text macro="edition"/>
+      <text macro="translator"/>
+      <text macro="editor"/>
+      <text macro="series-info"/>
+    </group>
+    <text macro="publisher-place-year"/>
+  </macro>
+  <macro name="render-report">
+    <group delimiter=", ">
+      <text variable="archive_location"/>
+      <text variable="archive"/>
+      <text variable="title" font-style="italic"/>
+      <text variable="genre"/>
+      <text macro="author-note" strip-periods="true" prefix="by "/>
+      <text variable="source"/>
+      <text variable="call-number"/>
+      <group delimiter=" ">
+        <text variable="collection-title" strip-periods="true"/>
+        <text macro="genre"/>
+        <text variable="number"/>
+      </group>
+    </group>
+    <text macro="publisher-place-year"/>
+  </macro>
+  <macro name="render-thesis">
+    <group delimiter=" ">
+      <text variable="title" font-style="italic"/>
+      <text macro="genre" prefix="(" suffix=","/>
+      <text variable="publisher" suffix=","/>
+      <date form="text" variable="issued" date-parts="year" suffix=") [unpublished]"/>
+    </group>
+  </macro>
+  <macro name="render-article-newspaper">
+    <group delimiter=" ">
+      <text variable="title" quotes="true" suffix=","/>
+      <text macro="container-title" font-style="italic"/>
+      <text macro="issued-long" prefix="(" suffix=")"/>
+      <text variable="page-first"/>
+    </group>
+    <text macro="internet-location"/>
+  </macro>
+  <macro name="render-article-magazine">
+    <group delimiter=" ">
+      <text variable="title" quotes="true" suffix=""/>
+      <text macro="container-title" font-style="italic"/>
+      <text macro="issued-long" prefix="(" suffix=")"/>
+      <text variable="page-first"/>
+    </group>
+    <text macro="internet-location"/>
+  </macro>
+  <macro name="render-webpage">
+    <group delimiter=" ">
+      <text variable="title" quotes="true" suffix=","/>
+      <text macro="issued-long" prefix="(" suffix=")"/>
+    </group>
+    <group delimiter=" ">
+      <text term="online" prefix=", " suffix=":"/>
+      <text macro="container-title" font-style="italic"/>
+      <text variable="URL" prefix="&lt;" suffix="&gt;"/>
+    </group>
+  </macro>
+  <!-- cases and bill legislations render the same for biblio and (first) cite -->
+  <macro name="render-bill">
+    <group delimiter=", ">
       <choose>
+        <if variable="container-title" match="none">
+          <!-- if no volume, assume bill -->
+          <text variable="publisher-place"/>
+          <text variable="authority"/>
+          <text variable="section"/>
+          <text variable="chapter-number"/>
+          <group delimiter=" ">
+            <text variable="title" font-style="italic"/>
+            <text variable="references" prefix="(" suffix=")"/>
+          </group>
+          <text variable="number-of-volumes"/>
+        
+          <group delimiter=" ">
+            <text variable="number"/>
+            <text macro="issued-long" prefix="(" suffix=")"/>
+          </group>
+        </if>
+        <else>
+          <text variable="number" prefix="Bill "/>
+          <group delimiter=" ">
+            <text variable="title" font-style="italic"/>
+            <text variable="references" prefix="(" suffix=")"/>
+          </group>
+          <text variable="chapter-number"/>
+          <text variable="authority"/>
+          <group delimiter=" ">
+            <date form="text" variable="issued" date-parts="year"/>
+          </group>
+          <text variable="section"/>
+        </else>
+      </choose>
+    </group>
+  </macro>
+  <macro name="render-legislation">
+	  
+	    <choose>
+		  <if variable="references" match="any">
+            <text variable="title"/>
+			<date form="text" variable="issued" date-parts="year" prefix=" (" suffix=")"/>
+        </if>
+        <else>
+		  <group delimiter=", ">
+            <group delimiter=" ">
+		   	  <text variable="title" font-style="italic"/>
+			  <text variable="references" prefix="(" suffix=")"/>
+
+
+			  <text macro="container-title"/>
+			  <date form="text" variable="issued" date-parts="year"/>
+		    </group>
+		    <text variable="section"/>
+		  </group>
+
+        </else>
+      </choose>
+
+	  
+	  
+	  
+		  
+	
+	
+  </macro>
+  <macro name="render-patent">
+    <group delimiter=" ">
+      <text variable="title" quotes="true" suffix=","/>
+      <text variable="publisher-place"/>
+      <text variable="number" prefix="Patent No "/>
+      <text variable="references" prefix=", PCT Patent No "/>
+      <text macro="submitted-long" prefix="(" suffix=")"/>
+    </group>
+  </macro>
+  <macro name="render-song">
+    <group delimiter=" ">
+      <text variable="title" quotes="true"/>
+      <text variable="medium" prefix="(" suffix=")"/>
+      <text macro="author-note" strip-periods="true" suffix=","/>
+      <text variable="publisher-place"/>
+      <text variable="call-number"/>
+      <text macro="issued-long" prefix="(" suffix=")"/>
+    </group>
+  </macro>
+  <macro name="render-manuscript">
+    <group delimiter=" ">
+      <text variable="title" quotes="true"/>
+      <text variable="medium" prefix="(" suffix=")"/>
+      <text macro="author-note" strip-periods="true" suffix=","/>
+      <text variable="publisher-place"/>
+      <text variable="call-number"/>
+      <text macro="issued-long" prefix="(" suffix=")"/>
+    </group>
+  </macro>
+  <macro name="render-case">
+        <text variable="title" font-style="italic" suffix=", " strip-periods="true"/>
+        <choose>
+          <if variable="container-title" match="none">
+            <group delimiter=" ">
+              <date form="text" variable="issued" date-parts="year"/>
+              <text variable="authority" strip-periods="true"/>
+              <text variable="page"/>
+            </group>
+          </if>
+          <else>
+            <date form="text" variable="issued" date-parts="year" prefix="[" suffix="] "/>
+            <text variable="volume" suffix=" "/>
+            <text variable="container-title" suffix=" " strip-periods="true"/>
+            <text variable="page"/>
+            <!-- COMMENTED OUT FOR 9TH ED  <text variable="authority" prefix=" (" suffix=")" strip-periods="true"/> -->
+          </else>
+        </choose>
+
+    <!-- COMMENTED OUT FOR 9TH ED  <text variable="URL" prefix=" (available on " suffix=")"/> -->
+  </macro>
+  <macro name="pinpoint">
+    <group delimiter=" ">
+      <choose>
+        <if locator="page">
+          <choose>
+            <if variable="locator">
+              <label variable="locator" plural="contextual" form="short" strip-periods="true" prefix=" "/>
+		      <text variable="locator"/>
+			 
+            </if>
+          </choose>
+        </if>
+		<else-if locator="section">
+		   <label variable="locator" plural="contextual" form="short" strip-periods="true" prefix=", "/>
+		   <text variable="locator"/>
+		</else-if>
+		<else-if locator="sub-verbo">
+		   <label variable="locator" plural="contextual" form="short" strip-periods="true" font-style="italic" prefix=" "/>
+		   <text variable="locator" quotes="true" />
+		</else-if>
+        <else>
+		  <label variable="locator" plural="contextual" form="short" strip-periods="true" prefix=" "/>
+		  <text variable="locator"/>
+        </else>
+      </choose>
+								
+    </group>
+  </macro>
+  <macro name="short-form">
+    <!-- Hump to overcome: cannot check against existence of short title.
+Not implemented: "cited to" for cases construct short casenames adding ref to article -->
+    <choose>
+      <if type="bill legal_case legislation" match="none">
+        <names variable="author">
+          <name and="symbol" form="short" delimiter-precedes-last="never"/>
+          <substitute>
+            <names variable="editor">
+              <name and="symbol" form="short"/>
+            </names>
+          </substitute>
+        </names>
+        <choose>
+          <if type="article-journal">
+            <text variable="title-short" quotes="true" prefix=", "/>
+          </if>
+        </choose>
+      </if>
+      <else>
+        <choose>
+          <if type="legal_case">
+            <choose>
+              <if variable="author">
+                <text variable="authority" suffix=", "/>
+                <date form="numeric" variable="issued" suffix=" "/>
+              </if>
+              <else-if variable="title" match="none">
+                <text variable="authority" suffix=", "/>
+                <date form="numeric" variable="issued" suffix=" "/>
+              </else-if>
+            </choose>
+          </if>
+        </choose>
+        <text variable="title" font-style="italic" form="short"/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="publisher-place-year">
+    <group delimiter=", " prefix=", " suffix="">
+      <group delimiter=", ">
+        <text variable="publisher-place"/>
+        <text variable="publisher"/>
+      </group>
+      <date form="text" variable="issued" date-parts="year"/>
+    </group>
+  </macro>
+  <citation et-al-min="4" et-al-use-first="1">
+    <!-- translator needs to be added for chapter book film etc. chapter? -->
+    <layout delimiter="; " suffix=".">
+      <choose>
+        <!-- Not implemented: ibid only needs capitalize-first if it's the first word in a footnote -->
         <if position="ibid-with-locator">
-          <text term="ibid" font-style="italic" strip-periods="true" text-case="capitalize-first"/>
-          <text macro="point-locators"/>
+          <group>
+            <text term="ibid" font-style="italic" strip-periods="true"/>
+            <text macro="pinpoint"/>
+          </group>
         </if>
         <else-if position="ibid">
-          <text term="ibid" font-style="italic" strip-periods="true" text-case="capitalize-first"/>
+          <text term="ibid" font-style="italic" strip-periods="true"/>
         </else-if>
+        <!-- For future versions? Cannot test for whether short form exists (Supra should be capitalized if no short form) -->
         <else-if position="subsequent">
-          <group delimiter=", ">
-            <choose>
-              <if type="bill legal_case legislation entry-dictionary" match="any">
-                <choose>
-                  <if type="legal_case">
-                    <choose>
-                      <if variable="author">
-                        <text variable="authority"/>
-                        <text macro="issued"/>
-                      </if>
-                      <else-if variable="title" match="none">
-                        <text variable="authority"/>
-                        <text macro="issued"/>
-                      </else-if>
-                    </choose>
-                  </if>
-                </choose>
-                <choose>
-                  <if variable="title-short" type="legislation bill entry-dictionary" match="all">
-                    <text variable="title-short"/>
-                  </if>
-                  <else-if variable="title" type="legal_case" match="any">
-                    <text variable="title" form="short" font-style="italic" strip-periods="true"/>
-                  </else-if>
-                  <else-if variable="title-short" match="any">
-                    <text variable="title-short" font-style="italic"/>
-                  </else-if>
-                  <else>
-                    <text variable="title" form="short" font-style="italic"/>
-                  </else>
-                </choose>
-              </if>
-              <else>
-                <text macro="contributors-short" strip-periods="true"/>
-              </else>
-            </choose>
-            <text value="supra" font-style="italic" suffix=" "/>
-          </group>
           <group delimiter=" ">
+            <group delimiter=", ">
+              <text macro="short-form"/>
+              <text value="supra" font-style="italic"/>
+            </group>
             <text value="note"/>
             <text variable="first-reference-note-number"/>
           </group>
-          <text macro="point-locators"/>
-        </else-if>
-        <else-if type="legislation">
-          <text macro="legislation-note"/>
-        </else-if>
-        <else-if type="bill">
-          <text macro="note-bill"/>
-        </else-if>
-        <else-if type="legal_case">
-          <text macro="note-case"/>
-        </else-if>
-        <else-if type="thesis">
-          <text macro="note-thesis"/>
-        </else-if>
-        <else-if type="chapter">
-          <text macro="note-chapter"/>
-        </else-if>
-        <else-if type="book report" match="any">
-          <text macro="note-book"/>
-        </else-if>
-        <else-if type="article-newspaper webpage post post-weblog" match="any">
-          <text macro="note-article-newspaper"/>
-        </else-if>
-        <else-if type="article-magazine">
-          <text macro="note-article-magazine"/>
-        </else-if>
-        <else-if type="article-journal">
-          <text macro="note-article-journal"/>
-        </else-if>
-        <else-if type="entry-dictionary">
-          <text macro="entrydic-note"/>
-        </else-if>
-        <else-if type="entry-encyclopedia">
-          <text macro="entryencyclo-note"/>
+          <text macro="pinpoint"/>
         </else-if>
         <else>
-          <group delimiter=", ">
-            <text macro="contributors-note" strip-periods="true"/>
-            <text variable="title" font-style="italic"/>
-            <text macro="description-note"/>
-            <text macro="secondary-contributors-note" strip-periods="true"/>
-            <group delimiter="">
-              <text macro="container-contributors-note" strip-periods="true"/>
-              <text macro="container-title-note"/>
+          <group>
+            <group delimiter=" ">
+              <choose>
+                <if type="legislation" match="any">
+				  <choose>
+				    <if variable="references" match="any">
+					  <group delimiter=" ">
+					  <text macro="pinpoint"/>
+					  <text macro="render-legislation"/>
+					  <text variable="note" prefix=", "/>
+					  </group>
+					</if>
+				    <else>
+					  <group delimiter="">
+					  <text macro="render-legislation"/>
+					  <text macro="pinpoint"/>
+					  <text variable="note" prefix=", "/>
+					  </group>
+					</else>
+				  </choose>
+                </if>
+                <else-if type="bill" match="any">
+                  <text macro="render-bill"/>
+				  <text macro="pinpoint"/>
+                  <text variable="note" prefix=", "/>
+                </else-if>
+                <else-if type="song" match="any">
+                  <text macro="render-song"/>
+				  <text macro="pinpoint"/>
+                  <text variable="note" prefix=", "/>
+                </else-if>
+                <else-if type="patent" match="any">
+                  <text macro="render-patent"/>
+				  <text macro="pinpoint"/>
+                  <text variable="note" prefix=", "/>
+                </else-if>
+                <else-if type="manuscript" match="any">
+                  <text macro="render-manuscript"/>
+				  <text macro="pinpoint"/>
+                  <text variable="note" prefix=", "/>
+                </else-if>
+                <else-if type="legal_case">
+				  <group delimiter="">
+                  <text macro="render-case"/>
+				  <text macro="pinpoint"/>
+                  <text variable="note" prefix=", "/>
+				  </group>
+                </else-if>
+                <else-if type="report">
+                  <text macro="render-report"/>
+				  <text macro="pinpoint"/>
+                  <text variable="note" prefix=", "/>
+                </else-if>
+                <else>
+				  
+                  <text macro="author-note" strip-periods="true"  suffix=", "/>
+                  <choose>
+                    <if type="article-journal">
+                      <text macro="render-article-journal"/>
+					  <text macro="pinpoint"/>
+					  <text variable="note" prefix=", "/>
+                    </if>
+                    <else-if type="chapter">
+                      <text macro="render-chapter"/>
+					  <text macro="pinpoint"/>
+					  <text variable="note" prefix=", "/>
+												   
+                    </else-if>
+                    <else-if type="entry-dictionary">
+                      <text macro="render-dictionary"/>
+					  <text macro="pinpoint"/>
+					  <text variable="note" prefix=", "/>
+                    </else-if>
+                    <else-if type="entry-encyclopedia">
+                      <text macro="render-encyclopedia"/>
+					  <text macro="pinpoint"/>
+					  <text variable="note" prefix=", "/>
+                    </else-if>
+                    <else-if type="thesis">
+                      <text macro="render-thesis"/>
+					  <text macro="pinpoint"/>
+					  <text variable="note" prefix=", "/>
+                    </else-if>
+                    <else-if type="article-newspaper" match="any">
+                      <text macro="render-article-newspaper"/>
+					  <text macro="pinpoint"/>
+					  <text variable="note" prefix=", "/>
+                    </else-if>
+                    <else-if type="article-magazine">
+                      <text macro="render-article-magazine"/>
+					  <text macro="pinpoint"/>
+					  <text variable="note" prefix=", "/>
+                    </else-if>
+                    <else-if type="webpage post-weblog" match="any">
+                      <text macro="render-webpage"/>
+					  <text macro="pinpoint"/>
+					  <text variable="note" prefix=", "/>
+                    </else-if>
+                    <else-if type="book">
+                      <text macro="render-book"/>
+					  <text macro="pinpoint"/>
+					  <text variable="note" prefix=", "/>
+                    </else-if>
+																																																																																																										
+                    <else>
+                      <group delimiter=" ">
+                        <group delimiter=", ">
+                          <text variable="title" font-style="italic"/>
+                          <text macro="translator"/>
+                          <text macro="edition"/>
+                        </group>
+                        <text macro="publisher-place-year"/>
+                      </group>					  
+					  <text macro="pinpoint"/>
+					  <text variable="note" prefix=", "/>
+                    </else>
+                  </choose>
+				  
+                </else>
+              </choose>
             </group>
-            <text variable="genre" strip-periods="true"/>
-            <text macro="collection-title" strip-periods="true"/>
-            <text variable="collection-number" strip-periods="true"/>
-            <text variable="publisher-place" strip-periods="true"/>
-            <text variable="publisher" strip-periods="true"/>
-            <text variable="event" strip-periods="true"/>
-            <text variable="issue" prefix="n°"/>
-            <text variable="volume" strip-periods="true"/>
-            <text macro="issued"/>
-            <text variable="page"/>
+									
+											   
+            <choose>
+              <if type="legal_case" match="any">
+                <text variable="references" prefix=", "/>
+                <text variable="title-short" prefix=" [" suffix="]" font-style="italic"/>
+              </if>
+            </choose>
           </group>
-          <text macro="point-locators"/>
-          <text macro="URL"/>
         </else>
       </choose>
     </layout>
   </citation>
-  <bibliography hanging-indent="true" subsequent-author-substitute="&#8212;&#8212;&#8212;" entry-spacing="0">
+  <bibliography et-al-min="4" et-al-use-first="1" subsequent-author-substitute="&#8212;&#8212;&#8212;">
     <sort>
       <key macro="sort-by-type"/>
-      <key macro="contributors-sort"/>
-      <key variable="issued"/>
+      <key macro="author-bib"/>
       <key variable="title"/>
+      <key variable="issued"/>
     </sort>
     <layout suffix=".">
       <choose>
-        <if type="legislation">
-          <text macro="legislation-bib"/>
+        <if type="bill legal_case legislation" match="any">
+          <choose>
+            <if type="legislation" match="any">
+              <text macro="render-legislation"/>
+            </if>
+            <else-if type="bill">
+              <text macro="render-bill"/>
+            </else-if>
+            <else-if type="legal_case">
+              <text macro="render-case"/>
+	      <text variable="note" prefix=", "/>
+            </else-if>
+          </choose>
         </if>
-        <else-if type="bill">
-          <text macro="bill"/>
-        </else-if>
-        <else-if type="legal_case">
-          <text macro="case"/>
-        </else-if>
-        <else-if type="thesis">
-          <text macro="thesis"/>
-        </else-if>
-        <else-if type="chapter paper-conference" match="any">
-          <text macro="chapter"/>
-        </else-if>
-        <else-if type="book report" match="any">
-          <text macro="book"/>
-        </else-if>
-        <else-if type="article-newspaper webpage post post-weblog" match="any">
-          <text macro="article-newspaper"/>
-        </else-if>
-        <else-if type="article-magazine">
-          <text macro="article-magazine"/>
-        </else-if>
-        <else-if type="article-journal">
-          <text macro="article-journal"/>
-        </else-if>
-        <else-if type="entry-dictionary">
-          <text macro="entrydic-bib"/>
-        </else-if>
-        <else-if type="entry-encyclopedia">
-          <text macro="entryencyclo-bib"/>
-        </else-if>
         <else>
-          <group delimiter=". ">
-            <text macro="contributors"/>
-            <group delimiter=", ">
-              <text variable="title" font-style="italic"/>
-              <text macro="description"/>
-              <text macro="secondary-contributors" strip-periods="true"/>
-              <group>
-                <text macro="container-contributors" strip-periods="true"/>
-                <text macro="container-title"/>
-              </group>
-              <text variable="genre" strip-periods="true"/>
-              <text macro="collection-title" strip-periods="true"/>
-              <text variable="collection-number" strip-periods="true"/>
-              <text variable="publisher-place" strip-periods="true"/>
-              <text variable="publisher" strip-periods="true"/>
-              <text variable="event" strip-periods="true"/>
-              <text variable="issue" prefix="n°"/>
-              <text variable="volume" strip-periods="true"/>
-              <text macro="issued"/>
-              <text variable="page" strip-periods="true"/>
-            </group>
+          <group delimiter=", ">
+            <choose>
+              <if type="article-journal">
+			    <text macro="author-bib" strip-periods="true"/>
+                <text macro="render-article-journal"/>
+              </if>
+              <else-if type="chapter">
+			    <text macro="author-bib" strip-periods="true"/>
+                <text macro="render-chapter"/>
+              </else-if>
+              <else-if type="thesis">
+			    <text macro="author-bib" strip-periods="true"/>
+                <text macro="render-thesis"/>
+              </else-if>
+              <else-if type="article-newspaper">
+			    <text macro="author-bib" strip-periods="true"/>
+                <text macro="render-article-newspaper"/>
+              </else-if>
+              <else-if type="article-magazine">
+			    <text macro="author-bib" strip-periods="true"/>
+                <text macro="render-article-magazine"/>
+              </else-if>
+              <else-if type="book">
+			    <text macro="author-bib" strip-periods="true"/>
+                <text macro="render-book"/>
+              </else-if>
+              <else-if type="webpage post-weblog" match="any">
+			    <text macro="author-bib" strip-periods="true"/>
+                <text macro="render-webpage"/>
+              </else-if>
+              <else-if type="entry-dictionary">
+			    <text macro="author-bib" strip-periods="true"/>
+                <text macro="render-dictionary"/>
+              </else-if>
+              <else-if type="entry-encyclopedia">
+			    <text macro="author-bib" strip-periods="true"/>
+                <text macro="render-encyclopedia"/>
+              </else-if>
+              <else-if type="report">
+			    <text macro="author-bib" strip-periods="true"/>
+                <text macro="render-report"/>
+              </else-if>
+              <else-if type="patent">
+                <text macro="render-patent"/>
+              </else-if>
+              <else-if type="song">
+                <text macro="render-song"/>
+              </else-if>
+              <else-if type="manuscript">
+			    <text macro="author-bib" strip-periods="true"/>
+                <text macro="render-manuscript"/>
+              </else-if>
+              <else>
+			    <text macro="author-bib" strip-periods="true"/>
+                <group>
+                  <group delimiter=", ">
+                    <text variable="title" font-style="italic"/>
+                    <text macro="edition"/>
+                    <text macro="translator"/>
+                    <text macro="editor"/>
+                  </group>
+                  <text macro="publisher-place-year"/>
+                </group>
+              </else>
+            </choose>
           </group>
         </else>
       </choose>

--- a/mcgill-fr.csl
+++ b/mcgill-fr.csl
@@ -41,10 +41,10 @@
         <single>à la p</single>
         <multiple>aux pp</multiple>
       </term>	  
-	  <term name="at" form="short">
-		<single>à la p</single>
-		<multiple>aux pp</multiple>
-	  </term>
+      <term name="at" form="short">
+	<single>à la p</single>
+	<multiple>aux pp</multiple>
+      </term>
       <term name="paragraph" form="short">
         <single>au para</single>
         <multiple>aux para</multiple>
@@ -70,8 +70,7 @@
       <term name="editor" form="short">dir</term>
       <term name="editor" form="verb">dir</term>
       <term name="translator" form="verb">traduit par</term>
-      <term name="in">dans</term>
-	  
+      <term name="in">dans</term>	  
     </terms>
   </locale>
   <macro name="editor">
@@ -199,8 +198,6 @@ all the other tests should have been done... -->
     <text macro="edition" prefix=", "/>
     <text macro="publisher-place-year"/>
     <text variable="page-first" prefix=" "/>    
-														 
-																				  
   </macro>
   <macro name="render-article-journal">
     <group delimiter=" ">
@@ -294,8 +291,7 @@ all the other tests should have been done... -->
             <text variable="title" font-style="italic"/>
             <text variable="references" prefix="(" suffix=")"/>
           </group>
-          <text variable="number-of-volumes"/>
-        
+          <text variable="number-of-volumes"/>        
           <group delimiter=" ">
             <text variable="number"/>
             <text macro="issued-long" prefix="(" suffix=")"/>
@@ -318,34 +314,23 @@ all the other tests should have been done... -->
     </group>
   </macro>
   <macro name="render-legislation">
-	  
-	    <choose>
-		  <if variable="references" match="any">
-            <text variable="title"/>
-			<date form="text" variable="issued" date-parts="year" prefix=" (" suffix=")"/>
-        </if>
-        <else>
-		  <group delimiter=", ">
-            <group delimiter=" ">
-		   	  <text variable="title" font-style="italic"/>
-			  <text variable="references" prefix="(" suffix=")"/>
-
-
-			  <text macro="container-title"/>
-			  <date form="text" variable="issued" date-parts="year"/>
-		    </group>
-		    <text variable="section"/>
-		  </group>
-
-        </else>
-      </choose>
-
-	  
-	  
-	  
-		  
-	
-	
+    <choose>
+      <if variable="references" match="any">
+        <text variable="title"/>
+	<date form="text" variable="issued" date-parts="year" prefix=" (" suffix=")"/>
+      </if>
+      <else>
+	<group delimiter=", ">
+          <group delimiter=" ">
+	    <text variable="title" font-style="italic"/>
+	    <text variable="references" prefix="(" suffix=")"/>
+ 	    <text macro="container-title"/>
+	    <date form="text" variable="issued" date-parts="year"/>
+	  </group>
+	  <text variable="section"/>
+	</group>
+      </else>
+    </choose>
   </macro>
   <macro name="render-patent">
     <group delimiter=" ">
@@ -377,24 +362,23 @@ all the other tests should have been done... -->
     </group>
   </macro>
   <macro name="render-case">
-        <text variable="title" font-style="italic" suffix=", " strip-periods="true"/>
-        <choose>
-          <if variable="container-title" match="none">
-            <group delimiter=" ">
-              <date form="text" variable="issued" date-parts="year"/>
-              <text variable="authority" strip-periods="true"/>
-              <text variable="page"/>
-            </group>
-          </if>
-          <else>
-            <date form="text" variable="issued" date-parts="year" prefix="[" suffix="] "/>
-            <text variable="volume" suffix=" "/>
-            <text variable="container-title" suffix=" " strip-periods="true"/>
-            <text variable="page"/>
-            <!-- COMMENTED OUT FOR 9TH ED  <text variable="authority" prefix=" (" suffix=")" strip-periods="true"/> -->
-          </else>
-        </choose>
-
+    <text variable="title" font-style="italic" suffix=", " strip-periods="true"/>
+    <choose>
+      <if variable="container-title" match="none">
+        <group delimiter=" ">
+          <date form="text" variable="issued" date-parts="year"/>
+          <text variable="authority" strip-periods="true"/>
+          <text variable="page"/>
+        </group>
+      </if>
+      <else>
+        <date form="text" variable="issued" date-parts="year" prefix="[" suffix="] "/>
+        <text variable="volume" suffix=" "/>
+        <text variable="container-title" suffix=" " strip-periods="true"/>
+        <text variable="page"/>
+        <!-- COMMENTED OUT FOR 9TH ED  <text variable="authority" prefix=" (" suffix=")" strip-periods="true"/> -->
+      </else>
+    </choose>
     <!-- COMMENTED OUT FOR 9TH ED  <text variable="URL" prefix=" (available on " suffix=")"/> -->
   </macro>
   <macro name="pinpoint">
@@ -404,30 +388,26 @@ all the other tests should have been done... -->
           <choose>
             <if variable="locator">
               <label variable="locator" plural="contextual" form="short" strip-periods="true" prefix=" "/>
-		      <text variable="locator"/>
-			 
+	      <text variable="locator"/>			 
             </if>
           </choose>
         </if>
-		<else-if locator="section">
-		   <label variable="locator" plural="contextual" form="short" strip-periods="true" prefix=", "/>
-		   <text variable="locator"/>
-		</else-if>
-		<else-if locator="sub-verbo">
-		   <label variable="locator" plural="contextual" form="short" strip-periods="true" font-style="italic" prefix=" "/>
-		   <text variable="locator" quotes="true" />
-		</else-if>
+	<else-if locator="section">
+	   <label variable="locator" plural="contextual" form="short" strip-periods="true" prefix=", "/>
+	   <text variable="locator"/>
+	</else-if>
+	<else-if locator="sub-verbo">
+	   <label variable="locator" plural="contextual" form="short" strip-periods="true" font-style="italic" prefix=" "/>
+	   <text variable="locator" quotes="true" />
+	</else-if>
         <else>
-		  <label variable="locator" plural="contextual" form="short" strip-periods="true" prefix=" "/>
-		  <text variable="locator"/>
+	  <label variable="locator" plural="contextual" form="short" strip-periods="true" prefix=" "/>
+	  <text variable="locator"/>
         </else>
-      </choose>
-								
+      </choose>								
     </group>
   </macro>
   <macro name="short-form">
-    <!-- Hump to overcome: cannot check against existence of short title.
-Not implemented: "cited to" for cases construct short casenames adding ref to article -->
     <choose>
       <if type="bill legal_case legislation" match="none">
         <names variable="author">
@@ -503,111 +483,103 @@ Not implemented: "cited to" for cases construct short casenames adding ref to ar
             <group delimiter=" ">
               <choose>
                 <if type="legislation" match="any">
-				  <choose>
-				    <if variable="references" match="any">
-					  <group delimiter=" ">
-					  <text macro="pinpoint"/>
-					  <text macro="render-legislation"/>
-					  <text variable="note" prefix=", "/>
-					  </group>
-					</if>
-				    <else>
-					  <group delimiter="">
-					  <text macro="render-legislation"/>
-					  <text macro="pinpoint"/>
-					  <text variable="note" prefix=", "/>
-					  </group>
-					</else>
-				  </choose>
+		  <choose>
+		    <if variable="references" match="any">
+		      <group delimiter=" ">
+			<text macro="pinpoint"/>
+			<text macro="render-legislation"/>
+			<text variable="note" prefix=", "/>
+		      </group>
+		    </if>
+		    <else>
+		      <group delimiter="">
+			<text macro="render-legislation"/>
+			<text macro="pinpoint"/>
+			<text variable="note" prefix=", "/>
+		      </group>
+		    </else>
+		  </choose>
                 </if>
                 <else-if type="bill" match="any">
                   <text macro="render-bill"/>
-				  <text macro="pinpoint"/>
+		  <text macro="pinpoint"/>
                   <text variable="note" prefix=", "/>
                 </else-if>
                 <else-if type="song" match="any">
                   <text macro="render-song"/>
-				  <text macro="pinpoint"/>
+		  <text macro="pinpoint"/>
                   <text variable="note" prefix=", "/>
                 </else-if>
-                <else-if type="patent" match="any">
-							
+                <else-if type="patent" match="any">					
                   <text macro="render-patent"/>
-				  <text macro="pinpoint"/>
+		  <text macro="pinpoint"/>
                   <text variable="note" prefix=", "/>
-			   
-                </else-if>
+		</else-if>
                 <else-if type="manuscript" match="any">
                   <text macro="render-manuscript"/>
-				  <text macro="pinpoint"/>
+		  <text macro="pinpoint"/>
                   <text variable="note" prefix=", "/>
                 </else-if>
                 <else-if type="legal_case">
-				  <group delimiter="">
-                  <text macro="render-case"/>
-				  <text macro="pinpoint"/>
-                  <text variable="note" prefix=", "/>
-				  </group>
+		  <group delimiter="">
+                    <text macro="render-case"/>
+		    <text macro="pinpoint"/>
+                    <text variable="note" prefix=", "/>
+		  </group>
                 </else-if>
                 <else-if type="report">
                   <text macro="render-report"/>
-				  <text macro="pinpoint"/>
+		  <text macro="pinpoint"/>
                   <text variable="note" prefix=", "/>
                 </else-if>
-                <else>
-				  
+                <else>			  
                   <text macro="author-note" strip-periods="true"  suffix=", "/>
                   <choose>
                     <if type="article-journal">
-							  
-                      <text macro="render-article-journal"/>
-					  <text macro="pinpoint"/>
-					  <text variable="note" prefix=", "/>
-													   
-                    </if>
-                    <else-if type="chapter">
-										 
-                      <text macro="render-chapter"/>
-					  <text macro="pinpoint"/>
-					  <text variable="note" prefix=", "/>
-												   
-                    </else-if>
-                    <else-if type="entry-dictionary">
-                      <text macro="render-dictionary"/>
-					  <text macro="pinpoint"/>
-					  <text variable="note" prefix=", "/>
-                    </else-if>
+		      <text macro="render-article-journal"/>
+		      <text macro="pinpoint"/>
+ 		      <text variable="note" prefix=", "/>
+		   </if>
+                   <else-if type="chapter">
+		     <text macro="render-chapter"/>
+		     <text macro="pinpoint"/>
+		     <text variable="note" prefix=", "/>
+		   </else-if>
+                   <else-if type="entry-dictionary">
+                     <text macro="render-dictionary"/>
+		     <text macro="pinpoint"/>
+		     <text variable="note" prefix=", "/>
+                   </else-if>
                     <else-if type="entry-encyclopedia">
                       <text macro="render-encyclopedia"/>
-					  <text macro="pinpoint"/>
-					  <text variable="note" prefix=", "/>
+		      <text macro="pinpoint"/>
+		      <text variable="note" prefix=", "/>
                     </else-if>
                     <else-if type="thesis">
                       <text macro="render-thesis"/>
-					  <text macro="pinpoint"/>
-					  <text variable="note" prefix=", "/>
+		      <text macro="pinpoint"/>
+		     <text variable="note" prefix=", "/>
                     </else-if>
                     <else-if type="article-newspaper" match="any">
                       <text macro="render-article-newspaper"/>
-					  <text macro="pinpoint"/>
-					  <text variable="note" prefix=", "/>
+		      <text macro="pinpoint"/>
+		      <text variable="note" prefix=", "/>
                     </else-if>
                     <else-if type="article-magazine">
                       <text macro="render-article-magazine"/>
-					  <text macro="pinpoint"/>
-					  <text variable="note" prefix=", "/>
+		      <text macro="pinpoint"/>
+		      <text variable="note" prefix=", "/>
                     </else-if>
                     <else-if type="webpage post-weblog" match="any">
                       <text macro="render-webpage"/>
-					  <text macro="pinpoint"/>
-					  <text variable="note" prefix=", "/>
+		      <text macro="pinpoint"/>
+		      <text variable="note" prefix=", "/>
                     </else-if>
                     <else-if type="book">
                       <text macro="render-book"/>
-					  <text macro="pinpoint"/>
-					  <text variable="note" prefix=", "/>
+		      <text macro="pinpoint"/>
+		      <text variable="note" prefix=", "/>
                     </else-if>
-																																																																																																										
                     <else>
                       <group delimiter=" ">
                         <group delimiter=", ">
@@ -617,16 +589,13 @@ Not implemented: "cited to" for cases construct short casenames adding ref to ar
                         </group>
                         <text macro="publisher-place-year"/>
                       </group>					  
-					  <text macro="pinpoint"/>
-					  <text variable="note" prefix=", "/>
+		      <text macro="pinpoint"/>
+		      <text variable="note" prefix=", "/>
                     </else>
-                  </choose>
-				  
+                  </choose>	  
                 </else>
               </choose>
             </group>
-									
-											   
             <choose>
               <if type="legal_case" match="any">
                 <text variable="references" prefix=", "/>
@@ -665,43 +634,43 @@ Not implemented: "cited to" for cases construct short casenames adding ref to ar
           <group delimiter=", ">
             <choose>
               <if type="article-journal">
-			    <text macro="author-bib" strip-periods="true"/>
+	        <text macro="author-bib" strip-periods="true"/>
                 <text macro="render-article-journal"/>
               </if>
               <else-if type="chapter">
-			    <text macro="author-bib" strip-periods="true"/>
+		<text macro="author-bib" strip-periods="true"/>
                 <text macro="render-chapter"/>
               </else-if>
               <else-if type="thesis">
-			    <text macro="author-bib" strip-periods="true"/>
+		<text macro="author-bib" strip-periods="true"/>
                 <text macro="render-thesis"/>
               </else-if>
               <else-if type="article-newspaper">
-			    <text macro="author-bib" strip-periods="true"/>
+		<text macro="author-bib" strip-periods="true"/>
                 <text macro="render-article-newspaper"/>
               </else-if>
               <else-if type="article-magazine">
-			    <text macro="author-bib" strip-periods="true"/>
+		<text macro="author-bib" strip-periods="true"/>
                 <text macro="render-article-magazine"/>
               </else-if>
               <else-if type="book">
-			    <text macro="author-bib" strip-periods="true"/>
+		<text macro="author-bib" strip-periods="true"/>
                 <text macro="render-book"/>
               </else-if>
               <else-if type="webpage post-weblog" match="any">
-			    <text macro="author-bib" strip-periods="true"/>
+		<text macro="author-bib" strip-periods="true"/>
                 <text macro="render-webpage"/>
               </else-if>
               <else-if type="entry-dictionary">
-			    <text macro="author-bib" strip-periods="true"/>
+		<text macro="author-bib" strip-periods="true"/>
                 <text macro="render-dictionary"/>
               </else-if>
               <else-if type="entry-encyclopedia">
-			    <text macro="author-bib" strip-periods="true"/>
+		<text macro="author-bib" strip-periods="true"/>
                 <text macro="render-encyclopedia"/>
               </else-if>
               <else-if type="report">
-			    <text macro="author-bib" strip-periods="true"/>
+		<text macro="author-bib" strip-periods="true"/>
                 <text macro="render-report"/>
               </else-if>
               <else-if type="patent">
@@ -711,11 +680,11 @@ Not implemented: "cited to" for cases construct short casenames adding ref to ar
                 <text macro="render-song"/>
               </else-if>
               <else-if type="manuscript">
-			    <text macro="author-bib" strip-periods="true"/>
+		<text macro="author-bib" strip-periods="true"/>
                 <text macro="render-manuscript"/>
               </else-if>
               <else>
-			    <text macro="author-bib" strip-periods="true"/>
+		<text macro="author-bib" strip-periods="true"/>
                 <group>
                   <group delimiter=", ">
                     <text variable="title" font-style="italic"/>

--- a/mcgill-fr.csl
+++ b/mcgill-fr.csl
@@ -38,8 +38,8 @@
 	  <term name="ordinal-01">&#x02B3;&#x1D49;</term>
       <term name="ordinal-02">&#x1D49;</term>
 	  <term name="page" form="short">
-        <single> à la p</single>
-        <multiple> aux pp</multiple>
+        <single>à la p</single>
+        <multiple>aux pp</multiple>
       </term>	  
 	  <term name="at" form="short">
 		<single>à la p</single>

--- a/mcgill-fr.csl
+++ b/mcgill-fr.csl
@@ -17,7 +17,7 @@
       <email>f.martin-bariteau@umontreal.ca</email>
       <uri>http://f-mb.github.io/cslegal/</uri>
     </contributor>
-	<contributor>
+    <contributor>
       <name>Jean-Sebastien Sauve</name>
     </contributor>
     <contributor>
@@ -34,29 +34,29 @@
     <style-options punctuation-in-quote="false"/>
     <terms>
       <term name="et-al">et al</term>
-      <term name="ordinal">&#x1D49;</term>
-	  <term name="ordinal-01">&#x02B3;&#x1D49;</term>
-      <term name="ordinal-02">&#x1D49;</term>
-	  <term name="page" form="short">
+      <term name="ordinal">&#7497;</term>
+      <term name="ordinal-01">ʳ&#7497;</term>
+      <term name="ordinal-02">&#7497;</term>
+      <term name="page" form="short">
         <single>à la p</single>
         <multiple>aux pp</multiple>
-      </term>	  
+      </term>
       <term name="at" form="short">
-	<single>à la p</single>
-	<multiple>aux pp</multiple>
+        <single>à la p</single>
+        <multiple>aux pp</multiple>
       </term>
       <term name="paragraph" form="short">
         <single>au para</single>
         <multiple>aux para</multiple>
       </term>
-	  <term name="sub verbo" form="short">
+      <term name="sub verbo" form="short">
         <single>sub verbo</single>
         <multiple>sub verbis</multiple>
       </term>
-	  <term name="part" form="short">
+      <term name="part" form="short">
         <single>Art</single>
         <multiple>Arts</multiple>
-      </term>			 
+      </term>
       <term name="section" form="short">
         <single>art</single>
         <multiple>arts</multiple>
@@ -70,7 +70,7 @@
       <term name="editor" form="short">dir</term>
       <term name="editor" form="verb">dir</term>
       <term name="translator" form="verb">traduit par</term>
-      <term name="in">dans</term>	  
+      <term name="in">dans</term>
     </terms>
   </locale>
   <macro name="editor">
@@ -116,7 +116,7 @@
       </if>
     </choose>
   </macro>
- <macro name="genre">
+  <macro name="genre">
     <text variable="genre"/>
   </macro>
   <macro name="issued-long">
@@ -185,7 +185,7 @@ all the other tests should have been done... -->
     <text macro="series-info" prefix=" "/>
     <text macro="edition" prefix=", "/>
     <text macro="publisher-place-year"/>
-    <text variable="page-first" prefix=" "/>     
+    <text variable="page-first" prefix=" "/>
   </macro>
   <macro name="render-encyclopedia">
     <group delimiter=" ">
@@ -197,7 +197,7 @@ all the other tests should have been done... -->
     <text macro="series-info" prefix=" "/>
     <text macro="edition" prefix=", "/>
     <text macro="publisher-place-year"/>
-    <text variable="page-first" prefix=" "/>    
+    <text variable="page-first" prefix=" "/>
   </macro>
   <macro name="render-article-journal">
     <group delimiter=" ">
@@ -291,7 +291,7 @@ all the other tests should have been done... -->
             <text variable="title" font-style="italic"/>
             <text variable="references" prefix="(" suffix=")"/>
           </group>
-          <text variable="number-of-volumes"/>        
+          <text variable="number-of-volumes"/>
           <group delimiter=" ">
             <text variable="number"/>
             <text macro="issued-long" prefix="(" suffix=")"/>
@@ -317,18 +317,18 @@ all the other tests should have been done... -->
     <choose>
       <if variable="references" match="any">
         <text variable="title"/>
-	<date form="text" variable="issued" date-parts="year" prefix=" (" suffix=")"/>
+        <date form="text" variable="issued" date-parts="year" prefix=" (" suffix=")"/>
       </if>
       <else>
-	<group delimiter=", ">
+        <group delimiter=", ">
           <group delimiter=" ">
-	    <text variable="title" font-style="italic"/>
-	    <text variable="references" prefix="(" suffix=")"/>
- 	    <text macro="container-title"/>
-	    <date form="text" variable="issued" date-parts="year"/>
-	  </group>
-	  <text variable="section"/>
-	</group>
+            <text variable="title" font-style="italic"/>
+            <text variable="references" prefix="(" suffix=")"/>
+            <text macro="container-title"/>
+            <date form="text" variable="issued" date-parts="year"/>
+          </group>
+          <text variable="section"/>
+        </group>
       </else>
     </choose>
   </macro>
@@ -388,23 +388,23 @@ all the other tests should have been done... -->
           <choose>
             <if variable="locator">
               <label variable="locator" plural="contextual" form="short" strip-periods="true" prefix=" "/>
-	      <text variable="locator"/>			 
+              <text variable="locator"/>
             </if>
           </choose>
         </if>
-	<else-if locator="section">
-	   <label variable="locator" plural="contextual" form="short" strip-periods="true" prefix=", "/>
-	   <text variable="locator"/>
-	</else-if>
-	<else-if locator="sub-verbo">
-	   <label variable="locator" plural="contextual" form="short" strip-periods="true" font-style="italic" prefix=" "/>
-	   <text variable="locator" quotes="true" />
-	</else-if>
+        <else-if locator="section">
+          <label variable="locator" plural="contextual" form="short" strip-periods="true" prefix=", "/>
+          <text variable="locator"/>
+        </else-if>
+        <else-if locator="sub-verbo">
+          <label variable="locator" plural="contextual" form="short" strip-periods="true" font-style="italic" prefix=" "/>
+          <text variable="locator" quotes="true"/>
+        </else-if>
         <else>
-	  <label variable="locator" plural="contextual" form="short" strip-periods="true" prefix=" "/>
-	  <text variable="locator"/>
+          <label variable="locator" plural="contextual" form="short" strip-periods="true" prefix=" "/>
+          <text variable="locator"/>
         </else>
-      </choose>								
+      </choose>
     </group>
   </macro>
   <macro name="short-form">
@@ -483,102 +483,102 @@ all the other tests should have been done... -->
             <group delimiter=" ">
               <choose>
                 <if type="legislation" match="any">
-		  <choose>
-		    <if variable="references" match="any">
-		      <group delimiter=" ">
-			<text macro="pinpoint"/>
-			<text macro="render-legislation"/>
-			<text variable="note" prefix=", "/>
-		      </group>
-		    </if>
-		    <else>
-		      <group delimiter="">
-			<text macro="render-legislation"/>
-			<text macro="pinpoint"/>
-			<text variable="note" prefix=", "/>
-		      </group>
-		    </else>
-		  </choose>
+                  <choose>
+                    <if variable="references" match="any">
+                      <group delimiter=" ">
+                        <text macro="pinpoint"/>
+                        <text macro="render-legislation"/>
+                        <text variable="note" prefix=", "/>
+                      </group>
+                    </if>
+                    <else>
+                      <group delimiter="">
+                        <text macro="render-legislation"/>
+                        <text macro="pinpoint"/>
+                        <text variable="note" prefix=", "/>
+                      </group>
+                    </else>
+                  </choose>
                 </if>
                 <else-if type="bill" match="any">
                   <text macro="render-bill"/>
-		  <text macro="pinpoint"/>
+                  <text macro="pinpoint"/>
                   <text variable="note" prefix=", "/>
                 </else-if>
                 <else-if type="song" match="any">
                   <text macro="render-song"/>
-		  <text macro="pinpoint"/>
+                  <text macro="pinpoint"/>
                   <text variable="note" prefix=", "/>
                 </else-if>
-                <else-if type="patent" match="any">					
+                <else-if type="patent" match="any">
                   <text macro="render-patent"/>
-		  <text macro="pinpoint"/>
+                  <text macro="pinpoint"/>
                   <text variable="note" prefix=", "/>
-		</else-if>
+                </else-if>
                 <else-if type="manuscript" match="any">
                   <text macro="render-manuscript"/>
-		  <text macro="pinpoint"/>
+                  <text macro="pinpoint"/>
                   <text variable="note" prefix=", "/>
                 </else-if>
                 <else-if type="legal_case">
-		  <group delimiter="">
+                  <group delimiter="">
                     <text macro="render-case"/>
-		    <text macro="pinpoint"/>
+                    <text macro="pinpoint"/>
                     <text variable="note" prefix=", "/>
-		  </group>
+                  </group>
                 </else-if>
                 <else-if type="report">
                   <text macro="render-report"/>
-		  <text macro="pinpoint"/>
+                  <text macro="pinpoint"/>
                   <text variable="note" prefix=", "/>
                 </else-if>
-                <else>			  
-                  <text macro="author-note" strip-periods="true"  suffix=", "/>
+                <else>
+                  <text macro="author-note" strip-periods="true" suffix=", "/>
                   <choose>
                     <if type="article-journal">
-		      <text macro="render-article-journal"/>
-		      <text macro="pinpoint"/>
- 		      <text variable="note" prefix=", "/>
-		   </if>
-                   <else-if type="chapter">
-		     <text macro="render-chapter"/>
-		     <text macro="pinpoint"/>
-		     <text variable="note" prefix=", "/>
-		   </else-if>
-                   <else-if type="entry-dictionary">
-                     <text macro="render-dictionary"/>
-		     <text macro="pinpoint"/>
-		     <text variable="note" prefix=", "/>
-                   </else-if>
+                      <text macro="render-article-journal"/>
+                      <text macro="pinpoint"/>
+                      <text variable="note" prefix=", "/>
+                    </if>
+                    <else-if type="chapter">
+                      <text macro="render-chapter"/>
+                      <text macro="pinpoint"/>
+                      <text variable="note" prefix=", "/>
+                    </else-if>
+                    <else-if type="entry-dictionary">
+                      <text macro="render-dictionary"/>
+                      <text macro="pinpoint"/>
+                      <text variable="note" prefix=", "/>
+                    </else-if>
                     <else-if type="entry-encyclopedia">
                       <text macro="render-encyclopedia"/>
-		      <text macro="pinpoint"/>
-		      <text variable="note" prefix=", "/>
+                      <text macro="pinpoint"/>
+                      <text variable="note" prefix=", "/>
                     </else-if>
                     <else-if type="thesis">
                       <text macro="render-thesis"/>
-		      <text macro="pinpoint"/>
-		     <text variable="note" prefix=", "/>
+                      <text macro="pinpoint"/>
+                      <text variable="note" prefix=", "/>
                     </else-if>
                     <else-if type="article-newspaper" match="any">
                       <text macro="render-article-newspaper"/>
-		      <text macro="pinpoint"/>
-		      <text variable="note" prefix=", "/>
+                      <text macro="pinpoint"/>
+                      <text variable="note" prefix=", "/>
                     </else-if>
                     <else-if type="article-magazine">
                       <text macro="render-article-magazine"/>
-		      <text macro="pinpoint"/>
-		      <text variable="note" prefix=", "/>
+                      <text macro="pinpoint"/>
+                      <text variable="note" prefix=", "/>
                     </else-if>
                     <else-if type="webpage post-weblog" match="any">
                       <text macro="render-webpage"/>
-		      <text macro="pinpoint"/>
-		      <text variable="note" prefix=", "/>
+                      <text macro="pinpoint"/>
+                      <text variable="note" prefix=", "/>
                     </else-if>
                     <else-if type="book">
                       <text macro="render-book"/>
-		      <text macro="pinpoint"/>
-		      <text variable="note" prefix=", "/>
+                      <text macro="pinpoint"/>
+                      <text variable="note" prefix=", "/>
                     </else-if>
                     <else>
                       <group delimiter=" ">
@@ -588,11 +588,11 @@ all the other tests should have been done... -->
                           <text macro="edition"/>
                         </group>
                         <text macro="publisher-place-year"/>
-                      </group>					  
-		      <text macro="pinpoint"/>
-		      <text variable="note" prefix=", "/>
+                      </group>
+                      <text macro="pinpoint"/>
+                      <text variable="note" prefix=", "/>
                     </else>
-                  </choose>	  
+                  </choose>
                 </else>
               </choose>
             </group>
@@ -626,7 +626,7 @@ all the other tests should have been done... -->
             </else-if>
             <else-if type="legal_case">
               <text macro="render-case"/>
-	      <text variable="note" prefix=", "/>
+              <text variable="note" prefix=", "/>
             </else-if>
           </choose>
         </if>
@@ -634,43 +634,43 @@ all the other tests should have been done... -->
           <group delimiter=", ">
             <choose>
               <if type="article-journal">
-	        <text macro="author-bib" strip-periods="true"/>
+                <text macro="author-bib" strip-periods="true"/>
                 <text macro="render-article-journal"/>
               </if>
               <else-if type="chapter">
-		<text macro="author-bib" strip-periods="true"/>
+                <text macro="author-bib" strip-periods="true"/>
                 <text macro="render-chapter"/>
               </else-if>
               <else-if type="thesis">
-		<text macro="author-bib" strip-periods="true"/>
+                <text macro="author-bib" strip-periods="true"/>
                 <text macro="render-thesis"/>
               </else-if>
               <else-if type="article-newspaper">
-		<text macro="author-bib" strip-periods="true"/>
+                <text macro="author-bib" strip-periods="true"/>
                 <text macro="render-article-newspaper"/>
               </else-if>
               <else-if type="article-magazine">
-		<text macro="author-bib" strip-periods="true"/>
+                <text macro="author-bib" strip-periods="true"/>
                 <text macro="render-article-magazine"/>
               </else-if>
               <else-if type="book">
-		<text macro="author-bib" strip-periods="true"/>
+                <text macro="author-bib" strip-periods="true"/>
                 <text macro="render-book"/>
               </else-if>
               <else-if type="webpage post-weblog" match="any">
-		<text macro="author-bib" strip-periods="true"/>
+                <text macro="author-bib" strip-periods="true"/>
                 <text macro="render-webpage"/>
               </else-if>
               <else-if type="entry-dictionary">
-		<text macro="author-bib" strip-periods="true"/>
+                <text macro="author-bib" strip-periods="true"/>
                 <text macro="render-dictionary"/>
               </else-if>
               <else-if type="entry-encyclopedia">
-		<text macro="author-bib" strip-periods="true"/>
+                <text macro="author-bib" strip-periods="true"/>
                 <text macro="render-encyclopedia"/>
               </else-if>
               <else-if type="report">
-		<text macro="author-bib" strip-periods="true"/>
+                <text macro="author-bib" strip-periods="true"/>
                 <text macro="render-report"/>
               </else-if>
               <else-if type="patent">
@@ -680,11 +680,11 @@ all the other tests should have been done... -->
                 <text macro="render-song"/>
               </else-if>
               <else-if type="manuscript">
-		<text macro="author-bib" strip-periods="true"/>
+                <text macro="author-bib" strip-periods="true"/>
                 <text macro="render-manuscript"/>
               </else-if>
               <else>
-		<text macro="author-bib" strip-periods="true"/>
+                <text macro="author-bib" strip-periods="true"/>
                 <group>
                   <group delimiter=", ">
                     <text variable="title" font-style="italic"/>

--- a/mcgill-fr.csl
+++ b/mcgill-fr.csl
@@ -117,33 +117,7 @@
       </if>
     </choose>
   </macro>
-  <macro name="URL">
-    <choose>
-      <if variable="DOI">
-        <text value=", doi&#160;: " font-variant="small-caps"/>
-        <text variable="DOI"/>
-      </if>
-      <else-if variable="URL">
-        <text value=", en ligne&#160;: "/>
-        <choose>
-          <if variable="archive" match="any">
-            <text variable="archive" text-case="capitalize-first"/>
-          </if>
-          <else>
-            <text variable="container-title" text-case="capitalize-first"/>
-          </else>
-        </choose>
-        <text variable="URL" prefix=" &lt;" suffix="&gt;"/>
-        <date variable="accessed" prefix=" (consulté le " suffix=")">
-          <date-part name="day" suffix=" "/>
-          <date-part name="month" suffix=" "/>
-          <date-part name="year"/>
-        </date>
-      </else-if>
-    </choose>
-  </macro>
-
-  <macro name="genre">
+ <macro name="genre">
     <text variable="genre"/>
   </macro>
   <macro name="issued-long">
@@ -557,9 +531,11 @@ Not implemented: "cited to" for cases construct short casenames adding ref to ar
                   <text variable="note" prefix=", "/>
                 </else-if>
                 <else-if type="patent" match="any">
+							
                   <text macro="render-patent"/>
 				  <text macro="pinpoint"/>
                   <text variable="note" prefix=", "/>
+			   
                 </else-if>
                 <else-if type="manuscript" match="any">
                   <text macro="render-manuscript"/>
@@ -583,11 +559,14 @@ Not implemented: "cited to" for cases construct short casenames adding ref to ar
                   <text macro="author-note" strip-periods="true"  suffix=", "/>
                   <choose>
                     <if type="article-journal">
+							  
                       <text macro="render-article-journal"/>
 					  <text macro="pinpoint"/>
 					  <text variable="note" prefix=", "/>
+													   
                     </if>
                     <else-if type="chapter">
+										 
                       <text macro="render-chapter"/>
 					  <text macro="pinpoint"/>
 					  <text variable="note" prefix=", "/>


### PR DESCRIPTION
Major update to mcgill-fr.csl to bring it up-to-date with 9th edition.  Based on recently updated mcgill-en.csl.  Library of examples found here:  https://www.zotero.org/groups/2577414/guide_mcgill_examples_franais/library