### PR TITLE
Update guide-des-citations-references-et-abreviations-juridiques.csl

### DIFF
--- a/guide-des-citations-references-et-abreviations-juridiques.csl
+++ b/guide-des-citations-references-et-abreviations-juridiques.csl
@@ -23,7 +23,7 @@
       <term name="ordinal-02">e</term>
       <term name="ordinal-03">e</term>
       <term name="ordinal-04">e</term>
-      <term name="cited">op. cit.</term>
+      <term name="cited">op.&#160;cit.</term>
       <term name="page" form="short">p.</term>
       <term name="editor" form="short">dir.</term>
     </terms>
@@ -42,7 +42,7 @@
           <name form="long" and="text" sort-separator=" " initialize-with="." font-style="normal">
             <name-part name="family" font-variant="small-caps"/>
           </name>
-          <label form="short" prefix=" (" suffix=".)"/>
+          <label form="short" prefix="&#160;(" suffix=".)"/>
         </names>
       </else-if>
     </choose>
@@ -52,7 +52,7 @@
       <name form="long" and="text" delimiter-precedes-last="never" sort-separator=" " initialize-with="." font-style="normal">
         <name-part name="family" font-variant="normal"/>
       </name>
-      <label form="short" prefix=" (" suffix=".)"/>
+      <label form="short" prefix="&#160;(" suffix=".)"/>
     </names>
   </macro>
   <macro name="translator">
@@ -147,7 +147,7 @@
           </date>
           <choose>
             <if variable="locator" match="any">
-              <text variable="locator" prefix="p. "/>
+              <text variable="locator" prefix="p.&#160;"/>
             </if>
           </choose>
         </group>
@@ -170,7 +170,7 @@
           <group delimiter=" " font-style="normal">
             <choose>
               <if variable="locator" match="any">
-                <text variable="locator" prefix="p. "/>
+                <text variable="locator" prefix="p.&#160;"/>
               </if>
               <else-if variable="locator" match="none">
                 <label variable="page" form="short"/>
@@ -205,7 +205,7 @@
           </group>
           <choose>
             <if variable="locator" match="any">
-              <text variable="locator" prefix="p. "/>
+              <text variable="locator" prefix="p.&#160;"/>
             </if>
           </choose>
         </group>
@@ -222,7 +222,7 @@
           </group>
           <choose>
             <if variable="locator" match="any">
-              <text variable="locator" prefix="p. "/>
+              <text variable="locator" prefix="p.&#160;"/>
             </if>
             <else-if variable="locator" match="none">
               <label variable="page" form="short"/>
@@ -235,7 +235,7 @@
         <group delimiter=" " font-style="normal">
           <choose>
             <if variable="locator" match="any">
-              <text variable="locator" prefix="p. "/>
+              <text variable="locator" prefix="p.&#160;"/>
             </if>
             <else-if variable="locator" match="none">
               <label variable="page" form="short"/>
@@ -254,7 +254,7 @@
           <group delimiter=" " font-style="normal">
             <choose>
               <if variable="locator" match="any">
-                <text variable="locator" prefix="p. "/>
+                <text variable="locator" prefix="p.&#160;"/>
               </if>
               <else-if variable="locator" match="none">
                 <label variable="page" form="short"/>
@@ -317,13 +317,13 @@
     </choose>
   </macro>
   <citation near-note-distance="1">
-    <layout delimiter=" ; ">
+    <layout delimiter="&#160;; ">
       <choose>
         <if position="ibid near-note">
           <group delimiter=", ">
             <text macro="author"/>
             <text term="ibid" font-style="italic" suffix="."/>
-            <text variable="locator" prefix="p. "/>
+            <text variable="locator" prefix="p.&#160;"/>
           </group>
         </if>
         <else-if position="subsequent">
@@ -376,7 +376,7 @@
                 <text variable="title" text-case="capitalize-first" form="short" quotes="true" font-style="normal"/>
               </else>
             </choose>
-            <text variable="locator" prefix="p. "/>
+            <text variable="locator" prefix="p.&#160;"/>
           </group>
         </else-if>
         <else>

--- a/guide-des-citations-references-et-abreviations-juridiques.csl
+++ b/guide-des-citations-references-et-abreviations-juridiques.csl
@@ -14,7 +14,7 @@
     </author>
     <category citation-format="note"/>
     <category field="law"/>
-    <updated>2023-03-11T17:14:02+00:00</updated>
+    <updated>2023-03-11T23:01:32+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale xml:lang="fr">
@@ -23,7 +23,7 @@
       <term name="ordinal-02">e</term>
       <term name="ordinal-03">e</term>
       <term name="ordinal-04">e</term>
