### PR TITLE
Update chicago-author-date.csl

### DIFF
--- a/chicago-author-date.csl
+++ b/chicago-author-date.csl
@@ -47,49 +47,49 @@
   </locale>
   <locale xml:lang="pt">
     <terms>
-	  <term name="accessed">acedido a</term>
-    <term name="editor" form="verb">editado por</term>
-    <term name="editor" form="verb-short">ed.</term>
-    <term name="container-author" form="verb">por</term>
-    <term name="translator" form="verb-short">traduzido por</term>
-	  <term name="translator" form="short">trad.</term>
-    <term name="editortranslator" form="verb">editado e traduzido por</term>
-    <term name="and">e</term>
-	  <term name="no date" form="long">s.d</term>
-	  <term name="no date" form="short">s.d.</term>
-	  <term name="in">em</term>
-	  <term name="at">em</term>
-	  <term name="by">por</term>
-	  <!-- PUNCTUATION -->
-    <term name="open-quote">"</term>
-    <term name="close-quote">"</term>
-    <!-- LONG MONTH FORMS -->
-    <term name="month-01">janeiro</term>
-    <term name="month-02">fevereiro</term>
-    <term name="month-03">março</term>
-    <term name="month-04">abril</term>
-    <term name="month-05">maio</term>
-    <term name="month-06">junho</term>
-    <term name="month-07">julho</term>
-    <term name="month-08">agosto</term>
-    <term name="month-09">setembro</term>
-    <term name="month-10">outubro</term>
-    <term name="month-11">novembro</term>
-    <term name="month-12">dezembro</term>
-    <!-- SHORT MONTH FORMS -->
-    <term name="month-01" form="short">jan.</term>
-    <term name="month-02" form="short">fev.</term>
-    <term name="month-03" form="short">mar.</term>
-    <term name="month-04" form="short">abr.</term>
-    <term name="month-05" form="short">mai.</term>
-    <term name="month-06" form="short">jun.</term>
-    <term name="month-07" form="short">jul.</term>
-    <term name="month-08" form="short">ago.</term>
-    <term name="month-09" form="short">set.</term>
-    <term name="month-10" form="short">out.</term>
-    <term name="month-11" form="short">nov.</term>
-    <term name="month-12" form="short">dez.</term>
-	</terms>
+      <term name="accessed">acedido a</term>
+      <term name="editor" form="verb">editado por</term>
+      <term name="editor" form="verb-short">ed.</term>
+      <term name="container-author" form="verb">por</term>
+      <term name="translator" form="verb-short">traduzido por</term>
+      <term name="translator" form="short">trad.</term>
+      <term name="editortranslator" form="verb">editado e traduzido por</term>
+      <term name="and">e</term>
+      <term name="no date" form="long">s.d</term>
+      <term name="no date" form="short">s.d.</term>
+      <term name="in">em</term>
+      <term name="at">em</term>
+      <term name="by">por</term>
+      <!-- PUNCTUATION -->
+      <term name="open-quote">"</term>
+      <term name="close-quote">"</term>
+      <!-- LONG MONTH FORMS -->
+      <term name="month-01">janeiro</term>
+      <term name="month-02">fevereiro</term>
+      <term name="month-03">março</term>
+      <term name="month-04">abril</term>
+      <term name="month-05">maio</term>
+      <term name="month-06">junho</term>
+      <term name="month-07">julho</term>
+      <term name="month-08">agosto</term>
+      <term name="month-09">setembro</term>
+      <term name="month-10">outubro</term>
+      <term name="month-11">novembro</term>
+      <term name="month-12">dezembro</term>
+      <!-- SHORT MONTH FORMS -->
+      <term name="month-01" form="short">jan.</term>
+      <term name="month-02" form="short">fev.</term>
+      <term name="month-03" form="short">mar.</term>
+      <term name="month-04" form="short">abr.</term>
+      <term name="month-05" form="short">mai.</term>
+      <term name="month-06" form="short">jun.</term>
+      <term name="month-07" form="short">jul.</term>
+      <term name="month-08" form="short">ago.</term>
+      <term name="month-09" form="short">set.</term>
+      <term name="month-10" form="short">out.</term>
+      <term name="month-11" form="short">nov.</term>
+      <term name="month-12" form="short">dez.</term>
+    </terms>
   </locale>
   <macro name="secondary-contributors">
     <choose>

