### PR TITLE
Update united-states-international-trade-commissio

### DIFF
--- a/united-states-international-trade-commission.csl
+++ b/united-states-international-trade-commission.csl
@@ -31,7 +31,7 @@
     <category citation-format="note"/>
     <category field="generic-base"/>
     <summary>A bibliographical style file for the United States International Trade Commission</summary>
-    <updated>2023-03-30T18:12:38+00:00</updated>
+    <updated>2023-04-04T12:17:26+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale xml:lang="en">
@@ -153,7 +153,7 @@
             </else>
           </choose>
         </else-if>
-        <else-if type="broadcast" match="any">
+        <else-if type="broadcast motion_picture" match="any">
           <names variable="director"/>
           <text variable="volume"/>
         </else-if>
@@ -221,7 +221,7 @@
           </choose>
         </if>
         <else-if type="motion_picture" match="any">
-          <names variable="producer"/>
+          <names variable="director"/>
         </else-if>
         <else-if type="broadcast" match="any">
           <names variable="director"/>
@@ -277,24 +277,10 @@
             <text variable="genre"/>
           </if>
           <else-if type="legislation bill" match="any">
-            <choose>
-              <if match="any" variable="title-short">
-                <text variable="title-short" text-case="title"/>
-              </if>
-              <else>
-                <text variable="title"/>
-              </else>
-            </choose>
+            <text variable="title" form="short"/>
           </else-if>
           <else-if type="book graphic map song" match="any">
-            <choose>
-              <if match="any" variable="title-short">
-                <text variable="title-short" text-case="title" suffix=","/>
-              </if>
-              <else>
-                <text variable="title" form="short" text-case="title" font-style="italic"/>
-              </else>
-            </choose>
+            <text variable="title" form="short" text-case="title" font-style="italic"/>
             <group>
               <text term="version"/>
               <text variable="version"/>
@@ -307,111 +293,44 @@
             <text variable="title" text-case="title" font-style="italic" prefix="review of "/>
           </else-if>
           <else-if type="webpage" match="all">
-            <choose>
-              <if match="any" variable="title-short">
-                <text variable="title-short" text-case="title" quotes="true"/>
-              </if>
-              <else>
-                <text variable="title" form="short" text-case="title" quotes="true"/>
-              </else>
-            </choose>
+            <text variable="title" form="short" text-case="title" quotes="true"/>
           </else-if>
           <else-if type="motion_picture" match="any">
             <group>
-              <choose>
-                <if match="any" variable="title-short">
-                  <text variable="title-short" text-case="title"/>
-                  <date form="text" variable="issued" prefix=", "/>
-                </if>
-                <else>
-                  <text variable="title" text-case="title" quotes="true"/>
-                  <date form="text" variable="issued" prefix=", "/>
-                </else>
-              </choose>
+              <text variable="title" form="short" text-case="title" quotes="true"/>
+              <date form="text" variable="issued" prefix=", "/>
             </group>
           </else-if>
           <else-if type="report" match="any">
-            <choose>
-              <if match="any" variable="title-short">
-                <text variable="title-short" text-case="title" font-style="italic"/>
-              </if>
-              <else>
-                <text variable="title" text-case="title" font-style="italic"/>
-              </else>
-            </choose>
+            <text variable="title" form="short" text-case="title" font-style="italic"/>
           </else-if>
           <else-if type="software" match="any">
-            <choose>
-              <if match="any" variable="title-short">
-                <text variable="title-short" form="short" text-case="title"/>
-              </if>
-              <else>
-                <text variable="title" form="short" text-case="title"/>
-              </else>
-            </choose>
+            <text variable="title" form="short" text-case="title"/>
           </else-if>
           <else-if type="speech" match="any"/>
           <else-if type="hearing" match="any">
-            <choose>
-              <if match="any" variable="title-short">
-                <text variable="title-short"/>
-              </if>
-              <else>
-                <text variable="title"/>
-              </else>
-            </choose>
+            <text variable="title" form="short" text-case="title"/>
           </else-if>
           <else>
