### PR TITLE
Fork bibtex style to create more barebones biber style

### DIFF
--- a/biber.csl
+++ b/biber.csl
@@ -1,0 +1,184 @@
+<?xml version="1.0" encoding="utf-8"?>
+<style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" demote-non-dropping-particle="sort-only" default-locale="en-US">
+  <info>
+    <title>BibTeX generic citation style</title>
+    <id>http://www.zotero.org/styles/bibtex</id>
+    <link href="http://www.zotero.org/styles/bibtex" rel="self"/>
+    <link href="http://www.bibtex.org/" rel="documentation"/>
+    <author>
+      <name>Markus Schaffner</name>
+    </author>
+    <contributor>
+      <name>Richard Karnesky</name>
+      <email>karnesky+zotero@gmail.com</email>
+      <uri>http://arc.nucapt.northwestern.edu/Richard_Karnesky</uri>
+    </contributor>
+    <contributor>
+      <name>Brenton M. Wiernik</name>
+      <email>zotero@wiernik.org</email>
+    </contributor>
+    <category citation-format="label"/>
+    <category field="generic-base"/>
+    <updated>2012-09-14T21:22:32+00:00</updated>
+    <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
+  </info>
+  <macro name="zotero2bibtexType">
+    <choose>
+      <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
+        <text value="book"/>
+      </if>
+      <else-if type="chapter" match="any">
+        <text value="inbook"/>
+      </else-if>
+      <else-if type="article article-journal article-magazine article-newspaper" match="any">
+        <text value="article"/>
+      </else-if>
+      <else-if type="thesis" match="any">
+        <text value="phdthesis"/>
+      </else-if>
+      <else-if type="manuscript" match="any">
+        <text value="unpublished"/>
+      </else-if>
+      <else-if type="paper-conference" match="any">
+        <text value="inproceedings"/>
+      </else-if>
+      <else-if type="report" match="any">
+        <text value="techreport"/>
+      </else-if>
+      <else>
+        <text value="misc"/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="citeKey">
+    <group delimiter="_">
+      <text macro="author-short" text-case="lowercase"/>
+      <text macro="issued-year"/>
+    </group>
+  </macro>
+  <macro name="author-short">
+    <names variable="author">
+      <name form="short" delimiter="_" delimiter-precedes-last="always" et-al-min="11" et-al-use-first="10"/>
+      <substitute>
+        <names variable="editor"/>
+        <names variable="translator"/>
+        <choose>
+          <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
+            <text variable="title" form="short"/>
+          </if>
+          <else>
+            <text variable="title" form="short"/>
+          </else>
+        </choose>
+      </substitute>
+    </names>
+  </macro>
+  <macro name="issued-year">
+    <date variable="issued">
+      <date-part name="year"/>
+    </date>
+  </macro>
+  <macro name="issued-month">
+    <date variable="issued">
+      <date-part name="month" form="short" strip-periods="true" text-case="lowercase"/>
+    </date>
+  </macro>
+  <macro name="author">
+    <names variable="author">
+      <name sort-separator=", " delimiter=" and " delimiter-precedes-last="always" name-as-sort-order="all"/>
+    </names>
+  </macro>
+  <macro name="editor-translator">
+    <names variable="editor translator" delimiter=", ">
+      <name sort-separator=", " delimiter=" and " delimiter-precedes-last="always" name-as-sort-order="all"/>
+    </names>
+  </macro>
+  <macro name="title">
+    <text variable="title"/>
+  </macro>
+  <macro name="number">
+    <text variable="issue"/>
+    <text variable="number"/>
+  </macro>
+  <macro name="container-title">
+    <choose>
+      <if type="chapter paper-conference" match="any">
+        <text variable="container-title" prefix=" booktitle={" suffix="}"/>
+      </if>
+      <else>
+        <text variable="container-title" prefix=" journal={" suffix="}"/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="publisher">
+    <choose>
+      <if type="thesis">
+        <text variable="publisher" prefix=" school={" suffix="}"/>
+      </if>
+      <else-if type="report">
+        <text variable="publisher" prefix=" institution={" suffix="}"/>
+      </else-if>
+      <else>
+        <text variable="publisher" prefix=" publisher={" suffix="}"/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="pages">
+    <text variable="page"/>
+  </macro>
+  <macro name="edition">
+    <!-- This should probably be ordinal? -->
+    <text variable="edition"/>
+  </macro>
+  <citation disambiguate-add-year-suffix="true" disambiguate-add-names="false" disambiguate-add-givenname="false" collapse="year">
+    <sort>
+      <key macro="author"/>
+      <key variable="issued"/>
+    </sort>
+    <layout delimiter="_">
+      <text macro="citeKey"/>
+    </layout>
+  </citation>
+  <bibliography hanging-indent="false">
+    <sort>
+      <key macro="author"/>
+      <key variable="issued"/>
+    </sort>
+    <layout>
+      <text macro="zotero2bibtexType" prefix=" @"/>
+      <group prefix="{" suffix=" }" delimiter=", ">
+        <text macro="citeKey"/>
+        <text variable="publisher-place" prefix=" address={" suffix="}"/>
+        <!--Fix This-->
+        <text variable="chapter-number" prefix=" chapter={" suffix="}"/>
+        <!--Fix This-->
+        <text macro="edition" prefix=" edition={" suffix="}"/>
+        <text variable="genre" prefix=" type={" suffix="}"/>
+        <text variable="collection-title" prefix=" series={" suffix="}"/>
+        <text macro="title" prefix=" title={" suffix="}"/>
+        <text variable="volume" prefix=" volume={" suffix="}"/>
+        <text variable="license" prefix=" rights={" suffix="}"/>
+        <text variable="ISBN" prefix=" ISBN={" suffix="}"/>
+        <text variable="ISSN" prefix=" ISSN={" suffix="}"/>
+        <text variable="call-number" prefix=" callNumber={" suffix="}"/>
+        <text variable="archive_location" prefix=" archiveLocation={" suffix="}"/>
+        <text variable="URL" prefix=" url={" suffix="}"/>
+        <text variable="DOI" prefix=" DOI={" suffix="}"/>
+        <text variable="abstract" prefix=" abstractNote={" suffix="}"/>
+        <text variable="note" prefix=" note={" suffix="}"/>
+        <text macro="number" prefix=" number={" suffix="}"/>
+        <text macro="container-title"/>
+        <text macro="publisher"/>
+        <text macro="author" prefix=" author={" suffix="}"/>
+        <text macro="editor-translator" prefix=" editor={" suffix="}"/>
+        <text macro="issued-year" prefix=" year={" suffix="}"/>
+        <text macro="issued-month" prefix=" month=" suffix=""/>
+        <text macro="pages" prefix=" pages={" suffix="}"/>
+        <text variable="collection-title" prefix=" collection={" suffix="}"/>
+        <text variable="keyword" prefix=" keywords={" suffix="}"/>
+        <text variable="language" prefix="language={" suffix="}"/>
+        <text variable="annote" prefix="annote={" suffix="}"/>
+      </group>
+    </layout>
+  </bibliography>
+</style>

