### PR TITLE
ACL: check if edition is ordinal before printing the word "edition"

### DIFF
--- a/association-for-computational-linguistics.csl
+++ b/association-for-computational-linguistics.csl
@@ -68,8 +68,17 @@
     </choose>
   </macro>
   <macro name="edition">
-    <number variable="edition" form="ordinal"/>
-    <text term="edition" prefix=" "/>
+    <choose>
+      <if is-numeric="edition">
+        <group delimiter=" ">
+          <number variable="edition" form="ordinal"/>
+          <text term="edition" form="short"/>
+        </group>
+      </if>
+      <else>
+        <text variable="edition"/>
+      </else>
+    </choose>
   </macro>
   <macro name="volume-or-number">
     <choose>


### PR DESCRIPTION
To address the problem that "edition" is being printed spuriously (acl-org/acl-anthology#2156). (macro copied from APA 6th edition)