-            <choose>
-              <if match="any" variable="title-short">
-                <text variable="title-short" form="short" text-case="title" quotes="true"/>
-              </if>
-              <else>
-                <text variable="title" form="short" text-case="title" quotes="true"/>
-              </else>
-            </choose>
+            <text variable="title" form="short" text-case="title" quotes="true"/>
           </else>
         </choose>
       </else-if>
       <else-if type="legislation bill" match="any">
-        <choose>
-          <if match="any" variable="title-short">
-            <text variable="title" form="short" text-case="title"/>
-          </if>
-          <else>
-            <text variable="title"/>
-          </else>
-        </choose>
+        <text variable="title" form="short"/>
       </else-if>
       <else-if type="book graphic map song" match="any">
-        <choose>
-          <if match="any" variable="title-short">
-            <text variable="title-short" form="short" text-case="title" quotes="false" font-style="italic" suffix=","/>
-          </if>
-          <else>
-            <text variable="title" form="short" text-case="title" quotes="false" font-style="italic"/>
-          </else>
-        </choose>
+        <text variable="title" form="short" text-case="title" font-style="italic"/>
         <group delimiter=" " prefix=", ">
           <text term="version"/>
           <text variable="version"/>
         </group>
       </else-if>
       <else-if type="interview patent" match="any">
-        <choose>
-          <if match="any" variable="title-short">
-            <group delimiter=" ">
-              <text variable="title-short"/>
-              <text macro="interviewer-note"/>
-            </group>
-          </if>
-          <else>
-            <group delimiter=" ">
-              <text variable="title" text-case="title"/>
-              <text macro="interviewer-note"/>
-            </group>
-          </else>
-        </choose>
+        <group delimiter=" ">
+          <text variable="title" form="short"/>
+          <text macro="interviewer-note"/>
+        </group>
       </else-if>
       <else-if variable="reviewed-author">
         <text variable="title" text-case="title" font-style="italic" prefix="review of "/>
@@ -423,73 +342,30 @@
         <text variable="title" form="short" text-case="title" quotes="true"/>
       </else-if>
       <else-if type="post-weblog" match="all" variable="author">
-        <choose>
-          <if match="any" variable="title-short">
-            <text variable="title-short" quotes="true"/>
-          </if>
-          <else>
-            <text variable="title"/>
-          </else>
-        </choose>
+        <text variable="title" form="short" text-case="title" quotes="true"/>
       </else-if>
       <else-if type="webpage post-weblog" match="any"/>
       <else-if type="article" match="any"/>
       <else-if type="motion_picture" match="any">
         <group>
-          <choose>
-            <if match="any" variable="title-short">
-              <text variable="title-short" text-case="title"/>
-            </if>
-            <else>
-              <text variable="title" text-case="title" quotes="true"/>
-            </else>
-          </choose>
+          <text variable="title" form="short" text-case="title" quotes="true"/>
         </group>
       </else-if>
       <else-if type="report" match="any">
-        <choose>
-          <if match="any" variable="title-short">
-            <text variable="title-short" text-case="title" font-style="italic"/>
-          </if>
-          <else>
-            <text variable="title" text-case="title" font-style="italic"/>
-          </else>
-        </choose>
+        <text variable="title" form="short" text-case="title" font-style="italic"/>
       </else-if>
       <else-if type="legal_case" match="any">
         <text variable="title" form="short" font-style="italic"/>
       </else-if>
       <else-if type="software" match="any">
-        <choose>
-          <if match="any" variable="title-short">
-            <text variable="title-short" form="short"/>
-          </if>
-          <else>
-            <text variable="title" form="short" text-case="title"/>
-          </else>
-        </choose>
+        <text variable="title" form="short" text-case="title"/>
       </else-if>
       <else-if type="speech" match="any">
