### PR TITLE
citation-label as preferred bibtex citeKey (issue #4753)

### DIFF
--- a/bibtex.csl
+++ b/bibtex.csl
@@ -47,10 +47,17 @@
     </choose>
   </macro>
   <macro name="citeKey">
-    <group delimiter="_">
-      <text macro="author-short" text-case="lowercase"/>
-      <text macro="issued-year"/>
-    </group>
+    <choose>
+      <if variable="citation-label">
+        <text variable="citation-label"/>
+      </if>
+      <else>
+        <group delimiter="_">
+          <text macro="author-short" text-case="lowercase"/>
+          <text macro="issued-year"/>
+        </group>
+      </else>
+    </choose>
   </macro>
   <macro name="author-short">
     <names variable="author">


### PR DESCRIPTION
Enables correct bibtex.csl output when author's last name includes spaces, by choosing the `citation-label` variable as citekey instead, if it's available. (edit for ref: issue #4753)