### PR TITLE
Create opto-electronic-advances.csl

### DIFF
--- a/opto-electronic-advances.csl
+++ b/opto-electronic-advances.csl
@@ -6,8 +6,8 @@
     <title-short>Opto-Electron Adv</title-short>
     <id>http://www.zotero.org/styles/opto-electronic-advances</id>
     <link href="http://www.zotero.org/styles/opto-electronic-advances" rel="self"/>
-    <link href="http://www.oejournal.org/J/OEA/Channel/15" rel="documentation"/>
     <link href="http://www.zotero.org/styles/nature" rel="template"/>
+    <link href="http://www.oejournal.org/J/OEA/Channel/15" rel="documentation"/>
     <author>
       <email>xuhaofan@hust.edu.cn</email>
       <name>Xuhao Fan</name>

--- a/opto-electronic-advances.csl
+++ b/opto-electronic-advances.csl
@@ -1,10 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
-<style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" demote-non-dropping-particle="sort-only" default-locale="en-GB">
+<style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" default-locale="en-GB">
   <!-- This style was edited with the Visual CSL Editor (https://editor.citationstyles.org/visualEditor/) -->
   <info>
     <title>Opto-Electronic Advances</title>
     <title-short>Opto-Electron Adv</title-short>
-    <id>http://www.zotero.org/styles/opto-electronic-advances</id>
     <link href="http://www.zotero.org/styles/opto-electronic-advances" rel="self"/>
     <link href="http://www.oejournal.org/J/OEA/Channel/15" rel="documentation"/>
     <author>

--- a/opto-electronic-advances.csl
+++ b/opto-electronic-advances.csl
@@ -20,7 +20,7 @@
       <email>yuncheng_liu@outlook.com</email>
     </author>
     <category citation-format="numeric"/>
-    <category field="generic-base"/>
+    <category field="physics"/>
     <issn>2096-4579</issn>
     <updated>2020-11-28T02:08:33+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>

--- a/opto-electronic-advances.csl
+++ b/opto-electronic-advances.csl
@@ -1,11 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
 <style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" demote-non-dropping-particle="sort-only" default-locale="en-GB">
   <!-- This style was edited with the Visual CSL Editor (https://editor.citationstyles.org/visualEditor/) -->
- <info>
+  <info>
     <title>Opto-Electronic Advances</title>
-    <title-short> Opto-Electron. Adv.</title-short>
+    <title-short>Opto-Electron Adv</title-short>
     <id>http://www.zotero.org/styles/opto-electronic-advances</id>
-    <link rel="self" href="http://www.zotero.org/styles/opto-electronic-advances"/>
+    <link href="http://www.zotero.org/styles/opto-electronic-advances" rel="self"/>
+    <link href="http://www.oejournal.org/J/OEA/Channel/15" rel="documentation"/>
     <author>
       <email>xuhaofan@hust.edu.cn</email>
       <name>Xuhao Fan</name>
@@ -14,11 +15,14 @@
       <name>Hui Gao</name>
       <email>snail.hui@163.com</email>
     </author>
+    <author>
+      <name>Yuncheng Liu</name>
+      <email>yuncheng_liu@outlook.com</email>
+    </author>
     <category citation-format="numeric"/>
-    <category field="science"/>
-    <category field="optics"/>
+    <category field="generic-base"/>
     <issn>2096-4579</issn>
-    <updated>2020-11-27T14:11:08+00:00</updated>
+    <updated>2020-11-28T01:46:07+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <macro name="title">
@@ -49,8 +53,8 @@
   <macro name="issuance">
     <choose>
       <if type="bill book graphic legal_case legislation motion_picture song thesis chapter" match="any">
-        <group delimiter="," suffix=".">
-          <group delimiter="," prefix="(" suffix=")">
+        <group delimiter="; " suffix=".">
+          <group delimiter=", " prefix="(" suffix=")">
             <text variable="publisher" form="long"/>
             <text variable="publisher-place"/>
             <date variable="issued">
@@ -66,8 +70,8 @@
         </group>
       </else-if>
       <else-if type="paper-conference" match="any">
-        <group delimiter="," suffix=";">
-          <group delimiter="," prefix="(" suffix=")">
+        <group delimiter=";" suffix=";">
+          <group delimiter=", " prefix="(" suffix=")">
             <text variable="publisher"/>
             <text variable="publisher-place"/>
             <date variable="issued">

--- a/opto-electronic-advances.csl
+++ b/opto-electronic-advances.csl
@@ -1,4 +1,7 @@
-<info>
+<?xml version="1.0" encoding="utf-8"?>
+<style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" demote-non-dropping-particle="sort-only" default-locale="en-GB">
+  <!-- This style was edited with the Visual CSL Editor (https://editor.citationstyles.org/visualEditor/) -->
+ <info>
     <title>Opto-Electronic Advances</title>
     <title-short> Opto-Electron. Adv.</title-short>
     <id>http://www.zotero.org/styles/opto-electronic-advances</id>

--- a/opto-electronic-advances.csl
+++ b/opto-electronic-advances.csl
@@ -1,9 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
-<style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" default-locale="en-GB">
+<style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" demote-non-dropping-particle="sort-only" default-locale="en-GB">
   <!-- This style was edited with the Visual CSL Editor (https://editor.citationstyles.org/visualEditor/) -->
   <info>
     <title>Opto-Electronic Advances</title>
     <title-short>Opto-Electron Adv</title-short>
+    <id>http://www.zotero.org/styles/opto-electronic-advances</id>
     <link href="http://www.zotero.org/styles/opto-electronic-advances" rel="self"/>
     <link href="http://www.oejournal.org/J/OEA/Channel/15" rel="documentation"/>
     <author>
@@ -21,7 +22,7 @@
     <category citation-format="numeric"/>
     <category field="generic-base"/>
     <issn>2096-4579</issn>
-    <updated>2020-11-28T01:46:07+00:00</updated>
+    <updated>2020-11-28T02:08:33+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <macro name="title">
@@ -36,7 +37,7 @@
   </macro>
   <macro name="author">
     <names variable="author">
-      <name and="symbol" delimiter-precedes-last="never" et-al-min="5" et-al-use-first="5" initialize-with=". " name-as-sort-order="all"/>
+      <name and="symbol" delimiter-precedes-last="never" et-al-min="6" et-al-use-first="5" initialize-with=". " name-as-sort-order="all"/>
       <label form="short" prefix=", "/>
       <et-al font-style="italic"/>
     </names>

--- a/opto-electronic-advances.csl
+++ b/opto-electronic-advances.csl
@@ -1,4 +1,4 @@
-  <info>
+<info>
     <title>Opto-Electronic Advances</title>
     <title-short> Opto-Electron. Adv.</title-short>
     <id>http://www.zotero.org/styles/opto-electronic-advances</id>

--- a/opto-electronic-advances.csl
+++ b/opto-electronic-advances.csl
@@ -1,0 +1,144 @@
+  <info>
+    <title>Opto-Electronic Advances</title>
+    <title-short> Opto-Electron. Adv.</title-short>
+    <id>http://www.zotero.org/styles/opto-electronic-advances</id>
+    <link rel="self" href="http://www.zotero.org/styles/opto-electronic-advances"/>
+    <author>
+      <email>xuhaofan@hust.edu.cn</email>
+      <name>Xuhao Fan</name>
+    </author>
+    <author>
+      <name>Hui Gao</name>
+      <email>snail.hui@163.com</email>
+    </author>
+    <category citation-format="numeric"/>
+    <category field="science"/>
+    <category field="optics"/>
+    <issn>2096-4579</issn>
+    <updated>2020-11-27T14:11:08+00:00</updated>
+    <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
+  </info>
+  <macro name="title">
+    <choose>
+      <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
+        <text variable="title" font-style="italic"/>
+      </if>
+      <else>
+        <text variable="title"/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="author">
+    <names variable="author">
+      <name and="symbol" delimiter-precedes-last="never" et-al-min="5" et-al-use-first="5" initialize-with=". " name-as-sort-order="all"/>
+      <label form="short" prefix=", "/>
+      <et-al font-style="italic"/>
+    </names>
+  </macro>
+  <macro name="access">
+    <choose>
+      <if variable="volume"/>
+      <else-if variable="DOI">
+        <text variable="DOI" prefix="doi:"/>
+      </else-if>
+    </choose>
+  </macro>
+  <macro name="issuance">
+    <choose>
+      <if type="bill book graphic legal_case legislation motion_picture song thesis chapter" match="any">
+        <group delimiter="," suffix=".">
+          <group delimiter="," prefix="(" suffix=")">
+            <text variable="publisher" form="long"/>
+            <text variable="publisher-place"/>
+            <date variable="issued">
+              <date-part name="year"/>
+            </date>
+          </group>
+        </group>
+      </if>
+      <else-if type="report webpage post post-weblog" match="any">
+        <group delimiter=" ">
+          <text variable="URL"/>
+          <date date-parts="year" form="text" variable="issued" prefix="(" suffix=")"/>
+        </group>
+      </else-if>
+      <else-if type="paper-conference" match="any">
+        <group delimiter="," suffix=";">
+          <group delimiter="," prefix="(" suffix=")">
+            <text variable="publisher"/>
+            <text variable="publisher-place"/>
+            <date variable="issued">
+              <date-part name="year"/>
+            </date>
+          </group>
+        </group>
+      </else-if>
+      <else>
+        <date variable="issued" prefix="(" suffix=")">
+          <date-part name="year"/>
+        </date>
+      </else>
+    </choose>
+  </macro>
+  <macro name="container-title">
+    <choose>
+      <if type="article-journal">
+        <text variable="container-title" font-style="italic" form="short"/>
+      </if>
+      <else>
+        <text variable="container-title" font-style="italic"/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="editor">
+    <choose>
+      <if type="chapter paper-conference" match="any">
+        <names variable="editor" prefix="(" suffix=")">
+          <label form="short" suffix=" "/>
+          <name and="symbol" delimiter-precedes-last="never" initialize-with=". " name-as-sort-order="all"/>
+        </names>
+      </if>
+    </choose>
+  </macro>
+  <macro name="volume">
+    <choose>
+      <if type="article-journal" match="any">
+        <text variable="volume" font-weight="bold" suffix=","/>
+      </if>
+      <else>
+        <group delimiter=" ">
+          <label variable="volume" form="short"/>
+          <text variable="volume"/>
+        </group>
+      </else>
+    </choose>
+  </macro>
+  <citation collapse="citation-number">
+    <sort>
+      <key variable="citation-number"/>
+    </sort>
+    <layout vertical-align="sup" delimiter="," prefix="[" suffix="]">
+      <text variable="citation-number"/>
+    </layout>
+  </citation>
+  <bibliography et-al-min="6" et-al-use-first="1" second-field-align="flush" entry-spacing="0" line-spacing="2">
+    <layout suffix=".">
+      <text variable="citation-number" suffix="."/>
+      <group delimiter=" ">
+        <text macro="author" suffix="."/>
+        <text macro="title" suffix="."/>
+        <choose>
+          <if type="chapter paper-conference" match="any">
+            <text term="in"/>
+          </if>
+        </choose>
+        <text macro="container-title"/>
+        <text macro="editor"/>
+        <text macro="volume"/>
+        <text variable="page"/>
+        <text macro="issuance"/>
+        <text macro="access"/>
+      </group>
+    </layout>
+  </bibliography>
+</style>

--- a/opto-electronic-advances.csl
+++ b/opto-electronic-advances.csl
@@ -7,6 +7,7 @@
     <id>http://www.zotero.org/styles/opto-electronic-advances</id>
     <link href="http://www.zotero.org/styles/opto-electronic-advances" rel="self"/>
     <link href="http://www.oejournal.org/J/OEA/Channel/15" rel="documentation"/>
+    <link href="http://www.zotero.org/styles/nature" rel="template"/>
     <author>
       <email>xuhaofan@hust.edu.cn</email>
       <name>Xuhao Fan</name>


### PR DESCRIPTION
This is a CSL citation style for "Opto-Electronic Advances" which can't  be found in the Zotero Style Repository before. The style was created by myself.