### PR TITLE
Update spec_helper.rb

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -44,7 +44,8 @@ UNUSED_MACROS_FILTER = %w{
 # These files and directories are ignored when checking for extra files
 EXTRA_FILES_FILTER = [
   'CONTRIBUTING.md', 'Gemfile', 'Gemfile.lock', 'README.md',
-  'dependent', 'Rakefile', 'renamed-styles.json'
+  'dependent', 'Rakefile', 'renamed-styles.json', 'REQUESTING.md', 'STYLE_DEVELOPMENT.md',
+  'STYLE_REQUIREMENTS.md', 'QUALITY_CONTROL.md'
 ]
 
 # These directories and their contents are ignored when checking for extra files


### PR DESCRIPTION
Allow non-CSL markdown files added in https://github.com/citation-style-language/styles/pull/5194.