### PR TITLE
Update norsk-apa-manual.csl

### DIFF
--- a/norsk-apa-manual.csl
+++ b/norsk-apa-manual.csl
@@ -10,7 +10,7 @@
     <category citation-format="author-date"/>
     <category field="psychology"/>
     <category field="generic-base"/>
-    <updated>2022-01-31T14:30:00+00:00</updated>
+    <updated>2023-09-14T03:18:49+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale xml:lang="en">
@@ -44,6 +44,7 @@
       <term name="et-al">et al.</term>
       <term name="letter">personlig kommunikasjon</term>
       <term name="letter" form="short">brev</term>
+      <term name="original-work-published">opprinnelig utgitt</term>
     </terms>
   </locale>
   <locale xml:lang="nn">
@@ -51,6 +52,7 @@
       <term name="et-al">et al.</term>
       <term name="letter">personlig kommunikasjon</term>
       <term name="letter" form="short">brev</term>
+      <term name="original-work-published">opphavleg gitt ut</term>
     </terms>
   </locale>
   <!-- General categories of item types:
@@ -1316,7 +1318,7 @@
             </if>
             <else>
               <group delimiter=" ">
-                <text value="Original work published"/>
+                <text term="original-work-published" text-case="capitalize-first"/>
                 <choose>
                   <if is-uncertain-date="original-date">
                     <text term="circa" form="short"/>


### PR DESCRIPTION
Updates the macro publication-history so that it uses the term origina-work-published, and provided translations into bokmål and nynorsk. Previously it used English ("Original work published").