-      <term name="cited">op.&#160;cit.</term>
+      <term name="cited">op. cit.</term>
       <term name="page" form="short">p.</term>
       <term name="editor" form="short">dir.</term>
     </terms>
@@ -42,7 +42,7 @@
           <name form="long" and="text" sort-separator=" " initialize-with="." font-style="normal">
             <name-part name="family" font-variant="small-caps"/>
           </name>
-          <label form="short" prefix="&#160;(" suffix=".)"/>
+          <label form="short" prefix=" (" suffix=".)"/>
         </names>
       </else-if>
     </choose>
@@ -52,7 +52,7 @@
       <name form="long" and="text" delimiter-precedes-last="never" sort-separator=" " initialize-with="." font-style="normal">
         <name-part name="family" font-variant="normal"/>
       </name>
-      <label form="short" prefix="&#160;(" suffix=".)"/>
+      <label form="short" prefix=" (" suffix=".)"/>
     </names>
   </macro>
   <macro name="translator">
@@ -147,7 +147,7 @@
           </date>
           <choose>
             <if variable="locator" match="any">
-              <text variable="locator" prefix="p.&#160;"/>
+              <text variable="locator" prefix="p. "/>
             </if>
           </choose>
         </group>
@@ -170,7 +170,7 @@
           <group delimiter=" " font-style="normal">
             <choose>
               <if variable="locator" match="any">
-                <text variable="locator" prefix="p.&#160;"/>
+                <text variable="locator" prefix="p. "/>
               </if>
               <else-if variable="locator" match="none">
                 <label variable="page" form="short"/>
@@ -205,7 +205,7 @@
           </group>
           <choose>
             <if variable="locator" match="any">
-              <text variable="locator" prefix="p.&#160;"/>
+              <text variable="locator" prefix="p. "/>
             </if>
           </choose>
         </group>
@@ -222,7 +222,7 @@
           </group>
           <choose>
             <if variable="locator" match="any">
-              <text variable="locator" prefix="p.&#160;"/>
+              <text variable="locator" prefix="p. "/>
             </if>
             <else-if variable="locator" match="none">
               <label variable="page" form="short"/>
@@ -235,7 +235,7 @@
         <group delimiter=" " font-style="normal">
           <choose>
             <if variable="locator" match="any">
-              <text variable="locator" prefix="p.&#160;"/>
+              <text variable="locator" prefix="p. "/>
             </if>
             <else-if variable="locator" match="none">
               <label variable="page" form="short"/>
@@ -254,7 +254,7 @@
           <group delimiter=" " font-style="normal">
             <choose>
               <if variable="locator" match="any">
-                <text variable="locator" prefix="p.&#160;"/>
+                <text variable="locator" prefix="p. "/>
               </if>
               <else-if variable="locator" match="none">
                 <label variable="page" form="short"/>
@@ -316,10 +316,17 @@
       </else-if>
     </choose>
   </macro>
-  <citation>
-    <layout delimiter="&#160;; ">
+  <citation near-note-distance="1">
+    <layout delimiter=" ; ">
       <choose>
-        <if position="subsequent">
+        <if position="ibid near-note">
+          <group delimiter=", ">
+            <text macro="author"/>
+            <text term="ibid" font-style="italic" suffix="."/>
+            <text variable="locator" prefix="p. "/>
+          </group>
+        </if>
+        <else-if position="subsequent">
           <group delimiter=", ">
             <text macro="author"/>
             <choose>
@@ -369,9 +376,9 @@
                 <text variable="title" text-case="capitalize-first" form="short" quotes="true" font-style="normal"/>
               </else>
             </choose>
-            <text variable="locator" prefix="p.&#160;"/>
+            <text variable="locator" prefix="p. "/>
           </group>
-        </if>
+        </else-if>
         <else>
           <group delimiter=", ">
             <text macro="author"/>

--- a/guide-des-citations-references-et-abreviations-juridiques.csl
+++ b/guide-des-citations-references-et-abreviations-juridiques.csl
@@ -23,7 +23,7 @@
       <term name="ordinal-02">e</term>
       <term name="ordinal-03">e</term>
       <term name="ordinal-04">e</term>
-      <term name="cited">op. cit.</term>
+      <term name="cited">op.&#160;cit.</term>
       <term name="page" form="short">p.</term>
       <term name="editor" form="short">dir.</term>
     </terms>
