### PR TITLE
Update journal-of-the-american-society-of-nephrology.csl

### DIFF
--- a/journal-of-the-american-society-of-nephrology.csl
+++ b/journal-of-the-american-society-of-nephrology.csl
@@ -119,7 +119,7 @@
       <text variable="citation-number"/>
     </layout>
   </citation>
-  <bibliography second-field-align="flush">
+  <bibliography second-field-align="flush" et-al-min="7" et-al-use-first="6">
     <layout>
       <text variable="citation-number" suffix=". "/>
       <text macro="author"/>


### PR DESCRIPTION
via https://forums.zotero.org/discussion/comment/378353/#Comment_378353

Guidelines: "List all authors when the number of authors is six or fewer. When the number of authors is greater than six, use et al. for all authors over six."
https://www.asn-online.org/g/blast/files/JASN%20Instructions%20for%20Authors.pdf