### PR TITLE
style for Revista Ladinia

### DIFF
--- a/revista-ladinia.csl
+++ b/revista-ladinia.csl
@@ -19,7 +19,7 @@
 		<category citation-format="author-date"/>
 		<category field="linguistics"/>
 		<issn>1124-1004</issn>
-		<updated>2022-04-22T12:16:36+01:00</updated>
+		<updated>2022-04-25T13:40:00+01:00</updated>
 		<rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
 	</info>
 	<locale xml:lang="it">
@@ -27,7 +27,8 @@
 			<term name="and others"></term>
 			<term name="no date">s.a.</term>
 			<term name="no-place">s.l.</term>
-			<term name="no-publisher">N.N.</term>
+			<term name="anonymous">N.N.</term>
+			<term name="volume">vol.</term>
 			<term name="editor">
 				<single>ed.</single>
 				<multiple>eds.</multiple>
@@ -39,7 +40,8 @@
 			<term name="and others"></term>
 			<term name="no date">s.a.</term>
 			<term name="no-place">s.l.</term>
-			<term name="no-publisher">N.N.</term>
+			<term name="anonymous">N.N.</term>
+			<term name="volume">vol.</term>
 			<term name="editor">
 				<single>ed.</single>
 				<multiple>eds.</multiple>
@@ -51,7 +53,8 @@
 			<term name="and others"></term>
 			<term name="no date">s.a.</term>
 			<term name="no-place">s.l.</term>
-			<term name="no-publisher">N.N.</term>
+			<term name="anonymous">N.N.</term>
+			<term name="volume">vol.</term>
 			<term name="editor">
 				<single>ed.</single>
 				<multiple>eds.</multiple>
@@ -62,7 +65,7 @@
 		<choose>
 			<if variable="author">
 				<names variable="author">
-					<name form="short" et-al-use-first="1">
+					<name name-as-sort-order="all" delimiter="/" form="short">
 						<name-part name="family" font-variant="small-caps"/>
 					</name>
 					<et-al term="and others" />
@@ -70,15 +73,14 @@
 			</if>
 			<else-if variable="editor">
 				<names variable="editor">
-					<name name-as-sort-order="all" delimiter="/">
+					<name name-as-sort-order="all" delimiter="/" form="short">
 						<name-part name="family" font-variant="small-caps"/>
 					</name>
-					<label prefix=" (" suffix=")"/>
 					<et-al term="and others" />
 				</names>
 			</else-if>
 			<else>
-				<text term="no-publisher"/>
+				<text term="anonymous"/>
 			</else>
 		</choose>
 	</macro>
@@ -102,7 +104,7 @@
 				</names>
 			</else-if>
 			<else>
-				<text term="no-publisher"/>
+				<text term="anonymous"/>
 			</else>
 		</choose>
 	</macro>
@@ -123,20 +125,20 @@
 			<if variable="publisher-place">
 				<text variable="publisher-place" suffix=" "/>
 			</if>
-			<else>
+			<else-if type="book" match="any">
 				<text term="no-place" suffix=" "/>
-			</else>
+			</else-if>
 		</choose>
 	</macro>
-	<citation et-al-min="2" et-al-use-first="1" initialize-with="." disambiguate-add-givenname="true" disambiguate-add-year-suffix="true" collapse="year">
+	<citation et-al-min="4" et-al-use-first="1" initialize-with="." disambiguate-add-givenname="true" disambiguate-add-year-suffix="true" collapse="year">
 		<sort>
 			<key macro="author"/>
 			<key macro="issued-year"/>
 		</sort>
-		<layout prefix="" suffix="" delimiter=", ">
+		<layout prefix="(" suffix=")" delimiter=", ">
 			<group delimiter=" ">
 				<text macro="author"/>
-				<text macro="issued-year" prefix="(" suffix=")"/>
+				<text macro="issued-year" />
 			</group>
 		</layout>
 	</citation>
@@ -150,8 +152,14 @@
 			<text macro="author-bibliography" suffix=": "/>
 			<group delimiter=", ">
 				<text variable="title" font-style="italic"/>
-				<text variable="container-title" prefix="in: "/>
-				<text variable="volume" prefix="vol. "/>
+				<group delimiter=": ">
+					<text term="in"/>
+					<text variable="container-title" />
+				</group>
+				<group delimiter=" ">
+					<text term="volume"/>
+					<text variable="volume" />
+				</group>
 				<text variable="issue" prefix="(" suffix=")"/>
 				<group>
 					<text macro="publisher-place"/>

