### PR TITLE
Rename and rework manual-of-legal-citation.csl

### DIFF
--- a/law-citation-manual.csl
+++ b/law-citation-manual.csl
@@ -1,250 +1,494 @@
 <?xml version="1.0" encoding="utf-8"?>
-<style xmlns="http://purl.org/net/xbiblio/csl" version="1.0" class="note" delimiter-precedes-last="always" demote-non-dropping-particle="never" initialize-with=" " name-delimiter=", " names-delimiter=". " name-as-sort-order="all" sort-separator=" " default-locale="zh-CN">
-  <!-- 半成品，需要更多的文献类型测试，有需要请提供 -->
+<style xmlns="http://purl.org/net/xbiblio/csl" class="note" version="1.0" initialize-with=". " demote-non-dropping-particle="sort-only" default-locale="zh-CN">
   <info>
-    <title>Law Citation Manual (中法学注引手册, 中文)</title>
-    <title-short>Chinese Law Journal (note)</title-short>
+    <title>Manual of Legal Citation (法学注引手册, 中文)</title>
     <id>http://www.zotero.org/styles/law-citation-manual</id>
     <link href="http://www.zotero.org/styles/law-citation-manual" rel="self"/>
-    <link href="http://www.zotero.org/styles/china-national-standard-gb-t-7714-2015-note" rel="template"/>
-    <link href="https://www.weibo.com/ttarticle/p/show?id=2309404436112734027798" rel="documentation"/>
+    <link href="http://www.zotero.org/styles/bluebook-law-review" rel="template"/>
+    <link href="https://www.pup.cn/bookDetail?id=910497ac470d4880ab56c6709bb1d7c5" rel="documentation"/>
     <link href="https://colr.xmu.edu.cn/_upload/article/files/67/3c/bdf817f64039947a52276727ef01/082c41aa-fed1-4460-97fa-7f471901a879.pdf" rel="documentation"/>
     <author>
-      <name>韩小土</name>
-      <email>redleafnew@163.com</email>
+      <name>Zeping Lee</name>
+      <email>zepinglee@gmail.com</email>
     </author>
-    <contributor>
-      <name>牛耕田</name>
-      <email>buffalo_d@163.com</email>
-    </contributor>
     <category citation-format="note"/>
     <category field="law"/>
-    <summary>中国法学引注</summary>
-    <updated>2021-03-09T00:44:28+00:00</updated>
+    <updated>2022-09-06T12:51:00+08:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
-  <locale xml:lang="zh-CN">
+  <locale xml:lang="en">
+    <date form="text" delimiter=" ">
+      <date-part name="day"/>
+      <date-part name="month"/>
+      <date-part name="year"/>
+    </date>
     <terms>
-      <term name="anonymous">佚名</term>
-      <term name="edition">版</term>
-      <term name="page" form="short">
-        <single>p.</single>
-        <multiple>pp.</multiple>
-      </term>
-      <!-- <term name="container-author" form="verb-short">著</term> 等修改-->
+      <term name="accessed">last visited</term>
+      <term name="page" form="short">p.</term>
     </terms>
   </locale>
-  <macro name="accessed-date">
-    <date variable="accessed" delimiter="" prefix="" suffix="">
-      <date-part name="year" suffix="年"/>
-      <date-part name="month" form="numeric" suffix="月"/>
-      <date-part name="day" suffix="日"/>
+  <locale xml:lang="zh">
+    <date form="text">
+      <date-part name="year" suffix="年" range-delimiter="&#8212;"/>
+      <date-part name="month" form="numeric" suffix="月" range-delimiter="&#8212;"/>
+      <date-part name="day" suffix="日" range-delimiter="&#8212;"/>
     </date>
