### PR TITLE
New citation style: "Norsk henvisningsstandard for rettsvitenskapelige tekster" (validated)

### DIFF
--- a/norsk-henvisningsstandard-for-rettsvitenskapelige-tekster.csl
+++ b/norsk-henvisningsstandard-for-rettsvitenskapelige-tekster.csl
@@ -62,7 +62,7 @@
   </macro>
   <macro name="author-short">
     <names variable="author">
-      <name form="short" et-al-min="4" et-al-use-first="3" delimiter-precedes-last="never" name-as-sort-order="first" and="text"/>
+      <name form="short" et-al-min="4" et-al-use-first="1" delimiter-precedes-last="never" name-as-sort-order="first" and="text"/>
       <et-al term="and others"/>
       <substitute>
         <names variable="editor"/>
@@ -71,7 +71,7 @@
   </macro>
   <macro name="author-full">
     <names variable="author">
-      <name et-al-min="4" et-al-use-first="3" delimiter-precedes-last="never" name-as-sort-order="first" and="text"/>
+      <name et-al-min="4" et-al-use-first="1" delimiter-precedes-last="never" name-as-sort-order="first" and="text"/>
       <et-al term="and others"/>
       <substitute>
         <names variable="editor"/>
@@ -80,7 +80,7 @@
   </macro>
   <macro name="editor">
     <names variable="editor">
-      <name/>
+      <name et-al-min="4" et-al-use-first="1" delimiter-precedes-last="never" and="text"/>
     </names>
     <label prefix=" (" suffix=")" variable="editor" form="short"/>
   </macro>
@@ -289,11 +289,11 @@
           <group suffix=".">
             <text macro="author-full"/>
             <text prefix=". " macro="title"/>
-            <text prefix=", i " macro="editor"/>
-            <text prefix=", " font-style="italic" variable="container-title"/>
+            <text prefix=" i " font-style="italic" variable="container-title"/>
+            <text prefix=", " macro="editor"/>
             <text macro="edition-short"/>
             <text prefix=", " variable="publisher"/>
-            <text prefix=", " macro="issued-no-parenthesis"/>
+            <text prefix=" " macro="issued-no-parenthesis"/>
             <text prefix=", " variable="URL"/>
             <text prefix=" " macro="accessed-date"/>
           </group>

--- a/norsk-henvisningsstandard-for-rettsvitenskapelige-tekster.csl
+++ b/norsk-henvisningsstandard-for-rettsvitenskapelige-tekster.csl
@@ -17,7 +17,7 @@
     </contributor>
     <category citation-format="note"/>
     <category field="law"/>
-    <summary>Norwegian standard citation style for citing Norwegiand and international legal sources. Based on "Formelle krav til rettsvitenskapelige tekster" (August 2017).</summary>
+    <summary>Norwegian standard citation style for citing Norwegian and international legal sources. Based on "Formelle krav til rettsvitenskapelige tekster" (August 2017).</summary>
     <updated>2021-06-08T10:53:00+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>

--- a/norsk-henvisningsstandard-for-rettsvitenskapelige-tekster.csl
+++ b/norsk-henvisningsstandard-for-rettsvitenskapelige-tekster.csl
@@ -279,7 +279,7 @@
         <else-if type="book thesis" match="any">
           <group suffix=".">
             <text macro="author-full"/>
-            <text prefix=". " macro="title"/>
+            <text prefix=", " macro="title"/>
             <text macro="edition-short"/>
             <text prefix=", " variable="publisher"/>
             <text prefix=" " macro="issued-no-parenthesis"/>

--- a/norsk-henvisningsstandard-for-rettsvitenskapelige-tekster.csl
+++ b/norsk-henvisningsstandard-for-rettsvitenskapelige-tekster.csl
@@ -6,7 +6,7 @@
     <id>http://www.zotero.org/styles/norsk-henvisningsstandard-for-rettsvitenskapelige-tekster</id>
     <link href="http://www.zotero.org/styles/norsk-henvisningsstandard-for-rettsvitenskapelige-tekster" rel="self"/>
     <link href="http://www.zotero.org/styles/universitetet-i-oslo-rettsvitenskap" rel="template"/>
-    <link href="hhttps://www.uib.no/sites/w3.uib.no/files/attachments/veiledning_for_henvisning_i_juridiske_tekster.pdf" rel="documentation"/>
+    <link href="https://www.uib.no/sites/w3.uib.no/files/attachments/veiledning_for_henvisning_i_juridiske_tekster.pdf" rel="documentation"/>
     <author>
       <name>Stian Øby Johansen</name>
       <email>s.o.johansen@jus.uio.no</email>

--- a/norsk-henvisningsstandard-for-rettsvitenskapelige-tekster.csl
+++ b/norsk-henvisningsstandard-for-rettsvitenskapelige-tekster.csl
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<style xmlns="http://purl.org/net/xbiblio/csl" class="note" version="1.0" default-locale="nb-NO" demote-non-dropping-particle="display-and-sort" page-range-format="expanded">
+<style xmlns="http://purl.org/net/xbiblio/csl" class="note" version="1.0" demote-non-dropping-particle="display-and-sort" page-range-format="expanded" default-locale="nb-NO">
   <info>
     <title>Norsk henvisningsstandard for rettsvitenskapelige tekster (Norsk - Bokmål)</title>
     <title-short>Norsk rettsvitenskap</title-short>
@@ -35,7 +35,7 @@
       <term name="close-quote">»</term>
       <term name="accessed">sitert</term>
       <term name="no date">udatert</term>
-      <term name="edition">utgave></term>
+      <term name="edition">utgave</term>
       <term name="edition" form="short">utg.</term>
       <term name="volume">bind</term>
     </terms>

--- a/norsk-henvisningsstandard-for-rettsvitenskapelige-tekster.csl
+++ b/norsk-henvisningsstandard-for-rettsvitenskapelige-tekster.csl
@@ -34,6 +34,8 @@
       <term name="close-quote">»</term>
       <term name="accessed">sitert</term>
       <term name="no date">udatert</term>
+      <term name="edition">utgave></term>
+      <term name="edition" form="short">utg.</term>
     </terms>
   </locale>
   <macro name="type-sorting">
@@ -80,6 +82,7 @@
     <names variable="editor">
       <name/>
     </names>
+    <label prefix=" (" suffix=")" variable="editor" form="short"/>
   </macro>
   <macro name="title-short">
     <choose>
@@ -191,6 +194,10 @@
       </else>
     </choose>
   </macro>
+  <macro name="edition-short">
+    <text prefix=", " suffix=". " variable="edition"/>
+    <label variable="edition" form="short"/>
+  </macro>
   <macro name="DOI">
     <choose>
       <if variable="DOI" match="none">
@@ -273,21 +280,19 @@
           <group suffix=".">
             <text macro="author-full"/>
             <text prefix=". " macro="title"/>
