### PR TITLE
Create universite-de-geneve-departement-de-francais-moderne.csl

### DIFF
--- a/universite-de-geneve-departement-de-francais-moderne.csl
+++ b/universite-de-geneve-departement-de-francais-moderne.csl
@@ -34,8 +34,8 @@
   <macro name="author">
     <choose>
       <if variable="author">
-        <names variable="author" font-variant="normal" vertical-align="baseline">
-          <name font-style="normal" font-variant="normal" vertical-align="baseline" delimiter="," and="text" delimiter-precedes-last="never" name-as-sort-order="all" sort-separator=" ">
+        <names variable="author" vertical-align="baseline">
+          <name vertical-align="baseline" delimiter="," and="text" delimiter-precedes-last="never" name-as-sort-order="all" sort-separator=" ">
             <name-part name="family" text-case="capitalize-first" font-variant="small-caps" suffix=","/>
           </name>
         </names>
@@ -45,7 +45,7 @@
       </else-if>
       <else-if variable="editor">
         <names variable="editor">
-          <name font-style="normal" and="text" delimiter-precedes-last="never" name-as-sort-order="all" sort-separator=" ">
+          <name and="text" delimiter-precedes-last="never" name-as-sort-order="all" sort-separator=" ">
             <name-part name="family" text-case="capitalize-first" font-variant="small-caps" suffix=","/>
           </name>
           <label form="short" prefix=" (" suffix=".)"/>
@@ -57,14 +57,14 @@
     <choose>
       <if variable="author">
         <names variable="author">
-          <name font-style="normal" and="text" delimiter-precedes-last="never" initialize="false" name-as-sort-order="first">
+          <name and="text" delimiter-precedes-last="never" initialize="false" name-as-sort-order="first">
             <name-part name="family" text-case="capitalize-first" font-variant="small-caps"/>
           </name>
         </names>
       </if>
       <else-if variable="editor">
         <names variable="editor" font-variant="normal">
-          <name font-style="normal" font-variant="normal" and="text" delimiter-precedes-last="never" name-as-sort-order="all">
+          <name and="text" delimiter-precedes-last="never" name-as-sort-order="all">
             <name-part name="family" text-case="capitalize-first" font-variant="small-caps"/>
           </name>
           <label form="short" prefix=" (" suffix=".)"/>
@@ -83,7 +83,7 @@
     <choose>
       <if variable="author">
         <names variable="author">
-          <name font-style="normal" and="text" delimiter-precedes-et-al="never" delimiter-precedes-last="never" name-as-sort-order="all">
+          <name and="text" delimiter-precedes-et-al="never" delimiter-precedes-last="never" name-as-sort-order="all">
             <name-part name="family" text-case="capitalize-first" font-variant="small-caps"/>
           </name>
         </names>
@@ -97,7 +97,7 @@
       </else-if>
       <else-if variable="editor">
         <names variable="editor">
-          <name font-style="normal" and="text" delimiter-precedes-last="never" name-as-sort-order="all">
+          <name and="text" delimiter-precedes-last="never" name-as-sort-order="all">
             <name-part name="family" text-case="capitalize-first" font-variant="small-caps"/>
           </name>
           <label form="short" prefix=" (" suffix=".)"/>
@@ -108,14 +108,14 @@
   <macro name="editor">
     <names variable="editor">
       <label form="short" suffix=". "/>
-      <name font-style="normal" font-variant="normal" and="text" delimiter-precedes-last="never" sort-separator=" ">
+      <name and="text" delimiter-precedes-last="never" sort-separator=" ">
         <name-part name="family" text-case="capitalize-first" font-variant="normal"/>
       </name>
     </names>
   </macro>
   <macro name="translator">
     <names variable="translator" prefix="trad. ">
-      <name font-style="normal" and="text" delimiter-precedes-last="never" sort-separator=" ">
+      <name and="text" delimiter-precedes-last="never" sort-separator=" ">
         <name-part name="family" text-case="capitalize-first" font-variant="normal"/>
       </name>
     </names>
@@ -157,7 +157,7 @@
                 <text variable="title" text-case="capitalize-first" quotes="true" font-style="normal"/>
               </group>
               <group>
-                <text value="dans" font-style="normal" prefix=" " suffix=" "/>
+                <text value="dans" prefix=" " suffix=" "/>
                 <text macro="director-min"/>
               </group>
               <group>
@@ -246,7 +246,7 @@
       <else-if type="chapter entry-dictionary entry-encyclopedia" match="any">
         <choose>
           <if match="any" variable="collection-editor">
-            <group font-style="normal" delimiter=", ">
+            <group delimiter=", ">
               <choose>
                 <if match="any" variable="volume">
                   <group vertical-align="sub" suffix=",">
@@ -549,7 +549,7 @@
         </else-if>
         <else>
           <group delimiter=", ">
