### PR TITLE
Bugfixes and improvements to the handling of the editors term for norsk-henvisningsstandard-for-rettsvitenskepelige-tekster.csl.

### DIFF
--- a/norsk-henvisningsstandard-for-rettsvitenskapelige-tekster.csl
+++ b/norsk-henvisningsstandard-for-rettsvitenskapelige-tekster.csl
@@ -76,7 +76,9 @@
       <name et-al-min="4" et-al-use-first="1" delimiter-precedes-last="never" name-as-sort-order="first" and="text"/>
       <et-al term="and others"/>
       <substitute>
-        <names variable="editor"/>
+        <names variable="editor">
+          <label prefix="(" suffix=")" form="short"/>
+        </names>
       </substitute>
     </names>
   </macro>
@@ -85,7 +87,6 @@
       <name et-al-min="4" et-al-use-first="1" delimiter-precedes-last="never" and="text"/>
       <et-al term="and others"/>
     </names>
-    <text prefix=" (" suffix=")" term="editor" form="short"/>
   </macro>
   <macro name="title-short">
     <choose>

--- a/norsk-henvisningsstandard-for-rettsvitenskapelige-tekster.csl
+++ b/norsk-henvisningsstandard-for-rettsvitenskapelige-tekster.csl
@@ -76,9 +76,7 @@
       <name et-al-min="4" et-al-use-first="1" delimiter-precedes-last="never" name-as-sort-order="first" and="text"/>
       <et-al term="and others"/>
       <substitute>
-        <names variable="editor">
-          <label prefix="(" suffix=")" form="short"/>
-        </names>
+        <text macro="editor"/>
       </substitute>
     </names>
   </macro>

--- a/norsk-henvisningsstandard-for-rettsvitenskapelige-tekster.csl
+++ b/norsk-henvisningsstandard-for-rettsvitenskapelige-tekster.csl
@@ -325,7 +325,7 @@
         <else-if type="chapter paper-conference" match="any">
           <group suffix=".">
             <text macro="author-full"/>
-            <text prefix=". " macro="title"/>
+            <text prefix=", " macro="title"/>
             <text prefix=" i " font-style="italic" variable="container-title"/>
             <text prefix=", " macro="editor"/>
             <text macro="volume"/>

--- a/norsk-henvisningsstandard-for-rettsvitenskapelige-tekster.csl
+++ b/norsk-henvisningsstandard-for-rettsvitenskapelige-tekster.csl
@@ -86,6 +86,7 @@
     <names variable="editor">
       <name et-al-min="4" et-al-use-first="1" delimiter-precedes-last="never" and="text"/>
       <et-al term="and others"/>
+      <label prefix=" (" suffix=")" form="short"/>
     </names>
   </macro>
   <macro name="title-short">

--- a/norsk-henvisningsstandard-for-rettsvitenskapelige-tekster.csl
+++ b/norsk-henvisningsstandard-for-rettsvitenskapelige-tekster.csl
@@ -83,6 +83,7 @@
   <macro name="editor">
     <names variable="editor">
       <name et-al-min="4" et-al-use-first="1" delimiter-precedes-last="never" and="text"/>
+      <et-al term="and others"/>
     </names>
     <text prefix=" (" suffix=")" term="editor" form="short"/>
   </macro>


### PR DESCRIPTION
Bugfixes and improvements to the handling of the editors term for norsk-henvisningsstandard-for-rettsvitenskepelige-tekster.csl.

**I need help with fixing one remaining bug before merging:**
Currently, the editors term (red.) appears correctly only when book section items are listed in the bibliography. When citing a book that only has editors, I have problems getting `<label>` tag to work. I believe the code at lines 78–82 is the culpit, but I can't understand what I am doing wrong.

Interestingly, I cannot really see what the CSL outputs either, since the Zotero Style Editor refuses to refresh when I have the book with only editors selected. Despite this, the CSL validator tells me that the CSL is valid. Probably I am doing something that is not kosher, but after reading the CSL specification and googling for hours I can't figure out what.


