### PR TITLE
Add `executive-producer` to apa.csl

### DIFF
--- a/apa.csl
+++ b/apa.csl
@@ -83,7 +83,7 @@
     </terms>
   </locale>
   <!-- TODO: New types: classic collection document event hearing performance periodical regulation -software- standard -->
-  <!-- TODO: New creator roles: chair compiler contributor curator executive-producer guest host narrator organizer performer producer script-writer series-creator -->
+  <!-- TODO: New creator roles: chair compiler contributor curator guest host narrator organizer performer producer script-writer series-creator -->
   <!-- TODO: New variables:
          available-date submitted
          part-number printing-number supplement-number
@@ -125,6 +125,10 @@
         <names variable="author"/>
         <names variable="illustrator"/>
         <names variable="director">
+          <name name-as-sort-order="all" and="symbol" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
+          <label form="long" prefix=" (" suffix=")" text-case="title"/>
+        </names>
+        <names variable="executive-producer">
           <name name-as-sort-order="all" and="symbol" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
           <label form="long" prefix=" (" suffix=")" text-case="title"/>
         </names>
@@ -213,6 +217,7 @@
             <names variable="author"/>
             <names variable="illustrator"/>
             <names variable="director"/>
+            <names variable="executive-producer"/>
             <choose>
               <if variable="container-title">
                 <choose>
@@ -412,7 +417,7 @@
         <choose>
           <if type="bill report" match="any">
             <!-- Bills, resolutions, and congressional reports are not italicized and substitute bill number if no title. -->
-            <!-- Can't distinguish congressional reports from other reports, 
+            <!-- Can't distinguish congressional reports from other reports,
                  but giving the genre and number seems fine for other reports too. -->
             <text macro="number"/>
             <text macro="bracketed"/>
@@ -490,7 +495,7 @@
     <choose>
       <if type="bill report">
         <!-- Bills, resolutions, and congressional reports are not italicized and substitute bill number if no title. -->
-        <!-- Can't distinguish congressional reports from other reports, 
+        <!-- Can't distinguish congressional reports from other reports,
              but giving the genre and number seems fine for other reports too. -->
         <choose>
           <if variable="title">
@@ -1024,6 +1029,10 @@
                   <name and="symbol" initialize-with=". " delimiter=", "/>
                   <label form="short" prefix=", " text-case="title"/>
                 </names>
+                <names variable="executive-producer" delimiter="; ">
+                  <name and="symbol" initialize-with=". " delimiter=", "/>
+                  <label form="long" prefix=", " text-case="title"/>
+                </names>
               </group>
             </if>
           </choose>
@@ -1345,6 +1354,10 @@
               <label form="short" text-case="title" prefix=" (" suffix=")"/>
               <substitute>
                 <names variable="editorial-director"/>
+                <names variable="executive-producer">
+                  <name and="symbol" initialize-with=". " delimiter=", "/>
+                  <label form="long" text-case="title" prefix=" (" suffix=")"/>
+                </names>
                 <names variable="collection-editor"/>
                 <names variable="container-author"/>
               </substitute>
@@ -1518,16 +1531,16 @@
         <if type="treaty">
           <group delimiter=", " suffix=".">
             <!-- APA generally defers to Bluebook for legal citations, but diverges without
-                explanation for treaty items. We follow the Bluebook format that was used 
+                explanation for treaty items. We follow the Bluebook format that was used
                 in APA 6th ed. -->
-            <!-- APA manual omits treaty parties/authors, but per Bluebook 
+            <!-- APA manual omits treaty parties/authors, but per Bluebook
                 they should be included at least for bilateral treaties. -->
             <names variable="author">
               <name initialize-with="." form="short" delimiter="-"/>
             </names>
             <text macro="date-legal"/>
-            <!-- APA manual omits treaty source/report called for by Bluebook in favor of just URL. 
-                Both are included here, following the APA style used for all other item types 
+            <!-- APA manual omits treaty source/report called for by Bluebook in favor of just URL.
+                Both are included here, following the APA style used for all other item types
                 to end the reference with a period, then give the URL afterward. -->
             <text macro="container-legal"/>
           </group>
@@ -1553,7 +1566,7 @@
         <text variable="title" text-case="title"/>
       </if>
       <else-if type="hearing">
-        <!-- APA uses a comma delimiter and omits "hearing before the" for hearings with testimony, 
+        <!-- APA uses a comma delimiter and omits "hearing before the" for hearings with testimony,
              but follows Bluebook rules (colon delimiter, prefix before the committee name) for
              references to the whole hearing. We simply follow the Bluebook rules for both, but
              use APA style capitalization (not capitalizing "Before" or the title of the hearing). -->
@@ -1609,14 +1622,14 @@
           </group>
           <choose>
             <if variable="issued">
-              <!-- APA manual includes "rev." before the revision year, 
+              <!-- APA manual includes "rev." before the revision year,
                    but this isn't part of the Bluebook rules. -->
               <date variable="issued">
                 <date-part name="year"/>
               </date>
             </if>
             <else>
-              <!-- Show proposal date for uncodified regualtions. 
+              <!-- Show proposal date for uncodified regualtions.
                    Assume date is entered literally ala "proposed May 23, 2016".
                    TODO: Add 'proposed' term here if that becomes available -->
               <date variable="submitted" form="text"/>


### PR DESCRIPTION
This is an attempt to implement the new `executive-producer` name variable in APA so that citations for TV episodes and series can use this variable. All questions and feedback are appreciated! I'm also not sure what is correct in APA for TV episodes without a director/writer listed (but with an executive producer) — see more details in my third example under "TV episodes" below.

Sources I used:
- [This page](https://apastyle.apa.org/style-grammar-guidelines/references/examples/film-television-references) on the official APA Style website
- Section 10.12 of the 7th edition of the _Publication Manual of the American Psychological Association_ (pages 341–3)

Below are some sample renderings using my modified CSL in Zotero.

### TV series

TV series with executive producer:
<img width="932" alt="Screenshot 2024-05-21 at 10 56 23" src="https://github.com/citation-style-language/styles/assets/24906038/d8fa3d2d-408f-402f-afff-95963d0f7ce2">

TV series without executive producer:
<img width="937" alt="Screenshot 2024-05-21 at 10 51 20" src="https://github.com/citation-style-language/styles/assets/24906038/c0732559-7f91-4dbd-a005-1ae52b434ed7">

### TV episodes

TV episode with director, series name, and executive producer:
<img width="932" alt="Screenshot 2024-05-21 at 08 38 52" src="https://github.com/citation-style-language/styles/assets/24906038/9c77e961-d43f-429c-bff3-41f20a0f5824">

TV episode or series with director and executive producer, but no series name (\*I couldn't find a source for this in the APA guide, but it seems reasonable and is incorrect / an edgecase anyway):
<img width="936" alt="Screenshot 2024-05-21 at 08 39 25" src="https://github.com/citation-style-language/styles/assets/24906038/dd8b0a6e-6cb9-4391-8285-318047faea4d">

TV episode with executive producer and series name, but no director (\*I also couldn't find a source for this, so I'm not 100% sure this is correct. Maybe the episode title should go first and be in the in-text cites instead of the executive producer? I can change it if anyone knows which is correct):
<img width="935" alt="Screenshot 2024-05-21 at 08 41 35" src="https://github.com/citation-style-language/styles/assets/24906038/38d7f35f-65cb-4841-80cf-f26e58b42cca">