-            <text macro="author" text-case="capitalize-all" strip-periods="false" quotes="false" font-variant="normal" font-weight="normal"/>
+            <text macro="author" text-case="capitalize-all" strip-periods="false" quotes="false" font-weight="normal"/>
             <group>
               <text macro="title"/>
             </group>

--- a/universite-de-geneve-departement-de-francais-moderne.csl
+++ b/universite-de-geneve-departement-de-francais-moderne.csl
@@ -46,7 +46,7 @@
       <else-if variable="editor">
         <names variable="editor">
           <name and="text" delimiter-precedes-last="never" name-as-sort-order="all" sort-separator=", ">
-            <name-part name="family" text-case="capitalize-first" font-variant="small-caps" suffix=","/>
+            <name-part name="family" text-case="capitalize-first" font-variant="small-caps"/>
           </name>
           <label form="short" prefix=" (" suffix=".)"/>
         </names>
@@ -109,14 +109,14 @@
     <names variable="editor">
       <label form="short" suffix=". "/>
       <name and="text" delimiter-precedes-last="never" sort-separator=" ">
-        <name-part name="family" text-case="capitalize-first" font-variant="normal"/>
+        <name-part name="family" text-case="capitalize-first"/>
       </name>
     </names>
   </macro>
   <macro name="translator">
     <names variable="translator" prefix="trad. ">
       <name and="text" delimiter-precedes-last="never" sort-separator=" ">
-        <name-part name="family" text-case="capitalize-first" font-variant="normal"/>
+        <name-part name="family" text-case="capitalize-first"/>
       </name>
     </names>
   </macro>
@@ -130,7 +130,7 @@
       <else-if type="article-journal article-newspaper article-magazine" match="any">
         <group delimiter=", ">
           <group>
-            <text variable="title" text-case="capitalize-first" quotes="true" font-style="normal"/>
+            <text variable="title" text-case="capitalize-first" quotes="true"/>
             <text macro="original-date"/>
           </group>
           <text variable="container-title" font-style="italic"/>
@@ -138,14 +138,14 @@
       </else-if>
       <else-if type="thesis" match="any">
         <group>
-          <text variable="title" text-case="capitalize-first" quotes="false" font-style="italic" suffix=","/>
+          <text variable="title" text-case="capitalize-first"font-style="italic" suffix=","/>
           <text variable="genre" suffix=", " prefix=" "/>
           <text variable="publisher"/>
         </group>
       </else-if>
       <else-if type="manuscript" match="any">
         <group delimiter=",">
-          <text variable="title" text-case="capitalize-first" quotes="true" font-style="normal"/>
+          <text variable="title" text-case="capitalize-first" quotes="true"/>
           <text variable="genre" prefix=" "/>
         </group>
       </else-if>
@@ -154,7 +154,7 @@
           <if match="any" variable="collection-editor">
             <group delimiter=", ">
               <group suffix=",">
-                <text variable="title" text-case="capitalize-first" quotes="true" font-style="normal"/>
+                <text variable="title" text-case="capitalize-first" quotes="true"/>
               </group>
               <group>
                 <text value="dans" prefix=" " suffix=" "/>
@@ -171,7 +171,7 @@
               <group suffix=",">
                 <choose>
                   <if match="any" variable="genre">
-                    <text variable="title" text-case="capitalize-first" quotes="true" font-style="normal"/>
+                    <text variable="title" text-case="capitalize-first" quotes="true"/>
                     <text macro="original-date"/>
                   </if>
                   <else>
@@ -549,7 +549,7 @@
         </else-if>
         <else>
           <group delimiter=", ">
-            <text macro="author" text-case="capitalize-all" strip-periods="false" quotes="false" font-weight="normal"/>
+            <text macro="author" text-case="capitalize-all"/>
             <group>
               <text macro="title"/>
             </group>

--- a/universite-de-geneve-departement-de-francais-moderne.csl
+++ b/universite-de-geneve-departement-de-francais-moderne.csl
@@ -137,9 +137,9 @@
         </group>
       </else-if>
       <else-if type="thesis" match="any">
-        <group>
-          <text variable="title" text-case="capitalize-first"font-style="italic" suffix=","/>
-          <text variable="genre" suffix=", " prefix=" "/>
+        <group delimiter=", ">
+          <text variable="title" text-case="capitalize-first" font-style="italic"/>
+          <text variable="genre"/>
           <text variable="publisher"/>
         </group>
       </else-if>

