### PR TITLE
Create isara-iso-690.csl

### DIFF
--- a/isara-iso-690.csl
+++ b/isara-iso-690.csl
@@ -35,7 +35,6 @@
     <names variable="editor">
       <name and="text" name-as-sort-order="all" sort-separator=", " delimiter=", " delimiter-precedes-last="never">
         <name-part name="family" text-case="uppercase"/>
-        <name-part name="given"/>
       </name>
       <label prefix=" (" form="short" suffix=".)"/>
     </names>
@@ -44,7 +43,6 @@
     <names variable="translator">
       <name and="text" name-as-sort-order="all" sort-separator=", " delimiter=", " delimiter-precedes-last="never">
         <name-part name="family" text-case="uppercase"/>
-        <name-part name="given"/>
       </name>
       <label prefix=" (" form="short" suffix=".)"/>
     </names>
@@ -53,7 +51,7 @@
     <choose>
       <if variable="issued">
         <date variable="issued">
-          <date-part name="year" form="long"/>
+          <date-part name="year"/>
         </date>
       </if>
       <else>
@@ -61,11 +59,10 @@
       </else>
     </choose>
   </macro>
-  <macro name="responsability">
+  <macro name="responsibility">
     <names variable="author">
       <name and="text" name-as-sort-order="all" sort-separator=", " delimiter=", " delimiter-precedes-last="never">
         <name-part name="family" text-case="uppercase"/>
-        <name-part name="given"/>
       </name>
       <substitute>
         <text macro="editor"/>
@@ -94,11 +91,10 @@
     <names variable="container-author">
       <name and="text" name-as-sort-order="all" sort-separator=", " delimiter=", " delimiter-precedes-last="never">
         <name-part name="family" text-case="uppercase"/>
-        <name-part name="given"/>
       </name>
     </names>
   </macro>
-  <macro name="container-responsability">
+  <macro name="container-responsibility">
     <choose>
       <if variable="container-author editor translator" match="any">
         <choose>
@@ -145,7 +141,7 @@
         </choose>
         <choose>
           <if variable="container-author editor translator" match="any">
-            <text macro="container-responsability"/>
+            <text macro="container-responsibility"/>
             <choose>
               <if variable="container-title event" match="any">
                 <text value=", "/>
@@ -347,14 +343,14 @@
   </citation>
   <bibliography>
     <sort>
-      <key macro="responsability"/>
+      <key macro="responsibility"/>
       <key macro="year-date"/>
     </sort>
     <layout>
       <choose>
         <if type="book map" match="any">
           <group>
-            <text macro="responsability" suffix=". "/>
+            <text macro="responsibility" suffix=". "/>
             <choose>
               <if variable="author editor translator" match="any">
                 <text macro="title" suffix=". "/>
@@ -371,7 +367,7 @@
         </if>
         <else-if type="article-journal article-magazine" match="any">
           <group>
-            <text macro="responsability" suffix=". "/>
+            <text macro="responsibility" suffix=". "/>
             <choose>
               <if variable="author editor translator" match="any">
                 <text macro="title" suffix=". "/>
@@ -387,7 +383,7 @@
         </else-if>
         <else-if type="article-newspaper">
           <group>
-            <text macro="responsability" suffix=". "/>
+            <text macro="responsibility" suffix=". "/>
             <choose>
               <if variable="author editor translator" match="any">
                 <text macro="title" suffix=". "/>
@@ -403,7 +399,7 @@
         </else-if>
         <else-if type="chapter entry entry-dictionary entry-encyclopedia" match="any">
           <group>
-            <text macro="responsability" suffix=". "/>
+            <text macro="responsibility" suffix=". "/>
             <choose>
               <if variable="author editor translator" match="any">
                 <text macro="title" suffix=". "/>
@@ -420,7 +416,7 @@
         </else-if>
         <else-if type="speech">
           <group>
-            <text macro="responsability" suffix=". "/>
+            <text macro="responsibility" suffix=". "/>
             <choose>
               <if variable="author editor translator" match="any">
                 <text macro="title" suffix=". "/>
