### PR TITLE
Update china-national-standard-gb-t-7714-2015-author-date.csl

### DIFF
--- a/china-national-standard-gb-t-7714-2015-author-date.csl
+++ b/china-national-standard-gb-t-7714-2015-author-date.csl
@@ -14,7 +14,7 @@
     <category citation-format="author-date"/>
     <category field="generic-base"/>
     <summary>The Chinese GB/T7714-2015 author-date style</summary>
-    <updated>2020-03-08T18:00:00+08:00</updated>
+    <updated>2021-11-25T18:00:00+08:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale xml:lang="zh-CN">
@@ -176,7 +176,11 @@
   </macro>
   <macro name="title">
     <text variable="title" text-case="title"/>
-    <text variable="number" prefix=": "/>
+    <choose>
+        <if type="bill broadcast legal_case legislation patent report song" match="any">
+          <text variable="number" prefix=": "/>
+        </if>
+    </choose>
     <group delimiter="/" prefix="[" suffix="]">
       <text macro="type-code"/>
       <choose>


### PR DESCRIPTION
Only show the number for bill broadcast legal_case legislation patent report song, otherwise, if there is 'number:' in Extra field, the number will show for item type of journal.