### PR TITLE
Create sociologia-ruralis.csl

### DIFF
--- a/sociologia-ruralis.csl
+++ b/sociologia-ruralis.csl
@@ -5,7 +5,7 @@
     <title-short>SocRur</title-short>
     <id>http://www.zotero.org/styles/sociologia-ruralis</id>
     <link href="http://www.zotero.org/styles/sociologia-ruralis" rel="self"/>
-    <link href="http://www.zotero.org/styles/journal-of-rural-studies" rel="template"/>
+    <link href="http://www.zotero.org/styles/elsevier-harvard" rel="template"/>
     <author>
       <name>Bernhard Grüner</name>
       <email>bernhard.gruener@uibk.ac.at</email>

--- a/sociologia-ruralis.csl
+++ b/sociologia-ruralis.csl
@@ -1,0 +1,226 @@
+<?xml version="1.0" encoding="utf-8"?>
+<style class="in-text" version="1.0" demote-non-dropping-particle="never" default-locale="en-GB" xmlns="http://purl.org/net/xbiblio/csl">
+  <info>
+    <title>Sociologia Ruralis</title>
+    <title-short>SocRur</title-short>
+    <id>http://www.zotero.org/styles/sociologia-ruralis</id>
+    <link href="http://www.zotero.org/styles/sociologia-ruralis" rel="self"/>
+    <link href="http://www.zotero.org/styles/journal-of-rural-studies" rel="template"/>
+    <author>
+      <name>Bernhard Grüner</name>
+      <email>bernhard.gruener@uibk.ac.at</email>
+    </author>
+    <category citation-format="author-date"/>
+    <category field="sociology"/>
+    <category field="generic-base"/>
+    <summary>Based on 'Journal of Rural Studies'-Style</summary>
+    <updated>2022-08-03T14:08:47+00:00</updated>
+    <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
+  </info>
+  <macro name="container">
+    <choose>
+      <if type="chapter paper-conference" match="any">
+        <text term="in" text-case="capitalize-first" prefix=". " suffix=": "/>
+        <names variable="editor translator" delimiter=", " suffix=", ">
+          <name and="symbol" initialize-with="." name-as-sort-order="all"/>
+          <label form="short" text-case="capitalize-first" prefix=" (" suffix=")"/>
+        </names>
+        <group delimiter=", ">
+          <text variable="container-title" text-case="title" font-style="italic"/>
+          <text variable="collection-title" text-case="title"/>
+        </group>
+      </if>
+      <else-if type="bill book graphic legal_case legislation motion_picture report song" match="any">
+        <group prefix=", " delimiter=", ">
+          <text variable="container-title"/>
+          <text variable="collection-title"/>
+        </group>
+      </else-if>
+      <else-if type="webpage" match="any">
+        <group font-style="italic" prefix=".">
+          <text variable="container-title" prefix=" "/>
+        </group>
+      </else-if>
+      <else>
+        <group prefix=". " delimiter=", ">
+          <text variable="container-title" font-style="italic" suffix=","/>
+          <text variable="collection-title"/>
+        </group>
+      </else>
+    </choose>
+  </macro>
+  <macro name="author">
+    <names variable="author">
+      <name and="symbol" delimiter-precedes-last="always" initialize-with="." name-as-sort-order="all"/>
+      <label form="short" prefix=" (" suffix=")" text-case="capitalize-first"/>
+      <substitute>
+        <names variable="editor"/>
+        <names variable="translator"/>
+        <text macro="title"/>
+      </substitute>
+    </names>
+  </macro>
+  <macro name="author-short">
+    <names variable="author">
+      <name form="short" and="symbol" initialize-with=". "/>
+      <substitute>
+        <names variable="editor"/>
+        <names variable="translator"/>
+        <choose>
+          <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
+            <text variable="title" form="short" font-style="italic"/>
+          </if>
+          <else>
+            <text variable="title" form="short" quotes="true"/>
+          </else>
+        </choose>
+      </substitute>
+    </names>
+  </macro>
+  <macro name="access">
+    <choose>
+      <if variable="DOI">
+        <text variable="DOI" prefix="https://doi.org/"/>
+      </if>
+      <else-if type="webpage post-weblog" match="any" variable="URL">
+        <group delimiter=" ">
+          <text variable="URL"/>
+          <group prefix="[" suffix="].">
+            <text term="accessed" text-case="capitalize-first" suffix=" "/>
+            <date delimiter="" variable="accessed">
+              <date-part name="day" form="ordinal" suffix=" "/>
+              <date-part name="month" suffix=" "/>
+              <date-part name="year"/>
+            </date>
+          </group>
+        </group>
+      </else-if>
+    </choose>
+  </macro>
+  <macro name="title">
+    <choose>
+      <if type="report thesis" match="any">
+        <text variable="title" font-style="italic" suffix="."/>
+        <group prefix=" (" suffix=")" delimiter=" ">
+          <text variable="genre"/>
+          <text variable="number" prefix="No. "/>
+        </group>
+      </if>
+      <else-if type="bill book graphic legal_case legislation motion_picture report song speech" match="any">
+        <text variable="title" font-style="italic"/>
+        <text macro="edition" prefix=", "/>
+      </else-if>
+      <else-if type="webpage">
+        <text variable="title"/>
+      </else-if>
+      <else>
+        <text variable="title"/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="publisher">
+    <group delimiter=": ">
+      <text variable="publisher-place"/>
+      <text variable="publisher"/>
+    </group>
+  </macro>
+  <macro name="event">
+    <choose>
+      <if variable="event">
+        <text term="presented at" text-case="capitalize-first" suffix=" "/>
+        <text variable="event"/>
+      </if>
+    </choose>
+  </macro>
+  <macro name="issued">
+    <choose>
+      <if variable="issued">
+        <date variable="issued">
+          <date-part name="year"/>
+        </date>
+      </if>
+      <else>
+        <text term="no date" form="short"/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="edition">
+    <group delimiter=" ">
+      <choose>
+        <if is-numeric="edition">
+          <number variable="edition" form="ordinal"/>
+        </if>
+        <else>
+          <text variable="edition" suffix="."/>
+        </else>
+      </choose>
+      <text value="edition"/>
+    </group>
+  </macro>
+  <macro name="locators">
+    <choose>
+      <if type="article-journal article-magazine article-newspaper" match="any">
+        <group prefix=" " delimiter=", ">
+          <group>
+            <text variable="volume"/>
+            <text variable="issue" prefix="(" suffix=")"/>
+          </group>
+          <text variable="page"/>
+        </group>
+      </if>
+      <else-if type="bill book graphic legal_case legislation motion_picture report song thesis" match="any">
+        <group delimiter=", " prefix=". ">
+          <text macro="event"/>
+          <text macro="publisher"/>
+        </group>
+      </else-if>
+      <else-if type="chapter paper-conference" match="any">
+        <group delimiter=", " prefix=". ">
+          <text macro="event"/>
+          <text macro="publisher"/>
+          <group>
+            <label variable="page" form="short" suffix=" "/>
+            <text variable="page"/>
+          </group>
+        </group>
+      </else-if>
+      <else-if type="patent">
+        <text variable="number" prefix=". "/>
+      </else-if>
+    </choose>
+  </macro>
+  <citation et-al-min="3" et-al-use-first="1" disambiguate-add-givenname="true" disambiguate-add-year-suffix="true" collapse="year" cite-group-delimiter=", ">
+    <sort>
+      <key macro="author"/>
+      <key macro="issued" sort="descending"/>
+    </sort>
+    <layout prefix="(" suffix=")" delimiter="; ">
+      <group delimiter=", ">
+        <text macro="author-short"/>
+        <text macro="issued"/>
+        <group delimiter=" ">
+          <label variable="locator" form="short"/>
+          <text variable="locator"/>
+        </group>
+      </group>
+    </layout>
+  </citation>
+  <bibliography hanging-indent="true" entry-spacing="0" line-spacing="1">
+    <sort>
+      <key macro="author"/>
+      <key macro="issued" sort="descending"/>
+    </sort>
+    <layout>
+      <group suffix=".">
+        <text macro="author"/>
+        <text macro="issued" prefix=" (" suffix=")"/>
+        <group prefix=" ">
+          <text macro="title"/>
+          <text macro="container"/>
+          <text macro="locators"/>
+        </group>
+      </group>
+      <text macro="access" prefix=". "/>
+    </layout>
+  </bibliography>
+</style>

