### PR TITLE
Update society-of-biblical-literature-fullnote-bibliography.csl

### DIFF
--- a/society-of-biblical-literature-fullnote-bibliography.csl
+++ b/society-of-biblical-literature-fullnote-bibliography.csl
@@ -32,7 +32,7 @@
     <category citation-format="note"/>
     <category field="theology"/>
     <summary>Society of Biblical Literature format with full notes and bibliography</summary>
-    <updated>2021-04-13T15:55:26+00:00</updated>
+    <updated>2021-05-06T18:37:26+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale xml:lang="en-US">
@@ -684,8 +684,8 @@
                   </if>
                   <else>
                     <group delimiter=" ">
-                      <label variable="locator" form="short"/>
-                      <text variable="locator"/>
+                        <label variable="locator" form="short"/>
+                        <text variable="locator"/>
                     </group>
                   </else>
                 </choose>
@@ -938,7 +938,7 @@
       <choose>
         <!-- Support custom citations via the annote variable. For discussion, see https://forums.zotero.org/discussion/comment/317370 -->
         <if variable="annote">
-          <group delimiter=" ">
+          <group delimiter=", ">
             <text variable="annote"/>
             <text macro="point-locators-subsequent"/>
           </group>

--- a/society-of-biblical-literature-fullnote-bibliography.csl
+++ b/society-of-biblical-literature-fullnote-bibliography.csl
@@ -32,7 +32,7 @@
     <category citation-format="note"/>
     <category field="theology"/>
     <summary>Society of Biblical Literature format with full notes and bibliography</summary>
-    <updated>2021-05-06T18:37:26+00:00</updated>
+    <updated>2021-05-06T18:48:02+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale xml:lang="en-US">
@@ -938,10 +938,20 @@
       <choose>
         <!-- Support custom citations via the annote variable. For discussion, see https://forums.zotero.org/discussion/comment/317370 -->
         <if variable="annote">
-          <group delimiter=", ">
-            <text variable="annote"/>
-            <text macro="point-locators-subsequent"/>
-          </group>
+          <choose>
+            <if locator="sub-verbo">
+              <group delimiter=", ">
+                <text variable="annote"/>
+                <text macro="point-locators-subsequent"/>
+              </group>
+            </if>
+            <else>
+              <group delimiter=" ">
+                <text variable="annote"/>
+                <text macro="point-locators-subsequent"/>
+              </group>
+            </else>
+          </choose>
         </if>
         <!-- Lexicon/Dictionary/Encyclopedia -->
         <else-if type="entry-dictionary entry-encyclopedia" match="any">

--- a/society-of-biblical-literature-fullnote-bibliography.csl
+++ b/society-of-biblical-literature-fullnote-bibliography.csl
@@ -32,7 +32,7 @@
     <category citation-format="note"/>
     <category field="theology"/>
     <summary>Society of Biblical Literature format with full notes and bibliography</summary>
-    <updated>2021-05-06T18:48:02+00:00</updated>
+    <updated>2021-05-10T14:27:36+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale xml:lang="en-US">
@@ -939,14 +939,14 @@
         <!-- Support custom citations via the annote variable. For discussion, see https://forums.zotero.org/discussion/comment/317370 -->
         <if variable="annote">
           <choose>
-            <if locator="sub-verbo">
-              <group delimiter=", ">
+            <if locator="section">
+              <group delimiter=" ">
                 <text variable="annote"/>
                 <text macro="point-locators-subsequent"/>
               </group>
             </if>
             <else>
-              <group delimiter=" ">
+              <group delimiter=", ">
                 <text variable="annote"/>
                 <text macro="point-locators-subsequent"/>
               </group>


### PR DESCRIPTION
When a custom citation is triggered by the annote variable being used, this change inserts a comma and space (rather than space only) as a delimiter before the locator. This helps prevent the need to store the comma in annote and improves interoperability with similar styles (e.g., Catholic Biblical Association) that require an identical abbreviated reference but a different delimiter (space only).