### PR TITLE
Create theses-de-sorbonne-universite.csl

### DIFF
--- a/theses-de-sorbonne-universite.csl
+++ b/theses-de-sorbonne-universite.csl
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <style xmlns="http://purl.org/net/xbiblio/csl" class="note" version="1.0" et-al-use-last="true" page-range-format="chicago" default-locale="fr-FR">
   <info>
-    <title>Thèse de Sorbonne Université (Sciences Humaines et Sociales)</title>
+    <title>Thèse de Sorbonne Université (Sciences Humaines et Sociales, Français)</title>
     <id>http://www.zotero.org/styles/theses-de-sorbonne-universite</id>
     <link href="http://www.zotero.org/styles/theses-de-sorbonne-universite" rel="self"/>
     <link href="https://hal.sorbonne-universite.fr/public/Fiche_documentation_Zotero_Sorbonne.pdf" rel="documentation"/>

--- a/theses-de-sorbonne-universite.csl
+++ b/theses-de-sorbonne-universite.csl
@@ -1,0 +1,2065 @@
+<?xml version="1.0" encoding="utf-8"?>
+<style class="note" version="1.0" et-al-use-last="true" page-range-format="chicago" default-locale="fr-FR" xmlns="http://purl.org/net/xbiblio/csl">
+  <info>
+    <title>Thèse de Sorbonne Université (Sciences Humaines et Sociales)</title>
+    <id>http://www.zotero.org/styles/theses-de-sorbonne-universite</id>
+    <link href="http://www.zotero.org/styles/theses-de-sorbonne-universite" rel="self"/>
+	<link href="https://hal.sorbonne-universite.fr/public/Fiche_documentation_Zotero_Sorbonne.pdf" rel="documentation"/>
+    <author>
+      <name>Morgane Muscat</name>
+      <email>morgane.muscat@gmail.com</email>
+    </author>
+    <author>
+      <name>Mélanie Friche</name>
+      <email>mfriche@protonmail.com</email>
+    </author>
+    <category citation-format="note"/>
+    <category field="generic-base"/>
+    <summary>Adaptation du style &quot;Chicago&quot; français pour les thèses de Sorbonne Université</summary>
+    <updated>2022-06-20T13:07:07+00:00</updated>
+    <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
+  </info>
+  <locale xml:lang="fr">
+    <style-options punctuation-in-quote="false"/>
+    <terms>
+	  <term name="open-quote">«&#8239;</term>
+      <term name="close-quote">&#8239;»</term>
+      <term name="in">dans</term>
+      <term name="editor" form="short">dir.</term>
+      <term name="editor" form="verb-short">éd.</term>
+      <term name="editor" form="verb">dir.</term>
+      <term name="editorial-director" form="short">dir.</term>
+      <term name="editorial-director" form="long">sous la direction de</term>
+      <term name="translator" form="verb-short">trad.</term>
+      <term name="translator" form="short">trad.</term>
+      <term name="editortranslator" form="verb-short">sous la dir. de et trad. par</term>
+      <term name="editortranslator" form="verb">sous la direction de et traduit par</term>
+      <term name="ordinal-01">ère</term>
+      <term name="ordinal-02">e</term>
+      <term name="ordinal-03">e</term>
+      <term name="ordinal-04">e</term>
+      <term name="cited">op.&#160;cit.</term>
+    </terms>
+  </locale>
+  <macro name="editor-translator">
+    <group delimiter=", ">
+      <group delimiter=" ">
+        <choose>
+          <if variable="container-author reviewed-author" match="any">
+            <group>
+              <names variable="container-author reviewed-author">
+                <label form="verb-short" text-case="lowercase" suffix=" "/>
+                <name and="text" delimiter=", "/>
+              </names>
+            </group>
+          </if>
+        </choose>
+      </group>
+      <choose>
+        <if type="chapter">
+          <names variable="editor translator" delimiter=", ">
+            <name and="text"/>
+            <label form="short" text-case="lowercase" prefix=" (" suffix=")"/>
+          </names>
+        </if>
+        <else>
+          <names variable="editor translator" delimiter=", ">
+            <label form="verb-short" text-case="lowercase" suffix=" "/>
+            <name and="text" delimiter=", "/>
+          </names>
+        </else>
+      </choose>
+    </group>
+  </macro>
+  <macro name="container-contributors-notes">
+    <text macro="editor-translator"/>
+  </macro>
+  <macro name="container-contributors">
+    <choose>
+      <if type="chapter entry-dictionary entry-encyclopedia paper-conference" match="any">
+        <group delimiter=", ">
+          <choose>
+            <if variable="author">
+              <choose>
+                <if variable="container-author" match="any">
+                  <names variable="container-author">
+                    <label form="verb-short" text-case="lowercase" suffix=" "/>
+                    <name and="text" delimiter=", "/>
+                  </names>
+                </if>
+              </choose>
+              <choose>
+                <if variable="container-author author" match="all">
+                  <group delimiter=". ">
+				    <group delimiter="&#160;">
+                    <label variable="page" form="short"/>
+                    <text variable="page"/>
+					</group>
+                    <names variable="editor translator" delimiter=", ">
+                      <label form="verb" suffix=" "/>
+                      <name and="text" delimiter=", "/>
+                    </names>
+                  </group>
+                </if>
+              </choose>
+            </if>
+          </choose>
+        </group>
+      </if>
+    </choose>
+  </macro>
+  <macro name="recipient-note">
+    <names variable="recipient" delimiter=", ">
+      <label form="verb" text-case="lowercase" suffix=" "/>
+      <name and="text" delimiter=", "/>
+    </names>
+  </macro>
+  <macro name="contributors-notes">
+    <choose>
+      <if variable="author">
+        <choose>
+          <if type="classic" match="any">
+            <names variable="author">
+              <name form="short"/>
+            </names>
+          </if>
+          <else>
+            <names variable="author">
+              <name and="text" delimiter-precedes-last="never" sort-separator=" "/>
+            </names>
+          </else>
+        </choose>
+      </if>
+      <else-if type="article-journal article-newspaper article-magazine chapter book bill paper-conference entry-dictionary entry-encyclopedia" match="any">
+        <names variable="editorial-director">
+          <name and="text" delimiter-precedes-last="never" sort-separator=" "/>
+          <label form="short" prefix=" (" suffix=".)"/>
+          <substitute>
+            <names variable="editor"/>
+          </substitute>
+        </names>
+      </else-if>
+      <else-if type="entry-dictionary entry-encyclopedia interview" match="none">
+        <text term="anonymous" form="short" text-case="capitalize-first"/>
+      </else-if>
+    </choose>
+  </macro>
+  <macro name="editor">
+    <choose>
+      <if type="interview">
+        <names variable="interviewer" prefix=" entretien réalisé par ">
+          <name form="long" and="text" delimiter-precedes-last="never" sort-separator=" " initialize-with=". "/>
+        </names>
+      </if>
+      <else-if type="entry-dictionary entry-encyclopedia chapter" match="any">
+        <text term="in" suffix=" "/>
+        <names variable="editorial-director">
+          <name and="text" delimiter-precedes-last="never" initialize="false" initialize-with="" sort-separator=" "/>
+          <label form="short" prefix=" (" suffix=".)"/>
+          <substitute>
+            <names variable="editor">
+              <label form="verb-short" prefix=" " suffix=" "/>
+              <name and="text" delimiter-precedes-last="never" initialize="false" initialize-with="" sort-separator=" "/>
+            </names>
+          </substitute>
+        </names>
+      </else-if>
+      <else-if type="thesis" match="any">
+        <names variable="editorial-director">
+          <label form="long" prefix=" " suffix=" "/>
+          <name and="text" delimiter-precedes-last="never" initialize="false" initialize-with="" sort-separator=" "/>
+          <substitute>
+            <names variable="editor">
+              <label form="verb-short" prefix=" " suffix=" "/>
+              <name and="text" delimiter-precedes-last="never" initialize="false" initialize-with="" sort-separator=" "/>
+            </names>
+          </substitute>
+        </names>
+      </else-if>
+      <else>
+        <names variable="editorial-director">
+          <name and="text" delimiter-precedes-last="never" initialize="false" initialize-with="" sort-separator=" "/>
+          <label form="short" prefix=" (" suffix=".)"/>
+          <substitute>
+            <names variable="editor">
+              <label form="verb-short" prefix=" " suffix=" "/>
+              <name and="text" delimiter-precedes-last="never" initialize="false" initialize-with="" sort-separator=" "/>
+            </names>
+          </substitute>
+        </names>
+      </else>
+    </choose>
+  </macro>
+  <macro name="translator">
+    <names variable="translator">
+      <label form="verb-short" suffix=" "/>
+      <name and="text" delimiter-precedes-last="never"/>
+    </names>
+  </macro>
+  <macro name="recipient">
+    <group delimiter=" ">
+      <choose>
+        <if type="personal_communication">
+          <choose>
+            <if variable="genre">
+              <text variable="genre" text-case="capitalize-first"/>
+            </if>
+            <else>
+              <text term="letter" text-case="capitalize-first"/>
+            </else>
+          </choose>
+        </if>
+      </choose>
+      <text macro="recipient-note"/>
+    </group>
+  </macro>
+  <macro name="contributors">
+    <group delimiter=". ">
+      <text macro="author-bib"/>
+      <text macro="recipient"/>
+    </group>
+  </macro>
+  <macro name="recipient-short">
+    <names variable="recipient">
+      <label form="verb" text-case="lowercase" suffix=" "/>
+      <name form="short" and="text" delimiter=", "/>
+    </names>
+  </macro>
+  <macro name="contributors-short">
+    <group delimiter=" ">
+      <names variable="author">
+        <name form="short" and="text" delimiter=", "/>
+        <substitute>
+          <names variable="editor"/>
+          <names variable="translator"/>
+        </substitute>
+      </names>
+      <text macro="recipient-short"/>
+    </group>
+  </macro>
+  <macro name="contributors-sort">
+    <names variable="author">
+      <name name-as-sort-order="all" and="text" sort-separator=", " delimiter=", " delimiter-precedes-last="never"/>
+      <substitute>
+        <names variable="editor"/>
+        <names variable="translator"/>
+        <text macro="title"/>
+      </substitute>
+    </names>
+  </macro>
+  <macro name="interviewer-note">
+    <names variable="interviewer" delimiter=", ">
+      <label form="verb" text-case="lowercase" suffix=" "/>
+      <name and="text" delimiter=", "/>
+    </names>
+  </macro>
+  <macro name="interviewer">
+    <names variable="interviewer" delimiter=", ">
+      <label form="verb" text-case="capitalize-first" suffix=" "/>
+      <name and="text" delimiter=", "/>
+    </names>
+  </macro>
+  <macro name="title-note">
+    <choose>
+      <if variable="title" match="none">
+        <text variable="genre"/>
+      </if>
+      <else-if type="book thesis classic graphic map motion_picture song" match="any">
+        <text variable="title" text-case="capitalize-first" font-style="italic"/>
+        <group delimiter=" " prefix=", ">
+          <text term="version"/>
+          <text variable="version"/>
+        </group>
+      </else-if>
+      <else-if type="legal_case interview patent" match="any">
+        <text variable="title"/>
+      </else-if>
+      <else-if variable="reviewed-author">
+        <text variable="title" font-style="italic" prefix="review of "/>
+      </else-if>
+      <else>
+        <text variable="title" text-case="capitalize-first" quotes="true"/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="title">
+    <choose>
+      <if variable="title" match="none">
+        <choose>
+          <if type="personal_communication" match="none">
+            <text variable="genre" text-case="capitalize-first"/>
+          </if>
+        </choose>
+      </if>
+      <else-if type="book thesis classic graphic motion_picture song" match="any">
+        <text variable="title" text-case="capitalize-first" font-style="italic"/>
+        <group prefix=" (" suffix=")" delimiter=" ">
+          <text term="version"/>
+          <text variable="version"/>
+        </group>
+      </else-if>
+      <else-if variable="reviewed-author">
+        <group delimiter=", ">
+          <text variable="title" font-style="italic" prefix="Review of "/>
+          <names variable="reviewed-author">
+            <label form="verb-short" text-case="lowercase" suffix=" "/>
+            <name and="text" delimiter=", "/>
+          </names>
+        </group>
+      </else-if>
+      <else-if type="bill legislation legal_case interview patent" match="any">
+        <text variable="title"/>
+      </else-if>
+      <else>
+        <text variable="title" text-case="capitalize-first" quotes="true"/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="title-short">
+    <choose>
+      <if variable="title" match="none">
+        <choose>
+          <if type="interview">
+            <text term="interview"/>
+          </if>
+          <else-if type="manuscript speech" match="any">
+            <text variable="genre" form="short"/>
+          </else-if>
+        </choose>
+      </if>
+      <else-if type="book classic thesis graphic motion_picture song" match="any">
+        <text variable="title" text-case="capitalize-first" form="short" font-style="italic"/>
+      </else-if>
+      <else-if type="legal_case" variable="title-short" match="all">
+        <text variable="title" font-style="italic" form="short"/>
+      </else-if>
+      <else-if type="patent interview" match="any">
+        <text variable="title" form="short"/>
+      </else-if>
+      <else-if type="legal_case bill legislation" match="any">
+        <text variable="title"/>
+      </else-if>
+      <else>
+        <text variable="title" text-case="capitalize-first" form="short" quotes="true"/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="date-disambiguate">
+    <choose>
+      <if disambiguate="true" type="personal_communication" match="any">
+        <text macro="issued"/>
+      </if>
+    </choose>
+  </macro>
+  <macro name="description-note">
+    <group delimiter=", ">
+      <text macro="interviewer-note"/>
+      <text variable="medium"/>
+      <choose>
+        <if variable="title" match="none"/>
+        <else-if type="manuscript thesis speech" match="any"/>
+        <else-if type="patent">
+          <group delimiter=" ">
+            <text variable="authority"/>
+            <text variable="number"/>
+          </group>
+        </else-if>
+        <else>
+          <text variable="genre"/>
+        </else>
+      </choose>
+      <choose>
+        <if type="map">
+          <text variable="scale"/>
+        </if>
+        <else-if type="graphic">
+          <text variable="dimensions"/>
+        </else-if>
+      </choose>
+    </group>
+  </macro>
+  <macro name="description">
+    <group delimiter=", ">
+      <group delimiter=". ">
+        <text macro="interviewer"/>
+        <text variable="medium" text-case="capitalize-first"/>
+      </group>
+      <choose>
+        <if variable="title" match="none"/>
+        <else-if type="thesis speech" match="any"/>
+        <else-if type="patent">
+          <group delimiter=" ">
+            <text variable="authority"/>
+            <text variable="number"/>
+          </group>
+        </else-if>
+        <else>
+          <text variable="genre" text-case="capitalize-first"/>
+        </else>
+      </choose>
+      <choose>
+        <if type="map">
+          <text variable="scale"/>
+        </if>
+        <else-if type="graphic">
+          <text variable="dimensions"/>
+        </else-if>
+      </choose>
+    </group>
+  </macro>
+  <macro name="container-title-note">
+    <choose>
+      <if type="chapter paper-conference entry-dictionary entry-encyclopedia" match="any">
+        <group delimiter=" ">
+          <text term="in"/>
+          <group delimiter=", ">
+            <choose>
+              <if variable="container-author" match="none">
+                <choose>
+                  <if variable="editor editorial-director" match="any">
+                    <text macro="editor"/>
+                  </if>
+                </choose>
+              </if>
+              <else>
+                <text macro="contributors-notes"/>
+              </else>
+            </choose>
+            <text variable="container-title" font-style="italic" text-case="capitalize-first"/>
+          </group>
+        </group>
+      </if>
+      <else-if type="article-journal" match="any">
+        <text variable="container-title" font-style="italic"/>
+      </else-if>
+      <else-if type="article-newspaper article-magazine" match="any">
+        <text term="in"/>
+        <text variable="container-title" font-style="italic"/>
+      </else-if>
+      <else-if type="webpage post post-weblog" match="any">
+        <text variable="container-title" font-style="italic" prefix=" sur "/>
+      </else-if>
+      <else-if type="speech" match="any">
+        <text variable="event" font-style="italic" prefix=" lors de la rencontre "/>
+      </else-if>
+      <else-if type="broadcast" match="any">
+        <text variable="container-title" font-style="italic" prefix=" dans l’émission "/>
+      </else-if>
+      <else>
+        <group delimiter=" ">
+          <text term="in"/>
+          <text variable="container-title" font-style="italic" text-case="capitalize-first"/>
+        </group>
+      </else>
+    </choose>
+  </macro>
+  <macro name="container-title">
+    <choose>
+	    <if type="classic book" match="any">
+        <group delimiter=" ">
+          <group delimiter=", ">
+            <choose>
+              <if variable="container-author" match="none">
+                <choose>
+                  <if variable="editorial-director" match="none">
+                    <text macro="editor"/>
+                  </if>
+                </choose>
+              </if>
+              <else>
+                <text macro="author-bib"/>
+              </else>
+            </choose>
+            <text variable="container-title" text-case="capitalize-first" font-style="italic" prefix="dans "/>
+          </group>
+        </group>
+      </if>
+      <else-if type="paper-conference entry-dictionary entry-encyclopedia" match="any">
+        <group delimiter=" ">
+          <group delimiter=", ">
+            <choose>
+              <if variable="container-author" match="none">
+                <choose>
+                  <if variable="editor editorial-director" match="any">
+                    <text macro="editor"/>
+                  </if>
+                </choose>
+              </if>
+              <else>
+                <text macro="author-bib"/>
+              </else>
+            </choose>
+            <text variable="container-title" text-case="capitalize-first" font-style="italic" prefix="dans "/>
+          </group>
+        </group>
+      </else-if>
+      <else-if type="chapter" match="any">
+        <group delimiter=" ">
+          <group delimiter=", ">
+            <choose>
+              <if variable="container-author" match="none">
+                <choose>
+                  <if variable="editor editorial-director" match="any">
+                    <text macro="editor"/>
+                    <text variable="container-title" text-case="capitalize-first" font-style="italic"/>
+                  </if>
+                </choose>
+              </if>
+              <else>
+                <text macro="author-bib"/>
+                <text variable="container-title" text-case="capitalize-first" font-style="italic" prefix="dans "/>
+              </else>
+            </choose>
+          </group>
+        </group>
+      </else-if>
+      <else-if type="article-journal article-newspaper article-magazine" match="any">
+        <text term="in" suffix=" "/>
+        <text variable="container-title" font-style="italic"/>
+      </else-if>
+      <else-if type="webpage post post-weblog" match="any">
+        <text variable="container-title" font-style="italic" prefix=" sur "/>
+      </else-if>
+      <else-if type="speech" match="any">
+        <text variable="event" font-style="italic" prefix=" lors de la rencontre "/>
+      </else-if>
+      <else-if type="broadcast" match="any">
+        <text variable="container-title" font-style="italic" prefix=" dans l’émission "/>
+      </else-if>
+      <else>
+        <group delimiter=" ">
+          <text term="in"/>
+          <text variable="container-title" font-style="italic" text-case="capitalize-first"/>
+        </group>
+      </else>
+    </choose>
+  </macro>
+  <macro name="collection-title">
+    <choose>
+      <if match="none" type="article-journal">
+        <choose>
+          <if match="none" is-numeric="collection-number">
+            <group delimiter=", ">
+              <text variable="collection-title" form="short" text-case="title" prefix="coll. « " suffix=" »"/>
+              <text variable="collection-number"/>
+            </group>
+          </if>
+          <else>
+            <group delimiter=", ">
+              <text variable="collection-title" form="short" text-case="title" prefix="coll. « " suffix=" »"/>
+              <text variable="collection-number"/>
+            </group>
+          </else>
+        </choose>
+      </if>
+    </choose>
+  </macro>
+  <macro name="collection-title-journal">
+    <choose>
+      <if type="article-journal">
+        <group delimiter=" ">
+          <text variable="collection-title" form="short" text-case="title"/>
+          <text variable="collection-number"/>
+        </group>
+      </if>
+    </choose>
+  </macro>
+  <macro name="collection">
+    <text variable="collection-title" quotes="true" prefix="coll. "/>
+  </macro>
+  <macro name="edition-note">
+    <choose>
+      <if type="book chapter graphic motion_picture paper-conference report song" match="any">
+        <choose>
+          <if is-numeric="edition">
+            <group delimiter=" ">
+              <number variable="edition" form="ordinal"/>
+              <text term="edition" form="short"/>
+            </group>
+          </if>
+          <else>
+            <text variable="edition"/>
+          </else>
+        </choose>
+      </if>
+    </choose>
+  </macro>
+  <macro name="edition">
+    <choose>
+      <if type="book chapter graphic motion_picture paper-conference report song" match="any">
+        <choose>
+          <if is-numeric="edition">
+            <group delimiter=" ">
+              <number variable="edition" form="ordinal"/>
+              <text term="edition" form="short"/>
+            </group>
+          </if>
+          <else>
+            <text variable="edition" text-case="capitalize-first" suffix=""/>
+          </else>
+        </choose>
+      </if>
+    </choose>
+  </macro>
+  <macro name="locators-note-join-with-space">
+    <choose>
+      <if type="article-journal" variable="volume" match="all">
+        <choose>
+          <if match="none" variable="collection-title">
+            <text macro="locators-note"/>
+          </if>
+        </choose>
+      </if>
+    </choose>
+  </macro>
+  <macro name="locators-note-join-with-comma">
+    <choose>
+      <if type="article-journal" match="none">
+        <text macro="locators-note"/>
+      </if>
+      <else-if type="article-journal">
+        <choose>
+          <if variable="volume" match="none">
+            <text macro="locators-note"/>
+          </if>
+          <else-if match="any" variable="collection-title">
+            <text macro="locators-note"/>
+          </else-if>
+        </choose>
+      </else-if>
+    </choose>
+  </macro>
+  <macro name="locators-note">
+    <choose>
+      <if type="article-journal">
+        <group delimiter=", ">
+          <text macro="collection-title-journal"/>
+          <number variable="volume"/>
+          <group delimiter=" ">
+            <text term="issue" form="short"/>
+            <number variable="issue"/>
+          </group>
+        </group>
+      </if>
+      <else-if type="bill legislation legal_case" match="any">
+        <text macro="legal-cites"/>
+      </else-if>
+      <else-if type="book chapter graphic motion_picture paper-conference report song" match="any">
+        <group delimiter=", ">
+          <text macro="edition-note"/>
+          <group delimiter=" ">
+            <text term="volume" form="short"/>
+            <number variable="volume" form="numeric"/>
+          </group>
+          <choose>
+            <if variable="locator" match="none">
+              <group delimiter=" ">
+                <number variable="number-of-volumes" form="numeric"/>
+                <text term="volume" form="short" plural="true"/>
+              </group>
+            </if>
+          </choose>
+        </group>
+      </else-if>
+    </choose>
+  </macro>
+  <macro name="legal-cites">
+    <choose>
+      <if type="legal_case" match="any">
+        <group delimiter=" ">
+          <choose>
+            <if variable="container-title">
+              <text variable="volume"/>
+              <text variable="container-title"/>
+              <group delimiter=" ">
+                <text term="section" form="symbol"/>
+                <text variable="section"/>
+              </group>
+				    <group delimiter="&#160;">
+                    <label variable="page" form="short"/>
+                    <text variable="page"/>
+					</group>
+            </if>
+            <else>
+              <text variable="number" prefix="No. "/>
+            </else>
+          </choose>
+        </group>
+      </if>
+      <else-if type="bill legislation" match="any">
+        <group delimiter=", ">
+          <choose>
+            <if variable="number">
+              <text variable="number" prefix="Pub. L. No. "/>
+              <group delimiter=" ">
+                <text term="section" form="symbol"/>
+                <text variable="section"/>
+              </group>
+              <group delimiter=" ">
+                <text variable="volume"/>
+                <text variable="container-title"/>
+                <text variable="page-first"/>
+              </group>
+            </if>
+            <else>
+              <group delimiter=" ">
+                <text variable="volume"/>
+                <text variable="container-title"/>
+                <text term="section" form="symbol"/>
+                <text variable="section"/>
+              </group>
+            </else>
+          </choose>
+        </group>
+      </else-if>
+    </choose>
+  </macro>
+  <macro name="locators-join-with-space">
+    <choose>
+      <if type="article-journal" variable="volume" match="all">
+        <choose>
+          <if match="none" variable="collection-title">
+            <text macro="locators"/>
+          </if>
+        </choose>
+      </if>
+    </choose>
+  </macro>
+  <macro name="locators-join-with-comma">
+    <choose>
+      <if type="bill chapter legislation legal_case paper-conference" match="any">
+        <text macro="locators"/>
+      </if>
+      <else-if type="article-journal">
+        <choose>
+          <if variable="volume" match="none">
+            <text macro="locators"/>
+          </if>
+          <else-if match="any" variable="collection-title">
+            <text macro="locators"/>
+          </else-if>
+        </choose>
+      </else-if>
+    </choose>
+  </macro>
+  <macro name="locators-join-with-period">
+    <choose>
+      <if type="bill legislation legal_case article-journal chapter paper-conference" match="none">
+        <text macro="locators"/>
+      </if>
+    </choose>
+  </macro>
+  <macro name="locators">
+    <choose>
+      <if type="article-journal">
+        <group delimiter=", ">
+          <text macro="collection-title-journal"/>
+          <number variable="volume"/>
+          <group delimiter=" ">
+            <text term="issue" form="short"/>
+            <number suffix=", " variable="issue"/>
+          </group>
+        </group>
+      </if>
+      <else-if type="bill legislation legal_case" match="any">
+        <text macro="legal-cites"/>
+      </else-if>
+      <else-if type="graphic motion_picture report song" match="any">
+        <group delimiter=". ">
+          <text macro="edition"/>
+          <group delimiter=" ">
+            <text term="volume" form="short" text-case="capitalize-first"/>
+            <number variable="volume" form="numeric"/>
+          </group>
+          <group delimiter=" ">
+            <number variable="number-of-volumes" form="numeric"/>
+            <text term="volume" form="short" plural="true"/>
+          </group>
+        </group>
+      </else-if>
+      <else-if type="chapter entry-dictionary entry-encyclopedia paper-conference" match="any">
+        <group delimiter=". ">
+          <text macro="edition"/>
+          <choose>
+            <if variable="page" match="none">
+              <group delimiter=" ">
+                <text term="volume" form="short" text-case="capitalize-first"/>
+                <number variable="volume" form="numeric"/>
+              </group>
+            </if>
+          </choose>
+        </group>
+      </else-if>
+    </choose>
+  </macro>
+  <macro name="locators-newspaper">
+    <choose>
+      <if type="article-newspaper">
+        <group delimiter=", ">
+          <group delimiter=" ">
+            <number variable="edition"/>
+            <text term="edition"/>
+          </group>
+          <group delimiter=" ">
+            <text term="section" form="short"/>
+            <text variable="section"/>
+          </group>
+        </group>
+      </if>
+    </choose>
+  </macro>
+  <macro name="event-note">
+    <text variable="event"/>
+  </macro>
+  <macro name="event">
+    <choose>
+      <if variable="title">
+        <group delimiter=" ">
+          <text term="presented at"/>
+          <text variable="event"/>
+        </group>
+      </if>
+      <else>
+        <group delimiter=" ">
+          <text term="presented at" text-case="capitalize-first"/>
+          <text variable="event"/>
+        </group>
+      </else>
+    </choose>
+  </macro>
+  <macro name="originally-published">
+    <group delimiter=", ">
+      <group delimiter=" : ">
+        <text variable="original-publisher-place"/>
+        <text variable="original-publisher"/>
+      </group>
+      <choose>
+        <if is-uncertain-date="original-date">
+          <date variable="original-date" form="numeric" date-parts="year" prefix="[" suffix="&#8239;?]"/>
+        </if>
+        <else>
+          <date variable="original-date" form="numeric" date-parts="year"/>
+        </else>
+      </choose>
+    </group>
+  </macro>
+  <macro name="reprint-note">
+    <choose>
+      <if variable="original-date issued" match="all">
+        <choose>
+          <if variable="original-publisher original-publisher-place" match="none">
+            <text value="repr."/>
+          </if>
+        </choose>
+      </if>
+    </choose>
+  </macro>
+  <macro name="reprint">
+    <choose>
+      <if variable="original-date issued" match="all"/>
+    </choose>
+  </macro>
+  <macro name="publisher">
+    <choose>
+      <if type="thesis">
+        <text variable="publisher"/>
+      </if>
+      <else-if type="speech">
+        <text variable="event-place"/>
+      </else-if>
+      <else>
+        <group delimiter=", ">
+          <choose>
+            <if variable="publisher-place" match="any">
+              <text variable="publisher-place"/>
+            </if>
+            <else>
+              <choose>
+                <if type="book classic" match="any">
+                  <text value="s. l."/>
+                </if>
+              </choose>
+            </else>
+          </choose>
+          <text variable="publisher"/>
+          <text macro="collection-title"/>
+          <text macro="volume-issue" text-case="capitalize-first"/>
+        </group>
+      </else>
+    </choose>
+  </macro>
+  <macro name="issued">
+    <choose>
+      <if variable="issued">
+        <choose>
+          <if type="entry-encyclopedia" variable="DOI" match="all">
+            <date variable="issued" form="numeric" date-parts="year"/>
+          </if>
+          <else-if type="entry-encyclopedia" variable="URL" match="all">
+            <date variable="issued" form="numeric" date-parts="year"/>
+          </else-if>
+          <else-if type="entry-dictionary" variable="DOI" match="all">
+            <date variable="issued" form="numeric" date-parts="year"/>
+          </else-if>
+          <else-if type="entry-dictionary" variable="URL" match="all">
+            <date variable="issued" form="numeric" date-parts="year"/>
+          </else-if>
+          <else-if type="legal_case">
+            <group delimiter=" ">
+              <text variable="authority"/>
+              <choose>
+                <if variable="container-title" match="any">
+                  <date variable="issued" form="numeric" date-parts="year"/>
+                </if>
+                <else>
+                  <date variable="issued" form="text"/>
+                </else>
+              </choose>
+            </group>
+          </else-if>
+          <else-if type="bill legislation motion_picture paper-conference song thesis" match="any">
+            <choose>
+              <if is-uncertain-date="issued">
+                <date variable="issued" form="numeric" date-parts="year" prefix="[" suffix="&#8239;?]"/>
+              </if>
+              <else>
+                <date variable="issued" form="numeric" date-parts="year"/>
+              </else>
+            </choose>
+          </else-if>
+          <else-if type="book chapter classic" match="any">
+            <choose>
+              <if is-uncertain-date="issued">
+                <date variable="issued" form="numeric" date-parts="year" prefix="[" suffix="&#8239;?]"/>
+              </if>
+              <else>
+                <date variable="issued" form="numeric" date-parts="year"/>
+              </else>
+            </choose>
+			<text macro="second-date" prefix=" "/>
+          </else-if>
+          <else-if type="patent">
+            <group delimiter=", ">
+              <group delimiter=" ">
+                <text value="filed"/>
+                <date variable="submitted" form="text"/>
+              </group>
+              <group delimiter=" ">
+                <choose>
+                  <if variable="issued submitted" match="all">
+                    <text term="and"/>
+                  </if>
+                </choose>
+                <text value="issued"/>
+                <date variable="issued" form="text"/>
+              </group>
+            </group>
+          </else-if>
+          <else>
+            <choose>
+              <if is-uncertain-date="issued">
+                <date variable="issued" form="text" prefix="[" suffix="&#8239;?]"/>
+              </if>
+              <else>
+                <date form="text" variable="issued"/>
+              </else>
+            </choose>
+          </else>
+        </choose>
+      </if>
+      <else-if variable="status">
+        <text variable="status"/>
+      </else-if>
+      <else-if variable="accessed URL" match="all"/>
+      <else>
+        <choose>
+          <if type="book classic" match="any">
+            <text term="no date" form="short"/>
+          </if>
+        </choose>
+      </else>
+    </choose>
+  </macro>
+  <macro name="point-locators-subsequent">
+    <choose>
+      <if type="legal_case" variable="locator" match="all">
+        <choose>
+          <if locator="page">
+            <group delimiter=" : ">
+              <number variable="volume"/>
+              <text variable="locator"/>
+            </group>
+          </if>
+          <else>
+            <group delimiter=" ">
+              <label variable="locator" form="short"/>
+              <text variable="locator"/>
+            </group>
+          </else>
+        </choose>
+      </if>
+      <else-if variable="locator">
+        <choose>
+          <if locator="page" match="none">
+            <group delimiter=" ">
+              <choose>
+                <if type="book graphic motion_picture report song" match="any">
+                  <choose>
+                    <if variable="volume">
+                      <group delimiter=", ">
+                        <group delimiter=" ">
+                          <text term="volume" form="short"/>
+                          <number variable="volume" form="numeric"/>
+                        </group>
+                        <label variable="locator" form="short"/>
+                      </group>
+                    </if>
+                    <else>
+                      <label variable="locator" form="short"/>
+                    </else>
+                  </choose>
+                </if>
+                <else>
+                  <label variable="locator" form="short"/>
+                </else>
+              </choose>
+              <text variable="locator"/>
+            </group>
+          </if>
+          <else-if type="book graphic motion_picture report song" match="any">
+            <group delimiter=" : ">
+              <number variable="volume" form="numeric"/>
+              <text variable="locator"/>
+            </group>
+          </else-if>
+          <else>
+            <text variable="locator"/>
+          </else>
+        </choose>
+      </else-if>
+    </choose>
+  </macro>
+  <macro name="point-locators-join-with-colon">
+    <choose>
+      <if type="article-journal">
+        <choose>
+          <if variable="locator page" match="any">
+            <choose>
+              <if variable="volume issue" match="any">
+                <text macro="point-locators"/>
+              </if>
+            </choose>
+          </if>
+        </choose>
+      </if>
+    </choose>
+  </macro>
+  <macro name="point-locators-join-with-comma">
+    <choose>
+      <if type="article-journal" match="none">
+        <text macro="point-locators"/>
+      </if>
+      <else-if variable="volume issue" match="none">
+        <text macro="point-locators"/>
+      </else-if>
+    </choose>
+  </macro>
+  <macro name="point-locators">
+    <choose>
+      <if variable="locator" match="none">
+        <choose>
+          <if type="article-journal chapter paper-conference" match="any">
+            <label prefix=", " variable="page" form="short"/>
+            <text variable="page"/>
+          </if>
+        </choose>
+      </if>
+      <else-if type="article-journal">
+        <group delimiter=" ">
+          <choose>
+            <if locator="page" match="none">
+              <label variable="locator" form="short" suffix=" "/>
+            </if>
+          </choose>
+          <text variable="locator" prefix=", p.&#160;"/>
+        </group>
+      </else-if>
+      <else-if type="legal_case"/>
+      <else>
+        <group delimiter=" ">
+          <choose>
+            <if locator="page" match="none">
+              <label variable="locator" form="short"/>
+            </if>
+          </choose>
+          <text variable="locator" prefix="p.&#160;"/>
+        </group>
+      </else>
+    </choose>
+  </macro>
+  <macro name="locators-chapter">
+    <choose>
+      <if type="chapter entry-dictionary entry-encyclopedia paper-conference" match="any">
+        <choose>
+          <if variable="author container-author" match="all"/>
+          <else>
+            <choose>
+              <if variable="page">
+                <number variable="volume" suffix=" : "/>
+				    <group delimiter="&#160;">
+                    <label variable="page" form="short"/>
+                    <text variable="page"/>
+					</group>
+              </if>
+            </choose>
+          </else>
+        </choose>
+      </if>
+    </choose>
+  </macro>
+  <macro name="locators-journal-join-with-colon">
+    <choose>
+      <if type="article-journal">
+        <choose>
+          <if variable="volume issue" match="any">
+				    <group delimiter="&#160;">
+                    <label variable="page" form="short"/>
+                    <text variable="page"/>
+					</group>
+          </if>
+        </choose>
+      </if>
+    </choose>
+  </macro>
+  <macro name="locators-journal-join-with-comma">
+    <choose>
+      <if type="article-journal">
+        <choose>
+          <if variable="volume issue" match="none">
+				    <group delimiter="&#160;">
+                    <label variable="page" form="short"/>
+                    <text variable="page"/>
+					</group>
+          </if>
+        </choose>
+      </if>
+    </choose>
+  </macro>
+  <macro name="archive-note">
+    <choose>
+      <if type="thesis">
+        <group delimiter=" ">
+          <text variable="archive"/>
+          <text variable="archive_location" prefix="(" suffix=")"/>
+        </group>
+      </if>
+      <else>
+        <group delimiter=", ">
+          <text variable="archive_location"/>
+          <text variable="archive"/>
+          <text variable="archive-place"/>
+        </group>
+      </else>
+    </choose>
+  </macro>
+  <macro name="archive">
+    <choose>
+      <if type="thesis">
+        <group delimiter=" ">
+          <text variable="archive"/>
+          <text variable="archive_location" prefix="(" suffix=")"/>
+        </group>
+      </if>
+      <else>
+        <group delimiter=". ">
+          <text variable="archive_location" text-case="capitalize-first"/>
+          <text variable="archive"/>
+          <text variable="archive-place"/>
+        </group>
+      </else>
+    </choose>
+  </macro>
+  <macro name="issue-note-join-with-space">
+    <choose>
+      <if type="article-journal bill legislation legal_case manuscript thesis" variable="publisher-place event-place publisher" match="any">
+        <choose>
+          <if type="article-newspaper" match="none">
+            <choose>
+              <if type="article-journal" match="none">
+                <text macro="issue-note"/>
+              </if>
+              <else-if variable="issue volume" match="any">
+                <text macro="issue-note"/>
+              </else-if>
+            </choose>
+          </if>
+        </choose>
+      </if>
+    </choose>
+  </macro>
+  <macro name="issue-note-join-with-comma">
+    <choose>
+      <if type="graphic map" match="any"/>
+      <else-if type="article-journal bill legislation legal_case manuscript thesis" variable="event-place publisher-place publisher" match="none">
+        <text macro="issue-note"/>
+      </else-if>
+      <else-if type="article-newspaper">
+        <text macro="issue-note"/>
+      </else-if>
+      <else-if type="article-journal">
+        <choose>
+          <if variable="volume issue" match="none">
+            <text macro="issue-note"/>
+          </if>
+        </choose>
+      </else-if>
+    </choose>
+  </macro>
+  <macro name="issue-map-graphic">
+    <choose>
+      <if type="graphic map" match="any">
+        <choose>
+          <if variable="publisher publisher-place" match="none">
+            <text macro="issued"/>
+          </if>
+        </choose>
+      </if>
+    </choose>
+  </macro>
+  <macro name="issue-note">
+    <choose>
+      <if type="bill legislation legal_case" match="any">
+        <text macro="issued"/>
+      </if>
+      <else-if type="article-journal">
+        <choose>
+          <if variable="volume issue" match="any">
+            <text macro="issued" prefix=", "/>
+          </if>
+          <else>
+            <text macro="issued"/>
+          </else>
+        </choose>
+      </else-if>
+      <else-if type="article-newspaper">
+        <text macro="issued"/>
+      </else-if>
+      <else-if type="manuscript thesis speech" match="any">
+        <group delimiter=", " prefix="(" suffix=")">
+          <choose>
+            <if variable="title" match="any">
+              <text variable="genre"/>
+            </if>
+          </choose>
+          <text variable="publisher"/>
+          <text macro="issued"/>
+        </group>
+      </else-if>
+      <else-if variable="publisher-place event-place publisher" match="any">
+        <group delimiter=", ">
+          <text macro="event-note"/>
+          <group delimiter=", " prefix=", ">
+            <text macro="originally-published"/>
+            <group delimiter=", ">
+              <text macro="reprint-note"/>
+              <text macro="publisher"/>
+            </group>
+          </group>
+          <text macro="issued"/>
+        </group>
+      </else-if>
+      <else>
+        <text macro="issued"/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="issue-join-with-space">
+    <choose>
+      <if type="article-journal" match="any">
+        <choose>
+          <if variable="issue volume" match="any">
+            <text macro="issue"/>
+          </if>
+        </choose>
+      </if>
+      <else-if type="bill legislation legal_case" match="any">
+        <text macro="issue"/>
+      </else-if>
+    </choose>
+  </macro>
+  <macro name="issue-join-with-period">
+    <choose>
+      <if type="article-journal bill legislation legal_case" match="none">
+        <choose>
+          <if type="speech" variable="publisher publisher-place" match="any">
+            <text macro="issue"/>
+          </if>
+        </choose>
+      </if>
+    </choose>
+  </macro>
+  <macro name="issue-join-with-comma">
+    <choose>
+      <if type="bill legislation legal_case" match="none">
+        <choose>
+          <if type="article-journal" match="none">
+            <choose>
+              <if type="speech" variable="publisher publisher-place" match="none">
+                <text macro="issue"/>
+              </if>
+            </choose>
+          </if>
+          <else-if variable="volume issue" match="none">
+            <text macro="issue"/>
+          </else-if>
+        </choose>
+      </if>
+    </choose>
+  </macro>
+  <macro name="issue">
+    <choose>
+      <if type="bill legislation legal_case" match="any">
+        <text macro="issued"/>
+      </if>
+      <else-if type="article-journal">
+        <choose>
+          <if variable="issue volume" match="any">
+            <text macro="issued" suffix=""/>
+          </if>
+          <else>
+            <text macro="issued"/>
+          </else>
+        </choose>
+      </else-if>
+      <else-if type="speech">
+        <group delimiter=", ">
+          <group delimiter=" ">
+            <choose>
+              <if variable="title" match="none"/>
+              <else>
+                <text variable="genre" text-case="capitalize-first"/>
+              </else>
+            </choose>
+            <text macro="event"/>
+          </group>
+          <text variable="event-place"/>
+          <text macro="issued"/>
+        </group>
+      </else-if>
+      <else-if type="article-newspaper">
+        <text macro="issued"/>
+      </else-if>
+      <else-if variable="publisher-place publisher" match="any">
+        <group delimiter=", ">
+          <choose>
+            <if type="thesis">
+              <text variable="genre" text-case="capitalize-first" prefix=" "/>
+            </if>
+          </choose>
+          <group delimiter=", ">
+            <group delimiter=", ">
+              <text macro="reprint"/>
+              <text macro="publisher"/>
+            </group>
+          </group>
+          <text macro="issued"/>
+        </group>
+      </else-if>
+      <else-if type="graphic map" match="none">
+        <text macro="issued"/>
+      </else-if>
+    </choose>
+  </macro>
+  <macro name="access-note">
+    <group>
+      <choose>
+        <if type="entry-encyclopedia" variable="DOI" match="all">
+          <date variable="accessed" form="text" prefix=", consulté le "/>
+        </if>
+        <else-if type="entry-encyclopedia" variable="URL" match="all">
+          <date variable="accessed" form="text" prefix=", consulté le "/>
+        </else-if>
+        <else-if type="entry-dictionary" variable="DOI" match="all">
+          <date variable="accessed" form="text" prefix=", consulté le "/>
+        </else-if>
+        <else-if type="entry-dictionary" variable="URL" match="all">
+          <date variable="accessed" form="text" prefix=", consulté le "/>
+        </else-if>
+        <else-if type="report" variable="URL" match="all">
+          <date variable="accessed" form="text" prefix=", consulté le "/>
+        </else-if>
+      </choose>
+      <choose>
+        <if type="graphic" match="any">
+          <text macro="archive-note"/>
+        </if>
+        <else-if type="article-journal bill book chapter legal_case legislation motion_picture paper-conference" match="none">
+          <text macro="archive-note"/>
+        </else-if>
+      </choose>
+      <choose>
+        <if variable="issued" match="none">
+          <group delimiter=" ">
+            <text term="accessed"/>
+            <date variable="accessed" form="text"/>
+          </group>
+        </if>
+      </choose>
+      <choose>
+        <if type="legal_case" match="none">
+          <choose>
+            <if variable="DOI">
+              <text variable="DOI" prefix=". https://doi.org/"/>
+            </if>
+            <else>
+              <text variable="URL" prefix=". "/>
+            </else>
+          </choose>
+        </if>
+      </choose>
+    </group>
+    <date form="text" variable="accessed" prefix=", consulté le "/>
+  </macro>
+  <macro name="access-note-online-reference">
+    <choose>
+      <if type="entry-encyclopedia" variable="DOI" match="all">
+        <date variable="accessed" form="text" prefix=", consulté le "/>
+      </if>
+      <else-if type="entry-encyclopedia" variable="URL" match="all">
+        <date variable="accessed" form="text" prefix=", consulté le "/>
+      </else-if>
+      <else-if type="entry-dictionary" variable="DOI" match="all">
+        <date variable="accessed" form="text" prefix=", consulté le "/>
+      </else-if>
+      <else-if type="entry-dictionary" variable="URL" match="all">
+        <date variable="accessed" form="text" prefix=", consulté le "/>
+      </else-if>
+      <else-if type="report" variable="URL" match="all">
+        <date variable="accessed" form="text" prefix=", consulté le "/>
+      </else-if>
+    </choose>
+  </macro>
+  <macro name="access">
+    <group>
+      <choose>
+        <if type="graphic" match="any">
+          <text macro="archive"/>
+        </if>
+        <else-if type="article-journal bill book chapter legal_case legislation motion_picture paper-conference" match="none">
+          <text macro="archive"/>
+        </else-if>
+      </choose>
+      <choose>
+        <if variable="issued" match="none">
+          <group delimiter=" ">
+            <text term="accessed" text-case="capitalize-first"/>
+            <date form="text" variable="accessed" prefix=", consulté le "/>
+          </group>
+        </if>
+      </choose>
+      <choose>
+        <if type="legal_case" match="none">
+          <choose>
+            <if variable="DOI">
+              <text variable="DOI" prefix="https://doi.org/"/>
+              <date variable="accessed" form="text" prefix=", consulté le "/>
+            </if>
+            <else>
+              <text variable="URL"/>
+              <date variable="accessed" form="text" prefix=", consulté le "/>
+            </else>
+          </choose>
+        </if>
+      </choose>
+    </group>
+  </macro>
+  <macro name="case-locator-subsequent">
+    <choose>
+      <if type="legal_case">
+        <group delimiter=" ">
+          <text variable="volume"/>
+          <text variable="container-title"/>
+        </group>
+      </if>
+    </choose>
+  </macro>
+  <macro name="case-pinpoint-subsequent">
+    <choose>
+      <if type="legal_case">
+        <group delimiter=" ">
+          <choose>
+            <if locator="page">
+              <text term="at"/>
+              <text variable="locator"/>
+            </if>
+            <else>
+              <label variable="locator"/>
+              <text variable="locator"/>
+            </else>
+          </choose>
+        </group>
+      </if>
+    </choose>
+  </macro>
+  <macro name="author-bib">
+    <choose>
+      <if variable="author">
+        <names variable="author">
+          <name form="long" and="text" delimiter-precedes-last="never" name-as-sort-order="all" sort-separator=" ">
+            <name-part name="family" font-variant="small-caps"/>
+          </name>
+          <label form="short" prefix=" (" suffix=".)"/>
+        </names>
+      </if>
+      <else-if type="article-journal article-newspaper article-magazine book chapter paper-conference entry-dictionary entry-encyclopedia" match="any">
+        <names variable="editorial-director">
+          <name form="long" and="text" delimiter-precedes-last="never" name-as-sort-order="all" sort-separator=" ">
+            <name-part name="family" font-variant="small-caps"/>
+          </name>
+          <label form="short" prefix=" (" suffix=".)"/>
+          <substitute>
+            <names variable="editor"/>
+          </substitute>
+        </names>
+      </else-if>
+      <else-if type="entry-dictionary entry-encyclopedia interview" match="none">
+        <text term="anonymous" text-case="capitalize-first"/>
+      </else-if>
+    </choose>
+  </macro>
+  <macro name="publisher-thesis">
+    <choose>
+      <if variable="publisher">
+        <text variable="publisher" suffix=", "/>
+      </if>
+      <else-if variable="publisher-place">
+        <text variable="publisher-place"/>
+      </else-if>
+    </choose>
+    <date variable="issued">
+      <date-part name="year"/>
+    </date>
+    <choose>
+      <if variable="number-of-pages">
+        <text variable="number-of-pages" prefix=", " suffix=" p.&#160;"/>
+      </if>
+      <else>
+        <choose>
+          <if variable="number-of-volumes">
+            <group>
+              <text variable="number-of-volumes" prefix=". " suffix=" "/>
+			  				    <group delimiter="&#160;">
+              <text term="volume" form="short" suffix="."/>
+			  					</group>
+            </group>
+          </if>
+        </choose>
+      </else>
+    </choose>
+  </macro>
+  <macro name="volume-issue">
+    <choose>
+      <if is-numeric="volume">
+        <text term="volume" form="short" suffix=". "/>
+        <text variable="volume"/>
+        <choose>
+          <if variable="issue" match="any">
+            <text variable="issue" prefix=" / "/>
+          </if>
+        </choose>
+      </if>
+      <else>
+        <text variable="volume"/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="publisher-book-magazine-newspaper">
+<group delimiter=", ">
+          <choose>
+            <if variable="publisher-place" match="any">
+              <text variable="publisher-place"/>
+            </if>
+          </choose>
+		            <choose>
+            <if variable="publisher" match="any">
+          <text variable="publisher"/>
+		              </if>
+          </choose>
+		  		            <choose>
+            <if variable="collection-title" match="any">
+          <text macro="collection-title"/>
+		              </if>
+          </choose>
+    <date variable="issued" prefix="">
+      <date-part name="month" form="long" suffix=" "/>
+      <date-part name="year"/>
+    </date>
+    <choose>
+      <if variable="number-of-pages">
+        <text variable="number-of-pages" prefix=", " suffix=" p.&#160;"/>
+      </if>
+      <else>
+        <choose>
+          <if variable="number-of-volumes">
+            <group>
+              <text variable="number-of-volumes" prefix=". " suffix=" "/>
+			  				    <group delimiter="&#160;">
+              <text term="volume" form="short" suffix="."/>
+			  					</group>
+            </group>
+          </if>
+        </choose>
+      </else>
+    </choose>
+	        </group>
+  </macro>
+  <macro name="publisher-book-journal">
+ <group delimiter=", ">
+          <choose>
+            <if variable="publisher-place" match="any">
+              <text variable="publisher-place"/>
+            </if>
+          </choose>
+		            <choose>
+            <if variable="publisher" match="any">
+          <text variable="publisher"/>
+		              </if>
+          </choose>
+		  		            <choose>
+            <if variable="collection-title" match="any">
+          <text macro="collection-title"/>
+		              </if>
+          </choose>
+    <date variable="issued" prefix="">
+      <date-part name="month" form="long" suffix=" "/>
+      <date-part name="year"/>
+    </date>
+    <choose>
+      <if variable="number-of-pages">
+        <text variable="number-of-pages" prefix=", " suffix=" p.&#160;"/>
+      </if>
+      <else>
+        <choose>
+          <if variable="number-of-volumes">
+            <group>
+              <text variable="number-of-volumes" prefix=". " suffix=" "/>
+			  				    <group delimiter="&#160;">
+              <text term="volume" form="short" suffix="."/>
+			  					</group>
+            </group>
+          </if>
+        </choose>
+      </else>
+    </choose>
+	        </group>
+  </macro>
+  <macro name="publication-title">
+    <choose>
+      <if variable="author editor translator title" match="none">
+        <text term="in" suffix=" "/>
+        <text variable="container-title" font-style="italic"/>
+      </if>
+    </choose>
+  </macro>
+  <macro name="volume">
+    <choose>
+      <if is-numeric="volume">
+        <text term="volume" form="short" suffix=". "/>
+        <text variable="volume"/>
+      </if>
+      <else>
+        <text variable="volume"/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="publisher-book">
+    <text macro="publisher" suffix=", "/>
+    <text macro="issued"/>
+	<choose>
+          <if variable="number-of-volumes">
+            <group>
+              <text variable="number-of-volumes" prefix=", " suffix=" "/>
+			  				    <group delimiter="&#160;">
+              <text term="volume" form="short" suffix="."/>
+			  					</group>
+            </group>
+          </if>
+        </choose>
+  </macro>
+  <macro name="firstedition-ndbp">
+    <choose>
+      <if is-uncertain-date="original-date">
+        <date variable="original-date" form="numeric" date-parts="year" prefix="[" suffix="&#8239;?]"/>
+      </if>
+      <else>
+        <date variable="original-date" form="numeric" date-parts="year" prefix="[" suffix="]"/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="firstedition-bib">
+    <group prefix="[" suffix="]">
+      <choose>
+        <if type="bill book legal_case report song motion_picture graphic thesis" match="any">
+          <text variable="original-title" text-case="capitalize-first" font-style="italic"/>
+        </if>
+        <else>
+          <text variable="original-title" text-case="capitalize-first" quotes="true"/>
+        </else>
+      </choose>
+      <text variable="original-publisher-place"/>
+      <text variable="original-publisher"/>
+      <choose>
+        <if is-uncertain-date="original-date">
+          <date variable="original-date" form="numeric" date-parts="year" suffix="&#8239;?"/>
+        </if>
+        <else>
+          <date variable="original-date" form="numeric" date-parts="year"/>
+        </else>
+      </choose>
+    </group>
+  </macro>
+  <macro name="extra">
+    <group delimiter=", ">
+      <text variable="note" form="short"/>
+    </group>
+  </macro>
+  <macro name="nb-vol-bib">
+<choose>
+          <if variable="number-of-volumes">
+            <group>
+              <text variable="number-of-volumes" prefix="" suffix=" "/>
+			  				    <group delimiter="&#160;">
+              <text term="volume" form="short" suffix="."/>
+			  					</group>
+            </group>
+          </if>
+        </choose>
+  </macro>
+  <macro name="second-date">
+    <choose>
+      <if type="book classic chapter">
+	  <choose>
+	  <if variable="submitted" match="any">
+	  <date variable="submitted" form="text" prefix="[" suffix="]"/>
+      </if>
+    </choose>
+      </if>
+    </choose>
+  </macro>
+  <citation>
+    <layout delimiter=" ; ">
+      <choose>
+        <if position="first">
+          <text macro="contributors-notes" font-variant="normal" suffix=", "/>
+          <choose>
+            <if type="thesis">
+              <group delimiter=", ">
+                <text macro="title"/>
+                <text macro="editor"/>
+                <text variable="genre"/>
+                <text macro="publisher-thesis"/>
+				<text macro="access"/>
+              </group>
+            </if>
+            <else-if type="article-magazine article-newspaper" match="any">
+              <group delimiter=", ">
+                <text macro="title"/>
+                <text macro="publication-title"/>
+                <text macro="translator" text-case="capitalize-first"/>
+                <text variable="edition" text-case="capitalize-first"/>
+                <text macro="editor" text-case="capitalize-first"/>
+                <text macro="publisher-book-magazine-newspaper"/>
+                <text variable="page" prefix="p.&#160;"/>
+				<text macro="access"/>
+              </group>
+            </else-if>
+            <else-if type="article-journal">
+              <group delimiter=", ">
+                <text macro="title"/>
+                <text macro="container-title-note"/>
+                <text macro="translator" text-case="capitalize-first"/>
+                <text variable="edition" text-case="capitalize-first"/>
+                <text macro="editor" text-case="capitalize-first"/>
+                <text macro="locators-note"/>
+                <text macro="publisher-book-journal"/>
+                <text variable="page" prefix="p.&#160;"/>
+				<text macro="access"/>
+              </group>
+            </else-if>
+            <else-if type="webpage">
+              <group>
+                <text macro="title" suffix=", "/>
+                <text macro="access"/>
+              </group>
+            </else-if>
+            <else-if type="chapter">
+              <group delimiter=", ">
+                <group delimiter=" ">
+                  <text macro="title"/>
+                  <text macro="container-contributors"/>
+                  <text macro="firstedition-ndbp"/>
+                </group>
+                <text macro="volume" text-case="capitalize-first"/>
+                <text macro="translator" text-case="capitalize-first"/>
+                <text variable="edition" text-case="capitalize-first"/>
+                <text macro="container-title"/>
+                <text macro="publisher-book"/>
+                <text variable="page" prefix="p.&#160;"/>
+				<text macro="access"/>
+              </group>
+            </else-if>
+            <else>
+              <group delimiter=", ">
+                <group delimiter=" ">
+                  <text macro="title"/>
+                  <text macro="publication-title"/>
+                  <text macro="firstedition-ndbp"/>
+                </group>
+                <text macro="container-title"/>
+                <choose>
+                  <if variable="container-author" match="any">
+                    <choose>
+                      <if variable="author" match="any">
+                        <text macro="editor"/>
+                      </if>
+                    </choose>
+                  </if>
+                </choose>
+                <text macro="translator" text-case="capitalize-first"/>
+                <text variable="edition" text-case="capitalize-first"/>
+                <text macro="publisher-book"/>
+                <text variable="page" prefix="p.&#160;"/>
+				<text macro="access"/>
+              </group>
+            </else>
+          </choose>
+          <group>
+            <choose>
+              <if match="any" locator="part note">
+                <label prefix=", " suffix=" " variable="locator"/>
+                <text variable="locator"/>
+              </if>
+              <else>
+                <label variable="locator" form="short" prefix=", "/>
+                <text variable="locator" form="short" prefix=" "/>
+              </else>
+            </choose>
+          </group>
+        </if>
+        <else-if position="ibid-with-locator">
+          <group>
+            <text term="ibid" form="long" font-style="italic" text-case="capitalize-first"/>
+            <group>
+              <choose>
+                <if match="any" locator="part note">
+                  <label prefix=", " suffix=" " variable="locator"/>
+                  <text variable="locator"/>
+                </if>
+                <else>
+                  <label variable="locator" form="short" prefix=", "/>
+                  <text variable="locator" form="short" prefix=" "/>
+                </else>
+              </choose>
+            </group>
+          </group>
+        </else-if>
+        <else-if position="ibid">
+          <text term="ibid" form="long" font-style="italic" text-case="capitalize-first" suffix="."/>
+        </else-if>
+        <else-if position="subsequent">
+          <group>
+            <text macro="contributors-notes" font-variant="normal" suffix=", "/>
+            <choose>
+              <if type="article-journal chapter entry-dictionary article article-magazine article-newspaper entry-encyclopedia paper-conference" match="any">
+                <text variable="title" form="short" text-case="capitalize-first" quotes="true" font-style="normal"/>
+                <text value="art.&#160;cit." font-style="normal" prefix=", "/>
+              </if>
+              <else-if type="book classic" match="any">
+                <choose>
+                  <if match="none" variable="editorial-director">
+                    <choose>
+                      <if match="any" variable="editor">
+                        <text variable="title" form="short" text-case="capitalize-first" quotes="false" font-style="italic"/>
+                        <text value="éd.&#160;cit." prefix=", "/>
+                      </if>
+                      <else-if match="none" variable="editor">
+                        <text variable="title" form="short" text-case="capitalize-first" quotes="false" font-style="italic"/>
+                        <text term="cited" font-style="italic" prefix=", "/>
+                      </else-if>
+                    </choose>
+                  </if>
+                  <else-if match="all" variable="editorial-director" type="book">
+                    <text variable="title" form="short" text-case="capitalize-first" quotes="false" font-style="italic"/>
+                    <text term="cited" font-style="italic" prefix=", "/>
+                  </else-if>
+                </choose>
+              </else-if>
+              <else>
+                <text variable="title" form="short" text-case="capitalize-first" quotes="false" font-style="italic"/>
+                <text term="cited" font-style="italic" prefix=", " suffix=""/>
+              </else>
+            </choose>
+          </group>
+          <group prefix=", ">
+            <choose>
+              <if match="any" locator="note part">
+                <label variable="locator"/>
+                <text variable="locator" prefix=" "/>
+              </if>
+              <else>
+                <label suffix=" " variable="locator" form="short"/>
+                <text variable="locator" prefix=" "/>
+              </else>
+            </choose>
+          </group>
+        </else-if>
+      </choose>
+    </layout>
+  </citation>
+  <bibliography hanging-indent="true" et-al-min="999" et-al-use-first="999" subsequent-author-substitute="———" entry-spacing="0">
+    <sort>
+      <key macro="contributors-sort"/>
+	  <key variable="original-date" sort="ascending"/>
+	  <key variable="issued" sort="ascending"/>
+    </sort>
+    <layout suffix=". ">
+      <choose>
+        <if type="entry-encyclopedia">
+          <group delimiter=", ">
+            <group delimiter=" ">
+              <group delimiter=", ">
+                <choose>
+                  <if variable="author" match="none">
+                    <text variable="container-title" font-style="italic" suffix="."/>
+                    <group delimiter=". ">
+                      <text macro="container-contributors-notes"/>
+                      <group prefix="(" suffix=")" delimiter=", ">
+                        <text macro="publisher"/>
+                        <text macro="issued"/>
+                      </group>
+                    </group>
+                    <text variable="title" prefix="s.v. " quotes="true"/>
+                  </if>
+                  <else-if variable="author">
+                    <group delimiter=". ">
+                      <text macro="contributors" suffix="."/>
+                      <text variable="title" quotes="true" suffix="."/>
+                      <group delimiter=", ">
+                        <text macro="container-title"/>
+                        <text macro="container-contributors" text-case="capitalize-first"/>
+                      </group>
+                      <text macro="publisher"/>
+                      <text macro="access-note-online-reference"/>
+                      <text macro="access"/>
+                    </group>
+                  </else-if>
+                </choose>
+              </group>
+            </group>
+          </group>
+        </if>
+        <else-if type="motion_picture">
+          <group delimiter=". ">
+            <group delimiter=". ">
+              <group delimiter=" ">
+                <group delimiter=". ">
+                  <group delimiter=", ">
+                    <text variable="title" font-style="italic"/>
+                    <text variable="medium"/>
+                  </group>
+                  <text macro="contributors-notes" prefix="Réalisé par "/>
+                  <group delimiter=", ">
+                    <text macro="publisher"/>
+                    <text macro="issued"/>
+                  </group>
+                </group>
+              </group>
+            </group>
+          </group>
+        </else-if>
+        <else-if type="legislation">
+          <group delimiter=" ">
+            <text variable="title"/>
+            <group prefix="(" suffix=")" delimiter=", ">
+              <text variable="section" prefix="chapitre "/>
+              <text variable="volume" prefix="r. "/>
+            </group>
+          </group>
+        </else-if>
+        <else-if type="bill">
+          <group delimiter=" ">
+            <text variable="title"/>
+            <group prefix="(RLRQ, " suffix=")" delimiter=", ">
+              <text variable="section" prefix="chapitre "/>
+              <text variable="number" prefix="r. "/>
+            </group>
+          </group>
+        </else-if>
+        <else>
+          <group delimiter=", ">
+            <group delimiter=", ">
+              <group delimiter=", ">
+                <group delimiter=" ">
+                  <group delimiter=", ">
+                    <group delimiter=", ">
+                      <group delimiter=", ">
+                        <group delimiter=", ">
+                          <group delimiter=", ">
+                            <text macro="contributors"/>
+                            <group delimiter=" ">
+                              <text macro="title"/>
+                              <text macro="firstedition-bib" prefix=" "/>
+                            </group>
+                            <text macro="issue-map-graphic"/>
+                          </group>
+                          <text macro="description"/>
+                          <group delimiter=", ">
+                            <text macro="container-title"/>
+                            <choose>
+                              <if variable="container-author" match="any">
+                                <choose>
+                                  <if variable="author" match="any">
+                                    <text macro="editor"/>
+                                  </if>
+                                </choose>
+                              </if>
+                            </choose>
+                            <choose>
+                              <if variable="container-title event" match="none">
+                                <choose>
+                                  <if variable="author" match="any">
+                                    <text macro="editor"/>
+                                  </if>
+                                </choose>
+                                <text macro="translator"/>
+                              </if>
+                            </choose>
+                            <text macro="container-contributors"/>
+                          </group>
+                        </group>
+                        <text macro="locators-join-with-comma"/>
+                        <text macro="locators-chapter"/>
+                      </group>
+                      <text macro="locators-join-with-space"/>
+                    </group>
+                    <text macro="issue-join-with-period"/>
+                  </group>
+                  <text macro="issue-join-with-space"/>
+                </group>
+                <text macro="issue-join-with-comma"/>
+                <text macro="locators-journal-join-with-comma"/>
+                <text macro="locators-newspaper"/>
+              </group>
+              <text macro="locators-journal-join-with-colon"/>
+            </group>
+            <text macro="locators-join-with-period"/>
+            <text macro="access-note-online-reference"/>
+            <text macro="access"/>
+			<text macro="nb-vol-bib"/>
+            <text macro="extra"/>
+          </group>
+        </else>
+      </choose>
+    </layout>
+  </bibliography>
+</style>

