### PR TITLE
Set citation givenname-disambiguation-rule=primary-name to ABNT styles

### DIFF
--- a/universidade-de-sao-paulo-escola-de-comunicacoes-e-artes-abnt.csl
+++ b/universidade-de-sao-paulo-escola-de-comunicacoes-e-artes-abnt.csl
@@ -15,7 +15,7 @@
     <category citation-format="author-date"/>
     <category field="generic-base"/>
     <summary>De acordo com ABNT-NBR 10520.2002 and ABNT-NBR 6023.2018</summary>
-    <updated>2019-11-21T16:57:15+00:00</updated>
+    <updated>2023-01-08T04:00:00+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale xml:lang="pt-BR">
@@ -95,7 +95,7 @@
     <names variable="author">
       <name form="short" name-as-sort-order="all" sort-separator=", " initialize-with=". " delimiter="; " delimiter-precedes-last="never">
         <name-part name="family" text-case="uppercase"/>
-        <name-part name="given" text-case="uppercase"/>
+        <name-part name="given"/>
       </name>
       <substitute>
         <names variable="editor"/>
@@ -339,7 +339,7 @@
       <text variable="archive" prefix=" "/>
     </group>
   </macro>
-  <citation et-al-min="4" et-al-use-first="1" collapse="year" disambiguate-add-year-suffix="true">
+  <citation et-al-min="4" et-al-use-first="1" collapse="year" disambiguate-add-year-suffix="true" disambiguate-add-names="true" disambiguate-add-givenname="true" givenname-disambiguation-rule="primary-name">
     <sort>
       <key macro="author"/>
       <key variable="issued"/>

--- a/universidade-do-estado-do-rio-de-janeiro-abnt.csl
+++ b/universidade-do-estado-do-rio-de-janeiro-abnt.csl
@@ -14,7 +14,7 @@
     </author>
     <category citation-format="author-date"/>
     <category field="generic-base"/>
-    <updated>2021-02-04T08:14:12+00:00</updated>
+    <updated>2023-01-08T04:00:00+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale xml:lang="pt-BR">
@@ -99,7 +99,7 @@
     <names variable="author">
       <name form="short" name-as-sort-order="all" sort-separator=", " initialize-with=". " delimiter="; " delimiter-precedes-last="never">
         <name-part name="family" text-case="uppercase"/>
-        <name-part name="given" text-case="uppercase"/>
+        <name-part name="given"/>
       </name>
       <substitute>
         <names variable="editor"/>
@@ -327,7 +327,7 @@
       <text variable="archive" prefix=" "/>
     </group>
   </macro>
-  <citation et-al-min="4" et-al-use-first="1" collapse="year" disambiguate-add-year-suffix="true">
+  <citation et-al-min="4" et-al-use-first="1" collapse="year" disambiguate-add-year-suffix="true" disambiguate-add-names="true" disambiguate-add-givenname="true" givenname-disambiguation-rule="primary-name">
     <sort>
       <key macro="issued-year"/>
       <key macro="author"/>

--- a/universidade-estadual-de-alagoas-abnt.csl
+++ b/universidade-estadual-de-alagoas-abnt.csl
@@ -16,7 +16,7 @@
     <category citation-format="author-date"/>
     <category field="generic-base"/>
     <summary>De acordo com ABNT-NBR 10520.2002 e ABNT-NBR 6023.2018</summary>
-    <updated>2022-02-18T19:02:00+00:00</updated>
+    <updated>2023-01-08T04:00:00+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale xml:lang="pt-BR">
@@ -120,7 +120,7 @@ do autor. Na regra da ABNT o sobrenome deve aparecer com todas as letras em caix
     <names variable="author">
       <name form="short" name-as-sort-order="all" sort-separator=", " initialize-with=". " delimiter="; " delimiter-precedes-last="never">
         <name-part name="family" text-case="uppercase"/>
-        <name-part name="given" text-case="uppercase"/>
+        <name-part name="given" text-case="capitalize-first"/>
       </name>
       <substitute>
         <names variable="editor"/>
@@ -391,7 +391,7 @@ em caixa alta. Utiliza-se antes do nome da conferencia a expressao "In". Segundo
   </macro>
   <!--Citacao-->
   <!--et al. aparece a partir de 04 autores-->
