### PR TITLE
Updating infoclio.ch styles

### DIFF
--- a/infoclio-de-kurzbelege.csl
+++ b/infoclio-de-kurzbelege.csl
@@ -5,7 +5,7 @@
     <id>http://www.zotero.org/styles/infoclio-de-kurzbelege</id>
     <link href="http://www.zotero.org/styles/infoclio-de-kurzbelege" rel="self"/>
     <link href="http://www.zotero.org/styles/infoclio-de" rel="template"/>
-    <link href="https://www.infoclio.ch/de/node/133932" rel="documentation"/>
+    <link href="https://www.infoclio.ch/de/zitierstil#zotero" rel="documentation"/>
     <author>
       <name>Nicolas Chachereau</name>
       <email>nicolas.chachereau@unil.ch</email>
@@ -25,7 +25,7 @@
     <category citation-format="note"/>
     <category field="history"/>
     <category field="social_science"/>
-    <updated>2021-04-15T17:51:45+02:00</updated>
+    <updated>2024-01-04T12:30:00+02:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale xml:lang="de">
@@ -35,7 +35,6 @@
       <term name="accessed">Stand</term>
       <term name="letter">Schreiben</term>
       <term name="number-of-volumes" form="short">Bd.</term>
-      <term name="no date" form="short">o. D.</term>
       <term name="edition">Ausgabe</term>
     </terms>
   </locale>
@@ -109,20 +108,28 @@
         <text macro="creator-for-short-references"/>
         <text macro="identifier-for-short-references"/>
       </group>
-      <date variable="issued" form="numeric" date-parts="year"/>
       <text macro="locator"/>
     </group>
   </macro>
   <macro name="creator">
-    <names variable="author">
-      <name sort-separator=", " name-as-sort-order="all" et-al-min="4" et-al-use-first="3"/>
-      <label form="short" prefix="&#160;(" suffix=")"/>
-      <substitute>
-        <names variable="editor"/>
-        <names variable="composer"/>
-        <names variable="director"/>
-      </substitute>
-    </names>
+    <choose>
+      <if variable="director">
+        <!-- special rule to avoid printing the label for directors -->
+        <names variable="director">
+          <name sort-separator=", " name-as-sort-order="all" et-al-min="4" et-al-use-first="3"/>
+        </names>
+      </if>
+      <else>
+        <names variable="author">
+          <name sort-separator=", " name-as-sort-order="all" et-al-min="4" et-al-use-first="3"/>
+          <label form="short" prefix="&#160;(" suffix=")"/>
+          <substitute>
+            <names variable="editor"/>
+            <names variable="composer"/>
+          </substitute>
+        </names>
+      </else>
+    </choose>
   </macro>
   <macro name="creator-for-short-references">
     <names variable="author">
@@ -136,7 +143,14 @@
     </names>
   </macro>
   <macro name="title">
-    <text variable="title"/>
+    <group delimiter=" ">
+      <text variable="title"/>
+      <choose>
+        <if type="book">
+          <text variable="event-title" prefix="[" suffix="]"/>
+        </if>
+      </choose>
+    </group>
   </macro>
   <macro name="identifier-for-short-references">
     <choose>
@@ -315,6 +329,11 @@
   </macro>
   <macro name="date">
     <choose>
+      <if is-uncertain-date="issued">
+        <text term="circa" form="short" suffix=" "/>
+      </if>
+    </choose>
+    <choose>
       <if type="book chapter paper-conference thesis" match="any">
         <choose>
           <if variable="issued">
@@ -325,21 +344,8 @@
               </if>
             </choose>
           </if>
-          <else>
-            <text term="no date" form="short"/>
-          </else>
         </choose>
       </if>
-      <else-if type="article-journal article-newspaper article-magazine graphic entry-encyclopedia entry-dictionary report speech interview manuscript personal_communication" match="any">
-        <choose>
-          <if variable="issued">
-            <date variable="issued" form="numeric" date-parts="year-month-day"/>
-          </if>
-          <else>
-            <text term="no date" form="short"/>
-          </else>
-        </choose>
-      </else-if>
       <else>
         <date variable="issued" form="numeric" date-parts="year-month-day"/>
       </else>

