### PR TITLE
Update harvard-imperial-college-london.csl

### DIFF
--- a/harvard-imperial-college-london.csl
+++ b/harvard-imperial-college-london.csl
@@ -107,6 +107,7 @@
       </if>
       <else>
         <text term="no date" form="short"/>
+        <text variable="year-suffix"/>
       </else>
     </choose>
   </macro>

--- a/harvard-imperial-college-london.csl
+++ b/harvard-imperial-college-london.csl
@@ -104,6 +104,7 @@
         <date variable="issued">
           <date-part name="year"/>
         </date>
+        <text variable="year-suffix"/>
       </if>
       <else>
         <text term="no date" form="short"/>


### PR DESCRIPTION
Added disambiguate-add-year-suffix code to deal with multiple sources with the same author and no date. ref.: https://forums.zotero.org/discussion/105914/disambiguate-add-year-suffix-not-working-when-data-is-n-d-no-date-term/p1