### PR TITLE
Update iso690-author-date-fr-no-abstract.csl

### DIFF
--- a/iso690-author-date-fr-no-abstract.csl
+++ b/iso690-author-date-fr-no-abstract.csl
@@ -7,7 +7,7 @@
     <link href="https://github.com/citation-style-language/styles/pull/405" rel="documentation"/>
     <author>
       <name>Pierre-Amiel Giraud</name>
-      <email>pierre-amiel.giraud@u-bordeaux3.fr</email>
+      <email>pierre-amiel.giraud@u-bordeaux-montaigne.fr</email>
     </author>
     <contributor>
       <name>Raphael Grolimund</name>
@@ -16,29 +16,21 @@
     <category citation-format="author-date"/>
     <category field="generic-base"/>
     <summary>Style based on ISO 690:2010(F), V1, derived from Mellifluo, Grolimund, Hardegger and Giraud version.</summary>
-    <updated>2020-11-19T21:30:00+00:00</updated>
+    <updated>2021-11-05T21:30:00+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
-  <locale>
+ <locale>
     <terms>
-      <term name="anonymous">Anon.</term>
       <term name="no date">[sans date]</term>
       <term name="in">in</term>
       <term name="online">en&#160;ligne</term>
       <term name="accessed">consulté&#160;le</term>
       <term name="retrieved">disponible</term>
       <term name="from">à l'adresse</term>
-      <term name="page" form="short">p.</term>
+      <term name="translator" form="short">trad.</term>
+      <term name="editor" form="short">éd.</term>
     </terms>
   </locale>
-  <macro name="author">
-    <names variable="author">
-      <name and="text" name-as-sort-order="all" sort-separator=", " delimiter=", " delimiter-precedes-last="never">
-        <name-part name="family" text-case="uppercase"/>
-        <name-part name="given"/>
-      </name>
-    </names>
-  </macro>
   <macro name="editor">
     <names variable="editor">
       <name and="text" name-as-sort-order="all" sort-separator=", " delimiter=", " delimiter-precedes-last="never">
@@ -57,41 +49,45 @@
       <label prefix=" (" form="short" suffix=".)"/>
     </names>
   </macro>
-  <macro name="responsability">
+  <macro name="year-date">
     <choose>
-      <if variable="author editor translator" match="any">
-        <choose>
-          <if variable="author">
-            <text macro="author"/>
-          </if>
-          <else-if variable="editor">
-            <text macro="editor"/>
-          </else-if>
-          <else>
-            <text macro="translator"/>
-          </else>
-        </choose>
+      <if variable="issued">
+        <date variable="issued">
+          <date-part name="year" form="long"/>
+        </date>
       </if>
       <else>
-        <text term="anonymous" text-case="uppercase"/>
+        <text term="no date"/>
       </else>
     </choose>
   </macro>
-  <macro name="author-citation">
+  <macro name="responsability">
+    <names variable="author">
+      <name and="text" name-as-sort-order="all" sort-separator=", " delimiter=", " delimiter-precedes-last="never">
+        <name-part name="family" text-case="uppercase"/>
+        <name-part name="given"/>
+      </name>
+      <substitute>
+        <text macro="editor"/>
+        <text macro="translator"/>
+        <text macro="title"/>
+      </substitute>
+    </names>
     <choose>
       <if variable="author editor translator" match="any">
-        <names variable="author">
-          <name form="short"/>
-          <substitute>
-            <names variable="editor"/>
-            <names variable="translator"/>
-          </substitute>
-        </names>
+        <text macro="year-date" prefix=", "/>
       </if>
-      <else>
-        <text term="anonymous" text-case="uppercase"/>
-      </else>
     </choose>
+  </macro>
+  <macro name="author-citation">
+    <names variable="author">
+      <name form="short"/>
+      <substitute>
+        <names variable="editor"/>
+        <names variable="translator"/>
+        <text variable="title" font-style="italic"/>
+      </substitute>
+    </names>
   </macro>
   <macro name="container-author">
     <names variable="container-author">
@@ -116,31 +112,36 @@
           </else>
         </choose>
       </if>
-      <else>
-        <text term="anonymous" text-case="uppercase"/>
-      </else>
-    </choose>
-  </macro>
-  <macro name="year-date">
-    <choose>
-      <if variable="issued">
-        <date variable="issued">
-          <date-part name="year" form="long"/>
-        </date>
-      </if>
-      <else>
-        <text term="no date"/>
-      </else>
     </choose>
   </macro>
   <macro name="title">
     <choose>
       <if type="book thesis map motion_picture song manuscript" match="any">