-            <text prefix=", " suffix=" utg." variable="edition"/>
-            <text prefix=", " suffix=":" variable="publisher-place"/>
-            <text prefix=" " variable="publisher"/>
-            <text prefix=", " macro="issued-no-parenthesis"/>
+            <text macro="edition-short"/>
+            <text prefix=", " variable="publisher"/>
+            <text prefix=" " macro="issued-no-parenthesis"/>
           </group>
         </else-if>
         <else-if type="chapter paper-conference" match="any">
           <group suffix=".">
             <text macro="author-full"/>
             <text prefix=". " macro="title"/>
-            <text prefix=", i " font-style="italic" variable="container-title"/>
-            <text prefix=", " suffix=" (red.)" macro="editor"/>
-            <text prefix=", " suffix=". utg.," variable="edition"/>
-            <text prefix=", " suffix=": " variable="publisher-place"/>
-            <text variable="publisher"/>
+            <text prefix=", i " macro="editor"/>
+            <text prefix=", " font-style="italic" variable="container-title"/>
+            <text macro="edition-short"/>
+            <text prefix=", " variable="publisher"/>
             <text prefix=", " macro="issued-no-parenthesis"/>
             <text prefix=", " variable="URL"/>
             <text prefix=" " macro="accessed-date"/>

--- a/norsk-henvisningsstandard-for-rettsvitenskapelige-tekster.csl
+++ b/norsk-henvisningsstandard-for-rettsvitenskapelige-tekster.csl
@@ -156,7 +156,8 @@
   <macro name="accessed-date">
     <choose>
       <if type="personal_communication">
-        <date variable="accessed" prefix=", e-post, ">
+        <text variable="genre" prefix=", " suffix=", "/>
+        <date variable="issued">
           <date-part name="day" form="numeric" suffix=". "/>
           <date-part name="month" form="long" suffix=" "/>
           <date-part name="year"/>

--- a/norsk-henvisningsstandard-for-rettsvitenskapelige-tekster.csl
+++ b/norsk-henvisningsstandard-for-rettsvitenskapelige-tekster.csl
@@ -6,7 +6,7 @@
     <id>http://www.zotero.org/styles/norsk-henvisningsstandard-for-rettsvitenskapelige-tekster</id>
     <link href="http://www.zotero.org/styles/norsk-henvisningsstandard-for-rettsvitenskapelige-tekster" rel="self"/>
     <link href="http://www.zotero.org/styles/universitetet-i-oslo-rettsvitenskap" rel="template"/>
-    <link href="https://www.uio.no/for-ansatte/enhetssider/jus/ledelses-og-utvalgsmoter/pmr/moter/2018/pmr5/vedlegg/sak9.pdf" rel="documentation"/>
+    <link href="hhttps://www.uib.no/sites/w3.uib.no/files/attachments/veiledning_for_henvisning_i_juridiske_tekster.pdf" rel="documentation"/>
     <author>
       <name>Stian Øby Johansen</name>
       <email>s.o.johansen@jus.uio.no</email>

--- a/norsk-henvisningsstandard-for-rettsvitenskapelige-tekster.csl
+++ b/norsk-henvisningsstandard-for-rettsvitenskapelige-tekster.csl
@@ -311,7 +311,6 @@
         </else-if>
         <else>
           <text variable="title"/>
-          <text macro="title-short"/>
         </else>
       </choose>
     </layout>

--- a/norsk-henvisningsstandard-for-rettsvitenskapelige-tekster.csl
+++ b/norsk-henvisningsstandard-for-rettsvitenskapelige-tekster.csl
@@ -9,8 +9,8 @@
     <author>
       <name>Hans Gunnar Slokvik Lian</name>
       <email>h.g.s.lian@ub.uio.no</email>
-	  <name>Stian Øby Johansen</name>
-	  <email>s.o.johansen@jus.uio.no</email>
+      <name>Stian Øby Johansen</name>
+      <email>s.o.johansen@jus.uio.no</email>
     </author>
     <category citation-format="note"/>
     <category field="law"/>

--- a/norsk-henvisningsstandard-for-rettsvitenskapelige-tekster.csl
+++ b/norsk-henvisningsstandard-for-rettsvitenskapelige-tekster.csl
@@ -9,6 +9,8 @@
     <author>
       <name>Hans Gunnar Slokvik Lian</name>
       <email>h.g.s.lian@ub.uio.no</email>
+    </author>
+    <author>
       <name>Stian Øby Johansen</name>
       <email>s.o.johansen@jus.uio.no</email>
     </author>
@@ -26,7 +28,7 @@
       <term name="editortranslator" form="verb-short">red. og overs.</term>
       <term name="editortranslator" form="verb">Redigert og oversatt av</term>
       <term name="translator" form="short">overs.</term>
-      <term name="and others">m.fl.</>
+      <term name="and others">m.fl.</term>
       <term name="open-quote">"</term>
       <term name="close-quote">"</term>
       <term name="accessed">sitert</term>

--- a/norsk-henvisningsstandard-for-rettsvitenskapelige-tekster.csl
+++ b/norsk-henvisningsstandard-for-rettsvitenskapelige-tekster.csl
@@ -17,7 +17,7 @@
     </contributor>
     <category citation-format="note"/>
     <category field="law"/>
-    <summary>Norwegian standard citation style for citing Norwegian and international legal sources. Based on "Veiledning for henvisninger i juridiske tekster" (February 2019).</summary>
+    <summary>Norwegian legal citation style based on "Veiledning for henvisninger i juridiske tekster" (February 2019).</summary>
     <updated>2021-06-08T10:53:00+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>

--- a/norsk-henvisningsstandard-for-rettsvitenskapelige-tekster.csl
+++ b/norsk-henvisningsstandard-for-rettsvitenskapelige-tekster.csl
@@ -4,8 +4,8 @@
     <title>Norsk henvisningsstandard for rettsvitenskapelige tekster (Norsk - Bokmål)</title>
     <title-short>Norsk rettsvitenskap</title-short>
     <id>http://www.zotero.org/styles/norsk-henvisningsstandard-for-rettsvitenskapelige-tekster</id>
-    <link href="http://www.zotero.org/styles/universitetet-i-oslo-rettsvitenskap" rel="self"/>
-    <link href="http://www.ub.uio.no/skrive-publisere/referere/referansestiler/rettsvitenskap.html" rel="documentation"/>
+    <link href="http://www.zotero.org/styles/norsk-henvisningsstandard-for-rettsvitenskapelige-tekster" rel="self"/>
+    <link href="https://www.uio.no/for-ansatte/enhetssider/jus/ledelses-og-utvalgsmoter/pmr/moter/2018/pmr5/vedlegg/sak9.pdf" rel="documentation"/>
     <author>
       <name>Hans Gunnar Slokvik Lian</name>
       <email>h.g.s.lian@ub.uio.no</email>

