### PR TITLE
Create industrial-health.csl

### DIFF
--- a/industrial-health.csl
+++ b/industrial-health.csl
@@ -14,7 +14,7 @@
     <category field="medicine"/>
     <issn>0019-8366</issn>
     <eissn>1880-8026</eissn>
-    <summary>Based on the American Medical Association style..</summary>
+    <summary>Based on the American Medical Association style, but superscript and right parenthesis only in the text. Bibliography by citation number followed by right parenthesis.</summary>
     <updated>2022-12-24T22:43:34+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>

--- a/industrial-health.csl
+++ b/industrial-health.csl
@@ -1,0 +1,277 @@
+<?xml version="1.0" encoding="utf-8"?>
+<style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" demote-non-dropping-particle="sort-only" page-range-format="expanded" initialize-with-hyphen="false" default-locale="en-US">
+  <info>
+    <title>Industrial Health</title>
+    <title-short>IndHealth</title-short>
+    <id>http://www.zotero.org/styles/industrial-health</id>
+    <link href="http://www.zotero.org/styles/american-medical-association-brackets" rel="template"/>
+    <link href="http://www.zotero.org/styles/industrial-health" rel="self"/>
+    <link href="https://www.jniosh.johas.go.jp/en/indu_hel/doc/instructions_authors.pdf" rel="documentation"/>
+    <issn>0019-8366</issn>
+    <eissn>1880-8026</eissn>
+    <author>
+      <name>Livio Tarchi</name>
+    </author>
+    <category citation-format="numeric"/>
+    <category field="medicine"/>
+    <summary>Based on the American Medical Association style..</summary>
+    <updated>2022-12-24T22:43:34+00:00</updated>
+    <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
+  </info>
+  <locale xml:lang="en">
+    <terms>
+      <term name="page-range-delimiter">-</term>
+      <term name="presented at">presented at</term>
+    </terms>
+  </locale>
+  <macro name="editor">
+    <names variable="editor">
+      <name name-as-sort-order="all" sort-separator=" " initialize-with="" delimiter=", " delimiter-precedes-last="always"/>
+      <label form="short" prefix=", "/>
+    </names>
+  </macro>
+  <macro name="author">
+    <group suffix=".">
+      <names variable="author">
+        <name name-as-sort-order="all" sort-separator=" " initialize-with="" delimiter=", " delimiter-precedes-last="always"/>
+        <label form="short" prefix=", "/>
+        <substitute>
+          <names variable="editor"/>
+          <text macro="title"/>
+        </substitute>
+      </names>
+    </group>
+  </macro>
+  <macro name="access">
+    <choose>
+      <if type="article-newspaper" match="none">
+        <choose>
+          <if variable="DOI">
+            <text value="doi:"/>
+            <text variable="DOI"/>
+          </if>
+          <else-if variable="URL">
+            <group delimiter=". ">
+              <choose>
+                <if type="webpage post post-weblog" match="any">
+                  <date variable="issued" prefix="Published " form="text"/>
+                </if>
+              </choose>
+              <group>
+                <text term="accessed" text-case="capitalize-first" suffix=" "/>
+                <date variable="accessed">
+                  <date-part name="month" suffix=" "/>
+                  <date-part name="day" suffix=", "/>
+                  <date-part name="year"/>
+                </date>
+              </group>
+              <text variable="URL"/>
+            </group>
+          </else-if>
+        </choose>
+      </if>
+    </choose>
+  </macro>
+  <macro name="title">
+    <choose>
+      <if type="bill book graphic legal_case legislation motion_picture report song thesis" match="any">
+        <text variable="title" font-style="italic" text-case="title"/>
+      </if>
+      <else>
+        <text variable="title"/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="publisher">
+    <text variable="publisher"/>
+  </macro>
+  <macro name="edition">
+    <choose>
+      <if is-numeric="edition">
+        <group delimiter=" ">
+          <number variable="edition" form="ordinal"/>
+          <text term="edition" form="short"/>
+        </group>
+      </if>
+      <else>
+        <text variable="edition" suffix="."/>
+      </else>
+    </choose>
+  </macro>
+  <citation collapse="citation-number">
+    <sort>
+      <key variable="citation-number"/>
+    </sort>
+    <layout delimiter="," suffix=")"  vertical-align="sup">
+      <text variable="citation-number"/>
+      <group prefix=", ">
+        <label variable="locator" form="short" strip-periods="true"/>
+        <text variable="locator"/>
+      </group>
+    </layout>
+  </citation>
+  <bibliography hanging-indent="false" et-al-min="7" et-al-use-first="3" second-field-align="flush">
+    <layout>
+      <text variable="citation-number" suffix=")"/>
+      <text macro="author"/>
+      <text macro="title" prefix=" " suffix="."/>
+      <choose>
+        <if type="bill book graphic legislation motion_picture report song" match="any">
+          <group suffix="." prefix=" " delimiter=" ">
+            <group delimiter=" ">
+              <text term="volume" form="short" text-case="capitalize-first" strip-periods="true"/>
+              <text variable="volume" suffix="."/>
+            </group>
+            <text macro="edition"/>
+            <text macro="editor" prefix="(" suffix=")"/>
+          </group>
+          <text macro="publisher" prefix=" "/>
+          <group suffix="." prefix="; ">
+            <date variable="issued">
+              <date-part name="year"/>
+            </date>
+            <text variable="page" prefix=":"/>
+          </group>
+        </if>
+        <else-if type="chapter paper-conference entry-dictionary entry-encyclopedia" match="any">
+          <group prefix=" " delimiter=" ">
+            <text term="in" text-case="capitalize-first" suffix=":"/>
+            <text macro="editor"/>
+            <text variable="container-title" font-style="italic" suffix="." text-case="title"/>
+            <group delimiter=" ">
+              <text term="volume" form="short" text-case="capitalize-first" strip-periods="true"/>
+              <text variable="volume" suffix="."/>
+            </group>
+            <text macro="edition"/>
+            <text variable="collection-title" suffix="."/>
+            <group suffix=".">
+              <text macro="publisher"/>
+              <group suffix="." prefix="; ">
+                <date variable="issued">
+                  <date-part name="year"/>
+                </date>
+                <text variable="page" prefix=":"/>
+              </group>
+            </group>
+          </group>
+        </else-if>
+        <else-if type="article-newspaper">
+          <text variable="container-title" font-style="italic" prefix=" " suffix=". "/>
+          <choose>
+            <if variable="URL">
+              <group delimiter=". " suffix=".">
+                <text variable="URL"/>
+                <group prefix="Published ">
+                  <date variable="issued">
+                    <date-part name="month" suffix=" "/>
+                    <date-part name="day" suffix=", "/>
+                    <date-part name="year"/>
+                  </date>
+                </group>
+                <group>
+                  <text term="accessed" text-case="capitalize-first" suffix=" "/>
+                  <date variable="accessed">
+                    <date-part name="month" suffix=" "/>
+                    <date-part name="day" suffix=", "/>
+                    <date-part name="year"/>
+                  </date>
+                </group>
+              </group>
+            </if>
+            <else>
+              <group delimiter=":" suffix=".">
+                <group>
+                  <date variable="issued">
+                    <date-part name="month" suffix=" "/>
+                    <date-part name="day" suffix=", "/>
+                    <date-part name="year"/>
+                  </date>
+                </group>
+                <text variable="page"/>
+              </group>
+            </else>
+          </choose>
+        </else-if>
+        <else-if type="legal_case">
+          <group suffix="," prefix=" " delimiter=" ">
+            <text macro="editor" prefix="(" suffix=")"/>
+          </group>
+          <group prefix=" " delimiter=" ">
+            <text variable="container-title"/>
+            <text variable="volume"/>
+          </group>
+          <text variable="page" prefix=", " suffix=" "/>
+          <group prefix="(" suffix=")." delimiter=" ">
+            <text variable="authority"/>
+            <date variable="issued">
+              <date-part name="year"/>
+            </date>
+          </group>
+        </else-if>
+        <else-if type="webpage post post-weblog" match="any">
+          <text variable="container-title" prefix=" " suffix="."/>
+        </else-if>
+        <else-if type="speech">
+          <group prefix=" " suffix=":">
+            <choose>
+              <if variable="genre">
+                <text variable="genre" suffix=" "/>
+                <text term="presented at"/>
+              </if>
+              <else>
+                <text term="presented at" text-case="capitalize-first"/>
+              </else>
+            </choose>
+          </group>
+          <group delimiter="; " prefix=" " suffix=".">
+            <text variable="event"/>
+            <group>
+              <date delimiter=" " variable="issued">
+                <date-part name="month"/>
+                <date-part name="day" suffix=","/>
+                <date-part name="year"/>
+              </date>
+            </group>
+            <text variable="event-place"/>
+          </group>
+        </else-if>
+        <else-if type="thesis" match="any">
+          <group delimiter=". " prefix=" " suffix=".">
+            <text variable="genre"/>
+            <group delimiter="; ">
+              <text variable="publisher"/>
+              <date date-parts="year" form="text" variable="issued"/>
+            </group>
+          </group>
+        </else-if>
+        <else>
+          <text macro="editor" prefix=" " suffix="."/>
+          <group prefix=" " suffix=".">
+            <text variable="container-title" font-style="italic" form="short" strip-periods="true" suffix="."/>
+            <group delimiter=";" prefix=" ">
+              <choose>
+                <if variable="issue volume" match="any">
+                  <date variable="issued">
+                    <date-part name="year"/>
+                  </date>
+                </if>
+                <else>
+                  <group delimiter=" ">
+                    <text value="Published online"/>
+                    <date form="text" date-parts="year-month-day" variable="issued"/>
+                  </group>
+                </else>
+              </choose>
+              <group>
+                <text variable="volume"/>
+                <text variable="issue" prefix="(" suffix=")"/>
+              </group>
+            </group>
+            <text variable="page" prefix=":"/>
+          </group>
+        </else>
+      </choose>
+      <text prefix=" " macro="access"/>
+    </layout>
+  </bibliography>
+</style>

