### PR TITLE
Update hochschule-bonn-rhein-sieg.csl

### DIFF
--- a/hochschule-bonn-rhein-sieg.csl
+++ b/hochschule-bonn-rhein-sieg.csl
@@ -258,7 +258,7 @@
       <key macro="author"/>
       <key macro="issued-year"/>
     </sort>
-    <layout prefix="(" suffix=")" delimiter="; ">
+    <layout prefix="" suffix="" delimiter="; ">
       <group delimiter=", ">
         <text macro="author-short"/>
         <text macro="issued-year"/>


### PR DESCRIPTION
Changed visualization of citations in footnotes. It was visualized in brackets. Now, no brackets are shown in footnote citations