### PR TITLE
Update cell-numeric-superscript.csl

### DIFF
--- a/cell-numeric-superscript.csl
+++ b/cell-numeric-superscript.csl
@@ -40,8 +40,8 @@
         <text variable="DOI"/>
       </if>
       <else-if match="any" type="webpage dataset entry-dictionary entry-encyclopedia post post-weblog">
-         <text variable="URL"/>
-       </else-if>
+        <text variable="URL"/>
+      </else-if>
     </choose>
   </macro>
   <macro name="title">

--- a/cell-numeric-superscript.csl
+++ b/cell-numeric-superscript.csl
@@ -36,16 +36,12 @@
   </macro>
   <macro name="access">
     <choose>
-      <if type="article-journal">
+      <if match="any" variable="DOI">
         <text variable="DOI"/>
       </if>
-      <else-if match="any" variable="URL">
-        <choose>
-          <if type="webpage dataset entry-dictionary entry-encyclopedia post post-weblog" match="any">
-            <text variable="URL"/>
-          </if>
-        </choose>
-      </else-if>
+      <else-if match="any" type="webpage dataset entry-dictionary entry-encyclopedia post post-weblog">
+         <text variable="URL"/>
+       </else-if>
     </choose>
   </macro>
   <macro name="title">

--- a/cell-numeric-superscript.csl
+++ b/cell-numeric-superscript.csl
@@ -36,13 +36,16 @@
   </macro>
   <macro name="access">
     <choose>
-      <if variable="URL">
+      <if type="article-journal">
+        <text variable="DOI"/>
+      </if>
+      <else-if match="any" variable="URL">
         <choose>
           <if type="webpage dataset entry-dictionary entry-encyclopedia post post-weblog" match="any">
             <text variable="URL"/>
           </if>
         </choose>
-      </if>
+      </else-if>
     </choose>
   </macro>
   <macro name="title">

--- a/cell-numeric.csl
+++ b/cell-numeric.csl
@@ -41,8 +41,8 @@
         <text variable="DOI"/>
       </if>
       <else-if match="any" type="webpage dataset entry-dictionary entry-encyclopedia post post-weblog">
-            <text variable="URL"/>
-        </else-if>
+        <text variable="URL"/>
+      </else-if>
     </choose>
   </macro>
   <macro name="title">

--- a/cell-numeric.csl
+++ b/cell-numeric.csl
@@ -37,18 +37,16 @@
   </macro>
   <macro name="access">
     <choose>
-      <if variable="URL">
-        <text value="Available at:" suffix=" "/>
-        <text variable="URL"/>
-        <group prefix=" [" suffix="]">
-          <text term="accessed" text-case="capitalize-first" suffix=" "/>
-          <date variable="accessed">
-            <date-part name="month" suffix=" "/>
-            <date-part name="day" suffix=", "/>
-            <date-part name="year"/>
-          </date>
-        </group>
+      <if type="article-journal">
+        <text variable="DOI"/>
       </if>
+      <else-if match="any" variable="URL">
+        <choose>
+          <if type="webpage dataset entry-dictionary entry-encyclopedia post post-weblog" match="any">
+            <text variable="URL"/>
+          </if>
+        </choose>
+      </else-if>
     </choose>
   </macro>
   <macro name="title">

--- a/cell-numeric.csl
+++ b/cell-numeric.csl
@@ -37,16 +37,12 @@
   </macro>
   <macro name="access">
     <choose>
-      <if type="article-journal">
+      <if variable="DOI">
         <text variable="DOI"/>
       </if>
-      <else-if match="any" variable="URL">
-        <choose>
-          <if type="webpage dataset entry-dictionary entry-encyclopedia post post-weblog" match="any">
+      <else-if match="any" type="webpage dataset entry-dictionary entry-encyclopedia post post-weblog">
             <text variable="URL"/>
-          </if>
-        </choose>
-      </else-if>
+        </else-if>
     </choose>
   </macro>
   <macro name="title">


### PR DESCRIPTION
via https://forums.zotero.org/discussion/99081/add-doi#latest

It looks like Cell generally has added DOIs now as it appears in the guidelines of OP's style, but also in the guidelines we based our style on:
https://www.cell.com/current-biology/authors
https://www.cell.com/chem/authors