### PR TITLE
Adicionar ponto e espaço antes de "Disponível em:"

### DIFF
--- a/associacao-brasileira-de-normas-tecnicas.csl
+++ b/associacao-brasileira-de-normas-tecnicas.csl
@@ -154,7 +154,7 @@ do autor. Na regra da ABNT o sobrenome deve aparecer com todas as letras em caix
   </macro>
   <!--A macro 'access' e utilizada em arquivos de paginas da web. Ela e responsavel por mostrar a URL do site pesquisado e a data do acesso-->
   <macro name="access">
-    <text variable="URL" prefix="Disponível em: &lt;" suffix="&gt;"/>
+    <text variable="URL" prefix=". Disponível em: &lt;" suffix="&gt;"/>
     <date variable="accessed" prefix=". Acesso em: ">
       <date-part name="day" suffix=" "/>
       <date-part name="month" form="short" suffix=". " text-case="lowercase"/>

--- a/associacao-brasileira-de-normas-tecnicas.csl
+++ b/associacao-brasileira-de-normas-tecnicas.csl
@@ -154,7 +154,7 @@ do autor. Na regra da ABNT o sobrenome deve aparecer com todas as letras em caix
   </macro>
   <!--A macro 'access' e utilizada em arquivos de paginas da web. Ela e responsavel por mostrar a URL do site pesquisado e a data do acesso-->
   <macro name="access">
-    <text variable="URL" prefix=". Disponível em: &lt;" suffix="&gt;"/>
+    <text variable="URL" prefix="Disponível em: &lt;" suffix="&gt;"/>
     <date variable="accessed" prefix=". Acesso em: ">
       <date-part name="day" suffix=" "/>
       <date-part name="month" form="short" suffix=". " text-case="lowercase"/>
@@ -605,7 +605,7 @@ em caixa alta. Utiliza-se antes do nome da conferencia a expressao "In". Segundo
           <!--Local-->
           <text variable="publisher" suffix=", "/>
           <!--Editor-->
-          <text macro="issued"/>
+          <text macro="issued" suffix=". "/>
           <!--Data-->
           <text macro="access"/>
           <!--URL, data do acesso-->


### PR DESCRIPTION
Verifiquei a necessidade dessa correção no uso de trabalho publicado em evento.