### PR TITLE
Add workaround for software style in ASA (sociology)

### DIFF
--- a/american-sociological-association.csl
+++ b/american-sociological-association.csl
@@ -21,7 +21,6 @@
   </info>
   <locale xml:lang="en">
     <terms>
-      <term name="reference">computer program</term>
       <term name="version">version</term>
     </terms>
   </locale>
@@ -86,6 +85,7 @@
       <if type="thesis">
         <text variable="title" text-case="title"/>
       </if>
+      <!-- Software Hack -->
       <else-if type="book" variable="version" match="all">
         <!-- Allow lower-case initial letters, e.g., iPhone, ggplot2 -->
         <text variable="title" font-style="italic"/>
@@ -233,14 +233,14 @@
         </else-if>
         <!--Software hack-->
         <else-if type="book" variable="version" match="all">
-          <group prefix=" " delimiter=" ">
+          <group prefix=" " delimiter=". ">
             <group>
-              <text macro="title"/>
-              <text term="reference" prefix=" [" suffix="]." text-case="lowercase"/>
+              <!-- To Do: localize once we have a proper term -->
+              <text macro="title" suffix=" [computer program]" />
             </group>
-            <group>
+            <group delimiter=" ">
               <text term="version" text-case="capitalize-first"/>
-              <text variable="version" suffix="."/>
+              <text variable="version"/>
             </group>
             <text variable="URL"/>
           </group>

--- a/american-sociological-association.csl
+++ b/american-sociological-association.csl
@@ -69,7 +69,7 @@
             <text prefix="(" suffix=")" variable="URL"/>
           </group>
         </if>
-        <else-if type="article-journal" match="any">
+        <else-if type="article-journal report" match="any">
           <text variable="DOI" prefix="doi: "/>
         </else-if>
       </choose>
@@ -220,6 +220,11 @@
             <text variable="genre"/>
             <text macro="publisher"/>
           </group>
+        </else-if>
+        <else-if type="book" variable="version">
+          <text variable="title" prefix=" " suffix=""/>
+          <text variable="version" prefix=" (version " suffix=") [Computer program]."/>
+          <text prefix=" Retrieved from " suffix="" variable="URL"/>
         </else-if>
         <else-if type="bill book graphic legal_case legislation motion_picture report song" match="any">
           <group delimiter=". ">

--- a/american-sociological-association.csl
+++ b/american-sociological-association.csl
@@ -21,7 +21,7 @@
   </info>
   <locale xml:lang="en">
     <terms>
-      <term name="retrieved">retrieved from</term>
+      <term name="program">computer program</term>
     </terms>
   </locale>
   <macro name="editor">
@@ -85,6 +85,10 @@
       <if type="thesis">
         <text variable="title" text-case="title"/>
       </if>
+      <else-if type="book" variable="version" match="all">
+        <!-- Allow lower-case initial letters, e.g., iPhone, ggplot2 -->
+        <text variable="title" font-style="italic"/>
+      </else-if>
       <else-if type="bill book graphic legal_case legislation motion_picture report song" match="any">
         <text variable="title" font-style="italic" text-case="title"/>
       </else-if>
@@ -229,12 +233,10 @@
         <!--Software hack-->
         <else-if type="book" variable="version" match="all">
           <group prefix=" " delimiter=" ">
-            <text variable="title"/>
-            <text variable="version" prefix="(version " suffix=") [Computer program]."/>
-            <group delimiter=" ">
-              <text term="retrieved" text-case="capitalize-first"/>
-              <text variable="URL"/>
-            </group>
+            <text macro="title"/>
+            <text term="program" prefix=" [" suffix="]. "/>
+            <text variable="version" prefix="Version " suffix="."/>
+            <text variable="URL"/>
           </group>
         </else-if>
         <else-if type="bill book graphic legal_case legislation motion_picture report song" match="any">

--- a/american-sociological-association.csl
+++ b/american-sociological-association.csl
@@ -19,6 +19,11 @@
     <updated>2020-09-18T10:38:12+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
+  <locale xml:lang="en">
+    <terms>
+      <term name="retrieved">retrieved from"</term>
+    </terms>
+  </locale>
   <macro name="editor">
     <names variable="editor">
       <label form="verb" suffix=" "/>
@@ -221,10 +226,16 @@
             <text macro="publisher"/>
           </group>
         </else-if>
-        <else-if type="book" variable="version">
-          <text variable="title" prefix=" " suffix=""/>
-          <text variable="version" prefix=" (version " suffix=") [Computer program]."/>
-          <text prefix=" Retrieved from " suffix="" variable="URL"/>
+        <!--Software hack-->
+        <else-if type="book" variable="version" match="all">
+          <group prefix=" " delimiter=" ">
+          <text variable="title"/>
+          <text variable="version" prefix="(version " suffix=") [Computer program]."/>
+            <group delimiter=" ">
+              <term name="retrieved" text-case="title"/>
+             <text variable="URL"/>
+            </group>
+          </group>
         </else-if>
         <else-if type="bill book graphic legal_case legislation motion_picture report song" match="any">
           <group delimiter=". ">

--- a/american-sociological-association.csl
+++ b/american-sociological-association.csl
@@ -21,7 +21,7 @@
   </info>
   <locale xml:lang="en">
     <terms>
-      <term name="retrieved">retrieved from"</term>
+      <term name="retrieved">retrieved from</term>
     </terms>
   </locale>
   <macro name="editor">
@@ -232,7 +232,7 @@
             <text variable="title"/>
             <text variable="version" prefix="(version " suffix=") [Computer program]."/>
             <group delimiter=" ">
-              <term name="retrieved" text-case="title"/>
+              <text term="retrieved" text-case="capitalize-first"/>
               <text variable="URL"/>
             </group>
           </group>

--- a/american-sociological-association.csl
+++ b/american-sociological-association.csl
@@ -229,11 +229,11 @@
         <!--Software hack-->
         <else-if type="book" variable="version" match="all">
           <group prefix=" " delimiter=" ">
-          <text variable="title"/>
-          <text variable="version" prefix="(version " suffix=") [Computer program]."/>
+            <text variable="title"/>
+            <text variable="version" prefix="(version " suffix=") [Computer program]."/>
             <group delimiter=" ">
               <term name="retrieved" text-case="title"/>
-             <text variable="URL"/>
+              <text variable="URL"/>
             </group>
           </group>
         </else-if>


### PR DESCRIPTION
* Include condition for CSL to interpret an item with type=book and an entry for version as a computer program following: https://forums.zotero.org/discussion/comment/363537/#Comment_363537
* Make citation entry for computer programs when type=book and version is present following style:

Last, First. Year. Program Name (version #) [Computer program]. Retrieved from <url>.