### PR TITLE
Update cardiff-university-harvard.csl

### DIFF
--- a/cardiff-university-harvard.csl
+++ b/cardiff-university-harvard.csl
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" demote-non-dropping-particle="sort-only">
+<style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" demote-non-dropping-particle="never">
   <!-- This style was edited with the Visual CSL Editor (https://editor.citationstyles.org/visualEditor/) -->
   <info>
     <title>Cardiff University - Harvard</title>


### PR DESCRIPTION
change demote non dropping particle to never as we realised that names such as van Gogh are appearing under G rather than V. We want them appearing under V.