### PR TITLE
Update norsk-henvisningsstandard-for-rettsvitenskapelige-tekster.csl

### DIFF
--- a/norsk-henvisningsstandard-for-rettsvitenskapelige-tekster.csl
+++ b/norsk-henvisningsstandard-for-rettsvitenskapelige-tekster.csl
@@ -292,8 +292,8 @@
             <text macro="author-full"/>
             <text prefix=", " macro="title"/>
             <text prefix=" " font-style="italic" variable="container-title"/>
-            <text prefix=" " macro="issued"/>
-            <group delimiter=" " prefix=" ">
+            <text prefix=" " macro="issued-no-parenthesis"/>
+            <group delimiter=" " prefix=", ">
               <text term="page" form="short"/>
               <text variable="page"/>
             </group>


### PR DESCRIPTION
Fixed an error in the handling of the year for journal articles in the bibliography.