### PR TITLE
CMoS: sort bibliography by only year part (discourse1843)

### DIFF
--- a/chicago-author-date-fr.csl
+++ b/chicago-author-date-fr.csl
@@ -12,7 +12,7 @@
     <category citation-format="author-date"/>
     <category field="generic-base"/>
     <summary>Adaptation française du style "Chicago" (méthode auteur-date), 17e édition</summary>
-    <updated>2019-09-23T00:00:00+00:00</updated>
+    <updated>2024-04-09T10:33:16+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale xml:lang="fr">
@@ -512,6 +512,11 @@
       </else>
     </choose>
   </macro>
+  <macro name="date-sort">
+    <date variable="issued">
+      <date-part name="year"/>
+    </date>
+  </macro>
   <macro name="day-month">
     <date variable="issued">
       <date-part name="month"/>
@@ -662,7 +667,7 @@
   <bibliography hanging-indent="true" et-al-min="11" et-al-use-first="7" subsequent-author-substitute="&#8212;&#8212;&#8212;" entry-spacing="0">
     <sort>
       <key macro="contributors"/>
-      <key variable="issued"/>
+      <key macro="date-sort"/>
       <key variable="title"/>
     </sort>
     <layout suffix=".">

--- a/chicago-author-date-no-em-dash.csl
+++ b/chicago-author-date-no-em-dash.csl
@@ -32,7 +32,7 @@
     <category citation-format="author-date"/>
     <category field="generic-base"/>
     <summary>The author-date variant of the Chicago style</summary>
-    <updated>2018-01-24T12:00:00+00:00</updated>
+    <updated>2024-04-09T10:33:15+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale xml:lang="en">
@@ -501,6 +501,11 @@
       </else>
     </choose>
   </macro>
+  <macro name="date-sort">
+    <date variable="issued">
+      <date-part name="year"/>
+    </date>
+  </macro>
   <macro name="day-month">
     <date variable="issued">
       <date-part name="month"/>
@@ -658,7 +663,7 @@
   <bibliography hanging-indent="true" et-al-min="11" et-al-use-first="7" entry-spacing="0">
     <sort>
       <key macro="contributors"/>
-      <key variable="issued"/>
+      <key macro="date-sort"/>
       <key variable="title"/>
     </sort>
     <layout suffix=".">

--- a/chicago-author-date.csl
+++ b/chicago-author-date.csl
@@ -32,7 +32,7 @@
     <category citation-format="author-date"/>
     <category field="generic-base"/>
     <summary>The author-date variant of the Chicago style</summary>
-    <updated>2018-01-24T12:00:00+00:00</updated>
+    <updated>2024-04-09T10:33:14+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale xml:lang="en">
@@ -501,6 +501,11 @@
       </else>
     </choose>
   </macro>
+  <macro name="date-sort">
+    <date variable="issued">
+      <date-part name="year"/>
+    </date>
+  </macro>
   <macro name="day-month">
     <date variable="issued">
       <date-part name="month"/>
@@ -658,7 +663,7 @@
   <bibliography hanging-indent="true" et-al-min="11" et-al-use-first="7" subsequent-author-substitute="&#8212;&#8212;&#8212;" entry-spacing="0">
     <sort>
       <key macro="contributors"/>
-      <key variable="issued"/>
+      <key macro="date-sort"/>
       <key variable="title"/>
     </sort>
     <layout suffix=".">


### PR DESCRIPTION
Discussed in <https://discourse.citationstyles.org/t/multiple-works-by-the-same-author-published-in-the-same-year-ordered-incorrectly-per-chicago-style/1843>.

I only modified styles of CMoS 17th edition since I don't have access to earlier versions.