--- a/revista-ladinia.csl
+++ b/revista-ladinia.csl
@@ -1,155 +1,154 @@
 <?xml version="1.0" encoding="utf-8"?>
-<style
-	xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0">
-	<info>
-		<title>Revista Ladinia</title>
-		<title-short>LADINIA</title-short>
-		<id>http://www.zotero.org/styles/revista-ladinia</id>
-		<link href="http://www.zotero.org/styles/revista-ladinia" rel="self"/>
-		<link href="http://www.zotero.org/styles/apa" rel="template"/>
-		<link href="https://micura.it/la/ativites/ladinia/style-sheet" rel="documentation"/>
-		<author>
-			<name>Samuel Frontull</name>
-			<email>samuel.frontull@uibk.ac.at</email>
-		</author>
-		<author>
-			<name>Paolo Anvidalfarei</name>
-			<email>paolo@micura.it</email>
-		</author>
-		<category citation-format="author-date"/>
-		<category field="linguistics"/>
-		<issn>1124-1004</issn>
-		<updated>2022-04-25T14:01:00+01:00</updated>
-		<rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
-	</info>
-	<locale xml:lang="it">
-		<terms>
-			<term name="and others"></term>
-			<term name="no date">s.a.</term>
-			<term name="no-place">s.l.</term>
-			<term name="anonymous">N.N.</term>
-			<term name="volume">vol.</term>
-			<term name="editor">
-				<single>ed.</single>
-				<multiple>eds.</multiple>
-			</term>
-		</terms>
-	</locale>
-	<locale xml:lang="de">
-		<terms>
-			<term name="and others"></term>
-			<term name="no date">s.a.</term>
-			<term name="no-place">s.l.</term>
-			<term name="anonymous">N.N.</term>
-			<term name="volume">vol.</term>
-			<term name="editor">
-				<single>ed.</single>
-				<multiple>eds.</multiple>
-			</term>
-		</terms>
-	</locale>
-	<locale xml:lang="en">
-		<terms>
-			<term name="and others"></term>
-			<term name="no date">s.a.</term>
-			<term name="no-place">s.l.</term>
-			<term name="anonymous">N.N.</term>
-			<term name="volume">vol.</term>
-			<term name="editor">
-				<single>ed.</single>
-				<multiple>eds.</multiple>
-			</term>
-		</terms>
-	</locale>
-	<macro name="author">
-		<names variable="author">
-			<name name-as-sort-order="all" delimiter="/" form="short">
-				<name-part name="family" font-variant="small-caps"/>
-			</name>
-			<et-al term="and others" />
-			<substitute>
-				<names variable="editor" />
-				<text term="anonymous" />
-			</substitute>
-		</names>
-	</macro>
-	<macro name="author-bibliography">
-		<names variable="author">
-			<name name-as-sort-order="all" delimiter="/">
-				<name-part name="family" font-variant="small-caps"/>
-			</name>
-			<et-al />
-			<substitute>
-				<names variable="editor translator">
-					<name name-as-sort-order="all" delimiter="/">
-						<name-part name="family" font-variant="small-caps"/>
-					</name>
-					<label prefix=" (" suffix=")"/>
-					<et-al />
-				</names>
-				<text term="anonymous"/>
-			</substitute>
-		</names>
-	</macro>
-	<macro name="issued-year">
-		<choose>
-			<if variable="issued">
-				<date variable="issued">
-					<date-part name="year"/>
-				</date>
-			</if>
-			<else>
-				<text term="no date"/>
-			</else>
-		</choose>
-	</macro>
-	<macro name="publisher-place">
-		<choose>
-			<if variable="publisher-place">
-				<text variable="publisher-place" suffix=" "/>
-			</if>
-			<else-if type="book" match="any">
-				<text term="no-place" suffix=" "/>
-			</else-if>
-		</choose>
-	</macro>
-	<citation et-al-min="4" et-al-use-first="1" initialize-with="." disambiguate-add-givenname="true" disambiguate-add-year-suffix="true" collapse="year">
-		<sort>
-			<key macro="author"/>
-			<key macro="issued-year"/>
-		</sort>
-		<layout prefix="(" suffix=")" delimiter=", ">
-			<group delimiter=" ">
-				<text macro="author"/>
-				<text macro="issued-year" />
-			</group>
-		</layout>
-	</citation>
-	<bibliography et-al-min="4" et-al-use-first="1">
-		<sort>
-			<key macro="author-bibliography"/>
-			<key macro="issued-year"/>
-			<key variable="title"/>
-		</sort>
-		<layout suffix=".">
-			<text macro="author-bibliography" suffix=": "/>
-			<group delimiter=", ">
-				<text variable="title" font-style="italic"/>
-				<group delimiter=": ">
-					<text term="in"/>
-					<text variable="container-title" />
-				</group>
-				<group delimiter=" ">
-					<text term="volume"/>
-					<text variable="volume" />
-				</group>
-				<text variable="issue" prefix="(" suffix=")"/>
-				<group>
-					<text macro="publisher-place"/>
-					<text macro="issued-year"/>
-				</group>
-				<text variable="page"/>
-			</group>
-		</layout>
-	</bibliography>
+<style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0">
+  <info>
+    <title>Revista Ladinia</title>
+    <title-short>LADINIA</title-short>
+    <id>http://www.zotero.org/styles/revista-ladinia</id>
+    <link href="http://www.zotero.org/styles/revista-ladinia" rel="self"/>
+    <link href="http://www.zotero.org/styles/apa" rel="template"/>
+    <link href="https://micura.it/la/ativites/ladinia/style-sheet" rel="documentation"/>
+    <author>
+      <name>Samuel Frontull</name>
+      <email>samuel.frontull@uibk.ac.at</email>
+    </author>
+    <author>
+      <name>Paolo Anvidalfarei</name>
+      <email>paolo@micura.it</email>
+    </author>
+    <category citation-format="author-date"/>
+    <category field="linguistics"/>
+    <issn>1124-1004</issn>
+    <updated>2022-04-25T14:01:00+01:00</updated>
+    <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
+  </info>
+  <locale xml:lang="it">
+    <terms>
+      <term name="and others"/>
+      <term name="no date">s.a.</term>
+      <term name="no-place">s.l.</term>
+      <term name="anonymous">N.N.</term>
+      <term name="volume">vol.</term>
+      <term name="editor">
+        <single>ed.</single>
+        <multiple>eds.</multiple>
+      </term>
+    </terms>
+  </locale>
+  <locale xml:lang="de">
+    <terms>
+      <term name="and others"/>
+      <term name="no date">s.a.</term>
+      <term name="no-place">s.l.</term>
+      <term name="anonymous">N.N.</term>
+      <term name="volume">vol.</term>
+      <term name="editor">
+        <single>ed.</single>
+        <multiple>eds.</multiple>
+      </term>
+    </terms>
+  </locale>
+  <locale xml:lang="en">
+    <terms>
+      <term name="and others"/>
+      <term name="no date">s.a.</term>
+      <term name="no-place">s.l.</term>
+      <term name="anonymous">N.N.</term>
+      <term name="volume">vol.</term>
+      <term name="editor">
+        <single>ed.</single>
+        <multiple>eds.</multiple>
+      </term>
+    </terms>
+  </locale>
+  <macro name="author">
+    <names variable="author">
+      <name name-as-sort-order="all" delimiter="/" form="short">
+        <name-part name="family" font-variant="small-caps"/>
+      </name>
+      <et-al term="and others"/>
+      <substitute>
+        <names variable="editor"/>
+        <text term="anonymous"/>
+      </substitute>
+    </names>
+  </macro>
+  <macro name="author-bibliography">
+    <names variable="author">
+      <name name-as-sort-order="all" delimiter="/">
+        <name-part name="family" font-variant="small-caps"/>
+      </name>
+      <et-al/>
+      <substitute>
+        <names variable="editor translator">
+          <name name-as-sort-order="all" delimiter="/">
+            <name-part name="family" font-variant="small-caps"/>
+          </name>
+          <label prefix=" (" suffix=")"/>
+          <et-al/>
+        </names>
+        <text term="anonymous"/>
+      </substitute>
+    </names>
+  </macro>
+  <macro name="issued-year">
+    <choose>
+      <if variable="issued">
+        <date variable="issued">
+          <date-part name="year"/>
+        </date>
+      </if>
+      <else>
+        <text term="no date"/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="publisher-place">
+    <choose>
+      <if variable="publisher-place">
+        <text variable="publisher-place" suffix=" "/>
+      </if>
+      <else-if type="book" match="any">
+        <text term="no-place" suffix=" "/>
+      </else-if>
+    </choose>
+  </macro>
+  <citation et-al-min="4" et-al-use-first="1" initialize-with="." disambiguate-add-givenname="true" disambiguate-add-year-suffix="true" collapse="year">
+    <sort>
+      <key macro="author"/>
+      <key macro="issued-year"/>
+    </sort>
+    <layout prefix="(" suffix=")" delimiter=", ">
+      <group delimiter=" ">
+        <text macro="author"/>
+        <text macro="issued-year"/>
+      </group>
+    </layout>
+  </citation>
+  <bibliography et-al-min="4" et-al-use-first="1">
+    <sort>
+      <key macro="author-bibliography"/>
+      <key macro="issued-year"/>
+      <key variable="title"/>
+    </sort>
+    <layout suffix=".">
+      <text macro="author-bibliography" suffix=": "/>
+      <group delimiter=", ">
+        <text variable="title" font-style="italic"/>
+        <group delimiter=": ">
+          <text term="in"/>
+          <text variable="container-title"/>
+        </group>
+        <group delimiter=" ">
+          <text term="volume"/>
+          <text variable="volume"/>
+        </group>
+        <text variable="issue" prefix="(" suffix=")"/>
+        <group>
+          <text macro="publisher-place"/>
+          <text macro="issued-year"/>
+        </group>
+        <text variable="page"/>
+      </group>
+    </layout>
+  </bibliography>
 </style>