--- a/infoclio-de.csl
+++ b/infoclio-de.csl
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<style xmlns="http://purl.org/net/xbiblio/csl" class="note" default-locale="de-CH" version="1.0" name-delimiter="; " delimiter-precedes-last="always" delimiter-precedes-et-al="never">
+<style xmlns="http://purl.org/net/xbiblio/csl" class="note" version="1.0" name-delimiter="; " delimiter-precedes-last="always" delimiter-precedes-et-al="never" default-locale="de-CH">
   <info>
     <title>infoclio.ch (Deutsch - Schweiz)</title>
     <id>http://www.zotero.org/styles/infoclio-de</id>

--- a/infoclio-de.csl
+++ b/infoclio-de.csl
@@ -5,7 +5,7 @@
     <id>http://www.zotero.org/styles/infoclio-de</id>
     <link href="http://www.zotero.org/styles/infoclio-de" rel="self"/>
     <link href="http://www.zotero.org/styles/infoclio-fr-smallcaps" rel="template"/>
-    <link href="https://www.infoclio.ch/de/node/133932" rel="documentation"/>
+    <link href="https://www.infoclio.ch/de/zitierstil#zotero" rel="documentation"/>
     <author>
       <name>Nicolas Chachereau</name>
       <email>nicolas.chachereau@unil.ch</email>
@@ -25,7 +25,7 @@
     <category citation-format="note"/>
     <category field="history"/>
     <category field="social_science"/>
-    <updated>2018-03-27T11:58:13+02:00</updated>
+    <updated>2024-01-04T12:30:00+02:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale xml:lang="de">
@@ -35,7 +35,6 @@
       <term name="accessed">Stand</term>
       <term name="letter">Schreiben</term>
       <term name="number-of-volumes" form="short">Bd.</term>
-      <term name="no date" form="short">o. D.</term>
       <term name="edition">Ausgabe</term>
     </terms>
   </locale>
@@ -112,20 +111,28 @@
         <text macro="creator-for-subsequent"/>
         <text macro="identifier-for-subsequent"/>
       </group>
-      <date variable="issued" form="numeric" date-parts="year"/>
       <text macro="locator"/>
     </group>
   </macro>
   <macro name="creator">
-    <names variable="author">
-      <name sort-separator=", " name-as-sort-order="all" et-al-min="4" et-al-use-first="3"/>
-      <label form="short" prefix="&#160;(" suffix=")"/>
-      <substitute>
-        <names variable="editor"/>
-        <names variable="composer"/>
-        <names variable="director"/>
-      </substitute>
-    </names>
+    <choose>
+      <if variable="director">
+        <!-- special rule to avoid printing the label for directors -->
+        <names variable="director">
+          <name sort-separator=", " name-as-sort-order="all" et-al-min="4" et-al-use-first="3"/>
+        </names>
+      </if>
+      <else>
+        <names variable="author">
+          <name sort-separator=", " name-as-sort-order="all" et-al-min="4" et-al-use-first="3"/>
+          <label form="short" prefix="&#160;(" suffix=")"/>
+          <substitute>
+            <names variable="editor"/>
+            <names variable="composer"/>
+          </substitute>
+        </names>
+      </else>
+    </choose>
   </macro>
   <macro name="creator-for-subsequent">
     <names variable="author">
@@ -139,7 +146,14 @@
     </names>
   </macro>
   <macro name="title">
-    <text variable="title"/>
+    <group delimiter=" ">
+      <text variable="title"/>
+      <choose>
+        <if type="book">
+          <text variable="event-title" prefix="[" suffix="]"/>
+        </if>
+      </choose>
+    </group>
   </macro>
   <macro name="identifier-for-subsequent">
     <choose>
@@ -318,6 +332,11 @@
   </macro>
   <macro name="date">
     <choose>
