### PR TITLE
Update american-institute-of-physics.csl

### DIFF
--- a/american-institute-of-physics.csl
+++ b/american-institute-of-physics.csl
@@ -83,9 +83,9 @@
   </macro>
   <citation collapse="citation-number">
     <sort>
-      <key variable="citation-number">
+      <key variable="citation-number"/>
     </sort>
-    <layout delimiter="," vertical-align="sup"/>
+    <layout delimiter="," vertical-align="sup">
       <text variable="citation-number"/>
     </layout>
   </citation>

--- a/american-institute-of-physics.csl
+++ b/american-institute-of-physics.csl
@@ -91,7 +91,6 @@
   </citation>
   <bibliography entry-spacing="0">
     <layout suffix=".">
-      <!-- Citation Number -->
       <text variable="citation-number" vertical-align="sup"/>
       <text macro="author" prefix=" " suffix=", "/>
       <choose>

--- a/american-institute-of-physics.csl
+++ b/american-institute-of-physics.csl
@@ -92,7 +92,7 @@
   <bibliography entry-spacing="0">
     <layout suffix=".">
       <!-- Citation Number -->
-      <text variable="citation-number" prefix="[" suffix="]"/>
+      <text variable="citation-number" vertical-align="sup"/>
       <text macro="author" prefix=" " suffix=", "/>
       <choose>
         <if type="bill book graphic legal_case legislation motion_picture report song" match="any">

--- a/american-institute-of-physics.csl
+++ b/american-institute-of-physics.csl
@@ -16,7 +16,7 @@
     <category field="physics"/>
     <!--<category term="materials science"/>-->
     <summary>Common style use by AIP publications.</summary>
-    <updated>2022-05-16T00:04:27+00:00</updated>
+    <updated>2012-09-27T22:06:38+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <macro name="author">
@@ -83,10 +83,10 @@
   </macro>
   <citation collapse="citation-number">
     <sort>
-      <key variable="citation-number"/>
+      <key variable="citation-number" vertical-align="sup"/>
     </sort>
     <layout delimiter=",">
-      <text variable="citation-number" prefix="[" suffix="]"/>
+      <text variable="citation-number"/>
     </layout>
   </citation>
   <bibliography entry-spacing="0">

--- a/american-institute-of-physics.csl
+++ b/american-institute-of-physics.csl
@@ -83,9 +83,9 @@
   </macro>
   <citation collapse="citation-number">
     <sort>
-      <key variable="citation-number" vertical-align="sup"/>
+      <key variable="citation-number">
     </sort>
-    <layout delimiter=",">
+    <layout delimiter="," vertical-align="sup"/>
       <text variable="citation-number"/>
     </layout>
   </citation>

--- a/american-institute-of-physics.csl
+++ b/american-institute-of-physics.csl
@@ -16,7 +16,7 @@
     <category field="physics"/>
     <!--<category term="materials science"/>-->
     <summary>Common style use by AIP publications.</summary>
-    <updated>2012-09-27T22:06:38+00:00</updated>
+    <updated>2022-05-16T00:04:27+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <macro name="author">
@@ -85,13 +85,14 @@
     <sort>
       <key variable="citation-number"/>
     </sort>
-    <layout delimiter="," vertical-align="sup">
-      <text variable="citation-number"/>
+    <layout delimiter=",">
+<text variable="citation-number" prefix="[" suffix="]"/>
     </layout>
   </citation>
   <bibliography entry-spacing="0">
     <layout suffix=".">
-      <text variable="citation-number" vertical-align="sup"/>
+       <!-- Citation Number -->
+      <text variable="citation-number" prefix="[" suffix="]"/>
       <text macro="author" prefix=" " suffix=", "/>
       <choose>
         <if type="bill book graphic legal_case legislation motion_picture report song" match="any">

--- a/american-institute-of-physics.csl
+++ b/american-institute-of-physics.csl
@@ -86,12 +86,12 @@
       <key variable="citation-number"/>
     </sort>
     <layout delimiter=",">
