### PR TITLE
Localize Metropolia style title

### DIFF
--- a/metropolia-university-of-applied-sciences-harvard.csl
+++ b/metropolia-university-of-applied-sciences-harvard.csl
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <style xmlns="http://purl.org/net/xbiblio/csl" version="1.0" class="in-text" name-as-sort-order="all" demote-non-dropping-particle="sort-only" default-locale="fi-FI">
   <info>
-    <title>Metropolia University of Applied Sciences - Harvard (Suomi)</title>
+    <title>Metropolia Ammattikorkeakoulu - Harvard (Suomi)</title>
     <id>http://www.zotero.org/styles/metropolia-university-of-applied-sciences-harvard</id>
     <link href="http://www.zotero.org/styles/metropolia-university-of-applied-sciences-harvard" rel="self"/>
     <link href="http://www.zotero.org/styles/university-of-helsinki-faculty-of-theology" rel="template"/>


### PR DESCRIPTION
Using title "Metropolia Ammattikorkeakoulu" for consistency. 

https://github.com/citation-style-language/styles/pull/5282#issuecomment-782547665

Note that Haaga-Helia is "ammattikorkeakoulu" (not capitalized) and Metropolia is "Ammattikorkeakoulu" (capitalized). Using the official school's naming convention, hence the difference.