### PR TITLE
Update urad-rs-za-makroekonomske-analize-in-razvoj.csl

### DIFF
--- a/urad-rs-za-makroekonomske-analize-in-razvoj.csl
+++ b/urad-rs-za-makroekonomske-analize-in-razvoj.csl
@@ -13,7 +13,7 @@
     </author>
     <category citation-format="author-date"/>
     <category field="generic-base"/>
-    <updated>2021-06-22T11:22:34+00:00</updated>
+    <updated>2021-08-25T13:10:38+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <macro name="container-contributors-booklike">
@@ -21,7 +21,7 @@
       <if variable="container-title">
         <names variable="editor translator" delimiter=", &amp; ">
           <name and="text" initialize-with=". " delimiter=", "/>
-          <label form="short" prefix=" (" text-case="title" suffix=")"/>
+          <label form="short" prefix=" (" text-case="lowercase" suffix=")"/>
           <substitute>
             <names variable="editorial-director"/>
             <names variable="collection-editor"/>
@@ -33,7 +33,6 @@
   </macro>
   <macro name="container-contributors">
     <choose>
-      <!-- book is here to catch software with container titles -->
       <if type="book broadcast chapter entry entry-dictionary entry-encyclopedia graphic map personal_communication report speech" match="any">
         <text macro="container-contributors-booklike"/>
       </if>
@@ -74,7 +73,6 @@
   </macro>
   <macro name="secondary-contributors">
     <choose>
-      <!-- book is here to catch software with container titles -->
       <if type="book broadcast chapter entry entry-dictionary entry-encyclopedia graphic map report" match="any">
         <text macro="secondary-contributors-booklike"/>
       </if>
@@ -109,7 +107,6 @@
         <choose>
           <if variable="original-author composer" match="any">
             <group delimiter="; ">
-              <!-- Replace prefix with performer label as that becomes available -->
               <names variable="author" prefix="Recorded by ">
                 <label form="verb" text-case="title"/>
                 <name and="text" initialize-with=". " delimiter=", "/>
@@ -183,12 +180,12 @@
     <choose>
       <if type="song">
         <names variable="composer" delimiter=", ">
-          <name name-as-sort-order="all" and="text" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
+          <name name-as-sort-order="all" and="text" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="never"/>
           <substitute>
             <names variable="original-author"/>
             <names variable="author"/>
             <names variable="translator">
-              <name name-as-sort-order="all" and="text" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
+              <name name-as-sort-order="all" and="text" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="never"/>
               <label form="short" prefix=" (" suffix=")" text-case="title"/>
             </names>
             <group delimiter=" ">
@@ -202,12 +199,12 @@
       <else-if type="treaty"/>
       <else>
         <names variable="author" font-weight="normal" delimiter=", ">
-          <name name-as-sort-order="all" and="text" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
+          <name name-as-sort-order="all" and="text" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="never"/>
           <substitute>
             <names variable="illustrator"/>
             <names variable="composer"/>
             <names variable="director">
-              <name name-as-sort-order="all" and="text" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
+              <name name-as-sort-order="all" and="text" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="never"/>
               <label form="long" prefix=" (" suffix=")" text-case="title"/>
             </names>
             <choose>
@@ -221,21 +218,21 @@
                   </else>
                 </choose>
                 <names variable="translator">
-                  <name name-as-sort-order="all" and="text" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
+                  <name name-as-sort-order="all" and="text" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="never"/>
                   <label form="short" prefix=" (" suffix=")" text-case="title"/>
                 </names>
               </if>
             </choose>
             <names variable="editor translator" delimiter=", ">
-              <name name-as-sort-order="all" and="text" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
+              <name name-as-sort-order="all" and="text" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="never"/>
               <label form="short" prefix=" (" suffix=")" text-case="title"/>
             </names>
             <names variable="editorial-director">
-              <name name-as-sort-order="all" and="text" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
+              <name name-as-sort-order="all" and="text" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="never"/>
               <label form="short" prefix=" (" suffix=")" text-case="title"/>
             </names>
             <names variable="collection-editor">
