### PR TITLE
Update tyndale-bulletin.csl

### DIFF
--- a/tyndale-bulletin.csl
+++ b/tyndale-bulletin.csl
@@ -16,14 +16,12 @@
     <issn>0082-7118</issn>
     <eissn>2752-7042</eissn>
     <summary>Tyndale Bulletin format with full notes and bibliography</summary>
-    <updated>2021-10-20T19:25:50+00:00</updated>
+    <updated>2022-01-02T01:47:37+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
     <!-- Tyndale Bulletin style differs from SBLHS2 only rarely (§4.1). The departures are that Tyndale Bulletin uses 
       1) hyphens, rather than en dashes, in page ranges (§§6, 6.3);
       2) insists that DOIs be included where available (§§11.1, 11.3.7); and
-      3) uses British-style quotation mark conventions (§§8.1, 11.1, 11.6.6–11.3.8). N.B.: §11.3.8 shows punctuation coming outside the quotation mark, rather than inside. But it needs to be confirmed that this isn't a mistake in the Tyndale Bulletin style guide (as is, e.g., the italicized comma after the book title in that section's examples). 
-      
-      N.B.: Currently, the citation for an untitled book review puts the book title in quotation marks rather than italics (contra §11.3.9), as does the same code in the SBL base style. Could this be due to the difference between en-US and en-GB? -->
+      3) uses British-style quotation mark conventions (§§8.1, 11.1, 11.6.6–11.3.8). N.B.: §11.3.8 shows punctuation coming outside the quotation mark, rather than inside. But it needs to be confirmed that this isn't a mistake in the Tyndale Bulletin style guide (as is, e.g., the italicized comma after the book title in that section's examples). -->
   </info>
   <locale xml:lang="en-GB">
     <style-options punctuation-in-quote="true"/>
@@ -267,6 +265,19 @@
       <else-if type="bill book graphic legal_case legislation motion_picture report song" match="any">
         <text variable="title" font-style="italic" text-case="title"/>
       </else-if>
+      <!-- Include "review of " prefix, italicize the book titles in untitled book reviews per §§11.3.8–11.3.9. -->
+      <else-if variable="reviewed-author">
+        <choose>
+          <!-- Include the review title, if avaialable, in quotation marks per §11.3.8. -->
+          <if variable="reviewed-title">
+            <text variable="title" quotes="true" suffix=", " text-case="title"/>
+            <text variable="reviewed-title" font-style="italic" prefix="review of " text-case="title"/>
+          </if>
+          <else>
+            <text variable="title" font-style="italic" prefix="review of " text-case="title"/>
+          </else>
+        </choose>
+      </else-if>
       <else>
         <text variable="title" quotes="true" text-case="title"/>
       </else>
@@ -283,6 +294,17 @@
       </if>
       <else-if type="bill book graphic legal_case legislation motion_picture report song" match="any">
         <text variable="title" font-style="italic" text-case="title"/>
+      </else-if>
+      <!-- Include the reviewed author for book reviews per §§11.3.8–11.3.9. -->
+      <else-if variable="reviewed-author">
+        <choose>
+          <if variable="reviewed-title">
+            <text variable="title" quotes="true" suffix=", " text-case="title"/>
+            <text variable="reviewed-title" font-style="italic" prefix="review of " text-case="title"/>
+          </if>
+        </choose>
+        <text variable="title" font-style="italic" prefix="Review of " suffix=", by " text-case="title"/>
+        <names variable="reviewed-author"/>
       </else-if>
       <else>
         <text variable="title" quotes="true" text-case="title"/>
@@ -306,6 +328,17 @@
       </if>
       <else-if type="bill book graphic legal_case legislation motion_picture report song" match="any">
         <text variable="title" form="short" font-style="italic" text-case="title"/>
+      </else-if>
+      <!-- For short citations, use the short review title if available. Otherwise, use a "review of " prefix, italicize the short book title per §11.3.8. -->
+      <else-if variable="reviewed-author">
+        <choose>
+          <if variable="reviewed-title">
+            <text variable="title" quotes="true" text-case="title"/>
+          </if>
+          <else>
+            <text variable="title" font-style="italic" form="short" prefix="review of " text-case="title"/>
+          </else>
+        </choose>
       </else-if>
       <else>
         <text variable="title" form="short" quotes="true" text-case="title"/>

