### PR TITLE
Update and rename elsevier-vancouver.csl to Vancouver-vith-doi.csl

### DIFF
--- a/Vancouver-vith-doi.csl
+++ b/Vancouver-vith-doi.csl
@@ -1,21 +1,21 @@
 <?xml version="1.0" encoding="utf-8"?>
 <style xmlns="http://purl.org/net/xbiblio/csl" page-range-format="minimal" class="in-text" version="1.0" demote-non-dropping-particle="sort-only" default-locale="en-US">
   <info>
-    <title>Elsevier - Vancouver</title>
+    <title>Vancouver with DOI</title>
     <id>http://www.zotero.org/styles/elsevier-vancouver</id>
     <link href="http://www.zotero.org/styles/elsevier-vancouver" rel="self"/>
     <link href="http://www.elsevier.com/journals/energy/0360-5442/guide-for-authors#68000" rel="documentation"/>
     <author>
-      <name>Richard Karnesky</name>
-      <email>karnesky+zotero@gmail.com</email>
+      <name>Richard Karnesky-adapted by Leon Stellander</name>
+      <email>karnesky+zotero@gmail.com - leonstellander@gmail.com</email>
       <uri>http://arc.nucapt.northwestern.edu/Richard_Karnesky</uri>
     </author>
     <category citation-format="numeric"/>
     <category field="generic-base"/>
-    <summary>A style for some Elsevier journals, resembles Vancouver style</summary>
-    <updated>2019-10-15T22:06:38+00:00</updated>
+    <summary>Vancouver style adapted from Elsevier-Vancouver by Richard Karnesky to include DOI. Square brackets are replaced with parentheses for references</summary>
+    <updated>2024-05-13T22:06:38+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
-  </info>
+ </info>
   <macro name="author">
     <names variable="author">
       <name initialize-with="" delimiter=", " delimiter-precedes-last="always" name-as-sort-order="all" sort-separator=" "/>
@@ -84,13 +84,13 @@
     <sort>
       <key variable="citation-number"/>
     </sort>
-    <layout prefix="[" suffix="]" delimiter=",">
+    <layout prefix="(" suffix=")" delimiter=",">
       <text variable="citation-number"/>
     </layout>
   </citation>
   <bibliography entry-spacing="0" second-field-align="flush" et-al-min="7" et-al-use-first="6">
     <layout suffix=".">
-      <text variable="citation-number" prefix="[" suffix="]"/>
+      <text variable="citation-number" prefix="" suffix="."/>
       <text macro="author" suffix=". "/>
       <choose>
         <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
@@ -161,3 +161,4 @@
     </layout>
   </bibliography>
 </style>
+


### PR DESCRIPTION
Elsevier Vancouver was used as a template for creating a Classic Vancouver referencing style including DOI. 

Changes include:
- Parentheses instead of square brackets for in-text referencing. Ex.
... this is a text [1].
to
... this is a text (1).

- Period instead of square brackets in bibliography. Ex.
[1] Article 1
[2] Article 2
to
1. Article 1
2. Article 2