### PR TITLE
Update revue-forestiere-francaise.csl

### DIFF
--- a/revue-forestiere-francaise.csl
+++ b/revue-forestiere-francaise.csl
@@ -169,7 +169,7 @@
       <choose>
         <if type="report">
           <group delimiter=", ">
-            <text variable="title" quotes="true"/>
+            <text variable="title" quotes="false"/>
             <text macro="translator"/>
             <text variable="genre"/>
             <text variable="collection-title" font-style="italic"/>
@@ -212,7 +212,7 @@
           </group>
         </else-if>
         <else-if type="chapter">
-          <text variable="title" quotes="true"/>
+          <text variable="title" quotes="false"/>
           <group prefix=", ">
             <text value="dans" suffix=" "/>
             <text macro="editor" suffix=", "/>
@@ -227,7 +227,7 @@
         </else-if>
         <else-if type="speech">
           <group delimiter=", ">
-            <text variable="title" quotes="true"/>
+            <text variable="title" quotes="false"/>
             <text variable="event"/>
             <text variable="event-place"/>
             <text macro="full-date"/>
@@ -236,7 +236,7 @@
         </else-if>
         <else-if type="article-newspaper article-magazine interview broadcast" match="any">
           <group delimiter=", ">
-            <text variable="title" quotes="true"/>
+            <text variable="title" quotes="false"/>
             <text variable="container-title" font-style="italic" prefix=" "/>
             <text macro="full-date"/>
             <text macro="translator"/>
@@ -245,7 +245,7 @@
         </else-if>
         <else>
           <group delimiter=" " suffix=",">
-            <text variable="title" quotes="true"/>
+            <text variable="title" quotes="false"/>
             <text macro="editor"/>
           </group>
           <group prefix=" " delimiter=", ">


### PR DESCRIPTION
Changed the quote instruction from true to false in the bibliography section, so that the name of the report/speech/chapter/etc. is not framed by quote marks
