### PR TITLE
make journal names title case

### DIFF
--- a/international-journal-of-wildland-fire.csl
+++ b/international-journal-of-wildland-fire.csl
@@ -110,7 +110,7 @@
     <group>
       <choose>
         <if type="article-journal">
-          <text variable="container-title" strip-periods="true"/>
+          <text variable="container-title" text-case="title" strip-periods="true"/>
         </if>
         <else>
           <text variable="container-title" form="short"/>


### PR DESCRIPTION
Trying to update australian-systematic-botany via its parent style international-journal-of-wildland-fire. I'm using the style in Paperpile and full journal titles are not capitalized.