### PR TITLE
Update apa.csl

### DIFF
--- a/apa-6th-edition-no-ampersand.csl
+++ b/apa-6th-edition-no-ampersand.csl
@@ -1096,14 +1096,8 @@
     <!--This should be localized -->
     <choose>
       <if type="bill legal_case legislation" match="any"/>
-      <else-if type="interview motion_picture song" match="any">
-        <text value="Original work recorded"/>
-      </else-if>
-      <else-if type="broadcast">
-        <text value="Original work broadcast"/>
-      </else-if>
       <else>
-        <text value="Original work published"/>
+        <text term="original-work-published" text-case="capitalize-first"/>
       </else>
     </choose>
   </macro>

--- a/apa-6th-edition.csl
+++ b/apa-6th-edition.csl
@@ -1095,14 +1095,8 @@
     <!--This should be localized -->
     <choose>
       <if type="bill legal_case legislation" match="any"/>
-      <else-if type="interview motion_picture song" match="any">
-        <text value="Original work recorded"/>
-      </else-if>
-      <else-if type="broadcast">
-        <text value="Original work broadcast"/>
-      </else-if>
       <else>
-        <text value="Original work published"/>
+        <text term="original-work-published" text-case="capitalize-first"/>
       </else>
     </choose>
   </macro>

--- a/apa-annotated-bibliography.csl
+++ b/apa-annotated-bibliography.csl
@@ -1598,7 +1598,7 @@
             </if>
             <else>
               <group delimiter=" ">
-                <text value="Original work published"/>
+                <text term="original-work-published" text-case="capitalize-first"/>
                 <choose>
                   <if is-uncertain-date="original-date">
                     <text term="circa" form="short"/>

--- a/apa-cv.csl
+++ b/apa-cv.csl
@@ -1345,7 +1345,7 @@
             </if>
             <else>
               <group delimiter=" ">
-                <text value="Original work published"/>
+                <text term="original-work-published" text-case="capitalize-first"/>
                 <choose>
                   <if is-uncertain-date="original-date">
                     <text term="circa" form="short"/>

--- a/apa-no-ampersand.csl
+++ b/apa-no-ampersand.csl
@@ -1598,7 +1598,7 @@
             </if>
             <else>
               <group delimiter=" ">
-                <text value="Original work published"/>
+                <text term="original-work-published" text-case="capitalize-first"/>
                 <choose>
                   <if is-uncertain-date="original-date">
                     <text term="circa" form="short"/>

--- a/apa-no-doi-no-issue.csl
+++ b/apa-no-doi-no-issue.csl
@@ -1102,14 +1102,8 @@
     <!--This should be localized -->
     <choose>
       <if type="bill legal_case legislation" match="any"/>
-      <else-if type="interview motion_picture song" match="any">
-        <text value="Original work recorded"/>
-      </else-if>
-      <else-if type="broadcast">
-        <text value="Original work broadcast"/>
-      </else-if>
       <else>
-        <text value="Original work published"/>
+        <text term="original-work-published" text-case="capitalize-first"/>
       </else>
     </choose>
   </macro>

--- a/apa-no-initials.csl
+++ b/apa-no-initials.csl
@@ -1598,7 +1598,7 @@
             </if>
             <else>
               <group delimiter=" ">
-                <text value="Original work published"/>
+                <text term="original-work-published" text-case="capitalize-first"/>
                 <choose>
                   <if is-uncertain-date="original-date">
                     <text term="circa" form="short"/>

--- a/apa-numeric-superscript-brackets.csl
+++ b/apa-numeric-superscript-brackets.csl
@@ -1401,7 +1401,7 @@
             </if>
             <else>
               <group delimiter=" ">
-                <text value="Original work published"/>
+                <text term="original-work-published" text-case="capitalize-first"/>
                 <choose>
                   <if is-uncertain-date="original-date">
                     <text term="circa" form="short"/>

