### PR TITLE
Updating infoclio.ch styles

### DIFF
--- a/infoclio-de-kurzbelege.csl
+++ b/infoclio-de-kurzbelege.csl
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<style xmlns="http://purl.org/net/xbiblio/csl" class="note" default-locale="de-CH" version="1.0" name-delimiter="; " delimiter-precedes-last="always" delimiter-precedes-et-al="never">
+<style xmlns="http://purl.org/net/xbiblio/csl" class="note" version="1.0" name-delimiter="; " delimiter-precedes-last="always" delimiter-precedes-et-al="never" default-locale="de-CH">
   <info>
     <title>infoclio.ch (Kurzbelege, Deutsch - Schweiz)</title>
     <id>http://www.zotero.org/styles/infoclio-de-kurzbelege</id>

--- a/infoclio-de-kurzbelege.csl
+++ b/infoclio-de-kurzbelege.csl
@@ -1,10 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
-<style xmlns="http://purl.org/net/xbiblio/csl" class="note" default-locale="fr-FR" version="1.0" delimiter-precedes-last="never" delimiter-precedes-et-al="never" and="text">
+<style xmlns="http://purl.org/net/xbiblio/csl" class="note" default-locale="de-CH" version="1.0" name-delimiter="; " delimiter-precedes-last="always" delimiter-precedes-et-al="never">
   <info>
-    <title>infoclio.ch (petites majuscules, Français)</title>
-    <id>http://www.zotero.org/styles/infoclio-fr-smallcaps</id>
-    <link href="http://www.zotero.org/styles/infoclio-fr-smallcaps" rel="self"/>
-    <link href="https://www.infoclio.ch/fr/node/138218" rel="documentation"/>
+    <title>infoclio.ch (Kurzbelege, Deutsch - Schweiz)</title>
+    <id>http://www.zotero.org/styles/infoclio-de-kurzbelege</id>
+    <link href="http://www.zotero.org/styles/infoclio-de-kurzbelege" rel="self"/>
+    <link href="http://www.zotero.org/styles/infoclio-de" rel="template"/>
+    <link href="https://www.infoclio.ch/de/node/133932" rel="documentation"/>
     <author>
       <name>Nicolas Chachereau</name>
       <email>nicolas.chachereau@unil.ch</email>
@@ -24,28 +25,18 @@
     <category citation-format="note"/>
     <category field="history"/>
     <category field="social_science"/>
-    <updated>2018-03-27T11:57:56+02:00</updated>
+    <updated>2021-04-15T17:51:45+02:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
-  <locale xml:lang="fr">
-    <date form="numeric">
-      <date-part name="day" form="numeric-leading-zeros" suffix="."/>
-      <date-part name="month" form="numeric-leading-zeros" suffix="."/>
-      <date-part name="year"/>
-    </date>
+  <locale xml:lang="de">
     <terms>
-      <term name="cited" form="short">cit.</term>
-      <term name="page" form="short">
-        <single>p.</single>
-        <multiple>pp.</multiple>
-      </term>
-      <term name="editor" form="short">
-        <single>éd.</single>
-        <multiple>éds.</multiple>
-      </term>
-      <term name="interviewer" form="verb">entretien réalisé par</term>
-      <term name="letter">courrier</term>
-      <term name="number-of-volumes" form="short">vol.</term>
+      <term name="editor" form="short">Hg.</term>
+      <term name="interviewer" form="verb">Interview geführt von</term>
+      <term name="accessed">Stand</term>
+      <term name="letter">Schreiben</term>
+      <term name="number-of-volumes" form="short">Bd.</term>
+      <term name="no date" form="short">o. D.</term>
+      <term name="edition">Ausgabe</term>
     </terms>
   </locale>
   <citation>
@@ -60,11 +51,8 @@
         <else-if position="ibid">
           <text term="ibid"/>
         </else-if>
-        <else-if position="subsequent">
-          <text macro="subsequent-reference"/>
-        </else-if>
         <else>
-          <text macro="complete-reference"/>
+          <text macro="short-reference"/>
         </else>
       </choose>
     </layout>
