### PR TITLE
 Create steel-research-international.csl

### DIFF
--- a/steel-research-international.csl
+++ b/steel-research-international.csl
@@ -1,0 +1,222 @@
+<?xml version="1.0" encoding="utf-8"?>
+<style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" demote-non-dropping-particle="sort-only" default-locale="en-US">
+  <info>
+    <title>Steel Research International</title>
+    <title-short>Steel Res. Int.</title-short>
+    <id>http://www.zotero.org/styles/steel-research-international</id>
+    <link href="http://www.zotero.org/styles/steel-research-international" rel="self"/>
+    <link href="https://onlinelibrary.wiley.com/page/journal/1869344x/homepage/author-guidelines" rel="documentation"/>
+    <author>
+      <name>Christian Schubert</name>
+    </author>
+    <contributor>
+      <name>Christian Schubert</name>
+      <email>5238962+c-schubert@users.noreply.github.com</email>
+    </contributor>
+    <category citation-format="author-date"/>
+    <category field="engineering"/>
+    <eissn>1869-344X</eissn>
+    <issnl>1611-3683</issnl>
+    <summary>
+    Citation style for the Steel research international
+    
+    There are some difficulties i.e. with patents, preprint  specifications and the variables that the CSL offers (nor preprint type or company variable availably), which probably cannot be fixed right now (perfectly) and need manual correction.
+    Also there is no way to automatically use or define journal or conference abbrevitation in the csl file right now?
+    </summary>
+    <updated>2021-11-10T16:22:30+01:00</updated>
+    <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
+  </info>
+<locale xml:lang="en-US">
+    <date form="text" delimiter=" ">
+      <date-part name="month" form="short" strip-periods="true"/>
+      <date-part name="year" font-weight="bold"/>
+    </date>
+    <terms>
+      <term name="chapter" form="short">Ch.</term>
+      <term name="editor" form="short">eds</term>
+    </terms>
+  </locale>
+  <macro name="author">
+    <names variable="author">
+      <name sort-separator=" " initialize-with="." delimiter=", " delimiter-precedes-last="always"/>
+    <substitute>
+        <names variable="editor"/>
+    </substitute>
+    </names>
+  </macro>
+  <macro name="title">
+   <choose>
+   <if type="book">
+        <text variable="title" font-style="italic"/>
+    </if>
+    <else-if type="chapter">
+        <text term="in" suffix=" "/>   
+        <text variable="title" font-style="italic"/>
+    </else-if>
+    <else-if type="paper-conference">
+        <text term="in" suffix=" "/>
+        <text variable="container-title" font-style="italic"/>
+    </else-if>
+    <else-if type="speech">
+        <text term="presented at" suffix=" "/>   
+        <text variable="title" font-style="italic"/>
+    </else-if>
+    <else-if type="thesis">
+        <text variable="genre" font-style="italic"/>
+    </else-if>
+    <else-if type="article-journal" match="any">
+        <text variable="container-title" font-style="italic"/>
+    </else-if>
+      <else-if type="article-magazine article-newspaper" match="any">
+        <text variable="container-title" font-style="italic"/>
+    </else-if>
+      <else-if type="webpage" match="any">
+        <text variable="title"/>
+    </else-if>
+    </choose>
+  </macro>
+  <macro name="editor">
+    <choose>
+    <if variable="editor">
+      <group prefix=" (" suffix=")" >
+      <names variable="editor">
+            <label form="short" text-case="capitalize-first" suffix=": "/>
+        <name sort-separator=" " initialize-with="."  delimiter=", " delimiter-precedes-last="always"/>
+      </names>
+      </group>
+    </if>
+    </choose>
+  </macro>
+  <macro name="publisher">
+    <choose>
+      <if type="article-journal article-magazine article-newspaper patent report" match="none">
+        <group  delimiter=", " prefix=", ">
+          <text variable="publisher"/>
+          <choose>
+          <!-- Specifications say if not obvious ... -->
+          <if type="thesis" match="none">
+            <text variable="publisher-place"/>
+          </if>
+          </choose>
+        </group>
+        </if>
+    </choose>
+  </macro>
+  <macro name="access">
+    <choose>
+      <if type="webpage" match="any">
+        <choose>
+        <if variable="URL">
+            <group delimiter=" " prefix=", ">
+            <text variable="URL"/>
+            </group>
+            <text macro="accessed-date"/>
+        </if>
+        </choose>
+      </if>
+      <else-if variable="DOI">
+        <group font-style="normal" text-decoration="none">
+            <text variable="DOI" prefix=", " />
+        </group>
+      </else-if>
+    </choose>
+  </macro>
+  <macro name="accessed-date">
+    <choose>
+      <if variable="URL">
+        <group prefix=", " delimiter=" ">
+          <text term="accessed" suffix=":"/>
+          <date variable="accessed" form="text"/>
+        </group>
+      </if>
+    </choose>
+  </macro>
+
+  <macro name="date">
+        <choose>
+        <if type="speech" match="any">
+            <date variable="issued" prefix=", " form="text"/>
+        </if>
+        <else-if type="webpage" match="none">
+          <group font-weight="bold">
+          <date variable="issued" form="text" date-parts="year"  prefix=" "/>
+          </group>
+        </else-if>
+        </choose>
+  </macro>
+  <macro name="pages">
+    <choose>
+      <if type="chapter" match="any">
+        <choose> 
+        <if variable="chapter-number">
+          <group delimiter=" ">
+          <text term="chapter" form="short" prefix=", " text-case="capitalize-first"/>
+          <text variable="chapter-number"/>
+          </group>
+        </if>
+        <else>
+          <group delimiter=" ">
+          <text term="page" form="short" prefix=", "/>
+          <text variable="page"/>
+          </group>
+        </else>
+        </choose>
+      </if>
+    </choose>
+  </macro>
+  <macro name="journal-volume">
+    <choose>
+      <if type="article-journal article-magazine" match="any">
+        <text variable="volume" prefix=", "/>
+      </if>
+    </choose>
+  </macro>
+  <macro name="journal-article-number">
+    <choose>
+      <if type="article-journal article-magazine" match="any">
+        <text variable="number" prefix=", "/>
+      </if>
+    </choose>
+  </macro>
+  <macro name="report-patent-numbers">
+    <choose>
+      <if type="report" match="any">
+        <text variable="number" prefix=", " suffix=","/>
+      </if>
+      <else-if type="patent" match="any">
+        <text variable="number" prefix=", " font-style="italic" suffix=","/>
+      </else-if>
+    </choose>
+  </macro>
+  <citation collapse="citation-number">
+    <sort>
+      <key variable="citation-number"/>
+    </sort>
+    <layout prefix="[" suffix="]" delimiter=",">
+      <group delimiter=",">
+        <text variable="citation-number"/>
+        <group>
+          <label variable="locator" form="short" plural="never"/>
+          <text variable="locator"/>
+        </group>
+      </group>
+    </layout>
+  </citation>
+  <bibliography second-field-align="flush">
+    <layout suffix="."> 
+      <text variable="citation-number" prefix="[" suffix="] "/>
+      <group  delimiter=", ">
+        <text macro="author"/>
+        <text macro="title"/>
+    </group>
+    <text macro="editor"/>    
+    <text macro="publisher"/>
+    <text macro="report-patent-numbers"/>
+    <text macro="date"/>
+    <text macro="journal-volume"/>
+    <text macro="journal-article-number"/>
+    <text macro="pages"/>
+    <text macro="access"/>
+    </layout>
+  </bibliography>
+</style>

