### PR TITLE
Fix journalAbbr suffix in elsevier

### DIFF
--- a/elsevier-with-titles-alphabetical.csl
+++ b/elsevier-with-titles-alphabetical.csl
@@ -122,7 +122,7 @@
         <else>
           <group delimiter=" ">
             <text variable="title" suffix=","/>
-            <text variable="container-title" form="short" text-case="title" suffix="."/>
+            <text variable="container-title" form="short" text-case="title"/>
             <text variable="volume"/>
             <text macro="year-date" prefix="(" suffix=")"/>
             <text variable="page" form="short"/>

--- a/elsevier-with-titles.csl
+++ b/elsevier-with-titles.csl
@@ -129,7 +129,7 @@
         <else>
           <group delimiter=" ">
             <text variable="title" suffix=","/>
-            <text variable="container-title" form="short" text-case="title" suffix="."/>
+            <text variable="container-title" form="short" text-case="title"/>
             <text variable="volume"/>
             <text macro="year-date" prefix="(" suffix=")"/>
             <text variable="page" form="short"/>


### PR DESCRIPTION
Elsevier's journals no longer have the suffix `.` after the publicationTitle in the reference list.

My reviewer's comment:

![image](https://github.com/citation-style-language/styles/assets/44738481/10c1cafd-36d5-417d-a7b6-3333f575b539)


example:

1. Applied Catalyst B: Enviroment (elsevier): https://www.sciencedirect.com/science/article/pii/S0926337323012493

   ![image](https://github.com/citation-style-language/styles/assets/44738481/932d7464-a085-4587-9200-db8cca38ffae)

2. [Journal of Catalysis](https://www.sciencedirect.com/journal/journal-of-catalysis) (elsevier): 
https://www.sciencedirect.com/science/article/pii/S0021951723004992

   ![image](https://github.com/citation-style-language/styles/assets/44738481/99dfad7c-5e34-45e3-9d3b-24d81a412b4c)

   ![image](https://github.com/citation-style-language/styles/assets/44738481/59bb1ad1-88af-4ff7-88d8-18d01bc1c75a)