--- a/chicago-author-date.csl
+++ b/chicago-author-date.csl
@@ -63,7 +63,6 @@
       <!-- PUNCTUATION -->
       <term name="open-quote">"</term>
       <term name="close-quote">"</term>
-
     </terms>
   </locale>
   <macro name="secondary-contributors">

--- a/chicago-author-date.csl
+++ b/chicago-author-date.csl
@@ -45,6 +45,52 @@
       <term name="translator" form="short">trans.</term>
     </terms>
   </locale>
+  <locale xml:lang="pt">
+    <terms>
+	  <term name="accessed">acedido a</term>
+    <term name="editor" form="verb">editado por</term>
+    <term name="editor" form="verb-short">ed.</term>
+    <term name="container-author" form="verb">por</term>
+    <term name="translator" form="verb-short">traduzido por</term>
+	  <term name="translator" form="short">trad.</term>
+    <term name="editortranslator" form="verb">editado e traduzido por</term>
+    <term name="and">e</term>
+	  <term name="no date" form="long">s.d</term>
+	  <term name="no date" form="short">s.d.</term>
+	  <term name="in">em</term>
+	  <term name="at">em</term>
+	  <term name="by">por</term>
+	  <!-- PUNCTUATION -->
+    <term name="open-quote">"</term>
+    <term name="close-quote">"</term>
+    <!-- LONG MONTH FORMS -->
+    <term name="month-01">janeiro</term>
+    <term name="month-02">fevereiro</term>
+    <term name="month-03">março</term>
+    <term name="month-04">abril</term>
+    <term name="month-05">maio</term>
+    <term name="month-06">junho</term>
+    <term name="month-07">julho</term>
+    <term name="month-08">agosto</term>
+    <term name="month-09">setembro</term>
+    <term name="month-10">outubro</term>
+    <term name="month-11">novembro</term>
+    <term name="month-12">dezembro</term>
+    <!-- SHORT MONTH FORMS -->
+    <term name="month-01" form="short">jan.</term>
+    <term name="month-02" form="short">fev.</term>
+    <term name="month-03" form="short">mar.</term>
+    <term name="month-04" form="short">abr.</term>
+    <term name="month-05" form="short">mai.</term>
+    <term name="month-06" form="short">jun.</term>
+    <term name="month-07" form="short">jul.</term>
+    <term name="month-08" form="short">ago.</term>
+    <term name="month-09" form="short">set.</term>
+    <term name="month-10" form="short">out.</term>
+    <term name="month-11" form="short">nov.</term>
+    <term name="month-12" form="short">dez.</term>
+	</terms>
+  </locale>
   <macro name="secondary-contributors">
     <choose>
       <if type="chapter entry-dictionary entry-encyclopedia paper-conference" match="none">
@@ -277,10 +323,10 @@
         <choose>
           <if variable="volume">
             <text variable="volume" prefix=" "/>
-            <group prefix=" (" suffix=")">
+            <group prefix=", ">
               <choose>
                 <if variable="issue">
-                  <text variable="issue"/>
+                  <text variable="issue" prefix="no."/>
                 </if>
                 <else>
                   <date variable="issued">

--- a/chicago-author-date.csl
+++ b/chicago-author-date.csl
@@ -45,11 +45,11 @@
       <term name="translator" form="short">trans.</term>
     </terms>
   </locale>
-   <locale xml:lang="pt-PT">
+  <locale xml:lang="pt-PT">
     <terms>
       <term name="accessed">acedido a</term>
-     </terms>
-      </locale>
+    </terms>
+  </locale>
   <locale xml:lang="pt">
     <terms>
       <term name="editor" form="verb">editado por</term>

