### PR TITLE
Create universidade-do-porto-faculdade-de-engenharia-chicago-pt.csl

### DIFF
--- a/universidade-do-porto-faculdade-de-engenharia-chicago-pt.csl
+++ b/universidade-do-porto-faculdade-de-engenharia-chicago-pt.csl
@@ -26,7 +26,7 @@
       <term name="editor" form="verb">editado por</term>
       <term name="editor" form="verb-short">ed.</term>
       <term name="container-author" form="verb">por</term>
-      <term name="translator" form="verb-short">trad.</term>
+      <term name="translator" form="verb-short">traduzido por</term>
       <term name="editortranslator" form="verb">editado e traduzido por</term>
       <term name="translator" form="short">trad.</term>
 	  <term name="and">e</term>
@@ -36,6 +36,35 @@
 	   <term name="at" form="long">em</term>
 	   <term name="by" form="long">por</term>
        <term name="by">por</term>
+	      <!-- PUNCTUATION -->
+    <term name="open-quote">"</term>
+    <term name="close-quote">"</term>
+    <!-- LONG MONTH FORMS -->
+    <term name="month-01">janeiro</term>
+    <term name="month-02">fevereiro</term>
+    <term name="month-03">março</term>
+    <term name="month-04">abril</term>
+    <term name="month-05">maio</term>
+    <term name="month-06">junho</term>
+    <term name="month-07">julho</term>
+    <term name="month-08">agosto</term>
+    <term name="month-09">setembro</term>
+    <term name="month-10">outubro</term>
+    <term name="month-11">novembro</term>
+    <term name="month-12">dezembro</term>
+    <!-- SHORT MONTH FORMS -->
+    <term name="month-01" form="short">jan.</term>
+    <term name="month-02" form="short">fev.</term>
+    <term name="month-03" form="short">mar.</term>
+    <term name="month-04" form="short">abr.</term>
+    <term name="month-05" form="short">mai.</term>
+    <term name="month-06" form="short">jun.</term>
+    <term name="month-07" form="short">jul.</term>
+    <term name="month-08" form="short">ago.</term>
+    <term name="month-09" form="short">set.</term>
+    <term name="month-10" form="short">out.</term>
+    <term name="month-11" form="short">nov.</term>
+    <term name="month-12" form="short">dez.</term>
     </terms>
   </locale>
   <macro name="secondary-contributors">
@@ -305,7 +334,7 @@
           </else-if>
           <else>
             <date variable="issued" prefix=", ">
-              <date-part name="month"/>
+              <date-part name="month" text-case="lowercase"/>
             </date>
           </else>
         </choose>
@@ -582,7 +611,7 @@
       <else-if type="patent">
         <group delimiter=", " prefix=", ">
           <group delimiter=" ">
-            <text value="submetida em"/>
+            <text value="submetida a"/>
             <date variable="submitted" form="text"/>
           </group>
           <group delimiter=" ">
@@ -591,7 +620,7 @@
                 <text term="and"/>
               </if>
             </choose>
-            <text value="publicada em"/>
+            <text value="publicada a"/>
             <date variable="issued" form="text"/>
           </group>
         </group>

--- a/universidade-do-porto-faculdade-de-engenharia-chicago-pt.csl
+++ b/universidade-do-porto-faculdade-de-engenharia-chicago-pt.csl
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" demote-non-dropping-particle="display-and-sort" page-range-format="chicago" default-locale="pt-PT">
   <info>
-    <title>Universidade do Porto - Faculdade de Engenharia - Chicago Manual of Style (Português - Portugal)</title>
+    <title>Universidade do Porto - Faculdade de Engenharia - Chicago Manual of Style 17th (author-date) (Português - Portugal)</title>
     <id>http://www.zotero.org/styles/universidade-do-porto-faculdade-de-engenharia-chicago-pt</id>
     <link href="http://www.zotero.org/styles/universidade-do-porto-faculdade-de-engenharia-chicago-pt" rel="self"/>
     <link href="http://www.zotero.org/styles/chicago-author-date" rel="template"/>

