### PR TITLE
Update catholic-biblical-association.csl

### DIFF
--- a/catholic-biblical-association.csl
+++ b/catholic-biblical-association.csl
@@ -405,13 +405,14 @@
       <if type="article-journal">
         <text variable="page" prefix=" "/>
       </if>
+	  <!-- Corrects the dictionary entry total page range output when a volume is cited. -->
       <else-if type="chapter entry-dictionary entry-encyclopedia" match="any">
         <choose>
           <if variable="volume">
-            <number variable="volume" form="numeric" suffix="."/>
+            <number variable="volume" form="numeric" suffix=":"/>
           </if>
         </choose>
-        <text variable="page" prefix=" "/>
+        <text variable="page"/>
       </else-if>
     </choose>
   </macro>

--- a/catholic-biblical-association.csl
+++ b/catholic-biblical-association.csl
@@ -6,7 +6,7 @@
     <link href="http://www.zotero.org/styles/catholic-biblical-association" rel="self"/>
     <link href="http://www.zotero.org/styles/society-of-biblical-literature-fullnote-bibliography" rel="template"/>
     <link href="https://assets.noviams.com/novi-file-uploads/cba/PDFs/CBQ-Instructions-for-Contributors-2020.pdf" rel="documentation"/>
-    <link href="http://cba.cua.edu/instruct2%5Ccbqinstr%5Cinstrcbq.pdf" rel="documentation"/>
+    <link href="https://www.catholicbiblical.org/cbq-instructions-for-contributors" rel="documentation"/>
     <author>
       <name>Nathan LaMontagne</name>
       <email>nathan.lamontagne@gmail.com</email>

--- a/catholic-biblical-association.csl
+++ b/catholic-biblical-association.csl
@@ -18,7 +18,7 @@
 	</contributor>
     <category citation-format="note"/>
     <category field="theology"/>
-    <updated>2021-03-30T19:39:25+00:00</updated>
+    <updated>2021-03-31T17:57:09+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale>
@@ -284,7 +284,7 @@
             </group>
           </if>
           <else>
-		    <!-- Removes an initial capital on text-based editions like rev. ed. -->
+            <!-- Removes an initial capital on text-based editions like rev. ed. -->
             <text variable="edition" suffix="."/>
           </else>
         </choose>
@@ -377,7 +377,7 @@
         <text variable="locator"/>
 	  </else-if>
       <else-if type="article-journal chapter" locator="page">
-        <text macro="pages"/>
+        <text macro="pages" prefix=" "/>
         <text variable="locator" prefix=", here "/>
       </else-if>
       <else-if type="entry-dictionary entry-encyclopedia" locator="page">

--- a/catholic-biblical-association.csl
+++ b/catholic-biblical-association.csl
@@ -5,6 +5,7 @@
     <id>http://www.zotero.org/styles/catholic-biblical-association</id>
     <link href="http://www.zotero.org/styles/catholic-biblical-association" rel="self"/>
     <link href="http://www.zotero.org/styles/society-of-biblical-literature-fullnote-bibliography" rel="template"/>
+	<link href="https://assets.noviams.com/novi-file-uploads/cba/PDFs/CBQ-Instructions-for-Contributors-2020.pdf" rel="documentation"/>
     <link href="http://cba.cua.edu/instruct2%5Ccbqinstr%5Cinstrcbq.pdf" rel="documentation"/>
     <author>
       <name>Nathan LaMontagne</name>
@@ -419,7 +420,8 @@
     </group>
   </macro>
   <citation et-al-min="4" et-al-use-first="1" disambiguate-add-names="true">
-    <layout delimiter="; ">
+    <!-- Adds a period at the end of a citation per current CBA guidelines (deference to CMS, examples in sec. 24). -->
+    <layout delimiter="; " suffix=".">
       <choose>
         <if position="ibid-with-locator">
           <group delimiter=", ">

--- a/catholic-biblical-association.csl
+++ b/catholic-biblical-association.csl
@@ -18,7 +18,7 @@
 	</contributor>
     <category citation-format="note"/>
     <category field="theology"/>
