### PR TITLE
Update university-of-roehampton-harvard.csl

### DIFF
--- a/university-of-roehampton-harvard.csl
+++ b/university-of-roehampton-harvard.csl
@@ -446,7 +446,7 @@
       <et-al font-style="italic"/>
     </names>
   </macro>
-  <citation disambiguate-add-year-suffix="true" collapse="year-suffix">
+  <citation et-al-min="4" et-al-use-first="1" disambiguate-add-year-suffix="true" collapse="year-suffix">
     <layout delimiter="; " prefix="(" suffix=")">
       <group delimiter=":">
         <group delimiter=", ">

--- a/university-of-roehampton-harvard.csl
+++ b/university-of-roehampton-harvard.csl
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" and="text"  demote-non-dropping-particle="sort-only" default-locale="en-GB">
+<style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" and="text" demote-non-dropping-particle="sort-only" default-locale="en-GB">
   <!-- This style was edited with the Visual CSL Editor (https://editor.citationstyles.org/visualEditor/) -->
   <info>
     <title>University of Roehampton - Harvard</title>
@@ -187,7 +187,7 @@
   <macro name="translator">
     <names variable="translator">
       <label form="verb" text-case="capitalize-first"/>
-      <name delimiter=". " prefix=" " suffix="." and="text" delimiter-precedes-last="never"  initialize-with="." name-as-sort-order="all"/>
+      <name delimiter=". " prefix=" " suffix="." and="text" delimiter-precedes-last="never" initialize-with="." name-as-sort-order="all"/>
       <et-al font-style="italic"/>
     </names>
   </macro>


### PR DESCRIPTION
Apologies for the double-posting; I couldn't work out how to modify my existing change proposal!

When generating citations, it was omitting the 'et al' on resources with 4+ authors. I've added it to line 449 this time (which I hope is the correct one), but can't be sure as I was ultimately using the Visual CSL editor to put it together in the first instance.