@@ -436,7 +432,7 @@
         </else-if>
         <else-if type="paper-conference">
           <group>
-            <text macro="responsability" suffix=". "/>
+            <text macro="responsibility" suffix=". "/>
             <choose>
               <if variable="author editor translator" match="any">
                 <text macro="title" suffix=". "/>
@@ -454,7 +450,7 @@
         </else-if>
         <else-if type="thesis">
           <group>
-            <text macro="responsability" suffix=". "/>
+            <text macro="responsbiility" suffix=". "/>
             <choose>
               <if variable="author editor translator" match="any">
                 <text macro="title" suffix=". "/>
@@ -468,7 +464,7 @@
         </else-if>
         <else-if type="post-weblog post webpage" match="any">
           <group>
-            <text macro="responsability" suffix=". "/>
+            <text macro="responsibility" suffix=". "/>
             <choose>
               <if variable="author editor translator" match="any">
                 <text macro="title" suffix=". "/>
@@ -481,7 +477,7 @@
         </else-if>
         <else-if type="broadcast motion_picture song" match="any">
           <group>
-            <text macro="responsability" suffix=". "/>
+            <text macro="responsibility" suffix=". "/>
             <choose>
               <if variable="author editor translator" match="any">
                 <text macro="title" suffix=". "/>
@@ -498,7 +494,7 @@
         </else-if>
         <else-if type="report">
           <group>
-            <text macro="responsability" suffix=". "/>
+            <text macro="responsibility" suffix=". "/>
             <choose>
               <if variable="author editor translator" match="any">
                 <text macro="title" suffix=". "/>
@@ -514,7 +510,7 @@
         </else-if>
         <else-if type="manuscript">
           <group>
-            <text macro="responsability" suffix=". "/>
+            <text macro="responsibility" suffix=". "/>
             <choose>
               <if variable="author editor translator" match="any">
                 <text macro="title" suffix=". "/>
@@ -530,7 +526,7 @@
         </else-if>
         <else-if type="patent">
           <group>
-            <text macro="responsability" suffix=". "/>
+            <text macro="responsibility" suffix=". "/>
             <choose>
               <if variable="author editor translator" match="any">
                 <text macro="title" suffix=". "/>
@@ -546,7 +542,7 @@
         </else-if>
         <else>
           <group>
-            <text macro="responsability" suffix=". "/>
+            <text macro="responsibility" suffix=". "/>
             <choose>
               <if variable="author editor translator" match="any">
                 <text macro="title" suffix=". "/>

--- a/isara-iso-690.csl
+++ b/isara-iso-690.csl
@@ -450,7 +450,7 @@
         </else-if>
         <else-if type="thesis">
           <group>
-            <text macro="responsbiility" suffix=". "/>
+            <text macro="responsibility" suffix=". "/>
             <choose>
               <if variable="author editor translator" match="any">
                 <text macro="title" suffix=". "/>

