### PR TITLE
Update american-journal-of-botany.csl

### DIFF
--- a/american-journal-of-botany.csl
+++ b/american-journal-of-botany.csl
@@ -109,7 +109,7 @@
       </else>
     </choose>
   </macro>
-  <citation et-al-min="3" et-al-use-first="1" disambiguate-add-year-suffix="true" disambiguate-add-names="true" collapse="year-suffix">
+  <citation et-al-min="3" et-al-use-first="1" disambiguate-add-year-suffix="true" disambiguate-add-names="false" collapse="year-suffix">
     <sort>
       <key macro="year-date"/>
     </sort>


### PR DESCRIPTION
Fixes disambiguation of et al names (should be "false").

An editor just changed this in my MS. For example, "Nitta, Ebihara, et al. (2020)" should be "Nitta et al. (2020a)".