+      <if is-uncertain-date="issued">
+        <text term="circa" form="short" suffix=" "/>
+      </if>
+    </choose>
+    <choose>
       <if type="book chapter paper-conference thesis" match="any">
         <choose>
           <if variable="issued">
@@ -328,21 +347,8 @@
               </if>
             </choose>
           </if>
-          <else>
-            <text term="no date" form="short"/>
-          </else>
         </choose>
       </if>
-      <else-if type="article-journal article-newspaper article-magazine graphic entry-encyclopedia entry-dictionary report speech interview manuscript personal_communication" match="any">
-        <choose>
-          <if variable="issued">
-            <date variable="issued" form="numeric" date-parts="year-month-day"/>
-          </if>
-          <else>
-            <text term="no date" form="short"/>
-          </else>
-        </choose>
-      </else-if>
       <else>
         <date variable="issued" form="numeric" date-parts="year-month-day"/>
       </else>

--- a/infoclio-fr-nocaps.csl
+++ b/infoclio-fr-nocaps.csl
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<style xmlns="http://purl.org/net/xbiblio/csl" class="note" default-locale="fr-FR" version="1.0" delimiter-precedes-last="never" delimiter-precedes-et-al="never" and="text">
+<style xmlns="http://purl.org/net/xbiblio/csl" class="note" version="1.0" delimiter-precedes-last="never" delimiter-precedes-et-al="never" and="text" default-locale="fr-FR">
   <info>
     <title>infoclio.ch (sans majuscules, Français)</title>
     <id>http://www.zotero.org/styles/infoclio-fr-nocaps</id>

--- a/infoclio-fr-nocaps.csl
+++ b/infoclio-fr-nocaps.csl
@@ -5,7 +5,7 @@
     <id>http://www.zotero.org/styles/infoclio-fr-nocaps</id>
     <link href="http://www.zotero.org/styles/infoclio-fr-nocaps" rel="self"/>
     <link href="http://www.zotero.org/styles/infoclio-fr-smallcaps" rel="template"/>
-    <link href="https://www.infoclio.ch/fr/node/138218" rel="documentation"/>
+    <link href="https://www.infoclio.ch/fr/stylecitation#zotero" rel="documentation"/>
     <author>
       <name>Nicolas Chachereau</name>
       <email>nicolas.chachereau@unil.ch</email>
@@ -25,7 +25,7 @@
     <category citation-format="note"/>
     <category field="history"/>
     <category field="social_science"/>
-    <updated>2018-03-27T11:58:06+02:00</updated>
+    <updated>2024-01-04T12:30:00+02:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale xml:lang="fr">
@@ -119,20 +119,28 @@
       <text macro="creator-for-subsequent"/>
       <text macro="identifier-for-subsequent"/>
       <text macro="op-cit"/>
-      <date variable="issued" form="numeric" date-parts="year"/>
       <text macro="locator"/>
     </group>
   </macro>
   <macro name="creator">
-    <names variable="author">
-      <name sort-separator=" " name-as-sort-order="all" et-al-min="4" et-al-use-first="3"/>
-      <label form="short" prefix="&#160;(" suffix=")"/>
-      <substitute>
-        <names variable="editor"/>
-        <names variable="composer"/>
-        <names variable="director"/>
-      </substitute>
-    </names>
+    <choose>
+      <if variable="director">
+        <!-- special rule to avoid printing the label for directors -->
+        <names variable="director">
+          <name sort-separator=" " name-as-sort-order="all" et-al-min="4" et-al-use-first="3"/>
+        </names>
+      </if>
+      <else>
+        <names variable="author">
+          <name sort-separator=" " name-as-sort-order="all" et-al-min="4" et-al-use-first="3"/>
+          <label form="short" prefix="&#160;(" suffix=")"/>
+          <substitute>
+            <names variable="editor"/>
+            <names variable="composer"/>
+          </substitute>
+        </names>
+      </else>
+    </choose>
   </macro>
   <macro name="creator-for-subsequent">
     <names variable="author">