--- a/theses-de-sorbonne-universite.csl
+++ b/theses-de-sorbonne-universite.csl
@@ -219,8 +219,6 @@
       <text macro="recipient"/>
     </group>
   </macro>
-
-
   <macro name="contributors-sort">
     <names variable="author">
       <name name-as-sort-order="all" and="text" sort-separator=", " delimiter=", " delimiter-precedes-last="never"/>
@@ -231,19 +229,12 @@
       </substitute>
     </names>
   </macro>
-  <macro name="interviewer-note">
-    <names variable="interviewer" delimiter=", ">
-      <label form="verb" text-case="lowercase" suffix=" "/>
-      <name and="text" delimiter=", "/>
-    </names>
-  </macro>
   <macro name="interviewer">
     <names variable="interviewer" delimiter=", ">
       <label form="verb" text-case="capitalize-first" suffix=" "/>
       <name and="text" delimiter=", "/>
     </names>
   </macro>
-
   <macro name="title">
     <choose>
       <if variable="title" match="none">
@@ -277,9 +268,6 @@
       </else>
     </choose>
   </macro>
-
-
-
   <macro name="description">
     <group delimiter=", ">
       <group delimiter=". ">
@@ -466,7 +454,6 @@
       </if>
     </choose>
   </macro>
-
   <macro name="edition-note">
     <choose>
       <if type="book chapter graphic motion_picture paper-conference report song" match="any">
