### PR TITLE
Update copernicus-publications.csl

### DIFF
--- a/copernicus-publications.csl
+++ b/copernicus-publications.csl
@@ -267,6 +267,7 @@
                 <text variable="page"/>
                 <text macro="doi"/>
               </group>
+            </else-if>
             <else>
               <group delimiter=", " suffix="," prefix=" ">
                 <text macro="title"/>

--- a/copernicus-publications.csl
+++ b/copernicus-publications.csl
@@ -255,7 +255,7 @@
             <else-if type="article-journal" match="any">
               <group delimiter=", " prefix=" ">
                 <text variable="title"/>
-                    <text variable="container-title" form="short"/>
+                <text variable="container-title" form="short"/>
                 <text variable="volume"/>
                 <text variable="page"/>
                 <text macro="doi"/>

--- a/copernicus-publications.csl
+++ b/copernicus-publications.csl
@@ -255,14 +255,7 @@
             <else-if type="article-journal" match="any">
               <group delimiter=", " prefix=" ">
                 <text variable="title"/>
-                <choose>
-                  <if match="any" variable="container-title-short">
-                    <text variable="container-title-short"/>
-                  </if>
-                  <else>
                     <text variable="container-title" form="short"/>
-                  </else>
-                </choose>
                 <text variable="volume"/>
                 <text variable="page"/>
                 <text macro="doi"/>

--- a/copernicus-publications.csl
+++ b/copernicus-publications.csl
@@ -255,12 +255,18 @@
             <else-if type="article-journal" match="any">
               <group delimiter=", " prefix=" ">
                 <text variable="title"/>
-                <text variable="container-title-short"/>
+                <choose>
+                  <if match="any" variable="container-title-short">
+                    <text variable="container-title-short"/>
+                  </if>
+                  <else>
+                    <text variable="container-title" form="short"/>
+                  </else>
+                </choose>
                 <text variable="volume"/>
                 <text variable="page"/>
                 <text macro="doi"/>
               </group>
-            </else-if>
             <else>
               <group delimiter=", " suffix="," prefix=" ">
                 <text macro="title"/>


### PR DESCRIPTION
Hi,

it seems container-title-short is not used very often by default (e.g. in Mendeley) and this creates problems for our users.
So I adapted:
If "container-title-short" exists, use it, else, go with "container-title form=short"

Thanks!