### PR TITLE
Fix Brazilian quotes

### DIFF
--- a/chicago-author-date.csl
+++ b/chicago-author-date.csl
@@ -65,8 +65,8 @@
       <term name="at">em</term>
       <term name="by">por</term>
       <!-- PUNCTUATION -->
-      <term name="open-quote">"</term>
-      <term name="close-quote">"</term>
+      <term name="open-quote">“</term>
+      <term name="close-quote">”</term>
     </terms>
   </locale>
   <macro name="secondary-contributors">


### PR DESCRIPTION
According to locale, Brazilian quotes should be:
```
<term name="open-quote">“</term>
<term name="close-quote">”</term>
```
https://github.com/citation-style-language/locales/blob/master/locales-pt-BR.xml#L163-L164 

These are also causing error in LaTeX/Pandoc translation, as both are the same symbol... see: https://github.com/jgm/citeproc/issues/123