### PR TITLE
Update china-national-standard-gb-t-7714-2015-author-date.csl

### DIFF
--- a/china-national-standard-gb-t-7714-2015-author-date.csl
+++ b/china-national-standard-gb-t-7714-2015-author-date.csl
@@ -176,7 +176,11 @@
   </macro>
   <macro name="title">
     <text variable="title" text-case="title"/>
-    <text variable="number" prefix=": "/>
+    <choose>
+        <if type=" bill broadcast legal_case legislation patent report song" match="any">
+          <text variable="number" prefix=": "/>
+        </if>
+    </choose>
     <group delimiter="/" prefix="[" suffix="]">
       <text macro="type-code"/>
       <choose>


### PR DESCRIPTION
Add only to show the number for bill broadcast legal_case legislation patent report song, otherwise, if there is 'number:' in Extra field, the number will show for item type of journal.