--- a/norsk-henvisningsstandard-for-rettsvitenskapelige-tekster.csl
+++ b/norsk-henvisningsstandard-for-rettsvitenskapelige-tekster.csl
@@ -17,7 +17,7 @@
     </contributor>
     <category citation-format="note"/>
     <category field="law"/>
-    <summary>Norwegian standard citation style for citing Norwegian and international legal sources. Based on "Formelle krav til rettsvitenskapelige tekster" (August 2017).</summary>
+    <summary>Norwegian standard citation style for citing Norwegian and international legal sources. Based on "Veiledning for henvisninger i juridiske tekster" (February 2019).</summary>
     <updated>2021-06-08T10:53:00+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>

--- a/norsk-henvisningsstandard-for-rettsvitenskapelige-tekster.csl
+++ b/norsk-henvisningsstandard-for-rettsvitenskapelige-tekster.csl
@@ -229,7 +229,7 @@
           </else-if>
           <else-if type="report">
             <text macro="author-short"/>
-            <text variable="number"/>
+            <text macro="issued"/>
           </else-if>
           <else>
             <text variable="title"/>

--- a/norsk-henvisningsstandard-for-rettsvitenskapelige-tekster.csl
+++ b/norsk-henvisningsstandard-for-rettsvitenskapelige-tekster.csl
@@ -1,0 +1,316 @@
+<?xml version="1.0" encoding="utf-8"?>
+<style xmlns="http://purl.org/net/xbiblio/csl" class="note" version="1.0" default-locale="nb-NO" demote-non-dropping-particle="display-and-sort" page-range-format="expanded">
+  <info>
+    <title>Norsk henvisningsstandard for rettsvitenskapelige tekster (Norsk - Bokmål)</title>
+    <title-short>Norsk rettsvitenskap</title-short>
+    <id>http://www.zotero.org/styles/norsk-henvisningsstandard-for-rettsvitenskapelige-tekster</id>
+    <link href="http://www.zotero.org/styles/universitetet-i-oslo-rettsvitenskap" rel="self"/>
+    <link href="http://www.ub.uio.no/skrive-publisere/referere/referansestiler/rettsvitenskap.html" rel="documentation"/>
+    <author>
+      <name>Hans Gunnar Slokvik Lian</name>
+      <email>h.g.s.lian@ub.uio.no</email>
+	  <name>Stian Øby Johansen</name>
+	  <email>s.o.johansen@jus.uio.no</email>
+    </author>
+    <category citation-format="note"/>
+    <category field="law"/>
+    <summary>Norwegian standard citation style for citing Norwegiand and international legal sources. Based on "Formelle krav til rettsvitenskapelige tekster" (August 2017).</summary>
+    <updated>2021-06-08T10:53:00+00:00</updated>
+    <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
+  </info>
+  <locale xml:lang="nb-NO">
+    <terms>
+      <term name="editor" form="verb-short">red.</term>
+      <term name="translator" form="verb-short">overs.</term>
+      <term name="translator" form="short">overs.</term>
+      <term name="editortranslator" form="verb-short">red. og overs.</term>
+      <term name="editortranslator" form="verb">Redigert og oversatt av</term>
+      <term name="translator" form="short">overs.</term>
+      <term name="and others">m.fl.</>
+      <term name="open-quote">"</term>
+      <term name="close-quote">"</term>
+      <term name="accessed">sitert</term>
+      <term name="no date">udatert</term>
+    </terms>
+  </locale>
+  <macro name="type-sorting">
+    <choose>
+      <if type="legislation legal_case bill" match="none">
+        <text value="1"/>
+      </if>
+      <else-if type="webpage">
+        <text value="2"/>
+      </else-if>
+      <else-if type="legislation">
+        <text value="3"/>
+      </else-if>
+      <else-if type="bill">
+        <text value="4"/>
+      </else-if>
+      <else-if type="legal_case">
+        <text value="5"/>
+      </else-if>
+      <else>
+        <text value="6"/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="author-short">
+    <names variable="author">
+      <name form="short" et-al-min="4" et-al-use-first="3" delimiter-precedes-last="never" name-as-sort-order="first" and="text"/>
+      <et-al term="and others"/>
+      <substitute>
+        <names variable="editor"/>
+      </substitute>
+    </names>
+  </macro>
+  <macro name="author-full">
+    <names variable="author">
+      <name et-al-min="4" et-al-use-first="3" delimiter-precedes-last="never" name-as-sort-order="first" and="text"/>
+      <et-al term="and others"/>
+      <substitute>
+        <names variable="editor"/>
+      </substitute>
+    </names>
+  </macro>
+  <macro name="editor">
+    <names variable="editor">
+      <name/>
+    </names>
+  </macro>
+  <macro name="title-short">
+    <choose>
+      <if type="article-journal chapter" match="any">
+        <text quotes="true" variable="title"/>
+      </if>
+      <else-if type="legislation">
+        <text variable="title-short"/>
+      </else-if>
+      <else-if type="legal_case">
+        <text variable="title"/>
+      </else-if>
+      <else>
+        <text font-style="italic" variable="title-short"/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="title">
+    <choose>
+      <if type="chapter article-journal article-newspaper article-magazine" match="any">
+        <text quotes="true" variable="title"/>
+      </if>
+      <else-if type="legal_case legislation" match="any">
+        <text variable="title"/>
+      </else-if>
+      <else>
+        <text font-style="italic" variable="title"/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="issued">
+    <choose>
+      <if type="personal_communication" match="none">
+        <date prefix="(" suffix=")" variable="issued">
+          <date-part name="year"/>
+        </date>
+      </if>
+      <else-if type="personal_communication" match="all">
+        <date variable="accessed" prefix="(" suffix=")">
+          <date-part name="year"/>
+        </date>
+      </else-if>
+      <else>
+        <text term="no date" prefix="(" suffix=")"/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="issued-full-date">
+    <date variable="issued">
+      <date-part name="day" form="numeric" suffix=". "/>
+      <date-part name="month" form="long" suffix=" "/>
+      <date-part name="year"/>
+    </date>
+  </macro>
+  <macro name="issued-no-parenthesis">
+    <choose>
+      <if variable="issued">
+        <date variable="issued">
+          <date-part name="year"/>
+        </date>
+      </if>
+      <else>
+        <text term="no date"/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="retrieved-from">
+    <choose>
+      <if type="article-journal">
+        <text variable="archive" text-case="capitalize-first" prefix="(Sitert fra " suffix=")"/>
+      </if>
+    </choose>
+  </macro>
+  <macro name="accessed-date">
+    <choose>
+      <if type="personal_communication">
+        <date variable="accessed" prefix=", e-post, ">
+          <date-part name="day" form="numeric" suffix=". "/>
+          <date-part name="month" form="long" suffix=" "/>
+          <date-part name="year"/>
+        </date>
+      </if>
+      <else>
+        <date variable="accessed" prefix=" [Sitert " suffix="]">
+          <date-part name="day" form="numeric" suffix=". "/>
+          <date-part name="month" form="long" suffix=" "/>
+          <date-part name="year"/>
+        </date>
+      </else>
+    </choose>
+  </macro>
+  <macro name="locator">
+    <choose>
+      <if type="legislation bill" match="none">
+        <group delimiter=" ">
+          <label variable="locator" form="short"/>
+          <text variable="locator"/>
+        </group>
+      </if>
+      <else-if locator="section paragraph" match="any">
+        <text variable="locator" prefix=" § "/>
+      </else-if>
+      <else>
+        <group delimiter=" ">
+          <label variable="locator" form="short"/>
+          <text variable="locator"/>
+        </group>
+      </else>
+    </choose>
+  </macro>
+  <citation disambiguate-add-givenname="true" givenname-disambiguation-rule="primary-name" disambiguate-add-year-suffix="true" et-al-min="2" et-al-use-first="1">
+    <sort>
+      <key macro="author-short"/>
+      <key macro="title-short"/>
+      <key macro="issued"/>
+    </sort>
+    <layout delimiter=", ">
+      <group delimiter=" ">
+        <choose>
+          <if type="book thesis chapter article-journal article-newspaper article-magazine personal_communication" match="any">
+            <text macro="author-short"/>
+            <text macro="issued"/>
+          </if>
+          <else-if type="legal_case">
+            <text macro="title"/>
+          </else-if>
+          <else-if type="legislation">
+            <text macro="title-short"/>
+          </else-if>
+          <else-if type="report">
+            <text macro="author-short"/>
+            <text variable="number"/>
+          </else-if>
+          <else>
+            <text variable="title"/>
+          </else>
+        </choose>
+        <text macro="locator"/>
+      </group>
+    </layout>
+  </citation>
+  <bibliography entry-spacing="0">
+    <sort>
+      <key macro="type-sorting"/>
+      <key macro="author-full"/>
+      <key variable="issued"/>
+      <key variable="title"/>
+    </sort>
+    <layout>
+      <choose>
+        <if type="article-journal">
+          <group suffix=".">
+            <text macro="author-full"/>
+            <text prefix=". " macro="title"/>
+            <text prefix=", " font-style="italic" variable="container-title"/>
+            <text prefix=" Årg. " variable="volume"/>
+            <text prefix=" " macro="issued"/>
+            <text prefix=", s. " variable="page"/>
+            <choose>
+              <if variable="DOI" match="none">
+                <text prefix=", " variable="URL"/>
+              </if>
+              <else>
+                <text prefix=", " variable="DOI"/>
+              </else>
+            </choose>
+            <text prefix=" " macro="retrieved-from"/>
+          </group>
+        </if>
+        <else-if type="article-newspaper article-magazine" match="any">
+          <group suffix=".">
+            <text macro="author-full"/>
+            <text prefix=". " macro="issued"/>
+            <text prefix=" " macro="title"/>
+            <text prefix=", " font-style="italic" variable="container-title"/>
+            <choose>
+              <if variable="URL" match="none">
+                <text prefix=", " macro="issued-full-date"/>
+              </if>
+              <else>
+                <text prefix=", " variable="URL"/>
+                <text macro="accessed-date"/>
+              </else>
+            </choose>
+          </group>
+        </else-if>
+        <else-if type="book thesis" match="any">
+          <group suffix=".">
+            <text macro="author-full"/>
+            <text prefix=". " macro="title"/>
+            <text prefix=", " suffix=" utg." variable="edition"/>
+            <text prefix=", " suffix=":" variable="publisher-place"/>
+            <text prefix=" " variable="publisher"/>
+            <text prefix=", " macro="issued-no-parenthesis"/>
+          </group>
+        </else-if>
+        <else-if type="chapter paper-conference" match="any">
+          <group suffix=".">
+            <text macro="author-full"/>
+            <text prefix=". " macro="title"/>
+            <text prefix=", i " font-style="italic" variable="container-title"/>
+            <text prefix=", " suffix=" (red.)" macro="editor"/>
+            <text prefix=", " suffix=". utg.," variable="edition"/>
+            <text prefix=", " suffix=": " variable="publisher-place"/>
+            <text variable="publisher"/>
+            <text prefix=", " macro="issued-no-parenthesis"/>
+            <text prefix=", " variable="URL"/>
+            <text prefix=" " macro="accessed-date"/>
+          </group>
+        </else-if>
+        <else-if type="legislation bill" match="any">
+          <group display="left-margin">
+            <text macro="issued-no-parenthesis"/>
+          </group>
+          <group display="right-inline" suffix=".">
+            <text macro="title"/>
+          </group>
+        </else-if>
+        <else-if type="legal_case">
+          <text macro="title"/>
+        </else-if>
+        <else-if type="personal_communication">
+          <text macro="author-full"/>
+          <text macro="accessed-date"/>
+        </else-if>
+        <else>
+          <group display="left-margin">
+            <text variable="title"/>
+          </group>
+          <group display="right-inline" suffix=".">
+            <text macro="title-short"/>
+          </group>
+        </else>
+      </choose>
+    </layout>
+  </bibliography>
+</style>

