### PR TITLE
harvard-university-of-bath.csl: correct et-al-min

### DIFF
--- a/harvard-university-of-bath.csl
+++ b/harvard-university-of-bath.csl
@@ -18,7 +18,7 @@
     <category citation-format="author-date"/>
     <category field="generic-base"/>
     <summary>Adaptation of Harvard referencing style used at the University of Bath.</summary>
-    <updated>2021-02-24T15:00:00+00:00</updated>
+    <updated>2021-10-05T08:20:00+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale xml:lang="en">

--- a/harvard-university-of-bath.csl
+++ b/harvard-university-of-bath.csl
@@ -301,7 +301,7 @@
       <text variable="page"/>
     </group>
   </macro>
-  <citation et-al-min="3" et-al-use-first="1" disambiguate-add-year-suffix="true" disambiguate-add-names="true" disambiguate-add-givenname="true">
+  <citation et-al-min="4" et-al-use-first="1" disambiguate-add-year-suffix="true" disambiguate-add-names="true" disambiguate-add-givenname="true">
     <layout prefix="(" suffix=")" delimiter="; ">
       <group delimiter=", ">
         <text macro="author-short"/>
@@ -630,9 +630,9 @@
             <text macro="edition"/>
             <text macro="series"/>
             <text macro="editor"/>
+            <text macro="publisher"/>
+            <text macro="archive"/>
           </group>
-          <text prefix=" " suffix="." macro="publisher"/>
-          <text prefix=" " suffix="." macro="archive"/>
         </else-if>
         <else-if type="broadcast">
           <group prefix=" " suffix="." delimiter=" ">


### PR DESCRIPTION
- Citations should abbreviate to “et al.” starting with four authors rather than three
- Tidy groupings for graphics/maps