--- a/tyndale-bulletin.csl
+++ b/tyndale-bulletin.csl
@@ -32,7 +32,7 @@
       <term name="editortranslator" form="verb-short">ed. and trans.</term>
       <term name="editortranslator" form="verb">edited and translated by</term>
       <!-- Use en dash in page ranges per the January 2022 update to the style guide. -->
-      <term name="page-range-delimiter">–</term>
+      <term name="page-range-delimiter">&#8211;</term>
       <term name="review-of">review of</term>
       <term name="section" form="short">
         <single>§</single>

--- a/tyndale-bulletin.csl
+++ b/tyndale-bulletin.csl
@@ -712,8 +712,8 @@
                   </if>
                   <else>
                     <group delimiter=" ">
-                        <label variable="locator" form="short"/>
-                        <text variable="locator"/>
+                      <label variable="locator" form="short"/>
+                      <text variable="locator"/>
                     </group>
                   </else>
                 </choose>

--- a/tyndale-bulletin.csl
+++ b/tyndale-bulletin.csl
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <style xmlns="http://purl.org/net/xbiblio/csl" class="note" version="1.0" demote-non-dropping-particle="sort-only" page-range-format="chicago" default-locale="en-GB">
   <info>
-<title>Tyndale Bulletin</title>
+    <title>Tyndale Bulletin</title>
     <id>http://www.zotero.org/styles/tyndale-bulletin</id>
     <link href="http://www.zotero.org/styles/tyndale-bulletin" rel="self"/>
     <link href="http://www.zotero.org/styles/society-of-biblical-literature-fullnote-bibliography" rel="template"/>
@@ -21,7 +21,7 @@
     <!-- Tyndale Bulletin style differs from SBLHS2 only rarely (§4.1). The departures are that Tyndale Bulletin uses 
       1) hyphens, rather than en dashes, in page ranges (§§6, 6.3);
       2) insists that DOIs be included where available (§§11.1, 11.3.7); and
