### PR TITLE
Include title transliteration

### DIFF
--- a/apa.csl
+++ b/apa.csl
@@ -1012,7 +1012,7 @@
     </group>
     <choose>
       <if match="any" variable="original-title">
-         <text variable="original-title" prefix="[" suffix="]"/>
+        <text variable="original-title" prefix="[" suffix="]"/>
       </if>
     </choose>
   </macro>

--- a/apa.csl
+++ b/apa.csl
@@ -1010,6 +1010,11 @@
         </else>
       </choose>
     </group>
+    <choose>
+      <if match="any" variable="original-title">
+         <text variable="original-title" prefix="[" suffix="]"/>
+      </if>
+    </choose>
   </macro>
   <macro name="bracketed-intext">
     <group prefix="[" suffix="]">


### PR DESCRIPTION
Guidance from APA: https://apastyle.apa.org/blog/transliterated-titles-references

The proposed solution is originally from @rrealrangel: https://gist.github.com/rrealrangel/1b11c587e6cadd1705a8d3b02ceb1717

Issues it fixes:
- https://forums.zotero.org/discussion/82405/csl-styles-that-handle-original-title
- https://forums.zotero.org/discussion/74386/how-to-reference-foreign-language-titles-according-to-apa-with-zotero

Original title appears according to APA guidelines if bib source contains "origtitle" tag  (Zotero Item Info / Extras contain "original-title")