### PR TITLE
Update journal-of-neolithic-archaeology.csl

### DIFF
--- a/journal-of-neolithic-archaeology.csl
+++ b/journal-of-neolithic-archaeology.csl
@@ -378,10 +378,6 @@
     </choose>
   </macro>
   <citation et-al-min="3" et-al-use-first="1" disambiguate-add-year-suffix="true">
-    <sort>
-      <key variable="issued"/>
-      <key macro="contributors-short-citation"/>
-    </sort>
     <layout prefix="(" suffix=")" delimiter="; ">
       <group delimiter=", ">
         <group delimiter=" ">


### PR DESCRIPTION
Remove the automatic sort order of in-text citations. It is more hindering than helpful.