### PR TITLE
Revert "chore: Set permissions for GitHub actions"

### DIFF
--- a/.github/workflows/sheldon.yaml
+++ b/.github/workflows/sheldon.yaml
@@ -4,14 +4,8 @@ on:
   pull_request_target:
     types: [ opened, synchronize, workflow_dispatch]
 
-permissions:
-  contents: read
-
 jobs:
   test:
-    permissions:
-      contents: write  # for stefanzweifel/git-auto-commit-action to push code in repo
-      pull-requests: read  # for dorny/paths-filter to read pull requests
     runs-on: ubuntu-latest
     env:
       GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
Reverts citation-style-language/styles#6096

Looks like this breaks reporting, see https://github.com/citation-style-language/styles/runs/7055772693?check_suite_focus=true