-              <name name-as-sort-order="all" and="text" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
+              <name name-as-sort-order="all" and="text" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="never"/>
               <label form="short" prefix=" (" suffix=")" text-case="title"/>
             </names>
             <choose>
@@ -266,18 +263,17 @@
           <if variable="archive DOI publisher URL" match="none">
             <group delimiter=", ">
               <names variable="author">
-                <name and="text" delimiter=", " initialize-with=". "/>
+                <name and="text" delimiter=", " delimiter-precedes-last="never" initialize-with=". "/>
                 <substitute>
                   <text variable="title" form="short" text-case="title" quotes="true"/>
                 </substitute>
               </names>
-              <!-- This should be localized -->
               <text value="personal communication"/>
             </group>
           </if>
           <else>
             <names variable="author" delimiter=", ">
-              <name form="short" and="text" delimiter=", " initialize-with=". "/>
+              <name form="short" and="text" delimiter-precedes-last="never" delimiter=", " initialize-with=". "/>
               <substitute>
                 <names variable="editor"/>
                 <names variable="translator"/>
@@ -297,7 +293,7 @@
       </else-if>
       <else-if type="song">
         <names variable="composer" delimiter=", ">
-          <name form="short" and="text" delimiter=", " initialize-with=". "/>
+          <name form="short" and="text" delimiter=", " delimiter-precedes-last="never" initialize-with=". "/>
           <substitute>
             <names variable="original-author"/>
             <names variable="author"/>
@@ -316,7 +312,7 @@
       </else-if>
       <else>
         <names variable="author" delimiter=", ">
-          <name form="short" and="text" delimiter=", " initialize-with=". "/>
+          <name form="short" and="text" delimiter=", " delimiter-precedes-last="never" initialize-with=". "/>
           <substitute>
             <names variable="illustrator"/>
             <names variable="composer"/>
@@ -363,7 +359,6 @@
     </choose>
   </macro>
   <macro name="patent-number">
-    <!-- authority: U.S. ; genre: patent ; number: 123,445 -->
     <group delimiter=" ">
       <text variable="authority"/>
       <choose>
@@ -371,12 +366,11 @@
           <text variable="genre" text-case="capitalize-first"/>
         </if>
         <else>
-          <!-- This should be localized -->
           <text value="patent" text-case="capitalize-first"/>
         </else>
       </choose>
       <group delimiter=" ">
-        <text term="issue" form="short" text-case="capitalize-first"/>
+        <text term="issue" form="short" text-case="lowercase"/>
         <text variable="number"/>
       </group>
     </group>
@@ -392,7 +386,7 @@
           <text term="retrieved" text-case="capitalize-first"/>
           <choose>
             <if type="post post-weblog webpage" match="any">
-              <date variable="accessed" form="text" suffix=","/>
+              <date variable="accessed" form="numeric" suffix=""/>
             </if>
           </choose>
           <text term="from"/>
@@ -402,7 +396,6 @@
       <else-if variable="archive">
         <choose>
           <if type="article article-journal article-magazine article-newspaper dataset paper-conference report speech thesis" match="any">
-            <!-- This section is for electronic database locations. Physical archives for these and other item types are called in 'publisher' macro -->
             <choose>
               <if variable="archive-place" match="none">
                 <group delimiter=" ">
@@ -434,7 +427,6 @@
       <else-if variable="title">
         <choose>
           <if variable="version" type="book" match="all">
-            <!---This is a hack until we have a software type -->
             <text variable="title"/>
           </if>
           <else-if variable="reviewed-author reviewed-title" type="review review-book" match="any">
@@ -467,12 +459,9 @@
       </else-if>
     </choose>
   </macro>
-  <!-- APA has four descriptive sections following the title: -->
-  <!-- (description), [format], container, event -->
   <macro name="description">
     <group>
       <choose>
-        <!-- book is here to catch software with container titles -->
         <if type="book report" match="any">
           <choose>
             <if variable="container-title">