--- a/norsk-henvisningsstandard-for-rettsvitenskapelige-tekster.csl
+++ b/norsk-henvisningsstandard-for-rettsvitenskapelige-tekster.csl
@@ -7,13 +7,13 @@
     <link href="http://www.zotero.org/styles/norsk-henvisningsstandard-for-rettsvitenskapelige-tekster" rel="self"/>
     <link href="https://www.uio.no/for-ansatte/enhetssider/jus/ledelses-og-utvalgsmoter/pmr/moter/2018/pmr5/vedlegg/sak9.pdf" rel="documentation"/>
     <author>
-      <name>Hans Gunnar Slokvik Lian</name>
-      <email>h.g.s.lian@ub.uio.no</email>
-    </author>
-    <author>
       <name>Stian Øby Johansen</name>
       <email>s.o.johansen@jus.uio.no</email>
     </author>
+    <contributor>
+      <name>Hans Gunnar Slokvik Lian</name>
+      <email>h.g.s.lian@ub.uio.no</email>
+    </contributor>
     <category citation-format="note"/>
     <category field="law"/>
     <summary>Norwegian standard citation style for citing Norwegiand and international legal sources. Based on "Formelle krav til rettsvitenskapelige tekster" (August 2017).</summary>

--- a/norsk-henvisningsstandard-for-rettsvitenskapelige-tekster.csl
+++ b/norsk-henvisningsstandard-for-rettsvitenskapelige-tekster.csl
@@ -30,8 +30,8 @@
       <term name="editortranslator" form="verb">Redigert og oversatt av</term>
       <term name="translator" form="short">overs.</term>
       <term name="and others">m.fl.</term>
