### PR TITLE
move citation number outside first field

### DIFF
--- a/acta-anaesthesiologica-scandinavica.csl
+++ b/acta-anaesthesiologica-scandinavica.csl
@@ -155,8 +155,8 @@
   </citation>
   <bibliography second-field-align="flush">
     <layout>
+      <text variable="citation-number" suffix=". "/>
       <group delimiter=". " suffix=". ">
-        <text variable="citation-number"/>
         <text macro="author"/>
         <text macro="title"/>
       </group>


### PR DESCRIPTION
In the bibliography layout, citation-number was inside the first group (field). This made second-field-align="flush" mess up the layout.