### PR TITLE
Update the-plant-genome.csl

### DIFF
--- a/the-plant-genome.csl
+++ b/the-plant-genome.csl
@@ -1,29 +1,30 @@
 <?xml version="1.0" encoding="utf-8"?>
 <style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" demote-non-dropping-particle="sort-only" default-locale="en-US">
   <info>
-    <title>The Plant Genome</title>
-    <id>http://www.zotero.org/styles/the-plant-genome</id>
-    <link href="http://www.zotero.org/styles/the-plant-genome" rel="self"/>
+    <title>The Plant Genome Modified</title>
+    <id>http://www.zotero.org/styles/the-plant-genome-modified</id>
+    <link href="http://www.zotero.org/styles/the-plant-genome-modified" rel="self"/>
+    <link href="http://www.zotero.org/styles/the-plant-genome" rel="template"/>
     <link href="http://www.zotero.org/styles/journal-of-dairy-science" rel="template"/>
     <link href="https://dl.sciencesocieties.org/publications/tpg/author-instructions" rel="documentation"/>
     <author>
-      <name>Patrick O'Brien</name>
+      <name></name>
     </author>
     <category citation-format="author-date"/>
     <category field="biology"/>
     <eissn>1940-3372</eissn>
-    <updated>2017-08-16T13:03:54+00:00</updated>
+    <updated>2017-08-17T01:31:39+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <macro name="editor">
     <names variable="editor" delimiter=", ">
-      <name and="text" initialize-with="." delimiter=", "/>
-      <label form="short" plural="never" prefix=", "/>
+      <name and="symbol" initialize-with="." delimiter=", " delimiter-precedes-last="never"/>
+      <label form="short" text-case="capitalize-first" prefix=" (" suffix=')'/>
     </names>
   </macro>
   <macro name="author">
     <names variable="author">
-      <name name-as-sort-order="first" and="text" sort-separator=", " initialize-with="." delimiter=", " delimiter-precedes-last="always"/>
+      <name name-as-sort-order="all" and="symbol" sort-separator=", " initialize-with="." delimiter=", " delimiter-precedes-last="always"/>
       <label form="short" prefix=" "/>
       <substitute>
         <names variable="editor"/>
@@ -33,7 +34,7 @@
   </macro>
   <macro name="author-short">
     <names variable="author">
-      <name form="short" and="text" delimiter=", " initialize-with="."/>
+      <name form="short" and="symbol" delimiter=", " initialize-with="."/>
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
@@ -44,7 +45,7 @@
   <macro name="title">
     <choose>
       <if type="book webpage" match="any">
-        <text variable="title" text-case="title"/>
+        <text variable="title" text-case="title" font-style="italic"/>
       </if>
       <else>
         <text variable="title"/>
@@ -88,7 +89,7 @@
       </group>
     </layout>
   </citation>
-  <bibliography line-spacing="2" hanging-indent="true">
+  <bibliography line-spacing="1" hanging-indent="true">
     <sort>
       <key macro="author" names-use-last="true"/>
       <key macro="year-date" names-use-last="true"/>
@@ -97,16 +98,16 @@
       <group delimiter=". ">
         <text macro="author"/>
         <date variable="issued">
-          <date-part name="year"/>
+          <date-part name="year" prefix="(" suffix=")"/>
         </date>
         <choose>
           <if type="book report chapter" match="any">
-            <group delimiter=". " prefix=" ">
-              <text macro="title"/>
+            <group delimiter=" ">
+              <text macro="title" suffix="."/>
               <text macro="edition"/>
-              <text macro="editor"/>
-              <text variable="collection-title"/>
-              <text variable="collection-number" prefix="No. "/>
+              <text macro="editor" prefix=" In " suffix=","/>
+              <text variable="container-title" font-style="italic"/>
+              <text variable="page" prefix="(pp. " suffix=")."/>
               <text macro="publisher"/>
             </group>
           </if>
@@ -145,8 +146,8 @@
           </else-if>
           <else-if type="thesis" match="any">
             <group prefix=" ">
-              <text macro="title" suffix="."/>
-              <text variable="genre" prefix=" " suffix=" Thesis."/>
+              <text macro="title" font-style="italic"/>
+              <text variable="genre" prefix=" [" suffix="]."/>
               <text variable="publisher" form="short" prefix=" " suffix=","/>
               <text variable="publisher-place" prefix=" "/>
             </group>
@@ -164,12 +165,12 @@
           <else>
             <group prefix=" ">
               <text macro="title"/>
-              <text variable="container-title" form="short" font-style="normal" prefix=". "/>
-              <group delimiter=":" prefix=" ">
-                <text variable="volume"/>
+              <text variable="container-title" font-style="italic" prefix=". " suffix=", "/>
+              <group delimiter=", " prefix=" ">
+                <text variable="volume" font-style="italic"/>
                 <text variable="page"/>
               </group>
-              <text variable="DOI" prefix=". doi:"/>
+              <text variable="DOI" prefix=". https://doi.org/"/>
             </group>
           </else>
         </choose>

--- a/the-plant-genome.csl
+++ b/the-plant-genome.csl
@@ -1,25 +1,24 @@
 <?xml version="1.0" encoding="utf-8"?>
 <style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" demote-non-dropping-particle="sort-only" default-locale="en-US">
   <info>
-    <title>The Plant Genome Modified</title>
-    <id>http://www.zotero.org/styles/the-plant-genome-modified</id>
-    <link href="http://www.zotero.org/styles/the-plant-genome-modified" rel="self"/>
-    <link href="http://www.zotero.org/styles/the-plant-genome" rel="template"/>
+    <title>The Plant Genome</title>
+    <id>http://www.zotero.org/styles/the-plant-genome</id>
+    <link href="http://www.zotero.org/styles/the-plant-genome" rel="self"/>
     <link href="http://www.zotero.org/styles/journal-of-dairy-science" rel="template"/>
     <link href="https://dl.sciencesocieties.org/publications/tpg/author-instructions" rel="documentation"/>
     <author>
-      <name></name>
+      <name>Patrick O'Brien</name>
     </author>
     <category citation-format="author-date"/>
     <category field="biology"/>
     <eissn>1940-3372</eissn>
-    <updated>2017-08-17T01:31:39+00:00</updated>
+    <updated>2021-05-05T12:00:00+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <macro name="editor">
     <names variable="editor" delimiter=", ">
       <name and="symbol" initialize-with="." delimiter=", " delimiter-precedes-last="never"/>
-      <label form="short" text-case="capitalize-first" prefix=" (" suffix=')'/>
+      <label form="short" text-case="capitalize-first" prefix=" (" suffix=")"/>
     </names>
   </macro>
   <macro name="author">


### PR DESCRIPTION
The original file lacks some formatting features of journal articles, thesis and book chapters, according to the style guidelines of the journal.

Changes I have made include: italics for titles of theses, journal names and book container, "and" as symbol, brackets in theses, add pages in books, years in parenthesis, "(Eds.)" specification in books.

