### PR TITLE
Update (bugfix) for norsk-henvisningsstandard-for-rettsvitenskapelige-tekster

### DIFF
--- a/norsk-henvisningsstandard-for-rettsvitenskapelige-tekster.csl
+++ b/norsk-henvisningsstandard-for-rettsvitenskapelige-tekster.csl
@@ -95,7 +95,7 @@
         <text quotes="true" variable="title"/>
       </if>
       <else-if type="legislation">
-        <text variable="title-short"/>
+        <text variable="title-short" text-case="capitalize-first"/>
       </else-if>
       <else>
         <text font-style="italic" variable="title-short"/>


### PR DESCRIPTION
Capitalize-first short titles for legislation ("Statute").