### PR TITLE
Closes #6576 Add support for using the forthcoming status.

### DIFF
--- a/bluebook-law-review.csl
+++ b/bluebook-law-review.csl
@@ -181,12 +181,21 @@
   </macro>
   <macro name="issuance">
     <choose>
-      <if type="article-journal article-magazine article-newspaper book broadcast chapter interview manuscript map patent personal_communication post-weblog song speech thesis webpage" match="any">
+      <!-- Check if the reference is marked as "forthcoming" -->
+      <if variable="status" match="forthcoming">
         <group>
-          <choose>
-            <if type="article-newspaper book chapter post-weblog thesis" match="any">
+          <text value="Forthcoming"/>
+          <date variable="issued">
+            <date-part name="year"/>
+          </date>
+        </group>
+      </if>
+      <else>
+        <choose>
+          <if type="article-journal article-magazine article-newspaper broadcast interview manuscript map patent personal_communication song speech thesis webpage post-weblog" match="any">
+            <group>
               <choose>
-                <if variable="issued">
+                <if type="article-newspaper thesis post-weblog" match="any">
                   <group suffix=", ">
                     <date variable="issued">
                       <date-part name="month" form="short"/>
@@ -194,64 +203,32 @@
                     </date>
                   </group>
                 </if>
-                <else>
-                  <group prefix=" (" suffix=")">
-                    <choose>
-                      <if variable="status">
-                        <group prefix="" suffix=" ">
-                          <text variable="status"/>
-                        </group>
-                      </if>
-                    </choose>
-                    <text term="no date" form="short"/>
-                    <text variable="year-suffix" prefix="-"/>
-                  </group>
-                </else>
-              </choose>
-            </if>
-            <else-if type="article-magazine">
-              <choose>
-                <if variable="status">
-                  <group prefix="" suffix=" ">
-                    <text variable="status"/>
-                  </group>
-                </if>
+                <else-if type="article-magazine">
+                  <date variable="issued">
+                    <date-part name="month" suffix=" " form="short"/>
+                  </date>
+                </else-if>
               </choose>
               <date variable="issued">
-                <date-part name="month" suffix=" " form="short"/>
+                <date-part name="year"/>
               </date>
-            </else-if>
-          </choose>
-          <choose>
-            <if variable="status">
-              <group prefix="" suffix=" ">
-                <text variable="status"/>
-              </group>
-            </if>
-          </choose>
-          <date variable="issued">
-            <date-part name="year"/>
-          </date>
-        </group>
-      </if>
-      <else>
-        <group delimiter=", ">
-          <text macro="editor-translator"/>
-          <group delimiter=" ">
-            <group delimiter=" ">
-              <text variable="edition"/>
-              <label variable="edition" form="short"/>
             </group>
-             <choose>
-                  <if variable="status">
-                    <text variable="status"/>
-                  </if>
-            </choose>
-            <date variable="issued">
-              <date-part name="year"/>
-            </date>
-          </group>
-        </group>
+          </if>
+          <else>
+            <group delimiter=", ">
+              <text macro="editor-translator"/>
+              <group delimiter=" ">
+                <group delimiter=" ">
+                  <text variable="edition"/>
+                  <label variable="edition" form="short"/>
+                </group>
+                <date variable="issued">
+                  <date-part name="year"/>
+                </date>
+              </group>
+            </group>
+          </else>
+        </choose>
       </else>
     </choose>
   </macro>

--- a/bluebook-law-review.csl
+++ b/bluebook-law-review.csl
@@ -181,22 +181,53 @@
   </macro>
   <macro name="issuance">
     <choose>
-      <if type="article-journal article-magazine article-newspaper broadcast interview manuscript map patent personal_communication song speech thesis webpage post-weblog" match="any">
+      <if type="article-journal article-magazine article-newspaper book broadcast chapter interview manuscript map patent personal_communication post-weblog song speech thesis webpage" match="any">
         <group>
           <choose>