-  </macro>
-  <macro name="author">
-    <choose>
-      <if variable="author">
-        <names variable="author">
-          <name>
-            <name-part name="family" text-case="uppercase"/>
-            <name-part name="given"/>
-          </name>
-        </names>
-      </if>
-    </choose>
-  </macro>
-  <macro name="container-author">
-    <names variable="container-author reviewed-author">
-      <name>
-        <name-part name="family" text-case="uppercase"/>
-        <name-part name="given"/>
-      </name>
+    <terms>
+      <term name="article-locator" form="short">条</term>
+      <term name="accessed">访问</term>
+      <term name="compiler">整理</term>
+      <term name="compiler" form="short">整理</term>
+      <term name="edition" form="short">版</term>
+      <term name="editor" form="short">主编</term>
+      <term name="ibid">同上注</term>
+      <term name="in">载</term>
+      <term name="op-cit">同前注</term>
+      <term name="page" form="short">页</term>
+      <term name="paragraph" form="short">款</term>
+      <term name="rule" form="short">条</term>
+      <term name="section" form="short">条</term>
+      <term name="open-quote">“</term>
+      <term name="close-quote">”</term>
+      <term name="open-inner-quote">‘</term>
+      <term name="close-inner-quote">’</term>
+    </terms>
+  </locale>
+  <locale>
+    <style-options punctuation-in-quote="false"/>
+    <terms>
+      <term name="page-range-delimiter">-</term>
+    </terms>
+  </locale>
+  <macro name="author-zh">
+    <names variable="author">
+      <name delimiter="、" delimiter-precedes-et-al="never"/>
+      <label form="short"/>
+      <substitute>
+        <names variable="editor"/>
+      </substitute>
     </names>
   </macro>
-  <macro name="edition">
-    <choose>
-      <if variable="edition">
-        <group delimiter=" ">
-          <text variable="edition"/>
-          <text term="edition"/>
-        </group>
-      </if>
-    </choose>
-  </macro>
-  <macro name="editor">
-    <names variable="editor translator">
-      <name>
-        <name-part name="family" text-case="uppercase"/>
-        <name-part name="given"/>
-      </name>
-      <label form="verb-short" prefix=", "/>
+  <!-- 略写文献时，标示文献性质的“编”“主编”等可以省略 -->
+  <macro name="author-short-zh">
+    <names variable="author">
+      <name delimiter="、" delimiter-precedes-et-al="never"/>
+      <substitute>
+        <names variable="editor"/>
+      </substitute>
     </names>
   </macro>
-  <macro name="issued-date">
-    <!--中文年月日  -->
+  <macro name="access-zh">
     <choose>
-      <if variable="issued">
-        <date variable="issued" delimiter="">
-          <date-part name="year" suffix="年"/>
-          <date-part name="month" form="numeric" suffix="月"/>
-          <date-part name="day" suffix="日"/>
-        </date>
-      </if>
-      <else>
-        <text term="no date" prefix="[" suffix="]"/>
-      </else>
-    </choose>
-  </macro>
-  <macro name="issue-date-year">
-    <choose>
-      <if variable="issued">
-        <date variable="issued" date-parts="year" form="numeric"/>
-      </if>
-      <else>
-        <text term="no date" prefix="[" suffix="]"/>
-      </else>
-    </choose>
-  </macro>
-  <macro name="publishing">
-    <choose>
-      <if variable="publisher">
-        <group delimiter=": ">
-          <group delimiter="">
-            <text variable="publisher" prefix="，"/>
-            <text macro="issue-date-year" suffix="年版"/>
-          </group>
-        </group>
-        <choose>
-          <if variable="locator">
-            <text variable="locator" prefix=": "/>
-          </if>
-          <else>
-            <text variable="page" prefix=": "/>
-          </else>
-        </choose>
-      </if>
-    </choose>
-  </macro>
-  <macro name="serial-information">
-    <group delimiter="">
-      <text macro="issue-date-year" suffix="年"/>
-    </group>
-    <text variable="issue" prefix="第" suffix="期"/>
-    <text variable="page" prefix="第" suffix="页"/>
-  </macro>
-  <macro name="title">
-    <text variable="title" text-case="title" prefix="《" suffix="》"/>
-  </macro>
-  <macro name="full-contents">
-    <text macro="author" suffix="："/>
-    <text macro="title"/>
-    <choose>
-      <if type="book bill chapter legislation paper-conference report" match="any">
-        <text macro="editor" prefix="，载"/>
-        <choose>
-          <if variable="container-title">
-            <text value="//"/>
-            <text macro="container-author" suffix="："/>
-            <text variable="container-title" text-case="title" prefix="《" suffix="》"/>
-          </if>
-          <else>
-            <text value=". "/>
-          </else>
-        </choose>
-        <text macro="edition" suffix="。"/>
-        <text macro="publishing"/>
-      </if>
-      <else-if type="article-journal article-magazine" match="any">
-        <group prefix="：">
+      <if variable="URL">
+        <group delimiter="，">
+          <text variable="URL"/>
           <choose>
