### PR TITLE
Update SBL 2nd ed. (Full Note) for 6.2.25 Electronic Book

### DIFF
--- a/society-of-biblical-literature-fullnote-bibliography.csl
+++ b/society-of-biblical-literature-fullnote-bibliography.csl
@@ -1114,7 +1114,6 @@
           <group delimiter=", ">
             <text macro="contributors-note"/>
             <text macro="title-note"/>
-            <text macro="description-note"/>
             <text macro="secondary-contributors-note"/>
             <text macro="container-title-note"/>
             <text macro="container-contributors-note"/>
@@ -1138,6 +1137,7 @@
           <text macro="locators-newspaper" prefix=", "/>
           <text macro="point-locators"/>
           <text macro="access-note" prefix=", "/>
+          <text macro="description-note" prefix=", "/>
         </else>
       </choose>
     </layout>
@@ -1167,7 +1167,6 @@
           <group delimiter=". ">
             <text macro="contributors"/>
             <text macro="title"/>
-            <text macro="description"/>
             <text macro="secondary-contributors"/>
             <text macro="container-title"/>
             <text macro="container-contributors"/>
@@ -1188,6 +1187,7 @@
           <text macro="locators-newspaper" prefix=", "/>
           <text macro="locators-journal"/>
           <text macro="access" prefix=". "/>
+          <text macro="description" prefix=". "/>
         </else>
       </choose>
     </layout>


### PR DESCRIPTION
eBook designation should be at the end of the citation rather than after the title according to SBL Handbook 6.2.25 Electronic Book