### PR TITLE
Update china-national-standard-gb-t-7714-2015-numeric.csl

### DIFF
--- a/china-national-standard-gb-t-7714-2015-numeric.csl
+++ b/china-national-standard-gb-t-7714-2015-numeric.csl
@@ -186,6 +186,54 @@
     </layout>
   </citation>
   <bibliography entry-spacing="0" et-al-min="4" et-al-use-first="3" line-spacing="1" second-field-align="flush">
+    <layout suffix="." locale="en">
+      <text variable="citation-number" prefix="[" suffix="]"/>
+      <text macro="author" suffix=". "/>
+      <text macro="title"/>
+      <choose>
+        <if type="book bill chapter legislation paper-conference report thesis" match="any">
+          <text macro="editor" prefix=". "/>
+          <choose>
+            <if variable="container-title">
+              <text value="//"/>
+              <text macro="container-author" suffix=". "/>
+              <text variable="container-title" suffix=". " text-case="title"/>
+            </if>
+            <else>
+              <text value=". "/>
+            </else>
+          </choose>
+          <text macro="edition" suffix=". "/>
+          <text macro="publishing"/>
+        </if>
+        <else-if type="article-journal article-magazine article-newspaper" match="any">
+          <group prefix=". ">
+            <choose>
+              <if variable="container-title">
+                <text variable="container-title" text-case="title"/>
+                <text macro="serial-information" prefix=", "/>
+              </if>
+              <else>
+                <text macro="serial-information" suffix=". "/>
+                <text macro="publishing"/>
+              </else>
+            </choose>
+          </group>
+        </else-if>
+        <else-if type="patent">
+          <text macro="issued-date" prefix=". "/>
+        </else-if>
+        <else>
+          <text macro="publishing" prefix=". "/>
+          <text macro="issued-date" prefix="(" suffix=")"/>
+        </else>
+      </choose>
+      <text macro="accessed-date"/>
+      <group delimiter=". " prefix=". ">
+        <text variable="URL"/>
+        <text variable="DOI" prefix="DOI:"/>
+      </group>
+    </layout>
     <layout suffix=".">
       <text variable="citation-number" prefix="[" suffix="]"/>
       <text macro="author" suffix=". "/>


### PR DESCRIPTION
Add dual language support for "et-al-min term"  (English: et al and Chinese: 等)in bibliography.