### PR TITLE
chore: Set permissions for GitHub actions

### DIFF
--- a/.github/workflows/sheldon.yaml
+++ b/.github/workflows/sheldon.yaml
@@ -4,8 +4,14 @@ on:
   pull_request_target:
     types: [ opened, synchronize, workflow_dispatch]
 
+permissions:
+  contents: read
+
 jobs:
   test:
+    permissions:
+      contents: write  # for stefanzweifel/git-auto-commit-action to push code in repo
+      pull-requests: read  # for dorny/paths-filter to read pull requests
     runs-on: ubuntu-latest
     env:
       GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
 Restrict the GitHub token permissions only to the required ones; this way, even if the attackers will succeed in compromising your workflow, they won’t be able to do much.

- Included permissions for the action. https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions

https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions

https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs

[Keeping your GitHub Actions and workflows secure Part 1: Preventing pwn requests](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)

Signed-off-by: nathannaveen <42319948+nathannaveen@users.noreply.github.com>