--- a/universidade-do-porto-faculdade-de-engenharia-chicago-pt.csl
+++ b/universidade-do-porto-faculdade-de-engenharia-chicago-pt.csl
@@ -135,7 +135,7 @@
   </macro>
     <macro name="contributors-short">
     <names variable="author">
-      <name form="short" and="text" delimiter=", " initialize-with=". "/>
+      <name form="short" and="text" delimiter-precedes-last="never" initialize-with=". "/>
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>

--- a/universidade-do-porto-faculdade-de-engenharia-chicago-pt.csl
+++ b/universidade-do-porto-faculdade-de-engenharia-chicago-pt.csl
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" demote-non-dropping-particle="display-and-sort" page-range-format="chicago" default-locale="pt-PT">
   <info>
-    <title>Universidade do Porto - Faculdade de Engenharia - Chicago Manual of Style - PT</title>
+    <title>Universidade do Porto - Faculdade de Engenharia - Chicago Manual of Style (Português - Portugal)</title>
     <id>http://www.zotero.org/styles/universidade-do-porto-faculdade-de-engenharia-chicago-pt</id>
     <link href="http://www.zotero.org/styles/universidade-do-porto-faculdade-de-engenharia-chicago-pt" rel="self"/>
     <link href="http://www.zotero.org/styles/chicago-author-date" rel="template"/>

