### PR TITLE
Update style-manual-australian-government.csl

### DIFF
--- a/style-manual-australian-government.csl
+++ b/style-manual-australian-government.csl
@@ -16,7 +16,7 @@
     <category citation-format="author-date"/>
     <category field="generic-base"/>
     <summary>Snooks style manual Australia Harvard author-date style</summary>
-    <updated>2022-03-21T08:44:06+00:00</updated>
+    <updated>2022-07-04T07:48:19+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale xml:lang="en">
@@ -32,7 +32,7 @@
   </macro>
   <macro name="author">
     <names variable="author">
-      <name and="symbol" initialize-with="" name-as-sort-order="all" sort-separator=" "/>
+      <name and="text" delimiter-precedes-last="never" initialize-with="" name-as-sort-order="all" sort-separator=" "/>
       <label form="short" strip-periods="true" prefix=" (" suffix=")"/>
       <substitute>
         <names variable="editor"/>
@@ -90,7 +90,7 @@
     <choose>
       <if variable="issued">
         <choose>
-          <if type="article-newspaper article-magazine" match="any">
+          <if type="article-newspaper article-magazine paper-conference speech" match="any">
             <date form="text" date-parts="year-month-day" variable="issued"/>
           </if>
           <else>
@@ -154,7 +154,7 @@
               <text macro="publisher"/>
             </group>
           </if>
-          <else-if type="chapter paper-conference" match="any">
+          <else-if type="chapter paper-conference speech" match="any">
             <group delimiter=", ">
               <text macro="title"/>
               <group delimiter=" ">
@@ -163,7 +163,7 @@
                 <text variable="container-title" font-style="italic"/>
               </group>
               <text variable="collection-title"/>
-              <text variable="event"/>
+              <text variable="event" font-style="italic"/>
               <text macro="publisher"/>
             </group>
           </else-if>


### PR DESCRIPTION
- fix "and" in bibliography
- fix issues for conference papers/speech

Kinda kickstarted via this thread: https://forums.zotero.org/discussion/98184/printing-conference-name-and-date-in-bibliography#latest

Guidelines here: https://www.stylemanual.gov.au/referencing-and-attribution/author-date