### PR TITLE
Fix the order for conference papers in APA styles

### DIFF
--- a/apa-annotated-bibliography.csl
+++ b/apa-annotated-bibliography.csl
@@ -14,7 +14,7 @@
     <category citation-format="author-date"/>
     <category field="psychology"/>
     <category field="generic-base"/>
-    <updated>2021-06-10T13:09:49+00:00</updated>
+    <updated>2022-01-31T14:30:00+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale xml:lang="en">
@@ -502,22 +502,7 @@
     </choose>
   </macro>
   <macro name="date-sort-date">
-    <choose>
-      <if type="article-magazine article-newspaper broadcast interview pamphlet personal_communication post post-weblog speech treaty webpage" match="any">
-        <date variable="issued" form="numeric"/>
-      </if>
-      <else-if type="paper-conference">
-        <!-- Capture 'speech' stored as 'paper-conference' -->
-        <choose>
-          <if variable="collection-editor editor editorial-director issue page volume" match="none">
-            <date variable="issued" form="numeric"/>
-          </if>
-        </choose>
-      </else-if>
-      <else>
-        <date variable="issued" form="numeric"/>
-      </else>
-    </choose>
+    <date variable="issued" form="numeric"/>
   </macro>
   <macro name="date-intext">
     <choose>

--- a/apa-cv.csl
+++ b/apa-cv.csl
@@ -14,7 +14,7 @@
     <category citation-format="author-date"/>
     <category field="psychology"/>
     <category field="generic-base"/>
-    <updated>2019-12-04T13:09:49+00:00</updated>
+    <updated>2022-01-31T14:30:00+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale xml:lang="en">
@@ -447,22 +447,7 @@
     </choose>
   </macro>
   <macro name="date-sort-date">
-    <choose>
-      <if type="article-magazine article-newspaper broadcast interview pamphlet personal_communication post post-weblog speech treaty webpage" match="any">
-        <date variable="issued" form="numeric"/>
-      </if>
-      <else-if type="paper-conference">
-        <!-- Capture 'speech' stored as 'paper-conference' -->
-        <choose>
-          <if variable="collection-editor editor editorial-director issue page volume" match="none">
-            <date variable="issued" form="numeric"/>
-          </if>
-        </choose>
-      </else-if>
-      <else>
-        <date variable="issued" form="numeric"/>
-      </else>
-    </choose>
+    <date variable="issued" form="numeric"/>
   </macro>
   <!-- APA has two description elements following the title:
         title (parenthetical) [bracketed]  -->

--- a/apa-no-ampersand.csl
+++ b/apa-no-ampersand.csl
@@ -14,7 +14,7 @@
     <category citation-format="author-date"/>
     <category field="psychology"/>
     <category field="generic-base"/>
-    <updated>2021-06-10T13:09:49+00:00</updated>
+    <updated>2022-01-31T14:30:00+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale xml:lang="en">
@@ -502,22 +502,7 @@
     </choose>
   </macro>
   <macro name="date-sort-date">
-    <choose>
-      <if type="article-magazine article-newspaper broadcast interview pamphlet personal_communication post post-weblog speech treaty webpage" match="any">
-        <date variable="issued" form="numeric"/>
-      </if>
-      <else-if type="paper-conference">
-        <!-- Capture 'speech' stored as 'paper-conference' -->
-        <choose>
-          <if variable="collection-editor editor editorial-director issue page volume" match="none">
-            <date variable="issued" form="numeric"/>
-          </if>
-        </choose>
-      </else-if>
-      <else>
-        <date variable="issued" form="numeric"/>
-      </else>
-    </choose>
+    <date variable="issued" form="numeric"/>
   </macro>
   <macro name="date-intext">
     <choose>

--- a/apa-no-initials.csl
+++ b/apa-no-initials.csl
@@ -14,7 +14,7 @@
     <category citation-format="author-date"/>
     <category field="psychology"/>
     <category field="generic-base"/>
-    <updated>2021-06-10T13:09:49+00:00</updated>
+    <updated>2022-01-31T14:30:00+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale xml:lang="en">
@@ -502,22 +502,7 @@
     </choose>
   </macro>
   <macro name="date-sort-date">
-    <choose>
-      <if type="article-magazine article-newspaper broadcast interview pamphlet personal_communication post post-weblog speech treaty webpage" match="any">
-        <date variable="issued" form="numeric"/>
-      </if>
-      <else-if type="paper-conference">
-        <!-- Capture 'speech' stored as 'paper-conference' -->
-        <choose>
-          <if variable="collection-editor editor editorial-director issue page volume" match="none">
-            <date variable="issued" form="numeric"/>
-          </if>
-        </choose>
-      </else-if>
-      <else>
-        <date variable="issued" form="numeric"/>
-      </else>
-    </choose>
+    <date variable="issued" form="numeric"/>
   </macro>
   <macro name="date-intext">
     <choose>

