### PR TITLE
Include chapter title in Science style

### DIFF
--- a/science.csl
+++ b/science.csl
@@ -144,6 +144,7 @@
                 <if type="chapter paper-conference" match="any">
                   <group delimiter=", ">
                     <group delimiter=" ">
+                      <text variable="title" prefix="&quot;" suffix="&quot;"/>
                       <text term="in"/>
                       <text variable="container-title" font-style="italic"/>
                     </group>


### PR DESCRIPTION
According to the official [Instructions for preparing an initial manuscript](https://www.science.org/content/page/instructions-preparing-initial-manuscript#science-citation-style) of the Science Magazine, chapter titles should be included before the book title.