### PR TITLE
Create universite-du-quebec-a-montreal-prenoms.csl

### DIFF
--- a/universite-du-quebec-a-montreal-prenoms-etudes-feministes-iref.csl
+++ b/universite-du-quebec-a-montreal-prenoms-etudes-feministes-iref.csl
@@ -1,0 +1,935 @@
+<?xml version="1.0" encoding="utf-8"?>
+<style class="in-text" version="1.0" et-al-min="3" et-al-use-first="1" initialize="false" demote-non-dropping-particle="never" default-locale="fr-CA" xmlns="http://purl.org/net/xbiblio/csl">
+  <info>
+    <title>Université du Québec à Montréal - APA - prénoms - Études féministes - IREF (Français - Canada)</title>
+    <title-short>UQAM prénoms</title-short>
+    <id>http://www.zotero.org/styles/universite-du-quebec-a-montreal-prenoms-etudes-feministes-iref</id>
+    <link href="http://www.zotero.org/styles/universite-du-quebec-a-montreal-prenoms-etudes-feministes-iref" rel="self"/>
+    <link href="http://www.zotero.org/styles/apa" rel="template"/>
+    <link href="https://uqam-ca.libguides.com/etudes-feministes/citer-ses-sources" rel="documentation"/>
+    <link href="http://www.guidemt.uqam.ca/citer/style-uqam" rel="documentation"/>
+    <link href="https://uqam-ca.libguides.com/c.php?g=725279&amp;p=5195760" rel="documentation"/>
+    <author>
+      <name>Jean-Jacques Rondeau</name>
+      <email>rondeau.jean-jacques@uqam.ca</email>
+    </author>
+    <contributor>
+      <name>Noémie Poirier Monfette</name>
+      <email>poirier_monfette.noemie@uqam.ca</email>
+    </contributor>
+    <category citation-format="author-date"/>
+    <category field="psychology"/>
+    <category field="generic-base"/>
+    <summary>Le style UQAM APA avec prénoms est une adaptation française canadienne de la 7e édition de la norme APA qui permet l'affichage des prénoms des personnes autrices dans les références en bibliographie.</summary>
+    <updated>2022-05-26T16:47:05+00:00</updated>
+    <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
+  </info>
+  <locale xml:lang="fr">
+    <terms>
+      <term name="editor" form="short">dir.</term>
+      <term name="editortranslator" form="short">éd. &amp; trad.</term>
+      <term name="translator" form="short">trad.</term>
+      <term name="no date" form="short">s. d.</term>
+      <term name="in">dans</term>
+      <term name="retrieved">récupéré</term>
+      <term name="from">de</term>
+      <term name="presented at">communication présentée au</term>
+      <term name="page" form="short">p.</term>
+      <term name="chapter-number" form="short">chap.</term>
+      <term name="section">section</term>
+      <term name="number-of-volumes" form="short">vol.</term>
+      <term name="number">numéro</term>
+      <term name="scale">échelle</term>
+      <term name="circa" form="short">v. </term>
+      <term name="interview" form="verb">interviewé par</term>
+      <term name="author" form="verb">enregistré par</term>
+      <term name="number" form="short">n&amp;#7506;</term>
+    </terms>
+  </locale>
+  <macro name="container-contributors">
+    <choose>
+      <if type="chapter paper-conference entry-encyclopedia entry-dictionary map" match="any">
+        <names variable="editor container-author" delimiter=", " suffix=", ">
+          <name and="text" delimiter-precedes-last="never" initialize="false"/>
+          <label form="short" prefix=" (" suffix=")"/>
+        </names>
+      </if>
+      <else-if type="interview broadcast" match="any">
+        <choose>
+          <if match="any" variable="container-title">
+            <text variable="publisher" suffix=", "/>
+          </if>
+        </choose>
+      </else-if>
+    </choose>
+  </macro>
+  <macro name="secondary-contributors">
+    <choose>
+      <if type="article-journal book chapter paper-conference entry-encyclopedia entry-dictionary" match="none">
+        <names variable="editor" delimiter=", " prefix=" (" suffix=")">
+          <name and="symbol" initialize="false"/>
+          <label form="short" prefix=", "/>
+        </names>
+      </if>
+    </choose>
+  </macro>
+  <macro name="author">
+    <choose>
+      <if match="any" variable="composer">
+        <names variable="composer">
+          <name and="text" delimiter-precedes-last="never" et-al-use-last="true" initialize="false" name-as-sort-order="all"/>
+        </names>
+      </if>
+      <else>
+        <names variable="author">
+          <name and="text" delimiter-precedes-last="never" et-al-use-last="true" initialize="false" name-as-sort-order="all"/>
+          <label form="short" prefix=" (" suffix=")"/>
+          <substitute>
+            <choose>
+              <if type="entry-dictionary entry-encyclopedia webpage manuscript legislation legal_case bill treaty article map article-magazine article-newspaper" match="any">
+                <text macro="title"/>
+              </if>
+              <else-if type="book" match="any">
+                <names variable="editor"/>
+                <text macro="title" font-style="italic"/>
+              </else-if>
+              <else>
+                <names variable="editor"/>
+                <names variable="translator"/>
+              </else>
+            </choose>
+            <choose>
+              <if type="report">
+                <text variable="publisher"/>
+                <text variable="title" font-style="italic" suffix="."/>
+              </if>
+            </choose>
+          </substitute>
+        </names>
+      </else>
+    </choose>
+  </macro>
+  <macro name="author-short">
+    <choose>
+      <if match="any" variable="composer">
+        <names variable="composer">
+          <name form="short" and="text" name-as-sort-order="all"/>
+        </names>
+      </if>
+      <else>
+        <names variable="author">
+          <name form="short" and="text" name-as-sort-order="all"/>
+          <et-al font-style="italic"/>
+          <substitute>
+            <choose>
+              <if variable="container-title">
+                <choose>
+                  <if type="bill legal_case legislation treaty article-journal" match="none">
+                    <text variable="title" quotes="true"/>
+                  </if>
+                </choose>
+              </if>
+            </choose>
+            <names variable="editor"/>
+            <names variable="translator"/>
+            <choose>
+              <if type="report">
+                <text variable="publisher"/>
+                <text variable="title" font-style="italic"/>
+              </if>
+              <else>
+                <choose>
+                  <if match="any" variable="title-short">
+                    <text variable="title-short" quotes="false"/>
+                  </if>
+                  <else>
+                    <text variable="title" font-style="italic"/>
+                  </else>
+                </choose>
+              </else>
+            </choose>
+          </substitute>
+        </names>
+      </else>
+    </choose>
+  </macro>
+  <macro name="access">
+    <choose>
+      <if type="thesis dataset" match="any">
+        <choose>
+          <if variable="DOI">
+            <text variable="DOI" prefix="https://doi.org/"/>
+          </if>
+          <else-if variable="archive" match="any">
+            <group delimiter=". ">
+              <text variable="archive" suffix="."/>
+              <text variable="URL"/>
+            </group>
+          </else-if>
+          <else>
+            <choose>
+              <if type="dataset" match="all" variable="accessed">
+                <group delimiter=" ">
+                  <text term="retrieved" text-case="capitalize-first"/>
+                  <date form="text" variable="accessed" prefix="le "/>
+                  <text term="from"/>
+                  <text variable="URL"/>
+                </group>
+              </if>
+              <else>
+                <text variable="URL"/>
+              </else>
+            </choose>
+          </else>
+        </choose>
+      </if>
+      <else>
+        <choose>
+          <if variable="DOI">
+            <text variable="DOI" prefix="https://doi.org/"/>
+          </if>
+          <else>
+            <choose>
+              <if type="entry-encyclopedia entry-dictionary map article" match="any">
+                <choose>
+                  <if match="any" variable="accessed">
+                    <group delimiter=" ">
+                      <text term="retrieved" text-case="capitalize-first"/>
+                      <date form="text" variable="accessed" prefix="le "/>
+                      <text term="from"/>
+                      <text variable="URL"/>
+                    </group>
+                  </if>
+                  <else>
+                    <text variable="URL"/>
+                  </else>
+                </choose>
+              </if>
+              <else>
+                <text variable="URL"/>
+              </else>
+            </choose>
+          </else>
+        </choose>
+      </else>
+    </choose>
+  </macro>
+  <macro name="title">
+    <choose>
+      <if type="legislation bill" match="any">
+        <choose>
+          <if match="any" variable="issued">
+            <group delimiter=". ">
+              <text variable="title" font-style="italic"/>
+              <text variable="container-title"/>
+            </group>
+          </if>
+          <else-if match="none" variable="number">
+            <group delimiter=". ">
+              <text variable="title" font-style="italic"/>
+              <text variable="container-title"/>
+            </group>
+          </else-if>
+          <else>
+            <group delimiter=". " suffix=", ">
+              <text variable="title" font-style="italic"/>
+              <text variable="container-title"/>
+            </group>
+          </else>
+        </choose>
+      </if>
+      <else-if type="interview" match="any">
+        <group delimiter=" " suffix=". ">
+          <text term="interview" form="verb" text-case="capitalize-first"/>
+          <names variable="interviewer">
+            <name and="text" initialize-with="."/>
+          </names>
+        </group>
+        <text variable="title"/>
+      </else-if>
+      <else-if type="legal_case" match="all" variable="references">
+        <text variable="title" font-style="italic" suffix=","/>
+      </else-if>
+      <else-if type="thesis report book graphic manuscript speech dataset legal_case treaty article webpage" match="any">
+        <text variable="title" font-style="italic"/>
+      </else-if>
+      <else-if type="motion_picture broadcast figure map article-journal entry-encyclopedia song musical_score" match="any">
+        <choose>
+          <if match="any" variable="container-title">
+            <text variable="title"/>
+          </if>
+          <else>
+            <text variable="title" font-style="italic"/>
+          </else>
+        </choose>
+      </else-if>
+      <else-if type="patent" match="any">
+        <text variable="title" font-style="italic"/>
+      </else-if>
+      <else>
+        <text variable="title"/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="publisher">
+    <choose>
+      <if type="speech" match="any">
+        <text variable="publisher-place"/>
+      </if>
+      <else-if type="post thesis" match="none">
+        <group delimiter=", ">
+          <choose>
+            <if type="book chapter report" match="any">
+              <text variable="publisher"/>
+            </if>
+            <else-if type="patent">
+              <group delimiter=", ">
+                <text variable="authority"/>
+                <text variable="publisher"/>
+              </group>
+            </else-if>
+            <else-if type="broadcast interview" match="all" variable="container-title"/>
+            <else-if type="manuscript" match="any">
+              <group delimiter=" ">
+                <text variable="archive"/>
+                <text variable="archive_location" prefix="(" suffix=")"/>
+              </group>
+              <text variable="publisher-place"/>
+            </else-if>
+            <else-if type="article-journal article-magazine article-newspaper post-weblog" match="none">
+              <text variable="publisher"/>
+            </else-if>
+          </choose>
+        </group>
+      </else-if>
+    </choose>
+  </macro>
+  <macro name="event">
+    <choose>
+      <if variable="container-title" match="none">
+        <choose>
+          <if variable="event">
+            <text variable="event"/>
+          </if>
+          <else-if type="speech" match="any">
+            <text variable="publisher"/>
+          </else-if>
+        </choose>
+      </if>
+    </choose>
+  </macro>
+  <macro name="extra">
+    <choose>
+      <if type="book thesis" match="any">
+        <choose>
+          <if match="any" is-numeric="number-of-volumes">
+            <group delimiter=" ">
+              <number variable="number-of-volumes"/>
+              <label variable="number-of-volumes" form="short"/>
+            </group>
+          </if>
+          <else>
+            <text variable="number-of-volumes" prefix="[" suffix="]"/>
+          </else>
+        </choose>
+      </if>
+      <else-if type="legal_case" match="all" variable="references">
+        <group delimiter=", " prefix="(" suffix=")">
+          <text variable="authority"/>
+          <date date-parts="year" form="text" variable="issued">
+            <date-part name="year"/>
+          </date>
+          <date delimiter=" " variable="issued">
+            <date-part name="day"/>
+            <date-part name="month"/>
+          </date>
+        </group>
+      </else-if>
+      <else-if type="article-journal" match="any">
+        <choose>
+          <if match="none" variable="container-title">
+            <text variable="genre"/>
+          </if>
+        </choose>
+      </else-if>
+    </choose>
+  </macro>
+  <macro name="issued">
+    <choose>
+      <if match="any" variable="original-date">
+        <choose>
+          <if type="musical_score book song" match="any">
+            <group prefix="(" suffix=")">
+              <date date-parts="year" form="text" variable="issued"/>
+              <text variable="year-suffix"/>
+            </group>
+          </if>
+          <else>
+            <group prefix="(" suffix=")">
+              <date delimiter="" variable="original-date">
+                <date-part name="year"/>
+              </date>
+              <text variable="year-suffix"/>
+              <date delimiter=" " variable="original-date" prefix=", ">
+                <date-part name="day" form="ordinal"/>
+                <date-part name="month"/>
+              </date>
+            </group>
+          </else>
+        </choose>
+      </if>
+      <else-if match="any" is-uncertain-date="issued">
+        <choose>
+          <if type="map" match="any">
+            <date form="text" variable="issued" prefix="(" suffix="?)"/>
+          </if>
+          <else>
+            <group delimiter=" " prefix="(" suffix=")">
+              <text term="circa" form="short"/>
+              <date variable="issued">
+                <date-part name="year"/>
+              </date>
+            </group>
+          </else>
+        </choose>
+      </else-if>
+      <else-if match="any" variable="status">
+        <group delimiter="-" prefix="(" suffix=")">
+          <text variable="status"/>
+          <text variable="year-suffix"/>
+        </group>
+      </else-if>
+      <else-if variable="issued">
+        <choose>
+          <if type="legal_case" match="all" variable="references"/>
+          <else-if type="bill legal_case" match="any">
+            <group prefix="(" suffix=").">
+              <date date-parts="year" form="text" variable="issued">
+                <date-part name="year"/>
+              </date>
+              <date delimiter=" " variable="issued" prefix=", ">
+                <date-part name="day"/>
+                <date-part name="month"/>
+              </date>
+            </group>
+          </else-if>
+          <else-if type="legislation" match="any"/>
+          <else-if type="dataset" match="any">
+            <group prefix="(" suffix=")">
+              <date delimiter="" variable="issued">
+                <date-part name="year"/>
+              </date>
+              <text variable="year-suffix" prefix="-"/>
+              <date delimiter="" variable="issued" prefix=", ">
+                <date-part name="day"/>
+                <date-part name="month" prefix=" "/>
+              </date>
+            </group>
+          </else-if>
+          <else>
+            <group prefix="(" suffix=").">
+              <date variable="issued">
+                <date-part name="year"/>
+              </date>
+              <text variable="year-suffix"/>
+              <choose>
+                <if type="article-journal bill book chapter graphic legal_case legislation paper-conference thesis patent" match="none">
+                  <group prefix=", ">
+                    <date variable="issued">
+                      <date-part name="day" form="ordinal"/>
+                      <date-part prefix=" " name="month"/>
+                    </date>
+                    <choose>
+                      <if type="entry-encyclopedia" match="any">
+                        <text variable="issue" prefix=", "/>
+                      </if>
+                    </choose>
+                  </group>
+                </if>
+              </choose>
+            </group>
+          </else>
+        </choose>
+      </else-if>
+      <else-if type="manuscript" match="all" variable="issue">
+        <text variable="issue" prefix="[" suffix="]."/>
+      </else-if>
+      <else>
+        <group prefix=" (" suffix=")">
+          <choose>
+            <if type="legislation" match="any"/>
+            <else-if type="graphic" match="none">
+              <text term="no date" form="short"/>
+              <text variable="year-suffix" prefix="-"/>
+            </else-if>
+          </choose>
+        </group>
+      </else>
+    </choose>
+  </macro>
+  <macro name="issued-sort">
+    <choose>
+      <if type="article-journal bill book chapter graphic legal_case legislation motion_picture paper-conference report song" match="none">
+        <date variable="issued">
+          <date-part name="year"/>
+          <date-part name="month"/>
+          <date-part name="day"/>
+        </date>
+      </if>
+      <else>
+        <date variable="issued">
+          <date-part name="year"/>
+        </date>
+      </else>
+    </choose>
+  </macro>
+  <macro name="issued-year">
+    <choose>
+      <if match="any" is-uncertain-date="issued">
+        <choose>
+          <if type="map" match="any">
+            <group>
+              <date form="text" variable="issued" suffix="?"/>
+            </group>
+          </if>
+          <else>
+            <group delimiter=" ">
+              <text term="circa" form="short"/>
+              <date variable="issued">
+                <date-part name="year"/>
+              </date>
+            </group>
+          </else>
+        </choose>
+        <text variable="year-suffix"/>
+      </if>
+      <else-if match="any" variable="status">
+        <group delimiter="-">
+          <text variable="status"/>
+          <text variable="year-suffix"/>
+        </group>
+      </else-if>
+      <else-if variable="issued">
+        <choose>
+          <if type="legislation" match="any"/>
+          <else>
+            <group delimiter="/">
+              <date variable="original-date" form="text"/>
+              <group>
+                <date variable="issued">
+                  <date-part name="year"/>
+                </date>
+                <text variable="year-suffix"/>
+              </group>
+            </group>
+          </else>
+        </choose>
+      </else-if>
+      <else>
+        <choose>
+          <if type="legislation" match="any">
+            <group delimiter=" ">
+              <text variable="container-title"/>
+              <text variable="section" prefix="(" suffix=")"/>
+            </group>
+          </if>
+          <else>
+            <group delimiter="-">
+              <text term="no date" form="short"/>
+              <text variable="year-suffix"/>
+            </group>
+          </else>
+        </choose>
+      </else>
+    </choose>
+  </macro>
+  <macro name="edition">
+    <choose>
+      <if is-numeric="edition">
+        <group delimiter=" ">
+          <number variable="edition" form="ordinal"/>
+          <text term="edition" form="short"/>
+        </group>
+      </if>
+      <else>
+        <text variable="edition"/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="translation-illustration">
+    <choose>
+      <if variable="translator illustrator" match="any">
+        <group delimiter=", ">
+          <names variable="translator" delimiter=", " prefix=" ">
+            <name and="text" delimiter-precedes-last="never" initialize="false"/>
+            <label form="short" prefix=", "/>
+          </names>
+          <names variable="illustrator">
+            <name and="text" delimiter-precedes-last="never" initialize="false"/>
+            <label form="short" prefix=", "/>
+          </names>
+        </group>
+      </if>
+    </choose>
+  </macro>
+  <macro name="locators">
+    <choose>
+      <if type="article-journal article-magazine review-book interview article" match="any">
+        <group prefix=", " delimiter=", ">
+          <group>
+            <text variable="volume" font-style="italic"/>
+            <text variable="issue" prefix="(" suffix=")"/>
+          </group>
+          <text variable="page"/>
+          <text variable="archive_location"/>
+        </group>
+      </if>
+      <else-if type="article-newspaper">
+        <text variable="publisher-place" prefix=" (" suffix=")"/>
+        <group delimiter=", " prefix=", ">
+          <text variable="section" prefix="section "/>
+          <text variable="page"/>
+        </group>
+      </else-if>
+      <else-if type="book paper-conference entry-encyclopedia chapter entry-dictionary musical_score map figure" match="any">
+        <group prefix=" (" suffix=")" delimiter=", ">
+          <group delimiter=", ">
+            <text macro="edition"/>
+            <text macro="translation-illustration"/>
+          </group>
+          <group delimiter=" ">
+            <label variable="volume" form="short"/>
+            <number variable="volume" form="numeric"/>
+          </group>
+          <group delimiter=" ">
+            <label variable="chapter-number" form="short"/>
+            <number variable="chapter-number"/>
+          </group>
+          <group delimiter=" ">
+            <text term="version"/>
+            <text variable="version"/>
+          </group>
+          <group delimiter=" ">
+            <label variable="page" form="short"/>
+            <text variable="page"/>
+          </group>
+        </group>
+        <choose>
+          <if type="book" match="any">
+            <text variable="number" prefix=" (" suffix=")"/>
+            <group prefix=" [" suffix="]">
+              <text variable="genre"/>
+              <text variable="medium"/>
+            </group>
+          </if>
+        </choose>
+      </else-if>
+      <else-if type="legal_case" match="any">
+        <group delimiter=" " prefix=" ">
+          <text variable="number"/>
+          <choose>
+            <if match="none" variable="references page">
+              <text variable="authority" prefix="(" suffix=")"/>
+            </if>
+            <else-if match="none" variable="references">
+              <text variable="authority"/>
+            </else-if>
+          </choose>
+          <text variable="page"/>
+        </group>
+        <text variable="source" prefix=". "/>
+      </else-if>
+      <else-if type="treaty" match="any">
+        <group delimiter=", ">
+          <group delimiter=" " prefix=", ">
+            <label variable="volume" form="short"/>
+            <text variable="volume"/>
+          </group>
+          <group delimiter=" ">
+            <label variable="page" form="short"/>
+            <text variable="page"/>
+          </group>
+          <group delimiter=" " prefix=" ">
+            <text term="issue" form="short"/>
+            <text variable="issue"/>
+          </group>
+        </group>
+      </else-if>
+      <else-if type="song" match="any">
+        <text variable="number" prefix=" (épisode " suffix=")"/>
+      </else-if>
+    </choose>
+  </macro>
+  <macro name="citation-locator">
+    <group>
+      <choose>
+        <if locator="chapter">
+          <label variable="locator" form="long" text-case="capitalize-first"/>
+        </if>
+        <else>
+          <label variable="locator" form="short"/>
+        </else>
+      </choose>
+      <text variable="locator" prefix=" "/>
+    </group>
+  </macro>
+  <macro name="container">
+    <group>
+      <choose>
+        <if type="chapter paper-conference entry-encyclopedia entry-dictionary song musical_score figure broadcast interview" match="any">
+          <choose>
+            <if match="any" variable="container-title">
+              <text term="in" text-case="capitalize-first" suffix=" "/>
+            </if>
+          </choose>
+        </if>
+        <else-if type="map" match="all" variable="container-author">
+          <text term="in" text-case="capitalize-first" suffix=" "/>
+        </else-if>
+      </choose>
+      <text macro="container-contributors"/>
+      <text macro="secondary-contributors"/>
+      <text macro="container-title"/>
+    </group>
+  </macro>
+  <macro name="container-title">
+    <choose>
+      <if type="bill legislation legal_case treaty report webpage" match="none">
+        <text variable="container-title" font-style="italic"/>
+      </if>
+      <else-if type="legal_case treaty report" match="any">
+        <choose>
+          <if match="none" variable="references">
+            <text variable="container-title"/>
+          </if>
+        </choose>
+      </else-if>
+      <else>
+        <group delimiter=" ">
+          <choose>
+            <if variable="container-title">
+              <choose>
+                <if type="legislation" match="none">
+                  <text variable="volume"/>
+                  <text variable="container-title"/>
+                  <group delimiter=" ">
+                    <text term="section" form="symbol"/>
+                    <text variable="section"/>
+                  </group>
+                </if>
+              </choose>
+            </if>
+          </choose>
+        </group>
+      </else>
+    </choose>
+  </macro>
+  <macro name="original-date">
+    <choose>
+      <if type="song musical_score book" match="any">
+        <group prefix="(" suffix=")">
+          <text value="Publication originale en "/>
+          <date variable="original-date">
+            <date-part name="year"/>
+          </date>
+        </group>
+      </if>
+      <else-if type="treaty" match="any">
+        <choose>
+          <if match="any" variable="original-date">
+            <group delimiter=" " suffix=".">
+              <text value="Entrée en vigueur le"/>
+              <date form="text" variable="issued">
+                <date-part name="day" form="ordinal"/>
+              </date>
+            </group>
+          </if>
+        </choose>
+      </else-if>
+    </choose>
+  </macro>
+  <macro name="title-extra">
+    <choose>
+      <if type="thesis" match="any">
+        <text variable="archive_location" prefix="(Publication n&amp;#7506;  " suffix=") "/>
+        <group delimiter=", " prefix="[" suffix="]">
+          <group delimiter=" ">
+            <text term="version"/>
+            <text variable="version"/>
+          </group>
+          <text variable="genre"/>
+          <text variable="publisher"/>
+        </group>
+      </if>
+      <else-if type="article-journal" match="any">
+        <choose>
+          <if match="any" variable="container-title">
+            <text variable="genre" prefix="[" suffix="]"/>
+          </if>
+        </choose>
+        <group delimiter=" " prefix="(" suffix=")">
+          <text term="version"/>
+          <text variable="version"/>
+        </group>
+      </else-if>
+      <else-if type="report" match="any">
+        <group delimiter=" ">
+          <text variable="number" prefix="(" suffix=")"/>
+          <group delimiter=" " prefix="[" suffix="]">
+            <text variable="genre"/>
+            <text variable="medium"/>
+          </group>
+          <group delimiter=" " prefix=". ">
+            <text term="number" text-case="capitalize-first"/>
+            <text variable="archive_location"/>
+          </group>
+        </group>
+      </else-if>
+      <else-if type="webpage dataset" match="any">
+        <group delimiter=" " prefix="(" suffix=")">
+          <text term="version"/>
+          <text variable="version"/>
+        </group>
+        <group delimiter=" " prefix=" ">
+          <text variable="number" prefix="(" suffix=")"/>
+          <text variable="genre" prefix="[" suffix="]"/>
+        </group>
+      </else-if>
+      <else-if type="patent" match="any">
+        <group delimiter=" " prefix="(" suffix=")">
+          <text variable="genre"/>
+          <text variable="number" font-style="normal"/>
+        </group>
+      </else-if>
+      <else-if type="song musical_score" match="any">
+        <choose>
+          <if match="any" variable="composer">
+            <group delimiter=";  " prefix=" [" suffix="]">
+              <group delimiter=" ">
+                <text term="author" form="verb" text-case="capitalize-first"/>
+                <names variable="author">
+                  <name and="text" delimiter-precedes-last="never"/>
+                </names>
+              </group>
+              <text variable="medium"/>
+              <text variable="genre"/>
+            </group>
+          </if>
+          <else>
+            <text variable="medium" prefix="[" suffix="]"/>
+            <text variable="genre" prefix="[" suffix="]"/>
+          </else>
+        </choose>
+      </else-if>
+      <else-if type="legislation bill" match="any">
+        <group delimiter=" ">
+          <text variable="number" prefix="c. "/>
+          <text variable="section" prefix="(" suffix=")"/>
+          <text variable="authority"/>
+        </group>
+      </else-if>
+      <else-if type="review-book" match="any">
+        <group delimiter=" " prefix="[" suffix="]">
+          <text variable="reviewed-title" font-style="italic" prefix="Compte rendu du livre " suffix=","/>
+          <text term="by"/>
+          <names variable="reviewed-author">
+            <name and="text" delimiter-precedes-last="never" initialize-with="."/>
+          </names>
+        </group>
+      </else-if>
+      <else-if type="broadcast" match="any">
+        <group delimiter=" ">
+          <group delimiter=" " prefix="(" suffix=")">
+            <text term="number" form="short"/>
+            <text variable="number"/>
+          </group>
+          <group prefix="[" suffix="]">
+            <text variable="medium"/>
+            <text variable="genre"/>
+          </group>
+        </group>
+      </else-if>
+      <else>
+        <choose>
+          <if type="musical_score book article" match="none">
+            <group delimiter=". ">
+              <choose>
+                <if type="manuscript" match="none">
+                  <text variable="archive" prefix=". "/>
+                </if>
+              </choose>
+              <group delimiter=" " prefix="[" suffix="]">
+                <text variable="medium"/>
+                <text variable="genre"/>
+              </group>
+              <group delimiter=" : ">
+                <text term="scale" text-case="capitalize-first"/>
+                <text variable="scale"/>
+              </group>
+              <number variable="number-of-pages"/>
+            </group>
+          </if>
+        </choose>
+      </else>
+    </choose>
+  </macro>
+  <macro name="container-title-extra">
+    <choose>
+      <if type="map" match="all">
+        <text variable="collection-title" prefix=". "/>
+        <text variable="number" prefix=", "/>
+      </if>
+      <else-if type="article" match="any">
+        <text variable="number" prefix=" (" suffix=")"/>
+        <choose>
+          <if match="none" variable="author editor">
+            <text variable="genre" prefix=". [" suffix="]"/>
+          </if>
+          <else>
+            <text variable="genre" prefix=" [" suffix="]"/>
+          </else>
+        </choose>
+      </else-if>
+    </choose>
+  </macro>
+  <citation et-al-min="3" et-al-use-first="1" et-al-subsequent-min="3" et-al-subsequent-use-first="1" disambiguate-add-year-suffix="true" collapse="year">
+    <sort>
+      <key macro="author-short"/>
+      <key macro="issued-sort"/>
+    </sort>
+    <layout prefix="(" suffix=")" delimiter=" ; ">
+      <group delimiter=", ">
+        <text macro="author-short"/>
+        <text macro="issued-year"/>
+        <text macro="citation-locator"/>
+      </group>
+    </layout>
+  </citation>
+  <bibliography delimiter-precedes-last="never" et-al-min="21" et-al-use-first="19" et-al-use-last="true" hanging-indent="true">
+    <sort>
+      <key macro="author"/>
+      <key macro="issued-sort" sort="ascending"/>
+      <key macro="title"/>
+    </sort>
+    <layout>
+      <group suffix=".">
+        <group delimiter=". ">
+          <text macro="author"/>
+          <text macro="issued"/>
+          <text macro="title" prefix=" "/>
+        </group>
+        <text macro="title-extra" prefix=" "/>
+        <text macro="container" prefix=". "/>
+        <text macro="container-title-extra"/>
+        <text macro="locators"/>
+        <group delimiter=", " prefix=". ">
+          <text macro="event"/>
+          <text macro="publisher"/>
+        </group>
+      </group>
+      <text macro="extra" prefix=" " suffix="."/>
+      <text macro="access" prefix=" "/>
+      <text macro="original-date" prefix=" "/>
+    </layout>
+  </bibliography>
+</style>

