### PR TITLE
Cross copy workflows to locales

### DIFF
--- a/.github/workflows/merge.yaml
+++ b/.github/workflows/merge.yaml
@@ -105,11 +105,14 @@ jobs:
         curl -H 'Content-Length:' -H "Authorization: $ZOTERO_UPDATE_TOKEN" -F 'payload={"type":"push","branch":"${{ steps.release.outputs.branch }}","status":0,"commit":"'$GITHUB_SHA'"}' https://styles-update.zotero.org:8826/
         curl -H 'Content-Length:' -H "Authorization: $ZOTERO_UPDATE_TOKEN" -F 'payload={"type":"push","branch":"${{ steps.release.outputs.branch }}","status":0,"commit":"'$GITHUB_SHA'"}' https://styles-update.zotero.org:8827/
 
+    - name: copy workflows to locales -- authorization
+      uses: webfactory/ssh-agent@v0.4.1
+      with:
+        ssh-private-key: ${{ secrets.BLIP_BLOOP }}
     - name: copy workflows to locales -- clone locales
       if: github.repository == 'retorquere/styles' && steps.update.outputs.workflows == 'true'
       uses: actions/checkout@v2
       with:
-        ssh-key: ${ secrets.BLIP_BLOOP }
         repository: 'retorquere/locales'
         path: 'locales'
     - name: copy workflows to locales -- copy workflows

--- a/.github/workflows/merge.yaml
+++ b/.github/workflows/merge.yaml
@@ -110,7 +110,7 @@ jobs:
       uses: drud/action-cross-commit@master
       with:
         source-folder: .github/workflows
-        destination-repository: https://csl-bot:${{ secrets.CSLBOT }}@github.com/citation-style-language/locales
+        destination-repository: https://csl-bot:${{ secrets.CSL_BOT_TOKEN }}@github.com/citation-style-language/locales
         destination-folder: .github/workflows
         destination-branch: master
         git-user: "csl-bot"

--- a/.github/workflows/merge.yaml
+++ b/.github/workflows/merge.yaml
@@ -106,7 +106,7 @@ jobs:
         curl -H 'Content-Length:' -H "Authorization: $ZOTERO_UPDATE_TOKEN" -F 'payload={"type":"push","branch":"${{ steps.release.outputs.branch }}","status":0,"commit":"'$GITHUB_SHA'"}' https://styles-update.zotero.org:8827/
 
     - name: Copy workflows to locales repository
-      if: github.repository == 'retorquere/styles'
+      if: github.repository == 'citation-style-language/styles' && steps.update.outputs.workflows == 'true'
       uses: drud/action-cross-commit@master
       with:
         source-folder: .github/workflows

--- a/.github/workflows/merge.yaml
+++ b/.github/workflows/merge.yaml
@@ -105,24 +105,14 @@ jobs:
         curl -H 'Content-Length:' -H "Authorization: $ZOTERO_UPDATE_TOKEN" -F 'payload={"type":"push","branch":"${{ steps.release.outputs.branch }}","status":0,"commit":"'$GITHUB_SHA'"}' https://styles-update.zotero.org:8826/
         curl -H 'Content-Length:' -H "Authorization: $ZOTERO_UPDATE_TOKEN" -F 'payload={"type":"push","branch":"${{ steps.release.outputs.branch }}","status":0,"commit":"'$GITHUB_SHA'"}' https://styles-update.zotero.org:8827/
 
-    - name: copy workflows to locales -- authorization
-      uses: webfactory/ssh-agent@v0.4.1
+    - name: Copy workflows to locales repository
+      if: github.repository == 'retorquere/styles'
+      uses: drud/action-cross-commit@master
       with:
