### PR TITLE
Removed space in year only citation

### DIFF
--- a/american-phytopathological-society.csl
+++ b/american-phytopathological-society.csl
@@ -14,6 +14,10 @@
       <name>Steve Kronmiller</name>
       <email>skronmiller@scisoc.org</email>
     </contributor>
+    <contributor>
+      <name>Anuj Sharma</name>
+      <email>rknx@outlook.com</email>
+    </contributor>
     <category citation-format="author-date"/>
     <summary>The American Phytopathological Society style.</summary>
     <updated>2012-09-27T22:06:38+00:00</updated>
@@ -80,18 +84,16 @@
     </group>
   </macro>
   <macro name="year-date">
-    <group prefix=" ">
-      <choose>
-        <if variable="issued">
-          <date variable="issued">
-            <date-part name="year"/>
-          </date>
-        </if>
-        <else>
-          <text term="no date" form="short"/>
-        </else>
-      </choose>
-    </group>
+    <choose>
+      <if variable="issued">
+        <date variable="issued">
+          <date-part name="year"/>
+        </date>
+      </if>
+      <else>
+        <text term="no date" form="short"/>
+      </else>
+    </choose>
   </macro>
   <macro name="edition">
     <choose>


### PR DESCRIPTION
When author name is suppressed in in-line citation, a space would be prefixed before year. This commit removes that space.