### PR TITLE
remove et-al from bibtex.csl

### DIFF
--- a/bibtex.csl
+++ b/bibtex.csl
@@ -54,7 +54,7 @@
   </macro>
   <macro name="author-short">
     <names variable="author">
-      <name form="short" delimiter="_" delimiter-precedes-last="always"/>
+      <name form="short" delimiter="_" delimiter-precedes-last="always" et-al-min="11" et-al-use-first="10"/>
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>

--- a/bibtex.csl
+++ b/bibtex.csl
@@ -125,7 +125,7 @@
   <macro name="edition">
     <text variable="edition"/>
   </macro>
-  <citation et-al-min="11" et-al-use-first="10" disambiguate-add-year-suffix="true" disambiguate-add-names="false" disambiguate-add-givenname="false" collapse="year">
+  <citation disambiguate-add-year-suffix="true" disambiguate-add-names="false" disambiguate-add-givenname="false" collapse="year">
     <sort>
       <key macro="author"/>
       <key variable="issued"/>
@@ -134,7 +134,7 @@
       <text macro="citeKey"/>
     </layout>
   </citation>
-  <bibliography hanging-indent="false" et-al-min="11" et-al-use-first="10">
+  <bibliography hanging-indent="false">
     <sort>
       <key macro="author"/>
       <key variable="issued"/>


### PR DESCRIPTION
Is there a need to use et-al truncation in the bibtex csl? Typically the bibtex formatter would specify whether and how the author list should be truncated, and the current implementation leaves bibtex assuming that the final author is "et al", resulting in citations like

Firstauthor, F., Secondauthor, S., & al., et. (2021). Title. *Journal.* *1*(1)

Specifically, the crossref api seems to use this style sheet to return bibtex data, and it would be great not to truncate the data coming from their service:
https://www.crossref.org/labs/citation-formatting-service/
