### PR TITLE
Amsterdam university press: remove a stray space

### DIFF
--- a/amsterdam-university-press-academic.csl
+++ b/amsterdam-university-press-academic.csl
@@ -6,7 +6,7 @@
     <id>http://www.zotero.org/styles/amsterdam-university-press-academic</id>
     <link href="http://www.zotero.org/styles/amsterdam-university-press-academic" rel="self"/>
     <link href="http://www.zotero.org/styles/modern-humanities-research-association" rel="template"/>
-    <link href=" https://www.aup.nl/en/publish/author-guidance" rel="documentation"/>
+    <link href="https://www.aup.nl/en/publish/author-guidance" rel="documentation"/>
     <link href="https://assets.ctfassets.net/w9b4jh0bui0y/2Zq8jT4ld6CgKo6Iig2IW/7687b7dc5ecb4febe678569476d29871/author_instructions_april_2018.pdf" rel="documentation"/>
     <author>
       <name>Rombert Stapel</name>


### PR DESCRIPTION
This removes a stray space in one of the `<link>` elements that breaks validation.