@@ -491,7 +480,6 @@
             <group delimiter=", ">
               <text variable="genre" text-case="capitalize-first"/>
               <choose>
-                <!-- In APA journals, the university of a thesis is always cited, even if another locator is given -->
                 <if variable="DOI URL archive" match="any">
                   <text variable="publisher"/>
                 </if>
@@ -540,7 +528,6 @@
           <group delimiter=", ">
             <choose>
               <if variable="genre">
-                <!-- Delimiting by , rather than "of" to avoid incorrect grammar -->
                 <group delimiter=", ">
                   <text variable="genre" text-case="capitalize-first"/>
                   <choose>
@@ -548,14 +535,12 @@
                       <text variable="reviewed-title" font-style="italic"/>
                     </if>
                     <else>
-                      <!-- Assume `title` is title of reviewed work -->
                       <text variable="title" font-style="italic"/>
                     </else>
                   </choose>
                 </group>
               </if>
               <else>
-                <!-- This should be localized -->
                 <group delimiter=" ">
                   <text value="Review of"/>
                   <choose>
@@ -563,7 +548,6 @@
                       <text variable="reviewed-title" font-style="italic"/>
                     </if>
                     <else>
-                      <!-- Assume `title` is title of reviewed work -->
                       <text variable="title" font-style="italic"/>
                     </else>
                   </choose>
@@ -589,14 +573,12 @@
           <if variable="reviewed-title" match="none">
             <choose>
               <if variable="genre">
-                <!-- Delimiting by , rather than "of" to avoid incorrect grammar -->
                 <group delimiter=", ">
                   <text variable="genre" text-case="capitalize-first"/>
                   <text variable="title" form="short" text-case="title" font-style="italic"/>
                 </group>
               </if>
               <else>
-                <!-- This should be localized -->
                 <group delimiter=" ">
                   <text value="Review of"/>
                   <text variable="title" form="short" text-case="title" font-style="italic"/>
@@ -612,7 +594,6 @@
       <else-if type="speech thesis" match="any">
         <text variable="medium" text-case="capitalize-first"/>
       </else-if>
-      <!-- book is here to catch software with container titles -->
       <else-if type="book report" match="any">
         <choose>
           <if variable="container-title" match="none">
@@ -658,7 +639,6 @@
             </group>
           </if>
           <else-if type="dataset">
-            <!-- This should be localized -->
             <text value="Data set"/>
           </else-if>
         </choose>
@@ -670,9 +650,7 @@
       <if variable="number">
         <group delimiter="; ">
           <group delimiter=" ">
-            <text variable="genre" text-case="title"/>
-            <!-- Replace with term="number" if that becomes available -->
-            <text term="issue" form="short" text-case="capitalize-first"/>
+            <text variable="genre"/>
             <text variable="number"/>
           </group>
           <text macro="locators"/>
@@ -697,7 +675,7 @@
     </choose>
   </macro>
   <macro name="title-and-descriptions">
-    <group delimiter=" ">
+    <group delimiter=", ">
       <text macro="title"/>
       <choose>
         <if variable="title interviewer" type="interview" match="any">
@@ -724,13 +702,11 @@
           </if>
         </choose>
         <group delimiter=" ">
-          <!-- Replace "archive" with "archive_collection" as that becomes available -->
           <text variable="archive"/>
           <text variable="archive_location" prefix="(" suffix=")"/>
         </group>
       </group>
       <group delimiter=", ">
-        <!-- Move "archive" here when "archive_collection" becomes available -->
         <text variable="archive-place"/>
       </group>
     </group>
@@ -783,7 +759,6 @@
           <choose>
             <if variable="event">
               <choose>
-                <!-- Only print publisher info if published in a proceedings -->
                 <if variable="collection-editor editor issue page volume" match="any">
                   <group delimiter=": ">
                     <text variable="publisher-place"/>
@@ -808,7 +783,6 @@
     <choose>
       <if variable="event" type="speech paper-conference" match="any">
         <choose>