-    <updated>2021-03-30T18:29:50+00:00</updated>
+    <updated>2021-03-30T19:39:25+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale>
@@ -165,11 +165,12 @@
           </else-if>
         </choose>
       </if>
+	  <!-- Enforces use of title case per CBA sec. 24. -->
       <else-if type="book">
-        <text variable="title" form="short" font-style="italic"/>
+        <text variable="title" form="short" font-style="italic" text-case="title"/>
       </else-if>
       <else>
-        <text variable="title" form="short" quotes="true"/>
+        <text variable="title" form="short" quotes="true" text-case="title"/>
       </else>
     </choose>
   </macro>

--- a/catholic-biblical-association.csl
+++ b/catholic-biblical-association.csl
@@ -18,7 +18,7 @@
 	</contributor>
     <category citation-format="note"/>
     <category field="theology"/>
-    <updated>2021-03-30T18:13:26+00:00</updated>
+    <updated>2021-03-30T18:29:50+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale>
@@ -283,7 +283,8 @@
             </group>
           </if>
           <else>
-            <text variable="edition" text-case="capitalize-first" suffix="."/>
+		    <!-- Removes an initial capital on text-based editions like rev. ed. -->
+            <text variable="edition" suffix="."/>
           </else>
         </choose>
       </if>

--- a/catholic-biblical-association.csl
+++ b/catholic-biblical-association.csl
@@ -17,7 +17,7 @@
 	</contributor>
     <category citation-format="note"/>
     <category field="theology"/>
-    <updated>2021-03-30T14:11:18+00:00</updated>
+    <updated>2021-03-30T14:37:24+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale>
@@ -213,9 +213,10 @@
     </names>
   </macro>
   <macro name="editor">
+    <!-- Outputs citation of a work with only editors per CMS with "[name], ed." or "[names], eds." -->
     <names variable="editor">
-      <label form="verb-short" prefix=", " suffix="."/>
       <name and="text" sort-separator=", " delimiter=", "/>
+	  <label form="short" prefix=", " suffix="."/>
     </names>
   </macro>
   <macro name="volumes">

--- a/catholic-biblical-association.csl
+++ b/catholic-biblical-association.csl
@@ -1,21 +1,21 @@
 <?xml version="1.0" encoding="utf-8"?>
-<style xmlns="http://purl.org/net/xbiblio/csl" class="note" version="1.0" demote-non-dropping-particle="sort-only" default-locale="en-US" page-range-format="chicago">
+<style xmlns="http://purl.org/net/xbiblio/csl" class="note" version="1.0" demote-non-dropping-particle="sort-only" page-range-format="chicago" default-locale="en-US">
   <info>
     <title>Catholic Biblical Association (full note)</title>
     <id>http://www.zotero.org/styles/catholic-biblical-association</id>
     <link href="http://www.zotero.org/styles/catholic-biblical-association" rel="self"/>
     <link href="http://www.zotero.org/styles/society-of-biblical-literature-fullnote-bibliography" rel="template"/>
-	<link href="https://assets.noviams.com/novi-file-uploads/cba/PDFs/CBQ-Instructions-for-Contributors-2020.pdf" rel="documentation"/>
+    <link href="https://assets.noviams.com/novi-file-uploads/cba/PDFs/CBQ-Instructions-for-Contributors-2020.pdf" rel="documentation"/>
     <link href="http://cba.cua.edu/instruct2%5Ccbqinstr%5Cinstrcbq.pdf" rel="documentation"/>
     <author>
       <name>Nathan LaMontagne</name>
       <email>nathan.lamontagne@gmail.com</email>
     </author>
-	<contributor>
-	  <name>J. David Stark</name>
-	  <email>david@jdavidstark.com</email>
-	  <uri>https://www.jdavidstark.com</uri>
-	</contributor>
+    <contributor>
+      <name>J. David Stark</name>
+      <email>david@jdavidstark.com</email>
+      <uri>https://www.jdavidstark.com</uri>
+    </contributor>
     <category citation-format="note"/>
     <category field="theology"/>
     <updated>2021-03-31T17:57:09+00:00</updated>
@@ -25,10 +25,10 @@
     <terms>
       <term name="editor" form="verb-short">ed.</term>
       <term name="translator" form="verb-short">trans.</term>
