### PR TITLE
Update apa-no-ampersand.csl

### DIFF
--- a/apa-no-ampersand.csl
+++ b/apa-no-ampersand.csl
@@ -1860,7 +1860,7 @@
       <text variable="locator"/>
     </group>
   </macro>
-  <citation et-al-min="3" et-al-use-first="1" disambiguate-add-year-suffix="true" disambiguate-add-names="true" disambiguate-add-givenname="true" collapse="year" givenname-disambiguation-rule="primary-name-with-initials">
+  <citation et-al-min="3" et-al-use-first="1" disambiguate-add-year-suffix="true" disambiguate-add-names="false" disambiguate-add-givenname="true" collapse="year" givenname-disambiguation-rule="primary-name-with-initials">
     <sort>
       <key macro="author-bib" names-min="3" names-use-first="1"/>
       <key macro="date-sort-group"/>


### PR DESCRIPTION
With disambiguate-add-names="true" et al was not functioning properly for >3. I believe default should be false to ensure it is first author + et al.