--- a/revista-ladinia.csl
+++ b/revista-ladinia.csl
@@ -62,39 +62,24 @@
 		</terms>
 	</locale>
 	<macro name="author">
-		<choose>
-			<if variable="author">
-				<names variable="author">
-					<name name-as-sort-order="all" delimiter="/" form="short">
-						<name-part name="family" font-variant="small-caps"/>
-					</name>
-					<et-al term="and others" />
-				</names>
-			</if>
-			<else-if variable="editor">
-				<names variable="editor">
-					<name name-as-sort-order="all" delimiter="/" form="short">
-						<name-part name="family" font-variant="small-caps"/>
-					</name>
-					<et-al term="and others" />
-				</names>
-			</else-if>
-			<else>
-				<text term="anonymous"/>
-			</else>
-		</choose>
+		<names variable="author">
+			<name name-as-sort-order="all" delimiter="/" form="short">
+				<name-part name="family" font-variant="small-caps"/>
+			</name>
+			<et-al term="and others" />
+			<substitute>
+				<names variable="editor" />
+				<text term="anonymous" />
+			</substitute>
+		</names>
 	</macro>
 	<macro name="author-bibliography">
-		<choose>
-			<if variable="author">
-				<names variable="author">
-					<name name-as-sort-order="all" delimiter="/">
-						<name-part name="family" font-variant="small-caps"/>
-					</name>
-					<et-al />
-				</names>
-			</if>
-			<else-if variable="editor">
+		<names variable="author">
+			<name name-as-sort-order="all" delimiter="/">
+				<name-part name="family" font-variant="small-caps"/>
+			</name>
+			<et-al />
+			<substitute>
 				<names variable="editor translator">
 					<name name-as-sort-order="all" delimiter="/">
 						<name-part name="family" font-variant="small-caps"/>