-	  <!-- Overrides the defaulte en dash delimiter with the hyphen delimiter required by CBA sec. 23. -->
-	  <term name="page-range-delimiter">-</term>
-	  <!-- Allow for section-based citations per CBA's fallback to CMS. -->
-	  <term name="section" form="short">
+      <!-- Overrides the defaulte en dash delimiter with the hyphen delimiter required by CBA sec. 23. -->
+      <term name="page-range-delimiter">-</term>
+      <!-- Allow for section-based citations per CBA's fallback to CMS. -->
+      <term name="section" form="short">
         <single>§</single>
         <multiple>§§</multiple>
       </term>
@@ -165,7 +165,7 @@
           </else-if>
         </choose>
       </if>
-	  <!-- Enforces use of title case per CBA sec. 24. -->
+      <!-- Enforces use of title case per CBA sec. 24. -->
       <else-if type="book">
         <text variable="title" form="short" font-style="italic" text-case="title"/>
       </else-if>
@@ -192,7 +192,7 @@
           </if>
         </choose>
       </if>
-	  <!-- Enforces use of title case per CBA sec. 24. -->
+      <!-- Enforces use of title case per CBA sec. 24. -->
       <else-if type="book">
         <text variable="title" font-style="italic" text-case="title"/>
       </else-if>
@@ -226,7 +226,7 @@
     <!-- Outputs citation of a work with only editors per CMS with "[name], ed." or "[names], eds." -->
     <names variable="editor">
       <name and="text" sort-separator=", " delimiter=", "/>
-	  <label form="short" prefix=", " suffix="."/>
+      <label form="short" prefix=", " suffix="."/>
     </names>
   </macro>
   <macro name="volumes">
@@ -264,13 +264,13 @@
   <macro name="collection">
     <!-- CBQ uses a series abbreviation scheme that resembles but is not identical to that of the SBL Handbook of Style. See CBQ's guidelines, sec. 43, https://assets.noviams.com/novi-file-uploads/cba/PDFs/CBQ-Instructions-for-Contributors-2020.pdf. The macro below allows for a collection-title-short form to be stored and used if it is available. If it does not exist, the style uses the full series name. -->
     <choose>
-	  <if variable="collection-title">
-	    <text variable="collection-title" form="short" />
-	  </if>
-	  <else>
-	    <text variable="collection-title"/>
-	  </else>
-	</choose>
+      <if variable="collection-title">
+        <text variable="collection-title" form="short"/>
+      </if>
+      <else>
+        <text variable="collection-title"/>
+      </else>
+    </choose>
     <text variable="collection-number" prefix=" "/>
   </macro>
   <macro name="edition">
@@ -371,11 +371,11 @@
       <if variable="locator" match="none">
         <text macro="pages" prefix=" "/>
       </if>
-	  <!-- Adds support for section-based citations. -->
-	  <else-if locator="section">
-		<text term="section" form="short" prefix=" "/>
+      <!-- Adds support for section-based citations. -->
+      <else-if locator="section">
+        <text term="section" form="short" prefix=" "/>
         <text variable="locator"/>
-	  </else-if>
+      </else-if>
       <else-if type="article-journal chapter" locator="page">
         <text macro="pages" prefix=" "/>
         <text variable="locator" prefix=", here "/>
@@ -384,20 +384,20 @@
         <text macro="pages"/>
         <text variable="locator" prefix=", esp. "/>
       </else-if>
-	  <!-- Corrects improper spacing and delimitation with volume-page citations. See CBA sec. 24. -->
+      <!-- Corrects improper spacing and delimitation with volume-page citations. See CBA sec. 24. -->
       <else-if variable="volume">
         <number variable="volume" form="numeric" prefix=" " suffix=":"/>
-		<text variable="locator"/>
+        <text variable="locator"/>
       </else-if>
