### PR TITLE
Update bibtex.csl to conform the standard for month

### DIFF
--- a/bibtex.csl
+++ b/bibtex.csl
@@ -80,7 +80,7 @@
   </macro>
   <macro name="issued-month">
     <date variable="issued">
-      <date-part name="month" form="short" strip-periods="true"/>
+      <date-part name="month" form="short" strip-periods="true" text-case="lowercase"/>
     </date>
   </macro>
   <macro name="author">
@@ -172,7 +172,7 @@
         <text macro="author" prefix=" author={" suffix="}"/>
         <text macro="editor-translator" prefix=" editor={" suffix="}"/>
         <text macro="issued-year" prefix=" year={" suffix="}"/>
-        <text macro="issued-month" prefix=" month={" suffix="}"/>
+        <text macro="issued-month" prefix=" month=" suffix=""/>
         <text macro="pages" prefix=" pages={" suffix="}"/>
         <text variable="collection-title" prefix=" collection={" suffix="}"/>
         <text variable="keyword" prefix=" keywords={" suffix="}"/>


### PR DESCRIPTION
the month should me in lowercase and not between brackets