### PR TITLE
Update administrative-science-quarterly.csl

### DIFF
--- a/administrative-science-quarterly.csl
+++ b/administrative-science-quarterly.csl
@@ -14,7 +14,7 @@
     <category field="social_science"/>
     <issn>0001-8392</issn>
     <eissn>1930-3815</eissn>
-    <updated>2022-01-07T15:49:10+00:00</updated>
+    <updated>2022-03-28T16:15:40+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale xml:lang="en">
@@ -219,6 +219,7 @@
           <date variable="issued">
             <date-part name="year"/>
           </date>
+          <text variable="year-suffix"/>
           <choose>
             <if type="article-journal bill book chapter graphic legal_case legislation motion_picture paper-conference report song" match="none">
               <date variable="issued">
@@ -310,7 +311,7 @@
       <text macro="citation-locator" prefix=": "/>
     </layout>
   </citation>
-  <bibliography et-al-min="8" et-al-use-first="7" entry-spacing="1" line-spacing="1" subsequent-author-substitute="">
+  <bibliography et-al-min="8" et-al-use-first="7" entry-spacing="1" line-spacing="1">
     <sort>
       <key macro="author"/>
       <key variable="issued" sort="ascending"/>


### PR DESCRIPTION
This fixes bibliography items from the same author and in the same year. Items should not be grouped by author and should contain year suffix (`2009a`, `2009b`...).

**Actual**
```
Chan, C. S.-c.

2009  “Creating a market in the presence of cultural resistance: The case of life insurance in China.” Theory and Society, 38: 271–305.

2009  “Invigorating the content in social embeddedness: An ethnography of life insurance transactions in China.” American Journal of Sociology, 115: 712–754.
```

**Expected** (according to the [submission guide](https://journals.sagepub.com/author-instructions/asq))
```
Chan, C. S.-c.

2009a  “Creating a market in the presence of cultural resistance: The case of life insurance in China.” Theory and Society, 38: 271–305.

Chan, C. S.-c.

2009b  “Invigorating the content in social embeddedness: An ethnography of life insurance transactions in China.” American Journal of Sociology, 115: 712–754.
```