-<text variable="citation-number" prefix="[" suffix="]"/>
+      <text variable="citation-number" prefix="[" suffix="]"/>
     </layout>
   </citation>
   <bibliography entry-spacing="0">
     <layout suffix=".">
-       <!-- Citation Number -->
+      <!-- Citation Number -->
       <text variable="citation-number" prefix="[" suffix="]"/>
       <text macro="author" prefix=" " suffix=", "/>
       <choose>

--- a/dependent/molecular-physics.csl
+++ b/dependent/molecular-physics.csl
@@ -6,8 +6,8 @@
     <link href="http://www.zotero.org/styles/molecular-physics" rel="self"/>
     <link href="http://www.zotero.org/styles/taylor-and-francis-aip" rel="independent-parent"/>
     <link href="https://www.tandfonline.com/action/authorSubmission?show=instructions&amp;journalCode=tmph20#references" rel="documentation"/>
-    <category field="physics"/>
     <category citation-format="numeric"/>
+    <category field="physics"/>
     <issn>0026-8976</issn>
     <eissn>1362-3028</eissn>
     <updated>2014-05-15T12:00:00+00:00</updated>

--- a/dependent/molecular-physics.csl
+++ b/dependent/molecular-physics.csl
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<style xmlns="http://purl.org/net/xbiblio/csl" version="1.0" default-locale="en-US">
+  <info>
+    <title>Molecular Physics</title>
+    <id>http://www.zotero.org/styles/molecular-physics</id>
+    <link href="http://www.zotero.org/styles/molecular-physics" rel="self"/>
+    <link href="http://www.zotero.org/styles/taylor-and-francis-aip" rel="independent-parent"/>
+    <link href="https://www.tandfonline.com/action/authorSubmission?show=instructions&amp;journalCode=tmph20#references" rel="documentation"/>
+    <category field="physics"/>
+    <category citation-format="numeric"/>
+    <issn>0026-8976</issn>
+    <eissn>1362-3028</eissn>
+    <updated>2014-05-15T12:00:00+00:00</updated>
+    <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
+  </info>
+</style>

