### PR TITLE
Update harvard-stellenbosch-university.csl

### DIFF
--- a/harvard-stellenbosch-university.csl
+++ b/harvard-stellenbosch-university.csl
@@ -286,7 +286,8 @@
           <else-if type="chapter paper-conference entry-encyclopedia entry-dictionary" match="any">
             <text macro="title"/>
             <group delimiter=" ">
-              <text term="in" text-case="capitalize-first"/>
+              <!-- TODO: editors must be before title -->
+              <text term="in" prefix=", "/>
               <text variable="container-title" font-style="italic"/>
             </group>
             <text macro="book-details"/>

--- a/harvard-stellenbosch-university.csl
+++ b/harvard-stellenbosch-university.csl
@@ -289,17 +289,17 @@
             <text variable="publisher"/>
           </else-if>
           <else-if type="chapter paper-conference entry-encyclopedia entry-dictionary" match="any">
-                          <group delimiter=", ">
-  <group delimiter=" ">
-  <group>
-            <text macro="title"/>
-              <text term="in" prefix=", "/>
+            <group delimiter=", ">
+              <group delimiter=" ">
+                <group>
+                  <text macro="title"/>
+                  <text term="in" prefix=", "/>
+                </group>
+                <group delimiter=" ">
+                  <text macro="editor-translator" suffix="."/>
+                  <text variable="container-title" font-style="italic"/>
+                </group>
               </group>
-            <group delimiter=" ">
-              <text macro="editor-translator" suffix="."/>
-              <text variable="container-title" font-style="italic"/>
-            </group>
-            </group>
               <text macro="edition-volume"/>
               <text macro="collection-details"/>
             </group>

--- a/harvard-stellenbosch-university.csl
+++ b/harvard-stellenbosch-university.csl
@@ -18,7 +18,7 @@
   </info>
   <locale xmlns="http://purl.org/net/xbiblio/csl" xml:lang="en-GB">
     <terms>
-      <term name="volume" form="short">v.</term>
+      <term name="volume" form="short">vol.</term>
       <term name="available at">available</term>
       <term name="open-quote">“</term>
       <term name="close-quote">”</term>
@@ -48,9 +48,10 @@
     <names variable="author">
       <name name-as-sort-order="all" and="symbol" sort-separator=", " initialize-with="." delimiter=", " delimiter-precedes-last="never"/>
       <et-al font-style="italic"/>
-      <label form="short" prefix=" " text-case="capitalize-first"/>
+      <label form="short" prefix=" (" suffix=")"/>
       <substitute>
-        <text macro="editor-translator"/>
+        <names variable="editor"/>
+        <names variable="translator"/>
         <choose>
           <if type="bill book graphic legal_case legislation motion_picture report song webpage" match="any">
             <text variable="title" font-style="italic"/>
@@ -177,26 +178,25 @@
       </else>
     </choose>
   </macro>
-  <macro name="book-details">
-    <group delimiter=". ">
-      <group delimiter=" ">
-        <number variable="edition" form="ordinal"/>
-        <label variable="edition" form="short"/>
-      </group>
-      <group delimiter=" ">
-        <label variable="volume" form="short" text-case="capitalize-first"/>
-        <text variable="volume"/>
-      </group>
-      <text macro="editor-translator"/>
-      <group delimiter=" " prefix="(" suffix=")">
-        <text variable="collection-title"/>
-        <group delimiter=" ">
-          <label variable="issue" form="short"/>
-          <text variable="collection-number"/>
-        </group>
-      </group>
-      <text macro="publisher"/>
+  <macro name="edition-volume">
+    <group delimiter=" ">
+      <number variable="edition" form="ordinal"/>
+      <label variable="edition" form="short"/>
     </group>
+    <group delimiter=" ">
+      <label variable="volume" form="short"/>
+      <text variable="volume"/>
+    </group>
+  </macro>
+  <macro name="collection-details">
+    <group delimiter=" " prefix=", " suffix=". ">
+      <text variable="collection-title"/>
+      <group delimiter=" ">
+        <label variable="issue" form="short"/>
+        <text variable="collection-number"/>
+      </group>
+    </group>
+    <text macro="publisher"/>
   </macro>
   <macro name="publisher">
     <group delimiter=": ">
@@ -241,7 +241,12 @@
         <choose>
           <if type="bill book graphic legal_case legislation motion_picture post-weblog song webpage" match="any">
             <text macro="title"/>
-            <text macro="book-details"/>
+            <group delimiter=". ">
+              <!-- TODO: "vol." must be preceded by ",", i.e., title must not end with "." but with "," if followed by volume. -->
+              <text macro="edition-volume"/>
+              <text macro="editor-translator"/>
+              <text macro="collection-details"/>
+            </group>
           </if>
           <else-if type="article-journal article-magazine" match="any">
             <text macro="title"/>
