### PR TITLE
Allow privileged testing of PRs

### DIFF
--- a/.github/workflows/sheldon.yaml
+++ b/.github/workflows/sheldon.yaml
@@ -20,10 +20,10 @@ jobs:
 
     # otherwise, checkout the current master, and the pr to the subdirectory 'pr'
     - uses: actions/checkout@v2
-      if: ! contains(github.event.pull_request.labels.*.name, 'owner-test')
+      if: "! contains(github.event.pull_request.labels.*.name, 'owner-test')"
     - uses: actions/checkout@v2
       path: pull-request
-      if: ! contains(github.event.pull_request.labels.*.name, 'owner-test')
+      if: "! contains(github.event.pull_request.labels.*.name, 'owner-test')"
       with:
         ref: ${{ github.event.pull_request.head.sha }}
 

--- a/.github/workflows/sheldon.yaml
+++ b/.github/workflows/sheldon.yaml
@@ -14,15 +14,18 @@ jobs:
     # this can only be triggered by people with repo write access -- such as people that can add
     # labels to a PR
     # https://securitylab.github.com/research/github-actions-preventing-pwn-requests
-    - uses: actions/checkout@v2
+    - name: Checkout repo for OWNER TEST
+      uses: actions/checkout@v2
       if: contains(github.event.pull_request.labels.*.name, 'owner-test')
       with:
         ref: ${{ github.event.pull_request.head.sha }}
 
     # otherwise, checkout the current master, and the pr to the subdirectory 'pr'
-    - uses: actions/checkout@v2
+    - name: Checkout base repo for pull-request test
+      uses: actions/checkout@v2
       if: "! contains(github.event.pull_request.labels.*.name, 'owner-test')"
-    - uses: actions/checkout@v2
+    - name: Checkout pull-request
+      uses: actions/checkout@v2
       if: "! contains(github.event.pull_request.labels.*.name, 'owner-test')"
       with:
         path: pull-request

--- a/.github/workflows/sheldon.yaml
+++ b/.github/workflows/sheldon.yaml
@@ -2,7 +2,7 @@ name: Pull request feedback
 
 on:
   pull_request_target:
-    types: [ opened, synchronize ]
+    types: [ opened, synchronize, labeled ]
 
 jobs:
   test:
@@ -10,7 +10,22 @@ jobs:
     env:
       GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
     steps:
+    # owner-test just checks out the PR -- this has an exfiltration risk, make SURE that
+    # this can only be triggered by people with repo write access -- such as people that can add
+    # labels to a PR
     - uses: actions/checkout@v2
+      if: contains(github.event.pull_request.labels.*.name, 'owner-test')
+      with:
+        ref: ${{ github.event.pull_request.head.sha }}
+
+    # otherwise, checkout the current master, and the pr to the subdirectory 'pr'
+    - uses: actions/checkout@v2
+      if: ! contains(github.event.pull_request.labels.*.name, 'owner-test')
+    - uses: actions/checkout@v2
+      path: pull-request
+      if: ! contains(github.event.pull_request.labels.*.name, 'owner-test')
+      with:
+        ref: ${{ github.event.pull_request.head.sha }}
 
     - name: Check for relevant changes
       uses: dorny/paths-filter@v2
@@ -29,12 +44,10 @@ jobs:
         echo changed: ${{ steps.changed.outputs.style_files }} ${{ steps.changed.outputs.locale_files }}
 
     - name: Set up Ruby
-      if: steps.changed.outputs.style == 'true' || steps.changed.outputs.locale == 'true'
       uses: ruby/setup-ruby@v1
       with:
         ruby-version: 2.7.1
     - name: but use cache to speed that up
-      if: steps.changed.outputs.style == 'true' || steps.changed.outputs.locale == 'true'
       uses: actions/cache@v2
       with:
         path: vendor/bundle
@@ -42,21 +55,15 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-gems-
     - name: Bundle install
-      if: steps.changed.outputs.style == 'true' || steps.changed.outputs.locale == 'true'
       run: |
         bundle config path vendor/bundle
         bundle update sheldon --jobs 4 --retry 3
-
-    - name: Apply the PR
-      if: steps.changed.outputs.style == 'true' || steps.changed.outputs.locale == 'true'
-      run: bundle exec sheldon --token=$GITHUB_TOKEN --apply
 
     - name: Welcome to a new PR
       if: github.event.action == 'opened' && steps.changed.outputs.style == 'true'
       run: bundle exec sheldon --token=$GITHUB_TOKEN --welcome
 
     - name: See if the styles/locales work
