### PR TITLE
Update harvard-swinburne-university-of-technology.csl to meet published spec

### DIFF
--- a/harvard-swinburne-university-of-technology.csl
+++ b/harvard-swinburne-university-of-technology.csl
@@ -83,9 +83,12 @@
   <macro name="year-date">
     <choose>
       <if variable="issued">
-        <date variable="issued" form="text">
-          <date-part name="year"/>
-        </date>
+        <choose>
+          <if is-uncertain-date="issued">
+            <text term="circa" form="short" suffix=" "/>
+          </if>
+        </choose>
+        <date variable="issued" form="text" date-parts="year"/>
       </if>
       <else>
         <text term="no date" form="short"/>

--- a/harvard-swinburne-university-of-technology.csl
+++ b/harvard-swinburne-university-of-technology.csl
@@ -28,6 +28,7 @@
         <single>ed.</single>
         <multiple>eds</multiple>
       </term>
+      <term name="accessed">viewed</term>
     </terms>
   </locale>
   <macro name="editor">
@@ -59,7 +60,7 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <text macro="title"/>
+        <text variable="title" font-style="italic"/>
       </substitute>
     </names>
   </macro>
@@ -82,7 +83,7 @@
   <macro name="year-date">
     <choose>
       <if variable="issued">
-        <date variable="issued">
+        <date variable="issued" form="text">
           <date-part name="year"/>
         </date>
       </if>
@@ -129,12 +130,12 @@
   <macro name="access">
     <choose>
       <if variable="URL">
-        <text value="viewed"/>
+        <text term="accessed"/>
         <group prefix=" " delimiter=", ">
-          <date variable="accessed" delimiter=" ">
-            <date-part name="day"/>
-            <date-part name="month"/>
+          <date variable="accessed" form="text">
             <date-part name="year"/>
+            <date-part name="month"/>
+            <date-part name="day"/>
           </date>
           <text variable="URL" prefix="&lt;" suffix="&gt;"/>
         </group>
@@ -160,8 +161,8 @@
       <key macro="author"/>
       <key variable="title"/>
     </sort>
-    <layout suffix=".">
-      <group delimiter=", ">
+    <layout>
+      <group delimiter=", " suffix=".">
         <group delimiter=" ">
           <text macro="author"/>
           <text macro="year-date"/>

--- a/harvard-swinburne-university-of-technology.csl
+++ b/harvard-swinburne-university-of-technology.csl
@@ -43,8 +43,7 @@
         <single>s.</single>
         <multiple>ss.</multiple>
       </term>
-      <term name="translator" form="verb-short">trans</term>
-      <term name="editortranslator" form="verb-short">ed. &amp; trans</term>
+      <term name="translator" form="verb-short">trans.</term>
     </terms>
   </locale>
   <macro name="editor">
@@ -57,6 +56,14 @@
       <names variable="editor" delimiter=", " suffix=",">
         <name and="symbol" initialize-with="" delimiter=", " delimiter-precedes-last="never"/>
         <label form="short" prefix=" (" suffix=")"/>
+      </names>
+    </group>
+  </macro>
+  <macro name="translator">
+    <group delimiter=" ">
+      <text term="translator" form="verb-short"/>
+      <names variable="translator" delimiter=", " suffix=",">
+        <name and="symbol" initialize-with="" delimiter=", " delimiter-precedes-last="never"/>
       </names>
     </group>
   </macro>
@@ -75,7 +82,6 @@
       <name form="short" and="symbol" delimiter=", " delimiter-precedes-last="never" initialize-with="" name-as-sort-order="all"/>
       <substitute>
         <names variable="editor"/>
-        <names variable="translator"/>
         <text variable="title" font-style="italic"/>
       </substitute>
     </names>
@@ -187,10 +193,9 @@
           <text macro="year-date"/>
         </group>
         <text macro="title"/>
