### PR TITLE
Update Society of Biblical Literature Full Note for 6.1.6

### DIFF
--- a/society-of-biblical-literature-fullnote-bibliography.csl
+++ b/society-of-biblical-literature-fullnote-bibliography.csl
@@ -990,7 +990,14 @@
           <text macro="archive-note"/>
         </else-if>
       </choose>
-      <text variable="URL"/>
+      <choose>
+        <if variable="DOI">
+          <text variable="DOI" prefix="https://doi.org/"/>
+        </if>
+        <else>
+          <text variable="URL"/>
+        </else>
+      </choose>
     </group>
   </macro>
   <macro name="access">
@@ -1003,7 +1010,14 @@
           <text macro="archive"/>
         </else-if>
       </choose>
-      <text variable="URL"/>
+      <choose>
+        <if variable="DOI">
+          <text variable="DOI" prefix="https://doi.org/"/>
+        </if>
+        <else>
+          <text variable="URL"/>
+        </else>
+      </choose>
     </group>
   </macro>
   <macro name="unsigned-dictionary-note">


### PR DESCRIPTION
SBL Handbook 6.1.6 recommends using DOI instead of URL if possible. This change checks for DOI variable and prefers it over URL if present.