--- a/apa-numeric-superscript.csl
+++ b/apa-numeric-superscript.csl
@@ -1401,7 +1401,7 @@
             </if>
             <else>
               <group delimiter=" ">
-                <text value="Original work published"/>
+                <text term="original-work-published" text-case="capitalize-first"/>
                 <choose>
                   <if is-uncertain-date="original-date">
                     <text term="circa" form="short"/>

--- a/apa-old-doi-prefix.csl
+++ b/apa-old-doi-prefix.csl
@@ -1096,14 +1096,8 @@
     <!--This should be localized -->
     <choose>
       <if type="bill legal_case legislation" match="any"/>
-      <else-if type="interview motion_picture song" match="any">
-        <text value="Original work recorded"/>
-      </else-if>
-      <else-if type="broadcast">
-        <text value="Original work broadcast"/>
-      </else-if>
       <else>
-        <text value="Original work published"/>
+        <text term="original-work-published" text-case="capitalize-first"/>
       </else>
     </choose>
   </macro>

--- a/apa-single-spaced.csl
+++ b/apa-single-spaced.csl
@@ -1598,7 +1598,7 @@
             </if>
             <else>
               <group delimiter=" ">
-                <text value="Original work published"/>
+                <text term="original-work-published" text-case="capitalize-first"/>
                 <choose>
                   <if is-uncertain-date="original-date">
                     <text term="circa" form="short"/>

--- a/apa-with-abstract.csl
+++ b/apa-with-abstract.csl
@@ -1598,7 +1598,7 @@
             </if>
             <else>
               <group delimiter=" ">
-                <text value="Original work published"/>
+                <text term="original-work-published" text-case="capitalize-first"/>
                 <choose>
                   <if is-uncertain-date="original-date">
                     <text term="circa" form="short"/>

--- a/apa.csl
+++ b/apa.csl
@@ -14,7 +14,7 @@
     <category citation-format="author-date"/>
     <category field="psychology"/>
     <category field="generic-base"/>
-    <updated>2022-01-31T14:30:00+00:00</updated>
+    <updated>2023-01-27T17:13:03+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale xml:lang="en">
@@ -41,42 +41,49 @@
         <single>issue</single>
         <multiple>issues</multiple>
       </term>
+      <term name="original-work-published">Original work published</term>
     </terms>
   </locale>
   <locale xml:lang="af">
     <terms>
       <term name="letter">persoonlike kommunikasie</term>
       <term name="letter" form="short">brief</term>
+      <term name="original-work-published">Oorspronklike werk gepubliseer</term>
     </terms>
   </locale>
   <locale xml:lang="ar">
     <terms>
       <term name="letter">اتصال شخصي</term>
       <term name="letter" form="short">خطاب</term>
+      <term name="original-work-published">تم نشر العمل الأصلي عام</term>
     </terms>
   </locale>
   <locale xml:lang="bg">
     <terms>
       <term name="letter">лична комуникация</term>
       <term name="letter" form="short">писмо</term>
+      <term name="original-work-published">Публикуван оригинален труд</term>
     </terms>
   </locale>
   <locale xml:lang="ca">
     <terms>
       <term name="letter">comunicació personal</term>
       <term name="letter" form="short">carta</term>
+      <term name="original-work-published">Obra original publicada</term>
     </terms>
   </locale>
   <locale xml:lang="cs">
     <terms>
       <term name="letter">osobní komunikace</term>
       <term name="letter" form="short">dopis</term>
+      <term name="original-work-published">Původní práce publikována</term>
     </terms>
   </locale>
   <locale xml:lang="cy">
     <terms>
       <term name="letter">cyfathrebu personol</term>
       <term name="letter" form="short">llythyr</term>
+      <term name="original-work-published">Gwaith gwreiddiol wedi ei gyhoeddi</term>
     </terms>
   </locale>
   <locale xml:lang="da">