-	  <else>
-	  <!-- Adds sub verbo to an initial citation where it had previously been left out. -->
-	    <choose>
-		  <if locator="sub-verbo" match="any">
-			<text term="sub verbo" form="short" prefix=" "/>
-	      </if>
-		</choose>
-	    <text variable="locator" prefix=" "/>
-	  </else>
+      <else>
+        <!-- Adds sub verbo to an initial citation where it had previously been left out. -->
+        <choose>
+          <if locator="sub-verbo" match="any">
+            <text term="sub verbo" form="short" prefix=" "/>
+          </if>
+        </choose>
+        <text variable="locator" prefix=" "/>
+      </else>
     </choose>
   </macro>
   <macro name="pages">
@@ -405,7 +405,7 @@
       <if type="article-journal">
         <text variable="page" prefix=" "/>
       </if>
-	  <!-- Corrects the dictionary entry total page range output when a volume is cited. -->
+      <!-- Corrects the dictionary entry total page range output when a volume is cited. -->
       <else-if type="chapter entry-dictionary entry-encyclopedia" match="any">
         <choose>
           <if variable="volume">
@@ -460,7 +460,7 @@
     <!-- Adds a period at the end of a citation per current CBA guidelines (deference to CMS, examples in sec. 24). -->
     <layout delimiter="; " suffix=".">
       <choose>
-	    <!-- Eliminates the spurious uppercasing of ibid. if it appears mid-note. -->
+        <!-- Eliminates the spurious uppercasing of ibid. if it appears mid-note. -->
         <if position="ibid-with-locator">
           <group delimiter=", ">
             <text term="ibid"/>
@@ -471,7 +471,7 @@
           <text term="ibid"/>
         </else-if>
         <else-if position="subsequent">
-					<choose>
+          <choose>
             <!-- Add support for custom citations specified via annote. -->
             <if variable="annote">
               <text macro="custom"/>

--- a/catholic-biblical-association.csl
+++ b/catholic-biblical-association.csl
@@ -18,7 +18,7 @@
 	</contributor>
     <category citation-format="note"/>
     <category field="theology"/>
-    <updated>2021-03-30T17:34:44+00:00</updated>
+    <updated>2021-03-30T18:13:26+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale>
@@ -388,6 +388,12 @@
 		<text variable="locator"/>
       </else-if>
 	  <else>
+	  <!-- Adds sub verbo to an initial citation where it had previously been left out. -->
+	    <choose>
+		  <if locator="sub-verbo" match="any">
+			<text term="sub verbo" form="short" prefix=" "/>
+	      </if>
+		</choose>
 	    <text variable="locator" prefix=" "/>
 	  </else>
     </choose>

--- a/catholic-biblical-association.csl
+++ b/catholic-biblical-association.csl
@@ -441,6 +441,21 @@
       </date>
     </group>
   </macro>
+  <macro name="custom">
+    <!-- Add support for custom citations specified via annote. -->
+    <group>
+      <text variable="annote"/>
+      <choose>
+        <if locator="sub-verbo" match="any">
+          <text term="sub verbo" form="short" prefix=" "/>
+          <text variable="locator" prefix=" "/>
+        </if>
+        <else>
+          <text variable="locator" prefix=" "/>
+        </else>
+      </choose>
+    </group>
+  </macro>
   <citation et-al-min="4" et-al-use-first="1" disambiguate-add-names="true">
     <!-- Adds a period at the end of a citation per current CBA guidelines (deference to CMS, examples in sec. 24). -->
     <layout delimiter="; " suffix=".">
@@ -456,46 +471,61 @@
           <text term="ibid"/>
         </else-if>
         <else-if position="subsequent">
-          <group delimiter=", ">
-            <text macro="contributors-short"/>
-            <text macro="title-short"/>
-            <text macro="point-locators-subsequent"/>
-          </group>
+					<choose>
+            <!-- Add support for custom citations specified via annote. -->
+            <if variable="annote">
+              <text macro="custom"/>
+            </if>
+            <else>
+              <group delimiter=", ">
+                <text macro="contributors-short"/>
+                <text macro="title-short"/>
+                <text macro="point-locators-subsequent"/>
+              </group>
+            </else>
+          </choose>
         </else-if>
         <else>
           <choose>
