### PR TITLE
Update China national standard GB/T 7714 styles

### DIFF
--- a/china-national-standard-gb-t-7714-2015-author-date.csl
+++ b/china-national-standard-gb-t-7714-2015-author-date.csl
@@ -1,88 +1,217 @@
 <?xml version="1.0" encoding="utf-8"?>
-<style xmlns="http://purl.org/net/xbiblio/csl" version="1.0" class="in-text" delimiter-precedes-last="always" demote-non-dropping-particle="never" name-delimiter=", " initialize-with=" " names-delimiter=". " name-as-sort-order="all" sort-separator=" " default-locale="zh-CN">
+<style xmlns="http://purl.org/net/xbiblio/csl" version="1.0" class="in-text" names-delimiter=". " name-as-sort-order="all" sort-separator=" " demote-non-dropping-particle="never" initialize-with=" " initialize-with-hyphen="false" page-range-format="expanded" default-locale="zh-CN">
   <info>
     <title>China National Standard GB/T 7714-2015 (author-date, 中文)</title>
-    <title-short>GB/T 7714-2015 (author-date)</title-short>
     <id>http://www.zotero.org/styles/china-national-standard-gb-t-7714-2015-author-date</id>
     <link href="http://www.zotero.org/styles/china-national-standard-gb-t-7714-2015-author-date" rel="self"/>
     <link href="http://www.zotero.org/styles/china-national-standard-gb-t-7714-2015-numeric" rel="template"/>
-    <link href="http://www.std.gov.cn/gb/search/gbDetailed?id=71F772D8055ED3A7E05397BE0A0AB82A" rel="documentation"/>
+    <link href="http://std.samr.gov.cn/gb/search/gbDetailed?id=71F772D8055ED3A7E05397BE0A0AB82A" rel="documentation"/>
     <author>
       <name>牛耕田</name>
       <email>buffalo_d@163.com</email>
     </author>
+    <contributor>
+      <name>Zeping Lee</name>
+      <email>zepinglee@gmail.com</email>
+    </contributor>
     <category citation-format="author-date"/>
     <category field="generic-base"/>
-    <summary>The Chinese GB/T7714-2015 author-date style</summary>
-    <updated>2021-11-25T18:00:00+08:00</updated>
+    <summary>The Chinese GB/T 7714-2015 author-date style</summary>
+    <updated>2022-01-20T00:00:00+08:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale xml:lang="zh-CN">
+    <date form="text">
+      <date-part name="year" suffix="年" range-delimiter="&#8212;"/>
+      <date-part name="month" form="numeric" suffix="月" range-delimiter="&#8212;"/>
+      <date-part name="day" suffix="日" range-delimiter="&#8212;"/>
+    </date>
     <terms>
-      <term name="anonymous">佚名</term>
-      <term name="edition">版</term>
-      <term name="page" form="short">
-        <single>p.</single>
-        <multiple>pp.</multiple>
-      </term>
+      <term name="anonymous" form="short">佚名</term>
+      <term name="edition" form="short">版</term>
+      <term name="open-quote">“</term>
+      <term name="close-quote">”</term>
+      <term name="open-inner-quote">‘</term>
+      <term name="close-inner-quote">’</term>
     </terms>
   </locale>
-  <macro name="accessed-date">
-    <date variable="accessed" delimiter="&#8211;" prefix="[" suffix="]">
-      <date-part name="year"/>
-      <date-part name="month" form="numeric-leading-zeros"/>
-      <date-part name="day" form="numeric-leading-zeros"/>
+  <locale>
+    <date form="numeric">
+      <date-part name="year" range-delimiter="/"/>
+      <date-part name="month" form="numeric-leading-zeros" prefix="-" range-delimiter="/"/>
+      <date-part name="day" form="numeric-leading-zeros" prefix="-" range-delimiter="/"/>
     </date>
+    <terms>
+      <term name="page-range-delimiter">-</term>
+    </terms>
+  </locale>
+  <!-- 引用日期 -->
+  <macro name="accessed-date">
+    <date variable="accessed" form="numeric" prefix="[" suffix="]"/>
   </macro>
+  <macro name="anon">
+    <text term="anonymous" form="short" text-case="capitalize-first" strip-periods="true"/>
+  </macro>
+  <!-- 主要责任者 -->
   <macro name="author">
-    <choose>
-      <if variable="author">
-        <names variable="author">
-          <name>
-            <name-part name="family" text-case="uppercase"/>
-            <name-part name="given"/>
-          </name>
-        </names>
-      </if>
-      <else>
-        <text term="anonymous"/>
-      </else>
-    </choose>
-  </macro>
-  <macro name="author-intext">
-    <choose>
-      <if variable="author">
-        <names variable="author">
-          <name form="short">
-            <name-part name="family" text-case="uppercase"/>
-          </name>
-        </names>
-      </if>
-      <else>
-        <text term="anonymous"/>
-      </else>
-    </choose>
-  </macro>
-  <macro name="container-author">
-    <names variable="container-author">
+    <names variable="author">
       <name>
         <name-part name="family" text-case="uppercase"/>
         <name-part name="given"/>
       </name>
+      <substitute>
+        <names variable="composer"/>
+        <names variable="illustrator"/>
+        <names variable="director"/>
+        <choose>
+          <if variable="container-title" match="none">
+            <names variable="editor"/>
+          </if>
+        </choose>
+        <text macro="anon"/>
+      </substitute>
     </names>
   </macro>
-  <macro name="edition">
+  <!-- 参考文献表的著者姓名与出版年 -->
+  <macro name="author-date">
+    <group delimiter=", ">
+      <text macro="author"/>
+      <text macro="issued-year"/>
+    </group>
+  </macro>
+  <!-- 正文引用的著者姓名 -->
+  <macro name="author-intext">
+    <names variable="author">
+      <!-- 国标 10.2.2 节要求姓氏与“et al.”“等”之间留适当空隙 -->
+      <name form="short" delimiter="&#160;" delimiter-precedes-et-al="always">
+        <name-part name="family" text-case="uppercase"/>
+      </name>
+      <substitute>
+        <names variable="composer"/>
+        <names variable="illustrator"/>
+        <names variable="director"/>
+        <choose>
+          <if variable="container-title" match="none">
+            <names variable="editor"/>
+          </if>
+        </choose>
+        <text macro="anon"/>
+      </substitute>
+    </names>
+  </macro>
+  <!-- 书籍的卷号（“第 x 卷”或“第 x 册”） -->
+  <macro name="book-volume">
     <choose>
-      <if variable="edition">
-        <group delimiter=" ">
-          <text variable="edition"/>
-          <text term="edition"/>
-        </group>
+      <if type="article article-journal article-magazine article-newspaper periodical" match="none">
+        <choose>
+          <if is-numeric="volume">
+            <group delimiter=" ">
+              <label variable="volume" form="short" text-case="capitalize-first"/>
+              <text variable="volume"/>
+            </group>
+          </if>
+          <else>
+            <text variable="volume"/>
+          </else>
+        </choose>
       </if>
     </choose>
   </macro>
-  <macro name="editor">
-    <names variable="editor translator">
+  <!-- 专著主要责任者 -->
+  <macro name="container-author">
+    <names variable="editor">
+      <name>
+        <name-part name="family" text-case="uppercase"/>
+        <name-part name="given"/>
+      </name>
+      <substitute>
+        <names variable="editorial-director"/>
+        <names variable="collection-editor"/>
+        <names variable="container-author"/>
+      </substitute>
+    </names>
+  </macro>
+  <!-- 专著题名 -->
+  <macro name="container-title">
+    <group delimiter=", ">
+      <group delimiter=": ">
+        <choose>
+          <if variable="container-title">
+            <text variable="container-title"/>
+          </if>
+          <else>
+            <text variable="event"/>
+          </else>
+        </choose>
+        <text macro="book-volume"/>
+      </group>
+      <choose>
+        <if variable="event-date">
+          <date variable="event-date" form="text"/>
+          <text variable="event-place"/>
+        </if>
+      </choose>
+    </group>
+  </macro>
+  <!-- 版本项 -->
+  <macro name="edition">
+    <choose>
+      <if is-numeric="edition">
+        <group delimiter=" ">
+          <number variable="edition" form="ordinal"/>
+          <text term="edition" form="short"/>
+        </group>
+      </if>
+      <else>
+        <text variable="edition"/>
+      </else>
+    </choose>
+  </macro>
+  <!-- 电子资源的更新或修改日期 -->
+  <macro name="issued-date">
+    <date variable="issued" form="numeric"/>
+  </macro>
+  <!-- 出版年 -->
+  <macro name="issued-year">
+    <choose>
+      <if is-uncertain-date="issued">
+        <date variable="issued" prefix="[" suffix="]">
+          <date-part name="year" range-delimiter="-"/>
+        </date>
+      </if>
+      <else>
+        <date variable="issued">
+          <date-part name="year" range-delimiter="-"/>
+        </date>
+      </else>
+    </choose>
+  </macro>
+  <!-- 专著的出版项 -->
+  <macro name="publishing">
+    <group delimiter=": ">
+      <group delimiter=", ">
+        <group delimiter=": ">
+          <text variable="publisher-place"/>
+          <text variable="publisher"/>
+        </group>
+      </group>
+      <text variable="page"/>
+    </group>
+    <choose>
+      <!-- 纯电子资源显示“更新或修改日期” -->
+      <if variable="publisher page" type="book chapter paper-conference thesis" match="none">
+        <choose>
+          <if variable="URL DOI" match="any">
+            <text macro="issued-date" prefix="(" suffix=")"/>
+          </if>
+        </choose>
+      </if>
+    </choose>
+    <text macro="accessed-date"/>
+  </macro>
+  <!-- 其他责任者 -->
+  <macro name="secondary-contributor">
+    <names variable="translator">
       <name>
         <name-part name="family" text-case="uppercase"/>
         <name-part name="given"/>
@@ -90,174 +219,251 @@
       <label form="short" prefix=", "/>
     </names>
   </macro>
-  <macro name="issued-date">
-    <choose>
-      <if variable="issued">
-        <date variable="issued" delimiter="&#8211;">
-          <date-part name="year"/>
-          <date-part name="month" form="numeric-leading-zeros"/>
-          <date-part name="day" form="numeric-leading-zeros"/>
-        </date>
-      </if>
-      <else>
-        <text term="no date" prefix="[" suffix="]"/>
-      </else>
-    </choose>
-  </macro>
-  <macro name="issue-date-year">
-    <choose>
-      <if variable="issued">
-        <date variable="issued" date-parts="year" form="numeric"/>
-      </if>
-      <else>
-        <text term="no date" prefix="[" suffix="]"/>
-      </else>
-    </choose>
-  </macro>
-  <macro name="publishing">
-    <choose>
-      <if variable="publisher">
-        <group delimiter=": ">
-          <text variable="publisher-place"/>
+  <!-- 连续出版物中的析出文献的出处项（年、卷、期等信息） -->
+  <macro name="periodical-publishing">
+    <group>
+      <group delimiter=": ">
+        <group>
           <group delimiter=", ">
-            <text variable="publisher"/>
+            <text macro="container-title" text-case="title"/>
+            <choose>
+              <if type="article-newspaper">
+                <text macro="issued-date"/>
+              </if>
+            </choose>
+            <text variable="volume"/>
           </group>
+          <text variable="issue" prefix="(" suffix=")"/>
         </group>
-        <text variable="page" prefix=": "/>
-      </if>
-    </choose>
-  </macro>
-  <macro name="serial-information">
-    <group delimiter=", ">
-      <text variable="volume"/>
+        <text variable="page"/>
+      </group>
+      <text macro="accessed-date"/>
     </group>
-    <text variable="issue" prefix="(" suffix=")"/>
-    <text variable="page" prefix=": "/>
   </macro>
-  <macro name="type-code">
-    <choose>
-      <if type="article-journal article-magazine" match="any">
-        <text value="J"/>
-      </if>
-      <else-if type="article-newspaper">
-        <text value="N"/>
-      </else-if>
-      <else-if type="bill legislation" match="any">
-        <text value="S"/>
-      </else-if>
-      <else-if type="book">
-        <text value="M"/>
-      </else-if>
-      <else-if type="chapter">
-        <text value="M"/>
-      </else-if>
-      <else-if type="dataset">
-        <text value="DS"/>
-      </else-if>
-      <else-if type="paper-conference">
-        <text value="C"/>
-      </else-if>
-      <else-if type="patent">
-        <text value="P"/>
-      </else-if>
-      <else-if type="post-weblog webpage" match="any">
-        <text value="EB"/>
-      </else-if>
-      <else-if type="report">
-        <text value="R"/>
-      </else-if>
-      <else-if type="thesis">
-        <text value="D"/>
-      </else-if>
-      <else>
-        <text value="Z"/>
-      </else>
-    </choose>
-  </macro>
+  <!-- 题名 -->
   <macro name="title">
-    <text variable="title" text-case="title"/>
-    <choose>
-        <if type="bill broadcast legal_case legislation patent report song" match="any">
-          <text variable="number" prefix=": "/>
-        </if>
-    </choose>
-    <group delimiter="/" prefix="[" suffix="]">
-      <text macro="type-code"/>
+    <group delimiter=", ">
+      <group delimiter=": ">
+        <text variable="title"/>
+        <group delimiter="&#8195;">
+          <choose>
+            <if variable="container-title" type="paper-conference" match="none">
+              <text macro="book-volume"/>
+            </if>
+          </choose>
+          <choose>
+            <if type="bill legal_case legislation patent regulation report standard" match="any">
+              <text variable="number"/>
+            </if>
+          </choose>
+        </group>
+      </group>
       <choose>
-        <if variable="URL">
+        <if variable="container-title" type="paper-conference" match="none">
+          <choose>
+            <if variable="event-date">
+              <text variable="event-place"/>
+              <date variable="event-date" form="text"/>
+            </if>
+          </choose>
+        </if>
+      </choose>
+    </group>
+    <text macro="type-code" prefix="[" suffix="]"/>
+  </macro>
+  <!-- 文献类型标识 -->
+  <macro name="type-code">
+    <group delimiter="/">
+      <choose>
+        <if type="article">
+          <choose>
+            <if variable="archive">
+              <text value="A"/>
+            </if >
+            <else>
+              <text value="M"/>
+            </else>
+          </choose>
+        </if>
+        <else-if type="article-journal article-magazine periodical" match="any">
+          <text value="J"/>
+        </else-if>
+        <else-if type="article-newspaper">
+          <text value="N"/>
+        </else-if>
+        <else-if type="bill collection legal_case legislation regulation" match="any">
+          <text value="A"/>
+        </else-if>
+        <else-if type="book chapter" match="any">
+          <text value="M"/>
+        </else-if>
+        <else-if type="dataset">
+          <text value="DS"/>
+        </else-if>
+        <else-if type="map">
+          <text value="CM"/>
+        </else-if>
+        <else-if type="paper-conference">
+          <text value="C"/>
+        </else-if>
+        <else-if type="patent">
+          <text value="P"/>
+        </else-if>
+        <else-if type="post post-weblog webpage" match="any">
+          <text value="EB"/>
+        </else-if>
+        <else-if type="report">
+          <text value="R"/>
+        </else-if>
+        <else-if type="software">
+          <text value="CP"/>
+        </else-if>
+        <else-if type="standard">
+          <text value="S"/>
+        </else-if>
+        <else-if type="thesis">
+          <text value="D"/>
+        </else-if>
+        <else>
+          <text value="Z"/>
+        </else>
+      </choose>
+      <choose>
+        <if variable="URL DOI" match="any">
           <text value="OL"/>
         </if>
       </choose>
     </group>
   </macro>
