### PR TITLE
Create romisch-germanische-kommission.csl

### DIFF
--- a/romisch-germanische-kommission.csl
+++ b/romisch-germanische-kommission.csl
@@ -1,0 +1,311 @@
+<?xml version="1.0" encoding="utf-8"?>
+<style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" demote-non-dropping-particle="sort-only" default-locale="de-DE">
+  <!-- info section -->
+  <!-- This style has been created for the Deutsche Gesellschaft fuer Ur- und Fruehgeschichte/German Association for Pre- and Protohistory. An older version of this style is known as "RGK_archaeology_DGUF"
+    For more information, please visit the website http://www.dguf.de -->
+  <info>
+    <title>Römisch-Germanische-Kommission</title>
+    <title-short>RGK</title-short>
+    <id>http://www.zotero.org/styles/romisch-germanische-kommission</id>
+    <link href="http://www.zotero.org/styles/romisch-germanische-kommission" rel="self"/>
+    <link href="https://www.dainst.org/documents/10180/1843167/Hinweise+f%C3%BCr+Publikationen+der+RGK+2017/6bb08db4-92e5-4732-937a-9ee5e9400877" rel="documentation"/>
+    <link href="https://journals.ub.uni-heidelberg.de/index.php/germania/libraryFiles/downloadPublic/197" rel="documentation"/>
+    <author>
+      <name>Thimo Jacob Brestel</name>
+      <email>mail@thimobrestel.de</email>
+    </author>
+    <author>
+      <name>Christoph Rinne</name>
+      <email>crinne@ufg.uni-kiel.de</email>
+    </author>
+    <category citation-format="author-date"/>
+    <category field="anthropology"/>
+    <category field="humanities"/>
+    <summary>This citation style uses the citation guidelines provided by the Romano-Germanic Commission of the German Archaeological Institute as published here:
+      Römisch-Germanischen Kommission des Deutschen Archäologischen Instituts (Hrsg.), Richtlinien für Veröffentlichungen zur Ur-, Vor- und Frühgeschichte, Archäologie der Römischen Provinzen und Archäologie des Mittelalters. Berichte der Römisch-Germanischen Kommission 71, 1990, 973-998.</summary>
+    <updated>2023-07-14T17:58:58+00:00</updated>
+    <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
+  </info>
+  <!-- terms section -->
+  <locale xml:lang="de">
+    <terms>
+      <term name="in">In</term>
+    </terms>
+  </locale>
+  <!-- macro section -->
+  <macro name="editor">
+    <names variable="editor">
+      <name initialize-with=". " delimiter-precedes-last="always" delimiter="/"/>
+      <label form="short" prefix=" (" suffix=".)" strip-periods="true"/>
+    </names>
+  </macro>
+  <macro name="author">
+    <names variable="author">
+      <name initialize-with=". " delimiter-precedes-last="always" delimiter="/"/>
+      <label form="short" prefix=" (" suffix=".)" strip-periods="true"/>
+      <substitute>
+        <names variable="editor"/>
+        <text variable="title"/>
+      </substitute>
+    </names>
+  </macro>
+  <macro name="author-sort">
+    <names variable="author">
+      <name name-as-sort-order="all" sort-separator=", " initialize-with="." delimiter-precedes-last="always" delimiter="/"/>
+      <substitute>
+        <names variable="editor"/>
+        <text variable="title"/>
+      </substitute>
+    </names>
+  </macro>
+  <macro name="author-short">
+    <choose>
+      <if variable="author">
+        <names variable="author">
+          <name form="short" delimiter="/" delimiter-precedes-last="always" et-al-min="3" et-al-use-first="1"/>
+        </names>
+      </if>
+      <else>
+        <names variable="editor">
+          <name form="short" delimiter="/" delimiter-precedes-last="always" et-al-min="3" et-al-use-first="1"/>
+        </names>
+      </else>
+    </choose>
+  </macro>
+  <macro name="container-author">
+    <names variable="container-author">
+      <name initialize-with=". " delimiter-precedes-last="always" delimiter="/"/>
+      <label form="short" prefix=" (" suffix=".)" strip-periods="true"/>
+    </names>
+  </macro>
+  <macro name="access">
+    <text variable="URL" prefix="&lt;" suffix="&gt;"/>
+    <group prefix=" (" delimiter=" " suffix=")">
+      <date variable="accessed">
+        <date-part name="day" form="numeric-leading-zeros" suffix="."/>
+        <date-part name="month" form="numeric-leading-zeros" suffix="."/>
+        <date-part name="year" form="long"/>
+      </date>
+    </group>
+  </macro>
+  <macro name="webpage-date">
+    <group prefix=", " delimiter=" " suffix=". ">
+      <text value="zuletzt aktualisiert am" prefix=" "/>
+      <date variable="issued">
+        <date-part name="day" form="numeric-leading-zeros" suffix="."/>
+        <date-part name="month" form="numeric-leading-zeros" suffix="."/>
+        <date-part name="year" form="long"/>
+      </date>
+    </group>
+  </macro>
+  <!--Since the citation of URLs is not specified in the Zitierrichtlinien der Römisch-Germanischen Komission
+  des Deutschen Archäologischen Institut (published in 1991) this style uses the specifications for URLs from the Zitierrichtlinien
+  des DAI (https://www.dainst.org/publikationen/publizieren-beim-dai/richtlinien)-->
+  <macro name="url">
+    <choose>
+      <if match="any" variable="URL">
+        <group display="block" prefix=" ">
+          <text variable="URL" prefix="&lt;" suffix="&gt;"/>
+          <choose>
+            <if match="none" is-uncertain-date="accessed">
+              <date form="text" variable="accessed" prefix=" (" suffix=")"/>
+            </if>
+          </choose>
+        </group>
+      </if>
+    </choose>
+  </macro>
+  <macro name="doi">
+    <choose>
+      <if match="any" variable="DOI">
+        <group prefix=" [" suffix="]">
+          <text value="DOI: "/>
+          <text variable="DOI"/>
+        </group>
+      </if>
+    </choose>
+  </macro>
+  <macro name="year-date">
+    <choose>
+      <if variable="issued">
+        <date variable="issued">
+          <date-part name="year"/>
+        </date>
+      </if>
+      <else>
+        <text term="no date" form="short"/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="collection">
+    <text variable="collection-title"/>
+    <text variable="collection-number" prefix=" "/>
+    <text variable="volume" prefix=" (" suffix=") "/>
+  </macro>
+  <macro name="published">
+    <text variable="edition" vertical-align="sup"/>
+    <group prefix="(" suffix=")" delimiter=" ">
+      <text variable="publisher-place"/>
+      <text macro="year-date"/>
+    </group>
+  </macro>
+  <macro name="pages">
+    <group prefix="" suffix="." delimiter="">
+      <text variable="page"/>
+    </group>
+  </macro>
+  <!-- citation section -->
+  <citation disambiguate-add-year-suffix="true" disambiguate-add-names="true" disambiguate-add-givenname="true">
+    <!-- the following replaces the source cited in the preceding citation with ibid. respectively ebd. (in German) -->
+    <layout prefix="" suffix="" delimiter="; ">
+      <choose>
+        <if position="ibid-with-locator">
+          <group delimiter=", ">
+            <text term="ibid" text-case="capitalize-first" suffix="."/>
+            <text variable="locator"/>
+          </group>
+        </if>
+        <else-if position="ibid">
+          <text term="ibid" text-case="capitalize-first" suffix="."/>
+        </else-if>
+        <else>
+          <group delimiter=", ">
+            <group delimiter=" ">
+              <text macro="author-short"/>
+              <text macro="year-date"/>
+            </group>
+            <text variable="locator"/>
+          </group>
+        </else>
+      </choose>
+    </layout>
+  </citation>
+  <!-- bibliography section -->
+  <bibliography hanging-indent="false" line-spacing="1" entry-spacing="1">
+    <sort>
+      <key macro="author-sort"/>
+      <key variable="issued"/>
+      <key variable="title"/>
+    </sort>
+    <layout suffix="">
+      <group suffix=": " display="block">
+        <text macro="author-short" suffix=" "/>
+        <date variable="issued">
+          <date-part name="year"/>
+        </date>
+      </group>
+      <group prefix="" delimiter=" " suffix=".">
+        <choose>
+          <if type="bill book graphic legal_case motion_picture report song chapter entry-dictionary paper-conference article article-journal article-magazine article-newspaper broadcast interview manuscript map patent personal_communication song speech thesis webpage" match="any">
+            <choose>
+              <if variable="author" match="any">
+                <text macro="author" suffix=","/>
+              </if>
+              <else-if variable="editor" match="any">
+                <text macro="editor" suffix=","/>
+              </else-if>
+              <else-if variable="author editor" match="all">
+                <text macro="editor" suffix=","/>
+              </else-if>
+            </choose>
+            <choose>
+              <if type="bill book graphic broadcast legal_case motion_picture report song manuscript map patent personal_communication speech " match="any">
+                <group prefix=" " delimiter=" " suffix="">
+                  <group prefix="" delimiter=". " suffix="">
+                    <text variable="title"/>
+                    <text macro="collection"/>
+                  </group>
+                  <text macro="published" prefix=" "/>
+                </group>
+              </if>
+              <else-if type="thesis" match="any">
+                <group prefix=" " delimiter=" " suffix="">
+                  <text variable="title"/>
+                  <group prefix="[" delimiter=" " suffix="]">
+                    <text variable="genre" prefix="unpubl. "/>
+                    <text variable="publisher"/>
+                    <date variable="issued">
+                      <date-part name="year"/>
+                    </date>
+                  </group>
+                </group>
+              </else-if>
+              <else-if type="chapter paper-conference" match="any">
+                <group prefix=" " delimiter=" " suffix="">
+                  <text variable="title" suffix=". "/>
+                  <group prefix="" delimiter=" ">
+                    <text term="in" suffix=":"/>
+                    <!-- if an entry of chapter in your library has an editor as well a container-author only the editor shows up in bibliography-->
+                    <choose>
+                      <if variable="editor" match="any">
+                        <text macro="editor" suffix=","/>
+                      </if>
+                      <else-if variable="container-author" match="any">
+                        <text macro="container-author" suffix=","/>
+                      </else-if>
+                      <else-if variable="container-author editor" match="all">
+                        <text macro="editor" suffix=","/>
+                      </else-if>
+                    </choose>
+                    <group suffix="" delimiter=". ">
+                      <text variable="container-title"/>
+                      <text macro="collection"/>
+                    </group>
+                    <text macro="published"/>
+                    <text macro="pages"/>
+                  </group>
+                </group>
+              </else-if>
+              <else-if type="article article-journal article-magazine article-newspaper interview" match="any">
+                <group prefix=" " delimiter=" " suffix="">
+                  <text variable="title" suffix="."/>
+                  <group prefix=" " delimiter=", " suffix="">
+                    <group prefix="" delimiter=" " suffix="">
+                      <text variable="container-title" form="short"/>
+                      <group prefix="" delimiter="/" suffix="">
+                        <text variable="volume"/>
+                        <text variable="issue"/>
+                      </group>
+                    </group>
+                    <date variable="issued">
+                      <date-part name="year"/>
+                    </date>
+                    <text macro="pages"/>
+                  </group>
+                </group>
+              </else-if>
+              <else-if type="webpage" match="any">
+                <group prefix=" " delimiter="" suffix=".">
+                  <text variable="title"/>
+                  <text macro="webpage-date"/>
+                  <text macro="access" prefix=" "/>
+                </group>
+              </else-if>
+            </choose>
+          </if>
+          <else-if type="entry-encyclopedia entry-dictionary" match="any">
+            <group prefix=" " delimiter=" " suffix="">
+              <group>
+                <text variable="container-title"/>
+                <text variable="edition" vertical-align="sup"/>
+              </group>
+              <text variable="volume"/>
+              <text macro="year-date" prefix="(" suffix=")"/>
+              <text macro="pages"/>
+              <text variable="title" prefix="s. v. "/>
+              <text macro="author" prefix="(" suffix=")"/>
+            </group>
+          </else-if>
+        </choose>
+        <choose>
+          <if variable="DOI" match="any">
+            <text macro="doi"/>
+          </if>
+          <else-if variable="URL" match="any">
+            <text macro="url"/>
+          </else-if>
+        </choose>
+      </group>
+    </layout>
+  </bibliography>
+</style>


### PR DESCRIPTION
This citation style uses the citation guidelines provided by the Romano-Germanic Commission of the German Archaeological Institute as published here: Römisch-Germanischen Kommission des Deutschen Archäologischen Instituts (Hrsg.), Richtlinien für Veröffentlichungen zur Ur-, Vor- und Frühgeschichte, Archäologie der Römischen Provinzen und Archäologie des Mittelalters. Berichte der Römisch-Germanischen Kommission 71, 1990, 973-998. The style is widely used in German speaking archaeology and beyond.