### PR TITLE
Create etudes-francaises.csl

### DIFF
--- a/etudes-francaises.csl
+++ b/etudes-francaises.csl
@@ -9,7 +9,7 @@
     <author>
       <name>Louis-Olivier Brassard</name>
       <email>louis-olivier.brassard@umontreal.ca</email>
-      <uri>https://https://www.loupbrun.ca</uri>
+      <uri>https://www.loupbrun.ca</uri>
     </author>
     <category citation-format="note"/>
     <category field="literature"/>

--- a/etudes-francaises.csl
+++ b/etudes-francaises.csl
@@ -18,7 +18,7 @@
     <issn>0014-2085</issn>
     <issn>1492-1405</issn>
     <summary>Références pour le style Études françaises. Aussi utilisé par les Presses de l’Université de Montréal (PUM).</summary>
-    <updated>2023-09-30T20:18:00-04:00</updated>
+    <updated>2023-10-02T21:24:00-04:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale xml:lang="fr">
@@ -37,7 +37,7 @@
       <term name="online">disponible en ligne&#8239;:</term>
       <term name="volume" form="short">vol.</term>
       <term name="number-of-volumes" form="short">vol.</term>
-      <term name="loc-cit" form="short">loc.cit.</term>
+      <term name="loc-cit" form="short">loc. cit.</term>
       <term name="op-cit" form="short">op. cit.</term>
     </terms>
   </locale>

--- a/etudes-francaises.csl
+++ b/etudes-francaises.csl
@@ -18,7 +18,7 @@
     <issn>0014-2085</issn>
     <issn>1492-1405</issn>
     <summary>Références pour le style Études françaises. Aussi utilisé par les Presses de l’Université de Montréal (PUM).</summary>
-    <updated>2023-09-15T10:15:00-04:00</updated>
+    <updated>2023-09-30T20:05:00-04:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale xml:lang="fr">
@@ -132,7 +132,7 @@
   </macro>
   <macro name="number-of-pages">
     <text variable="number-of-pages"/>
-    <label variable="number-of-pages" plural="always" prefix="&#160;"/>
+    <label variable="number-of-pages" form="short" plural="always" prefix="&#160;"/>
   </macro>
   <macro name="number-of-volumes">
     <choose>

--- a/etudes-francaises.csl
+++ b/etudes-francaises.csl
@@ -18,7 +18,7 @@
     <issn>0014-2085</issn>
     <issn>1492-1405</issn>
     <summary>Références pour le style Études françaises. Aussi utilisé par les Presses de l’Université de Montréal (PUM).</summary>
-    <updated>2023-10-02T21:24:00-04:00</updated>
+    <updated>2023-10-23T16:35:00-04:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale xml:lang="fr">
@@ -35,22 +35,6 @@
       <term name="open-inner-quote">”</term>
       <term name="close-inner-quote">”</term>
       <term name="online">disponible en ligne&#8239;:</term>
-      <term name="volume" form="short">vol.</term>
-      <term name="number-of-volumes" form="short">vol.</term>
-      <term name="loc-cit" form="short">loc. cit.</term>
-      <term name="op-cit" form="short">op. cit.</term>
-    </terms>
-  </locale>
-  <locale xml:lang="en">
-    <style-options punctuation-in-quote="false"/>
-    <terms>
-      <term name="translator" form="short">trans. by</term>
-      <term name="paragraph" form="symbol">§</term>
-      <term name="open-quote">“</term>
-      <term name="close-quote">”</term>
-      <term name="open-inner-quote">‘</term>
-      <term name="close-inner-quote">’</term>
-      <term name="online">available online:</term>
       <term name="volume" form="short">vol.</term>
       <term name="number-of-volumes" form="short">vol.</term>
       <term name="loc-cit" form="short">loc. cit.</term>

--- a/etudes-francaises.csl
+++ b/etudes-francaises.csl
@@ -18,7 +18,7 @@
     <issn>0014-2085</issn>
     <issn>1492-1405</issn>
     <summary>Références pour le style Études françaises. Aussi utilisé par les Presses de l’Université de Montréal (PUM).</summary>
-    <updated>2023-09-15T010:15:00-04:00</updated>
+    <updated>2023-09-15T10:15:00-04:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale xml:lang="fr">