@@ -499,24 +486,6 @@
           </else>
         </choose>
       </if>
-    </choose>
-  </macro>
-
-  <macro name="locators-note-join-with-comma">
-    <choose>
-      <if type="article-journal" match="none">
-        <text macro="locators-note"/>
-      </if>
-      <else-if type="article-journal">
-        <choose>
-          <if variable="volume" match="none">
-            <text macro="locators-note"/>
-          </if>
-          <else-if match="any" variable="collection-title">
-            <text macro="locators-note"/>
-          </else-if>
-        </choose>
-      </else-if>
     </choose>
   </macro>
   <macro name="locators-note">
@@ -870,42 +839,6 @@
       </else>
     </choose>
   </macro>
-
- 
-
-  <macro name="point-locators">
-    <choose>
-      <if variable="locator" match="none">
-        <choose>
-          <if type="article-journal chapter paper-conference" match="any">
-            <label prefix=", " variable="page" form="short"/>
-            <text variable="page"/>
-          </if>
-        </choose>
-      </if>
-      <else-if type="article-journal">
-        <group delimiter=" ">
-          <choose>
-            <if locator="page" match="none">
-              <label variable="locator" form="short" suffix=" "/>
-            </if>
-          </choose>
-          <text variable="locator" prefix=", p.&#160;"/>
-        </group>
-      </else-if>
-      <else-if type="legal_case"/>
-      <else>
-        <group delimiter=" ">
-          <choose>
-            <if locator="page" match="none">
-              <label variable="locator" form="short"/>
-            </if>
-          </choose>
-          <text variable="locator" prefix="p.&#160;"/>
-        </group>
-      </else>
-    </choose>
-  </macro>
   <macro name="locators-chapter">
     <choose>
       <if type="chapter entry-dictionary entry-encyclopedia paper-conference" match="any">
