### PR TITLE
Update weed-science-society-of-america.csl

### DIFF
--- a/weed-science-society-of-america.csl
+++ b/weed-science-society-of-america.csl
@@ -176,7 +176,7 @@
       <key macro="author"/>
       <key variable="issued"/>
     </sort>
-    <layout prefix="(" suffix=")" delimiter=", ">
+    <layout prefix="(" suffix=")" delimiter="; ">
       <group delimiter=" ">
         <text macro="author-short"/>
         <text macro="issued-year"/>

--- a/weed-science-society-of-america.csl
+++ b/weed-science-society-of-america.csl
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" default-locale="en-US" version="1.0" demote-non-dropping-particle="sort-only">
+<style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" demote-non-dropping-particle="sort-only" default-locale="en-US">
   <info>
     <title>Weed Science Society of America</title>
     <title-short>WSSA</title-short>


### PR DESCRIPTION
Changed line 179 in this style file. In-text citation groups should be separated by a semicolon instead of a colon, as noted in the journal instructions to authors: https://www.cambridge.org/core/journals/weed-science/information/author-instructions/preparing-your-materials