### PR TITLE
Adds missing space after title and moves space from title prefix to author suffix.

### DIFF
--- a/acta-anaesthesiologica-scandinavica.csl
+++ b/acta-anaesthesiologica-scandinavica.csl
@@ -157,7 +157,7 @@
     <layout>
       <text variable="citation-number" suffix=". "/>
       <text macro="author" suffix="."/>
-      <text macro="title" suffix="." prefix=" "/>
+      <text macro="title" suffix=". " prefix=" "/>
       <choose>
         <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
           <group prefix=" " delimiter=" ">

--- a/acta-anaesthesiologica-scandinavica.csl
+++ b/acta-anaesthesiologica-scandinavica.csl
@@ -155,9 +155,11 @@
   </citation>
   <bibliography second-field-align="flush">
     <layout>
-      <text variable="citation-number" suffix=". "/>
-      <text macro="author" suffix=". "/>
-      <text macro="title" suffix=". "/>
+      <group delimiter=". " suffix=". ">
+        <text variable="citation-number"/>
+        <text macro="author"/>
+        <text macro="title"/>
+      </group>
       <choose>
         <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
           <group prefix=" " delimiter=" ">

--- a/acta-anaesthesiologica-scandinavica.csl
+++ b/acta-anaesthesiologica-scandinavica.csl
@@ -156,8 +156,8 @@
   <bibliography second-field-align="flush">
     <layout>
       <text variable="citation-number" suffix=". "/>
-      <text macro="author" suffix="."/>
-      <text macro="title" suffix=". " prefix=" "/>
+      <text macro="author" suffix=". "/>
+      <text macro="title" suffix=". "/>
       <choose>
         <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
           <group prefix=" " delimiter=" ">


### PR DESCRIPTION
First commit (2a88753) fixes an error.
The second (9e7784c) should not change the output.