### PR TITLE
Update university-of-roehampton-harvard.csl

### DIFF
--- a/university-of-roehampton-harvard.csl
+++ b/university-of-roehampton-harvard.csl
@@ -429,7 +429,7 @@
       </if>
       <else>
         <names variable="author">
-          <name form="short" and="text" delimiter-precedes-last="never" initialize-with="."/>
+          <name form="short" and="text" delimiter-precedes-last="never" et-al-min="4" et-al-use-first="1" initialize-with="."/>
           <et-al font-style="italic"/>
           <substitute>
             <names variable="editor"/>


### PR DESCRIPTION
When generating citations, it was omitting the 'et al' on resources with 4+ authors. I've added the extra code needed for this to line 432