-            <if type="book chapter article-journal thesis paper-conference speech" match="any">
-              <group delimiter=", " suffix=" ">
-                <text macro="contributors"/>
-                <text macro="title"/>
-                <text macro="container-title"/>
-              </group>
-              <group delimiter="; " prefix="(" suffix=")">
-                <text macro="translator"/>
-                <text macro="volumes"/>
-                <text macro="secondary-contributors"/>
-                <text macro="collection"/>
-                <text macro="edition"/>
-                <text macro="issue-note"/>
-              </group>
-              <text macro="point-locators"/>
+            <if variable="annote">
+              <text macro="custom"/>
             </if>
-            <else-if type="entry-encyclopedia entry-dictionary" match="any">
-              <group delimiter=", ">
-                <text macro="contributors"/>
-                <text macro="title"/>
-                <text macro="container-title"/>
-                <text macro="point-locators"/>
-              </group>
-            </else-if>
-            <else-if type="webpage post" match="any">
-              <group delimiter=", ">
-                <text macro="contributors"/>
-                <text macro="title"/>
-                <text macro="webpage-title"/>
-                <text macro="webpage-information"/>
-              </group>
-            </else-if>
+            <else>
+              <choose>
+                <if type="book chapter article-journal thesis paper-conference speech" match="any">
+                  <group delimiter=", " suffix=" ">
+                    <text macro="contributors"/>
+                    <text macro="title"/>
+                    <text macro="container-title"/>
+                  </group>
+                  <group delimiter="; " prefix="(" suffix=")">
+                    <text macro="translator"/>
+                    <text macro="volumes"/>
+                    <text macro="secondary-contributors"/>
+                    <text macro="collection"/>
+                    <text macro="edition"/>
+                    <text macro="issue-note"/>
+                  </group>
+                  <text macro="point-locators"/>
+                </if>
+                <else-if type="entry-encyclopedia entry-dictionary" match="any">
+                  <group delimiter=", ">
+                    <text macro="contributors"/>
+                    <text macro="title"/>
+                    <text macro="container-title"/>
+                    <text macro="point-locators"/>
+                  </group>
+                </else-if>
+                <else-if type="webpage post" match="any">
+                  <group delimiter=", ">
+                    <text macro="contributors"/>
+                    <text macro="title"/>
+                    <text macro="webpage-title"/>
+                    <text macro="webpage-information"/>
+                  </group>
+                </else-if>
+              </choose>
+            </else>
           </choose>
         </else>
       </choose>

--- a/catholic-biblical-association.csl
+++ b/catholic-biblical-association.csl
@@ -12,7 +12,7 @@
     </author>
     <category citation-format="note"/>
     <category field="theology"/>
-    <updated>2019-11-05T09:18:20+00:00</updated>
+    <updated>2019-11-07T04:38:08+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale>
@@ -246,7 +246,18 @@
     </group>
   </macro>
   <macro name="collection">
-    <text variable="collection-title"/>
+    <!-- CBQ uses a series abbreviation scheme that resembles but is not identical to that of the SBL Handbook of Style. See CBQ's guidelines, §43, https://assets.noviams.com/novi-file-uploads/cba/PDFs/CBQ-Instructions-for-Contributors-2020.pdf. The macro below allows for a collection-title-cbq variable to be stored in Extra. If this variable exists, the style uses it. If it does not but collection-title-short does, the sytle uses it. If neither exists, the style uses the full series name. -->
+    <choose>
+	  <if variable="collection-title-cbq">
+	    <text variable="collection-title-cbq"/>
+	  </if>
+	  <else-if variable="collection-title-short">
+	    <text variable="collection-title-short"/>
+	  </else-if>
+	  <else>
+	    <text variable="collection-title"/>
+	  </else>
+	</choose>
     <text variable="collection-number" prefix=" "/>
   </macro>
   <macro name="edition">

--- a/catholic-biblical-association.csl
+++ b/catholic-biblical-association.csl
@@ -18,7 +18,7 @@
 	</contributor>
     <category citation-format="note"/>
     <category field="theology"/>
-    <updated>2021-03-30T16:13:44+00:00</updated>
+    <updated>2021-03-30T16:21:25+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale>
@@ -186,11 +186,12 @@
           </if>
         </choose>
       </if>
+	  <!-- Enforces use of title case per CBA sec. 24. -->
       <else-if type="book">
