### PR TITLE
Update bluebook-inline.csl

### DIFF
--- a/bluebook-inline.csl
+++ b/bluebook-inline.csl
@@ -227,4 +227,37 @@
       </choose>
     </layout>
   </citation>
+  <bibliography et-al-min="3" et-al-use-first="1">
+    <layout delimiter="; ">
+      <choose>
+        <if position="ibid">
+          <group delimiter=" ">
+            <text value="id." text-case="capitalize-first" font-style="italic"/>
+            <text macro="at_page"/>
+            <!-- period will not show up - this is for find-and-replace later. -->
+          </group>
+        </if>
+        <else-if position="subsequent" type="legal_case" match="any">
+          <!--CSL does not currently support reference to number of repeats, so cannot follow proper Bluebook repeat rule; choice is either short form, or long form.-->
+          <group delimiter=" ">
+            <text macro="source-short"/>
+            <text variable="locator" prefix="at "/>
+          </group>
+        </else-if>
+        <else-if position="subsequent">
+          <group delimiter=" ">
+            <text macro="source-short" suffix=","/>
+            <text value="supra" font-style="italic"/>
+            <text value="note"/>
+            <text variable="first-reference-note-number"/>
+            <text macro="at_page"/>
+          </group>
+        </else-if>
+        <else>
+          <text macro="source-long"/>
+          <text macro="access" prefix=", "/>
+        </else>
+      </choose>
+    </layout>
+  </bibliography>
 </style>

--- a/bluebook-inline.csl
+++ b/bluebook-inline.csl
@@ -228,7 +228,7 @@
     </layout>
   </citation>
   <bibliography et-al-min="3" et-al-use-first="1">
-    <layout delimiter="; ">
+    <layout>
       <choose>
         <if position="ibid">
           <group delimiter=" ">


### PR DESCRIPTION
There is an error using all 3 bluebook csl files.
A user has suggested the following addition:
"The bluebook csl file included the format for citation but not bibliography; I added bibliography and the error is gone."
https://forum.pkp.sfu.ca/t/bluebook-citation-style/55204/6
Worth a try?
Thanks,
Michal