### PR TITLE
Updating file to maintain Abertay's Style guide

### DIFF
--- a/harvard-university-of-abertay-dundee.csl
+++ b/harvard-university-of-abertay-dundee.csl
@@ -146,13 +146,13 @@
   <citation et-al-min="4" et-al-use-first="1" et-al-subsequent-min="3" et-al-subsequent-use-first="1" disambiguate-add-givenname="true" disambiguate-add-year-suffix="true" collapse="year">
     <layout prefix="(" suffix=")" delimiter="; ">
       <group delimiter=", ">
-          <text macro="author-short"/>
-          <choose>
-            <if type="personal_communication" match="any">
-              <text value="pers. comm."/>
-            </if>
-          </choose>
-          <text macro="year-date"/>
+        <text macro="author-short"/>
+        <choose>
+          <if type="personal_communication" match="any">
+            <text value="pers. comm."/>
+          </if>
+        </choose>
+        <text macro="year-date"/>
       </group>
     </layout>
   </citation>

--- a/harvard-university-of-abertay-dundee.csl
+++ b/harvard-university-of-abertay-dundee.csl
@@ -13,10 +13,13 @@
     <contributor>
       <name>Sebastian Karcher</name>
     </contributor>
+    <contributor>
+      <name>Naman Merchant</name>
+    </contributor>
     <category citation-format="author-date"/>
     <category field="generic-base"/>
     <summary>The Abertay version of the Harvard author-date style</summary>
-    <updated>2012-11-16T18:17:12+00:00</updated>
+    <updated>2022-09-11T21:02:45+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale xml:lang="en-GB">
@@ -47,6 +50,7 @@
     <names variable="author">
       <name and="text" delimiter-precedes-last="never" initialize-with="" name-as-sort-order="all"/>
       <label form="short" prefix=" (" suffix=")"/>
+      <et-al font-style="italic"/>
       <substitute>
         <names variable="editor"/>
         <text macro="anon"/>
@@ -56,6 +60,7 @@
   <macro name="author-short">
     <names variable="author">
       <name form="short" and="text" delimiter-precedes-last="never" initialize-with=". "/>
+      <et-al font-style="italic"/>
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
@@ -82,7 +87,7 @@
   <macro name="year-date">
     <choose>
       <if variable="issued">
-        <date variable="issued">
+        <date variable="issued" font-style="normal">
           <date-part name="year"/>
         </date>
       </if>
@@ -145,21 +150,17 @@
       </if>
     </choose>
   </macro>
-  <citation et-al-min="4" et-al-use-first="1" disambiguate-add-year-suffix="true" disambiguate-add-names="true" disambiguate-add-givenname="true" collapse="year" givenname-disambiguation-rule="by-cite">
+  <citation et-al-min="4" et-al-use-first="1" et-al-subsequent-min="3" et-al-subsequent-use-first="1" disambiguate-add-givenname="true" disambiguate-add-year-suffix="true" collapse="year">
     <layout prefix="(" suffix=")" delimiter="; ">
       <group delimiter=", ">
-        <group delimiter=" ">
-          <text macro="author-short"/>
+        <group delimiter=", ">
+          <text macro="author-short" font-style="normal"/>
           <choose>
             <if type="personal_communication" match="any">
               <text value="pers. comm."/>
             </if>
           </choose>
           <text macro="year-date"/>
-        </group>
-        <group delimiter=" ">
-          <label variable="locator" plural="never" form="short"/>
-          <text variable="page" form="short"/>
         </group>
       </group>
     </layout>
@@ -171,9 +172,11 @@
     </sort>
     <layout suffix=".">
       <group delimiter=", ">
-        <group delimiter=" ">
+        <group delimiter="">
           <text macro="author"/>
-          <text macro="year-date"/>
+          <group prefix=" (" suffix=")">
+            <text macro="year-date"/>
+          </group>
         </group>
         <text macro="title"/>
         <group delimiter=" ">

--- a/harvard-university-of-abertay-dundee.csl
+++ b/harvard-university-of-abertay-dundee.csl
@@ -69,14 +69,7 @@
     </names>
   </macro>
   <macro name="title">
-    <choose>
-      <if type="bill book graphic legal_case legislation motion_picture report song thesis" match="any">
-        <text variable="title" form="long" text-case="capitalize-first" font-style="normal" font-variant="normal"/>
-      </if>
-      <else>
-        <text variable="title" form="long" quotes="false" font-style="normal"/>
-      </else>
-    </choose>
+    <text variable="title"/>
   </macro>
   <macro name="publisher">
     <group delimiter=", ">
@@ -87,7 +80,7 @@
   <macro name="year-date">
     <choose>
       <if variable="issued">
-        <date variable="issued" font-style="normal">
+        <date variable="issued">
           <date-part name="year"/>
         </date>
       </if>
@@ -153,15 +146,13 @@
   <citation et-al-min="4" et-al-use-first="1" et-al-subsequent-min="3" et-al-subsequent-use-first="1" disambiguate-add-givenname="true" disambiguate-add-year-suffix="true" collapse="year">
     <layout prefix="(" suffix=")" delimiter="; ">
       <group delimiter=", ">
-        <group delimiter=", ">
-          <text macro="author-short" font-style="normal"/>
+          <text macro="author-short"/>
           <choose>
             <if type="personal_communication" match="any">
               <text value="pers. comm."/>
             </if>
           </choose>
           <text macro="year-date"/>
-        </group>
       </group>
     </layout>
   </citation>


### PR DESCRIPTION
Updating the file to maintain the Abertay Style guidelines found here: https://intranet.abertay.ac.uk/students/study-skills/referencing/harvard/

Log of Changes:
- Removed the page number from in-line citations. It's easier to add the page number for specific quotations, but not possible for regular users to remove the page number from the macros.
- Added brackets for the year in the Bibliography
- Changed  the et al in-line citation to be in italics
- Set disambiguate add names to false
- Added a comma between the in-line citation name and year