### PR TITLE
Update norsk-apa-manual.csl

### DIFF
--- a/norsk-apa-manual.csl
+++ b/norsk-apa-manual.csl
@@ -188,7 +188,7 @@
             </date>
             <text variable="year-suffix"/>
             <choose>
-              <if type="article-magazine article-newspaper broadcast interview motion_picture pamphlet personal_communication post post-weblog song speech webpage" match="any">
+              <if type="article-magazine article-newspaper broadcast entry-encyclopedia interview motion_picture pamphlet personal_communication post post-weblog song speech webpage" match="any">
                 <!-- Many video and audio examples in manual give full dates. Err on the side of too much information. -->
                 <date variable="issued">
                   <date-part prefix=", " name="day"/>


### PR DESCRIPTION
This makes it possible to use "entry-encyclopedia" for online encyclopedia articles with an update date - and to reproduce the full date in the bibliography, not just the year. Example:

In text: (Hoffmann, 2019).
In bibliography: 
Hoffmann, M. (2019, 29. november). Folkekunst. I Store norske leksikon. https://snl.no/.versionview/1031735