### PR TITLE
Update urad-rs-za-makroekonomske-analize-in-razvoj.csl

### DIFF
--- a/urad-rs-za-makroekonomske-analize-in-razvoj.csl
+++ b/urad-rs-za-makroekonomske-analize-in-razvoj.csl
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+
 <style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" demote-non-dropping-particle="never" page-range-format="expanded" default-locale="sl-SL">
   <info>
     <title>Urad RS za makroekonomske analize in razvoj (Slovenščina)</title>
@@ -13,7 +13,7 @@
     </author>
     <category citation-format="author-date"/>
     <category field="generic-base"/>
-    <updated>2021-09-02T13:59:07+00:00</updated>
+    <updated>2021-09-22T16:14:55+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <macro name="container-contributors-booklike">
@@ -205,7 +205,7 @@
             <names variable="composer"/>
             <names variable="director">
               <name name-as-sort-order="all" and="text" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="never"/>
-              <label form="long" prefix=" (" suffix=")" text-case="title"/>
+              <label form="long" prefix=" (" suffix=")" text-case="lowercase"/>
             </names>
             <choose>
               <if variable="container-title">
@@ -219,21 +219,21 @@
                 </choose>
                 <names variable="translator">
                   <name name-as-sort-order="all" and="text" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="never"/>
-                  <label form="short" prefix=" (" suffix=")" text-case="title"/>
+                  <label form="short" prefix=" (" suffix=")" text-case="lowercase"/>
                 </names>
               </if>
             </choose>
             <names variable="editor translator" delimiter=", ">
               <name name-as-sort-order="all" and="text" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="never"/>
-              <label form="short" prefix=" (" suffix=")" text-case="title"/>
+              <label form="short" text-case="lowercase" prefix=" (" suffix=")"/>
             </names>
             <names variable="editorial-director">
               <name name-as-sort-order="all" and="text" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="never"/>
-              <label form="short" prefix=" (" suffix=")" text-case="title"/>
+              <label form="short" prefix=" (" suffix=")" text-case="lowercase"/>
             </names>
             <names variable="collection-editor">
               <name name-as-sort-order="all" and="text" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="never"/>
-              <label form="short" prefix=" (" suffix=")" text-case="title"/>
+              <label form="short" prefix=" (" suffix=")" text-case="lowercase"/>
             </names>
             <choose>
               <if type="report">
@@ -671,30 +671,51 @@
       </if>
       <else>
         <group delimiter=", ">
-          <text variable="genre" text-case="capitalize-first"/>
+          <text variable="genre" text-case="lowercase"/>
           <text variable="medium" text-case="capitalize-first"/>
         </group>
       </else>
     </choose>
   </macro>
   <macro name="title-and-descriptions">
-    <group delimiter=", ">
-      <text macro="title"/>
-      <choose>
-        <if variable="title interviewer" type="interview" match="any">
-          <group delimiter=" ">
-            <text macro="description"/>
-            <text macro="format"/>
-          </group>
-        </if>
-        <else>
-          <group delimiter=" ">
-            <text macro="format"/>
-            <text macro="description"/>
-          </group>
-        </else>
-      </choose>
-    </group>
+    <choose>
+      <if type="report">
+        <choose>
+          <if variable="number page" match="none">
+            <group delimiter=" ">
+              <text macro="title"/>
+              <text macro="format"/>
+            </group>
+          </if>
+          <else>
+          <group delimiter=", ">
+              <text macro="title"/>
+              <text macro="format"/>
+              <text macro="description"/>
+            </group>
+          </else>
+        </choose>
+      </if>
+      <else>
+        <group delimiter=", ">
+          <text macro="title"/>
+          <choose>
+            <if variable="title interviewer" type="interview" match="any">
+              <group delimiter=" ">
+                <text macro="description"/>
+                <text macro="format"/>
+              </group>
+            </if>
+            <else>
+              <group delimiter=" ">
+                <text macro="format"/>
+                <text macro="description"/>
+              </group>
+            </else>
+          </choose>
+        </group>
+      </else>
+    </choose>
   </macro>
   <macro name="archive">
     <group delimiter=". ">
@@ -996,8 +1017,15 @@
       <if type="article-journal article-magazine figure review review-book" match="any">
         <group delimiter=", ">
           <group>
-            <text variable="volume" font-style="italic"/>
-            <text variable="issue" prefix="(" suffix=")"/>
+            <choose>
+              <if variable="volume" match="none">
+                <text variable="issue"/>
+              </if>
+              <else>
+                <text variable="volume" font-style="italic"/>
+                <text variable="issue" prefix="(" suffix=")"/>
+              </else>
+            </choose>
           </group>
           <text variable="page"/>
         </group>

--- a/urad-rs-za-makroekonomske-analize-in-razvoj.csl
+++ b/urad-rs-za-makroekonomske-analize-in-razvoj.csl
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" demote-non-dropping-particle="never" page-range-format="expanded" default-locale="sl-SL">
+<style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" demote-non-dropping-particle="never" page-range-format="expanded" default-locale="sl-SI">
   <info>
     <title>Urad RS za makroekonomske analize in razvoj (Slovenščina)</title>
     <title-short>UMAR</title-short>

--- a/urad-rs-za-makroekonomske-analize-in-razvoj.csl
+++ b/urad-rs-za-makroekonomske-analize-in-razvoj.csl
@@ -1,4 +1,4 @@
-
+<?xml version="1.0" encoding="utf-8"?>
 <style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" demote-non-dropping-particle="never" page-range-format="expanded" default-locale="sl-SL">
   <info>
     <title>Urad RS za makroekonomske analize in razvoj (Slovenščina)</title>


### PR DESCRIPTION
Minor fixes:
* lower case for editors et al
* lower case for report type (if no number)
* issue without volume not in parentheses
* no comma between title and description in report if only report type (no number) 