--- a/etudes-francaises.csl
+++ b/etudes-francaises.csl
@@ -5,6 +5,7 @@
     <title-short>ETFRA</title-short>
     <id>http://www.zotero.org/styles/etudes-francaises</id>
     <link href="http://www.zotero.org/styles/etudes-francaises" rel="self"/>
+    <link href="http://www.zotero.org/styles/bulletin-de-correspondance-hellenique" rel="template"/>
     <link href="https://revue-etudesfrancaises.umontreal.ca/wp-content/uploads/2023/02/protocole-de-redaction.pdf" rel="documentation"/>
     <author>
       <name>Louis-Olivier Brassard</name>
@@ -19,7 +20,6 @@
     <summary>Références pour le style Études françaises. Aussi utilisé par les Presses de l’Université de Montréal (PUM).</summary>
     <updated>2023-09-14T18:55:00-04:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
-    <link href="http://www.zotero.org/styles/bulletin-de-correspondance-hellenique" rel="template"/>
   </info>
   <locale xml:lang="fr">
     <terms>
@@ -60,22 +60,22 @@
   <macro name="volume">
     <choose>
       <if is-numeric="volume">
-        <group delimiter="&#xA0;">
-          <label variable="volume" form="short" />
-          <number variable="volume" />
+        <group delimiter="&#160;">
+          <label variable="volume" form="short"/>
+          <number variable="volume"/>
         </group>
       </if>
       <else>
         <group delimiter=" ">
-          <text variable="volume" />
+          <text variable="volume"/>
         </group>
       </else>
     </choose>
   </macro>
   <macro name="issue">
-    <group delimiter="&#xA0;" prefix=" ">
-      <label variable="issue" form="short" />
-      <text variable="issue" />
+    <group delimiter="&#160;" prefix=" ">
+      <label variable="issue" form="short"/>
+      <text variable="issue"/>
     </group>
   </macro>
   <macro name="book">
@@ -101,7 +101,7 @@
     </choose>
   </macro>
   <macro name="URL">
-    <group delimiter=" " >
+    <group delimiter=" ">
       <text term="online"/>
       <text variable="URL"/>
       <text macro="access" prefix="(" suffix=")"/>
@@ -117,13 +117,13 @@
   </macro>
   <macro name="number-of-pages">
     <text variable="number-of-pages"/>
-    <label variable="number-of-pages" plural="always" prefix="&#xA0;"/>
+    <label variable="number-of-pages" plural="always" prefix="&#160;"/>
   </macro>
   <macro name="number-of-volumes">
     <choose>
       <if variable="number-of-volumes">
-        <text variable="number-of-volumes" />
-        <label variable="number-of-volumes" form="short" prefix="&#xA0;" />
+        <text variable="number-of-volumes"/>
+        <label variable="number-of-volumes" form="short" prefix="&#160;"/>
       </if>
     </choose>
   </macro>
@@ -134,13 +134,13 @@
         <names variable="editor">
           <name font-variant="normal" sort-separator=" " and="text"/>
         </names>
-        <text macro="title" />
+        <text macro="title"/>
       </substitute>
     </names>
   </macro>
   <macro name="editor-translator">
     <names variable="translator" delimiter=", ">
-      <label form="short" suffix=" " />
+      <label form="short" suffix=" "/>
       <name sort-separator=" " delimiter=", " and="text" delimiter-precedes-last="never"/>
       <substitute>
         <text macro="editor"/>
@@ -164,11 +164,11 @@
   </macro>
   <macro name="pages">
     <group>
-      <text variable="page" prefix="p.&#xA0;"/>
+      <text variable="page" prefix="p.&#160;"/>
     </group>
   </macro>
   <macro name="access">
-    <group delimiter=" " >
+    <group delimiter=" ">
       <text term="accessed"/>
       <date variable="accessed" delimiter=" ">
         <date-part name="day"/>
@@ -179,9 +179,9 @@
   </macro>
   <macro name="collection">
     <group delimiter=" ">
-      <text variable="collection-title" quotes="true" />
-      <group delimiter="&#xA0;">
-      <label variable="collection-number" form="short" />
+      <text variable="collection-title" quotes="true"/>
+      <group delimiter="&#160;">
+        <label variable="collection-number" form="short"/>
         <text variable="collection-number"/>
       </group>
     </group>