--- a/steel-research-international.csl
+++ b/steel-research-international.csl
@@ -27,7 +27,7 @@
   </info>
   <locale xml:lang="en-US">
     <date form="text" delimiter=" ">
-      <date-part name="month" form="short" strip-periods="true"/>
+      <date-part name="month" form="short" strip-periods="true" suffix=" "/>
       <date-part name="year" font-weight="bold"/>
     </date>
     <terms>

--- a/steel-research-international.csl
+++ b/steel-research-international.csl
@@ -6,6 +6,7 @@
     <id>http://www.zotero.org/styles/steel-research-international</id>
     <link href="http://www.zotero.org/styles/steel-research-international" rel="self"/>
     <link href="https://onlinelibrary.wiley.com/page/journal/1869344x/homepage/author-guidelines" rel="documentation"/>
+    <link href="http://www.zotero.org/styles/taylor-and-francis-national-library-of-medicine" rel="template"/>
     <author>
       <name>Christian Schubert</name>
     </author>
@@ -17,16 +18,14 @@
     <category field="engineering"/>
     <eissn>1869-344X</eissn>
     <issnl>1611-3683</issnl>
-    <summary>
-    Citation style for the Steel research international
+    <summary>Citation style for the Steel research international
     
     There are some difficulties i.e. with patents, preprint  specifications and the variables that the CSL offers (nor preprint type or company variable availably), which probably cannot be fixed right now (perfectly) and need manual correction.
-    Also there is no way to automatically use or define journal or conference abbrevitation in the csl file right now?
-    </summary>
+    Also there is no way to automatically use or define journal or conference abbrevitation in the csl file right now?</summary>
     <updated>2021-11-10T16:22:30+01:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
-<locale xml:lang="en-US">
+  <locale xml:lang="en-US">
     <date form="text" delimiter=" ">
       <date-part name="month" form="short" strip-periods="true"/>
       <date-part name="year" font-weight="bold"/>
