### PR TITLE
Update lund-university-school-of-economics-and-management.csl

### DIFF
--- a/lund-university-school-of-economics-and-management.csl
+++ b/lund-university-school-of-economics-and-management.csl
@@ -338,7 +338,7 @@
       </if>
     </choose>
   </macro>
-  <citation et-al-min="4" et-al-use-first="1" disambiguate-add-year-suffix="true" collapse="year">
+  <citation et-al-min="3" et-al-use-first="1" disambiguate-add-year-suffix="true" collapse="year">
     <sort>
       <key macro="author"/>
       <key macro="issued-sort"/>


### PR DESCRIPTION
The style has changed regarding how many authors you spell out and when you use et al. Therefore I have changed the number 4 to 3 to match the style.