-  <citation et-al-min="2" et-al-use-first="1" disambiguate-add-year-suffix="true" disambiguate-add-names="true" disambiguate-add-givenname="true" collapse="year">
-    <sort>
-      <key macro="author-intext"/>
-      <key macro="issue-date-year" sort="ascending"/>
-    </sort>
-    <layout prefix="(" suffix=")" delimiter="; ">
+  <!-- 获取和访问路径以及 DOI -->
+  <macro name="url-doi">
+    <group delimiter=". ">
+      <text variable="URL"/>
+      <text variable="DOI" prefix="DOI:"/>
+    </group>
+  </macro>
+  <!-- 连续出版物的年卷期 -->
+  <macro name="year-volume-issue">
+    <group>
       <group delimiter=", ">
-        <text macro="author-intext"/>
-        <text macro="issue-date-year"/>
-        <group>
-          <label variable="locator" form="short"/>
-          <text variable="locator"/>
+        <text macro="issued-year"/>
+        <text variable="volume"/>
+      </group>
+      <text variable="issue" prefix="(" suffix=")"/>
+    </group>
+  </macro>
+  <!-- 专著和电子资源 -->
+  <macro name="monograph-layout">
+    <group delimiter=". " suffix=".">
+      <text macro="author-date"/>
+      <text macro="title"/>
+      <text macro="secondary-contributor"/>
+      <text macro="edition"/>
+      <text macro="publishing"/>
+      <text macro="url-doi"/>
+    </group>
+  </macro>
+  <!-- 专著中的析出文献 -->
+  <macro name="chapter-in-book-layout">
+    <group delimiter=". " suffix=".">
+      <text macro="author-date"/>
+      <group delimiter="//">
+        <group delimiter=". ">
+          <text macro="title"/>
+          <text macro="secondary-contributor"/>
+        </group>
+        <group delimiter=". ">
+          <text macro="container-author"/>
+          <text macro="container-title"/>
         </group>
       </group>
+      <text macro="edition"/>
+      <text macro="publishing"/>
+      <text macro="url-doi"/>
+    </group>
+  </macro>
+  <!-- 连续出版物 -->
+  <macro name="serial-layout">
+    <group delimiter=". " suffix=".">
+      <text macro="author-date"/>
+      <text macro="title"/>
+      <text macro="year-volume-issue"/>
+      <text macro="publishing"/>
+      <text variable="URL"/>
+      <text variable="DOI" prefix="DOI:"/>
+    </group>
+  </macro>
+  <!-- 连续出版物中的析出文献 -->
+  <macro name="article-in-periodical-layout">
+    <group delimiter=". " suffix=".">
+      <text macro="author-date"/>
+      <text macro="title"/>
+      <text macro="periodical-publishing"/>
+      <text macro="url-doi"/>
+    </group>
+  </macro>
+  <!-- 专利文献 -->
+  <macro name="patent-layout">
+    <group delimiter=". " suffix=".">
+      <text macro="author-date"/>
+      <text macro="title"/>
+      <group>
+        <text macro="issued-date"/>
+        <text macro="accessed-date"/>
+      </group>
+      <text macro="url-doi"/>
+    </group>
+  </macro>
+  <!-- 正文中引用的文献标注格式 -->
+  <macro name="citation-layout">
+    <group>
+      <group delimiter=", ">
+        <text macro="author-intext"/>
+        <text macro="issued-year"/>
+      </group>
+    </group>
+  </macro>
+  <!-- 参考文献表格式 -->
+  <macro name="entry-layout">
+    <choose>
+      <if type="article-journal article-magazine article-newspaper" match="any">
+        <text macro="article-in-periodical-layout"/>
+      </if>
+      <else-if type="periodical">
+        <text macro="serial-layout"/>
+      </else-if>
+      <else-if type="patent">
+        <text macro="patent-layout"/>
+      </else-if>
+      <else-if type="paper-conference" variable="container-title" match="any">
+        <text macro="chapter-in-book-layout"/>
+      </else-if>
+      <else>
+        <text macro="monograph-layout"/>
+      </else>
+    </choose>
+  </macro>
+  <citation et-al-min="2" et-al-use-first="1" disambiguate-add-year-suffix="true" disambiguate-add-names="true" disambiguate-add-givenname="true" givenname-disambiguation-rule="primary-name-with-initials" collapse="year">
+    <!-- 取消这部分注释可以使用 CSL-M 的功能支持双语 -->
+    <!-- <layout prefix="(" suffix=")" delimiter="; " locale="en">
+      <text macro="citation-layout"/>
+    </layout> -->
+    <layout prefix="(" suffix=")" delimiter="; ">
+      <text macro="citation-layout"/>
     </layout>
   </citation>
-  <bibliography entry-spacing="0" et-al-min="4" et-al-use-first="3" line-spacing="1" hanging-indent="true">
+  <bibliography entry-spacing="0" et-al-min="4" et-al-use-first="3" hanging-indent="true">
     <sort>
-      <key macro="author-intext"/>
-      <key macro="issue-date-year" sort="ascending"/>
+      <key macro="author"/>
+      <key macro="issued-year"/>
+      <key variable="title"/>
     </sort>
-    <layout suffix=".">
-      <text macro="author" suffix=", "/>
-      <text macro="issue-date-year" suffix=". "/>
-      <text macro="title"/>
-      <choose>
-        <if type="book bill chapter legislation paper-conference report thesis" match="any">
-          <text macro="editor" prefix=". "/>
-          <choose>
-            <if variable="container-title">
-              <text value="//"/>
-              <text macro="container-author" suffix=". "/>
-              <text variable="container-title" suffix=". " text-case="title"/>
-            </if>
-            <else>
-              <text value=". "/>
-            </else>
-          </choose>
-          <text macro="edition" suffix=". "/>
-          <text macro="publishing"/>
-        </if>
-        <else-if type="article-journal article-magazine article-newspaper" match="any">
-          <group prefix=". ">
-            <choose>
-              <if variable="container-title">
-                <text variable="container-title" text-case="title"/>
-                <text macro="serial-information" prefix=", "/>
-              </if>
-              <else>
-                <text macro="serial-information" suffix=". "/>
-                <text macro="publishing"/>
-              </else>
-            </choose>
-          </group>
-        </else-if>
-        <else-if type="patent">
-          <text macro="issued-date" prefix=". "/>
-        </else-if>
-        <else>
-          <text macro="publishing" prefix=". "/>
-          <text macro="issued-date" prefix="(" suffix=")"/>
-        </else>
-      </choose>
-      <text macro="accessed-date"/>
-      <group delimiter=". " prefix=". ">
-        <text variable="URL"/>
-        <text variable="DOI" prefix="DOI:"/>
-      </group>
+    <!-- 取消这部分注释可以使用 CSL-M 的功能支持双语 -->
+    <!-- <layout locale="en">
+      <text macro="entry-layout"/>
+    </layout> -->
+    <layout>
+      <text macro="entry-layout"/>
     </layout>
   </bibliography>
 </style>

--- a/china-national-standard-gb-t-7714-2015-author-date.csl
+++ b/china-national-standard-gb-t-7714-2015-author-date.csl
@@ -279,7 +279,7 @@
           <choose>
             <if variable="archive">
               <text value="A"/>
-            </if >
+            </if>
             <else>
               <text value="M"/>
             </else>
@@ -445,9 +445,7 @@
   </macro>
   <citation et-al-min="2" et-al-use-first="1" disambiguate-add-year-suffix="true" disambiguate-add-names="true" disambiguate-add-givenname="true" givenname-disambiguation-rule="primary-name-with-initials" collapse="year">
     <!-- 取消这部分注释可以使用 CSL-M 的功能支持双语 -->
-    <!-- <layout prefix="(" suffix=")" delimiter="; " locale="en">
-      <text macro="citation-layout"/>
-    </layout> -->
+    <!-- <layout prefix="(" suffix=")" delimiter="; " locale="en"><text macro="citation-layout"/></layout> -->
     <layout prefix="(" suffix=")" delimiter="; ">
       <text macro="citation-layout"/>
     </layout>
@@ -459,9 +457,7 @@
       <key variable="title"/>
     </sort>
     <!-- 取消这部分注释可以使用 CSL-M 的功能支持双语 -->
-    <!-- <layout locale="en">
-      <text macro="entry-layout"/>
-    </layout> -->
+    <!-- <layout locale="en"><text macro="entry-layout"/></layout> -->
     <layout>
       <text macro="entry-layout"/>
     </layout>

--- a/china-national-standard-gb-t-7714-2015-note.csl
+++ b/china-national-standard-gb-t-7714-2015-note.csl
@@ -1,302 +1,476 @@
 <?xml version="1.0" encoding="utf-8"?>
-<style xmlns="http://purl.org/net/xbiblio/csl" version="1.0" class="note" delimiter-precedes-last="always" demote-non-dropping-particle="never" initialize-with=" " name-delimiter=", " names-delimiter=". " name-as-sort-order="all" sort-separator=" " default-locale="zh-CN">
+<style xmlns="http://purl.org/net/xbiblio/csl" version="1.0" class="note" names-delimiter=". " name-as-sort-order="all" sort-separator=" " demote-non-dropping-particle="never" initialize-with=" " initialize-with-hyphen="false" page-range-format="expanded" default-locale="zh-CN">
   <info>
     <title>China National Standard GB/T 7714-2015 (note, 中文)</title>
-    <title-short>GB/T 7714-2015 (note)</title-short>
     <id>http://www.zotero.org/styles/china-national-standard-gb-t-7714-2015-note</id>
     <link href="http://www.zotero.org/styles/china-national-standard-gb-t-7714-2015-note" rel="self"/>
     <link href="http://www.zotero.org/styles/china-national-standard-gb-t-7714-2015-numeric" rel="template"/>
-    <link href="http://www.std.gov.cn/gb/search/gbDetailed?id=71F772D8055ED3A7E05397BE0A0AB82A" rel="documentation"/>
+    <link href="http://std.samr.gov.cn/gb/search/gbDetailed?id=71F772D8055ED3A7E05397BE0A0AB82A" rel="documentation"/>
     <author>
       <name>牛耕田</name>
       <email>buffalo_d@163.com</email>
     </author>
+    <contributor>
+      <name>Zeping Lee</name>
+      <email>zepinglee@gmail.com</email>
+    </contributor>
     <category citation-format="note"/>
     <category field="generic-base"/>
-    <summary>The Chinese GB/T7714-2015 with notes and bibliography</summary>
-    <updated>2020-03-07T05:07:26+00:00</updated>
+    <summary>The Chinese GB/T 7714-2015 with notes and bibliography</summary>
+    <updated>2022-01-20T00:00:00+08:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale xml:lang="zh-CN">
+    <date form="text">
+      <date-part name="year" suffix="年" range-delimiter="&#8212;"/>
+      <date-part name="month" form="numeric" suffix="月" range-delimiter="&#8212;"/>
+      <date-part name="day" suffix="日" range-delimiter="&#8212;"/>
+    </date>
     <terms>
-      <term name="anonymous">佚名</term>
-      <term name="edition">版</term>
-      <term name="page" form="short">
-        <single>p.</single>
-        <multiple>pp.</multiple>
-      </term>
-      <!-- <term name="container-author" form="verb-short">著</term> -->
+      <term name="edition" form="short">版</term>
+      <term name="open-quote">“</term>
+      <term name="close-quote">”</term>
+      <term name="open-inner-quote">‘</term>
+      <term name="close-inner-quote">’</term>
+      <term name="page" form="short"></term>
     </terms>
   </locale>
-  <macro name="accessed-date">
-    <date variable="accessed" delimiter="&#8211;" prefix="[" suffix="]">
-      <date-part name="year"/>
-      <date-part name="month" form="numeric-leading-zeros"/>
-      <date-part name="day" form="numeric-leading-zeros"/>
+  <locale>
+    <date form="numeric">
+      <date-part name="year" range-delimiter="/"/>
+      <date-part name="month" form="numeric-leading-zeros" prefix="-" range-delimiter="/"/>
+      <date-part name="day" form="numeric-leading-zeros" prefix="-" range-delimiter="/"/>
     </date>
+    <terms>
+      <term name="page-range-delimiter">-</term>
+    </terms>
+  </locale>
+  <!-- 引用日期 -->
+  <macro name="accessed-date">
+    <date variable="accessed" form="numeric" prefix="[" suffix="]"/>
   </macro>
+  <!-- 主要责任者 -->
   <macro name="author">
-    <choose>
-      <if variable="author">
-        <names variable="author">
-          <name>
-            <name-part name="family" text-case="uppercase"/>
-            <name-part name="given"/>
-          </name>
-        </names>
-      </if>
-      <else>
-        <text term="anonymous"/>
-      </else>
-    </choose>
-  </macro>
-  <macro name="container-author">
-    <names variable="container-author reviewed-author">
+    <names variable="author">
       <name>
         <name-part name="family" text-case="uppercase"/>
         <name-part name="given"/>
       </name>
-      <!-- <label form="verb-short" prefix=", "/> -->
-    </names>
-  </macro>
-  <macro name="edition">
-    <choose>
-      <if variable="edition">
-        <group delimiter=" ">
-          <text variable="edition"/>
-          <text term="edition"/>
-        </group>
-      </if>
-    </choose>
-  </macro>
-  <macro name="editor">
-    <names variable="editor translator">
-      <name>
-        <name-part name="family" text-case="uppercase"/>
-        <name-part name="given"/>
-      </name>
-      <label form="verb-short" prefix=", "/>
-    </names>
-  </macro>
-  <macro name="issued-date">
-    <choose>
-      <if variable="issued">
-        <date variable="issued" delimiter="&#8211;">
-          <date-part name="year"/>
-          <date-part name="month" form="numeric-leading-zeros"/>
-          <date-part name="day" form="numeric-leading-zeros"/>
-        </date>
-      </if>
-      <else>
-        <text term="no date" prefix="[" suffix="]"/>
-      </else>
-    </choose>
-  </macro>
-  <macro name="issue-date-year">
-    <choose>
-      <if variable="issued">
-        <date variable="issued" date-parts="year" form="numeric"/>
-      </if>
-      <else>
-        <text term="no date" prefix="[" suffix="]"/>
-      </else>
-    </choose>
-  </macro>
-  <macro name="publishing">
-    <choose>
-      <if variable="publisher">
-        <group delimiter=": ">
-          <text variable="publisher-place"/>
-          <group delimiter=", ">
-            <text variable="publisher"/>
-            <text macro="issue-date-year"/>
-          </group>
-        </group>
+      <substitute>
+        <names variable="composer"/>
+        <names variable="illustrator"/>
+        <names variable="director"/>
         <choose>