-        <text variable="title" font-style="italic"/>
+        <text variable="title" font-style="italic" text-case="title"/>
       </else-if>
       <else>
-        <text variable="title" quotes="true"/>
+        <text variable="title" quotes="true" text-case="title"/>
       </else>
     </choose>
   </macro>

--- a/catholic-biblical-association.csl
+++ b/catholic-biblical-association.csl
@@ -18,7 +18,7 @@
 	</contributor>
     <category citation-format="note"/>
     <category field="theology"/>
-    <updated>2021-03-30T16:21:25+00:00</updated>
+    <updated>2021-03-30T17:34:44+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale>
@@ -27,6 +27,11 @@
       <term name="translator" form="verb-short">trans.</term>
 	  <!-- Overrides the defaulte en dash delimiter with the hyphen delimiter required by CBA sec. 23. -->
 	  <term name="page-range-delimiter">-</term>
+	  <!-- Allow for section-based citations per CBA's fallback to CMS. -->
+	  <term name="section" form="short">
+        <single>§</single>
+        <multiple>§§</multiple>
+      </term>
     </terms>
   </locale>
   <!--
@@ -364,11 +369,16 @@
       <if variable="locator" match="none">
         <text macro="pages" prefix=" "/>
       </if>
-      <else-if type="article-journal chapter" match="any">
+	  <!-- Adds support for section-based citations. -->
+	  <else-if locator="section">
+		<text term="section" form="short" prefix=" "/>
+        <text variable="locator"/>
+	  </else-if>
+      <else-if type="article-journal chapter" locator="page">
         <text macro="pages"/>
         <text variable="locator" prefix=", here "/>
       </else-if>
-      <else-if type="entry-dictionary entry-encyclopedia" match="any">
+      <else-if type="entry-dictionary entry-encyclopedia" locator="page">
         <text macro="pages"/>
         <text variable="locator" prefix=", esp. "/>
       </else-if>

--- a/catholic-biblical-association.csl
+++ b/catholic-biblical-association.csl
@@ -423,14 +423,15 @@
     <!-- Adds a period at the end of a citation per current CBA guidelines (deference to CMS, examples in sec. 24). -->
     <layout delimiter="; " suffix=".">
       <choose>
+	    <!-- Eliminates the spurious uppercasing of ibid. if it appears mid-note. -->
         <if position="ibid-with-locator">
           <group delimiter=", ">
-            <text term="ibid" text-case="capitalize-first" suffix="."/>
+            <text term="ibid"/>
             <text macro="point-locators-subsequent"/>
           </group>
         </if>
         <else-if position="ibid">
-          <text term="ibid" text-case="capitalize-first" suffix="."/>
+          <text term="ibid"/>
         </else-if>
         <else-if position="subsequent">
           <group delimiter=", ">

--- a/catholic-biblical-association.csl
+++ b/catholic-biblical-association.csl
@@ -10,9 +10,14 @@
       <name>Nathan LaMontagne</name>
       <email>nathan.lamontagne@gmail.com</email>
     </author>
+	<contributor>
+	  <name>J. David Stark</name>
+	  <email>david@jdavidstark.com</email>
+	  <uri>https://www.jdavidstark.com</uri>
+	</contributor>
     <category citation-format="note"/>
     <category field="theology"/>
-    <updated>2019-11-07T04:38:08+00:00</updated>
+    <updated>2021-03-30T14:11:18+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale>
@@ -246,14 +251,11 @@
     </group>
   </macro>
   <macro name="collection">
-    <!-- CBQ uses a series abbreviation scheme that resembles but is not identical to that of the SBL Handbook of Style. See CBQ's guidelines, §43, https://assets.noviams.com/novi-file-uploads/cba/PDFs/CBQ-Instructions-for-Contributors-2020.pdf. The macro below allows for a collection-title-cbq variable to be stored in Extra. If this variable exists, the style uses it. If it does not but collection-title-short does, the sytle uses it. If neither exists, the style uses the full series name. -->
+    <!-- CBQ uses a series abbreviation scheme that resembles but is not identical to that of the SBL Handbook of Style. See CBQ's guidelines, sec. 43, https://assets.noviams.com/novi-file-uploads/cba/PDFs/CBQ-Instructions-for-Contributors-2020.pdf. The macro below allows for a collection-title-short form to be stored and used if it is available. If it does not exist, the style uses the full series name. -->
     <choose>
