### PR TITLE
Update apa csl to use software type 

### DIFF
--- a/apa-annotated-bibliography.csl
+++ b/apa-annotated-bibliography.csl
@@ -1330,8 +1330,8 @@
       <else-if type="dataset">
         <text value="Data set"/>
       </else-if>
-      <else-if type="book" variable="version" match="all">
-        <!-- Replace with type="software" and term="software" as that becomes available -->
+      <else-if type="software" variable="version" match="all">
+        <!-- Replace term="software" as that becomes available -->
         <text value="Computer software"/>
       </else-if>
       <else-if type="interview personal_communication" match="any">
@@ -1362,8 +1362,8 @@
       <else-if type="dataset">
         <text value="Data set"/>
       </else-if>
-      <else-if type="book" variable="version" match="all">
-        <!-- Replace with type="software" and term="software" as that becomes available -->
+      <else-if type="software" variable="version" match="all">
+        <!-- Replace term="software" as that becomes available -->
         <text value="Computer software"/>
       </else-if>
       <else-if type="interview personal_communication" match="any">

--- a/apa-cv.csl
+++ b/apa-cv.csl
@@ -1109,8 +1109,8 @@
       <else-if type="dataset">
         <text value="Data set"/>
       </else-if>
-      <else-if type="book" variable="version" match="all">
-        <!-- Replace with type="software" and term="software" as that becomes available -->
+      <else-if type="software" variable="version" match="all">
+        <!-- Replace term="software" as that becomes available -->
         <text value="Computer software"/>
       </else-if>
       <else-if type="interview personal_communication" match="any">

--- a/apa-eu.csl
+++ b/apa-eu.csl
@@ -1049,8 +1049,8 @@
       <else-if type="dataset">
         <text value="Data set"/>
       </else-if>
-      <else-if type="book" variable="version" match="all">
-        <!-- Replace with type="software" and term="software" as that becomes available -->
+      <else-if type="software" variable="version" match="all">
+        <!-- Replace term="software" as that becomes available -->
         <text value="Computer software"/>
       </else-if>
       <else-if type="interview personal_communication" match="any">
@@ -1081,8 +1081,8 @@
       <else-if type="dataset">
         <text value="Data set"/>
       </else-if>
-      <else-if type="book" variable="version" match="all">
-        <!-- Replace with type="software" and term="software" as that becomes available -->
+      <else-if type="software" variable="version" match="all">
+        <!-- Replace term="software" as that becomes available -->
         <text value="Computer software"/>
       </else-if>
       <else-if type="interview personal_communication" match="any">

--- a/apa-no-ampersand.csl
+++ b/apa-no-ampersand.csl
@@ -1330,8 +1330,8 @@
       <else-if type="dataset">
         <text value="Data set"/>
       </else-if>
-      <else-if type="book" variable="version" match="all">
-        <!-- Replace with type="software" and term="software" as that becomes available -->
+      <else-if type="software" variable="version" match="all">
+        <!-- Replace term="software" as that becomes available -->
         <text value="Computer software"/>
       </else-if>
       <else-if type="interview personal_communication" match="any">
@@ -1362,8 +1362,8 @@
       <else-if type="dataset">
         <text value="Data set"/>
       </else-if>
-      <else-if type="book" variable="version" match="all">
-        <!-- Replace with type="software" and term="software" as that becomes available -->
+      <else-if type="software" variable="version" match="all">
+        <!-- Replace term="software" as that becomes available -->
         <text value="Computer software"/>
       </else-if>
       <else-if type="interview personal_communication" match="any">

--- a/apa-no-initials.csl
+++ b/apa-no-initials.csl
@@ -1330,8 +1330,8 @@
       <else-if type="dataset">
         <text value="Data set"/>
       </else-if>
-      <else-if type="book" variable="version" match="all">
-        <!-- Replace with type="software" and term="software" as that becomes available -->
+      <else-if type="software" variable="version" match="all">
+        <!-- Replace term="software" as that becomes available -->
         <text value="Computer software"/>
       </else-if>
       <else-if type="interview personal_communication" match="any">
@@ -1362,8 +1362,8 @@
       <else-if type="dataset">
         <text value="Data set"/>
       </else-if>
-      <else-if type="book" variable="version" match="all">
-        <!-- Replace with type="software" and term="software" as that becomes available -->
+      <else-if type="software" variable="version" match="all">
+        <!-- Replace term="software" as that becomes available -->
         <text value="Computer software"/>
       </else-if>
       <else-if type="interview personal_communication" match="any">

--- a/apa-numeric-superscript-brackets.csl
+++ b/apa-numeric-superscript-brackets.csl
@@ -1133,8 +1133,8 @@
       <else-if type="dataset">
         <text value="Data set"/>
       </else-if>