@@ -954,7 +887,6 @@
       </if>
     </choose>
   </macro>
-
   <macro name="archive">
     <choose>
       <if type="thesis">
@@ -972,25 +904,6 @@
       </else>
     </choose>
   </macro>
-  <macro name="issue-note-join-with-space">
-    <choose>
-      <if type="article-journal bill legislation legal_case manuscript thesis" variable="publisher-place event-place publisher" match="any">
-        <choose>
-          <if type="article-newspaper" match="none">
-            <choose>
-              <if type="article-journal" match="none">
-                <text macro="issue-note"/>
-              </if>
-              <else-if variable="issue volume" match="any">
-                <text macro="issue-note"/>
-              </else-if>
-            </choose>
-          </if>
-        </choose>
-      </if>
-    </choose>
-  </macro>
-
   <macro name="issue-map-graphic">
     <choose>
       <if type="graphic map" match="any">
@@ -1146,7 +1059,6 @@
       </else-if>
     </choose>
   </macro>
-
   <macro name="access-note-online-reference">
     <choose>
       <if type="entry-encyclopedia" variable="DOI" match="all">
@@ -1200,8 +1112,6 @@
       </choose>
     </group>
   </macro>
-
-
   <macro name="author-bib">
     <choose>
       <if variable="author">

--- a/theses-de-sorbonne-universite.csl
+++ b/theses-de-sorbonne-universite.csl
@@ -667,9 +667,6 @@
       </if>
     </choose>
   </macro>
