### PR TITLE
Make style bilingual for thesis writing.

### DIFF
--- a/china-national-standard-gb-t-7714-2015-numeric.csl
+++ b/china-national-standard-gb-t-7714-2015-numeric.csl
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<style xmlns="http://purl.org/net/xbiblio/csl" version="1.0" class="in-text" default-locale="zh-CN" delimiter-precedes-last="always" demote-non-dropping-particle="never" initialize-with=" " name-delimiter=", " names-delimiter=". " name-as-sort-order="all" sort-separator=" ">
+<style xmlns="http://purl.org/net/xbiblio/csl" version="1.0" class="in-text" default-locale="en-US" delimiter-precedes-last="always" demote-non-dropping-particle="never" initialize-with=" " name-delimiter=", " names-delimiter=". " name-as-sort-order="all" sort-separator=" ">
   <info>
     <title>China National Standard GB/T 7714-2015 (numeric, 中文)</title>
     <title-short>GB/T 7714-2015</title-short>
@@ -7,13 +7,13 @@
     <link href="http://www.zotero.org/styles/china-national-standard-gb-t-7714-2015-numeric" rel="self"/>
     <link href="http://www.std.gov.cn/gb/search/gbDetailed?id=71F772D8055ED3A7E05397BE0A0AB82A" rel="documentation"/>
     <author>
-      <name>牛耕田</name>
+      <name>牛耕田 and lychichem</name>
       <email>buffalo_d@163.com</email>
     </author>
     <category citation-format="numeric"/>
     <category field="generic-base"/>
-    <summary>The Chinese GB/T7714-2015 numeric style</summary>
-    <updated>2019-04-27T18:00:00+08:00</updated>
+    <summary>The Chinese GB/T7714-2015 numeric style. If you need to remove DOI link, remove line 240 and 288. If you don't need uppercase names, remove all the 'text-case="uppercase"'. Please note that you need to set the "语言" string for Chinese content to "zh" in Zotero to use "等" for author names.</summary>
+    <updated>2021-04-16T21:20:00+08:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale xml:lang="zh-CN">
@@ -24,6 +24,12 @@
         <single>p.</single>
         <multiple>pp.</multiple>
       </term>
+    </terms>
+  </locale>
+  </locale>
+  <locale xml:lang="en-US">
+    <terms>
+      <term name="edition"> edition</term>
     </terms>
   </locale>
   <macro name="accessed-date">
@@ -59,7 +65,7 @@
   <macro name="edition">
     <choose>
       <if variable="edition">
-        <group delimiter=" ">
+        <group delimiter="">
           <text variable="edition"/>
           <text term="edition"/>
         </group>
@@ -186,6 +192,54 @@
     </layout>
   </citation>
   <bibliography entry-spacing="0" et-al-min="4" et-al-use-first="3" line-spacing="1" second-field-align="flush">
+    <layout suffix="." locale="zh">
+      <text variable="citation-number" prefix="[" suffix="]"/>
+      <text macro="author" suffix=". "/>
+      <text macro="title"/>
+      <choose>
+        <if type="book bill chapter legislation paper-conference report thesis" match="any">
+          <text macro="editor" prefix=". "/>
+          <choose>
+            <if variable="container-title">
+              <text value="//"/>
+              <text macro="container-author" suffix=". "/>
+              <text variable="container-title" suffix=". " text-case="title"/>
+            </if>
+            <else>
+              <text value=". "/>
+            </else>
+          </choose>
+          <text macro="edition" suffix=". "/>
+          <text macro="publishing"/>
+        </if>
+        <else-if type="article-journal article-magazine article-newspaper" match="any">
+          <group prefix=". ">
+            <choose>
+              <if variable="container-title">
+                <text variable="container-title" text-case="title"/>
+                <text macro="serial-information" prefix=", "/>
+              </if>
+              <else>
+                <text macro="serial-information" suffix=". "/>
+                <text macro="publishing"/>
+              </else>
+            </choose>
+          </group>
+        </else-if>
+        <else-if type="patent">
+          <text macro="issued-date" prefix=". "/>
+        </else-if>
+        <else>
+          <text macro="publishing" prefix=". "/>
+          <text macro="issued-date" prefix="(" suffix=")"/>
+        </else>
+      </choose>
+      <text macro="accessed-date"/>
+      <group delimiter=". " prefix=". ">
+        <text variable="URL"/>
+        <text variable="DOI" prefix="DOI:"/>
+      </group>
+    </layout>  
     <layout suffix=".">
       <text variable="citation-number" prefix="[" suffix="]"/>
       <text macro="author" suffix=". "/>

--- a/china-national-standard-gb-t-7714-2015-numeric.csl
+++ b/china-national-standard-gb-t-7714-2015-numeric.csl
@@ -26,7 +26,6 @@
       </term>
     </terms>
   </locale>
-  </locale>
   <locale xml:lang="en-US">
     <terms>
       <term name="edition"> edition</term>
@@ -209,7 +208,7 @@
               <text value=". "/>
             </else>
           </choose>
-          <text macro="edition" suffix=". "/>
+          <text macro="edition" prefix="第" suffix=". "/>
           <text macro="publishing"/>
         </if>
         <else-if type="article-journal article-magazine article-newspaper" match="any">


### PR DESCRIPTION
The work contains these fixes below:
1: Make the biblography bilingual to fit the thesis writing situation for Chinese students, where both Chinese and English contents are cited but mostly English contents are cited.
2. In Chinese, there's no need to add space between "edition" and the term "版", however in English there must have a space. The style deals with it properly now.
3. Update the summy on how to remove DOI link and not using uppercase for author names.