-            <if type="article-newspaper thesis post-weblog" match="any">
-              <group suffix=", ">
-                <date variable="issued">
-                  <date-part name="month" form="short"/>
-                  <date-part name="day" prefix=" "/>
-                </date>
-              </group>
+            <if type="article-newspaper book chapter post-weblog thesis" match="any">
+              <choose>
+                <if variable="issued">
+                  <group suffix=", ">
+                    <date variable="issued">
+                      <date-part name="month" form="short"/>
+                      <date-part name="day" prefix=" "/>
+                    </date>
+                  </group>
+                </if>
+                <else>
+                  <group prefix=" (" suffix=")">
+                    <choose>
+                      <if variable="status">
+                        <group prefix="" suffix=" ">
+                          <text variable="status"/>
+                        </group>
+                      </if>
+                    </choose>
+                    <text term="no date" form="short"/>
+                    <text variable="year-suffix" prefix="-"/>
+                  </group>
+                </else>
+              </choose>
             </if>
             <else-if type="article-magazine">
+              <choose>
+                <if variable="status">
+                  <group prefix="" suffix=" ">
+                    <text variable="status"/>
+                  </group>
+                </if>
+              </choose>
               <date variable="issued">
                 <date-part name="month" suffix=" " form="short"/>
               </date>
             </else-if>
+          </choose>
+          <choose>
+            <if variable="status">
+              <group prefix="" suffix=" ">
+                <text variable="status"/>
+              </group>
+            </if>
           </choose>
           <date variable="issued">
             <date-part name="year"/>
@@ -211,6 +242,11 @@
               <text variable="edition"/>
               <label variable="edition" form="short"/>
             </group>
+             <choose>
+                  <if variable="status">
+                    <text variable="status"/>
+                  </if>
+            </choose>
             <date variable="issued">
               <date-part name="year"/>
             </date>

--- a/bluebook-law-review.csl
+++ b/bluebook-law-review.csl
@@ -202,33 +202,33 @@
                       <date-part name="day" prefix=" "/>
                     </date>
                   </group>
-            </if>
-            <else-if type="article-magazine">
+                </if>
+                <else-if type="article-magazine">
+                  <date variable="issued">
+                    <date-part name="month" suffix=" " form="short"/>
+                  </date>
+                </else-if>
+              </choose>
               <date variable="issued">
-                <date-part name="month" suffix=" " form="short"/>
+                <date-part name="year"/>
               </date>
-            </else-if>
-          </choose>
-          <date variable="issued">
-            <date-part name="year"/>
-          </date>
-        </group>
-      </if>
-      <else>
-        <group delimiter=", ">
-          <text macro="editor-translator"/>
-          <group delimiter=" ">
-            <group delimiter=" ">
-              <text variable="edition"/>
-              <label variable="edition" form="short"/>
             </group>
-            <date variable="issued">
-              <date-part name="year"/>
-            </date>
-          </group>
-        </group>
-      </else>
-    </choose>
+          </if>
+          <else>
+            <group delimiter=", ">
+              <text macro="editor-translator"/>
+              <group delimiter=" ">
+                <group delimiter=" ">
+                  <text variable="edition"/>
+                  <label variable="edition" form="short"/>
+                </group>
+                <date variable="issued">
+                  <date-part name="year"/>
+                </date>
+              </group>
+            </group>
+          </else>
+        </choose>
       </else>
     </choose>
   </macro>

--- a/bluebook-law-review.csl
+++ b/bluebook-law-review.csl
@@ -181,9 +181,9 @@
   </macro>
   <macro name="issuance">
     <choose>
-      <if variable="status" match="forthcoming">
+      <if match="any" variable="status">
         <group>
-          <text value="Forthcoming"/>
+          <text variable="status" text-case="capitalize-first"/>
           <date variable="issued">
             <date-part name="year"/>
           </date>

--- a/bluebook-law-review.csl
+++ b/bluebook-law-review.csl
@@ -181,7 +181,6 @@
   </macro>
   <macro name="issuance">
     <choose>
