### PR TITLE
fix in-text delimiter issue harvard-university-of-the-west-of-england.csl

### DIFF
--- a/harvard-university-of-the-west-of-england.csl
+++ b/harvard-university-of-the-west-of-england.csl
@@ -264,11 +264,11 @@
       <key macro="author" names-use-last="true"/>
     </sort>
     <layout suffix=")" delimiter="; " prefix="(">
-      <group delimiter=" ">
-        <text macro="author-short" suffix=","/>
+      <group delimiter=", ">
+        <text macro="author-short"/>
         <text macro="year-date-citation"/>
         <group>
-          <label prefix=": " variable="locator" form="short"/>
+          <label variable="locator" form="short"/>
           <text variable="locator"/>
         </group>
       </group>


### PR DESCRIPTION
via https://forums.zotero.org/discussion/92994/help-with-editing-style-code-remove-space-from-in-text-citation#latest