### PR TITLE
Update society-for-american-archaeology.csl

### DIFF
--- a/society-for-american-archaeology.csl
+++ b/society-for-american-archaeology.csl
@@ -26,6 +26,10 @@
       <name>Erik Marsh</name>
       <email>erik.marsh@gmail.com</email>
     </contributor>
+    <contributor>
+      <name>Teodor Sandu</name>
+      <email>t.sandu@elsevier.com</email>
+    </contributor>
     <category citation-format="author-date"/>
     <category field="anthropology"/>
     <updated>2022-02-22T08:50:31+00:00</updated>

--- a/society-for-american-archaeology.csl
+++ b/society-for-american-archaeology.csl
@@ -360,7 +360,7 @@
       </group>
     </layout>
   </citation>
-  <bibliography subsequent-author-substitute="" entry-spacing="0" line-spacing="2">
+  <bibliography subsequent-author-substitute="" entry-spacing="1" line-spacing="2">
     <sort>
       <key macro="contributors"/>
       <key variable="issued"/>


### PR DESCRIPTION
Added bibliography entry spacing as per style guidelines:
https://library.cms.ok.ubc.ca/wp-content/uploads/sites/116/2019/08/SAA_Citation_Style_2018Rev1.pdf
https://swaa-anthro.org/wp-content/uploads/2021/03/SAA-citation-guide-2021.pdf
https://libguides.willamette.edu/citationguides/saa

As you can see, bibliography entries are all separated by a blank line, which was missing from this CSL definition. Thank you!