### PR TITLE
Added name of the editors of a given edition

### DIFF
--- a/guide-des-citations-references-et-abreviations-juridiques.csl
+++ b/guide-des-citations-references-et-abreviations-juridiques.csl
@@ -23,7 +23,7 @@
       <term name="ordinal-02">e</term>
       <term name="ordinal-03">e</term>
       <term name="ordinal-04">e</term>
-      <term name="cited">op. cit.</term>
+      <term name="cited">op.&#160;cit.</term>
       <term name="page" form="short">p.</term>
       <term name="editor" form="short">dir.</term>
     </terms>
@@ -42,7 +42,7 @@
           <name form="long" and="text" sort-separator=" " initialize-with="." font-style="normal">
             <name-part name="family" font-variant="small-caps"/>
           </name>
-          <label form="short" prefix=" (" suffix=".)"/>
+          <label form="short" prefix="&#160;(" suffix=".)"/>
         </names>
       </else-if>
     </choose>
@@ -52,7 +52,7 @@
       <name form="long" and="text" delimiter-precedes-last="never" sort-separator=" " initialize-with="." font-style="normal">
         <name-part name="family" font-variant="normal"/>
       </name>
-      <label form="short" prefix=" (" suffix=".)"/>
+      <label form="short" prefix="&#160;(" suffix=".)"/>
     </names>
   </macro>
   <macro name="translator">
@@ -139,7 +139,7 @@
           </date>
           <choose>
             <if variable="locator" match="any">
-              <text variable="locator" prefix="p. "/>
+              <text variable="locator" prefix="p.&#160;"/>
             </if>
           </choose>
         </group>
@@ -162,7 +162,7 @@
           <group delimiter=" " font-style="normal">
             <choose>
               <if variable="locator" match="any">
-                <text variable="locator" prefix="p. "/>
+                <text variable="locator" prefix="p.&#160;"/>
               </if>
               <else-if variable="locator" match="none">
                 <label variable="page" form="short"/>
@@ -197,7 +197,7 @@
           </group>
           <choose>
             <if variable="locator" match="any">
-              <text variable="locator" prefix="p. "/>
+              <text variable="locator" prefix="p.&#160;"/>
             </if>
           </choose>
         </group>
@@ -214,7 +214,7 @@
           </group>
           <choose>
             <if variable="locator" match="any">
-              <text variable="locator" prefix="p. "/>
+              <text variable="locator" prefix="p.&#160;"/>
             </if>
             <else-if variable="locator" match="none">
               <label variable="page" form="short"/>
@@ -227,7 +227,7 @@
         <group delimiter=" " font-style="normal">
           <choose>
             <if variable="locator" match="any">
-              <text variable="locator" prefix="p. "/>
+              <text variable="locator" prefix="p.&#160;"/>
             </if>
             <else-if variable="locator" match="none">
               <label variable="page" form="short"/>
@@ -246,7 +246,7 @@
           <group delimiter=" " font-style="normal">
             <choose>
               <if variable="locator" match="any">
-                <text variable="locator" prefix="p. "/>
+                <text variable="locator" prefix="p.&#160;"/>
               </if>
               <else-if variable="locator" match="none">
                 <label variable="page" form="short"/>
@@ -309,12 +309,12 @@
     </choose>
   </macro>
   <citation>
-    <layout delimiter=" ; ">
+    <layout delimiter="&#160;; ">
       <choose>
         <if position="ibid-with-locator subsequent">
           <group delimiter=", ">
             <text term="ibid" text-case="capitalize-first" font-style="italic" suffix="."/>
-            <text variable="locator" prefix="p. "/>
+            <text variable="locator" prefix="p.&#160;"/>
           </group>
         </if>
         <else-if position="ibid">
@@ -363,7 +363,7 @@
                 <text variable="title" text-case="capitalize-first" form="short" quotes="true" font-style="normal"/>
               </else>
             </choose>
