### PR TITLE
Create Food and Agriculture Organization of the United Nations (numeric)

### DIFF
--- a/food-and-agriculture-organization-of-the-united-nations-numeric.csl
+++ b/food-and-agriculture-organization-of-the-united-nations-numeric.csl
@@ -185,7 +185,7 @@
     </layout>
   </citation>
   <!-- bibliography -->
-   <bibliography entry-spacing="0" second-field-align="flush" line-spacing="1" et-al-min="10" et-al-use-first="7">
+  <bibliography entry-spacing="0" second-field-align="flush" line-spacing="1" et-al-min="10" et-al-use-first="7">
     <layout>
       <text variable="citation-number" suffix="."/>
       <choose>

--- a/food-and-agriculture-organization-of-the-united-nations-numeric.csl
+++ b/food-and-agriculture-organization-of-the-united-nations-numeric.csl
@@ -1,0 +1,396 @@
+<?xml version="1.0" encoding="utf-8"?>
+<style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" demote-non-dropping-particle="sort-only">
+  <!-- This style was edited with the Visual CSL Editor (http://editor.citationstyles.org/visualEditor/) -->
+  <info>
+    <title>Food and Agriculture Organization of the United Nations (numeric)</title>
+    <title-short>FAO (numeric)</title-short>
+    <id>http://www.zotero.org/styles/food-and-agriculture-organization-of-the-united-nations-numeric</id>
+    <link href="http://www.zotero.org/styles/food-and-agriculture-organization-of-the-united-nations-numeric" rel="self"/>
+    <link href="https://www.fao.org/3/cb8081en/cb8081en.pdf" rel="documentation"/>
+    <author>
+      <name>Bin Liu</name>
+      <email>lieubean@gmail.com</email>
+      <uri>https://www.linkedin.com/in/lieubean/</uri>
+    </author>
+    <contributor>
+      <name>Julian Plummer</name>
+      <email>julian.plummer@gmail.com</email>
+      <uri>https://www.linkedin.com/in/julian-plummer/</uri>
+    </contributor>
+    <contributor>
+      <name>Amy Knauff</name>
+      <email/>
+      <uri>https://www.linkedin.com/in/amy-knauff-92655442/</uri>
+    </contributor>
+    <contributor>
+      <name>Stephanie Wright</name>
+      <email/>
+      <uri>https://www.linkedin.com/in/piriet/</uri>
+    </contributor>
+    <category citation-format="author-date"/>
+    <category field="science"/>
+    <category field="social_science"/>
+    <summary>This style is created to meet the citation and bibliographical requirements of FAOSTYLE, and has been tested with Zotero and Mendeley. Last update: February 2022.</summary>
+    <updated>2023-05-12T10:12:14+00:00</updated>
+    <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
+  </info>
+  <!-- Locale settings for English. Settings for other languages could be added later to this section. -->
+  <locale xml:lang="en">
+    <style-options punctuation-in-quote="false"/>
+    <terms>
+      <term name="no date">undated</term>
+      <term name="presented at">Presentation at</term>
+      <term name="by">Adopted</term>
+    </terms>
+    <date delimiter=" " form="text">
+      <date-part name="day"/>
+      <date-part name="month"/>
+      <date-part name="year"/>
+    </date>
+  </locale>
+  <!-- Macros -->
+  <macro name="anonymous">
+    <text term="anonymous" text-case="capitalize-first"/>
+  </macro>
+  <macro name="editor">
+    <!-- Outputs "XX ed. / XX & XX eds." -->
+    <names variable="editor">
+      <name and="symbol" delimiter-precedes-last="never" initialize-with="."/>
+      <label form="short" strip-periods="true" prefix=", "/>
+    </names>
+  </macro>
+  <macro name="author">
+    <names variable="author">
+      <name and="symbol" delimiter-precedes-et-al="never" delimiter-precedes-last="never" initialize-with="." name-as-sort-order="all"/>
+      <et-al font-style="italic"/>
+      <label form="short" prefix=", "/>
+      <substitute>
+        <names variable="editor"/>
+        <names variable="translator"/>
+        <text macro="anonymous"/>
+      </substitute>
+    </names>
+  </macro>
+  <macro name="author-short">
+    <names variable="author">
+      <name form="short" and="text" delimiter-precedes-et-al="never" delimiter-precedes-last="never" initialize-with="."/>
+      <et-al font-style="italic"/>
+      <substitute>
+        <names variable="editor"/>
+        <names variable="translator"/>
+        <choose>
+          <!-- Author in in-line citation for materials w/o author / editor / translator: If the type is not case, use Anonymous; use italic title for case. -->
+          <if match="none" type="legal_case">
+            <text macro="anonymous"/>
+          </if>
+          <else>
+            <text variable="title" font-style="italic"/>
+          </else>
+        </choose>
+      </substitute>
+    </names>
+  </macro>
+  <macro name="date">
+    <!-- date format: year / undated / put "forthcoming" or else in "Date" field when needed. -->
+    <choose>
+      <if match="none" variable="issued">
+        <text term="no date"/>
+      </if>
+      <else>
+        <date date-parts="year" form="text" variable="issued"/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="title-and-genre">
+    <!-- For book, song, audio recording, etc.: Outputs "Title (italic) [Medium/Genre]". -->
+    <group delimiter=" ">
+      <text variable="title" font-style="italic"/>
+      <text variable="medium" prefix="[" suffix="]"/>
+      <text variable="genre" prefix="[" suffix="]"/>
+    </group>
+  </macro>
+  <macro name="periodical">
+    <!-- For journal and magazine: Outputs "Journal/Magazine title (italic), Vol(Issue): Page." Suffix is added because this can appear at the end of a reference. -->
+    <group suffix=".">
+      <text variable="container-title" form="long" font-style="italic"/>
+      <text variable="volume" prefix=", "/>
+      <text variable="issue" prefix="(" suffix=")"/>
+      <text variable="page" prefix=": "/>
+    </group>
+  </macro>
+  <macro name="edition">
+    <!-- Outputs edition info like "Second edition". -->
+    <number text-case="capitalize-first" variable="edition" form="long-ordinal"/>
+    <text term="edition" prefix=" "/>
+  </macro>
+  <macro name="vol">
+    <!-- Vol. xx -->
+    <group delimiter=" ">
+      <text term="volume" form="short" text-case="capitalize-first"/>
+      <text variable="volume"/>
+    </group>
+  </macro>
+  <macro name="in-and-container">
+    <!-- Outputs "In: XX ed. Container-title (italic)" if container-title exists. "XX ed. " will be omited if there's no editor. -->
+    <choose>
+      <if variable="container-title">
+        <group delimiter=" ">
+          <text term="in" text-case="capitalize-first" suffix=":"/>
+          <text macro="editor" suffix="."/>
+          <text variable="container-title" font-style="italic"/>
+        </group>
+      </if>
+    </choose>
+  </macro>
+  <macro name="series-and-number">
+    <!-- Outputs "Series-Title No. xxx" for various types.-->
+    <group delimiter=" ">
+      <text variable="collection-title"/>
+      <text variable="collection-number"/>
+      <!-- "Series Number" field for book section in Zotero. -->
+      <text variable="number"/>
+      <!-- "Report Number" field for report in Zotero. -->
+      <!-- "No. " must be entered in "Series Number" and "Report Number" in Zotero. -->
+      <!-- Mendeley doesn't offer a "Series Number / Report Number" field. "No. xxx" must be put in "Series" field. -->
+    </group>
+  </macro>
+  <macro name="publisher-and-place">
+    <!-- Outputs "place, publisher." Suffix is added because this can appear at the end of a reference. -->
+    <group delimiter=", " suffix=".">
+      <text variable="publisher-place"/>
+      <text variable="publisher"/>
+    </group>
+  </macro>
+  <macro name="Cite-and-URL">
+    <!-- Output "Cited day month year. URL" -->
+    <group delimiter=" " suffix=". ">
+      <text term="cited" text-case="capitalize-first"/>
+      <date form="text" variable="accessed"/>
+    </group>
+    <text variable="URL"/>
+  </macro>
+  <macro name="DOI-or-URL">
+    <!-- If DOI exists, outputs "https://doi.org/DOI". If DOI doesn't exist, then outputs URL. -->
+    <choose>
+      <if variable="DOI">
+        <text variable="DOI" prefix="https://doi.org/"/>
+      </if>
+      <else>
+        <text variable="URL"/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="event-title">
+    <choose>
+      <!-- TODO: We expect "event-title" to be used,
+           but processors and applications may not be updated yet.
+           This macro ensures that either "event" or "event-title" can be accpeted.
+           Remove if procesor logic and application adoption can handle this. -->
+      <if variable="event-title">
+        <text variable="event-title"/>
+      </if>
+      <else>
+        <text variable="event"/>
+      </else>
+    </choose>
+  </macro>
+  <!-- in-line citation: superscript number, separated by a comma followed by a space. -->
+  <citation collapse="citation-number">
+    <sort>
+      <key variable="citation-number"/>
+    </sort>
+    <layout delimiter=", " vertical-align="sup">
+      <text variable="citation-number"/>
+    </layout>
+  </citation>
+  <!-- bibliography -->
+   <bibliography entry-spacing="0" second-field-align="flush" line-spacing="1" et-al-min="10" et-al-use-first="7">
+    <layout>
+      <text variable="citation-number" suffix="."/>
+      <choose>
+        <if type="legal_case bill legislation" match="none">
+          <!-- Every item type except legal ones (case, bill and statute) uses "Anonymous" as author if there's no author. -->
+          <group delimiter=". ">
+            <text macro="author" font-weight="bold"/>
+            <text macro="date"/>
+            <choose>
+              <if type="book">
+                <!-- book and computer program in Zotero; book in Mendeley. -->
+                <text macro="title-and-genre"/>
+                <!-- For Computer Program in Zotero, put "CD-ROM"/ "DVD-ROM" etc. in "System" field. -->
+                <!-- For eBook in Mendeley, put "CD-ROM", "Kindle edition" etc. in "Genre" field. -->
+                <!-- For eBook in Zotero, put "Medium: CD-ROM", "Genre: Kindle edition" etc. in "Extra" field. -->
+                <text macro="edition"/>
+                <text macro="editor"/>
+                <text macro="vol"/>
+                <text macro="series-and-number"/>
+                <text macro="publisher-and-place"/>
+                <text macro="DOI-or-URL"/>
+              </if>
+              <else-if type="chapter">
+                <!-- book section -->
+                <text variable="title"/>
+                <text macro="in-and-container"/>
+                <group delimiter=" ">
+                  <text macro="edition" suffix=","/>
+                  <label variable="page" form="short"/>
+                  <text variable="page"/>
+                </group>
+                <text macro="vol"/>
+                <text macro="series-and-number"/>
+                <text macro="publisher-and-place"/>
+                <text macro="DOI-or-URL"/>
+              </else-if>
+              <else-if type="article-journal">
+                <!-- journal article -->
+                <text variable="title"/>
+                <text macro="periodical"/>
+                <text macro="DOI-or-URL"/>
+              </else-if>
+              <else-if type="article-magazine">
+                <!-- magazine article -->
+                <text variable="title"/>
+                <text macro="periodical"/>
+                <text macro="Cite-and-URL"/>
+              </else-if>
+              <else-if type="article-newspaper">
+                <!-- newspaper article -->
+                <text variable="title"/>
+                <group delimiter=", " suffix=".">
+                  <text variable="container-title" font-style="italic"/>
+                  <date form="text" variable="issued"/>
+                </group>
+                <text macro="Cite-and-URL"/>
+              </else-if>
+              <else-if type="webpage post-weblog" match="any">
+                <!-- web page and blog post -->
+                <text variable="title"/>
+                <text macro="in-and-container"/>
+                <text variable="publisher-place"/>
+                <!-- Put place in "Extra" field in Zotero, e.g. "Place: Rome". -->
+                <text macro="Cite-and-URL"/>
+              </else-if>
+              <else-if type="thesis">
+                <!-- thesis -->
+                <text variable="title" font-style="italic"/>
+                <text macro="publisher-and-place"/>
+                <text variable="genre" suffix="."/>
+                <!-- Suffix is added because this can appear at the end of a reference, i.e. when the thesis doesn't have DOI/URL. -->
+                <text macro="DOI-or-URL"/>
+              </else-if>
+              <else-if type="song motion_picture" match="any">
+                <!-- audio recording, film and video recording in Zotero; film and computer program in Mendeley -->
+                <text macro="title-and-genre"/>
+                <!-- Can put "audio recording", "video" etc. in "Format" field in Zotero. -->
+                <!-- Can put "audio recording", "video" etc. in "Genre" field in Mendeley. -->
+                <text macro="publisher-and-place"/>
+                <text macro="Cite-and-URL"/>
+              </else-if>
+              <else-if type="manuscript report" match="any">
+                <!-- manuscript and report -->
+                <text variable="title" font-style="italic"/>
+                <text variable="genre"/>
+                <text macro="series-and-number"/>
+                <text macro="publisher-and-place"/>
+                <text macro="DOI-or-URL"/>
+              </else-if>
+              <else-if type="article">
+                <!-- document, can be used for e.g. monograph -->
+                <text variable="title" font-style="italic"/>
+                <text variable="genre"/>
+                <text macro="series-and-number"/>
+                <text macro="publisher-and-place"/>
+                <text macro="Cite-and-URL"/>
+              </else-if>
+              <else-if type="speech">
+                <!-- presentation -->
+                <text variable="title"/>
+                <group delimiter=" ">
+                  <text term="presented at"/>
+                  <text macro="event-title" suffix=","/>
+                  <date form="text" variable="issued" suffix=","/>
+                  <text macro="publisher-and-place"/>
+                </group>
+                <text macro="Cite-and-URL"/>
+              </else-if>
+              <else-if type="paper-conference">
+                <!-- conference paper -->
+                <text variable="title" font-style="italic"/>
+                <text macro="in-and-container"/>
+                <text variable="collection-title"/>
+                <group delimiter=", " suffix=".">
+                  <text macro="event-title"/>
+                  <text variable="publisher-place"/>
+                  <text variable="publisher"/>
+                  <!-- Not using macro "publisher-and-place" here because event date needs to be appended and the suffix "." of the macro would appear. -->
+                  <date form="text" variable="issued"/>
+                </group>
+                <text macro="DOI-or-URL"/>
+              </else-if>
+              <else>
+                <!-- other item types -->
+                <text variable="title"/>
+                <text variable="genre"/>
+                <text macro="publisher-and-place"/>
+                <text macro="Cite-and-URL"/>
+              </else>
+            </choose>
+          </group>
+        </if>
+        <else-if type="legal_case">
+          <!-- case -->
+          <group delimiter=" ">
+            <text variable="title" font-style="italic" suffix="."/>
+            <text variable="authority" suffix=","/>
+            <!-- "Court" field in Zotero -->
+            <text variable="number" suffix="."/>
+            <!-- "Docket Number" field in Zotero -->
+            <date form="text" variable="issued" suffix="."/>
+            <text variable="note" suffix="."/>
+            <!-- "Extra" field in Zotero. Can be used to put any additional information. -->
+          </group>
+        </else-if>
+        <else-if type="bill">
+          <!-- legal instruments -->
+          <choose>
+            <if variable="title-short">
+              <text variable="title" form="short" font-style="italic" suffix=" "/>
+              <text variable="title" font-style="italic" prefix="(" suffix="). "/>
+            </if>
+            <else>
+              <text variable="title" font-style="italic" suffix=". "/>
+            </else>
+          </choose>
+          <group delimiter=" ">
+            <text term="by" suffix=":"/>
+            <text variable="publisher-place" suffix=","/>
+            <!-- Put "Place: xxxxx" in "Extra" field in Zotero -->
+            <date form="text" variable="issued" suffix="."/>
+            <group delimiter=", " suffix=".">
+              <text variable="number"/>
+              <!-- "Bill Number" field in Zotero -->
+              <group delimiter=" ">
+                <text variable="volume"/>
+                <!-- "Code Volume" field in Zotero -->
+                <text variable="container-title"/>
+                <!-- "Code" field in Zotero -->
+                <text variable="page"/>
+                <!-- "Code Pages" field in Zotero -->
+              </group>
+            </group>
+          </group>
+        </else-if>
+        <else-if type="legislation">
+          <!-- Type "statute" in Zotero, used for legislation -->
+          <group delimiter=" ">
+            <text macro="author" font-weight="bold" suffix="."/>
+            <text variable="title" font-style="italic" suffix=","/>
+            <text variable="number" suffix=","/>
+            <!-- "Public Law Number" field in Zotero -->
+            <text macro="date" suffix="."/>
+          </group>
+        </else-if>
+      </choose>
+    </layout>
+  </bibliography>
+</style>

--- a/food-and-agriculture-organization-of-the-united-nations-numeric.csl
+++ b/food-and-agriculture-organization-of-the-united-nations-numeric.csl
@@ -71,25 +71,6 @@
       </substitute>
     </names>
   </macro>
-  <macro name="author-short">
-    <names variable="author">
-      <name form="short" and="text" delimiter-precedes-et-al="never" delimiter-precedes-last="never" initialize-with="."/>
-      <et-al font-style="italic"/>
-      <substitute>
-        <names variable="editor"/>
-        <names variable="translator"/>
-        <choose>
-          <!-- Author in in-line citation for materials w/o author / editor / translator: If the type is not case, use Anonymous; use italic title for case. -->
-          <if match="none" type="legal_case">
-            <text macro="anonymous"/>
-          </if>
-          <else>
-            <text variable="title" font-style="italic"/>
-          </else>
-        </choose>
-      </substitute>
-    </names>
-  </macro>
   <macro name="date">
     <!-- date format: year / undated / put "forthcoming" or else in "Date" field when needed. -->
     <choose>


### PR DESCRIPTION
This is to add a numeric variant to the current "Food and Agriculture Organization of the United Nations" style (author-date). The numeric variant is indicated at https://www.fao.org/3/cb8081en/cb8081en.pdf (Chap 9.2.2 at p. 24).