### PR TITLE
Update environmental-values.csl to match requirements

### DIFF
--- a/environmental-values.csl
+++ b/environmental-values.csl
@@ -148,12 +148,18 @@
   <macro name="year-date">
     <choose>
       <if variable="issued">
-        <date variable="issued">
-          <date-part name="year"/>
-        </date>
+        <group delimiter=" ">
+          <date variable="original-date" form="text" date-parts="year" prefix="[" suffix="]"/>
+          <date variable="issued">
+            <date-part name="year"/>
+          </date>
+        </group>
       </if>
+      <else-if variable="status">
+        <text variable="status"/>
+      </else-if>
       <else>
-        <text value="n.d."/>
+        <text term="no date" form="short"/>
       </else>
     </choose>
   </macro>

--- a/environmental-values.csl
+++ b/environmental-values.csl
@@ -32,7 +32,7 @@
   <macro name="editor">
     <names variable="editor">
       <name delimiter-precedes-last="never" initialize-with="."/>
-      <label form="short" strip-periods="false" prefix=" (" suffix=")"/>
+      <label form="short" prefix=" (" suffix=")"/>
     </names>
   </macro>
   <macro name="collection-title">
@@ -130,9 +130,9 @@
   <macro name="author-short">
     <names variable="author">
       <name delimiter-precedes-last="always" initialize-with="." name-as-sort-order="all"/>
-      <label form="short" prefix=". "/>
+      <label form="short" prefix=" "/>
       <substitute>
-        <names variable="editor" suffix=" ed."/>
+        <names variable="editor"/>
         <text variable="title"/>
       </substitute>
     </names>

--- a/environmental-values.csl
+++ b/environmental-values.csl
@@ -13,7 +13,7 @@
     <category citation-format="author-date"/>
     <category field="humanities"/>
     <issn>0963-2719</issn>
-    <updated>2017-07-24T09:28:04+00:00</updated>
+    <updated>2021-03-28T08:30:02+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <macro name="title">
@@ -21,6 +21,9 @@
       <if type="bill book graphic legal_case motion_picture report song" match="any">
         <text variable="title" text-case="capitalize-first" font-style="italic"/>
       </if>
+      <else-if type="article-journal" match="any">
+        <text variable="title" text-case="capitalize-first" prefix="'" suffix="'"/>
+      </else-if>
       <else>
         <text variable="title"/>
       </else>
@@ -28,7 +31,7 @@
   </macro>
   <macro name="editor">
     <names variable="editor">
-      <name sort-separator=", " initialize-with="" delimiter=", " delimiter-precedes-last="always"/>
+      <name delimiter-precedes-last="never" initialize-with="."/>
       <label form="short" strip-periods="false" prefix=" (" suffix=")"/>
     </names>
   </macro>
@@ -128,10 +131,6 @@
     <names variable="author">
       <name delimiter-precedes-last="always" initialize-with="." name-as-sort-order="all"/>
       <label form="short" prefix=". "/>
-      <substitute>
-        <names variable="editor" suffix=" ed."/>
-        <text variable="title"/>
-      </substitute>
     </names>
   </macro>
   <macro name="date">
@@ -193,7 +192,7 @@
       <key macro="year-date" sort="ascending"/>
       <key macro="title"/>
     </sort>
-    <layout suffix=".">
+    <layout>
       <choose>
         <if type="bill book" match="any">
           <group delimiter=". ">
@@ -209,7 +208,7 @@
           <group delimiter=" ">
             <text macro="author-short"/>
             <text macro="year-date"/>
-            <text macro="title"/>
+            <text macro="title" prefix="'" suffix="'."/>
             <text term="in" text-case="capitalize-first"/>
             <text macro="container-author"/>
             <group delimiter=", " suffix=",">
@@ -262,13 +261,9 @@
               </group>
             </if>
             <else>
-              <text macro="title"/>
-              <group delimiter=", " prefix=" (" suffix="). ">
-                <text macro="volume"/>
-                <text macro="year-date"/>
-              </group>
+              <text macro="author-short" suffix=". "/>
               <text macro="year-date" suffix=". "/>
-              <text macro="author-short" prefix="Ed. " suffix=". "/>
+              <text macro="title" suffix=". "/>
               <text macro="publisher" suffix=". "/>
               <group delimiter=", " suffix=". ">
                 <text macro="volume" prefix="v."/>
@@ -289,6 +284,7 @@
             <text macro="collection-title" prefix="(Serie " suffix=") "/>
             <text macro="locators" suffix=": "/>
             <text variable="page"/>
+            <text variable="DOI" prefix="https://doi.org/"/>
           </group>
         </else-if>
         <else-if type="map" match="any">

--- a/environmental-values.csl
+++ b/environmental-values.csl
@@ -13,7 +13,7 @@
     <category citation-format="author-date"/>
     <category field="humanities"/>
     <issn>0963-2719</issn>
-    <updated>2021-03-28T08:30:02+00:00</updated>
+    <updated>2021-04-12T05:24:41+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <macro name="title">
@@ -22,7 +22,7 @@
         <text variable="title" text-case="capitalize-first" font-style="italic"/>
       </if>
       <else-if type="article-journal" match="any">
-        <text variable="title" text-case="capitalize-first" prefix="'" suffix="'"/>
+        <text variable="title" text-case="capitalize-first" quotes="true"/>
       </else-if>
       <else>
         <text variable="title"/>
