### PR TITLE
Update iso690-author-date-es.csl

### DIFF
--- a/iso690-author-date-es.csl
+++ b/iso690-author-date-es.csl
@@ -417,6 +417,7 @@
             <text macro="genre" suffix=". "/>
             <text macro="publisher-place" suffix=": "/>
             <text macro="publisher" suffix=", "/>
+            <text macro="collection" suffix=", "/>
             <text macro="page" suffix=". "/>
             <text macro="accessed" suffix=". "/>
             <text macro="isbn" suffix=". "/>


### PR DESCRIPTION
Added ‘<text macro="collection" suffix=", "/>’ in line 420 so that series and series number of conference proceedings can be displayed in the reference, if available.