--- a/taylor-and-francis-aip.csl
+++ b/taylor-and-francis-aip.csl
@@ -1,0 +1,158 @@
+<?xml version="1.0" encoding="utf-8"?>
+<style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" demote-non-dropping-particle="sort-only" default-locale="en-US">
+  <info>
+    <title>Taylor &amp; Francis - American Institute of Physics</title>
+    <title-short>AIP</title-short>
+    <id>http://www.zotero.org/styles/taylor-and-francis-aip</id>
+    <link href="http://www.zotero.org/styles/taylor-and-francis-aip" rel="self"/>
+    <link href="http://www.zotero.org/styles/american-institute-of-physics" rel="template"/>
+    <link href="http://www.tandf.co.uk/journals/authors/style/reference/tf_O.pdf" rel="documentation"/>
+    <!-- No attempt to make compound citations is made here <http://forums.zotero.org/discussion/4288/>-->
+    <author>
+      <name>Sebastian Karcher</name>
+    </author>
+    <category citation-format="numeric"/>
+    <category field="physics"/>
+    <!--<category term="materials science"/>-->
+    <summary>Common style use by AIP publications.</summary>
+    <updated>2022-05-16T00:04:27+00:00</updated>
+    <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
+  </info>
+  <macro name="author">
+    <names variable="author">
+      <name delimiter=", " initialize-with="." and="text"/>
+      <label form="long" prefix=", " suffix=" "/>
+      <substitute>
+        <names variable="editor"/>
+        <names variable="translator"/>
+      </substitute>
+    </names>
+  </macro>
+  <macro name="editor">
+    <names variable="editor">
+      <label form="verb" suffix=" "/>
+      <name delimiter=", " initialize-with="." and="text"/>
+    </names>
+  </macro>
+  <macro name="year-date">
+    <choose>
+      <if variable="issued">
+        <date variable="issued">
+          <date-part name="year"/>
+        </date>
+      </if>
+      <else>
+        <text term="no date" form="short"/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="day-date">
+    <choose>
+      <if variable="issued">
+        <date variable="issued">
+          <date-part name="day" suffix=" "/>
+          <date-part name="month" form="long" suffix=" "/>
+          <date-part name="year"/>
+        </date>
+      </if>
+      <else>
+        <text term="no date" form="short"/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="publisher">
+    <group prefix="(" suffix=")" delimiter=", ">
+      <text variable="publisher"/>
+      <text variable="publisher-place" text-case="title"/>
+      <text macro="year-date"/>
+    </group>
+  </macro>
+  <macro name="edition">
+    <choose>
+      <if is-numeric="edition">
+        <group delimiter=" ">
+          <number variable="edition" form="ordinal"/>
+          <text term="edition" form="short"/>
+        </group>
+      </if>
+      <else>
+        <text variable="edition"/>
+      </else>
+    </choose>
+  </macro>
+  <citation collapse="citation-number">
+    <sort>
+      <key variable="citation-number"/>
+    </sort>
+    <layout delimiter=",">
+      <text variable="citation-number" prefix="[" suffix="]"/>
+    </layout>
+  </citation>
+  <bibliography entry-spacing="0">
+    <layout suffix=".">
+      <!-- Citation Number -->
+      <text variable="citation-number" prefix="[" suffix="]"/>
+      <text macro="author" prefix=" " suffix=", "/>
+      <choose>
+        <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
+          <group delimiter=" ">
+            <group delimiter=", ">
+              <text variable="title" text-case="title" font-style="italic"/>
+              <text macro="edition"/>
+            </group>
+            <group delimiter=", ">
+              <text macro="publisher"/>
+              <group delimiter=" ">
+                <label variable="page" form="short"/>
+                <text variable="page"/>
+              </group>
+            </group>
+          </group>
+        </if>
+        <else-if type="chapter paper-conference" match="any">
+          <group delimiter=" ">
+            <text term="in"/>
+            <group delimiter=", ">
+              <text variable="container-title" form="short" text-case="title" font-style="italic"/>
+              <text macro="editor"/>
+              <text macro="edition"/>
+            </group>
+            <group delimiter=", ">
+              <text macro="publisher"/>
+              <group delimiter=" ">
+                <label variable="page" form="short"/>
+                <text variable="page"/>
+              </group>
+            </group>
+          </group>
+        </else-if>
+        <else-if type="patent">
+          <group delimiter=" ">
+            <text variable="number" prefix=" "/>
+            <text macro="day-date" prefix="(" suffix=")"/>
+          </group>
+        </else-if>
+        <else-if type="thesis">
+          <group delimiter=", ">
+            <text variable="title" text-case="title"/>
+            <text variable="genre"/>
+            <text variable="publisher"/>
+            <text macro="year-date"/>
+          </group>
+        </else-if>
+        <else>
+          <group delimiter=" ">
+            <text variable="container-title" form="short" text-case="title"/>
+            <group delimiter=", ">
+              <text variable="volume" font-weight="bold"/>
+              <group delimiter=" ">
+                <text variable="page-first"/>
+                <text macro="year-date" prefix="(" suffix=")"/>
+              </group>
+            </group>
+          </group>
+        </else>
+      </choose>
+    </layout>
+  </bibliography>
+</style>


### PR DESCRIPTION
I am about to submit a paper to [Molecular Physics ](https://www.tandfonline.com/journals/tmph20) and when looking at the reference guidelines I noted that it uses American Institute of Physics which Zotero has. However, based on the [document](
http://www.tandf.co.uk/journals/authors/style/reference/tf_O.pdf) provided by them. The link here downloads a PDF, you can navigate to the site [here](https://www.tandfonline.com/action/authorSubmission?show=instructions&journalCode=tmph20#references) and do it yourself. 

The citation style needs citations to look like this -> [1] and [1-14] while the one in the Zotero style repository it uses superscripts. This PR aims to fix this and update it to what Mol. Phys. requires. 