--- a/biber.csl
+++ b/biber.csl
@@ -138,10 +138,10 @@
   <macro name="link">
     <choose>
       <if variable="DOI">
-      <text variable="DOI" prefix="DOI={" suffix="}"/>
+        <text variable="DOI" prefix="DOI={" suffix="}"/>
       </if>
       <else-if variable="URL">
-      <text variable="URL" prefix="url={" suffix="}"/>
+        <text variable="URL" prefix="url={" suffix="}"/>
       </else-if>
     </choose>
   </macro>
@@ -165,7 +165,7 @@
     </sort>
     <layout>
       <text macro="zotero2bibtexType" prefix="@"/>
-      <group prefix="{" suffix="&#xA;}" delimiter=",&#xA;">
+      <group prefix="{" suffix="&#10;}" delimiter=",&#10;">
         <text macro="citeKey"/>
         <text variable="publisher-place" prefix="address={" suffix="}"/>
         <!--Fix This-->

--- a/biber.csl
+++ b/biber.csl
@@ -1,12 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
 <style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" demote-non-dropping-particle="sort-only" default-locale="en-US">
   <info>
-    <title>BibTeX generic citation style</title>
-    <id>http://www.zotero.org/styles/bibtex</id>
-    <link href="http://www.zotero.org/styles/bibtex" rel="self"/>
+    <title>Barebones Biber citation style</title>
+    <id>http://www.zotero.org/styles/biber</id>
+    <link href="http://www.zotero.org/styles/biber" rel="self"/>
     <link href="http://www.bibtex.org/" rel="documentation"/>
     <author>