-        <choose>
-          <if match="any" variable="title-short">
-            <text variable="title-short" quotes="true"/>
-            <date form="text" variable="issued" prefix=", "/>
-          </if>
-          <else>
-            <text variable="title" form="short" quotes="true"/>
-            <date form="text" variable="issued" prefix=", "/>
-          </else>
-        </choose>
+        <text variable="title" form="short" quotes="true"/>
+        <date form="text" variable="issued" prefix=", "/>
       </else-if>
       <else>
-        <choose>
-          <if match="any" variable="title-short">
-            <text variable="title-short" form="short" text-case="title" quotes="true"/>
-          </if>
-          <else>
-            <text variable="title" form="short" text-case="title" quotes="true"/>
-          </else>
-        </choose>
+        <text variable="title" form="short" text-case="title" quotes="true"/>
       </else>
     </choose>
   </macro>
@@ -623,14 +499,7 @@
         <else-if type="post-weblog" match="all" variable="author"/>
         <else-if type="webpage post-weblog" match="any">
           <text variable="container-title" suffix=","/>
-          <choose>
-            <if match="any" variable="title-short">
-              <text variable="title-short" quotes="true"/>
-            </if>
-            <else>
-              <text variable="title" text-case="title" quotes="true"/>
-            </else>
-          </choose>
+          <text variable="title" form="short" text-case="title" quotes="true"/>
         </else-if>
         <else-if type="bill legislation legal_case" match="none"/>
       </choose>
@@ -1598,7 +1467,7 @@
               </choose>
             </group>
           </if>
-          <else-if type="article book bill chapter paper-conference song thesis" match="any">
+          <else-if type="article book bill chapter paper-conference song thesis motion_picture" match="any">
             <choose>
               <if match="all" is-uncertain-date="issued">
                 <date form="text" date-parts="year-month-day" variable="issued"/>

--- a/united-states-international-trade-commission.csl
+++ b/united-states-international-trade-commission.csl
@@ -24,10 +24,14 @@
       <name>Peg Hausman</name>
       <email>Margaret.Hausman@usitc.gov</email>
     </contributor>
+    <contributor>
+      <name>Brian Rose</name>
+      <email>brian.rose@usitc.gov</email>
+    </contributor>
     <category citation-format="note"/>
     <category field="generic-base"/>
     <summary>A bibliographical style file for the United States International Trade Commission</summary>
-    <updated>2022-08-17T18:21:43+00:00</updated>
+    <updated>2023-03-27T15:29:33+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale xml:lang="en">
@@ -126,9 +130,12 @@
   <macro name="contributors-note">
     <group delimiter=" ">
       <choose>
-        <if match="any" variable="note">
-          <text variable="note"/>
+        <if match="all" variable="note" type="speech">
+          <text value="Warning: the 'extra' field does not populate correctly with presentation citation item types. Please edit this citation item in the Zotero app to resolve. A manual overwrite may be needed for abbreviated names." strip-periods="false" font-weight="normal"/>
         </if>
+        <else-if match="any" variable="note">
+          <text variable="note"/>
+        </else-if>
         <else-if type="webpage" match="any"/>
         <else-if type="article-magazine" match="all">
           <choose>
@@ -145,6 +152,10 @@
               <text variable="container-title" form="short" font-style="italic"/>
             </else>
           </choose>
+        </else-if>
+        <else-if type="broadcast" match="any">
+          <names variable="director"/>
+          <text variable="volume"/>
         </else-if>
         <else>
           <names variable="author">
@@ -209,6 +220,12 @@
             </else>
           </choose>
         </if>
+        <else-if type="motion_picture" match="any">
+          <names variable="producer"/>
+        </else-if>
+        <else-if type="broadcast" match="any">
+          <names variable="director"/>
+        </else-if>
         <else>
           <names variable="author">
             <name name-as-sort-order="first" and="text" sort-separator=", " delimiter=", " delimiter-precedes-last="always"/>
@@ -323,6 +340,27 @@
               </else>
             </choose>
           </else-if>
