### PR TITLE
Update ucl-university-college-apa.csl

### DIFF
--- a/ucl-university-college-apa.csl
+++ b/ucl-university-college-apa.csl
@@ -1555,7 +1555,7 @@
           <label variable="locator" text-case="capitalize-first"/>
         </if>
         <else>
-          <!-- Replaced form="short" to "symbol" to always show § instead of par intext -->  
+          <!-- Replaced form="short" to "symbol" to always show § instead of par intext -->
           <label variable="locator" form="symbol"/>
         </else>
       </choose>

--- a/ucl-university-college-apa.csl
+++ b/ucl-university-college-apa.csl
@@ -17,7 +17,7 @@
     </contributor>
     <category citation-format="author-date"/>
     <category field="generic-base"/>
-    <updated>2021-08-24T02:54:29+00:00</updated>
+    <updated>2022-09-06T13:44:06+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale xml:lang="da">
@@ -1555,7 +1555,8 @@
           <label variable="locator" text-case="capitalize-first"/>
         </if>
         <else>
-          <label variable="locator" form="short"/>
+          <!-- Replaced form="short" to "symbol" to always show § instead of par intext -->  
+          <label variable="locator" form="symbol"/>
         </else>
       </choose>
       <text variable="locator"/>


### PR DESCRIPTION
Replaced form="short" to "symbol" to always show § instead of par intext