-      <name>Markus Schaffner</name>
+      <name>Nathan Dwek</name>
+      <email>nathdwek@outlook.com</email>
     </author>
     <contributor>
       <name>Richard Karnesky</name>
@@ -17,9 +18,12 @@
       <name>Brenton M. Wiernik</name>
       <email>zotero@wiernik.org</email>
     </contributor>
+    <contributor>
+      <name>Markus Schaffner</name>
+    </contributor>
     <category citation-format="label"/>
     <category field="generic-base"/>
-    <updated>2012-09-14T21:22:32+00:00</updated>
+    <updated>2024-04-03T21:22:32+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <macro name="zotero2bibtexType">
@@ -44,6 +48,9 @@
       </else-if>
       <else-if type="report" match="any">
         <text value="techreport"/>
+      </else-if>
+      <else-if type="dataset" match="any">
+        <text value="dataset"/>
       </else-if>
       <else>
         <text value="misc"/>
@@ -78,9 +85,11 @@
       <date-part name="year"/>
     </date>
   </macro>
-  <macro name="issued-month">
-    <date variable="issued">
-      <date-part name="month" form="short" strip-periods="true" text-case="lowercase"/>
+  <macro name="issued-date">
+    <date variable="issued" delimiter="-">
+      <date-part name="year"/>
+      <date-part name="month" form="numeric-leading-zeros"/>
+      <date-part name="day" form="numeric-leading-zeros"/>
     </date>
   </macro>
   <macro name="author">
@@ -103,28 +112,38 @@
   <macro name="container-title">
     <choose>
       <if type="chapter paper-conference" match="any">
-        <text variable="container-title" prefix=" booktitle={" suffix="}"/>
+        <text variable="container-title" prefix="booktitle={" suffix="}"/>
       </if>
       <else>
-        <text variable="container-title" prefix=" journal={" suffix="}"/>
+        <text variable="container-title" prefix="journal={" suffix="}"/>
       </else>
     </choose>
   </macro>
   <macro name="publisher">
     <choose>
       <if type="thesis">
-        <text variable="publisher" prefix=" school={" suffix="}"/>
+        <text variable="publisher" prefix="school={" suffix="}"/>
       </if>
       <else-if type="report">
-        <text variable="publisher" prefix=" institution={" suffix="}"/>
+        <text variable="publisher" prefix="institution={" suffix="}"/>
       </else-if>
       <else>
-        <text variable="publisher" prefix=" publisher={" suffix="}"/>
+        <text variable="publisher" prefix="publisher={" suffix="}"/>
       </else>
     </choose>
   </macro>
   <macro name="pages">
     <text variable="page"/>
+  </macro>
+  <macro name="link">
+    <choose>
+      <if variable="DOI">
+      <text variable="DOI" prefix="DOI={" suffix="}"/>
+      </if>
+      <else-if variable="URL">
+      <text variable="URL" prefix="url={" suffix="}"/>
+      </else-if>
+    </choose>
   </macro>
   <macro name="edition">
     <!-- This should probably be ordinal? -->
@@ -145,39 +164,32 @@
       <key variable="issued"/>
     </sort>
     <layout>
-      <text macro="zotero2bibtexType" prefix=" @"/>
-      <group prefix="{" suffix=" }" delimiter=", ">
+      <text macro="zotero2bibtexType" prefix="@"/>
+      <group prefix="{" suffix="&#xA;}" delimiter=",&#xA;">
         <text macro="citeKey"/>
-        <text variable="publisher-place" prefix=" address={" suffix="}"/>
+        <text variable="publisher-place" prefix="address={" suffix="}"/>
         <!--Fix This-->