+          <else-if type="software" match="any">
+            <choose>
+              <if match="any" variable="title-short">
+                <text variable="title-short" form="short" text-case="title"/>
+              </if>
+              <else>
+                <text variable="title" form="short" text-case="title"/>
+              </else>
+            </choose>
+          </else-if>
+          <else-if type="speech" match="any"/>
+          <else-if type="hearing" match="any">
+            <choose>
+              <if match="any" variable="title-short">
+                <text variable="title-short"/>
+              </if>
+              <else>
+                <text variable="title"/>
+              </else>
+            </choose>
+          </else-if>
           <else>
             <choose>
               <if match="any" variable="title-short">
@@ -360,7 +398,20 @@
         </group>
       </else-if>
       <else-if type="interview patent" match="any">
-        <text variable="title" text-case="title"/>
+        <choose>
+          <if match="any" variable="title-short">
+            <group delimiter=" ">
+              <text variable="title-short"/>
+              <text macro="interviewer-note"/>
+            </group>
+          </if>
+          <else>
+            <group delimiter=" ">
+              <text variable="title" text-case="title"/>
+              <text macro="interviewer-note"/>
+            </group>
+          </else>
+        </choose>
       </else-if>
       <else-if variable="reviewed-author">
         <text variable="title" text-case="title" font-style="italic" prefix="review of "/>
@@ -371,7 +422,17 @@
         </names>
         <text variable="title" form="short" text-case="title" quotes="true"/>
       </else-if>
-      <else-if type="webpage" match="any"/>
+      <else-if type="post-weblog" match="all" variable="author">
+        <choose>
+          <if match="any" variable="title-short">
+            <text variable="title-short" quotes="true"/>
+          </if>
+          <else>
+            <text variable="title"/>
+          </else>
+        </choose>
+      </else-if>
+      <else-if type="webpage post-weblog" match="any"/>
       <else-if type="article" match="any"/>
       <else-if type="motion_picture" match="any">
         <group>
@@ -398,6 +459,28 @@
       <else-if type="legal_case" match="any">
         <text variable="title" form="short" font-style="italic"/>
       </else-if>
+      <else-if type="software" match="any">
+        <choose>
+          <if match="any" variable="title-short">
+            <text variable="title-short" form="short"/>
+          </if>
+          <else>
+            <text variable="title" form="short" text-case="title"/>
+          </else>
+        </choose>
+      </else-if>
+      <else-if type="speech" match="any">
+        <choose>
+          <if match="any" variable="title-short">
+            <text variable="title-short" quotes="true"/>
+            <date form="text" variable="issued" prefix=", "/>
+          </if>
+          <else>
+            <text variable="title" form="short" quotes="true"/>
+            <date form="text" variable="issued" prefix=", "/>
+          </else>
+        </choose>
+      </else-if>
       <else>
         <choose>
           <if match="any" variable="title-short">
@@ -411,68 +494,71 @@
     </choose>
   </macro>
   <macro name="title">
