### PR TITLE
Adds space after title writing in ABNT style file

### DIFF
--- a/universidade-de-sao-paulo-escola-de-comunicacoes-e-artes-abnt.csl
+++ b/universidade-de-sao-paulo-escola-de-comunicacoes-e-artes-abnt.csl
@@ -145,7 +145,7 @@
         <text variable="title" font-weight="bold"/>
       </else>
     </choose>
-    <text value=" "/>
+    <text value=""/>
   </macro>
   <macro name="container-title">
     <choose>
@@ -552,7 +552,7 @@
         </else-if>
         <else>
           <text macro="author" suffix=". "/>
-          <text macro="title"/>
+          <text macro="title" suffix=". "/>
           <text macro="container-contributors"/>
           <text macro="secondary-contributors"/>
           <text macro="container-title"/>

--- a/universidade-de-sao-paulo-escola-de-comunicacoes-e-artes-abnt.csl
+++ b/universidade-de-sao-paulo-escola-de-comunicacoes-e-artes-abnt.csl
@@ -145,7 +145,7 @@
         <text variable="title" font-weight="bold"/>
       </else>
     </choose>
-    <text value=""/>
+    <text value=" "/>
   </macro>
   <macro name="container-title">
     <choose>


### PR DESCRIPTION
The targeted ABNT style file has a problem in its title writing. It doesn't include a space after it, leading to `title` and `container-title` being shown gathered in the citation. Here is a made-example:

```
CABRAL, J. F.; Factors associated with functional disability in older adultsSciELO Preprints
```

After our correction, it is printed like:

```
CABRAL, J. F.; Factors associated with functional disability in older adults SciELO Preprints
```