--- a/isara-iso-690.csl
+++ b/isara-iso-690.csl
@@ -1,0 +1,574 @@
+<?xml version="1.0" encoding="utf-8"?>
+<style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" demote-non-dropping-particle="never" default-locale="fr-FR">
+  <info>
+    <title>Isara - ISO-690 (auteur-date, français)</title>
+    <id>http://www.zotero.org/styles/isara-iso-690</id>
+    <link href="http://www.zotero.org/styles/isara-iso-690" rel="self"/>
+	<link href="http://www.zotero.org/styles/iso690-author-date-fr-no-abstract" rel="template"/>
+	<link href="https://doc.isara.fr/se-former/guide-de-referencement-bibliographique/" rel="documentation"/>
+    <author>
+      <name>Oriane Debiez</name>
+      <email>lasource@isara.fr</email>
+    </author>
+	<author>
+      <name>Vincent Payet</name>
+    </author>
+    <category citation-format="author-date"/>
+    <category field="generic-base"/>
+    <summary>Style based on ISO 690:2010(F), V1, derived from Mellifluo, Grolimund, Hardegger and Giraud version.</summary>
+    <updated>2022-08-31T02:31:25+00:00</updated>
+    <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
+  </info>
+ <locale>
+    <terms>
+      <term name="no date">[sans date]</term>
+      <term name="in">in</term>
+      <term name="online">en&#160;ligne</term>
+      <term name="accessed">consulté&#160;le</term>
+      <term name="retrieved">disponible</term>
+      <term name="from">à l'adresse</term>
+      <term name="translator" form="short">trad.</term>
+      <term name="editor" form="short">éd.</term>
+    </terms>
+  </locale>
+  <macro name="editor">
+    <names variable="editor">
+      <name and="text" name-as-sort-order="all" sort-separator=", " delimiter=", " delimiter-precedes-last="never">
+        <name-part name="family" text-case="uppercase"/>
+        <name-part name="given"/>
+      </name>
+      <label prefix=" (" form="short" suffix=".)"/>
+    </names>
+  </macro>
+  <macro name="translator">
+    <names variable="translator">
+      <name and="text" name-as-sort-order="all" sort-separator=", " delimiter=", " delimiter-precedes-last="never">
+        <name-part name="family" text-case="uppercase"/>
+        <name-part name="given"/>
+      </name>
+      <label prefix=" (" form="short" suffix=".)"/>
+    </names>
+  </macro>
+  <macro name="year-date">
+    <choose>
+      <if variable="issued">
+        <date variable="issued">
+          <date-part name="year" form="long"/>
+        </date>
+      </if>
+      <else>
+        <text term="no date"/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="responsability">
+    <names variable="author">
+      <name and="text" name-as-sort-order="all" sort-separator=", " delimiter=", " delimiter-precedes-last="never">
+        <name-part name="family" text-case="uppercase"/>
+        <name-part name="given"/>
+      </name>
+      <substitute>
+        <text macro="editor"/>
+        <text macro="translator"/>
+        <text macro="title"/>
+      </substitute>
+    </names>
+    <choose>
+      <if variable="author editor translator" match="any">
+        <text macro="year-date" prefix=", "/>
+      </if>
+    </choose>
+  </macro>
+  <macro name="author-citation">
+    <names variable="author">
+      <name form="short"/>
+	    <et-al font-style="italic"/>
+      <substitute>
+        <names variable="editor"/>
+        <names variable="translator"/>
+        <text variable="title" font-style="italic" prefix="[Auteur ?] "/>
+      </substitute>
+    </names>
+  </macro>
+  <macro name="container-author">
+    <names variable="container-author">
+      <name and="text" name-as-sort-order="all" sort-separator=", " delimiter=", " delimiter-precedes-last="never">
+        <name-part name="family" text-case="uppercase"/>
+        <name-part name="given"/>
+      </name>
+    </names>
+  </macro>
+  <macro name="container-responsability">
+    <choose>
+      <if variable="container-author editor translator" match="any">
+        <choose>
+          <if variable="container-author">
+            <text macro="container-author"/>
+          </if>
+          <else-if variable="editor">
+            <text macro="editor"/>
+          </else-if>
+          <else>
+            <text macro="translator"/>
+          </else>
+        </choose>
+      </if>
+    </choose>
+  </macro>
+  <macro name="title">
+    <choose>
+      <if type="book thesis map motion_picture song manuscript" match="any">
+        <choose>
+          <if variable="author editor translator" match="any">
+            <text variable="title" font-style="italic"/>
+          </if>
+          <else>
+            <text variable="title" font-style="italic" prefix="[Auteur ?] " suffix=", "/>
+            <text macro="year-date" suffix=". "/>
+          </else>
+        </choose>
+      </if>
+      <else-if type="paper-conference speech chapter article-journal article-magazine article-newspaper entry entry-dictionary entry-encyclopedia post-weblog post webpage broadcast" match="any">
+        <choose>
+          <if variable="author editor translator" match="any">
+            <text variable="title" suffix=". "/>
+          </if>
+          <else>
+            <text macro="year-date" prefix="[Auteur ?], "  suffix=". "/>
+            <text variable="title" suffix=". "/>
+          </else>
+        </choose>
+        <choose>
+          <if type="chapter paper-conference" match="any">
+            <text term="in" text-case="capitalize-first" suffix="&#160;: "/>
+          </if>
+        </choose>
+        <choose>
+          <if variable="container-author editor translator" match="any">
+            <text macro="container-responsability"/>
+            <choose>
+              <if variable="container-title event" match="any">
+                <text value=", "/>
+              </if>
+            </choose>
+          </if>
+        </choose>
+        <choose>
+          <if variable="container-title">
+            <text variable="container-title" font-style="italic"/>
+          </if>
+          <else>
+            <text variable="event" font-style="italic"/>
+          </else>
+        </choose>
+      </else-if>
+      <else-if type="report">
+        <choose>
+          <if variable="author editor translator" match="any">
+            <text variable="number" suffix="&#160;: "/>
+            <text variable="title" font-style="italic"/>
+          </if>
+          <else>
+            <text variable="number" suffix="&#160;: "/>
+            <text variable="title" font-style="italic" prefix="[Auteur ?] " suffix=", "/>
+            <text macro="year-date" suffix=". "/>
+          </else>
+        </choose>
+      </else-if>
+      <else-if type="patent">
+        <choose>
+          <if variable="author editor translator" match="any">
+            <text variable="title"/>
+          </if>
+          <else>
+            <text variable="title" prefix="[Auteur ?] " suffix=", "/>
+            <text macro="year-date" suffix=". "/>
+          </else>
+        </choose>
+      </else-if>
+      <else>
+        <choose>
+          <if variable="author editor translator" match="any">
+            <text variable="title" font-style="italic"/>
+          </if>
+          <else>
+            <text variable="title" font-style="italic" prefix="[Auteur ?] " suffix=", "/>
+            <text macro="year-date" suffix=". "/>
+          </else>
+        </choose>
+      </else>
+    </choose>
+    <choose>
+      <if variable="URL">
+        <text term="online" prefix=" [" suffix="]"/>
+      </if>
+    </choose>
+  </macro>
+  <macro name="number">
+    <text variable="number"/>
+  </macro>
+  <macro name="medium">
+    <text variable="medium" prefix=" [" suffix="]"/>
+  </macro>
+  <macro name="genre">
+    <choose>
+      <if type="map">
+        <choose>
+          <if variable="genre">
+            <text variable="genre" prefix="[" suffix="]"/>
+          </if>
+          <else>
+            <text value="carte" prefix="[" suffix="]"/>
+          </else>
+        </choose>
+      </if>
+      <else>
+        <text variable="genre"/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="date">
+    <choose>
+      <if variable="issued">
+        <date variable="issued">
+          <date-part name="day" suffix=" "/>
+          <date-part name="month" suffix=" "/>
+          <date-part name="year"/>
+        </date>
+      </if>
+    </choose>
+  </macro>
+  <macro name="edition">
+    <text variable="edition" form="long"/>
+  </macro>
+  <macro name="publisher-group">
+    <group delimiter="&#160;: ">
+      <text variable="publisher-place"/>
+      <text variable="publisher"/>
+    </group>
+  </macro>
+  <macro name="issue">
+    <group delimiter=", ">
+      <text variable="volume" prefix="Vol.&#160;"/>
+      <choose>
+        <if variable="volume">
+          <text variable="issue" prefix="n°&#160;"/>
+          <text variable="page" prefix="pp.&#160;"/>
+        </if>
+        <else-if variable="issue">
+          <text variable="issue" prefix="N°&#160;"/>
+          <text variable="page" prefix="pp.&#160;"/>
+        </else-if>
+        <else>
+          <text variable="page" prefix="pp.&#160;"/>
+        </else>
+      </choose>
+    </group>
+  </macro>
+  <macro name="accessed">
+    <choose>
+      <if variable="URL">
+        <group prefix=" [" suffix="]">
+          <text term="accessed" text-case="capitalize-first"/>
+          <date variable="accessed">
+            <date-part name="day" prefix="&#160;"/>
+            <date-part name="month" prefix="&#160;"/>
+            <date-part name="year" prefix="&#160;"/>
+          </date>
+        </group>
+      </if>
+    </choose>
+  </macro>
+  <macro name="collection">
+    <group delimiter=", ">
+      <text variable="collection-title"/>
+      <text variable="collection-number"/>
+    </group>
+  </macro>
+  <macro name="page">
+    <choose>
+      <if type="book thesis manuscript" match="any">
+        <text variable="number-of-pages" suffix="&#160;p"/>
+      </if>
+      <else-if type="chapter paper-conference article-newspaper" match="any">
+        <text variable="page" prefix="pp.&#160;"/>
+      </else-if>
+      <else-if type="report patent" match="any">
+        <text variable="page" suffix="&#160;p"/>
+      </else-if>
+    </choose>
+  </macro>
+  <macro name="isbn">
+    <text variable="ISBN" prefix="ISBN&#160;"/>
+  </macro>
+  <macro name="doi">
+    <text variable="DOI" prefix="DOI&#160;"/>
+  </macro>
+  <macro name="url">
+    <choose>
+      <if variable="URL">
+        <group>
+          <text term="retrieved" suffix=" " text-case="capitalize-first"/>
+          <text term="from" suffix="&#160;: "/>
+          <text variable="URL"/>
+        </group>
+      </if>
+    </choose>
+  </macro>
+  <macro name="archive">
+    <group delimiter=":&#160;">
+      <text variable="archive"/>
+      <text macro="archive_location"/>
+    </group>
+  </macro>
+  <macro name="archive_location">
+    <choose>
+      <if variable="archive_location">
+        <text variable="archive_location"/>
+      </if>
+      <else>
+        <text variable="call-number"/>
+      </else>
+    </choose>
+  </macro>
+  <citation et-al-min="3" et-al-use-first="1" disambiguate-add-year-suffix="true" disambiguate-add-names="true" disambiguate-add-givenname="true" collapse="year" year-suffix-delimiter=", " after-collapse-delimiter="; ">
+    <layout prefix="(" suffix=")" delimiter="; ">
+      <group delimiter=", ">
+        <group delimiter=", ">
+          <text macro="author-citation"/>
+          <text macro="year-date"/>
+        </group>
+        <group>
+          <label variable="locator" suffix=".&#160;" form="short" strip-periods="true"/>
+          <text variable="locator"/>
+        </group>
+      </group>
+    </layout>
+  </citation>
+  <bibliography>
+    <sort>
+      <key macro="responsability"/>
+      <key macro="year-date"/>
+    </sort>
+    <layout>
+      <choose>
+        <if type="book map" match="any">
+          <group>
+            <text macro="responsability" suffix=". "/>
+            <choose>
+              <if variable="author editor translator" match="any">
+                <text macro="title" suffix=". "/>
+              </if>
+            </choose>
+            <text macro="genre" suffix=". "/>
+            <text macro="edition" suffix=". "/>
+            <text macro="publisher-group" suffix=". "/>
+            <text macro="accessed" suffix=". "/>
+            <text macro="collection" suffix=". "/>
+            <text macro="isbn" suffix=". "/>
+            <text macro="url"/>
+          </group>
+        </if>
+        <else-if type="article-journal article-magazine" match="any">
+          <group>
+            <text macro="responsability" suffix=". "/>
+            <choose>
+              <if variable="author editor translator" match="any">
+                <text macro="title" suffix=". "/>
+              </if>
+            </choose>
+            <text macro="edition" suffix=". "/>
+            <text macro="date" suffix=". "/>
+            <text macro="issue" suffix=". "/>
+            <text macro="accessed" suffix=". "/>
+            <text macro="doi" suffix=". "/>
+            <text macro="url"/>
+          </group>
+        </else-if>
+        <else-if type="article-newspaper">
+          <group>
+            <text macro="responsability" suffix=". "/>
+            <choose>
+              <if variable="author editor translator" match="any">
+                <text macro="title" suffix=". "/>
+              </if>
+            </choose>
+            <text macro="edition" suffix=". "/>
+            <text macro="publisher-group" suffix=", "/>
+            <text macro="date" suffix=". "/>
+            <text macro="page" suffix=". "/>
+            <text macro="accessed" suffix=". "/>
+            <text macro="url"/>
+          </group>
+        </else-if>
+        <else-if type="chapter entry entry-dictionary entry-encyclopedia" match="any">
+          <group>
+            <text macro="responsability" suffix=". "/>
+            <choose>
+              <if variable="author editor translator" match="any">
+                <text macro="title" suffix=". "/>
+              </if>
+            </choose>
+            <text macro="edition" suffix=". "/>
+            <text macro="publisher-group" suffix=". "/>
+            <text macro="page" suffix=". "/>
+            <text macro="collection" suffix=". "/>
+            <text macro="accessed" suffix=". "/>
+            <text macro="isbn" suffix=". "/>
+            <text macro="url"/>
+          </group>
+        </else-if>
+        <else-if type="speech">
+          <group>
+            <text macro="responsability" suffix=". "/>
+            <choose>
+              <if variable="author editor translator" match="any">
+                <text macro="title" suffix=". "/>
+              </if>
+            </choose>
+            <text macro="genre" suffix=". "/>
+            <text macro="publisher-group" suffix=". "/>
+            <text macro="date" suffix=". "/>
+            <text macro="accessed" suffix=". "/>
+            <text macro="page" suffix=". "/>
+            <text macro="url"/>
+          </group>
+        </else-if>
+        <else-if type="paper-conference">
+          <group>
+            <text macro="responsability" suffix=". "/>
+            <choose>
+              <if variable="author editor translator" match="any">
+                <text macro="title" suffix=". "/>
+              </if>
+            </choose>
+            <text macro="genre" suffix=". "/>
+            <text macro="publisher-group" suffix=". "/>
+            <text macro="date" suffix=". "/>
+            <text macro="page" suffix=". "/>
+            <text macro="accessed" suffix=". "/>
+            <text macro="collection" suffix=". "/>
+            <text macro="isbn" suffix=". "/>
+            <text macro="url"/>
+          </group>
+        </else-if>
+        <else-if type="thesis">
+          <group>
+            <text macro="responsability" suffix=". "/>
+            <choose>
+              <if variable="author editor translator" match="any">
+                <text macro="title" suffix=". "/>
+              </if>
+            </choose>
+            <text macro="genre" suffix=". "/>
+            <text macro="publisher-group" suffix=". "/>
+            <text macro="accessed" suffix=". "/>
+            <text macro="url"/>
+          </group>
+        </else-if>
+        <else-if type="post-weblog post webpage" match="any">
+          <group>
+            <text macro="responsability" suffix=". "/>
+            <choose>
+              <if variable="author editor translator" match="any">
+                <text macro="title" suffix=". "/>
+              </if>
+            </choose>
+            <text macro="date" suffix=". "/>
+            <text macro="accessed" suffix=". "/>
+            <text macro="url"/>
+          </group>
+        </else-if>
+        <else-if type="broadcast motion_picture song" match="any">
+          <group>
+            <text macro="responsability" suffix=". "/>
+            <choose>
+              <if variable="author editor translator" match="any">
+                <text macro="title" suffix=". "/>
+              </if>
+            </choose>
+            <text macro="medium" suffix=". "/>
+            <text macro="publisher-group" suffix=", "/>
+            <text macro="date" suffix=". "/>
+            <text macro="accessed" suffix=". "/>
+            <text macro="collection" suffix=". "/>
+            <text macro="isbn" suffix=". "/>
+            <text macro="url"/>
+          </group>
+        </else-if>
+        <else-if type="report">
+          <group>
+            <text macro="responsability" suffix=". "/>
+            <choose>
+              <if variable="author editor translator" match="any">
+                <text macro="title" suffix=". "/>
+              </if>
+            </choose>
+            <text macro="genre" suffix=". "/>
+            <text macro="edition" suffix=". "/>
+            <text macro="publisher-group" suffix=". "/>
+            <text macro="accessed" suffix=". "/>
+            <text macro="collection" suffix=". "/>
+            <text macro="url"/>
+          </group>
+        </else-if>
+        <else-if type="manuscript">
+          <group>
+            <text macro="responsability" suffix=". "/>
+            <choose>
+              <if variable="author editor translator" match="any">
+                <text macro="title" suffix=". "/>
+              </if>
+            </choose>
+            <text macro="genre" suffix=". "/>
+            <text macro="edition" suffix=". "/>
+            <text macro="publisher-group" suffix=". "/>
+            <text macro="accessed" suffix=". "/>
+            <text macro="collection" suffix=". "/>
+            <text macro="url"/>
+          </group>
+        </else-if>
+        <else-if type="patent">
+          <group>
+            <text macro="responsability" suffix=". "/>
+            <choose>
+              <if variable="author editor translator" match="any">
+                <text macro="title" suffix=". "/>
+              </if>
+            </choose>
+            <text macro="number" suffix=". "/>
+            <text macro="date" suffix=". "/>
+            <text macro="publisher-group" suffix=". "/>
+            <text macro="accessed" suffix=". "/>
+            <text macro="collection" suffix=". "/>
+            <text macro="url"/>
+          </group>
+        </else-if>
+        <else>
+          <group>
+            <text macro="responsability" suffix=". "/>
+            <choose>
+              <if variable="author editor translator" match="any">
+                <text macro="title" suffix=". "/>
+              </if>
+            </choose>
+            <text macro="medium" suffix=". "/>
+            <text macro="genre" suffix=". "/>
+            <text macro="date" suffix=". "/>
+            <text macro="edition" suffix=". "/>
+            <text macro="publisher-group" suffix=". "/>
+            <text macro="number" suffix=". "/>
+            <text macro="accessed" suffix=". "/>
+            <text macro="collection" suffix=". "/>
+            <text macro="page" suffix=". "/>
+            <text macro="isbn" suffix=". "/>
+            <text macro="url"/>
+          </group>
+        </else>
+      </choose>
+      <group display="right-inline">
+        <text macro="archive"/>
+      </group>
+    </layout>
+  </bibliography>
+</style>

