### PR TITLE
Fix ArchéoSciences

### DIFF
--- a/archeosciences.csl
+++ b/archeosciences.csl
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" delimiter-precedes-et-al="never" delimiter-precedes-last="never" page-range-format="expanded" demote-non-dropping-particle="never" default-locale="fr-FR">
   <!-- This style was edited with the Visual CSL Editor (https://editor.citationstyles.org/visualEditor/) -->
   <info>
@@ -17,7 +17,7 @@
     <issn>1960-1360</issn>
     <eissn>2104-3728</eissn>
     <summary>Style pour ArchéoSciences, revue d'Archéométrie.</summary>
-    <updated>2020-04-09T17:01:16+00:00</updated>
+    <updated>2021-06-14T08:02:34+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale xml:lang="fr">
@@ -160,9 +160,9 @@
         <choose>
           <if type="article-journal article-magazine article-newspaper" match="any">
             <group>
-              <text variable="container-title" font-style="italic" suffix=", "/>
-              <text variable="volume" suffix=", "/>
-              <text variable="issue" suffix=" "/>
+              <text variable="container-title" font-style="italic"/>
+              <text variable="volume" prefix=", "/>
+              <text variable="issue" prefix=", "/>
               <text macro="pages" prefix=": "/>
             </group>
           </if>

--- a/archeosciences.csl
+++ b/archeosciences.csl
@@ -28,7 +28,7 @@
       <term name="anonymous" form="short">anon.</term>
       <term name="accessed">consulté le</term>
       <term name="no date">sans date</term>
-      <term name="no date" form="short">s. d.</term>
+      <term name="no date" form="short">s.&#160;d.</term>
     </terms>
   </locale>
   <macro name="author">
@@ -137,7 +137,7 @@
       <key variable="issued"/>
       <key variable="author"/>
     </sort>
-    <layout delimiter="&#160; " prefix="(" suffix=")">
+    <layout delimiter="&#160;; " prefix="(" suffix=")">
       <group delimiter=", ">
         <text macro="author-short" font-variant="normal"/>
         <text macro="year-date"/>

--- a/archeosciences.csl
+++ b/archeosciences.csl
@@ -17,7 +17,7 @@
     <issn>1960-1360</issn>
     <eissn>2104-3728</eissn>
     <summary>Style pour ArchéoSciences, revue d'Archéométrie.</summary>
-    <updated>2021-06-14T08:02:34+00:00</updated>
+    <updated>2021-06-14T14:16:12+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale xml:lang="fr">
@@ -28,7 +28,7 @@
       <term name="anonymous" form="short">anon.</term>
       <term name="accessed">consulté le</term>
       <term name="no date">sans date</term>
-      <term name="no date" form="short">s.&#160;d.</term>
+      <term name="no date" form="short">s. d.</term>
     </terms>
   </locale>
   <macro name="author">
@@ -118,7 +118,7 @@
     </choose>
   </macro>
   <macro name="DOI">
-    <text variable="DOI" prefix="DOI : "/>
+    <text variable="DOI" prefix="DOI&#160;: "/>
   </macro>
   <macro name="collection">
     <group delimiter=" " suffix=".">
@@ -137,7 +137,7 @@
       <key variable="issued"/>
       <key variable="author"/>
     </sort>
-    <layout delimiter="&#160;; " prefix="(" suffix=")">
+    <layout delimiter="&#160; " prefix="(" suffix=")">
       <group delimiter=", ">
         <text macro="author-short" font-variant="normal"/>
         <text macro="year-date"/>
@@ -159,11 +159,13 @@
         <text macro="title"/>
         <choose>
           <if type="article-journal article-magazine article-newspaper" match="any">
-            <group>
-              <text variable="container-title" font-style="italic"/>
-              <text variable="volume" prefix=", "/>
-              <text variable="issue" prefix=", "/>
-              <text macro="pages" prefix=": "/>
+            <group delimiter="&#160;: ">
+              <group delimiter=", ">
+                <text variable="container-title" font-style="italic"/>
+                <text variable="volume"/>
+                <text variable="issue"/>
+              </group>
+              <text macro="pages"/>
             </group>
           </if>
           <else-if type="book" match="any">
@@ -195,7 +197,7 @@
             <text variable="version" prefix="Version "/>
             <text macro="collection"/>
             <text macro="publisher"/>
-            <text variable="URL" prefix="URL : "/>
+            <text variable="URL" prefix="URL&#160;: "/>
           </else-if>
           <else-if type="webpage">
             <text macro="URL"/>


### PR DESCRIPTION
Uses prefixes instead of suffixes to delimit volume and issue of journal articles.