### PR TITLE
Update Documentation for ACS

### DIFF
--- a/american-chemical-society.csl
+++ b/american-chemical-society.csl
@@ -5,7 +5,7 @@
     <title-short>ACS</title-short>
     <id>http://www.zotero.org/styles/american-chemical-society</id>
     <link href="http://www.zotero.org/styles/american-chemical-society" rel="self"/>
-    <link href="https://pubs.acs.org/doi/pdf/10.1021/bk-2006-STYG.ch014" rel="documentation"/>
+    <link href="https://doi.org/10.1021/acsguide.40303" rel="documentation"/>
     <author>
       <name>Julian Onions</name>
       <email>julian.onions@gmail.com</email>


### PR DESCRIPTION
The old Link is broken. ACS support gave a new link for documentation.