-        <text variable="title" font-style="italic"/>
+        <choose>
+          <if variable="author editor translator" match="any">
+            <text variable="title" font-style="italic"/>
+          </if>
+          <else>
+            <text variable="title" font-style="italic" suffix=", "/>
+            <text macro="year-date" suffix=". "/>
+          </else>
+        </choose>
       </if>
-      <else-if type="paper-conference speech chapter article-journal article-magazine article-newspaper post-weblog post webpage broadcast" match="any">
-        <text variable="title" suffix=". "/>
-        <text term="in" text-case="capitalize-first" suffix="&#160;: "/>
+      <else-if type="paper-conference speech chapter article-journal article-magazine article-newspaper entry entry-dictionary entry-encyclopedia post-weblog post webpage broadcast" match="any">
+        <choose>
+          <if variable="author editor translator" match="any">
+            <text variable="title" suffix=". "/>
+          </if>
+          <else>
+            <text variable="title" suffix=", "/>
+            <text macro="year-date" suffix=". "/>
+          </else>
+        </choose>
+        <choose>
+          <if type="chapter paper-conference" match="any">
+            <text term="in" text-case="capitalize-first" suffix="&#160;: "/>
+          </if>
+        </choose>
         <choose>
           <if variable="container-author editor translator" match="any">
             <text macro="container-responsability"/>
@@ -161,14 +162,39 @@
         </choose>
       </else-if>
       <else-if type="report">
-        <text variable="number" suffix="&#160;: "/>
-        <text variable="title" font-style="italic"/>
+        <choose>
+          <if variable="author editor translator" match="any">
+            <text variable="number" suffix="&#160;: "/>
+            <text variable="title" font-style="italic"/>
+          </if>
+          <else>
+            <text variable="number" suffix="&#160;: "/>
+            <text variable="title" font-style="italic" suffix=", "/>
+            <text macro="year-date" suffix=". "/>
+          </else>
+        </choose>
       </else-if>
       <else-if type="patent">
-        <text variable="title"/>
+        <choose>
+          <if variable="author editor translator" match="any">
+            <text variable="title"/>
+          </if>
+          <else>
+            <text variable="title" suffix=", "/>
+            <text macro="year-date" suffix=". "/>
+          </else>
+        </choose>
       </else-if>
       <else>
-        <text variable="title" font-style="italic"/>
+        <choose>
+          <if variable="author editor translator" match="any">
+            <text variable="title" font-style="italic"/>
+          </if>
+          <else>
+            <text variable="title" font-style="italic" suffix=", "/>
+            <text macro="year-date" suffix=". "/>
+          </else>
+        </choose>
       </else>
     </choose>
     <choose>
@@ -181,7 +207,7 @@
     <text variable="number"/>
   </macro>
   <macro name="medium">
-    <text variable="medium"/>
+    <text variable="medium" prefix=" [" suffix="]"/>
   </macro>
   <macro name="genre">
     <choose>
@@ -214,54 +240,29 @@
   <macro name="edition">
     <text variable="edition" form="long"/>
   </macro>
-  <macro name="publisher-place">
-    <choose>
-      <if type="patent manuscript article-newspaper broadcast motion_picture song" match="any">
-        <choose>
-          <if variable="publisher-place">
-            <text variable="publisher-place"/>
-          </if>
-        </choose>
-      </if>
-      <else>
-        <choose>
-          <if variable="publisher-place">
-            <text variable="publisher-place"/>
-          </if>
-          <else>
-            <text value="s.l." text-case="capitalize-first"/>
-          </else>
-        </choose>
-      </else>
-    </choose>
+  <macro name="publisher-group">
+    <group delimiter="&#160;: ">
+      <text variable="publisher-place"/>
+      <text variable="publisher"/>
+    </group>
   </macro>
   <macro name="issue">
     <group delimiter=", ">
       <text variable="volume" prefix="Vol.&#160;"/>
-      <text variable="issue" prefix="n°&#160;"/>
-      <text variable="page" prefix="pp.&#160;"/>
+      <choose>
+        <if variable="volume">
+          <text variable="issue" prefix="n°&#160;"/>
+          <text variable="page" prefix="pp.&#160;"/>
+        </if>
+        <else-if variable="issue">
+          <text variable="issue" prefix="N°&#160;"/>
+          <text variable="page" prefix="pp.&#160;"/>
+        </else-if>
+        <else>
+          <text variable="page" prefix="pp.&#160;"/>
+        </else>
+      </choose>
     </group>