@@ -102,11 +87,9 @@
 					<label prefix=" (" suffix=")"/>
 					<et-al />
 				</names>
-			</else-if>
-			<else>
 				<text term="anonymous"/>
-			</else>
-		</choose>
+			</substitute>
+		</names>
 	</macro>
 	<macro name="issued-year">
 		<choose>

--- a/revista-ladinia.csl
+++ b/revista-ladinia.csl
@@ -5,7 +5,7 @@
 		<title>Revista Ladinia</title>
 		<title-short>LADINIA</title-short>
 		<id>http://www.zotero.org/styles/revista-ladinia</id>
-		<link href="https://micura.it/la/ativites/ladinia/style-sheet/revista-ladinia" rel="self"/>
+		<link href="http://www.zotero.org/styles/revista-ladinia" rel="self"/>
 		<link href="http://www.zotero.org/styles/apa" rel="template"/>
 		<link href="https://micura.it/la/ativites/ladinia/style-sheet" rel="documentation"/>
 		<author>

--- a/revista-ladinia.csl
+++ b/revista-ladinia.csl
@@ -19,7 +19,7 @@
 		<category citation-format="author-date"/>
 		<category field="linguistics"/>
 		<issn>1124-1004</issn>
-		<updated>2022-04-25T13:40:00+01:00</updated>
+		<updated>2022-04-25T14:01:00+01:00</updated>
 		<rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
 	</info>
 	<locale xml:lang="it">
@@ -125,7 +125,7 @@
 			</group>
 		</layout>
 	</citation>