@@ -209,9 +209,9 @@
       </choose>
       <choose>
         <if variable="original-date">
-        <date variable="original-date" prefix="[" suffix="]">
-          <date-part name="year" />
-        </date>
+          <date variable="original-date" prefix="[" suffix="]">
+            <date-part name="year"/>
+          </date>
         </if>
       </choose>
     </group>
@@ -232,7 +232,7 @@
     </group>
   </macro>
   <macro name="pages-citation">
-    <label plural="never" suffix="&#xA0;" variable="locator" form="short"/>
+    <label plural="never" suffix="&#160;" variable="locator" form="short"/>
     <text variable="locator" form="short"/>
   </macro>
   <macro name="full-note">
@@ -257,7 +257,7 @@
             <text macro="number-of-pages"/>
           </group>
         </if>
-        <else-if type="entry-dictionary entry-encyclopedia" match="any" >
+        <else-if type="entry-dictionary entry-encyclopedia" match="any">
           <group delimiter=", ">
             <group delimiter=" ">
               <text variable="container-title" font-style="italic" text-case="title" form="short"/>
@@ -362,7 +362,7 @@
     </group>
   </macro>
   <citation et-al-min="4" et-al-use-first="1" disambiguate-add-year-suffix="true">
-    <layout delimiter="&#xA0;; " suffix=".">
+    <layout delimiter="&#160;; " suffix=".">
       <choose>
         <if position="ibid-with-locator">
           <group delimiter=", ">
@@ -392,12 +392,12 @@
             <text macro="full-note"/>
             <choose>
               <if variable="locator">
-                <text macro="pages-citation" />
+                <text macro="pages-citation"/>
               </if>
             </choose>
           </group>
         </else>
-     </choose>
+      </choose>
     </layout>
   </citation>
   <bibliography>

--- a/etudes-francaises.csl
+++ b/etudes-francaises.csl
@@ -18,13 +18,13 @@
     <issn>0014-2085</issn>
     <issn>1492-1405</issn>
     <summary>Références pour le style Études françaises. Aussi utilisé par les Presses de l’Université de Montréal (PUM).</summary>
-    <updated>2023-09-14T18:55:00-04:00</updated>
+    <updated>2023-09-15T010:15:00-04:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale xml:lang="fr">
     <terms>
       <term name="editor" form="short">dir.</term>
-      <term name="translator" form="short">trad. de</term>
+      <term name="translator" form="short">trad. par</term>
       <term name="collection-number" form="short">nº</term>
       <term name="in">dans</term>
       <term name="and">et</term>
@@ -102,9 +102,24 @@
   </macro>
   <macro name="URL">
     <group delimiter=" ">
+      <choose>
+        <if variable="DOI">
+          <text macro="DOI"/>
+        </if>
+        <else-if variable="URL">
+          <text term="online"/>
+          <group delimiter="&#8239;; ">
+            <text variable="URL"/>
+            <text macro="access"/>
+          </group>
+        </else-if>
+      </choose>
+    </group>
+  </macro>
+  <macro name="DOI">
+    <group delimiter=" ">
       <text term="online"/>
-      <text variable="URL"/>
-      <text macro="access" prefix="(" suffix=")"/>
+      <text variable="DOI"/>
     </group>
   </macro>
   <macro name="archive">
@@ -276,7 +291,7 @@
         <else-if type="webpage article-journal article-magazine article-newspaper broadcast personal_communication article" match="any">
           <group delimiter=", ">
             <text macro="title" quotes="true"/>
-            <text variable="container-title" form="short" font-style="italic" text-case="title"/>
+            <text variable="container-title" font-style="italic" text-case="title"/>
             <text macro="volume"/>
             <text macro="issue"/>
             <group delimiter=" ">
@@ -317,15 +332,15 @@
             <text macro="title" quotes="true"/>
             <choose>
               <if variable="editor container-author" match="any">
-                <group>
-                  <text term="in" suffix=" "/>
-                  <text macro="editor" suffix=", "/>
+                <group delimiter=" ">
+                  <text term="in"/>
+                  <text macro="editor" suffix=","/>
                   <text variable="container-title" font-style="italic" text-case="title"/>
                 </group>
               </if>
               <else>