-      3) uses British-style quotation mark conventions (§§8.1, 11.1, 11.6.6–11.3.8). N.B.: §11.3.8 shows punctuation coming outside the quotation mark, rather than inside. But it needs to be confirmed that this isn't a mistake in the Tyndale Bulletin style guide (as is, e.g., the italicized comma after the book title in that section's examples). -->
+      3) uses British-style quotation mark conventions (§§8.1, 11.1, 11.6.6&#8211;11.3.8). N.B.: §11.3.8 shows punctuation coming outside the quotation mark, rather than inside. But it needs to be confirmed that this isn't a mistake in the Tyndale Bulletin style guide (as is, e.g., the italicized comma after the book title in that section's examples). -->
   </info>
   <locale xml:lang="en-GB">
     <style-options punctuation-in-quote="true"/>
@@ -265,7 +265,7 @@
       <else-if type="bill book graphic legal_case legislation motion_picture report song" match="any">
         <text variable="title" font-style="italic" text-case="title"/>
       </else-if>
-      <!-- Include "review of " prefix, italicize the book titles in untitled book reviews per §§11.3.8–11.3.9. -->
+      <!-- Include "review of " prefix, italicize the book titles in untitled book reviews per §§11.3.8&#8211;11.3.9. -->
       <else-if variable="reviewed-author">
         <choose>
           <!-- Include the review title, if avaialable, in quotation marks per §11.3.8. -->
@@ -295,7 +295,7 @@
       <else-if type="bill book graphic legal_case legislation motion_picture report song" match="any">
         <text variable="title" font-style="italic" text-case="title"/>
       </else-if>
-      <!-- Include the reviewed author for book reviews per §§11.3.8–11.3.9. -->
+      <!-- Include the reviewed author for book reviews per §§11.3.8&#8211;11.3.9. -->
       <else-if variable="reviewed-author">
         <choose>
           <if variable="reviewed-title">
@@ -709,8 +709,8 @@
                   </if>
                   <else>
                     <group delimiter=" ">
-                        <label variable="locator" form="short"/>
-                        <text variable="locator"/>
+                      <label variable="locator" form="short"/>
+                      <text variable="locator"/>
                     </group>
                   </else>
                 </choose>

--- a/tyndale-bulletin.csl
+++ b/tyndale-bulletin.csl
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <style xmlns="http://purl.org/net/xbiblio/csl" class="note" version="1.0" demote-non-dropping-particle="sort-only" page-range-format="chicago" default-locale="en-GB">
   <info>
-    <title>Tyndale Bulletin</title>
+<title>Tyndale Bulletin</title>
     <id>http://www.zotero.org/styles/tyndale-bulletin</id>
     <link href="http://www.zotero.org/styles/tyndale-bulletin" rel="self"/>
     <link href="http://www.zotero.org/styles/society-of-biblical-literature-fullnote-bibliography" rel="template"/>

--- a/tyndale-bulletin.csl
+++ b/tyndale-bulletin.csl
@@ -270,8 +270,13 @@
         <choose>
           <!-- Include the review title, if avaialable, in quotation marks per §11.3.8. -->
           <if variable="reviewed-title">
-            <text variable="title" quotes="true" suffix=", " text-case="title"/>
-            <text variable="reviewed-title" font-style="italic" prefix="review of " text-case="title"/>
+            <group delimiter=", ">
+              <text variable="title" quotes="true" suffix=", " text-case="title"/>
+              <group delimiter=" ">
+                <text term="review-of" font-style="italic"/>
+                <text variable="reviewed-title" font-style="italic" text-case="title"/>
+              </group>
+            </group>
           </if>
           <else>
             <text variable="title" font-style="italic" prefix="review of " text-case="title"/>

--- a/tyndale-bulletin.csl
+++ b/tyndale-bulletin.csl
@@ -16,12 +16,12 @@
     <issn>0082-7118</issn>
     <eissn>2752-7042</eissn>
     <summary>Tyndale Bulletin format with full notes and bibliography</summary>
-    <updated>2022-01-04T17:34:29+00:00</updated>
+    <updated>2022-01-04T20:55:21+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
     <!-- Tyndale Bulletin style differs from SBLHS2 only rarely (§4.1). The departures are that Tyndale Bulletin uses 
       1) hyphens, rather than en dashes, in page ranges (§§6, 6.3);
       2) insists that DOIs be included where available (§§11.1, 11.3.7); and
-      3) uses British-style quotation mark conventions (§§8.1, 11.1, 11.6.6&#8211;11.3.8). N.B.: §11.3.8 shows punctuation coming outside the quotation mark, rather than inside. But it needs to be confirmed that this isn't a mistake in the Tyndale Bulletin style guide (as is, e.g., the italicized comma after the book title in that section's examples). -->
+      3) uses British-style quotation mark conventions (§§8.1, 11.1, 11.6.6-11.3.8). N.B.: §11.3.8 shows punctuation coming outside the quotation mark, rather than inside. But it needs to be confirmed that this isn't a mistake in the Tyndale Bulletin style guide (as is, e.g., the italicized comma after the book title in that section's examples). -->
   </info>
   <locale xml:lang="en-GB">
     <style-options punctuation-in-quote="true"/>
@@ -265,7 +265,7 @@
       <else-if type="bill book graphic legal_case legislation motion_picture report song" match="any">
         <text variable="title" font-style="italic" text-case="title"/>
       </else-if>
-      <!-- Include "review of " prefix, italicize the book titles in untitled book reviews per §§11.3.8&#8211;11.3.9. -->
+      <!-- Include "review of " prefix, italicize the book titles in untitled book reviews per §§11.3.8-11.3.9. -->
       <else-if variable="reviewed-author">
         <choose>
           <!-- Include the review title, if avaialable, in quotation marks per §11.3.8. -->