@@ -39,84 +38,84 @@
   <macro name="author">
     <names variable="author">
       <name sort-separator=" " initialize-with="." delimiter=", " delimiter-precedes-last="always"/>
-    <substitute>
+      <substitute>
         <names variable="editor"/>
-    </substitute>
+      </substitute>
     </names>
   </macro>
   <macro name="title">
-   <choose>
-   <if type="book">
+    <choose>
+      <if type="book">
         <text variable="title" font-style="italic"/>
-    </if>
-    <else-if type="chapter">
-        <text term="in" suffix=" "/>   
+      </if>
+      <else-if type="chapter">
+        <text term="in" suffix=" "/>
         <text variable="title" font-style="italic"/>
-    </else-if>
-    <else-if type="paper-conference">
+      </else-if>
+      <else-if type="paper-conference">
         <text term="in" suffix=" "/>
         <text variable="container-title" font-style="italic"/>
-    </else-if>
-    <else-if type="speech">
-        <text term="presented at" suffix=" "/>   
+      </else-if>
+      <else-if type="speech">
+        <text term="presented at" suffix=" "/>
         <text variable="title" font-style="italic"/>
-    </else-if>
-    <else-if type="thesis">
+      </else-if>
+      <else-if type="thesis">
         <text variable="genre" font-style="italic"/>
-    </else-if>
-    <else-if type="article-journal" match="any">
+      </else-if>
+      <else-if type="article-journal" match="any">
         <text variable="container-title" font-style="italic"/>
-    </else-if>
+      </else-if>
       <else-if type="article-magazine article-newspaper" match="any">
         <text variable="container-title" font-style="italic"/>
-    </else-if>
+      </else-if>
       <else-if type="webpage" match="any">
         <text variable="title"/>
-    </else-if>
+      </else-if>
     </choose>
   </macro>
   <macro name="editor">
     <choose>
-    <if variable="editor">
-      <group prefix=" (" suffix=")" >
-      <names variable="editor">
+      <if variable="editor">
+        <group prefix=" (" suffix=")">
+          <names variable="editor">
             <label form="short" text-case="capitalize-first" suffix=": "/>
-        <name sort-separator=" " initialize-with="."  delimiter=", " delimiter-precedes-last="always"/>
-      </names>
-      </group>
-    </if>
+            <name sort-separator=" " initialize-with="." delimiter=", " delimiter-precedes-last="always"/>
+          </names>
+        </group>
+      </if>
     </choose>
   </macro>
   <macro name="publisher">
     <choose>
       <if type="article-journal article-magazine article-newspaper patent report" match="none">
-        <group  delimiter=", " prefix=", ">
+        <group delimiter=", " prefix=", ">
           <text variable="publisher"/>
           <choose>
-          <!-- Specifications say if not obvious ... -->
-          <if type="thesis" match="none">
-            <text variable="publisher-place"/>
-          </if>
+            <!-- Specifications say if not obvious ... -->
+            <if type="thesis" match="none">
+              <text variable="publisher-place"/>
+            </if>
           </choose>
         </group>
-        </if>
+      </if>
     </choose>
   </macro>
   <macro name="access">
     <choose>
       <if type="webpage" match="any">
         <choose>
-        <if variable="URL">
+          <if variable="URL">
             <group delimiter=" " prefix=", ">
-            <text variable="URL"/>
+              <text variable="URL"/>
             </group>
             <text macro="accessed-date"/>
-        </if>
+          </if>
         </choose>
       </if>
       <else-if variable="DOI">
         <group font-style="normal" text-decoration="none">
-            <text variable="DOI" prefix=", " />
+          <text variable="DOI" prefix=", "/>
         </group>
       </else-if>
     </choose>
@@ -131,35 +130,34 @@
       </if>
     </choose>
   </macro>
-
   <macro name="date">
-        <choose>
-        <if type="speech" match="any">
-            <date variable="issued" prefix=", " form="text"/>
-        </if>
-        <else-if type="webpage" match="none">
-          <group font-weight="bold">
-          <date variable="issued" form="text" date-parts="year"  prefix=" "/>
-          </group>
-        </else-if>
-        </choose>
+    <choose>
+      <if type="speech" match="any">
+        <date variable="issued" prefix=", " form="text"/>
+      </if>
+      <else-if type="webpage" match="none">
+        <group font-weight="bold">
+          <date variable="issued" form="text" date-parts="year" prefix=" "/>
+        </group>
+      </else-if>
+    </choose>
   </macro>
   <macro name="pages">
     <choose>
       <if type="chapter" match="any">