--- a/universite-du-quebec-a-montreal-prenoms-etudes-feministes-iref.csl
+++ b/universite-du-quebec-a-montreal-prenoms-etudes-feministes-iref.csl
@@ -6,6 +6,7 @@
     <id>http://www.zotero.org/styles/universite-du-quebec-a-montreal-prenoms-etudes-feministes-iref</id>
     <link href="http://www.zotero.org/styles/universite-du-quebec-a-montreal-prenoms-etudes-feministes-iref" rel="self"/>
     <link href="http://www.zotero.org/styles/apa" rel="template"/>
+    <link href="http://www.zotero.org/styles/universite-du-quebec-a-montreal" rel="template"/>
     <link href="https://uqam-ca.libguides.com/etudes-feministes/citer-ses-sources" rel="documentation"/>
     <link href="http://www.guidemt.uqam.ca/citer/style-uqam" rel="documentation"/>
     <link href="https://uqam-ca.libguides.com/c.php?g=725279&amp;p=5195760" rel="documentation"/>

--- a/universite-du-quebec-a-montreal-prenoms-etudes-feministes-iref.csl
+++ b/universite-du-quebec-a-montreal-prenoms-etudes-feministes-iref.csl
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<style class="in-text" version="1.0" et-al-min="3" et-al-use-first="1" initialize="false" demote-non-dropping-particle="never" default-locale="fr-CA" xmlns="http://purl.org/net/xbiblio/csl">
+<style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" et-al-min="3" et-al-use-first="1" initialize="false" demote-non-dropping-particle="never" default-locale="fr-CA">
   <info>
     <title>Université du Québec à Montréal - APA - prénoms - Études féministes - IREF (Français - Canada)</title>
     <title-short>UQAM prénoms</title-short>

