### PR TITLE
[Frontiers in ...] Remove formatting for volume

### DIFF
--- a/frontiers-medical-journals.csl
+++ b/frontiers-medical-journals.csl
@@ -128,7 +128,7 @@
         <else>
           <text macro="title" prefix=" " suffix="."/>
           <group delimiter=" " prefix=" ">
-            <text variable="container-title" form="short" strip-periods="true"/>
+            <text variable="container-title" form="short" strip-periods="true" font-style="italic"/>
             <date variable="issued" prefix=" (" suffix=")">
               <date-part name="year"/>
             </date>

--- a/frontiers-medical-journals.csl
+++ b/frontiers-medical-journals.csl
@@ -128,11 +128,11 @@
         <else>
           <text macro="title" prefix=" " suffix="."/>
           <group delimiter=" " prefix=" ">
-            <text variable="container-title" form="short" strip-periods="true" font-style="italic"/>
+            <text variable="container-title" form="short" strip-periods="true"/>
             <date variable="issued" prefix=" (" suffix=")">
               <date-part name="year"/>
             </date>
-            <text variable="volume" font-weight="bold" suffix=":"/>
+            <text variable="volume" suffix=":"/>
           </group>
           <text variable="page" suffix="."/>
         </else>


### PR DESCRIPTION
It seems that the style for Frontiers ... has changed and that volume should no longer be in bold and journal names should not be in italics: https://www.frontiersin.org/about/author-guidelines