-      if: steps.changed.outputs.style == 'true' || steps.changed.outputs.locale == 'true'
       run: bundle exec rake
 
     - name: report

--- a/.github/workflows/sheldon.yaml
+++ b/.github/workflows/sheldon.yaml
@@ -22,9 +22,9 @@ jobs:
     - uses: actions/checkout@v2
       if: "! contains(github.event.pull_request.labels.*.name, 'owner-test')"
     - uses: actions/checkout@v2
-      path: pull-request
       if: "! contains(github.event.pull_request.labels.*.name, 'owner-test')"
       with:
+        path: pull-request
         ref: ${{ github.event.pull_request.head.sha }}
 
     - name: Check for relevant changes

--- a/.github/workflows/sheldon.yaml
+++ b/.github/workflows/sheldon.yaml
@@ -13,6 +13,7 @@ jobs:
     # owner-test just checks out the PR -- this has an exfiltration risk, make SURE that
     # this can only be triggered by people with repo write access -- such as people that can add
     # labels to a PR
+    # https://securitylab.github.com/research/github-actions-preventing-pwn-requests
     - uses: actions/checkout@v2
       if: contains(github.event.pull_request.labels.*.name, 'owner-test')
       with:

--- a/.github/workflows/sheldon.yaml
+++ b/.github/workflows/sheldon.yaml
@@ -16,17 +16,17 @@ jobs:
     # https://securitylab.github.com/research/github-actions-preventing-pwn-requests
     - name: Checkout repo for OWNER TEST
       uses: actions/checkout@v2
-      if: contains(github.event.pull_request.labels.*.name, 'owner-test')
+      if: contains(github.event.pull_request.labels.*.name, 'safe to test')
       with:
         ref: ${{ github.event.pull_request.head.sha }}
 
     # otherwise, checkout the current master, and the pr to the subdirectory 'pr'
     - name: Checkout base repo for pull-request test
       uses: actions/checkout@v2
-      if: "! contains(github.event.pull_request.labels.*.name, 'owner-test')"
+      if: "! contains(github.event.pull_request.labels.*.name, 'safe to test')"
     - name: Checkout pull-request
       uses: actions/checkout@v2
-      if: "! contains(github.event.pull_request.labels.*.name, 'owner-test')"
+      if: "! contains(github.event.pull_request.labels.*.name, 'safe to test')"
       with:
         path: pull-request
         ref: ${{ github.event.pull_request.head.sha }}

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,7 +4,7 @@ require 'yaml'
 
 STYLE_ROOT = File.expand_path('../..', __FILE__)
 PULL_REQUEST = File.join(STYLE_ROOT, 'pull-request')
-STYLE_ROOT = PULL_REQUEST if File.directory?(directory)
+STYLE_ROOT = PULL_REQUEST if File.directory?(PULL_REQUEST)
 
 ISSN = Hash.new { |h,k| h[k] = [] }
 TITLES = Hash.new { |h,k| h[k] = [] }

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,6 +3,8 @@ require 'json'
 require 'yaml'
 
 STYLE_ROOT = File.expand_path('../..', __FILE__)
+PULL_REQUEST = File.join(STYLE_ROOT, 'pull-request')
+STYLE_ROOT = PULL_REQUEST if File.directory?(directory)
 
 ISSN = Hash.new { |h,k| h[k] = [] }
 TITLES = Hash.new { |h,k| h[k] = [] }


### PR DESCRIPTION
With this PR, the "sheldon" test for PRs can run in one of two modes:

## standard mode

* The workflow checks out master on citation-style-language/styles to get the test framework
* The workflow checks out the PR into `pull-request`.
* The tests run the code from master, but spec_helper sees it is testing a PR, so loads the styles from there instead

## privileged mode

This only kicks in when the PR is labeled (edit: with a specific label that will trigger this behavior). Only repo owners can label, so this should be safe. Where with manual runs, each run would have to be started manually anew if you want to re-test the PR after syncing new commits, the label remains so would only have to be set once, and you also can clearly see which PRs run in privileged mode.

* The workflow checks out the PR *and runs the test from there*

----

I'll submit a buddy PR for the locales repo to update the spec_helper if this PR gets accepted. This PR removes Sheldon's diff-vetting; we could still apply that, but this setup should have the same safeguards against PR-exfiltration. The only extra of vetting is that PR tests will fail for mixed PRs as an extra alert, but I'm not sure whether that's worth having now.