### PR TITLE
Update Journal of Rheumatology

### DIFF
--- a/journal-of-rheumatology.csl
+++ b/journal-of-rheumatology.csl
@@ -5,7 +5,7 @@
     <id>http://www.zotero.org/styles/journal-of-rheumatology</id>
     <link href="http://www.zotero.org/styles/journal-of-rheumatology" rel="self"/>
     <link href="http://www.zotero.org/styles/vancouver" rel="template"/>
-    <link href="http://www.jrheum.com/guideforauthors.html#References" rel="documentation"/>
+    <link href="https://www.jrheum.org/guideforauthors#references" rel="documentation"/>
     <author>
       <name>Charles Parnot</name>
       <email>charles.parnot@gmail.com</email>

--- a/journal-of-rheumatology.csl
+++ b/journal-of-rheumatology.csl
@@ -15,7 +15,7 @@
     <category field="medicine"/>
     <issn>0315-162X</issn>
     <eissn>1499-2752</eissn>
-    <updated>2014-07-09T12:00:00+00:00</updated>
+    <updated>2024-06-09T12:00:00+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale xml:lang="en">
@@ -264,7 +264,7 @@
       <text variable="citation-number"/>
     </layout>
   </citation>
-  <bibliography et-al-min="7" et-al-use-first="6" second-field-align="flush">
+  <bibliography et-al-min="7" et-al-use-first="3" second-field-align="flush">
     <layout>
       <text variable="citation-number" suffix=". "/>
       <group delimiter=". " suffix=". ">


### PR DESCRIPTION
This PR updates the link for JRheum's reference guide and changes the number of authors before et al., as per the current [style guideline.](https://www.jrheum.org/guideforauthors#references)

> **Examples of correct forms of references are given below:**  
**Standard Journal Article.** (When 7 or more authors, list 3 and add “et al”.) Morrisroe K, Stevens W, Sahhar J, et al. The clinical and economic burden of systemic sclerosis related interstitial lung disease. Rheumatology 2020;59:1878-88.