-	  <if variable="collection-title-cbq">
-	    <text variable="collection-title-cbq"/>
+	  <if variable="collection-title">
+	    <text variable="collection-title" form="short" />
 	  </if>
-	  <else-if variable="collection-title-short">
-	    <text variable="collection-title-short"/>
-	  </else-if>
 	  <else>
 	    <text variable="collection-title"/>
 	  </else>

--- a/catholic-biblical-association.csl
+++ b/catholic-biblical-association.csl
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<style xmlns="http://purl.org/net/xbiblio/csl" class="note" version="1.0" demote-non-dropping-particle="sort-only" default-locale="en-US">
+<style xmlns="http://purl.org/net/xbiblio/csl" class="note" version="1.0" demote-non-dropping-particle="sort-only" default-locale="en-US" page-range-format="chicago">
   <info>
     <title>Catholic Biblical Association (full note)</title>
     <id>http://www.zotero.org/styles/catholic-biblical-association</id>
@@ -18,13 +18,15 @@
 	</contributor>
     <category citation-format="note"/>
     <category field="theology"/>
-    <updated>2021-03-30T14:37:24+00:00</updated>
+    <updated>2021-03-30T15:52:55+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale>
     <terms>
       <term name="editor" form="verb-short">ed.</term>
       <term name="translator" form="verb-short">trans.</term>
+	  <!-- Overrides the defaulte en dash delimiter with the hyphen delimiter required by CBA sec. 23. -->
+	  <term name="page-range-delimiter">-</term>
     </terms>
   </locale>
   <!--

--- a/catholic-biblical-association.csl
+++ b/catholic-biblical-association.csl
@@ -18,7 +18,7 @@
 	</contributor>
     <category citation-format="note"/>
     <category field="theology"/>
-    <updated>2021-03-30T15:52:55+00:00</updated>
+    <updated>2021-03-30T16:13:44+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale>
@@ -371,14 +371,14 @@
         <text macro="pages"/>
         <text variable="locator" prefix=", esp. "/>
       </else-if>
-      <else>
-        <choose>
-          <if variable="volume">
-            <number variable="volume" form="numeric" prefix=" " suffix="."/>
-          </if>
-        </choose>
-        <text variable="locator" prefix=" "/>
-      </else>
+	  <!-- Corrects improper spacing and delimitation with volume-page citations. See CBA sec. 24. -->
+      <else-if variable="volume">
+        <number variable="volume" form="numeric" prefix=" " suffix=":"/>
+		<text variable="locator"/>
+      </else-if>
+	  <else>
+	    <text variable="locator" prefix=" "/>
+	  </else>
     </choose>
   </macro>
   <macro name="pages">


### PR DESCRIPTION
This update

1. Adds current CBA documentation,
2. Adds support for custom citations specified by CBA and stored in annote,
3. Uses Chicago-style page range truncation,
4. Enforces the use of title case,
5. Allows CBA style to make use of a collection-title-short variable stored in Extra,
6. Corrects an improper output of a work cited with only editors as responsible parties (i.e., from ", ed. [name(s)]" to "[name], ed." or "[names], eds.",
7. Eliminates the spurious uppercasing of "ibid." if it appears not at the start of a sentence,
8. Removes a spurious initial capital from text-based editions (e.g., "rev. ed."),
9. Adds a sub verbo note where it had previously been left out of an initial citation,
10. Corrects improper delimitation and spacing with volume-page citations,
11. Changes the page range scheme to Chicago, and overrides the default e*n dash range delimiter with a hyphen, and
12. Adds a period at the end of a citation.

This update also offers partial support for section-based citations. But I'm having trouble

1. Getting §§ instead of § when there's more than one section being cited and
2. Getting section ranges to truncate properly according to Chicago-style rules.

If there are suggestions particularly about this last item, I'd be most grateful to be pointed to what I'm missing. And this is my first try at proposing style updates directly. So, please pardon and feel free to correct me if there's a better way of doing what I'm trying to achieve here.

Thank you so much!