@@ -286,11 +291,14 @@
           <else-if type="chapter paper-conference entry-encyclopedia entry-dictionary" match="any">
             <text macro="title"/>
             <group delimiter=" ">
-              <!-- TODO: editors must be before title -->
               <text term="in" prefix=", "/>
+              <text macro="editor-translator" suffix="."/>
               <text variable="container-title" font-style="italic"/>
             </group>
-            <text macro="book-details"/>
+            <group delimiter=", ">
+              <text macro="edition-volume" prefix=", "/>
+              <text macro="collection-details"/>
+            </group>
             <text variable="page"/>
           </else-if>
           <else-if type="patent" match="any">

--- a/harvard-stellenbosch-university.csl
+++ b/harvard-stellenbosch-university.csl
@@ -289,14 +289,18 @@
             <text variable="publisher"/>
           </else-if>
           <else-if type="chapter paper-conference entry-encyclopedia entry-dictionary" match="any">
+                          <group delimiter=", ">
+  <group delimiter=" ">
+  <group>
             <text macro="title"/>
-            <group delimiter=" ">
               <text term="in" prefix=", "/>
+              </group>
+            <group delimiter=" ">
               <text macro="editor-translator" suffix="."/>
               <text variable="container-title" font-style="italic"/>
             </group>
-            <group delimiter=", ">
-              <text macro="edition-volume" prefix=", "/>
+            </group>
+              <text macro="edition-volume"/>
               <text macro="collection-details"/>
             </group>
             <text variable="page"/>

--- a/harvard-stellenbosch-university.csl
+++ b/harvard-stellenbosch-university.csl
@@ -31,7 +31,7 @@
       <if variable="editor">
         <names variable="editor">
           <name and="symbol" initialize-with="." delimiter=", "/>
-          <label form="short" prefix=", " text-case="capitalize-first"/>
+          <label form="short" prefix=" (" suffix=")"/>
         </names>
       </if>
     </choose>
@@ -39,18 +39,18 @@
       <if variable="translator">
         <names variable="translator">
           <label form="verb" text-case="capitalize-first" suffix=" "/>
-          <name and="symbol" delimiter=", "/>
+          <name and="symbol" delimiter=" (" suffix=")"/>
         </names>
       </if>
     </choose>
   </macro>
   <macro name="author">
     <names variable="author">
-      <name name-as-sort-order="all" and="symbol" sort-separator=", " initialize-with="." delimiter=", " delimiter-precedes-last="never" et-al-min="9" et-al-use-first="8"/>
+      <name name-as-sort-order="all" and="symbol" sort-separator=", " initialize-with="." delimiter=", " delimiter-precedes-last="never"/>
+      <et-al font-style="italic"/>
       <label form="short" prefix=" " text-case="capitalize-first"/>
       <substitute>
-        <names variable="editor"/>
-        <names variable="translator"/>
+        <text macro="editor-translator"/>
         <choose>
           <if type="bill book graphic legal_case legislation motion_picture report song webpage" match="any">
             <text variable="title" font-style="italic"/>
@@ -64,7 +64,9 @@
   </macro>
   <macro name="author-short">
     <names variable="author">
-      <name form="short" and="symbol" delimiter=", " initialize-with="." delimiter-precedes-last="never" et-al-min="4" et-al-use-first="1"/>
+      <!-- TODO: and must be "symbol" in parenthesised citation but "text" in text-->
+      <name form="short" and="symbol" delimiter=", " initialize-with="." delimiter-precedes-last="never" et-al-subsequent-min="3" et-al-subsequent-use-first="1"/>
+      <et-al font-style="italic"/>
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
@@ -225,7 +227,7 @@
       </group>
     </layout>
   </citation>
-  <bibliography entry-spacing="0">
+  <bibliography entry-spacing="1">
     <sort>
       <key macro="author-short" names-min="1" names-use-first="1"/>
       <key macro="author-count" names-min="3" names-use-first="3"/>


### PR DESCRIPTION
Various corrections, per [documentation](https://libguides.sun.ac.za/c.php?g=742962&p=5316902), including:

- change "Eds." to "(eds.)" (and likewise for translator)
- never truncate author list at first, subsequently start truncating at 3 authors, then use only first author + et al
- italicise "et al."
- re-use `editor-translator` macro instead of just substituting the names
- change spacing between bibliography entries for legibility
- add TODO comment to note that, in citations, `and` must be `"symbol"` when in parentheses but `"text"` in text.