### PR TITLE
Update ucl-university-college-apa.csl

### DIFF
--- a/ucl-university-college-apa.csl
+++ b/ucl-university-college-apa.csl
@@ -17,7 +17,7 @@
     </contributor>
     <category citation-format="author-date"/>
     <category field="generic-base"/>
-    <updated>2022-09-06T13:44:06+00:00</updated>
+    <updated>2022-11-23T04:08:10+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale xml:lang="da">
@@ -1580,6 +1580,7 @@
   </citation>
   <bibliography hanging-indent="true" et-al-min="21" et-al-use-first="19" et-al-use-last="true" entry-spacing="0" line-spacing="2">
     <sort>
+      <key macro="legal-cites"/>
       <key macro="author-bib"/>
       <key macro="date-sort-group"/>
       <key macro="date-sort-date" sort="ascending"/>


### PR DESCRIPTION
Changed the sort order of key macros.
He had difficulties with legislation being sorted under author in the bibliography, where it should not. In Denmark we sort legislation under title (or short title). This quick fix solved it, without apparently affecting the sorting of other material in a negative way.