### PR TITLE
Sort American Physiological Society citation style according to updated author instructions

### DIFF
--- a/american-physiological-society.csl
+++ b/american-physiological-society.csl
@@ -160,8 +160,7 @@
   </citation>
   <bibliography second-field-align="flush">
     <sort>
-      <key macro="author"/>
-      <key variable="issued"/>
+      <key variable="citation-number"/>
     </sort>
     <layout suffix=".">
       <text variable="citation-number" suffix=". "/>

--- a/american-physiological-society.csl
+++ b/american-physiological-society.csl
@@ -6,7 +6,7 @@
     <id>http://www.zotero.org/styles/american-physiological-society</id>
     <link href="http://www.zotero.org/styles/american-physiological-society" rel="self"/>
     <link href="http://www.zotero.org/styles/vancouver" rel="template"/>
-    <link href="https://journals.physiology.org/author-info.manuscript-composition#EXAMPLE%20REFERENCES" rel="documentation"/>
+    <link href="https://journals.physiology.org/author-info.references" rel="documentation"/>
     <author>
       <name>Michael Berkowitz</name>
       <email>mberkowi@gmu.edu</email>


### PR DESCRIPTION
Sort the bibliography in order of citation number, instead of primarily by author name and secondarily by issued date