### PR TITLE
removes default-locale

### DIFF
--- a/universitat-bern-institut-fur-musikwissenschaft-note.csl
+++ b/universitat-bern-institut-fur-musikwissenschaft-note.csl
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<style xmlns="http://purl.org/net/xbiblio/csl" class="note" version="1.0" default-locale="de-DE">
+<style xmlns="http://purl.org/net/xbiblio/csl" class="note" version="1.0">
   <!-- This style was edited with the Visual CSL Editor (https://editor.citationstyles.org/visualEditor/) -->
   <info>
     <title>Universität Bern - Institut für Musikwissenschaft (note, Deutsch)</title>


### PR DESCRIPTION
This removes the default-locale. This style is primarly intended for writing in German, but depending on the preferred type of quotation marks, users may want to choose either "de-DE" or "de-CH".