### PR TITLE
Further improvements to norsk-henvisningsstandad-for-rettsvitenskapelige-tekster.csl

### DIFF
--- a/norsk-henvisningsstandard-for-rettsvitenskapelige-tekster.csl
+++ b/norsk-henvisningsstandard-for-rettsvitenskapelige-tekster.csl
@@ -38,6 +38,8 @@
       <term name="edition">utgave</term>
       <term name="edition" form="short">utg.</term>
       <term name="volume">bind</term>
+      <term name="page">side</term>
+      <term name="page" form="short">s.</term>
     </terms>
   </locale>
   <macro name="type-sorting">
@@ -215,7 +217,8 @@
       <if variable="container-title" match="any">
         <text variable="container-title"/>
         <text prefix=" " variable="volume"/>
-        <text prefix=" s. " variable="page"/>
+        <text prefix=" " suffix=" " term="page" form="short"/>
+        <text variable="page"/>
         <text prefix=" (" suffix=")" variable="title-short"/>
       </if>
       <else-if variable="number" match="any">
@@ -290,7 +293,8 @@
             <text prefix=", " macro="title"/>
             <text prefix=" " font-style="italic" variable="container-title"/>
             <text prefix=" " macro="issued"/>
-            <text prefix=" s. " variable="page"/>
+            <text prefix=" " suffix=" " term="page" form="short"/>
+            <text variable="page"/>
             <text macro="DOI"/>
             <text prefix=" " macro="retrieved-from"/>
           </group>

--- a/norsk-henvisningsstandard-for-rettsvitenskapelige-tekster.csl
+++ b/norsk-henvisningsstandard-for-rettsvitenskapelige-tekster.csl
@@ -203,14 +203,7 @@
     </choose>
   </macro>
   <macro name="DOI">
-    <choose>
-      <if variable="DOI" match="none">
-        <text prefix=", " variable="URL"/>
-      </if>
-      <else>
-        <text prefix=". DOI: https://doi.org/" variable="DOI"/>
-      </else>
-    </choose>
+    <text prefix=". DOI: https://doi.org/" variable="DOI"/>
   </macro>
   <macro name="nor-case">
     <choose>
@@ -325,6 +318,7 @@
             <text macro="edition-short"/>
             <text prefix=", " variable="publisher"/>
             <text prefix=" " macro="issued-no-parenthesis"/>
+            <text macro="DOI"/>
           </group>
         </else-if>
         <else-if type="chapter paper-conference" match="any">
@@ -337,8 +331,15 @@
             <text macro="edition-short"/>
             <text prefix=", " variable="publisher"/>
             <text prefix=" " macro="issued-no-parenthesis"/>
-            <text prefix=", " variable="URL"/>
-            <text prefix=" " macro="accessed-date"/>
+            <choose>
+              <if variable="DOI" match="any">
+                <text prefix=". DOI: https://doi.org/" variable="DOI"/>
+              </if>
+              <else-if variable="URL" match="any">
+                <text prefix=", " variable="URL"/>
+                <text macro="accessed-date"/>
+              </else-if>
+            </choose>
           </group>
         </else-if>
         <else-if type="legislation bill" match="any">


### PR DESCRIPTION
- Refactor so that the "page" term is used rather than hardcoded text prefixes.
- Refactor DOI macro and added DOI support to additional item types (book, book chapter, thesis, paper-conference)