### PR TITLE
remove default-locale journal-de-la-societe-des-oceanistes.csl

### DIFF
--- a/journal-de-la-societe-des-oceanistes.csl
+++ b/journal-de-la-societe-des-oceanistes.csl
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" demote-non-dropping-particle="sort-only" default-locale="en-GB">
+<style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" demote-non-dropping-particle="sort-only">
+<!-- Polyglot; journal publishes in English, and French -->
   <info>
     <title>Journal de la Société des Océanistes</title>
     <title-short>JSO</title-short>

--- a/journal-de-la-societe-des-oceanistes.csl
+++ b/journal-de-la-societe-des-oceanistes.csl
@@ -315,8 +315,8 @@
       <key macro="issued"/>
       <key macro="author"/>
     </sort>
-    <layout prefix="(" suffix=")" delimiter=" ; ">
-      <group delimiter=": ">
+    <layout prefix="(" suffix=")" delimiter="&#160;; ">
+      <group delimiter="&#160;: ">
         <group delimiter=", ">
           <text macro="author-short"/>
           <text macro="issued"/>

--- a/journal-de-la-societe-des-oceanistes.csl
+++ b/journal-de-la-societe-des-oceanistes.csl
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" demote-non-dropping-particle="sort-only">
-<!-- Polyglot; journal publishes in English, and French -->
+  <!-- Polyglot; journal publishes in English, and French -->
   <info>
     <title>Journal de la Société des Océanistes</title>
     <title-short>JSO</title-short>

--- a/journal-de-la-societe-des-oceanistes.csl
+++ b/journal-de-la-societe-des-oceanistes.csl
@@ -315,7 +315,7 @@
       <key macro="issued"/>
       <key macro="author"/>
     </sort>
-    <layout prefix="(" suffix=")" delimiter="&nbps;; ">
+    <layout prefix="(" suffix=")" delimiter="&nbsp;; ">
       <group delimiter=": ">
         <group delimiter=", ">
           <text macro="author-short"/>

--- a/journal-de-la-societe-des-oceanistes.csl
+++ b/journal-de-la-societe-des-oceanistes.csl
@@ -315,7 +315,7 @@
       <key macro="issued"/>
       <key macro="author"/>
     </sort>
-    <layout prefix="(" suffix=")" delimiter="; ">
+    <layout prefix="(" suffix=")" delimiter="&nbps;; ">
       <group delimiter=": ">
         <group delimiter=", ">
           <text macro="author-short"/>

--- a/journal-de-la-societe-des-oceanistes.csl
+++ b/journal-de-la-societe-des-oceanistes.csl
@@ -315,7 +315,7 @@
       <key macro="issued"/>
       <key macro="author"/>
     </sort>
-    <layout prefix="(" suffix=")" delimiter="&nbsp;; ">
+    <layout prefix="(" suffix=")" delimiter=" ; ">
       <group delimiter=": ">
         <group delimiter=", ">
           <text macro="author-short"/>


### PR DESCRIPTION
via https://forums.zotero.org/discussion/comment/398551/#Comment_398551

Was hoping the automatic locale also adds space before delimiters, but alas no. This needs a 2nd style in french?