### PR TITLE
Set initialize-with-hyphen to false for AMA styles

### DIFF
--- a/american-medical-association-10th-edition.csl
+++ b/american-medical-association-10th-edition.csl
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" demote-non-dropping-particle="sort-only" page-range-format="expanded" default-locale="en-US">
+<style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" demote-non-dropping-particle="sort-only" page-range-format="expanded" initialize-with-hyphen="false" default-locale="en-US">
   <info>
     <title>American Medical Association 10th edition</title>
     <title-short>AMA (10th ed.)</title-short>

--- a/american-medical-association-alphabetical.csl
+++ b/american-medical-association-alphabetical.csl
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" demote-non-dropping-particle="sort-only" page-range-format="expanded" default-locale="en-US">
+<style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" demote-non-dropping-particle="sort-only" page-range-format="expanded" initialize-with-hyphen="false" default-locale="en-US">
   <info>
     <title>American Medical Association 11th edition (sorted alphabetically)</title>
     <title-short>AMA (11th ed.)</title-short>

--- a/american-medical-association-no-et-al.csl
+++ b/american-medical-association-no-et-al.csl
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" demote-non-dropping-particle="sort-only" page-range-format="expanded" default-locale="en-US">
+<style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" demote-non-dropping-particle="sort-only" page-range-format="expanded" initialize-with-hyphen="false" default-locale="en-US">
   <info>
     <title>American Medical Association 11th edition (no "et al.")</title>
     <title-short>AMA (11th ed.)</title-short>

--- a/american-medical-association-no-url.csl
+++ b/american-medical-association-no-url.csl
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" demote-non-dropping-particle="sort-only" page-range-format="expanded" default-locale="en-US">
+<style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" demote-non-dropping-particle="sort-only" page-range-format="expanded" initialize-with-hyphen="false" default-locale="en-US">
   <info>
     <title>American Medical Association 11th edition (no URL)</title>
     <title-short>AMA (11th ed.)</title-short>

--- a/american-medical-association.csl
+++ b/american-medical-association.csl
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" demote-non-dropping-particle="sort-only" page-range-format="expanded" default-locale="en-US">
+<style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" demote-non-dropping-particle="sort-only" page-range-format="expanded" initialize-with-hyphen="false" default-locale="en-US">
   <info>
     <title>American Medical Association 11th edition</title>
     <title-short>AMA (11th ed.)</title-short>


### PR DESCRIPTION
## Background

As written [here](https://github.com/citation-style-language/styles/issues/5675), I recently discovered that the *AMA* csl styles were producing a first-name format that differs from the _AMA_ guidelines. Specifically, the *AMA* csls retain the hyphen between hyphenated first name, while the _AMA_ style guide stipulates that the hyphen should be removed:
<img width="818" alt="139144175-3e7e3bc7-f42c-4a40-b628-1efadfa5d695" src="https://user-images.githubusercontent.com/17973411/139145247-23b5bf41-9605-4f3a-b55f-25294a93a944.png">


I then discovered that a relevant setting exists within [the csl documentation](https://docs.citationstyles.org/en/stable/specification.html?highlight=hyphen#hyphenation-of-initialized-names): 
![Screen Shot 2021-10-27 at 3 54 32 PM](https://user-images.githubusercontent.com/17973411/139145528-f121f482-cc84-4e63-b89c-2e7baa7c87bf.png)



## Proposed solution

I propose adding `initialize-with-hyphen="false"` to each of the _AMA_ csl files.