@@ -81,25 +69,27 @@
   <macro name="complete-reference">
     <group delimiter=". ">
       <group delimiter=", ">
-        <text macro="creator"/>
-        <text macro="title"/>
         <group delimiter=": ">
-          <text macro="in"/>
+          <text macro="creator"/>
           <group delimiter=", ">
-            <text macro="container-creator"/>
-            <group delimiter=" ">
-              <text macro="container-information"/>
-              <text macro="journal-volume"/>
+            <text macro="title"/>
+            <group delimiter=": ">
+              <text macro="in"/>
+              <text macro="container-creator"/>
+              <group delimiter=", ">
+                <group delimiter=" ">
+                  <text macro="container-information"/>
+                  <text macro="journal-volume"/>
+                </group>
+                <text macro="volumes"/>
+              </group>
             </group>
-            <text macro="volumes"/>
+            <text macro="type-description"/>
           </group>
         </group>
-        <text macro="type-description"/>
         <text macro="alt-publisher"/>
-        <text macro="edition"/>
-        <text macro="place"/>
-        <text macro="publishing-house"/>
         <group delimiter=" ">
+          <text macro="place"/>
           <text macro="date"/>
           <date variable="original-date" form="text" prefix="[" suffix="]"/>
           <text macro="book-series"/>
@@ -113,20 +103,19 @@
       <text macro="url-non-web-documents"/>
     </group>
   </macro>
-  <macro name="subsequent-reference">
+  <macro name="short-reference">
     <group delimiter=", ">
-      <text macro="creator-for-subsequent"/>
-      <text macro="identifier-for-subsequent"/>
-      <text macro="op-cit"/>
+      <group delimiter=": ">
+        <text macro="creator-for-short-references"/>
+        <text macro="identifier-for-short-references"/>
+      </group>
       <date variable="issued" form="numeric" date-parts="year"/>
       <text macro="locator"/>
     </group>
   </macro>
   <macro name="creator">
     <names variable="author">
-      <name sort-separator=" " name-as-sort-order="all" et-al-min="4" et-al-use-first="3">
-        <name-part name="family" font-variant="small-caps"/>
-      </name>
+      <name sort-separator=", " name-as-sort-order="all" et-al-min="4" et-al-use-first="3"/>
       <label form="short" prefix="&#160;(" suffix=")"/>
       <substitute>
         <names variable="editor"/>
@@ -135,11 +124,9 @@
       </substitute>
     </names>
   </macro>
-  <macro name="creator-for-subsequent">
+  <macro name="creator-for-short-references">
     <names variable="author">
-      <name form="short" et-al-min="4" et-al-use-first="1">
-        <name-part name="family" font-variant="small-caps"/>
-      </name>
+      <name form="short" et-al-min="4" et-al-use-first="1"/>
       <label form="short" prefix="&#160;(" suffix=")"/>
       <substitute>
         <names variable="editor"/>
@@ -149,94 +136,38 @@
     </names>
   </macro>
   <macro name="title">
-    <choose>
-      <if type="book thesis graphic" match="any">
-        <text variable="title" font-style="italic"/>
-      </if>
-      <else-if type="article article-magazine article-newspaper article-journal entry entry-dictionary entry-encyclopedia report chapter paper-conference post post-weblog webpage song broadcast dataset" match="any">
-        <text variable="title" quotes="true"/>
-      </else-if>
-      <else-if type="motion_picture">
-        <choose>
-          <if variable="collection-title">
-            <text variable="title" quotes="true"/>
-          </if>
-          <else>
-            <text variable="title" font-style="italic"/>
-          </else>
-        </choose>
-      </else-if>
-      <else>
-        <text variable="title"/>
-      </else>
-    </choose>
+    <text variable="title"/>
   </macro>
-  <macro name="identifier-for-subsequent">
+  <macro name="identifier-for-short-references">
     <choose>
       <if variable="title title-short" match="any">
