### PR TITLE
Update ieee.csl to incl. video directors | add standard type

### DIFF
--- a/ieee.csl
+++ b/ieee.csl
@@ -155,7 +155,7 @@
   </macro>
   <macro name="title">
     <choose>
-      <if type="bill book graphic legal_case legislation motion_picture song" match="any">
+      <if type="bill book graphic legal_case legislation motion_picture song standard" match="any">
         <text variable="title" font-style="italic"/>
       </if>
       <else>
@@ -426,6 +426,18 @@
           <text macro="geographic-location" suffix=". "/>
           <group delimiter=", " suffix=".">
             <text macro="title"/>
+            <text macro="issued"/>
+          </group>
+          <text macro="access"/>
+        </else-if>
+        <else-if type="standard"> 
+          <group delimiter=", " suffix=".">
+            <text macro="title"/>
+            <group delimiter=" ">
+              <text variable="genre"/>
+              <text variable="number"/>
+            </group>
+            <text macro="geographic-location"/>
             <text macro="issued"/>
           </group>
           <text macro="access"/>

--- a/ieee.csl
+++ b/ieee.csl
@@ -45,7 +45,7 @@
     <category field="engineering"/>
     <category field="generic-base"/>
     <summary>IEEE style as per the 2021 guidelines, V 01.29.2021.</summary>
-    <updated>2024-03-2719:39:58+00:00</updated>
+    <updated>2024-03-27T11:41:27+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale xml:lang="en">
@@ -120,7 +120,7 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
-		<text macro="director"/>
+        <text macro="director"/>
       </substitute>
     </names>
   </macro>

--- a/ieee.csl
+++ b/ieee.csl
@@ -44,7 +44,7 @@
     <category citation-format="numeric"/>
     <category field="engineering"/>
     <category field="generic-base"/>
-    <summary>IEEE style as per the 2021 guidelines, V 01.29.2021.</summary>
+    <summary>IEEE style as per the 2023 guidelines, V 11.29.2023.</summary>
     <updated>2024-03-27T11:41:27+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
@@ -423,12 +423,11 @@
         <else-if type="article">
           <group delimiter=", " suffix=".">
             <text macro="title"/>
+            <text macro="issued"/>
             <group delimiter=": ">
-              <text variable="archive"/>
+              <text macro="publisher" font-style="italic"/>
               <text variable="number"/>
             </group>
-            <text macro="publisher"/>
-            <text macro="issued"/>
           </group>
           <text macro="access"/>
         </else-if>

--- a/ieee.csl
+++ b/ieee.csl
@@ -430,7 +430,7 @@
           </group>
           <text macro="access"/>
         </else-if>
-        <else-if type="standard"> 
+        <else-if type="standard">
           <group delimiter=", " suffix=".">
             <text macro="title"/>
             <group delimiter=" ">

--- a/ieee.csl
+++ b/ieee.csl
@@ -45,7 +45,7 @@
     <category field="engineering"/>
     <category field="generic-base"/>
     <summary>IEEE style as per the 2021 guidelines, V 01.29.2021.</summary>
-    <updated>2024-01-11T00:52:46+10:00</updated>
+    <updated>2024-03-2719:39:58+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale xml:lang="en">
@@ -120,6 +120,7 @@
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
+		<text macro="director"/>
       </substitute>
     </names>
   </macro>
@@ -127,6 +128,12 @@
     <names variable="editor">
       <name initialize-with=". " delimiter=", " and="text"/>
       <label form="short" prefix=", " text-case="capitalize-first"/>
+    </names>
+  </macro>
+  <macro name="director">
+    <names variable="director">
+      <name and="text" et-al-min="7" et-al-use-first="1" initialize-with=". "/>
+      <et-al font-style="italic"/>
     </names>
   </macro>
   <macro name="locators">

--- a/ieee.csl
+++ b/ieee.csl
@@ -420,7 +420,7 @@
           </group>
           <text macro="access"/>
         </else-if>
-        <else-if type="preprint">
+        <else-if type="article">
           <group delimiter=", " suffix=".">
             <text macro="title"/>
             <group delimiter=": ">

--- a/ieee.csl
+++ b/ieee.csl
@@ -56,6 +56,7 @@
     </date>
     <terms>
       <term name="chapter" form="short">ch.</term>
+      <term name="chapter-number" form="short">ch.</term>
       <term name="presented at">presented at the</term>
       <term name="available at">available</term>
     </terms>
@@ -155,7 +156,7 @@
   </macro>
   <macro name="title">
     <choose>
-      <if type="bill book graphic legal_case legislation motion_picture song standard" match="any">
+      <if type="bill book graphic legal_case legislation motion_picture song standard software" match="any">
         <text variable="title" font-style="italic"/>
       </if>
       <else>
@@ -381,6 +382,10 @@
             <text macro="collection"/>
             <text macro="publisher"/>
             <text macro="issued"/>
+            <group delimiter=" ">
+              <label variable="chapter-number" form="short"/>
+              <text variable="chapter-number"/>
+            </group>
             <text macro="page"/>
           </group>
           <text macro="access"/>
@@ -401,6 +406,27 @@
           <group delimiter=", " suffix=".">
             <text macro="title"/>
             <text variable="genre"/>
+            <text macro="publisher"/>
+            <text macro="issued"/>
+          </group>
+          <text macro="access"/>
+        </else-if>
+        <else-if type="software">
+          <group delimiter=". " suffix=".">
+            <text macro="title"/>
+            <text macro="issued" prefix="(" suffix=")"/>
+            <text variable="genre"/>
+            <text macro="publisher"/>
+          </group>
+          <text macro="access"/>
+        </else-if>
+        <else-if type="preprint">
+          <group delimiter=", " suffix=".">
+            <text macro="title"/>
+            <group delimiter=": ">
+              <text variable="archive"/>
+              <text variable="number"/>
+            </group>
             <text macro="publisher"/>
             <text macro="issued"/>
           </group>


### PR DESCRIPTION
https://forums.zotero.org/discussion/113145/ieee-online-video-e-g-youtube#latest

I feel like we should include some other names as well. Any suggestions which?

-----
Also adds the "standard" type to style:
![image](https://github.com/user-attachments/assets/454e7747-526b-4064-9306-baced8827be7)

![image](https://github.com/user-attachments/assets/bfa90994-d685-466f-a5f4-bd2c68d7d2b9)
Requested here: https://forums.zotero.org/discussion/115455/zotero-not-compliant-with-the-ieee-style-guide/p1