@@ -295,16 +295,19 @@
       <else-if type="bill book graphic legal_case legislation motion_picture report song" match="any">
         <text variable="title" font-style="italic" text-case="title"/>
       </else-if>
-      <!-- Include the reviewed author for book reviews per §§11.3.8&#8211;11.3.9. -->
+      <!-- Include the reviewed author for book reviews per §§11.3.8-11.3.9. -->
       <else-if variable="reviewed-author">
         <choose>
           <if variable="reviewed-title">
             <text variable="title" quotes="true" suffix=", " text-case="title"/>
-            <text variable="reviewed-title" font-style="italic" prefix="review of " text-case="title"/>
+            <text variable="reviewed-title" font-style="italic" prefix="review of " suffix=", by " text-case="title"/>
+            <names variable="reviewed-author"/>
           </if>
+          <else>
+            <text variable="title" font-style="italic" prefix="Review of " suffix=", by " text-case="title"/>
+            <names variable="reviewed-author"/>
+          </else>
         </choose>
-        <text variable="title" font-style="italic" prefix="Review of " suffix=", by " text-case="title"/>
-        <names variable="reviewed-author"/>
       </else-if>
       <else>
         <text variable="title" quotes="true" text-case="title"/>
@@ -709,8 +712,8 @@
                   </if>
                   <else>
                     <group delimiter=" ">
-                      <label variable="locator" form="short"/>
-                      <text variable="locator"/>
+                        <label variable="locator" form="short"/>
+                        <text variable="locator"/>
                     </group>
                   </else>
                 </choose>

--- a/tyndale-bulletin.csl
+++ b/tyndale-bulletin.csl
@@ -16,7 +16,7 @@
     <issn>0082-7118</issn>
     <eissn>2752-7042</eissn>
     <summary>Tyndale Bulletin format with full notes and bibliography</summary>
-    <updated>2022-01-02T01:47:37+00:00</updated>
+    <updated>2022-01-04T17:34:29+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
     <!-- Tyndale Bulletin style differs from SBLHS2 only rarely (§4.1). The departures are that Tyndale Bulletin uses 
       1) hyphens, rather than en dashes, in page ranges (§§6, 6.3);

--- a/tyndale-bulletin.csl
+++ b/tyndale-bulletin.csl
@@ -16,22 +16,24 @@
     <issn>0082-7118</issn>
     <eissn>2752-7042</eissn>
     <summary>Tyndale Bulletin format with full notes and bibliography</summary>
-    <updated>2022-01-04T20:55:21+00:00</updated>
+    <updated>2022-01-11T14:38:09+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
-    <!-- Tyndale Bulletin style differs from SBLHS2 only rarely (§4.1). The departures are that Tyndale Bulletin uses 
-      1) hyphens, rather than en dashes, in page ranges (§§6, 6.3);
-      2) insists that DOIs be included where available (§§11.1, 11.3.7); and
-      3) uses British-style quotation mark conventions (§§8.1, 11.1, 11.6.6-11.3.8). N.B.: §11.3.8 shows punctuation coming outside the quotation mark, rather than inside. But it needs to be confirmed that this isn't a mistake in the Tyndale Bulletin style guide (as is, e.g., the italicized comma after the book title in that section's examples). -->
+    <!-- Tyndale Bulletin style differs from SBLHS2 only rarely (§4.1). The departures are that Tyndale Bulletin 
+      1) insists that DOIs be included where available (§§11.1, 11.3.7) and
+      2) uses British-style quotation mark conventions (§§8.1, 11.1, 11.6.6-11.3.8). -->
   </info>
   <locale xml:lang="en-GB">
-    <style-options punctuation-in-quote="true"/>
+    <!-- Punctuate outside quotations per the January 2022 update to the style guide. -->
+    <style-options punctuation-in-quote="false"/>
     <terms>
       <term name="collection-editor" form="verb">edited by</term>
       <term name="collection-editor" form="verb-short">ed.</term>
       <term name="editor" form="verb-short">ed.</term>
       <term name="editortranslator" form="verb-short">ed. and trans.</term>
       <term name="editortranslator" form="verb">edited and translated by</term>