-            <if variable="container-title">
-              <text variable="container-title" text-case="title" prefix="载《" suffix="》"/>
-              <text macro="serial-information" prefix=""/>
-              <!--年前的前辍-->
-            </if>
-            <else>
-              <text macro="serial-information" suffix=". "/>
-              <text macro="publishing"/>
-            </else>
-          </choose>
-        </group>
-      </else-if>
-      <else-if type="article-newspaper">
-        <!-- 报纸-->
-        <group prefix="，">
-          <choose>
-            <if variable="container-title">
-              <text variable="container-title" text-case="title" prefix="载《" suffix="》"/>
-              <text macro="issued-date" prefix=""/>
-              <text variable="page" prefix="第" suffix="页"/>
-            </if>
-            <else>
-              <text macro="issued-date" suffix=". "/>
-              <text macro="publishing"/>
-            </else>
-          </choose>
-        </group>
-      </else-if>
-      <!-- 报纸-->
-      <else-if type="thesis">
-        <!--学位论文-->
-        <group prefix="，">
-          <choose>
-            <if variable="container-title">
-              <text variable="container-title" text-case="title" prefix="载《" suffix="》"/>
-            </if>
-            <else>
-              <group delimiter="">
-                <text variable="publisher"/>
-                <text macro="issue-date-year" suffix="年"/>
-                <text variable="genre" suffix="学位论文"/>
+            <!-- 一般不要求注明“访问日期”。网页没有显示上传日期的，引用时可以标注最后访问日期 -->
+            <if variable="issued" match="none">
+              <group>
+                <date variable="accessed" form="text"/>
+                <text term="accessed"/>
               </group>
-              <!--  <text macro="publishing"/>-->
-            </else>
+            </if>
           </choose>
         </group>
-      </else-if>
-      <!--学位论文-->
-      <else-if type="webpage">
-        <!--网页文献-->
-        <choose>
-          <if variable="issued">
-            <text macro="issued-date" prefix="，"/>
-          </if>
-        </choose>
-        <text variable="URL" prefix="，"/>
-        <text macro="accessed-date" prefix="，" suffix="访问"/>
-      </else-if>
-      <else>
-        <text macro="publishing" prefix="，"/>
-        <text macro="issued-date" prefix="" suffix=""/>
-      </else>
+      </if>
     </choose>
   </macro>
-  <citation et-al-min="4" et-al-use-first="3" disambiguate-add-names="true">
-    <layout suffix="。" delimiter="; ">
+  <macro name="source-zh">
+    <group delimiter="：">
+      <text macro="author-zh"/>
       <choose>
-        <if position="ibid-with-locator">
-          <text term="ibid"/>
-          <label variable="locator" form="short"/>
-          <text variable="locator"/>
+        <if type="article-journal article-magazine" match="any">
+          <group delimiter="，">
+            <text macro="title-zh"/>
+            <text macro="secondary-contributor-zh"/>
+            <text macro="container-zh"/>
+            <text macro="locator-zh"/>
+          </group>
         </if>
-        <else-if position="ibid">
-          <text term="ibid"/>
+        <else-if type="article-newspaper">
+          <group delimiter="，">
+            <text macro="title-zh"/>
+            <text macro="secondary-contributor-zh"/>
+            <text macro="container-zh"/>
+            <text macro="locator-or-page-zh"/>
+          </group>
         </else-if>