-          <if variable="locator">
-            <text variable="locator" prefix=": "/>
+          <if variable="container-title" match="none">
+            <names variable="editor"/>
+          </if>
+        </choose>
+      </substitute>
+    </names>
+  </macro>
+  <!-- 书籍的卷号（“第 x 卷”或“第 x 册”） -->
+  <macro name="book-volume">
+    <choose>
+      <if type="article article-journal article-magazine article-newspaper periodical" match="none">
+        <choose>
+          <if is-numeric="volume">
+            <group delimiter=" ">
+              <label variable="volume" form="short" text-case="capitalize-first"/>
+              <text variable="volume"/>
+            </group>
           </if>
           <else>
-            <text variable="page" prefix=": "/>
+            <text variable="volume"/>
           </else>
         </choose>
       </if>
     </choose>
   </macro>
-  <macro name="serial-information">
-    <group delimiter=", ">
-      <text macro="issue-date-year"/>
-      <text variable="volume"/>
-    </group>
-    <text variable="issue" prefix="(" suffix=")"/>
-    <text variable="page" prefix=": "/>
+  <!-- 专著主要责任者 -->
+  <macro name="container-author">
+    <names variable="editor">
+      <name>
+        <name-part name="family" text-case="uppercase"/>
+        <name-part name="given"/>
+      </name>
+      <substitute>
+        <names variable="editorial-director"/>
+        <names variable="collection-editor"/>
+        <names variable="container-author"/>
+      </substitute>
+    </names>
   </macro>
-  <macro name="type-code">
+  <!-- 专著题名 -->
+  <macro name="container-title">
+    <group delimiter=", ">
+      <group delimiter=": ">
+        <choose>
+          <if variable="container-title">
+            <text variable="container-title"/>
+          </if>
+          <else>
+            <text variable="event"/>
+          </else>
+        </choose>
+        <text macro="book-volume"/>
+      </group>
+      <choose>
+        <if variable="event-date">
+          <date variable="event-date" form="text"/>
+          <text variable="event-place"/>
+        </if>
+      </choose>
+    </group>
+  </macro>
+  <!-- 版本项 -->
+  <macro name="edition">
     <choose>
-      <if type="article-journal article-magazine" match="any">
-        <text value="J"/>
+      <if is-numeric="edition">
+        <group delimiter=" ">
+          <number variable="edition" form="ordinal"/>
+          <text term="edition" form="short"/>
+        </group>
       </if>
-      <else-if type="article-newspaper">
-        <text value="N"/>
-      </else-if>
-      <else-if type="bill legislation" match="any">
-        <text value="S"/>
-      </else-if>
-      <else-if type="book">
-        <text value="M"/>
-      </else-if>
-      <else-if type="chapter">
-        <text value="M"/>
-      </else-if>
-      <else-if type="dataset">
-        <text value="DS"/>
-      </else-if>
-      <else-if type="paper-conference">
-        <text value="C"/>
-      </else-if>
-      <else-if type="patent">
-        <text value="P"/>
-      </else-if>
-      <else-if type="post-weblog webpage" match="any">
-        <text value="EB"/>
-      </else-if>
-      <else-if type="report">
-        <text value="R"/>
-      </else-if>
-      <else-if type="thesis">
-        <text value="D"/>
-      </else-if>
       <else>
-        <text value="Z"/>
+        <text variable="edition"/>
       </else>
     </choose>
   </macro>
+  <!-- 电子资源的更新或修改日期 -->
+  <macro name="issued-date">
+    <date variable="issued" form="numeric"/>
+  </macro>
+  <!-- 出版年 -->
+  <macro name="issued-year">
+    <choose>
+      <if is-uncertain-date="issued">
+        <date variable="issued" prefix="[" suffix="]">
+          <date-part name="year" range-delimiter="-"/>
+        </date>
+      </if>
+      <else>
+        <date variable="issued">
+          <date-part name="year" range-delimiter="-"/>
+        </date>
+      </else>
+    </choose>
+  </macro>
+  <!-- 引文页码 -->
+  <macro name="page">
+    <choose>
+      <if variable="locator">
+        <text variable="locator"/>
+      </if>
+      <else>
+        <text variable="page"/>
+      </else>
+    </choose>
+  </macro>
+  <!-- 专著的出版项 -->
+  <macro name="publishing">
+    <group delimiter=": ">
+      <group delimiter=", ">
+        <group delimiter=": ">
+          <text variable="publisher-place"/>
+          <text variable="publisher"/>
+        </group>
+        <!-- 非电子资源显示“出版年” -->
+        <choose>
+          <if variable="publisher page" type="book chapter paper-conference thesis" match="any">
+            <text macro="issued-year"/>
+          </if>
+          <else-if variable="URL DOI" match="none">
+            <text macro="issued-year"/>
+          </else-if>
+        </choose>
+      </group>
+      <text macro="page"/>
+    </group>
+    <choose>
+      <!-- 纯电子资源显示“更新或修改日期” -->
+      <if variable="publisher page" type="book chapter paper-conference thesis" match="none">
+        <choose>
+          <if variable="URL DOI" match="any">
+            <text macro="issued-date" prefix="(" suffix=")"/>
+          </if>
+        </choose>
+      </if>
+    </choose>
+    <text macro="accessed-date"/>
+  </macro>
+  <!-- 其他责任者 -->
+  <macro name="secondary-contributor">
+    <names variable="translator">
+      <name>
+        <name-part name="family" text-case="uppercase"/>
+        <name-part name="given"/>
+      </name>
+      <label form="short" prefix=", "/>
+    </names>
+  </macro>
+  <!-- 连续出版物中的析出文献的出处项（年、卷、期等信息） -->
+  <macro name="periodical-publishing">
+    <group>
+      <group delimiter=": ">
+        <group>
+          <group delimiter=", ">
+            <text macro="container-title" text-case="title"/>
+            <choose>
+              <if type="article-newspaper">
+                <text macro="issued-date"/>
+              </if>
+              <else>
+                <text macro="issued-year"/>
+              </else>
+            </choose>
+            <text variable="volume"/>
+          </group>
+          <text variable="issue" prefix="(" suffix=")"/>
+        </group>
+        <text macro="page"/>
+      </group>
+      <text macro="accessed-date"/>
+    </group>
+  </macro>
+  <!-- 题名 -->
   <macro name="title">
-    <text variable="title" text-case="title"/>
-    <text variable="number" prefix=": "/>
-    <group delimiter="/" prefix="[" suffix="]">
-      <text macro="type-code"/>
+    <group delimiter=", ">
+      <group delimiter=": ">
+        <text variable="title"/>
+        <group delimiter="&#8195;">
+          <choose>
+            <if variable="container-title" type="paper-conference" match="none">
+              <text macro="book-volume"/>
+            </if>
+          </choose>
+          <choose>
+            <if type="bill legal_case legislation patent regulation report standard" match="any">
+              <text variable="number"/>
+            </if>
+          </choose>
+        </group>
+      </group>
       <choose>
-        <if variable="URL">
+        <if variable="container-title" type="paper-conference" match="none">
+          <choose>
+            <if variable="event-date">
+              <text variable="event-place"/>
+              <date variable="event-date" form="text"/>
+            </if>
+          </choose>
+        </if>
+      </choose>
+    </group>
+    <text macro="type-code" prefix="[" suffix="]"/>
+  </macro>
+  <!-- 文献类型标识 -->
+  <macro name="type-code">
+    <group delimiter="/">
+      <choose>
+        <if type="article">
+          <choose>
+            <if variable="archive">
+              <text value="A"/>
+            </if >
+            <else>
+              <text value="M"/>
+            </else>
+          </choose>
+        </if>
+        <else-if type="article-journal article-magazine periodical" match="any">
+          <text value="J"/>
+        </else-if>
+        <else-if type="article-newspaper">
+          <text value="N"/>
+        </else-if>
+        <else-if type="bill collection legal_case legislation regulation" match="any">
+          <text value="A"/>
+        </else-if>
+        <else-if type="book chapter" match="any">
+          <text value="M"/>
+        </else-if>
+        <else-if type="dataset">
+          <text value="DS"/>
+        </else-if>
+        <else-if type="map">
+          <text value="CM"/>
+        </else-if>
+        <else-if type="paper-conference">
+          <text value="C"/>
+        </else-if>
+        <else-if type="patent">
+          <text value="P"/>
+        </else-if>
+        <else-if type="post post-weblog webpage" match="any">
+          <text value="EB"/>
+        </else-if>
+        <else-if type="report">
+          <text value="R"/>
+        </else-if>
+        <else-if type="software">
+          <text value="CP"/>
+        </else-if>
+        <else-if type="standard">
+          <text value="S"/>
+        </else-if>
+        <else-if type="thesis">
+          <text value="D"/>
+        </else-if>
+        <else>
+          <text value="Z"/>
+        </else>
+      </choose>
+      <choose>
+        <if variable="URL DOI" match="any">
           <text value="OL"/>
         </if>
       </choose>
     </group>
   </macro>
-  <citation et-al-min="4" et-al-use-first="3" disambiguate-add-names="true">
-    <layout suffix="." delimiter="; ">
-      <choose>
-        <if position="ibid-with-locator">
-          <text term="ibid"/>
-          <label variable="locator" form="short"/>
-          <text variable="locator"/>
-        </if>
-        <else-if position="ibid">
-          <text term="ibid"/>
-        </else-if>
-        <else-if position="subsequent">
-          <text variable="first-reference-note-number" prefix="同【" suffix="】"/>
-          <label variable="locator" form="short"/>
-          <text variable="locator"/>
-        </else-if>
-        <else>
-          <text macro="author" suffix=". "/>
+  <!-- 获取和访问路径以及 DOI -->
+  <macro name="url-doi">
+    <group delimiter=". ">
+      <text variable="URL"/>
+      <text variable="DOI" prefix="DOI:"/>
+    </group>
+  </macro>
+  <!-- 连续出版物的年卷期 -->
+  <macro name="year-volume-issue">
+    <group>
+      <group delimiter=", ">
+        <text macro="issued-year"/>
+        <text variable="volume"/>
+      </group>
+      <text variable="issue" prefix="(" suffix=")"/>
+    </group>
+  </macro>
+  <!-- 专著和电子资源 -->
+  <macro name="monograph-layout">
+    <group delimiter=". " suffix=".">
+      <text macro="author"/>
+      <text macro="title"/>
+      <text macro="secondary-contributor"/>
+      <text macro="edition"/>
+      <text macro="publishing"/>
+      <text macro="url-doi"/>
+    </group>
+  </macro>
+  <!-- 专著中的析出文献 -->
+  <macro name="chapter-in-book-layout">
+    <group delimiter=". " suffix=".">
+      <text macro="author"/>
+      <group delimiter="//">
+        <group delimiter=". ">
           <text macro="title"/>
-          <choose>
-            <if type="book bill chapter legislation paper-conference report thesis" match="any">
-              <text macro="editor" prefix=". "/>
-              <choose>
-                <if variable="container-title">
-                  <text value="//"/>
-                  <text macro="container-author" suffix=". "/>
-                  <text variable="container-title" suffix=". " text-case="title"/>
-                </if>
-                <else>
-                  <text value=". "/>
-                </else>
-              </choose>
-              <text macro="edition" suffix=". "/>
-              <text macro="publishing"/>
-            </if>
-            <else-if type="article-journal article-magazine article-newspaper" match="any">
-              <group prefix=". ">
-                <choose>
-                  <if variable="container-title">
-                    <text variable="container-title" text-case="title"/>
-                    <text macro="serial-information" prefix=", "/>
-                  </if>
-                  <else>
-                    <text macro="serial-information" suffix=". "/>
-                    <text macro="publishing"/>
-                  </else>
-                </choose>
-              </group>
-            </else-if>
-            <else-if type="patent">
-              <text macro="issued-date" prefix=". "/>
-            </else-if>
-            <else>
-              <text macro="publishing" prefix=". "/>
-              <text macro="issued-date" prefix="(" suffix=")"/>
-            </else>
-          </choose>
-          <text macro="accessed-date"/>
-          <group delimiter=". " prefix=". ">
-            <text variable="URL"/>
-            <text variable="DOI" prefix="DOI:"/>
+          <text macro="secondary-contributor"/>
+        </group>
+        <group delimiter=". ">
+          <text macro="container-author"/>
+          <text macro="container-title"/>
+        </group>
+      </group>
+      <text macro="edition"/>
+      <text macro="publishing"/>
+      <text macro="url-doi"/>
+    </group>
+  </macro>
+  <!-- 连续出版物 -->
+  <macro name="serial-layout">
+    <group delimiter=". " suffix=".">
+      <text macro="author"/>
+      <text macro="title"/>
+      <text macro="year-volume-issue"/>
+      <text macro="publishing"/>
+      <text variable="URL"/>
+      <text variable="DOI" prefix="DOI:"/>
+    </group>
+  </macro>
+  <!-- 连续出版物中的析出文献 -->
+  <macro name="article-in-periodical-layout">
+    <group delimiter=". " suffix=".">
+      <text macro="author"/>
+      <text macro="title"/>
+      <text macro="periodical-publishing"/>
+      <text macro="url-doi"/>
+    </group>
+  </macro>
+  <!-- 专利文献 -->
+  <macro name="patent-layout">
+    <group delimiter=". " suffix=".">
+      <text macro="author"/>
+      <text macro="title"/>
+      <group>
+        <text macro="issued-date"/>
+        <text macro="accessed-date"/>
+      </group>
+      <text macro="url-doi"/>
+    </group>
+  </macro>
+  <!-- 正文中引用的文献标注格式 -->
+  <macro name="citation-layout">
+    <choose>
+      <if position="ibid-with-locator">
+        <text term="ibid"/>
+        <label variable="locator" form="short"/>
+        <text variable="locator"/>
+      </if>
+      <else-if position="ibid">
+        <text term="ibid"/>
+      </else-if>
+      <else-if position="subsequent">
+        <!-- 国标要求提供的示例中脚注编号是用圈码，在 CSL 中无法实现 -->
+        <!-- 这里改为用冒号隔开编号和页码 -->
+        <group delimiter=": ">
+          <text variable="first-reference-note-number" prefix="同"/>
+          <group delimiter=" ">
+            <label variable="locator" form="short"/>
+            <text variable="locator"/>
           </group>