--- a/universidade-do-porto-faculdade-de-engenharia-chicago-pt.csl
+++ b/universidade-do-porto-faculdade-de-engenharia-chicago-pt.csl
@@ -1,0 +1,745 @@
+<?xml version="1.0" encoding="utf-8"?>
+<style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" demote-non-dropping-particle="display-and-sort" page-range-format="chicago" default-locale="pt-PT">
+  <info>
+    <title>Universidade do Porto - Faculdade de Engenharia - Chicago Manual of Style - PT</title>
+    <id>http://www.zotero.org/styles/universidade-do-porto-faculdade-de-engenharia-chicago-pt</id>
+    <link href="http://www.zotero.org/styles/universidade-do-porto-faculdade-de-engenharia-chicago-pt" rel="self"/>
+    <link href="http://www.zotero.org/styles/chicago-author-date" rel="template"/>
+    <link href="https://feup.libguides.com/chicago" rel="documentation"/>
+    <author>
+      <name>Sérgio Bernardo</name>
+      <email>sergiob@fe.up.pt</email>
+    </author>
+    <contributor>
+      <name>Infoliteracia FEUP</name>
+      <email>infoliteracia@fe.up.pt</email>
+    </contributor>
+    <category citation-format="author-date"/>
+    <category field="engineering"/>
+    <summary>The author-date variant of the Chicago style by FEUP</summary>
+    <updated>2021-11-23T11:34:12+00:00</updated>
+    <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
+  </info>
+  <locale xml:lang="pt">
+    <terms>
+	  <term name="accessed">Acedido a</term>
+      <term name="editor" form="verb">editado por</term>
+      <term name="editor" form="verb-short">ed.</term>
+      <term name="container-author" form="verb">por</term>
+      <term name="translator" form="verb-short">trad.</term>
+      <term name="editortranslator" form="verb">editado e traduzido por</term>
+      <term name="translator" form="short">trad.</term>
+	  <term name="and">e</term>
+	  <term name="no date" form="long">s.d</term>
+	  <term name="no date" form="short">s.d.</term>
+	   <term name="in" form="long">em</term>
+	   <term name="at" form="long">em</term>
+	   <term name="by" form="long">por</term>
+       <term name="by">por</term>
+    </terms>
+  </locale>
+  <macro name="secondary-contributors">
+    <choose>
+      <if type="chapter entry-dictionary entry-encyclopedia paper-conference" match="none">
+        <group delimiter=". ">
+          <names variable="editor translator" delimiter=". ">
+            <label form="verb" text-case="capitalize-first" suffix=" "/>
+            <name and="text" delimiter=", "/>
+          </names>
+          <names variable="director" delimiter=". ">
+            <label form="verb" text-case="capitalize-first" suffix=" "/>
+            <name and="text" delimiter=", "/>
+          </names>
+        </group>
+      </if>
+    </choose>
+  </macro>
+  <macro name="container-contributors">
+    <choose>
+      <if type="chapter entry-dictionary entry-encyclopedia paper-conference" match="any">
+        <group prefix=", " delimiter=", ">
+          <names variable="container-author" delimiter=", ">
+            <label form="verb" suffix=" "/>
+            <name and="text" delimiter=", "/>
+          </names>
+          <names variable="editor translator" delimiter=", ">
+            <label form="verb" suffix=" "/>
+            <name and="text" delimiter=", "/>
+          </names>
+        </group>
+      </if>
+    </choose>
+  </macro>
+  <macro name="recipient">
+    <choose>
+      <if type="personal_communication">
+        <choose>
+          <if variable="genre">
+            <text variable="genre" text-case="capitalize-first"/>
+          </if>
+          <else>
+            <text term="letter" text-case="capitalize-first"/>
+          </else>
+        </choose>
+      </if>
+    </choose>
+    <names variable="recipient" delimiter=", ">
+      <label form="verb" prefix=" " text-case="lowercase" suffix=" "/>
+      <name and="text" delimiter=", "/>
+    </names>
+  </macro>
+  <macro name="substitute-title">
+    <choose>
+      <if type="article-magazine article-newspaper review review-book" match="any">
+        <text macro="container-title"/>
+      </if>
+    </choose>
+  </macro>
+  <macro name="contributors">
+    <choose>
+      <if type="book">
+        <group delimiter=". ">
+          <names variable="author">
+            <name and="text" name-as-sort-order="first" sort-separator=", " delimiter=", " delimiter-precedes-last="always"/>
+            <et-al/>
+            <label form="short" prefix=", "/>
+            <substitute>
+              <names variable="editor"/>
+              <names variable="translator"/>
+              <names variable="director"/>
+              <text macro="substitute-title"/>
+              <text macro="title"/>
+            </substitute>
+          </names>
+          <text macro="recipient"/>
+        </group>
+      </if>
+      <else-if type="book" match="none">
+        <group delimiter=". ">
+          <names variable="author">
+            <name and="text" name-as-sort-order="first" sort-separator=", " delimiter=", " delimiter-precedes-last="always"/>
+            <et-al/>
+            <label form="short" prefix=", "/>
+            <substitute>
+              <names variable="editor"/>
+              <names variable="translator"/>
+              <names variable="director"/>
+              <text macro="substitute-title"/>
+              <text macro="title"/>
+            </substitute>
+          </names>
+          <text macro="recipient"/>
+        </group>
+      </else-if>
+    </choose>
+  </macro>
+  <macro name="contributors-long">
+    <group delimiter=". ">
+      <names variable="author">
+        <substitute>
+          <names variable="editor"/>
+          <names variable="translator"/>
+          <names variable="director"/>
+          <text macro="substitute-title"/>
+          <text macro="title"/>
+        </substitute>
+      </names>
+      <text macro="recipient"/>
+    </group>
+  </macro>
+  <macro name="contributors-short">
+    <names variable="author">
+      <name form="short" and="text" delimiter=", " initialize-with=". "/>
+      <substitute>
+        <names variable="editor"/>
+        <names variable="translator"/>
+        <names variable="director"/>
+        <text macro="substitute-title"/>
+        <text macro="title"/>
+      </substitute>
+    </names>
+  </macro>
+  <macro name="interviewer">
+    <names variable="interviewer" delimiter=", ">
+      <label form="verb" prefix=" " text-case="capitalize-first" suffix=" "/>
+      <name and="text" delimiter=", "/>
+      <et-al/>
+    </names>
+  </macro>
+  <macro name="archive">
+    <group delimiter=". ">
+      <text variable="archive_location" text-case="capitalize-first"/>
+      <text variable="archive"/>
+      <text variable="archive-place"/>
+    </group>
+  </macro>
+  <macro name="access">
+    <group delimiter=". ">
+      <choose>
+        <if type="graphic report" match="any">
+          <text macro="archive"/>
+        </if>
+        <else-if type="article-journal bill book chapter legal_case legislation motion_picture paper-conference" match="none">
+          <text macro="archive"/>
+        </else-if>
+      </choose>
+      <choose>
+        <if type="webpage post-weblog" match="any">
+          <date form="text" variable="issued"/>
+        </if>
+      </choose>
+      <choose>
+        <if match="none" type="song article-journal article article-magazine">
+          <group delimiter=" ">
+            <text term="accessed" text-case="capitalize-first"/>
+            <date form="text" variable="accessed" prefix=""/>
+          </group>
+        </if>
+      </choose>
+      <choose>
+        <if type="legal_case" match="none">
+          <choose>
+            <if variable="DOI">
+              <text variable="DOI" prefix="https://doi.org/"/>
+            </if>
+            <else>
+              <text variable="URL"/>
+            </else>
+          </choose>
+        </if>
+      </choose>
+    </group>
+  </macro>
+  <macro name="title">
+    <choose>
+      <if variable="title" match="none">
+        <choose>
+          <if type="personal_communication" match="none">
+            <text variable="genre" text-case="capitalize-first"/>
+          </if>
+        </choose>
+      </if>
+      <else-if type="bill book graphic legislation motion_picture song" match="any">
+        <text variable="title" text-case="title" font-style="italic"/>
+        <group prefix=" (" suffix=")" delimiter=" ">
+          <text term="version"/>
+          <text variable="version"/>
+        </group>
+      </else-if>
+      <else-if variable="reviewed-author">
+        <choose>
+          <if variable="reviewed-title">
+            <group delimiter=". ">
+              <text variable="title" text-case="title" quotes="true"/>
+              <group delimiter=", ">
+                <text variable="reviewed-title" text-case="title" font-style="italic" prefix="Review of "/>
+                <names variable="reviewed-author">
+                  <label form="verb-short" text-case="lowercase" suffix=" "/>
+                  <name and="text" delimiter=", "/>
+                </names>
+              </group>
+            </group>
+          </if>
+          <else>
+            <group delimiter=", ">
+              <text variable="title" text-case="title" font-style="italic" prefix="Review of "/>
+              <names variable="reviewed-author">
+                <label form="verb-short" text-case="lowercase" suffix=" "/>
+                <name and="text" delimiter=", "/>
+              </names>
+            </group>
+          </else>
+        </choose>
+      </else-if>
+      <else-if type="legal_case interview patent webpage" match="any">
+        <text variable="title" quotes="false" prefix="&quot;" suffix="&quot;"/>
+      </else-if>
+      <else>
+        <text variable="title" text-case="title" quotes="false" prefix="&quot;" suffix="&quot;"/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="edition">
+    <choose>
+      <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
+        <choose>
+          <if is-numeric="edition">
+            <group delimiter=" " prefix=". ">
+              <number variable="edition" form="ordinal"/>
+              <text term="edition" form="short" strip-periods="true"/>
+            </group>
+          </if>
+          <else>
+            <text variable="edition" text-case="capitalize-first" prefix=". "/>
+          </else>
+        </choose>
+      </if>
+      <else-if type="chapter entry-dictionary entry-encyclopedia paper-conference" match="any">
+        <choose>
+          <if is-numeric="edition">
+            <group delimiter=" " prefix=", ">
+              <number variable="edition" form="ordinal"/>
+              <text term="edition" form="short"/>
+            </group>
+          </if>
+          <else>
+            <text variable="edition" prefix=", "/>
+          </else>
+        </choose>
+      </else-if>
+    </choose>
+  </macro>
+  <macro name="locators">
+    <choose>
+      <if type="article-journal">
+        <choose>
+          <if variable="volume">
+            <text variable="volume" prefix=" "/>
+            <group prefix=", ">
+              <choose>
+                <if variable="issue">
+                  <text variable="issue" prefix="no."/>
+                </if>
+                <else>
+                  <date variable="issued">
+                    <date-part name="month"/>
+                  </date>
+                </else>
+              </choose>
+            </group>
+          </if>
+          <else-if variable="issue">
+            <group delimiter=" " prefix=", ">
+              <text term="issue" form="short"/>
+              <text variable="issue"/>
+              <date variable="issued" prefix="(" suffix=")">
+                <date-part name="month"/>
+              </date>
+            </group>
+          </else-if>
+          <else>
+            <date variable="issued" prefix=", ">
+              <date-part name="month"/>
+            </date>
+          </else>
+        </choose>
+      </if>
+      <else-if type="legal_case">
+        <text variable="volume" prefix=", "/>
+        <text variable="container-title" prefix=" "/>
+        <text variable="page" prefix=" "/>
+      </else-if>
+      <else-if type="bill book graphic legal_case legislation motion_picture report song" match="any">
+        <group prefix=". " delimiter=". ">
+          <group>
+            <text term="volume" form="short" text-case="capitalize-first" suffix=" "/>
+            <number variable="volume" form="numeric"/>
+          </group>
+          <group>
+            <number variable="number-of-volumes" form="numeric"/>
+            <text term="volume" form="short" prefix=" " plural="true"/>
+          </group>
+        </group>
+      </else-if>
+      <else-if type="chapter entry-dictionary entry-encyclopedia paper-conference" match="any">
+        <choose>
+          <if variable="page" match="none">
+            <group prefix=". ">
+              <text term="volume" form="short" text-case="capitalize-first" suffix=" "/>
+              <number variable="volume" form="numeric"/>
+            </group>
+          </if>
+        </choose>
+      </else-if>
+    </choose>
+  </macro>
+  <macro name="locators-chapter">
+    <choose>
+      <if type="chapter entry-dictionary entry-encyclopedia paper-conference" match="any">
+        <choose>
+          <if variable="page">
+            <group prefix=", ">
+              <text variable="volume" suffix=":"/>
+              <text variable="page"/>
+            </group>
+          </if>
+        </choose>
+      </if>
+    </choose>
+  </macro>
+  <macro name="locators-article">
+    <choose>
+      <if type="article-newspaper">
+        <group prefix=", " delimiter=", ">
+          <group delimiter=" ">
+            <text variable="edition"/>
+            <text term="edition"/>
+          </group>
+          <group>
+            <text term="section" form="short" suffix=" "/>
+            <text variable="section"/>
+          </group>
+        </group>
+      </if>
+      <else-if type="article-journal">
+        <choose>
+          <if variable="volume issue" match="any">
+            <text variable="page" prefix=": "/>
+          </if>
+          <else>
+            <text variable="page" prefix=", "/>
+          </else>
+        </choose>
+      </else-if>
+    </choose>
+  </macro>
+  <macro name="point-locators">
+    <choose>
+      <if variable="locator">
+        <choose>
+          <if locator="page" match="none">
+            <choose>
+              <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
+                <choose>
+                  <if variable="volume">
+                    <group>
+                      <text term="volume" form="short" suffix=" "/>
+                      <number variable="volume" form="numeric"/>
+                      <label variable="locator" form="short" prefix=", " suffix=" "/>
+                    </group>
+                  </if>
+                  <else>
+                    <label variable="locator" form="short" suffix=" "/>
+                  </else>
+                </choose>
+              </if>
+              <else>
+                <label variable="locator" form="short" suffix=" "/>
+              </else>
+            </choose>
+          </if>
+          <else-if type="bill book graphic legal_case legislation motion_picture report song" match="any">
+            <number variable="volume" form="numeric" suffix=":"/>
+          </else-if>
+        </choose>
+        <text variable="locator"/>
+      </if>
+    </choose>
+  </macro>
+  <macro name="container-prefix">
+    <text term="in" text-case="lowercase" prefix="Comunicação apresentada "/>
+  </macro>
+  <macro name="container-title">
+    <choose>
+      <if type="chapter entry-dictionary entry-encyclopedia paper-conference" match="any">
+        <text macro="container-prefix" suffix=" "/>
+      </if>
+    </choose>
+    <choose>
+      <if type="webpage">
+        <text variable="container-title" text-case="title"/>
+      </if>
+      <else-if type="legal_case" match="none">
+        <group delimiter=" ">
+          <text variable="container-title" text-case="title" font-style="italic"/>
+          <choose>
+            <if type="post-weblog">
+              <text value="(blog)"/>
+            </if>
+          </choose>
+        </group>
+      </else-if>
+    </choose>
+  </macro>
+  <macro name="publisher">
+    <group delimiter=": ">
+      <text variable="publisher-place"/>
+      <text variable="publisher"/>
+    </group>
+  </macro>
+  <macro name="date">
+    <choose>
+      <if variable="issued">
+        <group delimiter=" ">
+          <date variable="original-date" form="text" date-parts="year" prefix="(" suffix=")"/>
+          <date variable="issued">
+            <date-part name="year"/>
+          </date>
+        </group>
+      </if>
+      <else-if variable="status">
+        <text variable="status" text-case="capitalize-first"/>
+      </else-if>
+      <else>
+        <text term="no date" form="short"/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="date-in-text">
+    <choose>
+      <if variable="issued">
+        <group delimiter=" ">
+          <date variable="original-date" form="text" date-parts="year" prefix="[" suffix="]"/>
+          <date variable="issued">
+            <date-part name="year"/>
+          </date>
+        </group>
+      </if>
+      <else-if variable="status">
+        <text variable="status"/>
+      </else-if>
+      <else>
+        <text term="no date" form="short"/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="day-month">
+    <date variable="issued">
+      <date-part name="month"/>
+      <date-part name="day" prefix=" "/>
+    </date>
+  </macro>
+  <macro name="collection-title">
+    <choose>
+      <if match="none" type="article-journal">
+        <choose>
+          <if match="none" is-numeric="collection-number">
+            <group delimiter=", ">
+              <text variable="collection-title" text-case="title"/>
+              <text variable="collection-number"/>
+            </group>
+          </if>
+          <else>
+            <group delimiter=" ">
+              <text variable="collection-title" text-case="title"/>
+              <text variable="collection-number"/>
+            </group>
+          </else>
+        </choose>
+      </if>
+    </choose>
+  </macro>
+  <macro name="collection-title-journal">
+    <choose>
+      <if type="article-journal">
+        <group delimiter=" ">
+          <text variable="collection-title"/>
+          <text variable="collection-number"/>
+        </group>
+      </if>
+    </choose>
+  </macro>
+  <macro name="event">
+    <group delimiter=" ">
+      <choose>
+        <if variable="genre">
+          <text term="presented at"/>
+        </if>
+        <else>
+          <text term="presented at" text-case="capitalize-first"/>
+        </else>
+      </choose>
+      <text variable="event"/>
+    </group>
+  </macro>
+  <macro name="description">
+    <choose>
+      <if type="interview">
+        <group delimiter=". ">
+          <text macro="interviewer"/>
+          <text variable="medium" text-case="capitalize-first"/>
+        </group>
+      </if>
+      <else-if type="patent">
+        <group delimiter=" " prefix=". ">
+          <text variable="authority"/>
+          <text variable="number"/>
+        </group>
+      </else-if>
+      <else>
+        <text variable="medium" text-case="capitalize-first" prefix=". "/>
+      </else>
+    </choose>
+    <choose>
+      <if variable="title" match="none"/>
+      <else-if type="thesis personal_communication speech" match="any"/>
+      <else>
+        <group delimiter=" " prefix=". ">
+          <text variable="genre" text-case="capitalize-first"/>
+          <choose>
+            <if type="report">
+              <text variable="number"/>
+            </if>
+          </choose>
+        </group>
+      </else>
+    </choose>
+  </macro>
+  <macro name="issue">
+    <choose>
+      <if type="legal_case">
+        <text variable="authority" prefix=". "/>
+      </if>
+      <else-if type="speech">
+        <group prefix=". " delimiter=", ">
+          <group delimiter=" ">
+            <text variable="genre" text-case="capitalize-first"/>
+            <text macro="event"/>
+          </group>
+          <text variable="event-place"/>
+          <text macro="day-month"/>
+        </group>
+      </else-if>
+      <else-if type="article-newspaper article-magazine personal_communication" match="any">
+        <date variable="issued" form="text" prefix=", "/>
+      </else-if>
+      <else-if type="patent">
+        <group delimiter=", " prefix=", ">
+          <group delimiter=" ">
+            <text value="submetida em"/>
+            <date variable="submitted" form="text"/>
+          </group>
+          <group delimiter=" ">
+            <choose>
+              <if variable="issued submitted" match="all">
+                <text term="and"/>
+              </if>
+            </choose>
+            <text value="publicada em"/>
+            <date variable="issued" form="text"/>
+          </group>
+        </group>
+      </else-if>
+      <else-if type="article-journal" match="any"/>
+      <else>
+        <group prefix=". " delimiter=", ">
+          <choose>
+            <if type="thesis">
+              <text variable="genre" text-case="capitalize-first"/>
+            </if>
+          </choose>
+          <text macro="publisher"/>
+        </group>
+      </else>
+    </choose>
+  </macro>
+  <citation et-al-min="4" et-al-use-first="1" disambiguate-add-year-suffix="true" disambiguate-add-names="true" disambiguate-add-givenname="true" givenname-disambiguation-rule="primary-name" collapse="year" after-collapse-delimiter="; ">
+    <layout prefix="(" suffix=")" delimiter="; ">
+      <group delimiter=", ">
+        <choose>
+          <if variable="issued accessed" match="any">
+            <group delimiter=" ">
+              <text macro="contributors-short"/>
+              <text macro="date-in-text"/>
+            </group>
+          </if>
+          <else>
+            <group delimiter=", ">
+              <text macro="contributors-short"/>
+              <text macro="date-in-text"/>
+            </group>
+          </else>
+        </choose>
+        <text macro="point-locators"/>
+      </group>
+    </layout>
+  </citation>
+  <bibliography hanging-indent="true" et-al-min="11" et-al-use-first="7" subsequent-author-substitute="———" entry-spacing="0">
+    <sort>
+      <key macro="contributors"/>
+      <key variable="issued"/>
+      <key variable="title"/>
+    </sort>
+    <layout suffix=".">
+      <choose>
+        <if type="entry-encyclopedia">
+          <group delimiter=" ">
+            <choose>
+              <if variable="author" match="none">
+                <group delimiter=", ">
+                  <text variable="container-title" font-style="italic" suffix="."/>
+                  <group delimiter=". ">
+                    <text macro="container-contributors"/>
+                    <group delimiter=", ">
+                      <text macro="publisher"/>
+                      <text macro="date"/>
+                    </group>
+                  </group>
+                  <text variable="title" prefix=" s.v. " quotes="true"/>
+                </group>
+              </if>
+              <else-if variable="author">
+                <group delimiter=". ">
+                  <text macro="contributors" suffix="."/>
+                  <text macro="date"/>
+                  <text variable="title" quotes="true"/>
+                  <text macro="container-title"/>
+                  <text macro="container-contributors" text-case="capitalize-first"/>
+                  <text macro="publisher"/>
+                  <text macro="access"/>
+                </group>
+              </else-if>
+            </choose>
+          </group>
+        </if>
+        <else-if type="motion_picture">
+          <group delimiter=". ">
+            <group delimiter=". ">
+              <group delimiter=" ">
+                <group delimiter=". ">
+                  <group delimiter=", ">
+                    <text variable="title" font-style="italic"/>
+                    <text variable="medium"/>
+                  </group>
+                  <group delimiter=", ">
+                    <text macro="publisher"/>
+                    <text macro="date"/>
+                  </group>
+                </group>
+              </group>
+            </group>
+          </group>
+        </else-if>
+        <else-if type="legislation">
+          <text macro="contributors" suffix=". "/>
+          <group delimiter=" ">
+            <text variable="title" font-style="italic"/>
+            <group prefix="(" suffix=")" delimiter=", ">
+              <text variable="section" prefix="capítulo "/>
+              <text variable="volume" prefix="vol. "/>
+            </group>
+          </group>
+        </else-if>
+        <else-if type="bill">
+          <text macro="contributors" suffix=". "/>
+          <group delimiter=" ">
+            <text variable="title" font-style="italic"/>
+            <group prefix="(RLRQ, " suffix=")" delimiter=", ">
+              <text variable="section" prefix="capítulo "/>
+              <text variable="number" prefix="nr. "/>
+            </group>
+          </group>
+        </else-if>
+        <else>
+          <group delimiter=". ">
+            <text macro="contributors"/>
+            <text macro="date"/>
+            <text macro="title"/>
+          </group>
+          <text macro="description"/>
+          <text macro="secondary-contributors" prefix=". "/>
+          <text macro="container-title" prefix=". "/>
+          <text macro="container-contributors"/>
+          <text macro="edition"/>
+          <text macro="locators-chapter"/>
+          <text macro="collection-title-journal" prefix=", " suffix=", "/>
+          <text macro="locators"/>
+          <text macro="collection-title" prefix=". "/>
+          <text macro="issue"/>
+          <text macro="locators-article"/>
+          <text macro="access" prefix=". "/>
+        </else>
+      </choose>
+    </layout>
+  </bibliography>
+</style>

