### PR TITLE
CMoS: fix the delimiter before journal pages (discourse1846)

### DIFF
--- a/chicago-author-date-no-em-dash.csl
+++ b/chicago-author-date-no-em-dash.csl
@@ -29,10 +29,14 @@
     <contributor>
       <name>Brenton M. Wiernik</name>
     </contributor>
+    <contributor>
+      <name>Zeping Lee</name>
+      <email>zepinglee@gmail.com</email>
+    </contributor>
     <category citation-format="author-date"/>
     <category field="generic-base"/>
     <summary>The author-date variant of the Chicago style</summary>
-    <updated>2024-04-09T10:33:15+00:00</updated>
+    <updated>2024-05-09T13:08:52+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale xml:lang="en">
@@ -385,8 +389,19 @@
       </if>
       <else-if type="article-journal">
         <choose>
-          <if variable="volume issue" match="any">
-            <text variable="page" prefix=": "/>
+          <if variable="volume">
+            <choose>
+              <if variable="issue">
+                <text variable="page" prefix=": "/>
+              </if>
+              <else>
+                <!-- CMoS 15.48: If the month or season is included, it is
+                  enclosed in parentheses, and a space follows the colon.
+                  Unfortunately we can't check the month in CSL v1.0.2.
+                -->
+                <text variable="page" prefix=":"/>
+              </else>
+            </choose>
           </if>
           <else>
             <text variable="page" prefix=", "/>

--- a/chicago-author-date.csl
+++ b/chicago-author-date.csl
@@ -29,10 +29,14 @@
     <contributor>
       <name>Brenton M. Wiernik</name>
     </contributor>
+    <contributor>
+      <name>Zeping Lee</name>
+      <email>zepinglee@gmail.com</email>
+    </contributor>
     <category citation-format="author-date"/>
     <category field="generic-base"/>
     <summary>The author-date variant of the Chicago style</summary>
-    <updated>2024-04-09T10:33:14+00:00</updated>
+    <updated>2024-05-09T13:08:37+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale xml:lang="en">
@@ -385,8 +389,19 @@
       </if>
       <else-if type="article-journal">
         <choose>
-          <if variable="volume issue" match="any">
-            <text variable="page" prefix=": "/>
+          <if variable="volume">
+            <choose>
+              <if variable="issue">
+                <text variable="page" prefix=": "/>
+              </if>
+              <else>
+                <!-- CMoS 15.48: If the month or season is included, it is
+                  enclosed in parentheses, and a space follows the colon.
+                  Unfortunately we can't check the month in CSL v1.0.2.
+                -->
+                <text variable="page" prefix=":"/>
+              </else>
+            </choose>
           </if>
           <else>
             <text variable="page" prefix=", "/>


### PR DESCRIPTION
Discussed in <https://discourse.citationstyles.org/t/unexpected-space-between-volume-and-page-number-s-when-no-issue-is-listed-chicago-style/1846> and it's confirmed in CMoS 15.47 and 15.48.

<img width="595" alt="Screenshot 2024-05-09 at 21 15 50" src="https://github.com/citation-style-language/styles/assets/12290822/a20cb3f9-71ce-40d0-9b21-72292b9aca7b">
<img width="590" alt="Screenshot 2024-05-09 at 21 16 16" src="https://github.com/citation-style-language/styles/assets/12290822/5dd30438-f055-4f72-9b07-35e4db49e825">

The following are the changes with the sample entries from CMoS.

```diff
<div class="csl-entry">Glass, Jennifer, and Philip Levchak. 2014. “Red States, Blue States, and Divorce: Understanding the Impact of Conservative Protestantism on Regional Variation in Divorce Rates.” <i>American Journal of Sociology</i> 119 (4): 1002–46. <a href="https://doi.org/10.1086/674703">https://doi.org/10.1086/674703</a>.</div>
-  <div class="csl-entry">Meyerovitch, Eva. 1959. “The Gnostic Manuscripts of Upper Egypt.” <i>Diogenes</i>, no. 25: 84–117.</div>
+  <div class="csl-entry">Meyerovitch, Eva. 1959. “The Gnostic Manuscripts of Upper Egypt.” <i>Diogenes</i>, no. 25, 84–117.</div>
-  <div class="csl-entry">Gunderson, Alex R., and Manuel Leal. 2015a. “Patterns of Thermal Constraint on Ectotherm Activity.” <i>American Naturalist</i> 185: 653–64. <a href="https://doi.org/10.1086/680849">https://doi.org/10.1086/680849</a>.</div>
+  <div class="csl-entry">Gunderson, Alex R., and Manuel Leal. 2015a. “Patterns of Thermal Constraint on Ectotherm Activity.” <i>American Naturalist</i> 185:653–64. <a href="https://doi.org/10.1086/680849">https://doi.org/10.1086/680849</a>.</div>
-  <div class="csl-entry">———. 2015b. “Patterns of Thermal Constraint on Ectotherm Activity.” <i>American Naturalist</i> 185 (May): 653–64. <a href="https://doi.org/10.1086/680849">https://doi.org/10.1086/680849</a>.</div>
+  <div class="csl-entry">———. 2015b. “Patterns of Thermal Constraint on Ectotherm Activity.” <i>American Naturalist</i> 185 (May):653–64. <a href="https://doi.org/10.1086/680849">https://doi.org/10.1086/680849</a>.</div>
```

Note that CMoS says:

> If the month or season is included, it is enclosed in parentheses, and a space follows the colon.

Unfortunately we can't check if an `issued` date has a month part with CSL v1.0.2 (though CSL-M has a `has-to-month-or-season` extension).

Additionally, the following part should be modified as well but I'm not sure about the French punctuation rules. Thus it's left untouched.

https://github.com/citation-style-language/styles/blob/533890226e8abbbeb31cd63a5b1180ffc6e4870d/chicago-author-date-fr.csl#L405-L414