-        </else>
-      </choose>
+        </group>
+      </else-if>
+      <else>
+        <text macro="entry-layout"/>
+      </else>
+    </choose>
+  </macro>
+  <!-- 参考文献表格式 -->
+  <macro name="entry-layout">
+    <choose>
+      <if type="article-journal article-magazine article-newspaper" match="any">
+        <text macro="article-in-periodical-layout"/>
+      </if>
+      <else-if type="periodical">
+        <text macro="serial-layout"/>
+      </else-if>
+      <else-if type="patent">
+        <text macro="patent-layout"/>
+      </else-if>
+      <else-if type="paper-conference" variable="container-title" match="any">
+        <text macro="chapter-in-book-layout"/>
+      </else-if>
+      <else>
+        <text macro="monograph-layout"/>
+      </else>
+    </choose>
+  </macro>
+  <citation et-al-min="4" et-al-use-first="3" disambiguate-add-names="true">
+    <!-- 取消这部分注释可以使用 CSL-M 的功能支持双语 -->
+    <!-- <layout delimiter="; " locale="en">
+      <text macro="citation-layout"/>
+    </layout> -->
+    <layout suffix="." delimiter="; ">
+      <text macro="citation-layout"/>
     </layout>
   </citation>
-  <bibliography entry-spacing="0" et-al-min="4" et-al-use-first="3" line-spacing="1" second-field-align="flush">
-    <layout suffix=".">
+  <bibliography entry-spacing="0" et-al-min="4" et-al-use-first="3" second-field-align="flush">
+    <!-- 取消这部分注释可以使用 CSL-M 的功能支持双语 -->
+    <!-- <layout locale="en">
       <text variable="citation-number" prefix="[" suffix="]"/>
-      <text macro="author" suffix=". "/>
-      <text macro="title"/>
-      <choose>
-        <if type="book bill chapter legislation paper-conference report thesis" match="any">
-          <text macro="editor" prefix=". "/>
-          <choose>
-            <if variable="container-title">
-              <text value="//"/>
-              <text macro="container-author" suffix=". "/>
-              <text variable="container-title" suffix=". " text-case="title"/>
-            </if>
-            <else>
-              <text value=". "/>
-            </else>
-          </choose>
-          <text macro="edition" suffix=". "/>
-          <text macro="publishing"/>
-        </if>
-        <else-if type="article-journal article-magazine article-newspaper" match="any">
-          <group prefix=". ">
-            <choose>
-              <if variable="container-title">
-                <text variable="container-title" text-case="title"/>
-                <text macro="serial-information" prefix=", "/>
-              </if>
-              <else>
-                <text macro="serial-information" suffix=". "/>
-                <text macro="publishing"/>
-              </else>
-            </choose>
-          </group>
-        </else-if>
-        <else-if type="patent">
-          <text macro="issued-date" prefix=". "/>
-        </else-if>
-        <else>
-          <text macro="publishing" prefix=". "/>
-          <text macro="issued-date" prefix="(" suffix=")"/>
-        </else>
-      </choose>
-      <text macro="accessed-date"/>
-      <group delimiter=". " prefix=". ">
-        <text variable="URL"/>
-        <text variable="DOI" prefix="DOI:"/>
-      </group>
+      <text macro="entry-layout"/>
+    </layout> -->
+    <layout>
+      <text variable="citation-number" prefix="[" suffix="]"/>
+      <text macro="entry-layout"/>
     </layout>
   </bibliography>
 </style>

--- a/china-national-standard-gb-t-7714-2015-note.csl
+++ b/china-national-standard-gb-t-7714-2015-note.csl
@@ -32,7 +32,7 @@
       <term name="close-quote">”</term>
       <term name="open-inner-quote">‘</term>
       <term name="close-inner-quote">’</term>
-      <term name="page" form="short"></term>
+      <term name="page" form="short"/>
     </terms>
   </locale>
   <locale>
@@ -271,7 +271,7 @@
           <choose>
             <if variable="archive">
               <text value="A"/>
-            </if >
+            </if>
             <else>
               <text value="M"/>
             </else>
@@ -455,19 +455,14 @@
   </macro>
   <citation et-al-min="4" et-al-use-first="3" disambiguate-add-names="true">
     <!-- 取消这部分注释可以使用 CSL-M 的功能支持双语 -->
-    <!-- <layout delimiter="; " locale="en">
-      <text macro="citation-layout"/>
-    </layout> -->
+    <!-- <layout delimiter="; " locale="en"><text macro="citation-layout"/></layout> -->
     <layout suffix="." delimiter="; ">
       <text macro="citation-layout"/>
     </layout>
   </citation>
   <bibliography entry-spacing="0" et-al-min="4" et-al-use-first="3" second-field-align="flush">
     <!-- 取消这部分注释可以使用 CSL-M 的功能支持双语 -->
-    <!-- <layout locale="en">
-      <text variable="citation-number" prefix="[" suffix="]"/>
-      <text macro="entry-layout"/>
-    </layout> -->
+    <!-- <layout locale="en"><text variable="citation-number" prefix="[" suffix="]"/><text macro="entry-layout"/></layout> -->
     <layout>
       <text variable="citation-number" prefix="[" suffix="]"/>
       <text macro="entry-layout"/>

--- a/china-national-standard-gb-t-7714-2015-numeric.csl
+++ b/china-national-standard-gb-t-7714-2015-numeric.csl
@@ -258,7 +258,7 @@
           <choose>
             <if variable="archive">
               <text value="A"/>
-            </if >
+            </if>
             <else>
               <text value="M"/>
             </else>
@@ -426,10 +426,7 @@
   </citation>
   <bibliography entry-spacing="0" et-al-min="4" et-al-use-first="3" second-field-align="flush">
     <!-- 取消这部分注释可以使用 CSL-M 的功能支持双语 -->
-    <!-- <layout locale="en">
-      <text variable="citation-number" prefix="[" suffix="]"/>
-      <text macro="entry-layout"/>
-    </layout> -->
+    <!-- <layout locale="en"><text variable="citation-number" prefix="[" suffix="]"/><text macro="entry-layout"/></layout> -->
     <layout>
       <text variable="citation-number" prefix="[" suffix="]"/>
       <text macro="entry-layout"/>

--- a/china-national-standard-gb-t-7714-2015-numeric.csl
+++ b/china-national-standard-gb-t-7714-2015-numeric.csl
@@ -1,73 +1,193 @@
 <?xml version="1.0" encoding="utf-8"?>
-<style xmlns="http://purl.org/net/xbiblio/csl" version="1.0" class="in-text" default-locale="zh-CN" delimiter-precedes-last="always" demote-non-dropping-particle="never" initialize-with=" " name-delimiter=", " names-delimiter=". " name-as-sort-order="all" sort-separator=" ">
+<style xmlns="http://purl.org/net/xbiblio/csl" version="1.0" class="in-text" names-delimiter=". " name-as-sort-order="all" sort-separator=" " demote-non-dropping-particle="never" initialize-with=" " initialize-with-hyphen="false" page-range-format="expanded" default-locale="zh-CN">
   <info>
     <title>China National Standard GB/T 7714-2015 (numeric, 中文)</title>
-    <title-short>GB/T 7714-2015</title-short>
     <id>http://www.zotero.org/styles/china-national-standard-gb-t-7714-2015-numeric</id>
     <link href="http://www.zotero.org/styles/china-national-standard-gb-t-7714-2015-numeric" rel="self"/>
-    <link href="http://www.std.gov.cn/gb/search/gbDetailed?id=71F772D8055ED3A7E05397BE0A0AB82A" rel="documentation"/>
+    <link href="http://std.samr.gov.cn/gb/search/gbDetailed?id=71F772D8055ED3A7E05397BE0A0AB82A" rel="documentation"/>
     <author>
       <name>牛耕田</name>
       <email>buffalo_d@163.com</email>
     </author>
+    <contributor>
+      <name>Zeping Lee</name>
+      <email>zepinglee@gmail.com</email>
+    </contributor>
     <category citation-format="numeric"/>
     <category field="generic-base"/>
-    <summary>The Chinese GB/T7714-2015 numeric style</summary>
-    <updated>2021-11-25T18:00:00+08:00</updated>
+    <summary>The Chinese GB/T 7714-2015 numeric style</summary>
+    <updated>2022-01-20T00:00:00+08:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale xml:lang="zh-CN">
+    <date form="text">
+      <date-part name="year" suffix="年" range-delimiter="&#8212;"/>
+      <date-part name="month" form="numeric" suffix="月" range-delimiter="&#8212;"/>
+      <date-part name="day" suffix="日" range-delimiter="&#8212;"/>
+    </date>
     <terms>
-      <term name="anonymous">佚名</term>
-      <term name="edition">版</term>
-      <term name="page" form="short">
-        <single>p.</single>
-        <multiple>pp.</multiple>
-      </term>
+      <term name="edition" form="short">版</term>
+      <term name="open-quote">“</term>
+      <term name="close-quote">”</term>
+      <term name="open-inner-quote">‘</term>
+      <term name="close-inner-quote">’</term>
     </terms>
   </locale>
-  <macro name="accessed-date">
-    <date variable="accessed" delimiter="&#8211;" prefix="[" suffix="]">
-      <date-part name="year"/>
-      <date-part name="month" form="numeric-leading-zeros"/>
-      <date-part name="day" form="numeric-leading-zeros"/>
+  <locale>
+    <date form="numeric">
+      <date-part name="year" range-delimiter="/"/>
+      <date-part name="month" form="numeric-leading-zeros" prefix="-" range-delimiter="/"/>
+      <date-part name="day" form="numeric-leading-zeros" prefix="-" range-delimiter="/"/>
     </date>
+    <terms>
+      <term name="page-range-delimiter">-</term>
+    </terms>
+  </locale>
+  <!-- 引用日期 -->
+  <macro name="accessed-date">
+    <date variable="accessed" form="numeric" prefix="[" suffix="]"/>
   </macro>
+  <!-- 主要责任者 -->
   <macro name="author">
-    <choose>
-      <if variable="author">
-        <names variable="author">
-          <name>
-            <name-part name="family" text-case="uppercase"/>
-            <name-part name="given"/>
-          </name>
-        </names>
-      </if>
-      <else>
-        <text term="anonymous"/>
-      </else>
-    </choose>
-  </macro>
-  <macro name="container-author">
-    <names variable="container-author">
+    <names variable="author">
       <name>
         <name-part name="family" text-case="uppercase"/>
         <name-part name="given"/>
       </name>
+      <substitute>
+        <names variable="composer"/>
+        <names variable="illustrator"/>
+        <names variable="director"/>
+        <choose>
+          <if variable="container-title" match="none">
+            <names variable="editor"/>
+          </if>
+        </choose>
+      </substitute>
     </names>
   </macro>
-  <macro name="edition">
+  <!-- 书籍的卷号（“第 x 卷”或“第 x 册”） -->
+  <macro name="book-volume">
     <choose>
-      <if variable="edition">
-        <group delimiter=" ">
-          <text variable="edition"/>
-          <text term="edition"/>
-        </group>
+      <if type="article article-journal article-magazine article-newspaper periodical" match="none">
+        <choose>
+          <if is-numeric="volume">
+            <group delimiter=" ">
+              <label variable="volume" form="short" text-case="capitalize-first"/>
+              <text variable="volume"/>
+            </group>
+          </if>
+          <else>
+            <text variable="volume"/>
+          </else>
+        </choose>
       </if>
     </choose>
   </macro>
-  <macro name="editor">
-    <names variable="editor translator">
+  <!-- 专著主要责任者 -->
+  <macro name="container-author">
+    <names variable="editor">
+      <name>
+        <name-part name="family" text-case="uppercase"/>
+        <name-part name="given"/>
+      </name>
+      <substitute>
+        <names variable="editorial-director"/>
+        <names variable="collection-editor"/>
+        <names variable="container-author"/>
+      </substitute>
+    </names>
+  </macro>
+  <!-- 专著题名 -->
+  <macro name="container-title">
+    <group delimiter=", ">
+      <group delimiter=": ">
+        <choose>
+          <if variable="container-title">
+            <text variable="container-title"/>
+          </if>
+          <else>
+            <text variable="event"/>
+          </else>
+        </choose>
+        <text macro="book-volume"/>
+      </group>
+      <choose>
+        <if variable="event-date">
+          <date variable="event-date" form="text"/>
+          <text variable="event-place"/>
+        </if>
+      </choose>
+    </group>
+  </macro>
+  <!-- 版本项 -->
+  <macro name="edition">
+    <choose>
+      <if is-numeric="edition">
+        <group delimiter=" ">
+          <number variable="edition" form="ordinal"/>
+          <text term="edition" form="short"/>
+        </group>
+      </if>
+      <else>
+        <text variable="edition"/>
+      </else>
+    </choose>
+  </macro>
+  <!-- 电子资源的更新或修改日期 -->
+  <macro name="issued-date">
+    <date variable="issued" form="numeric"/>
+  </macro>
+  <!-- 出版年 -->
+  <macro name="issued-year">
+    <choose>
+      <if is-uncertain-date="issued">
+        <date variable="issued" prefix="[" suffix="]">
+          <date-part name="year" range-delimiter="-"/>
+        </date>
+      </if>
+      <else>
+        <date variable="issued">
+          <date-part name="year" range-delimiter="-"/>
+        </date>
+      </else>
+    </choose>
+  </macro>
+  <!-- 专著的出版项 -->
+  <macro name="publishing">
+    <group delimiter=": ">
+      <group delimiter=", ">
+        <group delimiter=": ">
+          <text variable="publisher-place"/>
+          <text variable="publisher"/>
+        </group>
+        <!-- 非电子资源显示“出版年” -->
+        <choose>
+          <if variable="publisher page" type="book chapter paper-conference thesis" match="any">
+            <text macro="issued-year"/>
+          </if>
+          <else-if variable="URL DOI" match="none">
+            <text macro="issued-year"/>
+          </else-if>
+        </choose>
+      </group>
+      <text variable="page"/>
+    </group>
+    <choose>
+      <!-- 纯电子资源显示“更新或修改日期” -->
+      <if variable="publisher page" type="book chapter paper-conference thesis" match="none">
+        <choose>
+          <if variable="URL DOI" match="any">
+            <text macro="issued-date" prefix="(" suffix=")"/>
+          </if>
+        </choose>
+      </if>
+    </choose>
+    <text macro="accessed-date"/>
+  </macro>
+  <!-- 其他责任者 -->
+  <macro name="secondary-contributor">
+    <names variable="translator">
       <name>
         <name-part name="family" text-case="uppercase"/>
         <name-part name="given"/>
@@ -75,168 +195,244 @@
       <label form="short" prefix=", "/>
     </names>
   </macro>
-  <macro name="issued-date">
-    <choose>
-      <if variable="issued">
-        <date variable="issued" delimiter="&#8211;">
-          <date-part name="year"/>
-          <date-part name="month" form="numeric-leading-zeros"/>
-          <date-part name="day" form="numeric-leading-zeros"/>
-        </date>
-      </if>
-      <else>
-        <text term="no date" prefix="[" suffix="]"/>
-      </else>
-    </choose>
-  </macro>
-  <macro name="issue-date-year">
-    <choose>
-      <if variable="issued">
-        <date variable="issued" date-parts="year" form="numeric"/>
-      </if>
-      <else>
-        <text term="no date" prefix="[" suffix="]"/>
-      </else>
-    </choose>
-  </macro>
-  <macro name="publishing">
-    <choose>
-      <if variable="publisher">
-        <group delimiter=": ">
-          <text variable="publisher-place"/>
+  <!-- 连续出版物中的析出文献的出处项（年、卷、期等信息） -->
+  <macro name="periodical-publishing">
+    <group>
+      <group delimiter=": ">
+        <group>
           <group delimiter=", ">
