### PR TITLE
Create journal-of-music-archaeology.csl

### DIFF
--- a/journal-of-music-archaeology.csl
+++ b/journal-of-music-archaeology.csl
@@ -4,9 +4,8 @@
   <info>
     <title>Journal of Music Archaeology</title>
     <title-short>JMA</title-short>
-    <id>f1732a6e-39c0-11ed-a261-0242ac120002</id>
+    <id>http://www.zotero.org/styles/journal-of-music-archaeology</id>
     <link href="http://www.zotero.org/styles/journal-of-music-archaeology" rel="self"/>
-    <link href="http://www.zotero.org/styles/harvard-cardiff-university" rel="template"/>
     <author>
       <name>Stefan Hagel</name>
     </author>


### PR DESCRIPTION
CSL for newly founded Journal of Music Archaeology, published at the Austrian Academy of Sciences: https://jma.vlg.oeaw.ac.at/