### PR TITLE
Multiple references of the same author : sorted by date first, ascending

### DIFF
--- a/chicago-fullnote-bibliography-fr.csl
+++ b/chicago-fullnote-bibliography-fr.csl
@@ -1541,9 +1541,9 @@
   <bibliography hanging-indent="true" et-al-min="11" et-al-use-first="7" subsequent-author-substitute="&#8212;&#8212;&#8212;" entry-spacing="0">
     <sort>
       <key macro="contributors-sort"/>
+      <key variable="issued"/>
       <key variable="title"/>
       <key variable="genre"/>
-      <key variable="issued"/>
     </sort>
     <layout suffix=".">
       <choose>


### PR DESCRIPTION
Previously, the multiple references of the same author were sorted by title first, following the CMS, I am suggesting to sort them by ascending date of publication first.

Auparavant, les références multiples d'un même auteur étaient classées par titre, suivant le CMS je propose de les classer par date de publication ascendant en priorité. 

Sources :
- https://www.chicagomanualofstyle.org/book/ed17/part3/ch14/figures/fig009.html 
- https://www.chicagomanualofstyle.org/book/ed17/part3/ch15/psec018.html 
- https://www.chicagomanualofstyle.org/book/ed17/part3/ch14/psec071.html