### PR TITLE
Update geochimica-et-cosmochimica-acta.csl

### DIFF
--- a/geochimica-et-cosmochimica-acta.csl
+++ b/geochimica-et-cosmochimica-acta.csl
@@ -112,7 +112,7 @@
       <text variable="page"/>
     </group>
   </macro>
-  <citation and="text" et-al-min="3" et-al-use-first="1" disambiguate-add-year-suffix="true" disambiguate-add-names="false" disambiguate-add-givenname="true">
+  <citation and="text" et-al-min="3" et-al-use-first="1" disambiguate-add-year-suffix="true" disambiguate-add-names="false" disambiguate-add-givenname="true" cite-group-delimiter=", " collapse="year-suffix" year-suffix-delimiter=",">
     <sort>
       <key variable="issued"/>
       <key macro="author-short"/>


### PR DESCRIPTION
Added collapsed citations

Documentation: https://www.elsevier.com/journals/geochimica-et-cosmochimica-acta/0016-7037/guide-for-authors

> Multiple citations having the same authorship information are sorted by the earliest year, with all years groups together, e.g., (Li et al., 1996; Brown et al. 2001, 2008a,b, 2013; Stone and Smith, 2004).