--- a/industrial-health.csl
+++ b/industrial-health.csl
@@ -4,16 +4,16 @@
     <title>Industrial Health</title>
     <title-short>IndHealth</title-short>
     <id>http://www.zotero.org/styles/industrial-health</id>
-    <link href="http://www.zotero.org/styles/american-medical-association-brackets" rel="template"/>
     <link href="http://www.zotero.org/styles/industrial-health" rel="self"/>
+    <link href="http://www.zotero.org/styles/american-medical-association-brackets" rel="template"/>
     <link href="https://www.jniosh.johas.go.jp/en/indu_hel/doc/instructions_authors.pdf" rel="documentation"/>
-    <issn>0019-8366</issn>
-    <eissn>1880-8026</eissn>
     <author>
       <name>Livio Tarchi</name>
     </author>
     <category citation-format="numeric"/>
     <category field="medicine"/>
+    <issn>0019-8366</issn>
+    <eissn>1880-8026</eissn>
     <summary>Based on the American Medical Association style..</summary>
     <updated>2022-12-24T22:43:34+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
@@ -102,7 +102,7 @@
     <sort>
       <key variable="citation-number"/>
     </sort>
-    <layout delimiter="," suffix=")"  vertical-align="sup">
+    <layout delimiter="," suffix=")" vertical-align="sup">
       <text variable="citation-number"/>
       <group prefix=", ">
         <label variable="locator" form="short" strip-periods="true"/>


### PR DESCRIPTION
Create style csl for Industrial Health, published by the Japan Organization of occupational health and Safety - ISSN: 0019-8366 (Print Version), ISSN: 1880-8026 (Online Version). The style is based on AMA 11th brackets, but it is superscript and right parenthesis only in the text. The bibliography is represented by numbers followed by right parenthesis ")" and not period "."