-        ssh-private-key: ${{ secrets.BLIP_BLOOP }}
-    - name: copy workflows to locales -- clone locales
-      if: github.repository == 'retorquere/styles' && steps.update.outputs.workflows == 'true'
-      uses: actions/checkout@v2
-      with:
-        repository: 'retorquere/locales'
-        path: 'locales'
-    - name: copy workflows to locales -- copy workflows
-      if: github.repository == 'retorquere/styles' && steps.update.outputs.workflows == 'true'
-      run: |
-        mkdir -p locales/.github/workflows/
-        cp .github/workflows/*.yaml locales/.github/workflows/
-    - name: copy workflows to locales -- commit workflows
-      uses: stefanzweifel/git-auto-commit-action@v4
-      if: github.repository == 'retorquere/styles' && steps.update.outputs.workflows == 'true'
-      with:
-        repository: 'locales'
-        commit_message: copied ${{ steps.update.outputs.workflows_files }} to locales
+        source-folder: .github/workflows
+        destination-repository: https://blip-bloop:${{ secrets.BLIP_BLOOP }}@github.com/retorquere/locales
+        destination-folder: .github/workflows
+        destination-branch: master
+        git-user: "Blip Bloop"
+        git-user-email: blip-bloop@example.com
+        git-commit-message: "Cross-copy workflows"

--- a/.github/workflows/merge.yaml
+++ b/.github/workflows/merge.yaml
@@ -113,6 +113,6 @@ jobs:
         destination-repository: https://blip-bloop:${{ secrets.BLIP_BLOOP }}@github.com/retorquere/locales
         destination-folder: .github/workflows
         destination-branch: master
-        git-user: "Blip-Bloop"
+        git-user: "blip-bloop"
         git-user-email: blip-bloop@example.com
         git-commit-message: "Cross-copy workflows"

--- a/.github/workflows/merge.yaml
+++ b/.github/workflows/merge.yaml
@@ -109,9 +109,9 @@ jobs:
       if: github.repository == 'retorquere/styles' && steps.update.outputs.workflows == 'true'
       uses: actions/checkout@v2
       with:
+        ssh-key: ${ secrets.BLIP_BLOOP }
         repository: 'retorquere/locales'
         path: 'locales'
-        ssh-key: ${ secrets.BLIP_BLOOP }
     - name: copy workflows to locales -- copy workflows
       if: github.repository == 'retorquere/styles' && steps.update.outputs.workflows == 'true'
       run: |

--- a/.github/workflows/merge.yaml
+++ b/.github/workflows/merge.yaml
@@ -110,7 +110,7 @@ jobs:
       uses: drud/action-cross-commit@master
       with:
         source-folder: .github/workflows
-        destination-repository: https://csl-bot:${{ secrets.CSL_BOT_TOKEN }}@github.com/citation-style-language/locales
+        destination-repository: https://csl-bot:${{ secrets.CSLBOT_TOKEN }}@github.com/citation-style-language/locales
         destination-folder: .github/workflows
         destination-branch: master
         git-user: "csl-bot"

--- a/.github/workflows/merge.yaml
+++ b/.github/workflows/merge.yaml
@@ -106,19 +106,20 @@ jobs:
         curl -H 'Content-Length:' -H "Authorization: $ZOTERO_UPDATE_TOKEN" -F 'payload={"type":"push","branch":"${{ steps.release.outputs.branch }}","status":0,"commit":"'$GITHUB_SHA'"}' https://styles-update.zotero.org:8827/
 
     - name: copy workflows to locales -- clone locales
-      if: github.repository == 'citation-style-language/styles' && steps.update.outputs.workflows == 'true'
+      if: github.repository == 'retorquere/styles' && steps.update.outputs.workflows == 'true'
       uses: actions/checkout@v2
       with:
-        repository: 'citation-style-language/locales'
+        repository: 'retorquere/locales'
         path: 'locales'
+        ssh-key: ${ secrets.BLIP_BLOOP }
     - name: copy workflows to locales -- copy workflows
-      if: github.repository == 'citation-style-language/styles' && steps.update.outputs.workflows == 'true'
+      if: github.repository == 'retorquere/styles' && steps.update.outputs.workflows == 'true'
       run: |
         mkdir -p locales/.github/workflows/
         cp .github/workflows/*.yaml locales/.github/workflows/
     - name: copy workflows to locales -- commit workflows
       uses: stefanzweifel/git-auto-commit-action@v4
-      if: github.repository == 'citation-style-language/styles' && steps.update.outputs.workflows == 'true'
+      if: github.repository == 'retorquere/styles' && steps.update.outputs.workflows == 'true'
       with:
         repository: 'locales'
         commit_message: copied ${{ steps.update.outputs.workflows_files }} to locales

--- a/.github/workflows/merge.yaml
+++ b/.github/workflows/merge.yaml
@@ -110,9 +110,9 @@ jobs:
       uses: drud/action-cross-commit@master
       with:
         source-folder: .github/workflows
-        destination-repository: https://blip-bloop:${{ secrets.BLIP_BLOOP }}@github.com/retorquere/locales
+        destination-repository: https://csl-bot:${{ secrets.CSLBOT }}@github.com/citation-style-language/locales
         destination-folder: .github/workflows
         destination-branch: master
-        git-user: "blip-bloop"
-        git-user-email: blip-bloop@example.com
+        git-user: "csl-bot"
+        git-user-email: csl-bot@citationstyles.org
         git-commit-message: "Cross-copy workflows"

--- a/.github/workflows/merge.yaml
+++ b/.github/workflows/merge.yaml
@@ -113,6 +113,6 @@ jobs:
         destination-repository: https://blip-bloop:${{ secrets.BLIP_BLOOP }}@github.com/retorquere/locales
         destination-folder: .github/workflows
         destination-branch: master
-        git-user: "Blip Bloop"
+        git-user: "Blip-Bloop"
         git-user-email: blip-bloop@example.com
         git-commit-message: "Cross-copy workflows"

--- a/.github/workflows/merge.yaml
+++ b/.github/workflows/merge.yaml
@@ -114,5 +114,5 @@ jobs:
         destination-folder: .github/workflows
         destination-branch: master
         git-user: "csl-bot"
-        git-user-email: csl-bot@citationstyles.org
-        git-commit-message: "Cross-copy workflows"
+        git-user-email: github@citationstyles.org
+        git-commit-message: copied ${{ steps.update.outputs.workflows_files }} from styles


### PR DESCRIPTION
I seriously have no idea how I did this earlier, but this works. You'll need a personal access token for the bot (the current PR uses `csl-bot`, feel free to change) with `repo` and `change workflow` access, and put that in a secret (I've used `CSLBOT` here) on the `styles` repo.