### PR TITLE
Update iso690-author-date-es.csl

### DIFF
--- a/iso690-author-date-es.csl
+++ b/iso690-author-date-es.csl
@@ -204,7 +204,6 @@
     <group delimiter=", ">
       <text variable="volume" prefix="vol. "/>
       <text variable="issue" prefix="no. "/>
-      <text variable="page" prefix="pp. "/>
     </group>
   </macro>
   <macro name="publisher">
@@ -346,7 +345,8 @@
             <text macro="year-date" suffix=". "/>
             <text macro="title" suffix=", "/>
             <text macro="edition" suffix=". "/>
-            <text macro="issue" suffix=". "/>
+            <text macro="issue" suffix=", "/>
+            <text macro="page" suffix=". "/>
             <text macro="accessed" suffix=". "/>
             <text macro="issn" suffix=". "/>
             <text macro="doi" suffix=". "/>
@@ -390,8 +390,9 @@
             <text macro="edition" suffix=". "/>
             <text macro="publisher-place" suffix=": "/>
             <text macro="publisher" suffix=", "/>
-            <text macro="collection" suffix=", "/>
             <text macro="page" suffix=". "/>
+            <text macro="collection" suffix=", "/>
+            <text macro="issue" suffix=". "/>
             <text macro="accessed" suffix=". "/>
             <text macro="isbn" suffix=". "/>
             <text macro="url" suffix=". "/>
@@ -417,8 +418,9 @@
             <text macro="genre" suffix=". "/>
             <text macro="publisher-place" suffix=": "/>
             <text macro="publisher" suffix=", "/>
-            <text macro="collection" suffix=", "/>
             <text macro="page" suffix=". "/>
+            <text macro="collection" suffix=", "/>
+            <text macro="issue" suffix=". "/>
             <text macro="accessed" suffix=". "/>
             <text macro="isbn" suffix=". "/>
             <text macro="doi" suffix=". "/>


### PR DESCRIPTION
Removed page from issue macro. Added page to article-journal and article-magazine display. Added issue to paper-conference display macro. Moved page so that it goes after publisher in  paper-conference display macro. Same thing with chapter display macro. These changes are aimed at displaying collections and volume correctly in book chapters and conference proceedings that are part of series.