### PR TITLE
apsa - remove subsequent author em dashes

### DIFF
--- a/american-political-science-association.csl
+++ b/american-political-science-association.csl
@@ -16,6 +16,9 @@
     <contributor>
       <name>Patrick O'Brien</name>
     </contributor>
+    <contributor>
+      <name>Aaron Guerra</name>
+    </contributor>
     <category citation-format="author-date"/>
     <category field="political_science"/>
     <summary>The American Political Science Association style. Et al rules based on published APSR articles</summary>
@@ -175,7 +178,7 @@
       </group>
     </layout>
   </citation>
-  <bibliography hanging-indent="true" et-al-min="10" et-al-use-first="7" subsequent-author-substitute="&#8212;&#8212;&#8212;">
+  <bibliography hanging-indent="true" et-al-min="10" et-al-use-first="7">
     <sort>
       <key macro="author"/>
       <key macro="year-date"/>


### PR DESCRIPTION
"Avoid the use of ibid., idem, f., ff., op. cit. and loc. cit. (14.34–14.36). While these Latin abbreviations have been used for years in academia, they do not translate well, if at all, to online publication formats. Further, replacing the name in successive references of the same author(s) with three em-dashes (———) is no longer recommended by Chicago. It complicates the digitization process, does not align with online database sorting, and makes the source impractical outside of the context of the reference list (14.67)."

https://connect.apsanet.org/stylemanual/sample-page/references/
