### PR TITLE
Fix wrong article title prefix (period to comma)

### DIFF
--- a/norsk-henvisningsstandard-for-rettsvitenskapelige-tekster.csl
+++ b/norsk-henvisningsstandard-for-rettsvitenskapelige-tekster.csl
@@ -287,7 +287,7 @@
         <if type="article-journal">
           <group suffix=".">
             <text macro="author-full"/>
-            <text prefix=". " macro="title"/>
+            <text prefix=", " macro="title"/>
             <text prefix=" " font-style="italic" variable="container-title"/>
             <text prefix=" " macro="issued"/>
             <text prefix=" s. " variable="page"/>


### PR DESCRIPTION
Erroneous period after author name corrected to comma.