### PR TITLE
Update suburban-zeitschrift-fur-kritische-stadtforschung.csl

### DIFF
--- a/suburban-zeitschrift-fur-kritische-stadtforschung.csl
+++ b/suburban-zeitschrift-fur-kritische-stadtforschung.csl
@@ -14,7 +14,7 @@
     <category citation-format="author-date"/>
     <category field="social_science"/>
     <issn>2197-2567</issn>
-    <updated>2019-10-14T12:01:14+00:00</updated>
+    <updated>2024-03-28T10:36:54+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale xml:lang="de">
@@ -24,6 +24,7 @@
       <term name="anonymous" form="long">Ohne Verfasser</term>
       <term name="anonymous" form="short">O.V.</term>
       <term name="editor" form="short">hg.</term>
+      <term name="page-range-delimiter">-</term>
     </terms>
   </locale>
   <macro name="container">
@@ -32,8 +33,8 @@
         <group delimiter=", ">
           <group delimiter=": ">
             <text term="in" text-case="capitalize-first"/>
-            <names variable="editor translator" delimiter=", ">
-              <name delimiter-precedes-last="always" initialize-with="." name-as-sort-order="all"/>
+            <names variable="editor translator" font-weight="normal" delimiter=",">
+              <name delimiter=" / " delimiter-precedes-last="always" initialize-with="."/>
               <label form="short" text-case="capitalize-first" prefix=" (" suffix=")"/>
             </names>
           </group>
@@ -44,9 +45,8 @@
         </group>
       </if>
       <else-if type="book graphic legal_case motion_picture report song" match="any">
-        <group delimiter=", ">
+        <group font-weight="normal" delimiter=", ">
           <text variable="container-title"/>
-          <text variable="collection-title"/>
         </group>
       </else-if>
       <else-if type="article-journal article-magazine article" match="any">
@@ -89,7 +89,7 @@
       <else-if type="article-newspaper" match="any">
         <group delimiter=", ">
           <group delimiter=": ">
-            <text term="in"/>
+            <text term="in" text-case="title"/>
             <text variable="container-title"/>
           </group>
           <date variable="issued">
@@ -140,11 +140,11 @@
       <if type="webpage post post-weblog" match="any">
         <group delimiter=" ">
           <text variable="URL"/>
-          <group delimiter=" " prefix="[" suffix="]">
-            <text term="accessed"/>
+          <group delimiter=" " prefix="(" suffix=")">
+            <text term="accessed" suffix=" am"/>
             <date variable="accessed">
-              <date-part name="day" form="numeric-leading-zeros" suffix="."/>
-              <date-part name="month" form="numeric-leading-zeros" suffix="."/>
+              <date-part name="day" form="numeric" suffix="."/>
+              <date-part name="month" form="numeric" suffix="."/>
               <date-part name="year"/>
             </date>
           </group>
@@ -178,7 +178,7 @@
   </macro>
   <macro name="publisher">
     <group delimiter=": ">
-      <text variable="publisher-place"/>
+      <text variable="publisher-place" strip-periods="false"/>
       <text variable="publisher"/>
     </group>
   </macro>


### PR DESCRIPTION
We have updated the citation style for our journal sub\urban. zeitschrift für kritische stadtforschung. These are just a few minor changes in accordance with our style guides, such as changing page range delimiters to simple hyphens, or the order of first and last names of editors in book chapters.