-          <!-- Don't print event info if published in a proceedings -->
           <if variable="collection-editor editor issue page volume" match="none">
             <group delimiter=" ">
               <group delimiter=" ">
@@ -855,8 +829,8 @@
             </if>
             <else-if type="article article-magazine article-newspaper broadcast interview pamphlet personal_communication post post-weblog treaty webpage" match="any">
               <date variable="issued">
-                <date-part prefix=", " name="month"/>
-                <date-part prefix=" " name="day"/>
+                <date-part prefix=", " name="day" suffix="."/>
+                <date-part prefix=" " name="month"/>
               </date>
             </else-if>
             <else-if type="paper-conference">
@@ -869,7 +843,6 @@
                 </if>
               </choose>
             </else-if>
-            <!-- Only year: article-journal chapter entry entry-dictionary entry-encyclopedia dataset figure graphic motion_picture manuscript map musical_score paper-conference [published] patent report review review-book song thesis -->
           </choose>
         </group>
       </else-if>
@@ -909,7 +882,6 @@
         <if type="personal_communication">
           <choose>
             <if variable="archive DOI publisher URL" match="none">
-              <!-- These variables indicate that the letter is retrievable by the reader. If not, then use the APA in-text-only personal communication format -->
               <date variable="issued" form="text"/>
             </if>
             <else>
@@ -990,7 +962,6 @@
     </choose>
   </macro>
   <macro name="original-published">
-    <!--This should be localized -->
     <choose>
       <if type="bill legal_case legislation" match="any"/>
       <else-if type="interview motion_picture song" match="any">
@@ -1091,7 +1062,7 @@
         <else>
           <group>
             <text term="volume" form="short" plural="true" text-case="capitalize-first" suffix=" "/>
-            <number variable="number-of-volumes" form="numeric" prefix="1&#8211;"/>
+            <number variable="number-of-volumes" form="numeric" prefix="1–"/>
           </group>
         </else>
       </choose>
@@ -1122,7 +1093,6 @@
           <text macro="locators"/>
         </group>
         <choose>
-          <!--for advance online publication-->
           <if variable="issued">
             <choose>
               <if variable="page issue" match="none">
@@ -1140,7 +1110,6 @@
               <text macro="locators"/>
             </group>
             <choose>
-              <!--for advance online publication-->
               <if variable="issued">
                 <choose>
                   <if variable="page issue" match="none">
@@ -1152,10 +1121,9 @@
           </if>
         </choose>
       </else-if>
-      <!-- book is here to catch software with container titles -->
       <else-if type="book" variable="container-title" match="all">
         <group delimiter=" ">
-          <text term="in" text-case="capitalize-first" suffix=" "/>
+          <text term="in" text-case="capitalize-first" suffix=": "/>
           <group delimiter=", ">
             <text macro="container-contributors"/>
             <group delimiter=" ">
@@ -1168,7 +1136,7 @@
       </else-if>
       <else-if type="report" variable="container-title" match="all">
         <group delimiter=" ">
-          <text term="in" text-case="capitalize-first" suffix=" "/>
+          <text term="in" text-case="capitalize-first" suffix=": "/>
           <group delimiter=", ">
             <text macro="container-contributors"/>
             <group delimiter=" ">
@@ -1181,7 +1149,7 @@
       </else-if>
       <else-if type="song" variable="container-title" match="all">
         <group delimiter=" ">
-          <text term="in" text-case="capitalize-first" suffix=" "/>
+          <text term="in" text-case="capitalize-first" suffix=": "/>
           <group delimiter=", ">
             <text macro="container-contributors"/>
             <group delimiter=" ">
@@ -1210,7 +1178,6 @@
       </else-if>
       <else-if type="book">
         <choose>
-          <!-- book and software should not cite collection-title, only container-title -->
           <if variable="container-title">
             <text macro="container-booklike"/>
           </if>
@@ -1228,7 +1195,7 @@
     <choose>
       <if variable="container-title collection-title" match="any">
         <group delimiter=" ">