@@ -84,6 +91,7 @@
       <term name="et-al">et al.</term>
       <term name="letter">personlig kommunikation</term>
       <term name="letter" form="short">brev</term>
+      <term name="original-work-published">Originalt værk udgivet</term>
     </terms>
   </locale>
   <locale xml:lang="de">
@@ -91,12 +99,14 @@
       <term name="et-al">et al.</term>
       <term name="letter">persönliche Kommunikation</term>
       <term name="letter" form="short">Brief</term>
+      <term name="original-work-published">Originalarbeit veröffentlicht</term>
     </terms>
   </locale>
   <locale xml:lang="el">
     <terms>
       <term name="letter">προσωπική επικοινωνία</term>
       <term name="letter" form="short">επιστολή</term>
+      <term name="original-work-published">Εκδόθηκε πρωτότυπη εργασία</term>
     </terms>
   </locale>
   <locale xml:lang="es">
@@ -104,30 +114,35 @@
       <term name="from">de</term>
       <term name="letter">comunicación personal</term>
       <term name="letter" form="short">carta</term>
+      <term name="original-work-published">Obra original publicada en</term>
     </terms>
   </locale>
   <locale xml:lang="et">
     <terms>
       <term name="letter">isiklik suhtlus</term>
       <term name="letter" form="short">kiri</term>
+      <term name="original-work-published">Originaalteos avaldatud</term>
     </terms>
   </locale>
   <locale xml:lang="eu">
     <terms>
       <term name="letter">komunikazio pertsonala</term>
       <term name="letter" form="short">gutuna</term>
+      <term name="original-work-published">Jatorrizko lana argitaratua</term>
     </terms>
   </locale>
   <locale xml:lang="fa">
     <terms>
       <term name="letter">ارتباط شخصی</term>
       <term name="letter" form="short">نامه</term>
+      <term name="original-work-published">اثر اصلی منتشر شده است</term>
     </terms>
   </locale>
   <locale xml:lang="fi">
     <terms>
       <term name="letter">henkilökohtainen viestintä</term>
       <term name="letter" form="short">kirje</term>
+      <term name="original-work-published">Alkuperäinen teos julkaistu</term>
     </terms>
   </locale>
   <locale xml:lang="fr">
@@ -138,78 +153,91 @@
         <single>éd.</single>
         <multiple>éds.</multiple>
       </term>
+      <term name="original-work-published">Ouvrage original publié</term>
     </terms>
   </locale>
   <locale xml:lang="he">
     <terms>
       <term name="letter">תקשורת אישית</term>
       <term name="letter" form="short">מכתב</term>
+      <term name="original-work-published">עבודה מקורית פורסמה</term>
     </terms>
   </locale>
   <locale xml:lang="hr">
     <terms>
       <term name="letter">osobna komunikacija</term>
       <term name="letter" form="short">pismo</term>
+      <term name="original-work-published">Izvorni rad objavljen</term>
     </terms>
   </locale>
   <locale xml:lang="hu">
     <terms>
       <term name="letter">személyes kommunikáció</term>
       <term name="letter" form="short">levél</term>
+      <term name="original-work-published">Az eredeti mű megjelent</term>
     </terms>
   </locale>
   <locale xml:lang="id">
     <terms>
       <term name="letter">komunikasi pribadi</term>
       <term name="letter" form="short">surat</term>
+      <term name="original-work-published">Karya asli diterbitkan</term>
     </terms>
   </locale>
   <locale xml:lang="is">
     <terms>
       <term name="letter">persónuleg samskipti</term>
       <term name="letter" form="short">bréf</term>
+      <term name="original-work-published">Frumrit gefið út</term>
     </terms>
   </locale>
   <locale xml:lang="it">
     <terms>
       <term name="letter">comunicazione personale</term>
       <term name="letter" form="short">lettera</term>
+      <term name="original-work-published">Opera originale pubblicata</term>
     </terms>
   </locale>
   <locale xml:lang="ja">
     <terms>
       <term name="letter">個人的なやり取り</term>
       <term name="letter" form="short">手紙</term>