-                <group>
-                  <text term="in" suffix=" "/>
+                <group delimiter=" ">
+                  <text term="in"/>
                   <text variable="container-title" font-style="italic" text-case="title"/>
                 </group>
               </else>

--- a/etudes-francaises.csl
+++ b/etudes-francaises.csl
@@ -392,12 +392,12 @@
           <group delimiter=", ">
             <text macro="author"/>
             <choose>
-              <if type="book" match="any">
-                <text term="op-cit" form="short" font-style="italic"/>
-              </if>
-              <else-if type="article-journal article-magazine article-newspaper chapter" match="any">
+              <if type="article-journal article-magazine article-newspaper chapter" match="any">
                 <text term="loc-cit" form="short" font-style="italic"/>
-              </else-if>
+              </if>
+              <else>
+                <text term="op-cit" form="short" font-style="italic"/>
+              </else>
             </choose>
             <text macro="pages-citation"/>
           </group>

--- a/etudes-francaises.csl
+++ b/etudes-francaises.csl
@@ -17,7 +17,7 @@
     <issn>0014-2085</issn>
     <issn>1492-1405</issn>
     <summary>Références pour le style Études françaises. Aussi utilisé par les Presses de l’Université de Montréal (PUM).</summary>
-    <updated>2023-09-14T15:45:00-04:00</updated>
+    <updated>2023-09-14T18:55:00-04:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
     <link href="http://www.zotero.org/styles/bulletin-de-correspondance-hellenique" rel="template"/>
   </info>
@@ -36,6 +36,7 @@
       <term name="close-inner-quote">”</term>
       <term name="online">disponible en ligne&#8239;:</term>
       <term name="volume" form="short">vol.</term>
+      <term name="number-of-volumes" form="short">vol.</term>
       <term name="loc-cit" form="short">loc.cit.</term>
       <term name="op-cit" form="short">op. cit.</term>
     </terms>
@@ -50,6 +51,8 @@
       <term name="open-inner-quote">‘</term>
       <term name="close-inner-quote">’</term>
       <term name="online">available online:</term>
+      <term name="volume" form="short">vol.</term>
+      <term name="number-of-volumes" form="short">vol.</term>
       <term name="loc-cit" form="short">loc. cit.</term>
       <term name="op-cit" form="short">op. cit.</term>
     </terms>
@@ -84,7 +87,6 @@
       <text macro="collection"/>
       <text macro="year-date"/>
       <text macro="edition"/>
-      <text macro="number-of-pages"/>
     </group>
   </macro>
   <macro name="genre">
@@ -115,7 +117,15 @@
   </macro>
   <macro name="number-of-pages">
     <text variable="number-of-pages"/>
-    <text term="page" form="short" prefix="&#xA0;"/>
+    <label variable="number-of-pages" plural="always" prefix="&#xA0;"/>
+  </macro>
+  <macro name="number-of-volumes">
+    <choose>
+      <if variable="number-of-volumes">
+        <text variable="number-of-volumes" />
+        <label variable="number-of-volumes" form="short" prefix="&#xA0;" />
+      </if>
+    </choose>
   </macro>
   <macro name="author">
     <names variable="author" delimiter=", ">
@@ -236,15 +246,18 @@
         </else-if>
       </choose>
       <choose>
-        <if type="thesis report">
+        <if match="any" type="thesis report">
           <group delimiter=", ">
             <text macro="title" font-style="italic"/>
-            <text variable="genre"/>
+            <text variable="genre" text-case="lowercase"/>
             <text variable="publisher-place"/>
             <text variable="publisher"/>
+            <text macro="year-date"/>
+            <text macro="number-of-volumes"/>
+            <text macro="number-of-pages"/>
           </group>
         </if>
-        <else-if type="entry-dictionary entry-encyclopedia">
+        <else-if type="entry-dictionary entry-encyclopedia" match="any" >
           <group delimiter=", ">
             <group delimiter=" ">
               <text variable="container-title" font-style="italic" text-case="title" form="short"/>
@@ -290,7 +303,6 @@
                       <text macro="year-date"/>
                       <text macro="edition"/>
                     </group>