-      <!-- Check if the reference is marked as "forthcoming" -->
       <if variable="status" match="forthcoming">
         <group>
           <text value="Forthcoming"/>

--- a/duale-hochschule-baden-wurttemberg-department-of-international-business.csl
+++ b/duale-hochschule-baden-wurttemberg-department-of-international-business.csl
@@ -1,0 +1,331 @@
+<?xml version="1.0" encoding="utf-8"?>
+<style xmlns="http://purl.org/net/xbiblio/csl" class="note" version="1.0" demote-non-dropping-particle="sort-only" default-locale="en-GB">
+  <info>
+    <title>Duale Hochschule Baden-Württemberg - Department of International Business</title>
+    <id>http://www.zotero.org/styles/duale-hochschule-baden-wurttemberg-department-of-international-business</id>
+    <link href="http://www.zotero.org/styles/duale-hochschule-baden-wurttemberg-department-of-international-business" rel="self"/>
+    <link href="http://www.zotero.org/styles/wiesbaden-business-school" rel="template"/>
+    <link href="https://www.dhbw-stuttgart.de/studierendenportale/bwl-ib/Zitierrichtlinien/Guidelines_for_Academic_Writing_v1.7.1.pdf" rel="documentation"/>
+    <author>
+      <name>Patrick O'Brien, PhD</name>
+    </author>
+    <category citation-format="note"/>
+    <category field="humanities"/>
+    <summary>Based on the Guidelines for Academic Writing as of December 2022 (version 1.7).</summary>
+    <updated>2023-08-08T10:40:03+00:00</updated>
+    <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
+  </info>
+  <locale xml:lang="en">
+    <terms>
+      <term name="accessed" form="long">status as of</term>
+      <term name="on">of</term>
+    </terms>
+  </locale>
+  <locale xml:lang="de">
+    <terms>
+      <term name="et-al">et al.</term>
+      <term name="volume" form="short">Jg.</term>
+      <term name="issue" form="long">Heft</term>
+      <term name="retrieved">zugegriffen am</term>
+      <term name="anonymous" form="short">o.V.</term>
+      <term name="accessed">Stand</term>
+      <term name="section" form="short">
+        <single>Abs.</single>
+        <multiple>Abs.</multiple>
+      </term>
+    </terms>
+  </locale>
+  <macro name="author">
+    <names variable="author">
+      <name delimiter="; " delimiter-precedes-last="never" initialize-with=". " name-as-sort-order="all"/>
+      <label form="short" prefix=" (" suffix=")"/>
+      <substitute>
+        <names variable="editor"/>
+        <choose>
+          <if type="entry-dictionary entry-encyclopedia" match="any">
+            <text variable="container-title"/>
+          </if>
+        </choose>
+        <text macro="anonymous"/>
+      </substitute>
+    </names>
+  </macro>
+  <macro name="anonymous">
+    <text term="anonymous" form="short" text-case="capitalize-first" strip-periods="true"/>
+  </macro>
+  <macro name="author-short">
+    <names variable="author" delimiter=", ">
+      <name delimiter="; " delimiter-precedes-last="never" initialize-with=". " name-as-sort-order="all"/>
+      <label form="short"/>
+      <substitute>
+        <names variable="editor translator"/>
+        <text macro="anonymous" strip-periods="false"/>
+      </substitute>
+    </names>
+  </macro>
+  <macro name="editor">
+    <names variable="editor" delimiter="; ">
+      <name delimiter="; " delimiter-precedes-last="never" initialize-with=". " name-as-sort-order="all"/>
+      <label form="short" prefix=" (" suffix=")"/>
+    </names>
+  </macro>
+  <macro name="access">
+    <group delimiter=" ">
+      <text variable="URL"/>
+      <group delimiter=" " prefix="(" suffix=")">
+        <text term="accessed"/>
+        <date variable="accessed">
+          <date-part name="month" suffix=" "/>
+          <date-part name="day" suffix=", "/>
+          <date-part form="long" name="year"/>
+        </date>
+      </group>
+    </group>
+  </macro>
+  <macro name="date">
+    <choose>
+      <if variable="issued">
+        <date variable="issued">
+          <date-part form="numeric" name="day" suffix="."/>
+          <date-part form="numeric" name="month" suffix="."/>
+          <date-part form="long" name="year"/>
+        </date>
+      </if>
+      <else>
+        <date variable="accessed">
+          <date-part form="numeric" name="day" suffix="."/>
+          <date-part form="numeric" name="month" suffix="."/>
+          <date-part form="long" name="year"/>
+        </date>
+      </else>
+    </choose>
+  </macro>
+  <macro name="year-date">
+    <choose>
+      <if match="any" is-uncertain-date="issued">
+        <text term="no date"/>
+      </if>
+      <else>
+        <date variable="issued">
+          <date-part name="year"/>
+        </date>
+      </else>
+    </choose>
+    <choose>
+      <if type="interview" match="any">
+        <text variable="medium" prefix=", "/>
+      </if>
+    </choose>
+  </macro>
+  <macro name="pages">
+    <group delimiter=" ">
+      <label strip-periods="false" variable="page" form="short"/>
+      <text variable="page"/>
+    </group>
+  </macro>
+  <macro name="publisher">
+    <group delimiter=", ">
+      <choose>
+        <if type="report" match="any">
+          <text variable="publisher"/>
+        </if>
+      </choose>
+      <text variable="publisher-place"/>
+    </group>
+  </macro>
+  <macro name="edition">
+    <choose>
+      <if match="any" is-numeric="edition">
+        <group delimiter=". ">
+          <number variable="edition"/>
+          <label text-case="capitalize-first" variable="edition"/>
+        </group>
+      </if>
+      <else>
+        <text variable="edition"/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="type-sort">
+    <choose>
+      <if type="webpage post post-weblog" match="any">
+        <text value="X"/>
+      </if>
+      <else-if type="legal_case legislation" match="any">
+        <text value="Y"/>
+      </else-if>
+      <else-if type="interview" match="any">
+        <text value="Z"/>
+      </else-if>
+      <else>
+        <text value="A"/>
+      </else>
+    </choose>
+  </macro>
+  <citation et-al-min="4" et-al-use-first="1" disambiguate-add-year-suffix="true">
+    <layout delimiter="; " suffix=".">
+      <group delimiter=", ">
+        <group delimiter=" ">
+          <text macro="author-short"/>
+          <text macro="year-date" prefix="(" suffix=")"/>
+        </group>
+        <choose>
+          <if type="post post-weblog webpage" match="any">
+            <text macro="access"/>
+          </if>
+          <else-if type="interview" match="any">
+            <group delimiter=", ">
+              <text variable="genre"/>
+              <date form="text" date-parts="year-month-day" variable="issued"/>
+            </group>
+          </else-if>
+          <else-if type="entry-dictionary" match="any">
+            <text variable="title"/>
+          </else-if>
+        </choose>
+        <group delimiter=" ">
+          <label variable="locator" form="short"/>
+          <text variable="locator"/>
+        </group>
+      </group>
+    </layout>
+  </citation>
+  <bibliography>
+    <sort>
+      <key macro="type-sort"/>
+      <key macro="author"/>
+      <key macro="date"/>
+    </sort>
+    <layout suffix=".">
+      <choose>
+        <if type="legal_case" match="any">
+          <group delimiter=", ">
+            <group delimiter=" ">
+              <text variable="title" font-weight="bold"/>
+              <text term="from"/>
+              <date form="numeric" variable="issued"/>
+            </group>
+            <text variable="authority"/>
+            <text variable="number"/>
+            <group delimiter=" ">
+              <text variable="container-title"/>
+              <text variable="volume"/>
+            </group>
+            <group delimiter=" ">
+              <label variable="page" form="short"/>
+              <text variable="page-first"/>
+            </group>
+          </group>
+        </if>
+        <else>
+          <group>
+            <group delimiter=" ">
+              <group font-weight="bold">
+                <text macro="author"/>
+                <text macro="year-date" prefix=" (" suffix="):"/>
+              </group>
+              <text variable="title"/>
+            </group>
+            <choose>
+              <if type="webpage post-weblog post" match="any">
+                <group delimiter=". " prefix=", ">
+                  <text variable="container-title"/>
+                  <text macro="access"/>
+                </group>
+              </if>
+              <else-if type="speech" match="any">
+                <group delimiter=", " prefix=". ">
+                  <text variable="publisher-place"/>
+                  <text macro="date" prefix=", "/>
+                  <text macro="access" prefix=", "/>
+                </group>
+              </else-if>
+              <else-if type="article-journal" match="any">
+                <group delimiter=", " prefix=". ">
+                  <text variable="container-title"/>
+                  <group delimiter=". ">
+                    <label variable="volume" form="short"/>
+                    <text variable="volume"/>
+                  </group>
+                  <group delimiter=" ">
+                    <label variable="issue" form="short"/>
+                    <text variable="issue"/>
+                  </group>
+                  <text macro="pages"/>
+                </group>
+              </else-if>
+              <else-if type="article-newspaper article-magazine" match="any">
+                <group delimiter=", " prefix=". ">
+                  <text variable="container-title"/>
+                  <group delimiter=" ">
+                    <group delimiter=" ">
+                      <label text-case="capitalize-first" variable="issue" form="short"/>
+                      <text variable="issue"/>
+                    </group>
+                    <text term="on"/>
+                    <date form="text" variable="issued"/>
+                  </group>
+                  <text macro="pages"/>
+                </group>
+              </else-if>
+              <else-if type="chapter paper-conference" match="any">
+                <group delimiter=". " prefix=". ">
+                  <group delimiter=": ">
+                    <text term="in" text-case="capitalize-first"/>
+                    <text macro="editor"/>
+                    <text variable="container-title" font-style="normal"/>
+                  </group>
+                  <group delimiter=", ">
+                    <text macro="edition"/>
+                    <text macro="publisher"/>
+                    <text macro="pages"/>
+                  </group>
+                </group>
+              </else-if>
+              <else-if type="thesis" match="any">
+                <group delimiter=", " prefix=". ">
+                  <text variable="genre"/>
+                  <text macro="publisher"/>
+                </group>
+              </else-if>
+              <else-if type="interview" match="any">
+                <group delimiter=" " prefix=", ">
+                  <text variable="genre"/>
+                  <date form="text" variable="issued" prefix=" on "/>
+                  <group delimiter=" ">
+                    <text term="in"/>
+                    <text variable="publisher-place"/>
+                  </group>
+                </group>
+              </else-if>
+              <else-if type="report" match="any">
+                <group delimiter=", " prefix=". ">
+                  <group delimiter=" ">
+                    <text variable="genre"/>
+                    <group delimiter=" ">
+                      <label text-case="capitalize-first" variable="issue" form="short"/>
+                      <text variable="number"/>
+                    </group>
+                  </group>
+                  <text macro="publisher"/>
+                </group>
+              </else-if>
+              <else-if type="entry-dictionary entry-encyclopedia" match="any">
+                <group delimiter=", " prefix=", ">
+                  <text macro="edition"/>
+                  <text macro="publisher"/>
+                </group>
+              </else-if>
+              <else>
+                <group delimiter=", " prefix=". ">
+                  <text macro="edition"/>
+                  <text macro="publisher"/>
+                </group>
+              </else>
+            </choose>
+          </group>
+        </else>
+      </choose>
+    </layout>
+  </bibliography>
+</style>


### PR DESCRIPTION
Added additional types to the issuance  macro 

- book
- chapter

Then when crafting the issue date, I check the status variable, and place that as a prefix for the date.
```

                      <if variable="status">
                        <group prefix="" suffix=" ">
                          <text variable="status"/>
                        </group>
                      </if>

```

Other statuses might not make sense here, but I'm not sure how to check if the variable is forthcoming or retracted or other statuses.