+      <term name="original-work-published">オリジナル作品を公開</term>
     </terms>
   </locale>
   <locale xml:lang="ko">
     <terms>
       <term name="letter">개인 서신</term>
       <term name="letter" form="short">편지</term>
+      <term name="original-work-published">원작 공개</term>
     </terms>
   </locale>
   <locale xml:lang="la">
     <terms>
-      <term name="letter"/>
+      <term name="letter">communicationis personalis</term>
       <term name="letter" form="short">epistula</term>
+      <term name="original-work-published">Originale opus editum</term>
     </terms>
   </locale>
   <locale xml:lang="lt">
     <terms>
-      <term name="letter">communicationis personalis</term>
-      <term name="letter" form="short"/>
+      <term name="letter">asmeninis bendravimas</term>
+      <term name="letter" form="short">laišką</term>
+      <term name="original-work-published">Originalus darbas paskelbtas</term>
     </terms>
   </locale>
   <locale xml:lang="lv">
     <terms>
       <term name="letter">personīga komunikācija</term>
       <term name="letter" form="short">vēstule</term>
+      <term name="original-work-published">Publicēts oriģināldarbs</term>
     </terms>
   </locale>
   <locale xml:lang="mn">
     <terms>
       <term name="letter">хувийн харилцаа холбоо</term>
       <term name="letter" form="short">захиа</term>
+      <term name="original-work-published">Жинхэнэ бүтээл хэвлэгдсэн</term>
     </terms>
   </locale>
   <locale xml:lang="nb">
@@ -217,6 +245,7 @@
       <term name="et-al">et al.</term>
       <term name="letter">personlig kommunikasjon</term>
       <term name="letter" form="short">brev</term>
+      <term name="original-work-published">Originalt verk publisert</term>
     </terms>
   </locale>
   <locale xml:lang="nl">
@@ -224,6 +253,7 @@
       <term name="et-al">et al.</term>
       <term name="letter">persoonlijke communicatie</term>
       <term name="letter" form="short">brief</term>
+      <term name="original-work-published">Origineel werk gepubliceerd</term>
     </terms>
   </locale>
   <locale xml:lang="nn">
@@ -231,92 +261,108 @@
       <term name="et-al">et al.</term>
       <term name="letter">personlig kommunikasjon</term>
       <term name="letter" form="short">brev</term>
+      <term name="original-work-published">Originalt verk publisert</term>
     </terms>
   </locale>
   <locale xml:lang="pl">
     <terms>
       <term name="letter">osobista komunikacja</term>
       <term name="letter" form="short">list</term>
+      <term name="original-work-published">Opublikowano oryginalną pracę</term>
     </terms>
   </locale>
   <locale xml:lang="pt">
     <terms>
       <term name="letter">comunicação pessoal</term>
       <term name="letter" form="short">carta</term>
+      <term name="original-work-published">Trabalho original publicado</term>
     </terms>
   </locale>
   <locale xml:lang="ro">
     <terms>
       <term name="letter">comunicare personală</term>
       <term name="letter" form="short">scrisoare</term>
+      <term name="original-work-published">Lucrare originală publicată</term>
     </terms>
   </locale>
   <locale xml:lang="ru">
     <terms>
       <term name="letter">личная переписка</term>
       <term name="letter" form="short">письмо</term>
+      <term name="original-work-published">Оригинальная работа опубликована</term>
     </terms>
   </locale>
   <locale xml:lang="sk">
     <terms>
       <term name="letter">osobná komunikácia</term>
       <term name="letter" form="short">list</term>
+      <term name="original-work-published">Pôvodné dielo publikované</term>
     </terms>
   </locale>
   <locale xml:lang="sl">
     <terms>
       <term name="letter">osebna komunikacija</term>
       <term name="letter" form="short">pismo</term>