@@ -148,7 +156,14 @@
   <macro name="title">
     <choose>
       <if type="book thesis graphic" match="any">
-        <text variable="title" font-style="italic"/>
+        <group delimiter=" ">
+          <text variable="title" font-style="italic"/>
+          <choose>
+            <if type="book">
+              <text variable="event-title" prefix="[" suffix="]"/>
+            </if>
+          </choose>
+        </group>
       </if>
       <else-if type="article article-magazine article-newspaper article-journal entry entry-dictionary entry-encyclopedia report chapter paper-conference post post-weblog webpage song broadcast dataset" match="any">
         <text variable="title" quotes="true"/>
@@ -404,26 +419,14 @@
   </macro>
   <macro name="date">
     <choose>
-      <if type="book chapter paper-conference thesis" match="any">
-        <choose>
-          <if variable="issued">
-            <date variable="issued" form="numeric" date-parts="year"/>
-          </if>
-          <else>
-            <text term="no date" form="short"/>
-          </else>
-        </choose>
+      <if is-uncertain-date="issued">
+        <text term="circa" suffix=" "/>
       </if>
-      <else-if type="article-journal article-newspaper article-magazine graphic entry-encyclopedia entry-dictionary report speech interview manuscript personal_communication" match="any">
-        <choose>
-          <if variable="issued">
-            <date variable="issued" form="numeric" date-parts="year-month-day"/>
-          </if>
-          <else>
-            <text term="no date" form="short"/>
-          </else>
-        </choose>
-      </else-if>
+    </choose>
+    <choose>
+      <if type="book chapter paper-conference thesis" match="any">
+        <date variable="issued" form="numeric" date-parts="year"/>
+      </if>
       <else>
         <date variable="issued" form="numeric" date-parts="year-month-day"/>
       </else>

--- a/infoclio-fr-smallcaps.csl
+++ b/infoclio-fr-smallcaps.csl
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<style xmlns="http://purl.org/net/xbiblio/csl" class="note" default-locale="fr-FR" version="1.0" delimiter-precedes-last="never" delimiter-precedes-et-al="never" and="text">
+<style xmlns="http://purl.org/net/xbiblio/csl" class="note" version="1.0" delimiter-precedes-last="never" delimiter-precedes-et-al="never" and="text" default-locale="fr-FR">
   <info>
     <title>infoclio.ch (petites majuscules, Français)</title>
     <id>http://www.zotero.org/styles/infoclio-fr-smallcaps</id>

--- a/infoclio-fr-smallcaps.csl
+++ b/infoclio-fr-smallcaps.csl
@@ -4,7 +4,7 @@
     <title>infoclio.ch (petites majuscules, Français)</title>
     <id>http://www.zotero.org/styles/infoclio-fr-smallcaps</id>
     <link href="http://www.zotero.org/styles/infoclio-fr-smallcaps" rel="self"/>
-    <link href="https://www.infoclio.ch/fr/node/138218" rel="documentation"/>
+    <link href="https://www.infoclio.ch/fr/stylecitation#zotero" rel="documentation"/>
     <author>
       <name>Nicolas Chachereau</name>
       <email>nicolas.chachereau@unil.ch</email>
@@ -24,7 +24,7 @@
     <category citation-format="note"/>
     <category field="history"/>
     <category field="social_science"/>
-    <updated>2018-03-27T11:57:56+02:00</updated>
+    <updated>2024-01-04T12:30:00+02:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale xml:lang="fr">
@@ -118,22 +118,32 @@
       <text macro="creator-for-subsequent"/>
       <text macro="identifier-for-subsequent"/>
       <text macro="op-cit"/>
-      <date variable="issued" form="numeric" date-parts="year"/>
       <text macro="locator"/>
     </group>
   </macro>
   <macro name="creator">
