### PR TITLE
Update lancaster-university-harvard.csl

### DIFF
--- a/lancaster-university-harvard.csl
+++ b/lancaster-university-harvard.csl
@@ -428,7 +428,7 @@
         <text macro="author-short"/>
         <text macro="year"/>
         <group>
-          <label variable="locator" form="short"/>
+          <label variable="locator" form="short" suffix=" "/>
           <text variable="locator"/>
         </group>
       </group>


### PR DESCRIPTION
Adding the required space between "p." and the number when adding page numbers to citations. Please accept this change.