-	<bibliography et-al-min="3" et-al-use-first="1">
+	<bibliography et-al-min="4" et-al-use-first="1">
 		<sort>
 			<key macro="author-bibliography"/>
 			<key macro="issued-year"/>

--- a/revista-ladinia.csl
+++ b/revista-ladinia.csl
@@ -1,0 +1,164 @@
+<?xml version="1.0" encoding="utf-8"?>
+<style
+	xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0">
+	<info>
+		<title>Revista Ladinia</title>
+		<title-short>LADINIA</title-short>
+		<id>http://www.zotero.org/styles/revista-ladinia</id>
+		<link href="https://micura.it/la/ativites/ladinia/style-sheet/revista-ladinia" rel="self"/>
+		<link href="http://www.zotero.org/styles/apa" rel="template"/>
+		<link href="https://micura.it/la/ativites/ladinia/style-sheet" rel="documentation"/>
+		<author>
+			<name>Samuel Frontull</name>
+			<email>samuel.frontull@uibk.ac.at</email>
+		</author>
+		<author>
+			<name>Paolo Anvidalfarei</name>
+			<email>paolo@micura.it</email>
+		</author>
+		<category citation-format="author-date"/>
+		<category field="linguistics"/>
+		<issn>1124-1004</issn>
+		<updated>2022-04-22T12:16:36+01:00</updated>
+		<rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
+	</info>
+	<locale xml:lang="it">
+		<terms>
+			<term name="and others"></term>
+			<term name="no date">s.a.</term>
+			<term name="no-place">s.l.</term>
+			<term name="no-publisher">N.N.</term>
+			<term name="editor">
+				<single>ed.</single>
+				<multiple>eds.</multiple>
+			</term>
+		</terms>
+	</locale>
+	<locale xml:lang="de">
+		<terms>
+			<term name="and others"></term>
+			<term name="no date">s.a.</term>
+			<term name="no-place">s.l.</term>
+			<term name="no-publisher">N.N.</term>
+			<term name="editor">
+				<single>ed.</single>
+				<multiple>eds.</multiple>
+			</term>
+		</terms>
+	</locale>
+	<locale xml:lang="en">
+		<terms>
+			<term name="and others"></term>
+			<term name="no date">s.a.</term>
+			<term name="no-place">s.l.</term>
+			<term name="no-publisher">N.N.</term>
+			<term name="editor">
+				<single>ed.</single>
+				<multiple>eds.</multiple>
+			</term>
+		</terms>
+	</locale>
+	<macro name="author">
+		<choose>
+			<if variable="author">
+				<names variable="author">
+					<name form="short" et-al-use-first="1">
+						<name-part name="family" font-variant="small-caps"/>
+					</name>
+					<et-al term="and others" />
+				</names>
+			</if>
+			<else-if variable="editor">
+				<names variable="editor">
+					<name name-as-sort-order="all" delimiter="/">
+						<name-part name="family" font-variant="small-caps"/>
+					</name>
+					<label prefix=" (" suffix=")"/>
+					<et-al term="and others" />
+				</names>
+			</else-if>
+			<else>
+				<text term="no-publisher"/>
+			</else>
+		</choose>
+	</macro>
+	<macro name="author-bibliography">
+		<choose>
+			<if variable="author">
+				<names variable="author">
+					<name name-as-sort-order="all" delimiter="/">
+						<name-part name="family" font-variant="small-caps"/>
+					</name>
+					<et-al />
+				</names>
+			</if>
+			<else-if variable="editor">
+				<names variable="editor translator">
+					<name name-as-sort-order="all" delimiter="/">
+						<name-part name="family" font-variant="small-caps"/>
+					</name>
+					<label prefix=" (" suffix=")"/>
+					<et-al />
+				</names>
+			</else-if>
+			<else>
+				<text term="no-publisher"/>
+			</else>
+		</choose>
+	</macro>
+	<macro name="issued-year">
+		<choose>
+			<if variable="issued">
+				<date variable="issued">
+					<date-part name="year"/>
+				</date>
+			</if>
+			<else>
+				<text term="no date"/>
+			</else>
+		</choose>
+	</macro>
+	<macro name="publisher-place">
+		<choose>
+			<if variable="publisher-place">
+				<text variable="publisher-place" suffix=" "/>
+			</if>
+			<else>
+				<text term="no-place" suffix=" "/>
+			</else>
+		</choose>
+	</macro>
+	<citation et-al-min="2" et-al-use-first="1" initialize-with="." disambiguate-add-givenname="true" disambiguate-add-year-suffix="true" collapse="year">
+		<sort>
+			<key macro="author"/>
+			<key macro="issued-year"/>
+		</sort>
+		<layout prefix="" suffix="" delimiter=", ">
+			<group delimiter=" ">
+				<text macro="author"/>
+				<text macro="issued-year" prefix="(" suffix=")"/>
+			</group>
+		</layout>
+	</citation>
+	<bibliography et-al-min="3" et-al-use-first="1">
+		<sort>
+			<key macro="author-bibliography"/>
+			<key macro="issued-year"/>
+			<key variable="title"/>
+		</sort>
+		<layout suffix=".">
+			<text macro="author-bibliography" suffix=": "/>
+			<group delimiter=", ">
+				<text variable="title" font-style="italic"/>
+				<text variable="container-title" prefix="in: "/>
+				<text variable="volume" prefix="vol. "/>
+				<text variable="issue" prefix="(" suffix=")"/>
+				<group>
+					<text macro="publisher-place"/>
+					<text macro="issued-year"/>
+				</group>
+				<text variable="page"/>
+			</group>
+		</layout>
+	</bibliography>
+</style>