-        <choose> 
-        <if variable="chapter-number">
-          <group delimiter=" ">
-          <text term="chapter" form="short" prefix=", " text-case="capitalize-first"/>
-          <text variable="chapter-number"/>
-          </group>
-        </if>
-        <else>
-          <group delimiter=" ">
-          <text term="page" form="short" prefix=", "/>
-          <text variable="page"/>
-          </group>
-        </else>
+        <choose>
+          <if variable="chapter-number">
+            <group delimiter=" ">
+              <text term="chapter" form="short" prefix=", " text-case="capitalize-first"/>
+              <text variable="chapter-number"/>
+            </group>
+          </if>
+          <else>
+            <group delimiter=" ">
+              <text term="page" form="short" prefix=", "/>
+              <text variable="page"/>
+            </group>
+          </else>
         </choose>
       </if>
     </choose>
@@ -203,20 +201,20 @@
     </layout>
   </citation>
   <bibliography second-field-align="flush">
-    <layout suffix="."> 
+    <layout suffix=".">
       <text variable="citation-number" prefix="[" suffix="] "/>
-      <group  delimiter=", ">
+      <group delimiter=", ">
         <text macro="author"/>
         <text macro="title"/>
-    </group>
-    <text macro="editor"/>    
-    <text macro="publisher"/>
-    <text macro="report-patent-numbers"/>
-    <text macro="date"/>
-    <text macro="journal-volume"/>
-    <text macro="journal-article-number"/>
-    <text macro="pages"/>
-    <text macro="access"/>
+      </group>
+      <text macro="editor"/>
+      <text macro="publisher"/>
+      <text macro="report-patent-numbers"/>
+      <text macro="date"/>
+      <text macro="journal-volume"/>
+      <text macro="journal-article-number"/>
+      <text macro="pages"/>
+      <text macro="access"/>
     </layout>
   </bibliography>
 </style>

--- a/steel-research-international.csl
+++ b/steel-research-international.csl
@@ -43,7 +43,6 @@
             <name/>
             <label form="short" text-case="capitalize-first" prefix=" (" suffix=")"/>
         </names>
-        </names>
       </substitute>
     </names>
   </macro>

--- a/steel-research-international.csl
+++ b/steel-research-international.csl
@@ -39,7 +39,10 @@
     <names variable="author">
       <name sort-separator=" " initialize-with="." delimiter=", " delimiter-precedes-last="always"/>
       <substitute>
-        <names variable="editor"/>
+        <names variable="editor">
+        <label form="short" text-case="capitalize-first" suffix=": "/>
+        <name sort-separator=" " initialize-with="." delimiter=", " delimiter-precedes-last="always"/>
+        </names>
       </substitute>
     </names>
   </macro>
@@ -58,7 +61,7 @@
       </else-if>
       <else-if type="speech">
         <text term="presented at" suffix=" "/>
-        <text variable="title" font-style="italic"/>
+        <text variable="event" font-style="italic"/>
       </else-if>
       <else-if type="thesis">
         <text variable="genre" font-style="italic"/>
@@ -115,7 +118,7 @@
       </if>
       <else-if variable="DOI">
         <group font-style="normal" text-decoration="none">
-          <text variable="DOI" prefix=", "/>
+          <text variable="DOI" prefix=", DOI: "/>
         </group>
       </else-if>
     </choose>

--- a/steel-research-international.csl
+++ b/steel-research-international.csl
@@ -40,8 +40,9 @@
       <name sort-separator=" " initialize-with="." delimiter=", " delimiter-precedes-last="always"/>
       <substitute>
         <names variable="editor">
-        <label form="short" text-case="capitalize-first" suffix=": "/>
-        <name sort-separator=" " initialize-with="." delimiter=", " delimiter-precedes-last="always"/>
+            <name/>
+            <label form="short" text-case="capitalize-first" prefix=" (" suffix=")"/>
+        </names>
         </names>
       </substitute>
     </names>
@@ -53,7 +54,7 @@
       </if>
       <else-if type="chapter">
         <text term="in" suffix=" "/>
-        <text variable="title" font-style="italic"/>
+        <text variable="container-title" font-style="italic"/>
       </else-if>
       <else-if type="paper-conference">
         <text term="in" suffix=" "/>


### PR DESCRIPTION
First version for a Citation Style Language (csl) file for the journal "Steel Research International":

The sadly very poorly defined specifications are taken from here (reference section):
https://onlinelibrary.wiley.com/page/journal/1869344x/homepage/author-guidelines

The style file should work fine for the most common reference types. There are some parts which may need manual fine tuning of a paper's reference section in the end, before committing the paper. Nevertheless, this style should still be a work saver.

In particular, there are some difficulties i.e. for patents or preprint specifications and the variables that the CSL offers (nor preprint type or company variable available), which probably cannot be fixed right now (perfectly) and need manual correction.
Also, I guess there is no way to automatically use or define journal or conference abbreviations in the csl file at the moment?