-    <choose>
-      <if variable="title" match="none">
-        <choose>
-          <if type="personal_communication" match="none">
-            <text variable="genre" text-case="capitalize-first"/>
-          </if>
-        </choose>
-      </if>
-      <else-if type="book graphic song" match="any">
-        <text variable="title" text-case="title" quotes="false" font-style="italic"/>
-        <group prefix=" (" suffix=")" delimiter=" ">
-          <text term="version"/>
-          <text variable="version"/>
-        </group>
-      </else-if>
-      <else-if variable="reviewed-author">
-        <group delimiter=", ">
-          <text variable="title" text-case="title" font-style="italic" prefix="Review of "/>
-          <names variable="reviewed-author">
-            <label form="verb-short" text-case="lowercase" suffix=" "/>
-            <name and="text" delimiter=", "/>
-          </names>
-        </group>
-      </else-if>
-      <else-if type="bill legislation interview patent" match="any">
-        <text variable="title" text-case="title"/>
-      </else-if>
-      <else-if type="motion_picture" match="all">
-        <choose>
-          <if match="any" variable="issued">
-            <group delimiter=". ">
-              <text variable="title" text-case="title" quotes="true"/>
-              <text variable="dimensions" prefix="Video, "/>
-            </group>
-          </if>
-          <else-if match="any" variable="accessed">
-            <group>
-              <text variable="title" text-case="title" quotes="true" suffix=","/>
-              <date form="text" variable="accessed" prefix=" accessed " suffix=". "/>
-              <text variable="dimensions" prefix="Video, "/>
-            </group>
-          </else-if>
-          <else>
-            <text variable="title" text-case="title"/>
-          </else>
-        </choose>
-      </else-if>
-      <else-if type="report" match="any">
-        <text variable="title" text-case="title" font-style="italic"/>
-      </else-if>
-      <else-if type="legal_case" match="any">
-        <text variable="title" font-style="italic"/>
-      </else-if>
-      <else>
-        <text variable="title" text-case="title" quotes="true"/>
-      </else>
-    </choose>
+    <group delimiter=". ">
+      <choose>
+        <if variable="title" match="none">
+          <choose>
+            <if type="personal_communication" match="none">
+              <text variable="genre" text-case="capitalize-first"/>
+            </if>
+          </choose>
+        </if>
+        <else-if type="book graphic song" match="any">
+          <text variable="title" text-case="title" quotes="false" font-style="italic"/>
+          <group prefix=" (" suffix=")" delimiter=" ">
+            <text term="version"/>
+            <text variable="version"/>
+          </group>
+        </else-if>
+        <else-if variable="reviewed-author">
+          <group delimiter=", ">
+            <text variable="title" text-case="title" font-style="italic" prefix="Review of "/>
+            <names variable="reviewed-author">
+              <label form="verb-short" text-case="lowercase" suffix=" "/>
+              <name and="text" delimiter=", "/>
+            </names>
+          </group>
+        </else-if>
+        <else-if type="bill legislation interview patent" match="any">
+          <text variable="title" text-case="title"/>
+        </else-if>
+        <else-if type="motion_picture" match="all">
+          <choose>
+            <if match="any" variable="issued">
+              <group delimiter=". ">
+                <text variable="title" text-case="title" quotes="true"/>
+                <text variable="dimensions" prefix="Video, "/>
+              </group>
+            </if>
+            <else-if match="any" variable="accessed">
+              <group>
+                <text variable="title" text-case="title" quotes="true" suffix=","/>
+                <date form="text" variable="accessed" prefix=" accessed " suffix=". "/>
+                <text variable="dimensions" prefix="Video, "/>
+              </group>
+            </else-if>
+            <else>
+              <text variable="title" text-case="title"/>
+            </else>
+          </choose>
+        </else-if>
+        <else-if type="report" match="any">
+          <text variable="title" text-case="title" font-style="italic"/>
+        </else-if>
+        <else-if type="legal_case" match="any">
+          <text variable="title" font-style="italic"/>
+        </else-if>
+        <else-if type="software" match="any">
+          <text variable="title"/>
+        </else-if>
+        <else>
+          <text variable="title" text-case="title" quotes="true"/>
+        </else>
+      </choose>
+    </group>
   </macro>
   <macro name="description-note">
     <group delimiter=", ">
-      <text macro="interviewer-note"/>
-      <text variable="medium"/>
       <choose>
         <if variable="title" match="none"/>
         <else-if type="manuscript thesis speech" match="any"/>
@@ -481,6 +567,9 @@
             <text variable="authority"/>
             <text variable="number"/>
           </group>
+        </else-if>
+        <else-if type="interview" match="any">
+          <text variable="medium"/>
         </else-if>
       </choose>
       <choose>
@@ -531,9 +620,17 @@
       </choose>
       <choose>
         <if type="webpage" variable="author"/>
-        <else-if type="webpage" match="any">
+        <else-if type="post-weblog" match="all" variable="author"/>
+        <else-if type="webpage post-weblog" match="any">
           <text variable="container-title" suffix=","/>
