### PR TITLE
Render status field (for forthcoming, in press, etc.) to date groups

### DIFF
--- a/american-sociological-association.csl
+++ b/american-sociological-association.csl
@@ -248,7 +248,7 @@
           <group prefix=" " delimiter=". ">
             <group>
               <!-- To Do: localize once we have a proper term -->
-              <text macro="title" suffix=" [computer program]" />
+              <text macro="title" suffix=" [computer program]"/>
             </group>
             <group delimiter=" ">
               <text term="version" text-case="capitalize-first"/>

--- a/american-sociological-association.csl
+++ b/american-sociological-association.csl
@@ -130,6 +130,12 @@
           <date variable="issued" form="numeric" date-parts="year"/>
         </group>
       </if>
+      <else-if variable="status">
+        <group>
+          <text variable="status" text-case="lowercase"/>
+          <text variable="year-suffix" prefix="-"/>
+        </group>
+      </else-if>
       <else>
         <text term="no date" form="short"/>
       </else>
@@ -140,6 +146,12 @@
       <if variable="issued">
         <date variable="issued" form="numeric" date-parts="year"/>
       </if>
+      <else-if variable="status">
+        <group>
+          <text variable="status" text-case="lowercase"/>
+          <text variable="year-suffix" prefix="-"/>
+        </group>
+      </else-if>
       <else>
         <text term="no date" form="short"/>
       </else>
@@ -236,7 +248,7 @@
           <group prefix=" " delimiter=". ">
             <group>
               <!-- To Do: localize once we have a proper term -->
-              <text macro="title" suffix=" [computer program]"/>
+              <text macro="title" suffix=" [computer program]" />
             </group>
             <group delimiter=" ">
               <text term="version" text-case="capitalize-first"/>


### PR DESCRIPTION
Based on [this Zotero forum thread](https://forums.zotero.org/discussion/68198/apa-style-in-press-articles), I added an option to print the status field if issued does not exist and status does exist (and still defaults to 'n.d.' if neither exists) using the code in the [APA style](https://github.com/citation-style-language/styles/blob/51ff3dc6caa528d0658e2b36c35ab1b298511197/apa.csl#L477-L481).