-        <else-if position="subsequent">
-          <text macro="full-contents"/>
+        <else-if type="chapter paper-conference" match="any">
+          <group delimiter="，">
+            <text macro="title-zh"/>
+            <text macro="secondary-contributor-zh"/>
+            <text macro="container-zh"/>
+            <text macro="publisher-zh"/>
+            <text macro="locator-zh"/>
+          </group>
+        </else-if>
+        <else-if type="book thesis" match="any">
+          <group delimiter="，">
+            <text macro="title-zh"/>
+            <text macro="secondary-contributor-zh"/>
+            <text macro="publisher-zh"/>
+            <text macro="locator-zh"/>
+          </group>
+        </else-if>
+        <!-- 49. 引用个人博客、微信公众号 -->
+        <else-if type="post post-weblog webpage">
+          <group delimiter="，">
+            <text macro="title-zh"/>
+            <text macro="container-zh"/>
+            <text macro="access-zh"/>
+          </group>
+        </else-if>
+        <!-- (四)引用法律文件 -->
+        <else-if type="legislation">
+          <group delimiter="，">
+            <group>
+              <text macro="title-zh"/>
+              <choose>
+                <!-- 优先使用 locator 的条文序号 -->
+                <if variable="locator">
+                  <text macro="locator-zh"/>
+                </if>
+                <else>
+                  <text macro="section-zh"/>
+                </else>
+              </choose>
+            </group>
+            <text variable="number"/>
+            <group>
+              <text macro="issuance-zh"/>
+              <text value="发布"/>
+            </group>
+          </group>
+        </else-if>
+        <!-- (五)引用司法案例 -->
+        <else-if type="legal_case">
+          <group delimiter="，">
+            <text macro="title-zh"/>
+            <choose>
+              <if variable="container-title">
+                <choose>
+                  <if variable="number">
+                    <!-- 指导性案例 -->
+                    <group>
+                      <text macro="container-zh"/>
+                      <choose>
+                        <if is-numeric="number">
+                          <number variable="number"/>
+                          <text value="号"/>
+                        </if>
+                        <else>
+                          <text variable="number"/>
+                        </else>
+                      </choose>
+                      <text macro="issuance-zh" prefix="（" suffix="）"/>
+                    </group>
+                  </if>
+                  <else>
+                    <!-- 《最高人民法院公报》上的案例 -->
+                    <text macro="container-zh"/>
+                  </else>
+                </choose>
+              </if>
+              <else>
+                <group delimiter="，">
+                  <group>
+                    <text variable="authority"/>
+                    <choose>
+                      <if variable="genre">
+                        <!-- 用户需要在 genre 中填写司法案例的文书名称，如“民事判决书”、“行政判决书” -->
+                        <text variable="genre"/>
+                      </if>
+                      <else>
+                        <text value="判决书"/>
+                      </else>
+                    </choose>
+                    <text variable="number"/>
+                  </group>
+                  <text macro="issuance-zh"/>
+                </group>
+              </else>
+            </choose>
+          </group>
         </else-if>
         <else>
-          <text macro="full-contents"/>
+          <group delimiter="，">
+            <text macro="title-zh"/>
+            <text macro="container-zh"/>
+            <text macro="publisher-zh"/>
+            <text macro="locator-zh"/>
+          </group>
         </else>
       </choose>
