### PR TITLE
Update australasian-journal-of-philosophy.csl

### DIFF
--- a/australasian-journal-of-philosophy.csl
+++ b/australasian-journal-of-philosophy.csl
@@ -256,7 +256,7 @@
       </group>
     </layout>
   </citation>
-  <bibliography et-al-min="7" et-al-use-first="5" subsequent-author-substitute-rule="partial-each" hanging-indent="true" entry-spacing="1">
+  <bibliography et-al-min="7" et-al-use-first="5" subsequent-author-substitute-rule="partial-each" hanging-indent="true" entry-spacing="0">
     <sort>
       <key macro="author"/>
       <key macro="year-date"/>


### PR DESCRIPTION
change entry-spacing to 0 from default of 1; default is too loose (which I only noticed after pandoc updated to 3.1.8 and corrected its previously incorrect treatment of the defaults)