-  <macro name="event-note">
-    <text variable="event"/>
-  </macro>
   <macro name="event">
     <choose>
       <if variable="title">
@@ -684,33 +681,6 @@
           <text variable="event"/>
         </group>
       </else>
-    </choose>
-  </macro>
-  <macro name="originally-published">
-    <group delimiter=", ">
-      <group delimiter=" : ">
-        <text variable="original-publisher-place"/>
-        <text variable="original-publisher"/>
-      </group>
-      <choose>
-        <if is-uncertain-date="original-date">
-          <date variable="original-date" form="numeric" date-parts="year" prefix="[" suffix="&#8239;?]"/>
-        </if>
-        <else>
-          <date variable="original-date" form="numeric" date-parts="year"/>
-        </else>
-      </choose>
-    </group>
-  </macro>
-  <macro name="reprint-note">
-    <choose>
-      <if variable="original-date issued" match="all">
-        <choose>
-          <if variable="original-publisher original-publisher-place" match="none">
-            <text value="repr."/>
-          </if>
-        </choose>
-      </if>
     </choose>
   </macro>
   <macro name="reprint">

--- a/theses-de-sorbonne-universite.csl
+++ b/theses-de-sorbonne-universite.csl
@@ -915,53 +915,6 @@
       </if>
     </choose>
   </macro>