+      <term name="original-work-published">Objavljeno izvirno delo</term>
     </terms>
   </locale>
   <locale xml:lang="sr">
     <terms>
       <term name="letter">лична комуникација</term>
       <term name="letter" form="short">писмо</term>
+      <term name="original-work-published">Објављено оригинално дело</term>
     </terms>
   </locale>
   <locale xml:lang="sv">
     <terms>
       <term name="letter">personlig kommunikation</term>
       <term name="letter" form="short">brev</term>
+      <term name="original-work-published">Originalverk publicerat</term>
     </terms>
   </locale>
   <locale xml:lang="th">
     <terms>
       <term name="letter">การสื่อสารส่วนบุคคล</term>
       <term name="letter" form="short">จดหมาย</term>
+      <term name="original-work-published">เผยแพร่งานต้นฉบับแล้ว</term>
     </terms>
   </locale>
   <locale xml:lang="tr">
     <terms>
       <term name="letter">kişisel iletişim</term>
       <term name="letter" form="short">mektup</term>
+      <term name="original-work-published">Orijinal çalışma yayınlandı</term>
     </terms>
   </locale>
   <locale xml:lang="uk">
     <terms>
       <term name="letter">особисте спілкування</term>
       <term name="letter" form="short">лист</term>
+      <term name="original-work-published">Опубліковано оригінальний твір</term>
     </terms>
   </locale>
   <locale xml:lang="vi">
     <terms>
       <term name="letter">giao tiếp cá nhân</term>
       <term name="letter" form="short">thư</term>
+      <term name="original-work-published">Tác phẩm gốc đã xuất bản</term>
     </terms>
   </locale>
   <locale xml:lang="zh-CN">
     <terms>
       <term name="letter">的私人交流</term>
       <term name="letter" form="short">信函</term>
+      <term name="original-work-published">原创作品发表</term>
     </terms>
   </locale>
   <locale xml:lang="zh-TW">
     <terms>
       <term name="letter">私人通訊</term>
       <term name="letter" form="short">信函</term>
+      <term name="original-work-published">原創作品發表</term>
     </terms>
   </locale>
+  
   <!-- General categories of item types:
        Periodical: article-journal article-magazine article-newspaper post-weblog review review-book
        Periodical or Booklike: paper-conference
@@ -1599,7 +1645,7 @@
             </if>
             <else>
               <group delimiter=" ">
-                <text value="Original work published"/>
+                <text term="original-work-published"/>
                 <choose>
                   <if is-uncertain-date="original-date">
                     <text term="circa" form="short"/>

--- a/apa.csl
+++ b/apa.csl
@@ -14,7 +14,7 @@
     <category citation-format="author-date"/>
     <category field="psychology"/>
     <category field="generic-base"/>
-    <updated>2023-01-27T17:13:03+00:00</updated>
+    <updated>2022-10-02T20:08:41+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale xml:lang="en">
@@ -41,49 +41,42 @@
         <single>issue</single>
         <multiple>issues</multiple>
       </term>
-      <term name="original-work-published">Original work published</term>
     </terms>
   </locale>
   <locale xml:lang="af">
     <terms>
       <term name="letter">persoonlike kommunikasie</term>
       <term name="letter" form="short">brief</term>
-      <term name="original-work-published">Oorspronklike werk gepubliseer</term>
     </terms>
   </locale>
   <locale xml:lang="ar">
     <terms>
       <term name="letter">اتصال شخصي</term>
       <term name="letter" form="short">خطاب</term>
-      <term name="original-work-published">تم نشر العمل الأصلي عام</term>
     </terms>
   </locale>
   <locale xml:lang="bg">
     <terms>
       <term name="letter">лична комуникация</term>
       <term name="letter" form="short">писмо</term>
-      <term name="original-work-published">Публикуван оригинален труд</term>
     </terms>
   </locale>
   <locale xml:lang="ca">
     <terms>
       <term name="letter">comunicació personal</term>
       <term name="letter" form="short">carta</term>
