### PR TITLE
Update society-for-american-archaeology.csl

### DIFF
--- a/society-for-american-archaeology.csl
+++ b/society-for-american-archaeology.csl
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" demote-non-dropping-particle="sort-only">
-  <!-- Polyglot; journal publishes in English and Spanish -->
   <info>
     <title>Society for American Archaeology</title>
     <title-short>SAA</title-short>
@@ -19,9 +18,12 @@
       <name>Allison Grunwald</name>
       <email>agrunwa1@uwyo.edu</email>
     </contributor>
+    <contributor>
+      <email>erik.marsh@gmail.com</email>
+    </contributor>
     <category citation-format="author-date"/>
     <category field="anthropology"/>
-    <updated>2020-04-17T09:23:48+00:00</updated>
+    <updated>2020-11-23T22:11:55+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale>
@@ -238,7 +240,7 @@
     <group>
       <choose>
         <if locator="page" match="none">
-          <label variable="locator" form="short" suffix=" "/>
+          <label text-case="capitalize-first" suffix=" " variable="locator"/>
         </if>
       </choose>
       <text variable="locator"/>
@@ -338,6 +340,10 @@
     <date date-parts="year" form="text" variable="original-date"/>
   </macro>
   <citation et-al-min="3" et-al-use-first="1" disambiguate-add-year-suffix="true" disambiguate-add-names="true" disambiguate-add-givenname="false" collapse="year">
+    <sort>
+      <key macro="contributors"/>
+      <key variable="issued"/>
+    </sort>
     <layout prefix="(" suffix=")" delimiter="; ">
       <group delimiter=":">
         <group delimiter=" ">

--- a/society-for-american-archaeology.csl
+++ b/society-for-american-archaeology.csl
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" demote-non-dropping-particle="sort-only">
+  <!-- Polyglot; journal publishes in English and Spanish -->
   <info>
     <title>Society for American Archaeology</title>
     <title-short>SAA</title-short>
@@ -19,6 +20,7 @@
       <email>agrunwa1@uwyo.edu</email>
     </contributor>
     <contributor>
+      <name>Erik Marsh</name>
       <email>erik.marsh@gmail.com</email>
     </contributor>
     <category citation-format="author-date"/>


### PR DESCRIPTION
Adds missing sort element for inline citations. Fixes non-page number locator labels (chapters, etc.) to be long form and capitalize-first.