### PR TITLE
Update journal-of-threatened-taxa.csl

### DIFF
--- a/journal-of-threatened-taxa.csl
+++ b/journal-of-threatened-taxa.csl
@@ -12,7 +12,7 @@
       <email>citationstyler@gmail.com</email>
     </author>
     <author>
-    	<name>Aakash Singh Bais</name>
+      <name>Aakash Singh Bais</name>
     </author>
     <category citation-format="author-date"/>
     <category field="biology"/>

--- a/journal-of-threatened-taxa.csl
+++ b/journal-of-threatened-taxa.csl
@@ -11,11 +11,14 @@
       <name>Patrick O'Brien, PhD</name>
       <email>citationstyler@gmail.com</email>
     </author>
+    <author>
+    	<name>Aakash Singh Bais</name>
+    </author>
     <category citation-format="author-date"/>
     <category field="biology"/>
     <issn>0974-7893</issn>
     <eissn>0974-7907</eissn>
-    <updated>2019-08-06T10:28:38+00:00</updated>
+    <updated>2024-06-23T03:16:13+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale xml:lang="en">
@@ -69,6 +72,17 @@
   <macro name="author">
     <names variable="author">
       <name and="symbol" initialize-with="." name-as-sort-order="all"/>
+      <label form="short" text-case="capitalize-first" prefix=" (" suffix=")"/>
+      <substitute>
+        <names variable="editor"/>
+        <names variable="translator"/>
+        <text macro="title"/>
+      </substitute>
+    </names>
+  </macro>
+  <macro name="author-bib">
+    <names variable="author">
+      <name and="symbol" initialize-with="." name-as-sort-order="first"/>
       <label form="short" text-case="capitalize-first" prefix=" (" suffix=")"/>
       <substitute>
         <names variable="editor"/>
@@ -631,6 +645,7 @@
     <layout prefix="(" suffix=")" delimiter="; ">
       <group>
         <text macro="author-short"/>
+        <text value=", "/>
         <text macro="issued-year"/>
         <text macro="citation-locator"/>
       </group>
@@ -646,7 +661,7 @@
       <group>
         <group>
           <group font-weight="bold" delimiter=" ">
-            <text macro="author"/>
+            <text macro="author-bib"/>
             <text macro="issued" prefix="(" suffix="). "/>
           </group>
           <text macro="title-plus-extra"/>


### PR DESCRIPTION
Subsequent author names in Bibliography (after the fist author name) should have name followed by surname. Currently this is the reverse way. Also, a comma followed by a space (", ") should precede the year in in-text citations. This CSL file is thus being updated.