### PR TITLE
Fix delimiter in chicago-author-date.csl for in-text cites containing multiple works by same author

### DIFF
--- a/chicago-author-date.csl
+++ b/chicago-author-date.csl
@@ -634,7 +634,7 @@
     </choose>
   </macro>
   <citation et-al-min="4" et-al-use-first="1" disambiguate-add-year-suffix="true" disambiguate-add-names="true" disambiguate-add-givenname="true" givenname-disambiguation-rule="primary-name" collapse="year" after-collapse-delimiter="; ">
-    <layout prefix="(" suffix=")" delimiter="; ">
+    <layout prefix="(" suffix=")" delimiter=", ">
       <group delimiter=", ">
         <choose>
           <if variable="issued" match="any">


### PR DESCRIPTION
**Note:** All credit goes to @wmhorne for identifying this issue and its solution. I am writing this PR on his behalf.

As @wmhorne reported [here](https://discourse.citationstyles.org/t/semicolon-rather-than-comma-separates-works-by-same-author-in-chicago-author-date-page-numbers-not-used/1704), the Chicago style CSL is not correctly separating the years for in-text cites containing multiple references with the same author. 

[According to the CMoS](https://www.chicagomanualofstyle.org/book/ed17/part3/ch15/psec030.html), such works should be separated by commas (unless page numbers are present):

<img width="597" alt="Screenshot 2024-01-05 at 2 10 36 PM" src="https://github.com/citation-style-language/styles/assets/24906038/689c27a7-4bb2-4da9-a289-11ec99b05ec5">

&nbsp;

However, the current CSL separates all references with semicolons, even if they share the same author:

<img width="865" alt="Screenshot 2024-01-05 at 2 22 12 PM" src="https://github.com/citation-style-language/styles/assets/24906038/0c8f3f91-5744-4f03-9869-f7cb8ba22651">

(produced with current CSL + Zotero)


This PR will fix the issue:

<img width="512" alt="Screenshot 2024-01-05 at 2 36 35 PM" src="https://github.com/citation-style-language/styles/assets/24906038/1318c930-ed41-46ec-a4be-d7f5f388902f">

(produced with revised CSL + Zotero)

@wmhorne and I have been using this solution at large scale for three years now, and it has worked well across thousands of citations.