### PR TITLE
Update glossa.csl author order and locale

### DIFF
--- a/glossa.csl
+++ b/glossa.csl
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" demote-non-dropping-particle="never" default-locale="en-GB">
+<style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" demote-non-dropping-particle="never" default-locale="en-US">
   <info>
     <title>Glossa</title>
     <id>http://www.zotero.org/styles/glossa</id>
@@ -39,11 +39,11 @@
       <if type="chapter paper-conference entry-dictionary entry-encyclopedia" match="any">
         <group delimiter=", ">
           <names variable="container-author" delimiter=", ">
-            <name initialize-with=". " delimiter=" &amp; " delimiter-precedes-last="always"/>
+            <name initialize-with=". " delimiter=" &amp; " delimiter-precedes-last="always" name-as-sort-order="all"/>
             <label form="short" prefix=" (" text-case="title" suffix=")"/>
           </names>
           <names variable="editor translator" delimiter=", ">
-            <name delimiter=" &amp; " delimiter-precedes-last="always"/>
+            <name delimiter=" &amp; " delimiter-precedes-last="always" name-as-sort-order="all"/>
             <label form="short" prefix=" (" suffix=")"/>
           </names>
         </group>
@@ -55,11 +55,11 @@
       <if type="article-journal chapter paper-conference entry-dictionary entry-encyclopedia" match="none">
         <group delimiter=", " prefix=" (" suffix=")">
           <names variable="container-author" delimiter=", ">
-            <name initialize-with=". " delimiter=" &amp; " delimiter-precedes-last="always"/>
+            <name initialize-with=". " delimiter=" &amp; " delimiter-precedes-last="always" name-as-sort-order="all"/>
             <label form="short" prefix=", " text-case="title"/>
           </names>
           <names variable="editor translator" delimiter=", ">
-            <name initialize-with=". " delimiter=" &amp; " delimiter-precedes-last="always"/>
+            <name initialize-with=". " delimiter=" &amp; " delimiter-precedes-last="always" name-as-sort-order="all"/>
             <label form="short" prefix=", " text-case="title"/>
           </names>
         </group>
@@ -68,7 +68,7 @@
   </macro>
   <macro name="author">
     <names variable="author" suffix=".">
-      <name delimiter=" &amp; " delimiter-precedes-last="always" initialize="false" initialize-with="." name-as-sort-order="all"/>
+      <name delimiter=" &amp; " delimiter-precedes-last="always" initialize="false" name-as-sort-order="all"/>
       <label form="short" prefix=" (" suffix=")"/>
       <substitute>
         <names variable="editor"/>
@@ -87,7 +87,7 @@
   </macro>
   <macro name="author-short">
     <names variable="author">
-      <name form="short" delimiter=" &amp; " delimiter-precedes-last="always" initialize-with=". "/>
+      <name form="short" delimiter=" &amp; " delimiter-precedes-last="always" initialize-with=". " name-as-sort-order="all"/>
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>


### PR DESCRIPTION
add name-as-sort-order="all" to all author/editor categories as requested by Glossa editor to fix name ordering errors with edited volumes. change default locale to US.