-            <text variable="publisher"/>
-            <text macro="issue-date-year"/>
+            <text macro="container-title" text-case="title"/>
+            <choose>
+              <if type="article-newspaper">
+                <text macro="issued-date"/>
+              </if>
+              <else>
+                <text macro="issued-year"/>
+              </else>
+            </choose>
+            <text variable="volume"/>
           </group>
+          <text variable="issue" prefix="(" suffix=")"/>
         </group>
-        <text variable="page" prefix=": "/>
-      </if>
-    </choose>
-  </macro>
-  <macro name="serial-information">
-    <group delimiter=", ">
-      <text macro="issue-date-year"/>
-      <text variable="volume"/>
+        <text variable="page"/>
+      </group>
+      <text macro="accessed-date"/>
     </group>
-    <text variable="issue" prefix="(" suffix=")"/>
-    <text variable="page" prefix=": "/>
   </macro>
-  <macro name="type-code">
-    <choose>
-      <if type="article-journal article-magazine" match="any">
-        <text value="J"/>
-      </if>
-      <else-if type="article-newspaper">
-        <text value="N"/>
-      </else-if>
-      <else-if type="bill legislation" match="any">
-        <text value="S"/>
-      </else-if>
-      <else-if type="book">
-        <text value="M"/>
-      </else-if>
-      <else-if type="chapter">
-        <text value="M"/>
-      </else-if>
-      <else-if type="dataset">
-        <text value="DS"/>
-      </else-if>
-      <else-if type="paper-conference">
-        <text value="C"/>
-      </else-if>
-      <else-if type="patent">
-        <text value="P"/>
-      </else-if>
-      <else-if type="post-weblog webpage" match="any">
-        <text value="EB"/>
-      </else-if>
-      <else-if type="report">
-        <text value="R"/>
-      </else-if>
-      <else-if type="thesis">
-        <text value="D"/>
-      </else-if>
-      <else>
-        <text value="Z"/>
-      </else>
-    </choose>
-  </macro>
+  <!-- 题名 -->
   <macro name="title">
-    <text variable="title" text-case="title"/>
-    <choose>
-        <if type="bill broadcast legal_case legislation patent report song" match="any">
-          <text variable="number" prefix=": "/>
-        </if>
-    </choose>
-    <group delimiter="/" prefix="[" suffix="]">
-      <text macro="type-code"/>
+    <group delimiter=", ">
+      <group delimiter=": ">
+        <text variable="title"/>
+        <group delimiter="&#8195;">
+          <choose>
+            <if variable="container-title" type="paper-conference" match="none">
+              <text macro="book-volume"/>
+            </if>
+          </choose>
+          <choose>
+            <if type="bill legal_case legislation patent regulation report standard" match="any">
+              <text variable="number"/>
+            </if>
+          </choose>
+        </group>
+      </group>
       <choose>
-        <if variable="URL">
+        <if variable="container-title" type="paper-conference" match="none">
+          <choose>
+            <if variable="event-date">
+              <text variable="event-place"/>
+              <date variable="event-date" form="text"/>
+            </if>
+          </choose>
+        </if>
+      </choose>
+    </group>
+    <text macro="type-code" prefix="[" suffix="]"/>
+  </macro>
+  <!-- 文献类型标识 -->
+  <macro name="type-code">
+    <group delimiter="/">
+      <choose>
+        <if type="article">
+          <choose>
+            <if variable="archive">
+              <text value="A"/>
+            </if >
+            <else>
+              <text value="M"/>
+            </else>
+          </choose>
+        </if>
+        <else-if type="article-journal article-magazine periodical" match="any">
+          <text value="J"/>
+        </else-if>
+        <else-if type="article-newspaper">
+          <text value="N"/>
+        </else-if>
+        <else-if type="bill collection legal_case legislation regulation" match="any">
+          <text value="A"/>
+        </else-if>
+        <else-if type="book chapter" match="any">
+          <text value="M"/>
+        </else-if>
+        <else-if type="dataset">
+          <text value="DS"/>
+        </else-if>
+        <else-if type="map">
+          <text value="CM"/>
+        </else-if>
+        <else-if type="paper-conference">
+          <text value="C"/>
+        </else-if>
+        <else-if type="patent">
+          <text value="P"/>
+        </else-if>
+        <else-if type="post post-weblog webpage" match="any">
+          <text value="EB"/>
+        </else-if>
+        <else-if type="report">
+          <text value="R"/>
+        </else-if>
+        <else-if type="software">
+          <text value="CP"/>
+        </else-if>
+        <else-if type="standard">
+          <text value="S"/>
+        </else-if>
+        <else-if type="thesis">
+          <text value="D"/>
+        </else-if>
+        <else>
+          <text value="Z"/>
+        </else>
+      </choose>
+      <choose>
+        <if variable="URL DOI" match="any">
           <text value="OL"/>
         </if>
       </choose>
     </group>
   </macro>
-  <citation collapse="citation-number" after-collapse-delimiter=",">
-    <sort>
-      <key variable="citation-number" sort="ascending"/>
-    </sort>
-    <layout vertical-align="sup" delimiter="," prefix="[" suffix="]">
-      <text variable="citation-number"/>
-      <group prefix="(" suffix=")">
-        <label variable="locator" suffix=". " form="short" strip-periods="true"/>
-        <text variable="locator"/>
+  <!-- 获取和访问路径以及 DOI -->
+  <macro name="url-doi">
+    <group delimiter=". ">
+      <text variable="URL"/>
+      <text variable="DOI" prefix="DOI:"/>
+    </group>
+  </macro>
+  <!-- 连续出版物的年卷期 -->
+  <macro name="year-volume-issue">
+    <group>
+      <group delimiter=", ">
+        <text macro="issued-year"/>
+        <text variable="volume"/>
       </group>
+      <text variable="issue" prefix="(" suffix=")"/>
+    </group>
+  </macro>
+  <!-- 专著和电子资源 -->
+  <macro name="monograph-layout">
+    <group delimiter=". " suffix=".">
+      <text macro="author"/>
+      <text macro="title"/>
+      <text macro="secondary-contributor"/>
+      <text macro="edition"/>
+      <text macro="publishing"/>
+      <text macro="url-doi"/>
+    </group>
+  </macro>
+  <!-- 专著中的析出文献 -->
+  <macro name="chapter-in-book-layout">
+    <group delimiter=". " suffix=".">
+      <text macro="author"/>
+      <group delimiter="//">
+        <group delimiter=". ">
+          <text macro="title"/>
+          <text macro="secondary-contributor"/>
+        </group>
+        <group delimiter=". ">
+          <text macro="container-author"/>
+          <text macro="container-title"/>
+        </group>
+      </group>
+      <text macro="edition"/>
+      <text macro="publishing"/>
+      <text macro="url-doi"/>
+    </group>
+  </macro>
+  <!-- 连续出版物 -->
+  <macro name="serial-layout">
+    <group delimiter=". " suffix=".">
+      <text macro="author"/>
+      <text macro="title"/>
+      <text macro="year-volume-issue"/>
+      <text macro="publishing"/>
+      <text variable="URL"/>
+      <text variable="DOI" prefix="DOI:"/>
+    </group>
+  </macro>
+  <!-- 连续出版物中的析出文献 -->
+  <macro name="article-in-periodical-layout">
+    <group delimiter=". " suffix=".">
+      <text macro="author"/>
+      <text macro="title"/>
+      <text macro="periodical-publishing"/>
+      <text macro="url-doi"/>
+    </group>
+  </macro>
+  <!-- 专利文献 -->
+  <macro name="patent-layout">
+    <group delimiter=". " suffix=".">
+      <text macro="author"/>
+      <text macro="title"/>
+      <group>
+        <text macro="issued-date"/>
+        <text macro="accessed-date"/>
+      </group>
+      <text macro="url-doi"/>
+    </group>
+  </macro>
+  <!-- 正文中引用的文献标注格式 -->
+  <macro name="citation-layout">
+    <group>
+      <text variable="citation-number"/>
+    </group>
+  </macro>
+  <!-- 参考文献表格式 -->
+  <macro name="entry-layout">
+    <choose>
+      <if type="article-journal article-magazine article-newspaper" match="any">
+        <text macro="article-in-periodical-layout"/>
+      </if>
+      <else-if type="periodical">
+        <text macro="serial-layout"/>
+      </else-if>
+      <else-if type="patent">
+        <text macro="patent-layout"/>
+      </else-if>
+      <else-if type="paper-conference" variable="container-title" match="any">
+        <text macro="chapter-in-book-layout"/>
+      </else-if>
+      <else>
+        <text macro="monograph-layout"/>
+      </else>
+    </choose>
+  </macro>
+  <citation collapse="citation-number" after-collapse-delimiter=",">
+    <layout vertical-align="sup" delimiter="," prefix="[" suffix="]">
+      <text macro="citation-layout"/>
     </layout>
   </citation>
-  <bibliography entry-spacing="0" et-al-min="4" et-al-use-first="3" line-spacing="1" second-field-align="flush">
-    <layout suffix=".">
+  <bibliography entry-spacing="0" et-al-min="4" et-al-use-first="3" second-field-align="flush">
+    <!-- 取消这部分注释可以使用 CSL-M 的功能支持双语 -->
+    <!-- <layout locale="en">
       <text variable="citation-number" prefix="[" suffix="]"/>
-      <text macro="author" suffix=". "/>
-      <text macro="title"/>
-      <choose>
-        <if type="book bill chapter legislation paper-conference report thesis" match="any">
-          <text macro="editor" prefix=". "/>
-          <choose>
-            <if variable="container-title">
-              <text value="//"/>
-              <text macro="container-author" suffix=". "/>
-              <text variable="container-title" suffix=". " text-case="title"/>
-            </if>
-            <else>
-              <text value=". "/>
-            </else>
-          </choose>
-          <text macro="edition" suffix=". "/>
-          <text macro="publishing"/>
-        </if>
-        <else-if type="article-journal article-magazine article-newspaper" match="any">
-          <group prefix=". ">
-            <choose>
-              <if variable="container-title">
-                <text variable="container-title" text-case="title"/>
-                <text macro="serial-information" prefix=", "/>
-              </if>
-              <else>
-                <text macro="serial-information" suffix=". "/>
-                <text macro="publishing"/>
-              </else>
-            </choose>
-          </group>
-        </else-if>
-        <else-if type="patent">
-          <text macro="issued-date" prefix=". "/>
-        </else-if>
-        <else>
-          <text macro="publishing" prefix=". "/>
-          <text macro="issued-date" prefix="(" suffix=")"/>
-        </else>
-      </choose>
-      <text macro="accessed-date"/>
-      <group delimiter=". " prefix=". ">
-        <text variable="URL"/>
-        <text variable="DOI" prefix="DOI:"/>
-      </group>
+      <text macro="entry-layout"/>
+    </layout> -->
+    <layout>
+      <text variable="citation-number" prefix="[" suffix="]"/>
+      <text macro="entry-layout"/>
     </layout>
   </bibliography>
 </style>

--- a/chinese-gb7714-2005-author-date.csl
+++ b/chinese-gb7714-2005-author-date.csl
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
-<style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" demote-non-dropping-particle="sort-only" default-locale="zh-CN">
+<style xmlns="http://purl.org/net/xbiblio/csl" version="1.0" class="in-text" names-delimiter=". " name-as-sort-order="all" sort-separator=" " demote-non-dropping-particle="never" initialize-with=" " initialize-with-hyphen="false" page-range-format="expanded" default-locale="zh-CN">
   <info>
     <title>China National Standard GB/T 7714-2005 (author-date, 中文)</title>
     <id>http://www.zotero.org/styles/chinese-gb7714-2005-author-date</id>
     <link href="http://www.zotero.org/styles/chinese-gb7714-2005-author-date" rel="self"/>
-    <link href="http://www.zotero.org/styles/chinese-gb7714-2005-numeric" rel="template"/>
-    <link href="http://gradschool.ustc.edu.cn/ylb/material/xw/wdxz/19.pdf" rel="documentation"/>
+    <link href="http://www.zotero.org/styles/china-national-standard-gb-t-7714-2015-author-date" rel="template"/>
+    <link href="http://std.samr.gov.cn/gb/search/gbDetailed?id=71F772D78562D3A7E05397BE0A0AB82A" rel="documentation"/>
     <author>
       <name>heromyth</name>
       <email>zxpmyth@yahoo.com.cn</email>
@@ -14,203 +14,475 @@
       <name>Kristene Collins</name>
       <uri>http://www.mendeley.com/profiles/kristene-collins1/</uri>
     </contributor>
+    <contributor>
+      <name>Zeping Lee</name>
+      <email>zepinglee@gmail.com</email>
+    </contributor>
     <category citation-format="author-date"/>
     <category field="generic-base"/>
-    <summary>This style just partly implemented what the Chinese GB/T 7714-2005 requires.</summary>
-    <updated>2014-02-27T02:27:29+00:00</updated>
+    <summary>The Chinese GB/T 7714-2005 author-date style</summary>
+    <updated>2022-01-20T00:00:00+08:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
+  <locale xml:lang="zh-CN">
+    <date form="text">
+      <date-part name="year" suffix="年" range-delimiter="&#8212;"/>
+      <date-part name="month" form="numeric" suffix="月" range-delimiter="&#8212;"/>
+      <date-part name="day" suffix="日" range-delimiter="&#8212;"/>
+    </date>
+    <terms>
+      <term name="anonymous" form="short">佚名</term>
+      <term name="edition" form="short">版</term>
+      <term name="open-quote">“</term>
+      <term name="close-quote">”</term>
+      <term name="open-inner-quote">‘</term>
+      <term name="close-inner-quote">’</term>
+    </terms>
+  </locale>
+  <locale>
+    <date form="numeric">
+      <date-part name="year" range-delimiter="/"/>
+      <date-part name="month" form="numeric-leading-zeros" prefix="-" range-delimiter="/"/>
+      <date-part name="day" form="numeric-leading-zeros" prefix="-" range-delimiter="/"/>
+    </date>
+    <terms>
+      <term name="page-range-delimiter">-</term>
+    </terms>
+  </locale>
+  <!-- 引用日期 -->
+  <macro name="accessed-date">
+    <date variable="accessed" form="numeric" prefix="[" suffix="]"/>
+  </macro>
+  <macro name="anon">
+    <text term="anonymous" form="short" text-case="capitalize-first" strip-periods="true"/>
+  </macro>
+  <!-- 主要责任者 -->
   <macro name="author">