--- a/apa-numeric-superscript-brackets.csl
+++ b/apa-numeric-superscript-brackets.csl
@@ -15,7 +15,7 @@
     <category field="psychology"/>
     <category field="generic-base"/>
     <summary>APA style, with numeric in-text citations in brackets</summary>
-    <updated>2019-12-04T13:09:49+00:00</updated>
+    <updated>2022-01-31T14:30:00+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale xml:lang="en">
@@ -301,24 +301,6 @@
       </else-if>
       <else>
         <text value="0"/>
-      </else>
-    </choose>
-  </macro>
-  <macro name="date-sort-date">
-    <choose>
-      <if type="article-magazine article-newspaper broadcast interview pamphlet personal_communication post post-weblog speech treaty webpage" match="any">
-        <date variable="issued" form="numeric"/>
-      </if>
-      <else-if type="paper-conference">
-        <!-- Capture 'speech' stored as 'paper-conference' -->
-        <choose>
-          <if variable="collection-editor editor editorial-director issue page volume" match="none">
-            <date variable="issued" form="numeric"/>
-          </if>
-        </choose>
-      </else-if>
-      <else>
-        <date variable="issued" form="numeric"/>
       </else>
     </choose>
   </macro>

--- a/apa-numeric-superscript.csl
+++ b/apa-numeric-superscript.csl
@@ -15,7 +15,7 @@
     <category field="psychology"/>
     <category field="generic-base"/>
     <summary>APA style, with superscript numeric in-text citations</summary>
-    <updated>2019-12-04T13:09:49+00:00</updated>
+    <updated>2022-01-31T14:30:00+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale xml:lang="en">
@@ -301,24 +301,6 @@
       </else-if>
       <else>
         <text value="0"/>
-      </else>
-    </choose>
-  </macro>
-  <macro name="date-sort-date">
-    <choose>
-      <if type="article-magazine article-newspaper broadcast interview pamphlet personal_communication post post-weblog speech treaty webpage" match="any">
-        <date variable="issued" form="numeric"/>
-      </if>
-      <else-if type="paper-conference">
-        <!-- Capture 'speech' stored as 'paper-conference' -->
-        <choose>
-          <if variable="collection-editor editor editorial-director issue page volume" match="none">
-            <date variable="issued" form="numeric"/>
-          </if>
-        </choose>
-      </else-if>
-      <else>
-        <date variable="issued" form="numeric"/>
       </else>
     </choose>
   </macro>

--- a/apa-single-spaced.csl
+++ b/apa-single-spaced.csl
@@ -14,7 +14,7 @@
     <category citation-format="author-date"/>
     <category field="psychology"/>
     <category field="generic-base"/>
-    <updated>2021-06-10T13:09:49+00:00</updated>
+    <updated>2022-01-31T14:30:00+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale xml:lang="en">
@@ -502,22 +502,7 @@
     </choose>
   </macro>
   <macro name="date-sort-date">
-    <choose>
-      <if type="article-magazine article-newspaper broadcast interview pamphlet personal_communication post post-weblog speech treaty webpage" match="any">
-        <date variable="issued" form="numeric"/>
-      </if>
-      <else-if type="paper-conference">
-        <!-- Capture 'speech' stored as 'paper-conference' -->
-        <choose>
-          <if variable="collection-editor editor editorial-director issue page volume" match="none">
-            <date variable="issued" form="numeric"/>
-          </if>
-        </choose>
-      </else-if>
-      <else>
-        <date variable="issued" form="numeric"/>
-      </else>
-    </choose>
+    <date variable="issued" form="numeric"/>
   </macro>
   <macro name="date-intext">
     <choose>

--- a/apa-with-abstract.csl
+++ b/apa-with-abstract.csl
@@ -14,7 +14,7 @@
     <category citation-format="author-date"/>
     <category field="psychology"/>
     <category field="generic-base"/>
-    <updated>2021-06-10T13:09:49+00:00</updated>
+    <updated>2022-01-31T14:30:00+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale xml:lang="en">
@@ -502,22 +502,7 @@
     </choose>
   </macro>
   <macro name="date-sort-date">
