### PR TITLE
feat: Update jacc-cardiovascular-imaging.csl to current (2024) requirements.

### DIFF
--- a/jacc-cardiovascular-imaging.csl
+++ b/jacc-cardiovascular-imaging.csl
@@ -4,7 +4,7 @@
     <title>JACC: Cardiovascular Imaging</title>
     <title-short>JCMG</title-short>
     <id>http://www.zotero.org/styles/jacc-cardiovascular-imaging</id>
-    <link href="http://www.zotero.org/styles/styles/jacc-cardiovascular-imaging" rel="self"/>
+    <link href="http://www.zotero.org/styles/jacc-cardiovascular-imaging" rel="self"/>
     <link href="http://www.zotero.org/styles/elsevier-vancouver" rel="template"/>
     <link href="https://www.jaccsubmit-imaging.org/cgi-bin/main.plex?form_type=display_auth_instructions#refs" rel="documentation"/>
     <author>

--- a/jacc-cardiovascular-imaging.csl
+++ b/jacc-cardiovascular-imaging.csl
@@ -1,12 +1,11 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <style xmlns="http://purl.org/net/xbiblio/csl" page-range-format="minimal" class="in-text" version="1.0" demote-non-dropping-particle="sort-only" default-locale="en-US">
-  <!-- This style was edited with the Visual CSL Editor (https://editor.citationstyles.org/visualEditor/) -->
   <info>
-    <title>JACC: Cardiovascular Imaging 03 2024</title>
+    <title>JACC: Cardiovascular Imaging</title>
     <title-short>JCMG</title-short>
     <id>https://www.imagine-imaging.eu/styles/jacc-cardiovascular-imaging-03-2024</id>
-    <link href="https://www.imagine-imaging.eu/styles/jacc-cardiovascular-imaging-03-2024" rel="self"/>
-    <link href="https://www.zotero.org/styles/jacc-cardiovascular-imaging" rel="template"/>
+    <link href="https://www.imagine-imaging.eu/styles/jacc-cardiovascular-imaging" rel="self"/>
+    <link href="https://www.zotero.org/styles/elsevier-vancouver" rel="template"/>
     <link href="https://www.jaccsubmit-imaging.org/cgi-bin/main.plex?form_type=display_auth_instructions#refs" rel="documentation"/>
     <author>
       <name>Fabian Laqua</name>
@@ -17,8 +16,8 @@
     <category field="medicine"/>
     <issn>1936-878X</issn>
     <eissn>1876-7591</eissn>
-    <summary>New style for JACC: Cardiovascular Imaging - resembles AMA Style</summary>
-    <updated>2024-05-12T02:26:09+00:00</updated>
+    <summary>Style for JACC: Cardiovascular Imaging - resembles AMA Style</summary>
+    <updated>2025-07-31T10:04:24+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <macro name="access">
@@ -26,11 +25,14 @@
       <if variable="DOI">
         <text variable="DOI" prefix="https://doi.org/"/>
       </if>
-      <else-if type="webpage post-weblog" match="any">
+      <else-if type="webpage post-weblog post" match="any">
         <choose>
           <if variable="URL">
             <group delimiter=". ">
-              <date variable="accessed" prefix="Accessed " form="text"/>
+              <group delimiter=" ">
+                <text term="accessed" text-case="capitalize-first"/>
+                <date form="text" variable="accessed"/>
+              </group>
               <text variable="URL"/>
             </group>
           </if>
@@ -175,7 +177,7 @@
             <text macro="year-date"/>
           </group>
         </else-if>
-        <else-if type="webpage">
+        <else-if type="webpage post post-weblog" match="any">
           <group delimiter=" ">
             <text variable="title" form="long" suffix="."/>
             <text variable="container-title" form="long" suffix="." text-case="title"/>

--- a/jacc-cardiovascular-imaging.csl
+++ b/jacc-cardiovascular-imaging.csl
@@ -3,9 +3,9 @@
   <info>
     <title>JACC: Cardiovascular Imaging</title>
     <title-short>JCMG</title-short>
-    <id>https://www.imagine-imaging.eu/styles/jacc-cardiovascular-imaging-03-2024</id>
-    <link href="https://www.imagine-imaging.eu/styles/jacc-cardiovascular-imaging" rel="self"/>
-    <link href="https://www.zotero.org/styles/elsevier-vancouver" rel="template"/>
+    <id>http://www.zotero.org/styles/jacc-cardiovascular-imaging</id>
+    <link href="http://www.zotero.org/styles/styles/jacc-cardiovascular-imaging" rel="self"/>
+    <link href="http://www.zotero.org/styles/elsevier-vancouver" rel="template"/>
     <link href="https://www.jaccsubmit-imaging.org/cgi-bin/main.plex?form_type=display_auth_instructions#refs" rel="documentation"/>
     <author>
       <name>Fabian Laqua</name>

--- a/jacc-cardiovascular-imaging.csl
+++ b/jacc-cardiovascular-imaging.csl
@@ -59,7 +59,7 @@
     <choose>
       <if variable="issued">
         <date variable="issued">
-          <date-part name="year" form="long" range-delimiter="–"/>
+          <date-part name="year" form="long" range-delimiter="&#8211;"/>
         </date>
       </if>
       <else>

--- a/jacc-cardiovascular-imaging.csl
+++ b/jacc-cardiovascular-imaging.csl
@@ -1,35 +1,37 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <style xmlns="http://purl.org/net/xbiblio/csl" page-range-format="minimal" class="in-text" version="1.0" demote-non-dropping-particle="sort-only" default-locale="en-US">
+  <!-- This style was edited with the Visual CSL Editor (https://editor.citationstyles.org/visualEditor/) -->
   <info>
-    <title>JACC: Cardiovascular Imaging</title>
+    <title>JACC: Cardiovascular Imaging 03 2024</title>
     <title-short>JCMG</title-short>
-    <id>http://www.zotero.org/styles/jacc-cardiovascular-imaging</id>
-    <link href="http://www.zotero.org/styles/jacc-cardiovascular-imaging" rel="self"/>
-    <link href="http://www.zotero.org/styles/elsevier-vancouver" rel="template"/>
-    <link href="http://www.elsevier.com/journals/jacc-cardiovascular-imaging/1936-878X/guide-for-authors" rel="documentation"/>
+    <id>https://www.imagine-imaging.eu/styles/jacc-cardiovascular-imaging-03-2024</id>
+    <link href="https://www.imagine-imaging.eu/styles/jacc-cardiovascular-imaging-03-2024" rel="self"/>
+    <link href="https://www.zotero.org/styles/jacc-cardiovascular-imaging" rel="template"/>
+    <link href="https://www.jaccsubmit-imaging.org/cgi-bin/main.plex?form_type=display_auth_instructions#refs" rel="documentation"/>
     <author>
-      <name>Sankar</name>
-      <email>s.murugesan@elsevier.com</email>
+      <name>Fabian Laqua</name>
+      <email>fabian.laqua@imagine-imaging.eu</email>
+      <uri>www.imagine-imaging.eu</uri>
     </author>
     <category citation-format="numeric"/>
     <category field="medicine"/>
     <issn>1936-878X</issn>
     <eissn>1876-7591</eissn>
-    <summary>A style for some Elsevier journals, resembles Vancouver style</summary>
-    <updated>2015-01-08T10:00:00+00:00</updated>
+    <summary>New style for JACC: Cardiovascular Imaging - resembles AMA Style</summary>
+    <updated>2024-05-12T02:26:09+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <macro name="access">
     <choose>
       <if variable="DOI">
-        <text variable="DOI" prefix="Doi: "/>
+        <text variable="DOI" prefix="https://doi.org/"/>
       </if>
       <else-if type="webpage post-weblog" match="any">
         <choose>
           <if variable="URL">
             <group delimiter=". ">
-              <text variable="URL" prefix="Available at: "/>
               <date variable="accessed" prefix="Accessed " form="text"/>
+              <text variable="URL"/>
             </group>
           </if>
         </choose>
@@ -38,7 +40,7 @@
   </macro>
   <macro name="author">
     <names variable="author">
-      <name suffix="." form="long" initialize="true" initialize-with="" delimiter=", " delimiter-precedes-et-al="always" delimiter-precedes-last="contextual" name-as-sort-order="all" sort-separator=" "/>
+      <name delimiter-precedes-et-al="always" et-al-min="7" et-al-use-first="3" initialize-with="" name-as-sort-order="all" sort-separator=" "/>
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
@@ -55,7 +57,7 @@
     <choose>
       <if variable="issued">
         <date variable="issued">
-          <date-part name="year" form="long" range-delimiter="&#8211;"/>
+          <date-part name="year" form="long" range-delimiter="–"/>
         </date>
       </if>
       <else>
@@ -72,8 +74,8 @@
     </choose>
   </macro>
   <macro name="publisher">
-    <group delimiter="; ">
-      <group delimiter=": ">
+    <group delimiter=", ">
+      <group delimiter=":">
         <text variable="publisher-place"/>
         <text variable="publisher"/>
       </group>
@@ -91,7 +93,7 @@
       <if is-numeric="edition">
         <group delimiter=" ">
           <number variable="edition" form="ordinal"/>
-          <text term="edition" form="short"/>
+          <text term="edition"/>
         </group>
       </if>
       <else>
@@ -116,41 +118,43 @@
     <sort>
       <key variable="citation-number" sort="ascending"/>
     </sort>
-    <layout delimiter="," prefix="(" suffix=")">
-      <text variable="citation-number"/>
+    <layout vertical-align="sup" delimiter=",">
+      <text variable="citation-number" vertical-align="baseline"/>
     </layout>
   </citation>
   <bibliography entry-spacing="0" second-field-align="flush" et-al-min="7" et-al-use-first="3">
     <layout suffix=".">
-      <text variable="citation-number" suffix="."/>
-      <text macro="author" suffix=" "/>
+      <text variable="citation-number" vertical-align="baseline" suffix="."/>
+      <text macro="author" suffix=". "/>
       <choose>
         <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
           <group delimiter=". ">
-            <text variable="title" form="long"/>
+            <text variable="title" font-style="italic"/>
             <text variable="volume" prefix="vol. " form="long"/>
             <text macro="edition_book"/>
             <text macro="publisher"/>
+            <group>
+              <text variable="page" form="short" prefix=":"/>
+            </group>
           </group>
         </if>
         <else-if type="chapter paper-conference" match="any">
-          <group delimiter=". ">
+          <group>
             <group delimiter=". ">
-              <text variable="title" form="long"/>
+              <text variable="title" suffix="."/>
               <group delimiter=" ">
                 <text term="in" form="short" text-case="capitalize-first" suffix=":"/>
                 <text macro="editor"/>
               </group>
               <group delimiter=", ">
-                <text variable="container-title"/>
+                <text variable="container-title" font-style="italic" suffix=". "/>
                 <text variable="volume" form="long" prefix="vol. "/>
               </group>
               <text macro="edition_chapter"/>
             </group>
             <text macro="publisher"/>
-            <group delimiter=" ">
-              <label variable="page" form="short" plural="never"/>
-              <text variable="page" form="short"/>
+            <group vertical-align="baseline" delimiter=" ">
+              <text variable="page" form="short" prefix=":"/>
             </group>
           </group>
         </else-if>
@@ -183,7 +187,7 @@
             <group delimiter=" ">
               <group delimiter=". ">
                 <text variable="title" form="long"/>
-                <text variable="container-title" form="short" text-case="title" strip-periods="true"/>
+                <text variable="container-title" form="short" text-case="title" strip-periods="true" font-style="italic"/>
               </group>
               <group delimiter=";">
                 <text macro="year-date"/>


### PR DESCRIPTION
Since the 2015 version, JACC: Cardiovascular Imaging changed its style from Vancouver to AMA.