### PR TITLE
Update association-for-computing-machinery.csl

### DIFF
--- a/association-for-computing-machinery.csl
+++ b/association-for-computing-machinery.csl
@@ -88,7 +88,7 @@
   <macro name="access">
     <choose>
       <if variable="DOI">
-        <text variable="DOI" prefix="DOI:https://doi.org/"/>
+        <text variable="DOI" prefix="https://doi.org/"/>
       </if>
       <else-if variable="URL">
         <group delimiter=" ">


### PR DESCRIPTION
Removed "DOI" from DOI prefix.