-    <choose>
-      <if type="article-magazine article-newspaper broadcast interview pamphlet personal_communication post post-weblog speech treaty webpage" match="any">
-        <date variable="issued" form="numeric"/>
-      </if>
-      <else-if type="paper-conference">
-        <!-- Capture 'speech' stored as 'paper-conference' -->
-        <choose>
-          <if variable="collection-editor editor editorial-director issue page volume" match="none">
-            <date variable="issued" form="numeric"/>
-          </if>
-        </choose>
-      </else-if>
-      <else>
-        <date variable="issued" form="numeric"/>
-      </else>
-    </choose>
+    <date variable="issued" form="numeric"/>
   </macro>
   <macro name="date-intext">
     <choose>

--- a/apa.csl
+++ b/apa.csl
@@ -14,7 +14,7 @@
     <category citation-format="author-date"/>
     <category field="psychology"/>
     <category field="generic-base"/>
-    <updated>2021-06-10T13:09:49+00:00</updated>
+    <updated>2022-01-31T14:30:00+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale xml:lang="en">
@@ -502,22 +502,7 @@
     </choose>
   </macro>
   <macro name="date-sort-date">
-    <choose>
-      <if type="article-magazine article-newspaper broadcast interview pamphlet personal_communication post post-weblog speech treaty webpage" match="any">
-        <date variable="issued" form="numeric"/>
-      </if>
-      <else-if type="paper-conference">
-        <!-- Capture 'speech' stored as 'paper-conference' -->
-        <choose>
-          <if variable="collection-editor editor editorial-director issue page volume" match="none">
-            <date variable="issued" form="numeric"/>
-          </if>
-        </choose>
-      </else-if>
-      <else>
-        <date variable="issued" form="numeric"/>
-      </else>
-    </choose>
+    <date variable="issued" form="numeric"/>
   </macro>
   <macro name="date-intext">
     <choose>

--- a/begell-house-apa.csl
+++ b/begell-house-apa.csl
@@ -9,7 +9,7 @@
     <category citation-format="author-date"/>
     <category field="generic-base"/>
     <summary>The author-date variant of the Begell House American Psychological Association style</summary>
-    <updated>2020-02-20T16:31:00+00:00</updated>
+    <updated>2022-01-31T14:30:00+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale xml:lang="en">
@@ -225,22 +225,7 @@
     </choose>
   </macro>
   <macro name="date-sort-date">
-    <choose>
-      <if type="article-magazine article-newspaper broadcast interview pamphlet personal_communication post post-weblog speech treaty webpage" match="any">
-        <date variable="issued" form="numeric"/>
-      </if>
-      <else-if type="paper-conference">
-        <!-- Capture 'speech' stored as 'paper-conference' -->
-        <choose>
-          <if variable="collection-editor editor editorial-director issue page volume" match="none">
-            <date variable="issued" form="numeric"/>
-          </if>
-        </choose>
-      </else-if>
-      <else>
-        <date variable="issued" form="numeric"/>
-      </else>
-    </choose>
+    <date variable="issued" form="numeric"/>
   </macro>
   <macro name="date-intext">
     <choose>

--- a/citation-compass-apa-note.csl
+++ b/citation-compass-apa-note.csl
@@ -12,7 +12,7 @@
     </author>
     <category citation-format="note"/>
     <category field="generic-base"/>
-    <updated>2019-12-04T13:09:49+00:00</updated>
+    <updated>2022-01-31T14:30:00+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale xml:lang="en">
@@ -238,22 +238,7 @@
     </choose>
   </macro>
   <macro name="date-sort-date">
-    <choose>
-      <if type="article-magazine article-newspaper broadcast interview pamphlet personal_communication post post-weblog speech treaty webpage" match="any">
-        <date variable="issued" form="numeric"/>
-      </if>
-      <else-if type="paper-conference">
-        <!-- Capture 'speech' stored as 'paper-conference' -->
-        <choose>
-          <if variable="collection-editor editor editorial-director issue page volume" match="none">
-            <date variable="issued" form="numeric"/>
-          </if>
-        </choose>
-      </else-if>
-      <else>
-        <date variable="issued" form="numeric"/>
-      </else>
-    </choose>
+    <date variable="issued" form="numeric"/>
   </macro>
   <macro name="date-intext">
     <choose>

--- a/european-review-of-agricultural-economics.csl
+++ b/european-review-of-agricultural-economics.csl
@@ -16,7 +16,7 @@
     <category field="social_science"/>
     <issn>0165-1587</issn>
     <eissn>1464-3618</eissn>
