### PR TITLE
Remove extra sprace

### DIFF
--- a/ieee.csl
+++ b/ieee.csl
@@ -363,7 +363,7 @@
           <text macro="access"/>
         </else-if>
         <else-if type="chapter">
-          <group delimiter=", " suffix=". ">
+          <group delimiter=", " suffix=".">
             <text macro="title"/>
             <group delimiter=" ">
               <text term="in" suffix=" "/>


### PR DESCRIPTION
Follow-up to https://github.com/citation-style-language/styles/pull/6649. @POBrien333 merged to `group`s in "chapter". I think, by accident, the space in following change was not removed:

```diff
-         <group delimiter=", " suffix=", ">
+         <group delimiter=", " suffix=". ">
```

This PR fixes it.