--- a/universidade-do-porto-faculdade-de-engenharia-chicago-pt.csl
+++ b/universidade-do-porto-faculdade-de-engenharia-chicago-pt.csl
@@ -133,21 +133,7 @@
       </else-if>
     </choose>
   </macro>
-  <macro name="contributors-long">
-    <group delimiter=". ">
-      <names variable="author">
-        <substitute>
-          <names variable="editor"/>
-          <names variable="translator"/>
-          <names variable="director"/>
-          <text macro="substitute-title"/>
-          <text macro="title"/>
-        </substitute>
-      </names>
-      <text macro="recipient"/>
-    </group>
-  </macro>
-  <macro name="contributors-short">
+    <macro name="contributors-short">
     <names variable="author">
       <name form="short" and="text" delimiter=", " initialize-with=". "/>
       <substitute>


### PR DESCRIPTION
A portuguese translation of our style  universidade-do-porto-faculdade-de-engenharia-chicago.csl
This style is also improving the entries of Patents, web pages, and paper conference regarding portuguese language.

In conference proceedings the In was changed to "Comunicação apresentada em" meaning Paper presented at...

In Patents, the "issued" and "filling" was translated to: "submetida em".... and to "publicada em"

In Web pages - we have changed the accessed date to " Acedido a"....

By the default the quotes in portuguese were «« »», but we only use the double quotes " ". So we have changed in all titles (article titles, patent title... etc) which had «« »»
