### PR TITLE
Create north-pacific-anadromous-fish-commission-bulletin.csl

### DIFF
--- a/north-pacific-anadromous-fish-commission-bulletin.csl
+++ b/north-pacific-anadromous-fish-commission-bulletin.csl
@@ -17,7 +17,7 @@
     <category field="biology"/>
     <issn>1028-9127</issn>
     <summary>Style for NPAFC Bulletin</summary>
-    <updated>2023-02-25T00:07:43+00:00</updated>
+    <updated>2023-03-01T17:15:32+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale xml:lang="en-US">
@@ -158,7 +158,7 @@
     <choose>
       <if type="motion_picture broadcast article-newspaper article-magazine" match="none">
         <names variable="author">
-          <name and="text" delimiter-precedes-last="never" initialize-with="." name-as-sort-order="first"/>
+          <name and="text" delimiter-precedes-last="always" initialize-with="." name-as-sort-order="first"/>
           <label form="short" prefix=" (" suffix=")."/>
           <substitute>
             <names variable="editor"/>
@@ -171,7 +171,7 @@
         <choose>
           <if variable="author editor translator" match="any">
             <names variable="author">
-              <name name-as-sort-order="all" sort-separator=", " initialize-with="." delimiter="; " and="text" delimiter-precedes-last="never"/>
+              <name delimiter="; " and="text" delimiter-precedes-last="always" initialize-with="." name-as-sort-order="all"/>
               <label form="short" prefix=" (" suffix=")."/>
               <substitute>
                 <names variable="editor"/>
@@ -188,10 +188,10 @@
       <else>
         <choose>
           <if variable="container-title">
-            <text variable="container-title" font-style="italic"/>
+            <text variable="container-title" font-style="normal"/>
           </if>
           <else>
-            <text variable="title" font-style="italic"/>
+            <text variable="title" font-style="normal"/>
           </else>
         </choose>
       </else>
@@ -234,7 +234,7 @@
         <group delimiter=".  ">
           <choose>
             <if variable="ISBN ISSN" match="any">
-              <text variable="title" font-style="italic" text-case="capitalize-first"/>
+              <text variable="title" font-style="normal" text-case="capitalize-first"/>
             </if>
             <else>
               <text variable="title" text-case="capitalize-first"/>
@@ -250,7 +250,7 @@
         <group delimiter=".  ">
           <choose>
             <if variable="ISBN ISSN" match="any">
-              <text variable="title" font-style="italic" text-case="capitalize-first"/>
+              <text variable="title" font-style="normal" text-case="capitalize-first"/>
               <text variable="genre"/>
             </if>
             <else>
@@ -264,7 +264,7 @@
         <group delimiter=".  ">
           <choose>
             <if variable="publisher ISBN ISSN" match="any">
-              <text variable="title" text-case="title" font-style="italic"/>
+              <text variable="title" text-case="title" font-style="normal"/>
             </if>
             <else>
               <text variable="title" text-case="capitalize-first" font-style="normal"/>
@@ -289,7 +289,7 @@
       <else>
         <choose>
           <if variable="ISBN ISSN" match="any">
-            <text variable="title" font-style="italic" text-case="capitalize-first"/>
+            <text variable="title" font-style="normal" text-case="capitalize-first"/>
           </if>
           <else>
             <text variable="title" text-case="capitalize-first"/>
@@ -317,7 +317,7 @@
   <macro name="event">
     <choose>
       <if variable="editor" match="any">
-        <text variable="event" font-style="italic"/>
+        <text variable="event" font-style="normal"/>
       </if>
       <else>
         <text variable="event"/>

--- a/north-pacific-anadromous-fish-commission-bulletin.csl
+++ b/north-pacific-anadromous-fish-commission-bulletin.csl
@@ -17,7 +17,7 @@
     <category field="biology"/>
     <issn>1028-9127</issn>
     <summary>Style for NPAFC Bulletin</summary>
-    <updated>2023-03-01T17:15:32+00:00</updated>
+    <updated>2023-03-22T15:42:30+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale xml:lang="en-US">
@@ -150,7 +150,7 @@
         </choose>
       </else-if>
       <else>
-        <text variable="container-title" text-case="title" font-style="normal"/>
+        <text variable="container-title" form="short" text-case="title" font-style="normal"/>
       </else>
     </choose>
   </macro>

