### PR TITLE
Create cepheiden_main_wikipedia-templates.csl

### DIFF
--- a/cepheiden_main_wikipedia-templates.csl
+++ b/cepheiden_main_wikipedia-templates.csl
@@ -1,0 +1,301 @@
+<?xml version="1.0" encoding="utf-8"?>
+<style
+	xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" demote-non-dropping-particle="sort-only" default-locale="de-DE">
+	<info>
+		<title>Wikipedia Templates (https://de.wikipedia.org/wiki/Vorlage:Literatur) - 2022g</title>
+		<id>https://www.zotero.org/styles/wikipedia-templates_Vorlage.Literatur</id>
+		<!-- Referenzen & Dokumentation -->
+		<link href="https://www.zotero.org/styles/wikipedia-templates_Vorlage.Literatur" rel="self"/>
+		<link href="https://de.wikipedia.org/wiki/Vorlage:Literatur" rel="documentation"/>
+		<link href="https://de.wikipedia.org/wiki/Vorlage:Patent" rel="documentation"/>
+		<link href="https://de.wikipedia.org/wiki/Vorlage%3AInternetquelle" rel="documentation"/>
+		<link href="https://de.wikipedia.org/wiki/Benutzer:Cepheiden/Zotero" rel="documentation"/>
+		<link href="https://de.wikipedia.org/wiki/Benutzer:17387349L8764/Zotero2WikipediaDE" rel="documentation"/>
+		<link href="https://docs.citationstyles.org" rel="documentation"/>
+		<link href="https://jsonformatter.org/xml-formatter" rel="documentation"/>
+		<link href="https://validator.citationstyles.org" rel="documentation"/>
+		<link href="https://forums.zotero.org/discussion/93617/announcement-csl-1-0-2-launch-date#latest" rel="documentation"/>
+		<author>
+			<name>Cepheiden</name>
+		</author>
+		<contributor>
+			<name>17387349L8764</name>
+		</contributor>
+		<category field="generic-base"/>
+		<category citation-format="author-date"/>
+		<updated>2022-12-27T12:00:00+00:00</updated>
+		<summary>Style following de.Wikipedia WP:Zitierregeln</summary>
+		
+<!--
+* CSL-Skipt zum Export von Datenbankeinträgen in Zotero in eine Vorlage (Literatur, Internetquelle und Patent) der deutschsprachigen Wikipedia
+* Version: 0.31, 2022g
+* Datum: 2022-12-27
+* Autor: Cepheiden, 17387349L8764
+* Log: https://de.wikipedia.org/wiki/Benutzer:17387349L8764/Zotero2WikipediaDE
+-->
+
+		<rights>This work is licensed under a Creative Commons Attribution-Share Alike 3.0 License: http://creativecommons.org/licenses/by-sa/3.0/</rights>
+	</info>
+	<locale xml:lang="de">
+		<terms>
+			<term name="anonymous" form="short">o.&#160;A.</term>
+			<term name="no date" form="short">o.&#160;J.</term>
+			<term name="collection-editor" form="short">Hrsg.</term>
+			<term name="and others" form="short">u.&#160;a.</term>
+		</terms>
+	</locale>
+	<macro name="author" >
+		<names variable="author composer" delimiter=", ">
+			<name sort-separator=", "  delimiter-precedes-last="always"/>
+			<label form="long" prefix=" (" suffix=")"/>
+		</names>
+	</macro>
+	<macro name="author-container">
+		<names variable="container-author" delimiter=", ">
+			<name sort-separator=", " delimiter=", " delimiter-precedes-last="always"/>
+			<label form="long" prefix=" (" suffix=")"/>
+		</names>
+	</macro>
+	<macro name="editor">
+		<names variable="editor" delimiter=", ">
+			<name sort-separator=", " delimiter-precedes-last="always"/>
+		</names>
+	</macro>
+	<macro name="editor-collection">
+		<names variable="collection-editor" delimiter=", ">
+			<name sort-separator=", " delimiter-precedes-last="always"/>
+		</names>
+	</macro>
+	<macro name="translator">
+		<names variable="translator" delimiter=", ">
+			<name name-as-sort-order="all" delimiter=", " delimiter-precedes-last="always"/>
+			<label form="short" prefix=" (" suffix=")"/>
+		</names>
+	</macro>
+	<macro name="access">
+		<date variable="accessed">
+			<date-part name="year" form="long"/>
+			<date-part name="month" form="numeric-leading-zeros" prefix="-"/>
+			<date-part name="day" form="numeric-leading-zeros" prefix="-"/>
+		</date>
+	</macro>
+	<macro name="issued">
+		<date variable="issued"  prefix="Datum = " >
+			<date-part name="year" form="long"/>
+			<date-part name="month" form="numeric-leading-zeros" prefix="-"/>
+			<date-part name="day" form="numeric-leading-zeros" prefix="-"/>
+		</date>
+	</macro>
+	<macro name="volumes">
+		<group>
+			<number variable="volume" form="numeric"/>
+			<number variable="number-of-volumes" form="numeric" prefix=" v.&#160;"/>
+		</group>
+	</macro>
+	<macro name="edition">
+		<group>
+			<number variable="edition" form="numeric"/>
+		</group>
+	</macro>
+	<macro name="author-short">
+		<names variable="author">
+			<name form="short" and="symbol" delimiter=", " initialize-with=". " delimiter-precedes-last="never" font-variant="small-caps"/>
+			<et-al font-variant="normal"/>
+			<substitute>
+				<names variable="editor" font-variant="small-caps"/>
+				<names variable="translator" font-variant="small-caps"/>
+				<text variable="title" form="short" quotes="true"/>
+			</substitute>
+		</names>
+	</macro>
+	<macro name="cite-year">
+		<group>
+			<date variable="issued" prefix="_">
+				<date-part name="year"/>
+			</date>
+			<text variable="year-suffix"/>
+		</group>
+	</macro>
+	<macro name="locator">
+		<group>
+			<choose>
+				<if type="bill legislation" match="any">
+					<text variable="locator" prefix=" "/>
+				</if>
+				<else>
+					<label variable="locator" form="short" prefix=", "/>
+					<text variable="locator" prefix=" "/>
+				</else>
+			</choose>
+		</group>
+	</macro>
+	<bibliography hanging-indent="true" et-al-min="7" et-al-use-first="1">
+		<sort>
+			<!-- <key variable="type"/> -->
+			<key macro="author"/>
+			<key variable="issued"/>
+		</sort>
+		<layout>
+			<choose>
+				<!-- ########################################################### -->
+				<!-- Patente -->
+				<!-- https://de.wikipedia.org/wiki/Vorlage:Patent -->
+				<if type="patent">
+					<group prefix="{{Patent | " suffix="}}" delimiter=" | ">
+						<!-- <text variable="country" prefix="Land = "/> -->
+						<!-- not specified in https://docs.citationstyles.org/en/v1.0.2/specification.html -->
+						<text variable="jurisdiction" prefix="Land = "/>
+						<!-- Use Extra field, add e.g. {:jurisdiction:US} -->
+						<text variable="number" prefix="V-Nr = "/>
+						<text macro="author" prefix="Erfinder = "/>
+						<text macro="editor" prefix="Anmelder = "/>
+						<text variable="title" prefix="Titel = "/>
+						<date variable="issued"  prefix="V-Datum = " >
+							<date-part name="year"/>
+							<date-part name="month" form="numeric-leading-zeros"  prefix="-"/>
+							<date-part name="day" form="numeric-leading-zeros"  prefix="-"/>
+						</date>
+						<date variable="submitted"  prefix="A-Datum = " >
+							<date-part name="year"/>
+							<date-part name="month" form="numeric-leading-zeros"  prefix="-"/>
+							<date-part name="day" form="numeric-leading-zeros"  prefix="-"/>
+						</date>
+						<!-- <text variable="URL" prefix="Online = " /> -->
+						<!-- Undokumentierter Parameter -->
+					</group>
+				</if>
+				<!-- ########################################################### -->
+				<!-- Internetquellen & Websites -->
+				<!-- https://de.wikipedia.org/wiki/Vorlage%3AInternetquelle -->
+				<!-- Abstract wird als '1' unbenutzer Parameter importiert. Möglichkeit wäre Titelergänzung (titelerg) -->
+				<else-if type="webpage post-weblog post">
+					<group prefix="{{Internetquelle | " suffix="}}" delimiter=" | ">
+						<text macro="author" prefix="autor = "/>
+						<text macro="editor" prefix="hrsg = "/>
+						<text variable="title" prefix="titel = "/>
+						<text variable="URL" prefix="url = "/>
+						<text variable="container-title"  prefix="werk = " />
+						<date variable="issued"  prefix="datum = " >
+							<date-part name="year"/>
+							<date-part name="month" form="numeric-leading-zeros"  prefix="-"/>
+							<date-part name="day" form="numeric-leading-zeros"  prefix="-"/>
+						</date>
+						<text macro="access" prefix="zugriff = "/>
+					</group>
+				</else-if>
+				<!-- Alle anderen Typen für als Literatur ausgeben -->
+				<!-- keiner der oben genannten Fälle -->
+				<!-- https://de.wikipedia.org/wiki/Vorlage:Literatur -->
+				<else>
+					<group prefix="{{Literatur | " suffix="}}" delimiter=" | ">
+						<group delimiter=" | ">
+							<text macro="author" prefix="Autor = "/>
+							<choose>
+								<if type="book" match="any">
+									<text macro="editor-collection" prefix="HrsgReihe= "/>
+								</if>
+								<!-- keine Ausgabe des Herausgebers bei Artikeln -->
+								<else-if type="article article-journal article-magazine article-newspaper" match="none">
+									<text macro="editor" prefix="Hrsg = "/>
+								</else-if>
+							</choose>
+							<!-- <text macro="contributor"/> -->
+							<text macro="translator"/>
+						</group>
+						<text variable="title" prefix="Titel = " />
+						<choose>
+							<!-- ########################################################### -->
+							<!-- Bücher etc. -->
+							<if type="bill book thesis legal_case manuscript report song map map" match="any">
+								<text macro="author" prefix="Autor = "/>
+								<!-- vorgeschlagen -->
+								<text macro="editor" prefix="Hrsg = "/>
+								<!-- vorgeschlagen -->
+								<text macro="volumes"  prefix="BandReihe = " />
+								<text macro="edition"  prefix="Auflage = " />
+								<text variable="collection-title" prefix="Reihe = "/>
+								<text variable="collection-number" prefix="BandReihe = "/>
+								<text variable="publisher-place"  prefix="Ort = " />
+								<text variable="publisher"  prefix="Verlag = " />
+								<date variable="issued"  prefix="Datum = " >
+									<date-part name="year"/>
+								</date>
+								<text variable="ISBN" prefix="ISBN = "/>
+								<!--<text variable="LCCN" prefix="LCCN = "/> not supported by CSL 1.01-->
+								<!--<text variable="OCLC" prefix="OCLC = "/> not supported by CSL 1.01-->
+								<!--<text variable="DNB" prefix="DNB = "/> not supported by CSL 1.01-->
+								<!--<text variable="ZDB" prefix="ZDB = "/> not supported by CSL 1.01-->
+								<text variable="DOI" prefix="DOI = "/>
+							</if>
+							<!-- ########################################################### -->
+							<!-- Kapitel, Schriften von Tagungen, Konferenzen, Symposien, ...-->
+							<else-if type="chapter paper-conference entry-dictionary entry-encyclopedia" match="any">
+								<text variable="container-title" prefix="Sammelwerk = "/>
+								<text macro="volumes"  prefix="Band = " />
+								<text macro="edition"  prefix="Auflage = " />
+								<text variable="collection-title" prefix="Reihe = "/>
+								<text variable="collection-number" prefix="BandReihe = "/>
+								<text variable="publisher-place"  prefix="Ort = " />
+								<text variable="publisher"  prefix="Verlag = " />
+								<date variable="issued">
+									<date-part name="year" prefix="Datum = "/>
+								</date>
+								<text variable="ISBN" prefix="ISBN = "/>
+								<text variable="page" prefix="Seiten = "/>
+								<!--<text variable="LCCN" prefix="LCCN = "/> not supported by CSL 1.01-->
+								<!--<text variable="OCLC" prefix="OCLC = "/> not supported by CSL 1.01-->
+								<!--<text variable="DNB" prefix="DNB = "/> not supported by CSL 1.01-->
+								<!--<text variable="ZDB" prefix="ZDB = "/> not supported by CSL 1.01-->
+								<text variable="DOI" prefix="DOI= "/>
+							</else-if>
+							<!-- ########################################################### -->
+							<!-- Nichtselbständige Artikel -->
+							<else-if type="article article-journal article-magazine article-newspaper" match="any">
+								<group delimiter=" | ">
+									<group delimiter=" | ">
+										<text variable="container-title"  prefix="Sammelwerk = " />
+										<text macro="volumes"  prefix="Band = " />
+										<text macro="edition"  prefix="Auflage = " />
+										<text macro="editor" prefix="Hrsg = "/>
+										<!-- vorgeschlagen -->
+										<!--<date variable="issued"><date-part name="year" prefix="Jahr = "/></date>-->
+										<text macro="issued" />
+									</group>
+									<text variable="issue" prefix="Nummer = "/>
+									<!--<text variable="ISSN" prefix="ISSN = "/>-->
+									<text variable="page" prefix="Seiten = "/>
+									<text variable="DOI" prefix="DOI = "/>
+									<!--<text variable="arxiv" prefix="arxiv = "/> not supported by CSL 1.01-->
+									<text variable="PMID" prefix="PMID = "/>
+									<!--<text variable="ZDB" prefix="ZDB = "/> not supported by CSL 1.01-->
+								</group>
+							</else-if>
+						</choose>
+						<choose>
+							<!-- Was ist hier gemeint? Wenn DOI leer, dann URL? -->
+							<if variable="DOI">
+								<!-- empty -->
+							</if>
+							<else>
+								<text variable="URL" prefix="Online = " />
+							</else>
+						</choose>
+					</group>
+				</else>
+			</choose>
+		</layout>
+	</bibliography>
+	<citation et-al-min="3" et-al-use-first="1" disambiguate-add-year-suffix="true" disambiguate-add-names="false" disambiguate-add-givenname="false" collapse="year">
+		<sort>
+			<key macro="author"/>
+			<key variable="issued"/>
+		</sort>
+		<layout prefix="" suffix="" delimiter="; ">
+			<group>
+				<text macro="author-short"/>
+				<text macro="cite-year"/>
+				<text macro="locator"/>
+			</group>
+		</layout>
+	</citation>
+</style>


### PR DESCRIPTION
Based on https://github.com/192933488S/ZoteroCSL/blob/main/cepheiden_main_wikipedia-templates.csl

Update externally in several versions before committed to GitHub for current "most compatible" with various resource formats, named version "mod22g"

Checked with https://validator.citationstyles.org/