### PR TITLE
Update springer-vancouver-brackets.csl

### DIFF
--- a/springer-vancouver-brackets.csl
+++ b/springer-vancouver-brackets.csl
@@ -70,7 +70,7 @@
   </macro>
   <macro name="publisher">
     <choose>
-      <if type="thesis book chapter paper-conference" match="any">
+      <if type="thesis book chapter paper-conference article-journal article-newspaper article-magazine" match="any">
         <group delimiter=": " suffix=";">
           <choose>
             <if type="thesis">

--- a/springer-vancouver-brackets.csl
+++ b/springer-vancouver-brackets.csl
@@ -70,7 +70,7 @@
   </macro>
   <macro name="publisher">
     <choose>
-      <if type="thesis book chapter paper-conference article-journal article-newspaper article-magazine" match="any">
+      <if type="article-journal article-newspaper article-magazine" match="none">
         <group delimiter=": " suffix=";">
           <choose>
             <if type="thesis">

--- a/springer-vancouver-brackets.csl
+++ b/springer-vancouver-brackets.csl
@@ -5,7 +5,6 @@
     <id>http://www.zotero.org/styles/springer-vancouver-brackets</id>
     <link href="http://www.zotero.org/styles/springer-vancouver-brackets" rel="self"/>
     <link href="http://www.zotero.org/styles/vancouver" rel="template"/>
-    <!-- This style corresponds to 'Springer Vancouver' in the pdf document 'Key Style Points' at this url -->
     <link href="http://www.springer.com/cda/content/document/cda_downloaddocument/manuscript-guidelines-1.0.pdf" rel="documentation"/>
     <link href="http://www.springer.com/cda/content/document/cda_downloaddocument/Key_Style_Points_1.0.pdf" rel="documentation"/>
     <author>
@@ -16,7 +15,7 @@
     <category citation-format="numeric"/>
     <category field="generic-base"/>
     <summary>This style based on the NLM guidelines Citing Medicine is very similar to Vancouver and is used by a number of Springer publications.</summary>
-    <updated>2018-01-29T19:38:34+00:00</updated>
+    <updated>2023-05-14T09:16:49+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale xml:lang="en">
@@ -70,17 +69,21 @@
     </group>
   </macro>
   <macro name="publisher">
-    <group delimiter=": " suffix=";">
-      <choose>
-        <if type="thesis">
-          <text variable="publisher-place" prefix="[" suffix="]"/>
-        </if>
-        <else>
-          <text variable="publisher-place"/>
-        </else>
-      </choose>
-      <text variable="publisher"/>
-    </group>
+    <choose>
+      <if type="thesis book chapter paper-conference" match="any">
+        <group delimiter=": " suffix=";">
+          <choose>
+            <if type="thesis">
+              <text variable="publisher-place" prefix="[" suffix="]"/>
+            </if>
+            <else>
+              <text variable="publisher-place"/>
+            </else>
+          </choose>
+          <text variable="publisher"/>
+        </group>
+      </if>
+    </choose>
   </macro>
   <macro name="access">
     <choose>
@@ -118,7 +121,6 @@
         </group>
         <text macro="edition" prefix=" "/>
       </if>
-      <!--add event-name and event-place once they become available-->
       <else-if type="bill legislation" match="any">
         <group delimiter=", ">
           <group delimiter=". ">


### PR DESCRIPTION
See issue 2 on this forum post: https://forums.zotero.org/discussion/104977/academic-psychiatry-style-changes-needed#latest

**Add conditional so publisher information doesn't get printed for article-journal etc.**
I might am forgetting a book-like item type.
Or should we invert the conditional?


Guidelines: https://resource-cms.springernature.com/springer-cms/rest/v1/content/3322/data/Key+style+points