### PR TITLE
Update author-year disambiguation

### DIFF
--- a/american-phytopathological-society.csl
+++ b/american-phytopathological-society.csl
@@ -108,7 +108,7 @@
       </else>
     </choose>
   </macro>
-  <citation et-al-min="3" et-al-use-first="1" disambiguate-add-year-suffix="true" disambiguate-add-names="true" disambiguate-add-givenname="true" collapse="year">
+  <citation et-al-min="3" et-al-use-first="1" disambiguate-add-year-suffix="true" collapse="year">
     <layout prefix="(" suffix=")" delimiter="; ">
       <group delimiter=", ">
         <group delimiter=" ">


### PR DESCRIPTION
APS uses year-suffix (like Jones et. al 2019b) to disambiguate rather than first name or second author. Since all 3 disambiguation methods were kept true, it was causing multiple authors to show up in in-line citations. This commit removes first name disambiguation and second author disambiguation and only keeps the year-suffix disambiguation.