### PR TITLE
Create gost-r-7-0-5-2008-numeric-by-appearance.csl

### DIFF
--- a/gost-r-7-0-5-2008-numeric-by-appearance.csl
+++ b/gost-r-7-0-5-2008-numeric-by-appearance.csl
@@ -1,0 +1,173 @@
+<?xml version="1.0" encoding="utf-8"?>
+<style xmlns="http://purl.org/net/xbiblio/csl" version="1.0" class="in-text" default-locale="ru-RU">
+  <info>
+    <title>Russian GOST R 7.0.5-2008 (numeric, sorted by appearance, Ру́сский)</title>
+    <title-short>GOST R 7.0.5-2008 (numeric, sorted by appearance)</title-short>
+    <id>http://www.zotero.org/styles/gost-r-7-0-5-2008-numeric-by-appearance</id>
+    <link href="http://www.zotero.org/styles/gost-r-7-0-5-2008-numeric-by-appearance" rel="self"/>
+    <link href="http://www.zotero.org/styles/gost-r-7-0-5-2008-numeric-alphabetical" rel="template"/>
+    <link href="http://protect.gost.ru/document.aspx?control=7&amp;id=173511" rel="documentation"/>
+    <link href="http://standartgost.ru/g/%D0%93%D0%9E%D0%A1%D0%A2_%D0%A0_7.0.5-2008" rel="documentation"/>
+    <author>
+      <name>Eldar Khurmamatov</name>
+    </author>
+    <category citation-format="numeric"/>
+    <category field="generic-base"/>
+    <summary>Russian GOST-2008 style. Book, report, webpage, post-weblog and article chapters edited. Note!!! In articles form of № = Issue (Volume).</summary>
+    <updated>2023-05-03T18:43:56+00:00</updated>
+    <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
+  </info>
+  <locale xml:lang="ru">
+    <terms>
+      <term name="et-al"> [и др.].</term>
+      <term name="editor">под ред.</term>
+      <term name="accessed">дата обращения</term>
+      <term name="page" form="short">с.</term>
+      <term name="translator">перевод</term>
+    </terms>
+  </locale>
+  <macro name="editor">
+    <names variable="editor" delimiter=", " suffix=",">
+      <label prefix=" " suffix=" "/>
+      <name initialize-with=". "/>
+    </names>
+  </macro>
+  <macro name="author">
+    <names variable="author" delimiter="," prefix=" / " suffix=",">
+      <name et-al-min="6" et-al-use-first="5" initialize-with=". "/>
+      <label form="short" strip-periods="true"/>
+    </names>
+  </macro>
+  <macro name="access">
+    <group>
+      <text value="[Электронный ресурс]. "/>
+      <text variable="URL" prefix="URL: "/>
+      <group prefix=" (" suffix=").">
+        <text term="accessed" suffix=": "/>
+        <date variable="accessed">
+          <date-part name="day" suffix="." form="numeric-leading-zeros"/>
+          <date-part name="month" suffix="." form="numeric-leading-zeros"/>
+          <date-part name="year"/>
+        </date>
+      </group>
+    </group>
+  </macro>
+  <macro name="title">
+    <text variable="title"/>
+  </macro>
+  <macro name="translator">
+    <names variable="translator" delimiter="," suffix=",">
+      <label prefix=" " suffix=" "/>
+      <name initialize-with=". "/>
+    </names>
+  </macro>
+  <macro name="publisher">
+    <group suffix=",">
+      <text variable="publisher-place" suffix=":"/>
+      <text variable="publisher" prefix=" "/>
+    </group>
+    <text macro="year-date" prefix=" " suffix="."/>
+  </macro>
+  <macro name="year-date">
+    <date variable="issued">
+      <date-part name="year"/>
+    </date>
+  </macro>
+  <macro name="language-sort">
+    <text variable="note"/>
+    <text value="Z999"/>
+  </macro>
+  <macro name="citation-number">
+    <text variable="citation-number" suffix=". "/>
+  </macro>
+  <macro name="author-first">
+    <names variable="author">
+      <name delimiter-precedes-last="always" initialize-with=". " name-as-sort-order="all" sort-separator=" "/>
+      <label form="short" strip-periods="true" prefix=" " suffix="."/>
+    </names>
+  </macro>
+  <citation collapse="citation-number">
+    <sort>
+      <key variable="citation-number"/>
+    </sort>
+    <layout prefix="[" suffix="]" delimiter=", ">
+      <text variable="citation-number"/>
+      <group prefix=",">
+        <label plural="never" prefix=" " variable="locator" form="short"/>
+        <text variable="locator" form="short" prefix=" "/>
+      </group>
+    </layout>
+  </citation>
+  <bibliography et-al-min="4" et-al-use-first="1">
+    <sort>
+      <key variable="first-reference-note-number"/>
+    </sort>
+    <layout suffix=".">
+      <text macro="citation-number"/>
+      <text macro="author-first" suffix=" "/>
+      <choose>
+        <if type="book" match="any">
+          <group>
+            <group delimiter=" ">
+              <text macro="title"/>
+              <text macro="author"/>
+              <text macro="editor"/>
+              <text macro="translator"/>
+              <text variable="edition" suffix="-е изд.,"/>
+            </group>
+            <text macro="publisher" prefix=" "/>
+            <text variable="number-of-pages" prefix=" " suffix=" c."/>
+          </group>
+        </if>
+        <else-if type="chapter paper-conference" match="any">
+          <group>
+            <group delimiter=" ">
+              <text macro="title"/>
+              <text variable="collection-title" suffix=" /"/>
+              <text macro="editor"/>
+            </group>
+            <text macro="publisher" prefix=" "/>
+            <text variable="page" prefix="C. " suffix="."/>
+          </group>
+        </else-if>
+        <else-if type="webpage post-weblog" match="any">
+          <text macro="title"/>
+          <text variable="container-title" prefix=" // "/>
+          <text prefix=" " macro="access"/>
+        </else-if>
+        <else-if type="article-journal article-magazine article-newspaper broadcast interview manuscript personal_communication speech thesis" match="any">
+          <text macro="title"/>
+          <group delimiter=" " prefix=" ">
+            <text variable="container-title" prefix=" // " suffix="."/>
+            <text macro="year-date" suffix="."/>
+            <group suffix=".">
+              <text variable="issue" prefix="№ "/>
+              <text variable="volume" prefix=" (" suffix=")"/>
+            </group>
+            <text variable="page" prefix="C. " suffix="."/>
+          </group>
+        </else-if>
+        <else-if type="report">
+          <group suffix=".">
+            <text variable="publisher" suffix=". "/>
+            <text macro="title"/>
+          </group>
+          <text variable="publisher-place" prefix=" " suffix=","/>
+          <text macro="year-date" prefix=" "/>
+        </else-if>
+        <else>
+          <text macro="title" prefix=" "/>
+          <group delimiter=". " prefix=" " suffix=".">
+            <group prefix="// " delimiter=". ">
+              <text variable="container-title"/>
+              <text macro="year-date"/>
+              <text variable="volume" prefix="Т. "/>
+              <text variable="issue" prefix="№ "/>
+            </group>
+            <text variable="page" prefix="C. " suffix="."/>
+          </group>
+        </else>
+      </choose>
+    </layout>
+  </bibliography>
+</style>


### PR DESCRIPTION
Based on [GOST R 7.0.5-2008 (numeric, alphabetical) style](https://github.com/citation-style-language/styles/blob/master/gost-r-7-0-5-2008-numeric-alphabetical.csl). 

This new style is necessary for universities in Russia that require citations to be ordered by appearance in the text.