### PR TITLE
Update mcgill-fr.csl

### DIFF
--- a/mcgill-fr.csl
+++ b/mcgill-fr.csl
@@ -321,9 +321,8 @@ all the other tests should have been done... -->
       </if>
       <else>
         <group delimiter=", ">
+          <text variable="title" font-style="italic"/>
           <group delimiter=" ">
-            <text variable="title" font-style="italic"/>
-            <text variable="references" prefix="(" suffix=")"/>
             <text macro="container-title"/>
             <date form="text" variable="issued" date-parts="year"/>
           </group>

--- a/mcgill-fr.csl
+++ b/mcgill-fr.csl
@@ -27,7 +27,7 @@
     </contributor>
     <category citation-format="note"/>
     <category field="law"/>
-    <updated>2020-10-07T23:45:43+00:00</updated>
+    <updated>2020-10-21T23:45:43+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale xml:lang="fr">


### PR DESCRIPTION
Minor correction to formatting of legislation - punctuation after statute title.  Also ran style through CSL Style Formatter for consistency.