-                    <text macro="number-of-pages"/>
                   </group>
                 </else>
               </choose>

--- a/etudes-francaises.csl
+++ b/etudes-francaises.csl
@@ -1,0 +1,402 @@
+<?xml version="1.0" encoding="utf-8"?>
+<style xmlns="http://purl.org/net/xbiblio/csl" version="1.0" class="note" demote-non-dropping-particle="sort-only" page-range-format="expanded" default-locale="fr-CA">
+  <info>
+    <title>Études françaises (Français)</title>
+    <title-short>ETFRA</title-short>
+    <id>http://www.zotero.org/styles/etudes-francaises</id>
+    <link href="http://www.zotero.org/styles/etudes-francaises" rel="self"/>
+    <link href="https://revue-etudesfrancaises.umontreal.ca/wp-content/uploads/2023/02/protocole-de-redaction.pdf" rel="documentation"/>
+    <author>
+      <name>Louis-Olivier Brassard</name>
+      <email>louis-olivier.brassard@umontreal.ca</email>
+      <uri>https://https://www.loupbrun.ca</uri>
+    </author>
+    <category citation-format="note"/>
+    <category field="literature"/>
+    <category field="humanities"/>
+    <issn>0014-2085</issn>
+    <issn>1492-1405</issn>
+    <summary>Références pour le style Études françaises. Aussi utilisé par les Presses de l’Université de Montréal (PUM).</summary>
+    <updated>2023-09-14T15:45:00-04:00</updated>
+    <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
+    <link href="http://www.zotero.org/styles/bulletin-de-correspondance-hellenique" rel="template"/>
+  </info>
+  <locale xml:lang="fr">
+    <terms>
+      <term name="editor" form="short">dir.</term>
+      <term name="translator" form="short">trad. de</term>
+      <term name="collection-number" form="short">nº</term>
+      <term name="in">dans</term>
+      <term name="and">et</term>
+      <term name="paragraph" form="symbol">§</term>
+      <term name="accessed">page consultée le</term>
+      <term name="open-quote">«&#8239;</term>
+      <term name="close-quote">&#8239;»</term>
+      <term name="open-inner-quote">”</term>
+      <term name="close-inner-quote">”</term>
+      <term name="online">disponible en ligne&#8239;:</term>
+      <term name="volume" form="short">vol.</term>
+      <term name="loc-cit" form="short">loc.cit.</term>
+      <term name="op-cit" form="short">op. cit.</term>
+    </terms>
+  </locale>
+  <locale xml:lang="en">
+    <style-options punctuation-in-quote="false"/>
+    <terms>
+      <term name="translator" form="short">trans. by</term>
+      <term name="paragraph" form="symbol">§</term>
+      <term name="open-quote">“</term>
+      <term name="close-quote">”</term>
+      <term name="open-inner-quote">‘</term>
+      <term name="close-inner-quote">’</term>
+      <term name="online">available online:</term>
+      <term name="loc-cit" form="short">loc. cit.</term>
+      <term name="op-cit" form="short">op. cit.</term>
+    </terms>
+  </locale>
+  <macro name="volume">
+    <choose>
+      <if is-numeric="volume">
+        <group delimiter="&#xA0;">
+          <label variable="volume" form="short" />
+          <number variable="volume" />
+        </group>
+      </if>
+      <else>
+        <group delimiter=" ">
+          <text variable="volume" />
+        </group>
+      </else>
+    </choose>
+  </macro>
+  <macro name="issue">
+    <group delimiter="&#xA0;" prefix=" ">
+      <label variable="issue" form="short" />
+      <text variable="issue" />
+    </group>
+  </macro>
+  <macro name="book">
+    <group delimiter=", ">
+      <text macro="title" font-style="italic"/>
+      <text macro="genre"/>
+      <text macro="volume"/>
+      <text macro="publisher"/>
+      <text macro="collection"/>
+      <text macro="year-date"/>
+      <text macro="edition"/>
+      <text macro="number-of-pages"/>
+    </group>
+  </macro>
+  <macro name="genre">
+    <choose>
+      <if type="book chapter" variable="genre">
+        <group delimiter=", ">
+          <text variable="genre"/>
+          <text variable="event-place"/>
+          <date variable="event-date" form="text"/>
+        </group>
+      </if>
+    </choose>
+  </macro>
+  <macro name="URL">
+    <group delimiter=" " >
+      <text term="online"/>
+      <text variable="URL"/>
+      <text macro="access" prefix="(" suffix=")"/>
+    </group>
+  </macro>
+  <macro name="archive">
+    <group delimiter=", ">
+      <text variable="genre"/>
+      <text variable="archive"/>
+      <text variable="archive_location"/>
+      <text variable="call-number"/>
+    </group>
+  </macro>
+  <macro name="number-of-pages">
+    <text variable="number-of-pages"/>
+    <text term="page" form="short" prefix="&#xA0;"/>
+  </macro>
+  <macro name="author">
+    <names variable="author" delimiter=", ">
+      <name font-variant="normal" sort-separator=" " and="text" delimiter-precedes-last="never"/>
+      <substitute>
+        <names variable="editor">
+          <name font-variant="normal" sort-separator=" " and="text"/>
+        </names>
+        <text macro="title" />
+      </substitute>
+    </names>
+  </macro>
+  <macro name="editor-translator">
+    <names variable="translator" delimiter=", ">
+      <label form="short" suffix=" " />
+      <name sort-separator=" " delimiter=", " and="text" delimiter-precedes-last="never"/>
+      <substitute>
+        <text macro="editor"/>
+      </substitute>
+    </names>
+  </macro>
+  <macro name="editor">
+    <names variable="editor" font-variant="normal" delimiter=", ">
+      <name font-variant="normal" sort-separator=" " form="long" and="text" delimiter-precedes-last="never"/>
+      <label form="short" text-case="lowercase" font-variant="normal" prefix=" (" suffix=")"/>
+      <substitute>
+        <text macro="container-author"/>
+      </substitute>
+    </names>
+  </macro>
+  <macro name="container-author">
+    <names variable="container-author" delimiter=", ">
+      <name font-variant="normal" sort-separator=" " and="text" delimiter-precedes-last="never"/>
+      <et-al font-style="italic" font-variant="normal"/>
+    </names>
+  </macro>
+  <macro name="pages">
+    <group>
+      <text variable="page" prefix="p.&#xA0;"/>
+    </group>
+  </macro>
+  <macro name="access">
+    <group delimiter=" " >
+      <text term="accessed"/>
+      <date variable="accessed" delimiter=" ">
+        <date-part name="day"/>
+        <date-part name="month"/>
+        <date-part name="year"/>
+      </date>
+    </group>
+  </macro>
+  <macro name="collection">
+    <group delimiter=" ">
+      <text variable="collection-title" quotes="true" />
+      <group delimiter="&#xA0;">
+      <label variable="collection-number" form="short" />
+        <text variable="collection-number"/>
+      </group>
+    </group>
+  </macro>
+  <macro name="title">
+    <text variable="title" text-case="title"/>
+  </macro>
+  <macro name="publisher">
+    <group delimiter=", ">
+      <text variable="publisher-place"/>
+      <text variable="publisher"/>
+    </group>
+  </macro>
+  <macro name="year-date">
+    <group delimiter=" ">
+      <choose>
+        <if variable="issued">
+          <date variable="issued">
+            <date-part name="year"/>
+          </date>
+        </if>
+        <else>
+          <text term="no date" form="short"/>
+        </else>
+      </choose>
+      <choose>
+        <if variable="original-date">
+        <date variable="original-date" prefix="[" suffix="]">
+          <date-part name="year" />
+        </date>
+        </if>
+      </choose>
+    </group>
+  </macro>
+  <macro name="edition">
+    <group delimiter=", ">
+      <choose>
+        <if is-numeric="edition">
+          <group delimiter=" ">
+            <number variable="edition" form="ordinal"/>
+            <text term="edition" form="short" text-case="lowercase"/>
+          </group>
+        </if>
+        <else>
+          <text variable="edition"/>
+        </else>
+      </choose>
+    </group>
+  </macro>
+  <macro name="pages-citation">
+    <label plural="never" suffix="&#xA0;" variable="locator" form="short"/>
+    <text variable="locator" form="short"/>
+  </macro>
+  <macro name="full-note">
+    <group>
+      <choose>
+        <if match="any" variable="author">
+          <text macro="author" suffix=", "/>
+        </if>
+        <else-if match="none" variable="author">
+          <text macro="editor" suffix=", "/>
+        </else-if>
+      </choose>
+      <choose>
+        <if type="thesis report">
+          <group delimiter=", ">
+            <text macro="title" font-style="italic"/>
+            <text variable="genre"/>
+            <text variable="publisher-place"/>
+            <text variable="publisher"/>
+          </group>
+        </if>
+        <else-if type="entry-dictionary entry-encyclopedia">
+          <group delimiter=", ">
+            <group delimiter=" ">
+              <text variable="container-title" font-style="italic" text-case="title" form="short"/>
+              <number variable="volume" form="roman"/>
+            </group>
+            <text macro="year-date"/>
+            <group delimiter=" ">
+              <text term="column" form="short"/>
+              <text variable="page"/>
+            </group>
+            <group delimiter=" ">
+              <text macro="title" quotes="true"/>
+            </group>
+          </group>
+        </else-if>
+        <else-if type="webpage article-journal article-magazine article-newspaper broadcast personal_communication article" match="any">
+          <group delimiter=", ">
+            <text macro="title" quotes="true"/>
+            <text variable="container-title" form="short" font-style="italic" text-case="title"/>
+            <text macro="volume"/>
+            <text macro="issue"/>
+            <group delimiter=" ">
+              <text macro="year-date"/>
+              <text macro="edition"/>
+            </group>
+            <text macro="pages"/>
+          </group>
+        </else-if>
+        <else-if type="book">
+          <choose>
+            <if variable="author">
+              <choose>
+                <if variable="editor translator" match="none">
+                  <text macro="book"/>
+                </if>
+                <else>
+                  <group delimiter=", ">
+                    <text macro="title" font-style="italic"/>
+                    <text macro="editor-translator"/>
+                    <text macro="publisher"/>
+                    <text macro="collection"/>
+                    <group delimiter=" ">
+                      <text macro="year-date"/>
+                      <text macro="edition"/>
+                    </group>
+                    <text macro="number-of-pages"/>
+                  </group>
+                </else>
+              </choose>
+            </if>
+            <else>
+              <text macro="book"/>
+            </else>
+          </choose>
+        </else-if>
+        <else-if type="chapter paper-conference" match="any">
+          <group delimiter=", ">
+            <text macro="title" quotes="true"/>
+            <choose>
+              <if variable="editor container-author" match="any">
+                <group>
+                  <text term="in" suffix=" "/>
+                  <text macro="editor" suffix=", "/>
+                  <text variable="container-title" font-style="italic" text-case="title"/>
+                </group>
+              </if>
+              <else>
+                <group>
+                  <text term="in" suffix=" "/>
+                  <text variable="container-title" font-style="italic" text-case="title"/>
+                </group>
+              </else>
+            </choose>
+            <text macro="volume"/>
+            <text macro="genre"/>
+            <text macro="publisher"/>
+            <text macro="collection"/>
+            <group delimiter=" ">
+              <text macro="year-date"/>
+              <text macro="edition"/>
+            </group>
+            <text macro="pages"/>
+          </group>
+        </else-if>
+        <else-if type="manuscript map graphic">
+          <group delimiter=", ">
+            <text macro="title" quotes="true"/>
+            <text macro="archive"/>
+            <text macro="number-of-pages"/>
+          </group>
+        </else-if>
+        <else>
+          <group delimiter=", ">
+            <text macro="title" font-style="italic"/>
+            <text macro="genre"/>
+            <text macro="publisher"/>
+            <text macro="collection"/>
+            <text macro="year-date"/>
+          </group>
+        </else>
+      </choose>
+      <text macro="URL" prefix=", "/>
+    </group>
+  </macro>
+  <citation et-al-min="4" et-al-use-first="1" disambiguate-add-year-suffix="true">
+    <layout delimiter="&#xA0;; " suffix=".">
+      <choose>
+        <if position="ibid-with-locator">
+          <group delimiter=", ">
+            <text term="ibid" text-case="capitalize-first" font-style="italic" suffix="."/>
+            <text macro="pages-citation"/>
+          </group>
+        </if>
+        <else-if position="ibid">
+          <text term="ibid" text-case="capitalize-first" font-style="italic"/>
+        </else-if>
+        <else-if position="subsequent">
+          <group delimiter=", ">
+            <text macro="author"/>
+            <choose>
+              <if type="book" match="any">
+                <text term="op-cit" form="short" font-style="italic"/>
+              </if>
+              <else-if type="article-journal article-magazine article-newspaper chapter" match="any">
+                <text term="loc-cit" form="short" font-style="italic"/>
+              </else-if>
+            </choose>
+            <text macro="pages-citation"/>
+          </group>
+        </else-if>
+        <else>
+          <group delimiter=", ">
+            <text macro="full-note"/>
+            <choose>
+              <if variable="locator">
+                <text macro="pages-citation" />
+              </if>
+            </choose>
+          </group>
+        </else>
+     </choose>
+    </layout>
+  </citation>
+  <bibliography>
+    <sort>
+      <key macro="author"/>
+      <key variable="issued"/>
+      <key variable="page-first"/>
+      <key variable="title"/>
+    </sort>
+    <layout suffix=".">
+      <text macro="full-note"/>
+    </layout>
+  </bibliography>
+</style>