--- a/chicago-author-date.csl
+++ b/chicago-author-date.csl
@@ -45,9 +45,13 @@
       <term name="translator" form="short">trans.</term>
     </terms>
   </locale>
-  <locale xml:lang="pt-PT">
+   <locale xml:lang="pt-PT">
     <terms>
       <term name="accessed">acedido a</term>
+     </terms>
+      </locale>
+  <locale xml:lang="pt">
+    <terms>
       <term name="editor" form="verb">editado por</term>
       <term name="editor" form="verb-short">ed.</term>
       <term name="container-author" form="verb">por</term>

--- a/chicago-author-date.csl
+++ b/chicago-author-date.csl
@@ -45,7 +45,7 @@
       <term name="translator" form="short">trans.</term>
     </terms>
   </locale>
-  <locale xml:lang="pt">
+  <locale xml:lang="pt-PT">
     <terms>
       <term name="accessed">acedido a</term>
       <term name="editor" form="verb">editado por</term>
@@ -323,10 +323,10 @@
         <choose>
           <if variable="volume">
             <text variable="volume" prefix=" "/>
-            <group prefix=", ">
+            <group prefix=" (" suffix=")">
               <choose>
                 <if variable="issue">
-                  <text variable="issue" prefix="no."/>
+                  <text variable="issue"/>
                 </if>
                 <else>
                   <date variable="issued">

--- a/chicago-author-date.csl
+++ b/chicago-author-date.csl
@@ -63,32 +63,7 @@
       <!-- PUNCTUATION -->
       <term name="open-quote">"</term>
       <term name="close-quote">"</term>
-      <!-- LONG MONTH FORMS -->
-      <term name="month-01">janeiro</term>
-      <term name="month-02">fevereiro</term>
-      <term name="month-03">março</term>
-      <term name="month-04">abril</term>
-      <term name="month-05">maio</term>
-      <term name="month-06">junho</term>
-      <term name="month-07">julho</term>
-      <term name="month-08">agosto</term>
-      <term name="month-09">setembro</term>
-      <term name="month-10">outubro</term>
-      <term name="month-11">novembro</term>
-      <term name="month-12">dezembro</term>
-      <!-- SHORT MONTH FORMS -->
-      <term name="month-01" form="short">jan.</term>
-      <term name="month-02" form="short">fev.</term>
-      <term name="month-03" form="short">mar.</term>
-      <term name="month-04" form="short">abr.</term>
-      <term name="month-05" form="short">mai.</term>
-      <term name="month-06" form="short">jun.</term>
-      <term name="month-07" form="short">jul.</term>
-      <term name="month-08" form="short">ago.</term>
-      <term name="month-09" form="short">set.</term>
-      <term name="month-10" form="short">out.</term>
-      <term name="month-11" form="short">nov.</term>
-      <term name="month-12" form="short">dez.</term>
+
     </terms>
   </locale>
   <macro name="secondary-contributors">


### PR DESCRIPTION
Some changes proposal that will improve the Chicago author-date style in portuguese language. (both portuguese-portugal and portuguese-brasil). These changes were made in the code.

1) It would be also great to translate the following:
In line 628: <text value="filed"/>
and line 638  <text value="issued"/>
It would be better to have instead of filed - submetida em
and instead of issued - publicada em
But I guess it's not possible to localize text values, just terms. :(


2) Also I would like to propose a change for the all the languages. This changing is related how the volume in journal articles is shown. 
In this style code the volume number is shown as:   40 (3)
And the Chicago Manual of Style states that has to be 40, no.3

As stated in: https://www.chicagomanualofstyle.org/book/ed17/part2/ch09/psec027.html

And so, I would suggest the following alteration:
   
<if type="article-journal">
        <choose>
          <if variable="volume">
            <text variable="volume" prefix=" "/>
            <group prefix=", ">
              <choose>
                <if variable="issue">
                  <text variable="issue" prefix="no."/>