-      <else-if type="book" variable="version" match="all">
-        <!-- Replace with type="software" and term="software" as that becomes available -->
+      <else-if type="software" variable="version" match="all">
+        <!-- Replace term="software" as that becomes available -->
         <text value="Computer software"/>
       </else-if>
       <else-if type="interview personal_communication" match="any">
@@ -1165,8 +1165,8 @@
       <else-if type="dataset">
         <text value="Data set"/>
       </else-if>
-      <else-if type="book" variable="version" match="all">
-        <!-- Replace with type="software" and term="software" as that becomes available -->
+      <else-if type="software" variable="version" match="all">
+        <!-- Replace term="software" as that becomes available -->
         <text value="Computer software"/>
       </else-if>
       <else-if type="interview personal_communication" match="any">

--- a/apa-numeric-superscript.csl
+++ b/apa-numeric-superscript.csl
@@ -1133,8 +1133,8 @@
       <else-if type="dataset">
         <text value="Data set"/>
       </else-if>
-      <else-if type="book" variable="version" match="all">
-        <!-- Replace with type="software" and term="software" as that becomes available -->
+      <else-if type="software" variable="version" match="all">
+        <!-- Replace term="software" as that becomes available -->
         <text value="Computer software"/>
       </else-if>
       <else-if type="interview personal_communication" match="any">
@@ -1165,8 +1165,8 @@
       <else-if type="dataset">
         <text value="Data set"/>
       </else-if>
-      <else-if type="book" variable="version" match="all">
-        <!-- Replace with type="software" and term="software" as that becomes available -->
+      <else-if type="software" variable="version" match="all">
+        <!-- Replace term="software" as that becomes available -->
         <text value="Computer software"/>
       </else-if>
       <else-if type="interview personal_communication" match="any">

--- a/apa-single-spaced.csl
+++ b/apa-single-spaced.csl
@@ -1330,8 +1330,8 @@
       <else-if type="dataset">
         <text value="Data set"/>
       </else-if>
-      <else-if type="book" variable="version" match="all">
-        <!-- Replace with type="software" and term="software" as that becomes available -->
+      <else-if type="software" variable="version" match="all">
+        <!-- Replace term="software" as that becomes available -->
         <text value="Computer software"/>
       </else-if>
       <else-if type="interview personal_communication" match="any">
@@ -1362,8 +1362,8 @@
       <else-if type="dataset">
         <text value="Data set"/>
       </else-if>
-      <else-if type="book" variable="version" match="all">
-        <!-- Replace with type="software" and term="software" as that becomes available -->
+      <else-if type="software" variable="version" match="all">
+        <!-- Replace term="software" as that becomes available -->
         <text value="Computer software"/>
       </else-if>
       <else-if type="interview personal_communication" match="any">

--- a/apa-with-abstract.csl
+++ b/apa-with-abstract.csl
@@ -1330,8 +1330,8 @@
       <else-if type="dataset">
         <text value="Data set"/>
       </else-if>
-      <else-if type="book" variable="version" match="all">
-        <!-- Replace with type="software" and term="software" as that becomes available -->
+      <else-if type="software" variable="version" match="all">
+        <!-- Replace term="software" as that becomes available -->
         <text value="Computer software"/>
       </else-if>
       <else-if type="interview personal_communication" match="any">
@@ -1362,8 +1362,8 @@
       <else-if type="dataset">
         <text value="Data set"/>
       </else-if>
-      <else-if type="book" variable="version" match="all">
-        <!-- Replace with type="software" and term="software" as that becomes available -->
+      <else-if type="software" variable="version" match="all">
+        <!-- Replace term="software" as that becomes available -->
         <text value="Computer software"/>
       </else-if>
       <else-if type="interview personal_communication" match="any">

--- a/apa.csl
+++ b/apa.csl
@@ -1331,8 +1331,8 @@
       <else-if type="dataset">
         <text value="Data set"/>
       </else-if>
-      <else-if type="book" variable="version" match="all">
-        <!-- Replace with type="software" and term="software" as that becomes available -->
+      <else-if type="software" variable="version" match="all">
+        <!-- Replace term="software" as that becomes available -->
         <text value="Computer software"/>
       </else-if>
       <else-if type="interview personal_communication" match="any">
@@ -1363,8 +1363,8 @@
       <else-if type="dataset">
         <text value="Data set"/>
       </else-if>
-      <else-if type="book" variable="version" match="all">
-        <!-- Replace with type="software" and term="software" as that becomes available -->
+      <else-if type="software" variable="version" match="all">
+        <!-- Replace term="software" as that becomes available -->
         <text value="Computer software"/>
       </else-if>
       <else-if type="interview personal_communication" match="any">


### PR DESCRIPTION
https://docs.citationstyles.org/en/stable/specification.html#type-terms

The 'software' type is now available and it seems the apa style should use that, this fixes a bug where "[Computer Software]" is added for books when it should be for only software.  