--- a/etudes-francaises.csl
+++ b/etudes-francaises.csl
@@ -62,7 +62,7 @@
       <if is-numeric="volume">
         <group delimiter="&#160;">
           <label variable="volume" form="short"/>
-          <number variable="volume"/>
+          <number variable="volume" form="roman" text-case="uppercase"/>
         </group>
       </if>
       <else>

--- a/etudes-francaises.csl
+++ b/etudes-francaises.csl
@@ -18,7 +18,7 @@
     <issn>0014-2085</issn>
     <issn>1492-1405</issn>
     <summary>Références pour le style Études françaises. Aussi utilisé par les Presses de l’Université de Montréal (PUM).</summary>
-    <updated>2023-09-30T20:05:00-04:00</updated>
+    <updated>2023-09-30T20:18:00-04:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale xml:lang="fr">
@@ -107,10 +107,12 @@
           <text macro="DOI"/>
         </if>
         <else-if variable="URL">
-          <text term="online"/>
-          <group delimiter="&#8239;; ">
-            <text variable="URL"/>
-            <text macro="access"/>
+          <group delimiter=" ">
+            <text term="online"/>
+            <group delimiter="&#8239;; ">
+              <text variable="URL"/>
+              <text macro="access"/>
+            </group>
           </group>
         </else-if>
       </choose>


