### PR TITLE
Small improvement for web documents

### DIFF
--- a/azr-abkurzungs-und-zitierregeln-der-osterreichischen-rechtssprache-und-europarechtlicher-rechtsquellen.csl
+++ b/azr-abkurzungs-und-zitierregeln-der-osterreichischen-rechtssprache-und-europarechtlicher-rechtsquellen.csl
@@ -306,7 +306,14 @@
           <text variable="title" suffix=" "/>
           <text variable="URL" suffix=" "/>
           <text variable="locator" prefix="(" suffix="), "/>
-          <date variable="accessed" prefix="(aufgerufen am " suffix=")" form="numeric"/>
+          <choose>
+            <if variable="issued">
+              <date variable="issued" prefix="(Stand " suffix=")" form="numeric"/>
+            </if>
+            <else>
+              <date variable="accessed" prefix="(aufgerufen am " suffix=")" form="numeric"/>
+            </else>
+          </choose>
         </else-if>
         <else>
           <group delimiter=", ">
@@ -466,7 +473,14 @@
           <text variable="title" suffix=" "/>
           <text variable="URL" suffix=" "/>
           <text variable="locator" prefix="(" suffix="), "/>
-          <date variable="accessed" prefix="(aufgerufen am " suffix=")" form="numeric"/>
+          <choose>
+            <if variable="issued">
+              <date variable="issued" prefix="(Stand " suffix=")" form="numeric"/>
+            </if>
+            <else>
+              <date variable="accessed" prefix="(aufgerufen am " suffix=")" form="numeric"/>
+            </else>
+          </choose>
         </else-if>
         <else>
           <group delimiter=", ">


### PR DESCRIPTION
@PhilippTh would you have a quick look, please? This renders the date issued if it exists, prefixed with "Stand" instead of the date accessed, to comply with AZR Rz 88.