### PR TITLE
Update universite-de-montreal-apa.csl

### DIFF
--- a/universite-de-montreal-apa.csl
+++ b/universite-de-montreal-apa.csl
@@ -6,7 +6,7 @@
     <id>http://www.zotero.org/styles/universite-de-montreal-apa</id>
     <link href="http://www.zotero.org/styles/universite-de-montreal-apa" rel="self"/>
     <link href="http://www.zotero.org/styles/apa" rel="template"/>
-    <link href="https://bib.umontreal.ca/citer/apa" rel="documentation"/>
+    <link href="https://bib.umontreal.ca/citer/styles-bibliographiques/apa" rel="documentation"/>
     <author>
       <name>Florian Martin-Bariteau</name>
       <email>f.martin-bariteau@umontreal.ca</email>

--- a/universite-de-montreal-apa.csl
+++ b/universite-de-montreal-apa.csl
@@ -577,7 +577,7 @@
       </else>
     </choose>
   </macro>
-  <citation et-al-min="3" et-al-use-first="1" et-al-subsequent-min="3" et-al-subsequent-use-first="1" disambiguate-add-year-suffix="true" disambiguate-add-names="true" disambiguate-add-givenname="true" collapse="year" givenname-disambiguation-rule="primary-name">
+  <citation et-al-min="3" et-al-use-first="1" disambiguate-add-year-suffix="true" disambiguate-add-names="true" disambiguate-add-givenname="true" collapse="year" givenname-disambiguation-rule="primary-name">
     <sort>
       <key macro="author"/>
       <key macro="issued-sort"/>

--- a/universite-de-montreal-apa.csl
+++ b/universite-de-montreal-apa.csl
@@ -26,7 +26,7 @@
     <category field="psychology"/>
     <category field="generic-base"/>
     <summary>Adaptation en français canadien des normes de citation de l'APA (7e édition) basée sur le guide des Bibliothèques de l'Université de Montréal.</summary>
-    <updated>2020-07-10T04:04:36+00:00</updated>
+    <updated>2021-02-01T14:54:33+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale>
@@ -154,7 +154,7 @@
       <else>
         <choose>
           <if variable="DOI">
-            <text variable="DOI"/>
+            <text variable="DOI" prefix="https://doi.org/"/>
           </if>
           <else-if type="post">
             <group delimiter=" ">
@@ -577,7 +577,7 @@
       </else>
     </choose>
   </macro>
-  <citation et-al-min="3" et-al-use-first="1" et-al-subsequent-min="2" et-al-subsequent-use-first="1" disambiguate-add-year-suffix="true" disambiguate-add-names="true" disambiguate-add-givenname="true" collapse="year" givenname-disambiguation-rule="primary-name">
+  <citation et-al-min="3" et-al-use-first="1" et-al-subsequent-min="3" et-al-subsequent-use-first="1" disambiguate-add-year-suffix="true" disambiguate-add-names="true" disambiguate-add-givenname="true" collapse="year" givenname-disambiguation-rule="primary-name">
     <sort>
       <key macro="author"/>
       <key macro="issued-sort"/>


### PR DESCRIPTION
2 fixes were made in the file. 
All changes are based on the APA style guide of the Bibliothèques de l’Université de Montréal that has been updated in 2020 :
https://bib.umontreal.ca/citer/styles-bibliographiques/apa?tab=3281
1-	DOI now begin with https://
2-	Two authors in-text citations appear now as follows every time : (Stuart et Coward, 2020). Before, the first occurrence was ok: (Stuart et Coward, 2020). But the following ones were like that : (Stuart et al., 2020).