--- a/universite-du-quebec-a-montreal-prenoms.csl
+++ b/universite-du-quebec-a-montreal-prenoms.csl
@@ -1,11 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" et-al-min="3" et-al-use-first="1" initialize="false" demote-non-dropping-particle="never" default-locale="fr-CA">
   <info>
-    <title>Université du Québec à Montréal - APA - prénoms - Études féministes - IREF (Français - Canada)</title>
+    <title>Université du Québec à Montréal - APA - prénoms (Français - Canada)</title>
     <title-short>UQAM prénoms</title-short>
-    <id>http://www.zotero.org/styles/universite-du-quebec-a-montreal-prenoms-etudes-feministes-iref</id>
-    <link href="http://www.zotero.org/styles/universite-du-quebec-a-montreal-prenoms-etudes-feministes-iref" rel="self"/>
-    <link href="http://www.zotero.org/styles/apa" rel="template"/>
+    <id>http://www.zotero.org/styles/universite-du-quebec-a-montreal-prenoms</id>
+    <link href="http://www.zotero.org/styles/universite-du-quebec-a-montreal-prenoms" rel="self"/>
     <link href="http://www.zotero.org/styles/universite-du-quebec-a-montreal" rel="template"/>
     <link href="https://uqam-ca.libguides.com/etudes-feministes/citer-ses-sources" rel="documentation"/>
     <link href="http://www.guidemt.uqam.ca/citer/style-uqam" rel="documentation"/>


### PR DESCRIPTION
Hi,
This new style is based on the universite-du-quebec-a-montreal.csl. The sole modification is that all author first names (author, editor, translator, etc.) are not initialized in order to give credit to women authors.