-    <names variable="author" suffix="，">
-      <name initialize-with=" " name-as-sort-order="all" sort-separator=" " delimiter=", " delimiter-precedes-last="always">
+    <names variable="author">
+      <name>
+        <name-part name="family" text-case="uppercase"/>
+        <name-part name="given"/>
+      </name>
+      <substitute>
+        <names variable="composer"/>
+        <names variable="illustrator"/>
+        <names variable="director"/>
+        <choose>
+          <if variable="container-title" match="none">
+            <names variable="editor"/>
+          </if>
+        </choose>
+        <text macro="anon"/>
+      </substitute>
+    </names>
+  </macro>
+  <!-- 参考文献表的著者姓名与出版年 -->
+  <macro name="author-date">
+    <group delimiter=". ">
+      <text macro="author"/>
+      <text macro="issued-year"/>
+    </group>
+  </macro>
+  <!-- 正文引用的著者姓名 -->
+  <macro name="author-intext">
+    <names variable="author">
+      <!-- 国标 10.2.2 节要求姓氏与“et al.”“等”之间留适当空隙 -->
+      <name form="short" delimiter="&#160;" delimiter-precedes-et-al="always">
         <name-part name="family" text-case="uppercase"/>
       </name>
+      <substitute>
+        <names variable="composer"/>
+        <names variable="illustrator"/>
+        <names variable="director"/>
+        <choose>
+          <if variable="container-title" match="none">
+            <names variable="editor"/>
+          </if>
+        </choose>
+        <text macro="anon"/>
+      </substitute>
     </names>
   </macro>
-  <macro name="recipient">
-    <names variable="recipient">
-      <name name-as-sort-order="all" sort-separator=" " delimiter=", " delimiter-precedes-last="always"/>
-      <label form="short" prefix=", " text-case="lowercase"/>
-    </names>
-  </macro>
-  <macro name="interviewer">
-    <names variable="interviewer">
-      <name name-as-sort-order="all" sort-separator=" " delimiter=", " delimiter-precedes-last="always"/>
-      <label form="short" prefix=", " text-case="lowercase"/>
-    </names>
-  </macro>
-  <macro name="composer">
-    <names variable="composer">
-      <name name-as-sort-order="all" sort-separator=" " delimiter=", " delimiter-precedes-last="always"/>
-      <label form="short" prefix=", " text-case="lowercase"/>
-    </names>
-  </macro>
-  <macro name="original-author">
-    <names variable="original-author">
-      <name name-as-sort-order="all" sort-separator=" " delimiter=", " delimiter-precedes-last="always"/>
-      <label form="short" prefix=", " text-case="lowercase"/>
-    </names>
-  </macro>
-  <macro name="title">
-    <text variable="title"/>
-  </macro>
-  <macro name="titleField">
+  <!-- 书籍的卷号（“第 x 卷”或“第 x 册”） -->
+  <macro name="book-volume">
     <choose>
-      <if type="report">
-        <text macro="title" suffix="[R]. "/>
+      <if type="article article-journal article-magazine article-newspaper periodical" match="none">
+        <choose>
+          <if is-numeric="volume">
+            <group delimiter=" ">
+              <label variable="volume" form="short" text-case="capitalize-first"/>
+              <text variable="volume"/>
+            </group>
+          </if>
+          <else>
+            <text variable="volume"/>
+          </else>
+        </choose>
       </if>
-      <else-if type="thesis">
-        <text macro="title" suffix="[D]. "/>
-      </else-if>
-      <else-if type="bill legislation" match="any">
-        <text variable="number" suffix=", "/>
-        <text macro="title" suffix="[S]"/>
-      </else-if>
-      <else-if type="bill book graphic legal_case legislation motion_picture report song" match="any">
-        <text macro="title" suffix="[M]. "/>
-      </else-if>
-      <else-if type="paper-conference">
-        <text macro="title" suffix="[C]//"/>
-      </else-if>
-      <else-if type="chapter paper-conference" match="any">
-        <text macro="title" suffix="[G]//"/>
-      </else-if>
-      <else-if type="webpage">
-        <text macro="title" suffix="[EB/OL]. "/>
-      </else-if>
-      <else-if type="patent">
-        <text macro="title"/>
-        <text variable="number" prefix=": 中国, " suffix="[P].  "/>
-      </else-if>
-      <else>
-        <text macro="title" suffix="[J]. "/>
-      </else>
     </choose>
   </macro>
-  <macro name="secondaryAuthor">
+  <!-- 专著主要责任者 -->
+  <macro name="container-author">
     <names variable="editor">
-      <name initialize-with=" " name-as-sort-order="all" sort-separator=" " delimiter=", " delimiter-precedes-last="always">
+      <name>
         <name-part name="family" text-case="uppercase"/>
+        <name-part name="given"/>
       </name>
-    </names>
-    <names variable="translator">
-      <name name-as-sort-order="all" sort-separator=" " delimiter=", " delimiter-precedes-last="always" suffix=", 译"/>
+      <substitute>
+        <names variable="editorial-director"/>
+        <names variable="collection-editor"/>
+        <names variable="container-author"/>
+      </substitute>
     </names>
   </macro>
-  <macro name="publisher">
-    <choose>
-      <if type="chapter paper-conference" match="any">
-        <text variable="container-title" suffix=". "/>
-      </if>
-      <else-if type="report">
-        <text variable="collection-title" suffix=", "/>
-        <text variable="number" suffix=", "/>
-      </else-if>
-      <else-if type="bill legislation" match="any">
-        <text variable="container-title" prefix=". "/>
-      </else-if>
-      <else>
-        <text variable="container-title" suffix=", "/>
-      </else>
-    </choose>
-    <text variable="publisher-place" suffix=": "/>
+  <!-- 专著题名 -->
+  <macro name="container-title">
     <group delimiter=", ">
-      <text variable="publisher"/>
+      <group delimiter=": ">
+        <choose>
+          <if variable="container-title">
+            <text variable="container-title"/>
+          </if>
+          <else>
+            <text variable="event"/>
+          </else>
+        </choose>
+        <text macro="book-volume"/>
+      </group>
       <choose>
-        <if type="webpage" variable="container-title" match="all">
-          <date variable="issued" suffix=". ">
-            <date-part name="year"/>
-            <date-part name="month" form="numeric-leading-zeros" prefix="-"/>
-            <date-part name="day" form="numeric-leading-zeros" prefix="-"/>
-          </date>
+        <if variable="event-date">
+          <date variable="event-date" form="text"/>
+          <text variable="event-place"/>
         </if>
-        <else-if type="webpage"/>
-        <else-if type="patent">
-          <date variable="issued">
-            <date-part name="year"/>
-            <date-part name="month" form="numeric-leading-zeros" prefix="-"/>
-            <date-part name="day" form="numeric-leading-zeros" prefix="-"/>
-          </date>
-        </else-if>
-        <else-if variable="publisher">
-          <date variable="issued">
-            <date-part name="year"/>
-          </date>
-        </else-if>
-        <else-if type="bill legislation" match="any"/>
-        <else>
-          <date variable="issued">
-            <date-part name="year"/>
-          </date>
-        </else>
       </choose>
     </group>
-    <text variable="volume" prefix=", "/>
-    <text variable="issue" prefix="(" suffix=")"/>
   </macro>
-  <macro name="pageField">
-    <text variable="page"/>
-  </macro>
-  <macro name="referenceDate">
+  <!-- 版本项 -->
+  <macro name="edition">
     <choose>
-      <if type="webpage">
-        <date variable="issued" prefix="(" suffix=")">
-          <date-part name="year"/>
-          <date-part name="month" form="numeric-leading-zeros" prefix="-"/>
-          <date-part name="day" form="numeric-leading-zeros" prefix="-"/>
-        </date>
-        <date variable="accessed" prefix="[" suffix="]">
-          <date-part name="year"/>
-          <date-part name="month" form="numeric-leading-zeros" prefix="-"/>
-          <date-part name="day" form="numeric-leading-zeros" prefix="-"/>
-        </date>
+      <if is-numeric="edition">
+        <group delimiter=" ">
+          <number variable="edition" form="ordinal"/>
+          <text term="edition" form="short"/>
+        </group>
       </if>
+      <else>
+        <text variable="edition"/>
+      </else>
     </choose>
   </macro>
-  <macro name="access">
+  <!-- 电子资源的更新或修改日期 -->
+  <macro name="issued-date">
+    <date variable="issued" form="numeric"/>
+  </macro>
+  <!-- 出版年 -->
+  <macro name="issued-year">
     <choose>
-      <if variable="DOI">
-        <text variable="DOI" prefix="doi:"/>
+      <if is-uncertain-date="issued">
+        <date variable="issued" prefix="[" suffix="]">
+          <date-part name="year" range-delimiter="-"/>
+        </date>
       </if>
-      <else-if variable="URL">
-        <text variable="URL"/>
-      </else-if>
+      <else>
+        <date variable="issued">
+          <date-part name="year" range-delimiter="-"/>
+        </date>
+      </else>
     </choose>
   </macro>
-  <citation collapse="citation-number">
-    <sort>
-      <key variable="citation-label"/>
-    </sort>
-    <layout vertical-align="baseline" delimiter="；" prefix="（" suffix="）">
+  <!-- 专著的出版项 -->
+  <macro name="publishing">
+    <group delimiter=": ">
+      <group delimiter=", ">
+        <group delimiter=": ">
+          <text variable="publisher-place"/>
+          <text variable="publisher"/>
+        </group>
+      </group>
+      <text variable="page"/>
+    </group>
+    <choose>
+      <!-- 纯电子资源显示“更新或修改日期” -->
+      <if variable="publisher page" type="book chapter paper-conference thesis" match="none">
+        <choose>
+          <if variable="URL DOI" match="any">
+            <text macro="issued-date" prefix="(" suffix=")"/>
+          </if>
+        </choose>
+      </if>
+    </choose>
+    <text macro="accessed-date"/>
+  </macro>
+  <!-- 其他责任者 -->
+  <macro name="secondary-contributor">
+    <names variable="translator">
+      <name>
+        <name-part name="family" text-case="uppercase"/>
+        <name-part name="given"/>
+      </name>
+      <label form="short" prefix=", "/>
+    </names>
+  </macro>
+  <!-- 连续出版物中的析出文献的出处项（年、卷、期等信息） -->
+  <macro name="periodical-publishing">
+    <group>
+      <group delimiter=": ">
+        <group>
+          <group delimiter=", ">
+            <text macro="container-title" text-case="title"/>
+            <choose>
+              <if type="article-newspaper">
+                <text macro="issued-date"/>
+              </if>
+            </choose>
+            <text variable="volume"/>
+          </group>
+          <text variable="issue" prefix="(" suffix=")"/>
+        </group>
+        <text variable="page"/>
+      </group>
+      <text macro="accessed-date"/>
+    </group>
+  </macro>
+  <!-- 题名 -->
+  <macro name="title">
+    <group delimiter=", ">
+      <group delimiter=": ">
+        <text variable="title"/>
+        <group delimiter="&#8195;">
+          <choose>
+            <if variable="container-title" type="paper-conference" match="none">
+              <text macro="book-volume"/>
+            </if>
+          </choose>
+          <choose>
+            <if type="patent">
+              <group delimiter=", ">
+                <choose>
+                  <!-- 专利的国别应使用 `jurisdiction`，但 Zotero 没有对应的域，所以 `publisher-place` 作为备选 -->
+                  <if variable="jurisdiction">
+                    <text variable="jurisdiction"/>
+                  </if>
+                  <else>
+                    <text variable="publisher-place"/>
+                  </else>
+                </choose>
+                <text variable="number"/>
+              </group>
+            </if>
+            <else-if type="bill legal_case legislation regulation report standard" match="any">
+              <text variable="number"/>
+            </else-if>
+          </choose>
+        </group>
+      </group>
       <choose>
-        <if match="all" variable="author">
-          <text macro="author"/>
+        <if variable="container-title" type="paper-conference" match="none">
+          <choose>
+            <if variable="event-date">
+              <text variable="event-place"/>
+              <date variable="event-date" form="text"/>
+            </if>
+          </choose>
         </if>
-        <else-if match="all" variable="title">
-          <text macro="title" suffix="，"/>
-        </else-if>
       </choose>
-      <date date-parts="year" form="numeric" variable="issued"/>
+    </group>
+    <text macro="type-code" prefix="[" suffix="]"/>
+  </macro>
+  <!-- 文献类型标识 -->
+  <macro name="type-code">
+    <group delimiter="/">
+      <choose>
+        <if type="article">
+          <choose>
+            <if variable="archive">
+              <text value="A"/>
+            </if >
+            <else>
+              <text value="M"/>
+            </else>
+          </choose>
+        </if>
+        <else-if type="article-journal article-magazine periodical" match="any">
+          <text value="J"/>
+        </else-if>
+        <else-if type="article-newspaper">
+          <text value="N"/>
+        </else-if>
+        <else-if type="book chapter" match="any">
+          <text value="M"/>
+        </else-if>
+        <else-if type="dataset">
+          <text value="DB"/>
+        </else-if>
+        <else-if type="paper-conference">
+          <text value="C"/>
+        </else-if>
+        <else-if type="patent">
+          <text value="P"/>
+        </else-if>
+        <else-if type="post post-weblog webpage" match="any">
+          <text value="EB"/>
+        </else-if>
+        <else-if type="report">
+          <text value="R"/>
+        </else-if>
+        <else-if type="software">
+          <text value="CP"/>
+        </else-if>
+        <else-if type="standard">
+          <text value="S"/>
+        </else-if>
+        <else-if type="thesis">
+          <text value="D"/>
+        </else-if>
+        <else-if variable="URL">
+          <text value="EB"/>
+        </else-if>
+        <else>
+          <text value="M"/>
+        </else>
+      </choose>
+      <choose>
+        <if variable="URL DOI" match="any">
+          <text value="OL"/>
+        </if>
+      </choose>
+    </group>
+  </macro>
+  <!-- 获取和访问路径以及 DOI -->
+  <macro name="url-doi">
+    <choose>
+      <if variable="URL">
+        <text variable="URL"/>
+      </if>
+      <else>
+        <text variable="DOI" prefix="https://doi.org/"/>
+      </else>
+    </choose>
+  </macro>
+  <!-- 连续出版物的年卷期 -->
+  <macro name="year-volume-issue">
+    <group>
+      <group delimiter=", ">
+        <text macro="issued-year"/>
+        <text variable="volume"/>
+      </group>
+      <text variable="issue" prefix="(" suffix=")"/>
+    </group>
+  </macro>
+  <!-- 专著和电子资源 -->
+  <macro name="monograph-layout">
+    <group delimiter=". " suffix=".">
+      <text macro="author-date"/>
+      <text macro="title"/>
+      <text macro="secondary-contributor"/>
+      <text macro="edition"/>
+      <text macro="publishing"/>
+      <text macro="url-doi"/>
+    </group>
+  </macro>
+  <!-- 专著中的析出文献 -->
+  <macro name="chapter-in-book-layout">
+    <group delimiter=". " suffix=".">
+      <text macro="author-date"/>
+      <group delimiter="//">
+        <group delimiter=". ">
+          <text macro="title"/>
+          <text macro="secondary-contributor"/>
+        </group>
+        <group delimiter=". ">
+          <text macro="container-author"/>
+          <text macro="container-title"/>
+        </group>
+      </group>
+      <text macro="edition"/>
+      <text macro="publishing"/>
+      <text macro="url-doi"/>
+    </group>
+  </macro>
+  <!-- 连续出版物 -->
+  <macro name="serial-layout">
+    <group delimiter=". " suffix=".">
+      <text macro="author-date"/>
+      <text macro="title"/>
+      <text macro="year-volume-issue"/>
+      <text macro="publishing"/>
+      <text variable="URL"/>
+      <text variable="DOI" prefix="DOI:"/>
+    </group>
+  </macro>
+  <!-- 连续出版物中的析出文献 -->
+  <macro name="article-in-periodical-layout">
+    <group delimiter=". " suffix=".">
+      <text macro="author-date"/>
+      <text macro="title"/>
+      <text macro="periodical-publishing"/>
+      <text macro="url-doi"/>
+    </group>
+  </macro>
+  <!-- 专利文献 -->
+  <macro name="patent-layout">
+    <group delimiter=". " suffix=".">
+      <text macro="author-date"/>
+      <text macro="title"/>
+      <group>
+        <text macro="issued-date"/>
+        <text macro="accessed-date"/>
+      </group>
+      <text macro="url-doi"/>
+    </group>
+  </macro>
+  <!-- 正文中引用的文献标注格式 -->
+  <macro name="citation-layout">
+    <group>
+      <group delimiter=", ">
+        <text macro="author-intext"/>
+        <text macro="issued-year"/>
+      </group>
+    </group>
+  </macro>
+  <!-- 参考文献表格式 -->
+  <macro name="entry-layout">
+    <choose>
+      <if type="article-journal article-magazine article-newspaper" match="any">
+        <text macro="article-in-periodical-layout"/>
+      </if>
+      <else-if type="periodical">
+        <text macro="serial-layout"/>
+      </else-if>
+      <else-if type="patent">
+        <text macro="patent-layout"/>
+      </else-if>
+      <else-if type="paper-conference" variable="container-title" match="any">
+        <text macro="chapter-in-book-layout"/>
+      </else-if>
+      <else>
+        <text macro="monograph-layout"/>
+      </else>
+    </choose>
+  </macro>
+  <citation et-al-min="2" et-al-use-first="1" disambiguate-add-year-suffix="true" disambiguate-add-names="true" disambiguate-add-givenname="true" givenname-disambiguation-rule="primary-name-with-initials" collapse="year">
+    <!-- 取消这部分注释可以使用 CSL-M 的功能支持双语 -->
+    <!-- <layout prefix="(" suffix=")" delimiter="; " locale="en">
+      <text macro="citation-layout"/>
+    </layout> -->
+    <layout prefix="(" suffix=")" delimiter="; ">
+      <text macro="citation-layout"/>
     </layout>
   </citation>
