### PR TITLE
Fix `publisher` macro for Swinburne Harvard

### DIFF
--- a/harvard-swinburne-university-of-technology.csl
+++ b/harvard-swinburne-university-of-technology.csl
@@ -16,6 +16,9 @@
     <contributor>
       <name>Kiran Castellino</name>
     </contributor>
+    <contributor>
+      <name>Duale Siad</name>
+    </contributor>
     <category citation-format="author-date"/>
     <category field="generic-base"/>
     <summary>The version of the Harvard author-date style used by Swinburne University of Technology, Australia</summary>
@@ -97,10 +100,14 @@
     </choose>
   </macro>
   <macro name="publisher">
-    <group delimiter=", ">
-      <text variable="publisher"/>
-      <text variable="publisher-place"/>
-    </group>
+    <choose>
+      <if type="book">
+        <group delimiter=", ">
+          <text variable="publisher"/>
+          <text variable="publisher-place"/>
+        </group>
+      </if>
+    </choose>
   </macro>
   <macro name="year-date">
     <choose>


### PR DESCRIPTION
According to the [brief guide](https://www.swinburne.edu.au/downloads/Swinbure-Harvard-brief-guide-01092021.pdf) listed on the [Swinburne Harvard page](https://www.swinburne.edu.au/library/search/referencing-guides/harvard-style-guide/), publisher information must only be listed if the citation is of an e-book.

Closes #7110