### PR TITLE
Fix erroneous comma in ACL in-text citation

### DIFF
--- a/association-for-computational-linguistics.csl
+++ b/association-for-computational-linguistics.csl
@@ -169,8 +169,10 @@
   <citation et-al-min="3" et-al-use-first="1" disambiguate-add-year-suffix="true">
     <!-- no sorting for citation -->
     <layout prefix="(" suffix=")" delimiter="; ">
-      <text macro="author-short" suffix=", "/>
-      <text macro="year-date"/>
+      <group delimiter=", ">
+        <text macro="author-short"/>
+        <text macro="year-date"/>
+      </group>
     </layout>
   </citation>
   <bibliography et-al-min="20" et-al-use-first="19">

--- a/association-for-computational-linguistics.csl
+++ b/association-for-computational-linguistics.csl
@@ -169,8 +169,8 @@
   <citation et-al-min="3" et-al-use-first="1" disambiguate-add-year-suffix="true">
     <!-- no sorting for citation -->
     <layout prefix="(" suffix=")" delimiter="; ">
-      <text macro="author-short"/>
-      <text macro="year-date" prefix=", "/>
+      <text macro="author-short" suffix=", "/>
+      <text macro="year-date"/>
     </layout>
   </citation>
   <bibliography et-al-min="20" et-al-use-first="19">


### PR DESCRIPTION
When doing an in-text citation, for example
"proposed by `Author` (`year`)",
there is an erroneous comma before the year, i.e.
"proposed by `Author` (, `year`)".
This is because the comma is set as a prefix to the year. Changing it to a suffix to the author fixes this problem.