-    <updated>2021-07-28T07:15:06+00:00</updated>
+    <updated>2022-01-31T14:30:00+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale xml:lang="en">
@@ -215,21 +215,7 @@
     </choose>
   </macro>
   <macro name="date-sort-date">
-    <choose>
-      <if type="article-magazine article-newspaper broadcast interview pamphlet personal_communication post post-weblog speech treaty webpage" match="any">
-        <date variable="issued" form="numeric"/>
-      </if>
-      <else-if type="paper-conference">
-        <choose>
-          <if variable="collection-editor editor editorial-director issue page volume" match="none">
-            <date variable="issued" form="numeric"/>
-          </if>
-        </choose>
-      </else-if>
-      <else>
-        <date variable="issued" form="numeric"/>
-      </else>
-    </choose>
+    <date variable="issued" form="numeric"/>
   </macro>
   <macro name="date-intext">
     <choose>

--- a/fundamental-and-applied-limnology.csl
+++ b/fundamental-and-applied-limnology.csl
@@ -15,7 +15,7 @@
     <category field="biology"/>
     <issn>1863-9135</issn>
     <eissn>2363-7110</eissn>
-    <updated>2021-06-17T13:09:49+00:00</updated>
+    <updated>2022-01-31T14:30:00+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale xml:lang="en">
@@ -231,22 +231,7 @@
     </choose>
   </macro>
   <macro name="date-sort-date">
-    <choose>
-      <if type="article-magazine article-newspaper broadcast interview pamphlet personal_communication post post-weblog speech treaty webpage" match="any">
-        <date variable="issued" form="numeric"/>
-      </if>
-      <else-if type="paper-conference">
-        <!-- Capture 'speech' stored as 'paper-conference' -->
-        <choose>
-          <if variable="collection-editor editor editorial-director issue page volume" match="none">
-            <date variable="issued" form="numeric"/>
-          </if>
-        </choose>
-      </else-if>
-      <else>
-        <date variable="issued" form="numeric"/>
-      </else>
-    </choose>
+    <date variable="issued" form="numeric"/>
   </macro>
   <macro name="date-intext">
     <choose>

--- a/norsk-apa-manual-note.csl
+++ b/norsk-apa-manual-note.csl
@@ -12,7 +12,7 @@
     </author>
     <category citation-format="note"/>
     <category field="generic-base"/>
-    <updated>2020-01-14T02:24:58+00:00</updated>
+    <updated>2022-01-31T14:30:00+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale xml:lang="nb">
@@ -212,22 +212,7 @@
     </choose>
   </macro>
   <macro name="date-sort-date">
-    <choose>
-      <if type="article-magazine article-newspaper broadcast interview pamphlet personal_communication post post-weblog speech treaty webpage" match="any">
-        <date variable="issued" form="numeric"/>
-      </if>
-      <else-if type="paper-conference">
-        <!-- Capture 'speech' stored as 'paper-conference' -->
-        <choose>
-          <if variable="collection-editor editor editorial-director issue page volume" match="none">
-            <date variable="issued" form="numeric"/>
-          </if>
-        </choose>
-      </else-if>
-      <else>
-        <date variable="issued" form="numeric"/>
-      </else>
-    </choose>
+    <date variable="issued" form="numeric"/>
   </macro>
   <macro name="date-intext">
     <choose>

--- a/norsk-apa-manual.csl
+++ b/norsk-apa-manual.csl
@@ -10,7 +10,7 @@
     <category citation-format="author-date"/>
     <category field="psychology"/>
     <category field="generic-base"/>
-    <updated>2020-10-28T12:00:00+00:00</updated>
+    <updated>2022-01-31T14:30:00+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale xml:lang="en">
@@ -240,22 +240,7 @@
     </choose>
   </macro>
   <macro name="date-sort-date">
-    <choose>
-      <if type="article-magazine article-newspaper broadcast interview pamphlet personal_communication post post-weblog speech treaty webpage" match="any">
-        <date variable="issued" form="numeric"/>
-      </if>
-      <else-if type="paper-conference">
-        <!-- Capture 'speech' stored as 'paper-conference' -->
-        <choose>
-          <if variable="collection-editor editor editorial-director issue page volume" match="none">
-            <date variable="issued" form="numeric"/>
-          </if>
-        </choose>
-      </else-if>
-      <else>
-        <date variable="issued" form="numeric"/>
-      </else>
-    </choose>
+    <date variable="issued" form="numeric"/>
   </macro>
   <macro name="date-intext">
     <choose>

