### PR TITLE
Improvements to norsk-henvisningsstandard-for-rettsvitenskapelige-tekster.csl

### DIFF
--- a/norsk-henvisningsstandard-for-rettsvitenskapelige-tekster.csl
+++ b/norsk-henvisningsstandard-for-rettsvitenskapelige-tekster.csl
@@ -94,9 +94,6 @@
       <else-if type="legislation">
         <text variable="title-short"/>
       </else-if>
-      <else-if type="legal_case">
-        <text variable="title"/>
-      </else-if>
       <else>
         <text font-style="italic" variable="title-short"/>
       </else>
@@ -107,13 +104,13 @@
       <if type="chapter article-journal article-newspaper article-magazine" match="any">
         <text quotes="true" variable="title"/>
       </if>
-      <else-if type="legal_case legislation" match="any">
-        <text variable="title"/>
-      </else-if>
       <else>
         <text font-style="italic" variable="title"/>
       </else>
     </choose>
+  </macro>
+  <macro name="nor-case">
+      <text variable="title"/>
   </macro>
   <macro name="issued">
     <choose>
@@ -232,7 +229,7 @@
             <text macro="issued"/>
           </if>
           <else-if type="legal_case">
-            <text macro="title"/>
+            <text macro="nor-case"/>
           </else-if>
           <else-if type="legislation">
             <text macro="title-short"/>
@@ -315,7 +312,7 @@
           <text macro="title"/>
         </else-if>
         <else-if type="legal_case">
-          <text macro="title"/>
+          <text macro="nor-case"/>
         </else-if>
         <else-if type="personal_communication">
           <text macro="author-full"/>

--- a/norsk-henvisningsstandard-for-rettsvitenskapelige-tekster.csl
+++ b/norsk-henvisningsstandard-for-rettsvitenskapelige-tekster.csl
@@ -249,7 +249,7 @@
       <key macro="title-short"/>
       <key macro="issued"/>
     </sort>
-    <layout delimiter=", ">
+    <layout delimiter="; ">
       <group delimiter=" ">
         <choose>
           <if type="book thesis chapter article-journal article-newspaper article-magazine personal_communication" match="any">

--- a/norsk-henvisningsstandard-for-rettsvitenskapelige-tekster.csl
+++ b/norsk-henvisningsstandard-for-rettsvitenskapelige-tekster.csl
@@ -110,7 +110,23 @@
     </choose>
   </macro>
   <macro name="nor-case">
-      <text variable="title"/>
+    <choose>
+      <if variable="container-title" match="any">
+        <text variable="container-title"/>
+        <text prefix=" " variable="volume"/>
+        <text prefix=" s. " variable="page"/>
+        <text prefix=" (" suffix=")" variable="title-short"/>
+      </if>
+      <else-if variable="number" match="any">
+        <text variable="number"/>
+        <text prefix=" (" suffix=")" variable="title-short"/>
+      </else-if>
+      <else>
+        <text suffix="s dom av " macro="author-full"/>
+        <text macro="issued-full-date"/>
+        <text prefix=" (" suffix=")" variable="title-short"/>
+      </else>
+    </choose>
   </macro>
   <macro name="issued">
     <choose>

--- a/norsk-henvisningsstandard-for-rettsvitenskapelige-tekster.csl
+++ b/norsk-henvisningsstandard-for-rettsvitenskapelige-tekster.csl
@@ -28,7 +28,7 @@
       <term name="translator" form="verb-short">overs.</term>
       <term name="translator" form="short">overs.</term>
       <term name="editortranslator" form="verb-short">red. og overs.</term>
-      <term name="editortranslator" form="verb">Redigert og oversatt av</term>
+      <term name="editortranslator" form="verb">redigert og oversatt av</term>
       <term name="translator" form="short">overs.</term>
       <term name="and others">et al.</term>
       <term name="open-quote">«</term>

--- a/norsk-henvisningsstandard-for-rettsvitenskapelige-tekster.csl
+++ b/norsk-henvisningsstandard-for-rettsvitenskapelige-tekster.csl
@@ -109,7 +109,6 @@
         <text prefix=" " suffix=" " macro="issued-full-date"/>
         <text prefix="nr. " suffix=" " variable="volume"/>
         <text variable="title"/>
-        <text prefix=" (" suffix=")" variable="title-short"/>
       </else-if>
       <else>
         <text font-style="italic" variable="title"/>
@@ -233,6 +232,7 @@
     <choose>
       <if position="first">
         <text macro="title"/>
+        <text prefix=" (" suffix=")" variable="title-short"/>
       </if>
       <else-if variable="title-short" match="any">
         <text macro="title-short"/>
@@ -337,7 +337,7 @@
           </group>
         </else-if>
         <else-if type="legislation bill" match="any">
-          <text macro="nor-legislation"/>
+          <text macro="title"/>
         </else-if>
         <else-if type="legal_case">
           <text macro="nor-case"/>