-        <group delimiter=" ">
-          <text macro="editor"/>
-          <text variable="container-title" font-style="italic"/>
-        </group>
+        <text macro="translator"/>
+        <text macro="editor"/>
+        <text variable="container-title" font-style="italic"/>
         <text macro="locators-journal"/>
         <text macro="edition"/>
         <text variable="genre"/>

--- a/harvard-swinburne-university-of-technology.csl
+++ b/harvard-swinburne-university-of-technology.csl
@@ -151,11 +151,7 @@
       <if variable="URL">
         <text term="accessed"/>
         <group prefix=" " delimiter=", ">
-          <date variable="accessed" form="text">
-            <date-part name="year"/>
-            <date-part name="month"/>
-            <date-part name="day"/>
-          </date>
+          <date variable="accessed" form="text"/>
           <text variable="URL" prefix="&lt;" suffix="&gt;"/>
         </group>
       </if>

--- a/harvard-swinburne-university-of-technology.csl
+++ b/harvard-swinburne-university-of-technology.csl
@@ -1,12 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
-<style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" demote-non-dropping-particle="sort-only" default-locale="en-GB">
+<style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" and="symbol" demote-non-dropping-particle="sort-only" default-locale="en-GB">
   <info>
     <title>Swinburne University of Technology - Harvard</title>
+    <title-short>Swinburne Harvard</title-short>
     <id>http://www.zotero.org/styles/harvard-swinburne-university-of-technology</id>
     <link href="http://www.zotero.org/styles/harvard-swinburne-university-of-technology" rel="self"/>
-    <!--<link href="http://www.lib.monash.edu.au/tutorials/citing/harvard.html" rel="documentation"/>
-    If the same style is used by Monash University, it should get a dependent style pointing to this one -->
-    <link href="http://www.swinburne.edu.au/lib/researchhelp/harvard_system.htm" rel="documentation"/>
+    <link href="https://www.swinburne.edu.au/library/search/referencing-guides/harvard-style-guide/" rel="documentation"/>
     <author>
       <name>Julian Onions</name>
       <email>julian.onions@gmail.com</email>
@@ -14,10 +13,13 @@
     <contributor>
       <name>Sebastian Karcher</name>
     </contributor>
+    <contributor>
+      <name>Kiran Castellino</name>
+    </contributor>
     <category citation-format="author-date"/>
     <category field="generic-base"/>
-    <summary>The Australian version of the Harvard author-date style</summary>
-    <updated>2012-09-27T22:06:38+00:00</updated>
+    <summary>The version of the Harvard author-date style used by Swinburne University of Technology, Australia</summary>
+    <updated>2021-08-28T11:17:24+10:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale xml:lang="en-GB">
@@ -41,16 +43,13 @@
       </names>
     </group>
   </macro>
-  <macro name="anon">
-    <text term="anonymous" form="short" text-case="capitalize-first" strip-periods="true"/>
-  </macro>
   <macro name="author">
     <names variable="author">
       <name name-as-sort-order="all" and="symbol" sort-separator=", " initialize-with="" delimiter=", " delimiter-precedes-last="never"/>
       <label form="short" prefix=" (" suffix=")"/>
       <substitute>
         <names variable="editor"/>
-        <text macro="anon"/>
+        <text macro="title"/>
       </substitute>
     </names>
   </macro>
@@ -60,13 +59,13 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-        <text macro="anon"/>
+        <text macro="title"/>
       </substitute>
     </names>
   </macro>
   <macro name="title">
     <choose>
-      <if type="bill book graphic legal_case legislation motion_picture report song thesis" match="any">
+      <if type="bill book graphic legal_case legislation motion_picture report song thesis webpage" match="any">
         <text variable="title" font-style="italic"/>
       </if>
       <else>
@@ -134,7 +133,7 @@
         <group prefix=" " delimiter=", ">
           <date variable="accessed" delimiter=" ">
             <date-part name="day"/>
-            <date-part name="month" suffix=","/>
+            <date-part name="month"/>
             <date-part name="year"/>
           </date>
           <text variable="URL" prefix="&lt;" suffix="&gt;"/>
