### PR TITLE
Fix missing § locators in juristische-schulung.csl

### DIFF
--- a/juristische-schulung.csl
+++ b/juristische-schulung.csl
@@ -144,7 +144,16 @@
               <text macro="edition"/>
             </else>
           </choose>
-          <text variable="locator" prefix=", "/>
+          <choose>
+              <!-- "S." as a locator is ommited. Many books however are instead cited by § plus margin number. The § has to appear. -->
+              <if locator="page">
+                  <text variable="locator" prefix=", "/>
+              </if>
+              <else>
+                  <label variable="locator" form="symbol" prefix=", "/>
+                  <text variable="locator" prefix=" "/>
+              </else>
+          </choose>
         </else-if>
         <!-- Legal commentary or handbook should be of publication type "entry-encyclopedia"
         - The term "Bearbeiter" (author of a certain chapter) in the following examples should be added by you and is not governed by this stylesheet


### PR DESCRIPTION
The locator for book citations in this journal is only ommitted if the work is referenced by page (German "S." abbreviation). Any other locators should not be ommitted. Most notably, many German law science books are cited by § plus margin number (and some only by margin number). The previous version would swallow the § in that case.

  -quintus