-        <choose>
-          <if type="book thesis graphic" match="any">
-            <text variable="title" font-style="italic" form="short"/>
-          </if>
-          <else-if type="article article-magazine article-newspaper article-journal entry entry-dictionary entry-encyclopedia report chapter paper-conference post post-weblog webpage song broadcast dataset" match="any">
-            <text variable="title" quotes="true" form="short"/>
-          </else-if>
-          <else-if type="motion_picture">
-            <choose>
-              <if variable="collection-title">
-                <text variable="title" quotes="true"/>
-              </if>
-              <else>
-                <text variable="title" font-style="italic"/>
-              </else>
-            </choose>
-          </else-if>
-          <else>
-            <text variable="title" form="short"/>
-          </else>
-        </choose>
+        <text variable="title" form="short"/>
       </if>
       <else-if type="personal_communication">
         <group delimiter=" ">
           <text term="letter"/>
           <names variable="recipient">
             <label form="verb" prefix=" " suffix=" "/>
-            <name et-al-min="3" et-al-use-first="1"/>
+            <name et-al-min="2" et-al-use-first="1"/>
           </names>
         </group>
       </else-if>
       <else-if type="interview">
         <names variable="interviewer" delimiter=", ">
           <label form="verb" prefix=" " suffix=" "/>
-          <name et-al-min="3" et-al-use-first="1"/>
+          <name et-al-min="2" et-al-use-first="1"/>
         </names>
       </else-if>
       <else-if type="report song broadcast motion_picture webpage post post-weblog" match="any">
         <!-- these types have either collection-title or container-title -->
-        <text variable="collection-title" font-style="italic"/>
-        <text variable="container-title" font-style="italic"/>
+        <text variable="collection-title"/>
+        <text variable="container-title"/>
       </else-if>
     </choose>
   </macro>
-  <macro name="op-cit">
-    <group font-style="italic" delimiter="&#160;" suffix=".">
-      <choose>
-        <if type="article article-magazine article-newspaper article-journal entry entry-dictionary entry-encyclopedia chapter paper-conference post post-weblog" match="any">
-          <text value="art."/>
-        </if>
-        <else-if type="manuscript personal_communication interview report webpage" match="any">
-          <text value="doc."/>
-        </else-if>
-        <else-if type="book thesis graphic motion_picture song broadcast" match="any">
-          <text value="op."/>
-        </else-if>
-      </choose>
-      <text term="cited" form="short"/>
-    </group>
-  </macro>
   <macro name="in">
     <choose>
-      <if type="chapter paper-conference entry-encyclopedia entry-dictionary" match="any">
+      <if type="chapter paper-conference entry-encyclopedia entry-dictionary article-magazine article-newspaper article-journal" match="any">
         <text term="in"/>
       </if>
     </choose>
@@ -245,9 +176,7 @@
     <choose>
       <if type="chapter paper-conference" match="any">
         <names variable="editor">
-          <name sort-separator=" " name-as-sort-order="all" et-al-min="4" et-al-use-first="3">
-            <name-part name="family" font-variant="small-caps"/>
-          </name>
+          <name sort-separator=", " name-as-sort-order="all" et-al-min="4" et-al-use-first="3"/>
           <label form="short" prefix="&#160;(" suffix=")"/>
           <substitute>
             <names variable="container-author"/>
@@ -260,14 +189,14 @@
   <macro name="container-information">
     <choose>
       <if type="chapter paper-conference entry-encyclopedia entry-dictionary article-newspaper article-magazine article-journal" match="any">
-        <text variable="container-title" font-style="italic"/>
+        <text variable="container-title"/>
       </if>
       <else-if type="report song broadcast motion_picture webpage post post-weblog" match="any">
         <group delimiter=", ">
           <text variable="genre"/>
           <!-- these types have either collection-title or container-title -->
-          <text variable="collection-title" font-style="italic"/>
-          <text variable="container-title" font-style="italic"/>
+          <text variable="collection-title"/>
+          <text variable="container-title"/>
         </group>
       </else-if>
     </choose>
@@ -316,7 +245,7 @@
             <text term="letter"/>
             <names variable="recipient">
               <label form="verb" prefix=" " suffix=" "/>