@@ -131,6 +131,10 @@
     <names variable="author">
       <name delimiter-precedes-last="always" initialize-with="." name-as-sort-order="all"/>
       <label form="short" prefix=". "/>
+      <substitute>
+        <names variable="editor" suffix=" ed."/>
+        <text variable="title"/>
+      </substitute>
     </names>
   </macro>
   <macro name="date">
@@ -170,6 +174,9 @@
   </macro>
   <macro name="volume">
     <text variable="volume" font-weight="bold"/>
+  </macro>
+  <macro name="doi">
+    <text variable="DOI" prefix="https://doi.org/"/>
   </macro>
   <citation et-al-min="3" et-al-use-first="1" collapse="year">
     <sort>
@@ -214,7 +221,7 @@
           <group delimiter=" ">
             <text macro="author-short"/>
             <text macro="year-date"/>
-            <text macro="title" prefix="'" suffix="'."/>
+            <text macro="title" quotes="true" suffix="."/>
             <text term="in" text-case="capitalize-first"/>
             <text macro="container-author"/>
             <group delimiter=", " suffix=",">
@@ -222,6 +229,9 @@
               <text macro="container-title"/>
             </group>
             <text macro="locators"/>
+          </group>
+          <group display="block">
+            <text macro="doi"/>
           </group>
         </else-if>
         <else-if type="thesis">
@@ -275,6 +285,9 @@
                 <text macro="volume" prefix="v."/>
                 <text variable="page" suffix=" p"/>
               </group>
+              <group display="block">
+                <text macro="doi"/>
+              </group>
             </else>
           </choose>
         </else-if>
@@ -290,7 +303,9 @@
             <text macro="collection-title" prefix="(Serie " suffix=") "/>
             <text macro="locators" suffix=": "/>
             <text variable="page"/>
-            <text variable="DOI" prefix="https://doi.org/"/>
+          </group>
+          <group display="block">
+            <text macro="doi"/>
           </group>
         </else-if>
         <else-if type="map" match="any">


### PR DESCRIPTION
Instructions: https://www.whpress.co.uk/EV/EVinst.html

One thing I did not implement is DOI on the new line. I see the instructions here but this does not work in the visual editor. https://stackoverflow.com/questions/24911522/csl-how-to-insert-a-line-break-in-bibliography

I am not sure if the changes occur at the right levels and if the problems will creep in in other styles.

----

Remove commas after names in inline ciations. (expected by publisher: (Aldred 2006: 142)), (current and erroneous): (City of Melbourne, 2012: 55)

Remove space after volume number in Journal Article, e.g. (publisher example): Aldred, J. 2006. ‘Incommensurability and monetary valuation’. Land Economics 82(3): 141–161.

Add signle inverted commas to the title in Journal Article, e.g.(publisher example): Aldred, J. 2006. ‘Incommensurability and monetary valuation’. Land Economics 82(3): 141–161.

Add full stop before In in Book Section, e.g. (publisher example): Holland, A. 1997. ‘Substitutability: Why strong sustainability is weak and absurdly strong sustainability is not absurd’. In J. Foster (ed.), Valuing Nature? Economics, Ethics and Environment, pp. 119–134. London: Routledge.

Add signle inverted commas to the title in Book Section, e.g. (publisher example): Holland, A. 1997. ‘Substitutability: Why strong sustainability is weak and absurdly strong sustainability is not absurd’. In J. Foster (ed.), Valuing Nature? Economics, Ethics and Environment, pp. 119–134. London: Routledge.

Ensure full stops after author initials in all styles. These are missing in Edited Book editor names, for example, e.g. (erroneous formatting example): Mares, I. 2001 'Firms and the welfare state: When, why, and how does social policy matter to employers?' In PA Hall, and D Soskice (eds.), Varieties of capitalism. The institutional foundations of comparative advantage, pp. 184–213. Oxford University Press: New York.

Ensure full stops after year. These are missing in Edited Book names, for example, e.g. (erroneous formatting example): Mares, I. 2001 'Firms and the welfare state: When, why, and how does social policy matter to employers?' In PA Hall, and D Soskice (eds.), Varieties of capitalism. The institutional foundations of comparative advantage, pp. 184–213. Oxford University Press: New York.

Ensure no trailing space and full stop in Report, e.g. (erroneous formatting example): Urban Forest Strategy 2012–2032: Making a Great City Greener (2012). 2012. Ed. City of Melbourne. City of Melbourne: Melbourne. . and in Thesis, , e.g. (erroneous formatting example): Hawking, S. 1966. 'Properties of expanding universes'. Doctoral thesis. University of Cambridge: Cambridge, UK. .

Remove ed. from the Author or Report, e.g. (erroneous formatting example): Urban Forest Strategy 2012–2032: Making a Great City Greener (2012). 2012. Ed. City of Melbourne. City of Melbourne: Melbourne. .

Remove commas before end in multiple author names, e.g. (erroneous formatting example): Mares, I. 2001 'Firms and the welfare state: When, why, and how does social policy matter to employers?'. In PA Hall, and D Soskice (eds.), Varieties of capitalism. The institutional foundations of comparative advantage, pp. 184–213. Oxford University Press: New York., cf. (publisher example): Martinez-Alier, J., G. Munda and J. O’Neill. 1998. ‘Weak comparability of values as a foundation for ecological economics’. Ecological Economics 26: 277–286.

(publisher instructions) The reference list should include DOIs where available. They should start on a new line and be formatted like this: https://doi.org/10.1023/A:1007113830879