--- a/norsk-henvisningsstandard-for-rettsvitenskapelige-tekster.csl
+++ b/norsk-henvisningsstandard-for-rettsvitenskapelige-tekster.csl
@@ -165,7 +165,7 @@
         <date-part name="day" form="numeric" suffix=". "/>
         <date-part name="month" form="long" suffix=" "/>
         <date-part name="year"/>
-    </date>
+      </date>
     </group>
   </macro>
   <macro name="locator">
@@ -301,7 +301,7 @@
             <text prefix=", " font-style="italic" variable="container-title"/>
             <choose>
               <if variable="issued" match="any">
-              <text prefix=", " macro="issued-full-date"/>
+                <text prefix=", " macro="issued-full-date"/>
               </if>
             </choose>
             <choose>

--- a/norsk-henvisningsstandard-for-rettsvitenskapelige-tekster.csl
+++ b/norsk-henvisningsstandard-for-rettsvitenskapelige-tekster.csl
@@ -33,7 +33,7 @@
       <term name="and others">et al.</term>
       <term name="open-quote">«</term>
       <term name="close-quote">»</term>
-      <term name="accessed">sitert</term>
+      <term name="accessed">lest</term>
       <term name="no date">udatert</term>
       <term name="edition">utgave</term>
       <term name="edition" form="short">utg.</term>
@@ -185,23 +185,14 @@
     </choose>
   </macro>
   <macro name="accessed-date">
-    <choose>
-      <if type="personal_communication">
-        <text variable="genre" prefix=", " suffix=", "/>
-        <date variable="issued">
-          <date-part name="day" form="numeric" suffix=". "/>
-          <date-part name="month" form="long" suffix=" "/>
-          <date-part name="year"/>
-        </date>
-      </if>
-      <else>
-        <date variable="accessed" prefix=" [Sitert " suffix="]">
-          <date-part name="day" form="numeric" suffix=". "/>
-          <date-part name="month" form="long" suffix=" "/>
-          <date-part name="year"/>
-        </date>
-      </else>
-    </choose>
+    <group prefix=" (" suffix=")">
+      <text term="accessed"/>
+      <date variable="accessed" prefix=" ">
+        <date-part name="day" form="numeric" suffix=". "/>
+        <date-part name="month" form="long" suffix=" "/>
+        <date-part name="year"/>
+    </date>
+    </group>
   </macro>
   <macro name="locator">
     <choose>
@@ -298,17 +289,18 @@
         <else-if type="article-newspaper article-magazine" match="any">
           <group suffix=".">
             <text macro="author-full"/>
-            <text prefix=". " macro="issued"/>
-            <text prefix=" " macro="title"/>
+            <text prefix=", " macro="title"/>
             <text prefix=", " font-style="italic" variable="container-title"/>
             <choose>
-              <if variable="URL" match="none">
-                <text prefix=", " macro="issued-full-date"/>
+              <if variable="issued" match="any">
+              <text prefix=", " macro="issued-full-date"/>
               </if>
-              <else>
+            </choose>
+            <choose>
+              <if variable="URL" match="any">
                 <text prefix=", " variable="URL"/>
                 <text macro="accessed-date"/>
-              </else>
+              </if>
             </choose>
           </group>
         </else-if>
@@ -344,7 +336,7 @@
         </else-if>
         <else-if type="personal_communication">
           <text macro="author-full"/>
-          <text macro="accessed-date"/>
+          <text prefix=" " macro="issued"/>
         </else-if>
         <else>
           <text variable="title"/>

--- a/norsk-henvisningsstandard-for-rettsvitenskapelige-tekster.csl
+++ b/norsk-henvisningsstandard-for-rettsvitenskapelige-tekster.csl
@@ -104,6 +104,9 @@
       <if type="chapter article-journal article-newspaper article-magazine" match="any">
         <text quotes="true" variable="title"/>
       </if>
+      <else-if type="legislation">
+        <text variable="title"/>
+      </else-if>
       <else>
         <text font-style="italic" variable="title"/>
       </else>
@@ -125,6 +128,16 @@
         <text suffix="s dom av " macro="author-full"/>
         <text macro="issued-full-date"/>
         <text prefix=" (" suffix=")" variable="title-short"/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="nor-legislation">
+    <choose>
+      <if position="first">
+        <text macro="title"/>
+      </if>
+      <else>
+        <text variable="title-short"/>
       </else>
     </choose>
   </macro>
@@ -248,7 +261,7 @@
             <text macro="nor-case"/>
           </else-if>
           <else-if type="legislation">
-            <text macro="title-short"/>
+            <text macro="nor-legislation"/>
           </else-if>
           <else-if type="report">
             <text macro="author-short"/>
@@ -324,7 +337,6 @@
           </group>
         </else-if>
         <else-if type="legislation bill" match="any">
