### PR TITLE
Update norsk-apa-manual.csl

### DIFF
--- a/norsk-apa-manual.csl
+++ b/norsk-apa-manual.csl
@@ -191,8 +191,8 @@
               <if type="article-magazine article-newspaper broadcast interview motion_picture pamphlet personal_communication post post-weblog song speech webpage" match="any">
                 <!-- Many video and audio examples in manual give full dates. Err on the side of too much information. -->
                 <date variable="issued">
-                  <date-part prefix=", " name="month"/>
-                  <date-part prefix=" " name="day"/>
+                  <date-part prefix=", " name="day"/>
+                  <date-part prefix=". " name="month"/>
                 </date>
               </if>
               <else-if type="paper-conference">


### PR DESCRIPTION
This will display f.ex.  (2021, 13. mars) and not (2021, mars 13). The first is correct according to the Norwegian APA-manual.