### PR TITLE
Update food-and-agriculture-organization-of-the-united-nations.csl 

### DIFF
--- a/food-and-agriculture-organization-of-the-united-nations.csl
+++ b/food-and-agriculture-organization-of-the-united-nations.csl
@@ -62,7 +62,7 @@
   </macro>
   <macro name="author-short">
     <names variable="author">
-      <name form="short" and="text" delimiter-precedes-et-al="never" delimiter-precedes-last="never" et-al-min="4" et-al-use-first="1" initialize-with="."/>
+      <name form="short" and="text" delimiter-precedes-et-al="never" delimiter-precedes-last="never" initialize-with="."/>
       <et-al font-style="italic"/>
       <substitute>
         <names variable="editor"/>
@@ -139,7 +139,7 @@
     </group>
   </macro>
   <!-- in-line citation: (author, date) -->
-  <citation disambiguate-add-year-suffix="true" collapse="year">
+  <citation disambiguate-add-year-suffix="true" collapse="year" et-al-min="4" et-al-use-first="1">
     <sort>
       <key variable="author"/>
       <key variable="issued"/>

--- a/food-and-agriculture-organization-of-the-united-nations.csl
+++ b/food-and-agriculture-organization-of-the-united-nations.csl
@@ -177,7 +177,7 @@
                 <text macro="editor"/>
                 <group>
                   <text variable="collection-title"/>
-                  <text variable="collection-number"/>
+                  <text variable="collection-number" prefix=" "/>
                   <!-- Mendeley doesn't offer a "Series Number / Report Number" field. "No. xxx" must be put in "Series" field. -->
                 </group>
                 <text macro="publisher-and-place" suffix="."/>
@@ -200,9 +200,9 @@
                 </group>
                 <group>
                   <text variable="collection-title"/>
-                  <text variable="collection-number"/>
+                  <text variable="collection-number" prefix=" "/>
                   <!-- "Series Number" field for book section in Zotero. -->
-                  <text variable="number"/>
+                  <text variable="number" prefix=" "/>
                   <!-- "Report Number" field for report in Zotero. -->
                   <!-- Mendeley doesn't offer a "Series Number / Report Number" field. "No. xxx" must be put in "Series" field. -->
                 </group>

--- a/food-and-agriculture-organization-of-the-united-nations.csl
+++ b/food-and-agriculture-organization-of-the-united-nations.csl
@@ -50,7 +50,8 @@
   </macro>
   <macro name="author">
     <names variable="author">
-      <name and="symbol" delimiter-precedes-last="never" initialize-with="." name-as-sort-order="all"/>
+      <name and="symbol" delimiter-precedes-et-al="never" delimiter-precedes-last="never" et-al-min="8" et-al-use-first="7" initialize-with="." name-as-sort-order="all"/>
+      <et-al font-style="italic"/>
       <label form="short" prefix=", "/>
       <substitute>
         <names variable="editor"/>

--- a/food-and-agriculture-organization-of-the-united-nations.csl
+++ b/food-and-agriculture-organization-of-the-united-nations.csl
@@ -50,7 +50,7 @@
   </macro>
   <macro name="author">
     <names variable="author">
-      <name and="symbol" delimiter-precedes-et-al="never" delimiter-precedes-last="never" et-al-min="8" et-al-use-first="7" initialize-with="." name-as-sort-order="all"/>
+      <name and="symbol" delimiter-precedes-et-al="never" delimiter-precedes-last="never" initialize-with="." name-as-sort-order="all"/>
       <et-al font-style="italic"/>
       <label form="short" prefix=", "/>
       <substitute>
@@ -129,7 +129,7 @@
           <text variable="URL"/>
         </group>
       </else>
-    </choose>   
+    </choose>
   </macro>
   <macro name="number_of_pages-label">
     <!-- 1 p. / x pp. -->
@@ -151,7 +151,7 @@
     </layout>
   </citation>
   <!-- bibliography -->
-  <bibliography entry-spacing="0">
+  <bibliography entry-spacing="0" et-al-min="8" et-al-use-first="7">
     <sort>
       <key macro="author"/>
       <key variable="issued"/>

--- a/food-and-agriculture-organization-of-the-united-nations.csl
+++ b/food-and-agriculture-organization-of-the-united-nations.csl
@@ -177,7 +177,7 @@
                 <text macro="editor"/>
                 <group>
                   <text variable="collection-title"/>
-                  <text variable="collection-number" prefix=" No. "/>
+                  <text variable="collection-number"/>
                   <!-- Mendeley doesn't offer a "Series Number / Report Number" field. "No. xxx" must be put in "Series" field. -->
                 </group>
                 <text macro="publisher-and-place" suffix="."/>
@@ -200,9 +200,9 @@
                 </group>
                 <group>
                   <text variable="collection-title"/>
-                  <text variable="collection-number" prefix=" No. "/>
+                  <text variable="collection-number"/>
                   <!-- "Series Number" field for book section in Zotero. -->
-                  <text variable="number" prefix=" No. "/>
+                  <text variable="number"/>
                   <!-- "Report Number" field for report in Zotero. -->
                   <!-- Mendeley doesn't offer a "Series Number / Report Number" field. "No. xxx" must be put in "Series" field. -->
                 </group>


### PR DESCRIPTION
Adjust the code so that most item types show DOI if DOI exists, and show "also available at URL" if DOI doesn't exist. This is according to the suggestion at: https://github.com/zotero/translators/pull/2249#discussion_r646665445.

Also move et-al usage to "author-short" macro.