### PR TITLE
Updating the file to maintain the Abertay Guide

### DIFF
--- a/harvard-university-of-abertay-dundee.csl
+++ b/harvard-university-of-abertay-dundee.csl
@@ -1,9 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" demote-non-dropping-particle="sort-only" default-locale="en-GB">
+  <!-- This style was edited with the Visual CSL Editor (https://editor.citationstyles.org/visualEditor/) -->
   <info>
-    <title>University of Abertay Dundee - Harvard</title>
-    <id>http://www.zotero.org/styles/harvard-university-of-abertay-dundee</id>
-    <link href="http://www.zotero.org/styles/harvard-university-of-abertay-dundee" rel="self"/>
+    <title>Abertay University - Harvard</title>
+    <id>http://www.zotero.org/styles/abertay-university-harvard</id>
+    <link href="http://www.zotero.org/styles/abertay-university-harvard" rel="self"/>
     <link href="https://portal.abertay.ac.uk/portal/page/portal/Library/Referencing" rel="documentation"/>
     <author>
       <name>Gregory Goltsov</name>
@@ -13,10 +14,13 @@
     <contributor>
       <name>Sebastian Karcher</name>
     </contributor>
+    <contributor>
+      <name>Naman Merchant</name>
+    </contributor>
     <category citation-format="author-date"/>
     <category field="generic-base"/>
     <summary>The Abertay version of the Harvard author-date style</summary>
-    <updated>2012-11-16T18:17:12+00:00</updated>
+    <updated>2022-09-11T20:42:15+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale xml:lang="en-GB">
@@ -47,6 +51,7 @@
     <names variable="author">
       <name and="text" delimiter-precedes-last="never" initialize-with="" name-as-sort-order="all"/>
       <label form="short" prefix=" (" suffix=")"/>
+      <et-al font-style="italic"/>
       <substitute>
         <names variable="editor"/>
         <text macro="anon"/>
@@ -56,6 +61,7 @@
   <macro name="author-short">
     <names variable="author">
       <name form="short" and="text" delimiter-precedes-last="never" initialize-with=". "/>
+      <et-al font-style="italic"/>
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
@@ -82,7 +88,7 @@
   <macro name="year-date">
     <choose>
       <if variable="issued">
-        <date variable="issued">
+        <date variable="issued" font-style="normal">
           <date-part name="year"/>
         </date>
       </if>
@@ -145,21 +151,17 @@
       </if>
     </choose>
   </macro>
-  <citation et-al-min="4" et-al-use-first="1" disambiguate-add-year-suffix="true" disambiguate-add-names="true" disambiguate-add-givenname="true" collapse="year" givenname-disambiguation-rule="by-cite">
+  <citation et-al-min="4" et-al-use-first="1" et-al-subsequent-min="3" et-al-subsequent-use-first="1" disambiguate-add-givenname="true" disambiguate-add-year-suffix="true" collapse="year">
     <layout prefix="(" suffix=")" delimiter="; ">
       <group delimiter=", ">
-        <group delimiter=" ">
-          <text macro="author-short"/>
+        <group delimiter=", ">
+          <text macro="author-short" font-style="normal"/>
           <choose>
             <if type="personal_communication" match="any">
               <text value="pers. comm."/>
             </if>
           </choose>
           <text macro="year-date"/>
-        </group>
-        <group delimiter=" ">
-          <label variable="locator" plural="never" form="short"/>
-          <text variable="page" form="short"/>
         </group>
       </group>
     </layout>
@@ -171,9 +173,11 @@
     </sort>
     <layout suffix=".">
       <group delimiter=", ">
-        <group delimiter=" ">
+        <group delimiter="">
           <text macro="author"/>
-          <text macro="year-date"/>
+          <group prefix=" (" suffix=")">
+            <text macro="year-date"/>
+          </group>
         </group>
         <text macro="title"/>
         <group delimiter=" ">


### PR DESCRIPTION
Updating the file to maintain the Abertay Style guidelines found here: https://intranet.abertay.ac.uk/students/study-skills/referencing/harvard/

Log of Changes:
- Changed the name of the file to Abertay University - the university officially changed its name in 2020 see here for proof: https://www.legislation.gov.uk/ssi/2020/286/made
- Removed the page number from in-line citations. It's easier to add the page number for specific quotations, but not possible for regular users to remove the page number from the macros.
- Added brackets for the year in the Bibliography
- Changed  the et al in-line citation to be in italics
- Set disambiguate add names to false
- Added a comma between the in-line citation name and year