**Here is how the bibliography references should look:**
Arnesen, Finn et al. (red.), _Agreement on the European Economic Area: A Commentary_, Nomos 2018.

Dystland, Marthe Kristine Fjeld, Ida Sørebø og Fredrik Bøckman Finstad, «Article 7 [Binding effect and implementation of EU legal acts]» i _Agreement on the European Economic Area: A Commentary_, Finn Arnesen et al. (red.), Nomos 2018.


**And here is the CSL JSON for two items in question:**
`[
	{
		"id": "http://zotero.org/groups/4308632/items/YEV34Z5H",
		"type": "book",
		"abstract": "The provisions of the Agreement on the European Economic Area (EEA) determine the relations of the EFTA States Norway, Iceland and Liechtenstein with the EU and its Member States. On the basis of EEA, these three countries are largely integrated into the single market of the EU. The EEA is also discussed as a possible model for the EU and UK relations after the Brexit.\n\nArticle by article, the new commentary outlines the importance of the EEA for legal practice, including all extensive annexes and protocols. There is also included both the essential secondary law of EEA and cross-links to EU law. Moreover, the commentary involves the current status of EEA law in Norway, Iceland and Liechtenstein, taking legislation and jurisprudence into account.\n\nThe commentary focuses on the EEA rules on free movement of goods, movement of persons, services, capital, transport policy and competition law. In addition, the commentary intensively discusses the responsibilities and procedures of both the European Surveillance Authority and EFTA Court and the complementary agreement between Norway, Iceland and Liechtenstein.",
		"ISBN": "978-3-8452-7579-6",
		"language": "English",
		"note": "DOI: 10.5771/9783845275796",
		"publisher": "Nomos",
		"source": "Crossref",
		"title": "Agreement on the European Economic Area: A Commentary",
		"title-short": "Agreement on the European Economic Area",
		"URL": "https://www.nomos-elibrary.de/index.php?doi=10.5771/9783845275796",
		"editor": [
			{
				"family": "Arnesen",
				"given": "Finn"
			},
			{
				"family": "Fredriksen",
				"given": "Halvard Haukeland"
			},
			{
				"family": "Graver",
				"given": "Hans Petter"
			},
			{
				"family": "Mestad",
				"given": "Ola"
			},
			{
				"family": "Vedder",
				"given": "Christoph"
			}
		],
		"accessed": {
			"date-parts": [
				[
					"2018",
					10,
					30
				]
			]
		},
		"issued": {
			"date-parts": [
				[
					"2018"
				]
			]
		}
	},
	{
		"id": "http://zotero.org/groups/4308632/items/2EPM5WLF",
		"type": "chapter",
		"container-title": "Agreement on the European Economic Area: A Commentary",
		"ISBN": "978-3-8487-3219-7",
		"language": "English",
		"note": "DOI: 10.5771/9783845275796-248",
		"page": "248-270",
		"publisher": "Nomos",
		"title": "Article 7 [Binding effect and implementation of EU legal acts]",
		"author": [
			{
				"family": "Dystland",
				"given": "Marthe Kristine Fjeld"
			},
			{
				"family": "Sørebø",
				"given": "Ida"
			},
			{
				"family": "Finstad",
				"given": "Fredrik Bøckman"
			}
		],
		"editor": [
			{
				"family": "Arnesen",
				"given": "Finn"
			},
			{
				"family": "Fredriksen",
				"given": "Halvard Haukeland"
			},
			{
				"family": "Graver",
				"given": "Hans Petter"
			},
			{
				"family": "Mestad",
				"given": "Ola"
			},
			{
				"family": "Vedder",
				"given": "Christoph"
			}
		],
		"issued": {
			"date-parts": [
				[
					"2018"
				]
			]
		}
	}
]`