-    <names variable="author">
-      <name sort-separator=" " name-as-sort-order="all" et-al-min="4" et-al-use-first="3">
-        <name-part name="family" font-variant="small-caps"/>
-      </name>
-      <label form="short" prefix="&#160;(" suffix=")"/>
-      <substitute>
-        <names variable="editor"/>
-        <names variable="composer"/>
-        <names variable="director"/>
-      </substitute>
-    </names>
+    <choose>
+      <if variable="director">
+        <!-- special rule to avoid printing the label for directors -->
+        <names variable="director">
+          <name sort-separator=" " name-as-sort-order="all" et-al-min="4" et-al-use-first="3">
+            <name-part name="family" font-variant="small-caps"/>
+          </name>
+        </names>
+      </if>
+      <else>
+        <names variable="author">
+          <name sort-separator=" " name-as-sort-order="all" et-al-min="4" et-al-use-first="3">
+            <name-part name="family" font-variant="small-caps"/>
+          </name>
+          <label form="short" prefix="&#160;(" suffix=")"/>
+          <substitute>
+            <names variable="editor"/>
+            <names variable="composer"/>
+          </substitute>
+        </names>
+      </else>
+    </choose>
   </macro>
   <macro name="creator-for-subsequent">
     <names variable="author">
@@ -151,7 +161,14 @@
   <macro name="title">
     <choose>
       <if type="book thesis graphic" match="any">
-        <text variable="title" font-style="italic"/>
+        <group delimiter=" ">
+          <text variable="title" font-style="italic"/>
+          <choose>
+            <if type="book">
+              <text variable="event-title" prefix="[" suffix="]"/>
+            </if>
+          </choose>
+        </group>
       </if>
       <else-if type="article article-magazine article-newspaper article-journal entry entry-dictionary entry-encyclopedia report chapter paper-conference post post-weblog webpage song broadcast dataset" match="any">
         <text variable="title" quotes="true"/>
@@ -409,26 +426,14 @@
   </macro>
   <macro name="date">
     <choose>
-      <if type="book chapter paper-conference thesis" match="any">
-        <choose>
-          <if variable="issued">
-            <date variable="issued" form="numeric" date-parts="year"/>
-          </if>
-          <else>
-            <text term="no date" form="short"/>
-          </else>
-        </choose>
+      <if is-uncertain-date="issued">
+        <text term="circa" suffix=" "/>
       </if>
-      <else-if type="article-journal article-newspaper article-magazine graphic entry-encyclopedia entry-dictionary report speech interview manuscript personal_communication" match="any">
-        <choose>
-          <if variable="issued">
-            <date variable="issued" form="numeric" date-parts="year-month-day"/>
-          </if>
-          <else>
-            <text term="no date" form="short"/>
-          </else>
-        </choose>
-      </else-if>
+    </choose>
+    <choose>
+      <if type="book chapter paper-conference thesis" match="any">
+        <date variable="issued" form="numeric" date-parts="year"/>
+      </if>
       <else>
         <date variable="issued" form="numeric" date-parts="year-month-day"/>
       </else>


### PR DESCRIPTION
This is an update to a custom style for history students in Switzerland. See #234 for the original pull request, and #5391 for the last update.

What this year's update brings:

- For some reason, Zotero now passes a "director" label (which it didn't do before), and the style would automatically display it. But our guidelines call for the director to be mentioned as the author, without any label. I added a special rule for this case.
- Uncertain dates are now supported (Zotero users can add uncertain dates by writing e.g. `date: 1932~` in the `Extra` field)
- If a book specifies the variable `event-title` (e.g. in the `Extra` field), it gets displayed between square brackets after the title. The use case is exhibition catalogues, for instance for art history.
- For many document types, missing dates were automatically reported using the CSL term `no date`. In some cases, however, the date should not appear (for instance, the guidelines provide for citing journals, using the book document type, and dates are not needed in this case). Unfortunately, there is apparently no way for a user to differenciate "There should be a date, but it's missing" from "No date needed".
- The publication year is no longer specified in subsequent citations.
- The link to the documentation has been updated.

I look forward to your feedback. Thank you for your invaluable work on this repository! 🙏

cc @janbaumanninfoclio
