### PR TITLE
Fix variable used for the label after indication of number of pages

### DIFF
--- a/universite-de-lausanne-histoire.csl
+++ b/universite-de-lausanne-histoire.csl
@@ -469,13 +469,13 @@
       <else-if variable="volume">
         <group delimiter="&#160;">
           <number variable="number-of-pages"/>
-          <label variable="page" form="short"/>
+          <label variable="number-of-pages" form="short"/>
         </group>
       </else-if>
       <else-if variable="number-of-volumes" match="none">
         <group delimiter="&#160;">
           <number variable="number-of-pages"/>
-          <label variable="page" form="short"/>
+          <label variable="number-of-pages" form="short"/>
         </group>
       </else-if>
     </choose>


### PR DESCRIPTION
A small fix to the variable referenced by the label for displaying the number of pages. 

(Interestingly, the original coding did not cause problems with Zotero, even though the CSL specification [states](https://citation-style-language.readthedocs.io/en/stable/specification.html#label) that the label should not be rendered if the selected variable is empty. citeproc-js seems to somehow match `page` and `number-of-pages`. pandoc-citeproc, however, is not so lenient, [as a user of this style discovered](https://github.com/LausanneCitationStyle/Lausanne/issues/19)).