### PR TITLE
Update cambridge-university-press-author-date-cambridge-a.csl

### DIFF
--- a/cambridge-university-press-author-date-cambridge-a.csl
+++ b/cambridge-university-press-author-date-cambridge-a.csl
@@ -17,7 +17,7 @@
     <category citation-format="author-date"/>
     <category field="generic-base"/>
     <summary>CambridgeA style required by Journal of Tropical Ecology as of December 2022. Modified from 'cambridge-university-press-author-date' (which seems now to be CambridgeB) by Eric Marcon</summary>
-    <updated>2022-12-13T12:00:00+00:00</updated>
+    <updated>2022-12-21T12:00:00+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale xml:lang="en">
@@ -228,8 +228,7 @@
                 <text variable="publisher"/>
               </group>
               <group>
-                <label variable="page" form="short" prefix=" " suffix=" "/>
-                <text variable="page"/>
+                <text variable="page" prefix=", "/>
               </group>
             </if>
           </choose>


### PR DESCRIPTION
The documentation writes that chapter pages are not preceded by "pp".
"Publisher, 10-12" is correct but "Publisher pp. 10-12" is not.

Sorry, I had missed that when I added the style.