-  <citation et-al-min="4" et-al-use-first="1" collapse="year" disambiguate-add-year-suffix="true">
+  <citation et-al-min="4" et-al-use-first="1" collapse="year" disambiguate-add-year-suffix="true" disambiguate-add-names="true" disambiguate-add-givenname="true" givenname-disambiguation-rule="primary-name">
     <sort>
       <!--Puxa o autor primeiro-->
       <key macro="author"/>

--- a/universidade-estadual-paulista-campus-de-dracena-abnt.csl
+++ b/universidade-estadual-paulista-campus-de-dracena-abnt.csl
@@ -14,7 +14,7 @@
     <category citation-format="author-date"/>
     <category field="generic-base"/>
     <summary>The Brazilian Standard Style in accordance with ABNT-NBR 10520.2002 and ABNT-NBR 6023.2002</summary>
-    <updated>2018-06-08T11:25:37+00:00</updated>
+    <updated>2023-01-08T04:00:00+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale xml:lang="pt-BR">
@@ -99,7 +99,7 @@
     <names variable="author">
       <name form="short" name-as-sort-order="all" sort-separator=", " initialize-with=". " delimiter="; " delimiter-precedes-last="never">
         <name-part name="family" text-case="uppercase"/>
-        <name-part name="given" text-case="uppercase"/>
+        <name-part name="given" text-case="capitalize-first"/>
       </name>
       <substitute>
         <names variable="editor"/>
@@ -333,7 +333,7 @@
       <text variable="archive" prefix=" "/>
     </group>
   </macro>
-  <citation et-al-min="4" et-al-use-first="1" collapse="year" disambiguate-add-year-suffix="true">
+  <citation et-al-min="4" et-al-use-first="1" collapse="year" disambiguate-add-year-suffix="true" disambiguate-add-names="true" disambiguate-add-givenname="true" givenname-disambiguation-rule="primary-name">
     <sort>
       <key macro="author"/>
       <key variable="issued"/>

--- a/universidade-federal-de-juiz-de-fora.csl
+++ b/universidade-federal-de-juiz-de-fora.csl
@@ -26,7 +26,7 @@
     </contributor>
     <category citation-format="author-date"/>
     <category field="generic-base"/>
-    <updated>2018-05-01T12:00:00+00:00</updated>
+    <updated>2023-01-08T04:00:00+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale xml:lang="pt-BR">
@@ -193,7 +193,7 @@
     <names variable="author">
       <name form="short" name-as-sort-order="all" sort-separator=", " delimiter="; " delimiter-precedes-last="always">
         <name-part name="family" text-case="uppercase"/>
-        <name-part name="given" text-case="uppercase"/>
+        <name-part name="given" text-case="capitalize-first"/>
       </name>
       <et-al font-style="italic"/>
       <substitute>

--- a/universidade-federal-de-sergipe-departamento-de-engenharia-de-producao-abnt.csl
+++ b/universidade-federal-de-sergipe-departamento-de-engenharia-de-producao-abnt.csl
@@ -15,7 +15,7 @@
     <category citation-format="author-date"/>
     <category field="generic-base"/>
     <summary>Modelo de citações e referências para o Trabalho de Conclusão de Curso em Engenharia de Produção da UFS</summary>
-    <updated>2020-07-24T21:18:56+00:00</updated>
+    <updated>2023-01-08T04:00:00+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale xml:lang="pt-BR">
@@ -120,7 +120,7 @@
     <names variable="author">
       <name form="short" delimiter="; " delimiter-precedes-last="never" initialize-with=". " name-as-sort-order="all">
         <name-part name="family" text-case="uppercase"/>
-        <name-part name="given" text-case="uppercase"/>
+        <name-part name="given"/>
       </name>
       <et-al font-style="italic"/>
       <substitute>
@@ -414,7 +414,7 @@
       </else>
     </choose>
   </macro>
-  <citation et-al-min="4" et-al-use-first="1" disambiguate-add-year-suffix="true" collapse="year" delimiter-precedes-et-al="never">
+  <citation et-al-min="4" et-al-use-first="1" disambiguate-add-year-suffix="true" collapse="year" delimiter-precedes-et-al="never" disambiguate-add-names="true" disambiguate-add-givenname="true" givenname-disambiguation-rule="primary-name">
     <sort>
       <key macro="author"/>
       <key variable="issued"/>


### PR DESCRIPTION
Some ABNT styles used in Brazilian universities were missing a disambiguation-rule for the citation style.
This changes makes it fit with the rules in the [NBR 10520-2002](http://www2.uesb.br/biblioteca/wp-content/uploads/2016/05/NBR-10520-CITA%C3%87%C3%95ES.pdf).