-      <term name="original-work-published">Obra original publicada</term>
     </terms>
   </locale>
   <locale xml:lang="cs">
     <terms>
       <term name="letter">osobní komunikace</term>
       <term name="letter" form="short">dopis</term>
-      <term name="original-work-published">Původní práce publikována</term>
     </terms>
   </locale>
   <locale xml:lang="cy">
     <terms>
       <term name="letter">cyfathrebu personol</term>
       <term name="letter" form="short">llythyr</term>
-      <term name="original-work-published">Gwaith gwreiddiol wedi ei gyhoeddi</term>
     </terms>
   </locale>
   <locale xml:lang="da">
@@ -91,7 +84,6 @@
       <term name="et-al">et al.</term>
       <term name="letter">personlig kommunikation</term>
       <term name="letter" form="short">brev</term>
-      <term name="original-work-published">Originalt værk udgivet</term>
     </terms>
   </locale>
   <locale xml:lang="de">
@@ -99,14 +91,12 @@
       <term name="et-al">et al.</term>
       <term name="letter">persönliche Kommunikation</term>
       <term name="letter" form="short">Brief</term>
-      <term name="original-work-published">Originalarbeit veröffentlicht</term>
     </terms>
   </locale>
   <locale xml:lang="el">
     <terms>
       <term name="letter">προσωπική επικοινωνία</term>
       <term name="letter" form="short">επιστολή</term>
-      <term name="original-work-published">Εκδόθηκε πρωτότυπη εργασία</term>
     </terms>
   </locale>
   <locale xml:lang="es">
@@ -114,35 +104,30 @@
       <term name="from">de</term>
       <term name="letter">comunicación personal</term>
       <term name="letter" form="short">carta</term>
-      <term name="original-work-published">Obra original publicada en</term>
     </terms>
   </locale>
   <locale xml:lang="et">
     <terms>
       <term name="letter">isiklik suhtlus</term>
       <term name="letter" form="short">kiri</term>
-      <term name="original-work-published">Originaalteos avaldatud</term>
     </terms>
   </locale>
   <locale xml:lang="eu">
     <terms>
       <term name="letter">komunikazio pertsonala</term>
       <term name="letter" form="short">gutuna</term>
-      <term name="original-work-published">Jatorrizko lana argitaratua</term>
     </terms>
   </locale>
   <locale xml:lang="fa">
     <terms>
       <term name="letter">ارتباط شخصی</term>
       <term name="letter" form="short">نامه</term>
-      <term name="original-work-published">اثر اصلی منتشر شده است</term>
     </terms>
   </locale>
   <locale xml:lang="fi">
     <terms>
       <term name="letter">henkilökohtainen viestintä</term>
       <term name="letter" form="short">kirje</term>
-      <term name="original-work-published">Alkuperäinen teos julkaistu</term>
     </terms>
   </locale>
   <locale xml:lang="fr">
@@ -153,91 +138,78 @@
         <single>éd.</single>
         <multiple>éds.</multiple>
       </term>
-      <term name="original-work-published">Ouvrage original publié</term>
     </terms>
   </locale>
   <locale xml:lang="he">
     <terms>
       <term name="letter">תקשורת אישית</term>
       <term name="letter" form="short">מכתב</term>
-      <term name="original-work-published">עבודה מקורית פורסמה</term>
     </terms>
   </locale>
   <locale xml:lang="hr">
     <terms>
       <term name="letter">osobna komunikacija</term>
       <term name="letter" form="short">pismo</term>
-      <term name="original-work-published">Izvorni rad objavljen</term>
     </terms>
   </locale>
   <locale xml:lang="hu">
     <terms>
       <term name="letter">személyes kommunikáció</term>
       <term name="letter" form="short">levél</term>
-      <term name="original-work-published">Az eredeti mű megjelent</term>
     </terms>
   </locale>
   <locale xml:lang="id">
     <terms>
       <term name="letter">komunikasi pribadi</term>
       <term name="letter" form="short">surat</term>