-          <text variable="title" text-case="title" quotes="true"/>
+          <choose>
+            <if match="any" variable="title-short">
+              <text variable="title-short" quotes="true"/>
+            </if>
+            <else>
+              <text variable="title" text-case="title" quotes="true"/>
+            </else>
+          </choose>
         </else-if>
         <else-if type="bill legislation legal_case" match="none"/>
       </choose>
@@ -549,7 +646,7 @@
           <text variable="container-title"/>
         </if>
         <else-if type="post-weblog">
-          <text variable="container-title" text-case="title" font-style="italic" suffix=" (blog)"/>
+          <text variable="container-title" text-case="title" font-style="italic"/>
         </else-if>
         <else-if type="article-magazine" match="all">
           <choose>
@@ -573,12 +670,17 @@
     <choose>
       <if match="none" type="article-journal">
         <choose>
-          <if match="none" is-numeric="collection-number">
+          <if match="none" is-numeric="collection-number" type="software">
             <group delimiter=", ">
               <text variable="collection-title" text-case="title"/>
               <text variable="collection-number"/>
             </group>
           </if>
+          <else-if type="software" match="any">
+            <group>
+              <text variable="collection-title" text-case="capitalize-first"/>
+            </group>
+          </else-if>
           <else>
             <group delimiter=" ">
               <text variable="collection-title" text-case="title"/>
@@ -978,6 +1080,7 @@
               <date form="text" date-parts="year-month-day" variable="issued"/>
             </group>
           </else-if>
+          <else-if type="software" match="any"/>
           <else>
             <choose>
               <if is-uncertain-date="issued">
@@ -994,6 +1097,7 @@
         <text variable="status"/>
       </else-if>
       <else-if variable="accessed URL" match="all"/>
+      <else-if type="software" match="any"/>
       <else>
         <text term="no date" form="short"/>
       </else>
@@ -1180,9 +1284,6 @@
       <if type="bill legislation legal_case" match="any">
         <text macro="issued-note"/>
       </if>
-      <else-if type="speech" match="any">
-        <date form="text" date-parts="year-month-day" variable="issued"/>
-      </else-if>
       <else-if type="article-journal">
         <choose>
           <if variable="volume issue" match="any">
@@ -1196,7 +1297,7 @@
       <else-if type="article-newspaper">
         <text macro="issued-note"/>
       </else-if>
-      <else-if type="manuscript thesis speech" match="any">
+      <else-if type="manuscript thesis" match="any">
         <group delimiter=", ">
           <choose>
             <if variable="title" match="any"/>
@@ -1348,7 +1449,7 @@
         </else-if>
       </choose>
       <choose>
-        <if variable="issued" match="none" type="legislation">
+        <if variable="issued" match="none" type="legislation software">
           <group font-variant="normal" delimiter=" ">
             <text term="accessed" text-case="lowercase"/>
             <date variable="accessed" form="text"/>
@@ -1356,6 +1457,20 @@
         </if>
         <else-if type="motion_picture" match="all" is-uncertain-date="accessed">
           <date form="text" date-parts="year-month-day" variable="issued"/>
+        </else-if>
+        <else-if type="software" match="all">
+          <group>
+            <choose>
+              <if match="any" variable="accessed">
+                <text term="accessed" suffix=" "/>
+                <date form="text" variable="accessed"/>
+              </if>
+              <else>
+                <text value="accessed" suffix=" "/>
+                <date form="text" date-parts="year-month-day" variable="issued"/>
+              </else>
+            </choose>
+          </group>
         </else-if>
       </choose>
       <choose>
@@ -1380,7 +1495,7 @@
         </else-if>
       </choose>
       <choose>
-        <if variable="issued" match="none" type="legislation motion_picture">
+        <if variable="issued" match="none" type="legislation motion_picture software">
           <group delimiter=" " suffix=".">
             <text term="accessed" text-case="title"/>
             <date form="text" variable="accessed"/>
