### PR TITLE
Update american-journal-of-botany.csl

### DIFF
--- a/american-journal-of-botany.csl
+++ b/american-journal-of-botany.csl
@@ -109,7 +109,7 @@
       </else>
     </choose>
   </macro>
-  <citation et-al-min="3" et-al-use-first="1" disambiguate-add-year-suffix="true" disambiguate-add-names="false" collapse="year-suffix">
+  <citation et-al-min="3" et-al-use-first="1" disambiguate-add-year-suffix="true" disambiguate-add-names="false" collapse="year-suffix" cite-group-delimiter=", ">
     <sort>
       <key macro="year-date"/>
     </sort>


### PR DESCRIPTION
For inline citations with same author and same year, set the disambiguation suffixes (a, b, c, etc.) delimited with ", " (instead of "; " that was apparently the default when not specified). Example: (AuthorA et al. 2019; AuthorB et al., 2021a, b) Instead of previously: (AuthorA et al. 2019; AuthorB et al., 2021a; b)