### PR TITLE
Add publisher information to dictionaries and encyclopedias for SBL 2nd edition

### DIFF
--- a/society-of-biblical-literature-author-date.csl
+++ b/society-of-biblical-literature-author-date.csl
@@ -483,6 +483,7 @@
         </group>
       </group>
       <text macro="point-locators"/>
+      <text macro="issue"/>
     </group>
   </macro>
   <citation et-al-min="4" et-al-use-first="1" disambiguate-add-names="true" disambiguate-add-year-suffix="true" disambiguate-add-givenname="true" givenname-disambiguation-rule="primary-name" collapse="year" after-collapse-delimiter="; ">

--- a/society-of-biblical-literature-fullnote-bibliography.csl
+++ b/society-of-biblical-literature-fullnote-bibliography.csl
@@ -984,6 +984,7 @@
             <text macro="container-title-note"/>
           </group>
           <text macro="point-locators"/>
+          <text macro="issue-note"/>
         </group>
       </else>
     </choose>
@@ -996,6 +997,7 @@
         <text macro="container-title-note"/>
       </group>
       <text macro="point-locators"/>
+      <text macro="issue"/>
     </group>
   </macro>
   <citation et-al-min="4" et-al-use-first="1" disambiguate-add-names="true">


### PR DESCRIPTION
SBL 2nd edition is currently missing the publisher information when citing a dictionary or encyclopedia entry.