### PR TITLE
Update norsk-apa-manual-note.csl

### DIFF
--- a/norsk-apa-manual-note.csl
+++ b/norsk-apa-manual-note.csl
@@ -163,7 +163,7 @@
               <if type="article-magazine article-newspaper broadcast interview motion_picture pamphlet personal_communication post post-weblog song speech webpage" match="any">
                 <!-- Many video and audio examples in manual give full dates. Err on the side of too much information. -->
                 <date variable="issued">
-                  <date-part prefix=", " name="day"/>  
+                  <date-part prefix=", " name="day"/>
                   <date-part prefix=". " name="month"/>
                 </date>
               </if>

--- a/norsk-apa-manual-note.csl
+++ b/norsk-apa-manual-note.csl
@@ -163,8 +163,8 @@
               <if type="article-magazine article-newspaper broadcast interview motion_picture pamphlet personal_communication post post-weblog song speech webpage" match="any">
                 <!-- Many video and audio examples in manual give full dates. Err on the side of too much information. -->
                 <date variable="issued">
-                  <date-part prefix=", " name="month"/>
-                  <date-part prefix=" " name="day"/>
+                  <date-part prefix=", " name="day"/>  
+                  <date-part prefix=". " name="month"/>
                 </date>
               </if>
               <else-if type="paper-conference">


### PR DESCRIPTION
This should display f.ex. (2021, 13. mars) and not (2021, mars 13). The first one is correct according to the Norwegian APA7-manual (it is more in line with DD-MM commonly used in Norway).