### PR TITLE
Update glossa.csl

### DIFF
--- a/glossa.csl
+++ b/glossa.csl
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" default-locale="en-GB" demote-non-dropping-particle="never">
+<style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" demote-non-dropping-particle="never" default-locale="en-GB">
   <info>
     <title>Glossa</title>
     <id>http://www.zotero.org/styles/glossa</id>

--- a/glossa.csl
+++ b/glossa.csl
@@ -39,11 +39,11 @@
       <if type="chapter paper-conference entry-dictionary entry-encyclopedia" match="any">
         <group delimiter=", ">
           <names variable="container-author" delimiter=", ">
-            <name and="symbol" initialize-with=". " delimiter=", "/>
+            <name initialize-with=". " delimiter=" &amp; " delimiter-precedes-last="always"/>
             <label form="short" prefix=" (" text-case="title" suffix=")"/>
           </names>
           <names variable="editor translator" delimiter=", ">
-            <name and="symbol" delimiter=", "/>
+            <name delimiter=" &amp; " delimiter-precedes-last="always"/>
             <label form="short" prefix=" (" suffix=")"/>
           </names>
         </group>
@@ -55,11 +55,11 @@
       <if type="article-journal chapter paper-conference entry-dictionary entry-encyclopedia" match="none">
         <group delimiter=", " prefix=" (" suffix=")">
           <names variable="container-author" delimiter=", ">
-            <name and="symbol" initialize-with=". " delimiter=", "/>
+            <name initialize-with=". " delimiter=" &amp; "  delimiter-precedes-last="always"/>
             <label form="short" prefix=", " text-case="title"/>
           </names>
           <names variable="editor translator" delimiter=", ">
-            <name and="symbol" initialize-with=". " delimiter=", "/>
+            <name initialize-with=". " delimiter=" &amp; "  delimiter-precedes-last="always"/>
             <label form="short" prefix=", " text-case="title"/>
           </names>
         </group>
@@ -68,7 +68,7 @@
   </macro>
   <macro name="author">
     <names variable="author" suffix=".">
-      <name delimiter=" &amp; " and="symbol" delimiter-precedes-last="never" initialize="false" initialize-with="." name-as-sort-order="all"/>
+      <name delimiter=" &amp; " delimiter-precedes-last="always" initialize="false" initialize-with="." name-as-sort-order="all"/>
       <label form="short" prefix=" (" suffix=")"/>
       <substitute>
         <names variable="editor"/>
@@ -87,7 +87,7 @@
   </macro>
   <macro name="author-short">
     <names variable="author">
-      <name form="short" and="symbol" delimiter=", " initialize-with=". "/>
+      <name form="short" delimiter=" &amp; " delimiter-precedes-last="always" initialize-with=". "/>
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>

--- a/glossa.csl
+++ b/glossa.csl
@@ -14,11 +14,15 @@
       <name>Brenton M. Wiernik</name>
       <email>zotero@wiernik.org</email>
     </contributor>
+    <contributor>
+      <name>Lisa Levinson</name>
+      <email>lisa.levinson@gmail.com</email>
+    </contributor>
     <category citation-format="author-date"/>
     <category field="linguistics"/>
     <eissn>2397-1835</eissn>
     <summary>Citation style for Glossa based on APA 6th edition.</summary>
-    <updated>2017-09-30T02:59:26+00:00</updated>
+    <updated>2022-05-24T20:26:54+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale xml:lang="en">
@@ -64,7 +68,7 @@
   </macro>
   <macro name="author">
     <names variable="author" suffix=".">
-      <name and="symbol" delimiter-precedes-last="never" initialize="false" initialize-with="." name-as-sort-order="first"/>
+      <name delimiter=" &amp; " and="symbol" delimiter-precedes-last="never" initialize="false" initialize-with="." name-as-sort-order="all"/>
       <label form="short" prefix=" (" suffix=")"/>
       <substitute>
         <names variable="editor"/>

--- a/glossa.csl
+++ b/glossa.csl
@@ -55,11 +55,11 @@
       <if type="article-journal chapter paper-conference entry-dictionary entry-encyclopedia" match="none">
         <group delimiter=", " prefix=" (" suffix=")">
           <names variable="container-author" delimiter=", ">
-            <name initialize-with=". " delimiter=" &amp; "  delimiter-precedes-last="always"/>
+            <name initialize-with=". " delimiter=" &amp; " delimiter-precedes-last="always"/>
             <label form="short" prefix=", " text-case="title"/>
           </names>
           <names variable="editor translator" delimiter=", ">
-            <name initialize-with=". " delimiter=" &amp; "  delimiter-precedes-last="always"/>
+            <name initialize-with=". " delimiter=" &amp; " delimiter-precedes-last="always"/>
             <label form="short" prefix=", " text-case="title"/>
           </names>
         </group>


### PR DESCRIPTION
changed all authors to be Lastname, Firstname and separated by ampersand, according to updated stylesheet (as requested by Glossa journal editor)