-  </macro>
-  <macro name="publisher">
-    <choose>
-      <if type="broadcast motion_picture song report" match="any">
-        <choose>
-          <if variable="publisher">
-            <text variable="publisher"/>
-          </if>
-        </choose>
-      </if>
-      <else>
-        <choose>
-          <if variable="publisher">
-            <text variable="publisher"/>
-          </if>
-          <else>
-            <text value="s.n."/>
-          </else>
-        </choose>
-      </else>
-    </choose>
   </macro>
   <macro name="accessed">
     <choose>
@@ -314,12 +315,10 @@
     </choose>
   </macro>
   <macro name="archive">
-    <text variable="archive"/>
-    <choose>
-      <if variable="archive_location">
-        <text value="&#160;:&#160;"/>
-      </if>
-    </choose>
+    <group delimiter=":&#160;">
+      <text variable="archive"/>
+      <text macro="archive_location"/>
+    </group>
   </macro>
   <macro name="archive_location">
     <choose>
@@ -331,14 +330,17 @@
       </else>
     </choose>
   </macro>
-  <citation et-al-min="3" et-al-use-first="1" disambiguate-add-year-suffix="true" disambiguate-add-names="true" disambiguate-add-givenname="true" collapse="year" year-suffix-delimiter=", " after-collapse-delimiter="&#160;; ">
-    <layout prefix="(" suffix=")" delimiter="&#160;; ">
-      <group delimiter=", p.&#160;">
+  <citation et-al-min="4" et-al-use-first="1" disambiguate-add-year-suffix="true" disambiguate-add-names="true" disambiguate-add-givenname="true" collapse="year" year-suffix-delimiter=", " after-collapse-delimiter="; ">
+    <layout prefix="(" suffix=")" delimiter="; ">
+      <group delimiter=", ">
         <group delimiter=" ">
           <text macro="author-citation"/>
           <text macro="year-date"/>
         </group>
-        <text variable="locator"/>
+        <group>
+          <label variable="locator" suffix=".&#160;" form="short" strip-periods="true"/>
+          <text variable="locator"/>
+        </group>
       </group>
     </layout>
   </citation>
@@ -346,196 +348,225 @@
     <sort>
       <key macro="responsability"/>
       <key macro="year-date"/>
-      <key macro="title"/>
     </sort>
     <layout>
       <choose>
         <if type="book map" match="any">
           <group>
-            <text macro="responsability" suffix=", "/>
-            <text macro="year-date" suffix=". "/>
-            <text macro="title" suffix=". "/>
+            <text macro="responsability" suffix=". "/>
+            <choose>
+              <if variable="author editor translator" match="any">
+                <text macro="title" suffix=". "/>
+              </if>
+            </choose>
             <text macro="genre" suffix=". "/>
             <text macro="edition" suffix=". "/>
-            <text macro="publisher-place" suffix="&#160;: "/>
-            <text macro="publisher" suffix=". "/>
+            <text macro="publisher-group" suffix=". "/>
             <text macro="accessed" suffix=". "/>
             <text macro="collection" suffix=". "/>
             <text macro="isbn" suffix=". "/>
-            <text macro="url" suffix=". "/>
+            <text macro="url"/>
           </group>
         </if>
         <else-if type="article-journal article-magazine" match="any">
           <group>
-            <text macro="responsability" suffix=", "/>
-            <text macro="year-date" suffix=". "/>
-            <text macro="title" suffix=". "/>
+            <text macro="responsability" suffix=". "/>
+            <choose>
+              <if variable="author editor translator" match="any">
+                <text macro="title" suffix=". "/>
+              </if>
+            </choose>
             <text macro="edition" suffix=". "/>
             <text macro="date" suffix=". "/>
             <text macro="issue" suffix=". "/>
             <text macro="accessed" suffix=". "/>
             <text macro="doi" suffix=". "/>
-            <text macro="url" suffix=". "/>
+            <text macro="url"/>
           </group>
         </else-if>
         <else-if type="article-newspaper">
           <group>
-            <text macro="responsability" suffix=", "/>
-            <text macro="year-date" suffix=". "/>
-            <text macro="title" suffix=". "/>
+            <text macro="responsability" suffix=". "/>
+            <choose>
+              <if variable="author editor translator" match="any">
+                <text macro="title" suffix=". "/>
+              </if>
+            </choose>
             <text macro="edition" suffix=". "/>
-            <text macro="publisher-place" suffix=", "/>
+            <text macro="publisher-group" suffix=", "/>
             <text macro="date" suffix=". "/>
             <text macro="page" suffix=". "/>
             <text macro="accessed" suffix=". "/>
