### PR TITLE
Updates in research-institute-for-nature-and-forest.csl (development to version 0.1.2)

### DIFF
--- a/research-institute-for-nature-and-forest.csl
+++ b/research-institute-for-nature-and-forest.csl
@@ -135,7 +135,6 @@
     <choose>
       <if type="webpage">
         <text variable="title"/>
-        <text value="WWW document" prefix=" [" suffix="]"/>
       </if>
       <else-if variable="container-title" match="none">
         <text variable="title"/>

--- a/research-institute-for-nature-and-forest.csl
+++ b/research-institute-for-nature-and-forest.csl
@@ -12,7 +12,7 @@
     </author>
     <author>
       <name>Floris Vanderhaeghe</name>
-      <email>floris.vanderhaeghe@inbo.be</email>
+      <uri>https://github.com/florisvdh</uri>
     </author>
     <contributor>
       <name>Thierry Onkelinx</name>

--- a/research-institute-for-nature-and-forest.csl
+++ b/research-institute-for-nature-and-forest.csl
@@ -22,7 +22,7 @@
     <category field="biology"/>
     <category field="botany"/>
     <category field="zoology"/>
-    <updated>2020-10-12T12:01:18+02:00</updated>
+    <updated>2020-12-18T17:09:06+01:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale xml:lang="en">


### PR DESCRIPTION
A few small changes; essentially a `text` element has been dropped from the `title` macro if `type` is `webpage`.