### PR TITLE
Create european-environment-agency-numeric

### DIFF
--- a/european-environment-agency-numeric
+++ b/european-environment-agency-numeric
@@ -1,0 +1,362 @@
+<?xml version="1.0" encoding="utf-8"?>
+<style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" demote-non-dropping-particle="never" page-range-format="expanded" default-locale="en-GB">
+  <info>
+    <title>European Environment Agency numeric</title>
+    <title-short>EEA numeric</title-short>
+    <id>http://www.zotero.org/styles/eea-numeric</id>
+    <link href="http://www.zotero.org/styles/eea-numeric" rel="self"/>
+    <link href="https://www.eea.europa.eu/about-us/documents/eea-writing-manual.pdf" rel="documentation"/>
+    <author>
+      <name>Prepress Projects Ltd</name>
+      <email>xml-development@prepress-projects.co.uk</email>
+    </author>
+    <category citation-format="numeric"/>
+    <category field="science"/>
+    <summary>European Environment Agency style with numbered references</summary>
+    <updated>2024-06-27T12:14:36+00:00</updated>
+    <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
+  </info>
+  <locale xml:lang="en-US">
+    <terms>
+      <term name="editor" form="short">
+        <single>ed.</single>
+        <multiple>eds</multiple>
+      </term>
+      <term name="page-range-delimiter">-</term>
+      <term name="open-quote">‘</term>
+      <term name="close-quote">’</term>
+      <term name="open-inner-quote">“</term>
+      <term name="close-inner-quote">”</term>
+      <term name="no date">undated</term>
+      <term name="in press">forthcoming</term>
+    </terms>
+  </locale>
+  <locale xml:lang="en-UK">
+    <terms>
+      <term name="editor" form="short">
+        <single>ed.</single>
+        <multiple>eds</multiple>
+      </term>
+      <term name="page-range-delimiter">-</term>
+      <term name="open-quote">‘</term>
+      <term name="close-quote">’</term>
+      <term name="open-inner-quote">“</term>
+      <term name="close-inner-quote">”</term>
+      <term name="no date">undated</term>
+      <term name="in press">forthcoming</term>
+    </terms>
+  </locale>
+  <macro name="editor">
+    <names variable="editor" delimiter=", ">
+      <name and="text" initialize-with=". " name-as-sort-order="all"/>
+      <label form="short" text-case="lowercase" prefix=" (" suffix=")"/>
+    </names>
+  </macro>
+  <macro name="author">
+    <names variable="author">
+      <name and="text" delimiter-precedes-et-al="always" delimiter-precedes-last="never" et-al-min="3" et-al-use-first="1" initialize-with=". " name-as-sort-order="all"/>
+      <label form="short" text-case="lowercase" strip-periods="true" prefix=", " suffix="."/>
+      <substitute>
+        <names variable="editor"/>
+        <text macro="editor"/>
+      </substitute>
+    </names>
+  </macro>
+  <macro name="author-short">
+    <names variable="author">
+      <name form="short" and="text" et-al-min="3" initialize-with=". "/>
+      <substitute>
+        <names variable="editor"/>
+        <names variable="translator"/>
+        <text variable="title"/>
+      </substitute>
+    </names>
+  </macro>
+  <macro name="access">
+    <choose>
+      <if variable="URL">
+        <group delimiter=" ">
+          <text variable="URL" prefix="(" suffix=")"/>
+          <group>
+            <text term="accessed" text-case="lowercase" suffix=" "/>
+            <date variable="accessed">
+              <date-part name="day" suffix=" "/>
+              <date-part name="month" suffix=" "/>
+              <date-part name="year"/>
+            </date>
+          </group>
+        </group>
+      </if>
+    </choose>
+  </macro>
+  <macro name="title">
+    <choose>
+      <if type="book graphic legal_case motion_picture report song" match="any">
+        <text variable="title" font-style="italic"/>
+      </if>
+      <else>
+        <text variable="title" quotes="false"/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="publisher">
+    <group delimiter=", ">
+      <text variable="publisher"/>
+      <text variable="publisher-place"/>
+    </group>
+  </macro>
+  <macro name="year-date">
+    <group>
+      <choose>
+        <if variable="issued">
+          <date variable="issued">
+            <date-part name="year"/>
+          </date>
+        </if>
+        <else>
+          <text term="in press"/>
+        </else>
+      </choose>
+    </group>
+  </macro>
+  <macro name="edition">
+    <choose>
+      <if is-numeric="edition">
+        <group delimiter=" ">
+          <number variable="edition" form="ordinal"/>
+          <text term="edition" form="short" strip-periods="true"/>
+        </group>
+      </if>
+      <else>
+        <text variable="edition"/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="citation-locator">
+    <choose>
+      <if match="any" locator="chapter">
+        <text variable="locator" prefix="Chapter "/>
+      </if>
+      <else-if match="any" locator="figure">
+        <text variable="locator" prefix="Figure "/>
+      </else-if>
+      <else-if match="any" locator="page">
+        <label variable="locator" form="short" plural="contextual" suffix=" "/>
+        <text variable="locator"/>
+      </else-if>
+      <else-if match="any" locator="section">
+        <text variable="locator" prefix="section "/>
+      </else-if>
+      <else>
+        <text variable="locator"/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="page">
+    <label variable="page" form="short" plural="contextual" suffix=" "/>
+    <text variable="page"/>
+  </macro>
+  <macro name="report-data">
+    <choose>
+      <if variable="genre">
+        <text variable="genre"/>
+      </if>
+      <else-if variable="collection-title">
+        <text variable="collection-title"/>
+      </else-if>
+    </choose>
+  </macro>
+  <macro name="legislation-number">
+    <choose>
+      <if variable="container-title">
+        <text variable="container-title"/>
+      </if>
+      <else-if variable="volume">
+        <text variable="volume"/>
+      </else-if>
+      <else-if variable="number">
+        <text variable="number"/>
+      </else-if>
+    </choose>
+  </macro>
+  <citation>
+    <sort>
+      <key variable="citation-number"/>
+    </sort>
+    <layout delimiter="," vertical-align="sup">
+      <text variable="citation-number"/>
+      <group prefix="(" suffix=")">
+        <label variable="locator" form="short" strip-periods="true"/>
+        <text variable="locator"/>
+      </group>
+    </layout>
+  </citation>
+  <bibliography hanging-indent="false" et-al-min="3" et-al-use-first="1" second-field-align="flush">
+    <layout suffix=".">
+      <text variable="citation-number" suffix="."/>
+      <text macro="author" suffix=", "/>
+      <date variable="issued" suffix=", ">
+        <date-part name="year"/>
+      </date>
+      <choose>
+        <if type="article-newspaper article-magazine" match="any">
+          <group delimiter=", ">
+            <text variable="title" quotes="true"/>
+            <text variable="container-title" font-style="italic"/>
+            <date form="text" variable="issued">
+              <date-part name="day"/>
+              <date-part name="month"/>
+              <date-part name="year"/>
+            </date>
+            <text variable="publisher-place"/>
+          </group>
+          <text macro="access" prefix=" "/>
+        </if>
+        <else-if type="article-journal" match="any">
+          <group delimiter=" " prefix=" " suffix=",">
+            <text macro="title" quotes="true"/>
+            <text macro="editor"/>
+          </group>
+          <group prefix=" ">
+            <text variable="container-title" font-style="italic"/>
+            <group prefix=" ">
+              <text variable="volume"/>
+              <text variable="issue" prefix="(" suffix=")"/>
+            </group>
+            <text macro="page" prefix=", "/>
+            <text variable="DOI" prefix=" (DOI: " suffix=")"/>
+          </group>
+        </else-if>
+        <else-if type="bill legislation" match="any">
+          <group delimiter=" " prefix=" " suffix=".">
+            <text variable="title"/>
+            <text macro="legislation-number" prefix=" (" suffix=")"/>
+          </group>
+        </else-if>
+        <else-if type="book" match="any">
+          <text macro="title" prefix=" " suffix=","/>
+          <group delimiter=" " prefix=" ">
+            <text macro="publisher"/>
+          </group>
+        </else-if>
+        <else-if type="chapter" match="any">
+          <text macro="title" quotes="true" suffix=","/>
+          <group delimiter=" " prefix=" ">
+            <text term="in" text-case="lowercase" suffix=":"/>
+            <text macro="editor" suffix=","/>
+            <text variable="container-title" font-style="italic" suffix=","/>
+            <text variable="collection-title" suffix=","/>
+            <group>
+              <text macro="publisher"/>
+              <text macro="page" prefix=", " text-case="lowercase"/>
+            </group>
+          </group>
+        </else-if>
+        <else-if type="entry-encyclopedia" match="any">
+          <text macro="title" quotes="true"/>
+          <group>
+            <text variable="volume" prefix=" " suffix=" "/>
+            <text variable="container-title" font-style="italic" suffix=", "/>
+            <text macro="publisher"/>
+          </group>
+        </else-if>
+        <else-if type="paper-conference" match="any">
+          <choose>
+            <if match="all" variable="event container-title">
+              <group delimiter=", ">
+                <text variable="title" quotes="true"/>
+                <text variable="event" prefix="conference paper presented at: "/>
+                <text variable="event-place"/>
+                <date form="text" date-parts="year-month-day" variable="issued">
+                  <date-part name="day"/>
+                  <date-part name="month"/>
+                  <date-part name="year"/>
+                </date>
+              </group>
+            </if>
+            <else>
+              <group delimiter=", ">
+                <text variable="title" quotes="true"/>
+                <text variable="container-title"/>
+                <text variable="event" prefix="conference paper presented at: "/>
+                <text variable="event-place"/>
+                <date form="text" date-parts="year-month-day" variable="issued">
+                  <date-part name="day"/>
+                  <date-part name="month"/>
+                  <date-part name="year"/>
+                </date>
+              </group>
+            </else>
+          </choose>
+        </else-if>
+        <else-if type="report">
+          <group delimiter=" ">
+            <group delimiter=", ">
+              <text macro="title"/>
+              <group delimiter=" ">
+                <text macro="report-data"/>
+                <text variable="number" prefix="No "/>
+              </group>
+              <text macro="publisher"/>
+            </group>
+            <text macro="access"/>
+          </group>
+        </else-if>
+        <else-if type="article">
+          <group delimiter=" ">
+            <group delimiter=", ">
+              <text macro="title" quotes="true"/>
+              <text macro="publisher"/>
+            </group>
+            <text macro="access"/>
+          </group>
+        </else-if>
+        <else-if type="speech" match="any">
+          <group delimiter=", ">
+            <text variable="title" quotes="true"/>
+            <text variable="event" prefix="presentation given at: "/>
+            <text variable="event-place"/>
+            <date form="text" date-parts="year-month-day" variable="issued">
+              <date-part name="day"/>
+              <date-part name="month"/>
+              <date-part name="year"/>
+            </date>
+          </group>
+        </else-if>
+        <else-if type="webpage post-weblog" match="any">
+          <group delimiter=" ">
+            <group delimiter=", ">
+              <text variable="title" quotes="true"/>
+              <text variable="container-title"/>
+            </group>
+            <text macro="access" prefix=" "/>
+          </group>
+        </else-if>
+        <else>
+          <group delimiter=", ">
+            <text macro="title"/>
+            <choose>
+              <if match="any" variable="container-title">
+                <text variable="container-title" suffix="."/>
+              </if>
+            </choose>
+            <text macro="edition"/>
+            <group delimiter=" ">
+              <choose>
+                <if match="any" variable="genre">
+                  <text variable="genre"/>
+                </if>
+                <else-if match="any" variable="collection-title">
+                  <text variable="collection-title"/>
+                </else-if>
+              </choose>
+              <text variable="number"/>
+              <text macro="access"/>
+            </group>
+            <text macro="publisher" prefix=" "/>
+          </group>
+        </else>
+      </choose>
+    </layout>
+  </bibliography>
+</style>


### PR DESCRIPTION
This is an alternative style for references in European Environment Agency reports, with numeric citations instead of author–date citations, to be used in specific reports when requested by the European Environment Agency.