-            <text macro="isbn" suffix=". "/>
-            <text macro="url" suffix=". "/>
+            <text macro="url"/>
           </group>
         </else-if>
         <else-if type="chapter entry entry-dictionary entry-encyclopedia" match="any">
           <group>
-            <text macro="responsability" suffix=", "/>
-            <text macro="year-date" suffix=". "/>
-            <text macro="title" suffix=". "/>
+            <text macro="responsability" suffix=". "/>
+            <choose>
+              <if variable="author editor translator" match="any">
+                <text macro="title" suffix=". "/>
+              </if>
+            </choose>
             <text macro="edition" suffix=". "/>
-            <text macro="publisher-place" suffix="&#160;: "/>
-            <text macro="publisher" suffix=". "/>
-            <text macro="collection" suffix=". "/>
+            <text macro="publisher-group" suffix=". "/>
             <text macro="page" suffix=". "/>
+            <text macro="collection" suffix=". "/>
             <text macro="accessed" suffix=". "/>
             <text macro="isbn" suffix=". "/>
-            <text macro="url" suffix=". "/>
+            <text macro="url"/>
           </group>
         </else-if>
         <else-if type="speech">
           <group>
-            <text macro="responsability" suffix=", "/>
-            <text macro="year-date" suffix=". "/>
-            <text macro="title" suffix=". "/>
+            <text macro="responsability" suffix=". "/>
+            <choose>
+              <if variable="author editor translator" match="any">
+                <text macro="title" suffix=". "/>
+              </if>
+            </choose>
             <text macro="genre" suffix=". "/>
-            <text macro="publisher-place" suffix=". "/>
+            <text macro="publisher-group" suffix=". "/>
             <text macro="date" suffix=". "/>
             <text macro="accessed" suffix=". "/>
             <text macro="page" suffix=". "/>
-            <text macro="url" suffix=". "/>
+            <text macro="url"/>
           </group>
         </else-if>
         <else-if type="paper-conference">
           <group>
-            <text macro="responsability" suffix=", "/>
-            <text macro="year-date" suffix=". "/>
-            <text macro="title" suffix=". "/>
+            <text macro="responsability" suffix=". "/>
+            <choose>
+              <if variable="author editor translator" match="any">
+                <text macro="title" suffix=". "/>
+              </if>
+            </choose>
             <text macro="genre" suffix=". "/>
-            <text macro="publisher-place" suffix="&#160;: "/>
-            <text macro="publisher" suffix=". "/>
+            <text macro="publisher-group" suffix=". "/>
             <text macro="date" suffix=". "/>
             <text macro="page" suffix=". "/>
             <text macro="accessed" suffix=". "/>
+            <text macro="collection" suffix=". "/>
             <text macro="isbn" suffix=". "/>
-            <text macro="url" suffix=". "/>
+            <text macro="url"/>
           </group>
         </else-if>
         <else-if type="thesis">
           <group>
-            <text macro="responsability" suffix=", "/>
-            <text macro="year-date" suffix=". "/>
-            <text macro="title" suffix=". "/>
+            <text macro="responsability" suffix=". "/>
+            <choose>
+              <if variable="author editor translator" match="any">
+                <text macro="title" suffix=". "/>
+              </if>
+            </choose>
             <text macro="genre" suffix=". "/>
-            <text macro="publisher-place" suffix="&#160;: "/>
-            <text macro="publisher" suffix=". "/>
+            <text macro="publisher-group" suffix=". "/>
             <text macro="accessed" suffix=". "/>
-            <text macro="url" suffix=". "/>
+            <text macro="url"/>
           </group>
         </else-if>
         <else-if type="post-weblog post webpage" match="any">
           <group>
-            <text macro="responsability" suffix=", "/>
-            <text macro="year-date" suffix=". "/>
-            <text macro="title" suffix=". "/>
+            <text macro="responsability" suffix=". "/>
+            <choose>
+              <if variable="author editor translator" match="any">
+                <text macro="title" suffix=". "/>
+              </if>
+            </choose>
             <text macro="date" suffix=". "/>
             <text macro="accessed" suffix=". "/>
-            <text macro="url" suffix=". "/>
+            <text macro="url"/>
           </group>
         </else-if>
         <else-if type="broadcast motion_picture song" match="any">
           <group>
-            <text macro="responsability" suffix=", "/>
-            <text macro="year-date" suffix=". "/>
-            <text macro="title" suffix=". "/>
+            <text macro="responsability" suffix=". "/>
+            <choose>
+              <if variable="author editor translator" match="any">
+                <text macro="title" suffix=". "/>
+              </if>
+            </choose>
             <text macro="medium" suffix=". "/>
