### PR TITLE
infoclio.ch styles for German: remove non-breaking space delimiters

### DIFF
--- a/infoclio-de-kurzbelege.csl
+++ b/infoclio-de-kurzbelege.csl
@@ -40,7 +40,7 @@
     </terms>
   </locale>
   <citation>
-    <layout suffix="." delimiter="&#160;; ">
+    <layout suffix="." delimiter="; ">
       <choose>
         <if position="ibid-with-locator">
           <group delimiter=", ">

--- a/infoclio-de.csl
+++ b/infoclio-de.csl
@@ -40,7 +40,7 @@
     </terms>
   </locale>
   <citation>
-    <layout suffix="." delimiter="&#160;; ">
+    <layout suffix="." delimiter="; ">
       <choose>
         <if position="ibid-with-locator">
           <group delimiter=", ">


### PR DESCRIPTION
Some users (cc @maehr) rightly remarked that in the German-language styles of infoclio.ch for history students in Switzerland*, there should be no space before the semicolons used to delimit subsequent citations. This is indeed something that is used in French but not in German. This PR fixes this issue.

As always, many thanks for the maintainance of the styles! 

(*see #234 for the original pull request and backlinks to subsequent updates).