### PR TITLE
ping distribution-updater

### DIFF
--- a/.github/workflows/merge.yaml
+++ b/.github/workflows/merge.yaml
@@ -15,6 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+      DISTRIBUTION_UPDATER_TOKEN: "${{ secrets.DISTRIBUTION_UPDATER_TOKEN }}"
     steps:
     - uses: actions/checkout@v2
       if: github.event_name == 'push'
@@ -89,3 +90,8 @@ jobs:
         repository: 'release'
         commit_message: ${{ github.event.inputs.commit_message }}
       if: github.event_name == 'workflow_dispatch'
+
+    - name: ping distribution-updater
+      run: |
+        curl -H "Authorization: $DISTRIBUTION_UPDATER_TOKEN" -F 'payload={"type":"pull_request","branch":"master","status":0,"commit":"'$GITHUB_SHA'"}' https://styles-update.zotero.org:8826/
+        curl -H "Authorization: $DISTRIBUTION_UPDATER_TOKEN" -F 'payload={"type":"pull_request","branch":"master","status":0,"commit":"'$GITHUB_SHA'"}' https://styles-update.zotero.org:8827/

--- a/.github/workflows/merge.yaml
+++ b/.github/workflows/merge.yaml
@@ -92,6 +92,7 @@ jobs:
       if: github.event_name == 'workflow_dispatch'
 
     - name: ping distribution-updater
+      if: github.repository == 'citation-style-language/styles'
       run: |
         curl -H "Authorization: $DISTRIBUTION_UPDATER_TOKEN" -F 'payload={"type":"pull_request","branch":"master","status":0,"commit":"'$GITHUB_SHA'"}' https://styles-update.zotero.org:8826/
         curl -H "Authorization: $DISTRIBUTION_UPDATER_TOKEN" -F 'payload={"type":"pull_request","branch":"master","status":0,"commit":"'$GITHUB_SHA'"}' https://styles-update.zotero.org:8827/

--- a/.github/workflows/sheldon.yaml
+++ b/.github/workflows/sheldon.yaml
@@ -14,24 +14,26 @@ jobs:
 
     - name: Check for relevant changes
       uses: dorny/paths-filter@v2
-      id: sheldon
+      id: changed
       with:
         list-files: shell
         filters: |
-          changed:
+          style:
             - '*.csl'
+          locale:
+            - '*.xml'
 
     - name: Changed files
       run: |
-        echo changed: ${{ steps.sheldon.outputs.changed_files }}
+        echo changed: ${{ steps.changed.outputs.style_files }} ${{ steps.changed.outputs.locale_files }}
 
     - name: Set up Ruby
-      if: steps.sheldon.outputs.changed == 'true'
+      if: steps.changed.outputs.style == 'true' || steps.changed.outputs.locale == 'true'
       uses: ruby/setup-ruby@v1
       with:
         ruby-version: 2.7.1
     - name: but use cache to speed that up
-      if: steps.sheldon.outputs.changed == 'true'
+      if: steps.changed.outputs.style == 'true' || steps.changed.outputs.locale == 'true'
       uses: actions/cache@v2
       with:
         path: vendor/bundle
@@ -39,23 +41,23 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-gems-
     - name: Bundle install
-      if: steps.sheldon.outputs.changed == 'true'
+      if: steps.changed.outputs.style == 'true' || steps.changed.outputs.locale == 'true'
       run: |
         bundle config path vendor/bundle
         bundle update sheldon --jobs 4 --retry 3
 
     - name: Apply the PR
-      if: steps.sheldon.outputs.changed == 'true'
+      if: steps.changed.outputs.style == 'true' || steps.changed.outputs.locale == 'true'
       run: bundle exec sheldon --token=$GITHUB_TOKEN --apply
 
     - name: Welcome to a new PR
-      if: github.event.action == 'opened' && steps.sheldon.outputs.changed == 'true'
+      if: github.event.action == 'opened' && steps.changed.outputs.style == 'true'
       run: bundle exec sheldon --token=$GITHUB_TOKEN --welcome
 
-    - name: See if the styles work
-      if: steps.sheldon.outputs.changed == 'true'
+    - name: See if the styles/locales work
+      if: steps.changed.outputs.style == 'true' || steps.changed.outputs.locale == 'true'
       run: bundle exec rake
 
     - name: report
-      if: (failure() || success()) && steps.sheldon.outputs.changed == 'true'
+      if: (failure() || success()) && steps.changed.outputs.style == 'true'
       run: bundle exec sheldon --token=$GITHUB_TOKEN --report --verbose


### PR DESCRIPTION
Assuming the distribution updater is going to bail on notifications of failed runs, this should do it (after setting the appropriate secret). If the ping for a failed build is still desired, that's just two lines and an `if` test extra.