-  <bibliography et-al-min="4" et-al-use-first="3" second-field-align="flush" entry-spacing="0">
-    <layout suffix=".">
-      <text macro="author" suffix=". "/>
-      <text macro="titleField"/>
-      <text macro="secondaryAuthor" suffix=". "/>
-      <text variable="edition" prefix="第" suffix="版. "/>
-      <text macro="publisher"/>
-      <text macro="pageField" prefix=": "/>
-      <text macro="referenceDate"/>
-      <choose>
-        <if type="webpage" match="any">
-          <text macro="access" prefix=". "/>
-        </if>
-      </choose>
-      <text macro="recipient"/>
-      <text macro="interviewer"/>
-      <text macro="composer"/>
-      <text macro="original-author"/>
+  <bibliography entry-spacing="0" et-al-min="4" et-al-use-first="3" hanging-indent="true">
+    <sort>
+      <key macro="author"/>
+      <key macro="issued-year"/>
+      <key variable="title"/>
+    </sort>
+    <!-- 取消这部分注释可以使用 CSL-M 的功能支持双语 -->
+    <!-- <layout locale="en">
+      <text macro="entry-layout"/>
+    </layout> -->
+    <layout>
+      <text macro="entry-layout"/>
     </layout>
   </bibliography>
 </style>

--- a/chinese-gb7714-2005-author-date.csl
+++ b/chinese-gb7714-2005-author-date.csl
@@ -297,7 +297,7 @@
           <choose>
             <if variable="archive">
               <text value="A"/>
-            </if >
+            </if>
             <else>
               <text value="M"/>
             </else>
@@ -464,9 +464,7 @@
   </macro>
   <citation et-al-min="2" et-al-use-first="1" disambiguate-add-year-suffix="true" disambiguate-add-names="true" disambiguate-add-givenname="true" givenname-disambiguation-rule="primary-name-with-initials" collapse="year">
     <!-- 取消这部分注释可以使用 CSL-M 的功能支持双语 -->
-    <!-- <layout prefix="(" suffix=")" delimiter="; " locale="en">
-      <text macro="citation-layout"/>
-    </layout> -->
+    <!-- <layout prefix="(" suffix=")" delimiter="; " locale="en"><text macro="citation-layout"/></layout> -->
     <layout prefix="(" suffix=")" delimiter="; ">
       <text macro="citation-layout"/>
     </layout>
@@ -478,9 +476,7 @@
       <key variable="title"/>
     </sort>
     <!-- 取消这部分注释可以使用 CSL-M 的功能支持双语 -->
-    <!-- <layout locale="en">
-      <text macro="entry-layout"/>
-    </layout> -->
+    <!-- <layout locale="en"><text macro="entry-layout"/></layout> -->
     <layout>
       <text macro="entry-layout"/>
     </layout>

--- a/chinese-gb7714-2005-numeric.csl
+++ b/chinese-gb7714-2005-numeric.csl
@@ -1,215 +1,454 @@
 <?xml version="1.0" encoding="utf-8"?>
-<style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" demote-non-dropping-particle="sort-only" default-locale="zh-CN">
+<style xmlns="http://purl.org/net/xbiblio/csl" version="1.0" class="in-text" names-delimiter=". " name-as-sort-order="all" sort-separator=" " demote-non-dropping-particle="never" initialize-with=" " initialize-with-hyphen="false" page-range-format="expanded" default-locale="zh-CN">
   <info>
     <title>China National Standard GB/T 7714-2005 (numeric, 中文)</title>
     <id>http://www.zotero.org/styles/chinese-gb7714-2005-numeric</id>
     <link href="http://www.zotero.org/styles/chinese-gb7714-2005-numeric" rel="self"/>
+    <link href="http://www.zotero.org/styles/china-national-standard-gb-t-7714-2015-numeric" rel="template"/>
     <link href="http://std.samr.gov.cn/gb/search/gbDetailed?id=71F772D78562D3A7E05397BE0A0AB82A" rel="documentation"/>
     <author>
       <name>heromyth</name>
       <email>zxpmyth@yahoo.com.cn</email>
     </author>
+    <contributor>
+      <name>Zeping Lee</name>
+      <email>zepinglee@gmail.com</email>
+    </contributor>
     <category citation-format="numeric"/>
-    <category field="engineering"/>
     <category field="generic-base"/>
-    <category field="science"/>
-    <summary>This style just partly implemented what the Chinese GB/T 7714-2005 requires.</summary>
-    <updated>2021-11-21T09:38:41+00:00</updated>
+    <summary>The Chinese GB/T 7714-2005 numeric style</summary>
+    <updated>2022-01-20T00:00:00+08:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
+  <locale xml:lang="zh-CN">
+    <date form="text">
+      <date-part name="year" suffix="年" range-delimiter="&#8212;"/>
+      <date-part name="month" form="numeric" suffix="月" range-delimiter="&#8212;"/>
+      <date-part name="day" suffix="日" range-delimiter="&#8212;"/>
+    </date>
+    <terms>
+      <term name="edition" form="short">版</term>
+      <term name="open-quote">“</term>
+      <term name="close-quote">”</term>
+      <term name="open-inner-quote">‘</term>
+      <term name="close-inner-quote">’</term>
+    </terms>
+  </locale>
+  <locale>
+    <date form="numeric">
+      <date-part name="year" range-delimiter="/"/>
+      <date-part name="month" form="numeric-leading-zeros" prefix="-" range-delimiter="/"/>
+      <date-part name="day" form="numeric-leading-zeros" prefix="-" range-delimiter="/"/>
+    </date>
+    <terms>
+      <term name="page-range-delimiter">-</term>
+    </terms>
+  </locale>
+  <!-- 引用日期 -->
+  <macro name="accessed-date">
+    <date variable="accessed" form="numeric" prefix="[" suffix="]"/>
+  </macro>
+  <!-- 主要责任者 -->
   <macro name="author">
     <names variable="author">
-      <name initialize-with=" " name-as-sort-order="all" sort-separator=" " delimiter=", " delimiter-precedes-last="always">
+      <name>
         <name-part name="family" text-case="uppercase"/>
+        <name-part name="given"/>
       </name>
-    </names>
-  </macro>
-  <macro name="recipient">
-    <names variable="recipient">
-      <name name-as-sort-order="all" sort-separator=" " delimiter=", " delimiter-precedes-last="always"/>
-      <label form="short" prefix=", " text-case="lowercase"/>
-    </names>
-  </macro>
-  <macro name="interviewer">
-    <names variable="interviewer">
-      <name name-as-sort-order="all" sort-separator=" " delimiter=", " delimiter-precedes-last="always"/>
-      <label form="short" prefix=", " text-case="lowercase"/>
-    </names>
-  </macro>
-  <macro name="composer">
-    <names variable="composer">
-      <name name-as-sort-order="all" sort-separator=" " delimiter=", " delimiter-precedes-last="always"/>
-      <label form="short" prefix=", " text-case="lowercase"/>
-    </names>
-  </macro>
-  <macro name="original-author">
-    <names variable="original-author">
-      <name name-as-sort-order="all" sort-separator=" " delimiter=", " delimiter-precedes-last="always"/>
-      <label form="short" prefix=", " text-case="lowercase"/>
-    </names>
-  </macro>
-  <macro name="title">
-    <text variable="title"/>
-  </macro>
-  <macro name="titleField">
-    <choose>
-      <if type="report">
-        <text macro="title" suffix="[R]. "/>
-      </if>
-      <else-if type="thesis">
-        <text macro="title" suffix="[D]. "/>
-      </else-if>
-      <else-if type="bill legislation" match="any">
-        <text variable="number" suffix=", "/>
-        <text macro="title" suffix="[S]"/>
-      </else-if>
-      <else-if type="bill book graphic legal_case legislation motion_picture report song" match="any">
-        <text macro="title" suffix="[M]. "/>
-      </else-if>
-      <else-if type="paper-conference">
-        <text macro="title" suffix="[C]//"/>
-      </else-if>
-      <else-if type="chapter paper-conference" match="any">
-        <text macro="title" suffix="[G]//"/>
-      </else-if>
-      <else-if type="webpage">
-        <text macro="title" suffix="[EB/OL]. "/>
-      </else-if>
-      <else-if type="patent">
-        <text macro="title"/>
-        <text variable="number" prefix=": 中国, " suffix="[P].  "/>
-      </else-if>
-      <else>
-        <text macro="title" suffix="[J]. "/>
-      </else>
-    </choose>
-  </macro>
-  <macro name="secondaryAuthor">
-    <names variable="editor">
-      <name initialize-with=" " name-as-sort-order="all" sort-separator=" " delimiter=", " delimiter-precedes-last="always">
-        <name-part name="family" text-case="uppercase"/>
-      </name>
-    </names>
-    <names variable="translator">
-      <name name-as-sort-order="all" sort-separator=" " delimiter=", " delimiter-precedes-last="always" suffix=", 译"/>
-    </names>
-  </macro>
-  <macro name="publisher">
-    <choose>
-      <if type="chapter paper-conference" match="any">
-        <text variable="container-title" suffix=". "/>
-      </if>
-      <else-if type="report">
-        <text variable="collection-title" suffix=", "/>
-        <text variable="number" suffix=", "/>
-      </else-if>
-      <else-if type="bill legislation" match="any">
-        <text variable="container-title" prefix=". "/>
-      </else-if>
-      <else>
-        <text variable="container-title" suffix=", "/>
-      </else>
-    </choose>
-    <!--
-
-<text variable="event" suffix="event "/>
-<text variable="event-place" suffix="event-place "/>
-<text variable="original-title" suffix="original-title"/>
-
- -->
-    <text variable="publisher-place" suffix=": "/>
-    <group delimiter=", ">
-       <choose>
-          <if type="bill book chapter graphic legal_case legislation motion_picture paper-conference report song" match="any">
-            <text variable="publisher"/>
+      <substitute>
+        <names variable="composer"/>
+        <names variable="illustrator"/>
+        <names variable="director"/>
+        <choose>
+          <if variable="container-title" match="none">
+            <names variable="editor"/>
           </if>
-        <else-if type="webpage" variable="container-title" match="all">
-          <date variable="issued" suffix=". ">
-            <date-part name="year"/>
-            <date-part name="month" form="numeric-leading-zeros" prefix="-"/>
-            <date-part name="day" form="numeric-leading-zeros" prefix="-"/>
-          </date>
-        </else-if>
-        <else-if type="webpage"/>
-        <else-if type="patent">
-          <date variable="issued">
-            <date-part name="year"/>
-            <date-part name="month" form="numeric-leading-zeros" prefix="-"/>
-            <date-part name="day" form="numeric-leading-zeros" prefix="-"/>
-          </date>
-        </else-if>
-        <else-if variable="publisher">
-          <date variable="issued">
-            <date-part name="year"/>
-          </date>
-        </else-if>
-        <else-if type="bill legislation" match="any"/>
-        <else>
-          <date variable="issued">
-            <date-part name="year"/>
-          </date>
-        </else>
-      </choose>
-    </group>
-    <text variable="volume" prefix=", "/>
-    <text variable="issue" prefix="(" suffix=")"/>
+        </choose>
+      </substitute>
+    </names>
   </macro>
-  <macro name="pageField">
-    <text variable="page"/>
-  </macro>
-  <macro name="referenceDate">
+  <!-- 书籍的卷号（“第 x 卷”或“第 x 册”） -->
+  <macro name="book-volume">
     <choose>
-      <if type="webpage">
-        <date variable="issued" prefix="(" suffix=")">
-          <date-part name="year"/>
-          <date-part name="month" form="numeric-leading-zeros" prefix="-"/>
-          <date-part name="day" form="numeric-leading-zeros" prefix="-"/>
-        </date>
-        <date variable="accessed" prefix="[" suffix="]">
-          <date-part name="year"/>
-          <date-part name="month" form="numeric-leading-zeros" prefix="-"/>
-          <date-part name="day" form="numeric-leading-zeros" prefix="-"/>
-        </date>
+      <if type="article article-journal article-magazine article-newspaper periodical" match="none">
+        <choose>
+          <if is-numeric="volume">
+            <group delimiter=" ">
+              <label variable="volume" form="short" text-case="capitalize-first"/>
+              <text variable="volume"/>
+            </group>
+          </if>
+          <else>
+            <text variable="volume"/>
+          </else>
+        </choose>
       </if>
     </choose>
   </macro>