-      <term name="open-quote">"</term>
-      <term name="close-quote">"</term>
+      <term name="open-quote">«</term>
+      <term name="close-quote">»</term>
       <term name="accessed">sitert</term>
       <term name="no date">udatert</term>
     </terms>

--- a/norsk-henvisningsstandard-for-rettsvitenskapelige-tekster.csl
+++ b/norsk-henvisningsstandard-for-rettsvitenskapelige-tekster.csl
@@ -5,6 +5,7 @@
     <title-short>Norsk rettsvitenskap</title-short>
     <id>http://www.zotero.org/styles/norsk-henvisningsstandard-for-rettsvitenskapelige-tekster</id>
     <link href="http://www.zotero.org/styles/norsk-henvisningsstandard-for-rettsvitenskapelige-tekster" rel="self"/>
+    <link href="http://www.zotero.org/styles/universitetet-i-oslo-rettsvitenskap" rel="template"/>
     <link href="https://www.uio.no/for-ansatte/enhetssider/jus/ledelses-og-utvalgsmoter/pmr/moter/2018/pmr5/vedlegg/sak9.pdf" rel="documentation"/>
     <author>
       <name>Stian Øby Johansen</name>

--- a/norsk-henvisningsstandard-for-rettsvitenskapelige-tekster.csl
+++ b/norsk-henvisningsstandard-for-rettsvitenskapelige-tekster.csl
@@ -235,10 +235,9 @@
           <group suffix=".">
             <text macro="author-full"/>
             <text prefix=". " macro="title"/>
-            <text prefix=", " font-style="italic" variable="container-title"/>
-            <text prefix=" Årg. " variable="volume"/>
+            <text prefix=" " font-style="italic" variable="container-title"/>
             <text prefix=" " macro="issued"/>
-            <text prefix=", s. " variable="page"/>
+            <text prefix=" s. " variable="page"/>
             <choose>
               <if variable="DOI" match="none">
                 <text prefix=", " variable="URL"/>

--- a/norsk-henvisningsstandard-for-rettsvitenskapelige-tekster.csl
+++ b/norsk-henvisningsstandard-for-rettsvitenskapelige-tekster.csl
@@ -30,13 +30,14 @@
       <term name="editortranslator" form="verb-short">red. og overs.</term>
       <term name="editortranslator" form="verb">Redigert og oversatt av</term>
       <term name="translator" form="short">overs.</term>
-      <term name="and others">m.fl.</term>
+      <term name="and others">et al.</term>
       <term name="open-quote">«</term>
       <term name="close-quote">»</term>
       <term name="accessed">sitert</term>
       <term name="no date">udatert</term>
       <term name="edition">utgave></term>
       <term name="edition" form="short">utg.</term>
+      <term name="volume">bind</term>
     </terms>
   </locale>
   <macro name="type-sorting">
@@ -199,6 +200,14 @@
     <text prefix=", " suffix=". " variable="edition"/>
     <label variable="edition" form="short"/>
   </macro>
+  <macro name="volume">
+    <choose>
+      <if variable="volume" match="any">
+        <label prefix=", " variable="volume"/>
+        <text prefix=" " variable="volume"/>
+      </if>
+    </choose>
+  </macro>
   <macro name="DOI">
     <choose>
       <if variable="DOI" match="none">
@@ -281,6 +290,7 @@
           <group suffix=".">
             <text macro="author-full"/>
             <text prefix=", " macro="title"/>
+            <text macro="volume"/>
             <text macro="edition-short"/>
             <text prefix=", " variable="publisher"/>
             <text prefix=" " macro="issued-no-parenthesis"/>
@@ -292,6 +302,7 @@
             <text prefix=". " macro="title"/>
             <text prefix=" i " font-style="italic" variable="container-title"/>
             <text prefix=", " macro="editor"/>
+            <text macro="volume"/>
             <text macro="edition-short"/>
             <text prefix=", " variable="publisher"/>
             <text prefix=" " macro="issued-no-parenthesis"/>

--- a/norsk-henvisningsstandard-for-rettsvitenskapelige-tekster.csl
+++ b/norsk-henvisningsstandard-for-rettsvitenskapelige-tekster.csl
@@ -243,7 +243,7 @@
                 <text prefix=", " variable="URL"/>
               </if>
               <else>
-                <text prefix=", " variable="DOI"/>
+                <text prefix=". DOI: " variable="DOI"/>
               </else>
             </choose>
             <text prefix=" " macro="retrieved-from"/>

--- a/norsk-henvisningsstandard-for-rettsvitenskapelige-tekster.csl
+++ b/norsk-henvisningsstandard-for-rettsvitenskapelige-tekster.csl
@@ -24,6 +24,7 @@
   <locale xml:lang="nb-NO">
     <terms>
       <term name="editor" form="verb-short">red.</term>
+      <term name="editor" form="short">red.</term>
       <term name="translator" form="verb-short">overs.</term>
       <term name="translator" form="short">overs.</term>
       <term name="editortranslator" form="verb-short">red. og overs.</term>
@@ -82,7 +83,7 @@
     <names variable="editor">
       <name et-al-min="4" et-al-use-first="1" delimiter-precedes-last="never" and="text"/>
     </names>
-    <label prefix=" (" suffix=")" variable="editor" form="short"/>
+    <text prefix=" (" suffix=")" term="editor" form="short"/>
   </macro>
   <macro name="title-short">
     <choose>

--- a/norsk-henvisningsstandard-for-rettsvitenskapelige-tekster.csl
+++ b/norsk-henvisningsstandard-for-rettsvitenskapelige-tekster.csl
@@ -299,12 +299,8 @@
           </group>
         </else-if>
         <else-if type="legislation bill" match="any">
-          <group display="left-margin">
-            <text macro="issued-no-parenthesis"/>
-          </group>
-          <group display="right-inline" suffix=".">
-            <text macro="title"/>
-          </group>
+          <text macro="issued-no-parenthesis"/>
+          <text macro="title"/>
         </else-if>
         <else-if type="legal_case">
           <text macro="title"/>
@@ -314,12 +310,8 @@
           <text macro="accessed-date"/>
         </else-if>
         <else>
-          <group display="left-margin">
-            <text variable="title"/>
-          </group>
-          <group display="right-inline" suffix=".">
-            <text macro="title-short"/>
-          </group>
+          <text variable="title"/>
+          <text macro="title-short"/>
         </else>
       </choose>
     </layout>

--- a/norsk-henvisningsstandard-for-rettsvitenskapelige-tekster.csl
+++ b/norsk-henvisningsstandard-for-rettsvitenskapelige-tekster.csl
@@ -204,7 +204,7 @@
         <text prefix=", " variable="URL"/>
       </if>
       <else>
