### PR TITLE
in-text >> superscript for T&F ACS style

### DIFF
--- a/taylor-and-francis-acs.csl
+++ b/taylor-and-francis-acs.csl
@@ -125,7 +125,7 @@
     <sort>
       <key variable="citation-number"/>
     </sort>
-    <layout vertical-align="baseline" delimiter=", " prefix="[" suffix="]" vertical-align="sup">
+    <layout vertical-align="sup" delimiter=", " prefix="[" suffix="]">
       <text variable="citation-number"/>
     </layout>
   </citation>
@@ -232,7 +232,7 @@
             </group>
           </group>
         </else-if>
-        <else-if type="webpage">
+        <else-if type="webpage post post-weblog" match="any">
           <group delimiter=" ">
             <text variable="title"/>
             <text variable="URL"/>

--- a/taylor-and-francis-acs.csl
+++ b/taylor-and-francis-acs.csl
@@ -14,7 +14,7 @@
     <category field="chemistry"/>
     <category field="generic-base"/>
     <summary>The American Chemical Society style for Taylor &amp; Francis journals.</summary>
-    <updated>2019-06-13T12:53:43+00:00</updated>
+    <updated>2022-01-14T12:53:43+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale xml:lang="en">
@@ -125,7 +125,7 @@
     <sort>
       <key variable="citation-number"/>
     </sort>
-    <layout vertical-align="baseline" delimiter=", " prefix="[" suffix="]">
+    <layout vertical-align="baseline" delimiter=", " prefix="[" suffix="]" vertical-align="sup">
       <text variable="citation-number"/>
     </layout>
   </citation>


### PR DESCRIPTION
via https://forums.zotero.org/discussion/93915/no-supercribt-for-taylor-francis-american-chemical-society-acs-style#latest