### PR TITLE
Update urad-rs-za-makroekonomske-analize-in-razvoj.csl

### DIFF
--- a/urad-rs-za-makroekonomske-analize-in-razvoj.csl
+++ b/urad-rs-za-makroekonomske-analize-in-razvoj.csl
@@ -13,7 +13,7 @@
     </author>
     <category citation-format="author-date"/>
     <category field="generic-base"/>
-    <updated>2021-09-02T13:59:07+00:00</updated>
+    <updated>2021-09-22T08:32:55+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <macro name="container-contributors-booklike">
@@ -205,7 +205,7 @@
             <names variable="composer"/>
             <names variable="director">
               <name name-as-sort-order="all" and="text" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="never"/>
-              <label form="long" prefix=" (" suffix=")" text-case="title"/>
+              <label form="long" prefix=" (" suffix=")" text-case="lowercase"/>
             </names>
             <choose>
               <if variable="container-title">
@@ -219,21 +219,21 @@
                 </choose>
                 <names variable="translator">
                   <name name-as-sort-order="all" and="text" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="never"/>
-                  <label form="short" prefix=" (" suffix=")" text-case="title"/>
+                  <label form="short" prefix=" (" suffix=")" text-case="lowercase"/>
                 </names>
               </if>
             </choose>
             <names variable="editor translator" delimiter=", ">
               <name name-as-sort-order="all" and="text" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="never"/>
-              <label form="short" prefix=" (" suffix=")" text-case="title"/>
+              <label form="short" text-case="lowercase" prefix=" (" suffix=")"/>
             </names>
             <names variable="editorial-director">
               <name name-as-sort-order="all" and="text" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="never"/>
-              <label form="short" prefix=" (" suffix=")" text-case="title"/>
+              <label form="short" prefix=" (" suffix=")" text-case="lowercase"/>
             </names>
             <names variable="collection-editor">
               <name name-as-sort-order="all" and="text" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="never"/>
-              <label form="short" prefix=" (" suffix=")" text-case="title"/>
+              <label form="short" prefix=" (" suffix=")" text-case="lowercase"/>
             </names>
             <choose>
               <if type="report">
@@ -671,7 +671,7 @@
       </if>
       <else>
         <group delimiter=", ">
-          <text variable="genre" text-case="capitalize-first"/>
+          <text variable="genre" text-case="lowercase"/>
           <text variable="medium" text-case="capitalize-first"/>
         </group>
       </else>


### PR DESCRIPTION
Minor fixes:
* change title case to lowercase for editors, translators and similar
* change capitalize first to lowercase for bracketed descriptions of reports.