### PR TITLE
Create ausonius-editions-medievale.csl

### DIFF
--- a/ausonius-editions-medievale.csl
+++ b/ausonius-editions-medievale.csl
@@ -1,0 +1,332 @@
+<?xml version="1.0" encoding="utf-8"?>
+<style xmlns="http://purl.org/net/xbiblio/csl" class="note" version="1.0" default-locale="fr-FR">
+  <!-- DESCRIPTION DE LA FEUILLE DE STYLE -->
+  <info>
+    <!-- Référence de la feuille de style -->
+    <title>Ausonius Éditions Médiévale</title>
+    <id>http://www.zotero.org/styles/ausonius-editions-medievale</id>
+    <link href="http://www.zotero.org/styles/ausonius-editions-medievale" rel="self"/>
+    <!-- Documentation -->
+    <link href="https://ausoniuseditions.u-bordeaux-montaigne.fr" rel="documentation"/>
+    <link href=" https:// guides.lib.berkeley.edu/c.php?g=381579&amp;p=2585381" rel="documentation"/>
+    <link href="https://docs.citationstyles.org/en/stable/specification.html" rel="documentation"/>
+    <!-- Crédits -->
+    <author>
+      <name>Julien Gravier (UMR 5607 Ausonius)</name>
+      <email>julien.gravier@u-bordeaux-montaigne.fr</email>
+    </author>
+    <author>
+      <name>Sandra Sauer (Université Bordeaux Montaigne)</name>
+      <email>sandra.sauer@u-bordeaux-montaigne.fr</email>
+    </author>
+    <author>
+      <name>Alexandre Zanni (UMR 5607 Ausonius)</name>
+      <email>alexandre.zanni@etu.u-bordeaux-montaigne.fr</email>
+    </author>
+    <contributor>
+      <name>Ausonius Editions (UMR 5607 Ausonius)</name>
+      <uri>https://ausoniuseditions.u-bordeaux-montaigne.fr/</uri>
+    </contributor>
+    <category citation-format="note"/>
+    <category field="history"/>
+    <category field="humanities"/>
+    <category field="social_science"/>
+    <summary>Style CSL "Ausonius éditions médiévales", réalisé en collaboration avec Ausonius Éditions, pour l'insertion à part d'une bibliographie des sources médiévales éditées, tel que spécicifié dans le Guide de de l'auteur du 15 juin 2022) - CSL style  "Ausonius éditions médiévales", realised with the collaboration of the Ausonius Editions team, in order to insert an apart bibliography of the edited medieval sources, according to the "Guide de l'auteur - 15 juin 2022").</summary>
+    <!-- Informations -->
+    <published>2023-01-06T05:43:05+00:00</published>
+    <updated>2023-12-04T18:08:32+00:00</updated>
+    <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
+  </info>
+  <!-- PARAMETRAGE LOCALE\TERMS -->
+  <locale xml:lang="fr">
+    <terms>
+      <term name="editor">éd.</term>
+      <term name="open-quote">“</term>
+      <term name="close-quote">”</term>
+      <term name="open-inner-quote">‘</term>
+      <term name="close-inner-quote">’</term>
+      <!-- Pour les docs en ligne -->
+      <term name="online">[En ligne], mis en ligne le</term>
+      <term name="online" form="short">[En ligne]</term>
+      <term name="accessed">consulté le</term>
+      <!-- Pour les locators -->
+      <term name="page" form="short"/>
+    </terms>
+  </locale>
+  <locale xml:lang="en">
+    <terms>
+      <term name="editor">ed.</term>
+      <term name="open-quote">“</term>
+      <term name="close-quote">”</term>
+      <term name="open-inner-quote">‘</term>
+      <term name="close-inner-quote">’</term>
+      <!-- Pour les docs en ligne -->
+      <term name="online">[Online], uploaded</term>
+      <term name="online" form="short">[Online]</term>
+      <term name="accessed">accessed</term>
+      <!-- Pour les locators -->
+      <term name="page" form="short"/>
+    </terms>
+  </locale>
+  <locale xml:lang="es">
+    <terms>
+      <term name="editor">ed.</term>
+      <term name="open-quote">“</term>
+      <term name="close-quote">”</term>
+      <term name="open-inner-quote">‘</term>
+      <term name="close-inner-quote">’</term>
+      <!-- Pour les docs en ligne -->
+      <term name="online">[En línea], subido</term>
+      <term name="online" form="short">[En línea]</term>
+      <term name="accessed">accedido</term>
+      <!-- Pour les locators -->
+      <term name="page" form="short"/>
+    </terms>
+  </locale>
+  <locale xml:lang="de">
+    <terms>
+      <term name="editor">hrsg.</term>
+      <term name="open-quote">“</term>
+      <term name="close-quote">”</term>
+      <term name="open-inner-quote">‘</term>
+      <term name="close-inner-quote">’</term>
+      <!-- Pour les docs en ligne -->
+      <term name="online">[Online], hochgeladen</term>
+      <term name="online" form="short">[Online]</term>
+      <term name="accessed">zugegriffen</term>
+      <!-- Pour les locators -->
+      <term name="page" form="short"/>
+    </terms>
+  </locale>
+  <locale xml:lang="it">
+    <terms>
+      <term name="editor">ed.</term>
+      <term name="open-quote">“</term>
+      <term name="close-quote">”</term>
+      <term name="open-inner-quote">‘</term>
+      <term name="close-inner-quote">’</term>
+      <!-- Pour les docs en ligne -->
+      <term name="online">[Online], caricato</term>
+      <term name="online" form="short">[Online]</term>
+      <term name="accessed">consultato</term>
+      <!-- Pour les locators -->
+      <term name="page" form="short"/>
+    </terms>
+  </locale>
+  <!-- PARAMETRAGE MACROS -->
+  <!-- Bloc auteur/éditeur/directeur -->
+  <macro name="bloc_auteur-ed">
+    <choose>
+      <if variable="author">
+        <names variable="author">
+          <name and="text" delimiter-precedes-last="never"/>
+        </names>
+        <text term="editor" prefix=", " suffix=" "/>
+        <names variable="editor">
+          <name and="text" name-as-sort-order="all" sort-separator=", " initialize-with=". " delimiter-precedes-last="never"/>
+        </names>
+      </if>
+      <else-if variable="editor">
+        <names variable="editor">
+          <name and="text" name-as-sort-order="all" sort-separator=", " initialize-with=". " delimiter-precedes-last="never"/>
+        </names>
+        <text term="editor" prefix=", "/>
+      </else-if>
+      <else>
+        <text term="anonymous"/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="bloc_auteur-ed_short">
+    <choose>
+      <if variable="author">
+        <names variable="author">
+          <name and="symbol" delimiter-precedes-last="never"/>
+        </names>
+        <text term="editor" prefix=", " suffix=" "/>
+        <names variable="editor">
+          <name form="short" and="symbol" delimiter-precedes-et-al="never" et-al-min="3" et-al-use-first="1"/>
+          <et-al font-style="italic"/>
+        </names>
+      </if>
+      <else-if variable="editor">
+        <names variable="editor">
+          <name form="short" and="symbol" delimiter-precedes-et-al="never" et-al-min="3" et-al-use-first="1"/>
+          <et-al font-style="italic"/>
+        </names>
+        <text term="editor" prefix=", "/>
+      </else-if>
+      <else>
+        <text term="anonymous"/>
+      </else>
+    </choose>
+  </macro>
+  <!-- Bloc date publication -->
+  <macro name="date-pub-originale">
+    <date variable="original-date">
+      <date-part name="year" prefix=" [" suffix="]"/>
+    </date>
+  </macro>
+  <macro name="bloc_date-publication">
+    <text macro="date-pub-originale"/>
+    <group prefix=" (" suffix=")">
+      <choose>
+        <if variable="issued accessed" match="any">
+          <date variable="issued">
+            <date-part name="year"/>
+          </date>
+        </if>
+        <else-if variable="status">
+          <text variable="status"/>
+        </else-if>
+        <else>
+          <text term="forthcoming"/>
+        </else>
+      </choose>
+    </group>
+  </macro>
+  <macro name="bloc_date-publication_short">
+    <text macro="date-pub-originale"/>
+    <group>
+      <choose>
+        <if variable="issued">
+          <date variable="issued" prefix=" ">
+            <date-part name="year"/>
+          </date>
+        </if>
+        <else-if variable="accessed">
+          <text variable="title" quotes="true" prefix=" "/>
+        </else-if>
+        <else-if variable="status">
+          <text variable="status" prefix=" "/>
+        </else-if>
+        <else>
+          <text term="forthcoming" prefix=" "/>
+        </else>
+      </choose>
+    </group>
+  </macro>
+  <!-- Bloc titre -->
+  <macro name="description_ouvrage">
+    <text variable="volume-title" font-style="italic" prefix="&#160;: "/>
+    <number variable="volume" form="roman" text-case="uppercase" font-style="italic" prefix=". "/>
+    <choose>
+      <if type="thesis">
+        <text variable="genre" prefix=", "/>
+        <text variable="publisher" prefix=", "/>
+      </if>
+    </choose>
+    <choose>
+      <if variable="collection-number">
+        <text variable="collection-title" prefix=", "/>
+        <number variable="collection-number" prefix=" "/>
+      </if>
+    </choose>
+    <choose>
+      <if variable="edition original-date" match="all">
+        <text variable="edition" prefix=" [" suffix="]"/>
+      </if>
+    </choose>
+    <text variable="publisher-place" prefix=", "/>
+  </macro>
+  <macro name="bloc_titre-ouvrage-contribution-article">
+    <choose>
+      <if type="book thesis manuscript article" match="any">
+        <text variable="title" font-style="italic"/>
+        <text macro="description_ouvrage"/>
+      </if>
+      <else-if type="chapter" match="any">
+        <group suffix=", ">
+          <text variable="title" quotes="true"/>
+        </group>
+        <text variable="container-title" form="short" font-style="italic"/>
+        <text macro="description_ouvrage"/>
+      </else-if>
+      <else-if type="article-journal article-newspaper article-magazine" match="any">
+        <group suffix=", ">
+          <text variable="title" quotes="true"/>
+        </group>
+        <text variable="container-title" form="short" font-style="italic"/>
+        <text variable="volume" prefix=", "/>
+        <text variable="issue" prefix="-"/>
+      </else-if>
+      <else>
+        <text variable="title" font-style="italic"/>
+      </else>
+    </choose>
+    <text variable="page" prefix=", "/>
+  </macro>
+  <!-- Bloc en ligne -->
+  <macro name="bloc_en-ligne">
+    <choose>
+      <if variable="accessed" match="any">
+        <choose>
+          <if variable="available-date">
+            <text term="online"/>
+            <date variable="available-date" form="text" prefix=" "/>
+          </if>
+          <else-if variable="issued">
+            <text term="online"/>
+            <date variable="issued" form="text" prefix=" "/>
+          </else-if>
+          <else>
+            <text term="online" form="short"/>
+          </else>
+        </choose>
+        <text term="accessed" prefix=", "/>
+        <date variable="accessed" form="text" prefix=" "/>
+      </if>
+    </choose>
+  </macro>
+  <macro name="bloc_en-ligne_lien">
+    <choose>
+      <if variable="accessed" match="any">
+        <choose>
+          <if variable="DOI">
+            <text variable="DOI" prefix="DOI&#160;: "/>
+          </if>
+          <else>
+            <text variable="URL" prefix="URL&#160;: "/>
+          </else>
+        </choose>
+      </if>
+    </choose>
+  </macro>
+  <!-- Bloc locator -->
+  <macro name="bloc_locator">
+    <label variable="locator" form="short"/>
+    <text variable="locator" prefix=" "/>
+  </macro>
+  <!-- DESCRIPTION DES NOTES ET REFERENCES BIBLIOGRAPHIQUES -->
+  <citation disambiguate-add-year-suffix="true" collapse="year" cite-group-delimiter=", ">
+    <sort>
+      <key macro="bloc_auteur-ed_short"/>
+      <key variable="issued"/>
+      <key variable="volume"/>
+      <key variable="page-first"/>
+    </sort>
+    <layout delimiter="&#160;; " suffix=".">
+      <text macro="bloc_auteur-ed_short"/>
+      <text macro="bloc_date-publication_short"/>
+      <text macro="bloc_locator" prefix=", "/>
+    </layout>
+  </citation>
+  <bibliography>
+    <sort>
+      <key macro="bloc_auteur-ed_short"/>
+      <key variable="issued"/>
+      <key variable="title"/>
+      <key variable="volume"/>
+      <key variable="page-first"/>
+    </sort>
+    <layout>
+      <group suffix=".">
+        <text macro="bloc_auteur-ed"/>
+        <text macro="bloc_date-publication"/>
+        <text macro="bloc_titre-ouvrage-contribution-article" prefix="&#160;: "/>
+        <text macro="bloc_en-ligne" prefix=" "/>
+      </group>
+      <text macro="bloc_en-ligne_lien" prefix=" "/>
+    </layout>
+  </bibliography>
+</style>

--- a/ausonius-editions-medievale.csl
+++ b/ausonius-editions-medievale.csl
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<style xmlns="http://purl.org/net/xbiblio/csl" class="note" version="1.0" default-locale="fr-FR">
+<style xmlns="http://purl.org/net/xbiblio/csl" class="note" version="1.0">
   <!-- DESCRIPTION DE LA FEUILLE DE STYLE -->
   <info>
     <!-- Référence de la feuille de style -->


### PR DESCRIPTION
Style CSL "Ausonius éditions médiévales", réalisé en collaboration avec Ausonius Éditions, pour l'insertion à part d'une bibliographie des sources médiévales éditées, tel que spécicifié dans le Guide de de l'auteur du 15 juin 2022).  

------------------------------------------------------------------- 
CSL style  "Ausonius éditions médiévales", realised with the collaboration of the Ausonius Editions team, in order to insert an apart bibliography of the edited medieval sources, according to the "Guide de l'auteur - 15 juin 2022").