### PR TITLE
Update ieee.csl

### DIFF
--- a/ieee.csl
+++ b/ieee.csl
@@ -73,7 +73,7 @@
       <if type="bill book chapter graphic legal_case legislation motion_picture paper-conference report song" match="any">
         <choose>
           <if is-numeric="edition">
-            <group delimiter=" " suffix=", ">
+            <group delimiter=" ">
               <number variable="edition" form="ordinal"/>
               <text term="edition" form="short"/>
             </group>
@@ -433,7 +433,6 @@
             <text macro="title"/>
             <text macro="locators"/>
           </group>
-          <text macro="edition"/>
           <text macro="collection"/>
           <group delimiter=", " suffix=".">
             <text macro="publisher"/>


### PR DESCRIPTION
revert error with double edition introduced in #6478 and as reported at https://forums.zotero.org/discussion/104003/problem-bei-der-zitation-mit-ieee#latest
* edit "edition" macro
* remove edition macro call in bibliography as it's already called via the "locators" macro

I'm wondering about the line 82 `<text variable="edition" text-case="capitalize-first" suffix="."/>`. Do we want/need a suffix here?