### PR TITLE
removes abstract from issued macro

### DIFF
--- a/universitat-bern-institut-fur-sozialanthropologie.csl
+++ b/universitat-bern-institut-fur-sozialanthropologie.csl
@@ -12,6 +12,9 @@
       <name>Manuel Meister</name>
       <email>manuel@meister.id</email>
     </author>
+	<contributor>
+	  <name>Denis Maier</name>
+	</contributor>
     <category citation-format="author-date"/>
     <category field="anthropology"/>
     <summary>Citation style for Social Anthropology of the University of Berne</summary>
@@ -309,7 +312,6 @@
     </choose>
   </macro>
   <macro name="issued">
-    <text variable="abstract"/>
     <choose>
       <if type="bill legal_case legislation" match="none">
         <choose>

--- a/universitat-bern-institut-fur-sozialanthropologie.csl
+++ b/universitat-bern-institut-fur-sozialanthropologie.csl
@@ -12,9 +12,9 @@
       <name>Manuel Meister</name>
       <email>manuel@meister.id</email>
     </author>
-	<contributor>
-	  <name>Denis Maier</name>
-	</contributor>
+    <contributor>
+      <name>Denis Maier</name>
+    </contributor>
     <category citation-format="author-date"/>
     <category field="anthropology"/>
     <summary>Citation style for Social Anthropology of the University of Berne</summary>


### PR DESCRIPTION
I don't see why the the `issued` macro should render the abstract. @manuelmeister Is there any reason for that? I couldn't find anything in the Zitierrichtlinien.