### PR TITLE
Propose empty.csl

### DIFF
--- a/empty.csl
+++ b/empty.csl
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="utf-8"?>
+<style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" demote-non-dropping-particle="sort-only" default-locale="en-US">
+  <info>
+    <title>Completely empty CSL style (for hiding references, e.g. when rendering Quarto to HTML)</title>
+    <id>http://www.zotero.org/styles/empty</id>
+    <link href="http://www.zotero.org/styles/empty" rel="self"/>
+    <author>
+      <name>Florian "floe" Echtler</name>
+      <email>floe@butterbrot.org</email>
+      <uri>https://floe.butterbrot.org/</uri>
+    </author>
+    <category citation-format="numeric"/>
+    <updated>2017-07-15T14:06:44+00:00</updated>
+    <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
+  </info>
+  <citation collapse="citation-number">
+    <sort>
+      <key variable="citation-number"/>
+    </sort>
+    <layout prefix="" suffix="" delimiter="">
+      <!-- text variable="citation-number"/ -->
+    </layout>
+  </citation>
+  <bibliography entry-spacing="0" second-field-align="flush" et-al-min="3" et-al-use-first="1">
+    <sort>
+      <key variable="title"/>
+    </sort>
+    <layout suffix="">
+      <!-- text variable="citation-number" prefix="[" suffix="]"/ -->
+    </layout>
+  </bibliography>
+</style>

--- a/empty.csl
+++ b/empty.csl
@@ -18,7 +18,7 @@
       <key variable="citation-number"/>
     </sort>
     <layout prefix="" suffix="" delimiter="">
-      <!-- text variable="citation-number"/ -->
+      <text value=""/>
     </layout>
   </citation>
   <bibliography entry-spacing="0" second-field-align="flush" et-al-min="3" et-al-use-first="1">
@@ -26,7 +26,7 @@
       <key variable="title"/>
     </sort>
     <layout suffix="">
-      <!-- text variable="citation-number" prefix="[" suffix="]"/ -->
+      <text value=""/>
     </layout>
   </bibliography>
 </style>


### PR DESCRIPTION
Completely empty CSL style (for hiding references, e.g. when rendering Quarto to HTML). Couldn't find anything suitable for that purpose, so I created an empty style myself.