-        <text prefix=". DOI: " variable="DOI"/>
+        <text prefix=". DOI: https://doi.org/" variable="DOI"/>
       </else>
     </choose>
   </macro>

--- a/norsk-henvisningsstandard-for-rettsvitenskapelige-tekster.csl
+++ b/norsk-henvisningsstandard-for-rettsvitenskapelige-tekster.csl
@@ -191,6 +191,16 @@
       </else>
     </choose>
   </macro>
+  <macro name="DOI">
+    <choose>
+      <if variable="DOI" match="none">
+        <text prefix=", " variable="URL"/>
+      </if>
+      <else>
+        <text prefix=". DOI: " variable="DOI"/>
+      </else>
+    </choose>
+  </macro>
   <citation disambiguate-add-givenname="true" givenname-disambiguation-rule="primary-name" disambiguate-add-year-suffix="true" et-al-min="2" et-al-use-first="1">
     <sort>
       <key macro="author-short"/>
@@ -238,14 +248,7 @@
             <text prefix=" " font-style="italic" variable="container-title"/>
             <text prefix=" " macro="issued"/>
             <text prefix=" s. " variable="page"/>
-            <choose>
-              <if variable="DOI" match="none">
-                <text prefix=", " variable="URL"/>
-              </if>
-              <else>
-                <text prefix=". DOI: " variable="DOI"/>
-              </else>
-            </choose>
+            <text macro="DOI"/>
             <text prefix=" " macro="retrieved-from"/>
           </group>
         </if>