-  <macro name="issue-note">
-    <choose>
-      <if type="bill legislation legal_case" match="any">
-        <text macro="issued"/>
-      </if>
-      <else-if type="article-journal">
-        <choose>
-          <if variable="volume issue" match="any">
-            <text macro="issued" prefix=", "/>
-          </if>
-          <else>
-            <text macro="issued"/>
-          </else>
-        </choose>
-      </else-if>
-      <else-if type="article-newspaper">
-        <text macro="issued"/>
-      </else-if>
-      <else-if type="manuscript thesis speech" match="any">
-        <group delimiter=", " prefix="(" suffix=")">
-          <choose>
-            <if variable="title" match="any">
-              <text variable="genre"/>
-            </if>
-          </choose>
-          <text variable="publisher"/>
-          <text macro="issued"/>
-        </group>
-      </else-if>
-      <else-if variable="publisher-place event-place publisher" match="any">
-        <group delimiter=", ">
-          <text macro="event-note"/>
-          <group delimiter=", " prefix=", ">
-            <text macro="originally-published"/>
-            <group delimiter=", ">
-              <text macro="reprint-note"/>
-              <text macro="publisher"/>
-            </group>
-          </group>
-          <text macro="issued"/>
-        </group>
-      </else-if>
-      <else>
-        <text macro="issued"/>
-      </else>
-    </choose>
-  </macro>
   <macro name="issue-join-with-space">
     <choose>
       <if type="article-journal" match="any">

--- a/theses-de-sorbonne-universite.csl
+++ b/theses-de-sorbonne-universite.csl
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
-<style class="note" version="1.0" et-al-use-last="true" page-range-format="chicago" default-locale="fr-FR" xmlns="http://purl.org/net/xbiblio/csl">
+<style xmlns="http://purl.org/net/xbiblio/csl" class="note" version="1.0" et-al-use-last="true" page-range-format="chicago" default-locale="fr-FR">
   <info>
     <title>Thèse de Sorbonne Université (Sciences Humaines et Sociales)</title>
     <id>http://www.zotero.org/styles/theses-de-sorbonne-universite</id>
     <link href="http://www.zotero.org/styles/theses-de-sorbonne-universite" rel="self"/>
-	<link href="https://hal.sorbonne-universite.fr/public/Fiche_documentation_Zotero_Sorbonne.pdf" rel="documentation"/>
+    <link href="https://hal.sorbonne-universite.fr/public/Fiche_documentation_Zotero_Sorbonne.pdf" rel="documentation"/>
     <author>
       <name>Morgane Muscat</name>
       <email>morgane.muscat@gmail.com</email>
@@ -15,14 +15,14 @@
     </author>
     <category citation-format="note"/>
     <category field="generic-base"/>
-    <summary>Adaptation du style &quot;Chicago&quot; français pour les thèses de Sorbonne Université</summary>
+    <summary>Adaptation du style "Chicago" français pour les thèses de Sorbonne Université</summary>
     <updated>2022-06-20T13:07:07+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale xml:lang="fr">
     <style-options punctuation-in-quote="false"/>
     <terms>
-	  <term name="open-quote">«&#8239;</term>
+      <term name="open-quote">«&#8239;</term>
       <term name="close-quote">&#8239;»</term>
       <term name="in">dans</term>
       <term name="editor" form="short">dir.</term>
@@ -91,10 +91,10 @@
               <choose>
                 <if variable="container-author author" match="all">
                   <group delimiter=". ">
-				    <group delimiter="&#160;">
-                    <label variable="page" form="short"/>
-                    <text variable="page"/>
-					</group>
+                    <group delimiter="&#160;">
+                      <label variable="page" form="short"/>
+                      <text variable="page"/>
+                    </group>
                     <names variable="editor translator" delimiter=", ">
                       <label form="verb" suffix=" "/>
                       <name and="text" delimiter=", "/>
@@ -345,7 +345,7 @@
   </macro>
   <macro name="container-title">
     <choose>
-	    <if type="classic book" match="any">
+      <if type="classic book" match="any">
         <group delimiter=" ">
           <group delimiter=", ">
             <choose>
@@ -430,13 +430,13 @@
         <choose>
           <if match="none" is-numeric="collection-number">
             <group delimiter=", ">
-              <text variable="collection-title" form="short" text-case="title" prefix="coll. « " suffix=" »"/>
+              <text variable="collection-title" form="short" text-case="title" prefix="coll. «&#160;" suffix="&#160;»"/>
               <text variable="collection-number"/>
             </group>
           </if>
           <else>
             <group delimiter=", ">
-              <text variable="collection-title" form="short" text-case="title" prefix="coll. « " suffix=" »"/>
+              <text variable="collection-title" form="short" text-case="title" prefix="coll. «&#160;" suffix="&#160;»"/>
               <text variable="collection-number"/>
             </group>
           </else>
@@ -534,10 +534,10 @@
                 <text term="section" form="symbol"/>
                 <text variable="section"/>
               </group>
-				    <group delimiter="&#160;">
-                    <label variable="page" form="short"/>
-                    <text variable="page"/>
-					</group>
+              <group delimiter="&#160;">
+                <label variable="page" form="short"/>
+                <text variable="page"/>
+              </group>
             </if>
             <else>
               <text variable="number" prefix="No. "/>
@@ -765,7 +765,7 @@
                 <date variable="issued" form="numeric" date-parts="year"/>
               </else>
             </choose>
-			<text macro="second-date" prefix=" "/>
+            <text macro="second-date" prefix=" "/>
           </else-if>
           <else-if type="patent">
             <group delimiter=", ">
@@ -817,11 +817,11 @@
           <else>
             <choose>
               <if variable="page">
-                <number variable="volume" suffix=" : "/>
-				    <group delimiter="&#160;">
-                    <label variable="page" form="short"/>
-                    <text variable="page"/>
-					</group>
+                <number variable="volume" suffix="&#160;: "/>
+                <group delimiter="&#160;">
+                  <label variable="page" form="short"/>
+                  <text variable="page"/>
+                </group>
               </if>
             </choose>
           </else>
@@ -834,10 +834,10 @@
       <if type="article-journal">
         <choose>
           <if variable="volume issue" match="any">
-				    <group delimiter="&#160;">
-                    <label variable="page" form="short"/>
-                    <text variable="page"/>
-					</group>
+            <group delimiter="&#160;">
+              <label variable="page" form="short"/>
+              <text variable="page"/>
+            </group>
           </if>
         </choose>
       </if>
@@ -848,10 +848,10 @@
       <if type="article-journal">
         <choose>
           <if variable="volume issue" match="none">
-				    <group delimiter="&#160;">
-                    <label variable="page" form="short"/>
-                    <text variable="page"/>
-					</group>
+            <group delimiter="&#160;">
+              <label variable="page" form="short"/>
+              <text variable="page"/>
+            </group>
           </if>
         </choose>
       </if>
@@ -1075,16 +1075,16 @@
     </date>
     <choose>
       <if variable="number-of-pages">
