### PR TITLE
Update biophysics-and-physicobiology.csl

### DIFF
--- a/biophysics-and-physicobiology.csl
+++ b/biophysics-and-physicobiology.csl
@@ -33,16 +33,16 @@
   </macro>
   <macro name="author">
     <names variable="author">
-      <name delimiter-precedes-last="never" and="symbol" initialize-with=". " name-as-sort-order="all"/>
+      <name delimiter-precedes-last="never" initialize-with=". " name-as-sort-order="all"/>
       <label form="short" prefix=", "/>
-      <et-al font-style="italic"/>
+      <et-al font-style="normal"/>
       <substitute>
         <names variable="editor"/>
       </substitute>
     </names>
   </macro>
   <macro name="access">
-    <text variable="DOI" prefix="DOI: "/>
+    <text variable="DOI" prefix="https://doi.org/"/>
   </macro>
   <macro name="issuance">
     <choose>
@@ -72,10 +72,10 @@
   <macro name="container-title">
     <choose>
       <if type="article-journal">
-        <text variable="container-title" form="short" font-style="italic"/>
+        <text variable="container-title" form="short" font-style="normal"/>
       </if>
       <else>
-        <text variable="container-title" font-style="italic"/>
+        <text variable="container-title" font-style="normal"/>
       </else>
     </choose>
   </macro>
@@ -84,8 +84,8 @@
       <if type="chapter paper-conference" match="any">
         <names variable="editor" prefix="(" suffix=")">
           <label form="short" suffix=" "/>
-          <name delimiter-precedes-last="never" initialize-with=". " name-as-sort-order="all" and="symbol"/>
-          <et-al font-style="italic"/>
+          <name delimiter-precedes-last="never" initialize-with=". " name-as-sort-order="all"/>
+          <et-al font-style="normal"/>
         </names>
       </if>
     </choose>
@@ -93,12 +93,12 @@
   <macro name="volume">
     <choose>
       <if type="article-journal" match="any">
-        <text variable="volume" suffix=","/>
+        <text variable="volume" font-weight="normal" suffix=","/>
       </if>
       <else>
         <group delimiter=" ">
           <label variable="volume" form="short"/>
-          <text variable="volume"/>
+          <text variable="volume" font-weight="normal"/>
         </group>
       </else>
     </choose>


### PR DESCRIPTION
We, the Editorial Office of Biophysics and Physicobiology, have just modified slightly the Citation Style on 1st October 2021. Please see our Updated Instruction for Authors (https://www.biophys.jp/biophysics_and_physicobiology03.html).
The summary of our changes are:
1) "&" before the last author should be deleted, and only insert ", " before the last author.
2) "et al." for more than six authors should be changed from italic to normal fonts.
3) Journal name should be described by normal fonts, not by italic fonts.
4) Volume number should be described by normal fonts, not by bold-faced fonts.
5) DOI information should be described by URL.