### PR TITLE
Removed "page" (s. ) term for articles that do not have page numbers.

### DIFF
--- a/norsk-henvisningsstandard-for-rettsvitenskapelige-tekster.csl
+++ b/norsk-henvisningsstandard-for-rettsvitenskapelige-tekster.csl
@@ -286,12 +286,10 @@
             <text prefix=", " macro="title"/>
             <text prefix=" " font-style="italic" variable="container-title"/>
             <text prefix=" " macro="issued"/>
-            <choose>
-              <if variable="page" match="any">
-                <text prefix=" " suffix=" " term="page" form="short"/>
-                <text variable="page"/>
-              </if>
-            </choose>
+            <group delimiter=" " prefix=" ">
+              <text term="page" form="short"/>
+              <text variable="page"/>
+            </group>
             <text macro="DOI"/>
             <text prefix=" " macro="retrieved-from"/>
           </group>

--- a/norsk-henvisningsstandard-for-rettsvitenskapelige-tekster.csl
+++ b/norsk-henvisningsstandard-for-rettsvitenskapelige-tekster.csl
@@ -286,8 +286,12 @@
             <text prefix=", " macro="title"/>
             <text prefix=" " font-style="italic" variable="container-title"/>
             <text prefix=" " macro="issued"/>
-            <text prefix=" " suffix=" " term="page" form="short"/>
-            <text variable="page"/>
+            <choose>
+              <if variable="page" match="any">
+                <text prefix=" " suffix=" " term="page" form="short"/>
+                <text variable="page"/>
+              </if>
+            </choose>
             <text macro="DOI"/>
             <text prefix=" " macro="retrieved-from"/>
           </group>


### PR DESCRIPTION
Currently, in the bibliography articles without a page number (e.g. preprints with only a DOI) will still display the page term: "s. " - which is equivalent to "p. " in English.

This commit adds a check for whether a page number exists, and omits the page term if there is no page number.