+    </group>
+  </macro>
+  <macro name="title-zh">
+    <choose>
+      <if type="webpage">
+        <choose>
+          <if variable="container-title">
+            <text variable="title" prefix="《" suffix="》"/>
+          </if>
+          <else>
+            <text variable="title"/>
+          </else>
+        </choose>
+      </if>
+      <else-if type="legal_case">
+        <text variable="title"/>
+      </else-if>
+      <else>
+        <text variable="title" prefix="《" suffix="》"/>
+      </else>
+    </choose>
+    <text macro="edition-zh" prefix="（" suffix="）"/>
+  </macro>
+  <!-- 其他贡献者(翻译、 整理、校对) -->
+  <macro name="secondary-contributor-zh">
+    <names variable="translator" delimiter="，">
+      <name delimiter="、"/>
+      <label form="short"/>
+      <substitute>
+        <names variable="compiler"/>
+      </substitute>
+    </names>
+  </macro>
+  <macro name="edition-zh">
+    <choose>
+      <if is-numeric="edition">
+        <text value="第"/>
+        <number variable="edition"/>
+        <label variable="edition" form="short"/>
+      </if>
+      <else>
+        <text variable="edition"/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="editor-zh">
+    <names variable="editor">
+      <name delimiter="、"/>
+      <label form="short"/>
+    </names>
+  </macro>
+  <macro name="container-zh">
+    <choose>
+      <if type="article-journal article-magazine" match="any">
+        <text term="in"/>
+        <text variable="container-title" prefix="《" suffix="》"/>
+        <text macro="issuance-zh"/>
+        <text macro="issue-zh"/>
+      </if>
+      <else-if type="chapter paper-conference" match="any">
+        <text term="in"/>
+        <group delimiter="：">
+          <text macro="editor-zh"/>
+          <text variable="container-title" prefix="《" suffix="》"/>
+        </group>
+        <text macro="volume-zh"/>
+        <text macro="issue-zh"/>
+      </else-if>
+      <else-if type="legal_case">
+        <choose>
+          <if variable="number">
+            <!-- 指导性案例 -->
+            <text variable="container-title"/>
+          </if>
+          <else>
+            <!-- 《最高人民法院公报》 -->
+            <text term="in"/>
+            <text variable="container-title" prefix="《" suffix="》"/>
+            <text macro="issuance-zh"/>
+            <text macro="issue-zh"/>
+          </else>
+        </choose>
+      </else-if>
+      <else-if type="article-newspaper">
+        <text term="in"/>
+        <text variable="container-title" prefix="《" suffix="》"/>
+        <text macro="issuance-zh"/>
+      </else-if>
+      <else-if type="post post-weblog webpage">
+        <!-- 2020 年版的网络文献和微信公众号文章的网站标题与上传日期之间均无逗号 -->
+        <text term="in"/>
+        <text variable="container-title"/>
+        <text macro="issuance-zh"/>
+      </else-if>
+      <else>
+        <text term="in"/>
+        <text variable="container-title" prefix="《" suffix="》"/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="volume-zh">
+    <choose>
+      <if is-numeric="volume">
+        <text value="第"/>
+        <number variable="volume"/>
+        <label variable="volume" form="short"/>
+      </if>
+      <else>
+        <text variable="volume"/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="issue-zh">
+    <choose>
+      <if is-numeric="issue">
+        <text value="第"/>
+        <number variable="issue"/>
+        <choose>
+          <if type="chapter paper-conference" match="any">
+            <text value="辑"/>
+          </if>
+          <else>
+            <label variable="issue" form="short"/>
+          </else>
+        </choose>
+      </if>
+      <else>
+        <text variable="issue"/>
+      </else>
+    </choose>
+  </macro>
+  <!-- 条文序号 -->
+  <macro name="section-zh">
+    <choose>
+      <if is-numeric="section">
+        <text value="第"/>
+        <number variable="section"/>
+        <label variable="section"/>
+      </if>
+      <else>
+        <text variable="section"/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="publisher-zh">
+    <text variable="publisher"/>
+    <choose>
+      <if type="post webpage">
+        <text macro="issuance-zh"/>
+      </if>
+      <else>
+        <text macro="issuance-zh"/>
+        <choose>
+          <if type="thesis">
+            <choose>
+              <if variable="genre">
+                <text variable="genre"/>
+              </if>
+              <else>
+                <text value="博士学位论文"/>
+              </else>
+            </choose>
+          </if>
+          <else>
+            <text term="edition" form="short"/>
+          </else>
+        </choose>
+      </else>
+    </choose>
+  </macro>
+  <macro name="issuance-zh">
+    <choose>
+      <if type="article-magazine article-newspaper legal_case legislation post post-weblog webpage" match="any">
+        <date variable="issued" form="text"/>
+      </if>
+      <else>
+        <date variable="issued" form="text" date-parts="year"/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="locator-zh">
+    <choose>
+      <if is-numeric="locator">
+        <text value="第"/>
+        <text variable="locator"/>
+        <choose>
+          <if locator="page" type="article-newspaper" match="all">
+            <text value="版"/>
+          </if>
+          <else>
+            <label variable="locator" form="short"/>
+          </else>
+        </choose>
+      </if>
+      <else>
+        <text variable="locator"/>
+      </else>
+    </choose>
+  </macro>
+  <!-- 报纸的出版信息，一般注明年、月、日;必要时，注明版次。 -->
+  <macro name="locator-or-page-zh">
+    <choose>
+      <if variable="locator">
+        <text macro="locator-zh"/>
+      </if>
+      <else-if variable="page" type="article-newspaper" match="all">
+        <choose>
+          <if is-numeric="page">
+            <text value="第"/>
+            <text variable="page"/>
+            <text value="版"/>
+          </if>
+          <else>
+            <text variable="page"/>
+          </else>
+        </choose>
+      </else-if>
+    </choose>
+  </macro>
+  <macro name="citation-layout-zh">
+    <choose>
+      <if position="ibid-with-locator">
+        <text term="ibid"/>
+        <text macro="locator-zh" prefix="，"/>
+      </if>
+      <else-if position="ibid">
+        <text term="ibid"/>
+      </else-if>
+      <else-if position="subsequent">
+        <choose>
+          <if disambiguate="true">
+            <group delimiter="，">
+              <text variable="first-reference-note-number" prefix="同前注〔" suffix="〕"/>
+              <group delimiter="：">
+                <text macro="author-short-zh"/>
+                <text variable="title" form="short" prefix="《" suffix="》"/>
+              </group>
+              <text macro="locator-zh"/>
+            </group>
+          </if>
+          <else>
+            <group delimiter="，">
+              <text term="op-cit"/>
+              <text macro="author-short-zh" suffix="书"/>
+              <text macro="locator-zh"/>
+            </group>
+          </else>
+        </choose>
+      </else-if>
+      <else>
+        <text macro="source-zh"/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="citation-number">
+    <text variable="citation-number" prefix="〔" suffix="〕"/>
+  </macro>
+  <!-- 作者人数为三人或者三人以上的，原则上第一次列明全部，再次引用时可以只列第一作者，后加“等”。 -->
+  <!-- 作者人数众多，不便全部列明的，可以根据情况列 1-2 个，后面加“等”。 -->
+  <citation et-al-min="6" et-al-use-first="2" et-al-subsequent-min="3" et-al-subsequent-use-first="1">
+    <layout suffix="。" delimiter="；">
+      <text macro="citation-layout-zh"/>
     </layout>
   </citation>
