### PR TITLE
Move content from wiki pages to markdown files

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,11 +4,11 @@ The CSL style repository is the central location on the web for collecting and m
 Software products like Zotero, Mendeley, and Papers all draw their styles from our repository.
 
 We welcome style submissions (and corrections), and are particularly interested in styles for journals and published style guides.
-If you wish to submit a different type of style, please first check our [Criteria for Accepting Styles](https://github.com/citation-style-language/styles/wiki/Criteria-for-Accepting-Styles).
+If you wish to submit a different type of style, please first check our [Criteria for Accepting Styles](https://github.com/citation-style-language/styles/blob/master/README.md#criteria-for-inclusion).
 
 To submit a style, please follow the following steps (for locale files, follow the same steps in the  [locales](https://github.com/citation-style-language/locales) repository):
 
-#### 1. Check that your style meets all our [style requirements](https://github.com/citation-style-language/styles/wiki/Style-Requirements)
+#### 1. Check that your style meets all our [style requirements](https://github.com/citation-style-language/styles/blob/master/STYLE_REQUIREMENTS.md)
 
 #### 2. [Validate](https://validator.citationstyles.org/) your style against the CSL schema, and correct any validation errors
 
@@ -20,7 +20,7 @@ To start, create a GitHub account and sign in.
 ##### 3a. Submitting a new style
 
 1. Visit https://github.com/citation-style-language/styles and click the "Create new file" button.
-   When submitting a [dependent style](https://github.com/citation-style-language/styles/wiki/Requesting-Styles#dependent-styles), first navigate to the [dependent](https://github.com/citation-style-language/styles/tree/master/dependent) subdirectory.
+   When submitting a [dependent style](https://github.com/citation-style-language/styles/blob/master/REQUESTING.md#dependent-styles), first navigate to the [dependent](https://github.com/citation-style-language/styles/tree/master/dependent) subdirectory.
 2. Type in the file name of the style in the "Name your file..." text field at the top.
    Don't forget to add the ".csl" extension (e.g., "journal-of-results.csl" instead of just "journal-of-results")!
 3. Paste the style code into the "<> Edit new file" tab below.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,7 +28,7 @@ To start, create a GitHub account and sign in.
 5. In the next window, click the "Create pull request" button.
    Describe the changes you've made, and click the "Create pull request" button once more.
 
-(for more help, see GitHub's instructions on [Creating new files](https://help.github.com/articles/creating-new-files))
+(For more help, see GitHub's instructions on [Creating new files](https://help.github.com/articles/creating-new-files).)
 
 ##### 3b. Submitting changes to an existing style
 
@@ -41,7 +41,7 @@ To start, create a GitHub account and sign in.
 5. In the next window, click the "Create pull request" button.
    Describe the changes you've made, and click the "Create pull request" button once more.
 
-(for more help, see GitHub's instructions on [Editing files in another user's repository](https://help.github.com/articles/editing-files-in-another-user-s-repository))
+(For more help, see GitHub's instructions on [Editing files in another user's repository](https://help.github.com/articles/editing-files-in-another-user-s-repository).)
 
 Instead of relying solely on the GitHub website, you can also use a git client, such as [GitHub Desktop](https://desktop.github.com/) for Mac and Windows, or [SmartGit](http://www.syntevo.com/smartgit/).
 When using a client, [fork](https://help.github.com/articles/fork-a-repo/) the [style repository](https://github.com/citation-style-language/styles), create a branch off of "master", commit your changes, and then create a [pull request](https://help.github.com/articles/using-pull-requests/).

--- a/QUALITY_CONTROL.md
+++ b/QUALITY_CONTROL.md
@@ -1,20 +1,31 @@
 # CSL Style Quality Control
 
-We love the CSL style repository, and wish to keep it in tip-top shape. Because we have thousands of styles and hundreds of contributors, we rely heavily on automated quality control and periodic maintenance. This page describes our best practices.
+We love the CSL style repository, and wish to keep it in tip-top shape. 
+Because we have thousands of styles and hundreds of contributors, we rely heavily on automated quality control and periodic maintenance. 
+This page describes our best practices.
 
 ## Forks and Pull Requests
 
-The "master" branch of the style repository stores the styles for the most recent CSL release. To allow changes to be reviewed before they end up in "master", we try to avoid committing changes directly to "master" as much as possible.
+The "master" branch of the style repository stores the styles for the most recent CSL release. 
+To allow changes to be reviewed before they end up in "master", we try to avoid committing changes directly to "master" as much as possible.
 
-Instead, we rely heavily on forks, branches, and pull requests. Only our maintainers have direct commit access to the repository. Contributors can fork the repository, make their changes in their copy of the repository (ideally in a branch), and create a pull request. This allows us to review your changes, and merge them into the official repository.
+Instead, we rely heavily on forks, branches, and pull requests. 
+Only our maintainers have direct commit access to the repository. 
+Contributors can fork the repository, make their changes in their copy of the repository (ideally in a branch), and create a pull request. 
+This allows us to review your changes, and merge them into the official repository.
 
 ## Travis CI
 
-[Travis CI](https://travis-ci.org/) is a Continuous Integration service that runs a series of checks on every commit made to the "master" branch, and on every commit in incoming pull requests. Each Travis test run is called a "build".
+[Travis CI](https://travis-ci.org/) is a Continuous Integration service that runs a series of checks on every commit made to the "master" branch, and on every commit in incoming pull requests. 
+Each Travis test run is called a "build".
 
-If Travis doesn't detect any problems in your pull request, it will report that the build passed. Otherwise the build fails, and you will find a link to the build report that shows which tests failed. Add a new commit to your pull request, and Travis will start a new build and run all tests again. Only pull requests that pass all the Travis tests can be accepted into the repository.
+If Travis doesn't detect any problems in your pull request, it will report that the build passed. 
+Otherwise the build fails, and you will find a link to the build report that shows which tests failed. 
+Add a new commit to your pull request, and Travis will start a new build and run all tests again. 
+Only pull requests that pass all the Travis tests can be accepted into the repository.
 
-The tests are stored in the style repository itself. Among other things, they make sure that:
+The tests are stored in the style repository itself. 
+Among other things, they make sure that:
 
 * there are no styles with the same file name, title, or ISSN
 * all styles are named correctly, and have style IDs and "self" links matching the file names
@@ -28,7 +39,8 @@ It is possible to [run the tests locally](#Test-Environment) on your computer, w
 
 ## Indentation, Ordering, and Escaping
 
-To keep styles consistently formatted, we manually run a [Python script](https://github.com/citation-style-language/utilities/blob/master/csl-reindenting-and-info-reordering.py) every few weeks or so. The script does the following:
+To keep styles consistently formatted, we manually run a [Python script](https://github.com/citation-style-language/utilities/blob/master/csl-reindenting-and-info-reordering.py) every few weeks or so. 
+The script does the following:
 
 * reindent the XML code, using 2 spaces per indentation level
 * put the elements in the `</info>` section in a standard order
@@ -44,7 +56,7 @@ _Here we keep track of problematic CSL code patterns we have observed in the wil
 
 ### Superscript on citation-number instead of whole citation
 
-In numeric styles where superscripted numbers are used, it's important to superscript the entire citation so that any punctuation is also superscripted, and e.g. use
+In numeric styles where superscripted numbers are used, it's important to superscript the entire citation so that any punctuation is also superscripted, and e.g. use:
 
 ```xml
 <layout delimiter="," vertical-align="sup">
@@ -52,7 +64,7 @@ In numeric styles where superscripted numbers are used, it's important to supers
 </layout>
 ```
 
-instead of
+instead of:
 
 ```xml
 <layout delimiter=",">
@@ -74,7 +86,9 @@ If the second field in the bibliography is flushed, then it should not have a sp
 
 **Fix**
 
-Delete `prefix=" "` by hand, but it seems possible to automatically delete the last prefix attribute in this pattern. No, critical case found. Moreover, no case with a different prefix beginning with a space found.
+Delete `prefix=" "` by hand, but it seems possible to automatically delete the last prefix attribute in this pattern. 
+No, critical case found. 
+Moreover, no case with a different prefix beginning with a space found.
 
 **History**
 
@@ -89,7 +103,13 @@ Delete `prefix=" "` by hand, but it seems possible to automatically delete the l
 
 **Fix**
 
-Manually look at every case and either (i) delete the space in suffix, (ii) delete the space in the prefix, (iii) use a group with `delimiter=" "`, or (iv) rewritte some parts of the style. This can take some time in order to not change the punctation. It may be possible to restrict the search pattern more, in order to obtain smaller sets of the same/similar replacements.
+Manually look at every case and either 
+  (i) delete the space in suffix, 
+  (ii) delete the space in the prefix, 
+  (iii) use a group with `delimiter=" "`, or 
+  (iv) rewritte some parts of the style. 
+This can take some time in order to not change the punctation. 
+It may be possible to restrict the search pattern more, in order to obtain smaller sets of the same/similar replacements.
 
 **History**
 
@@ -100,30 +120,38 @@ Manually look at every case and either (i) delete the space in suffix, (ii) dele
 
 [![Build Status](https://secure.travis-ci.org/citation-style-language/styles.png?branch=master)](http://travis-ci.org/citation-style-language/styles)
 
-To maintain the quality of the styles in the official repository, we have set up an environment for quality-control testing in the repository's [master branch](https://github.com/citation-style-language/styles/tree/master). After every commit to this branch, the tests will be executed on [Travis CI](http://travis-ci.org/#!/citation-style-language/styles) in order to alert us should new (or newly updated) styles break any of the quality control rules.
+To maintain the quality of the styles in the official repository, we have set up an environment for quality-control testing in the repository's [master branch](https://github.com/citation-style-language/styles/tree/master). 
+After every commit to this branch, the tests will be executed on [Travis CI](http://travis-ci.org/#!/citation-style-language/styles) in order to alert us should new (or newly updated) styles break any of the quality control rules.
 
 If you are a style author, maintainer or would like to contribute to an existing style, you are advised to install the test environment on your computer in order to run the tests while you're working on a style and to make sure all tests are still passing before you commit any changes to the repository.
 
 ### Installation
 
-Before installing the test environment, please make sure that Ruby is available on you computer. If Ruby is not installed, please follow the [official instructions](http://www.ruby-lang.org/en/downloads/) on how to install it on your operating-system. The test environment should work on all current releases of Ruby and is backwards compatible with version 1.8.7. Some of our tests involve RelaxNG schema validation; these tests are based on [libxml](http://www.xmlsoft.org/) via [Nokogiri](http://nokogiri.org/). Please see these [operating-system specific instructions](http://nokogiri.org/tutorials/installing_nokogiri.html) if you have any problems installing the test setup because of these requirements.
+Before installing the test environment, please make sure that Ruby is available on you computer. 
+If Ruby is not installed, please follow the [official instructions](http://www.ruby-lang.org/en/downloads/) on how to install it on your operating-system. 
+The test environment should work on all current releases of Ruby and is backwards compatible with version 1.8.7. 
+Some of our tests involve RelaxNG schema validation; these tests are based on [libxml](http://www.xmlsoft.org/) via [Nokogiri](http://nokogiri.org/). 
+Please see these [operating-system specific instructions](http://nokogiri.org/tutorials/installing_nokogiri.html) if you have any problems installing the test setup because of these requirements.
 
 **Note: it seems in Ruby 1.8.7 you can get some failures with [] and {} comparison failing**
 
-Once Ruby is installed on your computer, it is easy to setup the test environment. First, clone into the official repository (if you have previously cloned the repository you can skip this step):
+Once Ruby is installed on your computer, it is easy to setup the test environment. 
+First, clone into the official repository (if you have previously cloned the repository you can skip this step):
 
     $ git clone https://github.com/citation-style-language/styles.git
     $ cd styles
 
 You should work directly on the master branch.
 
-Next, we will install all requirements using [Bundler](http://gembundler.com/) (run `[sudo] gem install bundler` to make sure you have the latest version installed). Please note that depending on how Ruby is installed on your system you might need administrator privileges to install Ruby Gems, therefore, we have prefixed the commands with an optional `[sudo]`:
+Next, we will install all requirements using [Bundler](http://gembundler.com/) (run `[sudo] gem install bundler` to make sure you have the latest version installed). 
+Please note that depending on how Ruby is installed on your system you might need administrator privileges to install Ruby Gems, therefore, we have prefixed the commands with an optional `[sudo]`:
 
     $ [sudo] bundle install
 
 ### Usage
 
-Once your bundle is installed there are two ways to run the tests. You can use rake:
+Once your bundle is installed there are two ways to run the tests. 
+You can use rake:
 
     $ rake
 
@@ -131,7 +159,9 @@ Or you can run the tests using `rspec`:
 
     $ bundle exec rspec spec
 
-The latter is useful if you would like to pass special parameters. For example, if your Terminal does not support colors, the output may be illegible. In this case try running the tests with:
+The latter is useful if you would like to pass special parameters. 
+For example, if your Terminal does not support colors, the output may be illegible. 
+In this case try running the tests with:
 
     $ bundle exec rspec spec --no-color
 
@@ -143,15 +173,19 @@ Will print a summary of all tests for each style.
 
 #### Testing styles in isolation
 
-With the growing number of styles and tests available in the repository the number of test cases to execute has risen into the range of 100,000 – for obvious reasons, execution may take up to a few minutes on your computer. In order to allow for quicker feedback-loops when working on styles, you can set the environment variable CSL_TEST to control which styles to include in the test.
+With the growing number of styles and tests available in the repository the number of test cases to execute has risen into the range of 100,000 – for obvious reasons, execution may take up to a few minutes on your computer. 
+In order to allow for quicker feedback-loops when working on styles, you can set the environment variable CSL_TEST to control which styles to include in the test.
 
-The CSL_TEST variable may contain a list of file names (separated by spaces) of styles to include; please note that the name should be the file's full base-name including the '.csl' extension, however, for additional flexibility, you can include regular expression wildcards as well.
+The CSL_TEST variable may contain a list of file names (separated by spaces) of styles to include; 
+please note that the name should be the file's full base-name including the '.csl' extension. 
+However, for additional flexibility, you can include regular expression wildcards as well.
 
     $ CSL_TEST="apa.csl vancouver.csl" bundle exec rspec spec
 
     $ CSL_TEST="chicago.*" bundle exec rspec spec
 
-Finally, you can set the CSL_TEST variable to the special value 'git'; by doing that you can limit the styles to be included in the test run to those styles which are currently marked as modified in your local git repository.
+Finally, you can set the CSL_TEST variable to the special value 'git'; 
+by doing that you can limit the styles to be included in the test run to those styles which are currently marked as modified in your local git repository.
 
     $ CSL_TEST="git" bundle exec rspec spec
 

--- a/QUALITY_CONTROL.md
+++ b/QUALITY_CONTROL.md
@@ -1,0 +1,160 @@
+# CSL Style Quality Control
+
+We love the CSL style repository, and wish to keep it in tip-top shape. Because we have thousands of styles and hundreds of contributors, we rely heavily on automated quality control and periodic maintenance. This page describes our best practices.
+
+## Forks and Pull Requests
+
+The "master" branch of the style repository stores the styles for the most recent CSL release. To allow changes to be reviewed before they end up in "master", we try to avoid committing changes directly to "master" as much as possible.
+
+Instead, we rely heavily on forks, branches, and pull requests. Only our maintainers have direct commit access to the repository. Contributors can fork the repository, make their changes in their copy of the repository (ideally in a branch), and create a pull request. This allows us to review your changes, and merge them into the official repository.
+
+## Travis CI
+
+[Travis CI](https://travis-ci.org/) is a Continuous Integration service that runs a series of checks on every commit made to the "master" branch, and on every commit in incoming pull requests. Each Travis test run is called a "build".
+
+If Travis doesn't detect any problems in your pull request, it will report that the build passed. Otherwise the build fails, and you will find a link to the build report that shows which tests failed. Add a new commit to your pull request, and Travis will start a new build and run all tests again. Only pull requests that pass all the Travis tests can be accepted into the repository.
+
+The tests are stored in the style repository itself. Among other things, they make sure that:
+
+* there are no styles with the same file name, title, or ISSN
+* all styles are named correctly, and have style IDs and "self" links matching the file names
+* all styles validate against the CSL schema
+* all styles have the correct license
+* all "template" and "independent-parent" links point to existing independent styles
+* all style macros are defined and used
+* the root directory contains all independent styles, and the "dependent" subdirectory all dependent styles
+
+It is possible to [run the tests locally](#Test-Environment) on your computer, which is especially useful to frequent contributors.
+
+## Indentation, Ordering, and Escaping
+
+To keep styles consistently formatted, we manually run a [Python script](https://github.com/citation-style-language/utilities/blob/master/csl-reindenting-and-info-reordering.py) every few weeks or so. The script does the following:
+
+* reindent the XML code, using 2 spaces per indentation level
+* put the elements in the `</info>` section in a standard order
+* escape characters that are hard to identify by eye (such as the various dashes and spaces)
+
+## Extra-strict Validation
+
+Every so often, we also manually run a [bash script](https://github.com/citation-style-language/utilities/blob/master/style-qc.sh) that validates the styles against a [customized CSL schema](https://github.com/citation-style-language/schema/blob/master/csl-repository.rnc) that is extra strict, and includes requirements specific to our repository. 
+
+## Repairing Problematic Code Patterns
+
+_Here we keep track of problematic CSL code patterns we have observed in the wild, and provide information on how they can be detected and corrected._
+
+### Superscript on citation-number instead of whole citation
+
+In numeric styles where superscripted numbers are used, it's important to superscript the entire citation so that any punctuation is also superscripted, and e.g. use
+
+```xml
+<layout delimiter="," vertical-align="sup">
+  <text variable="citation-number"/>
+</layout>
+```
+
+instead of
+
+```xml
+<layout delimiter=",">
+  <text variable="citation-number" vertical-align="sup"/>
+</layout>
+```
+
+**History**
+
+2016-10: [#2256](https://github.com/citation-style-language/styles/issues/2256) : 47 hits
+
+### Spaces if second field is flushed
+
+If the second field in the bibliography is flushed, then it should not have a space as a prefix.
+
+**Search patterns**
+
+    <bibliography[^>]*second-field-align="flush"[^>]*>.*<layout[^>]*>\r\n\s*<text variable="citation-number"[^>]*/>\r\n\s*<text[^>]*prefix=" "
+
+**Fix**
+
+Delete `prefix=" "` by hand, but it seems possible to automatically delete the last prefix attribute in this pattern. No, critical case found. Moreover, no case with a different prefix beginning with a space found.
+
+**History**
+
+2015-01: [#1349](https://github.com/citation-style-language/styles/pull/1349) and [#1346](https://github.com/citation-style-language/styles/pull/1346) : ca. 39 matches
+
+
+### Adjacent spaces from suffix and prefix
+
+**Search Pattern**
+
+    <[^/>]*suffix="[^"/>]* "[^/>]*/?>\s*\r\n\s*<[^/>]*prefix=" [^"/>]*"[^/>]*/?>
+
+**Fix**
+
+Manually look at every case and either (i) delete the space in suffix, (ii) delete the space in the prefix, (iii) use a group with `delimiter=" "`, or (iv) rewritte some parts of the style. This can take some time in order to not change the punctation. It may be possible to restrict the search pattern more, in order to obtain smaller sets of the same/similar replacements.
+
+**History**
+
+2015-01: [#1301](https://github.com/citation-style-language/styles/issues/1301) : ca. 300 hits in 230 files
+
+
+## Test Environment
+
+[![Build Status](https://secure.travis-ci.org/citation-style-language/styles.png?branch=master)](http://travis-ci.org/citation-style-language/styles)
+
+To maintain the quality of the styles in the official repository, we have set up an environment for quality-control testing in the repository's [master branch](https://github.com/citation-style-language/styles/tree/master). After every commit to this branch, the tests will be executed on [Travis CI](http://travis-ci.org/#!/citation-style-language/styles) in order to alert us should new (or newly updated) styles break any of the quality control rules.
+
+If you are a style author, maintainer or would like to contribute to an existing style, you are advised to install the test environment on your computer in order to run the tests while you're working on a style and to make sure all tests are still passing before you commit any changes to the repository.
+
+### Installation
+
+Before installing the test environment, please make sure that Ruby is available on you computer. If Ruby is not installed, please follow the [official instructions](http://www.ruby-lang.org/en/downloads/) on how to install it on your operating-system. The test environment should work on all current releases of Ruby and is backwards compatible with version 1.8.7. Some of our tests involve RelaxNG schema validation; these tests are based on [libxml](http://www.xmlsoft.org/) via [Nokogiri](http://nokogiri.org/). Please see these [operating-system specific instructions](http://nokogiri.org/tutorials/installing_nokogiri.html) if you have any problems installing the test setup because of these requirements.
+
+**Note: it seems in Ruby 1.8.7 you can get some failures with [] and {} comparison failing**
+
+Once Ruby is installed on your computer, it is easy to setup the test environment. First, clone into the official repository (if you have previously cloned the repository you can skip this step):
+
+    $ git clone https://github.com/citation-style-language/styles.git
+    $ cd styles
+
+You should work directly on the master branch.
+
+Next, we will install all requirements using [Bundler](http://gembundler.com/) (run `[sudo] gem install bundler` to make sure you have the latest version installed). Please note that depending on how Ruby is installed on your system you might need administrator privileges to install Ruby Gems, therefore, we have prefixed the commands with an optional `[sudo]`:
+
+    $ [sudo] bundle install
+
+### Usage
+
+Once your bundle is installed there are two ways to run the tests. You can use rake:
+
+    $ rake
+
+Or you can run the tests using `rspec`:
+
+    $ bundle exec rspec spec
+
+The latter is useful if you would like to pass special parameters. For example, if your Terminal does not support colors, the output may be illegible. In this case try running the tests with:
+
+    $ bundle exec rspec spec --no-color
+
+Or, if you would like a more verbose output of all tests, you can switch to a different format, for example:
+
+    $ bundle exec rspec spec --format documentation
+
+Will print a summary of all tests for each style.
+
+#### Testing styles in isolation
+
+With the growing number of styles and tests available in the repository the number of test cases to execute has risen into the range of 100,000 – for obvious reasons, execution may take up to a few minutes on your computer. In order to allow for quicker feedback-loops when working on styles, you can set the environment variable CSL_TEST to control which styles to include in the test.
+
+The CSL_TEST variable may contain a list of file names (separated by spaces) of styles to include; please note that the name should be the file's full base-name including the '.csl' extension, however, for additional flexibility, you can include regular expression wildcards as well.
+
+    $ CSL_TEST="apa.csl vancouver.csl" bundle exec rspec spec
+
+    $ CSL_TEST="chicago.*" bundle exec rspec spec
+
+Finally, you can set the CSL_TEST variable to the special value 'git'; by doing that you can limit the styles to be included in the test run to those styles which are currently marked as modified in your local git repository.
+
+    $ CSL_TEST="git" bundle exec rspec spec
+
+#### Windows
+
+For colored output of the test results on Windows, [see this guide](http://softkube.com/blog/ansi-command-line-colors-under-windows/).

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ The primary components of the CSL ecosystem are:
 This README describes our official curated repository of CSL styles, hosted at https://github.com/citation-style-language/styles/.
 CSL locale files, which provide default localization data for CSL styles (such as translations and date formats), can be found at https://github.com/citation-style-language/locales.
 
-For more information about CSL and CSL styles, check out https://citationstyles.org/ and the [repository wiki](https://github.com/citation-style-language/styles/wiki).
+For more information about CSL and CSL styles, check out https://citationstyles.org/ and the information files in this repository ([Style Requirements](https://github.com/citation-style-language/styles/blob/master/STYLE_REQUIREMENTS.md), [Style Development](https://github.com/citation-style-language/styles/blob/master/STYLE_DEVELOPMENT.md), [Requesting Styles](https://github.com/citation-style-language/styles/blob/master/REQUESTING.md), [Contributing Styles](https://github.com/citation-style-language/styles/blob/master/CONTRIBUTING.md), and [Quality Control](https://github.com/citation-style-language/styles/blob/master/QUALITY_CONTROL.md)).
 
 Criteria for inclusion
 ----------------------
@@ -29,7 +29,7 @@ The official CSL style repository is the only repository of its kind, is used by
 The popularity of this repository is in large part due to its crowd-sourced nature, and, we believe, also due to our careful curation.
 While we evaluate style submissions on a case-by-case basis, we generally use the following criteria for inclusion in the CSL style repository:
 
-* Styles must be of sufficient quality and meet our [Style Requirements](https://github.com/citation-style-language/styles/wiki/Style-Requirements).
+* Styles must be of sufficient quality and meet our [style requirements](https://github.com/citation-style-language/styles/blob/master/STYLE_REQUIREMENTS.md).
   While we may be able to assist with this, its ultimately the submitter's responsibility to provide a style that meets our standards.
 * Styles should be based on an official style guide (and link to the style guide in online or printed form).
 * Styles should be of interest to a wider audience.

--- a/REQUESTING.md
+++ b/REQUESTING.md
@@ -1,0 +1,69 @@
+# Requesting CSL Styles
+
+Below are instructions to request new CSL styles and to report problems in existing styles.
+
+We only have a few volunteers who respond to incoming requests, so please follow our instructions closely to make the process more efficient. While we typically work for free, we do charge for e.g. the creation of styles for universities or departments ([contact us](http://citationstyles.org/contact/) for pricing). You can also try to [edit CSL styles](https://github.com/citation-style-language/styles/blob/master/STYLE_DEVELOPMENT.md#editing-styles) yourself.
+
+## Requesting a New Style
+
+1. First, make sure the style you're requesting isn't already available. The easiest way to check this is to search the [Zotero Style Repository](http://www.zotero.org/styles), which has all our styles.
+2. If we don't have the style, try a quick search of the [Zotero forums](http://forums.zotero.org/) to see if there is already a Zotero forum thread for the style you want to request. If there is an existing thread, check whether you can provide any missing information that we might need to create the style. The thread might also contain (technical) reasons why we currently cannot support your style.
+3. If you can't find an existing Zotero forum thread, create a new one. **If you have already started a thread, just update it; do not create a new one.** Name your post "Style Request: [name of style]", and include the following information:
+
+    * A link to online style documentation (e.g. for a journal, this would generally be a link to the journal's "Instructions to Authors" section). 
+    * For journals, the journal's ISSN (print version) and/or e-ISSN (online version). If you can't find this information on the journal website, try looking up the journal in the [NLM Catalog](http://www.ncbi.nlm.nih.gov/nlmcatalog).
+    * Two citations, for a journal article and a book chapter, in the format of the style you're requesting. **Create these citations for the two items shown below, the article by Campbell and Pedersen and book chapter by Mares. If your request does not contain these specific citations, you will be asked to revise it**. Provide both in-text citations and bibliographic entries. For e.g. the APA style, these citations would look like:
+
+      > In-text citation:  
+      > (Campbell & Pedersen, 2007)  
+      > (Mares, 2001)
+      >
+      > Bibliography:  
+      > Campbell, J. L., & Pedersen, O. K. (2007). The varieties of capitalism and hybrid success. *Comparative Political Studies*, *40*(3), 307–332. https://doi.org/10.1177/0010414006286542  
+      > Mares, I. (2001). Firms and the welfare state: When, why, and how does social policy matter to employers? In P. A. Hall & D. Soskice (Eds.), *Varieties of capitalism. The institutional foundations of comparative advantage* (pp. 184–213). New York: Oxford University Press.  
+
+      | Field               | Value                                                                            |
+      |---------------------|----------------------------------------------------------------------------------|
+      | Type                | article-journal                                                                  |
+      | Title               | The varieties of capitalism and hybrid success                                   |
+      | Author              | John L. Campbell, Ove K. Pedersen                                                |
+      | Issued              | 2007/3/1                                                                         |
+      | Container-title     | Comparative Political Studies                                                    |
+      | Volume              | 40                                                                               |
+      | Issue               | 3                                                                                |
+      | Page                | 307-332                                                                          |
+      | URL                 | http://cps.sagepub.com.turing.library.northwestern.edu/content/40/3/307.abstract |
+      | DOI                 | 10.1177/0010414006286542                                                         |
+      | ISSN                | 1552-3829                                                                        |
+      | JournalAbbreviation | Comp. Polit. Stud.                                                               |
+      | Language            | en-US                                                                            |
+      | Accessed            | 2010/7/26                                                                        |
+
+      | Field           | Value                                                                                   |
+      |-----------------|-----------------------------------------------------------------------------------------|
+      | Type            | chapter                                                                                 |
+      | Title           | Firms and the welfare state: When, why, and how does social policy matter to employers? |
+      | Author          | Isabela Mares                                                                           |
+      | Editor          | Peter A Hall, David Soskice                                                             |
+      | Issued          | 2001                                                                                    |
+      | Container-title | Varieties of capitalism. The institutional foundations of comparative advantage         |
+      | Page            | 184-213                                                                                 |
+      | Publisher       | Oxford University Press                                                                 |
+      | Publisher-place | New York                                                                                |
+      | Event-place     | New York                                                                                |
+      | ISBN            | 9780199247752                                                                           |
+      | Language        | en-US                                                                                   |
+
+    * Finally, if possible, also provide a link to a freely available paper formatted with the style you're requesting. Published papers often help clarify formatting requirements not discussed in the style guide. For journals that aren't open access, you can often find a free sample issue, or you maybe be able to find a freely available PDF of a recent journal article via e.g. Google Scholar.
+
+P.S. Instead of requesting a new style, you can also look for an existing CSL style that has a format identical or similar to what you're looking for. You can do this with our [CSL style editor](http://editor.citationstyles.org/). Visit the “Search by Example” tab, and change one of the example references into the desired format (using the metadata of the selected item). Click “Search”, and the editor will show you the CSL styles that most closely match the format you provided. See also the [CSL editor user guide](https://github.com/citation-style-editor/csl-editor/wiki/User-guide-for-the-CSL-Editor). 
+
+### Dependent Styles
+
+Please tell us if we already have a CSL style with the format you're looking for, but with a different style name. For instance, journals from the same publisher (e.g. "Nature" and "Nature Biotechnology") often use the same style format. Other journals simply use one of the main style guides, such as APA.
+
+In these cases, we can create a *dependent style*. These dependent styles (e.g. the CSL style for "Nature Biotechnology") simply point to a regular *independent style* with the desired style format (e.g. the CSL style for "Nature"). Dependent styles don't define a style format themselves and are much easier to create than independent styles.
+
+## Reporting Style Errors
+
+Requesting changes to existing CSL styles is very similar to requesting new styles. However, in this case, there will often already be a Zotero forum thread for your style of interest. Before posting, please make sure you have the most recent version of the style installed. In your post, give examples of how the existing CSL style format should change, and include the relevant excerpt from the style guidelines, or just give a link to the guidelines.

--- a/REQUESTING.md
+++ b/REQUESTING.md
@@ -2,17 +2,29 @@
 
 Below are instructions to request new CSL styles and to report problems in existing styles.
 
-We only have a few volunteers who respond to incoming requests, so please follow our instructions closely to make the process more efficient. While we typically work for free, we do charge for e.g. the creation of styles for universities or departments ([contact us](http://citationstyles.org/contact/) for pricing). You can also try to [edit CSL styles](https://github.com/citation-style-language/styles/blob/master/STYLE_DEVELOPMENT.md#editing-styles) yourself.
+We only have a few volunteers who respond to incoming requests, so please follow our instructions closely to make the process more efficient. 
+While we typically work for free, we do charge for, e.g., creating styles for universities or departments ([contact us](http://citationstyles.org/contact/) for pricing). 
+You can also try to [edit CSL styles](https://github.com/citation-style-language/styles/blob/master/STYLE_DEVELOPMENT.md#editing-styles) yourself.
 
 ## Requesting a New Style
 
-1. First, make sure the style you're requesting isn't already available. The easiest way to check this is to search the [Zotero Style Repository](http://www.zotero.org/styles), which has all our styles.
-2. If we don't have the style, try a quick search of the [Zotero forums](http://forums.zotero.org/) to see if there is already a Zotero forum thread for the style you want to request. If there is an existing thread, check whether you can provide any missing information that we might need to create the style. The thread might also contain (technical) reasons why we currently cannot support your style.
-3. If you can't find an existing Zotero forum thread, create a new one. **If you have already started a thread, just update it; do not create a new one.** Name your post "Style Request: [name of style]", and include the following information:
+1. First, make sure the style you're requesting isn't already available. 
+   The easiest way to check this is to search the [Zotero Style Repository](http://www.zotero.org/styles), which has all our styles.
+2. If we don't have the style, try a quick search of the [Zotero forums](http://forums.zotero.org/) to see if there is already a Zotero forum thread for the style you want to request. 
+   If there is an existing thread, check whether you can provide any missing information that we might need to create the style. 
+   The thread might also contain (technical) reasons why we currently cannot support your style.
+3. If you can't find an existing Zotero forum thread, create a new one. 
+   **If you have already started a thread, just update it; do not create a new one.** 
+   Name your post "Style Request: [name of style]", and include the following information:
 
     * A link to online style documentation (e.g. for a journal, this would generally be a link to the journal's "Instructions to Authors" section). 
-    * For journals, the journal's ISSN (print version) and/or e-ISSN (online version). If you can't find this information on the journal website, try looking up the journal in the [NLM Catalog](http://www.ncbi.nlm.nih.gov/nlmcatalog).
-    * Two citations, for a journal article and a book chapter, in the format of the style you're requesting. **Create these citations for the two items shown below, the article by Campbell and Pedersen and book chapter by Mares. If your request does not contain these specific citations, you will be asked to revise it**. Provide both in-text citations and bibliographic entries. For e.g. the APA style, these citations would look like:
+    * For journals, the journal's ISSN (print version) and/or e-ISSN (online version). 
+      If you can't find this information on the journal website, try looking up the journal in the [NLM Catalog](http://www.ncbi.nlm.nih.gov/nlmcatalog).
+    * Two citations, for a journal article and a book chapter, in the format of the style you're requesting. 
+      **Create these citations for the two items shown below, the article by Campbell and Pedersen and book chapter by Mares.** 
+      **If your request does not contain these specific citations, you will be asked to revise it**. 
+      Provide both in-text citations and bibliographic entries. 
+      For, e.g., the APA style, these citations would look like:
 
       > In-text citation:  
       > (Campbell & Pedersen, 2007)  
@@ -54,16 +66,29 @@ We only have a few volunteers who respond to incoming requests, so please follow
       | ISBN            | 9780199247752                                                                           |
       | Language        | en-US                                                                                   |
 
-    * Finally, if possible, also provide a link to a freely available paper formatted with the style you're requesting. Published papers often help clarify formatting requirements not discussed in the style guide. For journals that aren't open access, you can often find a free sample issue, or you maybe be able to find a freely available PDF of a recent journal article via e.g. Google Scholar.
+    * Finally, if possible, also provide a link to a freely available paper formatted with the style you're requesting. 
+      Published papers often help clarify formatting requirements not discussed in the style guide. 
+      For journals that aren't open access, you can often find a free sample issue, or you maybe be able to find a freely available PDF of a recent journal article via, e.g., Google Scholar.
 
-P.S. Instead of requesting a new style, you can also look for an existing CSL style that has a format identical or similar to what you're looking for. You can do this with our [CSL style editor](http://editor.citationstyles.org/). Visit the “Search by Example” tab, and change one of the example references into the desired format (using the metadata of the selected item). Click “Search”, and the editor will show you the CSL styles that most closely match the format you provided. See also the [CSL editor user guide](https://github.com/citation-style-editor/csl-editor/wiki/User-guide-for-the-CSL-Editor). 
+P.S. Instead of requesting a new style, you can also look for an existing CSL style that has a format identical or similar to what you're looking for. 
+You can do this with our [CSL style editor](http://editor.citationstyles.org/). 
+Visit the “Search by Example” tab, and change one of the example references into the desired format (using the metadata of the selected item). 
+Click “Search”, and the editor will show you the CSL styles that most closely match the format you provided. 
+See also the [CSL editor user guide](https://github.com/citation-style-editor/csl-editor/wiki/User-guide-for-the-CSL-Editor). 
 
 ### Dependent Styles
 
-Please tell us if we already have a CSL style with the format you're looking for, but with a different style name. For instance, journals from the same publisher (e.g. "Nature" and "Nature Biotechnology") often use the same style format. Other journals simply use one of the main style guides, such as APA.
+Please tell us if we already have a CSL style with the format you're looking for, but with a different style name. 
+For instance, journals from the same publisher (e.g. "Nature" and "Nature Biotechnology") often use the same style format. 
+Other journals simply use one of the main style guides, such as APA.
 
-In these cases, we can create a *dependent style*. These dependent styles (e.g. the CSL style for "Nature Biotechnology") simply point to a regular *independent style* with the desired style format (e.g. the CSL style for "Nature"). Dependent styles don't define a style format themselves and are much easier to create than independent styles.
+In these cases, we can create a *dependent style*. 
+These dependent styles (e.g. the CSL style for "Nature Biotechnology") simply point to a regular *independent style* with the desired style format (e.g. the CSL style for "Nature"). 
+Dependent styles don't define a style format themselves and are much easier to create than independent styles.
 
 ## Reporting Style Errors
 
-Requesting changes to existing CSL styles is very similar to requesting new styles. However, in this case, there will often already be a Zotero forum thread for your style of interest. Before posting, please make sure you have the most recent version of the style installed. In your post, give examples of how the existing CSL style format should change, and include the relevant excerpt from the style guidelines, or just give a link to the guidelines.
+Requesting changes to existing CSL styles is very similar to requesting new styles. 
+However, in this case, there will often already be a Zotero forum thread for your style of interest. 
+Before posting, please make sure you have the most recent version of the style installed. 
+In your post, give examples of how the existing CSL style format should change, and include the relevant excerpt from the style guidelines, or just give a link to the guidelines.

--- a/STYLE_DEVELOPMENT.md
+++ b/STYLE_DEVELOPMENT.md
@@ -205,7 +205,7 @@ You can also use [Validator.nu](http://validator.nu/?schema=https%3A%2F%2Fgithub
 
 #### Local Validators
 
-You can also validate your style/locale on your own computer with any tool that offers XML validation and supports the RELAX NG Compact schema language. Examples are the [Atom](https://atom.io/) with the [atomic-csl plugin](https://github.com/bdarcus/atomic-csl), [Emacs](http://www.gnu.org/software/emacs/) with the [nXML addon](http://www.thaiopensource.com/nxml-mode/), the [oXygen XML Editor](http://www.oxygenxml.com/), and the command-line utilities [Jing](http://www.thaiopensource.com/relaxng/jing.html) and [RNV](http://www.davidashen.net/rnv.html).
+You can also validate your style/locale on your own computer with any tool that offers XML validation and supports the RELAX NG Compact schema language. Examples are the [Atom](https://atom.io/) with the [atomic-csl plugin](https://github.com/bdarcus/atomic-csl), [Emacs](http://www.gnu.org/software/emacs/) with the [nXML addon](http://www.thaiopensource.com/nxml-mode/), [jEdit](http://www.jedit.org/) with the XML addon and the [CSL schema](https://github.com/citation-style-language/schema/zipball/v1.0), and the command-line utilities [Jing](http://www.thaiopensource.com/relaxng/jing.html) and [RNV](http://www.davidashen.net/rnv.html).
 
 
 ## Quality Control

--- a/STYLE_DEVELOPMENT.md
+++ b/STYLE_DEVELOPMENT.md
@@ -1,20 +1,27 @@
 # CSL Style Development
 
-CSL relies on volunteers to develop, edit, and maintain its library of citation styles. Below are guidelines and tips for editing and developing CSL styles.
+CSL relies on volunteers to develop, edit, and maintain its library of citation styles. 
+Below are guidelines and tips for editing and developing CSL styles.
 
 
 ## Editing Styles
 
 ### CSL Visual Editor
 
-To edit styles, you can use the [Visual CSL Editor](http://editor.citationstyles.org/about/), developed in a cooperation between Mendeley and Columbia University Library. See the [CSL Visual Editor user guide](https://github.com/citation-style-editor/csl-editor/wiki/User-guide-for-the-CSL-Editor). If you have questions about editing styles with the CSL Visual Editor, you can still ask for help on the [Zotero forums](https://zotero.org/forum) or on the [CSL Discourse page](https://discourse.citationstyles.org/). Please only use the [Issues page of this repository](https://github.com/citation-style-language/styles/issues) to report bugs, not to ask general style editing questions.
+To edit styles, you can use the [Visual CSL Editor](http://editor.citationstyles.org/about/), developed in a cooperation between Mendeley and Columbia University Library. 
+See the [CSL Visual Editor user guide](https://github.com/citation-style-editor/csl-editor/wiki/User-guide-for-the-CSL-Editor). 
+If you have questions about editing styles with the CSL Visual Editor, you can still ask for help on the [Zotero forums](https://zotero.org/forum) or on the [CSL Discourse page](https://discourse.citationstyles.org/). 
+Please only use the [Issues page of this repository](https://github.com/citation-style-language/styles/issues) to report bugs, not to ask general style editing questions.
 
 
 ### Manually editing CSL styles
 
-You can also edit CSL styles manually. Zotero includes a [built-in CSL Style Editor](https://zotero.org/support/dev/citation_styles/reference_test_pane) that allows you to see how your edits change style output in real time.
+You can also edit CSL styles manually. 
+Zotero includes a [built-in CSL Style Editor](https://zotero.org/support/dev/citation_styles/reference_test_pane) that allows you to see how your edits change style output in real time.
 
-You can also edit CSL styles in any plain text editor (e.g. Notepad on Windows or TextEdit on macOS). Note that text editors with XML support can be of great benefit by offering features like syntax highlighting and real-time validation. Popular choices are [Atom Editor](https://atom.io/), [VS Code](https://code.visualstudio.com/), the [oXygen XML Editor](https://www.oxygenxml.com/), [Emacs in nXML mode](https://www.thaiopensource.com/nxml-mode/), and [jEdit](https://www.jedit.org/). 
+You can also edit CSL styles in any plain text editor (e.g. Notepad on Windows or TextEdit on macOS). 
+Note that text editors with XML support can be very useful by offering features like syntax highlighting and real-time validation. 
+Popular choices are [Atom Editor](https://atom.io/), [VS Code](https://code.visualstudio.com/), the [oXygen XML Editor](https://www.oxygenxml.com/), [Emacs in nXML mode](https://www.thaiopensource.com/nxml-mode/), and [jEdit](https://www.jedit.org/). 
 
 Currently, most documentation for editing CSL styles can be found at:
 
@@ -23,31 +30,38 @@ Currently, most documentation for editing CSL styles can be found at:
 
 ### 1 - Start from the Right Style
 
-If you want to improve an existing CSL style, make sure that you start from the most recent version. The most recent version of each CSL style can be found in the [`master` branch of this repository](https://github.com/citation-style-language/styles).
+If you want to improve an existing CSL style, make sure that you start from the most recent version. 
+The most recent version of each CSL style can be found in the [`master` branch of this repository](https://github.com/citation-style-language/styles).
 
-If you want to create a new style, find an existing style that closely matches what you need using the previews in the style repository. Typically the best way to find a most similar style is the ["seach by example"](http://editor.citationstyles.org/searchByExample/) function of the CSL Visual Editor. 
+If you want to create a new style, find an existing style that closely matches what you need using the previews in the style repository. 
+Typically the best way to find a most similar style is the ["seach by example"](http://editor.citationstyles.org/searchByExample/) function of the CSL Visual Editor. 
 
 
 ### 2 - Edit the Style
 
-Download the style you want to edit to your computer, and open it your plain text editor. Make any edits and save your style. Be sure that the new file has a `.csl` file extension (you can generally do this by simply typing ”.csl” after the name of your file).
+Download the style you want to edit to your computer, and open it your plain text editor. 
+Make any edits and save your style. 
+Be sure that the new file has a `.csl` file extension (you can generally do this by simply typing ”.csl” after the name of your file).
 
 If you are using the Zotero CSL Editor, be sure to save your edits often using the "Save" button to avoid losing your changes.
 
-See the [[http://citationstyles.org/citation-style-language/documentation/|documentation page]] of the CSL project website for information on making CSL changes (in particular, make sure to take a look at the [[http://citationstyles.org/downloads/specification.html|CSL specification]]. Below we discuss a few common and simple style edits to get you started.
-
-Refer to the [CSL documentation](http://citationstyles.org/citation-style-language/documentation/) for information on the various options available in CSL styles. We discuss some common edits below to help get you started.
+Refer to the [CSL specification](http://citationstyles.org/downloads/specification.html) for information on the various options available in CSL styles. 
+Below, we discuss a few common style edits to get you started.
 
 #### Changing punctuation
 
-In this example, we want to display the publisher ("CSHL Press") and the location of the publisher ("Cold Spring Harbor, NY") in a bibliographic entry. While this can be achieved with the code
+In this example, we want to display the publisher ("CSHL Press") and the location of the publisher ("Cold Spring Harbor, NY") in a bibliographic entry. 
+While this can be achieved with the code:
 
 ```xml
 <text variable="publisher"/>
 <text variable="publisher-place"/>
 ```
 
-this would result in "CSHL PressCold Spring Harbor, NY". Fortunately, we can add some punctuation with the `prefix`, `suffix`, and `delimiter` attributes. Let's say we want to separate the `publisher` and `publisher-place` by a comma-space, and wrap the whole in parentheses, i.e. "(CSHL Press, Cold Spring Harbor, NY)". This can be done with:
+this would result in "CSHL PressCold Spring Harbor, NY". 
+Fortunately, we can add some punctuation with the `prefix`, `suffix`, and `delimiter` attributes. 
+Let's say we want to separate the `publisher` and `publisher-place` by a comma-space, and wrap the whole in parentheses, i.e. "(CSHL Press, Cold Spring Harbor, NY)". 
+This can be done with:
 
 ```xml
 <group delimiter=", " prefix="(" suffix=")">
@@ -56,7 +70,8 @@ this would result in "CSHL PressCold Spring Harbor, NY". Fortunately, we can add
 </group>
 ```
 
-The advantage of use a `group` element is that whenever you have a `publisher`, but no `publisher-place`, you don't end up with incorrect punctuation: the output would become "(CSHL Press)". If you would set the punctuation directly onto the `text` elements, e.g.
+The advantage of use a `group` element is that whenever you have a `publisher`, but no `publisher-place`, you don't end up with incorrect punctuation: the output would become "(CSHL Press)". 
+If you would set the punctuation directly onto the `text` elements, e.g.:
 
 ```xml
 <text variable="publisher" prefix="("/>
@@ -67,7 +82,8 @@ you would lose the closing bracket, i.e. "(CSHL Press".
 
 #### Changing et-al abbreviation
 
-There are two main settings for et-al abbreviation (e.g., rendering the names "Doe, Smith & Johnson" as "Doe et al."). The minimum number of names that activates et-al abbreviation, and the number of names shown before "et al.".
+There are two main settings for et-al abbreviation (e.g., rendering the names "Doe, Smith & Johnson" as "Doe et al."). 
+The minimum number of names that activates et-al abbreviation, and the number of names shown before "et al.".
 
 In CSL, these settings can appear on the `style`, `citation`, `bibliography` or `names` elements in the form of the `et-al-min` and `et-al-use-first` attributes (it is possible to have separate settings for items that have been cited previously by using the `et-al-subsequent-min` and `et-al-subsequent-use-first` attributes).
 
@@ -79,13 +95,17 @@ For example,
 </citation>
 ```
 
-will result in name lists like "Doe", "Doe & Smith" and, if there are three or more names, "Doe et al.". Try changing these numbers and observe the effect.
+will result in name lists like "Doe", "Doe & Smith" and, if there are three or more names, "Doe et al.". 
+Try changing these numbers and observe the effect.
 
 #### Changing disambiguation rules
 
-CSL offers multiple methods to disambiguate cites or names. For example, a style might normally render only the family name (e.g., "(Doe 1999, Doe 2002)"). If the authors are Jane Doe and Thomas Doe, these names can be disambiguated by adding initials or the full given names (e.g., "(J. Doe 1999, T. Doe 2002)").
+CSL offers multiple methods to disambiguate cites or names. 
+For example, a style might normally render only the family name (e.g., "(Doe 1999, Doe 2002)"). 
+If the authors are Jane Doe and Thomas Doe, these names can be disambiguated by adding initials or the full given names (e.g., "(J. Doe 1999, T. Doe 2002)").
 
-Disambiguation methods are selected on the `citation` element. For example, to disable [given name disambiguation](https://zotero.org/support/kb/given_name_disambiguation), delete the `disambiguate-add-givenname` attribute, e.g. change
+Disambiguation methods are selected on the `citation` element. 
+For example, to disable [given name disambiguation](https://zotero.org/support/kb/given_name_disambiguation), delete the `disambiguate-add-givenname` attribute, e.g., change:
 
 ```xml
 <citation disambiguate-add-givenname="true">
@@ -93,7 +113,7 @@ Disambiguation methods are selected on the `citation` element. For example, to d
 </citation>
 ```
 
-to
+to:
 
 ```xml
 <citation>
@@ -103,7 +123,8 @@ to
 
 #### Changing author separation
 
-By default, several authors are separated by a delimiter `, ` and the word `and`. This settings can be changed, for example to use the symbol `&` instead:
+By default, several authors are separated by a delimiter `, ` and the word `and`. 
+This settings can be changed, for example to use the symbol `&` instead:
 
 ```xml
 <names variable="author">
@@ -123,7 +144,10 @@ or to not use `and` at all, but to use the delimiter `/`:
 
 #### Conditional rendering (full footnote style)
 
-The appearance of citations in (full) footnote styles may depend on their position in the paper. If the same source is cited twice, it may be that a shortened version is used in the second (and any further) citation. To handle this distinction, one can use [conditional rendering based on the position](http://citationstyles.org/downloads/specification.html#choose) of the citation. A generic structure could then look like
+The appearance of citations in (full) footnote styles may depend on their position in the paper. 
+If the same source is cited twice, it may be that a shortened version is used in the second (and any further) citation. 
+To handle this distinction, one can use [conditional rendering based on the position](http://citationstyles.org/downloads/specification.html#choose) of the citation. 
+A generic structure could then look like:
 
 ```xml
 <citation>
@@ -150,16 +174,21 @@ If a case is missing in your style, you can add a new case and specify how infor
 
 #### Note: Updating from Older CSL Versions
 
-You should alway begun editing from a style that uses the current version of CSL. If you are starting from an older version of CSL (e.g. CSL 0.8.1), you should first [upgrading it to the current CSL version](http://citationstyles.org/downloads/upgrade-notes.html#updating-csl-0-8-styles) to take advantage of the newest CSL features.
+You should alway begun editing from a style that uses the current version of CSL. 
+If you are starting from an older version of CSL (e.g. CSL 0.8.1), you should first [upgrading it to the current CSL version](http://citationstyles.org/downloads/upgrade-notes.html#updating-csl-0-8-styles) to take advantage of the newest CSL features.
 
-CSL 0.8.1 and 1.0 styles can be easily distinguished by looking at the ```<style/>``` element at the top of the style. CSL 1.0 styles include a ```version``` attribute on this element with a value of "1.0", e.g. ```<style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0">```. CSL 0.8.1 styles lack this attribute. 
+CSL 0.8.1 and 1.0 styles can be easily distinguished by looking at the ```<style/>``` element at the top of the style. 
+CSL 1.0 styles include a ```version``` attribute on this element with a value of "1.0", e.g. ```<style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0">```. 
+CSL 0.8.1 styles lack this attribute. 
 
 
 ### 3 - Change the Style Title and ID
 
-**Important:** Before installing your edited style in your reference manager or otherwise using it, you must change the style title and ID at the top of the style code. If you don't change these, your reference manager may overwrite your modified style the next time the original style is updated.
+**Important:** Before installing your edited style in your reference manager or otherwise using it, you must change the style title and ID at the top of the style code. 
+If you don't change these, your reference manager may overwrite your modified style the next time the original style is updated.
 
-The style title and ID are stored within the `<title/>` and `<id/>` elements near the top of the style. For example,
+The style title and ID are stored within the `<title/>` and `<id/>` elements near the top of the style. 
+For example:
 
 ```xml
 <title>American Psychological Association 6th edition</title>
@@ -167,7 +196,7 @@ The style title and ID are stored within the `<title/>` and `<id/>` elements nea
 <id>http://www.zotero.org/styles/apa</id>
 ```
 
-can be changed to
+can be changed to:
 
 ```xml
 <title>American Psychological Association 6th edition - Modified</title>
@@ -175,12 +204,14 @@ can be changed to
 <id>fa1f25a6-1d63-4936-909b-f275ba16ac15</id>
 ```
 
-You should use a [UUID](https://www.uuidgenerator.net/), rather than a URI, for your new style ID. This ensures that the style ID is universally unique. 
+You should use a [UUID](https://www.uuidgenerator.net/), rather than a URI, for your new style ID. 
+This ensures that the style ID is universally unique. 
 
 
 ## Validation
 
-We rely heavily on validation against the CSL schema to make sure all CSL styles and [[locale files|https://github.com/citation-style-language/locales/wiki]] are of sufficient quality. Only styles and locales that are valid XML and conform to the CSL schema can be expected to work correctly with all CSL-compatible applications.
+We rely heavily on validation against the CSL schema to make sure all CSL styles and [locale files](https://github.com/citation-style-language/locales/wiki) are of sufficient quality. 
+Only styles and locales that are valid XML and conform to the CSL schema can be expected to work correctly with all CSL-compatible applications.
 
 ### CSL Validator
 
@@ -192,25 +223,38 @@ If the [CSL Validator](http://validator.citationstyles.org/) website is down or 
 
 #### csl-validator.js
 
-CSL styles and locale files can also be validated at [](http://simonster.github.io/csl-validator.js/). Just paste in your style or locale and click the "Validate" button to validate against the CSL 1.0.1 schema. If there aren't any validation errors you will get the message "Validation successful.".
+CSL styles and locale files can also be validated at [](http://simonster.github.io/csl-validator.js/). 
+Just paste in your style or locale and click the "Validate" button to validate against the CSL 1.0.1 schema. 
+If there aren't any validation errors you will get the message "Validation successful.".
 
 #### Validator.nu
 
 You can also use [Validator.nu](http://validator.nu/?schema=https%3A%2F%2Fgithub.com%2Fcitation-style-language%2Fschema%2Fraw%2Fv1.0.1%2Fcsl.rnc&parser=xml&laxtype=yes&showsource=yes):
 
-  - Select your style or locale. You can provide an URL if your style/locale is accessible online (the "Address" option), select the file on your computer ("File Upload"), or copy and paste the complete code into the text box ("Text Field").
-  - (pre-selected if using the link above) Enter the URL to the CSL schema in the "Schemas" text field. For CSL 1.0.1, this is https://github.com/citation-style-language/schema/raw/v1.0.1/csl.rnc. To validate styles in the older CSL 1.0 and 0.8.1 formats, use https://github.com/citation-style-language/schema/raw/v1.0/csl.rnc or https://github.com/citation-style-language/schema/raw/v0.8.1/csl.rnc, respectively.
-  - (pre-selected if using the link above) In the "Parser" drop-down menu, select the "XML; don't load external entities" option. Also check the "Be lax about HTTP Content-Type" check-box.
-  - Click the “Validate” button. If the style/locale is valid, you will get the message “The document validates according to the specified schema(s) and to additional constraints checked by the validator.”, or, if the style/locale is invalid, "There were errors.". Warnings can be ignored; only errors are important.
+  - Select your style or locale. 
+    You can provide an URL if your style/locale is accessible online (the "Address" option), select the file on your computer ("File Upload"), or copy and paste the complete code into the text box ("Text Field").
+  - (pre-selected if using the link above) 
+    Enter the URL to the CSL schema in the "Schemas" text field. 
+    For CSL 1.0.1, this is https://github.com/citation-style-language/schema/raw/v1.0.1/csl.rnc. 
+    To validate styles in the older CSL 1.0 and 0.8.1 formats, use https://github.com/citation-style-language/schema/raw/v1.0/csl.rnc or https://github.com/citation-style-language/schema/raw/v0.8.1/csl.rnc, respectively.
+  - (pre-selected if using the link above) 
+    In the "Parser" drop-down menu, select the "XML; don't load external entities" option. 
+    Also check the "Be lax about HTTP Content-Type" check-box.
+  - Click the “Validate” button. 
+    If the style/locale is valid, you will get the message “The document validates according to the specified schema(s) and to additional constraints checked by the validator.”, or, if the style/locale is invalid, "There were errors.". 
+    Warnings can be ignored; only errors are important.
 
 #### Local Validators
 
-You can also validate your style/locale on your own computer with any tool that offers XML validation and supports the RELAX NG Compact schema language. Examples are the [Atom](https://atom.io/) with the [atomic-csl plugin](https://github.com/bdarcus/atomic-csl), [Emacs](http://www.gnu.org/software/emacs/) with the [nXML addon](http://www.thaiopensource.com/nxml-mode/), [jEdit](http://www.jedit.org/) with the XML addon and the [CSL schema](https://github.com/citation-style-language/schema/zipball/v1.0), and the command-line utilities [Jing](http://www.thaiopensource.com/relaxng/jing.html) and [RNV](http://www.davidashen.net/rnv.html).
+You can also validate your style/locale on your own computer with any tool that offers XML validation and supports the RELAX NG Compact schema language. 
+Examples are the [Atom](https://atom.io/) with the [atomic-csl plugin](https://github.com/bdarcus/atomic-csl), [Emacs](http://www.gnu.org/software/emacs/) with the [nXML addon](http://www.thaiopensource.com/nxml-mode/), [jEdit](http://www.jedit.org/) with the XML addon and the [CSL schema](https://github.com/citation-style-language/schema/zipball/v1.0), and the command-line utilities [Jing](http://www.thaiopensource.com/relaxng/jing.html) and [RNV](http://www.davidashen.net/rnv.html).
 
 
 ## Quality Control
 
-We strive to keep the CSL Style Repository in tip-top shape. Becuase we have thousands of styles and hundreds of contributors, we rely heavily on automated quality control and periodic maintenance. Please see [Quality Control](https://github.com/citation-style-language/styles/blob/master/QUALITY_CONTROL.md) for our best practices.
+We strive to keep the CSL Style Repository in tip-top shape. 
+Becuase we have thousands of styles and hundreds of contributors, we rely heavily on automated quality control and periodic maintenance. 
+Please see [Quality Control](https://github.com/citation-style-language/styles/blob/master/QUALITY_CONTROL.md) for our best practices.
 
 
 ## Sharing Styles
@@ -222,4 +266,5 @@ You can also host CSL styles on your own website.
 
 ## Getting Help
 
-If you have questions about editing CSL styles, you can still ask for help on the [Zotero forums](https://zotero.org/forum) or on the [CSL Discourse page](https://discourse.citationstyles.org/). Please only use the [Issues page of this repository](https://github.com/citation-style-language/styles/issues) to report bugs, not to ask general style editing questions.
+If you have questions about editing CSL styles, you can still ask for help on the [Zotero forums](https://zotero.org/forum) or on the [CSL Discourse page](https://discourse.citationstyles.org/). 
+Please only use the [Issues page of this repository](https://github.com/citation-style-language/styles/issues) to report bugs, not to ask general style editing questions.

--- a/STYLE_DEVELOPMENT.md
+++ b/STYLE_DEVELOPMENT.md
@@ -201,11 +201,8 @@ can be changed to:
 ```xml
 <title>American Psychological Association 6th edition - Modified</title>
 <title-short>APA - modified</title-short>
-<id>fa1f25a6-1d63-4936-909b-f275ba16ac15</id>
+<id>http://www.zotero.org/styles/apa-modified</id>
 ```
-
-You should use a [UUID](https://www.uuidgenerator.net/), rather than a URI, for your new style ID. 
-This ensures that the style ID is universally unique. 
 
 
 ## Validation

--- a/STYLE_DEVELOPMENT.md
+++ b/STYLE_DEVELOPMENT.md
@@ -1,0 +1,225 @@
+# CSL Style Development
+
+CSL relies on volunteers to develop, edit, and maintain its library of citation styles. Below are guidelines and tips for editing and developing CSL styles.
+
+
+## Editing Styles
+
+### CSL Visual Editor
+
+To edit styles, you can use the [Visual CSL Editor](http://editor.citationstyles.org/about/), developed in a cooperation between Mendeley and Columbia University Library. See the [CSL Visual Editor user guide](https://github.com/citation-style-editor/csl-editor/wiki/User-guide-for-the-CSL-Editor). If you have questions about editing styles with the CSL Visual Editor, you can still ask for help on the [Zotero forums](https://zotero.org/forum) or on the [CSL Discourse page](https://discourse.citationstyles.org/). Please only use the [Issues page of this repository](https://github.com/citation-style-language/styles/issues) to report bugs, not to ask general style editing questions.
+
+
+### Manually editing CSL styles
+
+You can also edit CSL styles manually. Zotero includes a [built-in CSL Style Editor](https://zotero.org/support/dev/citation_styles/reference_test_pane) that allows you to see how your edits change style output in real time.
+
+You can also edit CSL styles in any plain text editor (e.g. Notepad on Windows or TextEdit on macOS). Note that text editors with XML support can be of great benefit by offering features like syntax highlighting and real-time validation. Popular choices are [Atom Editor](https://atom.io/), [VS Code](https://code.visualstudio.com/), the [oXygen XML Editor](https://www.oxygenxml.com/), [Emacs in nXML mode](https://www.thaiopensource.com/nxml-mode/), and [jEdit](https://www.jedit.org/). 
+
+Currently, most documentation for editing CSL styles can be found at:
+
+* http://citationstyles.org/citation-style-language/documentation/
+
+
+### 1 - Start from the Right Style
+
+If you want to improve an existing CSL style, make sure that you start from the most recent version. The most recent version of each CSL style can be found in the [`master` branch of this repository](https://github.com/citation-style-language/styles).
+
+If you want to create a new style, find an existing style that closely matches what you need using the previews in the style repository. Typically the best way to find a most similar style is the ["seach by example"](http://editor.citationstyles.org/searchByExample/) function of the CSL Visual Editor. 
+
+
+### 2 - Edit the Style
+
+Download the style you want to edit to your computer, and open it your plain text editor. Make any edits and save your style. Be sure that the new file has a `.csl` file extension (you can generally do this by simply typing ”.csl” after the name of your file).
+
+If you are using the Zotero CSL Editor, be sure to save your edits often using the "Save" button to avoid losing your changes.
+
+See the [[http://citationstyles.org/citation-style-language/documentation/|documentation page]] of the CSL project website for information on making CSL changes (in particular, make sure to take a look at the [[http://citationstyles.org/downloads/specification.html|CSL specification]]. Below we discuss a few common and simple style edits to get you started.
+
+Refer to the [CSL documentation](http://citationstyles.org/citation-style-language/documentation/) for information on the various options available in CSL styles. We discuss some common edits below to help get you started.
+
+#### Changing punctuation
+
+In this example, we want to display the publisher ("CSHL Press") and the location of the publisher ("Cold Spring Harbor, NY") in a bibliographic entry. While this can be achieved with the code
+
+```xml
+<text variable="publisher"/>
+<text variable="publisher-place"/>
+```
+
+this would result in "CSHL PressCold Spring Harbor, NY". Fortunately, we can add some punctuation with the `prefix`, `suffix`, and `delimiter` attributes. Let's say we want to separate the `publisher` and `publisher-place` by a comma-space, and wrap the whole in parentheses, i.e. "(CSHL Press, Cold Spring Harbor, NY)". This can be done with:
+
+```xml
+<group delimiter=", " prefix="(" suffix=")">
+  <text variable="publisher"/>
+  <text variable="publisher-place"/>
+</group>
+```
+
+The advantage of use a `group` element is that whenever you have a `publisher`, but no `publisher-place`, you don't end up with incorrect punctuation: the output would become "(CSHL Press)". If you would set the punctuation directly onto the `text` elements, e.g.
+
+```xml
+<text variable="publisher" prefix="("/>
+<text variable="publisher-place" prefix=", " suffix=")"/>
+```
+
+you would lose the closing bracket, i.e. "(CSHL Press".
+
+#### Changing et-al abbreviation
+
+There are two main settings for et-al abbreviation (e.g., rendering the names "Doe, Smith & Johnson" as "Doe et al."). The minimum number of names that activates et-al abbreviation, and the number of names shown before "et al.".
+
+In CSL, these settings can appear on the `style`, `citation`, `bibliography` or `names` elements in the form of the `et-al-min` and `et-al-use-first` attributes (it is possible to have separate settings for items that have been cited previously by using the `et-al-subsequent-min` and `et-al-subsequent-use-first` attributes).
+
+For example,
+
+```xml
+<citation et-al-min="3" et-al-use-first="1">
+  ...
+</citation>
+```
+
+will result in name lists like "Doe", "Doe & Smith" and, if there are three or more names, "Doe et al.". Try changing these numbers and observe the effect.
+
+#### Changing disambiguation rules
+
+CSL offers multiple methods to disambiguate cites or names. For example, a style might normally render only the family name (e.g., "(Doe 1999, Doe 2002)"). If the authors are Jane Doe and Thomas Doe, these names can be disambiguated by adding initials or the full given names (e.g., "(J. Doe 1999, T. Doe 2002)").
+
+Disambiguation methods are selected on the `citation` element. For example, to disable [given name disambiguation](https://zotero.org/support/kb/given_name_disambiguation), delete the `disambiguate-add-givenname` attribute, e.g. change
+
+```xml
+<citation disambiguate-add-givenname="true">
+  ...
+</citation>
+```
+
+to
+
+```xml
+<citation>
+  ...
+</citation>
+```
+
+#### Changing author separation
+
+By default, several authors are separated by a delimiter `, ` and the word `and`. This settings can be changed, for example to use the symbol `&` instead:
+
+```xml
+<names variable="author">
+  <name form="short" and="symbol" delimiter=", "/>
+  ...
+</names>
+```
+
+or to not use `and` at all, but to use the delimiter `/`:
+
+```xml
+<names variable="author">
+  <name form="short" delimiter="/"/>
+  ..
+</names>
+```
+
+#### Conditional rendering (full footnote style)
+
+The appearance of citations in (full) footnote styles may depend on their position in the paper. If the same source is cited twice, it may be that a shortened version is used in the second (and any further) citation. To handle this distinction, one can use [conditional rendering based on the position](http://citationstyles.org/downloads/specification.html#choose) of the citation. A generic structure could then look like
+
+```xml
+<citation>
+  <layout>
+    <choose>
+      <if position="ibid-with-locator">
+        ...
+      </if>
+      <else-if position="ibid">
+        ...
+      </else-if>
+      <else-if position="subsequent">
+        ...
+      </else-if>
+      <else>
+        ...
+      </else>
+    </citation>
+  </layout>
+</citation>
+```
+
+If a case is missing in your style, you can add a new case and specify how information should be rendered in that case (e.g. see [Chicago (full note)](https://www.zotero.org/styles/chicago-fullnote-bibliography?source=1) for an example).
+
+#### Note: Updating from Older CSL Versions
+
+You should alway begun editing from a style that uses the current version of CSL. If you are starting from an older version of CSL (e.g. CSL 0.8.1), you should first [upgrading it to the current CSL version](http://citationstyles.org/downloads/upgrade-notes.html#updating-csl-0-8-styles) to take advantage of the newest CSL features.
+
+CSL 0.8.1 and 1.0 styles can be easily distinguished by looking at the ```<style/>``` element at the top of the style. CSL 1.0 styles include a ```version``` attribute on this element with a value of "1.0", e.g. ```<style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0">```. CSL 0.8.1 styles lack this attribute. 
+
+
+### 3 - Change the Style Title and ID
+
+**Important:** Before installing your edited style in your reference manager or otherwise using it, you must change the style title and ID at the top of the style code. If you don't change these, your reference manager may overwrite your modified style the next time the original style is updated.
+
+The style title and ID are stored within the `<title/>` and `<id/>` elements near the top of the style. For example,
+
+```xml
+<title>American Psychological Association 6th edition</title>
+<title-short>APA</title-short>
+<id>http://www.zotero.org/styles/apa</id>
+```
+
+can be changed to
+
+```xml
+<title>American Psychological Association 6th edition - Modified</title>
+<title-short>APA - modified</title-short>
+<id>fa1f25a6-1d63-4936-909b-f275ba16ac15</id>
+```
+
+You should use a [UUID](https://www.uuidgenerator.net/), rather than a URI, for your new style ID. This ensures that the style ID is universally unique. 
+
+
+## Validation
+
+We rely heavily on validation against the CSL schema to make sure all CSL styles and [[locale files|https://github.com/citation-style-language/locales/wiki]] are of sufficient quality. Only styles and locales that are valid XML and conform to the CSL schema can be expected to work correctly with all CSL-compatible applications.
+
+### CSL Validator
+
+To validate your style or locale file, please use our own [CSL Validator](http://validator.citationstyles.org/). Styles and locales can be selected via URL, file upload, or copy and paste into a text field.
+
+### Alternative validators
+
+If the [CSL Validator](http://validator.citationstyles.org/) website is down or doesn't work, you can try one of the validators below.
+
+#### csl-validator.js
+
+CSL styles and locale files can also be validated at [](http://simonster.github.io/csl-validator.js/). Just paste in your style or locale and click the "Validate" button to validate against the CSL 1.0.1 schema. If there aren't any validation errors you will get the message "Validation successful.".
+
+#### Validator.nu
+
+You can also use [Validator.nu](http://validator.nu/?schema=https%3A%2F%2Fgithub.com%2Fcitation-style-language%2Fschema%2Fraw%2Fv1.0.1%2Fcsl.rnc&parser=xml&laxtype=yes&showsource=yes):
+
+  - Select your style or locale. You can provide an URL if your style/locale is accessible online (the "Address" option), select the file on your computer ("File Upload"), or copy and paste the complete code into the text box ("Text Field").
+  - (pre-selected if using the link above) Enter the URL to the CSL schema in the "Schemas" text field. For CSL 1.0.1, this is https://github.com/citation-style-language/schema/raw/v1.0.1/csl.rnc. To validate styles in the older CSL 1.0 and 0.8.1 formats, use https://github.com/citation-style-language/schema/raw/v1.0/csl.rnc or https://github.com/citation-style-language/schema/raw/v0.8.1/csl.rnc, respectively.
+  - (pre-selected if using the link above) In the "Parser" drop-down menu, select the "XML; don't load external entities" option. Also check the "Be lax about HTTP Content-Type" check-box.
+  - Click the “Validate” button. If the style/locale is valid, you will get the message “The document validates according to the specified schema(s) and to additional constraints checked by the validator.”, or, if the style/locale is invalid, "There were errors.". Warnings can be ignored; only errors are important.
+
+#### Local Validators
+
+You can also validate your style/locale on your own computer with any tool that offers XML validation and supports the RELAX NG Compact schema language. Examples are the [Atom](https://atom.io/) with the [atomic-csl plugin](https://github.com/bdarcus/atomic-csl), [Emacs](http://www.gnu.org/software/emacs/) with the [nXML addon](http://www.thaiopensource.com/nxml-mode/), the [oXygen XML Editor](http://www.oxygenxml.com/), and the command-line utilities [Jing](http://www.thaiopensource.com/relaxng/jing.html) and [RNV](http://www.davidashen.net/rnv.html).
+
+
+## Quality Control
+
+We strive to keep the CSL Style Repository in tip-top shape. Becuase we have thousands of styles and hundreds of contributors, we rely heavily on automated quality control and periodic maintenance. Please see [Quality Control](https://github.com/citation-style-language/styles/blob/master/QUALITY_CONTROL.md) for our best practices.
+
+
+## Sharing Styles
+
+If you think that your modified style might be useful to other people, consider [submitting](https://github.com/citation-style-language/styles/blob/master/CONTRIBUTING.md) it to the CSL Style Repository.
+
+You can also host CSL styles on your own website.
+
+
+## Getting Help
+
+If you have questions about editing CSL styles, you can still ask for help on the [Zotero forums](https://zotero.org/forum) or on the [CSL Discourse page](https://discourse.citationstyles.org/). Please only use the [Issues page of this repository](https://github.com/citation-style-language/styles/issues) to report bugs, not to ask general style editing questions.

--- a/STYLE_REQUIREMENTS.md
+++ b/STYLE_REQUIREMENTS.md
@@ -1,0 +1,120 @@
+# CSL Style Repository Requirements
+
+Before submitting your style to the CSL style repository, please make sure it follows our requirements:
+
+##### 1 - Title Abbreviations
+
+The style name in `<title/>` should be written out in full. To store a title abbreviation, use the `<title-short/>` element, e.g.:
+
+```xml
+   <info>
+     <title>Modern Humanities Research Association</title>
+     <title-short>MHRA</title-short>
+   </info>
+```
+
+For university department styles (and other institutional styles), always put the name of the institution before the name of the department. Institutional styles may also mention the type of style (e.g. "Vancouver", "APA", or "Harvard") in the title. Use hyphens to separate these elements, e.g. "Oxford Brookes University - Faculty of Health and Life Sciences - Harvard". 
+
+##### 2 - Title Diacritics
+
+Don't remove diacritics from the style title. E.g. use `<title>Associação Brasileira de Normas Técnicas</title>` instead of `<title>Associacao Brasileira de Normas Tecnicas</title>`.
+
+##### 3 - Style Locale
+
+If your style is meant to be used in one particular language, set the `default-locale` attribute on `<style/>` to the appropriate locale code. For example, CSL styles for English-language journals should typically be set to US English ("en-US") or British English ("en-GB"). For a list of languages and their locale codes, see https://github.com/citation-style-language/locales/wiki.
+
+When using `default-locale`, add the chosen locale to the style title, unless the language is English. Use the localized name for the locale, rather than translating to English (e.g. "Deutsch" instead of "German"). An example:
+
+```xml
+   <style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" default-locale="de-DE">
+     <info>
+       <title>Zeitschrift für Soziologie (Deutsch)</title>
+       <id>http://www.zotero.org/styles/zeitschrift-fur-soziologie</id>
+     </info>
+   </style>
+```
+
+##### 4 - File Name
+
+The file name of a style should be based on its title. However, file names may only contain lowercase roman letters (a-z), digits (0-9), and single hyphens (-), and must end with the ".csl" extension. To create the file name from the title:
+
+  * replace capitals with lowercase letters
+  * replace ampersands with "and" (e.g., "Arts & Health" becomes "arts-and-health.csl")
+  * replace spaces and apostrophes with hyphens (e.g., "Documents d'archéologie française (French)" becomes "documents-d-archeologie-francaise.csl")
+  * drop diacritics (e.g., "für" becomes "fur", not "fuer")
+  * drop text between parentheses (e.g., "Ugeskrift for Læger (Danish)" becomes "ugeskrift-for-laeger.csl")
+  * avoid abbreviations (e.g., use "modern-humanities-research-association.csl" instead of "mhra.csl")
+  * add the ".csl" extension
+
+You can use a 'slugify' tool like https://blog.tersmitten.nl/slugify/ to quickly lowercase titles and replace spaces by hyphens, although you may have to make some more changes by hand.
+
+##### 5 - Style ID
+
+For existing styles, do not change the style ID. For new styles, the style ID must be a [UUID](https://www.uuidgenerator.net/). For example:
+
+```xml
+   <info>
+     <id>fa1f25a6-1d63-4936-909b-f275ba16ac15</id>
+   </info>
+```
+
+##### 6 - "self" Link
+
+The style's "self" link, which tells where the style will available online, must be "http://www.zotero.org/styles/file-name", with "**file-name**" representing the style's file name without the ".csl" extension. E.g., "http://www.zotero.org/styles/modern-humanities-research-association" for "modern-humanities-research-association.csl":
+
+```xml
+   <info>
+     <link href="http://www.zotero.org/styles/modern-humanities-research-association" rel="self"/>
+   </info>
+```
+
+##### 7 - License
+
+The style must be licensed under the Creative Commons Attribution-ShareAlike 3.0 License. Use the exact text below, without any hard line breaks for ``<rights/>``:
+
+```xml
+   <info>
+     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
+   </info>
+```
+
+##### 8 - "template" Link
+
+If you started from another CSL style, delete the original style authors and contributors, and point to the original style with a "template" link:
+
+```xml
+   <info>
+     <link href="http://www.zotero.org/styles/original-style" rel="template"/>
+   </info>
+```
+
+##### 9 - ISSN and eISSN
+
+Journal styles should list the journal's print ISSN (``<issn/>``) and online ISSN (``<eissn/>``), if available:
+
+```xml
+   <info>
+     <issn>0028-0836</issn>
+     <eissn>1476-4687</eissn>
+   </info>
+```
+
+##### 10 - "documentation" Link
+
+Independent styles should have a "documentation" link that points to a description of the style's citation format. For journals this is typically the "instructions to authors" webpage. If a style guide is only available in print, provide a URL that allows us to locate a paper copy.
+
+```xml
+   <info>
+     <link href="http://www.mhra.org.uk/Publications/Books/StyleGuide/download.shtml" rel="documentation"/>
+   </info>
+```
+
+##### 11 - XML Indentation
+
+Indent the style's XML with 2 spaces per level. Some text editors support automatic indentation of XML. Alternatively, use our [style formatter](http://formatter.citationstyles.org/) tool.
+
+##### 12 - Validation
+
+Make sure your finished style [validates](https://github.com/citation-style-language/styles/blob/master/STYLE_DEVELOPMENT.md#validation) against the CSL schema.
+
+That's it! You're ready to [submit](https://github.com/citation-style-language/styles/blob/master/CONTRIBUTING.md) your style!

--- a/STYLE_REQUIREMENTS.md
+++ b/STYLE_REQUIREMENTS.md
@@ -30,13 +30,12 @@ For example, CSL styles for English-language journals should typically be set to
 For a list of languages and their locale codes, see https://github.com/citation-style-language/locales/wiki.
 
 When using `default-locale`, add the chosen locale to the style title, unless the language is English. 
-Use the localized name for the locale, rather than translating to English (e.g. "Deutsch" instead of "German"). 
 An example:
 
 ```xml
    <style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" default-locale="de-DE">
      <info>
-       <title>Zeitschrift für Soziologie (Deutsch)</title>
+       <title>Zeitschrift für Soziologie (German)</title>
        <id>http://www.zotero.org/styles/zeitschrift-fur-soziologie</id>
      </info>
    </style>
@@ -60,13 +59,12 @@ You can use a 'slugify' tool like https://blog.tersmitten.nl/slugify/ to quickly
 
 ##### 5 - Style ID
 
-For existing styles, do not change the style ID. 
-For new styles, the style ID must be a [UUID](https://www.uuidgenerator.net/). 
-For example:
+The style ID must be "http://www.zotero.org/styles/file-name", with "file-name" representing the style's file name without the ".csl" extension. 
+For example, the style ID would be "http://www.zotero.org/styles/modern-humanities-research-association" for "modern-humanities-research-association.csl":
 
 ```xml
    <info>
-     <id>fa1f25a6-1d63-4936-909b-f275ba16ac15</id>
+     <id>http://www.zotero.org/styles/modern-humanities-research-association</id>
    </info>
 ```
 

--- a/STYLE_REQUIREMENTS.md
+++ b/STYLE_REQUIREMENTS.md
@@ -4,7 +4,8 @@ Before submitting your style to the CSL style repository, please make sure it fo
 
 ##### 1 - Title Abbreviations
 
-The style name in `<title/>` should be written out in full. To store a title abbreviation, use the `<title-short/>` element, e.g.:
+The style name in `<title/>` should be written out in full. 
+To store a title abbreviation, use the `<title-short/>` element, e.g.:
 
 ```xml
    <info>
@@ -13,17 +14,24 @@ The style name in `<title/>` should be written out in full. To store a title abb
    </info>
 ```
 
-For university department styles (and other institutional styles), always put the name of the institution before the name of the department. Institutional styles may also mention the type of style (e.g. "Vancouver", "APA", or "Harvard") in the title. Use hyphens to separate these elements, e.g. "Oxford Brookes University - Faculty of Health and Life Sciences - Harvard". 
+For university department styles (and other institutional styles), always put the name of the institution before the name of the department. 
+Institutional styles may also mention the type of style (e.g. "Vancouver", "APA", or "Harvard") in the title. 
+Use hyphens to separate these elements, e.g. "Oxford Brookes University - Faculty of Health and Life Sciences - Harvard". 
 
 ##### 2 - Title Diacritics
 
-Don't remove diacritics from the style title. E.g. use `<title>Associação Brasileira de Normas Técnicas</title>` instead of `<title>Associacao Brasileira de Normas Tecnicas</title>`.
+Don't remove diacritics from the style title. 
+For example, use `<title>Associação Brasileira de Normas Técnicas</title>` instead of `<title>Associacao Brasileira de Normas Tecnicas</title>`.
 
 ##### 3 - Style Locale
 
-If your style is meant to be used in one particular language, set the `default-locale` attribute on `<style/>` to the appropriate locale code. For example, CSL styles for English-language journals should typically be set to US English ("en-US") or British English ("en-GB"). For a list of languages and their locale codes, see https://github.com/citation-style-language/locales/wiki.
+If your style is meant to be used in one particular language, set the `default-locale` attribute on `<style/>` to the appropriate locale code. 
+For example, CSL styles for English-language journals should typically be set to US English ("en-US") or British English ("en-GB"). 
+For a list of languages and their locale codes, see https://github.com/citation-style-language/locales/wiki.
 
-When using `default-locale`, add the chosen locale to the style title, unless the language is English. Use the localized name for the locale, rather than translating to English (e.g. "Deutsch" instead of "German"). An example:
+When using `default-locale`, add the chosen locale to the style title, unless the language is English. 
+Use the localized name for the locale, rather than translating to English (e.g. "Deutsch" instead of "German"). 
+An example:
 
 ```xml
    <style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" default-locale="de-DE">
@@ -36,7 +44,9 @@ When using `default-locale`, add the chosen locale to the style title, unless th
 
 ##### 4 - File Name
 
-The file name of a style should be based on its title. However, file names may only contain lowercase roman letters (a-z), digits (0-9), and single hyphens (-), and must end with the ".csl" extension. To create the file name from the title:
+The file name of a style should be based on its title. 
+However, file names may only contain lowercase roman letters (a-z), digits (0-9), and single hyphens (-), and must end with the ".csl" extension. 
+To create the file name from the title:
 
   * replace capitals with lowercase letters
   * replace ampersands with "and" (e.g., "Arts & Health" becomes "arts-and-health.csl")
@@ -50,7 +60,9 @@ You can use a 'slugify' tool like https://blog.tersmitten.nl/slugify/ to quickly
 
 ##### 5 - Style ID
 
-For existing styles, do not change the style ID. For new styles, the style ID must be a [UUID](https://www.uuidgenerator.net/). For example:
+For existing styles, do not change the style ID. 
+For new styles, the style ID must be a [UUID](https://www.uuidgenerator.net/). 
+For example:
 
 ```xml
    <info>
@@ -60,7 +72,8 @@ For existing styles, do not change the style ID. For new styles, the style ID mu
 
 ##### 6 - "self" Link
 
-The style's "self" link, which tells where the style will available online, must be "http://www.zotero.org/styles/file-name", with "**file-name**" representing the style's file name without the ".csl" extension. E.g., "http://www.zotero.org/styles/modern-humanities-research-association" for "modern-humanities-research-association.csl":
+The style's "self" link, which tells where the style will available online, must be "http://www.zotero.org/styles/file-name", with "**file-name**" representing the style's file name without the ".csl" extension. 
+For example, "http://www.zotero.org/styles/modern-humanities-research-association" for "modern-humanities-research-association.csl":
 
 ```xml
    <info>
@@ -70,7 +83,8 @@ The style's "self" link, which tells where the style will available online, must
 
 ##### 7 - License
 
-The style must be licensed under the Creative Commons Attribution-ShareAlike 3.0 License. Use the exact text below, without any hard line breaks for ``<rights/>``:
+The style must be licensed under the Creative Commons Attribution-ShareAlike 3.0 License. 
+Use the exact text below, without any hard line breaks for ``<rights/>``:
 
 ```xml
    <info>
@@ -101,7 +115,9 @@ Journal styles should list the journal's print ISSN (``<issn/>``) and online ISS
 
 ##### 10 - "documentation" Link
 
-Independent styles should have a "documentation" link that points to a description of the style's citation format. For journals this is typically the "instructions to authors" webpage. If a style guide is only available in print, provide a URL that allows us to locate a paper copy.
+Independent styles should have a "documentation" link that points to a description of the style's citation format. 
+For journals, this is typically the "instructions to authors" webpage. 
+If a style guide is only available in print, provide a URL that allows us to locate a paper copy.
 
 ```xml
    <info>
@@ -111,7 +127,9 @@ Independent styles should have a "documentation" link that points to a descripti
 
 ##### 11 - XML Indentation
 
-Indent the style's XML with 2 spaces per level. Some text editors support automatic indentation of XML. Alternatively, use our [style formatter](http://formatter.citationstyles.org/) tool.
+Indent the style's XML with 2 spaces per level. 
+Some text editors support automatic indentation of XML. 
+Alternatively, use our [style formatter](http://formatter.citationstyles.org/) tool.
 
 ##### 12 - Validation
 


### PR DESCRIPTION
Moves content on style requests, style editing, and repository quality control to markdown files for easier access and version control. 

In doing so, I updated the Style Development guidelines to refer to two policy changes we've discussed for some time--using UUIDs instead of URIs for style ids and using localized locale labels instead of English labels. Are we good with updating those?