### PR TITLE
[JACC] Remove unnecessary space in superscript comma separation

### DIFF
--- a/journal-of-the-american-college-of-cardiology.csl
+++ b/journal-of-the-american-college-of-cardiology.csl
@@ -108,7 +108,7 @@
     <sort>
       <key variable="citation-number"/>
     </sort>
-    <layout delimiter=", " vertical-align="sup">
+    <layout delimiter="," vertical-align="sup">
       <text variable="citation-number"/>
     </layout>
   </citation>


### PR DESCRIPTION
Hi. First-time PR here. I hope I got it right.

The JACC doesn't use spaces after comma (<sup>1,2</sup> instead of <sup>1, 2</sup>) in their reference numbering style. This PR removes the unnecessary space.

[Example article](https://www.jacc.org/doi/10.1016/j.jacc.2023.11.003):

![Screenshot 2024-01-07 at 11 23 06](https://github.com/citation-style-language/styles/assets/12557040/221272f0-1072-49eb-95a0-6c30c0b07fab)

Ready to review.