### PR TITLE
Update harvard-bournemouth-university.csl

### DIFF
--- a/harvard-bournemouth-university.csl
+++ b/harvard-bournemouth-university.csl
@@ -14,7 +14,7 @@
     <summary>Bournemouth University Harvard style based on based on the British Standards BS 5605:1990 Recommendations for citing and
     referencing published material and BS 1629:1989 Recommendations or references to
     published materials.</summary>
-    <updated>2013-03-16T02:03:44+00:00</updated>
+    <updated>2021-05-31T12:00:00+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <macro name="author">

--- a/harvard-bournemouth-university.csl
+++ b/harvard-bournemouth-university.csl
@@ -5,7 +5,7 @@
     <id>http://www.zotero.org/styles/harvard-bournemouth-university</id>
     <link href="http://www.zotero.org/styles/harvard-bournemouth-university" rel="self"/>
     <link href="http://www.zotero.org/styles/taylor-and-francis-harvard-x" rel="template"/>
-    <link href="http://www.bournemouth.ac.uk/library/local-assets/how-to/docs/citing-references.pdf" rel="documentation"/>
+    <link href="https://libguides.bournemouth.ac.uk/ld.php?content_id=33139758" rel="documentation"/>
     <author>
       <name>Sebastian Karcher</name>
     </author>
@@ -21,7 +21,7 @@
     <choose>
       <if type="motion_picture broadcast" match="none">
         <names variable="author">
-          <name name-as-sort-order="all" sort-separator=", " initialize-with=". " delimiter=", " and="text"/>
+          <name name-as-sort-order="all" sort-separator=", " initialize-with=". " delimiter=", " and="text" delimiter-precedes-last="never"/>
           <label form="short" prefix=", "/>
           <et-al font-style="italic"/>
           <substitute>
@@ -310,7 +310,7 @@
       <key macro="issued"/>
       <key macro="author"/>
     </sort>
-    <layout prefix="(" suffix=")" delimiter=", ">
+    <layout prefix="(" suffix=")" delimiter="; ">
       <group delimiter=", ">
         <group delimiter=" ">
           <text macro="author-short"/>


### PR DESCRIPTION
- Old documentation hyperlink lead to 404
- When more than one source is cited, the delimiter should be ;
- Oxford commas are not used for authors/editors/translators in BU-Harvard