### PR TITLE
Update the-journal-of-egyptian-archaeology.csl

### DIFF
--- a/the-journal-of-egyptian-archaeology.csl
+++ b/the-journal-of-egyptian-archaeology.csl
@@ -206,7 +206,7 @@
         <choose>
           <if variable="URL" match="any">
             <group delimiter=" ">
-              <text variable="URL" prefix="&lt;" suffix="&gt;"/>
+              <text variable="URL" prefix="&lt;" suffix=">"/>
               <text term="accessed" suffix=" "/>
             </group>
             <date variable="accessed">

--- a/the-journal-of-egyptian-archaeology.csl
+++ b/the-journal-of-egyptian-archaeology.csl
@@ -202,7 +202,7 @@
         <choose>
           <if variable="URL" match="any">
             <group delimiter=" ">
-              <text variable="URL" prefix="&lt;" suffix="&gt;"/>
+              <text variable="URL" prefix="&lt;" suffix=">"/>
               <text term="accessed" suffix=" "/>
             </group>
             <date variable="accessed">

--- a/the-journal-of-egyptian-archaeology.csl
+++ b/the-journal-of-egyptian-archaeology.csl
@@ -6,15 +6,15 @@
     <id>http://www.zotero.org/styles/the-journal-of-egyptian-archaeology</id>
     <link href="http://www.zotero.org/styles/the-journal-of-egyptian-archaeology" rel="self"/>
     <link href="http://www.zotero.org/styles/journal-of-the-history-of-collections" rel="template"/>
-    <link href="http://www.ees.ac.uk/publications/journal-egyptian-archaeology.html" rel="documentation"/>
+    <link href="https://www.ees.ac.uk/writing-for-the-jea" rel="documentation"/>
+    <link href="https://journals.sagepub.com/pb-assets/cmscontent/EGA/JEA_Referencing_Style.pdf" rel="documentation"/>
     <author>
       <name>Patrick O'Brien</name>
-      <email>obrienpat86@gmail.com</email>
     </author>
     <category citation-format="note"/>
     <category field="history"/>
     <issn>0307-5133</issn>
-    <updated>2018-01-04T11:08:07+00:00</updated>
+    <updated>2022-03-16T09:46:35+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale xml:lang="en">
@@ -151,10 +151,6 @@
       </if>
     </choose>
   </macro>
-  <macro name="pageref-subsequent">
-    <label variable="locator" form="short" suffix=" "/>
-    <text variable="locator"/>
-  </macro>
   <macro name="volref">
     <group delimiter=" ">
       <text variable="volume"/>
@@ -226,7 +222,7 @@
           <group delimiter=", ">
             <text macro="author-short"/>
             <text macro="container-short"/>
-            <text macro="pageref-subsequent"/>
+            <text macro="pageref"/>
           </group>
         </if>
         <else>

--- a/the-journal-of-egyptian-archaeology.csl
+++ b/the-journal-of-egyptian-archaeology.csl
@@ -14,7 +14,7 @@
     <category citation-format="note"/>
     <category field="history"/>
     <issn>0307-5133</issn>
-    <updated>2022-03-16T09:46:35+00:00</updated>
+    <updated>2022-03-18T08:56:24+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale xml:lang="en">
@@ -28,6 +28,10 @@
       <term name="close-quote">’</term>
       <term name="open-inner-quote">“</term>
       <term name="close-inner-quote">”</term>
+      <term name="editor" form="short">
+        <single>ed.</single>
+        <multiple>eds</multiple>
+      </term>
     </terms>
   </locale>
   <macro name="author">
@@ -79,7 +83,7 @@
     <group delimiter=" ">
       <text term="in" suffix=" "/>
       <names variable="editor">
-        <name form="short" and="text" initialize-with=". "/>
+        <name form="short" and="text" et-al-min="2" et-al-use-first="1" initialize-with=". "/>
         <label form="short" prefix=" (" suffix=")" strip-periods="false"/>
         <substitute>
           <names variable="editor"/>
@@ -202,7 +206,7 @@
         <choose>
           <if variable="URL" match="any">
             <group delimiter=" ">
-              <text variable="URL" prefix="&lt;" suffix=">"/>
+              <text variable="URL" prefix="&lt;" suffix="&gt;"/>
               <text term="accessed" suffix=" "/>
             </group>
             <date variable="accessed">


### PR DESCRIPTION
fix error with subsequent locators showing label.
Came in via emails.

> I found your name as author in this file and wonder if you are supporting/maintaining it and if you can assist?  I think I found a bug in it:
> I am using MS Word 365 and downloaded latest version of Paperpile (beta) yesterday which includes your CSL file by default.
>There are a few little difficulties, and I'm not sure whether some of them are Paperpile or the CSL but the following seems to be the CSL:
>The first reference shows the page number without the P. correctly.  e.g.
>[1] J. Quibell, Excavations at Saqqara 1911 – 1912: The Tomb of Hesy (Cairo, 1913), 19.

>Subsequent references include "P." - which they should not.
>[1] Quibell, Excavations at Saqqara 1911 – 1912: The Tomb of Hesy, p. 19.