--- a/sociologia-ruralis.csl
+++ b/sociologia-ruralis.csl
@@ -6,6 +6,7 @@
     <id>http://www.zotero.org/styles/sociologia-ruralis</id>
     <link href="http://www.zotero.org/styles/sociologia-ruralis" rel="self"/>
     <link href="http://www.zotero.org/styles/elsevier-harvard" rel="template"/>
+    <link href="https://onlinelibrary.wiley.com/page/journal/14679523/homepage/forauthors.html" rel="documentation"/>
     <author>
       <name>Bernhard Grüner</name>
       <email>bernhard.gruener@uibk.ac.at</email>
@@ -13,7 +14,9 @@
     <category citation-format="author-date"/>
     <category field="sociology"/>
     <category field="generic-base"/>
-    <summary>Based on 'Journal of Rural Studies'-Style</summary>
+    <issn>0038-0199</issn>
+    <issn>1467-9523</issn>
+    <summary>Style for Journal 'Sociologia Ruralis', based on the 'Journal of Rural Studies'-Style</summary>
     <updated>2022-08-03T14:08:47+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>

--- a/sociologia-ruralis.csl
+++ b/sociologia-ruralis.csl
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<style class="in-text" version="1.0" demote-non-dropping-particle="never" default-locale="en-GB" xmlns="http://purl.org/net/xbiblio/csl">
+<style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" demote-non-dropping-particle="never" default-locale="en-GB">
   <info>
     <title>Sociologia Ruralis</title>
     <title-short>SocRur</title-short>


### PR DESCRIPTION
For the journal 'Sociologia Ruralis' no official citation style was provided by the publisher. 

The now uploaded style is based on an already existing style ([http://www.zotero.org/styles/journal-of-rural-studies](url) respectively [http://www.zotero.org/styles/elsevier-harvard](url)) and has been adapted to the journals' author guidelines (see [https://onlinelibrary.wiley.com/page/journal/14679523/homepage/forauthors.html](url)). 

**Note:** However, the guidelines on the journals' website differ from its actual bibliography-format in the articles. I have therefore adapted the bibliography-format to a recent article (year 2022) [https://doi.org/10.1111/soru.12382](url) and crossed-checked it with some others. 