-          <text term="in" text-case="capitalize-first"/>
+          <text term="in" text-case="capitalize-first" suffix=": "/>
           <group delimiter=", ">
             <text macro="container-contributors"/>
             <choose>
@@ -1250,7 +1217,6 @@
                       </if>
                     </choose>
                   </group>
-                  <!-- Replace with volume-title as that becomes available -->
                   <group delimiter=": ">
                     <text macro="container-title"/>
                     <choose>
@@ -1265,7 +1231,6 @@
                 </group>
               </if>
               <else>
-                <!-- Replace with volume-title as that becomes available -->
                 <group delimiter=": ">
                   <text macro="container-title"/>
                   <choose>
@@ -1311,16 +1276,12 @@
       </else-if>
     </choose>
   </macro>
-  <!-- After 'source', APA also prints publication history (original publication, reprint info, retraction info) -->
   <macro name="publication-history">
     <choose>
       <if type="patent" match="none">
         <group prefix="(" suffix=")">
           <choose>
             <if variable="references">
-              <!-- This provides the option for more elaborate description 
-                   of publication history, such as full "reprinted" references
-                   (example 26) or retracted references -->
               <text variable="references"/>
             </if>
             <else>
@@ -1354,14 +1315,13 @@
   <macro name="legal-cites">
     <choose>
       <if type="legal_case">
-        <group delimiter=" " prefix=", ">
+        <group delimiter=" ">
           <group delimiter=" ">
             <choose>
               <if variable="container-title">
                 <text variable="volume"/>
                 <text variable="container-title"/>
                 <group delimiter=" ">
-                  <!--change to label variable="section" as that becomes available -->
                   <text term="section" form="symbol"/>
                   <text variable="section"/>
                 </group>
@@ -1371,8 +1331,7 @@
                 <group delimiter=" ">
                   <choose>
                     <if is-numeric="number">
-                      <!-- Replace with term="number" if that becomes available -->
-                      <text term="issue" form="short" text-case="capitalize-first"/>
+                      <text term="issue" form="short" text-case="lowercase"/>
                     </if>
                   </choose>
                   <text variable="number"/>
@@ -1384,7 +1343,6 @@
             <text variable="authority"/>
             <choose>
               <if variable="container-title" match="any">
-                <!--Only print year for cases published in reporters-->
                 <date variable="issued" form="numeric" date-parts="year"/>
               </if>
               <else>
@@ -1402,13 +1360,7 @@
             </date>
             <choose>
               <if variable="number">
-                <!--There's a public law number-->
-                <text variable="number" prefix="Pub. L. No. "/>
-                <group delimiter=" ">
-                  <!--change to label variable="section" as that becomes available -->
-                  <text term="section" form="symbol"/>
-                  <text variable="section"/>
-                </group>
+                <text variable="number" prefix="Ur. l. RS, št. "/>
                 <group delimiter=" ">
                   <text variable="volume"/>
                   <text variable="container-title"/>
@@ -1419,9 +1371,6 @@
                 <group delimiter=" ">
                   <text variable="volume"/>
                   <text variable="container-title"/>
-                  <!--change to label variable="section" as that becomes available -->
-                  <text term="section" form="symbol"/>
-                  <text variable="section"/>
                 </group>
               </else>
             </choose>
@@ -1455,6 +1404,10 @@
       <key macro="author"/>
       <key macro="issued-sort" sort="ascending"/>
       <key macro="title"/>
+      <key macro="container-title"/>
+      <key variable="volume"/>
+      <key variable="issue"/>
+      <key variable="number"/>
     </sort>
     <layout>
       <group delimiter=" ">


### PR DESCRIPTION
Minor changes to capitalization and punctuation according to Slovenian grammar: 
* no commas before "and"
* remove capitalization of editor and number terms
* change date format for accessed and published dates
* change pub.l.no to ur.l.št
* remove comma after accessed date
* add colon after "in"
* add volume, issue and number to bibliography sort
* remove a few commas that didn't seem right.