### PR TITLE
Add support for blog posts (CSL: post-weblog).

### DIFF
--- a/norsk-henvisningsstandard-for-rettsvitenskapelige-tekster.csl
+++ b/norsk-henvisningsstandard-for-rettsvitenskapelige-tekster.csl
@@ -18,7 +18,7 @@
     <category citation-format="note"/>
     <category field="law"/>
     <summary>Norwegian legal citation style based on "Veiledning for henvisninger i juridiske tekster" (February 2019).</summary>
-    <updated>2021-06-08T10:53:00+00:00</updated>
+    <updated>2021-07-01T13:45:00+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale xml:lang="nb-NO">

--- a/norsk-henvisningsstandard-for-rettsvitenskapelige-tekster.csl
+++ b/norsk-henvisningsstandard-for-rettsvitenskapelige-tekster.csl
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<style xmlns="http://purl.org/net/xbiblio/csl" class="note" version="1.0" demote-non-dropping-particle="display-and-sort" page-range-format="expanded" default-locale="nb-NO">
+<style xmlns="http://purl.org/net/xbiblio/csl" class="note" version="1.0" demote-non-dropping-particle="sort-only" page-range-format="expanded" default-locale="nb-NO">
   <info>
     <title>Norsk henvisningsstandard for rettsvitenskapelige tekster (Norsk - Bokmål)</title>
     <title-short>Norsk rettsvitenskap</title-short>
@@ -18,7 +18,7 @@
     <category citation-format="note"/>
     <category field="law"/>
     <summary>Norwegian legal citation style based on "Veiledning for henvisninger i juridiske tekster" (February 2019).</summary>
-    <updated>2021-07-01T13:45:00+00:00</updated>
+    <updated>2021-07-01T15:10:00+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale xml:lang="nb-NO">

--- a/norsk-henvisningsstandard-for-rettsvitenskapelige-tekster.csl
+++ b/norsk-henvisningsstandard-for-rettsvitenskapelige-tekster.csl
@@ -102,7 +102,7 @@
   </macro>
   <macro name="title">
     <choose>
-      <if type="chapter article-journal article-newspaper article-magazine" match="any">
+      <if type="chapter article-journal article-newspaper article-magazine post-weblog" match="any">
         <text quotes="true" variable="title"/>
       </if>
       <else-if type="legislation">
@@ -253,7 +253,7 @@
     <layout delimiter="; ">
       <group delimiter=" ">
         <choose>
-          <if type="book thesis chapter article-journal article-newspaper article-magazine personal_communication" match="any">
+          <if type="book thesis chapter article-journal article-newspaper article-magazine post-weblog personal_communication" match="any">
             <text macro="author-short"/>
             <text macro="issued"/>
           </if>
@@ -295,7 +295,7 @@
             <text prefix=" " macro="retrieved-from"/>
           </group>
         </if>
-        <else-if type="article-newspaper article-magazine" match="any">
+        <else-if type="article-newspaper article-magazine post-weblog" match="any">
           <group suffix=".">
             <text macro="author-full"/>
             <text prefix=", " macro="title"/>


### PR DESCRIPTION
Blogs are cited in the same way as newspaper articles, so I added support for them by just tacking on "post-weblog" in the applicable if-loops of relevant macros.