### PR TITLE
correct name disambiguation rules

### DIFF
--- a/the-university-of-winchester-harvard.csl
+++ b/the-university-of-winchester-harvard.csl
@@ -362,7 +362,7 @@
       </else>
     </choose>
   </macro>
-  <citation et-al-min="3" et-al-use-first="1" disambiguate-add-year-suffix="true" disambiguate-add-names="true" disambiguate-add-givenname="true" collapse="year" givenname-disambiguation-rule="primary-name">
+  <citation et-al-min="3" et-al-use-first="1" disambiguate-add-year-suffix="true" disambiguate-add-names="true" disambiguate-add-givenname="false" collapse="year" givenname-disambiguation-rule="by-cite">
     <sort>
       <key macro="author"/>
       <key macro="issued-sort"/>


### PR DESCRIPTION
in the current version, the citations disambiguate across years rather than within years. i am an academic at the university of winchester and i asked the academic skills team whether this was correct. they confirmed that it was not correct. this correction now means that citations disambiguate only within years (by adding a letter a, b, c) etc.