-            <text macro="publisher-place" suffix="&#160;: "/>
-            <text macro="publisher" suffix=". "/>
+            <text macro="publisher-group" suffix=", "/>
             <text macro="date" suffix=". "/>
             <text macro="accessed" suffix=". "/>
             <text macro="collection" suffix=". "/>
             <text macro="isbn" suffix=". "/>
-            <text macro="url" suffix=". "/>
+            <text macro="url"/>
           </group>
         </else-if>
         <else-if type="report">
           <group>
-            <text macro="responsability" suffix=", "/>
-            <text macro="year-date" suffix=". "/>
-            <text macro="title" suffix=". "/>
+            <text macro="responsability" suffix=". "/>
+            <choose>
+              <if variable="author editor translator" match="any">
+                <text macro="title" suffix=". "/>
+              </if>
+            </choose>
             <text macro="genre" suffix=". "/>
             <text macro="edition" suffix=". "/>
-            <text macro="publisher-place" suffix=". "/>
-            <text macro="publisher" suffix=". "/>
+            <text macro="publisher-group" suffix=". "/>
             <text macro="accessed" suffix=". "/>
             <text macro="collection" suffix=". "/>
-            <text macro="url" suffix=". "/>
+            <text macro="url"/>
           </group>
         </else-if>
         <else-if type="manuscript">
           <group>
-            <text macro="responsability" suffix=", "/>
-            <text macro="year-date" suffix=". "/>
-            <text macro="title" suffix=". "/>
+            <text macro="responsability" suffix=". "/>
+            <choose>
+              <if variable="author editor translator" match="any">
+                <text macro="title" suffix=". "/>
+              </if>
+            </choose>
             <text macro="genre" suffix=". "/>
             <text macro="edition" suffix=". "/>
-            <text macro="publisher-place" suffix=". "/>
+            <text macro="publisher-group" suffix=". "/>
             <text macro="accessed" suffix=". "/>
             <text macro="collection" suffix=". "/>
-            <text macro="url" suffix=". "/>
+            <text macro="url"/>
           </group>
         </else-if>
         <else-if type="patent">
           <group>
-            <text macro="responsability" suffix=", "/>
-            <text macro="year-date" suffix=". "/>
-            <text macro="title" suffix=". "/>
+            <text macro="responsability" suffix=". "/>
+            <choose>
+              <if variable="author editor translator" match="any">
+                <text macro="title" suffix=". "/>
+              </if>
+            </choose>
             <text macro="number" suffix=". "/>
             <text macro="date" suffix=". "/>
-            <text macro="publisher-place" suffix=". "/>
+            <text macro="publisher-group" suffix=". "/>
             <text macro="accessed" suffix=". "/>
             <text macro="collection" suffix=". "/>
-            <text macro="url" suffix=". "/>
+            <text macro="url"/>
           </group>
         </else-if>
         <else>
           <group>
-            <text macro="responsability" suffix=", "/>
-            <text macro="year-date" suffix=". "/>
-            <text macro="title" suffix=". "/>
+            <text macro="responsability" suffix=". "/>
+            <choose>
+              <if variable="author editor translator" match="any">
+                <text macro="title" suffix=". "/>
+              </if>
+            </choose>
             <text macro="medium" suffix=". "/>
             <text macro="genre" suffix=". "/>
             <text macro="date" suffix=". "/>
             <text macro="edition" suffix=". "/>
-            <text macro="publisher-place" suffix="&#160;: "/>
-            <text macro="publisher" suffix=". "/>
+            <text macro="publisher-group" suffix=". "/>
+            <text macro="number" suffix=". "/>
             <text macro="accessed" suffix=". "/>
             <text macro="collection" suffix=". "/>
             <text macro="page" suffix=". "/>
             <text macro="isbn" suffix=". "/>
-            <text macro="url" suffix=". "/>
+            <text macro="url"/>
           </group>
         </else>
       </choose>
-      <group>
-        <group display="block">
-          <text macro="archive"/>
-          <text macro="archive_location"/>
-        </group>
+      <group display="right-inline">
+        <text macro="archive"/>
       </group>
     </layout>
   </bibliography>


### PR DESCRIPTION
Hello,
Here I propose an update to take into account all the improvements from the iso690-author-date-fr style, made by @grolimur  and alii since 2013.

As a reminder, iso690-author-date-fr-no-abstract is only a fork/copy of iso690-author-date-fr truncated of lines concerning abstracts and notes (yes, this is a very trivial fork).

Thanks to all for maintaining this repo over the years.