-            <text variable="locator" prefix="p. "/>
+            <text variable="locator" prefix="p.&#160;"/>
           </group>
         </else-if>
         <else>

--- a/guide-des-citations-references-et-abreviations-juridiques.csl
+++ b/guide-des-citations-references-et-abreviations-juridiques.csl
@@ -3,8 +3,8 @@
   <!-- This style was edited with the Visual CSL Editor (https://editor.citationstyles.org/visualEditor/) -->
   <info>
     <title>Guide des citations, références et abréviations juridiques 6e édition (French)</title>
-    <id>http://www.zotero.org/styles/guide-des-citations-references-et-abreviations-juridiques</id>
-    <link href="http://www.zotero.org/styles/guide-des-citations-references-et-abreviations-juridiques" rel="self"/>
+    <id>http://www.zotero.org/styles/guide-des-citations-references-et-abreviations-juridiques-6e-edition</id>
+    <link href="http://www.zotero.org/styles/guide-des-citations-references-et-abreviations-juridiques-6e-edition" rel="self"/>
     <link href="http://www.zotero.org/styles/le-mouvement-social" rel="template"/>
     <link href="https://legalworld.wolterskluwer.be/media/4562/guide-des-citations-references-abreviations-juridiques.pdf" rel="documentation"/>
     <link href="https://github.com/citation-style-language/styles/files/5551152/Guide.des.citation.references.et.abreviations.juridiques.CSL.docx" rel="documentation"/>
@@ -14,8 +14,8 @@
     </author>
     <category citation-format="note"/>
     <category field="law"/>
-    <updated>2020-11-15T16:28:23+00:00</updated>
-    <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
+    <updated>2020-11-29T15:58:08+00:00</updated>
+    <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 4.0 License</rights>
   </info>
   <locale xml:lang="fr">
     <terms>
@@ -23,7 +23,7 @@
       <term name="ordinal-02">e</term>
       <term name="ordinal-03">e</term>
       <term name="ordinal-04">e</term>
-      <term name="cited">op.&#160;cit.</term>
+      <term name="cited">op. cit.</term>
       <term name="page" form="short">p.</term>
       <term name="editor" form="short">dir.</term>
     </terms>
@@ -42,7 +42,7 @@
           <name form="long" and="text" sort-separator=" " initialize-with="." font-style="normal">
             <name-part name="family" font-variant="small-caps"/>
           </name>
-          <label form="short" prefix="&#160;(" suffix=".)"/>
+          <label form="short" prefix=" (" suffix=".)"/>
         </names>
       </else-if>
     </choose>
@@ -52,7 +52,7 @@
       <name form="long" and="text" delimiter-precedes-last="never" sort-separator=" " initialize-with="." font-style="normal">
         <name-part name="family" font-variant="normal"/>
       </name>
-      <label form="short" prefix="&#160;(" suffix=".)"/>
+      <label form="short" prefix=" (" suffix=".)"/>
     </names>
   </macro>
   <macro name="translator">
@@ -139,7 +139,7 @@
           </date>
           <choose>
             <if variable="locator" match="any">
-              <text variable="locator" prefix="p.&#160;"/>
+              <text variable="locator" prefix="p. "/>
             </if>
           </choose>
         </group>
@@ -162,7 +162,7 @@
           <group delimiter=" " font-style="normal">
             <choose>
               <if variable="locator" match="any">
-                <text variable="locator" prefix="p.&#160;"/>
+                <text variable="locator" prefix="p. "/>
               </if>
               <else-if variable="locator" match="none">
                 <label variable="page" form="short"/>
@@ -197,7 +197,7 @@
           </group>
           <choose>
             <if variable="locator" match="any">
-              <text variable="locator" prefix="p.&#160;"/>
+              <text variable="locator" prefix="p. "/>
             </if>
           </choose>
         </group>
@@ -214,7 +214,7 @@
           </group>
           <choose>
             <if variable="locator" match="any">
-              <text variable="locator" prefix="p.&#160;"/>
+              <text variable="locator" prefix="p. "/>
             </if>
             <else-if variable="locator" match="none">
               <label variable="page" form="short"/>
@@ -227,7 +227,7 @@
         <group delimiter=" " font-style="normal">
           <choose>
             <if variable="locator" match="any">
-              <text variable="locator" prefix="p.&#160;"/>
+              <text variable="locator" prefix="p. "/>
             </if>
             <else-if variable="locator" match="none">
               <label variable="page" form="short"/>
@@ -246,7 +246,7 @@
           <group delimiter=" " font-style="normal">
             <choose>
               <if variable="locator" match="any">
-                <text variable="locator" prefix="p.&#160;"/>
+                <text variable="locator" prefix="p. "/>
               </if>
               <else-if variable="locator" match="none">
                 <label variable="page" form="short"/>
@@ -279,6 +279,15 @@
           </if>
           <else>
             <text variable="edition" text-case="capitalize-first" suffix="."/>
+            <choose>
+              <if type="book" match="all" variable="editor edition">
+                <names variable="editor" prefix=" par ">
+                  <name and="text" delimiter-precedes-last="never" initialize-with="." sort-separator="">
+                    <name-part name="family"/>
+                  </name>
+                </names>
+              </if>
+            </choose>
           </else>
         </choose>
       </if>
@@ -300,12 +309,12 @@
     </choose>
   </macro>
   <citation>
-    <layout delimiter="&#160;; ">
+    <layout delimiter=" ; ">
       <choose>
         <if position="ibid-with-locator subsequent">
           <group delimiter=", ">
             <text term="ibid" text-case="capitalize-first" font-style="italic" suffix="."/>
-            <text variable="locator" prefix="p.&#160;"/>
+            <text variable="locator" prefix="p. "/>
           </group>
         </if>
         <else-if position="ibid">
@@ -354,7 +363,7 @@
                 <text variable="title" text-case="capitalize-first" form="short" quotes="true" font-style="normal"/>
               </else>
             </choose>
-            <text variable="locator" prefix="p.&#160;"/>
+            <text variable="locator" prefix="p. "/>
           </group>
         </else-if>
         <else>

--- a/guide-des-citations-references-et-abreviations-juridiques.csl
+++ b/guide-des-citations-references-et-abreviations-juridiques.csl
@@ -3,8 +3,8 @@
   <!-- This style was edited with the Visual CSL Editor (https://editor.citationstyles.org/visualEditor/) -->
   <info>
     <title>Guide des citations, références et abréviations juridiques 6e édition (French)</title>
-    <id>http://www.zotero.org/styles/guide-des-citations-references-et-abreviations-juridiques-6e-edition</id>
-    <link href="http://www.zotero.org/styles/guide-des-citations-references-et-abreviations-juridiques-6e-edition" rel="self"/>
+    <id>http://www.zotero.org/styles/guide-des-citations-references-et-abreviations-juridiques</id>
+    <link href="http://www.zotero.org/styles/guide-des-citations-references-et-abreviations-juridiques" rel="self"/>
     <link href="http://www.zotero.org/styles/le-mouvement-social" rel="template"/>
     <link href="https://legalworld.wolterskluwer.be/media/4562/guide-des-citations-references-abreviations-juridiques.pdf" rel="documentation"/>
     <link href="https://github.com/citation-style-language/styles/files/5551152/Guide.des.citation.references.et.abreviations.juridiques.CSL.docx" rel="documentation"/>
@@ -15,7 +15,7 @@
     <category citation-format="note"/>
     <category field="law"/>
     <updated>2020-11-29T15:58:08+00:00</updated>
-    <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 4.0 License</rights>
+    <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale xml:lang="fr">
     <terms>


### PR DESCRIPTION
Added support for the name of the editors of a given edition.
e.g. in H. DE PAGE, Traité élémentaire de droit civil belge, 4e éd. par A. Meinertzhagen-Limpens, Bruxelles, Bruylant, 1997
added support for "par A. Meinertzhagen-Limpens"