### PR TITLE
Update united-states-international-trade-commission.csl

### DIFF
--- a/united-states-international-trade-commission.csl
+++ b/united-states-international-trade-commission.csl
@@ -31,7 +31,7 @@
     <category citation-format="note"/>
     <category field="generic-base"/>
     <summary>A bibliographical style file for the United States International Trade Commission</summary>
-    <updated>2023-05-04T17:11:06+00:00</updated>
+    <updated>2023-05-10T12:30:45+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale xml:lang="en">
@@ -315,7 +315,7 @@
             <text variable="title" form="short" text-case="title" font-style="italic"/>
           </else-if>
           <else-if type="software dataset" match="any">
-            <text variable="title" form="short" text-case="title"/>
+            <text variable="title" form="short"/>
           </else-if>
           <else-if type="speech" match="any"/>
           <else-if type="hearing" match="any">
@@ -380,7 +380,7 @@
         <text variable="title" form="short" font-style="italic"/>
       </else-if>
       <else-if type="software personal_communication dataset" match="any">
-        <text variable="title" form="short" text-case="title"/>
+        <text variable="title" form="short"/>
       </else-if>
       <else-if type="speech" match="any">
         <text variable="title" form="short" quotes="false"/>
@@ -996,7 +996,7 @@
         <text variable="status"/>
       </else-if>
       <else-if variable="accessed URL" match="all"/>
-      <else-if type="software" match="any"/>
+      <else-if type="software dataset" match="any"/>
       <else>
         <text term="no date" form="short"/>
       </else>
@@ -1562,7 +1562,7 @@
       </else-if>
       <else-if match="all" variable="accessed URL"/>
       <else-if type="legislation" match="any"/>
-      <else-if type="software" match="any">
+      <else-if type="software dataset" match="any">
         <date form="text" date-parts="year-month-day" variable="issued"/>
       </else-if>
       <else>


### PR DESCRIPTION
hotfix to resolve some style bugs and to meet editor requests for specific capitalization formatting in certain circumstances.