### PR TITLE
Update american-physics-society.csl

### DIFF
--- a/american-physics-society.csl
+++ b/american-physics-society.csl
@@ -193,7 +193,7 @@
         <else>
           <!--article-journal article-magazine article-newspaper review review-book-->
           <group delimiter=", ">
-            <text variable="title" text-case="title" font-style="italic"/>
+            <text variable="title"/>
             <group delimiter=" ">
               <text variable="container-title" form="short" text-case="title"/>
               <group delimiter=", ">


### PR DESCRIPTION
Fix title handling for APS, seehttps://forums.zotero.org/discussion/115101/aps-translators-article-titles-should-not-be-in-italic#latest

(Leaving everything but articles as is, based on unclear guidance and existing examples)