### PR TITLE
Create descending-publications-based-on-ieee-with-url.csl

### DIFF
--- a/descending-publications-based-on-ieee-with-url.csl
+++ b/descending-publications-based-on-ieee-with-url.csl
@@ -4,7 +4,7 @@
     <title>Descending Publications based on IEEE with URL</title>
     <id>http://www.zotero.org/styles/descending-publications-based-on-ieee-with-url</id>
     <link href="http://www.zotero.org/styles/descending-publications-based-on-ieee-with-url" rel="self"/>
-    <link rel="template" href="https://www.zotero.org/styles/ieee-with-url"/>
+    <link rel="template" href="http://www.zotero.org/styles/ieee-with-url"/>
     <link href="https://ieeeauthorcenter.ieee.org/wp-content/uploads/IEEE-Reference-Guide.pdf" rel="documentation"/>
     <link href="https://journals.ieeeauthorcenter.ieee.org/your-role-in-article-production/ieee-editorial-style-manual/" rel="documentation"/>
     <author>
@@ -190,9 +190,6 @@
   </macro>
   <macro name="doi">
     <text variable="DOI" prefix="doi: "/>
-  </macro>
-  <macro name="citation-number">
-    <text variable="citation-number"/>
   </macro>
   <citation collapse="citation-number">
     <sort>

--- a/descending-publications-based-on-ieee-with-url.csl
+++ b/descending-publications-based-on-ieee-with-url.csl
@@ -191,6 +191,9 @@
   <macro name="doi">
     <text variable="DOI" prefix="doi: "/>
   </macro>
+  <macro name="citation-number">
+    <text variable="citation-number"/>
+  </macro>
   <citation collapse="citation-number">
     <sort>
       <key variable="citation-number"/>
@@ -204,8 +207,8 @@
   </citation>
   <bibliography entry-spacing="0" second-field-align="flush">
     <sort>
-      <key variable="issued" sort="descending"/>
-      <key variable="citation-number" sort="descending"/>
+      <key macro="issued" sort="ascending"/>
+      <key macro="citation-number" sort="descending"/>
     </sort>
     <layout>
       <text variable="citation-number" prefix="[" suffix="]"/>

--- a/descending-publications-based-on-ieee-with-url.csl
+++ b/descending-publications-based-on-ieee-with-url.csl
@@ -4,7 +4,7 @@
     <title>Descending Publications based on IEEE with URL</title>
     <id>http://www.zotero.org/styles/descending-publications-based-on-ieee-with-url</id>
     <link href="http://www.zotero.org/styles/descending-publications-based-on-ieee-with-url" rel="self"/>
-    <link rel="template" href="http://www.zotero.org/styles/ieee-with-url"/>
+    <link href="http://www.zotero.org/styles/ieee-with-url" rel="template"/>
     <link href="https://ieeeauthorcenter.ieee.org/wp-content/uploads/IEEE-Reference-Guide.pdf" rel="documentation"/>
     <link href="https://journals.ieeeauthorcenter.ieee.org/your-role-in-article-production/ieee-editorial-style-manual/" rel="documentation"/>
     <author>

