### PR TITLE
GitHub Workflows security hardening

### DIFF
--- a/.github/workflows/label-gun.yml
+++ b/.github/workflows/label-gun.yml
@@ -6,8 +6,13 @@ on:
   issue_comment:
     types: [created, edited, closed]
 
+permissions: {}
 jobs:
   label:
+    permissions:
+      issues: write # to add label to an issues (retorquere/label-gun)
+      pull-requests: write # to add label, comment on pull request (retorquere/label-gun)
+
     runs-on: ubuntu-latest
     steps:
       - uses: retorquere/label-gun@main

--- a/.github/workflows/merge.yaml
+++ b/.github/workflows/merge.yaml
@@ -12,8 +12,13 @@ on:
         description: Commit message
         required: true
 
+permissions: {}
 jobs:
   release:
+    permissions:
+      contents: write # to create a release
+      pull-requests: read # to read pull requests (dorny/paths-filter)
+
     runs-on: ubuntu-latest
     env:
       GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/sheldon.yaml
+++ b/.github/workflows/sheldon.yaml
@@ -4,8 +4,13 @@ on:
   pull_request_target:
     types: [ opened, synchronize, workflow_dispatch]
 
+permissions: {}
 jobs:
   test:
+    permissions:
+      contents: write # to push code in repo (stefanzweifel/git-auto-commit-action)
+      pull-requests: write # to comment on pull requests
+
     runs-on: ubuntu-latest
     env:
       GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
This PR adds explicit [permissions section](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions) to workflows. This is a security best practice because by default workflows run with [extended set of permissions](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token) (except from `on: pull_request` [from external forks](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)). By specifying any permission explicitly all others are set to none. By using the principle of least privilege the damage a compromised workflow can do (because of an [injection](https://securitylab.github.com/research/github-actions-untrusted-input/) or compromised third party tool or action) is restricted.
It is recommended to have [most strict permissions on the top level](https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions) and grant write permissions on [job level](https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs) case by case.