-        <text variable="number-of-pages" prefix=", " suffix=" p.&#160;"/>
+        <text variable="number-of-pages" prefix=", " suffix="&#160;p.&#160;"/>
       </if>
       <else>
         <choose>
           <if variable="number-of-volumes">
             <group>
-              <text variable="number-of-volumes" prefix=". " suffix=" "/>
-			  				    <group delimiter="&#160;">
-              <text term="volume" form="short" suffix="."/>
-			  					</group>
+              <text variable="number-of-volumes" prefix=". " suffix="&#160;"/>
+              <group delimiter="&#160;">
+                <text term="volume" form="short" suffix="."/>
+              </group>
             </group>
           </if>
         </choose>
@@ -1094,11 +1094,11 @@
   <macro name="volume-issue">
     <choose>
       <if is-numeric="volume">
-        <text term="volume" form="short" suffix=". "/>
+        <text term="volume" form="short" suffix=".&#160;"/>
         <text variable="volume"/>
         <choose>
           <if variable="issue" match="any">
-            <text variable="issue" prefix=" / "/>
+            <text variable="issue" prefix="&#160;/&#160;"/>
           </if>
         </choose>
       </if>
@@ -1108,84 +1108,84 @@
     </choose>
   </macro>
   <macro name="publisher-book-magazine-newspaper">
-<group delimiter=", ">
+    <group delimiter=", ">
+      <choose>
+        <if variable="publisher-place" match="any">
+          <text variable="publisher-place"/>
+        </if>
+      </choose>
+      <choose>
+        <if variable="publisher" match="any">
+          <text variable="publisher"/>
+        </if>
+      </choose>
+      <choose>
+        <if variable="collection-title" match="any">
+          <text macro="collection-title"/>
+        </if>
+      </choose>
+      <date variable="issued" prefix="">
+        <date-part name="month" form="long" suffix=" "/>
+        <date-part name="year"/>
+      </date>
+      <choose>
+        <if variable="number-of-pages">
+          <text variable="number-of-pages" prefix=", " suffix="&#160;p.&#160;"/>
+        </if>
+        <else>
           <choose>
-            <if variable="publisher-place" match="any">
-              <text variable="publisher-place"/>
+            <if variable="number-of-volumes">
+              <group>
+                <text variable="number-of-volumes" prefix=". " suffix="&#160;"/>
+                <group delimiter="&#160;">
+                  <text term="volume" form="short" suffix="."/>
+                </group>
+              </group>
             </if>
           </choose>
-		            <choose>
-            <if variable="publisher" match="any">
-          <text variable="publisher"/>
-		              </if>
-          </choose>
-		  		            <choose>
-            <if variable="collection-title" match="any">
-          <text macro="collection-title"/>
-		              </if>
-          </choose>
-    <date variable="issued" prefix="">
-      <date-part name="month" form="long" suffix=" "/>
-      <date-part name="year"/>
-    </date>
-    <choose>
-      <if variable="number-of-pages">
-        <text variable="number-of-pages" prefix=", " suffix=" p.&#160;"/>
-      </if>
-      <else>
-        <choose>
-          <if variable="number-of-volumes">
-            <group>
-              <text variable="number-of-volumes" prefix=". " suffix=" "/>
-			  				    <group delimiter="&#160;">
-              <text term="volume" form="short" suffix="."/>
-			  					</group>
-            </group>
-          </if>
-        </choose>
-      </else>
-    </choose>
-	        </group>
+        </else>
+      </choose>
+    </group>
   </macro>
   <macro name="publisher-book-journal">
- <group delimiter=", ">
+    <group delimiter=", ">
+      <choose>
+        <if variable="publisher-place" match="any">
+          <text variable="publisher-place"/>
+        </if>
+      </choose>
+      <choose>
+        <if variable="publisher" match="any">
+          <text variable="publisher"/>
+        </if>
+      </choose>
+      <choose>
+        <if variable="collection-title" match="any">
+          <text macro="collection-title"/>
+        </if>
+      </choose>
+      <date variable="issued" prefix="">
+        <date-part name="month" form="long" suffix=" "/>
+        <date-part name="year"/>
+      </date>
+      <choose>
+        <if variable="number-of-pages">
+          <text variable="number-of-pages" prefix=", " suffix="&#160;p.&#160;"/>
+        </if>
+        <else>
           <choose>
-            <if variable="publisher-place" match="any">
-              <text variable="publisher-place"/>
+            <if variable="number-of-volumes">
+              <group>
+                <text variable="number-of-volumes" prefix=". " suffix="&#160;"/>
+                <group delimiter="&#160;">
+                  <text term="volume" form="short" suffix="."/>
+                </group>
+              </group>
             </if>
           </choose>
-		            <choose>
-            <if variable="publisher" match="any">
-          <text variable="publisher"/>
-		              </if>
-          </choose>
-		  		            <choose>
-            <if variable="collection-title" match="any">
-          <text macro="collection-title"/>
-		              </if>
-          </choose>
-    <date variable="issued" prefix="">
-      <date-part name="month" form="long" suffix=" "/>
-      <date-part name="year"/>
-    </date>
-    <choose>
-      <if variable="number-of-pages">
-        <text variable="number-of-pages" prefix=", " suffix=" p.&#160;"/>
-      </if>
-      <else>
-        <choose>
-          <if variable="number-of-volumes">
-            <group>
-              <text variable="number-of-volumes" prefix=". " suffix=" "/>
-			  				    <group delimiter="&#160;">
-              <text term="volume" form="short" suffix="."/>
-			  					</group>
-            </group>
-          </if>
-        </choose>
-      </else>
-    </choose>
-	        </group>
+        </else>
+      </choose>
+    </group>
   </macro>
   <macro name="publication-title">
     <choose>
@@ -1198,7 +1198,7 @@
   <macro name="volume">
     <choose>
       <if is-numeric="volume">
-        <text term="volume" form="short" suffix=". "/>
+        <text term="volume" form="short" suffix=".&#160;"/>
         <text variable="volume"/>
       </if>
       <else>
@@ -1209,16 +1209,16 @@
   <macro name="publisher-book">
     <text macro="publisher" suffix=", "/>
     <text macro="issued"/>
-	<choose>
-          <if variable="number-of-volumes">
-            <group>
-              <text variable="number-of-volumes" prefix=", " suffix=" "/>
-			  				    <group delimiter="&#160;">
-              <text term="volume" form="short" suffix="."/>
-			  					</group>
-            </group>
-          </if>
-        </choose>
+    <choose>
+      <if variable="number-of-volumes">
+        <group>
+          <text variable="number-of-volumes" prefix=", " suffix="&#160;"/>
+          <group delimiter="&#160;">
+            <text term="volume" form="short" suffix="."/>
+          </group>
+        </group>
+      </if>
+    </choose>
   </macro>
   <macro name="firstedition-ndbp">
     <choose>
@@ -1258,25 +1258,25 @@
     </group>
   </macro>
   <macro name="nb-vol-bib">
-<choose>
-          <if variable="number-of-volumes">
-            <group>
-              <text variable="number-of-volumes" prefix="" suffix=" "/>
-			  				    <group delimiter="&#160;">
-              <text term="volume" form="short" suffix="."/>
-			  					</group>
-            </group>
-          </if>
-        </choose>
+    <choose>
+      <if variable="number-of-volumes">
+        <group>
+          <text variable="number-of-volumes" prefix="" suffix="&#160;"/>
+          <group delimiter="&#160;">
+            <text term="volume" form="short" suffix="."/>
+          </group>
+        </group>
+      </if>
+    </choose>
   </macro>
   <macro name="second-date">
     <choose>
       <if type="book classic chapter">
-	  <choose>
-	  <if variable="submitted" match="any">
-	  <date variable="submitted" form="text" prefix="[" suffix="]"/>
-      </if>
-    </choose>
+        <choose>
+          <if variable="submitted" match="any">
+            <date variable="submitted" form="text" prefix="[" suffix="]"/>
+          </if>
+        </choose>
       </if>
     </choose>
   </macro>
@@ -1292,7 +1292,7 @@
                 <text macro="editor"/>
                 <text variable="genre"/>
                 <text macro="publisher-thesis"/>
-				<text macro="access"/>
+                <text macro="access"/>
               </group>
             </if>
             <else-if type="article-magazine article-newspaper" match="any">
@@ -1304,7 +1304,7 @@
                 <text macro="editor" text-case="capitalize-first"/>
                 <text macro="publisher-book-magazine-newspaper"/>
                 <text variable="page" prefix="p.&#160;"/>
-				<text macro="access"/>
+                <text macro="access"/>
               </group>
             </else-if>
             <else-if type="article-journal">
@@ -1317,7 +1317,7 @@
                 <text macro="locators-note"/>
                 <text macro="publisher-book-journal"/>
                 <text variable="page" prefix="p.&#160;"/>
-				<text macro="access"/>
+                <text macro="access"/>
               </group>
             </else-if>
             <else-if type="webpage">
@@ -1339,7 +1339,7 @@
                 <text macro="container-title"/>
                 <text macro="publisher-book"/>
                 <text variable="page" prefix="p.&#160;"/>
-				<text macro="access"/>
+                <text macro="access"/>
               </group>
             </else-if>
             <else>
@@ -1363,7 +1363,7 @@
                 <text variable="edition" text-case="capitalize-first"/>
                 <text macro="publisher-book"/>
                 <text variable="page" prefix="p.&#160;"/>
-				<text macro="access"/>
+                <text macro="access"/>
               </group>
             </else>
           </choose>
@@ -1375,7 +1375,7 @@
               </if>
               <else>
                 <label variable="locator" form="short" prefix=", "/>
-                <text variable="locator" form="short" prefix=" "/>
+                <text variable="locator" form="short" prefix="&#160;"/>
               </else>
             </choose>
           </group>
@@ -1391,7 +1391,7 @@
                 </if>
                 <else>
                   <label variable="locator" form="short" prefix=", "/>
-                  <text variable="locator" form="short" prefix=" "/>
+                  <text variable="locator" form="short" prefix="&#160;"/>
                 </else>
               </choose>
             </group>
@@ -1450,11 +1450,11 @@
       </choose>
     </layout>
   </citation>
-  <bibliography hanging-indent="true" subsequent-author-substitute="———" entry-spacing="0">
+  <bibliography hanging-indent="true" subsequent-author-substitute="&#8212;&#8212;&#8212;" entry-spacing="0">
     <sort>
       <key macro="contributors-sort"/>
-	  <key variable="original-date" sort="ascending"/>
-	  <key variable="issued" sort="ascending"/>
+      <key variable="original-date" sort="ascending"/>
+      <key variable="issued" sort="ascending"/>
     </sort>
     <layout suffix=". ">
       <choose>
@@ -1589,7 +1589,7 @@
             <text macro="locators-join-with-period"/>
             <text macro="access-note-online-reference"/>
             <text macro="access"/>
-			<text macro="nb-vol-bib"/>
+            <text macro="nb-vol-bib"/>
             <text macro="extra"/>
           </group>
         </else>

--- a/theses-de-sorbonne-universite.csl
+++ b/theses-de-sorbonne-universite.csl
@@ -219,12 +219,7 @@
       <text macro="recipient"/>
     </group>
   </macro>
-  <macro name="recipient-short">
-    <names variable="recipient">
-      <label form="verb" text-case="lowercase" suffix=" "/>
-      <name form="short" and="text" delimiter=", "/>
-    </names>
-  </macro>
+
 
   <macro name="contributors-sort">
     <names variable="author">
@@ -283,40 +278,8 @@
     </choose>
   </macro>
 
-  <macro name="date-disambiguate">
-    <choose>
-      <if disambiguate="true" type="personal_communication" match="any">
-        <text macro="issued"/>
-      </if>
-    </choose>
-  </macro>
-  <macro name="description-note">
-    <group delimiter=", ">
-      <text macro="interviewer-note"/>
-      <text variable="medium"/>
-      <choose>
-        <if variable="title" match="none"/>
-        <else-if type="manuscript thesis speech" match="any"/>
-        <else-if type="patent">
-          <group delimiter=" ">
-            <text variable="authority"/>
-            <text variable="number"/>
-          </group>
-        </else-if>
-        <else>
-          <text variable="genre"/>
-        </else>
-      </choose>
-      <choose>
-        <if type="map">
-          <text variable="scale"/>
-        </if>
-        <else-if type="graphic">
-          <text variable="dimensions"/>
-        </else-if>
-      </choose>
-    </group>
-  </macro>
+
+
   <macro name="description">
     <group delimiter=", ">
       <group delimiter=". ">
@@ -538,17 +501,7 @@
       </if>
     </choose>
   </macro>
-  <macro name="locators-note-join-with-space">
-    <choose>
-      <if type="article-journal" variable="volume" match="all">
-        <choose>
-          <if match="none" variable="collection-title">
-            <text macro="locators-note"/>
-          </if>
-        </choose>
-      </if>
-    </choose>
-  </macro>
+
   <macro name="locators-note-join-with-comma">
     <choose>
       <if type="article-journal" match="none">
@@ -918,21 +871,7 @@
     </choose>
   </macro>
 
