### PR TITLE
Localize more language descriptors in style titles

### DIFF
--- a/STYLE_REQUIREMENTS.md
+++ b/STYLE_REQUIREMENTS.md
@@ -35,7 +35,7 @@ An example:
 ```xml
    <style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" default-locale="de-DE">
      <info>
-       <title>Zeitschrift für Soziologie (German)</title>
+       <title>Zeitschrift für Soziologie (Deutsch)</title>
        <id>http://www.zotero.org/styles/zeitschrift-fur-soziologie</id>
      </info>
    </style>

--- a/archiv-fur-die-civilistische-praxis.csl
+++ b/archiv-fur-die-civilistische-praxis.csl
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <style xmlns="http://purl.org/net/xbiblio/csl" class="note" version="1.0" demote-non-dropping-particle="never" default-locale="de-DE">
   <info>
-    <title>Archiv für die civilistische Praxis (German)</title>
+    <title>Archiv für die civilistische Praxis (Deutsch)</title>
     <title-short>AcP</title-short>
     <id>http://www.zotero.org/styles/archiv-fur-die-civilistische-praxis</id>
     <link href="http://www.zotero.org/styles/archiv-fur-die-civilistische-praxis" rel="self"/>

--- a/austrian-legal.csl
+++ b/austrian-legal.csl
@@ -2,7 +2,7 @@
 <style xmlns="http://purl.org/net/xbiblio/csl" version="1.0" class="note" default-locale="de-AT">
   <!-- This style was edited with the Visual CSL Editor (http://editor.citationstyles.org/visualEditor/) -->
   <info>
-    <title>Austrian Legal (German - Austria)</title>
+    <title>Austrian Legal (Deutsch - Österreich)</title>
     <id>http://www.zotero.org/styles/austrian-legal</id>
     <link href="http://www.zotero.org/styles/austrian-legal" rel="self"/>
     <link href="http://www.lexisnexis.at/service/training-und-hilfe/zitieren.aspx" rel="documentation"/>

--- a/azr-abkurzungs-und-zitierregeln-der-osterreichischen-rechtssprache-und-europarechtlicher-rechtsquellen.csl
+++ b/azr-abkurzungs-und-zitierregeln-der-osterreichischen-rechtssprache-und-europarechtlicher-rechtsquellen.csl
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <style xmlns="http://purl.org/net/xbiblio/csl" version="1.0" class="note" default-locale="de-AT">
   <info>
-    <title>AZR - Abkürzungs- und Zitierregeln der österreichischen Rechtssprache und europarechtlicher Rechtsquellen (German - Austria)</title>
+    <title>AZR - Abkürzungs- und Zitierregeln der österreichischen Rechtssprache und europarechtlicher Rechtsquellen (Deutsch - Österreich)</title>
     <title-short>AZR</title-short>
     <id>http://www.zotero.org/styles/azr-abkurzungs-und-zitierregeln-der-osterreichischen-rechtssprache-und-europarechtlicher-rechtsquellen</id>
     <link href="http://www.zotero.org/styles/azr-abkurzungs-und-zitierregeln-der-osterreichischen-rechtssprache-und-europarechtlicher-rechtsquellen" rel="self"/>

--- a/beltz-padagogik.csl
+++ b/beltz-padagogik.csl
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" demote-non-dropping-particle="never" default-locale="de-DE">
   <info>
-    <title>Beltz - Pädagogik (German)</title>
+    <title>Beltz - Pädagogik (Deutsch)</title>
     <id>http://www.zotero.org/styles/beltz-padagogik</id>
     <link href="http://www.zotero.org/styles/beltz-padagogik" rel="self"/>
     <link href="http://www.zotero.org/styles/deutsche-sprache" rel="template"/>

--- a/bitonline.csl
+++ b/bitonline.csl
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <style xmlns="http://purl.org/net/xbiblio/csl" class="note" version="1.0" default-locale="de-DE">
   <info>
-    <title>b.i.t.online (note, German)</title>
+    <title>b.i.t.online (note, Deutsch)</title>
     <id>http://www.zotero.org/styles/bitonline</id>
     <link href="http://www.zotero.org/styles/bitonline" rel="self"/>
     <link href="http://www.zotero.org/styles/technische-universitat-dresden-historische-musikwissenschaft-note" rel="template"/>

--- a/chicago-author-date-de.csl
+++ b/chicago-author-date-de.csl
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" demote-non-dropping-particle="sort-only" default-locale="de-DE">
   <info>
-    <title>Chicago Manual of Style 16th edition (author-date, German)</title>
+    <title>Chicago Manual of Style 16th edition (author-date, Deutsch)</title>
     <id>http://www.zotero.org/styles/chicago-author-date-de</id>
     <link href="http://www.zotero.org/styles/chicago-author-date-de" rel="self"/>
     <link href="http://www.chicagomanualofstyle.org/tools_citationguide.html" rel="documentation"/>

--- a/computer-und-recht.csl
+++ b/computer-und-recht.csl
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <style xmlns="http://purl.org/net/xbiblio/csl" version="1.0" class="note" default-locale="de-DE">
   <info>
-    <title>Computer und Recht (German)</title>
+    <title>Computer und Recht (Deutsch)</title>
     <title-short>CR</title-short>
     <id>http://www.zotero.org/styles/computer-und-recht</id>
     <link href="http://www.zotero.org/styles/computer-und-recht" rel="self"/>

--- a/dependent/abi-technik.csl
+++ b/dependent/abi-technik.csl
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <style xmlns="http://purl.org/net/xbiblio/csl" version="1.0" default-locale="de-DE">
   <info>
-    <title>ABI Technik (German)</title>
+    <title>ABI Technik (Deutsch)</title>
     <id>http://www.zotero.org/styles/abi-technik</id>
     <link href="http://www.zotero.org/styles/abi-technik" rel="self"/>
     <link href="http://www.zotero.org/styles/chicago-fullnote-bibliography" rel="independent-parent"/>

--- a/dependent/arthroskopie.csl
+++ b/dependent/arthroskopie.csl
@@ -2,7 +2,7 @@
 <style xmlns="http://purl.org/net/xbiblio/csl" version="1.0" default-locale="de-DE">
   <!-- Generated with https://github.com/citation-style-language/utilities/tree/master/generate_dependent_styles/data/springer-fachzeitschriften-medizin -->
   <info>
-    <title>Arthroskopie (German)</title>
+    <title>Arthroskopie (Deutsch)</title>
     <title-short>Arthroskopie</title-short>
     <id>http://www.zotero.org/styles/arthroskopie</id>
     <link href="http://www.zotero.org/styles/arthroskopie" rel="self"/>

--- a/dependent/beitrage-zur-popularmusikforschung.csl
+++ b/dependent/beitrage-zur-popularmusikforschung.csl
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <style xmlns="http://purl.org/net/xbiblio/csl" version="1.0" default-locale="de-DE">
   <info>
-    <title>Beiträge zur Popularmusikforschung (German)</title>
+    <title>Beiträge zur Popularmusikforschung (Deutsch)</title>
     <id>http://www.zotero.org/styles/beitrage-zur-popularmusikforschung</id>
     <link href="http://www.zotero.org/styles/beitrage-zur-popularmusikforschung" rel="self"/>
     <link href="http://www.zotero.org/styles/gesellschaft-fur-popularmusikforschung" rel="independent-parent"/>

--- a/dependent/berliner-journal-fur-soziologie.csl
+++ b/dependent/berliner-journal-fur-soziologie.csl
@@ -2,7 +2,7 @@
 <style xmlns="http://purl.org/net/xbiblio/csl" version="1.0" default-locale="de-DE">
   <!-- Generated with https://github.com/citation-style-language/utilities/tree/master/generate_dependent_styles/data/springer -->
   <info>
-    <title>Berliner Journal für Soziologie (German)</title>
+    <title>Berliner Journal für Soziologie (Deutsch)</title>
     <title-short>Berlin J Soziol</title-short>
     <id>http://www.zotero.org/styles/berliner-journal-fur-soziologie</id>
     <link href="http://www.zotero.org/styles/berliner-journal-fur-soziologie" rel="self"/>

--- a/dependent/best-practice-onkologie.csl
+++ b/dependent/best-practice-onkologie.csl
@@ -2,7 +2,7 @@
 <style xmlns="http://purl.org/net/xbiblio/csl" version="1.0" default-locale="de-DE">
   <!-- Generated with https://github.com/citation-style-language/utilities/tree/master/generate_dependent_styles/data/springer-fachzeitschriften-medizin -->
   <info>
-    <title>best practice onkologie (German)</title>
+    <title>best practice onkologie (Deutsch)</title>
     <title-short>best practice onkologie</title-short>
     <id>http://www.zotero.org/styles/best-practice-onkologie</id>
     <link href="http://www.zotero.org/styles/best-practice-onkologie" rel="self"/>

--- a/dependent/bibliotek-for-laeger.csl
+++ b/dependent/bibliotek-for-laeger.csl
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <style xmlns="http://purl.org/net/xbiblio/csl" version="1.0" default-locale="da-DK">
   <info>
-    <title>Bibliotek for Læger (Danish)</title>
+    <title>Bibliotek for Læger (Dansk)</title>
     <id>http://www.zotero.org/styles/bibliotek-for-laeger</id>
     <link href="http://www.zotero.org/styles/bibliotek-for-laeger" rel="self"/>
     <link href="http://www.zotero.org/styles/vancouver" rel="independent-parent"/>

--- a/dependent/bundesgesundheitsblatt-gesundheitsforschung-gesundheitsschutz.csl
+++ b/dependent/bundesgesundheitsblatt-gesundheitsforschung-gesundheitsschutz.csl
@@ -2,7 +2,7 @@
 <style xmlns="http://purl.org/net/xbiblio/csl" version="1.0" default-locale="de-DE">
   <!-- Generated with https://github.com/citation-style-language/utilities/tree/master/generate_dependent_styles/data/springer-fachzeitschriften-medizin -->
   <info>
-    <title>Bundesgesundheitsblatt - Gesundheitsforschung - Gesundheitsschutz (German)</title>
+    <title>Bundesgesundheitsblatt - Gesundheitsforschung - Gesundheitsschutz (Deutsch)</title>
     <title-short>Bundesgesundheitsblatt Gesundheitsforschung Gesundheitsschutz</title-short>
     <id>http://www.zotero.org/styles/bundesgesundheitsblatt-gesundheitsforschung-gesundheitsschutz</id>
     <link href="http://www.zotero.org/styles/bundesgesundheitsblatt-gesundheitsforschung-gesundheitsschutz" rel="self"/>

--- a/dependent/coaching-theorie-and-praxis.csl
+++ b/dependent/coaching-theorie-and-praxis.csl
@@ -2,7 +2,7 @@
 <style xmlns="http://purl.org/net/xbiblio/csl" version="1.0" default-locale="de-DE">
   <!-- Generated with https://github.com/citation-style-language/utilities/tree/master/generate_dependent_styles/data/springer -->
   <info>
-    <title>Coaching | Theorie &amp; Praxis (German)</title>
+    <title>Coaching | Theorie &amp; Praxis (Deutsch)</title>
     <id>http://www.zotero.org/styles/coaching-theorie-and-praxis</id>
     <link href="http://www.zotero.org/styles/coaching-theorie-and-praxis" rel="self"/>
     <link href="http://www.zotero.org/styles/springer-socpsych-author-date" rel="independent-parent"/>

--- a/dependent/coloproctology.csl
+++ b/dependent/coloproctology.csl
@@ -2,7 +2,7 @@
 <style xmlns="http://purl.org/net/xbiblio/csl" version="1.0" default-locale="de-DE">
   <!-- Generated with https://github.com/citation-style-language/utilities/tree/master/generate_dependent_styles/data/springer-fachzeitschriften-medizin -->
   <info>
-    <title>coloproctology (German)</title>
+    <title>coloproctology (Deutsch)</title>
     <title-short>coloproctology</title-short>
     <id>http://www.zotero.org/styles/coloproctology</id>
     <link href="http://www.zotero.org/styles/coloproctology" rel="self"/>

--- a/dependent/datenbank-spektrum.csl
+++ b/dependent/datenbank-spektrum.csl
@@ -2,7 +2,7 @@
 <style xmlns="http://purl.org/net/xbiblio/csl" version="1.0" default-locale="de-DE">
   <!-- Generated with https://github.com/citation-style-language/utilities/tree/master/generate_dependent_styles/data/springer -->
   <info>
-    <title>Datenbank-Spektrum (German)</title>
+    <title>Datenbank-Spektrum (Deutsch)</title>
     <title-short>Datenbank Spektrum</title-short>
     <id>http://www.zotero.org/styles/datenbank-spektrum</id>
     <link href="http://www.zotero.org/styles/datenbank-spektrum" rel="self"/>

--- a/dependent/der-anaesthesist.csl
+++ b/dependent/der-anaesthesist.csl
@@ -2,7 +2,7 @@
 <style xmlns="http://purl.org/net/xbiblio/csl" version="1.0" default-locale="de-DE">
   <!-- Generated with https://github.com/citation-style-language/utilities/tree/master/generate_dependent_styles/data/springer-fachzeitschriften-medizin -->
   <info>
-    <title>Der Anaesthesist (German)</title>
+    <title>Der Anaesthesist (Deutsch)</title>
     <title-short>Anaesthesist</title-short>
     <id>http://www.zotero.org/styles/der-anaesthesist</id>
     <link href="http://www.zotero.org/styles/der-anaesthesist" rel="self"/>

--- a/dependent/der-chirurg.csl
+++ b/dependent/der-chirurg.csl
@@ -2,7 +2,7 @@
 <style xmlns="http://purl.org/net/xbiblio/csl" version="1.0" default-locale="de-DE">
   <!-- Generated with https://github.com/citation-style-language/utilities/tree/master/generate_dependent_styles/data/springer-fachzeitschriften-medizin -->
   <info>
-    <title>Der Chirurg (German)</title>
+    <title>Der Chirurg (Deutsch)</title>
     <title-short>Chirurg</title-short>
     <id>http://www.zotero.org/styles/der-chirurg</id>
     <link href="http://www.zotero.org/styles/der-chirurg" rel="self"/>

--- a/dependent/der-diabetologe.csl
+++ b/dependent/der-diabetologe.csl
@@ -2,7 +2,7 @@
 <style xmlns="http://purl.org/net/xbiblio/csl" version="1.0" default-locale="de-DE">
   <!-- Generated with https://github.com/citation-style-language/utilities/tree/master/generate_dependent_styles/data/springer-fachzeitschriften-medizin -->
   <info>
-    <title>Der Diabetologe (German)</title>
+    <title>Der Diabetologe (Deutsch)</title>
     <title-short>Diabetologe</title-short>
     <id>http://www.zotero.org/styles/der-diabetologe</id>
     <link href="http://www.zotero.org/styles/der-diabetologe" rel="self"/>

--- a/dependent/der-freie-zahnarzt.csl
+++ b/dependent/der-freie-zahnarzt.csl
@@ -2,7 +2,7 @@
 <style xmlns="http://purl.org/net/xbiblio/csl" version="1.0" default-locale="de-DE">
   <!-- Generated with https://github.com/citation-style-language/utilities/tree/master/generate_dependent_styles/data/springer-fachzeitschriften-medizin -->
   <info>
-    <title>Der Freie Zahnarzt (German)</title>
+    <title>Der Freie Zahnarzt (Deutsch)</title>
     <title-short>Freie Zahnarzt</title-short>
     <id>http://www.zotero.org/styles/der-freie-zahnarzt</id>
     <link href="http://www.zotero.org/styles/der-freie-zahnarzt" rel="self"/>

--- a/dependent/der-gastroenterologe.csl
+++ b/dependent/der-gastroenterologe.csl
@@ -2,7 +2,7 @@
 <style xmlns="http://purl.org/net/xbiblio/csl" version="1.0" default-locale="de-DE">
   <!-- Generated with https://github.com/citation-style-language/utilities/tree/master/generate_dependent_styles/data/springer-fachzeitschriften-medizin -->
   <info>
-    <title>Der Gastroenterologe (German)</title>
+    <title>Der Gastroenterologe (Deutsch)</title>
     <title-short>Gastroenterologe</title-short>
     <id>http://www.zotero.org/styles/der-gastroenterologe</id>
     <link href="http://www.zotero.org/styles/der-gastroenterologe" rel="self"/>

--- a/dependent/der-gynakologe.csl
+++ b/dependent/der-gynakologe.csl
@@ -2,7 +2,7 @@
 <style xmlns="http://purl.org/net/xbiblio/csl" version="1.0" default-locale="de-DE">
   <!-- Generated with https://github.com/citation-style-language/utilities/tree/master/generate_dependent_styles/data/springer-fachzeitschriften-medizin -->
   <info>
-    <title>Der Gynäkologe (German)</title>
+    <title>Der Gynäkologe (Deutsch)</title>
     <title-short>Gynäkologe</title-short>
     <id>http://www.zotero.org/styles/der-gynakologe</id>
     <link href="http://www.zotero.org/styles/der-gynakologe" rel="self"/>

--- a/dependent/der-hautarzt.csl
+++ b/dependent/der-hautarzt.csl
@@ -2,7 +2,7 @@
 <style xmlns="http://purl.org/net/xbiblio/csl" version="1.0" default-locale="de-DE">
   <!-- Generated with https://github.com/citation-style-language/utilities/tree/master/generate_dependent_styles/data/springer-fachzeitschriften-medizin -->
   <info>
-    <title>Der Hautarzt (German)</title>
+    <title>Der Hautarzt (Deutsch)</title>
     <title-short>Hautarzt</title-short>
     <id>http://www.zotero.org/styles/der-hautarzt</id>
     <link href="http://www.zotero.org/styles/der-hautarzt" rel="self"/>

--- a/dependent/der-internist.csl
+++ b/dependent/der-internist.csl
@@ -2,7 +2,7 @@
 <style xmlns="http://purl.org/net/xbiblio/csl" version="1.0" default-locale="de-DE">
   <!-- Generated with https://github.com/citation-style-language/utilities/tree/master/generate_dependent_styles/data/springer-fachzeitschriften-medizin -->
   <info>
-    <title>Der Internist (German)</title>
+    <title>Der Internist (Deutsch)</title>
     <title-short>Internist</title-short>
     <id>http://www.zotero.org/styles/der-internist</id>
     <link href="http://www.zotero.org/styles/der-internist" rel="self"/>

--- a/dependent/der-junge-zahnarzt.csl
+++ b/dependent/der-junge-zahnarzt.csl
@@ -2,7 +2,7 @@
 <style xmlns="http://purl.org/net/xbiblio/csl" version="1.0" default-locale="de-DE">
   <!-- Generated with https://github.com/citation-style-language/utilities/tree/master/generate_dependent_styles/data/springer-fachzeitschriften-medizin -->
   <info>
-    <title>der junge zahnarzt (German)</title>
+    <title>der junge zahnarzt (Deutsch)</title>
     <title-short>der junge zahnarzt</title-short>
     <id>http://www.zotero.org/styles/der-junge-zahnarzt</id>
     <link href="http://www.zotero.org/styles/der-junge-zahnarzt" rel="self"/>

--- a/dependent/der-kardiologe.csl
+++ b/dependent/der-kardiologe.csl
@@ -2,7 +2,7 @@
 <style xmlns="http://purl.org/net/xbiblio/csl" version="1.0" default-locale="de-DE">
   <!-- Generated with https://github.com/citation-style-language/utilities/tree/master/generate_dependent_styles/data/springer-fachzeitschriften-medizin -->
   <info>
-    <title>Der Kardiologe (German)</title>
+    <title>Der Kardiologe (Deutsch)</title>
     <title-short>Kardiologe</title-short>
     <id>http://www.zotero.org/styles/der-kardiologe</id>
     <link href="http://www.zotero.org/styles/der-kardiologe" rel="self"/>

--- a/dependent/der-mkg-chirurg.csl
+++ b/dependent/der-mkg-chirurg.csl
@@ -2,7 +2,7 @@
 <style xmlns="http://purl.org/net/xbiblio/csl" version="1.0" default-locale="de-DE">
   <!-- Generated with https://github.com/citation-style-language/utilities/tree/master/generate_dependent_styles/data/springer-fachzeitschriften-medizin -->
   <info>
-    <title>Der MKG-Chirurg (German)</title>
+    <title>Der MKG-Chirurg (Deutsch)</title>
     <title-short>MKG-Chirurg</title-short>
     <id>http://www.zotero.org/styles/der-mkg-chirurg</id>
     <link href="http://www.zotero.org/styles/der-mkg-chirurg" rel="self"/>

--- a/dependent/der-nephrologe.csl
+++ b/dependent/der-nephrologe.csl
@@ -2,7 +2,7 @@
 <style xmlns="http://purl.org/net/xbiblio/csl" version="1.0" default-locale="de-DE">
   <!-- Generated with https://github.com/citation-style-language/utilities/tree/master/generate_dependent_styles/data/springer-fachzeitschriften-medizin -->
   <info>
-    <title>Der Nephrologe (German)</title>
+    <title>Der Nephrologe (Deutsch)</title>
     <title-short>Nephrologe</title-short>
     <id>http://www.zotero.org/styles/der-nephrologe</id>
     <link href="http://www.zotero.org/styles/der-nephrologe" rel="self"/>

--- a/dependent/der-nervenarzt.csl
+++ b/dependent/der-nervenarzt.csl
@@ -2,7 +2,7 @@
 <style xmlns="http://purl.org/net/xbiblio/csl" version="1.0" default-locale="de-DE">
   <!-- Generated with https://github.com/citation-style-language/utilities/tree/master/generate_dependent_styles/data/springer-fachzeitschriften-medizin -->
   <info>
-    <title>Der Nervenarzt (German)</title>
+    <title>Der Nervenarzt (Deutsch)</title>
     <title-short>Nervenarzt</title-short>
     <id>http://www.zotero.org/styles/der-nervenarzt</id>
     <link href="http://www.zotero.org/styles/der-nervenarzt" rel="self"/>

--- a/dependent/der-onkologe.csl
+++ b/dependent/der-onkologe.csl
@@ -2,7 +2,7 @@
 <style xmlns="http://purl.org/net/xbiblio/csl" version="1.0" default-locale="de-DE">
   <!-- Generated with https://github.com/citation-style-language/utilities/tree/master/generate_dependent_styles/data/springer-fachzeitschriften-medizin -->
   <info>
-    <title>Der Onkologe (German)</title>
+    <title>Der Onkologe (Deutsch)</title>
     <title-short>Onkologe</title-short>
     <id>http://www.zotero.org/styles/der-onkologe</id>
     <link href="http://www.zotero.org/styles/der-onkologe" rel="self"/>

--- a/dependent/der-ophthalmologe.csl
+++ b/dependent/der-ophthalmologe.csl
@@ -2,7 +2,7 @@
 <style xmlns="http://purl.org/net/xbiblio/csl" version="1.0" default-locale="de-DE">
   <!-- Generated with https://github.com/citation-style-language/utilities/tree/master/generate_dependent_styles/data/springer-fachzeitschriften-medizin -->
   <info>
-    <title>Der Ophthalmologe (German)</title>
+    <title>Der Ophthalmologe (Deutsch)</title>
     <title-short>Ophthalmologe</title-short>
     <id>http://www.zotero.org/styles/der-ophthalmologe</id>
     <link href="http://www.zotero.org/styles/der-ophthalmologe" rel="self"/>

--- a/dependent/der-orthopade.csl
+++ b/dependent/der-orthopade.csl
@@ -2,7 +2,7 @@
 <style xmlns="http://purl.org/net/xbiblio/csl" version="1.0" default-locale="de-DE">
   <!-- Generated with https://github.com/citation-style-language/utilities/tree/master/generate_dependent_styles/data/springer-fachzeitschriften-medizin -->
   <info>
-    <title>Der Orthopäde (German)</title>
+    <title>Der Orthopäde (Deutsch)</title>
     <title-short>Orthopäde</title-short>
     <id>http://www.zotero.org/styles/der-orthopade</id>
     <link href="http://www.zotero.org/styles/der-orthopade" rel="self"/>

--- a/dependent/der-pathologe.csl
+++ b/dependent/der-pathologe.csl
@@ -2,7 +2,7 @@
 <style xmlns="http://purl.org/net/xbiblio/csl" version="1.0" default-locale="de-DE">
   <!-- Generated with https://github.com/citation-style-language/utilities/tree/master/generate_dependent_styles/data/springer-fachzeitschriften-medizin -->
   <info>
-    <title>Der Pathologe (German)</title>
+    <title>Der Pathologe (Deutsch)</title>
     <title-short>Pathologe</title-short>
     <id>http://www.zotero.org/styles/der-pathologe</id>
     <link href="http://www.zotero.org/styles/der-pathologe" rel="self"/>

--- a/dependent/der-pneumologe.csl
+++ b/dependent/der-pneumologe.csl
@@ -2,7 +2,7 @@
 <style xmlns="http://purl.org/net/xbiblio/csl" version="1.0" default-locale="de-DE">
   <!-- Generated with https://github.com/citation-style-language/utilities/tree/master/generate_dependent_styles/data/springer-fachzeitschriften-medizin -->
   <info>
-    <title>Der Pneumologe (German)</title>
+    <title>Der Pneumologe (Deutsch)</title>
     <title-short>Pneumologe</title-short>
     <id>http://www.zotero.org/styles/der-pneumologe</id>
     <link href="http://www.zotero.org/styles/der-pneumologe" rel="self"/>

--- a/dependent/der-radiologe.csl
+++ b/dependent/der-radiologe.csl
@@ -2,7 +2,7 @@
 <style xmlns="http://purl.org/net/xbiblio/csl" version="1.0" default-locale="de-DE">
   <!-- Generated with https://github.com/citation-style-language/utilities/tree/master/generate_dependent_styles/data/springer-fachzeitschriften-medizin -->
   <info>
-    <title>Der Radiologe (German)</title>
+    <title>Der Radiologe (Deutsch)</title>
     <title-short>Radiologe</title-short>
     <id>http://www.zotero.org/styles/der-radiologe</id>
     <link href="http://www.zotero.org/styles/der-radiologe" rel="self"/>

--- a/dependent/der-schmerz.csl
+++ b/dependent/der-schmerz.csl
@@ -2,7 +2,7 @@
 <style xmlns="http://purl.org/net/xbiblio/csl" version="1.0" default-locale="de-DE">
   <!-- Generated with https://github.com/citation-style-language/utilities/tree/master/generate_dependent_styles/data/springer-fachzeitschriften-medizin -->
   <info>
-    <title>Der Schmerz (German)</title>
+    <title>Der Schmerz (Deutsch)</title>
     <title-short>Schmerz</title-short>
     <id>http://www.zotero.org/styles/der-schmerz</id>
     <link href="http://www.zotero.org/styles/der-schmerz" rel="self"/>

--- a/dependent/der-unfallchirurg.csl
+++ b/dependent/der-unfallchirurg.csl
@@ -2,7 +2,7 @@
 <style xmlns="http://purl.org/net/xbiblio/csl" version="1.0" default-locale="de-DE">
   <!-- Generated with https://github.com/citation-style-language/utilities/tree/master/generate_dependent_styles/data/springer-fachzeitschriften-medizin -->
   <info>
-    <title>Der Unfallchirurg (German)</title>
+    <title>Der Unfallchirurg (Deutsch)</title>
     <title-short>Unfallchirurg</title-short>
     <id>http://www.zotero.org/styles/der-unfallchirurg</id>
     <link href="http://www.zotero.org/styles/der-unfallchirurg" rel="self"/>

--- a/dependent/der-urologe.csl
+++ b/dependent/der-urologe.csl
@@ -2,7 +2,7 @@
 <style xmlns="http://purl.org/net/xbiblio/csl" version="1.0" default-locale="de-DE">
   <!-- Generated with https://github.com/citation-style-language/utilities/tree/master/generate_dependent_styles/data/springer-fachzeitschriften-medizin -->
   <info>
-    <title>Der Urologe (German)</title>
+    <title>Der Urologe (Deutsch)</title>
     <title-short>Urologe</title-short>
     <id>http://www.zotero.org/styles/der-urologe</id>
     <link href="http://www.zotero.org/styles/der-urologe" rel="self"/>

--- a/dependent/durchstarten-zur-diplomarbeit-in-text.csl
+++ b/dependent/durchstarten-zur-diplomarbeit-in-text.csl
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <style xmlns="http://purl.org/net/xbiblio/csl" version="1.0" default-locale="de-DE">
   <info>
-    <title>Durchstarten zur Diplomarbeit (BHS) (in-text, German)</title>
+    <title>Durchstarten zur Diplomarbeit (BHS) (in-text, Deutsch)</title>
     <id>http://www.zotero.org/styles/durchstarten-zur-diplomarbeit-in-text</id>
     <link href="http://www.zotero.org/styles/durchstarten-zur-diplomarbeit-in-text" rel="self"/>
     <link href="http://www.zotero.org/styles/die-bachelorarbeit-samac-et-al-in-text" rel="independent-parent"/>

--- a/dependent/durchstarten-zur-diplomarbeit-note.csl
+++ b/dependent/durchstarten-zur-diplomarbeit-note.csl
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <style xmlns="http://purl.org/net/xbiblio/csl" version="1.0" default-locale="de-DE">
   <info>
-    <title>Durchstarten zur Diplomarbeit (BHS) (note, German)</title>
+    <title>Durchstarten zur Diplomarbeit (BHS) (note, Deutsch)</title>
     <id>http://www.zotero.org/styles/durchstarten-zur-diplomarbeit-note</id>
     <link href="http://www.zotero.org/styles/durchstarten-zur-diplomarbeit-note" rel="self"/>
     <link href="http://www.zotero.org/styles/die-bachelorarbeit-samac-et-al-note" rel="independent-parent"/>

--- a/dependent/durchstarten-zur-vorwissenschaftlichen-arbeit-in-text.csl
+++ b/dependent/durchstarten-zur-vorwissenschaftlichen-arbeit-in-text.csl
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <style xmlns="http://purl.org/net/xbiblio/csl" version="1.0" default-locale="de-DE">
   <info>
-    <title>Durchstarten zur Vorwissenschaftlichen Arbeit (AHS) (in-text, German)</title>
+    <title>Durchstarten zur Vorwissenschaftlichen Arbeit (AHS) (in-text, Deutsch)</title>
     <id>http://www.zotero.org/styles/durchstarten-zur-vorwissenschaftlichen-arbeit-in-text</id>
     <link href="http://www.zotero.org/styles/durchstarten-zur-vorwissenschaftlichen-arbeit-in-text" rel="self"/>
     <link href="http://www.zotero.org/styles/die-bachelorarbeit-samac-et-al-in-text" rel="independent-parent"/>

--- a/dependent/durchstarten-zur-vorwissenschaftlichen-arbeit-note.csl
+++ b/dependent/durchstarten-zur-vorwissenschaftlichen-arbeit-note.csl
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <style xmlns="http://purl.org/net/xbiblio/csl" version="1.0" default-locale="de-DE">
   <info>
-    <title>Durchstarten zur Vorwissenschaftlichen Arbeit (AHS) (note, German)</title>
+    <title>Durchstarten zur Vorwissenschaftlichen Arbeit (AHS) (note, Deutsch)</title>
     <id>http://www.zotero.org/styles/durchstarten-zur-vorwissenschaftlichen-arbeit-note</id>
     <link href="http://www.zotero.org/styles/durchstarten-zur-vorwissenschaftlichen-arbeit-note" rel="self"/>
     <link href="http://www.zotero.org/styles/die-bachelorarbeit-samac-et-al-note" rel="independent-parent"/>

--- a/dependent/e-and-i-elektrotechnik-und-informationstechnik.csl
+++ b/dependent/e-and-i-elektrotechnik-und-informationstechnik.csl
@@ -2,7 +2,7 @@
 <style xmlns="http://purl.org/net/xbiblio/csl" version="1.0" default-locale="de-DE">
   <!-- Generated with https://github.com/citation-style-language/utilities/tree/master/generate_dependent_styles/data/springer -->
   <info>
-    <title>e &amp; i Elektrotechnik und Informationstechnik (German)</title>
+    <title>e &amp; i Elektrotechnik und Informationstechnik (Deutsch)</title>
     <title-short>Elektrotech. Inftech.</title-short>
     <id>http://www.zotero.org/styles/e-and-i-elektrotechnik-und-informationstechnik</id>
     <link href="http://www.zotero.org/styles/e-and-i-elektrotechnik-und-informationstechnik" rel="self"/>

--- a/dependent/erwerbs-obstbau.csl
+++ b/dependent/erwerbs-obstbau.csl
@@ -2,7 +2,7 @@
 <style xmlns="http://purl.org/net/xbiblio/csl" version="1.0" default-locale="de-DE">
   <!-- Generated with https://github.com/citation-style-language/utilities/tree/master/generate_dependent_styles/data/springer -->
   <info>
-    <title>Erwerbs-Obstbau (German)</title>
+    <title>Erwerbs-Obstbau (Deutsch)</title>
     <title-short>Erwerbs-Obstbau</title-short>
     <id>http://www.zotero.org/styles/erwerbs-obstbau</id>
     <link href="http://www.zotero.org/styles/erwerbs-obstbau" rel="self"/>

--- a/dependent/ethik-in-der-medizin.csl
+++ b/dependent/ethik-in-der-medizin.csl
@@ -2,7 +2,7 @@
 <style xmlns="http://purl.org/net/xbiblio/csl" version="1.0" default-locale="de-DE">
   <!-- Generated with https://github.com/citation-style-language/utilities/tree/master/generate_dependent_styles/data/springer -->
   <info>
-    <title>Ethik in der Medizin (German)</title>
+    <title>Ethik in der Medizin (Deutsch)</title>
     <title-short>Ethik Med</title-short>
     <id>http://www.zotero.org/styles/ethik-in-der-medizin</id>
     <link href="http://www.zotero.org/styles/ethik-in-der-medizin" rel="self"/>

--- a/dependent/forensische-psychiatrie-psychologie-kriminologie.csl
+++ b/dependent/forensische-psychiatrie-psychologie-kriminologie.csl
@@ -2,7 +2,7 @@
 <style xmlns="http://purl.org/net/xbiblio/csl" version="1.0" default-locale="de-DE">
   <!-- Generated with https://github.com/citation-style-language/utilities/tree/master/generate_dependent_styles/data/springer -->
   <info>
-    <title>Forensische Psychiatrie, Psychologie, Kriminologie (German)</title>
+    <title>Forensische Psychiatrie, Psychologie, Kriminologie (Deutsch)</title>
     <title-short>Forens Psychiatr Psychol Kriminol</title-short>
     <id>http://www.zotero.org/styles/forensische-psychiatrie-psychologie-kriminologie</id>
     <link href="http://www.zotero.org/styles/forensische-psychiatrie-psychologie-kriminologie" rel="self"/>

--- a/dependent/forschung-im-ingenieurwesen.csl
+++ b/dependent/forschung-im-ingenieurwesen.csl
@@ -2,7 +2,7 @@
 <style xmlns="http://purl.org/net/xbiblio/csl" version="1.0" default-locale="de-DE">
   <!-- Generated with https://github.com/citation-style-language/utilities/tree/master/generate_dependent_styles/data/springer -->
   <info>
-    <title>Forschung im Ingenieurwesen (German)</title>
+    <title>Forschung im Ingenieurwesen (Deutsch)</title>
     <title-short>Forsch Ingenieurwes</title-short>
     <id>http://www.zotero.org/styles/forschung-im-ingenieurwesen</id>
     <link href="http://www.zotero.org/styles/forschung-im-ingenieurwesen" rel="self"/>

--- a/dependent/forum-der-psychoanalyse.csl
+++ b/dependent/forum-der-psychoanalyse.csl
@@ -2,7 +2,7 @@
 <style xmlns="http://purl.org/net/xbiblio/csl" version="1.0" default-locale="de-DE">
   <!-- Generated with https://github.com/citation-style-language/utilities/tree/master/generate_dependent_styles/data/springer -->
   <info>
-    <title>Forum der Psychoanalyse (German)</title>
+    <title>Forum der Psychoanalyse (Deutsch)</title>
     <title-short>Forum Psychoanal</title-short>
     <id>http://www.zotero.org/styles/forum-der-psychoanalyse</id>
     <link href="http://www.zotero.org/styles/forum-der-psychoanalyse" rel="self"/>

--- a/dependent/forum.csl
+++ b/dependent/forum.csl
@@ -2,7 +2,7 @@
 <style xmlns="http://purl.org/net/xbiblio/csl" version="1.0" default-locale="de-DE">
   <!-- Generated with https://github.com/citation-style-language/utilities/tree/master/generate_dependent_styles/data/springer-fachzeitschriften-medizin -->
   <info>
-    <title>Forum (German)</title>
+    <title>Forum (Deutsch)</title>
     <title-short>Forum</title-short>
     <id>http://www.zotero.org/styles/forum</id>
     <link href="http://www.zotero.org/styles/forum" rel="self"/>

--- a/dependent/gefasschirurgie.csl
+++ b/dependent/gefasschirurgie.csl
@@ -2,7 +2,7 @@
 <style xmlns="http://purl.org/net/xbiblio/csl" version="1.0" default-locale="de-DE">
   <!-- Generated with https://github.com/citation-style-language/utilities/tree/master/generate_dependent_styles/data/springer-fachzeitschriften-medizin -->
   <info>
-    <title>Gefässchirurgie (German)</title>
+    <title>Gefässchirurgie (Deutsch)</title>
     <title-short>Gefässchirurgie</title-short>
     <id>http://www.zotero.org/styles/gefasschirurgie</id>
     <link href="http://www.zotero.org/styles/gefasschirurgie" rel="self"/>

--- a/dependent/gesunde-pflanzen.csl
+++ b/dependent/gesunde-pflanzen.csl
@@ -2,7 +2,7 @@
 <style xmlns="http://purl.org/net/xbiblio/csl" version="1.0" default-locale="de-DE">
   <!-- Generated with https://github.com/citation-style-language/utilities/tree/master/generate_dependent_styles/data/springer -->
   <info>
-    <title>Gesunde Pflanzen (German)</title>
+    <title>Gesunde Pflanzen (Deutsch)</title>
     <title-short>Gesunde Pflanzen</title-short>
     <id>http://www.zotero.org/styles/gesunde-pflanzen</id>
     <link href="http://www.zotero.org/styles/gesunde-pflanzen" rel="self"/>

--- a/dependent/grundwasser.csl
+++ b/dependent/grundwasser.csl
@@ -2,7 +2,7 @@
 <style xmlns="http://purl.org/net/xbiblio/csl" version="1.0" default-locale="de-DE">
   <!-- Generated with https://github.com/citation-style-language/utilities/tree/master/generate_dependent_styles/data/springer -->
   <info>
-    <title>Grundwasser (German)</title>
+    <title>Grundwasser (Deutsch)</title>
     <title-short>Grundwasser</title-short>
     <id>http://www.zotero.org/styles/grundwasser</id>
     <link href="http://www.zotero.org/styles/grundwasser" rel="self"/>

--- a/dependent/gruppe-interaktion-organisation-zeitschrift-fur-angewandte-organisationspsychologie.csl
+++ b/dependent/gruppe-interaktion-organisation-zeitschrift-fur-angewandte-organisationspsychologie.csl
@@ -2,7 +2,7 @@
 <style xmlns="http://purl.org/net/xbiblio/csl" version="1.0" default-locale="de-DE">
   <!-- Generated with https://github.com/citation-style-language/utilities/tree/master/generate_dependent_styles/data/springer -->
   <info>
-    <title>Gruppe. Interaktion. Organisation. Zeitschrift für Angewandte Organisationspsychologie (German)</title>
+    <title>Gruppe. Interaktion. Organisation. Zeitschrift für Angewandte Organisationspsychologie (Deutsch)</title>
     <title-short>Gruppendyn Organisationsberat</title-short>
     <id>http://www.zotero.org/styles/gruppe-interaktion-organisation-zeitschrift-fur-angewandte-organisationspsychologie</id>
     <link href="http://www.zotero.org/styles/gruppe-interaktion-organisation-zeitschrift-fur-angewandte-organisationspsychologie" rel="self"/>

--- a/dependent/gynakologische-endokrinologie.csl
+++ b/dependent/gynakologische-endokrinologie.csl
@@ -2,7 +2,7 @@
 <style xmlns="http://purl.org/net/xbiblio/csl" version="1.0" default-locale="de-DE">
   <!-- Generated with https://github.com/citation-style-language/utilities/tree/master/generate_dependent_styles/data/springer-fachzeitschriften-medizin -->
   <info>
-    <title>Gynäkologische Endokrinologie (German)</title>
+    <title>Gynäkologische Endokrinologie (Deutsch)</title>
     <title-short>Gynäkologische Endokrinologie</title-short>
     <id>http://www.zotero.org/styles/gynakologische-endokrinologie</id>
     <link href="http://www.zotero.org/styles/gynakologische-endokrinologie" rel="self"/>

--- a/dependent/hautnah.csl
+++ b/dependent/hautnah.csl
@@ -2,7 +2,7 @@
 <style xmlns="http://purl.org/net/xbiblio/csl" version="1.0" default-locale="de-DE">
   <!-- Generated with https://github.com/citation-style-language/utilities/tree/master/generate_dependent_styles/data/springer -->
   <info>
-    <title>hautnah (German)</title>
+    <title>hautnah (Deutsch)</title>
     <id>http://www.zotero.org/styles/hautnah</id>
     <link href="http://www.zotero.org/styles/hautnah" rel="self"/>
     <link href="http://www.zotero.org/styles/springer-basic-brackets" rel="independent-parent"/>

--- a/dependent/heilberufescience.csl
+++ b/dependent/heilberufescience.csl
@@ -2,7 +2,7 @@
 <style xmlns="http://purl.org/net/xbiblio/csl" version="1.0" default-locale="de-DE">
   <!-- Generated with https://github.com/citation-style-language/utilities/tree/master/generate_dependent_styles/data/springer -->
   <info>
-    <title>HeilberufeScience (German)</title>
+    <title>HeilberufeScience (Deutsch)</title>
     <title-short>HBScience</title-short>
     <id>http://www.zotero.org/styles/heilberufescience</id>
     <link href="http://www.zotero.org/styles/heilberufescience" rel="self"/>

--- a/dependent/herz.csl
+++ b/dependent/herz.csl
@@ -2,7 +2,7 @@
 <style xmlns="http://purl.org/net/xbiblio/csl" version="1.0" default-locale="de-DE">
   <!-- Generated with https://github.com/citation-style-language/utilities/tree/master/generate_dependent_styles/data/springer -->
   <info>
-    <title>Herz (German)</title>
+    <title>Herz (Deutsch)</title>
     <id>http://www.zotero.org/styles/herz</id>
     <link href="http://www.zotero.org/styles/herz" rel="self"/>
     <link href="http://www.zotero.org/styles/springer-basic-brackets" rel="independent-parent"/>

--- a/dependent/herzschrittmachertherapie-elektrophysiologie.csl
+++ b/dependent/herzschrittmachertherapie-elektrophysiologie.csl
@@ -2,7 +2,7 @@
 <style xmlns="http://purl.org/net/xbiblio/csl" version="1.0" default-locale="de-DE">
   <!-- Generated with https://github.com/citation-style-language/utilities/tree/master/generate_dependent_styles/data/springer-fachzeitschriften-medizin -->
   <info>
-    <title>Herzschrittmachertherapie + Elektrophysiologie (German)</title>
+    <title>Herzschrittmachertherapie + Elektrophysiologie (Deutsch)</title>
     <title-short>Herzschrittmachertherapie Elektrophysiologie</title-short>
     <id>http://www.zotero.org/styles/herzschrittmachertherapie-elektrophysiologie</id>
     <link href="http://www.zotero.org/styles/herzschrittmachertherapie-elektrophysiologie" rel="self"/>

--- a/dependent/hmd-praxis-der-wirtschaftsinformatik.csl
+++ b/dependent/hmd-praxis-der-wirtschaftsinformatik.csl
@@ -2,7 +2,7 @@
 <style xmlns="http://purl.org/net/xbiblio/csl" version="1.0" default-locale="de-DE">
   <!-- Generated with https://github.com/citation-style-language/utilities/tree/master/generate_dependent_styles/data/springer -->
   <info>
-    <title>HMD Praxis der Wirtschaftsinformatik (German)</title>
+    <title>HMD Praxis der Wirtschaftsinformatik (Deutsch)</title>
     <id>http://www.zotero.org/styles/hmd-praxis-der-wirtschaftsinformatik</id>
     <link href="http://www.zotero.org/styles/hmd-praxis-der-wirtschaftsinformatik" rel="self"/>
     <link href="http://www.zotero.org/styles/springer-basic-author-date" rel="independent-parent"/>

--- a/dependent/hno.csl
+++ b/dependent/hno.csl
@@ -2,7 +2,7 @@
 <style xmlns="http://purl.org/net/xbiblio/csl" version="1.0" default-locale="de-DE">
   <!-- Generated with https://github.com/citation-style-language/utilities/tree/master/generate_dependent_styles/data/springer-fachzeitschriften-medizin -->
   <info>
-    <title>HNO (German)</title>
+    <title>HNO (Deutsch)</title>
     <title-short>HNO</title-short>
     <id>http://www.zotero.org/styles/hno</id>
     <link href="http://www.zotero.org/styles/hno" rel="self"/>

--- a/dependent/informatik-spektrum.csl
+++ b/dependent/informatik-spektrum.csl
@@ -2,7 +2,7 @@
 <style xmlns="http://purl.org/net/xbiblio/csl" version="1.0" default-locale="de-DE">
   <!-- Generated with https://github.com/citation-style-language/utilities/tree/master/generate_dependent_styles/data/springer -->
   <info>
-    <title>Informatik-Spektrum (German)</title>
+    <title>Informatik-Spektrum (Deutsch)</title>
     <title-short>Informatik Spektrum</title-short>
     <id>http://www.zotero.org/styles/informatik-spektrum</id>
     <link href="http://www.zotero.org/styles/informatik-spektrum" rel="self"/>

--- a/dependent/informationspraxis.csl
+++ b/dependent/informationspraxis.csl
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <style xmlns="http://purl.org/net/xbiblio/csl" version="1.0" default-locale="de-DE">
   <info>
-    <title>Informationspraxis (German)</title>
+    <title>Informationspraxis (Deutsch)</title>
     <id>http://www.zotero.org/styles/informationspraxis</id>
     <link href="http://www.zotero.org/styles/informationspraxis" rel="self"/>
     <link href="http://www.zotero.org/styles/harvard-gesellschaft-fur-bildung-und-forschung-in-europa" rel="independent-parent"/>

--- a/dependent/journal-fur-asthetische-chirurgie.csl
+++ b/dependent/journal-fur-asthetische-chirurgie.csl
@@ -2,7 +2,7 @@
 <style xmlns="http://purl.org/net/xbiblio/csl" version="1.0" default-locale="de-DE">
   <!-- Generated with https://github.com/citation-style-language/utilities/tree/master/generate_dependent_styles/data/springer-fachzeitschriften-medizin -->
   <info>
-    <title>Journal für Ästhetische Chirurgie (German)</title>
+    <title>Journal für Ästhetische Chirurgie (Deutsch)</title>
     <title-short>Journal Ästhetische Chirurgie</title-short>
     <id>http://www.zotero.org/styles/journal-fur-asthetische-chirurgie</id>
     <link href="http://www.zotero.org/styles/journal-fur-asthetische-chirurgie" rel="self"/>

--- a/dependent/journal-fur-mathematik-didaktik.csl
+++ b/dependent/journal-fur-mathematik-didaktik.csl
@@ -2,7 +2,7 @@
 <style xmlns="http://purl.org/net/xbiblio/csl" version="1.0" default-locale="de-DE">
   <!-- Generated with https://github.com/citation-style-language/utilities/tree/master/generate_dependent_styles/data/springer -->
   <info>
-    <title>Journal für Mathematik-Didaktik (German)</title>
+    <title>Journal für Mathematik-Didaktik (Deutsch)</title>
     <title-short>J Math Didakt</title-short>
     <id>http://www.zotero.org/styles/journal-fur-mathematik-didaktik</id>
     <link href="http://www.zotero.org/styles/journal-fur-mathematik-didaktik" rel="self"/>

--- a/dependent/journal-fur-verbraucherschutz-und-lebensmittelsicherheit.csl
+++ b/dependent/journal-fur-verbraucherschutz-und-lebensmittelsicherheit.csl
@@ -2,7 +2,7 @@
 <style xmlns="http://purl.org/net/xbiblio/csl" version="1.0" default-locale="de-DE">
   <!-- Generated with https://github.com/citation-style-language/utilities/tree/master/generate_dependent_styles/data/springer -->
   <info>
-    <title>Journal für Verbraucherschutz und Lebensmittelsicherheit (German)</title>
+    <title>Journal für Verbraucherschutz und Lebensmittelsicherheit (Deutsch)</title>
     <title-short>J. Verbr. Lebensm.</title-short>
     <id>http://www.zotero.org/styles/journal-fur-verbraucherschutz-und-lebensmittelsicherheit</id>
     <link href="http://www.zotero.org/styles/journal-fur-verbraucherschutz-und-lebensmittelsicherheit" rel="self"/>

--- a/dependent/list-forum-fur-wirtschafts-und-finanzpolitik.csl
+++ b/dependent/list-forum-fur-wirtschafts-und-finanzpolitik.csl
@@ -2,7 +2,7 @@
 <style xmlns="http://purl.org/net/xbiblio/csl" version="1.0" default-locale="de-DE">
   <!-- Generated with https://github.com/citation-style-language/utilities/tree/master/generate_dependent_styles/data/springer -->
   <info>
-    <title>List Forum für Wirtschafts- und Finanzpolitik (German)</title>
+    <title>List Forum für Wirtschafts- und Finanzpolitik (Deutsch)</title>
     <id>http://www.zotero.org/styles/list-forum-fur-wirtschafts-und-finanzpolitik</id>
     <link href="http://www.zotero.org/styles/list-forum-fur-wirtschafts-und-finanzpolitik" rel="self"/>
     <link href="http://www.zotero.org/styles/springer-socpsych-author-date" rel="independent-parent"/>

--- a/dependent/manedsskrift-for-almen-praksis.csl
+++ b/dependent/manedsskrift-for-almen-praksis.csl
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <style xmlns="http://purl.org/net/xbiblio/csl" version="1.0" default-locale="da-DK">
   <info>
-    <title>Månedsskrift for almen praksis (Danish)</title>
+    <title>Månedsskrift for almen praksis (Dansk)</title>
     <id>http://www.zotero.org/styles/manedsskrift-for-almen-praksis</id>
     <link href="http://www.zotero.org/styles/manedsskrift-for-almen-praksis" rel="self"/>
     <link href="http://www.zotero.org/styles/vancouver" rel="independent-parent"/>

--- a/dependent/manuelle-medizin.csl
+++ b/dependent/manuelle-medizin.csl
@@ -2,7 +2,7 @@
 <style xmlns="http://purl.org/net/xbiblio/csl" version="1.0" default-locale="de-DE">
   <!-- Generated with https://github.com/citation-style-language/utilities/tree/master/generate_dependent_styles/data/springer-fachzeitschriften-medizin -->
   <info>
-    <title>Manuelle Medizin (German)</title>
+    <title>Manuelle Medizin (Deutsch)</title>
     <title-short>Manuelle Medizin</title-short>
     <id>http://www.zotero.org/styles/manuelle-medizin</id>
     <link href="http://www.zotero.org/styles/manuelle-medizin" rel="self"/>

--- a/dependent/mathematische-semesterberichte.csl
+++ b/dependent/mathematische-semesterberichte.csl
@@ -2,7 +2,7 @@
 <style xmlns="http://purl.org/net/xbiblio/csl" version="1.0" default-locale="de-DE">
   <!-- Generated with https://github.com/citation-style-language/utilities/tree/master/generate_dependent_styles/data/springer -->
   <info>
-    <title>Mathematische Semesterberichte (German)</title>
+    <title>Mathematische Semesterberichte (Deutsch)</title>
     <title-short>Math Semesterber</title-short>
     <id>http://www.zotero.org/styles/mathematische-semesterberichte</id>
     <link href="http://www.zotero.org/styles/mathematische-semesterberichte" rel="self"/>

--- a/dependent/medizinische-genetik.csl
+++ b/dependent/medizinische-genetik.csl
@@ -2,7 +2,7 @@
 <style xmlns="http://purl.org/net/xbiblio/csl" version="1.0" default-locale="de-DE">
   <!-- Generated with https://github.com/citation-style-language/utilities/tree/master/generate_dependent_styles/data/springer-fachzeitschriften-medizin -->
   <info>
-    <title>medizinische genetik (German)</title>
+    <title>medizinische genetik (Deutsch)</title>
     <title-short>medizinische genetik</title-short>
     <id>http://www.zotero.org/styles/medizinische-genetik</id>
     <link href="http://www.zotero.org/styles/medizinische-genetik" rel="self"/>

--- a/dependent/medizinische-klinik-intensivmedizin-und-notfallmedizin.csl
+++ b/dependent/medizinische-klinik-intensivmedizin-und-notfallmedizin.csl
@@ -2,7 +2,7 @@
 <style xmlns="http://purl.org/net/xbiblio/csl" version="1.0" default-locale="de-DE">
   <!-- Generated with https://github.com/citation-style-language/utilities/tree/master/generate_dependent_styles/data/springer-fachzeitschriften-medizin -->
   <info>
-    <title>Medizinische Klinik - Intensivmedizin und Notfallmedizin (German)</title>
+    <title>Medizinische Klinik - Intensivmedizin und Notfallmedizin (Deutsch)</title>
     <title-short>Medizinische Klinik Intensivmedizin Notfallmedizin</title-short>
     <id>http://www.zotero.org/styles/medizinische-klinik-intensivmedizin-und-notfallmedizin</id>
     <link href="http://www.zotero.org/styles/medizinische-klinik-intensivmedizin-und-notfallmedizin" rel="self"/>

--- a/dependent/monatsschrift-kinderheilkunde.csl
+++ b/dependent/monatsschrift-kinderheilkunde.csl
@@ -2,7 +2,7 @@
 <style xmlns="http://purl.org/net/xbiblio/csl" version="1.0" default-locale="de-DE">
   <!-- Generated with https://github.com/citation-style-language/utilities/tree/master/generate_dependent_styles/data/springer-fachzeitschriften-medizin -->
   <info>
-    <title>Monatsschrift Kinderheilkunde (German)</title>
+    <title>Monatsschrift Kinderheilkunde (Deutsch)</title>
     <title-short>Monatsschrift Kinderheilkunde</title-short>
     <id>http://www.zotero.org/styles/monatsschrift-kinderheilkunde</id>
     <link href="http://www.zotero.org/styles/monatsschrift-kinderheilkunde" rel="self"/>

--- a/dependent/neuroforum.csl
+++ b/dependent/neuroforum.csl
@@ -2,7 +2,7 @@
 <style xmlns="http://purl.org/net/xbiblio/csl" version="1.0" default-locale="de-DE">
   <!-- Generated with https://github.com/citation-style-language/utilities/tree/master/generate_dependent_styles/data/springer -->
   <info>
-    <title>Neuroforum (German)</title>
+    <title>Neuroforum (Deutsch)</title>
     <id>http://www.zotero.org/styles/neuroforum</id>
     <link href="http://www.zotero.org/styles/neuroforum" rel="self"/>
     <link href="http://www.zotero.org/styles/springer-basic-brackets" rel="independent-parent"/>

--- a/dependent/neuropsychiatrie.csl
+++ b/dependent/neuropsychiatrie.csl
@@ -2,7 +2,7 @@
 <style xmlns="http://purl.org/net/xbiblio/csl" version="1.0" default-locale="de-DE">
   <!-- Generated with https://github.com/citation-style-language/utilities/tree/master/generate_dependent_styles/data/springer -->
   <info>
-    <title>neuropsychiatrie (German)</title>
+    <title>neuropsychiatrie (Deutsch)</title>
     <title-short>Neuropsychiatr</title-short>
     <id>http://www.zotero.org/styles/neuropsychiatrie</id>
     <link href="http://www.zotero.org/styles/neuropsychiatrie" rel="self"/>

--- a/dependent/notfall-rettungsmedizin.csl
+++ b/dependent/notfall-rettungsmedizin.csl
@@ -2,7 +2,7 @@
 <style xmlns="http://purl.org/net/xbiblio/csl" version="1.0" default-locale="de-DE">
   <!-- Generated with https://github.com/citation-style-language/utilities/tree/master/generate_dependent_styles/data/springer-fachzeitschriften-medizin -->
   <info>
-    <title>Notfall +  Rettungsmedizin (German)</title>
+    <title>Notfall +  Rettungsmedizin (Deutsch)</title>
     <title-short>Notfall Rettungsmedizin</title-short>
     <id>http://www.zotero.org/styles/notfall-rettungsmedizin</id>
     <link href="http://www.zotero.org/styles/notfall-rettungsmedizin" rel="self"/>

--- a/dependent/o-bib.csl
+++ b/dependent/o-bib.csl
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <style xmlns="http://purl.org/net/xbiblio/csl" version="1.0" default-locale="de-DE">
   <info>
-    <title>o-bib (German)</title>
+    <title>o-bib (Deutsch)</title>
     <id>http://www.zotero.org/styles/o-bib</id>
     <link href="http://www.zotero.org/styles/o-bib" rel="self"/>
     <link href="http://www.zotero.org/styles/infoclio-de" rel="independent-parent"/>

--- a/dependent/obere-extremitat.csl
+++ b/dependent/obere-extremitat.csl
@@ -2,7 +2,7 @@
 <style xmlns="http://purl.org/net/xbiblio/csl" version="1.0" default-locale="de-DE">
   <!-- Generated with https://github.com/citation-style-language/utilities/tree/master/generate_dependent_styles/data/springer-fachzeitschriften-medizin -->
   <info>
-    <title>Obere Extremität (German)</title>
+    <title>Obere Extremität (Deutsch)</title>
     <title-short>Obere Extremität</title-short>
     <id>http://www.zotero.org/styles/obere-extremitat</id>
     <link href="http://www.zotero.org/styles/obere-extremitat" rel="self"/>

--- a/dependent/operative-orthopadie-und-traumatologie.csl
+++ b/dependent/operative-orthopadie-und-traumatologie.csl
@@ -2,7 +2,7 @@
 <style xmlns="http://purl.org/net/xbiblio/csl" version="1.0" default-locale="de-DE">
   <!-- Generated with https://github.com/citation-style-language/utilities/tree/master/generate_dependent_styles/data/springer-fachzeitschriften-medizin -->
   <info>
-    <title>Operative Orthopädie und Traumatologie (German)</title>
+    <title>Operative Orthopädie und Traumatologie (Deutsch)</title>
     <title-short>Operative Orthopädie Traumatologie</title-short>
     <id>http://www.zotero.org/styles/operative-orthopadie-und-traumatologie</id>
     <link href="http://www.zotero.org/styles/operative-orthopadie-und-traumatologie" rel="self"/>

--- a/dependent/organisationsberatung-supervision-coaching.csl
+++ b/dependent/organisationsberatung-supervision-coaching.csl
@@ -2,7 +2,7 @@
 <style xmlns="http://purl.org/net/xbiblio/csl" version="1.0" default-locale="de-DE">
   <!-- Generated with https://github.com/citation-style-language/utilities/tree/master/generate_dependent_styles/data/springer -->
   <info>
-    <title>Organisationsberatung, Supervision, Coaching (German)</title>
+    <title>Organisationsberatung, Supervision, Coaching (Deutsch)</title>
     <title-short>Organisationsberat Superv Coach</title-short>
     <id>http://www.zotero.org/styles/organisationsberatung-supervision-coaching</id>
     <link href="http://www.zotero.org/styles/organisationsberatung-supervision-coaching" rel="self"/>

--- a/dependent/osterreichische-zeitschrift-fur-soziologie.csl
+++ b/dependent/osterreichische-zeitschrift-fur-soziologie.csl
@@ -2,7 +2,7 @@
 <style xmlns="http://purl.org/net/xbiblio/csl" version="1.0" default-locale="de-DE">
   <!-- Generated with https://github.com/citation-style-language/utilities/tree/master/generate_dependent_styles/data/springer -->
   <info>
-    <title>Österreichische Zeitschrift für Soziologie (German)</title>
+    <title>Österreichische Zeitschrift für Soziologie (Deutsch)</title>
     <title-short>Österreich Z Soziol</title-short>
     <id>http://www.zotero.org/styles/osterreichische-zeitschrift-fur-soziologie</id>
     <link href="http://www.zotero.org/styles/osterreichische-zeitschrift-fur-soziologie" rel="self"/>

--- a/dependent/padiatrie-und-padologie.csl
+++ b/dependent/padiatrie-und-padologie.csl
@@ -2,7 +2,7 @@
 <style xmlns="http://purl.org/net/xbiblio/csl" version="1.0" default-locale="de-DE">
   <!-- Generated with https://github.com/citation-style-language/utilities/tree/master/generate_dependent_styles/data/springer -->
   <info>
-    <title>Pädiatrie &amp; Pädologie (German)</title>
+    <title>Pädiatrie &amp; Pädologie (Deutsch)</title>
     <id>http://www.zotero.org/styles/padiatrie-und-padologie</id>
     <link href="http://www.zotero.org/styles/padiatrie-und-padologie" rel="self"/>
     <link href="http://www.zotero.org/styles/springer-basic-brackets" rel="independent-parent"/>

--- a/dependent/pontifical-gregorian-university-de.csl
+++ b/dependent/pontifical-gregorian-university-de.csl
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <style xmlns="http://purl.org/net/xbiblio/csl" version="1.0" default-locale="de-DE">
   <info>
-    <title>Pontifical Gregorian University (German)</title>
+    <title>Pontifical Gregorian University (Deutsch)</title>
     <id>http://www.zotero.org/styles/pontifical-gregorian-university-de</id>
     <link href="http://www.zotero.org/styles/pontifical-gregorian-university-de" rel="self"/>
     <link href="http://www.zotero.org/styles/pontifical-gregorian-university" rel="independent-parent"/>
@@ -12,7 +12,7 @@
     </author>
     <category citation-format="note"/>
     <category field="theology"/>
-    <summary>The Pontifical Gregorian University (Pontificia Università Gregoriana) style (German)</summary>
+    <summary>The Pontifical Gregorian University (Pontificia Università Gregoriana) style (Deutsch)</summary>
     <updated>2016-06-09T14:56:21+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>

--- a/dependent/pravention-und-gesundheitsforderung.csl
+++ b/dependent/pravention-und-gesundheitsforderung.csl
@@ -2,7 +2,7 @@
 <style xmlns="http://purl.org/net/xbiblio/csl" version="1.0" default-locale="de-DE">
   <!-- Generated with https://github.com/citation-style-language/utilities/tree/master/generate_dependent_styles/data/springer-fachzeitschriften-medizin -->
   <info>
-    <title>Prävention und Gesundheitsförderung (German)</title>
+    <title>Prävention und Gesundheitsförderung (Deutsch)</title>
     <title-short>Prävention Gesundheitsförderung</title-short>
     <id>http://www.zotero.org/styles/pravention-und-gesundheitsforderung</id>
     <link href="http://www.zotero.org/styles/pravention-und-gesundheitsforderung" rel="self"/>

--- a/dependent/prifysgol-caerdydd-harvard.csl
+++ b/dependent/prifysgol-caerdydd-harvard.csl
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <style xmlns="http://purl.org/net/xbiblio/csl" version="1.0" default-locale="cy-GB">
   <info>
-    <title>Prifysgol Caerdydd - Harvard (Welsh)</title>
+    <title>Prifysgol Caerdydd - Harvard (Cymraeg)</title>
     <id>http://www.zotero.org/styles/prifysgol-caerdydd-harvard</id>
     <link href="http://www.zotero.org/styles/prifysgol-caerdydd-harvard" rel="self"/>
     <link href="http://www.zotero.org/styles/harvard-cardiff-university" rel="independent-parent"/>

--- a/dependent/psychopraxis-neuropraxis.csl
+++ b/dependent/psychopraxis-neuropraxis.csl
@@ -2,7 +2,7 @@
 <style xmlns="http://purl.org/net/xbiblio/csl" version="1.0" default-locale="de-DE">
   <!-- Generated with https://github.com/citation-style-language/utilities/tree/master/generate_dependent_styles/data/springer -->
   <info>
-    <title>psychopraxis. neuropraxis (German)</title>
+    <title>psychopraxis. neuropraxis (Deutsch)</title>
     <id>http://www.zotero.org/styles/psychopraxis-neuropraxis</id>
     <link href="http://www.zotero.org/styles/psychopraxis-neuropraxis" rel="self"/>
     <link href="http://www.zotero.org/styles/springer-basic-brackets" rel="independent-parent"/>

--- a/dependent/psychotherapeut.csl
+++ b/dependent/psychotherapeut.csl
@@ -2,7 +2,7 @@
 <style xmlns="http://purl.org/net/xbiblio/csl" version="1.0" default-locale="de-DE">
   <!-- Generated with https://github.com/citation-style-language/utilities/tree/master/generate_dependent_styles/data/springer-fachzeitschriften-medizin -->
   <info>
-    <title>Psychotherapeut (German)</title>
+    <title>Psychotherapeut (Deutsch)</title>
     <title-short>Psychotherapeut</title-short>
     <id>http://www.zotero.org/styles/psychotherapeut</id>
     <link href="http://www.zotero.org/styles/psychotherapeut" rel="self"/>

--- a/dependent/psychotherapie-forum.csl
+++ b/dependent/psychotherapie-forum.csl
@@ -2,7 +2,7 @@
 <style xmlns="http://purl.org/net/xbiblio/csl" version="1.0" default-locale="de-DE">
   <!-- Generated with https://github.com/citation-style-language/utilities/tree/master/generate_dependent_styles/data/springer -->
   <info>
-    <title>Psychotherapie Forum (German)</title>
+    <title>Psychotherapie Forum (Deutsch)</title>
     <id>http://www.zotero.org/styles/psychotherapie-forum</id>
     <link href="http://www.zotero.org/styles/psychotherapie-forum" rel="self"/>
     <link href="http://www.zotero.org/styles/springer-socpsych-author-date" rel="independent-parent"/>

--- a/dependent/publizistik.csl
+++ b/dependent/publizistik.csl
@@ -2,7 +2,7 @@
 <style xmlns="http://purl.org/net/xbiblio/csl" version="1.0" default-locale="de-DE">
   <!-- Generated with https://github.com/citation-style-language/utilities/tree/master/generate_dependent_styles/data/springer -->
   <info>
-    <title>Publizistik (German)</title>
+    <title>Publizistik (Deutsch)</title>
     <title-short>Publizistik</title-short>
     <id>http://www.zotero.org/styles/publizistik</id>
     <link href="http://www.zotero.org/styles/publizistik" rel="self"/>

--- a/dependent/rechtsmedizin.csl
+++ b/dependent/rechtsmedizin.csl
@@ -2,7 +2,7 @@
 <style xmlns="http://purl.org/net/xbiblio/csl" version="1.0" default-locale="de-DE">
   <!-- Generated with https://github.com/citation-style-language/utilities/tree/master/generate_dependent_styles/data/springer-fachzeitschriften-medizin -->
   <info>
-    <title>Rechtsmedizin (German)</title>
+    <title>Rechtsmedizin (Deutsch)</title>
     <title-short>Rechtsmedizin</title-short>
     <id>http://www.zotero.org/styles/rechtsmedizin</id>
     <link href="http://www.zotero.org/styles/rechtsmedizin" rel="self"/>

--- a/dependent/rheuma-plus.csl
+++ b/dependent/rheuma-plus.csl
@@ -2,7 +2,7 @@
 <style xmlns="http://purl.org/net/xbiblio/csl" version="1.0" default-locale="de-DE">
   <!-- Generated with https://github.com/citation-style-language/utilities/tree/master/generate_dependent_styles/data/springer -->
   <info>
-    <title>rheuma plus (German)</title>
+    <title>rheuma plus (Deutsch)</title>
     <id>http://www.zotero.org/styles/rheuma-plus</id>
     <link href="http://www.zotero.org/styles/rheuma-plus" rel="self"/>
     <link href="http://www.zotero.org/styles/springer-basic-brackets" rel="independent-parent"/>

--- a/dependent/samples.csl
+++ b/dependent/samples.csl
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <style xmlns="http://purl.org/net/xbiblio/csl" version="1.0" default-locale="de-DE">
   <info>
-    <title>Samples (German)</title>
+    <title>Samples (Deutsch)</title>
     <id>http://www.zotero.org/styles/samples</id>
     <link href="http://www.zotero.org/styles/samples" rel="self"/>
     <link href="http://www.zotero.org/styles/gesellschaft-fur-popularmusikforschung" rel="independent-parent"/>

--- a/dependent/somnologie-schlafforschung-und-schlafmedizin.csl
+++ b/dependent/somnologie-schlafforschung-und-schlafmedizin.csl
@@ -2,7 +2,7 @@
 <style xmlns="http://purl.org/net/xbiblio/csl" version="1.0" default-locale="de-DE">
   <!-- Generated with https://github.com/citation-style-language/utilities/tree/master/generate_dependent_styles/data/springer-fachzeitschriften-medizin -->
   <info>
-    <title>Somnologie - Schlafforschung und Schlafmedizin (German)</title>
+    <title>Somnologie - Schlafforschung und Schlafmedizin (Deutsch)</title>
     <title-short>Somnologie Schlafforschung Schlafmedizin</title-short>
     <id>http://www.zotero.org/styles/somnologie-schlafforschung-und-schlafmedizin</id>
     <link href="http://www.zotero.org/styles/somnologie-schlafforschung-und-schlafmedizin" rel="self"/>

--- a/dependent/soziale-passagen.csl
+++ b/dependent/soziale-passagen.csl
@@ -2,7 +2,7 @@
 <style xmlns="http://purl.org/net/xbiblio/csl" version="1.0" default-locale="de-DE">
   <!-- Generated with https://github.com/citation-style-language/utilities/tree/master/generate_dependent_styles/data/springer -->
   <info>
-    <title>Soziale Passagen (German)</title>
+    <title>Soziale Passagen (Deutsch)</title>
     <title-short>Soz Passagen</title-short>
     <id>http://www.zotero.org/styles/soziale-passagen</id>
     <link href="http://www.zotero.org/styles/soziale-passagen" rel="self"/>

--- a/dependent/soziale-probleme.csl
+++ b/dependent/soziale-probleme.csl
@@ -2,7 +2,7 @@
 <style xmlns="http://purl.org/net/xbiblio/csl" version="1.0" default-locale="de-DE">
   <!-- Generated with https://github.com/citation-style-language/utilities/tree/master/generate_dependent_styles/data/springer -->
   <info>
-    <title>Soziale Probleme (German)</title>
+    <title>Soziale Probleme (Deutsch)</title>
     <id>http://www.zotero.org/styles/soziale-probleme</id>
     <link href="http://www.zotero.org/styles/soziale-probleme" rel="self"/>
     <link href="http://www.zotero.org/styles/springer-humanities-author-date" rel="independent-parent"/>

--- a/dependent/spektrum-der-augenheilkunde.csl
+++ b/dependent/spektrum-der-augenheilkunde.csl
@@ -2,7 +2,7 @@
 <style xmlns="http://purl.org/net/xbiblio/csl" version="1.0" default-locale="de-DE">
   <!-- Generated with https://github.com/citation-style-language/utilities/tree/master/generate_dependent_styles/data/springer -->
   <info>
-    <title>Spektrum der Augenheilkunde (German)</title>
+    <title>Spektrum der Augenheilkunde (Deutsch)</title>
     <title-short>Spektrum Augenheilkd.</title-short>
     <id>http://www.zotero.org/styles/spektrum-der-augenheilkunde</id>
     <link href="http://www.zotero.org/styles/spektrum-der-augenheilkunde" rel="self"/>

--- a/dependent/sportwissenschaft.csl
+++ b/dependent/sportwissenschaft.csl
@@ -2,7 +2,7 @@
 <style xmlns="http://purl.org/net/xbiblio/csl" version="1.0" default-locale="de-DE">
   <!-- Generated with https://github.com/citation-style-language/utilities/tree/master/generate_dependent_styles/data/springer -->
   <info>
-    <title>Sportwissenschaft (German)</title>
+    <title>Sportwissenschaft (Deutsch)</title>
     <title-short>Sportwiss</title-short>
     <id>http://www.zotero.org/styles/sportwissenschaft</id>
     <link href="http://www.zotero.org/styles/sportwissenschaft" rel="self"/>

--- a/dependent/standort.csl
+++ b/dependent/standort.csl
@@ -2,7 +2,7 @@
 <style xmlns="http://purl.org/net/xbiblio/csl" version="1.0" default-locale="de-DE">
   <!-- Generated with https://github.com/citation-style-language/utilities/tree/master/generate_dependent_styles/data/springer -->
   <info>
-    <title>Standort (German)</title>
+    <title>Standort (Deutsch)</title>
     <title-short>Standort</title-short>
     <id>http://www.zotero.org/styles/standort</id>
     <link href="http://www.zotero.org/styles/standort" rel="self"/>

--- a/dependent/stomatologie.csl
+++ b/dependent/stomatologie.csl
@@ -2,7 +2,7 @@
 <style xmlns="http://purl.org/net/xbiblio/csl" version="1.0" default-locale="de-DE">
   <!-- Generated with https://github.com/citation-style-language/utilities/tree/master/generate_dependent_styles/data/springer-fachzeitschriften-medizin -->
   <info>
-    <title>Stomatologie (German)</title>
+    <title>Stomatologie (Deutsch)</title>
     <title-short>Stomatologie</title-short>
     <id>http://www.zotero.org/styles/stomatologie</id>
     <link href="http://www.zotero.org/styles/stomatologie" rel="self"/>

--- a/dependent/trauma-und-berufskrankheit.csl
+++ b/dependent/trauma-und-berufskrankheit.csl
@@ -2,7 +2,7 @@
 <style xmlns="http://purl.org/net/xbiblio/csl" version="1.0" default-locale="de-DE">
   <!-- Generated with https://github.com/citation-style-language/utilities/tree/master/generate_dependent_styles/data/springer-fachzeitschriften-medizin -->
   <info>
-    <title>Trauma und Berufskrankheit (German)</title>
+    <title>Trauma und Berufskrankheit (Deutsch)</title>
     <title-short>Trauma Berufskrankheit</title-short>
     <id>http://www.zotero.org/styles/trauma-und-berufskrankheit</id>
     <link href="http://www.zotero.org/styles/trauma-und-berufskrankheit" rel="self"/>

--- a/dependent/uwf-umweltwirtschaftsforum.csl
+++ b/dependent/uwf-umweltwirtschaftsforum.csl
@@ -2,7 +2,7 @@
 <style xmlns="http://purl.org/net/xbiblio/csl" version="1.0" default-locale="de-DE">
   <!-- Generated with https://github.com/citation-style-language/utilities/tree/master/generate_dependent_styles/data/springer -->
   <info>
-    <title>uwf UmweltWirtschaftsForum (German)</title>
+    <title>uwf UmweltWirtschaftsForum (Deutsch)</title>
     <title-short>uwf</title-short>
     <id>http://www.zotero.org/styles/uwf-umweltwirtschaftsforum</id>
     <link href="http://www.zotero.org/styles/uwf-umweltwirtschaftsforum" rel="self"/>

--- a/dependent/wiener-klinische-wochenschrift-education.csl
+++ b/dependent/wiener-klinische-wochenschrift-education.csl
@@ -2,7 +2,7 @@
 <style xmlns="http://purl.org/net/xbiblio/csl" version="1.0" default-locale="de-DE">
   <!-- Generated with https://github.com/citation-style-language/utilities/tree/master/generate_dependent_styles/data/springer -->
   <info>
-    <title>Wiener klinische Wochenschrift Education (German)</title>
+    <title>Wiener klinische Wochenschrift Education (Deutsch)</title>
     <title-short>Wien. Klin. Wochenschr. Educ</title-short>
     <id>http://www.zotero.org/styles/wiener-klinische-wochenschrift-education</id>
     <link href="http://www.zotero.org/styles/wiener-klinische-wochenschrift-education" rel="self"/>

--- a/dependent/wiener-klinisches-magazin.csl
+++ b/dependent/wiener-klinisches-magazin.csl
@@ -2,7 +2,7 @@
 <style xmlns="http://purl.org/net/xbiblio/csl" version="1.0" default-locale="de-DE">
   <!-- Generated with https://github.com/citation-style-language/utilities/tree/master/generate_dependent_styles/data/springer -->
   <info>
-    <title>Wiener klinisches Magazin (German)</title>
+    <title>Wiener klinisches Magazin (Deutsch)</title>
     <id>http://www.zotero.org/styles/wiener-klinisches-magazin</id>
     <link href="http://www.zotero.org/styles/wiener-klinisches-magazin" rel="self"/>
     <link href="http://www.zotero.org/styles/springer-basic-brackets" rel="independent-parent"/>

--- a/dependent/wiener-medizinische-wochenschrift.csl
+++ b/dependent/wiener-medizinische-wochenschrift.csl
@@ -2,7 +2,7 @@
 <style xmlns="http://purl.org/net/xbiblio/csl" version="1.0" default-locale="de-DE">
   <!-- Generated with https://github.com/citation-style-language/utilities/tree/master/generate_dependent_styles/data/springer -->
   <info>
-    <title>Wiener Medizinische Wochenschrift (German)</title>
+    <title>Wiener Medizinische Wochenschrift (Deutsch)</title>
     <title-short>Wien Med Wochenschr</title-short>
     <id>http://www.zotero.org/styles/wiener-medizinische-wochenschrift</id>
     <link href="http://www.zotero.org/styles/wiener-medizinische-wochenschrift" rel="self"/>

--- a/dependent/wissen-kompakt.csl
+++ b/dependent/wissen-kompakt.csl
@@ -2,7 +2,7 @@
 <style xmlns="http://purl.org/net/xbiblio/csl" version="1.0" default-locale="de-DE">
   <!-- Generated with https://github.com/citation-style-language/utilities/tree/master/generate_dependent_styles/data/springer-fachzeitschriften-medizin -->
   <info>
-    <title>wissen kompakt (German)</title>
+    <title>wissen kompakt (Deutsch)</title>
     <title-short>wissen kompakt</title-short>
     <id>http://www.zotero.org/styles/wissen-kompakt</id>
     <link href="http://www.zotero.org/styles/wissen-kompakt" rel="self"/>

--- a/dependent/zeitschrift-fur-aussen-und-sicherheitspolitik.csl
+++ b/dependent/zeitschrift-fur-aussen-und-sicherheitspolitik.csl
@@ -2,7 +2,7 @@
 <style xmlns="http://purl.org/net/xbiblio/csl" version="1.0" default-locale="de-DE">
   <!-- Generated with https://github.com/citation-style-language/utilities/tree/master/generate_dependent_styles/data/springer -->
   <info>
-    <title>Zeitschrift für Außen- und Sicherheitspolitik (German)</title>
+    <title>Zeitschrift für Außen- und Sicherheitspolitik (Deutsch)</title>
     <title-short>Z Außen Sicherheitspolit</title-short>
     <id>http://www.zotero.org/styles/zeitschrift-fur-aussen-und-sicherheitspolitik</id>
     <link href="http://www.zotero.org/styles/zeitschrift-fur-aussen-und-sicherheitspolitik" rel="self"/>

--- a/dependent/zeitschrift-fur-bildungsforschung.csl
+++ b/dependent/zeitschrift-fur-bildungsforschung.csl
@@ -2,7 +2,7 @@
 <style xmlns="http://purl.org/net/xbiblio/csl" version="1.0" default-locale="de-DE">
   <!-- Generated with https://github.com/citation-style-language/utilities/tree/master/generate_dependent_styles/data/springer -->
   <info>
-    <title>Zeitschrift für Bildungsforschung (German)</title>
+    <title>Zeitschrift für Bildungsforschung (Deutsch)</title>
     <title-short>Z f Bildungsforsch</title-short>
     <id>http://www.zotero.org/styles/zeitschrift-fur-bildungsforschung</id>
     <link href="http://www.zotero.org/styles/zeitschrift-fur-bildungsforschung" rel="self"/>

--- a/dependent/zeitschrift-fur-didaktik-der-naturwissenschaften.csl
+++ b/dependent/zeitschrift-fur-didaktik-der-naturwissenschaften.csl
@@ -2,7 +2,7 @@
 <style xmlns="http://purl.org/net/xbiblio/csl" version="1.0" default-locale="de-DE">
   <!-- Generated with https://github.com/citation-style-language/utilities/tree/master/generate_dependent_styles/data/springer -->
   <info>
-    <title>Zeitschrift für Didaktik der Naturwissenschaften (German)</title>
+    <title>Zeitschrift für Didaktik der Naturwissenschaften (Deutsch)</title>
     <id>http://www.zotero.org/styles/zeitschrift-fur-didaktik-der-naturwissenschaften</id>
     <link href="http://www.zotero.org/styles/zeitschrift-fur-didaktik-der-naturwissenschaften" rel="self"/>
     <link href="http://www.zotero.org/styles/springer-socpsych-author-date" rel="independent-parent"/>

--- a/dependent/zeitschrift-fur-die-gesamte-versicherungswissenschaft.csl
+++ b/dependent/zeitschrift-fur-die-gesamte-versicherungswissenschaft.csl
@@ -2,7 +2,7 @@
 <style xmlns="http://purl.org/net/xbiblio/csl" version="1.0" default-locale="de-DE">
   <!-- Generated with https://github.com/citation-style-language/utilities/tree/master/generate_dependent_styles/data/springer -->
   <info>
-    <title>Zeitschrift für die gesamte Versicherungswissenschaft (German)</title>
+    <title>Zeitschrift für die gesamte Versicherungswissenschaft (Deutsch)</title>
     <title-short>ZVersWiss</title-short>
     <id>http://www.zotero.org/styles/zeitschrift-fur-die-gesamte-versicherungswissenschaft</id>
     <link href="http://www.zotero.org/styles/zeitschrift-fur-die-gesamte-versicherungswissenschaft" rel="self"/>

--- a/dependent/zeitschrift-fur-energiewirtschaft.csl
+++ b/dependent/zeitschrift-fur-energiewirtschaft.csl
@@ -2,7 +2,7 @@
 <style xmlns="http://purl.org/net/xbiblio/csl" version="1.0" default-locale="de-DE">
   <!-- Generated with https://github.com/citation-style-language/utilities/tree/master/generate_dependent_styles/data/springer -->
   <info>
-    <title>Zeitschrift für Energiewirtschaft (German)</title>
+    <title>Zeitschrift für Energiewirtschaft (Deutsch)</title>
     <title-short>Z Energiewirtsch</title-short>
     <id>http://www.zotero.org/styles/zeitschrift-fur-energiewirtschaft</id>
     <link href="http://www.zotero.org/styles/zeitschrift-fur-energiewirtschaft" rel="self"/>

--- a/dependent/zeitschrift-fur-epileptologie.csl
+++ b/dependent/zeitschrift-fur-epileptologie.csl
@@ -2,7 +2,7 @@
 <style xmlns="http://purl.org/net/xbiblio/csl" version="1.0" default-locale="de-DE">
   <!-- Generated with https://github.com/citation-style-language/utilities/tree/master/generate_dependent_styles/data/springer-fachzeitschriften-medizin -->
   <info>
-    <title>Zeitschrift für Epileptologie (German)</title>
+    <title>Zeitschrift für Epileptologie (Deutsch)</title>
     <title-short>Zeitschrift Epileptologie</title-short>
     <id>http://www.zotero.org/styles/zeitschrift-fur-epileptologie</id>
     <link href="http://www.zotero.org/styles/zeitschrift-fur-epileptologie" rel="self"/>

--- a/dependent/zeitschrift-fur-erziehungswissenschaft.csl
+++ b/dependent/zeitschrift-fur-erziehungswissenschaft.csl
@@ -2,7 +2,7 @@
 <style xmlns="http://purl.org/net/xbiblio/csl" version="1.0" default-locale="de-DE">
   <!-- Generated with https://github.com/citation-style-language/utilities/tree/master/generate_dependent_styles/data/springer -->
   <info>
-    <title>Zeitschrift für Erziehungswissenschaft (German)</title>
+    <title>Zeitschrift für Erziehungswissenschaft (Deutsch)</title>
     <title-short>Z Erziehungswiss</title-short>
     <id>http://www.zotero.org/styles/zeitschrift-fur-erziehungswissenschaft</id>
     <link href="http://www.zotero.org/styles/zeitschrift-fur-erziehungswissenschaft" rel="self"/>

--- a/dependent/zeitschrift-fur-gerontologie-und-geriatrie.csl
+++ b/dependent/zeitschrift-fur-gerontologie-und-geriatrie.csl
@@ -2,7 +2,7 @@
 <style xmlns="http://purl.org/net/xbiblio/csl" version="1.0" default-locale="de-DE">
   <!-- Generated with https://github.com/citation-style-language/utilities/tree/master/generate_dependent_styles/data/springer-fachzeitschriften-medizin -->
   <info>
-    <title>Zeitschrift für Gerontologie und Geriatrie (German)</title>
+    <title>Zeitschrift für Gerontologie und Geriatrie (Deutsch)</title>
     <title-short>Zeitschrift Gerontologie Geriatrie</title-short>
     <id>http://www.zotero.org/styles/zeitschrift-fur-gerontologie-und-geriatrie</id>
     <link href="http://www.zotero.org/styles/zeitschrift-fur-gerontologie-und-geriatrie" rel="self"/>

--- a/dependent/zeitschrift-fur-herz-thorax-und-gefasschirurgie.csl
+++ b/dependent/zeitschrift-fur-herz-thorax-und-gefasschirurgie.csl
@@ -2,7 +2,7 @@
 <style xmlns="http://purl.org/net/xbiblio/csl" version="1.0" default-locale="de-DE">
   <!-- Generated with https://github.com/citation-style-language/utilities/tree/master/generate_dependent_styles/data/springer-fachzeitschriften-medizin -->
   <info>
-    <title>Zeitschrift für Herz-,Thorax- und Gefäßchirurgie (German)</title>
+    <title>Zeitschrift für Herz-,Thorax- und Gefäßchirurgie (Deutsch)</title>
     <title-short>Zeitschrift Herz Thorax- Gefäßchirurgie</title-short>
     <id>http://www.zotero.org/styles/zeitschrift-fur-herz-thorax-und-gefasschirurgie</id>
     <link href="http://www.zotero.org/styles/zeitschrift-fur-herz-thorax-und-gefasschirurgie" rel="self"/>

--- a/dependent/zeitschrift-fur-immobilienokonomie.csl
+++ b/dependent/zeitschrift-fur-immobilienokonomie.csl
@@ -2,7 +2,7 @@
 <style xmlns="http://purl.org/net/xbiblio/csl" version="1.0" default-locale="de-DE">
   <!-- Generated with https://github.com/citation-style-language/utilities/tree/master/generate_dependent_styles/data/springer -->
   <info>
-    <title>Zeitschrift für Immobilienökonomie (German)</title>
+    <title>Zeitschrift für Immobilienökonomie (Deutsch)</title>
     <id>http://www.zotero.org/styles/zeitschrift-fur-immobilienokonomie</id>
     <link href="http://www.zotero.org/styles/zeitschrift-fur-immobilienokonomie" rel="self"/>
     <link href="http://www.zotero.org/styles/springer-basic-author-date" rel="independent-parent"/>

--- a/dependent/zeitschrift-fur-psychodrama-und-soziometrie.csl
+++ b/dependent/zeitschrift-fur-psychodrama-und-soziometrie.csl
@@ -2,7 +2,7 @@
 <style xmlns="http://purl.org/net/xbiblio/csl" version="1.0" default-locale="de-DE">
   <!-- Generated with https://github.com/citation-style-language/utilities/tree/master/generate_dependent_styles/data/springer -->
   <info>
-    <title>Zeitschrift für Psychodrama und Soziometrie (German)</title>
+    <title>Zeitschrift für Psychodrama und Soziometrie (Deutsch)</title>
     <title-short>Z Psychodrama Soziometr</title-short>
     <id>http://www.zotero.org/styles/zeitschrift-fur-psychodrama-und-soziometrie</id>
     <link href="http://www.zotero.org/styles/zeitschrift-fur-psychodrama-und-soziometrie" rel="self"/>

--- a/dependent/zeitschrift-fur-rheumatologie.csl
+++ b/dependent/zeitschrift-fur-rheumatologie.csl
@@ -2,7 +2,7 @@
 <style xmlns="http://purl.org/net/xbiblio/csl" version="1.0" default-locale="de-DE">
   <!-- Generated with https://github.com/citation-style-language/utilities/tree/master/generate_dependent_styles/data/springer-fachzeitschriften-medizin -->
   <info>
-    <title>Zeitschrift für Rheumatologie (German)</title>
+    <title>Zeitschrift für Rheumatologie (Deutsch)</title>
     <title-short>Zeitschrift Rheumatologie</title-short>
     <id>http://www.zotero.org/styles/zeitschrift-fur-rheumatologie</id>
     <link href="http://www.zotero.org/styles/zeitschrift-fur-rheumatologie" rel="self"/>

--- a/dependent/zeitschrift-fur-vergleichende-politikwissenschaft.csl
+++ b/dependent/zeitschrift-fur-vergleichende-politikwissenschaft.csl
@@ -2,7 +2,7 @@
 <style xmlns="http://purl.org/net/xbiblio/csl" version="1.0" default-locale="de-DE">
   <!-- Generated with https://github.com/citation-style-language/utilities/tree/master/generate_dependent_styles/data/springer -->
   <info>
-    <title>Zeitschrift für Vergleichende Politikwissenschaft (German)</title>
+    <title>Zeitschrift für Vergleichende Politikwissenschaft (Deutsch)</title>
     <title-short>Z Vgl Polit Wiss</title-short>
     <id>http://www.zotero.org/styles/zeitschrift-fur-vergleichende-politikwissenschaft</id>
     <link href="http://www.zotero.org/styles/zeitschrift-fur-vergleichende-politikwissenschaft" rel="self"/>

--- a/dependent/zeitschrift-fur-weiterbildungsforschung-report.csl
+++ b/dependent/zeitschrift-fur-weiterbildungsforschung-report.csl
@@ -2,7 +2,7 @@
 <style xmlns="http://purl.org/net/xbiblio/csl" version="1.0" default-locale="de-DE">
   <!-- Generated with https://github.com/citation-style-language/utilities/tree/master/generate_dependent_styles/data/springer -->
   <info>
-    <title>Zeitschrift für Weiterbildungsforschung - Report (German)</title>
+    <title>Zeitschrift für Weiterbildungsforschung - Report (Deutsch)</title>
     <id>http://www.zotero.org/styles/zeitschrift-fur-weiterbildungsforschung-report</id>
     <link href="http://www.zotero.org/styles/zeitschrift-fur-weiterbildungsforschung-report" rel="self"/>
     <link href="http://www.zotero.org/styles/springer-socpsych-author-date" rel="independent-parent"/>

--- a/dependent/zentralblatt-fur-arbeitsmedizin-arbeitsschutz-und-ergonomie.csl
+++ b/dependent/zentralblatt-fur-arbeitsmedizin-arbeitsschutz-und-ergonomie.csl
@@ -2,7 +2,7 @@
 <style xmlns="http://purl.org/net/xbiblio/csl" version="1.0" default-locale="de-DE">
   <!-- Generated with https://github.com/citation-style-language/utilities/tree/master/generate_dependent_styles/data/springer-fachzeitschriften-medizin -->
   <info>
-    <title>Zentralblatt für Arbeitsmedizin, Arbeitsschutz und Ergonomie (German)</title>
+    <title>Zentralblatt für Arbeitsmedizin, Arbeitsschutz und Ergonomie (Deutsch)</title>
     <title-short>Zentralblatt Arbeitsmedizin Arbeitsschutz Ergonomie</title-short>
     <id>http://www.zotero.org/styles/zentralblatt-fur-arbeitsmedizin-arbeitsschutz-und-ergonomie</id>
     <link href="http://www.zotero.org/styles/zentralblatt-fur-arbeitsmedizin-arbeitsschutz-und-ergonomie" rel="self"/>

--- a/dependent/zurcher-hochschule-fur-angewandte-wissenschaften-zitierguide.csl
+++ b/dependent/zurcher-hochschule-fur-angewandte-wissenschaften-zitierguide.csl
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <style xmlns="http://purl.org/net/xbiblio/csl" version="1.0" class="note" default-locale="de-CH">
   <info>
-    <title>Zürcher Hochschule für Angewandte Wissenschaften - ZitierGuide (Roger Müller) (German - Switzerland)</title>
+    <title>Zürcher Hochschule für Angewandte Wissenschaften - ZitierGuide (Roger Müller) (Deutsch - Schweiz)</title>
     <title-short>ZHAW-ZitierGuide-Müller</title-short>
     <id>http://www.zotero.org/styles/zurcher-hochschule-fur-angewandte-wissenschaften-zitierguide</id>
     <link href="http://www.zotero.org/styles/zurcher-hochschule-fur-angewandte-wissenschaften-zitierguide" rel="self"/>

--- a/der-moderne-staat.csl
+++ b/der-moderne-staat.csl
@@ -2,7 +2,7 @@
 <style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" demote-non-dropping-particle="sort-only" default-locale="de-DE">
   <!-- This style was edited with the Visual CSL Editor (http://editor.citationstyles.org/visualEditor/) -->
   <info>
-    <title>der moderne staat (German)</title>
+    <title>der moderne staat (Deutsch)</title>
     <title-short>dms</title-short>
     <id>http://www.zotero.org/styles/der-moderne-staat</id>
     <link href="http://www.zotero.org/styles/der-moderne-staat" rel="self"/>

--- a/deutsche-gesellschaft-fur-psychologie.csl
+++ b/deutsche-gesellschaft-fur-psychologie.csl
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" demote-non-dropping-particle="sort-only" default-locale="de-DE">
   <info>
-    <title>Deutsche Gesellschaft für Psychologie (German)</title>
+    <title>Deutsche Gesellschaft für Psychologie (Deutsch)</title>
     <id>http://www.zotero.org/styles/deutsche-gesellschaft-fur-psychologie</id>
     <link href="http://www.zotero.org/styles/deutsche-gesellschaft-fur-psychologie" rel="self"/>
     <link href="https://www.psychologie.uni-bonn.de/de/studium/richtlinien-zur-manuskriptgestaltung/view" rel="documentation"/>

--- a/deutsche-sprache.csl
+++ b/deutsche-sprache.csl
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" demote-non-dropping-particle="never" default-locale="de-DE">
   <info>
-    <title>Deutsche Sprache (German)</title>
+    <title>Deutsche Sprache (Deutsch)</title>
     <id>http://www.zotero.org/styles/deutsche-sprache</id>
     <link href="http://www.zotero.org/styles/deutsche-sprache" rel="self"/>
     <link xml:lang="de" href="http://pub.ids-mannheim.de/laufend/deusprach/hinweise.pdf" rel="documentation"/>

--- a/die-bachelorarbeit-samac-et-al-in-text.csl
+++ b/die-bachelorarbeit-samac-et-al-in-text.csl
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" demote-non-dropping-particle="never" default-locale="de-DE">
   <info>
-    <title>Die Bachelorarbeit (Samac et al.) (in-text, German)</title>
+    <title>Die Bachelorarbeit (Samac et al.) (in-text, Deutsch)</title>
     <id>http://www.zotero.org/styles/die-bachelorarbeit-samac-et-al-in-text</id>
     <link href="http://www.zotero.org/styles/die-bachelorarbeit-samac-et-al-in-text" rel="self"/>
     <link href="http://www.zotero.org/styles/apa" rel="template"/>

--- a/die-bachelorarbeit-samac-et-al-note.csl
+++ b/die-bachelorarbeit-samac-et-al-note.csl
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <style xmlns="http://purl.org/net/xbiblio/csl" class="note" version="1.0" demote-non-dropping-particle="never" default-locale="de-DE">
   <info>
-    <title>Die Bachelorarbeit (Samac et al.) (note, German)</title>
+    <title>Die Bachelorarbeit (Samac et al.) (note, Deutsch)</title>
     <id>http://www.zotero.org/styles/die-bachelorarbeit-samac-et-al-note</id>
     <link href="http://www.zotero.org/styles/die-bachelorarbeit-samac-et-al-note" rel="self"/>
     <link href="http://www.zotero.org/styles/apa" rel="template"/>

--- a/donau-universitat-krems-department-fur-e-governance-in-wirthschaft-und-verwaltung.csl
+++ b/donau-universitat-krems-department-fur-e-governance-in-wirthschaft-und-verwaltung.csl
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <style xmlns="http://purl.org/net/xbiblio/csl" class="note" version="1.0" page-range-format="chicago" default-locale="de-AT">
   <info>
-    <title>Donau-Universität Krems - Department für E-Governance in Wirtschaft und Verwaltung (German - Austria)</title>
+    <title>Donau-Universität Krems - Department für E-Governance in Wirtschaft und Verwaltung (Deutsch - Österreich)</title>
     <id>http://www.zotero.org/styles/donau-universitat-krems-department-fur-e-governance-in-wirthschaft-und-verwaltung</id>
     <link href="http://www.zotero.org/styles/donau-universitat-krems-department-fur-e-governance-in-wirthschaft-und-verwaltung" rel="self"/>
     <link href="http://www.zotero.org/styles/chicago-fullnote-bibliography" rel="template"/>

--- a/egretta.csl
+++ b/egretta.csl
@@ -2,7 +2,7 @@
 <style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" and="symbol" initialize-with="." demote-non-dropping-particle="never" default-locale="de-AT">
   <!-- This style was edited with the Visual CSL Editor (http://editor.citationstyles.org/visualEditor/) -->
   <info>
-    <title>Egretta (German - Austria)</title>
+    <title>Egretta (Deutsch - Österreich)</title>
     <title-short>Egretta</title-short>
     <id>http://www.zotero.org/styles/egretta</id>
     <link href="http://www.zotero.org/styles/egretta" rel="self"/>

--- a/eva-berlin-konferenz.csl
+++ b/eva-berlin-konferenz.csl
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" demote-non-dropping-particle="never" default-locale="de-DE">
   <info>
-    <title>EVA Berlin Konferenz (German)</title>
+    <title>EVA Berlin Konferenz (Deutsch)</title>
     <id>http://www.zotero.org/styles/eva-berlin-konferenz</id>
     <link href="http://www.zotero.org/styles/eva-berlin-konferenz" rel="self"/>
     <link href="http://www.zotero.org/styles/iso690-numeric-en" rel="template"/>

--- a/fachhochschule-kiel-fachbereich-medien.csl
+++ b/fachhochschule-kiel-fachbereich-medien.csl
@@ -2,7 +2,7 @@
 <style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" demote-non-dropping-particle="sort-only" default-locale="de-DE">
   <!-- This style was edited with the Visual CSL Editor (http://editor.citationstyles.org/visualEditor/) -->
   <info>
-    <title>Fachhochschule Kiel - Fachbereich Medien (German)</title>
+    <title>Fachhochschule Kiel - Fachbereich Medien (Deutsch)</title>
     <title-short>FH Kiel | Medien</title-short>
     <id>http://www.zotero.org/styles/fachhochschule-kiel-fachbereich-medien</id>
     <link href="http://www.zotero.org/styles/fachhochschule-kiel-fachbereich-medien" rel="self"/>

--- a/ferdinand-porsche-fern-fachhochschule.csl
+++ b/ferdinand-porsche-fern-fachhochschule.csl
@@ -2,8 +2,8 @@
 <style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" demote-non-dropping-particle="sort-only" default-locale="de-AT">
   <!-- This style was edited with the Visual CSL Editor (https://editor.citationstyles.org/visualEditor/) -->
   <info>
-    <title>Ferdinand Porsche Fernfachhochschule (German - Austria)</title>
-    <title-short>Ferdinand Porsche FFH (German - Austria)</title-short>
+    <title>Ferdinand Porsche Fernfachhochschule (Deutsch - Österreich)</title>
+    <title-short>Ferdinand Porsche FFH (Deutsch - Österreich)</title-short>
     <id>http://www.zotero.org/styles/ferdinand-porsche-fern-fachhochschule</id>
     <link href="http://www.zotero.org/styles/ferdinand-porsche-fern-fachhochschule" rel="self"/>
     <link href="http://www.zotero.org/styles/harvard-cite-them-right" rel="template"/>

--- a/foerster-geisteswissenschaft.csl
+++ b/foerster-geisteswissenschaft.csl
@@ -6,7 +6,7 @@ INFORMATIONEN ZUM ZITIERSTIL
 ================================================================================
 -->
   <info>
-    <title>Sascha Foerster - Geisteswissenschaft (German)</title>
+    <title>Sascha Foerster - Geisteswissenschaft (Deutsch)</title>
     <title-short>zoteroSF</title-short>
     <id>http://www.zotero.org/styles/foerster-geisteswissenschaft</id>
     <link href="http://www.zotero.org/styles/foerster-geisteswissenschaft" rel="self"/>

--- a/forum-qualitative-sozialforschung.csl
+++ b/forum-qualitative-sozialforschung.csl
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" demote-non-dropping-particle="never" default-locale="de-DE">
   <info>
-    <title>Forum: Qualitative Sozialforschung (German)</title>
+    <title>Forum: Qualitative Sozialforschung (Deutsch)</title>
     <title-short>FQS</title-short>
     <id>http://www.zotero.org/styles/forum-qualitative-sozialforschung</id>
     <link href="http://www.zotero.org/styles/forum-qualitative-sozialforschung" rel="self"/>

--- a/freie-universitat-berlin-geographische-wissenschaften.csl
+++ b/freie-universitat-berlin-geographische-wissenschaften.csl
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" default-locale="de-DE" demote-non-dropping-particle="never">
   <info>
-    <title>Freie Universität Berlin - Geographische Wissenschaften (German)</title>
+    <title>Freie Universität Berlin - Geographische Wissenschaften (Deutsch)</title>
     <id>http://www.zotero.org/styles/freie-universitat-berlin-geographische-wissenschaften</id>
     <link href="http://www.zotero.org/styles/freie-universitat-berlin-geographische-wissenschaften" rel="self"/>
     <link href="http://www.geo.fu-berlin.de/geog/fachrichtungen/physgeog/medien/download/Studium_und_Lehre/Empfehlungen_Hausarbeiten.pdf?1373748910" rel="documentation"/>

--- a/friedrich-schiller-universitat-jena-medizinische-fakultat.csl
+++ b/friedrich-schiller-universitat-jena-medizinische-fakultat.csl
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" demote-non-dropping-particle="sort-only" default-locale="de-DE">
   <info>
-    <title>Friedrich-Schiller-Universität Jena - Medizinische Fakultät (German)</title>
+    <title>Friedrich-Schiller-Universität Jena - Medizinische Fakultät (Deutsch)</title>
     <id>http://www.zotero.org/styles/friedrich-schiller-universitat-jena-medizinische-fakultat</id>
     <link href="http://www.zotero.org/styles/friedrich-schiller-universitat-jena-medizinische-fakultat" rel="self"/>
     <link href="http://www.zotero.org/styles/aquatic-conservation" rel="template"/>

--- a/geistes-und-kulturwissenschaften-heilmann.csl
+++ b/geistes-und-kulturwissenschaften-heilmann.csl
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <style xmlns="http://purl.org/net/xbiblio/csl" version="1.0" class="note" demote-non-dropping-particle="sort-only" default-locale="de-DE">
   <info>
-    <title>Geistes- und Kulturwissenschaften (Heilmann) (German)</title>
+    <title>Geistes- und Kulturwissenschaften (Heilmann) (Deutsch)</title>
     <id>http://www.zotero.org/styles/geistes-und-kulturwissenschaften-heilmann</id>
     <link href="http://www.zotero.org/styles/geistes-und-kulturwissenschaften-heilmann" rel="self"/>
     <link href="http://www.tillheilmann.info/english.php" rel="documentation"/>

--- a/georg-august-universitat-gottingen-institut-fur-ethnologie-und-ethnologische-sammlung.csl
+++ b/georg-august-universitat-gottingen-institut-fur-ethnologie-und-ethnologische-sammlung.csl
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" demote-non-dropping-particle="sort-only" default-locale="de-DE">
   <info>
-    <title>Georg-August-Universität Göttingen - Institut für Ethnologie und Ethnologische Sammlung (German)</title>
+    <title>Georg-August-Universität Göttingen - Institut für Ethnologie und Ethnologische Sammlung (Deutsch)</title>
     <id>http://www.zotero.org/styles/georg-august-universitat-gottingen-institut-fur-ethnologie-und-ethnologische-sammlung</id>
     <link href="http://www.zotero.org/styles/georg-august-universitat-gottingen-institut-fur-ethnologie-und-ethnologische-sammlung" rel="self"/>
     <link href="http://www.uni-goettingen.de/de/86102.html" rel="documentation"/>

--- a/gesellschaft-fur-popularmusikforschung.csl
+++ b/gesellschaft-fur-popularmusikforschung.csl
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" demote-non-dropping-particle="sort-only" default-locale="de-DE">
   <info>
-    <title>Gesellschaft fur Popularmusikforschung (German)</title>
+    <title>Gesellschaft fur Popularmusikforschung (Deutsch)</title>
     <title-short>GfPM</title-short>
     <id>http://www.zotero.org/styles/gesellschaft-fur-popularmusikforschung</id>
     <link href="http://www.zotero.org/styles/gesellschaft-fur-popularmusikforschung" rel="self"/>

--- a/gewerblicher-rechtsschutz-und-urheberrecht.csl
+++ b/gewerblicher-rechtsschutz-und-urheberrecht.csl
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <style xmlns="http://purl.org/net/xbiblio/csl" version="1.0" class="note" default-locale="de-DE">
   <info>
-    <title>Gewerblicher Rechtsschutz und Urheberrecht (German)</title>
+    <title>Gewerblicher Rechtsschutz und Urheberrecht (Deutsch)</title>
     <title-short>GRUR</title-short>
     <id>http://www.zotero.org/styles/gewerblicher-rechtsschutz-und-urheberrecht</id>
     <link href="http://www.zotero.org/styles/gewerblicher-rechtsschutz-und-urheberrecht" rel="self"/>

--- a/hamburg-school-of-food-science.csl
+++ b/hamburg-school-of-food-science.csl
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" name-as-sort-order="all" demote-non-dropping-particle="sort-only" default-locale="de-DE">
   <info>
-    <title>Hamburg School of Food Science (diploma, German)</title>
+    <title>Hamburg School of Food Science (diploma, Deutsch)</title>
     <title-short>Diplom-LC-UHH</title-short>
     <id>http://www.zotero.org/styles/hamburg-school-of-food-science</id>
     <link href="http://www.zotero.org/styles/hamburg-school-of-food-science" rel="self"/>

--- a/harvard-gesellschaft-fur-bildung-und-forschung-in-europa.csl
+++ b/harvard-gesellschaft-fur-bildung-und-forschung-in-europa.csl
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" demote-non-dropping-particle="sort-only" default-locale="de-DE">
   <info>
-    <title>Gesellschaft für Bildung und Forschung in Europa - Harvard (German)</title>
+    <title>Gesellschaft für Bildung und Forschung in Europa - Harvard (Deutsch)</title>
     <title-short>GBFE</title-short>
     <id>http://www.zotero.org/styles/harvard-gesellschaft-fur-bildung-und-forschung-in-europa</id>
     <link href="http://www.zotero.org/styles/harvard-gesellschaft-fur-bildung-und-forschung-in-europa" rel="self"/>

--- a/harvard-institut-fur-praxisforschung-de.csl
+++ b/harvard-institut-fur-praxisforschung-de.csl
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" demote-non-dropping-particle="sort-only" default-locale="de-DE">
   <info>
-    <title>Institut für Praxisforschung - Harvard (Bahr &amp; Frackmann) (German)</title>
+    <title>Institut für Praxisforschung - Harvard (Bahr &amp; Frackmann) (Deutsch)</title>
     <id>http://www.zotero.org/styles/harvard-institut-fur-praxisforschung-de</id>
     <link href="http://www.zotero.org/styles/harvard-institut-fur-praxisforschung-de" rel="self"/>
     <link href="http://www.zotero.org/styles/fachhochschule-vorarlberg-author-date" rel="template"/>

--- a/harvard-theologisches-seminar-adelshofen.csl
+++ b/harvard-theologisches-seminar-adelshofen.csl
@@ -2,7 +2,7 @@
 <style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" demote-non-dropping-particle="sort-only" default-locale="de-DE">
   <!-- This style was edited with the Visual CSL Editor (http://editor.citationstyles.org/visualEditor/) -->
   <info>
-    <title>Theologisches Seminar Adelshofen - Harvard (German)</title>
+    <title>Theologisches Seminar Adelshofen - Harvard (Deutsch)</title>
     <title-short>TSA</title-short>
     <id>http://www.zotero.org/styles/harvard-theologisches-seminar-adelshofen</id>
     <link href="http://www.zotero.org/styles/harvard-theologisches-seminar-adelshofen" rel="self"/>

--- a/heiliger-dienst.csl
+++ b/heiliger-dienst.csl
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <style xmlns="http://purl.org/net/xbiblio/csl" class="note" version="1.0" names-delimiter="" demote-non-dropping-particle="sort-only" default-locale="de-DE">
   <info>
-    <title>Heiliger Dienst (German)</title>
+    <title>Heiliger Dienst (Deutsch)</title>
     <id>http://www.zotero.org/styles/heiliger-dienst</id>
     <link href="http://www.zotero.org/styles/heiliger-dienst" rel="self"/>
     <link href="http://www.zotero.org/styles/jahrbuch-der-osterreichischen-byzantinischen-gesellschaft" rel="template"/>

--- a/historia-scribere.csl
+++ b/historia-scribere.csl
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <style xmlns="http://purl.org/net/xbiblio/csl" class="note" version="1.0" delimiter-precedes-et-al="never" delimiter-precedes-last="always" default-locale="de-AT">
   <info>
-    <title>historia.scribere (German)</title>
+    <title>historia.scribere (Deutsch)</title>
     <id>http://www.zotero.org/styles/historia-scribere</id>
     <link href="http://www.zotero.org/styles/historia-scribere" rel="self"/>
     <link href="http://www.zotero.org/styles/metropol-verlag" rel="template"/>

--- a/hochschule-bonn-rhein-sieg.csl
+++ b/hochschule-bonn-rhein-sieg.csl
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" demote-non-dropping-particle="sort-only" default-locale="de-DE">
   <info>
-    <title>Hochschule Bonn-Rhein-Sieg (German)</title>
+    <title>Hochschule Bonn-Rhein-Sieg (Deutsch)</title>
     <id>http://www.zotero.org/styles/hochschule-bonn-rhein-sieg</id>
     <link href="http://www.zotero.org/styles/hochschule-bonn-rhein-sieg" rel="self"/>
     <link href="http://www.zotero.org/styles/deutsche-gesellschaft-fur-psychologie" rel="template"/>

--- a/hochschule-fur-soziale-arbeit-fhnw.csl
+++ b/hochschule-fur-soziale-arbeit-fhnw.csl
@@ -2,7 +2,7 @@
 <style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" demote-non-dropping-particle="sort-only" default-locale="de-CH">
   <!-- This style was edited with the Visual CSL Editor (http://editor.citationstyles.org/visualEditor/) -->
   <info>
-    <title>Hochschule für Soziale Arbeit FHNW (German - Switzerland)</title>
+    <title>Hochschule für Soziale Arbeit FHNW (Deutsch - Schweiz)</title>
     <title-short>HSA FHNW</title-short>
     <id>http://www.zotero.org/styles/hochschule-fur-soziale-arbeit-fhnw</id>
     <link href="http://www.zotero.org/styles/hochschule-fur-soziale-arbeit-fhnw" rel="self"/>

--- a/hochschule-fur-wirtschaft-und-recht-berlin.csl
+++ b/hochschule-fur-wirtschaft-und-recht-berlin.csl
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <style xmlns="http://purl.org/net/xbiblio/csl" class="note" default-locale="de-DE" version="1.0" demote-non-dropping-particle="sort-only">
   <info>
-    <title>Hochschule für Wirtschaft und Recht Berlin (German)</title>
+    <title>Hochschule für Wirtschaft und Recht Berlin (Deutsch)</title>
     <title-short>HWR Berlin</title-short>
     <id>http://www.zotero.org/styles/hochschule-fur-wirtschaft-und-recht-berlin</id>
     <link href="http://www.zotero.org/styles/hochschule-fur-wirtschaft-und-recht-berlin" rel="self"/>

--- a/hochschule-hannover-soziale-arbeit.csl
+++ b/hochschule-hannover-soziale-arbeit.csl
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" demote-non-dropping-particle="never" default-locale="de-DE">
   <info>
-    <title>Hochschule Hannover - Soziale Arbeit (German)</title>
+    <title>Hochschule Hannover - Soziale Arbeit (Deutsch)</title>
     <id>http://www.zotero.org/styles/hochschule-hannover-soziale-arbeit</id>
     <link href="http://www.zotero.org/styles/hochschule-hannover-soziale-arbeit" rel="self"/>
     <link href="http://www.zotero.org/styles/beltz-padagogik" rel="template"/>

--- a/hochschule-munchen-fakultat-fur-angewandte-sozialwissenschaften.csl
+++ b/hochschule-munchen-fakultat-fur-angewandte-sozialwissenschaften.csl
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" demote-non-dropping-particle="sort-only" default-locale="de-DE">
   <info>
-    <title>Hochschule München - Fakultät für Angewandte Sozialwissenschaften (German)</title>
+    <title>Hochschule München - Fakultät für Angewandte Sozialwissenschaften (Deutsch)</title>
     <title-short>MUAS</title-short>
     <id>http://www.zotero.org/styles/hochschule-munchen-fakultat-fur-angewandte-sozialwissenschaften</id>
     <link href="http://www.zotero.org/styles/hochschule-munchen-fakultat-fur-angewandte-sozialwissenschaften" rel="self"/>

--- a/hochschule-osnabruck-fakultat-agrarwissenschaften-und-landschaftsarchitektur.csl
+++ b/hochschule-osnabruck-fakultat-agrarwissenschaften-und-landschaftsarchitektur.csl
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" default-locale="de-DE" demote-non-dropping-particle="never">
   <info>
-    <title>Hochschule Osnabrück - Fakultät Agrarwissenschaften und Landschaftsarchitektur (German)</title>
+    <title>Hochschule Osnabrück - Fakultät Agrarwissenschaften und Landschaftsarchitektur (Deutsch)</title>
     <title-short>HSOS-AuL</title-short>
     <id>http://www.zotero.org/styles/hochschule-osnabruck-fakultat-agrarwissenschaften-und-landschaftsarchitektur</id>
     <link href="http://www.zotero.org/styles/hochschule-osnabruck-fakultat-agrarwissenschaften-und-landschaftsarchitektur" rel="self"/>

--- a/hochschule-pforzheim-fakultat-fur-wirtschaft-und-recht.csl
+++ b/hochschule-pforzheim-fakultat-fur-wirtschaft-und-recht.csl
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <style xmlns="http://purl.org/net/xbiblio/csl" class="note" version="1.0" demote-non-dropping-particle="sort-only" default-locale="de-DE">
   <info>
-    <title>Hochschule Pforzheim - Fakultät für Wirtschaft und Recht (German)</title>
+    <title>Hochschule Pforzheim - Fakultät für Wirtschaft und Recht (Deutsch)</title>
     <id>http://www.zotero.org/styles/hochschule-pforzheim-fakultat-fur-wirtschaft-und-recht</id>
     <link href="http://www.zotero.org/styles/hochschule-pforzheim-fakultat-fur-wirtschaft-und-recht" rel="self"/>
     <link href="http://www.zotero.org/styles/arachne" rel="template"/>

--- a/im-gesprach.csl
+++ b/im-gesprach.csl
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" demote-non-dropping-particle="sort-only" default-locale="de-DE">
   <info>
-    <title>Im Gespräch - Hefte der Martin Buber-Gesellschaft (German)</title>
+    <title>Im Gespräch - Hefte der Martin Buber-Gesellschaft (Deutsch)</title>
     <title-short>Im Gespräch</title-short>
     <id>http://www.zotero.org/styles/im-gesprach</id>
     <link href="http://www.zotero.org/styles/im-gesprach" rel="self"/>

--- a/infoclio-de.csl
+++ b/infoclio-de.csl
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <style xmlns="http://purl.org/net/xbiblio/csl" class="note" default-locale="de-CH" version="1.0" name-delimiter="; " delimiter-precedes-last="always" delimiter-precedes-et-al="never">
   <info>
-    <title>infoclio.ch (German - Switzerland)</title>
+    <title>infoclio.ch (Deutsch - Schweiz)</title>
     <id>http://www.zotero.org/styles/infoclio-de</id>
     <link href="http://www.zotero.org/styles/infoclio-de" rel="self"/>
     <link href="http://www.zotero.org/styles/infoclio-fr-smallcaps" rel="template"/>

--- a/interdisziplinare-anthropologie.csl
+++ b/interdisziplinare-anthropologie.csl
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <style xmlns="http://purl.org/net/xbiblio/csl" class="note" version="1.0" page-range-format="expanded" demote-non-dropping-particle="never" default-locale="de-DE">
   <info>
-    <title>Interdisziplinäre Anthropologie (German)</title>
+    <title>Interdisziplinäre Anthropologie (Deutsch)</title>
     <title-short>IA</title-short>
     <id>http://www.zotero.org/styles/interdisziplinare-anthropologie</id>
     <link href="http://www.zotero.org/styles/interdisziplinare-anthropologie" rel="self"/>

--- a/interdisziplinare-zeitschrift-fur-technologie-und-lernen.csl
+++ b/interdisziplinare-zeitschrift-fur-technologie-und-lernen.csl
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" demote-non-dropping-particle="never" default-locale="de-DE">
   <info>
-    <title>Interdisziplinäre Zeitschrift für Technologie und Lernen (German)</title>
+    <title>Interdisziplinäre Zeitschrift für Technologie und Lernen (Deutsch)</title>
     <title-short>iTeL</title-short>
     <id>http://www.zotero.org/styles/interdisziplinare-zeitschrift-fur-technologie-und-lernen</id>
     <link href="http://www.zotero.org/styles/interdisziplinare-zeitschrift-fur-technologie-und-lernen" rel="self"/>

--- a/iso690-author-date-de.csl
+++ b/iso690-author-date-de.csl
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" demote-non-dropping-particle="never" default-locale="de-DE">
   <info>
-    <title>ISO-690 (author-date, German)</title>
+    <title>ISO-690 (author-date, Deutsch)</title>
     <id>http://www.zotero.org/styles/iso690-author-date-de</id>
     <link href="http://www.zotero.org/styles/iso690-author-date-de" rel="self"/>
     <link href="http://www.zotero.org/styles/iso690-author-date-en" rel="template"/>

--- a/jahrbuch-fur-evangelikale-theologie.csl
+++ b/jahrbuch-fur-evangelikale-theologie.csl
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <style xmlns="http://purl.org/net/xbiblio/csl" class="note" version="1.0" demote-non-dropping-particle="sort-only" default-locale="de-DE">
   <info>
-    <title>Jahrbuch für evangelikale Theologie (German)</title>
+    <title>Jahrbuch für evangelikale Theologie (Deutsch)</title>
     <title-short>JETh</title-short>
     <id>http://www.zotero.org/styles/jahrbuch-fur-evangelikale-theologie</id>
     <link href="http://www.zotero.org/styles/jahrbuch-fur-evangelikale-theologie" rel="self"/>

--- a/journalistica.csl
+++ b/journalistica.csl
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <style xmlns="http://purl.org/net/xbiblio/csl" default-locale="da-DK" class="in-text" version="1.0" demote-non-dropping-particle="sort-only">
   <info>
-    <title>Journalistica (Danish)</title>
+    <title>Journalistica (Dansk)</title>
     <id>http://www.zotero.org/styles/journalistica</id>
     <link href="http://www.zotero.org/styles/journalistica" rel="self"/>
     <link href="http://ojs.statsbiblioteket.dk/index.php/journalistica/about/submissions#authorGuidelines" rel="documentation"/>

--- a/juristische-schulung.csl
+++ b/juristische-schulung.csl
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <style xmlns="http://purl.org/net/xbiblio/csl" version="1.0" class="note" default-locale="de-DE">
   <info>
-    <title>Juristische Schulung (German)</title>
+    <title>Juristische Schulung (Deutsch)</title>
     <title-short>JuS</title-short>
     <id>http://www.zotero.org/styles/juristische-schulung</id>
     <link href="http://www.zotero.org/styles/juristische-schulung" rel="self"/>

--- a/juristische-zitierweise-offentliches-recht.csl
+++ b/juristische-zitierweise-offentliches-recht.csl
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <style xmlns="http://purl.org/net/xbiblio/csl" version="1.0" class="note" default-locale="de-DE">
   <info>
-    <title>Juristische Zitierweise - Öffentliches Recht (German)</title>
+    <title>Juristische Zitierweise - Öffentliches Recht (Deutsch)</title>
     <id>http://www.zotero.org/styles/juristische-zitierweise-offentliches-recht</id>
     <link href="http://www.zotero.org/styles/juristische-zitierweise-offentliches-recht" rel="self"/>
     <link href="http://www.zotero.org/styles/juristische-zitierweise" rel="template"/>

--- a/juristische-zitierweise-schweizer.csl
+++ b/juristische-zitierweise-schweizer.csl
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <style xmlns="http://purl.org/net/xbiblio/csl" class="note" version="1.0" default-locale="de-CH">
   <info>
-    <title>Juristische Zitierweise Schweizer (Ryser Büschi et al.) (German - Switzerland)</title>
+    <title>Juristische Zitierweise Schweizer (Ryser Büschi et al.) (Deutsch - Schweiz)</title>
     <id>http://www.zotero.org/styles/juristische-zitierweise-schweizer</id>
     <link href="http://www.zotero.org/styles/juristische-zitierweise-schweizer" rel="self"/>
     <link href="http://www.zotero.org/styles/juristische-zitierweise" rel="template"/>

--- a/juristische-zitierweise.csl
+++ b/juristische-zitierweise.csl
@@ -2,7 +2,7 @@
 <style xmlns="http://purl.org/net/xbiblio/csl" version="1.0" class="note" default-locale="de-DE">
   <!-- This style was edited with the Visual CSL Editor (http://editor.citationstyles.org/visualEditor/) -->
   <info>
-    <title>Juristische Zitierweise (Stüber) (German)</title>
+    <title>Juristische Zitierweise (Stüber) (Deutsch)</title>
     <id>http://www.zotero.org/styles/juristische-zitierweise</id>
     <link href="http://www.zotero.org/styles/juristische-zitierweise" rel="self"/>
     <link href="www.niederle-media.de/Zitieren.pdf" rel="documentation"/>

--- a/kolner-zeitschrift-fur-soziologie-und-sozialpsychologie.csl
+++ b/kolner-zeitschrift-fur-soziologie-und-sozialpsychologie.csl
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" demote-non-dropping-particle="sort-only" default-locale="de-DE">
   <info>
-    <title>Kölner Zeitschrift für Soziologie und Sozialpsychologie (German)</title>
+    <title>Kölner Zeitschrift für Soziologie und Sozialpsychologie (Deutsch)</title>
     <title-short>KZfSS</title-short>
     <id>http://www.zotero.org/styles/kolner-zeitschrift-fur-soziologie-und-sozialpsychologie</id>
     <link href="http://www.zotero.org/styles/kolner-zeitschrift-fur-soziologie-und-sozialpsychologie" rel="self"/>

--- a/kommunikation-und-recht.csl
+++ b/kommunikation-und-recht.csl
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <style xmlns="http://purl.org/net/xbiblio/csl" version="1.0" class="note" default-locale="de-DE">
   <info>
-    <title>Kommunikation und Recht (German)</title>
+    <title>Kommunikation und Recht (Deutsch)</title>
     <title-short>K&amp;R</title-short>
     <id>http://www.zotero.org/styles/kommunikation-und-recht</id>
     <link href="http://www.zotero.org/styles/kommunikation-und-recht" rel="self"/>

--- a/kritische-ausgabe.csl
+++ b/kritische-ausgabe.csl
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <style xmlns="http://purl.org/net/xbiblio/csl" class="note" version="1.0" demote-non-dropping-particle="sort-only" default-locale="de-DE">
   <info>
-    <title>Kritische Ausgabe (German)</title>
+    <title>Kritische Ausgabe (Deutsch)</title>
     <id>http://www.zotero.org/styles/kritische-ausgabe</id>
     <link href="http://www.zotero.org/styles/kritische-ausgabe" rel="self"/>
     <link href="http://kritische-ausgabe.de/" rel="documentation"/>

--- a/kunstakademie-munster.csl
+++ b/kunstakademie-munster.csl
@@ -2,7 +2,7 @@
 <style xmlns="http://purl.org/net/xbiblio/csl" version="1.0" class="note" demote-non-dropping-particle="sort-only" default-locale="de-DE">
   <!-- ====== KOPFTEIL ================================-->
   <info>
-    <title>Kunstakademie Münster (German)</title>
+    <title>Kunstakademie Münster (Deutsch)</title>
     <id>http://www.zotero.org/styles/kunstakademie-munster</id>
     <link href="http://www.zotero.org/styles/kunstakademie-munster" rel="self"/>
     <link href="http://www.zotero.org/styles/theologie-und-philosophie" rel="template"/>

--- a/lauterbornia.csl
+++ b/lauterbornia.csl
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" and="symbol" delimiter-precedes-et-al="never" delimiter-precedes-last="never" demote-non-dropping-particle="never" default-locale="de-DE">
   <info>
-    <title>Lauterbornia - Internationale Zeitschrift für Faunistik und Floristik des Süßwassers (German)</title>
+    <title>Lauterbornia - Internationale Zeitschrift für Faunistik und Floristik des Süßwassers (Deutsch)</title>
     <id>http://www.zotero.org/styles/lauterbornia</id>
     <link href="http://www.zotero.org/styles/lauterbornia" rel="self"/>
     <link href="http://www.zotero.org/styles/zeitschrift-fur-soziologie" rel="template"/>

--- a/leviathan.csl
+++ b/leviathan.csl
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <style xmlns="http://purl.org/net/xbiblio/csl" class="note" version="1.0" demote-non-dropping-particle="sort-only" default-locale="de-DE">
   <info>
-    <title>Leviathan (German)</title>
+    <title>Leviathan (Deutsch)</title>
     <id>http://www.zotero.org/styles/leviathan</id>
     <link href="http://www.zotero.org/styles/leviathan" rel="self"/>
     <link href="http://www.wzb.eu/de/publikationen/leviathan" rel="documentation"/>

--- a/mercator-institut-fur-sprachforderung-und-deutsch-als-zweitsprache.csl
+++ b/mercator-institut-fur-sprachforderung-und-deutsch-als-zweitsprache.csl
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" and="symbol" delimiter-precedes-et-al="never" delimiter-precedes-last="never" initialize="false" initialize-with="." page-range-format="expanded" demote-non-dropping-particle="never" default-locale="de-DE">
   <info>
-    <title>Mercator-Institut für Sprachförderung und Deutsch als Zweitsprache (German)</title>
+    <title>Mercator-Institut für Sprachförderung und Deutsch als Zweitsprache (Deutsch)</title>
     <id>http://www.zotero.org/styles/mercator-institut-fur-sprachforderung-und-deutsch-als-zweitsprache</id>
     <link href="http://www.zotero.org/styles/mercator-institut-fur-sprachforderung-und-deutsch-als-zweitsprache" rel="self"/>
     <link href="http://www.zotero.org/styles/deutsche-gesellschaft-fur-psychologie" rel="template"/>

--- a/metropol-verlag.csl
+++ b/metropol-verlag.csl
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <style xmlns="http://purl.org/net/xbiblio/csl" class="note" version="1.0" name-delimiter="; " delimiter-precedes-et-al="never" delimiter-precedes-last="always" default-locale="de-DE">
   <info>
-    <title>Metropol Verlag (German)</title>
+    <title>Metropol Verlag (Deutsch)</title>
     <id>http://www.zotero.org/styles/metropol-verlag</id>
     <link href="http://www.zotero.org/styles/metropol-verlag" rel="self"/>
     <link href="http://www.zotero.org/styles/infoclio-de" rel="template"/>

--- a/mohr-siebeck-recht.csl
+++ b/mohr-siebeck-recht.csl
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <style xmlns="http://purl.org/net/xbiblio/csl" class="note" version="1.0" delimiter-precedes-et-al="never" delimiter-precedes-last="never" et-al-min="11" et-al-use-first="10" initialize="false" page-range-format="expanded" demote-non-dropping-particle="never" default-locale="de-AT">
   <info>
-    <title>Mohr Siebeck - Recht (German - Austria)</title>
+    <title>Mohr Siebeck - Recht (Deutsch - Österreich)</title>
     <id>http://www.zotero.org/styles/mohr-siebeck-recht</id>
     <link href="http://www.zotero.org/styles/mohr-siebeck-recht" rel="self"/>
     <link href="http://www.mohr.de/fileadmin/user_upload/Hinweise_Autoren_PDF/Merkblaetter/merkjura2006.pdf" rel="documentation"/>

--- a/natur-und-landschaft.csl
+++ b/natur-und-landschaft.csl
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" demote-non-dropping-particle="sort-only" default-locale="de-DE">
   <info>
-    <title>Natur und Landschaft (German)</title>
+    <title>Natur und Landschaft (Deutsch)</title>
     <id>http://www.zotero.org/styles/natur-und-landschaft</id>
     <link href="http://www.zotero.org/styles/natur-und-landschaft" rel="self"/>
     <link href="http://www.zotero.org/styles/biosocieties" rel="template"/>

--- a/nccr-mediality.csl
+++ b/nccr-mediality.csl
@@ -2,7 +2,7 @@
 <style xmlns="http://purl.org/net/xbiblio/csl" version="1.0" class="note" default-locale="de-DE" demote-non-dropping-particle="sort-only">
   <!-- This style was edited with the Visual CSL Editor (http://editor.citationstyles.org/visualEditor/) -->
   <info>
-    <title>NCCR Mediality. Medienwandel - Medienwechsel - Medienwissen (German)</title>
+    <title>NCCR Mediality. Medienwandel - Medienwechsel - Medienwissen (Deutsch)</title>
     <title-short>NCCR Mediality</title-short>
     <id>http://www.zotero.org/styles/nccr-mediality</id>
     <link href="http://www.zotero.org/styles/nccr-mediality" rel="self"/>

--- a/neue-juristische-wochenschrift.csl
+++ b/neue-juristische-wochenschrift.csl
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <style xmlns="http://purl.org/net/xbiblio/csl" version="1.0" class="note" default-locale="de-DE">
   <info>
-    <title>Neue Juristische Wochenschrift (German)</title>
+    <title>Neue Juristische Wochenschrift (Deutsch)</title>
     <title-short>NJW (Articles)</title-short>
     <id>http://www.zotero.org/styles/neue-juristische-wochenschrift</id>
     <link href="http://www.zotero.org/styles/neue-juristische-wochenschrift" rel="self"/>

--- a/osterreichische-zeitschrift-fur-politikwissenschaft.csl
+++ b/osterreichische-zeitschrift-fur-politikwissenschaft.csl
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" demote-non-dropping-particle="sort-only" default-locale="de-AT">
   <info>
-    <title>Österreichische Zeitschrift für Politikwissenschaft (German - Austria)</title>
+    <title>Österreichische Zeitschrift für Politikwissenschaft (Deutsch - Österreich)</title>
     <title-short>OEZP</title-short>
     <id>http://www.zotero.org/styles/osterreichische-zeitschrift-fur-politikwissenschaft</id>
     <link href="http://www.zotero.org/styles/osterreichische-zeitschrift-fur-politikwissenschaft" rel="self"/>

--- a/owbarth-verlag.csl
+++ b/owbarth-verlag.csl
@@ -2,7 +2,7 @@
 <style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" demote-non-dropping-particle="sort-only" default-locale="de-DE">
   <!-- This style was edited with the Visual CSL Editor (http://editor.citationstyles.org/visualEditor/) -->
   <info>
-    <title>O.W. Barth Verlag (German)</title>
+    <title>O.W. Barth Verlag (Deutsch)</title>
     <id>http://www.zotero.org/styles/owbarth-verlag</id>
     <link href="http://www.zotero.org/styles/owbarth-verlag" rel="self"/>
     <link href="http://www.zotero.org/styles/din-1505-2" rel="template"/>

--- a/padagogische-hochschule-fachhochschule-nordwestschweiz.csl
+++ b/padagogische-hochschule-fachhochschule-nordwestschweiz.csl
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <style xmlns="http://purl.org/net/xbiblio/csl" version="1.0" default-locale="de-CH" class="in-text" demote-non-dropping-particle="sort-only">
   <info>
-    <title>Pädagogische Hochschule Fachhochschule Nordwestschweiz (German - Switzerland)</title>
+    <title>Pädagogische Hochschule Fachhochschule Nordwestschweiz (Deutsch - Schweiz)</title>
     <title-short>Schreibberatung PH FHNW (Empfehlungen)</title-short>
     <id>http://www.zotero.org/styles/padagogische-hochschule-fachhochschule-nordwestschweiz</id>
     <link href="http://www.zotero.org/styles/padagogische-hochschule-fachhochschule-nordwestschweiz" rel="self"/>

--- a/padagogische-hochschule-heidelberg.csl
+++ b/padagogische-hochschule-heidelberg.csl
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" demote-non-dropping-particle="sort-only" default-locale="de-DE">
   <info>
-    <title>Pädagogische Hochschule Heidelberg (German)</title>
+    <title>Pädagogische Hochschule Heidelberg (Deutsch)</title>
     <title-short>PH Heidelberg</title-short>
     <id>http://www.zotero.org/styles/padagogische-hochschule-heidelberg</id>
     <link href="http://www.zotero.org/styles/padagogische-hochschule-heidelberg" rel="self"/>

--- a/padagogische-hochschule-vorarlberg.csl
+++ b/padagogische-hochschule-vorarlberg.csl
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" demote-non-dropping-particle="sort-only" default-locale="de-DE">
   <info>
-    <title>Pädagogische Hochschule Vorarlberg (German)</title>
+    <title>Pädagogische Hochschule Vorarlberg (Deutsch)</title>
     <title-short>PH Vorarlberg</title-short>
     <id>http://www.zotero.org/styles/padagogische-hochschule-vorarlberg</id>
     <link href="http://www.zotero.org/styles/padagogische-hochschule-vorarlberg" rel="self"/>

--- a/philippika.csl
+++ b/philippika.csl
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <style xmlns="http://purl.org/net/xbiblio/csl" class="note" version="1.0" demote-non-dropping-particle="never" page-range-format="expanded">
   <info>
-    <title>Philippika (German)</title>
+    <title>Philippika (Deutsch)</title>
     <id>http://www.zotero.org/styles/philippika</id>
     <link href="http://www.zotero.org/styles/philippika" rel="self"/>
     <link href="http://www.zotero.org/styles/cahiers-du-centre-gustave-glotz" rel="template"/>

--- a/philipps-universitat-marburg-note.csl
+++ b/philipps-universitat-marburg-note.csl
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <style xmlns="http://purl.org/net/xbiblio/csl" class="note" version="1.0" demote-non-dropping-particle="never" default-locale="de-DE">
   <info>
-    <title>Philipps-Universität Marburg - Erziehungswissenschaften (note, German)</title>
+    <title>Philipps-Universität Marburg - Erziehungswissenschaften (note, Deutsch)</title>
     <id>http://www.zotero.org/styles/philipps-universitat-marburg-note</id>
     <link href="http://www.zotero.org/styles/philipps-universitat-marburg-note" rel="self"/>
     <link href="http://www.zotero.org/styles/die-bachelorarbeit-samac-et-al-note" rel="template"/>

--- a/politische-vierteljahresschrift.csl
+++ b/politische-vierteljahresschrift.csl
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" demote-non-dropping-particle="sort-only" default-locale="de-DE">
   <info>
-    <title>Politische Vierteljahresschrift (German)</title>
+    <title>Politische Vierteljahresschrift (Deutsch)</title>
     <title-short>PVS</title-short>
     <id>http://www.zotero.org/styles/politische-vierteljahresschrift</id>
     <link href="http://www.zotero.org/styles/politische-vierteljahresschrift" rel="self"/>

--- a/ruhr-universitat-bochum-medizinische-fakultat-numeric.csl
+++ b/ruhr-universitat-bochum-medizinische-fakultat-numeric.csl
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" demote-non-dropping-particle="never" default-locale="de-DE">
   <info>
-    <title>Ruhr-Universität Bochum - Medizinische Fakultät (numerisch, German)</title>
+    <title>Ruhr-Universität Bochum - Medizinische Fakultät (numerisch, Deutsch)</title>
     <id>http://www.zotero.org/styles/ruhr-universitat-bochum-medizinische-fakultat-numeric</id>
     <link href="http://www.zotero.org/styles/ruhr-universitat-bochum-medizinische-fakultat-numeric" rel="self"/>
     <link href="http://www.zotero.org/styles/apa" rel="template"/>

--- a/soziale-welt.csl
+++ b/soziale-welt.csl
@@ -2,7 +2,7 @@
 <style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" demote-non-dropping-particle="sort-only" default-locale="de-DE">
   <!-- This style was edited with the Visual CSL Editor (http://steveridout.com/csl/visualEditor/) -->
   <info>
-    <title>Soziale Welt (German)</title>
+    <title>Soziale Welt (Deutsch)</title>
     <id>http://www.zotero.org/styles/soziale-welt</id>
     <link href="http://www.zotero.org/styles/soziale-welt" rel="self"/>
     <link href="http://www.soziale-welt.nomos.de/fileadmin/soziale-welt/doc/Autorenhinweise_sw.pdf" rel="documentation"/>
@@ -17,7 +17,7 @@
     <category citation-format="author-date"/>
     <category field="social_science"/>
     <issn>0038-6073</issn>
-    <summary>Stil für Soziale Welt (German)</summary>
+    <summary>Stil für Soziale Welt (Deutsch)</summary>
     <updated>2015-11-23T15:49:26+01:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>

--- a/sozialpadagogisches-institut-berlin-walter-may.csl
+++ b/sozialpadagogisches-institut-berlin-walter-may.csl
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" demote-non-dropping-particle="sort-only" default-locale="de-DE">
   <info>
-    <title>Sozialpädagogisches Institut Berlin - Walter May (German)</title>
+    <title>Sozialpädagogisches Institut Berlin - Walter May (Deutsch)</title>
     <title-short>SPI</title-short>
     <id>http://www.zotero.org/styles/sozialpadagogisches-institut-berlin-walter-may</id>
     <link href="http://www.zotero.org/styles/sozialpadagogisches-institut-berlin-walter-may" rel="self"/>

--- a/sozialwissenschaften-heilmann.csl
+++ b/sozialwissenschaften-heilmann.csl
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <style xmlns="http://purl.org/net/xbiblio/csl" version="1.0" class="in-text" default-locale="de-DE" demote-non-dropping-particle="sort-only">
   <info>
-    <title>Sozialwissenschaften (Heilmann) (German)</title>
+    <title>Sozialwissenschaften (Heilmann) (Deutsch)</title>
     <id>http://www.zotero.org/styles/sozialwissenschaften-heilmann</id>
     <link href="http://www.zotero.org/styles/sozialwissenschaften-heilmann" rel="self"/>
     <link href="http://www.tillheilmann.info/english.php" rel="documentation"/>

--- a/soziologie.csl
+++ b/soziologie.csl
@@ -2,7 +2,7 @@
 <style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" delimiter-precedes-et-al="never" delimiter-precedes-last="never" demote-non-dropping-particle="never" default-locale="de-DE">
   <!-- This style was edited with the Visual CSL Editor (http://editor.citationstyles.org/visualEditor/) -->
   <info>
-    <title>Soziologie (German)</title>
+    <title>Soziologie (Deutsch)</title>
     <id>http://www.zotero.org/styles/soziologie</id>
     <link href="http://www.zotero.org/styles/soziologie" rel="self"/>
     <link href="http://www.zotero.org/styles/zeitschrift-fur-soziologie" rel="template"/>

--- a/soziologiemagazin.csl
+++ b/soziologiemagazin.csl
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" name-delimiter="/" initialize="false" initialize-with="." demote-non-dropping-particle="display-and-sort" default-locale="de-DE">
   <info>
-    <title>Soziologiemagazin (German)</title>
+    <title>Soziologiemagazin (Deutsch)</title>
     <title-short>SozMag</title-short>
     <id>http://www.zotero.org/styles/soziologiemagazin</id>
     <link href="http://www.zotero.org/styles/soziologiemagazin" rel="self"/>

--- a/springer-fachzeitschriften-medizin-psychologie.csl
+++ b/springer-fachzeitschriften-medizin-psychologie.csl
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" demote-non-dropping-particle="sort-only" default-locale="de-DE">
   <info>
-    <title>Springer - Fachzeitschriften Medizin Psychologie (German)</title>
+    <title>Springer - Fachzeitschriften Medizin Psychologie (Deutsch)</title>
     <id>http://www.zotero.org/styles/springer-fachzeitschriften-medizin-psychologie</id>
     <link href="http://www.zotero.org/styles/springer-fachzeitschriften-medizin-psychologie" rel="self"/>
     <link href="http://www.zotero.org/styles/springer-basic-brackets-no-et-al-alphabetical" rel="template"/>

--- a/springer-vs-author-date.csl
+++ b/springer-vs-author-date.csl
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" demote-non-dropping-particle="sort-only" default-locale="de-DE">
   <info>
-    <title>Springer VS (author-date, German)</title>
+    <title>Springer VS (author-date, Deutsch)</title>
     <id>http://www.zotero.org/styles/springer-vs-author-date</id>
     <link href="http://www.zotero.org/styles/springer-vs-author-date" rel="self"/>
     <link href="http://www.zotero.org/styles/kolner-zeitschrift-fur-soziologie-und-sozialpsychologie" rel="template"/>

--- a/steinbeis-hochschule-school-of-management-and-innovation.csl
+++ b/steinbeis-hochschule-school-of-management-and-innovation.csl
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <style xmlns="http://purl.org/net/xbiblio/csl" class="note" version="1.0" demote-non-dropping-particle="display-and-sort" page-range-format="expanded" default-locale="de-DE">
   <info>
-    <title>Steinbeis-Hochschule - School of Management &amp; Innovation (German)</title>
+    <title>Steinbeis-Hochschule - School of Management &amp; Innovation (Deutsch)</title>
     <id>http://www.zotero.org/styles/steinbeis-hochschule-school-of-management-and-innovation</id>
     <link href="http://www.zotero.org/styles/steinbeis-hochschule-school-of-management-and-innovation" rel="self"/>
     <author>

--- a/stuttgart-media-university.csl
+++ b/stuttgart-media-university.csl
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <style xmlns="http://purl.org/net/xbiblio/csl" class="note" default-locale="de-DE" version="1.0" demote-non-dropping-particle="sort-only">
   <info>
-    <title>Hochschule der Medien Stuttgart (German)</title>
+    <title>Hochschule der Medien Stuttgart (Deutsch)</title>
     <title-short>HdM Stuttgart</title-short>
     <id>http://www.zotero.org/styles/stuttgart-media-university</id>
     <link href="http://www.zotero.org/styles/stuttgart-media-university" rel="self"/>

--- a/suburban-zeitschrift-fur-kritische-stadtforschung.csl
+++ b/suburban-zeitschrift-fur-kritische-stadtforschung.csl
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" demote-non-dropping-particle="never" default-locale="de-DE">
   <info>
-    <title>sub\urban - Zeitschrift für kritische Stadtforschung (German)</title>
+    <title>sub\urban - Zeitschrift für kritische Stadtforschung (Deutsch)</title>
     <id>http://www.zotero.org/styles/suburban-zeitschrift-fur-kritische-stadtforschung</id>
     <link href="http://www.zotero.org/styles/suburban-zeitschrift-fur-kritische-stadtforschung" rel="self"/>
     <link href="http://www.zotero.org/styles/zdfm-zeitschrift-fur-diversitatsforschung-und-management" rel="template"/>

--- a/tagungsberichte-der-historischen-kommission-fur-ost-und-westpreussische-landesforschung.csl
+++ b/tagungsberichte-der-historischen-kommission-fur-ost-und-westpreussische-landesforschung.csl
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <style xmlns="http://purl.org/net/xbiblio/csl" class="note" version="1.0" demote-non-dropping-particle="sort-only" default-locale="de-DE">
   <info>
-    <title>Tagungsberichte der Historischen Kommission für ost- und westpreußische Landesforschung (German)</title>
+    <title>Tagungsberichte der Historischen Kommission für ost- und westpreußische Landesforschung (Deutsch)</title>
     <title-short>HiKo-OWP</title-short>
     <id>http://www.zotero.org/styles/tagungsberichte-der-historischen-kommission-fur-ost-und-westpreussische-landesforschung</id>
     <link href="http://www.zotero.org/styles/tagungsberichte-der-historischen-kommission-fur-ost-und-westpreussische-landesforschung" rel="self"/>

--- a/technische-universitat-dortmund-ag-virtual-machining.csl
+++ b/technische-universitat-dortmund-ag-virtual-machining.csl
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" demote-non-dropping-particle="sort-only" default-locale="de-DE">
   <info>
-    <title>Technische Universität Dortmund - AG Virtual Machining (German)</title>
+    <title>Technische Universität Dortmund - AG Virtual Machining (Deutsch)</title>
     <title-short>TU-Dortmund AGVM</title-short>
     <id>http://www.zotero.org/styles/technische-universitat-dortmund-ag-virtual-machining</id>
     <link href="http://www.zotero.org/styles/technische-universitat-dortmund-ag-virtual-machining" rel="self"/>

--- a/technische-universitat-dresden-betriebswirtschaftslehre-rechnungswesen-controlling.csl
+++ b/technische-universitat-dresden-betriebswirtschaftslehre-rechnungswesen-controlling.csl
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" demote-non-dropping-particle="never" page-range-format="expanded" default-locale="de-DE">
   <info>
-    <title>Technische Universität Dresden - Betriebswirtschaftslehre/Rechnungswesen/Controlling (German)</title>
+    <title>Technische Universität Dresden - Betriebswirtschaftslehre/Rechnungswesen/Controlling (Deutsch)</title>
     <title-short>TUD BWL/BRW (APA)</title-short>
     <id>http://www.zotero.org/styles/technische-universitat-dresden-betriebswirtschaftslehre-rechnungswesen-controlling</id>
     <link href="http://www.zotero.org/styles/technische-universitat-dresden-betriebswirtschaftslehre-rechnungswesen-controlling" rel="self"/>

--- a/technische-universitat-dresden-forstwissenschaft.csl
+++ b/technische-universitat-dresden-forstwissenschaft.csl
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" demote-non-dropping-particle="never" default-locale="de-DE">
   <info>
-    <title>Technische Universität Dresden - Forstwissenschaft (author-date, German)</title>
+    <title>Technische Universität Dresden - Forstwissenschaft (author-date, Deutsch)</title>
     <title-short>TU Dresden - Forst</title-short>
     <id>http://www.zotero.org/styles/technische-universitat-dresden-forstwissenschaft</id>
     <link href="http://www.zotero.org/styles/technische-universitat-dresden-forstwissenschaft" rel="self"/>

--- a/technische-universitat-dresden-historische-musikwissenschaft-note.csl
+++ b/technische-universitat-dresden-historische-musikwissenschaft-note.csl
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <style xmlns="http://purl.org/net/xbiblio/csl" class="note" version="1.0" initialize-with="." default-locale="de-DE">
   <info>
-    <title>Technische Universität Dresden - Historische Musikwissenschaft (note, German)</title>
-    <title-short>TUD Historische Musikwissenschaft (note, German)</title-short>
+    <title>Technische Universität Dresden - Historische Musikwissenschaft (note, Deutsch)</title>
+    <title-short>TUD Historische Musikwissenschaft (note, Deutsch)</title-short>
     <id>http://www.zotero.org/styles/technische-universitat-dresden-historische-musikwissenschaft-note</id>
     <link href="http://www.zotero.org/styles/technische-universitat-dresden-historische-musikwissenschaft-note" rel="self"/>
     <link href="http://www.zotero.org/styles/foerster-geisteswissenschaft" rel="template"/>

--- a/technische-universitat-dresden-kunstgeschichte-note.csl
+++ b/technische-universitat-dresden-kunstgeschichte-note.csl
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <style xmlns="http://purl.org/net/xbiblio/csl" class="note" version="1.0" initialize-with="." name-as-sort-order="all" default-locale="de-DE">
   <info>
-    <title>Technische Universität Dresden - Kunstgeschichte (note, German)</title>
-    <title-short>TUD Kunstgeschichte (note, German)</title-short>
+    <title>Technische Universität Dresden - Kunstgeschichte (note, Deutsch)</title>
+    <title-short>TUD Kunstgeschichte (note, Deutsch)</title-short>
     <id>http://www.zotero.org/styles/technische-universitat-dresden-kunstgeschichte-note</id>
     <link href="http://www.zotero.org/styles/technische-universitat-dresden-kunstgeschichte-note" rel="self"/>
     <link href="http://www.zotero.org/styles/technische-universitat-dresden-historische-musikwissenschaft-note" rel="template"/>

--- a/technische-universitat-dresden-linguistik.csl
+++ b/technische-universitat-dresden-linguistik.csl
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" demote-non-dropping-particle="never" default-locale="de-DE">
   <info>
-    <title>Technische Universität Dresden - Linguistik (German)</title>
-    <title-short>TUD Linguistik (German)</title-short>
+    <title>Technische Universität Dresden - Linguistik (Deutsch)</title>
+    <title-short>TUD Linguistik (Deutsch)</title-short>
     <id>http://www.zotero.org/styles/technische-universitat-dresden-linguistik</id>
     <link href="http://www.zotero.org/styles/technische-universitat-dresden-linguistik" rel="self"/>
     <link href="http://www.zotero.org/styles/deutsche-sprache" rel="template"/>

--- a/technische-universitat-dresden-medienwissenschaft-und-neuere-deutsche-literatur-note.csl
+++ b/technische-universitat-dresden-medienwissenschaft-und-neuere-deutsche-literatur-note.csl
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <style xmlns="http://purl.org/net/xbiblio/csl" class="note" version="1.0" initialize-with="." default-locale="de-DE">
   <info>
-    <title>Technische Universität Dresden - Medienwissenschaft und Neuere Deutsche Literatur (note, German)</title>
-    <title-short>TUD Germanistik (note, German)</title-short>
+    <title>Technische Universität Dresden - Medienwissenschaft und Neuere Deutsche Literatur (note, Deutsch)</title>
+    <title-short>TUD Germanistik (note, Deutsch)</title-short>
     <id>http://www.zotero.org/styles/technische-universitat-dresden-medienwissenschaft-und-neuere-deutsche-literatur-note</id>
     <link href="http://www.zotero.org/styles/technische-universitat-dresden-medienwissenschaft-und-neuere-deutsche-literatur-note" rel="self"/>
     <link href="http://www.zotero.org/styles/technische-universitat-dresden-historische-musikwissenschaft-note" rel="template"/>

--- a/technische-universitat-dresden-wirtschaftswissenschaften.csl
+++ b/technische-universitat-dresden-wirtschaftswissenschaften.csl
@@ -2,7 +2,7 @@
 <style xmlns="http://purl.org/net/xbiblio/csl" class="note" default-locale="de-DE" version="1.0" demote-non-dropping-particle="sort-only">
   <!-- This style was edited with the Visual CSL Editor (http://editor.citationstyles.org/visualEditor/) -->
   <info>
-    <title>Technische Universität Dresden - Wirtschaftswissenschaften (German)</title>
+    <title>Technische Universität Dresden - Wirtschaftswissenschaften (Deutsch)</title>
     <title-short>TUD WiWi</title-short>
     <id>http://www.zotero.org/styles/technische-universitat-dresden-wirtschaftswissenschaften</id>
     <link href="http://www.zotero.org/styles/technische-universitat-dresden-wirtschaftswissenschaften" rel="self"/>

--- a/technische-universitat-munchen-controlling.csl
+++ b/technische-universitat-munchen-controlling.csl
@@ -2,7 +2,7 @@
 <style xmlns="http://purl.org/net/xbiblio/csl" class="note" default-locale="de-DE" version="1.0" demote-non-dropping-particle="sort-only">
   <!-- This style was edited with the Visual CSL Editor (http://editor.citationstyles.org/visualEditor/) -->
   <info>
-    <title>Technische Universität München - Controlling (German)</title>
+    <title>Technische Universität München - Controlling (Deutsch)</title>
     <title-short>TUM Controlling</title-short>
     <id>http://www.zotero.org/styles/technische-universitat-munchen-controlling</id>
     <link href="http://www.zotero.org/styles/technische-universitat-munchen-controlling" rel="self"/>

--- a/technische-universitat-munchen-unternehmensfuhrung.csl
+++ b/technische-universitat-munchen-unternehmensfuhrung.csl
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <style xmlns="http://purl.org/net/xbiblio/csl" class="note" default-locale="de-DE" version="1.0" demote-non-dropping-particle="sort-only">
   <info>
-    <title>Technische Universität München - Unternehmensführung (German)</title>
+    <title>Technische Universität München - Unternehmensführung (Deutsch)</title>
     <title-short>TUM Unternehmensführung</title-short>
     <id>http://www.zotero.org/styles/technische-universitat-munchen-unternehmensfuhrung</id>
     <link href="http://www.zotero.org/styles/technische-universitat-munchen-unternehmensfuhrung" rel="self"/>

--- a/technische-universitat-wien.csl
+++ b/technische-universitat-wien.csl
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <style xmlns="http://purl.org/net/xbiblio/csl" class="note" default-locale="de-DE" version="1.0" demote-non-dropping-particle="sort-only">
   <info>
-    <title>Technische Universität Wien (dissertation) (German)</title>
+    <title>Technische Universität Wien (dissertation) (Deutsch)</title>
     <title-short>TU Wien</title-short>
     <id>http://www.zotero.org/styles/technische-universitat-wien</id>
     <link href="http://www.zotero.org/styles/technische-universitat-wien" rel="self"/>

--- a/tgm-wien-diplom.csl
+++ b/tgm-wien-diplom.csl
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <style xmlns="http://purl.org/net/xbiblio/csl" class="note" default-locale="de-DE" version="1.0" demote-non-dropping-particle="sort-only">
   <info>
-    <title>TGM Wien Diplomarbeit (German)</title>
+    <title>TGM Wien Diplomarbeit (Deutsch)</title>
     <id>http://www.zotero.org/styles/tgm-wien-diplom</id>
     <link href="http://www.zotero.org/styles/tgm-wien-diplom" rel="self"/>
     <link href="http://www.tgm.ac.at/" rel="documentation"/>

--- a/tgm-wien-diplomarbeit-onorm.csl
+++ b/tgm-wien-diplomarbeit-onorm.csl
@@ -2,7 +2,7 @@
 <style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" demote-non-dropping-particle="sort-only" default-locale="de-AT">
   <!-- This style was edited with the Visual CSL Editor (http://editor.citationstyles.org/visualEditor/) -->
   <info>
-    <title>TGM Wien Diplomarbeit ÖNORM (German - Austria)</title>
+    <title>TGM Wien Diplomarbeit ÖNORM (Deutsch - Österreich)</title>
     <title-short>TGM ÖNORM</title-short>
     <id>http://www.zotero.org/styles/tgm-wien-diplomarbeit-onorm</id>
     <link href="http://www.zotero.org/styles/tgm-wien-diplomarbeit-onorm" rel="self"/>

--- a/theologie-und-philosophie.csl
+++ b/theologie-und-philosophie.csl
@@ -2,7 +2,7 @@
 <style xmlns="http://purl.org/net/xbiblio/csl" version="1.0" class="note" default-locale="de-DE" demote-non-dropping-particle="sort-only">
   <!-- ====== KOPFTEIL ================================-->
   <info>
-    <title>Theologie und Philosophie (German)</title>
+    <title>Theologie und Philosophie (Deutsch)</title>
     <title-short>ThPh</title-short>
     <id>http://www.zotero.org/styles/theologie-und-philosophie</id>
     <link href="http://www.zotero.org/styles/theologie-und-philosophie" rel="self"/>

--- a/thieme-german.csl
+++ b/thieme-german.csl
@@ -2,7 +2,7 @@
 <style xmlns="http://purl.org/net/xbiblio/csl" version="1.0" demote-non-dropping-particle="sort-only" class="in-text" page-range-format="expanded" default-locale="de-DE">
   <!-- This style was edited with the Visual CSL Editor (https://editor.citationstyles.org/visualEditor/) -->
   <info>
-    <title>Thieme-German (German)</title>
+    <title>Thieme-German (Deutsch)</title>
     <id>http://www.zotero.org/styles/thieme-german</id>
     <link href="http://www.zotero.org/styles/thieme-german" rel="self"/>
     <link href="http://www.thieme.de/de/autorenlounge/fuer-zeitschriftenautoren-1789.htm" rel="documentation"/>

--- a/ucl-university-college-harvard.csl
+++ b/ucl-university-college-harvard.csl
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <style xmlns="http://purl.org/net/xbiblio/csl" version="1.0" class="in-text" and="symbol" default-locale="da-DK">
   <info>
-    <title>UCL University College - Harvard (Danish)</title>
+    <title>UCL University College - Harvard (Dansk)</title>
     <id>http://www.zotero.org/styles/ucl-university-college-harvard</id>
     <link href="http://www.zotero.org/styles/ucl-university-college-harvard" rel="self"/>
     <link href="https://sites.google.com/ucl.dk/ucl-formelle-krav/harvard" rel="documentation"/>

--- a/ugeskrift-for-laeger.csl
+++ b/ugeskrift-for-laeger.csl
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" demote-non-dropping-particle="sort-only" page-range-format="minimal" default-locale="da-DK">
   <info>
-    <title>Ugeskrift for Læger (Danish)</title>
+    <title>Ugeskrift for Læger (Dansk)</title>
     <id>http://www.zotero.org/styles/ugeskrift-for-laeger</id>
     <link href="http://www.zotero.org/styles/ugeskrift-for-laeger" rel="self"/>
     <link href="http://www.zotero.org/styles/vancouver" rel="template"/>

--- a/universitat-bern-institut-fur-musikwissenschaft-note.csl
+++ b/universitat-bern-institut-fur-musikwissenschaft-note.csl
@@ -2,7 +2,7 @@
 <style xmlns="http://purl.org/net/xbiblio/csl" class="note" version="1.0" default-locale="de-DE">
   <!-- This style was edited with the Visual CSL Editor (https://editor.citationstyles.org/visualEditor/) -->
   <info>
-    <title>Universität Bern - Institut für Musikwissenschaft (note, German)</title>
+    <title>Universität Bern - Institut für Musikwissenschaft (note, Deutsch)</title>
     <id>http://www.zotero.org/styles/universitat-bern-institut-fur-musikwissenschaft-note</id>
     <link href="http://www.zotero.org/styles/universitat-bern-institut-fur-musikwissenschaft-note" rel="self"/>
     <!--Stilvorgaben des Instituts für Musikwissenschaft -->

--- a/universitat-bern-institut-fur-sozialanthropologie.csl
+++ b/universitat-bern-institut-fur-sozialanthropologie.csl
@@ -2,7 +2,7 @@
 <style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" and="text" et-al-min="4" et-al-use-first="1" page-range-format="expanded" demote-non-dropping-particle="never" default-locale="de-CH">
   <!-- This style was edited with the Visual CSL Editor (https://editor.citationstyles.org/visualEditor/) -->
   <info>
-    <title>Universität Bern - Institut für Sozialanthropologie (German - Switzerland)</title>
+    <title>Universität Bern - Institut für Sozialanthropologie (Deutsch - Schweiz)</title>
     <title-short>Unibe Soz. Anthropologie</title-short>
     <id>http://www.zotero.org/styles/universitat-bern-institut-fur-sozialanthropologie</id>
     <link href="http://www.zotero.org/styles/universitat-bern-institut-fur-sozialanthropologie" rel="self"/>

--- a/universitat-bremen-institut-fur-politikwissenschaft.csl
+++ b/universitat-bremen-institut-fur-politikwissenschaft.csl
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" demote-non-dropping-particle="sort-only" default-locale="de-DE">
   <info>
-    <title>Universität Bremen - Institut für Politikwissenschaft (German)</title>
+    <title>Universität Bremen - Institut für Politikwissenschaft (Deutsch)</title>
     <title-short>IfP Uni Bremen</title-short>
     <id>http://www.zotero.org/styles/universitat-bremen-institut-fur-politikwissenschaft</id>
     <link href="http://www.zotero.org/styles/universitat-bremen-institut-fur-politikwissenschaft" rel="self"/>

--- a/universitat-bremen-lehrstuhl-fur-innovatives-markenmanagement.csl
+++ b/universitat-bremen-lehrstuhl-fur-innovatives-markenmanagement.csl
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <style xmlns="http://purl.org/net/xbiblio/csl" class="note" version="1.0" demote-non-dropping-particle="never" default-locale="de-DE">
   <info>
-    <title>Universität Bremen - Lehrstuhl für innovatives Markenmanagement (German)</title>
+    <title>Universität Bremen - Lehrstuhl für innovatives Markenmanagement (Deutsch)</title>
     <id>http://www.zotero.org/styles/universitat-bremen-lehrstuhl-fur-innovatives-markenmanagement</id>
     <link href="http://www.zotero.org/styles/universitat-bremen-lehrstuhl-fur-innovatives-markenmanagement" rel="self"/>
     <link href="http://www.zotero.org/styles/forum-qualitative-social-research" rel="template"/>

--- a/universitat-freiburg-geschichte.csl
+++ b/universitat-freiburg-geschichte.csl
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <style xmlns="http://purl.org/net/xbiblio/csl" class="note" version="1.0" initialize-with="." name-as-sort-order="all" default-locale="de-DE">
   <info>
-    <title>Albert-Ludwigs-Universität Freiburg - Geschichte (German)</title>
+    <title>Albert-Ludwigs-Universität Freiburg - Geschichte (Deutsch)</title>
     <id>http://www.zotero.org/styles/universitat-freiburg-geschichte</id>
     <link href="http://www.zotero.org/styles/universitat-freiburg-geschichte" rel="self"/>
     <link href="http://www.zotero.org/styles/technische-universitat-dresden-kunstgeschichte-note" rel="template"/>

--- a/universitat-heidelberg-historisches-seminar.csl
+++ b/universitat-heidelberg-historisches-seminar.csl
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <style xmlns="http://purl.org/net/xbiblio/csl" class="note" default-locale="de-DE" version="1.0" page-range-format="expanded">
   <info>
-    <title>Universität Heidelberg - Historisches Seminar (German)</title>
+    <title>Universität Heidelberg - Historisches Seminar (Deutsch)</title>
     <id>http://www.zotero.org/styles/universitat-heidelberg-historisches-seminar</id>
     <link href="http://www.zotero.org/styles/universitat-heidelberg-historisches-seminar" rel="self"/>
     <link href="http://www.uni-heidelberg.de/fakultaeten/philosophie/zegk/histsem/index.html" rel="documentation"/>

--- a/universitat-heidelberg-medizinische-fakultat-mannheim-numeric.csl
+++ b/universitat-heidelberg-medizinische-fakultat-mannheim-numeric.csl
@@ -2,7 +2,7 @@
 <style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" initialize-with="" name-as-sort-order="all" demote-non-dropping-particle="sort-only" default-locale="de-DE">
   <!-- This style was edited with the Visual CSL Editor (https://editor.citationstyles.org/visualEditor/) -->
   <info>
-    <title>Universität Heidelberg - Medizinische Fakultät Mannheim (numerisch, German)</title>
+    <title>Universität Heidelberg - Medizinische Fakultät Mannheim (numerisch, Deutsch)</title>
     <title-short>MedMa</title-short>
     <id>http://www.zotero.org/styles/universitat-heidelberg-medizinische-fakultat-mannheim-numeric</id>
     <link href="http://www.zotero.org/styles/universitat-heidelberg-medizinische-fakultat-mannheim-numeric" rel="self"/>

--- a/universitat-mainz-geographisches-institut.csl
+++ b/universitat-mainz-geographisches-institut.csl
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" default-locale="de-DE" version="1.0" demote-non-dropping-particle="sort-only">
   <info>
-    <title>Universität Mainz - Geographisches Institut (German)</title>
+    <title>Universität Mainz - Geographisches Institut (Deutsch)</title>
     <id>http://www.zotero.org/styles/universitat-mainz-geographisches-institut</id>
     <link href="http://www.zotero.org/styles/universitat-mainz-geographisches-institut" rel="self"/>
     <link href="http://www.zotero.org/styles/european-retail-research" rel="template"/>

--- a/universitat-mannheim-germanistische-linguistik.csl
+++ b/universitat-mannheim-germanistische-linguistik.csl
@@ -2,7 +2,7 @@
 <style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" demote-non-dropping-particle="sort-only" default-locale="de-DE">
   <!-- This style was edited with the Visual CSL Editor (https://editor.citationstyles.org/visualEditor/) -->
   <info>
-    <title>Universität Mannheim - Germanistische Linguistik (German)</title>
+    <title>Universität Mannheim - Germanistische Linguistik (Deutsch)</title>
     <id>http://www.zotero.org/styles/universitat-mannheim-germanistische-linguistik</id>
     <link href="http://www.zotero.org/styles/universitat-mannheim-germanistische-linguistik" rel="self"/>
     <link href="http://www.zotero.org/styles/universitat-bremen-institut-fur-politikwissenschaft" rel="template"/>

--- a/universitat-stuttgart-planung-und-partizipation.csl
+++ b/universitat-stuttgart-planung-und-partizipation.csl
@@ -2,7 +2,7 @@
 <style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" initialize="false" initialize-with="." name-as-sort-order="all" demote-non-dropping-particle="never" default-locale="de-DE">
   <!-- This style was edited with the Visual CSL Editor (https://editor.citationstyles.org/visualEditor/) -->
   <info>
-    <title>Universität Stuttgart - Planung und Partizipation (German)</title>
+    <title>Universität Stuttgart - Planung und Partizipation (Deutsch)</title>
     <title-short>Stuttgart MPP</title-short>
     <id>http://www.zotero.org/styles/universitat-stuttgart-planung-und-partizipation</id>
     <link href="http://www.zotero.org/styles/universitat-stuttgart-planung-und-partizipation" rel="self"/>

--- a/universitat-zu-koln-seminar-fur-abwl-und-finanzierungslehre.csl
+++ b/universitat-zu-koln-seminar-fur-abwl-und-finanzierungslehre.csl
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <style xmlns="http://purl.org/net/xbiblio/csl" class="note" default-locale="de-DE" version="1.0" demote-non-dropping-particle="sort-only">
   <info>
-    <title>Universität zu Köln - Seminar für ABWL und Finanzierungslehre (German)</title>
+    <title>Universität zu Köln - Seminar für ABWL und Finanzierungslehre (Deutsch)</title>
     <id>http://www.zotero.org/styles/universitat-zu-koln-seminar-fur-abwl-und-finanzierungslehre</id>
     <link href="http://www.zotero.org/styles/universitat-zu-koln-seminar-fur-abwl-und-finanzierungslehre" rel="self"/>
     <link href="http://www.zotero.org/styles/stuttgart-media-university" rel="template"/>

--- a/universitatsmedizin-gottingen.csl
+++ b/universitatsmedizin-gottingen.csl
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" demote-non-dropping-particle="never" default-locale="de-DE">
   <info>
-    <title>Universitätsmedizin Göttingen (German)</title>
+    <title>Universitätsmedizin Göttingen (Deutsch)</title>
     <title-short>UMG</title-short>
     <id>http://www.zotero.org/styles/universitatsmedizin-gottingen</id>
     <link href="http://www.zotero.org/styles/universitatsmedizin-gottingen" rel="self"/>

--- a/university-college-lillebaelt-apa.csl
+++ b/university-college-lillebaelt-apa.csl
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" demote-non-dropping-particle="never" and="symbol" initialize-with=". " delimiter-precedes-last="never" default-locale="da-DK">
   <info>
-    <title>University College Lillebælt - APA (Danish)</title>
+    <title>University College Lillebælt - APA (Dansk)</title>
     <id>http://www.zotero.org/styles/university-college-lillebaelt-apa</id>
     <link href="http://www.zotero.org/styles/university-college-lillebaelt-apa" rel="self"/>
     <link href="http://www.zotero.org/styles/apa" rel="template"/>

--- a/westfalische-wilhelms-universitat-munster-medizinische-fakultat.csl
+++ b/westfalische-wilhelms-universitat-munster-medizinische-fakultat.csl
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" demote-non-dropping-particle="sort-only" default-locale="de-DE">
   <info>
-    <title>Westfälische Wilhelms-Universität Münster - Medizinische Fakultät (German)</title>
+    <title>Westfälische Wilhelms-Universität Münster - Medizinische Fakultät (Deutsch)</title>
     <title-short>WWU</title-short>
     <id>http://www.zotero.org/styles/westfalische-wilhelms-universitat-munster-medizinische-fakultat</id>
     <link href="http://www.zotero.org/styles/westfalische-wilhelms-universitat-munster-medizinische-fakultat" rel="self"/>

--- a/wirtschaftsuniversitat-wien-abteilung-fur-bildungswissenschaft.csl
+++ b/wirtschaftsuniversitat-wien-abteilung-fur-bildungswissenschaft.csl
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" initialize="false" initialize-with="." name-as-sort-order="all" demote-non-dropping-particle="never" default-locale="de-AT">
   <info>
-    <title>Wirtschaftsuniversität Wien - Abteilung für Bildungswissenschaft (German - Austria)</title>
+    <title>Wirtschaftsuniversität Wien - Abteilung für Bildungswissenschaft (Deutsch - Österreich)</title>
     <title-short>WU Bildungswissenschaften</title-short>
     <id>http://www.zotero.org/styles/wirtschaftsuniversitat-wien-abteilung-fur-bildungswissenschaft</id>
     <link href="http://www.zotero.org/styles/wirtschaftsuniversitat-wien-abteilung-fur-bildungswissenschaft" rel="self"/>

--- a/wirtschaftsuniversitat-wien-handel-und-marketing.csl
+++ b/wirtschaftsuniversitat-wien-handel-und-marketing.csl
@@ -2,7 +2,7 @@
 <style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" name-delimiter="/" demote-non-dropping-particle="never" default-locale="de-AT">
   <!-- This style was edited with the Visual CSL Editor (http://editor.citationstyles.org/visualEditor/) -->
   <info>
-    <title>Wirtschaftsuniversität Wien - Handel und Marketing (German - Austria)</title>
+    <title>Wirtschaftsuniversität Wien - Handel und Marketing (Deutsch - Österreich)</title>
     <title-short>WU H&amp;M</title-short>
     <id>http://www.zotero.org/styles/wirtschaftsuniversitat-wien-handel-und-marketing</id>
     <link href="http://www.zotero.org/styles/wirtschaftsuniversitat-wien-handel-und-marketing" rel="self"/>

--- a/wirtschaftsuniversitat-wien-institut-fur-bwl-des-aussenhandels.csl
+++ b/wirtschaftsuniversitat-wien-institut-fur-bwl-des-aussenhandels.csl
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <style xmlns="http://purl.org/net/xbiblio/csl" class="note" version="1.0" name-as-sort-order="all" demote-non-dropping-particle="sort-only" default-locale="de-AT">
   <info>
-    <title>Wirtschaftsuniversität Wien - Institut für BWL des Außenhandels (German - Austria)</title>
+    <title>Wirtschaftsuniversität Wien - Institut für BWL des Außenhandels (Deutsch - Österreich)</title>
     <id>http://www.zotero.org/styles/wirtschaftsuniversitat-wien-institut-fur-bwl-des-aussenhandels</id>
     <link href="http://www.zotero.org/styles/wirtschaftsuniversitat-wien-institut-fur-bwl-des-aussenhandels" rel="self"/>
     <link href="http://www.zotero.org/styles/universitat-zu-koln-seminar-fur-abwl-und-finanzierungslehre" rel="template"/>

--- a/wirtschaftsuniversitat-wien-wirtschaftspadagogik.csl
+++ b/wirtschaftsuniversitat-wien-wirtschaftspadagogik.csl
@@ -2,7 +2,7 @@
 <style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" initialize="false" initialize-with="." name-as-sort-order="all" demote-non-dropping-particle="never" default-locale="de-AT">
   <!-- This style was edited with the Visual CSL Editor (http://editor.citationstyles.org/visualEditor/) -->
   <info>
-    <title>Wirtschaftsuniversität Wien - Wirtschaftspädagogik (German - Austria)</title>
+    <title>Wirtschaftsuniversität Wien - Wirtschaftspädagogik (Deutsch - Österreich)</title>
     <title-short>WU Wipäd</title-short>
     <id>http://www.zotero.org/styles/wirtschaftsuniversitat-wien-wirtschaftspadagogik</id>
     <link href="http://www.zotero.org/styles/wirtschaftsuniversitat-wien-wirtschaftspadagogik" rel="self"/>

--- a/wissenschaftlicher-industrielogistik-dialog.csl
+++ b/wissenschaftlicher-industrielogistik-dialog.csl
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" demote-non-dropping-particle="sort-only" default-locale="de-AT">
   <info>
-    <title>Wissenschaftlicher Industrielogistik-Dialog (German - Austria)</title>
+    <title>Wissenschaftlicher Industrielogistik-Dialog (Deutsch - Österreich)</title>
     <title-short>WilD</title-short>
     <id>http://www.zotero.org/styles/wissenschaftlicher-industrielogistik-dialog</id>
     <link href="http://www.zotero.org/styles/wissenschaftlicher-industrielogistik-dialog" rel="self"/>

--- a/zdfm-zeitschrift-fur-diversitatsforschung-und-management.csl
+++ b/zdfm-zeitschrift-fur-diversitatsforschung-und-management.csl
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" name-delimiter="/" demote-non-dropping-particle="never" default-locale="de-AT">
   <info>
-    <title>ZDfm &#8211; Zeitschrift für Diversitätsforschung und -management (German - Austria)</title>
+    <title>ZDfm &#8211; Zeitschrift für Diversitätsforschung und -management (Deutsch - Österreich)</title>
     <id>http://www.zotero.org/styles/zdfm-zeitschrift-fur-diversitatsforschung-und-management</id>
     <link href="http://www.zotero.org/styles/zdfm-zeitschrift-fur-diversitatsforschung-und-management" rel="self"/>
     <link href="http://www.zotero.org/styles/wirtschaftsuniversitat-wien-handel-und-marketing" rel="template"/>

--- a/zeitgeschichte.csl
+++ b/zeitgeschichte.csl
@@ -2,7 +2,7 @@
 <style xmlns="http://purl.org/net/xbiblio/csl" class="note" version="1.0" names-delimiter="/" demote-non-dropping-particle="sort-only" default-locale="de-DE">
   <!-- This style was edited with the Visual CSL Editor (http://editor.citationstyles.org/visualEditor/) -->
   <info>
-    <title>Zeitgeschichte (German)</title>
+    <title>Zeitgeschichte (Deutsch)</title>
     <title-short>Zeitgeschichte</title-short>
     <id>http://www.zotero.org/styles/zeitgeschichte</id>
     <link href="http://www.zotero.org/styles/zeitgeschichte" rel="self"/>

--- a/zeitschrift-fur-deutsche-philologie.csl
+++ b/zeitschrift-fur-deutsche-philologie.csl
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <style xmlns="http://purl.org/net/xbiblio/csl" class="note" version="1.0" demote-non-dropping-particle="sort-only" default-locale="de-DE">
   <info>
-    <title>Zeitschrift für deutsche Philologie (German)</title>
+    <title>Zeitschrift für deutsche Philologie (Deutsch)</title>
     <title-short>ZfdPh</title-short>
     <id>http://www.zotero.org/styles/zeitschrift-fur-deutsche-philologie</id>
     <link href="http://www.zotero.org/styles/zeitschrift-fur-deutsche-philologie" rel="self"/>

--- a/zeitschrift-fur-die-geschichte-des-oberrheins.csl
+++ b/zeitschrift-fur-die-geschichte-des-oberrheins.csl
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <style xmlns="http://purl.org/net/xbiblio/csl" class="note" version="1.0" default-locale="de-DE">
   <info>
-    <title>Zeitschrift für die Geschichte des Oberrheins (German)</title>
+    <title>Zeitschrift für die Geschichte des Oberrheins (Deutsch)</title>
     <id>http://www.zotero.org/styles/zeitschrift-fur-die-geschichte-des-oberrheins</id>
     <link href="http://www.zotero.org/styles/zeitschrift-fur-die-geschichte-des-oberrheins" rel="self"/>
     <link href="http://www.zotero.org/styles/chicago-note-bibliography" rel="template"/>

--- a/zeitschrift-fur-digitale-geisteswissenschaften.csl
+++ b/zeitschrift-fur-digitale-geisteswissenschaften.csl
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <style xmlns="http://purl.org/net/xbiblio/csl" version="1.0" class="note" default-locale="de-DE">
   <info>
-    <title>Zeitschrift für digitale Geisteswissenschaften (German)</title>
+    <title>Zeitschrift für digitale Geisteswissenschaften (Deutsch)</title>
     <title-short>ZfdG</title-short>
     <id>http://www.zotero.org/styles/zeitschrift-fur-digitale-geisteswissenschaften</id>
     <link href="http://www.zotero.org/styles/zeitschrift-fur-digitale-geisteswissenschaften" rel="self"/>

--- a/zeitschrift-fur-internationale-beziehungen.csl
+++ b/zeitschrift-fur-internationale-beziehungen.csl
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" demote-non-dropping-particle="never" default-locale="de-DE">
   <info>
-    <title>Zeitschrift für Internationale Beziehungen (German)</title>
+    <title>Zeitschrift für Internationale Beziehungen (Deutsch)</title>
     <title-short>ZIB</title-short>
     <id>http://www.zotero.org/styles/zeitschrift-fur-internationale-beziehungen</id>
     <link href="http://www.zotero.org/styles/zeitschrift-fur-internationale-beziehungen" rel="self"/>

--- a/zeitschrift-fur-medien-und-kulturforschung.csl
+++ b/zeitschrift-fur-medien-und-kulturforschung.csl
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <style xmlns="http://purl.org/net/xbiblio/csl" version="1.0" class="note" default-locale="de-DE" demote-non-dropping-particle="sort-only">
   <info>
-    <title>Zeitschrift für Medien- und Kulturforschung (German)</title>
+    <title>Zeitschrift für Medien- und Kulturforschung (Deutsch)</title>
     <title-short>ZMK</title-short>
     <id>http://www.zotero.org/styles/zeitschrift-fur-medien-und-kulturforschung</id>
     <link href="http://www.zotero.org/styles/zeitschrift-fur-medien-und-kulturforschung" rel="self"/>

--- a/zeitschrift-fur-medienwissenschaft.csl
+++ b/zeitschrift-fur-medienwissenschaft.csl
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <style xmlns="http://purl.org/net/xbiblio/csl" version="1.0" class="note" default-locale="de-DE" demote-non-dropping-particle="sort-only">
   <info>
-    <title>Zeitschrift für Medienwissenschaft (German)</title>
+    <title>Zeitschrift für Medienwissenschaft (Deutsch)</title>
     <title-short>ZfM</title-short>
     <id>http://www.zotero.org/styles/zeitschrift-fur-medienwissenschaft</id>
     <link href="http://www.zotero.org/styles/zeitschrift-fur-medienwissenschaft" rel="self"/>

--- a/zeitschrift-fur-ostmitteleuropa-forschung.csl
+++ b/zeitschrift-fur-ostmitteleuropa-forschung.csl
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <style xmlns="http://purl.org/net/xbiblio/csl" version="1.0" class="note" default-locale="de-DE" demote-non-dropping-particle="sort-only">
   <info>
-    <title>Zeitschrift für Ostmitteleuropa-Forschung (German)</title>
+    <title>Zeitschrift für Ostmitteleuropa-Forschung (Deutsch)</title>
     <title-short>ZfO</title-short>
     <id>http://www.zotero.org/styles/zeitschrift-fur-ostmitteleuropa-forschung</id>
     <link href="http://www.zotero.org/styles/zeitschrift-fur-ostmitteleuropa-forschung" rel="self"/>

--- a/zeitschrift-fur-padagogik.csl
+++ b/zeitschrift-fur-padagogik.csl
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" demote-non-dropping-particle="sort-only" default-locale="de-DE">
   <info>
-    <title>Zeitschrift für Pädagogik (German)</title>
+    <title>Zeitschrift für Pädagogik (Deutsch)</title>
     <title-short>ZfPäd</title-short>
     <id>http://www.zotero.org/styles/zeitschrift-fur-padagogik</id>
     <link href="http://www.zotero.org/styles/zeitschrift-fur-padagogik" rel="self"/>

--- a/zeitschrift-fur-parlamentsfragen.csl
+++ b/zeitschrift-fur-parlamentsfragen.csl
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <style xmlns="http://purl.org/net/xbiblio/csl" version="1.0" class="note" default-locale="de-DE" demote-non-dropping-particle="sort-only">
   <info>
-    <title>Zeitschrift für Parlamentsfragen (German)</title>
+    <title>Zeitschrift für Parlamentsfragen (Deutsch)</title>
     <title-short>ZParl</title-short>
     <id>http://www.zotero.org/styles/zeitschrift-fur-parlamentsfragen</id>
     <link href="http://www.zotero.org/styles/zeitschrift-fur-parlamentsfragen" rel="self"/>

--- a/zeitschrift-fur-qualitative-forschung.csl
+++ b/zeitschrift-fur-qualitative-forschung.csl
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" demote-non-dropping-particle="never" default-locale="de-DE">
   <info>
-    <title>Zeitschrift für Qualitative Forschung (German)</title>
+    <title>Zeitschrift für Qualitative Forschung (Deutsch)</title>
     <title-short>ZQF</title-short>
     <id>http://www.zotero.org/styles/zeitschrift-fur-qualitative-forschung</id>
     <link href="http://www.zotero.org/styles/zeitschrift-fur-qualitative-forschung" rel="self"/>

--- a/zeitschrift-fur-soziologie.csl
+++ b/zeitschrift-fur-soziologie.csl
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" and="symbol" delimiter-precedes-et-al="never" delimiter-precedes-last="never" demote-non-dropping-particle="never" default-locale="de-DE">
   <info>
-    <title>Zeitschrift für Soziologie (German)</title>
+    <title>Zeitschrift für Soziologie (Deutsch)</title>
     <title-short>ZfS</title-short>
     <id>http://www.zotero.org/styles/zeitschrift-fur-soziologie</id>
     <link href="http://www.zotero.org/styles/zeitschrift-fur-soziologie" rel="self"/>

--- a/zeitschrift-fur-theologie-und-kirche.csl
+++ b/zeitschrift-fur-theologie-und-kirche.csl
@@ -2,7 +2,7 @@
 <style xmlns="http://purl.org/net/xbiblio/csl" class="note" version="1.0" demote-non-dropping-particle="never" default-locale="de-DE">
   <!-- This style was edited with the Visual CSL Editor (http://editor.citationstyles.org/visualEditor/) -->
   <info>
-    <title>Zeitschrift für Theologie und Kirche (German)</title>
+    <title>Zeitschrift für Theologie und Kirche (Deutsch)</title>
     <title-short>ZThK</title-short>
     <id>http://www.zotero.org/styles/zeitschrift-fur-theologie-und-kirche</id>
     <link href="http://www.zotero.org/styles/zeitschrift-fur-theologie-und-kirche" rel="self"/>

--- a/zeitschrift-fur-zahnarztliche-implantologie.csl
+++ b/zeitschrift-fur-zahnarztliche-implantologie.csl
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" demote-non-dropping-particle="sort-only" default-locale="de-DE">
   <info>
-    <title>Zeitschrift für Zahnärztliche Implantologie (German)</title>
+    <title>Zeitschrift für Zahnärztliche Implantologie (Deutsch)</title>
     <title-short>ZZI</title-short>
     <id>http://www.zotero.org/styles/zeitschrift-fur-zahnarztliche-implantologie</id>
     <link href="http://www.zotero.org/styles/zeitschrift-fur-zahnarztliche-implantologie" rel="self"/>

--- a/zitierguide-leitfaden-zum-fachgerechten-zitieren-in-rechtswissenschaftlichen-arbeiten.csl
+++ b/zitierguide-leitfaden-zum-fachgerechten-zitieren-in-rechtswissenschaftlichen-arbeiten.csl
@@ -2,7 +2,7 @@
 <style xmlns="http://purl.org/net/xbiblio/csl" version="1.0" class="note" default-locale="de-CH">
   <!-- This style was edited with the Visual CSL Editor (https://editor.citationstyles.org/visualEditor/) -->
   <info>
-    <title>ZitierGuide: Leitfaden zum fachgerechten Zitieren in rechtswissenschaftlichen Arbeiten (Roger Müller) (German - Switzerland)</title>
+    <title>ZitierGuide: Leitfaden zum fachgerechten Zitieren in rechtswissenschaftlichen Arbeiten (Roger Müller) (Deutsch - Schweiz)</title>
     <id>http://www.zotero.org/styles/zitierguide-leitfaden-zum-fachgerechten-zitieren-in-rechtswissenschaftlichen-arbeiten</id>
     <link href="http://www.zotero.org/styles/zitierguide-leitfaden-zum-fachgerechten-zitieren-in-rechtswissenschaftlichen-arbeiten" rel="self"/>
     <link href="http://www.zotero.org/styles/juristische-zitierweise-schweizer" rel="template"/>


### PR DESCRIPTION
For https://github.com/citation-style-language/styles/issues/4921.

Regex:

Find: `German([^\(]*\)<)`
Replace: `Deutsch$1`