-      <term name="page-range-delimiter">-</term>
+      <!-- Use en dash in page ranges per the January 2022 update to the style guide. -->
+      <term name="page-range-delimiter">–</term>
+      <term name="review-of">review of</term>
       <term name="section" form="short">
         <single>§</single>
         <multiple>§§</multiple>
@@ -265,21 +267,22 @@
       <else-if type="bill book graphic legal_case legislation motion_picture report song" match="any">
         <text variable="title" font-style="italic" text-case="title"/>
       </else-if>
-      <!-- Include "review of " prefix, italicize the book titles in untitled book reviews per §§11.3.8-11.3.9. -->
+      <!-- Include "review of" prefix, italicize the book titles in untitled book reviews per §§11.3.8-11.3.9. -->
       <else-if variable="reviewed-author">
         <choose>
           <!-- Include the review title, if avaialable, in quotation marks per §11.3.8. -->
           <if variable="reviewed-title">
-            <group delimiter=", ">
+            <group delimiter=" ">
               <text variable="title" quotes="true" suffix=", " text-case="title"/>
-              <group delimiter=" ">
-                <text term="review-of" font-style="italic"/>
-                <text variable="reviewed-title" font-style="italic" text-case="title"/>
-              </group>
+              <text term="review-of"/>
+              <text variable="reviewed-title" font-style="italic" text-case="title"/>
             </group>
           </if>
           <else>
-            <text variable="title" font-style="italic" prefix="review of " text-case="title"/>
+            <group delimiter=" ">
+              <text term="review-of"/>
+              <text variable="title" font-style="italic" text-case="title"/>
+            </group>
           </else>
         </choose>
       </else-if>
@@ -304,13 +307,25 @@
       <else-if variable="reviewed-author">
         <choose>
           <if variable="reviewed-title">
-            <text variable="title" quotes="true" suffix=", " text-case="title"/>
-            <text variable="reviewed-title" font-style="italic" prefix="review of " suffix=", by " text-case="title"/>
-            <names variable="reviewed-author"/>
+            <group delimiter=" ">
+              <text variable="title" quotes="true" suffix="," text-case="title"/>
+              <text term="review-of"/>
+              <text variable="reviewed-title" font-style="italic" suffix="," text-case="title"/>
+              <names variable="reviewed-author">
+                <label form="verb" suffix=" "/>
+                <name and="text"/>
+              </names>
+            </group>
           </if>
           <else>
-            <text variable="title" font-style="italic" prefix="Review of " suffix=", by " text-case="title"/>
-            <names variable="reviewed-author"/>
+            <group delimiter=" ">
+              <text term="review-of" text-case="capitalize-first"/>
+              <text variable="title" font-style="italic" suffix=", " text-case="title"/>
+              <names variable="reviewed-author">
+                <label form="verb" suffix=" "/>
+                <name and="text"/>
+              </names>
+            </group>
           </else>
         </choose>
       </else-if>
@@ -337,14 +352,17 @@
       <else-if type="bill book graphic legal_case legislation motion_picture report song" match="any">
         <text variable="title" form="short" font-style="italic" text-case="title"/>
       </else-if>
-      <!-- For short citations, use the short review title if available. Otherwise, use a "review of " prefix, italicize the short book title per §11.3.8. -->
+      <!-- For short citations, use the short review title if available. Otherwise, use a "review of" prefix, italicize the short book title per §11.3.8. -->
       <else-if variable="reviewed-author">
         <choose>
           <if variable="reviewed-title">
             <text variable="title" quotes="true" text-case="title"/>
           </if>
           <else>
-            <text variable="title" font-style="italic" form="short" prefix="review of " text-case="title"/>
+            <group delimiter=" ">
+              <text term="review-of"/>
+              <text variable="title" font-style="italic" form="short" text-case="title"/>
+            </group>
           </else>
         </choose>
       </else-if>


### PR DESCRIPTION
Corrects output for footnotes and bibliography per §§11.3.8–11.3.9 of the Tyndale Bulletin style guide for titled and untitled book reviews.