@@ -1393,8 +1508,24 @@
             <if variable="DOI">
               <text variable="DOI" prefix="https://doi.org/"/>
             </if>
-            <else>
+            <else-if type="software" match="any">
               <text variable="URL"/>
+              <group>
+                <choose>
+                  <if match="any" variable="accessed">
+                    <date form="text" variable="accessed" prefix="(accessed " suffix=")"/>
+                  </if>
+                  <else-if match="any" variable="issued">
+                    <date form="text" variable="issued" prefix="(accessed " suffix=")"/>
+                  </else-if>
+                  <else>
+                    <text value="(accessed various dates)"/>
+                  </else>
+                </choose>
+              </group>
+            </else-if>
+            <else>
+              <text variable="URL" prefix="Available at "/>
             </else>
           </choose>
         </if>
@@ -1414,12 +1545,24 @@
   </macro>
   <macro name="editor-note">
     <names variable="editor">
-      <name form="short" and="text" delimiter-precedes-last="always" name-as-sort-order="first"/>
+      <name form="short" and="text" et-al-min="4" name-as-sort-order="first"/>
     </names>
   </macro>
   <macro name="collection-title-note">
     <choose>
       <if type="article-journal report book" match="any"/>
+      <else-if type="chapter" match="any">
+        <group prefix="in ">
+          <text variable="container-title" font-style="italic"/>
+        </group>
+      </else-if>
+      <else-if type="paper-conference" match="any"/>
+      <else-if type="software" match="any">
+        <group>
+          <text variable="collection-title" quotes="true"/>
+          <text variable="collection-number"/>
+        </group>
+      </else-if>
       <else>
         <choose>
           <if match="none" is-numeric="collection-number">
@@ -1455,7 +1598,7 @@
               </choose>
             </group>
           </if>
-          <else-if type="article book bill chapter motion_picture paper-conference song thesis" match="any">
+          <else-if type="article book bill chapter paper-conference song thesis" match="any">
             <choose>
               <if match="all" is-uncertain-date="issued">
                 <date form="text" date-parts="year-month-day" variable="issued"/>
@@ -1502,6 +1645,8 @@
               <if match="all" is-uncertain-date="issued">
                 <date form="text" variable="issued" prefix="[" suffix="?]"/>
               </if>
+              <else-if type="speech" match="any"/>
+              <else-if type="software motion_picture" match="any"/>
               <else>
                 <date form="text" date-parts="year-month-day" variable="issued"/>
               </else>
@@ -1513,6 +1658,11 @@
         <text variable="status"/>
       </else-if>
       <else-if match="all" variable="accessed URL"/>
+      <else-if type="software" match="all">
+        <group suffix=".">
+          <text value="Accessed various dates"/>
+        </group>
+      </else-if>
       <else-if type="legislation" match="any"/>
       <else>
         <text term="no date"/>

--- a/united-states-international-trade-commission.csl
+++ b/united-states-international-trade-commission.csl
@@ -31,7 +31,7 @@
     <category citation-format="note"/>
     <category field="generic-base"/>
     <summary>A bibliographical style file for the United States International Trade Commission</summary>
-    <updated>2023-03-27T15:29:33+00:00</updated>
+    <updated>2023-03-30T18:12:38+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale xml:lang="en">
@@ -1545,7 +1545,7 @@
   </macro>
   <macro name="editor-note">
     <names variable="editor">
-      <name form="short" and="text" et-al-min="4" name-as-sort-order="first"/>
+      <name form="short" and="text" et-al-min="4" et-al-use-first="1" name-as-sort-order="first"/>
     </names>
   </macro>
   <macro name="collection-title-note">


### PR DESCRIPTION
Changelog summary:

-	Added code to support new item types, such as hearing, interview, and software (i.e., databases) 
- 	Updated Zotero styles to conform to Editors guidance document 
- 	Various bug fixes for Blogs, Book, Book Sections, Broadcasts, Presentations, and Videos item types. 
- 	Resolved title conflicts between blog and webpage titles that may not be put in the author field