--- a/universite-de-geneve-departement-de-francais-moderne.csl
+++ b/universite-de-geneve-departement-de-francais-moderne.csl
@@ -1,0 +1,588 @@
+<?xml version="1.0" encoding="utf-8"?>
+<style xmlns="http://purl.org/net/xbiblio/csl" class="note" default-locale="fr-FR" version="1.0" page-range-format="expanded">
+  <!-- This style was edited with the Visual CSL Editor (https://editor.citationstyles.org/visualEditor/) -->
+  <info>
+    <title>Université de Genève - Département de français moderne (French)</title>
+    <title-short>UNIGE-FRAMO</title-short>
+    <id>http://www.zotero.org/styles/universite-de-geneve-departement-de-francais-moderne</id>
+    <link href="http://www.zotero.org/styles/universite-de-geneve-departement-de-francais-moderne" rel="self"/>
+    <link href="http://www.zotero.org/styles/aix-marseille-universite-departement-d-etudes-asiatiques" rel="template"/>
+    <link href="https://www.unige.ch/lettres/framo/files/5615/8799/0756/normes_redactionnelles_FRAMO.pdf" rel="documentation"/>
+    <author>
+      <name>Benjamin Paul</name>
+      <email>Benjamin.Paul@unige.ch</email>
+    </author>
+    <category citation-format="note"/>
+    <category field="humanities"/>
+    <category field="literature"/>
+    <summary>Style Zotero conforme aux normes bibliographiques établies par le département de français moderne de l'Université de Genève</summary>
+    <updated>2021-01-13T11:42:21+00:00</updated>
+    <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
+  </info>
+  <locale xml:lang="fr">
+    <terms>
+      <term name="ordinal-01">ère</term>
+      <term name="ordinal-02">e</term>
+      <term name="ordinal-03">e</term>
+      <term name="ordinal-04">e</term>
+      <term name="cited">op. cit.</term>
+      <term name="page" form="short">p.</term>
+      <term name="editor" form="short">éd.</term>
+      <term name="opus" form="short">t. </term>
+    </terms>
+  </locale>
+  <macro name="author">
+    <choose>
+      <if variable="author">
+        <names variable="author" font-variant="normal" vertical-align="baseline">
+          <name font-style="normal" font-variant="normal" vertical-align="baseline" delimiter="," and="text" delimiter-precedes-last="never" name-as-sort-order="all" sort-separator=" ">
+            <name-part name="family" text-case="capitalize-first" font-variant="small-caps" suffix=","/>
+          </name>
+        </names>
+      </if>
+      <else-if match="any" variable="collection-editor">
+        <text macro="director"/>
+      </else-if>
+      <else-if variable="editor">
+        <names variable="editor">
+          <name font-style="normal" and="text" delimiter-precedes-last="never" name-as-sort-order="all" sort-separator=" ">
+            <name-part name="family" text-case="capitalize-first" font-variant="small-caps" suffix=","/>
+          </name>
+          <label form="short" prefix=" (" suffix=".)"/>
+        </names>
+      </else-if>
+    </choose>
+  </macro>
+  <macro name="author-opcit">
+    <choose>
+      <if variable="author">
+        <names variable="author">
+          <name font-style="normal" and="text" delimiter-precedes-last="never" initialize="false" name-as-sort-order="first">
+            <name-part name="family" text-case="capitalize-first" font-variant="small-caps"/>
+          </name>
+        </names>
+      </if>
+      <else-if variable="editor">
+        <names variable="editor" font-variant="normal">
+          <name font-style="normal" font-variant="normal" and="text" delimiter-precedes-last="never" name-as-sort-order="all">
+            <name-part name="family" text-case="capitalize-first" font-variant="small-caps"/>
+          </name>
+          <label form="short" prefix=" (" suffix=".)"/>
+        </names>
+      </else-if>
+      <else-if match="any" variable="collection-editor">
+        <names variable="collection-editor">
+          <name name-as-sort-order="all">
+            <name-part name="family" text-case="capitalize-first" font-variant="small-caps"/>
+          </name>
+        </names>
+      </else-if>
+    </choose>
+  </macro>
+  <macro name="author-bib">
+    <choose>
+      <if variable="author">
+        <names variable="author">
+          <name font-style="normal" and="text" delimiter-precedes-et-al="never" delimiter-precedes-last="never" name-as-sort-order="all">
+            <name-part name="family" text-case="capitalize-first" font-variant="small-caps"/>
+          </name>
+        </names>
+      </if>
+      <else-if match="any" variable="collection-editor">
+        <names variable="collection-editor" suffix=" (dir.)">
+          <name and="text" delimiter-precedes-et-al="never" delimiter-precedes-last="never" name-as-sort-order="all">
+            <name-part name="family" text-case="capitalize-first" font-variant="small-caps"/>
+          </name>
+        </names>
+      </else-if>
+      <else-if variable="editor">
+        <names variable="editor">
+          <name font-style="normal" and="text" delimiter-precedes-last="never" name-as-sort-order="all">
+            <name-part name="family" text-case="capitalize-first" font-variant="small-caps"/>
+          </name>
+          <label form="short" prefix=" (" suffix=".)"/>
+        </names>
+      </else-if>
+    </choose>
+  </macro>
+  <macro name="editor">
+    <names variable="editor">
+      <label form="short" suffix=". "/>
+      <name font-style="normal" font-variant="normal" and="text" delimiter-precedes-last="never" sort-separator=" ">
+        <name-part name="family" text-case="capitalize-first" font-variant="normal"/>
+      </name>
+    </names>
+  </macro>
+  <macro name="translator">
+    <names variable="translator" prefix="trad. ">
+      <name font-style="normal" and="text" delimiter-precedes-last="never" sort-separator=" ">
+        <name-part name="family" text-case="capitalize-first" font-variant="normal"/>
+      </name>
+    </names>
+  </macro>
+  <macro name="title">
+    <choose>
+      <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
+        <text macro="opus-title"/>
+        <text variable="title" text-case="capitalize-first" font-style="italic"/>
+        <text macro="original-date"/>
+      </if>
+      <else-if type="article-journal article-newspaper article-magazine" match="any">
+        <group delimiter=", ">
+          <group>
+            <text variable="title" text-case="capitalize-first" quotes="true" font-style="normal"/>
+            <text macro="original-date"/>
+          </group>
+          <text variable="container-title" font-style="italic"/>
+        </group>
+      </else-if>
+      <else-if type="thesis" match="any">
+        <group>
+          <text variable="title" text-case="capitalize-first" quotes="false" font-style="italic" suffix=","/>
+          <text variable="genre" suffix=", " prefix=" "/>
+          <text variable="publisher"/>
+        </group>
+      </else-if>
+      <else-if type="manuscript" match="any">
+        <group delimiter=",">
+          <text variable="title" text-case="capitalize-first" quotes="true" font-style="normal"/>
+          <text variable="genre" prefix=" "/>
+        </group>
+      </else-if>
+      <else-if type="chapter" match="any">
+        <choose>
+          <if match="any" variable="collection-editor">
+            <group delimiter=", ">
+              <group suffix=",">
+                <text variable="title" text-case="capitalize-first" quotes="true" font-style="normal"/>
+              </group>
+              <group>
+                <text value="dans" font-style="normal" prefix=" " suffix=" "/>
+                <text macro="director-min"/>
+              </group>
+              <group>
+                <text variable="container-title" text-case="capitalize-first" font-style="italic"/>
+                <text macro="original-date"/>
+              </group>
+            </group>
+          </if>
+          <else>
+            <group delimiter=", ">
+              <group suffix=",">
+                <choose>
+                  <if match="any" variable="genre">
+                    <text variable="title" text-case="capitalize-first" quotes="true" font-style="normal"/>
+                    <text macro="original-date"/>
+                  </if>
+                  <else>
+                    <text variable="title" text-case="capitalize-first" font-style="italic"/>
+                    <text macro="original-date"/>
+                  </else>
+                </choose>
+              </group>
+              <group>
+                <text value="dans" suffix=" "/>
+                <text variable="container-title" text-case="capitalize-first" font-style="italic"/>
+              </group>
+            </group>
+          </else>
+        </choose>
+      </else-if>
+      <else-if type="webpage" match="any">
+        <group delimiter=", ">
+          <text variable="title" text-case="capitalize-first" quotes="true"/>
+          <text variable="container-title" text-case="capitalize-first" font-style="italic"/>
+          <date variable="issued">
+            <date-part name="day" suffix=" "/>
+            <date-part name="month" suffix=" "/>
+            <date-part name="year"/>
+          </date>
+          <text variable="URL" text-decoration="underline"/>
+        </group>
+      </else-if>
+      <else>
+        <text variable="title" quotes="true"/>
+        <text macro="original-date"/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="pub-place">
+    <choose>
+      <if type="bill book chapter entry-dictionary entry-encyclopedia graphic legal_case legislation manuscript motion_picture paper-conference report song thesis" match="any">
+        <text variable="publisher-place"/>
+      </if>
+    </choose>
+  </macro>
+  <macro name="publisher">
+    <choose>
+      <if type="bill book chapter entry-dictionary entry-encyclopedia graphic legal_case legislation motion_picture paper-conference report song" match="any">
+        <text variable="publisher"/>
+      </if>
+    </choose>
+  </macro>
+  <macro name="yearpage">
+    <choose>
+      <if type="bill book graphic legal_case legislation manuscript motion_picture paper-conference report song thesis" match="any">
+        <group delimiter=", " font-style="normal">
+          <date variable="issued">
+            <date-part name="year"/>
+          </date>
+          <choose>
+            <if type="book" match="all" variable="container-title"/>
+            <else>
+              <group>
+                <text term="opus" form="short"/>
+                <text variable="volume" strip-periods="false" vertical-align="baseline"/>
+              </group>
+            </else>
+          </choose>
+          <choose>
+            <if variable="locator" match="any">
+              <text variable="locator" prefix="p. "/>
+            </if>
+          </choose>
+        </group>
+      </if>
+      <else-if type="chapter entry-dictionary entry-encyclopedia" match="any">
+        <choose>
+          <if match="any" variable="collection-editor">
+            <group font-style="normal" delimiter=", ">
+              <choose>
+                <if match="any" variable="volume">
+                  <group vertical-align="sub" suffix=",">
+                    <text term="opus" form="short"/>
+                    <text variable="volume"/>
+                  </group>
+                </if>
+              </choose>
+              <date variable="issued">
+                <date-part name="year"/>
+              </date>
+              <choose>
+                <if variable="locator" match="any">
+                  <text variable="locator" prefix="p. "/>
+                </if>
+                <else-if variable="locator" match="none">
+                  <choose>
+                    <if match="any" variable="page">
+                      <group>
+                        <label plural="never" suffix=" " variable="page" form="short"/>
+                        <text variable="page"/>
+                      </group>
+                    </if>
+                  </choose>
+                </else-if>
+              </choose>
+            </group>
+          </if>
+          <else>
+            <group delimiter=", ">
+              <date variable="issued">
+                <date-part name="year"/>
+              </date>
+              <group>
+                <text term="opus" form="short"/>
+                <text variable="volume"/>
+              </group>
+              <choose>
+                <if match="any" variable="locator">
+                  <text variable="locator" prefix="p. "/>
+                </if>
+                <else-if match="none" variable="locator">
+                  <choose>
+                    <if match="any" variable="page">
+                      <group delimiter=" ">
+                        <label plural="never" suffix=" " variable="page" form="short"/>
+                        <text variable="page"/>
+                      </group>
+                    </if>
+                  </choose>
+                </else-if>
+              </choose>
+            </group>
+          </else>
+        </choose>
+      </else-if>
+      <else-if type="article-newspaper article-magazine article article-journal" match="any">
+        <group delimiter=", ">
+          <date variable="issued">
+            <date-part name="year"/>
+          </date>
+          <choose>
+            <if variable="locator" match="any">
+              <text variable="locator" prefix="p. "/>
+            </if>
+            <else-if variable="locator" match="none">
+              <choose>
+                <if match="any" variable="page">
+                  <group delimiter=" ">
+                    <label plural="never" variable="page" form="short"/>
+                    <text variable="page"/>
+                  </group>
+                </if>
+              </choose>
+            </else-if>
+          </choose>
+        </group>
+      </else-if>
+    </choose>
+  </macro>
+  <macro name="yearpage-bib">
+    <choose>
+      <if type="bill book graphic legal_case legislation manuscript motion_picture paper-conference report song thesis" match="any">
+        <group delimiter=", ">
+          <date variable="issued">
+            <date-part name="year"/>
+          </date>
+          <choose>
+            <if type="book" match="all" variable="container-title"/>
+            <else>
+              <group>
+                <text term="opus" form="short"/>
+                <text variable="volume"/>
+              </group>
+            </else>
+          </choose>
+          <group>
+            <label variable="locator" form="short"/>
+            <text variable="locator"/>
+          </group>
+        </group>
+      </if>
+      <else-if type="chapter entry-dictionary entry-encyclopedia" match="any">
+        <group delimiter=", " font-style="normal">
+          <date variable="issued">
+            <date-part name="year"/>
+          </date>
+          <group>
+            <text term="opus" form="short"/>
+            <text variable="volume"/>
+          </group>
+          <group>
+            <label variable="page" form="short"/>
+            <text variable="page" prefix=" "/>
+          </group>
+        </group>
+      </else-if>
+      <else-if type="article-newspaper article-magazine" match="any">
+        <group delimiter=" " font-style="normal">
+          <label variable="page" form="short"/>
+          <text variable="page"/>
+        </group>
+      </else-if>
+    </choose>
+  </macro>
+  <macro name="edition">
+    <choose>
+      <if type="bill book chapter graphic legal_case legislation motion_picture paper-conference report song" match="any">
+        <choose>
+          <if is-numeric="edition">
+            <group delimiter=" ">
+              <number variable="edition" form="ordinal"/>
+              <text term="edition" form="short"/>
+            </group>
+          </if>
+          <else>
+            <text variable="edition"/>
+          </else>
+        </choose>
+        <text macro="issue" prefix=", "/>
+      </if>
+      <else-if type="article-journal article-magazine article article-newspaper" match="any">
+        <group delimiter=", " font-style="normal">
+          <text macro="voljournal"/>
+        </group>
+      </else-if>
+    </choose>
+  </macro>
+  <macro name="voljournal">
+    <group delimiter=", ">
+      <text variable="volume" prefix="vol. "/>
+      <text variable="issue" prefix="n° "/>
+      <choose>
+        <if match="any" variable="original-title">
+          <text variable="original-title" font-style="italic" prefix=" "/>
+        </if>
+      </choose>
+    </group>
+  </macro>
+  <macro name="issue">
+    <choose>
+      <if is-numeric="issue">
+        <text term="issue" form="short" suffix=" "/>
+        <text variable="issue"/>
+      </if>
+      <else>
+        <text variable="issue"/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="collection">
+    <choose>
+      <if is-numeric="collection-number">
+        <group prefix=" coll.">
+          <text variable="collection-title" quotes="true"/>
+        </group>
+        <text variable="collection-number" prefix=", n˚ "/>
+      </if>
+      <else>
+        <group prefix=" coll. ">
+          <text variable="collection-title" quotes="false"/>
+        </group>
+      </else>
+    </choose>
+  </macro>
+  <macro name="sort-type">
+    <choose>
+      <if type="book chapter thesis" match="any">
+        <text value="1"/>
+      </if>
+      <else-if type="article entry-dictionary entry-encyclopedia article-journal paper-conference review review-book speech webpage" match="any">
+        <text value="2"/>
+      </else-if>
+      <else>
+        <text value="3"/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="original-date">
+    <choose>
+      <if match="any" variable="original-date">
+        <date date-parts="year" form="text" variable="original-date" prefix=" [" suffix="]">
+          <date-part name="year"/>
+        </date>
+      </if>
+    </choose>
+  </macro>
+  <macro name="director">
+    <names variable="collection-editor" suffix=" (dir.)">
+      <name and="text" delimiter-precedes-et-al="never" delimiter-precedes-last="never" name-as-sort-order="all">
+        <name-part name="family" text-case="capitalize-first" font-variant="small-caps"/>
+      </name>
+    </names>
+  </macro>
+  <macro name="opus-title">
+    <choose>
+      <if type="book" match="all" variable="container-title">
+        <group delimiter=", ">
+          <text variable="container-title" text-case="capitalize-first" font-style="italic"/>
+          <group>
+            <text term="opus" form="short"/>
+            <text variable="volume" suffix=", "/>
+          </group>
+        </group>
+      </if>
+    </choose>
+  </macro>
+  <macro name="director-min">
+    <names variable="collection-editor" suffix=" (dir.)">
+      <name and="text" delimiter-precedes-et-al="never" delimiter-precedes-last="never">
+        <name-part name="family" text-case="capitalize-first"/>
+        <name-part name="given" text-case="capitalize-first"/>
+      </name>
+    </names>
+  </macro>
+  <citation>
+    <layout suffix="." delimiter=" ; ">
+      <choose>
+        <if position="ibid-with-locator">
+          <group delimiter=", ">
+            <text term="ibid" text-case="capitalize-first" font-style="italic" suffix="."/>
+            <text variable="locator" prefix="p. "/>
+          </group>
+        </if>
+        <else-if position="ibid">
+          <text term="ibid" text-case="capitalize-first" font-style="italic"/>
+        </else-if>
+        <else-if position="subsequent">
+          <group delimiter=", ">
+            <text macro="author-opcit"/>
+            <choose>
+              <if type="book" match="all" variable="container-title">
+                <text variable="title" form="short" text-case="capitalize-first" font-style="italic"/>
+              </if>
+              <else-if type="bill book graphic legal_case legislation motion_picture report song thesis" match="any">
+                <text variable="title" form="short" text-case="capitalize-first" font-style="italic"/>
+              </else-if>
+              <else-if type="chapter" match="all" variable="genre">
+                <text variable="title" form="short" text-case="capitalize-first" quotes="true"/>
+                <group>
+                  <text value="dans" prefix=" " suffix=" "/>
+                  <text variable="container-title" form="short" text-case="capitalize-first" font-style="italic"/>
+                </group>
+              </else-if>
+              <else-if type="chapter" match="all" variable="collection-editor">
+                <text variable="title" form="short" text-case="capitalize-first" quotes="true"/>
+                <group>
+                  <text value="dans" prefix=" " suffix=" "/>
+                  <text macro="director-min"/>
+                </group>
+                <text variable="container-title" form="short" text-case="capitalize-first" font-style="italic"/>
+              </else-if>
+              <else-if type="chapter" match="any">
+                <text variable="title" form="short" text-case="capitalize-first" font-style="italic"/>
+                <group>
+                  <text value="dans" prefix=" " suffix=" "/>
+                  <text variable="container-title" form="short" text-case="capitalize-first" font-style="italic"/>
+                </group>
+              </else-if>
+              <else>
+                <text variable="title" form="short" text-case="capitalize-first" quotes="true" font-style="normal"/>
+              </else>
+            </choose>
+            <choose>
+              <if type="article article-journal article-magazine article-newspaper" match="any">
+                <text value="art. cit."/>
+              </if>
+              <else-if type="book" match="all" variable="editor">
+                <text value="éd. cit."/>
+              </else-if>
+              <else-if type="chapter" match="all" variable="editor">
+                <text value="éd. cit."/>
+              </else-if>
+              <else>
+                <text term="cited" font-style="italic" suffix="."/>
+              </else>
+            </choose>
+            <text variable="locator" prefix="p. "/>
+          </group>
+        </else-if>
+        <else>
+          <group delimiter=", ">
+            <text macro="author" text-case="capitalize-all" strip-periods="false" quotes="false" font-variant="normal" font-weight="normal"/>
+            <group>
+              <text macro="title"/>
+            </group>
+            <text macro="editor"/>
+            <text macro="translator"/>
+            <text macro="edition"/>
+            <text macro="pub-place"/>
+            <text macro="publisher"/>
+            <text macro="collection"/>
+            <text macro="yearpage"/>
+          </group>
+        </else>
+      </choose>
+    </layout>
+  </citation>
+  <bibliography subsequent-author-substitute="─">
+    <sort>
+      <key macro="author" names-min="3" names-use-first="3"/>
+      <key variable="issued" sort="descending"/>
+      <key macro="sort-type"/>
+    </sort>
+    <layout suffix=".">
+      <group delimiter=", ">
+        <text macro="author-bib"/>
+        <text macro="title"/>
+        <text macro="editor"/>
+        <text macro="translator"/>
+        <text macro="edition"/>
+        <text macro="pub-place"/>
+        <text macro="publisher"/>
+        <text macro="collection"/>
+        <text macro="yearpage-bib"/>
+      </group>
+    </layout>
+  </bibliography>
+</style>

--- a/universite-de-geneve-departement-de-francais-moderne.csl
+++ b/universite-de-geneve-departement-de-francais-moderne.csl
@@ -25,7 +25,7 @@
       <term name="ordinal-02">e</term>
       <term name="ordinal-03">e</term>
       <term name="ordinal-04">e</term>
-      <term name="cited">op. cit.</term>
+      <term name="cited">op. cit.</term>
       <term name="page" form="short">p.</term>
       <term name="editor" form="short">éd.</term>
       <term name="opus" form="short">t. </term>
@@ -34,9 +34,9 @@
   <macro name="author">
     <choose>
       <if variable="author">
-        <names variable="author" vertical-align="baseline">
-          <name vertical-align="baseline" delimiter="," and="text" delimiter-precedes-last="never" name-as-sort-order="all" sort-separator=" ">
-            <name-part name="family" text-case="capitalize-first" font-variant="small-caps" suffix=","/>
+        <names variable="author">
+          <name delimiter=", " and="text" delimiter-precedes-last="never" name-as-sort-order="all" sort-separator=", ">
+            <name-part name="family" text-case="capitalize-first" font-variant="small-caps"/>
           </name>
         </names>
       </if>
@@ -45,10 +45,10 @@
       </else-if>
       <else-if variable="editor">
         <names variable="editor">
-          <name and="text" delimiter-precedes-last="never" name-as-sort-order="all" sort-separator=" ">
+          <name and="text" delimiter-precedes-last="never" name-as-sort-order="all" sort-separator=", ">
             <name-part name="family" text-case="capitalize-first" font-variant="small-caps" suffix=","/>
           </name>
-          <label form="short" prefix=" (" suffix=".)"/>
+          <label form="short" prefix=" (" suffix=".)"/>
         </names>
       </else-if>
     </choose>
@@ -63,11 +63,11 @@
         </names>
       </if>
       <else-if variable="editor">
-        <names variable="editor" font-variant="normal">
+        <names variable="editor">
           <name and="text" delimiter-precedes-last="never" name-as-sort-order="all">
             <name-part name="family" text-case="capitalize-first" font-variant="small-caps"/>
           </name>
-          <label form="short" prefix=" (" suffix=".)"/>
+          <label form="short" prefix=" (" suffix=".)"/>
         </names>
       </else-if>
       <else-if match="any" variable="collection-editor">
@@ -100,7 +100,7 @@
           <name and="text" delimiter-precedes-last="never" name-as-sort-order="all">
             <name-part name="family" text-case="capitalize-first" font-variant="small-caps"/>
           </name>
-          <label form="short" prefix=" (" suffix=".)"/>
+          <label form="short" prefix=" (" suffix=".)"/>
         </names>
       </else-if>
     </choose>
@@ -238,7 +238,7 @@
           </choose>
           <choose>
             <if variable="locator" match="any">
-              <text variable="locator" prefix="p. "/>
+              <text variable="locator" prefix="p. "/>
             </if>
           </choose>
         </group>
@@ -260,7 +260,7 @@
               </date>
               <choose>
                 <if variable="locator" match="any">
-                  <text variable="locator" prefix="p. "/>
+                  <text variable="locator" prefix="p. "/>
                 </if>
                 <else-if variable="locator" match="none">
                   <choose>
@@ -310,7 +310,7 @@
           </date>
           <choose>
             <if variable="locator" match="any">
-              <text variable="locator" prefix="p. "/>
+              <text variable="locator" prefix="p. "/>
             </if>
             <else-if variable="locator" match="none">
               <choose>
@@ -360,7 +360,7 @@
           </group>
           <group>
             <label variable="page" form="short"/>
-            <text variable="page" prefix=" "/>
+            <text variable="page" prefix=" "/>
           </group>
         </group>
       </else-if>
@@ -409,7 +409,7 @@
   <macro name="issue">
     <choose>
       <if is-numeric="issue">
-        <text term="issue" form="short" suffix=" "/>
+        <text term="issue" form="short" suffix=" "/>
         <text variable="issue"/>
       </if>
       <else>
@@ -423,7 +423,7 @@
         <group prefix=" coll.">
           <text variable="collection-title" quotes="true"/>
         </group>
-        <text variable="collection-number" prefix=", n˚ "/>
+        <text variable="collection-number" prefix=", n˚ "/>
       </if>
       <else>
         <group prefix=" coll. ">
@@ -483,7 +483,7 @@
     </names>
   </macro>
   <citation>
-    <layout suffix="." delimiter=" ; ">
+    <layout suffix="." delimiter=" ; ">
       <choose>
         <if position="ibid-with-locator">
           <group delimiter=", ">
@@ -544,7 +544,7 @@
                 <text term="cited" font-style="italic" suffix="."/>
               </else>
             </choose>
-            <text variable="locator" prefix="p. "/>
+            <text variable="locator" prefix="p. "/>
           </group>
         </else-if>
         <else>

--- a/universite-de-geneve-departement-de-langue-et-de-litterature-francaises-modernes.csl
+++ b/universite-de-geneve-departement-de-langue-et-de-litterature-francaises-modernes.csl
@@ -2,7 +2,7 @@
 <style xmlns="http://purl.org/net/xbiblio/csl" class="note" version="1.0" page-range-format="expanded" default-locale="fr-FR">
   <!-- This style was edited with the Visual CSL Editor (https://editor.citationstyles.org/visualEditor/) -->
   <info>
-    <title>Université de Genève - Département de langue et de littérature françaises modernes (French)</title>
+    <title>Université de Genève - Département de langue et de littérature françaises modernes (Français)</title>
     <title-short>UNIGE-FRAMO</title-short>
     <id>http://www.zotero.org/styles/universite-de-geneve-departement-de-langue-et-de-litterature-francaises-modernes</id>
     <link href="http://www.zotero.org/styles/universite-de-geneve-departement-de-langue-et-de-litterature-francaises-modernes" rel="self"/>

--- a/universite-de-geneve-departement-de-langue-et-de-litterature-francaises-modernes.csl
+++ b/universite-de-geneve-departement-de-langue-et-de-litterature-francaises-modernes.csl
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
-<style xmlns="http://purl.org/net/xbiblio/csl" class="note" default-locale="fr-FR" version="1.0" page-range-format="expanded">
+<style xmlns="http://purl.org/net/xbiblio/csl" class="note" version="1.0" page-range-format="expanded" default-locale="fr-FR">
   <!-- This style was edited with the Visual CSL Editor (https://editor.citationstyles.org/visualEditor/) -->
   <info>
-    <title>Université de Genève - Département de français moderne (French)</title>
+    <title>Université de Genève - Département de langue et de littérature françaises modernes (French)</title>
     <title-short>UNIGE-FRAMO</title-short>
-    <id>http://www.zotero.org/styles/universite-de-geneve-departement-de-francais-moderne</id>
-    <link href="http://www.zotero.org/styles/universite-de-geneve-departement-de-francais-moderne" rel="self"/>
+    <id>http://www.zotero.org/styles/universite-de-geneve-departement-de-langue-et-de-litterature-francaises-modernes</id>
+    <link href="http://www.zotero.org/styles/universite-de-geneve-departement-de-langue-et-de-litterature-francaises-modernes" rel="self"/>
     <link href="http://www.zotero.org/styles/aix-marseille-universite-departement-d-etudes-asiatiques" rel="template"/>
     <link href="https://www.unige.ch/lettres/framo/files/5615/8799/0756/normes_redactionnelles_FRAMO.pdf" rel="documentation"/>
     <author>
@@ -25,7 +25,7 @@
       <term name="ordinal-02">e</term>
       <term name="ordinal-03">e</term>
       <term name="ordinal-04">e</term>
-      <term name="cited">op. cit.</term>
+      <term name="cited">op.&#160;cit.</term>
       <term name="page" form="short">p. </term>
       <term name="editor">éd. </term>
       <term name="opus" form="short">t. </term>
@@ -488,7 +488,7 @@
     </names>
   </macro>
   <citation>
-    <layout suffix="." delimiter=" ; ">
+    <layout suffix="." delimiter="&#160;; ">
       <choose>
         <if position="ibid-with-locator">
           <group delimiter=", ">


### PR DESCRIPTION
Hello !

I would like to submit this new CSL style for Zotero to the repository. It matches the official citation norms used by the departement of french litterature from the University of Geneva (UNIGE), in Switzerland.  The documentation can be found here : https://www.unige.ch/lettres/framo/files/5615/8799/0756/normes_redactionnelles_FRAMO.pdf 
...and I'm currently working on a written tutorial, but I cannot complete it without uploading the style first, since I would like to link the style in it. I plan on modifying the CSL file once the tutorial is online. 
Thank you very much for your consideration. 
All the best,
Benjamin PAUL (University of Geneva)