### PR TITLE
cell.csl: Add a macro for DOI and webpage accessed date.

### DIFF
--- a/cell.csl
+++ b/cell.csl
@@ -58,13 +58,9 @@
     </names>
   </macro>
   <macro name="doi">
-      <if type="article-newspaper" match="any">
-        <choose>
-          <if variable="DOI">
-            <text variable="DOI" prefix="https://doi.org/"/>
-          </if>
-        </choose>
-      </if>
+        <if variable="DOI">
+          <text variable="DOI" prefix="https://doi.org/"/>
+        </if>
   </macro>
   <citation et-al-min="3" et-al-use-first="1" disambiguate-add-year-suffix="true" collapse="year">
     <sort>

--- a/cell.csl
+++ b/cell.csl
@@ -57,34 +57,14 @@
       <label form="short" prefix=", "/>
     </names>
   </macro>
-  <macro name="accessed-doi">
-    <choose>
+  <macro name="doi">
       <if type="article-newspaper" match="none">
         <choose>
           <if variable="DOI">
             <text variable="DOI" prefix="https://doi.org/"/>
           </if>
-          <else-if variable="URL">
-            <group delimiter=". ">
-              <choose>
-                <if type="webpage post post-weblog" match="any">
-                  <date variable="issued" prefix=" Accessed " form="text"/>
-                </if>
-              </choose>
-              <group>
-                <text term="accessed" text-case="capitalize-first" suffix=" "/>
-                <date variable="accessed">
-                  <date-part name="month" suffix=" "/>
-                  <date-part name="day" suffix=", "/>
-                  <date-part name="year"/>
-                </date>
-              </group>
-              <text variable="URL"/>
-            </group>
-          </else-if>
         </choose>
       </if>
-    </choose>
   </macro>
   <citation et-al-min="3" et-al-use-first="1" disambiguate-add-year-suffix="true" collapse="year">
     <sort>
@@ -116,11 +96,13 @@
           <if type="article article-magazine article-newspaper article-journal review" match="any">
             <text variable="title" suffix="."/>
             <text variable="container-title" form="short" text-case="title"/>
-            <group delimiter=", ">
+            <group delimiter=", " suffix=". ">
               <text variable="volume" font-style="italic"/>
               <text variable="page"/>
-              <text macro="accessed-doi"/>
             </group>
+	    <group>
+	      <text macro="doi"/>
+	    </group>
           </if>
           <else-if type="chapter paper-conference" match="any">
             <text variable="title" suffix="."/>
@@ -138,7 +120,6 @@
           <else>
             <text variable="title"/>
             <text macro="publisher"/>
-            <text macro="accessed-doi"/>
           </else>
         </choose>
       </group>

--- a/cell.csl
+++ b/cell.csl
@@ -58,7 +58,7 @@
     </names>
   </macro>
   <macro name="doi">
-      <if type="article-newspaper" match="none">
+      <if type="article-newspaper" match="any">
         <choose>
           <if variable="DOI">
             <text variable="DOI" prefix="https://doi.org/"/>

--- a/cell.csl
+++ b/cell.csl
@@ -58,9 +58,11 @@
     </names>
   </macro>
   <macro name="doi">
-        <if variable="DOI">
-          <text variable="DOI" prefix="https://doi.org/"/>
-        </if>
+    <choose>
+    <if variable="DOI">
+      <text variable="DOI" prefix="https://doi.org/"/>
+    </if>
+    </choose>
   </macro>
   <citation et-al-min="3" et-al-use-first="1" disambiguate-add-year-suffix="true" collapse="year">
     <sort>

--- a/cell.csl
+++ b/cell.csl
@@ -62,6 +62,9 @@
       <if variable="DOI">
         <text variable="DOI" prefix="https://doi.org/"/>
       </if>
+      <else-if type="webpage post post-weblog" match="any">
+        <text variable="URL"/>
+      </else-if>
     </choose>
   </macro>
   <citation et-al-min="3" et-al-use-first="1" disambiguate-add-year-suffix="true" collapse="year">

--- a/cell.csl
+++ b/cell.csl
@@ -59,9 +59,9 @@
   </macro>
   <macro name="doi">
     <choose>
-    <if variable="DOI">
-      <text variable="DOI" prefix="https://doi.org/"/>
-    </if>
+      <if variable="DOI">
+        <text variable="DOI" prefix="https://doi.org/"/>
+      </if>
     </choose>
   </macro>
   <citation et-al-min="3" et-al-use-first="1" disambiguate-add-year-suffix="true" collapse="year">
@@ -98,9 +98,9 @@
               <text variable="volume" font-style="italic"/>
               <text variable="page"/>
             </group>
-	    <group>
-	      <text macro="doi"/>
-	    </group>
+            <group>
+              <text macro="doi"/>
+            </group>
           </if>
           <else-if type="chapter paper-conference" match="any">
             <text variable="title" suffix="."/>

--- a/cell.csl
+++ b/cell.csl
@@ -112,5 +112,35 @@
         </choose>
       </group>
     </layout>
+    <macro name="accessed-doi">
+      <choose>
+	<if type="article-newspaper" match="none">
+          <choose>
+            <if variable="DOI">
+              <text value=" doi:"/>
+              <text variable="DOI"/>
+            </if>
+            <else-if variable="URL">
+              <group delimiter=". ">
+		<choose>
+                  <if type="webpage post post-weblog" match="any">
+                    <date variable="issued" prefix=" Accessed " form="text"/>
+                  </if>
+		</choose>
+		<group>
+                  <text term="accessed" text-case="capitalize-first" suffix=" "/>
+                  <date variable="accessed">
+                    <date-part name="month" suffix=" "/>
+                    <date-part name="day" suffix=", "/>
+                    <date-part name="year"/>
+                  </date>
+		</group>
+		<text variable="URL"/>
+              </group>
+            </else-if>
+          </choose>
+	</if>
+      </choose>
+    </macro>
   </bibliography>
 </style>