-  <macro name="point-locators-join-with-colon">
-    <choose>
-      <if type="article-journal">
-        <choose>
-          <if variable="locator page" match="any">
-            <choose>
-              <if variable="volume issue" match="any">
-                <text macro="point-locators"/>
-              </if>
-            </choose>
-          </if>
-        </choose>
-      </if>
-    </choose>
-  </macro>
+ 
 
   <macro name="point-locators">
     <choose>
@@ -1015,23 +954,7 @@
       </if>
     </choose>
   </macro>
-  <macro name="archive-note">
-    <choose>
-      <if type="thesis">
-        <group delimiter=" ">
-          <text variable="archive"/>
-          <text variable="archive_location" prefix="(" suffix=")"/>
-        </group>
-      </if>
-      <else>
-        <group delimiter=", ">
-          <text variable="archive_location"/>
-          <text variable="archive"/>
-          <text variable="archive-place"/>
-        </group>
-      </else>
-    </choose>
-  </macro>
+
   <macro name="archive">
     <choose>
       <if type="thesis">
@@ -1067,24 +990,7 @@
       </if>
     </choose>
   </macro>
-  <macro name="issue-note-join-with-comma">
-    <choose>
-      <if type="graphic map" match="any"/>
-      <else-if type="article-journal bill legislation legal_case manuscript thesis" variable="event-place publisher-place publisher" match="none">
-        <text macro="issue-note"/>
-      </else-if>
-      <else-if type="article-newspaper">
-        <text macro="issue-note"/>
-      </else-if>
-      <else-if type="article-journal">
-        <choose>
-          <if variable="volume issue" match="none">
-            <text macro="issue-note"/>
-          </if>
-        </choose>
-      </else-if>
-    </choose>
-  </macro>
+
   <macro name="issue-map-graphic">
     <choose>
       <if type="graphic map" match="any">

--- a/theses-de-sorbonne-universite.csl
+++ b/theses-de-sorbonne-universite.csl
@@ -225,18 +225,7 @@
       <name form="short" and="text" delimiter=", "/>
     </names>
   </macro>
-  <macro name="contributors-short">
-    <group delimiter=" ">
-      <names variable="author">
-        <name form="short" and="text" delimiter=", "/>
-        <substitute>
-          <names variable="editor"/>
-          <names variable="translator"/>
-        </substitute>
-      </names>
-      <text macro="recipient-short"/>
-    </group>
-  </macro>
+
   <macro name="contributors-sort">
     <names variable="author">
       <name name-as-sort-order="all" and="text" sort-separator=", " delimiter=", " delimiter-precedes-last="never"/>
@@ -259,29 +248,7 @@
       <name and="text" delimiter=", "/>
     </names>
   </macro>
-  <macro name="title-note">
-    <choose>
-      <if variable="title" match="none">
-        <text variable="genre"/>
-      </if>
-      <else-if type="book thesis classic graphic map motion_picture song" match="any">
-        <text variable="title" text-case="capitalize-first" font-style="italic"/>
-        <group delimiter=" " prefix=", ">
-          <text term="version"/>
-          <text variable="version"/>
-        </group>
-      </else-if>
-      <else-if type="legal_case interview patent" match="any">
-        <text variable="title"/>
-      </else-if>
-      <else-if variable="reviewed-author">
-        <text variable="title" font-style="italic" prefix="review of "/>
-      </else-if>
-      <else>
-        <text variable="title" text-case="capitalize-first" quotes="true"/>
-      </else>
-    </choose>
-  </macro>
+
   <macro name="title">
     <choose>
       <if variable="title" match="none">
@@ -315,35 +282,7 @@
       </else>
     </choose>
   </macro>
-  <macro name="title-short">
-    <choose>
-      <if variable="title" match="none">
-        <choose>
-          <if type="interview">
-            <text term="interview"/>
-          </if>
-          <else-if type="manuscript speech" match="any">
-            <text variable="genre" form="short"/>
-          </else-if>
-        </choose>
-      </if>
-      <else-if type="book classic thesis graphic motion_picture song" match="any">
-        <text variable="title" text-case="capitalize-first" form="short" font-style="italic"/>
-      </else-if>
-      <else-if type="legal_case" variable="title-short" match="all">
-        <text variable="title" font-style="italic" form="short"/>
-      </else-if>
-      <else-if type="patent interview" match="any">
-        <text variable="title" form="short"/>
-      </else-if>
-      <else-if type="legal_case bill legislation" match="any">
-        <text variable="title"/>
-      </else-if>
-      <else>
-        <text variable="title" text-case="capitalize-first" form="short" quotes="true"/>
-      </else>
-    </choose>
-  </macro>
+
   <macro name="date-disambiguate">
     <choose>
       <if disambiguate="true" type="personal_communication" match="any">
@@ -564,9 +503,7 @@
       </if>
     </choose>
   </macro>
-  <macro name="collection">
-    <text variable="collection-title" quotes="true" prefix="coll. "/>
-  </macro>
+
   <macro name="edition-note">
     <choose>
       <if type="book chapter graphic motion_picture paper-conference report song" match="any">
@@ -980,65 +917,7 @@
       </else>
     </choose>
   </macro>
-  <macro name="point-locators-subsequent">
-    <choose>
-      <if type="legal_case" variable="locator" match="all">
-        <choose>
-          <if locator="page">
-            <group delimiter=" : ">
-              <number variable="volume"/>
-              <text variable="locator"/>
-            </group>
-          </if>
-          <else>
-            <group delimiter=" ">
-              <label variable="locator" form="short"/>
-              <text variable="locator"/>
-            </group>
-          </else>
-        </choose>
-      </if>
-      <else-if variable="locator">
-        <choose>
-          <if locator="page" match="none">
-            <group delimiter=" ">
-              <choose>
-                <if type="book graphic motion_picture report song" match="any">
-                  <choose>
-                    <if variable="volume">
-                      <group delimiter=", ">
-                        <group delimiter=" ">
-                          <text term="volume" form="short"/>
-                          <number variable="volume" form="numeric"/>
-                        </group>
-                        <label variable="locator" form="short"/>
-                      </group>
-                    </if>
-                    <else>
-                      <label variable="locator" form="short"/>
-                    </else>
-                  </choose>
-                </if>
-                <else>
-                  <label variable="locator" form="short"/>
-                </else>
-              </choose>
-              <text variable="locator"/>
-            </group>
-          </if>
-          <else-if type="book graphic motion_picture report song" match="any">
-            <group delimiter=" : ">
-              <number variable="volume" form="numeric"/>
-              <text variable="locator"/>
-            </group>
-          </else-if>
-          <else>
-            <text variable="locator"/>
-          </else>
-        </choose>
-      </else-if>
-    </choose>
-  </macro>
+
   <macro name="point-locators-join-with-colon">
     <choose>
       <if type="article-journal">
@@ -1054,16 +933,7 @@
       </if>
     </choose>
   </macro>
-  <macro name="point-locators-join-with-comma">
-    <choose>
-      <if type="article-journal" match="none">
-        <text macro="point-locators"/>
-      </if>
-      <else-if variable="volume issue" match="none">
-        <text macro="point-locators"/>
-      </else-if>
-    </choose>
-  </macro>
+
   <macro name="point-locators">
     <choose>
       <if variable="locator" match="none">
@@ -1370,56 +1240,7 @@
       </else-if>
     </choose>
   </macro>
-  <macro name="access-note">
-    <group>
-      <choose>
-        <if type="entry-encyclopedia" variable="DOI" match="all">
-          <date variable="accessed" form="text" prefix=", consulté le "/>
-        </if>
-        <else-if type="entry-encyclopedia" variable="URL" match="all">
-          <date variable="accessed" form="text" prefix=", consulté le "/>
-        </else-if>
-        <else-if type="entry-dictionary" variable="DOI" match="all">
-          <date variable="accessed" form="text" prefix=", consulté le "/>
-        </else-if>
-        <else-if type="entry-dictionary" variable="URL" match="all">
-          <date variable="accessed" form="text" prefix=", consulté le "/>
-        </else-if>
-        <else-if type="report" variable="URL" match="all">
-          <date variable="accessed" form="text" prefix=", consulté le "/>
-        </else-if>
-      </choose>
-      <choose>
-        <if type="graphic" match="any">
-          <text macro="archive-note"/>
-        </if>
-        <else-if type="article-journal bill book chapter legal_case legislation motion_picture paper-conference" match="none">
-          <text macro="archive-note"/>
-        </else-if>
-      </choose>
-      <choose>
-        <if variable="issued" match="none">
-          <group delimiter=" ">
-            <text term="accessed"/>
-            <date variable="accessed" form="text"/>
-          </group>
-        </if>
-      </choose>
-      <choose>
-        <if type="legal_case" match="none">
-          <choose>
-            <if variable="DOI">
-              <text variable="DOI" prefix=". https://doi.org/"/>
-            </if>
-            <else>
-              <text variable="URL" prefix=". "/>
-            </else>
-          </choose>
-        </if>
-      </choose>
-    </group>
-    <date form="text" variable="accessed" prefix=", consulté le "/>
-  </macro>
+
   <macro name="access-note-online-reference">
     <choose>
       <if type="entry-encyclopedia" variable="DOI" match="all">
@@ -1473,34 +1294,8 @@
       </choose>
     </group>
   </macro>
-  <macro name="case-locator-subsequent">
-    <choose>
-      <if type="legal_case">
-        <group delimiter=" ">
-          <text variable="volume"/>
-          <text variable="container-title"/>
-        </group>
-      </if>
-    </choose>
-  </macro>
-  <macro name="case-pinpoint-subsequent">
-    <choose>
-      <if type="legal_case">
-        <group delimiter=" ">
-          <choose>
-            <if locator="page">
-              <text term="at"/>
-              <text variable="locator"/>
-            </if>
-            <else>
-              <label variable="locator"/>
-              <text variable="locator"/>
-            </else>
-          </choose>
-        </group>
-      </if>
-    </choose>
-  </macro>
+
+
   <macro name="author-bib">
     <choose>
       <if variable="author">
@@ -1916,7 +1711,7 @@
       </choose>
     </layout>
   </citation>
-  <bibliography hanging-indent="true" et-al-min="999" et-al-use-first="999" subsequent-author-substitute="———" entry-spacing="0">
+  <bibliography hanging-indent="true" subsequent-author-substitute="———" entry-spacing="0">
     <sort>
       <key macro="contributors-sort"/>
 	  <key variable="original-date" sort="ascending"/>


### PR DESCRIPTION
English version:
Documentation of the Zotero Sorbonne style 
Key Features 
Designed according to the recommendations of Sorbonne University Presses, validated by the heads of departments of the Faculty of Arts for the theses of Sorbonne University. 

Major contribution:

- 1st style to differentiate ed. cit., art. cit., op. cit. Cit. (art. cit. appears when the type of document is "article" or "book chapter" (for collective works), ed. cit. appears when the type of document is "book" or "classic" with a "publisher" filled in but no "editorial-director" (dir.), op. cit. in other cases). These abbreviations appear after the author's name and the short title.
- Support for anthologies; possibility to display two titles in italics (e.g. Marivaux, La Dispute, ed. Frédéric Deloffre, in Théâtre complet). - Differentiation of the scientific editor of a text (ed.) and the director of publication of a collective work (ed.)
- Presence of a type: "classical work" where the author appears only with his surname in note (eg Marivaux) but his full name in biblio (Marivaux, Pierre Carlet de Chamblain de). - Possibility of entering two original dates of publication, to differentiate in the case of a literary text the original date of the work and the original date of the edition (e.g. Marivaux, La Dispute, ed. Frédéric Deloffre, 2002).
- Use of French quotation marks.

Documentation du style Zotero Sorbonne 
Caractéristiques principales  
Pensé selon les recommandations de Sorbonne Université Presses, validées par les directeurs de départements de la Faculté des Lettres pour les thèses de Sorbonne Université. 

Apport majeur : 1er style à différencier éd. cit., art. cit., op. cit. (art. cit. apparaît quand le type de document est « article » ou « chapitre de livre » (pour les ouvrages collectifs), éd. cit. apparaît quand le type de document est « livre » ou « classic » avec un « éditeur » renseigné mais pas de « editorial-director » (dir.), op. cit. dans les autres cas). Ces abréviations apparaissent après le nom de l’auteur et le titre abrégé.

Prise en charge des anthologies ; possibilité d’afficher deux titres en italiques (ex : Marivaux, La Dispute, éd. Frédéric Deloffre, dans Théâtre complet). - Différenciation de l’éditeur scientifique d’un texte (éd.) et du directeur de publication d’un ouvrage collectif (dir.)

Présence d’un type : « œuvre classique » où l’auteur ne s’affiche qu’avec son patronyme en note (ex : Marivaux) mais son nom complet en biblio (Marivaux, Pierre Carlet de Chamblain de). - Possibilité d’entrer deux dates originales de publication, pour différencier dans le cas d’un texte littéraire la date originale de l’œuvre et la date originale de l’édition (ex : Marivaux, La Dispute [1744], éd. Frédéric Deloffre, 2002 [1996]).

Utilisation des guillemets français. 