--- a/isara-iso-690.csl
+++ b/isara-iso-690.csl
@@ -4,13 +4,13 @@
     <title>Isara - ISO-690 (auteur-date, français)</title>
     <id>http://www.zotero.org/styles/isara-iso-690</id>
     <link href="http://www.zotero.org/styles/isara-iso-690" rel="self"/>
-	<link href="http://www.zotero.org/styles/iso690-author-date-fr-no-abstract" rel="template"/>
-	<link href="https://doc.isara.fr/se-former/guide-de-referencement-bibliographique/" rel="documentation"/>
+    <link href="http://www.zotero.org/styles/iso690-author-date-fr-no-abstract" rel="template"/>
+    <link href="https://doc.isara.fr/se-former/guide-de-referencement-bibliographique/" rel="documentation"/>
     <author>
       <name>Oriane Debiez</name>
       <email>lasource@isara.fr</email>
     </author>
-	<author>
+    <author>
       <name>Vincent Payet</name>
     </author>
     <category citation-format="author-date"/>
@@ -19,7 +19,7 @@
     <updated>2022-08-31T02:31:25+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
- <locale>
+  <locale>
     <terms>
       <term name="no date">[sans date]</term>
       <term name="in">in</term>
@@ -82,7 +82,7 @@
   <macro name="author-citation">
     <names variable="author">
       <name form="short"/>
-	    <et-al font-style="italic"/>
+      <et-al font-style="italic"/>
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
@@ -134,7 +134,7 @@
             <text variable="title" suffix=". "/>
           </if>
           <else>
-            <text macro="year-date" prefix="[Auteur ?], "  suffix=". "/>
+            <text macro="year-date" prefix="[Auteur ?], " suffix=". "/>
             <text variable="title" suffix=". "/>
           </else>
         </choose>


### PR DESCRIPTION
New style based on the ISO-690 standard and the work of Raphaël Grolimund and Pierre-Amiel Giraud in 2021/2022, adapted to the requirements of the **Isara** engineering school (Lyon, France) for use with Zotero:
- "Et al." (in italic) for 3 or more authors in the citation
- A comma between the author and the date in the citation
- Mention [Auteur ?] before the title if no author, editor or translator is indicated
- Mention [sans date] if no date is indicated