--- a/cell.csl
+++ b/cell.csl
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<style xmlns="http://purl.org/net/xbiblio/csl" version="1.0" class="in-text" default-locale="en-US" demote-non-dropping-particle="sort-only" page-range-format="expanded">
+<style xmlns="http://purl.org/net/xbiblio/csl" version="1.0" class="in-text" demote-non-dropping-particle="sort-only" page-range-format="expanded" default-locale="en-US">
   <info>
     <title>Cell</title>
     <id>http://www.zotero.org/styles/cell</id>
@@ -67,20 +67,20 @@
           </if>
           <else-if variable="URL">
             <group delimiter=". ">
-	      <choose>
+              <choose>
                 <if type="webpage post post-weblog" match="any">
                   <date variable="issued" prefix=" Accessed " form="text"/>
                 </if>
-	      </choose>
-	      <group>
+              </choose>
+              <group>
                 <text term="accessed" text-case="capitalize-first" suffix=" "/>
                 <date variable="accessed">
                   <date-part name="month" suffix=" "/>
                   <date-part name="day" suffix=", "/>
                   <date-part name="year"/>
                 </date>
-	      </group>
-	      <text variable="URL"/>
+              </group>
+              <text variable="URL"/>
             </group>
           </else-if>
         </choose>
@@ -120,7 +120,7 @@
             <group delimiter=", ">
               <text variable="volume" font-style="italic"/>
               <text variable="page"/>
-	      <text macro="accessed-doi"/>
+              <text macro="accessed-doi"/>
             </group>
           </if>
           <else-if type="chapter paper-conference" match="any">
@@ -139,7 +139,7 @@
           <else>
             <text variable="title"/>
             <text macro="publisher"/>
-	    <text macro="accessed-doi"/>		
+            <text macro="accessed-doi"/>
           </else>
         </choose>
       </group>

--- a/cell.csl
+++ b/cell.csl
@@ -62,8 +62,7 @@
       <if type="article-newspaper" match="none">
         <choose>
           <if variable="DOI">
-            <text value=" doi:"/>
-            <text variable="DOI"/>
+            <text variable="DOI" prefix="https://doi.org/"/>
           </if>
           <else-if variable="URL">
             <group delimiter=". ">

--- a/cell.csl
+++ b/cell.csl
@@ -57,6 +57,36 @@
       <label form="short" prefix=", "/>
     </names>
   </macro>
+  <macro name="accessed-doi">
+    <choose>
+      <if type="article-newspaper" match="none">
+        <choose>
+          <if variable="DOI">
+            <text value=" doi:"/>
+            <text variable="DOI"/>
+          </if>
+          <else-if variable="URL">
+            <group delimiter=". ">
+	      <choose>
+                <if type="webpage post post-weblog" match="any">
+                  <date variable="issued" prefix=" Accessed " form="text"/>
+                </if>
+	      </choose>
+	      <group>
+                <text term="accessed" text-case="capitalize-first" suffix=" "/>
+                <date variable="accessed">
+                  <date-part name="month" suffix=" "/>
+                  <date-part name="day" suffix=", "/>
+                  <date-part name="year"/>
+                </date>
+	      </group>
+	      <text variable="URL"/>
+            </group>
+          </else-if>
+        </choose>
+      </if>
+    </choose>
+  </macro>
   <citation et-al-min="3" et-al-use-first="1" disambiguate-add-year-suffix="true" collapse="year">
     <sort>
       <key macro="author-short" names-min="1" names-use-first="1"/>
@@ -90,6 +120,7 @@
             <group delimiter=", ">
               <text variable="volume" font-style="italic"/>
               <text variable="page"/>
+	      <text macro="accessed-doi"/>
             </group>
           </if>
           <else-if type="chapter paper-conference" match="any">
@@ -108,39 +139,10 @@
           <else>
             <text variable="title"/>
             <text macro="publisher"/>
+	    <text macro="accessed-doi"/>		
           </else>
         </choose>
       </group>
     </layout>
-    <macro name="accessed-doi">
-      <choose>
-	<if type="article-newspaper" match="none">
-          <choose>
-            <if variable="DOI">
-              <text value=" doi:"/>
-              <text variable="DOI"/>
-            </if>
-            <else-if variable="URL">
-              <group delimiter=". ">
-		<choose>
-                  <if type="webpage post post-weblog" match="any">
-                    <date variable="issued" prefix=" Accessed " form="text"/>
-                  </if>
-		</choose>
-		<group>
-                  <text term="accessed" text-case="capitalize-first" suffix=" "/>
-                  <date variable="accessed">
-                    <date-part name="month" suffix=" "/>
-                    <date-part name="day" suffix=", "/>
-                    <date-part name="year"/>
-                  </date>
-		</group>
-		<text variable="URL"/>
-              </group>
-            </else-if>
-          </choose>
-	</if>
-      </choose>
-    </macro>
   </bibliography>
 </style>


### PR DESCRIPTION
Hi,
- I recently found that Cell journals require the use of DOI at the end of the reference list see: https://www.cell.com/cell/authors#format `We encourage the inclusion of DOIs in all journal article references`
- Some references are sometimes from webpages and it is better to add the accessed date.

This pull request adds a macro to display DOI for articles and Accessed date to webpages.

Hope this will be usefull,
Best,
Nicolas