-              <name/>
+              <name and="text" delimiter-precedes-last="never"/>
             </names>
           </group>
           <text variable="genre"/>
@@ -325,7 +254,7 @@
       <else-if type="interview">
         <names variable="interviewer" delimiter=", ">
           <label form="verb" prefix=" " suffix=" "/>
-          <name/>
+          <name and="text" delimiter-precedes-last="never"/>
         </names>
       </else-if>
       <else-if type="motion_picture song broadcast" match="any">
@@ -360,30 +289,14 @@
   </macro>
   <macro name="alt-publisher">
     <choose>
-      <if type="song motion_picture broadcast" match="any">
-        <!--
+      <if type="thesis report song motion_picture broadcast" match="any">
+        <!-- university for theses,
+             institution for reports,
              label for songs,
              distributor for films,
              studio for video recordings,
              network for broadcasts -->
         <text variable="publisher"/>
-      </if>
-    </choose>
-  </macro>
-  <macro name="edition">
-    <choose>
-      <if type="book chapter entry-dictionary entry-encyclopedia" match="any">
-        <choose>
-          <if is-numeric="edition">
-            <group delimiter="&#160;">
-              <number variable="edition" form="ordinal"/>
-              <label variable="edition"/>
-            </group>
-          </if>
-          <else>
-            <text variable="edition"/>
-          </else>
-        </choose>
       </if>
     </choose>
   </macro>
@@ -400,19 +313,17 @@
       </else>
     </choose>
   </macro>
-  <macro name="publishing-house">
-    <choose>
-      <if type="book chapter thesis report paper-conference entry-dictionary entry-encyclopedia" match="any">
-        <text variable="publisher"/>
-      </if>
-    </choose>
-  </macro>
   <macro name="date">
     <choose>
       <if type="book chapter paper-conference thesis" match="any">
         <choose>
           <if variable="issued">
             <date variable="issued" form="numeric" date-parts="year"/>
+            <choose>
+              <if is-numeric="edition">
+                <number vertical-align="sup" variable="edition"/>
+              </if>
+            </choose>
           </if>
           <else>
             <text term="no date" form="short"/>
@@ -501,7 +412,7 @@
         <group delimiter=", ">
           <text variable="archive"/>
           <text variable="archive_location"/>
-          <text variable="call-number" prefix="Cote: "/>
+          <text variable="call-number" prefix="Signatur: "/>
         </group>
       </if>
     </choose>
@@ -548,7 +459,7 @@
     </choose>
   </macro>
   <macro name="accessed">
-    <group delimiter=" ">
+    <group delimiter=": ">
       <text term="accessed"/>
       <date variable="accessed" form="numeric" date-parts="year-month-day"/>
     </group>

--- a/infoclio-de.csl
+++ b/infoclio-de.csl
@@ -292,7 +292,7 @@
   </macro>
   <macro name="alt-publisher">
     <choose>
-      <if type="book chapter paper-conference entry-dictionary entry-encyclopedia" match="none">
+      <if type="thesis report song motion_picture broadcast" match="any">
         <!-- university for theses,
              institution for reports,
              label for songs,

--- a/infoclio-fr-nocaps.csl
+++ b/infoclio-fr-nocaps.csl
@@ -355,7 +355,7 @@
   </macro>
   <macro name="alt-publisher">
     <choose>
-      <if type="book chapter thesis report paper-conference entry-dictionary entry-encyclopedia" match="none">
+      <if type="song motion_picture broadcast" match="any">
         <!--
              label for songs,
              distributor for films,


### PR DESCRIPTION
This is a small update to a custom style for history students in Switzerland. See #234 for the original pull request, and #3898 for the last update.

Changes:

- `publisher` field is only displayed for specific types, rather than almost any type (this change was necessary because many translators have started including the "publisher" variable in the Extra field for journal articles).
- New CSL file for a common style for German-speaking historians, where footnotes only include a short version of the reference. Except for this change, the file is the same as `infoclio-de.csl`.

I know I tend to use the same text in my pull request, but that does not mean I'm not sincere when I write: Thank you again for taking the time to maintain the styles!