### PR TITLE
Fix malformed XML in raptor-journal.csl

### DIFF
--- a/raptor-journal.csl
+++ b/raptor-journal.csl
@@ -1,4 +1,3 @@
-﻿
 <?xml version="1.0" encoding="utf-8"?>
 <style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" and="symbol" initialize-with="" demote-non-dropping-particle="never" default-locale="en-US">
   <!-- This style was edited with the Visual CSL Editor (https://editor.citationstyles.org/visualEditor/) -->


### PR DESCRIPTION
According the XML specification, the `<?xml ?>` declaration must be at the beginning of an XML file and nothing should precede it.

I encountered this error when I tried to read the file using citeproc-java. It seems the Java XML parser does not like byte-order marks. I hope, the BOM was not necessary in this case but it seems the file is just normal UTF-8.