### PR TITLE
Fix Haaga-Helia style's locales

### DIFF
--- a/haaga-helia-university-of-applied-sciences-harvard.csl
+++ b/haaga-helia-university-of-applied-sciences-harvard.csl
@@ -13,7 +13,7 @@
     <category citation-format="author-date"/>
     <category field="generic-base"/>
     <summary>Haaga-Helia University of Applied Sciences referencing style (Finnish and English)</summary>
-    <updated>2021-02-19T15:36:51Z</updated>
+    <updated>2021-02-21T03:51:30Z</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <citation et-al-min="6" et-al-use-first="1" et-al-subsequent-min="3" et-al-subsequent-use-first="1" disambiguate-add-year-suffix="true">
@@ -212,7 +212,7 @@
   <macro name="title">
     <text variable="title"/>
   </macro>
-  <locale xml:lang="fi-FI">
+  <locale xml:lang="fi">
     <date form="text">
       <date-part name="day" suffix="."/>
       <date-part name="month" suffix="." form="numeric"/>
@@ -228,7 +228,7 @@
       <term name="page">s.</term>
     </terms>
   </locale>
-  <locale xml:lang="en-GB">
+  <locale xml:lang="en">
     <date form="text">
       <date-part name="day" suffix=" "/>
       <date-part name="month" suffix=" "/>


### PR DESCRIPTION
Quickly checked [Zotero style repository](https://www.zotero.org/styles/?q=haaga-helia) and realized that the locale setup is probably too pedantic in the configuration.

Incorrect render (no locale match?) in zotero.org/styles example output:
```
Hisakata, R., Nishida, S. and Johnston, A. 2016. An adaptable metric shapes perceptual space. Current Biology, 26, 14, page 1911–1915. available at: https://doi.org/10.1016/j.cub.2016.05.047. Accessed: October 3, 2016.
```

Expected output:
```
Hisakata, R., Nishida, S. & Johnston, A. 2016. An adaptable metric shapes perceptual space. Current Biology, 26, 14, pp. 1911–1915. URL: https://doi.org/10.1016/j.cub.2016.05.047. Accessed: October 3, 2016.
```