-  <macro name="access">
-    <choose>
-      <if variable="DOI">
-        <text variable="DOI" prefix="doi:"/>
-      </if>
-      <else-if variable="URL">
-        <text variable="URL"/>
-      </else-if>
-    </choose>
+  <!-- 专著主要责任者 -->
+  <macro name="container-author">
+    <names variable="editor">
+      <name>
+        <name-part name="family" text-case="uppercase"/>
+        <name-part name="given"/>
+      </name>
+      <substitute>
+        <names variable="editorial-director"/>
+        <names variable="collection-editor"/>
+        <names variable="container-author"/>
+      </substitute>
+    </names>
   </macro>
-  <citation collapse="citation-number">
-    <sort>
-      <key variable="citation-number" sort="ascending"/>
-    </sort>
-    <layout vertical-align="sup" prefix="[" suffix="]" delimiter=",">
-      <text variable="citation-number"/>
-    </layout>
-  </citation>
-  <bibliography et-al-min="4" et-al-use-first="3" second-field-align="flush" entry-spacing="0">
-    <layout suffix=".">
-      <text variable="citation-number" prefix="[" suffix="]"/>
-      <text macro="author" suffix=". "/>
-      <text macro="titleField"/>
-      <text macro="secondaryAuthor" suffix=". "/>
-      <text variable="edition" prefix="第" suffix="版. "/>
-      <text macro="publisher"/>
-      <text macro="pageField" prefix=": "/>
-      <text macro="referenceDate"/>
+  <!-- 专著题名 -->
+  <macro name="container-title">
+    <group delimiter=", ">
+      <group delimiter=": ">
+        <choose>
+          <if variable="container-title">
+            <text variable="container-title"/>
+          </if>
+          <else>
+            <text variable="event"/>
+          </else>
+        </choose>
+        <text macro="book-volume"/>
+      </group>
       <choose>
-        <if type="webpage" match="any">
-          <text macro="access" prefix=". "/>
+        <if variable="event-date">
+          <date variable="event-date" form="text"/>
+          <text variable="event-place"/>
         </if>
       </choose>
-      <text macro="recipient"/>
-      <text macro="interviewer"/>
-      <text macro="composer"/>
-      <text macro="original-author"/>
+    </group>
+  </macro>
+  <!-- 版本项 -->
+  <macro name="edition">
+    <choose>
+      <if is-numeric="edition">
+        <group delimiter=" ">
+          <number variable="edition" form="ordinal"/>
+          <text term="edition" form="short"/>
+        </group>
+      </if>
+      <else>
+        <text variable="edition"/>
+      </else>
+    </choose>
+  </macro>
+  <!-- 电子资源的更新或修改日期 -->
+  <macro name="issued-date">
+    <date variable="issued" form="numeric"/>
+  </macro>
+  <!-- 出版年 -->
+  <macro name="issued-year">
+    <choose>
+      <if is-uncertain-date="issued">
+        <date variable="issued" prefix="[" suffix="]">
+          <date-part name="year" range-delimiter="-"/>
+        </date>
+      </if>
+      <else>
+        <date variable="issued">
+          <date-part name="year" range-delimiter="-"/>
+        </date>
+      </else>
+    </choose>
+  </macro>
+  <!-- 专著的出版项 -->
+  <macro name="publishing">
+    <group delimiter=": ">
+      <group delimiter=", ">
+        <group delimiter=": ">
+          <text variable="publisher-place"/>
+          <text variable="publisher"/>
+        </group>
+        <!-- 非电子资源显示“出版年” -->
+        <choose>
+          <if variable="publisher page" type="book chapter paper-conference thesis" match="any">
+            <text macro="issued-year"/>
+          </if>
+          <else-if variable="URL DOI" match="none">
+            <text macro="issued-year"/>
+          </else-if>
+        </choose>
+      </group>
+      <text variable="page"/>
+    </group>
+    <choose>
+      <!-- 纯电子资源显示“更新或修改日期” -->
+      <if variable="publisher page" type="book chapter paper-conference thesis" match="none">
+        <choose>
+          <if variable="URL DOI" match="any">
+            <text macro="issued-date" prefix="(" suffix=")"/>
+          </if>
+        </choose>
+      </if>
+    </choose>
+    <text macro="accessed-date"/>
+  </macro>
+  <!-- 其他责任者 -->
+  <macro name="secondary-contributor">
+    <names variable="translator">
+      <name>
+        <name-part name="family" text-case="uppercase"/>
+        <name-part name="given"/>
+      </name>
+      <label form="short" prefix=", "/>
+    </names>
+  </macro>
+  <!-- 连续出版物中的析出文献的出处项（年、卷、期等信息） -->
+  <macro name="periodical-publishing">
+    <group>
+      <group delimiter=": ">
+        <group>
+          <group delimiter=", ">
+            <text macro="container-title" text-case="title"/>
+            <choose>
+              <if type="article-newspaper">
+                <text macro="issued-date"/>
+              </if>
+              <else>
+                <text macro="issued-year"/>
+              </else>
+            </choose>
+            <text variable="volume"/>
+          </group>
+          <text variable="issue" prefix="(" suffix=")"/>
+        </group>
+        <text variable="page"/>
+      </group>
+      <text macro="accessed-date"/>
+    </group>
+  </macro>
+  <!-- 题名 -->
+  <macro name="title">
+    <group delimiter=", ">
+      <group delimiter=": ">
+        <text variable="title"/>
+        <group delimiter="&#8195;">
+          <choose>
+            <if variable="container-title" type="paper-conference" match="none">
+              <text macro="book-volume"/>
+            </if>
+          </choose>
+          <choose>
+            <if type="patent">
+              <group delimiter=", ">
+                <choose>
+                  <!-- 专利的国别应使用 `jurisdiction`，但 Zotero 没有对应的域，所以 `publisher-place` 作为备选 -->
+                  <if variable="jurisdiction">
+                    <text variable="jurisdiction"/>
+                  </if>
+                  <else>
+                    <text variable="publisher-place"/>
+                  </else>
+                </choose>
+                <text variable="number"/>
+              </group>
+            </if>
+            <else-if type="bill legal_case legislation regulation report standard" match="any">
+              <text variable="number"/>
+            </else-if>
+          </choose>
+        </group>
+      </group>
+      <choose>
+        <if variable="container-title" type="paper-conference" match="none">
+          <choose>
+            <if variable="event-date">
+              <text variable="event-place"/>
+              <date variable="event-date" form="text"/>
+            </if>
+          </choose>
+        </if>
+      </choose>
+    </group>
+    <text macro="type-code" prefix="[" suffix="]"/>
+  </macro>
+  <!-- 文献类型标识 -->
+  <macro name="type-code">
+    <group delimiter="/">
+      <choose>
+        <if type="article">
+          <choose>
+            <if variable="archive">
+              <text value="A"/>
+            </if >
+            <else>
+              <text value="M"/>
+            </else>
+          </choose>
+        </if>
+        <else-if type="article-journal article-magazine periodical" match="any">
+          <text value="J"/>
+        </else-if>
+        <else-if type="article-newspaper">
+          <text value="N"/>
+        </else-if>
+        <else-if type="book chapter" match="any">
+          <text value="M"/>
+        </else-if>
+        <else-if type="dataset">
+          <text value="DB"/>
+        </else-if>
+        <else-if type="paper-conference">
+          <text value="C"/>
+        </else-if>
+        <else-if type="patent">
+          <text value="P"/>
+        </else-if>
+        <else-if type="post post-weblog webpage" match="any">
+          <text value="EB"/>
+        </else-if>
+        <else-if type="report">
+          <text value="R"/>
+        </else-if>
+        <else-if type="software">
+          <text value="CP"/>
+        </else-if>
+        <else-if type="standard">
+          <text value="S"/>
+        </else-if>
+        <else-if type="thesis">
+          <text value="D"/>
+        </else-if>
+        <else-if variable="URL">
+          <text value="EB"/>
+        </else-if>
+        <else>
+          <text value="M"/>
+        </else>
+      </choose>
+      <choose>
+        <if variable="URL DOI" match="any">
+          <text value="OL"/>
+        </if>
+      </choose>
+    </group>
+  </macro>
+  <!-- 获取和访问路径以及 DOI -->
+  <macro name="url-doi">
+    <choose>
+      <if variable="URL">
+        <text variable="URL"/>
+      </if>
+      <else>
+        <text variable="DOI" prefix="https://doi.org/"/>
+      </else>
+    </choose>
+  </macro>
+  <!-- 连续出版物的年卷期 -->
+  <macro name="year-volume-issue">
+    <group>
+      <group delimiter=", ">
+        <text macro="issued-year"/>
+        <text variable="volume"/>
+      </group>
+      <text variable="issue" prefix="(" suffix=")"/>
+    </group>
+  </macro>
+  <!-- 专著和电子资源 -->
+  <macro name="monograph-layout">
+    <group delimiter=". " suffix=".">
+      <text macro="author"/>
+      <text macro="title"/>
+      <text macro="secondary-contributor"/>
+      <text macro="edition"/>
+      <text macro="publishing"/>
+      <text macro="url-doi"/>
+    </group>
+  </macro>
+  <!-- 专著中的析出文献 -->
+  <macro name="chapter-in-book-layout">
+    <group delimiter=". " suffix=".">
+      <text macro="author"/>
+      <group delimiter="//">
+        <group delimiter=". ">
+          <text macro="title"/>
+          <text macro="secondary-contributor"/>
+        </group>
+        <group delimiter=". ">
+          <text macro="container-author"/>
+          <text macro="container-title"/>
+        </group>
+      </group>
+      <text macro="edition"/>
+      <text macro="publishing"/>
+      <text macro="url-doi"/>
+    </group>
+  </macro>
+  <!-- 连续出版物 -->
+  <macro name="serial-layout">
+    <group delimiter=". " suffix=".">
+      <text macro="author"/>
+      <text macro="title"/>
+      <text macro="year-volume-issue"/>
+      <text macro="publishing"/>
+      <text variable="URL"/>
+      <text variable="DOI" prefix="DOI:"/>
+    </group>
+  </macro>
+  <!-- 连续出版物中的析出文献 -->
+  <macro name="article-in-periodical-layout">
+    <group delimiter=". " suffix=".">
+      <text macro="author"/>
+      <text macro="title"/>
+      <text macro="periodical-publishing"/>
+      <text macro="url-doi"/>
+    </group>
+  </macro>
+  <!-- 专利文献 -->
+  <macro name="patent-layout">
+    <group delimiter=". " suffix=".">
+      <text macro="author"/>
+      <text macro="title"/>
+      <group>
+        <text macro="issued-date"/>
+        <text macro="accessed-date"/>
+      </group>
+      <text macro="url-doi"/>
+    </group>
+  </macro>
+  <!-- 正文中引用的文献标注格式 -->
+  <macro name="citation-layout">
+    <group>
+      <text variable="citation-number"/>
+    </group>
+  </macro>
+  <!-- 参考文献表格式 -->
+  <macro name="entry-layout">
+    <choose>
+      <if type="article-journal article-magazine article-newspaper" match="any">
+        <text macro="article-in-periodical-layout"/>
+      </if>
+      <else-if type="periodical">
+        <text macro="serial-layout"/>
+      </else-if>
+      <else-if type="patent">
+        <text macro="patent-layout"/>
+      </else-if>
+      <else-if type="paper-conference" variable="container-title" match="any">
+        <text macro="chapter-in-book-layout"/>
+      </else-if>
+      <else>
+        <text macro="monograph-layout"/>
+      </else>
+    </choose>
+  </macro>
+  <citation collapse="citation-number" after-collapse-delimiter=",">
+    <layout vertical-align="sup" delimiter="," prefix="[" suffix="]">
+      <text macro="citation-layout"/>
+    </layout>
+  </citation>
+  <bibliography entry-spacing="0" et-al-min="4" et-al-use-first="3" second-field-align="flush">
+    <!-- 取消这部分注释可以使用 CSL-M 的功能支持双语 -->
+    <!-- <layout locale="en">
+      <text variable="citation-number" prefix="[" suffix="]"/>
+      <text macro="entry-layout"/>
+    </layout> -->
+    <layout>
+      <text variable="citation-number" prefix="[" suffix="]"/>
+      <text macro="entry-layout"/>
     </layout>
   </bibliography>
 </style>

--- a/chinese-gb7714-2005-numeric.csl
+++ b/chinese-gb7714-2005-numeric.csl
@@ -273,7 +273,7 @@
           <choose>
             <if variable="archive">
               <text value="A"/>
-            </if >
+            </if>
             <else>
               <text value="M"/>
             </else>
@@ -442,10 +442,7 @@
   </citation>
   <bibliography entry-spacing="0" et-al-min="4" et-al-use-first="3" second-field-align="flush">
     <!-- 取消这部分注释可以使用 CSL-M 的功能支持双语 -->
-    <!-- <layout locale="en">
-      <text variable="citation-number" prefix="[" suffix="]"/>
-      <text macro="entry-layout"/>
-    </layout> -->
+    <!-- <layout locale="en"><text variable="citation-number" prefix="[" suffix="]"/><text macro="entry-layout"/></layout> -->
     <layout>
       <text variable="citation-number" prefix="[" suffix="]"/>
       <text macro="entry-layout"/>


### PR DESCRIPTION
This is a rework of the China national standard GB/T 7714 styles (both 2005 and 2015 versions). The outputs are now more closely to the standards.

I've collected all the example entries from the standard in [zepinglee/china-national-standard-gb-t-7714-2015/gbt7714-numeric.txt](https://github.com/zepinglee/china-national-standard-gb-t-7714-2015/blob/standard/gbt7714-numeric.txt) as well as structured JSON data in that repo. This is a comparison between the standard and the output of the original `.csl` styles: <https://github.com/zepinglee/china-national-standard-gb-t-7714-2015/compare/standard...original>. After my edit, less differences are produced ([zepinglee/china-national-standard-gb-t-7714-2015@standard...main](https://github.com/zepinglee/china-national-standard-gb-t-7714-2015/compare/standard...main#diff-cfbf4589528ea9beaeebb77942283da69f584518d16eefcb63677b17ea328615)). Most of the differences are related to multi-language issues. They cannot be solved with current CSL v1.0.2 as far as I know.

The notable changes are as follows.

1. Entry types from CSL v1.0.2 are added.
2. The document links are updated.
1. The role of `editor` is allowed to be the primary contributor of a book instead the anonymous term.
2. The anonymous term is omitted in numeric and note styles as specified in the standard.
3. Sentence case (actually no case conversion) is used for titles and container titles instead of title case. This is not explicitly specified in the style but is used in the all the examples.
4. The names of proceeding editor are moved after the "//" mark (which is used as "In:").
5. The edition number is now checked if it is numeric.
6. The `page-range-delimiter` is changed to hyphen as specified in the standard, which is similar to Vancouver style.
7. The hyphens in ISO dates (yyyy-mm-dd) are corrected (rather than en dashes).
8. The missing issued date in `report` type is fixed.
9. Cite items are not sorted. 
10. A space is inserted in the author-date citation ahead of `et-al` term in Chinese, which is required by the standard.