--- a/technische-universitat-dresden-betriebswirtschaftslehre-rechnungswesen-controlling.csl
+++ b/technische-universitat-dresden-betriebswirtschaftslehre-rechnungswesen-controlling.csl
@@ -14,7 +14,7 @@
     <category citation-format="author-date"/>
     <category field="social_science"/>
     <summary>Zitierstil entsprechend den Zitierrichtlinien des Lehrstuhls Betriebswirtschaftslehre, insbesondere betriebliches Rechnungwesen und Controlling, der Fakultät Wirtschaftswissenschaften, Technische Universität Dresden.</summary>
-    <updated>2020-10-15T12:00:00+00:00</updated>
+    <updated>2022-01-31T14:30:00+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale xml:lang="de">
@@ -222,22 +222,7 @@
     </choose>
   </macro>
   <macro name="date-sort-date">
-    <choose>
-      <if type="article-magazine article-newspaper broadcast interview pamphlet personal_communication post post-weblog speech treaty webpage" match="any">
-        <date variable="issued" form="numeric"/>
-      </if>
-      <else-if type="paper-conference">
-        <!-- Capture 'speech' stored as 'paper-conference' -->
-        <choose>
-          <if variable="collection-editor editor editorial-director issue page volume" match="none">
-            <date variable="issued" form="numeric"/>
-          </if>
-        </choose>
-      </else-if>
-      <else>
-        <date variable="issued" form="numeric"/>
-      </else>
-    </choose>
+    <date variable="issued" form="numeric"/>
   </macro>
   <macro name="date-intext">
     <choose>

--- a/ucl-university-college-apa.csl
+++ b/ucl-university-college-apa.csl
@@ -17,7 +17,7 @@
     </contributor>
     <category citation-format="author-date"/>
     <category field="generic-base"/>
-    <updated>2020-11-04T04:07:19+00:00</updated>
+    <updated>2022-01-31T14:30:00+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale xml:lang="da">
@@ -214,22 +214,7 @@
     </choose>
   </macro>
   <macro name="date-sort-date">
-    <choose>
-      <if type="article-magazine article-newspaper broadcast interview pamphlet personal_communication post post-weblog speech treaty webpage" match="any">
-        <date variable="issued" form="numeric"/>
-      </if>
-      <else-if type="paper-conference">
-        <!-- Capture 'speech' stored as 'paper-conference' -->
-        <choose>
-          <if variable="collection-editor editor editorial-director issue page volume" match="none">
-            <date variable="issued" form="numeric"/>
-          </if>
-        </choose>
-      </else-if>
-      <else>
-        <date variable="issued" form="numeric"/>
-      </else>
-    </choose>
+    <date variable="issued" form="numeric"/>
   </macro>
   <macro name="date-intext">
     <choose>

--- a/university-of-gothenburg-apa-7th-edition-swedish-legislations.csl
+++ b/university-of-gothenburg-apa-7th-edition-swedish-legislations.csl
@@ -14,7 +14,7 @@
     <category citation-format="author-date"/>
     <category field="law"/>
     <summary>This is a edited version of American Psychological Association 7th edition for University of Gothenburg with support for references to Swedish legislations, motions, propositions and Official Reports of the Swedish Government through the use of the Zotero item type "statute" (författning), for use in Swedish and English.</summary>
-    <updated>2021-02-15T15:25:56+00:00</updated>
+    <updated>2022-01-31T14:30:00+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <macro name="author-bib">
@@ -188,21 +188,7 @@
     </choose>
   </macro>
   <macro name="date-sort-date">
-    <choose>
-      <if type="article-magazine article-newspaper broadcast interview pamphlet personal_communication post post-weblog speech treaty webpage" match="any">
-        <date variable="issued" form="numeric"/>
-      </if>
-      <else-if type="paper-conference">
-        <choose>
-          <if variable="collection-editor editor editorial-director issue page volume" match="none">
-            <date variable="issued" form="numeric"/>
-          </if>
-        </choose>
-      </else-if>
-      <else>
-        <date variable="issued" form="numeric"/>
-      </else>
-    </choose>
+    <date variable="issued" form="numeric"/>
   </macro>
   <macro name="date-intext">
     <choose>


### PR DESCRIPTION
The current code in the macro date-sort-date is outputting in all
cases the same
   <date variable="issued" form="numeric"/>
except for conference papers with editors etc., where not output
at all is given. Consequently these conference papers will be moved
to the end of a block or the bibliography at all (apa-cv showed this
error instructively. This fixes the macro as discussed in
https://forums.zotero.org/discussion/94197/ .

It updates all styles which where be found with
> grep 'macro name="date-sort-date"' *.csl