--- a/north-pacific-anadromous-fish-commission-bulletin.csl
+++ b/north-pacific-anadromous-fish-commission-bulletin.csl
@@ -8,12 +8,14 @@
     <link href="http://www.zotero.org/styles/north-pacific-anadromous-fish-commission-bulletin" rel="self"/>
     <link href="http://www.zotero.org/styles/water-alternatives" rel="template"/>
     <link href="https://npafc.org/bulletin/" rel="documentation"/>
+    <link href="https://github.com/citation-style-language/styles/pull/6436#issue-1603667772" rel="documentation"/>
     <author>
       <name>Brett Johnson</name>
       <email>brett.johnson@hakai.org</email>
     </author>
     <category citation-format="author-date"/>
     <category field="biology"/>
+    <issn>1028-9127</issn>
     <summary>Style for NPAFC Bulletin</summary>
     <updated>2023-02-25T00:07:43+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>

--- a/north-pacific-anadromous-fish-commission-bulletin.csl
+++ b/north-pacific-anadromous-fish-commission-bulletin.csl
@@ -1,0 +1,519 @@
+<?xml version="1.0" encoding="utf-8"?>
+<style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" demote-non-dropping-particle="sort-only" default-locale="en-US">
+  <!-- This style was edited with the Visual CSL Editor (https://editor.citationstyles.org/visualEditor/) -->
+  <info>
+    <title>North Pacific Anadromous Fish Commission Bulletin</title>
+    <title-short>NPAFC-Bulletin</title-short>
+    <id>http://www.zotero.org/styles/north-pacific-anadromous-fish-commission-bulletin</id>
+    <link href="http://www.zotero.org/styles/north-pacific-anadromous-fish-commission-bulletin" rel="self"/>
+    <link href="https://www.zotero.org/styles/canadian-biosystems-engineering" rel="template"/>
+    <link href="https://npafc.org/bulletin/" rel="documentation"/>
+    <author>
+      <name>Brett Johnson</name>
+      <email>brett.johnson@hakai.org</email>
+    </author>
+    <category citation-format="author-date"/>
+    <category field="biology"/>
+    <summary>Style for NPAFC Bulletin</summary>
+    <updated>2023-02-25T00:07:43+00:00</updated>
+    <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
+  </info>
+  <locale xml:lang="en-US">
+    <date form="numeric">
+      <date-part name="day" suffix=" " range-delimiter="-"/>
+      <date-part name="month" suffix=" "/>
+      <date-part name="year" range-delimiter="/"/>
+    </date>
+    <terms>
+      <term name="editor" form="short">
+        <single>Ed</single>
+        <multiple>Eds</multiple>
+      </term>
+    </terms>
+  </locale>
+  <macro name="container">
+    <choose>
+      <if type="paper-conference speech" match="any">
+        <choose>
+          <if variable="container-title event" match="any">
+            <text value="In " font-style="normal"/>
+          </if>
+        </choose>
+        <group delimiter=", ">
+          <names variable="editor translator" delimiter=", ">
+            <name name-as-sort-order="all" sort-separator=", " initialize-with="." delimiter="; " and="text" delimiter-precedes-last="never"/>
+            <label form="short" prefix=" (" suffix=")"/>
+          </names>
+          <group delimiter=" ">
+            <choose>
+              <if variable="ISBN ISSN container-title" match="any">
+                <group font-style="normal">
+                  <choose>
+                    <if variable="container-title">
+                      <text variable="container-title"/>
+                    </if>
+                    <else>
+                      <text variable="event"/>
+                    </else>
+                  </choose>
+                  <text variable="genre"/>
+                  <text variable="collection-title"/>
+                </group>
+              </if>
+              <else>
+                <choose>
+                  <if variable="container-title">
+                    <text variable="container-title"/>
+                  </if>
+                  <else>
+                    <text variable="event"/>
+                  </else>
+                </choose>
+                <text variable="genre"/>
+                <text variable="collection-title"/>
+              </else>
+            </choose>
+          </group>
+        </group>
+      </if>
+      <else-if type="chapter" match="any">
+        <group delimiter=", " prefix="In ">
+          <group delimiter=" ">
+            <choose>
+              <if variable="ISBN" match="any" type="chapter">
+                <text variable="container-title" text-case="title" font-style="normal"/>
+                <text variable="collection-number"/>
+                <text variable="issue"/>
+              </if>
+              <else>
+                <text variable="container-title"/>
+                <text variable="collection-title" prefix=", "/>
+                <text variable="collection-number"/>
+                <text variable="issue"/>
+              </else>
+            </choose>
+          </group>
+          <names variable="editor translator" delimiter=", ">
+            <label form="short" text-case="lowercase" prefix=" " suffix=". "/>
+            <name delimiter="; " and="text" delimiter-precedes-last="never" initialize-with="."/>
+          </names>
+        </group>
+      </else-if>
+      <else-if type="bill book graphic legal_case legislation motion_picture report song" match="any">
+        <text variable="container-title"/>
+        <group delimiter=" ">
+          <text variable="collection-title"/>
+          <group delimiter="/">
+            <text variable="volume"/>
+            <text variable="collection-number"/>
+          </group>
+          <text variable="issue"/>
+        </group>
+      </else-if>
+      <else-if type="broadcast">
+        <choose>
+          <if variable="container-title">
+            <group delimiter=", ">
+              <text variable="number" prefix="Episode "/>
+              <text variable="title" text-case="capitalize-first"/>
+            </group>
+          </if>
+        </choose>
+      </else-if>
+      <else-if type="article">
+        <group delimiter=" " suffix=", ">
+          <choose>
+            <if variable="ISBN ISSN" match="any">
+              <text variable="container-title" font-style="normal"/>
+              <text variable="genre"/>
+              <text variable="collection-title"/>
+              <text variable="collection-number"/>
+              <text variable="issue"/>
+            </if>
+            <else>
+              <text variable="container-title"/>
+              <text variable="genre"/>
+              <text variable="collection-title"/>
+              <text variable="collection-number"/>
+              <text variable="issue"/>
+            </else>
+          </choose>
+        </group>
+      </else-if>
+      <else-if type="article-newspaper">
+        <choose>
+          <if variable="author editor translator" match="any">
+            <text variable="container-title" text-case="capitalize-first" font-style="normal"/>
+          </if>
+        </choose>
+      </else-if>
+      <else>
+        <text variable="container-title" text-case="title" font-style="normal"/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="author">
+    <choose>
+      <if type="motion_picture broadcast article-newspaper article-magazine" match="none">
+        <names variable="author">
+          <name and="text" delimiter-precedes-last="never" initialize-with="." name-as-sort-order="first"/>
+          <label form="short" prefix=" (" suffix=")."/>
+          <substitute>
+            <names variable="editor"/>
+            <names variable="translator"/>
+            <text macro="title"/>
+          </substitute>
+        </names>
+      </if>
+      <else-if type="article-newspaper article-magazine" match="any">
+        <choose>
+          <if variable="author editor translator" match="any">
+            <names variable="author">
+              <name name-as-sort-order="all" sort-separator=", " initialize-with="." delimiter="; " and="text" delimiter-precedes-last="never"/>
+              <label form="short" prefix=" (" suffix=")."/>
+              <substitute>
+                <names variable="editor"/>
+                <names variable="translator"/>
+                <text macro="title"/>
+              </substitute>
+            </names>
+          </if>
+          <else>
+            <text variable="container-title"/>
+          </else>
+        </choose>
+      </else-if>
+      <else>
+        <choose>
+          <if variable="container-title">
+            <text variable="container-title" font-style="italic"/>
+          </if>
+          <else>
+            <text variable="title" font-style="italic"/>
+          </else>
+        </choose>
+      </else>
+    </choose>
+  </macro>
+  <macro name="author-short">
+    <names variable="author">
+      <name form="short" and="text" et-al-min="3" et-al-use-first="1" initialize-with=". " name-as-sort-order="first"/>
+      <substitute>
+        <names variable="editor"/>
+        <names variable="translator"/>
+        <choose>
+          <if type="bill book graphic legal_case legislation motion_picture song" match="any">
+            <text variable="title" form="short"/>
+          </if>
+          <else>
+            <text variable="container-title" form="short"/>
+          </else>
+        </choose>
+      </substitute>
+    </names>
+  </macro>
+  <macro name="accessed">
+    <choose>
+      <if type="article-journal book chapter" match="any"/>
+      <else-if variable="URL DOI" match="any">
+        <group prefix=" (" suffix=")">
+          <date variable="accessed">
+            <date-part name="year"/>
+            <date-part name="month" form="numeric" prefix="/" suffix="/"/>
+            <date-part name="day"/>
+          </date>
+        </group>
+      </else-if>
+    </choose>
+  </macro>
+  <macro name="title">
+    <choose>
+      <if type="report" match="any">
+        <group delimiter=".  ">
+          <choose>
+            <if variable="ISBN ISSN" match="any">
+              <text variable="title" font-style="italic" text-case="capitalize-first"/>
+            </if>
+            <else>
+              <text variable="title" text-case="capitalize-first"/>
+            </else>
+          </choose>
+          <group delimiter=" ">
+            <text variable="genre"/>
+            <text variable="number"/>
+          </group>
+        </group>
+      </if>
+      <else-if type="thesis" match="any">
+        <group delimiter=".  ">
+          <choose>
+            <if variable="ISBN ISSN" match="any">
+              <text variable="title" font-style="italic" text-case="capitalize-first"/>
+              <text variable="genre"/>
+            </if>
+            <else>
+              <text variable="title" text-case="capitalize-first" prefix="  "/>
+              <text variable="genre"/>
+            </else>
+          </choose>
+        </group>
+      </else-if>
+      <else-if type="bill book graphic legal_case legislation song" match="any">
+        <group delimiter=".  ">
+          <choose>
+            <if variable="publisher ISBN ISSN" match="any">
+              <text variable="title" text-case="title" font-style="italic"/>
+            </if>
+            <else>
+              <text variable="title" text-case="capitalize-first" font-style="normal"/>
+            </else>
+          </choose>
+          <text macro="edition"/>
+        </group>
+      </else-if>
+      <else-if type="webpage chapter paper-conference article-journal article-magazine article-newspaper" match="any">
+        <text variable="title"/>
+      </else-if>
+      <else-if type="patent">
+        <group delimiter=".  ">
+          <text variable="title"/>
+          <group delimiter=", ">
+            <text variable="authority"/>
+            <text variable="number"/>
+          </group>
+        </group>
+      </else-if>
+      <else-if type="motion_picture broadcast" match="any"/>
+      <else>
+        <choose>
+          <if variable="ISBN ISSN" match="any">
+            <text variable="title" font-style="italic" text-case="capitalize-first"/>
+          </if>
+          <else>
+            <text variable="title" text-case="capitalize-first"/>
+          </else>
+        </choose>
+      </else>
+    </choose>
+  </macro>
+  <macro name="publisher">
+    <choose>
+      <if type="thesis" match="any">
+        <group delimiter=", ">
+          <text variable="publisher"/>
+          <text variable="publisher-place"/>
+        </group>
+      </if>
+      <else>
+        <group delimiter=": ">
+          <text variable="publisher-place"/>
+          <text variable="publisher"/>
+        </group>
+      </else>
+    </choose>
+  </macro>
+  <macro name="event">
+    <choose>
+      <if variable="editor" match="any">
+        <text variable="event" font-style="italic"/>
+      </if>
+      <else>
+        <text variable="event"/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="issued">
+    <choose>
+      <if variable="issued">
+        <date variable="issued">
+          <date-part name="year"/>
+        </date>
+      </if>
+      <else-if variable="accessed">
+        <choose>
+          <if type="webpage">
+            <date variable="accessed">
+              <date-part name="year"/>
+            </date>
+          </if>
+          <else>
+            <text term="no date" form="short"/>
+          </else>
+        </choose>
+      </else-if>
+      <else>
+        <text term="no date" form="short"/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="edition">
+    <group delimiter=" ">
+      <choose>
+        <if is-numeric="edition">
+          <group delimiter=" ">
+            <number variable="edition" form="ordinal"/>
+            <text term="edition"/>
+          </group>
+        </if>
+        <else>
+          <text variable="edition" suffix="."/>
+        </else>
+      </choose>
+    </group>
+  </macro>
+  <macro name="web_availibility">
+    <choose>
+      <if variable="DOI">
+        <text variable="DOI" prefix="https://doi.org/"/>
+        <text macro="accessed"/>
+      </if>
+      <else-if variable="URL">
+        <text variable="URL"/>
+        <text macro="accessed"/>
+      </else-if>
+    </choose>
+  </macro>
+  <macro name="locators">
+    <choose>
+      <if type="article-journal article-magazine" match="any">
+        <group prefix=" " delimiter=": ">
+          <group delimiter="">
+            <text variable="volume"/>
+            <text variable="issue" prefix="(" suffix=")"/>
+          </group>
+          <group delimiter=", ">
+            <text variable="page"/>
+          </group>
+        </group>
+      </if>
+      <else-if type="webpage"/>
+      <else-if type="article-newspaper" match="any">
+        <date variable="issued" prefix=". ">
+          <date-part name="day" suffix=" " range-delimiter="-"/>
+          <date-part name="month" suffix=" "/>
+          <date-part name="year" range-delimiter="/"/>
+        </date>
+      </else-if>
+      <else-if type="article" match="any">
+        <group delimiter=", ">
+          <group delimiter=". ">
+            <group delimiter=" ">
+              <label variable="page" form="short"/>
+              <text variable="page"/>
+            </group>
+            <text macro="publisher"/>
+          </group>
+          <date variable="issued">
+            <date-part name="day" prefix=" " suffix=" " range-delimiter="-"/>
+            <date-part name="month" suffix=" "/>
+            <date-part name="year" range-delimiter="/"/>
+          </date>
+        </group>
+      </else-if>
+      <else-if type="bill book graphic legal_case legislation motion_picture report song thesis" match="any">
+        <group delimiter=", " prefix=". ">
+          <text macro="event"/>
+          <text macro="publisher"/>
+        </group>
+      </else-if>
+      <else-if type="broadcast">
+        <group delimiter=". " prefix=", ">
+          <text variable="publisher"/>
+          <date variable="issued">
+            <date-part name="day" suffix=" " range-delimiter="-"/>
+            <date-part name="month" suffix=" "/>
+            <date-part name="year" range-delimiter="/"/>
+          </date>
+        </group>
+      </else-if>
+      <else-if type="chapter" match="any">
+        <group delimiter=". " prefix=", ">
+          <group delimiter=" ">
+            <text variable="page" form="short"/>
+          </group>
+          <text macro="event"/>
+          <text macro="publisher"/>
+        </group>
+      </else-if>
+      <else-if type="paper-conference speech" match="any">
+        <group delimiter=", " prefix=", ">
+          <group delimiter=". ">
+            <group delimiter=" ">
+              <text variable="page"/>
+            </group>
+            <text macro="publisher"/>
+          </group>
+          <date variable="event-date">
+            <date-part name="day" suffix=" " range-delimiter="-"/>
+            <date-part name="month" suffix=" "/>
+            <date-part name="year" range-delimiter="/"/>
+          </date>
+        </group>
+      </else-if>
+      <else-if type="interview personal_communication" match="any">
+        <group delimiter=". " prefix=". ">
+          <choose>
+            <if variable="title" match="none">
+              <text value="Personal communication"/>
+            </if>
+          </choose>
+          <text variable="medium" text-case="lowercase" prefix="By "/>
+          <date variable="issued">
+            <date-part name="day" suffix=" " range-delimiter="-"/>
+            <date-part name="month" suffix=" "/>
+            <date-part name="year" range-delimiter="/"/>
+          </date>
+        </group>
+      </else-if>
+    </choose>
+  </macro>
+  <citation et-al-min="3" et-al-use-first="1" disambiguate-add-year-suffix="true" disambiguate-add-names="false" cite-group-delimiter=", " collapse="year">
+    <sort>
+      <key macro="author-short"/>
+    </sort>
+    <layout prefix="(" suffix=")" delimiter="; ">
+      <group delimiter=": ">
+        <group delimiter=" ">
+          <text macro="author-short"/>
+          <text macro="issued"/>
+        </group>
+        <text variable="locator"/>
+      </group>
+    </layout>
+  </citation>
+  <bibliography hanging-indent="true" entry-spacing="0" line-spacing="1">
+    <sort>
+      <key macro="author"/>
+      <key macro="issued" sort="ascending"/>
+    </sort>
+    <layout>
+      <text macro="author" suffix=".  "/>
+      <group delimiter=".  ">
+        <text macro="issued"/>
+        <text macro="title"/>
+        <text macro="container"/>
+      </group>
+      <text macro="locators"/>
+      <choose>
+        <if type="webpage">
+          <text macro="web_availibility" prefix=". "/>
+        </if>
+        <else>
+          <text macro="web_availibility" prefix=". "/>
+        </else>
+      </choose>
+      <choose>
+        <if variable="URL DOI" match="any">
+          <choose>
+            <if variable="accessed" match="none">
+              <text value="."/>
+            </if>
+          </choose>
+        </if>
+        <else>
+          <text value="."/>
+        </else>
+      </choose>
+    </layout>
+  </bibliography>
+</style>

--- a/north-pacific-anadromous-fish-commission-bulletin.csl
+++ b/north-pacific-anadromous-fish-commission-bulletin.csl
@@ -6,7 +6,7 @@
     <title-short>NPAFC-Bulletin</title-short>
     <id>http://www.zotero.org/styles/north-pacific-anadromous-fish-commission-bulletin</id>
     <link href="http://www.zotero.org/styles/north-pacific-anadromous-fish-commission-bulletin" rel="self"/>
-    <link href="https://www.zotero.org/styles/canadian-biosystems-engineering" rel="template"/>
+    <link href="http://www.zotero.org/styles/water-alternatives" rel="template"/>
     <link href="https://npafc.org/bulletin/" rel="documentation"/>
     <author>
       <name>Brett Johnson</name>


### PR DESCRIPTION
Here is .csl file for the North Pacific Anadromous Fish Commission's bespoke citation style. 

I only have a word doc that indicates the citation style, and as far as I can tell it's not available on their website. So I will paste it here below:

References in Text
 For one author: Suzuki (1980), or (Suzuki 1980), no comma between name and year.
 For two authors: Suzuki and Yamada (1980), or (Suzuki and Yamada 1980).
 For more than two authors: Suzuki et al. (1980), or (Suzuki et al. 1980), “et al.” is used with a
period, not italicized and not underlined.
 For two or more references given together: Smith (1980, 1981), Suzuki and Yamada (1983), and
Smith (1984), or (Smith 1980, 1981; Suzuki and Yamada 1983; Smith 1984). Note: references are
listed first in order of publication date, then alphabetically by author.
 Same author(s), same date (incl. in press): add “a”, “b”, … after the date, e.g., (1999a, b, c; in
press b). Please note the space or lack thereof.
 In press: Suzuki (in press), or (Suzuki in press). The publication must be accepted for publication,
preferably at the galley stage; if this is not the case, cite as unpublished data or personal
communication.
 This volume: same format as for “In press”, e.g., Suzuki (this volume), or (Suzuki this volume).
 Unpublished data by an author: where the author(s) needs (need) to be identified; e.g., (Smith
unpublished data; Beacham et al. unpublished data).
 Unpublished information from a colleague: first initial and name of the colleague, e-mail address,
and pers. comm., all in parentheses, i.e., (J. Smith, smithj@......, pers. comm.).
 Edited book: (Gordon and Hourston 1993) no need to put “[ed.]” in the text.
 Corporate author: full spelling of the name of the company (with the acronym in parentheses) at
the first appearance and thereafter that only the acronym should be used, e.g., (American Public
Health Association (APHA), American Water Works Association, and Water Pollution Control
Federation 1975).

References in the Reference List
 References should be listed in alphabetical order according to the surname of the first author.
 References with the same first author are listed in the following order.
(1) First: papers with one author are listed in chronological order.
(2) Second: papers with two authors are listed in alphabetical order by the last name of the
second author and then in chronological order.
(3) Third: papers with three or more authors are listed in chronological order.

 The objective of consistent format is to ensure that all necessary information for retrieving a work is
provided as succinctly as possible. In a particular instance if modification of the format would
facilitate retrieval, e.g., by addition of a date, or page numbers, or other specifics, modification is
approved.
 Indent after the 1 st line of the reference by a ½ inch as demonstrated in the following examples.
 In the reference list, the first author is shown surname first, followed by their initials. The following
authors in the citation are shown with initials first, then surname (see examples below).
 Follow the spacing convention between words as illustrated in the following references: double space
after last author, year, and article title; single space after journal title and volume number. Use the
en-dash to show the range in page numbers.