-          <text macro="issued-no-parenthesis"/>
           <text macro="title"/>
         </else-if>
         <else-if type="legal_case">

--- a/norsk-henvisningsstandard-for-rettsvitenskapelige-tekster.csl
+++ b/norsk-henvisningsstandard-for-rettsvitenskapelige-tekster.csl
@@ -105,7 +105,11 @@
         <text quotes="true" variable="title"/>
       </if>
       <else-if type="legislation">
+        <text variable="container-title"/>
+        <text prefix=" " suffix=" " macro="issued-full-date"/>
+        <text prefix="nr. " suffix=" " variable="volume"/>
         <text variable="title"/>
+        <text prefix=" (" suffix=")" variable="title-short"/>
       </else-if>
       <else>
         <text font-style="italic" variable="title"/>
@@ -136,8 +140,12 @@
       <if position="first">
         <text macro="title"/>
       </if>
+      <else-if variable="title-short" match="any">
+        <text macro="title-short"/>
+      </else-if>
       <else>
-        <text variable="title-short"/>
+        <text variable="container-title"/>
+        <text prefix=" " variable="title"/>
       </else>
     </choose>
   </macro>
@@ -329,7 +337,7 @@
           </group>
         </else-if>
         <else-if type="legislation bill" match="any">
-          <text macro="title"/>
+          <text macro="nor-legislation"/>
         </else-if>
         <else-if type="legal_case">
           <text macro="nor-case"/>

--- a/norsk-henvisningsstandard-for-rettsvitenskapelige-tekster.csl
+++ b/norsk-henvisningsstandard-for-rettsvitenskapelige-tekster.csl
@@ -178,7 +178,7 @@
         </group>
       </if>
       <else-if locator="section paragraph" match="any">
-        <text variable="locator" prefix=" § "/>
+        <text variable="locator" prefix=" §&#160;"/>
       </else-if>
       <else>
         <group delimiter=" ">

--- a/norsk-henvisningsstandard-for-rettsvitenskapelige-tekster.csl
+++ b/norsk-henvisningsstandard-for-rettsvitenskapelige-tekster.csl
@@ -116,39 +116,6 @@
       </else>
     </choose>
   </macro>
-  <macro name="nor-case">
-    <choose>
-      <if variable="container-title" match="any">
-        <text variable="container-title"/>
-        <text prefix=" " variable="volume"/>
-        <text prefix=" s. " variable="page"/>
-        <text prefix=" (" suffix=")" variable="title-short"/>
-      </if>
-      <else-if variable="number" match="any">
-        <text variable="number"/>
-        <text prefix=" (" suffix=")" variable="title-short"/>
-      </else-if>
-      <else>
-        <text suffix="s dom av " macro="author-full"/>
-        <text macro="issued-full-date"/>
-        <text prefix=" (" suffix=")" variable="title-short"/>
-      </else>
-    </choose>
-  </macro>
-  <macro name="nor-legislation">
-    <choose>
-      <if position="first">
-        <text macro="title"/>
-      </if>
-      <else-if variable="title-short" match="any">
-        <text macro="title-short"/>
-      </else-if>
-      <else>
-        <text variable="container-title"/>
-        <text prefix=" " variable="title"/>
-      </else>
-    </choose>
-  </macro>
   <macro name="issued">
     <choose>
       <if type="personal_communication" match="none">
@@ -240,6 +207,39 @@
       </if>
       <else>
         <text prefix=". DOI: https://doi.org/" variable="DOI"/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="nor-case">
+    <choose>
+      <if variable="container-title" match="any">
+        <text variable="container-title"/>
+        <text prefix=" " variable="volume"/>
+        <text prefix=" s. " variable="page"/>
+        <text prefix=" (" suffix=")" variable="title-short"/>
+      </if>
+      <else-if variable="number" match="any">
+        <text variable="number"/>
+        <text prefix=" (" suffix=")" variable="title-short"/>
+      </else-if>
+      <else>
+        <text suffix="s dom av " macro="author-full"/>
+        <text macro="issued-full-date"/>
+        <text prefix=" (" suffix=")" variable="title-short"/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="nor-legislation">
+    <choose>
+      <if position="first">
+        <text macro="title"/>
+      </if>
+      <else-if variable="title-short" match="any">
+        <text macro="title-short"/>
+      </else-if>
+      <else>
+        <text variable="container-title"/>
+        <text prefix=" " variable="title"/>
       </else>
     </choose>
   </macro>


### PR DESCRIPTION
A few further improvements and fixes for norsk-henvisningsstandard-for-rettsvitenskapelige-tekster.csl

**Highlights:**
- Initial support for Norwegian legislation ("lover" and "forskrifter").
- Support for Norwegian case-law (judgments and decisions from "tingrett", "lagmannsrett" and "Høyesterett").