-        <text variable="chapter-number" prefix=" chapter={" suffix="}"/>
+        <text variable="chapter-number" prefix="chapter={" suffix="}"/>
         <!--Fix This-->
-        <text macro="edition" prefix=" edition={" suffix="}"/>
-        <text variable="genre" prefix=" type={" suffix="}"/>
-        <text variable="collection-title" prefix=" series={" suffix="}"/>
-        <text macro="title" prefix=" title={" suffix="}"/>
-        <text variable="volume" prefix=" volume={" suffix="}"/>
-        <text variable="license" prefix=" rights={" suffix="}"/>
-        <text variable="ISBN" prefix=" ISBN={" suffix="}"/>
-        <text variable="ISSN" prefix=" ISSN={" suffix="}"/>
-        <text variable="call-number" prefix=" callNumber={" suffix="}"/>
-        <text variable="archive_location" prefix=" archiveLocation={" suffix="}"/>
-        <text variable="URL" prefix=" url={" suffix="}"/>
-        <text variable="DOI" prefix=" DOI={" suffix="}"/>
-        <text variable="abstract" prefix=" abstractNote={" suffix="}"/>
-        <text variable="note" prefix=" note={" suffix="}"/>
-        <text macro="number" prefix=" number={" suffix="}"/>
+        <text macro="edition" prefix="edition={" suffix="}"/>
+        <text variable="genre" prefix="type={" suffix="}"/>
+        <text variable="collection-title" prefix="series={" suffix="}"/>
+        <text macro="title" prefix="title={" suffix="}"/>
+        <text variable="volume" prefix="volume={" suffix="}"/>
+        <text variable="license" prefix="rights={" suffix="}"/>
+        <text variable="ISBN" prefix="ISBN={" suffix="}"/>
+        <text variable="ISSN" prefix="ISSN={" suffix="}"/>
+        <text variable="call-number" prefix="callNumber={" suffix="}"/>
+        <text variable="archive_location" prefix="archiveLocation={" suffix="}"/>
+        <text macro="link"/>
+        <text macro="number" prefix="number={" suffix="}"/>
         <text macro="container-title"/>
         <text macro="publisher"/>
-        <text macro="author" prefix=" author={" suffix="}"/>
-        <text macro="editor-translator" prefix=" editor={" suffix="}"/>
-        <text macro="issued-year" prefix=" year={" suffix="}"/>
-        <text macro="issued-month" prefix=" month=" suffix=""/>
-        <text macro="pages" prefix=" pages={" suffix="}"/>
-        <text variable="collection-title" prefix=" collection={" suffix="}"/>
-        <text variable="keyword" prefix=" keywords={" suffix="}"/>
-        <text variable="language" prefix="language={" suffix="}"/>
-        <text variable="annote" prefix="annote={" suffix="}"/>
+        <text macro="author" prefix="author={" suffix="}"/>
+        <text macro="editor-translator" prefix="editor={" suffix="}"/>
+        <text macro="issued-date" prefix="date=" suffix=""/>
+        <text macro="pages" prefix="pages={" suffix="}"/>
+        <text variable="collection-title" prefix="collection={" suffix="}"/>
       </group>
     </layout>
   </bibliography>


### PR DESCRIPTION
I have been using this more barebones biber style for a while, and find it easier to work with on the day to day, using a text-editor for bib files.

Summary of changes:
* Remove a few "typically verbose" attributes that are not used anyway by most common citation-styles: `abstractnote`, `annote`, `keywords`, `note`
* One attribute per line (LF line endings)
* `date` attribute as YYYY-MM-DD instead of `year` and `month` attribute 
* Add `@dataset` entry type
* Remove `language` attribute (maybe to discuss?)
* If there is a DOI, export only `DOI` attribute and not the `URL` attribute. (maybe to discuss?)

To sum up, make the resulting  .bib file easier to work with, mostly by removing attributes that are very rarely actually used by the citation styles, and by adding linebreaks between attributes. In addition, some biber specific updates: new dataset entry type, and date as a numeric rather than month and year as text.

Finally some cosmetic preferences that change the typical bibliography output: remove the language attribute, and print DOI and no URL is DOI is available, otherwise fall back on URL. Those can be discussed.