### PR TITLE
Create institut-francais-darcheologie-orientale-domaine-des-etudes-arabes-en.csl

### DIFF
--- a/institut-francais-darcheologie-orientale-arab-studies.csl
+++ b/institut-francais-darcheologie-orientale-arab-studies.csl
@@ -1,13 +1,14 @@
 <?xml version="1.0" encoding="utf-8"?>
-<style class="note" version="1.0" initialize-with="." page-range-format="expanded" demote-non-dropping-particle="sort-only" default-locale="en-GB" xmlns="http://purl.org/net/xbiblio/csl">
+<style xmlns="http://purl.org/net/xbiblio/csl" class="note" version="1.0" initialize-with="." page-range-format="expanded" demote-non-dropping-particle="sort-only" default-locale="en-GB">
   <!-- This style was edited with the Visual CSL Editor (https://editor.citationstyles.org/visualEditor/) -->
   <info>
-    <title>Institut français d'archéologie orientale - Domaine des études arabes (English)</title>
+    <title>Institut français d'archéologie orientale - Arab Studies (English)</title>
     <title-short>IFAO AR (EN)</title-short>
-    <id>http://www.zotero.org/styles/institut-francais-darcheologie-orientale-domaine-des-etudes-arabes-en</id>
-    <link href="http://www.zotero.org/styles/institut-francais-darcheologie-orientale-domaine-des-etudes-arabes-en" rel="self"/>
+    <id>http://www.zotero.org/styles/institut-francais-darcheologie-orientale-arab-studies</id>
+    <link href="http://www.zotero.org/styles/institut-francais-darcheologie-orientale-arab-studies" rel="self"/>
     <link href="http://www.zotero.org/styles/institut-francais-darcheologie-orientale" rel="template"/>
-    <link rel="documentation" href="https://www.ifao.egnet.net/uploads/publications/normes/IFAO_publications_normes_bibliographiques_pub_arabisantes_2021_angl.pdf"/>
+    <link href="https://www.ifao.egnet.net/publications/publier/normes-ed/" rel="documentation"/>
+    <link href="https://www.ifao.egnet.net/uploads/publications/normes/IFAO_publications_normes_bibliographiques_pub_arabisantes_2021_angl.pdf" rel="documentation"/>
     <author>
       <name>Nicolas Souchon</name>
       <email>souchon.nicolas.ns@gmail.com</email>
@@ -125,7 +126,7 @@
     <text variable="genre"/>
   </macro>
   <macro name="pages">
-    <group delimiter=" ">
+    <group delimiter="&#160;">
       <choose>
         <if match="any" is-numeric="page">
           <text term="page" form="short" plural="true"/>
@@ -135,7 +136,7 @@
     </group>
   </macro>
   <macro name="accessed">
-    <group delimiter=" ">
+    <group delimiter="&#160;">
       <text term="accessed" text-case="lowercase"/>
       <date form="text" variable="accessed"/>
     </group>
@@ -167,7 +168,7 @@
     <text variable="URL" prefix="&lt;" suffix="&gt;"/>
   </macro>
   <macro name="edition">
-    <group delimiter=" ">
+    <group delimiter="&#160;">
       <number variable="edition" form="ordinal"/>
       <label variable="edition" form="short"/>
     </group>
@@ -189,7 +190,7 @@
     </choose>
   </macro>
   <macro name="locator">
-    <group delimiter=" ">
+    <group delimiter="&#160;">
       <label plural="never" variable="locator" form="short"/>
       <text variable="locator"/>
     </group>
@@ -200,7 +201,7 @@
         <name-part name="family" font-variant="normal"/>
       </name>
       <et-al font-style="normal"/>
-      <label form="short" prefix=" (" suffix=")"/>
+      <label form="short" prefix="&#160;(" suffix=")"/>
     </names>
   </macro>
   <macro name="status">
@@ -219,7 +220,7 @@
   <macro name="citation">
     <choose>
       <if match="any" variable="author editor">
-        <group delimiter=", ">
+        <group delimiter=",&#160;">
           <choose>
             <if match="any" variable="author">
               <text macro="author-short"/>
@@ -248,9 +249,9 @@
               <else>
                 <choose>
                   <if match="any" variable="original-date">
-                    <group delimiter=" ">
+                    <group delimiter="&#160;">
                       <text macro="original-date"/>
-                      <group delimiter=" " prefix="(" suffix=")">
+                      <group delimiter="&#160;" prefix="(" suffix=")">
                         <text term="edition" form="short"/>
                         <text macro="issued-year"/>
                       </group>
@@ -274,7 +275,7 @@
         </group>
       </if>
       <else-if type="entry-dictionary entry-encyclopedia" match="any">
-        <group delimiter=", ">
+        <group delimiter=",&#160;">
           <text macro="container-title"/>
           <text macro="title"/>
           <group>
@@ -377,12 +378,12 @@
     <sort>
       <key macro="sort"/>
     </sort>
-    <layout delimiter=" ; " suffix=".">
+    <layout delimiter="&#160;; " suffix=".">
       <text macro="citation"/>
       <text macro="locator" prefix=", "/>
     </layout>
   </citation>
-  <bibliography initialize="false" subsequent-author-substitute="—">
+  <bibliography initialize="false" subsequent-author-substitute="&#8212;">
     <sort>
       <key macro="sort"/>
       <key variable="issued"/>
@@ -400,7 +401,7 @@
                   <text macro="editor"/>
                 </else>
               </choose>
-              <group delimiter=" ">
+              <group delimiter="&#160;">
                 <text macro="title" font-style="normal"/>
                 <text macro="volume"/>
                 <text macro="original-date" prefix="(" suffix=")"/>
@@ -416,7 +417,7 @@
                 </if>
               </choose>
               <text macro="note"/>
-              <group delimiter=" ">
+              <group delimiter="&#160;">
                 <text macro="collection-title"/>
                 <text macro="collection-number"/>
               </group>
@@ -434,7 +435,7 @@
                           <text macro="status"/>
                         </if>
                         <else>
-                          <group delimiter=" ">
+                          <group delimiter="&#160;">
                             <text macro="issued-year"/>
                             <text macro="edition" prefix="(" suffix=")"/>
                           </group>
@@ -451,7 +452,7 @@
             <group delimiter=", ">
               <text macro="author"/>
               <text macro="title" quotes="false"/>
-              <group delimiter=" ">
+              <group delimiter="&#160;">
                 <text macro="container-title"/>
                 <group delimiter=", ">
                   <number variable="volume"/>
@@ -476,7 +477,7 @@
             <group delimiter=", ">
               <text macro="author"/>
               <text macro="title" quotes="false"/>
-              <group delimiter=" ">
+              <group delimiter="&#160;">
                 <text term="in" font-style="normal"/>
                 <text macro="editor-name-first" suffix=","/>
                 <text macro="container-title"/>
@@ -493,7 +494,7 @@
                 </if>
               </choose>
               <text macro="note"/>
-              <group delimiter=" ">
+              <group delimiter="&#160;">
                 <text macro="collection-title"/>
                 <text macro="collection-number"/>
               </group>
@@ -511,7 +512,7 @@
                           <text macro="status"/>
                         </if>
                         <else>
-                          <group delimiter=" ">
+                          <group delimiter="&#160;">
                             <text macro="issued-year"/>
                             <text macro="edition"/>
                           </group>
@@ -619,13 +620,13 @@
             <group delimiter=", ">
               <text macro="author"/>
               <text macro="container-title"/>
-              <group delimiter=" ">
+              <group delimiter="&#160;">
                 <text macro="genre"/>
               </group>
               <text macro="URL"/>
               <choose>
                 <if match="any" variable="issued">
-                  <group delimiter=" ">
+                  <group delimiter="&#160;">
                     <text value="version"/>
                     <text macro="issued-year-month-day"/>
                   </group>
@@ -637,17 +638,17 @@
           <else-if type="post-weblog" match="any">
             <group delimiter=", ">
               <text macro="author"/>
-              <group delimiter=" ">
+              <group delimiter="&#160;">
                 <text macro="title" quotes="false"/>
                 <text term="in" font-style="normal"/>
                 <text macro="container-title"/>
               </group>
-              <group delimiter=" ">
+              <group delimiter="&#160;">
                 <text macro="genre"/>
                 <text term="online"/>
               </group>
               <text macro="URL"/>
-              <group delimiter=" ">
+              <group delimiter="&#160;">
                 <text value="publié le"/>
                 <text macro="issued-year-month-day"/>
               </group>

--- a/institut-francais-darcheologie-orientale-domaine-des-etudes-arabes-en.csl
+++ b/institut-francais-darcheologie-orientale-domaine-des-etudes-arabes-en.csl
@@ -6,7 +6,7 @@
     <title-short>IFAO AR (EN)</title-short>
     <id>http://www.zotero.org/styles/institut-francais-darcheologie-orientale-domaine-des-etudes-arabes-en</id>
     <link href="http://www.zotero.org/styles/institut-francais-darcheologie-orientale-domaine-des-etudes-arabes-en" rel="self"/>
-    <link href="http://www.zotero.org/styles/institut-francais-darcheologie-orientale-domaine-des-etudes-arabes" rel="template"/>
+    <link href="http://www.zotero.org/styles/institut-francais-darcheologie-orientale" rel="template"/>
     <link rel="documentation" href="https://www.ifao.egnet.net/uploads/publications/normes/IFAO_publications_normes_bibliographiques_pub_arabisantes_2021_angl.pdf"/>
     <author>
       <name>Nicolas Souchon</name>

--- a/institut-francais-darcheologie-orientale-domaine-des-etudes-arabes-en.csl
+++ b/institut-francais-darcheologie-orientale-domaine-des-etudes-arabes-en.csl
@@ -1,0 +1,671 @@
+<?xml version="1.0" encoding="utf-8"?>
+<style class="note" version="1.0" initialize-with="." page-range-format="expanded" demote-non-dropping-particle="sort-only" default-locale="en-GB" xmlns="http://purl.org/net/xbiblio/csl">
+  <!-- This style was edited with the Visual CSL Editor (https://editor.citationstyles.org/visualEditor/) -->
+  <info>
+    <title>Institut français d'archéologie orientale - Domaine des études arabes (English)</title>
+    <title-short>IFAO AR (EN)</title-short>
+    <id>http://www.zotero.org/styles/institut-francais-darcheologie-orientale-domaine-des-etudes-arabes-en</id>
+    <link href="http://www.zotero.org/styles/institut-francais-darcheologie-orientale-domaine-des-etudes-arabes-en" rel="self"/>
+    <link href="http://www.zotero.org/styles/institut-francais-darcheologie-orientale-domaine-des-etudes-arabes" rel="template"/>
+    <link rel="documentation" href="https://www.ifao.egnet.net/uploads/publications/normes/IFAO_publications_normes_bibliographiques_pub_arabisantes_2021_angl.pdf"/>
+    <author>
+      <name>Nicolas Souchon</name>
+      <email>souchon.nicolas.ns@gmail.com</email>
+    </author>
+    <category citation-format="note"/>
+    <category field="history"/>
+    <summary>Style sheet for the arabic studies publications of the Institut français d'archéologie orientale</summary>
+    <updated>2021-07-11T17:51:15+00:00</updated>
+    <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
+  </info>
+  <locale xml:lang="en">
+    <terms>
+      <term name="no date" form="short">n.d.</term>
+      <term name="sub verbo" form="short">s.v.</term>
+      <term name="open-quote">“</term>
+      <term name="close-quote">”</term>
+      <term name="open-inner-quote">‘</term>
+      <term name="close-inner-quote">’</term>
+      <term name="available at">available from</term>
+      <term name="translator" form="short">trans.</term>
+    </terms>
+  </locale>
+  <macro name="title">
+    <choose>
+      <if type="book manuscript" match="any">
+        <text variable="title" quotes="false" font-style="italic"/>
+      </if>
+      <else-if type="thesis" match="any">
+        <text variable="title" quotes="true"/>
+      </else-if>
+      <else>
+        <text variable="title" quotes="true"/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="title-short">
+    <text variable="title-short" font-style="italic"/>
+  </macro>
+  <macro name="container-title">
+    <text variable="container-title" form="short" font-style="italic"/>
+  </macro>
+  <macro name="collection-title">
+    <text variable="collection-title" form="short"/>
+  </macro>
+  <macro name="author">
+    <names variable="author">
+      <name and="symbol" delimiter-precedes-last="never" initialize="false" name-as-sort-order="all">
+        <name-part name="family"/>
+        <name-part name="given"/>
+      </name>
+    </names>
+  </macro>
+  <macro name="author-short">
+    <names variable="author">
+      <name form="short" font-variant="normal" et-al-min="3" et-al-use-first="1">
+        <name-part name="family" font-variant="normal"/>
+      </name>
+      <et-al font-style="normal"/>
+    </names>
+  </macro>
+  <macro name="editor">
+    <names variable="editor" font-variant="normal" text-decoration="none">
+      <name font-variant="normal" and="symbol" delimiter-precedes-last="never" initialize="false" name-as-sort-order="all">
+        <name-part name="family" font-variant="normal"/>
+        <name-part name="given"/>
+      </name>
+      <label form="short" prefix=" (" suffix=")"/>
+      <substitute>
+        <text macro="container-author"/>
+      </substitute>
+    </names>
+  </macro>
+  <macro name="translator">
+    <names variable="translator">
+      <name and="symbol" delimiter-precedes-last="never" initialize="false">
+        <name-part name="given" font-variant="normal"/>
+        <name-part name="family" font-variant="normal"/>
+      </name>
+      <label form="short" prefix=" (" suffix=")"/>
+    </names>
+  </macro>
+  <macro name="publisher">
+    <text variable="publisher" text-case="capitalize-first"/>
+  </macro>
+  <macro name="publisher-place">
+    <choose>
+      <if match="any" variable="publisher-place">
+        <text variable="publisher-place" text-case="capitalize-first"/>
+      </if>
+      <else>
+        <text value="[n.p.]"/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="archive">
+    <text variable="archive" text-case="capitalize-first"/>
+  </macro>
+  <macro name="archive-location">
+    <text variable="archive_location"/>
+  </macro>
+  <macro name="collection-number">
+    <number variable="collection-number"/>
+  </macro>
+  <macro name="volume">
+    <choose>
+      <if match="any" is-numeric="volume">
+        <number text-case="uppercase" variable="volume" form="roman"/>
+      </if>
+      <else-if match="none" is-numeric="volume">
+        <text variable="volume"/>
+      </else-if>
+    </choose>
+  </macro>
+  <macro name="genre">
+    <text variable="genre"/>
+  </macro>
+  <macro name="pages">
+    <group delimiter=" ">
+      <choose>
+        <if match="any" is-numeric="page">
+          <text term="page" form="short" plural="true"/>
+        </if>
+      </choose>
+      <text variable="page"/>
+    </group>
+  </macro>
+  <macro name="accessed">
+    <group delimiter=" ">
+      <text term="accessed" text-case="lowercase"/>
+      <date form="text" variable="accessed"/>
+    </group>
+  </macro>
+  <macro name="issued-year-month-day">
+    <choose>
+      <if match="any" variable="issued">
+        <date form="text" date-parts="year-month-day" variable="issued"/>
+      </if>
+      <else>
+        <text term="no date" form="short" text-case="lowercase" prefix="[" suffix="]"/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="issued-year">
+    <choose>
+      <if match="any" variable="issued">
+        <date date-parts="year" form="text" variable="issued"/>
+      </if>
+      <else>
+        <text term="no date" form="short" prefix="[" suffix="]"/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="original-date">
+    <date date-parts="year" form="text" variable="original-date"/>
+  </macro>
+  <macro name="URL">
+    <text variable="URL" prefix="&lt;" suffix="&gt;"/>
+  </macro>
+  <macro name="edition">
+    <group delimiter=" ">
+      <number variable="edition" form="ordinal"/>
+      <label variable="edition" form="short"/>
+    </group>
+  </macro>
+  <macro name="sort">
+    <choose>
+      <if match="any" variable="author">
+        <text macro="author"/>
+      </if>
+      <else-if match="any" variable="editor">
+        <text macro="editor"/>
+      </else-if>
+      <else-if type="webpage" match="all" variable="container-title">
+        <text macro="container-title"/>
+      </else-if>
+      <else>
+        <text macro="title"/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="locator">
+    <group delimiter=" ">
+      <label plural="never" variable="locator" form="short"/>
+      <text variable="locator"/>
+    </group>
+  </macro>
+  <macro name="editor-short">
+    <names variable="editor">
+      <name form="short" font-variant="normal" et-al-min="3" et-al-use-first="1">
+        <name-part name="family" font-variant="normal"/>
+      </name>
+      <et-al font-style="normal"/>
+      <label form="short" prefix=" (" suffix=")"/>
+    </names>
+  </macro>
+  <macro name="status">
+    <text term="forthcoming" prefix="(" suffix=")"/>
+  </macro>
+  <macro name="event-place">
+    <text variable="event-place"/>
+  </macro>
+  <macro name="event-date">
+    <date delimiter="" variable="event-date">
+      <date-part name="day" suffix=" "/>
+      <date-part name="month" prefix=" " suffix=" "/>
+      <date-part name="year" range-delimiter="-" prefix=" "/>
+    </date>
+  </macro>
+  <macro name="citation">
+    <choose>
+      <if match="any" variable="author editor">
+        <group delimiter=", ">
+          <choose>
+            <if match="any" variable="author">
+              <text macro="author-short"/>
+            </if>
+            <else>
+              <text macro="editor-short"/>
+            </else>
+          </choose>
+          <choose>
+            <if type="entry-dictionary" match="any">
+              <text macro="title"/>
+            </if>
+          </choose>
+          <group>
+            <choose>
+              <if type="entry-dictionary entry-encyclopedia" match="any">
+                <choose>
+                  <if match="any" variable="status">
+                    <text macro="status"/>
+                  </if>
+                  <else>
+                    <text macro="issued-year"/>
+                  </else>
+                </choose>
+              </if>
+              <else>
+                <choose>
+                  <if match="any" variable="original-date">
+                    <group delimiter=" ">
+                      <text macro="original-date"/>
+                      <group delimiter=" " prefix="(" suffix=")">
+                        <text term="edition" form="short"/>
+                        <text macro="issued-year"/>
+                      </group>
+                    </group>
+                  </if>
+                  <else-if match="any" variable="status">
+                    <group>
+                      <text macro="status"/>
+                    </group>
+                  </else-if>
+                  <else>
+                    <group>
+                      <text macro="issued-year"/>
+                    </group>
+                  </else>
+                </choose>
+              </else>
+            </choose>
+            <text macro="year-suffix"/>
+          </group>
+        </group>
+      </if>
+      <else-if type="entry-dictionary entry-encyclopedia" match="any">
+        <group delimiter=", ">
+          <text macro="container-title"/>
+          <text macro="title"/>
+          <group>
+            <choose>
+              <if match="any" variable="status">
+                <text macro="status"/>
+              </if>
+              <else>
+                <text macro="issued-year"/>
+              </else>
+            </choose>
+            <text macro="year-suffix"/>
+          </group>
+        </group>
+      </else-if>
+      <else>
+        <choose>
+          <if type="webpage" match="any">
+            <text macro="container-title"/>
+          </if>
+          <else>
+            <group delimiter=", ">
+              <choose>
+                <if match="any" variable="title-short">
+                  <text macro="title-short"/>
+                </if>
+                <else>
+                  <text macro="title"/>
+                </else>
+              </choose>
+              <choose>
+                <if match="any" variable="original-date">
+                  <group delimiter=" ">
+                    <text macro="original-date"/>
+                    <group delimiter=" " prefix="(" suffix=")">
+                      <text term="edition"/>
+                      <text macro="issued-year"/>
+                    </group>
+                  </group>
+                </if>
+                <else-if match="any" variable="status">
+                  <group>
+                    <text macro="status"/>
+                  </group>
+                </else-if>
+                <else>
+                  <group>
+                    <text macro="issued-year"/>
+                  </group>
+                </else>
+              </choose>
+              <text macro="year-suffix"/>
+            </group>
+          </else>
+        </choose>
+      </else>
+    </choose>
+  </macro>
+  <macro name="container-author">
+    <names variable="container-author">
+      <name and="symbol" delimiter-precedes-last="never" initialize="false" initialize-with="">
+        <name-part name="given" font-variant="normal"/>
+        <name-part name="family" font-variant="normal"/>
+      </name>
+    </names>
+  </macro>
+  <macro name="year-suffix">
+    <text variable="year-suffix"/>
+  </macro>
+  <macro name="note">
+    <text variable="note"/>
+  </macro>
+  <macro name="editor-name-first">
+    <names variable="editor">
+      <name and="symbol" delimiter-precedes-last="never" initialize="false">
+        <name-part name="given"/>
+        <name-part name="family"/>
+      </name>
+      <label form="short" prefix=" (" suffix=")"/>
+      <substitute>
+        <text macro="container-author-name-first"/>
+      </substitute>
+    </names>
+  </macro>
+  <macro name="container-author-name-first">
+    <names variable="container-author">
+      <name and="symbol" initialize="false">
+        <name-part name="given"/>
+        <name-part name="family"/>
+      </name>
+    </names>
+  </macro>
+  <macro name="number-of-volumes">
+    <group delimiter=" ">
+      <number variable="number-of-volumes"/>
+      <text term="volume" form="short"/>
+    </group>
+  </macro>
+  <citation name-delimiter=", " initialize="false" near-note-distance="1" disambiguate-add-givenname="true" disambiguate-add-year-suffix="true" givenname-disambiguation-rule="all-names" collapse="citation-number">
+    <sort>
+      <key macro="sort"/>
+    </sort>
+    <layout delimiter=" ; " suffix=".">
+      <text macro="citation"/>
+      <text macro="locator" prefix=", "/>
+    </layout>
+  </citation>
+  <bibliography initialize="false" subsequent-author-substitute="—">
+    <sort>
+      <key macro="sort"/>
+      <key variable="issued"/>
+    </sort>
+    <layout>
+      <group display="left-margin" delimiter=", " suffix=".">
+        <choose>
+          <if type="book" match="any">
+            <group delimiter=", ">
+              <choose>
+                <if match="any" variable="author">
+                  <text macro="author"/>
+                </if>
+                <else>
+                  <text macro="editor"/>
+                </else>
+              </choose>
+              <group delimiter=" ">
+                <text macro="title" font-style="normal"/>
+                <text macro="volume"/>
+                <text macro="original-date" prefix="(" suffix=")"/>
+              </group>
+              <text macro="translator"/>
+              <choose>
+                <if match="any" variable="genre">
+                  <group delimiter=", ">
+                    <text macro="genre" text-case="capitalize-first"/>
+                    <text macro="event-place"/>
+                    <text macro="event-date"/>
+                  </group>
+                </if>
+              </choose>
+              <text macro="note"/>
+              <group delimiter=" ">
+                <text macro="collection-title"/>
+                <text macro="collection-number"/>
+              </group>
+              <group>
+                <choose>
+                  <if match="none" variable="publisher-place issued">
+                    <text value="n.p., n.d." prefix="[" suffix="]"/>
+                  </if>
+                  <else>
+                    <group delimiter=", ">
+                      <text macro="publisher"/>
+                      <text macro="publisher-place"/>
+                      <choose>
+                        <if match="any" variable="status">
+                          <text macro="status"/>
+                        </if>
+                        <else>
+                          <group delimiter=" ">
+                            <text macro="issued-year"/>
+                            <text macro="edition" prefix="(" suffix=")"/>
+                          </group>
+                        </else>
+                      </choose>
+                    </group>
+                  </else>
+                </choose>
+                <text macro="year-suffix"/>
+              </group>
+            </group>
+          </if>
+          <else-if type="article-journal article-magazine article-newspaper article" match="any">
+            <group delimiter=", ">
+              <text macro="author"/>
+              <text macro="title" quotes="false"/>
+              <group delimiter=" ">
+                <text macro="container-title"/>
+                <group delimiter=", ">
+                  <number variable="volume"/>
+                  <number variable="issue"/>
+                </group>
+              </group>
+              <group>
+                <choose>
+                  <if match="any" variable="status">
+                    <text macro="status"/>
+                  </if>
+                  <else>
+                    <text macro="issued-year-month-day"/>
+                  </else>
+                </choose>
+                <text macro="year-suffix"/>
+              </group>
+              <text macro="pages"/>
+            </group>
+          </else-if>
+          <else-if type="chapter paper-conference" match="any">
+            <group delimiter=", ">
+              <text macro="author"/>
+              <text macro="title" quotes="false"/>
+              <group delimiter=" ">
+                <text term="in" font-style="normal"/>
+                <text macro="editor-name-first" suffix=","/>
+                <text macro="container-title"/>
+                <text macro="volume"/>
+                <text macro="original-date" prefix="(" suffix=")"/>
+              </group>
+              <choose>
+                <if match="any" variable="genre">
+                  <group delimiter=", ">
+                    <text macro="genre"/>
+                    <text macro="event-place"/>
+                    <text macro="event-date"/>
+                  </group>
+                </if>
+              </choose>
+              <text macro="note"/>
+              <group delimiter=" ">
+                <text macro="collection-title"/>
+                <text macro="collection-number"/>
+              </group>
+              <choose>
+                <if match="none" variable="publisher-place issued">
+                  <text value="n.p., n.d." prefix="[" suffix="]"/>
+                </if>
+                <else>
+                  <group delimiter=", ">
+                    <text macro="publisher"/>
+                    <text macro="publisher-place"/>
+                    <group>
+                      <choose>
+                        <if match="any" variable="status">
+                          <text macro="status"/>
+                        </if>
+                        <else>
+                          <group delimiter=" ">
+                            <text macro="issued-year"/>
+                            <text macro="edition"/>
+                          </group>
+                        </else>
+                      </choose>
+                      <text macro="year-suffix"/>
+                    </group>
+                  </group>
+                </else>
+              </choose>
+              <text macro="pages"/>
+            </group>
+          </else-if>
+          <else-if type="manuscript" match="any">
+            <group delimiter=", ">
+              <text macro="author"/>
+              <text macro="title" quotes="false"/>
+              <text macro="genre"/>
+              <text macro="issued-year"/>
+              <text macro="archive"/>
+              <text macro="archive-location"/>
+            </group>
+          </else-if>
+          <else-if type="entry-dictionary" match="any">
+            <group delimiter=", ">
+              <text macro="author"/>
+              <text macro="title"/>
+              <text macro="container-title"/>
+              <text macro="number-of-volumes"/>
+              <choose>
+                <if match="none" variable="publisher-place issued">
+                  <text value="n.p., n.d."/>
+                </if>
+                <else>
+                  <group delimiter=", ">
+                    <text macro="publisher"/>
+                    <text macro="publisher-place"/>
+                    <choose>
+                      <if match="any" variable="status">
+                        <text macro="status"/>
+                      </if>
+                      <else>
+                        <text macro="issued-year"/>
+                      </else>
+                    </choose>
+                  </group>
+                </else>
+              </choose>
+              <text macro="volume"/>
+              <text macro="pages"/>
+            </group>
+          </else-if>
+          <else-if type="entry-encyclopedia" match="any">
+            <group delimiter=", ">
+              <text macro="author"/>
+              <text macro="title"/>
+              <text macro="container-title"/>
+              <text macro="edition" vertical-align="baseline"/>
+              <text macro="volume"/>
+              <choose>
+                <if match="none" variable="publisher-place issued">
+                  <text value="n.p., n.d." prefix="[" suffix="]"/>
+                </if>
+                <else>
+                  <group delimiter=", ">
+                    <text macro="publisher"/>
+                    <text macro="publisher-place"/>
+                  </group>
+                  <group>
+                    <choose>
+                      <if match="any" variable="status">
+                        <text macro="status"/>
+                      </if>
+                      <else>
+                        <text macro="issued-year"/>
+                      </else>
+                    </choose>
+                    <text macro="year-suffix"/>
+                  </group>
+                </else>
+              </choose>
+              <text macro="pages"/>
+            </group>
+          </else-if>
+          <else-if type="thesis" match="any">
+            <group delimiter=", ">
+              <text macro="author"/>
+              <text macro="title"/>
+              <text macro="genre"/>
+              <text macro="publisher"/>
+              <text macro="issued-year"/>
+            </group>
+          </else-if>
+          <else-if type="report" match="any">
+            <group delimiter=", ">
+              <text macro="author"/>
+              <text macro="title" quotes="false"/>
+              <text macro="genre"/>
+              <text macro="publisher"/>
+              <text macro="publisher-place"/>
+              <text macro="issued-year"/>
+            </group>
+          </else-if>
+          <else-if type="webpage" match="any">
+            <group delimiter=", ">
+              <text macro="author"/>
+              <text macro="container-title"/>
+              <group delimiter=" ">
+                <text macro="genre"/>
+              </group>
+              <text macro="URL"/>
+              <choose>
+                <if match="any" variable="issued">
+                  <group delimiter=" ">
+                    <text value="version"/>
+                    <text macro="issued-year-month-day"/>
+                  </group>
+                </if>
+              </choose>
+              <text macro="accessed"/>
+            </group>
+          </else-if>
+          <else-if type="post-weblog" match="any">
+            <group delimiter=", ">
+              <text macro="author"/>
+              <group delimiter=" ">
+                <text macro="title" quotes="false"/>
+                <text term="in" font-style="normal"/>
+                <text macro="container-title"/>
+              </group>
+              <group delimiter=" ">
+                <text macro="genre"/>
+                <text term="online"/>
+              </group>
+              <text macro="URL"/>
+              <group delimiter=" ">
+                <text value="publié le"/>
+                <text macro="issued-year-month-day"/>
+              </group>
+              <text macro="accessed"/>
+            </group>
+          </else-if>
+        </choose>
+        <choose>
+          <if match="any" variable="URL">
+            <choose>
+              <if type="webpage post-weblog" match="none">
+                <text macro="URL"/>
+                <text macro="accessed"/>
+              </if>
+            </choose>
+          </if>
+        </choose>
+      </group>
+    </layout>
+  </bibliography>
+</style>


### PR DESCRIPTION
Create a new CSL style for the updated version of the Institut français d'archéologie orientale’s standards for Arabic studies publications in English (available here: https://www.ifao.egnet.net/uploads/publications/normes/IFAO_publications_normes_bibliographiques_pub_arabisantes_2021_angl.pdf)