### PR TITLE
Remove issue numbers from BJOC style

### DIFF
--- a/beilstein-journal-of-organic-chemistry.csl
+++ b/beilstein-journal-of-organic-chemistry.csl
@@ -154,7 +154,6 @@
                 <if variable="volume">
                   <group delimiter=" ">
                     <text variable="volume" font-style="italic"/>
-                    <text variable="issue" prefix="(" suffix=")"/>
                   </group>
                 </if>
                 <else>

--- a/beilstein-journal-of-organic-chemistry.csl
+++ b/beilstein-journal-of-organic-chemistry.csl
@@ -3,7 +3,7 @@
   <!-- This style was edited with the Visual CSL Editor (https://editor.citationstyles.org/visualEditor/) -->
   <info>
     <title>Beilstein Journal of Organic Chemistry</title>
-    <title-short>Beilstein</title-short>
+    <title-short>BJOC</title-short>
     <id>http://www.zotero.org/styles/beilstein-journal-of-organic-chemistry</id>
     <link href="http://www.zotero.org/styles/beilstein-journal-of-organic-chemistry" rel="self"/>
     <link href="http://www.zotero.org/styles/american-chemical-society" rel="template"/>


### PR DESCRIPTION
According to BJOC instruction, issue numbers should only be included for "journal with non-continuous (i.e. issue-based) pagination". And the vast majority of chemistry journals have continuous pagination within volumes so this field should not be included.

This PR is motivated by the fact that I just got a format check report from bjoc instructing me to "please delete all issue numbers (numbers in parentheses) from journal references in the reference list ;)