-      <term name="original-work-published">Karya asli diterbitkan</term>
     </terms>
   </locale>
   <locale xml:lang="is">
     <terms>
       <term name="letter">persónuleg samskipti</term>
       <term name="letter" form="short">bréf</term>
-      <term name="original-work-published">Frumrit gefið út</term>
     </terms>
   </locale>
   <locale xml:lang="it">
     <terms>
       <term name="letter">comunicazione personale</term>
       <term name="letter" form="short">lettera</term>
-      <term name="original-work-published">Opera originale pubblicata</term>
     </terms>
   </locale>
   <locale xml:lang="ja">
     <terms>
       <term name="letter">個人的なやり取り</term>
       <term name="letter" form="short">手紙</term>
-      <term name="original-work-published">オリジナル作品を公開</term>
     </terms>
   </locale>
   <locale xml:lang="ko">
     <terms>
       <term name="letter">개인 서신</term>
       <term name="letter" form="short">편지</term>
-      <term name="original-work-published">원작 공개</term>
     </terms>
   </locale>
   <locale xml:lang="la">
     <terms>
-      <term name="letter">communicationis personalis</term>
+      <term name="letter"/>
       <term name="letter" form="short">epistula</term>
-      <term name="original-work-published">Originale opus editum</term>
     </terms>
   </locale>
   <locale xml:lang="lt">
     <terms>
-      <term name="letter">asmeninis bendravimas</term>
-      <term name="letter" form="short">laišką</term>
-      <term name="original-work-published">Originalus darbas paskelbtas</term>
+      <term name="letter">communicationis personalis</term>
+      <term name="letter" form="short"/>
     </terms>
   </locale>
   <locale xml:lang="lv">
     <terms>
       <term name="letter">personīga komunikācija</term>
       <term name="letter" form="short">vēstule</term>
-      <term name="original-work-published">Publicēts oriģināldarbs</term>
     </terms>
   </locale>
   <locale xml:lang="mn">
     <terms>
       <term name="letter">хувийн харилцаа холбоо</term>
       <term name="letter" form="short">захиа</term>
-      <term name="original-work-published">Жинхэнэ бүтээл хэвлэгдсэн</term>
     </terms>
   </locale>
   <locale xml:lang="nb">
@@ -245,7 +217,6 @@
       <term name="et-al">et al.</term>
       <term name="letter">personlig kommunikasjon</term>
       <term name="letter" form="short">brev</term>
-      <term name="original-work-published">Originalt verk publisert</term>
     </terms>
   </locale>
   <locale xml:lang="nl">
@@ -253,7 +224,6 @@
       <term name="et-al">et al.</term>
       <term name="letter">persoonlijke communicatie</term>
       <term name="letter" form="short">brief</term>
-      <term name="original-work-published">Origineel werk gepubliceerd</term>
     </terms>
   </locale>
   <locale xml:lang="nn">
@@ -261,105 +231,90 @@
       <term name="et-al">et al.</term>
       <term name="letter">personlig kommunikasjon</term>
       <term name="letter" form="short">brev</term>
-      <term name="original-work-published">Originalt verk publisert</term>
     </terms>
   </locale>
   <locale xml:lang="pl">
     <terms>
       <term name="letter">osobista komunikacja</term>
       <term name="letter" form="short">list</term>
-      <term name="original-work-published">Opublikowano oryginalną pracę</term>
     </terms>
   </locale>
   <locale xml:lang="pt">
     <terms>
       <term name="letter">comunicação pessoal</term>
       <term name="letter" form="short">carta</term>
-      <term name="original-work-published">Trabalho original publicado</term>
     </terms>
   </locale>
   <locale xml:lang="ro">
     <terms>
       <term name="letter">comunicare personală</term>
       <term name="letter" form="short">scrisoare</term>