@@ -42,7 +42,7 @@
           <name form="long" and="text" sort-separator=" " initialize-with="." font-style="normal">
             <name-part name="family" font-variant="small-caps"/>
           </name>
-          <label form="short" prefix=" (" suffix=".)"/>
+          <label form="short" prefix="&#160;(" suffix=".)"/>
         </names>
       </else-if>
     </choose>
@@ -52,7 +52,7 @@
       <name form="long" and="text" delimiter-precedes-last="never" sort-separator=" " initialize-with="." font-style="normal">
         <name-part name="family" font-variant="normal"/>
       </name>
-      <label form="short" prefix=" (" suffix=".)"/>
+      <label form="short" prefix="&#160;(" suffix=".)"/>
     </names>
   </macro>
   <macro name="translator">
@@ -147,7 +147,7 @@
           </date>
           <choose>
             <if variable="locator" match="any">
-              <text variable="locator" prefix="p. "/>
+              <text variable="locator" prefix="p.&#160;"/>
             </if>
           </choose>
         </group>
@@ -170,7 +170,7 @@
           <group delimiter=" " font-style="normal">
             <choose>
               <if variable="locator" match="any">
-                <text variable="locator" prefix="p. "/>
+                <text variable="locator" prefix="p.&#160;"/>
               </if>
               <else-if variable="locator" match="none">
                 <label variable="page" form="short"/>
@@ -205,7 +205,7 @@
           </group>
           <choose>
             <if variable="locator" match="any">
-              <text variable="locator" prefix="p. "/>
+              <text variable="locator" prefix="p.&#160;"/>
             </if>
           </choose>
         </group>
@@ -222,7 +222,7 @@
           </group>
           <choose>
             <if variable="locator" match="any">
-              <text variable="locator" prefix="p. "/>
+              <text variable="locator" prefix="p.&#160;"/>
             </if>
             <else-if variable="locator" match="none">
               <label variable="page" form="short"/>
@@ -235,7 +235,7 @@
         <group delimiter=" " font-style="normal">
           <choose>
             <if variable="locator" match="any">
-              <text variable="locator" prefix="p. "/>
+              <text variable="locator" prefix="p.&#160;"/>
             </if>
             <else-if variable="locator" match="none">
               <label variable="page" form="short"/>
@@ -254,7 +254,7 @@
           <group delimiter=" " font-style="normal">
             <choose>
               <if variable="locator" match="any">
-                <text variable="locator" prefix="p. "/>
+                <text variable="locator" prefix="p.&#160;"/>
               </if>
               <else-if variable="locator" match="none">
                 <label variable="page" form="short"/>
@@ -317,7 +317,7 @@
     </choose>
   </macro>
   <citation>
-    <layout delimiter=" ; ">
+    <layout delimiter="&#160;; ">
       <choose>
         <if position="subsequent">
           <group delimiter=", ">
@@ -369,7 +369,7 @@
                 <text variable="title" text-case="capitalize-first" form="short" quotes="true" font-style="normal"/>
               </else>
             </choose>
-            <text variable="locator" prefix="p. "/>
+            <text variable="locator" prefix="p.&#160;"/>
           </group>
         </if>
         <else>

--- a/guide-des-citations-references-et-abreviations-juridiques.csl
+++ b/guide-des-citations-references-et-abreviations-juridiques.csl
@@ -319,7 +319,7 @@
   <citation near-note-distance="1">
     <layout delimiter="&#160;; ">
       <choose>
-        <if position="ibid near-note">
+        <if position="ibid near-note" match="all">
           <group delimiter=", ">
             <text macro="author"/>
             <text term="ibid" font-style="italic" suffix="."/>

--- a/guide-des-citations-references-et-abreviations-juridiques.csl
+++ b/guide-des-citations-references-et-abreviations-juridiques.csl
@@ -14,7 +14,7 @@
     </author>
     <category citation-format="note"/>
     <category field="law"/>
-    <updated>2022-04-05T19:59:30+00:00</updated>
+    <updated>2023-03-11T17:14:02+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale xml:lang="fr">
@@ -23,7 +23,7 @@
       <term name="ordinal-02">e</term>
       <term name="ordinal-03">e</term>
       <term name="ordinal-04">e</term>
-      <term name="cited">op.&#160;cit.</term>
+      <term name="cited">op. cit.</term>
       <term name="page" form="short">p.</term>
       <term name="editor" form="short">dir.</term>
     </terms>
