### PR TITLE
Update united-states-international-trade-commission.csl

### DIFF
--- a/united-states-international-trade-commission.csl
+++ b/united-states-international-trade-commission.csl
@@ -31,7 +31,7 @@
     <category citation-format="note"/>
     <category field="generic-base"/>
     <summary>A bibliographical style file for the United States International Trade Commission</summary>
-    <updated>2023-05-01T12:23:30+00:00</updated>
+    <updated>2023-05-04T17:11:06+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale xml:lang="en">
@@ -534,7 +534,7 @@
           <text variable="title" form="short" text-case="title" quotes="true"/>
         </else-if>
         <else-if type="broadcast" match="any">
-          <text variable="container-title" form="short"/>
+          <text variable="container-title" form="short" font-style="normal"/>
         </else-if>
         <else-if type="bill legislation legal_case" match="none"/>
       </choose>
@@ -1015,6 +1015,16 @@
           </if>
         </choose>
       </if>
+    </choose>
+  </macro>
+  <macro name="point-locators-join-with-comma">
+    <choose>
+      <if type="article-journal" match="none">
+        <text macro="point-locators"/>
+      </if>
+      <else-if variable="volume issue" match="none">
+        <text macro="point-locators"/>
+      </else-if>
     </choose>
   </macro>
   <macro name="point-locators">
@@ -1589,6 +1599,7 @@
             </group>
           </group>
           <text macro="point-locators-join-with-colon"/>
+          <text macro="point-locators-join-with-comma"/>
         </group>
         <text macro="access-note"/>
       </group>


### PR DESCRIPTION
Hotfix for an issue where page numbers do not appear in footnote citations