### PR TITLE
Update harvard-cite-them-right.csl

### DIFF
--- a/harvard-cite-them-right.csl
+++ b/harvard-cite-them-right.csl
@@ -12,7 +12,7 @@
     <category citation-format="author-date"/>
     <category field="generic-base"/>
     <summary>Harvard according to Cite Them Right, 11th edition.</summary>
-    <updated>2022-06-27T11:10:37+00:00</updated>
+    <updated>2022-10-29T12:10:37+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale xml:lang="en-GB">
@@ -34,7 +34,7 @@
         <choose>
           <if variable="container-author" match="none">
             <names variable="editor translator" delimiter=", ">
-              <name and="text" initialize-with="."/>
+              <name and="text" initialize-with="." name-as-sort-order="all"/>
               <label form="short" prefix=" (" suffix=")"/>
             </names>
           </if>


### PR DESCRIPTION
Added name-as-sort-order="all" in the macro "editor" to have the correct format for container authors and book editor