### PR TITLE
 Add status field (for forthcoming, in press, etc.) to date groupsInclude status field as date if defined

### DIFF
--- a/american-sociological-association.csl
+++ b/american-sociological-association.csl
@@ -130,6 +130,12 @@
           <date variable="issued" form="numeric" date-parts="year"/>
         </group>
       </if>
+      <else-if variable="status">
+        <group>
+          <text variable="status" text-case="lowercase"/>
+          <text variable="year-suffix" prefix="-"/>
+        </group>
+      </else-if>
       <else>
         <text term="no date" form="short"/>
       </else>
@@ -140,6 +146,12 @@
       <if variable="issued">
         <date variable="issued" form="numeric" date-parts="year"/>
       </if>
+      <else-if variable="status">
+        <group>
+          <text variable="status" text-case="lowercase"/>
+          <text variable="year-suffix" prefix="-"/>
+        </group>
+      </else-if>
       <else>
         <text term="no date" form="short"/>
       </else>


### PR DESCRIPTION
Based on [this Zotero forum thread](https://forums.zotero.org/discussion/68198/apa-style-in-press-articles), I added an option to print the status field if issued does not exist and status does exist (and still defaults to 'n.d.' if neither exists) using the code in the [APA style](https://github.com/citation-style-language/styles/blob/51ff3dc6caa528d0658e2b36c35ab1b298511197/apa.csl#L477-L481).