--- a/revista-ladinia.csl
+++ b/revista-ladinia.csl
@@ -27,7 +27,6 @@
       <term name="no date">s.a.</term>
       <term name="no-place">s.l.</term>
       <term name="anonymous">N.N.</term>
-      <term name="volume">vol.</term>
       <term name="editor">
         <single>ed.</single>
         <multiple>eds.</multiple>
@@ -40,7 +39,6 @@
       <term name="no date">s.a.</term>
       <term name="no-place">s.l.</term>
       <term name="anonymous">N.N.</term>
-      <term name="volume">vol.</term>
       <term name="editor">
         <single>ed.</single>
         <multiple>eds.</multiple>
@@ -53,7 +51,6 @@
       <term name="no date">s.a.</term>
       <term name="no-place">s.l.</term>
       <term name="anonymous">N.N.</term>
-      <term name="volume">vol.</term>
       <term name="editor">
         <single>ed.</single>
         <multiple>eds.</multiple>
@@ -80,16 +77,11 @@
       <name name-as-sort-order="all" delimiter="/">
         <name-part name="family" font-variant="small-caps"/>
       </name>
+      <label prefix=" (" suffix=")"/>
       <et-al/>
       <substitute>
-        <names variable="editor translator">
-          <name name-as-sort-order="all" delimiter="/">
-            <name-part name="family" font-variant="small-caps"/>
-          </name>
-          <label prefix=" (" suffix=")"/>
-          <et-al/>
-        </names>
-        <text term="anonymous"/>
+        <names variable="editor translator" />
+        <text macro="anonymous"/>
       </substitute>
     </names>
   </macro>
@@ -142,7 +134,7 @@
           <text variable="container-title"/>
         </group>
         <group delimiter=" ">
-          <text term="volume"/>
+          <text term="volume" form="short"/>
           <text variable="volume"/>
         </group>
         <text variable="issue" prefix="(" suffix=")"/>

--- a/revista-ladinia.csl
+++ b/revista-ladinia.csl
@@ -68,9 +68,12 @@
       <et-al term="and others"/>
       <substitute>
         <names variable="editor"/>
-        <text term="anonymous"/>
+        <text macro="anonymous"/>
       </substitute>
     </names>
+  </macro>
+  <macro name="anonymous">
+    <text term="anonymous"/>
   </macro>
   <macro name="author-bibliography">
     <names variable="author">

--- a/revista-ladinia.csl
+++ b/revista-ladinia.csl
@@ -80,7 +80,7 @@
       <label prefix=" (" suffix=")"/>
       <et-al/>
       <substitute>
-        <names variable="editor translator" />
+        <names variable="editor translator"/>
         <text macro="anonymous"/>
       </substitute>
     </names>


### PR DESCRIPTION
Submission for the style of the "Ladinia" journal [1] published annually by the Ladin Institute “Micurá de Rü”.
It is based on APA [2] and includes adaptations according to the guidelines for authors [3].

[1] [https://www.micura.it/en/activities/ladinia](https://www.micura.it/en/activities/ladinia)
[2] [http://www.zotero.org/styles/apa](http://www.zotero.org/styles/apa)
[3] [https://www.micura.it/en/activities/ladinia/style-sheet](https://www.micura.it/en/activities/ladinia/style-sheet)