### PR TITLE
ACS, AMA, Vancouver: Remove hardcoded space after `citation-number`

### DIFF
--- a/american-chemical-society.csl
+++ b/american-chemical-society.csl
@@ -148,7 +148,7 @@
   </citation>
   <bibliography second-field-align="flush" entry-spacing="0">
     <layout suffix=".">
-      <text variable="citation-number" prefix="(" suffix=") "/>
+      <text variable="citation-number" prefix="(" suffix=")"/>
       <text macro="author" suffix=" "/>
       <choose>
         <if type="article-journal review" match="any">

--- a/american-medical-association.csl
+++ b/american-medical-association.csl
@@ -124,7 +124,7 @@
   </citation>
   <bibliography hanging-indent="false" et-al-min="7" et-al-use-first="3" second-field-align="flush">
     <layout>
-      <text variable="citation-number" suffix=". "/>
+      <text variable="citation-number" suffix="."/>
       <text macro="author"/>
       <text macro="title" prefix=" " suffix="."/>
       <choose>

--- a/vancouver.csl
+++ b/vancouver.csl
@@ -323,7 +323,7 @@
   </citation>
   <bibliography et-al-min="7" et-al-use-first="6" second-field-align="flush">
     <layout>
-      <text variable="citation-number" suffix=". "/>
+      <text variable="citation-number" suffix="."/>
       <group delimiter=". " suffix=". ">
         <text macro="author"/>
         <text macro="title"/>


### PR DESCRIPTION
https://github.com/zotero/zotero/issues/2633
https://discourse.citationstyles.org/t/space-after-first-field-in-plain-text-mode-when-using-second-field-align/1762

No longer necessary for citeproc-js after Juris-M/citeproc-js#207