### PR DESCRIPTION
Checks, as per the [style requirements](https://github.com/citation-style-language/styles/blob/master/STYLE_REQUIREMENTS.md):

- [x] **Title Abbreviations** Études françaises, `ETFRA`
- [x] **Title Diacritics** “É” and “ç” retained
- [x] **Style Locale** default `fr-CA`
- [x] **File Name** `etudes-francaises.csl`
- [x] **Style ID** `http://www.zotero.org/styles/etudes-francaises`
- [x] **"self" Link** `http://www.zotero.org/styles/etudes-francaises`
- [x] **License** CC BY-SA 3.0
- [x] **"template" Link** `http://www.zotero.org/styles/bulletin-de-correspondance-hellenique`
- [x] **ISSN and eISSN** `0014-2085` `1492-1405`
- [x] **"documentation" Link** `https://revue-etudesfrancaises.umontreal.ca/wp-content/uploads/2023/02/protocole-de-redaction.pdf`
- [x] **XML Indentation** 2 spaces
- [x] **Validation** validated against the CSL schema through the [online validator](https://validator.citationstyles.org/)

Other TODOs:

- [x] Test against all examples provided in [PDF documentation](https://revue-etudesfrancaises.umontreal.ca/wp-content/uploads/2023/02/protocole-de-redaction.pdf) (last updated 2021, see date in PDF documentation).
- [x] Set last updated to correct datetime before merging.

---

I maintain the individual style here (with some tests), in an upstream Git repository:

* https://git.loupbrun.ca/louis/csl-etudes-francaises

* https://github.com/loup-brun/csl-etudes-francaises (mirror repository)