-      <term name="original-work-published">Lucrare originală publicată</term>
     </terms>
   </locale>
   <locale xml:lang="ru">
     <terms>
       <term name="letter">личная переписка</term>
       <term name="letter" form="short">письмо</term>
-      <term name="original-work-published">Оригинальная работа опубликована</term>
     </terms>
   </locale>
   <locale xml:lang="sk">
     <terms>
       <term name="letter">osobná komunikácia</term>
       <term name="letter" form="short">list</term>
-      <term name="original-work-published">Pôvodné dielo publikované</term>
     </terms>
   </locale>
   <locale xml:lang="sl">
     <terms>
       <term name="letter">osebna komunikacija</term>
       <term name="letter" form="short">pismo</term>
-      <term name="original-work-published">Objavljeno izvirno delo</term>
     </terms>
   </locale>
   <locale xml:lang="sr">
     <terms>
       <term name="letter">лична комуникација</term>
       <term name="letter" form="short">писмо</term>
-      <term name="original-work-published">Објављено оригинално дело</term>
     </terms>
   </locale>
   <locale xml:lang="sv">
     <terms>
       <term name="letter">personlig kommunikation</term>
       <term name="letter" form="short">brev</term>
-      <term name="original-work-published">Originalverk publicerat</term>
     </terms>
   </locale>
   <locale xml:lang="th">
     <terms>
       <term name="letter">การสื่อสารส่วนบุคคล</term>
       <term name="letter" form="short">จดหมาย</term>
-      <term name="original-work-published">เผยแพร่งานต้นฉบับแล้ว</term>
     </terms>
   </locale>
   <locale xml:lang="tr">
     <terms>
       <term name="letter">kişisel iletişim</term>
       <term name="letter" form="short">mektup</term>
-      <term name="original-work-published">Orijinal çalışma yayınlandı</term>
     </terms>
   </locale>
   <locale xml:lang="uk">
     <terms>
       <term name="letter">особисте спілкування</term>
       <term name="letter" form="short">лист</term>
-      <term name="original-work-published">Опубліковано оригінальний твір</term>
     </terms>
   </locale>
   <locale xml:lang="vi">
     <terms>
       <term name="letter">giao tiếp cá nhân</term>
       <term name="letter" form="short">thư</term>
-      <term name="original-work-published">Tác phẩm gốc đã xuất bản</term>
     </terms>
   </locale>
   <locale xml:lang="zh-CN">
     <terms>
       <term name="letter">的私人交流</term>
       <term name="letter" form="short">信函</term>
-      <term name="original-work-published">原创作品发表</term>
     </terms>
   </locale>
   <locale xml:lang="zh-TW">
     <terms>
       <term name="letter">私人通訊</term>
       <term name="letter" form="short">信函</term>
-      <term name="original-work-published">原創作品發表</term>
     </terms>
   </locale>
   <!-- General categories of item types:
@@ -1644,7 +1599,7 @@
             </if>
             <else>
               <group delimiter=" ">
-                <text term="original-work-published"/>
+                <text term="original-work-published" text-case="capitalize-first"/>
                 <choose>
                   <if is-uncertain-date="original-date">
                     <text term="circa" form="short"/>

--- a/apa.csl
+++ b/apa.csl
@@ -362,7 +362,6 @@
       <term name="original-work-published">原創作品發表</term>
     </terms>
   </locale>
-  
   <!-- General categories of item types:
        Periodical: article-journal article-magazine article-newspaper post-weblog review review-book
        Periodical or Booklike: paper-conference


### PR DESCRIPTION
This is for localizing the “Original work published” text that appears at the end of a reference when the original date of a work is present. I created the term "original-work-published" within each locale section. Then, I used Google Translate to add a translation to each locale (but for Spanish, which is my first language). Next, in the macro “publication history", I replaced the “text value” with the correspondent “text term” I created.  I also corrected some mistakes in Latin (la) and Lithuanian (lt) locales.