--- a/descending-publications-based-on-ieee-with-url.csl
+++ b/descending-publications-based-on-ieee-with-url.csl
@@ -1,0 +1,328 @@
+<?xml version="1.0" encoding="utf-8"?>
+<style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" demote-non-dropping-particle="sort-only">
+  <info>
+    <title>Descending Publications based on IEEE with URL</title>
+    <id>http://www.zotero.org/styles/descending-publications-based-on-ieee-with-url</id>
+    <link href="http://www.zotero.org/styles/descending-publications-based-on-ieee-with-url" rel="self"/>
+    <link rel="template" href="https://www.zotero.org/styles/ieee-with-url"/>
+    <link href="https://ieeeauthorcenter.ieee.org/wp-content/uploads/IEEE-Reference-Guide.pdf" rel="documentation"/>
+    <link href="https://journals.ieeeauthorcenter.ieee.org/your-role-in-article-production/ieee-editorial-style-manual/" rel="documentation"/>
+    <author>
+      <name>Andreas Gruhn</name>
+    </author>
+    <category citation-format="numeric"/>
+    <category field="engineering"/>
+    <category field="generic-base"/>
+    <summary>IEEE style with URLs as per the 2018 guidelines but sorted descending by date and citation number for online publication lists.</summary>
+    <updated>2022-11-13T21:32:22+00:00</updated>
+    <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
+  </info>
+  <locale xml:lang="en">
+    <terms>
+      <term name="chapter" form="short">ch.</term>
+      <term name="presented at">presented at the</term>
+      <term name="available at">available</term>
+    </terms>
+  </locale>
+  <macro name="edition">
+    <choose>
+      <if type="bill book chapter graphic legal_case legislation motion_picture paper-conference report song" match="any">
+        <choose>
+          <if is-numeric="edition">
+            <group delimiter=" ">
+              <number variable="edition" form="ordinal"/>
+              <text term="edition" form="short"/>
+            </group>
+          </if>
+          <else>
+            <text variable="edition" text-case="capitalize-first" suffix="."/>
+          </else>
+        </choose>
+      </if>
+    </choose>
+  </macro>
+  <macro name="issued">
+    <choose>
+      <if type="article-journal report" match="any">
+        <date variable="issued">
+          <date-part name="month" form="short" suffix=" "/>
+          <date-part name="year" form="long"/>
+        </date>
+      </if>
+      <else-if type="bill book chapter graphic legal_case legislation motion_picture paper-conference song thesis" match="any">
+        <date variable="issued">
+          <date-part name="year" form="long"/>
+        </date>
+      </else-if>
+      <else>
+        <date variable="issued">
+          <date-part name="day" form="numeric-leading-zeros" suffix="-"/>
+          <date-part name="month" form="short" suffix="-" strip-periods="true"/>
+          <date-part name="year" form="long"/>
+        </date>
+      </else>
+    </choose>
+  </macro>
+  <macro name="author">
+    <names variable="author">
+      <name and="text" et-al-min="7" et-al-use-first="1" initialize-with=". "/>
+      <label form="short" prefix=", " text-case="capitalize-first"/>
+      <et-al font-style="italic"/>
+      <substitute>
+        <names variable="editor"/>
+        <names variable="translator"/>
+      </substitute>
+    </names>
+  </macro>
+  <macro name="editor">
+    <names variable="editor">
+      <name initialize-with=". " delimiter=", " and="text"/>
+      <label form="short" prefix=", " text-case="capitalize-first"/>
+    </names>
+  </macro>
+  <macro name="locators">
+    <group delimiter=", ">
+      <text macro="edition"/>
+      <group delimiter=" ">
+        <text term="volume" form="short"/>
+        <number variable="volume" form="numeric"/>
+      </group>
+      <group delimiter=" ">
+        <number variable="number-of-volumes" form="numeric"/>
+        <text term="volume" form="short" plural="true"/>
+      </group>
+      <group delimiter=" ">
+        <text term="issue" form="short"/>
+        <number variable="issue" form="numeric"/>
+      </group>
+    </group>
+  </macro>
+  <macro name="title">
+    <choose>
+      <if type="bill book graphic legal_case legislation motion_picture song" match="any">
+        <text variable="title" font-style="italic"/>
+      </if>
+      <else>
+        <text variable="title" quotes="true"/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="publisher">
+    <choose>
+      <if type="bill book chapter graphic legal_case legislation motion_picture paper-conference song" match="any">
+        <group delimiter=": ">
+          <text variable="publisher-place"/>
+          <text variable="publisher"/>
+        </group>
+      </if>
+      <else>
+        <group delimiter=", ">
+          <text variable="publisher"/>
+          <text variable="publisher-place"/>
+        </group>
+      </else>
+    </choose>
+  </macro>
+  <macro name="event">
+    <choose>
+      <if type="paper-conference speech" match="any">
+        <choose>
+          <if variable="container-title">
+            <group delimiter=", ">
+              <group delimiter=" ">
+                <text term="in"/>
+                <text variable="container-title" font-style="italic"/>
+              </group>
+              <text variable="event-place"/>
+            </group>
+          </if>
+          <else>
+            <group delimiter=", ">
+              <group delimiter=" ">
+                <text term="presented at"/>
+                <text variable="event"/>
+              </group>
+              <text variable="event-place"/>
+            </group>
+          </else>
+        </choose>
+      </if>
+    </choose>
+  </macro>
+  <macro name="access">
+    <choose>
+      <if variable="URL">
+        <group delimiter=". ">
+          <group delimiter=": ">
+            <text term="available at" text-case="capitalize-first"/>
+            <text variable="URL"/>
+          </group>
+          <group prefix="[" suffix="]" delimiter=": ">
+            <text term="accessed" text-case="capitalize-first"/>
+            <date variable="accessed">
+              <date-part name="day" form="numeric-leading-zeros" suffix="-"/>
+              <date-part name="month" form="short" suffix="-" strip-periods="true"/>
+              <date-part name="year" form="long"/>
+            </date>
+          </group>
+        </group>
+      </if>
+    </choose>
+  </macro>
+  <macro name="page">
+    <group>
+      <label variable="page" form="short" suffix=" "/>
+      <text variable="page"/>
+    </group>
+  </macro>
+  <macro name="citation-locator">
+    <group delimiter=" ">
+      <choose>
+        <if locator="page">
+          <label variable="locator" form="short"/>
+        </if>
+        <else>
+          <label variable="locator" form="short" text-case="capitalize-first"/>
+        </else>
+      </choose>
+      <text variable="locator"/>
+    </group>
+  </macro>
+  <macro name="doi">
+    <text variable="DOI" prefix="doi: "/>
+  </macro>
+  <macro name="citation-number">
+    <text variable="citation-number"/>
+  </macro>
+  <citation collapse="citation-number">
+    <sort>
+      <key variable="citation-number"/>
+    </sort>
+    <layout delimiter=", ">
+      <group prefix="[" suffix="]" delimiter=", ">
+        <text variable="citation-number"/>
+        <text macro="citation-locator"/>
+      </group>
+    </layout>
+  </citation>
+  <bibliography entry-spacing="0" second-field-align="flush">
+    <sort>
+      <key variable="issued" sort="descending"/>
+      <key variable="citation-number" sort="descending"/>
+    </sort>
+    <layout>
+      <text variable="citation-number" prefix="[" suffix="]"/>
+      <text macro="author" suffix=", "/>
+      <group suffix=". ">
+        <choose>
+          <if type="article-journal">
+            <group delimiter=", ">
+              <text macro="title"/>
+              <text variable="container-title" font-style="italic" form="short"/>
+              <text macro="locators"/>
+              <text macro="page"/>
+              <text macro="issued"/>
+              <text macro="doi" suffix="."/>
+            </group>
+          </if>
+          <else-if type="paper-conference">
+            <group delimiter=", ">
+              <text macro="title"/>
+              <text macro="event"/>
+              <text macro="issued"/>
+              <text macro="locators"/>
+              <text macro="page"/>
+              <text macro="doi"/>
+            </group>
+          </else-if>
+          <else-if type="report">
+            <group delimiter=", ">
+              <text macro="title"/>
+              <text macro="publisher"/>
+              <group delimiter=" ">
+                <text variable="genre"/>
+                <text variable="number"/>
+              </group>
+              <text macro="issued"/>
+            </group>
+          </else-if>
+          <else-if type="thesis">
+            <group delimiter=", ">
+              <text macro="title"/>
+              <text variable="genre"/>
+              <text macro="publisher"/>
+              <text macro="issued"/>
+            </group>
+          </else-if>
+          <else-if type="webpage post post-weblog" match="any">
+            <group delimiter=", " suffix=". ">
+              <text macro="title"/>
+              <text variable="container-title" font-style="italic"/>
+              <text macro="issued"/>
+            </group>
+          </else-if>
+          <else-if type="patent">
+            <text macro="title" suffix=", "/>
+            <text variable="number"/>
+            <text macro="issued"/>
+          </else-if>
+          <else-if type="bill book graphic legal_case legislation motion_picture report song" match="any">
+            <group delimiter=", " suffix=". ">
+              <text macro="title"/>
+              <text macro="locators"/>
+            </group>
+            <group delimiter=", ">
+              <text macro="publisher"/>
+              <text macro="issued"/>
+              <text macro="page"/>
+            </group>
+          </else-if>
+          <else-if type="article-magazine article-newspaper broadcast interview manuscript map patent personal_communication song speech thesis webpage" match="any">
+            <group delimiter=", ">
+              <text macro="title"/>
+              <text variable="container-title" font-style="italic"/>
+              <text macro="locators"/>
+              <text macro="publisher"/>
+              <text macro="page"/>
+              <text macro="issued"/>
+            </group>
+          </else-if>
+          <else-if type="chapter paper-conference" match="any">
+            <group delimiter=", " suffix=", ">
+              <text macro="title"/>
+              <group delimiter=" ">
+                <text term="in"/>
+                <text variable="container-title" font-style="italic"/>
+              </group>
+              <text macro="locators"/>
+            </group>
+            <text macro="editor" suffix=" "/>
+            <group delimiter=", ">
+              <text macro="publisher"/>
+              <text macro="issued"/>
+              <text macro="page"/>
+            </group>
+          </else-if>
+          <else>
+            <group delimiter=", " suffix=". ">
+              <text macro="title"/>
+              <text variable="container-title" font-style="italic"/>
+              <text macro="locators"/>
+            </group>
+            <group delimiter=", ">
+              <text macro="publisher"/>
+              <text macro="page"/>
+              <text macro="issued"/>
+            </group>
+          </else>
+        </choose>
+        <choose>
+          <if variable="URL">
+            <text value=" [Online]"/>
+          </if>
+        </choose>
+      </group>
+      <text macro="access"/>
+    </layout>
+  </bibliography>
+</style>


### PR DESCRIPTION
Many researchers prefer a descending publication list on their websites so that the total number and most recent papers published are visible at first glance. This improves the visibility of one's research for funding bodies.