-  <bibliography entry-spacing="0" et-al-min="4" et-al-use-first="3" line-spacing="1" second-field-align="flush">
+  <bibliography second-field-align="flush" et-al-min="6" et-al-use-first="2">
     <layout suffix="。">
-      <text variable="citation-number" prefix="〔" suffix="〕"/>
-      <text macro="full-contents"/>
+      <text macro="citation-number"/>
+      <text macro="source-zh"/>
     </layout>
   </bibliography>
 </style>


### PR DESCRIPTION
In a previous PR (#5314), @redleafnew created the style of “Law Citation Manual” (法学引注手册) whose English name and id are based on the discussion <https://github.com/citation-style-language/styles/pull/5314#issuecomment-797228999>. However the official English name “Manual of Legal Citation” is given in the cover page of the 2020 published edition (see <https://www.pup.cn/bookDetail?id=910497ac470d4880ab56c6709bb1d7c5> from the publisher). Thus I suggest renaming the style to `manual-of-legal-citation.csl`.

As commented in the file by @redleafnew, the previous version was incomplete and required further development and testing. I then collected all the example entries from the official book (<https://www.zotero.org/groups/4677213/chinese_csl_development/collections/GTTN32IE>) and rewrote the csl style completely. It's necessary for a thorough rewrite because the previous version was based on the China national standard GB/T 7714 but actually the Manual of Legal Citation has a different format structure. This new version of csl has been reviewed by Gitee user `jiji2022` and `himejima` (see Gitee discussions in Chinese [#I55MKC](https://gitee.com/redleafnew00/Chinese-STD-GB-T-7714-related-csl/issues/I55MKC), [I55P4F](https://gitee.com/redleafnew00/Chinese-STD-GB-T-7714-related-csl/issues/I55P4F), [I5IMWS](https://gitee.com/redleafnew00/Chinese-STD-GB-T-7714-related-csl/issues/I5IMWS) and [I5J26I](https://gitee.com/redleafnew00/Chinese-STD-GB-T-7714-related-csl/issues/I5J26I)).

