### PR TITLE
[don't merge] chore: Included githubactions in the dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/academy-of-management-review.csl
+++ b/academy-of-management-review.csl
@@ -38,7 +38,7 @@
   <macro name="container-contributors">
     <choose>
       <if type="chapter paper-conference" match="any">
-        <text term="in" suffix=" "/>
+        <text term="in" text-case="capitalize-first" suffix=" "/>
         <names variable="editor translator" delimiter=", " suffix=", ">
           <name and="symbol" initialize-with=". " delimiter=", "/>
           <label form="short" prefix=" (" text-case="capitalize-first" suffix=")"/>

--- a/academy-of-management-review.csl
+++ b/academy-of-management-review.csl
@@ -38,7 +38,7 @@
   <macro name="container-contributors">
     <choose>
       <if type="chapter paper-conference" match="any">
-        <text term="in" text-case="capitalize-first" suffix=" "/>
+        <text term="in" suffix=" "/>
         <names variable="editor translator" delimiter=", " suffix=", ">
           <name and="symbol" initialize-with=". " delimiter=", "/>
           <label form="short" prefix=" (" text-case="capitalize-first" suffix=")"/>


### PR DESCRIPTION
This should help with keeping the GitHub actions updated on new releases. This will also help with keeping it secure.

Dependabot helps in keeping the supply chain secure https://docs.github.com/en/code-security/dependabot

GitHub actions up to date https://docs.github.com/en/code-security/dependabot/working-with-dependabot/keeping-your-actions-up-to-date-with-dependabot

https://github.com/ossf/scorecard/blob/main/docs/checks.md#dependency-update-tool
Signed-off-by: naveen <172697+naveensrinivasan@users.noreply.github.com>