@@ -42,7 +42,7 @@
           <name form="long" and="text" sort-separator=" " initialize-with="." font-style="normal">
             <name-part name="family" font-variant="small-caps"/>
           </name>
-          <label form="short" prefix="&#160;(" suffix=".)"/>
+          <label form="short" prefix=" (" suffix=".)"/>
         </names>
       </else-if>
     </choose>
@@ -52,7 +52,7 @@
       <name form="long" and="text" delimiter-precedes-last="never" sort-separator=" " initialize-with="." font-style="normal">
         <name-part name="family" font-variant="normal"/>
       </name>
-      <label form="short" prefix="&#160;(" suffix=".)"/>
+      <label form="short" prefix=" (" suffix=".)"/>
     </names>
   </macro>
   <macro name="translator">
@@ -147,7 +147,7 @@
           </date>
           <choose>
             <if variable="locator" match="any">
-              <text variable="locator" prefix="p.&#160;"/>
+              <text variable="locator" prefix="p. "/>
             </if>
           </choose>
         </group>
@@ -170,7 +170,7 @@
           <group delimiter=" " font-style="normal">
             <choose>
               <if variable="locator" match="any">
-                <text variable="locator" prefix="p.&#160;"/>
+                <text variable="locator" prefix="p. "/>
               </if>
               <else-if variable="locator" match="none">
                 <label variable="page" form="short"/>
@@ -205,7 +205,7 @@
           </group>
           <choose>
             <if variable="locator" match="any">
-              <text variable="locator" prefix="p.&#160;"/>
+              <text variable="locator" prefix="p. "/>
             </if>
           </choose>
         </group>
@@ -222,7 +222,7 @@
           </group>
           <choose>
             <if variable="locator" match="any">
-              <text variable="locator" prefix="p.&#160;"/>
+              <text variable="locator" prefix="p. "/>
             </if>
             <else-if variable="locator" match="none">
               <label variable="page" form="short"/>
@@ -235,7 +235,7 @@
         <group delimiter=" " font-style="normal">
           <choose>
             <if variable="locator" match="any">
-              <text variable="locator" prefix="p.&#160;"/>
+              <text variable="locator" prefix="p. "/>
             </if>
             <else-if variable="locator" match="none">
               <label variable="page" form="short"/>
@@ -254,7 +254,7 @@
           <group delimiter=" " font-style="normal">
             <choose>
               <if variable="locator" match="any">
-                <text variable="locator" prefix="p.&#160;"/>
+                <text variable="locator" prefix="p. "/>
               </if>
               <else-if variable="locator" match="none">
                 <label variable="page" form="short"/>
@@ -317,18 +317,9 @@
     </choose>
   </macro>
   <citation>
-    <layout delimiter="&#160;; ">
+    <layout delimiter=" ; ">
       <choose>
-        <if position="ibid-with-locator subsequent">
-          <group delimiter=", ">
-            <text term="ibid" text-case="capitalize-first" font-style="italic" suffix="."/>
-            <text variable="locator" prefix="p.&#160;"/>
-          </group>
-        </if>
-        <else-if position="ibid">
-          <text term="ibid" text-case="capitalize-first" font-style="italic"/>
-        </else-if>
-        <else-if position="subsequent">
+        <if position="subsequent">
           <group delimiter=", ">
             <text macro="author"/>
             <choose>
@@ -353,7 +344,14 @@
               <else-if type="article-journal" match="any">
                 <text term="cited" font-style="italic" suffix="."/>
                 <text variable="container-title" form="short" font-style="italic"/>
-                <date date-parts="year-month" form="text" variable="issued"/>
+                <choose>
+                  <if match="any" variable="volume">
+                    <text variable="volume"/>
+                  </if>
+                  <else>
+                    <date date-parts="year-month" form="text" variable="issued"/>
+                  </else>
+                </choose>
               </else-if>
               <else-if type="entry-encyclopedia" match="any">
                 <text variable="title" quotes="true"/>
@@ -371,9 +369,9 @@
                 <text variable="title" text-case="capitalize-first" form="short" quotes="true" font-style="normal"/>
               </else>
             </choose>
-            <text variable="locator" prefix="p.&#160;"/>
+            <text variable="locator" prefix="p. "/>
           </group>
-        </else-if>
+        </if>
         <else>
           <group delimiter=", ">
             <text macro="author"/>


### PR DESCRIPTION
Two corrections:
- disable 'ibid.' since its behaviour is erratic when non-Zotero references are also added in the document
- correct the use of "op. cit". when a journal article has a volume and no date (such as R.W.)