@@ -150,13 +149,13 @@
           <text macro="year-date"/>
         </group>
         <group delimiter=" ">
-          <label variable="locator" plural="never" form="short"/>
+          <label variable="locator" form="short"/>
           <text variable="locator"/>
         </group>
       </group>
     </layout>
   </citation>
-  <bibliography hanging-indent="true">
+  <bibliography hanging-indent="false">
     <sort>
       <key macro="author"/>
       <key variable="title"/>
@@ -167,7 +166,11 @@
           <text macro="author"/>
           <text macro="year-date"/>
         </group>
-        <text macro="title"/>
+        <choose>
+          <if match="any" variable="author editor translator">
+            <text macro="title"/>
+          </if>
+        </choose>
         <group delimiter=" ">
           <text macro="editor"/>
           <text variable="container-title" font-style="italic"/>

--- a/harvard-swinburne-university-of-technology.csl
+++ b/harvard-swinburne-university-of-technology.csl
@@ -186,11 +186,7 @@
           <text macro="author"/>
           <text macro="year-date"/>
         </group>
-        <choose>
-          <if match="any" variable="author editor translator">
-            <text macro="title"/>
-          </if>
-        </choose>
+        <text macro="title"/>
         <group delimiter=" ">
           <text macro="editor"/>
           <text variable="container-title" font-style="italic"/>

--- a/harvard-swinburne-university-of-technology.csl
+++ b/harvard-swinburne-university-of-technology.csl
@@ -24,11 +24,27 @@
   </info>
   <locale xml:lang="en-GB">
     <terms>
+      <term name="accessed">viewed</term>
+      <term name="anonymous" form="short">Anon</term>
+      <term name="edition" form="short">edn</term>
       <term name="editor" form="short">
         <single>ed.</single>
         <multiple>eds</multiple>
       </term>
-      <term name="accessed">viewed</term>
+      <term name="chapter" form="short">
+        <single>ch.</single>
+        <multiple>chs</multiple>
+      </term>
+      <term name="issue" form="short">
+        <single>no.</single>
+        <multiple>nos</multiple>
+      </term>
+      <term name="section" form="short">
+        <single>s.</single>
+        <multiple>ss.</multiple>
+      </term>
+      <term name="translator" form="verb-short">trans</term>
+      <term name="editortranslator" form="verb-short">ed. &amp; trans</term>
     </terms>
   </locale>
   <macro name="editor">
@@ -56,7 +72,7 @@
   </macro>
   <macro name="author-short">
     <names variable="author">
-      <name form="short" and="symbol" delimiter=", " delimiter-precedes-last="never" initialize-with=". "/>
+      <name form="short" and="symbol" delimiter=", " delimiter-precedes-last="never" initialize-with="" name-as-sort-order="all"/>
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
@@ -146,6 +162,10 @@
     </choose>
   </macro>
   <citation et-al-min="4" et-al-use-first="1" disambiguate-add-year-suffix="true" disambiguate-add-names="true" disambiguate-add-givenname="true" collapse="year" givenname-disambiguation-rule="by-cite">
+    <sort>
+      <key macro="author-short"/>
+      <key macro="year-date"/>
+    </sort>
     <layout prefix="(" suffix=")" delimiter="; ">
       <group delimiter=", ">
         <group delimiter=" ">
@@ -164,8 +184,8 @@
       <key macro="author"/>
       <key variable="title"/>
     </sort>
-    <layout>
-      <group delimiter=", " suffix=".">
+    <layout suffix=".">
+      <group delimiter=", ">
         <group delimiter=" ">
           <text macro="author"/>
           <text macro="year-date"/>


### PR DESCRIPTION
This PR makes several changes so that the CSL format matches the Swinburne Harvard spec correctly:

- Use ampersands in references
- Update documentation link to current URL
- Remove references to Monash University
- Remove `anon` macro, as Swinburne Harvard falls back to the title
- Italicise webpage title
- Remove suffix from months in dates
- Allow plural locators
- Disable hanging indents in bibliography
- Add logic for placement of title based on whether author is known