### PR TITLE
Update "Zeitschrift für deutsche Philologie"

### DIFF
--- a/zeitschrift-fur-deutsche-philologie.csl
+++ b/zeitschrift-fur-deutsche-philologie.csl
@@ -49,8 +49,8 @@
       <if type="entry-encyclopedia" match="all" variable="author editor"/>
       <else>
         <names variable="editor translator" delimiter=", ">
-          <label form="verb-short" text-case="lowercase"/>
-          <name prefix=" " delimiter-precedes-last="always"/>
+          <label form="verb-short" text-case="lowercase" suffix=" "/>
+          <name delimiter-precedes-last="always"/>
         </names>
       </else>
     </choose>


### PR DESCRIPTION
Fixes double spaces before last editor, which appeared due to the combination of `delimiter=", "` on `cs:names` and `prefix=" "` on `cs:name`.