--- a/zeitschrift-fur-fantastikforschung.csl
+++ b/zeitschrift-fur-fantastikforschung.csl
@@ -1,0 +1,546 @@
+<?xml version="1.0" encoding="utf-8"?>
+<style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" page-range-format="minimal-two" demote-non-dropping-particle="never" default-locale="de-DE">
+  <info>
+    <title>Zeitschrift für Fantastikforschung (Deutsch)</title>
+    <title-short>ZFF</title-short>
+    <id>http://www.zotero.org/styles/zeitschrift-fur-fantastikforschung</id>
+    <link href="http://www.zotero.org/styles/zeitschrift-fur-fantastikforschung" rel="self"/>
+    <link href="http://www.zotero.org/styles/modern-language-association" rel="template"/>
+    <link href="https://zff.openlibhums.org/site/stylesheet/" rel="documentation"/>
+    <author>
+      <name>Simon Spiegel</name>
+      <email>simon@simifilm.ch</email>
+    </author>
+    <category citation-format="author"/>
+    <category field="generic-base"/>
+    <issn>2192-0885</issn>
+    <summary>Stil für die Zeitschrift für Fantastikforschung</summary>
+    <updated>2021-06-06T10:42:10+00:00</updated>
+    <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
+  </info>
+  <locale xml:lang="en">
+    <date form="text">
+      <date-part name="day" suffix=" "/>
+      <date-part name="month" suffix=" " form="short"/>
+      <date-part name="year"/>
+    </date>
+    <terms>
+      <term name="month-01" form="short">Jan.</term>
+      <term name="month-02" form="short">Feb.</term>
+      <term name="month-03" form="short">Mar.</term>
+      <term name="month-04" form="short">Apr.</term>
+      <term name="month-05" form="short">May</term>
+      <term name="month-06" form="short">June</term>
+      <term name="month-07" form="short">July</term>
+      <term name="month-08" form="short">Aug.</term>
+      <term name="month-09" form="short">Sept.</term>
+      <term name="month-10" form="short">Oct.</term>
+      <term name="month-11" form="short">Nov.</term>
+      <term name="month-12" form="short">Dec.</term>
+      <term name="translator" form="short">trans.</term>
+    </terms>
+  </locale>
+  <locale xml:lang="de">
+    <date form="text">
+      <date-part name="day" suffix=" "/>
+      <date-part name="month" suffix=" " form="short"/>
+      <date-part name="year"/>
+    </date>
+    <terms>
+      <term name="month-01" form="short">Jan.</term>
+      <term name="month-02" form="short">Feb.</term>
+      <term name="month-03" form="short">Mär.</term>
+      <term name="month-04" form="short">Apr.</term>
+      <term name="month-05" form="short">Mai</term>
+      <term name="month-06" form="short">Jun.</term>
+      <term name="month-07" form="short">Jul.</term>
+      <term name="month-08" form="short">Aug.</term>
+      <term name="month-09" form="short">Sept.</term>
+      <term name="month-10" form="short">Okt.</term>
+      <term name="month-11" form="short">Nov.</term>
+      <term name="month-12" form="short">Dez.</term>
+      <term name="translator" form="short">Übers. von</term>
+      <term name="et-al">et al.</term>
+      <term name="editor" form="short">
+        <single>Hg.</single>
+        <multiple>Hg.</multiple>
+      </term>
+      <term name="open-inner-quote">›</term>
+      <term name="close-inner-quote">‹</term>
+      <term name="open-quote">»</term>
+      <term name="close-quote">«</term>
+      <term name="accessed"/>
+    </terms>
+  </locale>
+  <macro name="author">
+    <choose>
+      <if type="motion_picture" match="any">
+        <text variable="title" font-variant="small-caps" suffix=". "/>
+        <names variable="author"/>
+      </if>
+      <else>
+        <names variable="author">
+          <name and="text" delimiter-precedes-et-al="never" delimiter-precedes-last="never" initialize="false" initialize-with=". " name-as-sort-order="first"/>
+          <label form="short" prefix=", "/>
+          <substitute>
+            <names variable="editor"/>
+            <names variable="translator"/>
+            <text macro="title"/>
+          </substitute>
+        </names>
+      </else>
+    </choose>
+  </macro>
+  <macro name="author-short">
+    <group delimiter=", ">
+      <names variable="author">
+        <name form="short" initialize-with=". " and="text"/>
+        <substitute>
+          <names variable="editor"/>
+          <names variable="translator"/>
+          <text macro="title-short"/>
+        </substitute>
+      </names>
+      <choose>
+        <if disambiguate="true">
+          <text macro="title-short"/>
+        </if>
+      </choose>
+    </group>
+  </macro>
+  <macro name="title">
+    <choose>
+      <if variable="container-title" match="any">
+        <choose>
+          <if type="book" match="any">
+            <text variable="container-title" font-style="italic" text-case="title"/>
+            <label prefix=". " variable="volume" form="short"/>
+            <text variable="volume" prefix=" " suffix=": "/>
+            <text variable="title" strip-periods="false" font-style="italic" suffix=", "/>
+          </if>
+          <else>
+            <text variable="title" text-case="title" quotes="true" suffix="."/>
+          </else>
+        </choose>
+      </if>
+      <else-if type="motion_picture" match="any"/>
+      <else>
+        <choose>
+          <if variable="container-title" match="any">
+            <text variable="container-title" text-case="title" font-style="italic"/>
+            <label prefix=". " variable="volume" form="short"/>
+            <text variable="volume" prefix=" " suffix=": "/>
+          </if>
+        </choose>
+        <choose>
+          <if match="all" variable="author editor">
+            <text variable="title" font-style="italic" suffix=","/>
+          </if>
+          <else>
+            <text variable="title" text-case="title" font-style="italic" suffix="."/>
+          </else>
+        </choose>
+      </else>
+    </choose>
+  </macro>
+  <macro name="title-short">
+    <choose>
+      <if variable="container-title" match="any">
+        <text variable="title" form="short" text-case="title" quotes="false" prefix="»" suffix="«"/>
+      </if>
+      <else>
+        <text variable="title" form="short" font-style="italic" text-case="title"/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="container-title">
+    <choose>
+      <if type="article article-journal" match="any">
+        <text variable="container-title" font-style="italic" suffix=" "/>
+      </if>
+      <else-if type="chapter" match="any">
+        <text variable="container-title" font-style="italic" suffix=", "/>
+        <choose>
+          <if match="any" variable="volume">
+            <label variable="volume" form="short"/>
+            <text variable="volume" prefix=" " suffix=". "/>
+          </if>
+        </choose>
+      </else-if>
+      <else-if type="book" match="any"/>
+      <else>
+        <text variable="container-title" text-case="title" font-style="italic" suffix=", "/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="other-contributors">
+    <group delimiter=" ">
+      <choose>
+        <if variable="container-title" match="any">
+          <names variable="container-author editor illustrator interviewer" delimiter=", " suffix=". ">
+            <label form="short" plural="never" suffix=" "/>
+            <name and="text"/>
+          </names>
+          <names variable="translator">
+            <label form="short" prefix=" " suffix=" "/>
+            <name suffix=". "/>
+          </names>
+        </if>
+        <else>
+          <choose>
+            <if match="all" variable="editor translator">
+              <names variable="editor">
+                <label form="short"/>
+                <name suffix="."/>
+              </names>
+              <names variable="translator" delimiter=", " suffix=". ">
+                <label form="short" text-case="capitalize-first" suffix=" "/>
+                <name and="text"/>
+              </names>
+            </if>
+            <else>
+              <names variable="container-author editor illustrator interviewer" delimiter=", " suffix=".">
+                <label form="short" text-case="capitalize-first" suffix=" "/>
+                <name and="text"/>
+              </names>
+            </else>
+          </choose>
+        </else>
+      </choose>
+      <names variable="director">
+        <label form="verb" suffix=" " text-case="capitalize-first"/>
+        <name and="text"/>
+      </names>
+    </group>
+  </macro>
+  <macro name="version">
+    <group delimiter=", ">
+      <choose>
+        <if is-numeric="edition">
+          <group delimiter=" ">
+            <number variable="edition" form="ordinal"/>
+            <text term="edition" form="short" suffix=", "/>
+          </group>
+        </if>
+        <else>
+          <text variable="edition" text-case="capitalize-first"/>
+        </else>
+      </choose>
+      <text variable="version"/>
+    </group>
+  </macro>
+  <macro name="volume-lowercase">
+    <group delimiter=" ">
+      <choose>
+        <if type="article article-journal" match="any">
+          <text variable="volume"/>
+        </if>
+      </choose>
+    </group>
+  </macro>
+  <macro name="number">
+    <group>
+      <group>
+        <choose>
+          <if variable="edition container-title" match="any">
+            <text macro="volume-lowercase"/>
+          </if>
+          <else-if variable="author" match="all">
+            <choose>
+              <if variable="editor translator container-author illustrator interviewer director" match="any">
+                <text macro="volume-lowercase"/>
+              </if>
+            </choose>
+          </else-if>
+          <else-if variable="editor" match="all">
+            <choose>
+              <if variable="translator container-author illustrator interviewer director" match="any">
+                <text macro="volume-lowercase"/>
+              </if>
+            </choose>
+          </else-if>
+          <else-if variable="container-author illustrator interviewer director" match="any">
+            <text macro="volume-lowercase"/>
+          </else-if>
+          <else>
+            <group delimiter=" ">
+              <text term="volume" form="short" text-case="capitalize-first"/>
+              <text variable="volume"/>
+            </group>
+          </else>
+        </choose>
+      </group>
+      <group delimiter=" ">
+        <choose>
+          <if match="any" variable="volume number">
+            <text variable="issue" prefix="."/>
+          </if>
+          <else>
+            <text variable="issue"/>
+          </else>
+        </choose>
+      </group>
+      <choose>
+        <if type="report">
+          <text variable="genre" suffix=". "/>
+        </if>
+      </choose>
+      <text variable="number" suffix=". "/>
+    </group>
+  </macro>
+  <macro name="publisher">
+    <text variable="publisher"/>
+    <choose>
+      <if type="motion_picture" match="any">
+        <text variable="publisher-place"/>
+      </if>
+    </choose>
+  </macro>
+  <macro name="publication-date">
+    <choose>
+      <if type="book chapter paper-conference motion_picture" match="any">
+        <group>
+          <date date-parts="year" form="numeric" variable="issued" prefix=", "/>
+        </group>
+      </if>
+      <else-if type="article-journal" match="any">
+        <group prefix=" " suffix=": ">
+          <date date-parts="year-month" form="text" variable="issued" prefix="(" suffix=")"/>
+        </group>
+      </else-if>
+      <else-if type="article-magazine" match="any">
+        <group prefix=" " suffix="">
+          <date date-parts="year-month-day" form="text" variable="issued" prefix="" suffix=""/>
+        </group>
+      </else-if>
+      <else-if type="webpage post-weblog post" match="any">
+        <date form="text" variable="issued"/>
+      </else-if>
+    </choose>
+  </macro>
+  <macro name="location">
+    <group>
+      <group delimiter=" ">
+        <choose>
+          <if type="article article-journal" match="any">
+            <text variable="page" prefix=" "/>
+          </if>
+          <else>
+            <text variable="page" prefix=". "/>
+          </else>
+        </choose>
+      </group>
+      <choose>
+        <if variable="source" match="none">
+          <text macro="URI"/>
+        </if>
+      </choose>
+    </group>
+  </macro>
+  <macro name="container2-title">
+    <group delimiter=", ">
+      <choose>
+        <if type="speech">
+          <text variable="event"/>
+          <date variable="event-date" form="text"/>
+          <text variable="event-place"/>
+        </if>
+      </choose>
+      <text variable="archive"/>
+      <text variable="archive-place"/>
+      <text variable="archive_location"/>
+    </group>
+  </macro>
+  <macro name="container2-location">
+    <choose>
+      <if variable="source">
+        <choose>
+          <if variable="DOI URL" match="any">
+            <group delimiter=", " prefix=". ">
+              <text variable="source" font-style="normal"/>
+              <text macro="URI"/>
+            </group>
+          </if>
+        </choose>
+      </if>
+    </choose>
+  </macro>
+  <macro name="URI">
+    <choose>
+      <if variable="DOI">
+        <text variable="DOI" prefix=". DOI: https://doi.org/"/>
+      </if>
+      <else>
+        <choose>
+          <if type="book chapter" match="any">
+            <text value=", "/>
+          </if>
+        </choose>
+        <group delimiter=",a " prefix=", ">
+          <text variable="URL"/>
+        </group>
+      </else>
+    </choose>
+  </macro>
+  <macro name="accessed">
+    <choose>
+      <if variable="issued" match="none">
+        <group delimiter=" ">
+          <text term="accessed" text-case="capitalize-first"/>
+          <date form="text" variable="accessed" prefix=", "/>
+        </group>
+      </if>
+      <else>
+        <choose>
+          <if match="any" variable="DOI"/>
+          <else>
+            <date variable="accessed" form="text" date-parts="year-month-day" prefix=", "/>
+          </else>
+        </choose>
+      </else>
+    </choose>
+  </macro>
+  <macro name="cite-film">
+    <choose>
+      <if type="motion_picture broadcast" match="any">
+        <choose>
+          <if match="any" position="first">
+            <text variable="container-title" font-variant="small-caps" suffix=". "/>
+            <text variable="number" suffix=": "/>
+            <text variable="title" font-variant="small-caps"/>
+            <choose>
+              <if match="any" variable="original-title">
+                <text variable="original-title" font-variant="small-caps" prefix=" ("/>
+                <text variable="publisher-place" prefix=", " suffix=" "/>
+              </if>
+              <else>
+                <text variable="publisher-place" prefix=" (" suffix=" "/>
+              </else>
+            </choose>
+            <date date-parts="year" form="text" variable="issued"/>
+            <choose>
+              <if type="broadcast" match="all" variable="container-title">
+                <text value="Regie: " prefix=", "/>
+              </if>
+              <else-if type="broadcast" match="any">
+                <text value="Idee: " prefix=", "/>
+              </else-if>
+              <else-if type="motion_picture" match="any">
+                <text value="Regie: " prefix=", "/>
+              </else-if>
+            </choose>
+            <names variable="author">
+              <name and="text"/>
+            </names>
+            <text variable="locator" prefix="; "/>
+            <text value=")"/>
+          </if>
+          <else>
+            <choose>
+              <if match="any" variable="title-short">
+                <text variable="title-short" font-variant="small-caps"/>
+                <text variable="locator" prefix=" (" suffix=")"/>
+              </if>
+              <else>
+                <text variable="title" font-variant="small-caps"/>
+                <text variable="locator" prefix=" (" suffix=")"/>
+              </else>
+            </choose>
+          </else>
+        </choose>
+      </if>
+    </choose>
+  </macro>
+  <macro name="bib-film">
+    <choose>
+      <if match="any" variable="original-title">
+        <text variable="title" font-variant="small-caps"/>
+        <text variable="original-title" font-variant="small-caps" prefix=" (" suffix="). "/>
+      </if>
+      <else>
+        <text variable="container-title" font-variant="small-caps" suffix=". "/>
+        <text variable="number" suffix=": "/>
+        <text variable="title" font-variant="small-caps" suffix=". "/>
+      </else>
+    </choose>
+    <choose>
+      <if type="broadcast" match="all" variable="container-title">
+        <text value="Regie" prefix=" " suffix=": "/>
+      </if>
+      <else-if type="broadcast" match="any">
+        <text value="Idee" prefix=" " suffix=": "/>
+      </else-if>
+      <else>
+        <text value="Regie" prefix=" " suffix=": "/>
+      </else>
+    </choose>
+    <names variable="author" suffix=". ">
+      <label/>
+      <name and="text"/>
+    </names>
+    <text variable="publisher-place" suffix=" "/>
+    <date date-parts="year" form="text" variable="issued"/>
+  </macro>
+  <citation et-al-min="3" et-al-use-first="1" disambiguate-add-names="true" disambiguate-add-givenname="true">
+    <layout delimiter="; ">
+      <choose>
+        <if type="motion_picture broadcast" match="any">
+          <text macro="cite-film"/>
+        </if>
+        <else>
+          <choose>
+            <if locator="page line" match="any">
+              <group delimiter=" ">
+                <text macro="author-short"/>
+                <text variable="locator"/>
+              </group>
+            </if>
+            <else>
+              <group delimiter=", ">
+                <text macro="author-short"/>
+                <group>
+                  <label variable="locator" form="short"/>
+                  <text variable="locator"/>
+                </group>
+              </group>
+            </else>
+          </choose>
+        </else>
+      </choose>
+    </layout>
+  </citation>
+  <bibliography et-al-min="3" et-al-use-first="1" entry-spacing="0" line-spacing="2" hanging-indent="true">
+    <sort>
+      <key macro="author"/>
+      <key variable="title"/>
+    </sort>
+    <layout suffix=".">
+      <choose>
+        <if type="motion_picture broadcast" match="any">
+          <text macro="bib-film"/>
+        </if>
+        <else>
+          <group>
+            <text macro="author" suffix=". "/>
+            <text macro="title" font-variant="normal" suffix=" "/>
+            <date date-parts="year" form="numeric" variable="original-date" suffix=". "/>
+            <group>
+              <text macro="container-title"/>
+              <text macro="other-contributors"/>
+              <text macro="version"/>
+              <text macro="number"/>
+              <text macro="publisher"/>
+              <text macro="publication-date"/>
+              <text macro="location"/>
+            </group>
+            <group delimiter=", ">
+              <text macro="container2-title"/>
+              <text macro="container2-location"/>
+            </group>
+            <text macro="accessed"/>
+          </group>
+        </else>
+      </choose>
+    </layout>
+  </bibliography>
+</style>


### PR DESCRIPTION
First step towards implementing the new Norwegian standard citation style for legal sources. Based on the new standard style guide document: https://www.uio.no/for-ansatte/enhetssider/jus/ledelses-og-utvalgsmoter/pmr/moter/2018/pmr5/vedlegg/sak9.pdf

Since this standard is closely related to universitetet-i-oslo-rettsvitenskap.csl, this first version is a slightly edited version of that style. The original author of that style (Hans Gunnar Slokvik Lian) is thus credited besides me. I intend to be the one maintaining this style going forward (since Hans Gunnar is no longer working with legal citation).

**PS**: this is my very first pull request ever on GitHub (or, technically second since I made a mistake with #5493). Please tell me if I am doing something fundamentally wrong, and I'll go back and do more homework...