### PR TITLE
Temporarily fix missing delimiter when both writer(s) and director(s) are listed

### DIFF
--- a/apa-annotated-bibliography.csl
+++ b/apa-annotated-bibliography.csl
@@ -185,8 +185,11 @@
               </choose>
             </if>
           </choose>
-          <!-- TODO: Replace `delimiter` with `collapse` to combine names variables when that becomes available. -->
-          <names variable="series-creator executive-producer" delimiter=", &amp; ">
+          <names variable="executive-producer">
+            <name name-as-sort-order="all" and="symbol" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
+            <label form="long" prefix=" (" suffix=")" text-case="title"/>
+          </names>
+          <names variable="series-creator">
             <name name-as-sort-order="all" and="symbol" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
             <label form="long" prefix=" (" suffix=")" text-case="title"/>
           </names>
@@ -310,8 +313,8 @@
                 </choose>
               </if>
             </choose>
-            <!-- TODO: Replace `delimiter` with `collapse` to combine names variables when that becomes available. -->
-            <names variable="series-creator executive-producer" delimiter=", &amp; "/>
+            <names variable="executive-producer"/>
+            <names variable="series-creator"/>
             <names variable="editor"/>
             <names variable="editorial-director"/>
             <names variable="compiler"/>
@@ -1559,10 +1562,11 @@
             </else>
           </choose>
           <group delimiter=", ">
-            <names variable="series-creator executive-producer" delimiter=", &amp; ">
+            <names variable="executive-producer">
               <name and="symbol" initialize-with=". " delimiter=", "/>
               <label form="long" text-case="title" prefix=" (" suffix=")"/>
               <substitute>
+                <names variable="series-creator"/>
                 <names variable="editor-translator">
                   <name and="symbol" initialize-with=". " delimiter=", "/>
                   <label form="short" text-case="title" prefix=" (" suffix=")"/>

--- a/apa-annotated-bibliography.csl
+++ b/apa-annotated-bibliography.csl
@@ -140,8 +140,17 @@
           <!-- Note: `narrator` only cited in secondary-contributors -->
           <names variable="illustrator"/>
           <!-- TODO: Replace `delimiter` with `collapse` to combine names variables when that becomes available. -->
-          <names variable="script-writer director" delimiter=", &amp; ">
-            <!-- Note: Actors/performers and producers [not executive] not cited in APA style. -->
+          <choose>
+            <if type="broadcast">
+              <names variable="script-writer director" delimiter=", &amp; ">
+                <!-- Note: Actors/performers and producers [not executive] not cited in APA style. -->
+                <name name-as-sort-order="all" and="symbol" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
+                <label form="long" prefix=" (" suffix=")" text-case="title"/>
+              </names>
+            </if>
+          </choose>
+          <names variable="director">
+            <!-- For non-broadcast items, APA only cites directors and not writers. -->
             <name name-as-sort-order="all" and="symbol" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
             <label form="long" prefix=" (" suffix=")" text-case="title"/>
           </names>
@@ -283,7 +292,12 @@
             <names variable="author"/>
             <names variable="illustrator"/>
             <!-- TODO: Replace `delimiter` with `collapse` to combine names variables when that becomes available. -->
-            <names variable="script-writer director" delimiter=", &amp; "/>
+            <choose>
+              <if type="broadcast">
+                <names variable="script-writer director" delimiter=", &amp; "/>
+              </if>
+            </choose>
+            <names variable="director"/>
             <!-- TODO: Replace `delimiter` with `collapse` to combine names variables when that becomes available. -->
             <names variable="guest host" delimiter=", &amp; "/>
             <names variable="producer"/>

--- a/apa-annotated-bibliography.csl
+++ b/apa-annotated-bibliography.csl
@@ -139,12 +139,14 @@
           <names variable="author"/>
           <!-- Note: `narrator` only cited in secondary-contributors -->
           <names variable="illustrator"/>
-          <names variable="script-writer director">
+          <!-- TODO: Replace `delimiter` with `collapse` to combine names variables when that becomes available. -->
+          <names variable="script-writer director" delimiter=", &amp; ">
             <!-- Note: Actors/performers and producers [not executive] not cited in APA style. -->
             <name name-as-sort-order="all" and="symbol" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
             <label form="long" prefix=" (" suffix=")" text-case="title"/>
           </names>
-          <names variable="guest host">
+          <!-- TODO: Replace `delimiter` with `collapse` to combine names variables when that becomes available. -->
+          <names variable="guest host" delimiter=", &amp; ">
             <name name-as-sort-order="all" and="symbol" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
             <label form="long" prefix=" (" suffix=")" text-case="title"/>
           </names>
@@ -174,17 +176,18 @@
               </choose>
             </if>
           </choose>
-          <names variable="series-creator executive-producer">
+          <!-- TODO: Replace `delimiter` with `collapse` to combine names variables when that becomes available. -->
+          <names variable="series-creator executive-producer" delimiter=", &amp; ">
             <name name-as-sort-order="all" and="symbol" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
             <label form="long" prefix=" (" suffix=")" text-case="title"/>
           </names>
-          <names variable="editor-translator" delimiter=", ">
+          <names variable="editor-translator">
             <name name-as-sort-order="all" and="symbol" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
             <label form="short" prefix=" (" suffix=")" text-case="title"/>
           </names>
           <!-- TODO: Split editor and translator into separate lines once processors begin to automatically create
                the editor-translator variable. -->
-          <names variable="editor translator" delimiter=", ">
+          <names variable="editor translator" delimiter=", &amp; ">
             <name name-as-sort-order="all" and="symbol" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
             <label form="short" prefix=" (" suffix=")" text-case="title"/>
           </names>
@@ -279,8 +282,10 @@
           <substitute>
             <names variable="author"/>
             <names variable="illustrator"/>
-            <names variable="script-writer director"/>
-            <names variable="guest host"/>
+            <!-- TODO: Replace `delimiter` with `collapse` to combine names variables when that becomes available. -->
+            <names variable="script-writer director" delimiter=", &amp; "/>
+            <!-- TODO: Replace `delimiter` with `collapse` to combine names variables when that becomes available. -->
+            <names variable="guest host" delimiter=", &amp; "/>
             <names variable="producer"/>
             <choose>
               <if variable="container-title">
@@ -291,7 +296,8 @@
                 </choose>
               </if>
             </choose>
-            <names variable="series-creator executive-producer"/>
+            <!-- TODO: Replace `delimiter` with `collapse` to combine names variables when that becomes available. -->
+            <names variable="series-creator executive-producer" delimiter=", &amp; "/>
             <names variable="editor"/>
             <names variable="editorial-director"/>
             <names variable="compiler"/>
@@ -1549,7 +1555,7 @@
                 </names>
                 <!-- TODO: Split editor and translator lines once processors start to automatically
                            create editor-translator variable. -->
-                <names variable="editor translator">
+                <names variable="editor translator" delimiter=", &amp; ">
                   <name and="symbol" initialize-with=". " delimiter=", "/>
                   <label form="short" text-case="title" prefix=" (" suffix=")"/>
                 </names>

--- a/apa-annotated-bibliography.csl
+++ b/apa-annotated-bibliography.csl
@@ -197,9 +197,8 @@
             <name name-as-sort-order="all" and="symbol" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
             <label form="short" prefix=" (" suffix=")" text-case="title"/>
           </names>
-          <!-- TODO: Split editor and translator into separate lines once processors begin to automatically create
-               the editor-translator variable. -->
-          <names variable="editor translator" delimiter=", &amp; ">
+          <!-- Note: Translator is not cited as a primary creator (only as Ed. & Trans.). -->
+          <names variable="editor">
             <name name-as-sort-order="all" and="symbol" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
             <label form="short" prefix=" (" suffix=")" text-case="title"/>
           </names>
@@ -1195,33 +1194,44 @@
           </names>
         </if>
       </choose>
-      <!-- TODO: When editor-translator becomes available in processors, add a test: 
-                 variable="editor-translator" match="none"; then print translator -->
       <choose>
         <if type="post webpage" match="none">
           <!-- Webpages treat container-title like publisher -->
-          <choose>
-            <if variable="container-title" match="none">
-              <group delimiter="; ">
-                <names variable="container-author">
-                  <label form="verb-short" suffix=" " text-case="title"/>
-                  <name and="symbol" initialize-with=". " delimiter=", "/>
-                </names>
-                <names variable="editor translator" delimiter="; ">
-                  <name and="symbol" initialize-with=". " delimiter=", "/>
-                  <label form="short" prefix=", " text-case="title"/>
-                </names>
-                <names variable="illustrator narrator" delimiter="; ">
-                  <name and="symbol" initialize-with=". " delimiter=", "/>
-                  <label form="short" prefix=", " text-case="title"/>
-                </names>
-                <names variable="compiler chair organizer curator series-creator executive-producer" delimiter="; ">
-                  <name and="symbol" initialize-with=". " delimiter=", "/>
-                  <label form="long" prefix=", " text-case="title"/>
-                </names>
-              </group>
-            </if>
-          </choose>
+          <group delimiter="; ">
+            <names variable="illustrator narrator" delimiter="; ">
+              <name and="symbol" initialize-with=". " delimiter=", "/>
+              <label form="short" prefix=", " text-case="title"/>
+            </names>
+            <choose>
+              <if variable="container-title" match="none">
+                <group delimiter="; ">
+                  <names variable="container-author">
+                    <label form="verb-short" suffix=" " text-case="title"/>
+                    <name and="symbol" initialize-with=". " delimiter=", "/>
+                  </names>
+                  <names variable="editor translator" delimiter="; ">
+                    <name and="symbol" initialize-with=". " delimiter=", "/>
+                    <label form="short" prefix=", " text-case="title"/>
+                  </names>
+                  <names variable="compiler chair organizer curator series-creator executive-producer" delimiter="; ">
+                    <name and="symbol" initialize-with=". " delimiter=", "/>
+                    <label form="long" prefix=", " text-case="title"/>
+                  </names>
+                </group>
+              </if>
+              <else>
+                <choose>
+                  <!-- TODO: Check logic once processors start to automatically populate editor-translator. -->
+                  <if variable="editor-translator" match="none">
+                    <names variable="translator" delimiter="; ">
+                      <name and="symbol" initialize-with=". " delimiter=", "/>
+                      <label form="short" prefix=", " text-case="title"/>
+                    </names>
+                  </if>
+                </choose>
+              </else>
+            </choose>
+          </group>
         </if>
         <else>
           <group delimiter="; ">
@@ -1571,9 +1581,10 @@
                   <name and="symbol" initialize-with=". " delimiter=", "/>
                   <label form="short" text-case="title" prefix=" (" suffix=")"/>
                 </names>
-                <!-- TODO: Split editor and translator lines once processors start to automatically
-                           create editor-translator variable. -->
-                <names variable="editor translator" delimiter=", &amp; ">
+                <!-- TODO: Translator omitted here on the assumption that editor-translators are uncommon 
+                           for chapter citations. If needed, direct entry or automatic population of
+                           `editor-translator` can produce combined labels. -->
+                <names variable="editor">
                   <name and="symbol" initialize-with=". " delimiter=", "/>
                   <label form="short" text-case="title" prefix=" (" suffix=")"/>
                 </names>

--- a/apa-cv.csl
+++ b/apa-cv.csl
@@ -185,8 +185,11 @@
               </choose>
             </if>
           </choose>
-          <!-- TODO: Replace `delimiter` with `collapse` to combine names variables when that becomes available. -->
-          <names variable="series-creator executive-producer" delimiter=", &amp; ">
+          <names variable="executive-producer">
+            <name name-as-sort-order="all" and="symbol" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
+            <label form="long" prefix=" (" suffix=")" text-case="title"/>
+          </names>
+          <names variable="series-creator">
             <name name-as-sort-order="all" and="symbol" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
             <label form="long" prefix=" (" suffix=")" text-case="title"/>
           </names>
@@ -310,8 +313,8 @@
                 </choose>
               </if>
             </choose>
-            <!-- TODO: Replace `delimiter` with `collapse` to combine names variables when that becomes available. -->
-            <names variable="series-creator executive-producer" delimiter=", &amp; "/>
+            <names variable="executive-producer"/>
+            <names variable="series-creator"/>
             <names variable="editor"/>
             <names variable="editorial-director"/>
             <names variable="compiler"/>
@@ -1559,10 +1562,11 @@
             </else>
           </choose>
           <group delimiter=", ">
-            <names variable="series-creator executive-producer" delimiter=", &amp; ">
+            <names variable="executive-producer">
               <name and="symbol" initialize-with=". " delimiter=", "/>
               <label form="long" text-case="title" prefix=" (" suffix=")"/>
               <substitute>
+                <names variable="series-creator"/>
                 <names variable="editor-translator">
                   <name and="symbol" initialize-with=". " delimiter=", "/>
                   <label form="short" text-case="title" prefix=" (" suffix=")"/>

--- a/apa-cv.csl
+++ b/apa-cv.csl
@@ -140,8 +140,17 @@
           <!-- Note: `narrator` only cited in secondary-contributors -->
           <names variable="illustrator"/>
           <!-- TODO: Replace `delimiter` with `collapse` to combine names variables when that becomes available. -->
-          <names variable="script-writer director" delimiter=", &amp; ">
-            <!-- Note: Actors/performers and producers [not executive] not cited in APA style. -->
+          <choose>
+            <if type="broadcast">
+              <names variable="script-writer director" delimiter=", &amp; ">
+                <!-- Note: Actors/performers and producers [not executive] not cited in APA style. -->
+                <name name-as-sort-order="all" and="symbol" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
+                <label form="long" prefix=" (" suffix=")" text-case="title"/>
+              </names>
+            </if>
+          </choose>
+          <names variable="director">
+            <!-- For non-broadcast items, APA only cites directors and not writers. -->
             <name name-as-sort-order="all" and="symbol" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
             <label form="long" prefix=" (" suffix=")" text-case="title"/>
           </names>
@@ -283,7 +292,12 @@
             <names variable="author"/>
             <names variable="illustrator"/>
             <!-- TODO: Replace `delimiter` with `collapse` to combine names variables when that becomes available. -->
-            <names variable="script-writer director" delimiter=", &amp; "/>
+            <choose>
+              <if type="broadcast">
+                <names variable="script-writer director" delimiter=", &amp; "/>
+              </if>
+            </choose>
+            <names variable="director"/>
             <!-- TODO: Replace `delimiter` with `collapse` to combine names variables when that becomes available. -->
             <names variable="guest host" delimiter=", &amp; "/>
             <names variable="producer"/>

--- a/apa-cv.csl
+++ b/apa-cv.csl
@@ -139,12 +139,14 @@
           <names variable="author"/>
           <!-- Note: `narrator` only cited in secondary-contributors -->
           <names variable="illustrator"/>
-          <names variable="script-writer director">
+          <!-- TODO: Replace `delimiter` with `collapse` to combine names variables when that becomes available. -->
+          <names variable="script-writer director" delimiter=", &amp; ">
             <!-- Note: Actors/performers and producers [not executive] not cited in APA style. -->
             <name name-as-sort-order="all" and="symbol" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
             <label form="long" prefix=" (" suffix=")" text-case="title"/>
           </names>
-          <names variable="guest host">
+          <!-- TODO: Replace `delimiter` with `collapse` to combine names variables when that becomes available. -->
+          <names variable="guest host" delimiter=", &amp; ">
             <name name-as-sort-order="all" and="symbol" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
             <label form="long" prefix=" (" suffix=")" text-case="title"/>
           </names>
@@ -174,17 +176,18 @@
               </choose>
             </if>
           </choose>
-          <names variable="series-creator executive-producer">
+          <!-- TODO: Replace `delimiter` with `collapse` to combine names variables when that becomes available. -->
+          <names variable="series-creator executive-producer" delimiter=", &amp; ">
             <name name-as-sort-order="all" and="symbol" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
             <label form="long" prefix=" (" suffix=")" text-case="title"/>
           </names>
-          <names variable="editor-translator" delimiter=", ">
+          <names variable="editor-translator">
             <name name-as-sort-order="all" and="symbol" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
             <label form="short" prefix=" (" suffix=")" text-case="title"/>
           </names>
           <!-- TODO: Split editor and translator into separate lines once processors begin to automatically create
                the editor-translator variable. -->
-          <names variable="editor translator" delimiter=", ">
+          <names variable="editor translator" delimiter=", &amp; ">
             <name name-as-sort-order="all" and="symbol" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
             <label form="short" prefix=" (" suffix=")" text-case="title"/>
           </names>
@@ -279,8 +282,10 @@
           <substitute>
             <names variable="author"/>
             <names variable="illustrator"/>
-            <names variable="script-writer director"/>
-            <names variable="guest host"/>
+            <!-- TODO: Replace `delimiter` with `collapse` to combine names variables when that becomes available. -->
+            <names variable="script-writer director" delimiter=", &amp; "/>
+            <!-- TODO: Replace `delimiter` with `collapse` to combine names variables when that becomes available. -->
+            <names variable="guest host" delimiter=", &amp; "/>
             <names variable="producer"/>
             <choose>
               <if variable="container-title">
@@ -291,7 +296,8 @@
                 </choose>
               </if>
             </choose>
-            <names variable="series-creator executive-producer"/>
+            <!-- TODO: Replace `delimiter` with `collapse` to combine names variables when that becomes available. -->
+            <names variable="series-creator executive-producer" delimiter=", &amp; "/>
             <names variable="editor"/>
             <names variable="editorial-director"/>
             <names variable="compiler"/>
@@ -1549,7 +1555,7 @@
                 </names>
                 <!-- TODO: Split editor and translator lines once processors start to automatically
                            create editor-translator variable. -->
-                <names variable="editor translator">
+                <names variable="editor translator" delimiter=", &amp; ">
                   <name and="symbol" initialize-with=". " delimiter=", "/>
                   <label form="short" text-case="title" prefix=" (" suffix=")"/>
                 </names>

--- a/apa-cv.csl
+++ b/apa-cv.csl
@@ -197,9 +197,8 @@
             <name name-as-sort-order="all" and="symbol" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
             <label form="short" prefix=" (" suffix=")" text-case="title"/>
           </names>
-          <!-- TODO: Split editor and translator into separate lines once processors begin to automatically create
-               the editor-translator variable. -->
-          <names variable="editor translator" delimiter=", &amp; ">
+          <!-- Note: Translator is not cited as a primary creator (only as Ed. & Trans.). -->
+          <names variable="editor">
             <name name-as-sort-order="all" and="symbol" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
             <label form="short" prefix=" (" suffix=")" text-case="title"/>
           </names>
@@ -1195,33 +1194,44 @@
           </names>
         </if>
       </choose>
-      <!-- TODO: When editor-translator becomes available in processors, add a test: 
-                 variable="editor-translator" match="none"; then print translator -->
       <choose>
         <if type="post webpage" match="none">
           <!-- Webpages treat container-title like publisher -->
-          <choose>
-            <if variable="container-title" match="none">
-              <group delimiter="; ">
-                <names variable="container-author">
-                  <label form="verb-short" suffix=" " text-case="title"/>
-                  <name and="symbol" initialize-with=". " delimiter=", "/>
-                </names>
-                <names variable="editor translator" delimiter="; ">
-                  <name and="symbol" initialize-with=". " delimiter=", "/>
-                  <label form="short" prefix=", " text-case="title"/>
-                </names>
-                <names variable="illustrator narrator" delimiter="; ">
-                  <name and="symbol" initialize-with=". " delimiter=", "/>
-                  <label form="short" prefix=", " text-case="title"/>
-                </names>
-                <names variable="compiler chair organizer curator series-creator executive-producer" delimiter="; ">
-                  <name and="symbol" initialize-with=". " delimiter=", "/>
-                  <label form="long" prefix=", " text-case="title"/>
-                </names>
-              </group>
-            </if>
-          </choose>
+          <group delimiter="; ">
+            <names variable="illustrator narrator" delimiter="; ">
+              <name and="symbol" initialize-with=". " delimiter=", "/>
+              <label form="short" prefix=", " text-case="title"/>
+            </names>
+            <choose>
+              <if variable="container-title" match="none">
+                <group delimiter="; ">
+                  <names variable="container-author">
+                    <label form="verb-short" suffix=" " text-case="title"/>
+                    <name and="symbol" initialize-with=". " delimiter=", "/>
+                  </names>
+                  <names variable="editor translator" delimiter="; ">
+                    <name and="symbol" initialize-with=". " delimiter=", "/>
+                    <label form="short" prefix=", " text-case="title"/>
+                  </names>
+                  <names variable="compiler chair organizer curator series-creator executive-producer" delimiter="; ">
+                    <name and="symbol" initialize-with=". " delimiter=", "/>
+                    <label form="long" prefix=", " text-case="title"/>
+                  </names>
+                </group>
+              </if>
+              <else>
+                <choose>
+                  <!-- TODO: Check logic once processors start to automatically populate editor-translator. -->
+                  <if variable="editor-translator" match="none">
+                    <names variable="translator" delimiter="; ">
+                      <name and="symbol" initialize-with=". " delimiter=", "/>
+                      <label form="short" prefix=", " text-case="title"/>
+                    </names>
+                  </if>
+                </choose>
+              </else>
+            </choose>
+          </group>
         </if>
         <else>
           <group delimiter="; ">
@@ -1571,9 +1581,10 @@
                   <name and="symbol" initialize-with=". " delimiter=", "/>
                   <label form="short" text-case="title" prefix=" (" suffix=")"/>
                 </names>
-                <!-- TODO: Split editor and translator lines once processors start to automatically
-                           create editor-translator variable. -->
-                <names variable="editor translator" delimiter=", &amp; ">
+                <!-- TODO: Translator omitted here on the assumption that editor-translators are uncommon 
+                           for chapter citations. If needed, direct entry or automatic population of
+                           `editor-translator` can produce combined labels. -->
+                <names variable="editor">
                   <name and="symbol" initialize-with=". " delimiter=", "/>
                   <label form="short" text-case="title" prefix=" (" suffix=")"/>
                 </names>

--- a/apa-no-ampersand.csl
+++ b/apa-no-ampersand.csl
@@ -1626,7 +1626,7 @@
                 </names>
                 <!-- TODO: Split editor and translator lines once processors start to automatically
                            create editor-translator variable. -->
-                <names variable="editor translator" delimiter=", "> 
+                <names variable="editor translator" delimiter=", ">
                   <!-- TODO: We can't do the group with 'and' term structure here because that will 
                              disable editor-translator combination. Use just a comma delimiter as a compromise. 
                   -->

--- a/apa-no-ampersand.csl
+++ b/apa-no-ampersand.csl
@@ -219,12 +219,8 @@
             <name name-as-sort-order="all" and="text" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
             <label form="short" prefix=" (" suffix=")" text-case="title"/>
           </names>
-          <!-- TODO: Split editor and translator into separate lines once processors begin to automatically create
-               the editor-translator variable. -->
-          <names variable="editor translator" delimiter=", ">
-            <!-- TODO: We can't do the group with 'and' term structure here because that will 
-                       disable editor-translator combination. Use just a comma delimiter as a compromise. 
-            -->
+          <!-- Note: Translator is not cited as a primary creator (only as Ed. & Trans.). -->
+          <names variable="editor">
             <name name-as-sort-order="all" and="text" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
             <label form="short" prefix=" (" suffix=")" text-case="title"/>
           </names>
@@ -1248,33 +1244,44 @@
           </names>
         </if>
       </choose>
-      <!-- TODO: When editor-translator becomes available in processors, add a test: 
-                 variable="editor-translator" match="none"; then print translator -->
       <choose>
         <if type="post webpage" match="none">
           <!-- Webpages treat container-title like publisher -->
-          <choose>
-            <if variable="container-title" match="none">
-              <group delimiter="; ">
-                <names variable="container-author">
-                  <label form="verb-short" suffix=" " text-case="title"/>
-                  <name and="text" initialize-with=". " delimiter=", "/>
-                </names>
-                <names variable="editor translator" delimiter="; ">
-                  <name and="text" initialize-with=". " delimiter=", "/>
-                  <label form="short" prefix=", " text-case="title"/>
-                </names>
-                <names variable="illustrator narrator" delimiter="; ">
-                  <name and="text" initialize-with=". " delimiter=", "/>
-                  <label form="short" prefix=", " text-case="title"/>
-                </names>
-                <names variable="compiler chair organizer curator series-creator executive-producer" delimiter="; ">
-                  <name and="text" initialize-with=". " delimiter=", "/>
-                  <label form="long" prefix=", " text-case="title"/>
-                </names>
-              </group>
-            </if>
-          </choose>
+          <group delimiter="; ">
+            <names variable="illustrator narrator" delimiter="; ">
+              <name and="symbol" initialize-with=". " delimiter=", "/>
+              <label form="short" prefix=", " text-case="title"/>
+            </names>
+            <choose>
+              <if variable="container-title" match="none">
+                <group delimiter="; ">
+                  <names variable="container-author">
+                    <label form="verb-short" suffix=" " text-case="title"/>
+                    <name and="symbol" initialize-with=". " delimiter=", "/>
+                  </names>
+                  <names variable="editor translator" delimiter="; ">
+                    <name and="symbol" initialize-with=". " delimiter=", "/>
+                    <label form="short" prefix=", " text-case="title"/>
+                  </names>
+                  <names variable="compiler chair organizer curator series-creator executive-producer" delimiter="; ">
+                    <name and="symbol" initialize-with=". " delimiter=", "/>
+                    <label form="long" prefix=", " text-case="title"/>
+                  </names>
+                </group>
+              </if>
+              <else>
+                <choose>
+                  <!-- TODO: Check logic once processors start to automatically populate editor-translator. -->
+                  <if variable="editor-translator" match="none">
+                    <names variable="translator" delimiter="; ">
+                      <name and="symbol" initialize-with=". " delimiter=", "/>
+                      <label form="short" prefix=", " text-case="title"/>
+                    </names>
+                  </if>
+                </choose>
+              </else>
+            </choose>
+          </group>
         </if>
         <else>
           <group delimiter="; ">
@@ -1624,12 +1631,10 @@
                   <name and="text" initialize-with=". " delimiter=", "/>
                   <label form="short" text-case="title" prefix=" (" suffix=")"/>
                 </names>
-                <!-- TODO: Split editor and translator lines once processors start to automatically
-                           create editor-translator variable. -->
-                <names variable="editor translator" delimiter=", ">
-                  <!-- TODO: We can't do the group with 'and' term structure here because that will 
-                             disable editor-translator combination. Use just a comma delimiter as a compromise. 
-                  -->
+                <!-- TODO: Translator omitted here on the assumption that editor-translators are uncommon 
+                           for chapter citations. If needed, direct entry or automatic population of
+                           `editor-translator` can produce combined labels. -->
+                <names variable="editor">
                   <name and="text" initialize-with=". " delimiter=", "/>
                   <label form="short" text-case="title" prefix=" (" suffix=")"/>
                 </names>

--- a/apa-no-ampersand.csl
+++ b/apa-no-ampersand.csl
@@ -139,12 +139,14 @@
           <names variable="author"/>
           <!-- Note: `narrator` only cited in secondary-contributors -->
           <names variable="illustrator"/>
-          <names variable="script-writer director">
+          <!-- TODO: Replace `delimiter` with `collapse` to combine names variables when that becomes available. -->
+          <names variable="script-writer director" delimiter=", &amp; ">
             <!-- Note: Actors/performers and producers [not executive] not cited in APA style. -->
             <name name-as-sort-order="all" and="text" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
             <label form="long" prefix=" (" suffix=")" text-case="title"/>
           </names>
-          <names variable="guest host">
+          <!-- TODO: Replace `delimiter` with `collapse` to combine names variables when that becomes available. -->
+          <names variable="guest host" delimiter=", &amp; ">
             <name name-as-sort-order="all" and="text" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
             <label form="long" prefix=" (" suffix=")" text-case="title"/>
           </names>
@@ -174,17 +176,18 @@
               </choose>
             </if>
           </choose>
-          <names variable="series-creator executive-producer">
+          <!-- TODO: Replace `delimiter` with `collapse` to combine names variables when that becomes available. -->
+          <names variable="series-creator executive-producer" delimiter=", &amp; ">
             <name name-as-sort-order="all" and="text" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
             <label form="long" prefix=" (" suffix=")" text-case="title"/>
           </names>
-          <names variable="editor-translator" delimiter=", ">
+          <names variable="editor-translator">
             <name name-as-sort-order="all" and="text" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
             <label form="short" prefix=" (" suffix=")" text-case="title"/>
           </names>
           <!-- TODO: Split editor and translator into separate lines once processors begin to automatically create
                the editor-translator variable. -->
-          <names variable="editor translator" delimiter=", ">
+          <names variable="editor translator" delimiter=", &amp; ">
             <name name-as-sort-order="all" and="text" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
             <label form="short" prefix=" (" suffix=")" text-case="title"/>
           </names>
@@ -279,8 +282,10 @@
           <substitute>
             <names variable="author"/>
             <names variable="illustrator"/>
-            <names variable="script-writer director"/>
-            <names variable="guest host"/>
+            <!-- TODO: Replace `delimiter` with `collapse` to combine names variables when that becomes available. -->
+            <names variable="script-writer director" delimiter=", &amp; "/>
+            <!-- TODO: Replace `delimiter` with `collapse` to combine names variables when that becomes available. -->
+            <names variable="guest host" delimiter=", &amp; "/>
             <names variable="producer"/>
             <choose>
               <if variable="container-title">
@@ -291,7 +296,8 @@
                 </choose>
               </if>
             </choose>
-            <names variable="series-creator executive-producer"/>
+            <!-- TODO: Replace `delimiter` with `collapse` to combine names variables when that becomes available. -->
+            <names variable="series-creator executive-producer" delimiter=", &amp; "/>
             <names variable="editor"/>
             <names variable="editorial-director"/>
             <names variable="compiler"/>
@@ -1549,7 +1555,7 @@
                 </names>
                 <!-- TODO: Split editor and translator lines once processors start to automatically
                            create editor-translator variable. -->
-                <names variable="editor translator">
+                <names variable="editor translator" delimiter=", &amp; ">
                   <name and="text" initialize-with=". " delimiter=", "/>
                   <label form="short" text-case="title" prefix=" (" suffix=")"/>
                 </names>

--- a/apa-no-ampersand.csl
+++ b/apa-no-ampersand.csl
@@ -20,12 +20,12 @@
   <locale xml:lang="en">
     <terms>
       <term name="editortranslator" form="short">
-        <single>ed. &amp; trans.</single>
-        <multiple>eds. &amp; trans.</multiple>
+        <single>ed. and trans.</single>
+        <multiple>eds. and trans.</multiple>
       </term>
       <term name="editor-translator" form="short">
-        <single>ed. &amp; trans.</single>
-        <multiple>eds. &amp; trans.</multiple>
+        <single>ed. and trans.</single>
+        <multiple>eds. and trans.</multiple>
       </term>
       <term name="translator" form="short">trans.</term>
       <term name="interviewer" form="short">
@@ -139,14 +139,25 @@
           <names variable="author"/>
           <!-- Note: `narrator` only cited in secondary-contributors -->
           <names variable="illustrator"/>
-          <!-- TODO: Replace `delimiter` with `collapse` to combine names variables when that becomes available. -->
+          <!-- TODO: Replace this group with `collapse` to combine names variables when that becomes available. -->
           <choose>
             <if type="broadcast">
-              <names variable="script-writer director" delimiter=", &amp; ">
-                <!-- Note: Actors/performers and producers [not executive] not cited in APA style. -->
-                <name name-as-sort-order="all" and="text" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
-                <label form="long" prefix=" (" suffix=")" text-case="title"/>
-              </names>
+              <!-- Note: Actors/performers and producers [not executive] not cited in APA style. -->
+              <group>
+                <names variable="script-writer" delimiter=", ">
+                  <name name-as-sort-order="all" and="text" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
+                  <label form="long" prefix=" (" suffix=")" text-case="title"/>
+                </names>
+                <choose>
+                  <if variable="script-writer director" match="all">
+                    <text term="and" prefix=", " suffix=" "/>
+                  </if>
+                </choose>
+                <names variable="director" delimiter=", ">
+                  <name name-as-sort-order="all" and="text" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
+                  <label form="long" prefix=" (" suffix=")" text-case="title"/>
+                </names>
+              </group>
             </if>
           </choose>
           <names variable="director">
@@ -154,12 +165,22 @@
             <name name-as-sort-order="all" and="text" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
             <label form="long" prefix=" (" suffix=")" text-case="title"/>
           </names>
-          <!-- TODO: Replace `delimiter` with `collapse` to combine names variables when that becomes available. -->
-          <!-- TODO: Replace the delimiter with a group so that a localized text 'and' can be used -->
-          <names variable="guest host" delimiter=", &amp; ">
-            <name name-as-sort-order="all" and="text" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
-            <label form="long" prefix=" (" suffix=")" text-case="title"/>
-          </names>
+          <!-- TODO: Replace this group with `collapse` to combine names variables when that becomes available. -->
+          <group>
+            <names variable="guest" delimiter=", ">
+              <name name-as-sort-order="all" and="text" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
+              <label form="long" prefix=" (" suffix=")" text-case="title"/>
+            </names>
+            <choose>
+              <if variable="guest host" match="all">
+                <text term="and" prefix=", " suffix=" "/>
+              </if>
+            </choose>
+            <names variable="host" delimiter=", ">
+              <name name-as-sort-order="all" and="text" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
+              <label form="long" prefix=" (" suffix=")" text-case="title"/>
+            </names>
+          </group>
           <names variable="producer">
             <!-- Note: Producers not cited if there is a writer/director, but use if they are the principle creator. -->
             <name name-as-sort-order="all" and="text" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
@@ -186,8 +207,11 @@
               </choose>
             </if>
           </choose>
-          <!-- TODO: Replace `delimiter` with `collapse` to combine names variables when that becomes available. -->
-          <names variable="series-creator executive-producer" delimiter=", &amp; ">
+          <names variable="series-creator" delimiter=", ">
+            <name name-as-sort-order="all" and="text" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
+            <label form="long" prefix=" (" suffix=")" text-case="title"/>
+          </names>
+          <names variable="executive-producer" delimiter=", ">
             <name name-as-sort-order="all" and="text" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
             <label form="long" prefix=" (" suffix=")" text-case="title"/>
           </names>
@@ -197,7 +221,10 @@
           </names>
           <!-- TODO: Split editor and translator into separate lines once processors begin to automatically create
                the editor-translator variable. -->
-          <names variable="editor translator" delimiter=", &amp; ">
+          <names variable="editor translator" delimiter=", ">
+            <!-- TODO: We can't do the group with 'and' term structure here because that will 
+                       disable editor-translator combination. Use just a comma delimiter as a compromise. 
+            -->
             <name name-as-sort-order="all" and="text" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
             <label form="short" prefix=" (" suffix=")" text-case="title"/>
           </names>
@@ -292,16 +319,43 @@
           <substitute>
             <names variable="author"/>
             <names variable="illustrator"/>
-            <!-- TODO: Replace `delimiter` with `collapse` to combine names variables when that becomes available. -->
-            <!-- TODO: Replace delimter with a group so that a localized text 'and' can be used here -->
+            <!-- TODO: Replace this group with `collapse` to combine names variables when that becomes available. -->
             <choose>
               <if type="broadcast">
-                <names variable="script-writer director" delimiter=", &amp; "/>
+                <group>
+                  <names variable="script-writer" delimiter=", ">
+                    <name form="short" and="text" delimiter=", " initialize-with=". "/>
+                  </names>
+                  <choose>
+                    <if variable="script-writer director" match="all">
+                      <text term="and" prefix=", " suffix=" "/>
+                    </if>
+                  </choose>
+                  <names variable="director" delimiter=", ">
+                    <name form="short" and="text" delimiter=", " initialize-with=". "/>
+                  </names>
+                </group>
               </if>
             </choose>
             <names variable="director"/>
-            <!-- TODO: Replace `delimiter` with `collapse` to combine names variables when that becomes available. -->
-            <names variable="guest host" delimiter=", &amp; "/>
+            <!-- TODO: Replace this group with `collapse` to combine names variables when that becomes available. -->
+            <choose>
+              <if type="broadcast">
+                <group>
+                  <names variable="guest" delimiter=", ">
+                    <name form="short" and="text" delimiter=", " initialize-with=". "/>
+                  </names>
+                  <choose>
+                    <if variable="guest host" match="all">
+                      <text term="and" prefix=", " suffix=" "/>
+                    </if>
+                  </choose>
+                  <names variable="host" delimiter=", ">
+                    <name form="short" and="text" delimiter=", " initialize-with=". "/>
+                  </names>
+                </group>
+              </if>
+            </choose>
             <names variable="producer"/>
             <choose>
               <if variable="container-title">
@@ -312,8 +366,8 @@
                 </choose>
               </if>
             </choose>
-            <!-- TODO: Replace `delimiter` with `collapse` to combine names variables when that becomes available. -->
-            <names variable="series-creator executive-producer" delimiter=", &amp; "/>
+            <names variable="executive-producer"/>
+            <names variable="series-creator"/>
             <names variable="editor"/>
             <names variable="editorial-director"/>
             <names variable="compiler"/>
@@ -1561,17 +1615,21 @@
             </else>
           </choose>
           <group delimiter=", ">
-            <names variable="series-creator executive-producer" delimiter=", &amp; ">
+            <names variable="executive-producer">
               <name and="text" initialize-with=". " delimiter=", "/>
               <label form="long" text-case="title" prefix=" (" suffix=")"/>
               <substitute>
+                <names variable="series-creator"/>
                 <names variable="editor-translator">
                   <name and="text" initialize-with=". " delimiter=", "/>
                   <label form="short" text-case="title" prefix=" (" suffix=")"/>
                 </names>
                 <!-- TODO: Split editor and translator lines once processors start to automatically
                            create editor-translator variable. -->
-                <names variable="editor translator" delimiter=", &amp; ">
+                <names variable="editor translator" delimiter=", "> 
+                  <!-- TODO: We can't do the group with 'and' term structure here because that will 
+                             disable editor-translator combination. Use just a comma delimiter as a compromise. 
+                  -->
                   <name and="text" initialize-with=". " delimiter=", "/>
                   <label form="short" text-case="title" prefix=" (" suffix=")"/>
                 </names>

--- a/apa-no-ampersand.csl
+++ b/apa-no-ampersand.csl
@@ -140,12 +140,22 @@
           <!-- Note: `narrator` only cited in secondary-contributors -->
           <names variable="illustrator"/>
           <!-- TODO: Replace `delimiter` with `collapse` to combine names variables when that becomes available. -->
-          <names variable="script-writer director" delimiter=", &amp; ">
-            <!-- Note: Actors/performers and producers [not executive] not cited in APA style. -->
+          <choose>
+            <if type="broadcast">
+              <names variable="script-writer director" delimiter=", &amp; ">
+                <!-- Note: Actors/performers and producers [not executive] not cited in APA style. -->
+                <name name-as-sort-order="all" and="text" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
+                <label form="long" prefix=" (" suffix=")" text-case="title"/>
+              </names>
+            </if>
+          </choose>
+          <names variable="director">
+            <!-- For non-broadcast items, APA only cites directors and not writers. -->
             <name name-as-sort-order="all" and="text" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
             <label form="long" prefix=" (" suffix=")" text-case="title"/>
           </names>
           <!-- TODO: Replace `delimiter` with `collapse` to combine names variables when that becomes available. -->
+          <!-- TODO: Replace the delimiter with a group so that a localized text 'and' can be used -->
           <names variable="guest host" delimiter=", &amp; ">
             <name name-as-sort-order="all" and="text" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
             <label form="long" prefix=" (" suffix=")" text-case="title"/>
@@ -283,7 +293,13 @@
             <names variable="author"/>
             <names variable="illustrator"/>
             <!-- TODO: Replace `delimiter` with `collapse` to combine names variables when that becomes available. -->
-            <names variable="script-writer director" delimiter=", &amp; "/>
+            <!-- TODO: Replace delimter with a group so that a localized text 'and' can be used here -->
+            <choose>
+              <if type="broadcast">
+                <names variable="script-writer director" delimiter=", &amp; "/>
+              </if>
+            </choose>
+            <names variable="director"/>
             <!-- TODO: Replace `delimiter` with `collapse` to combine names variables when that becomes available. -->
             <names variable="guest host" delimiter=", &amp; "/>
             <names variable="producer"/>

--- a/apa-no-initials.csl
+++ b/apa-no-initials.csl
@@ -139,12 +139,14 @@
           <names variable="author"/>
           <!-- Note: `narrator` only cited in secondary-contributors -->
           <names variable="illustrator"/>
-          <names variable="script-writer director">
+          <!-- TODO: Replace `delimiter` with `collapse` to combine names variables when that becomes available. -->
+          <names variable="script-writer director" delimiter=", &amp; ">
             <!-- Note: Actors/performers and producers [not executive] not cited in APA style. -->
             <name name-as-sort-order="all" and="symbol" sort-separator=", " initialize="false" initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
             <label form="long" prefix=" (" suffix=")" text-case="title"/>
           </names>
-          <names variable="guest host">
+          <!-- TODO: Replace `delimiter` with `collapse` to combine names variables when that becomes available. -->
+          <names variable="guest host" delimiter=", &amp; ">
             <name name-as-sort-order="all" and="symbol" sort-separator=", " initialize="false" initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
             <label form="long" prefix=" (" suffix=")" text-case="title"/>
           </names>
@@ -174,17 +176,18 @@
               </choose>
             </if>
           </choose>
-          <names variable="series-creator executive-producer">
+          <!-- TODO: Replace `delimiter` with `collapse` to combine names variables when that becomes available. -->
+          <names variable="series-creator executive-producer" delimiter=", &amp; ">
             <name name-as-sort-order="all" and="symbol" sort-separator=", " initialize="false" initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
             <label form="long" prefix=" (" suffix=")" text-case="title"/>
           </names>
-          <names variable="editor-translator" delimiter=", ">
+          <names variable="editor-translator">
             <name name-as-sort-order="all" and="symbol" sort-separator=", " initialize="false" initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
             <label form="short" prefix=" (" suffix=")" text-case="title"/>
           </names>
           <!-- TODO: Split editor and translator into separate lines once processors begin to automatically create
                the editor-translator variable. -->
-          <names variable="editor translator" delimiter=", ">
+          <names variable="editor translator" delimiter=", &amp; ">
             <name name-as-sort-order="all" and="symbol" sort-separator=", " initialize="false" initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
             <label form="short" prefix=" (" suffix=")" text-case="title"/>
           </names>
@@ -279,8 +282,10 @@
           <substitute>
             <names variable="author"/>
             <names variable="illustrator"/>
-            <names variable="script-writer director"/>
-            <names variable="guest host"/>
+            <!-- TODO: Replace `delimiter` with `collapse` to combine names variables when that becomes available. -->
+            <names variable="script-writer director" delimiter=", &amp; "/>
+            <!-- TODO: Replace `delimiter` with `collapse` to combine names variables when that becomes available. -->
+            <names variable="guest host" delimiter=", &amp; "/>
             <names variable="producer"/>
             <choose>
               <if variable="container-title">
@@ -291,7 +296,8 @@
                 </choose>
               </if>
             </choose>
-            <names variable="series-creator executive-producer"/>
+            <!-- TODO: Replace `delimiter` with `collapse` to combine names variables when that becomes available. -->
+            <names variable="series-creator executive-producer" delimiter=", &amp; "/>
             <names variable="editor"/>
             <names variable="editorial-director"/>
             <names variable="compiler"/>
@@ -1549,7 +1555,7 @@
                 </names>
                 <!-- TODO: Split editor and translator lines once processors start to automatically
                            create editor-translator variable. -->
-                <names variable="editor translator">
+                <names variable="editor translator" delimiter=", &amp; ">
                   <name and="symbol" initialize="false" initialize-with=". " delimiter=", "/>
                   <label form="short" text-case="title" prefix=" (" suffix=")"/>
                 </names>

--- a/apa-no-initials.csl
+++ b/apa-no-initials.csl
@@ -185,9 +185,12 @@
               </choose>
             </if>
           </choose>
-          <!-- TODO: Replace `delimiter` with `collapse` to combine names variables when that becomes available. -->
-          <names variable="series-creator executive-producer" delimiter=", &amp; ">
-            <name name-as-sort-order="all" and="symbol" sort-separator=", " initialize="false" initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
+          <names variable="executive-producer">
+            <name name-as-sort-order="all" and="symbol" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
+            <label form="long" prefix=" (" suffix=")" text-case="title"/>
+          </names>
+          <names variable="series-creator">
+            <name name-as-sort-order="all" and="symbol" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
             <label form="long" prefix=" (" suffix=")" text-case="title"/>
           </names>
           <names variable="editor-translator">
@@ -310,8 +313,8 @@
                 </choose>
               </if>
             </choose>
-            <!-- TODO: Replace `delimiter` with `collapse` to combine names variables when that becomes available. -->
-            <names variable="series-creator executive-producer" delimiter=", &amp; "/>
+            <names variable="executive-producer"/>
+            <names variable="series-creator"/>
             <names variable="editor"/>
             <names variable="editorial-director"/>
             <names variable="compiler"/>
@@ -1559,10 +1562,11 @@
             </else>
           </choose>
           <group delimiter=", ">
-            <names variable="series-creator executive-producer" delimiter=", &amp; ">
+            <names variable="executive-producer">
               <name and="symbol" initialize="false" initialize-with=". " delimiter=", "/>
               <label form="long" text-case="title" prefix=" (" suffix=")"/>
               <substitute>
+                <names variable="series-creator"/>
                 <names variable="editor-translator">
                   <name and="symbol" initialize="false" initialize-with=". " delimiter=", "/>
                   <label form="short" text-case="title" prefix=" (" suffix=")"/>

--- a/apa-no-initials.csl
+++ b/apa-no-initials.csl
@@ -140,8 +140,17 @@
           <!-- Note: `narrator` only cited in secondary-contributors -->
           <names variable="illustrator"/>
           <!-- TODO: Replace `delimiter` with `collapse` to combine names variables when that becomes available. -->
-          <names variable="script-writer director" delimiter=", &amp; ">
-            <!-- Note: Actors/performers and producers [not executive] not cited in APA style. -->
+          <choose>
+            <if type="broadcast">
+              <names variable="script-writer director" delimiter=", &amp; ">
+                <!-- Note: Actors/performers and producers [not executive] not cited in APA style. -->
+                <name name-as-sort-order="all" and="symbol" sort-separator=", " initialize="false" initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
+                <label form="long" prefix=" (" suffix=")" text-case="title"/>
+              </names>
+            </if>
+          </choose>
+          <names variable="director">
+            <!-- For non-broadcast items, APA only cites directors and not writers. -->
             <name name-as-sort-order="all" and="symbol" sort-separator=", " initialize="false" initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
             <label form="long" prefix=" (" suffix=")" text-case="title"/>
           </names>
@@ -283,7 +292,12 @@
             <names variable="author"/>
             <names variable="illustrator"/>
             <!-- TODO: Replace `delimiter` with `collapse` to combine names variables when that becomes available. -->
-            <names variable="script-writer director" delimiter=", &amp; "/>
+            <choose>
+              <if type="broadcast">
+                <names variable="script-writer director" delimiter=", &amp; "/>
+              </if>
+            </choose>
+            <names variable="director"/>
             <!-- TODO: Replace `delimiter` with `collapse` to combine names variables when that becomes available. -->
             <names variable="guest host" delimiter=", &amp; "/>
             <names variable="producer"/>

--- a/apa-no-initials.csl
+++ b/apa-no-initials.csl
@@ -197,9 +197,8 @@
             <name name-as-sort-order="all" and="symbol" sort-separator=", " initialize="false" initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
             <label form="short" prefix=" (" suffix=")" text-case="title"/>
           </names>
-          <!-- TODO: Split editor and translator into separate lines once processors begin to automatically create
-               the editor-translator variable. -->
-          <names variable="editor translator" delimiter=", &amp; ">
+          <!-- Note: Translator is not cited as a primary creator (only as Ed. & Trans.). -->
+          <names variable="editor">
             <name name-as-sort-order="all" and="symbol" sort-separator=", " initialize="false" initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
             <label form="short" prefix=" (" suffix=")" text-case="title"/>
           </names>
@@ -1195,33 +1194,44 @@
           </names>
         </if>
       </choose>
-      <!-- TODO: When editor-translator becomes available in processors, add a test: 
-                 variable="editor-translator" match="none"; then print translator -->
       <choose>
         <if type="post webpage" match="none">
           <!-- Webpages treat container-title like publisher -->
-          <choose>
-            <if variable="container-title" match="none">
-              <group delimiter="; ">
-                <names variable="container-author">
-                  <label form="verb-short" suffix=" " text-case="title"/>
-                  <name and="symbol" initialize="false" initialize-with=". " delimiter=", "/>
-                </names>
-                <names variable="editor translator" delimiter="; ">
-                  <name and="symbol" initialize="false" initialize-with=". " delimiter=", "/>
-                  <label form="short" prefix=", " text-case="title"/>
-                </names>
-                <names variable="illustrator narrator" delimiter="; ">
-                  <name and="symbol" initialize="false" initialize-with=". " delimiter=", "/>
-                  <label form="short" prefix=", " text-case="title"/>
-                </names>
-                <names variable="compiler chair organizer curator series-creator executive-producer" delimiter="; ">
-                  <name and="symbol" initialize="false" initialize-with=". " delimiter=", "/>
-                  <label form="long" prefix=", " text-case="title"/>
-                </names>
-              </group>
-            </if>
-          </choose>
+          <group delimiter="; ">
+            <names variable="illustrator narrator" delimiter="; ">
+              <name and="symbol" initialize="false" initialize-with=". " delimiter=", "/>
+              <label form="short" prefix=", " text-case="title"/>
+            </names>
+            <choose>
+              <if variable="container-title" match="none">
+                <group delimiter="; ">
+                  <names variable="container-author">
+                    <label form="verb-short" suffix=" " text-case="title"/>
+                    <name and="symbol" initialize="false" initialize-with=". " delimiter=", "/>
+                  </names>
+                  <names variable="editor translator" delimiter="; ">
+                    <name and="symbol" initialize="false" initialize-with=". " delimiter=", "/>
+                    <label form="short" prefix=", " text-case="title"/>
+                  </names>
+                  <names variable="compiler chair organizer curator series-creator executive-producer" delimiter="; ">
+                    <name and="symbol" initialize="false" initialize-with=". " delimiter=", "/>
+                    <label form="long" prefix=", " text-case="title"/>
+                  </names>
+                </group>
+              </if>
+              <else>
+                <choose>
+                  <!-- TODO: Check logic once processors start to automatically populate editor-translator. -->
+                  <if variable="editor-translator" match="none">
+                    <names variable="translator" delimiter="; ">
+                      <name and="symbol" initialize="false" initialize-with=". " delimiter=", "/>
+                      <label form="short" prefix=", " text-case="title"/>
+                    </names>
+                  </if>
+                </choose>
+              </else>
+            </choose>
+          </group>
         </if>
         <else>
           <group delimiter="; ">
@@ -1571,9 +1581,10 @@
                   <name and="symbol" initialize="false" initialize-with=". " delimiter=", "/>
                   <label form="short" text-case="title" prefix=" (" suffix=")"/>
                 </names>
-                <!-- TODO: Split editor and translator lines once processors start to automatically
-                           create editor-translator variable. -->
-                <names variable="editor translator" delimiter=", &amp; ">
+                <!-- TODO: Translator omitted here on the assumption that editor-translators are uncommon 
+                           for chapter citations. If needed, direct entry or automatic population of
+                           `editor-translator` can produce combined labels. -->
+                <names variable="editor">
                   <name and="symbol" initialize="false" initialize-with=". " delimiter=", "/>
                   <label form="short" text-case="title" prefix=" (" suffix=")"/>
                 </names>

--- a/apa-numeric-superscript-brackets.csl
+++ b/apa-numeric-superscript-brackets.csl
@@ -186,8 +186,11 @@
               </choose>
             </if>
           </choose>
-          <!-- TODO: Replace `delimiter` with `collapse` to combine names variables when that becomes available. -->
-          <names variable="series-creator executive-producer" delimiter=", &amp; ">
+          <names variable="executive-producer">
+            <name name-as-sort-order="all" and="symbol" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
+            <label form="long" prefix=" (" suffix=")" text-case="title"/>
+          </names>
+          <names variable="series-creator">
             <name name-as-sort-order="all" and="symbol" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
             <label form="long" prefix=" (" suffix=")" text-case="title"/>
           </names>
@@ -311,8 +314,8 @@
                 </choose>
               </if>
             </choose>
-            <!-- TODO: Replace `delimiter` with `collapse` to combine names variables when that becomes available. -->
-            <names variable="series-creator executive-producer" delimiter=", &amp; "/>
+            <names variable="executive-producer"/>
+            <names variable="series-creator"/>
             <names variable="editor"/>
             <names variable="editorial-director"/>
             <names variable="compiler"/>
@@ -1560,10 +1563,11 @@
             </else>
           </choose>
           <group delimiter=", ">
-            <names variable="series-creator executive-producer" delimiter=", &amp; ">
+            <names variable="executive-producer">
               <name and="symbol" initialize-with=". " delimiter=", "/>
               <label form="long" text-case="title" prefix=" (" suffix=")"/>
               <substitute>
+                <names variable="series-creator"/>
                 <names variable="editor-translator">
                   <name and="symbol" initialize-with=". " delimiter=", "/>
                   <label form="short" text-case="title" prefix=" (" suffix=")"/>

--- a/apa-numeric-superscript-brackets.csl
+++ b/apa-numeric-superscript-brackets.csl
@@ -141,8 +141,17 @@
           <!-- Note: `narrator` only cited in secondary-contributors -->
           <names variable="illustrator"/>
           <!-- TODO: Replace `delimiter` with `collapse` to combine names variables when that becomes available. -->
-          <names variable="script-writer director" delimiter=", &amp; ">
-            <!-- Note: Actors/performers and producers [not executive] not cited in APA style. -->
+          <choose>
+            <if type="broadcast">
+              <names variable="script-writer director" delimiter=", &amp; ">
+                <!-- Note: Actors/performers and producers [not executive] not cited in APA style. -->
+                <name name-as-sort-order="all" and="symbol" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
+                <label form="long" prefix=" (" suffix=")" text-case="title"/>
+              </names>
+            </if>
+          </choose>
+          <names variable="director">
+            <!-- For non-broadcast items, APA only cites directors and not writers. -->
             <name name-as-sort-order="all" and="symbol" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
             <label form="long" prefix=" (" suffix=")" text-case="title"/>
           </names>
@@ -284,7 +293,12 @@
             <names variable="author"/>
             <names variable="illustrator"/>
             <!-- TODO: Replace `delimiter` with `collapse` to combine names variables when that becomes available. -->
-            <names variable="script-writer director" delimiter=", &amp; "/>
+            <choose>
+              <if type="broadcast">
+                <names variable="script-writer director" delimiter=", &amp; "/>
+              </if>
+            </choose>
+            <names variable="director"/>
             <!-- TODO: Replace `delimiter` with `collapse` to combine names variables when that becomes available. -->
             <names variable="guest host" delimiter=", &amp; "/>
             <names variable="producer"/>

--- a/apa-numeric-superscript-brackets.csl
+++ b/apa-numeric-superscript-brackets.csl
@@ -198,9 +198,8 @@
             <name name-as-sort-order="all" and="symbol" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
             <label form="short" prefix=" (" suffix=")" text-case="title"/>
           </names>
-          <!-- TODO: Split editor and translator into separate lines once processors begin to automatically create
-               the editor-translator variable. -->
-          <names variable="editor translator" delimiter=", &amp; ">
+          <!-- Note: Translator is not cited as a primary creator (only as Ed. & Trans.). -->
+          <names variable="editor">
             <name name-as-sort-order="all" and="symbol" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
             <label form="short" prefix=" (" suffix=")" text-case="title"/>
           </names>
@@ -1196,33 +1195,44 @@
           </names>
         </if>
       </choose>
-      <!-- TODO: When editor-translator becomes available in processors, add a test: 
-                 variable="editor-translator" match="none"; then print translator -->
       <choose>
         <if type="post webpage" match="none">
           <!-- Webpages treat container-title like publisher -->
-          <choose>
-            <if variable="container-title" match="none">
-              <group delimiter="; ">
-                <names variable="container-author">
-                  <label form="verb-short" suffix=" " text-case="title"/>
-                  <name and="symbol" initialize-with=". " delimiter=", "/>
-                </names>
-                <names variable="editor translator" delimiter="; ">
-                  <name and="symbol" initialize-with=". " delimiter=", "/>
-                  <label form="short" prefix=", " text-case="title"/>
-                </names>
-                <names variable="illustrator narrator" delimiter="; ">
-                  <name and="symbol" initialize-with=". " delimiter=", "/>
-                  <label form="short" prefix=", " text-case="title"/>
-                </names>
-                <names variable="compiler chair organizer curator series-creator executive-producer" delimiter="; ">
-                  <name and="symbol" initialize-with=". " delimiter=", "/>
-                  <label form="long" prefix=", " text-case="title"/>
-                </names>
-              </group>
-            </if>
-          </choose>
+          <group delimiter="; ">
+            <names variable="illustrator narrator" delimiter="; ">
+              <name and="symbol" initialize-with=". " delimiter=", "/>
+              <label form="short" prefix=", " text-case="title"/>
+            </names>
+            <choose>
+              <if variable="container-title" match="none">
+                <group delimiter="; ">
+                  <names variable="container-author">
+                    <label form="verb-short" suffix=" " text-case="title"/>
+                    <name and="symbol" initialize-with=". " delimiter=", "/>
+                  </names>
+                  <names variable="editor translator" delimiter="; ">
+                    <name and="symbol" initialize-with=". " delimiter=", "/>
+                    <label form="short" prefix=", " text-case="title"/>
+                  </names>
+                  <names variable="compiler chair organizer curator series-creator executive-producer" delimiter="; ">
+                    <name and="symbol" initialize-with=". " delimiter=", "/>
+                    <label form="long" prefix=", " text-case="title"/>
+                  </names>
+                </group>
+              </if>
+              <else>
+                <choose>
+                  <!-- TODO: Check logic once processors start to automatically populate editor-translator. -->
+                  <if variable="editor-translator" match="none">
+                    <names variable="translator" delimiter="; ">
+                      <name and="symbol" initialize-with=". " delimiter=", "/>
+                      <label form="short" prefix=", " text-case="title"/>
+                    </names>
+                  </if>
+                </choose>
+              </else>
+            </choose>
+          </group>
         </if>
         <else>
           <group delimiter="; ">
@@ -1572,9 +1582,10 @@
                   <name and="symbol" initialize-with=". " delimiter=", "/>
                   <label form="short" text-case="title" prefix=" (" suffix=")"/>
                 </names>
-                <!-- TODO: Split editor and translator lines once processors start to automatically
-                           create editor-translator variable. -->
-                <names variable="editor translator" delimiter=", &amp; ">
+                <!-- TODO: Translator omitted here on the assumption that editor-translators are uncommon 
+                           for chapter citations. If needed, direct entry or automatic population of
+                           `editor-translator` can produce combined labels. -->
+                <names variable="editor">
                   <name and="symbol" initialize-with=". " delimiter=", "/>
                   <label form="short" text-case="title" prefix=" (" suffix=")"/>
                 </names>

--- a/apa-numeric-superscript-brackets.csl
+++ b/apa-numeric-superscript-brackets.csl
@@ -140,12 +140,14 @@
           <names variable="author"/>
           <!-- Note: `narrator` only cited in secondary-contributors -->
           <names variable="illustrator"/>
-          <names variable="script-writer director">
+          <!-- TODO: Replace `delimiter` with `collapse` to combine names variables when that becomes available. -->
+          <names variable="script-writer director" delimiter=", &amp; ">
             <!-- Note: Actors/performers and producers [not executive] not cited in APA style. -->
             <name name-as-sort-order="all" and="symbol" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
             <label form="long" prefix=" (" suffix=")" text-case="title"/>
           </names>
-          <names variable="guest host">
+          <!-- TODO: Replace `delimiter` with `collapse` to combine names variables when that becomes available. -->
+          <names variable="guest host" delimiter=", &amp; ">
             <name name-as-sort-order="all" and="symbol" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
             <label form="long" prefix=" (" suffix=")" text-case="title"/>
           </names>
@@ -175,17 +177,18 @@
               </choose>
             </if>
           </choose>
-          <names variable="series-creator executive-producer">
+          <!-- TODO: Replace `delimiter` with `collapse` to combine names variables when that becomes available. -->
+          <names variable="series-creator executive-producer" delimiter=", &amp; ">
             <name name-as-sort-order="all" and="symbol" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
             <label form="long" prefix=" (" suffix=")" text-case="title"/>
           </names>
-          <names variable="editor-translator" delimiter=", ">
+          <names variable="editor-translator">
             <name name-as-sort-order="all" and="symbol" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
             <label form="short" prefix=" (" suffix=")" text-case="title"/>
           </names>
           <!-- TODO: Split editor and translator into separate lines once processors begin to automatically create
                the editor-translator variable. -->
-          <names variable="editor translator" delimiter=", ">
+          <names variable="editor translator" delimiter=", &amp; ">
             <name name-as-sort-order="all" and="symbol" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
             <label form="short" prefix=" (" suffix=")" text-case="title"/>
           </names>
@@ -280,8 +283,10 @@
           <substitute>
             <names variable="author"/>
             <names variable="illustrator"/>
-            <names variable="script-writer director"/>
-            <names variable="guest host"/>
+            <!-- TODO: Replace `delimiter` with `collapse` to combine names variables when that becomes available. -->
+            <names variable="script-writer director" delimiter=", &amp; "/>
+            <!-- TODO: Replace `delimiter` with `collapse` to combine names variables when that becomes available. -->
+            <names variable="guest host" delimiter=", &amp; "/>
             <names variable="producer"/>
             <choose>
               <if variable="container-title">
@@ -292,7 +297,8 @@
                 </choose>
               </if>
             </choose>
-            <names variable="series-creator executive-producer"/>
+            <!-- TODO: Replace `delimiter` with `collapse` to combine names variables when that becomes available. -->
+            <names variable="series-creator executive-producer" delimiter=", &amp; "/>
             <names variable="editor"/>
             <names variable="editorial-director"/>
             <names variable="compiler"/>
@@ -1550,7 +1556,7 @@
                 </names>
                 <!-- TODO: Split editor and translator lines once processors start to automatically
                            create editor-translator variable. -->
-                <names variable="editor translator">
+                <names variable="editor translator" delimiter=", &amp; ">
                   <name and="symbol" initialize-with=". " delimiter=", "/>
                   <label form="short" text-case="title" prefix=" (" suffix=")"/>
                 </names>

--- a/apa-numeric-superscript.csl
+++ b/apa-numeric-superscript.csl
@@ -186,8 +186,11 @@
               </choose>
             </if>
           </choose>
-          <!-- TODO: Replace `delimiter` with `collapse` to combine names variables when that becomes available. -->
-          <names variable="series-creator executive-producer" delimiter=", &amp; ">
+          <names variable="executive-producer">
+            <name name-as-sort-order="all" and="symbol" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
+            <label form="long" prefix=" (" suffix=")" text-case="title"/>
+          </names>
+          <names variable="series-creator">
             <name name-as-sort-order="all" and="symbol" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
             <label form="long" prefix=" (" suffix=")" text-case="title"/>
           </names>
@@ -311,8 +314,8 @@
                 </choose>
               </if>
             </choose>
-            <!-- TODO: Replace `delimiter` with `collapse` to combine names variables when that becomes available. -->
-            <names variable="series-creator executive-producer" delimiter=", &amp; "/>
+            <names variable="executive-producer"/>
+            <names variable="series-creator"/>
             <names variable="editor"/>
             <names variable="editorial-director"/>
             <names variable="compiler"/>
@@ -1560,10 +1563,11 @@
             </else>
           </choose>
           <group delimiter=", ">
-            <names variable="series-creator executive-producer" delimiter=", &amp; ">
+            <names variable="executive-producer">
               <name and="symbol" initialize-with=". " delimiter=", "/>
               <label form="long" text-case="title" prefix=" (" suffix=")"/>
               <substitute>
+                <names variable="series-creator"/>
                 <names variable="editor-translator">
                   <name and="symbol" initialize-with=". " delimiter=", "/>
                   <label form="short" text-case="title" prefix=" (" suffix=")"/>

--- a/apa-numeric-superscript.csl
+++ b/apa-numeric-superscript.csl
@@ -141,8 +141,17 @@
           <!-- Note: `narrator` only cited in secondary-contributors -->
           <names variable="illustrator"/>
           <!-- TODO: Replace `delimiter` with `collapse` to combine names variables when that becomes available. -->
-          <names variable="script-writer director" delimiter=", &amp; ">
-            <!-- Note: Actors/performers and producers [not executive] not cited in APA style. -->
+          <choose>
+            <if type="broadcast">
+              <names variable="script-writer director" delimiter=", &amp; ">
+                <!-- Note: Actors/performers and producers [not executive] not cited in APA style. -->
+                <name name-as-sort-order="all" and="symbol" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
+                <label form="long" prefix=" (" suffix=")" text-case="title"/>
+              </names>
+            </if>
+          </choose>
+          <names variable="director">
+            <!-- For non-broadcast items, APA only cites directors and not writers. -->
             <name name-as-sort-order="all" and="symbol" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
             <label form="long" prefix=" (" suffix=")" text-case="title"/>
           </names>
@@ -284,7 +293,12 @@
             <names variable="author"/>
             <names variable="illustrator"/>
             <!-- TODO: Replace `delimiter` with `collapse` to combine names variables when that becomes available. -->
-            <names variable="script-writer director" delimiter=", &amp; "/>
+            <choose>
+              <if type="broadcast">
+                <names variable="script-writer director" delimiter=", &amp; "/>
+              </if>
+            </choose>
+            <names variable="director"/>
             <!-- TODO: Replace `delimiter` with `collapse` to combine names variables when that becomes available. -->
             <names variable="guest host" delimiter=", &amp; "/>
             <names variable="producer"/>

--- a/apa-numeric-superscript.csl
+++ b/apa-numeric-superscript.csl
@@ -198,9 +198,8 @@
             <name name-as-sort-order="all" and="symbol" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
             <label form="short" prefix=" (" suffix=")" text-case="title"/>
           </names>
-          <!-- TODO: Split editor and translator into separate lines once processors begin to automatically create
-               the editor-translator variable. -->
-          <names variable="editor translator" delimiter=", &amp; ">
+          <!-- Note: Translator is not cited as a primary creator (only as Ed. & Trans.). -->
+          <names variable="editor">
             <name name-as-sort-order="all" and="symbol" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
             <label form="short" prefix=" (" suffix=")" text-case="title"/>
           </names>
@@ -1196,33 +1195,44 @@
           </names>
         </if>
       </choose>
-      <!-- TODO: When editor-translator becomes available in processors, add a test: 
-                 variable="editor-translator" match="none"; then print translator -->
       <choose>
         <if type="post webpage" match="none">
           <!-- Webpages treat container-title like publisher -->
-          <choose>
-            <if variable="container-title" match="none">
-              <group delimiter="; ">
-                <names variable="container-author">
-                  <label form="verb-short" suffix=" " text-case="title"/>
-                  <name and="symbol" initialize-with=". " delimiter=", "/>
-                </names>
-                <names variable="editor translator" delimiter="; ">
-                  <name and="symbol" initialize-with=". " delimiter=", "/>
-                  <label form="short" prefix=", " text-case="title"/>
-                </names>
-                <names variable="illustrator narrator" delimiter="; ">
-                  <name and="symbol" initialize-with=". " delimiter=", "/>
-                  <label form="short" prefix=", " text-case="title"/>
-                </names>
-                <names variable="compiler chair organizer curator series-creator executive-producer" delimiter="; ">
-                  <name and="symbol" initialize-with=". " delimiter=", "/>
-                  <label form="long" prefix=", " text-case="title"/>
-                </names>
-              </group>
-            </if>
-          </choose>
+          <group delimiter="; ">
+            <names variable="illustrator narrator" delimiter="; ">
+              <name and="symbol" initialize-with=". " delimiter=", "/>
+              <label form="short" prefix=", " text-case="title"/>
+            </names>
+            <choose>
+              <if variable="container-title" match="none">
+                <group delimiter="; ">
+                  <names variable="container-author">
+                    <label form="verb-short" suffix=" " text-case="title"/>
+                    <name and="symbol" initialize-with=". " delimiter=", "/>
+                  </names>
+                  <names variable="editor translator" delimiter="; ">
+                    <name and="symbol" initialize-with=". " delimiter=", "/>
+                    <label form="short" prefix=", " text-case="title"/>
+                  </names>
+                  <names variable="compiler chair organizer curator series-creator executive-producer" delimiter="; ">
+                    <name and="symbol" initialize-with=". " delimiter=", "/>
+                    <label form="long" prefix=", " text-case="title"/>
+                  </names>
+                </group>
+              </if>
+              <else>
+                <choose>
+                  <!-- TODO: Check logic once processors start to automatically populate editor-translator. -->
+                  <if variable="editor-translator" match="none">
+                    <names variable="translator" delimiter="; ">
+                      <name and="symbol" initialize-with=". " delimiter=", "/>
+                      <label form="short" prefix=", " text-case="title"/>
+                    </names>
+                  </if>
+                </choose>
+              </else>
+            </choose>
+          </group>
         </if>
         <else>
           <group delimiter="; ">
@@ -1572,9 +1582,10 @@
                   <name and="symbol" initialize-with=". " delimiter=", "/>
                   <label form="short" text-case="title" prefix=" (" suffix=")"/>
                 </names>
-                <!-- TODO: Split editor and translator lines once processors start to automatically
-                           create editor-translator variable. -->
-                <names variable="editor translator" delimiter=", &amp; ">
+                <!-- TODO: Translator omitted here on the assumption that editor-translators are uncommon 
+                           for chapter citations. If needed, direct entry or automatic population of
+                           `editor-translator` can produce combined labels. -->
+                <names variable="editor">
                   <name and="symbol" initialize-with=". " delimiter=", "/>
                   <label form="short" text-case="title" prefix=" (" suffix=")"/>
                 </names>

--- a/apa-numeric-superscript.csl
+++ b/apa-numeric-superscript.csl
@@ -140,12 +140,14 @@
           <names variable="author"/>
           <!-- Note: `narrator` only cited in secondary-contributors -->
           <names variable="illustrator"/>
-          <names variable="script-writer director">
+          <!-- TODO: Replace `delimiter` with `collapse` to combine names variables when that becomes available. -->
+          <names variable="script-writer director" delimiter=", &amp; ">
             <!-- Note: Actors/performers and producers [not executive] not cited in APA style. -->
             <name name-as-sort-order="all" and="symbol" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
             <label form="long" prefix=" (" suffix=")" text-case="title"/>
           </names>
-          <names variable="guest host">
+          <!-- TODO: Replace `delimiter` with `collapse` to combine names variables when that becomes available. -->
+          <names variable="guest host" delimiter=", &amp; ">
             <name name-as-sort-order="all" and="symbol" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
             <label form="long" prefix=" (" suffix=")" text-case="title"/>
           </names>
@@ -175,17 +177,18 @@
               </choose>
             </if>
           </choose>
-          <names variable="series-creator executive-producer">
+          <!-- TODO: Replace `delimiter` with `collapse` to combine names variables when that becomes available. -->
+          <names variable="series-creator executive-producer" delimiter=", &amp; ">
             <name name-as-sort-order="all" and="symbol" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
             <label form="long" prefix=" (" suffix=")" text-case="title"/>
           </names>
-          <names variable="editor-translator" delimiter=", ">
+          <names variable="editor-translator">
             <name name-as-sort-order="all" and="symbol" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
             <label form="short" prefix=" (" suffix=")" text-case="title"/>
           </names>
           <!-- TODO: Split editor and translator into separate lines once processors begin to automatically create
                the editor-translator variable. -->
-          <names variable="editor translator" delimiter=", ">
+          <names variable="editor translator" delimiter=", &amp; ">
             <name name-as-sort-order="all" and="symbol" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
             <label form="short" prefix=" (" suffix=")" text-case="title"/>
           </names>
@@ -280,8 +283,10 @@
           <substitute>
             <names variable="author"/>
             <names variable="illustrator"/>
-            <names variable="script-writer director"/>
-            <names variable="guest host"/>
+            <!-- TODO: Replace `delimiter` with `collapse` to combine names variables when that becomes available. -->
+            <names variable="script-writer director" delimiter=", &amp; "/>
+            <!-- TODO: Replace `delimiter` with `collapse` to combine names variables when that becomes available. -->
+            <names variable="guest host" delimiter=", &amp; "/>
             <names variable="producer"/>
             <choose>
               <if variable="container-title">
@@ -292,7 +297,8 @@
                 </choose>
               </if>
             </choose>
-            <names variable="series-creator executive-producer"/>
+            <!-- TODO: Replace `delimiter` with `collapse` to combine names variables when that becomes available. -->
+            <names variable="series-creator executive-producer" delimiter=", &amp; "/>
             <names variable="editor"/>
             <names variable="editorial-director"/>
             <names variable="compiler"/>
@@ -1550,7 +1556,7 @@
                 </names>
                 <!-- TODO: Split editor and translator lines once processors start to automatically
                            create editor-translator variable. -->
-                <names variable="editor translator">
+                <names variable="editor translator" delimiter=", &amp; ">
                   <name and="symbol" initialize-with=". " delimiter=", "/>
                   <label form="short" text-case="title" prefix=" (" suffix=")"/>
                 </names>

--- a/apa-single-spaced.csl
+++ b/apa-single-spaced.csl
@@ -185,8 +185,11 @@
               </choose>
             </if>
           </choose>
-          <!-- TODO: Replace `delimiter` with `collapse` to combine names variables when that becomes available. -->
-          <names variable="series-creator executive-producer" delimiter=", &amp; ">
+          <names variable="executive-producer">
+            <name name-as-sort-order="all" and="symbol" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
+            <label form="long" prefix=" (" suffix=")" text-case="title"/>
+          </names>
+          <names variable="series-creator">
             <name name-as-sort-order="all" and="symbol" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
             <label form="long" prefix=" (" suffix=")" text-case="title"/>
           </names>
@@ -310,8 +313,8 @@
                 </choose>
               </if>
             </choose>
-            <!-- TODO: Replace `delimiter` with `collapse` to combine names variables when that becomes available. -->
-            <names variable="series-creator executive-producer" delimiter=", &amp; "/>
+            <names variable="executive-producer"/>
+            <names variable="series-creator"/>
             <names variable="editor"/>
             <names variable="editorial-director"/>
             <names variable="compiler"/>
@@ -1559,10 +1562,11 @@
             </else>
           </choose>
           <group delimiter=", ">
-            <names variable="series-creator executive-producer" delimiter=", &amp; ">
+            <names variable="executive-producer">
               <name and="symbol" initialize-with=". " delimiter=", "/>
               <label form="long" text-case="title" prefix=" (" suffix=")"/>
               <substitute>
+                <names variable="series-creator"/>
                 <names variable="editor-translator">
                   <name and="symbol" initialize-with=". " delimiter=", "/>
                   <label form="short" text-case="title" prefix=" (" suffix=")"/>

--- a/apa-single-spaced.csl
+++ b/apa-single-spaced.csl
@@ -140,8 +140,17 @@
           <!-- Note: `narrator` only cited in secondary-contributors -->
           <names variable="illustrator"/>
           <!-- TODO: Replace `delimiter` with `collapse` to combine names variables when that becomes available. -->
-          <names variable="script-writer director" delimiter=", &amp; ">
-            <!-- Note: Actors/performers and producers [not executive] not cited in APA style. -->
+          <choose>
+            <if type="broadcast">
+              <names variable="script-writer director" delimiter=", &amp; ">
+                <!-- Note: Actors/performers and producers [not executive] not cited in APA style. -->
+                <name name-as-sort-order="all" and="symbol" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
+                <label form="long" prefix=" (" suffix=")" text-case="title"/>
+              </names>
+            </if>
+          </choose>
+          <names variable="director">
+            <!-- For non-broadcast items, APA only cites directors and not writers. -->
             <name name-as-sort-order="all" and="symbol" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
             <label form="long" prefix=" (" suffix=")" text-case="title"/>
           </names>
@@ -283,7 +292,12 @@
             <names variable="author"/>
             <names variable="illustrator"/>
             <!-- TODO: Replace `delimiter` with `collapse` to combine names variables when that becomes available. -->
-            <names variable="script-writer director" delimiter=", &amp; "/>
+            <choose>
+              <if type="broadcast">
+                <names variable="script-writer director" delimiter=", &amp; "/>
+              </if>
+            </choose>
+            <names variable="director"/>
             <!-- TODO: Replace `delimiter` with `collapse` to combine names variables when that becomes available. -->
             <names variable="guest host" delimiter=", &amp; "/>
             <names variable="producer"/>

--- a/apa-single-spaced.csl
+++ b/apa-single-spaced.csl
@@ -139,12 +139,14 @@
           <names variable="author"/>
           <!-- Note: `narrator` only cited in secondary-contributors -->
           <names variable="illustrator"/>
-          <names variable="script-writer director">
+          <!-- TODO: Replace `delimiter` with `collapse` to combine names variables when that becomes available. -->
+          <names variable="script-writer director" delimiter=", &amp; ">
             <!-- Note: Actors/performers and producers [not executive] not cited in APA style. -->
             <name name-as-sort-order="all" and="symbol" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
             <label form="long" prefix=" (" suffix=")" text-case="title"/>
           </names>
-          <names variable="guest host">
+          <!-- TODO: Replace `delimiter` with `collapse` to combine names variables when that becomes available. -->
+          <names variable="guest host" delimiter=", &amp; ">
             <name name-as-sort-order="all" and="symbol" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
             <label form="long" prefix=" (" suffix=")" text-case="title"/>
           </names>
@@ -174,17 +176,18 @@
               </choose>
             </if>
           </choose>
-          <names variable="series-creator executive-producer">
+          <!-- TODO: Replace `delimiter` with `collapse` to combine names variables when that becomes available. -->
+          <names variable="series-creator executive-producer" delimiter=", &amp; ">
             <name name-as-sort-order="all" and="symbol" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
             <label form="long" prefix=" (" suffix=")" text-case="title"/>
           </names>
-          <names variable="editor-translator" delimiter=", ">
+          <names variable="editor-translator">
             <name name-as-sort-order="all" and="symbol" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
             <label form="short" prefix=" (" suffix=")" text-case="title"/>
           </names>
           <!-- TODO: Split editor and translator into separate lines once processors begin to automatically create
                the editor-translator variable. -->
-          <names variable="editor translator" delimiter=", ">
+          <names variable="editor translator" delimiter=", &amp; ">
             <name name-as-sort-order="all" and="symbol" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
             <label form="short" prefix=" (" suffix=")" text-case="title"/>
           </names>
@@ -279,8 +282,10 @@
           <substitute>
             <names variable="author"/>
             <names variable="illustrator"/>
-            <names variable="script-writer director"/>
-            <names variable="guest host"/>
+            <!-- TODO: Replace `delimiter` with `collapse` to combine names variables when that becomes available. -->
+            <names variable="script-writer director" delimiter=", &amp; "/>
+            <!-- TODO: Replace `delimiter` with `collapse` to combine names variables when that becomes available. -->
+            <names variable="guest host" delimiter=", &amp; "/>
             <names variable="producer"/>
             <choose>
               <if variable="container-title">
@@ -291,7 +296,8 @@
                 </choose>
               </if>
             </choose>
-            <names variable="series-creator executive-producer"/>
+            <!-- TODO: Replace `delimiter` with `collapse` to combine names variables when that becomes available. -->
+            <names variable="series-creator executive-producer" delimiter=", &amp; "/>
             <names variable="editor"/>
             <names variable="editorial-director"/>
             <names variable="compiler"/>
@@ -1549,7 +1555,7 @@
                 </names>
                 <!-- TODO: Split editor and translator lines once processors start to automatically
                            create editor-translator variable. -->
-                <names variable="editor translator">
+                <names variable="editor translator" delimiter=", &amp; ">
                   <name and="symbol" initialize-with=". " delimiter=", "/>
                   <label form="short" text-case="title" prefix=" (" suffix=")"/>
                 </names>

--- a/apa-single-spaced.csl
+++ b/apa-single-spaced.csl
@@ -197,9 +197,8 @@
             <name name-as-sort-order="all" and="symbol" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
             <label form="short" prefix=" (" suffix=")" text-case="title"/>
           </names>
-          <!-- TODO: Split editor and translator into separate lines once processors begin to automatically create
-               the editor-translator variable. -->
-          <names variable="editor translator" delimiter=", &amp; ">
+          <!-- Note: Translator is not cited as a primary creator (only as Ed. & Trans.). -->
+          <names variable="editor">
             <name name-as-sort-order="all" and="symbol" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
             <label form="short" prefix=" (" suffix=")" text-case="title"/>
           </names>
@@ -1195,33 +1194,44 @@
           </names>
         </if>
       </choose>
-      <!-- TODO: When editor-translator becomes available in processors, add a test: 
-                 variable="editor-translator" match="none"; then print translator -->
       <choose>
         <if type="post webpage" match="none">
           <!-- Webpages treat container-title like publisher -->
-          <choose>
-            <if variable="container-title" match="none">
-              <group delimiter="; ">
-                <names variable="container-author">
-                  <label form="verb-short" suffix=" " text-case="title"/>
-                  <name and="symbol" initialize-with=". " delimiter=", "/>
-                </names>
-                <names variable="editor translator" delimiter="; ">
-                  <name and="symbol" initialize-with=". " delimiter=", "/>
-                  <label form="short" prefix=", " text-case="title"/>
-                </names>
-                <names variable="illustrator narrator" delimiter="; ">
-                  <name and="symbol" initialize-with=". " delimiter=", "/>
-                  <label form="short" prefix=", " text-case="title"/>
-                </names>
-                <names variable="compiler chair organizer curator series-creator executive-producer" delimiter="; ">
-                  <name and="symbol" initialize-with=". " delimiter=", "/>
-                  <label form="long" prefix=", " text-case="title"/>
-                </names>
-              </group>
-            </if>
-          </choose>
+          <group delimiter="; ">
+            <names variable="illustrator narrator" delimiter="; ">
+              <name and="symbol" initialize-with=". " delimiter=", "/>
+              <label form="short" prefix=", " text-case="title"/>
+            </names>
+            <choose>
+              <if variable="container-title" match="none">
+                <group delimiter="; ">
+                  <names variable="container-author">
+                    <label form="verb-short" suffix=" " text-case="title"/>
+                    <name and="symbol" initialize-with=". " delimiter=", "/>
+                  </names>
+                  <names variable="editor translator" delimiter="; ">
+                    <name and="symbol" initialize-with=". " delimiter=", "/>
+                    <label form="short" prefix=", " text-case="title"/>
+                  </names>
+                  <names variable="compiler chair organizer curator series-creator executive-producer" delimiter="; ">
+                    <name and="symbol" initialize-with=". " delimiter=", "/>
+                    <label form="long" prefix=", " text-case="title"/>
+                  </names>
+                </group>
+              </if>
+              <else>
+                <choose>
+                  <!-- TODO: Check logic once processors start to automatically populate editor-translator. -->
+                  <if variable="editor-translator" match="none">
+                    <names variable="translator" delimiter="; ">
+                      <name and="symbol" initialize-with=". " delimiter=", "/>
+                      <label form="short" prefix=", " text-case="title"/>
+                    </names>
+                  </if>
+                </choose>
+              </else>
+            </choose>
+          </group>
         </if>
         <else>
           <group delimiter="; ">
@@ -1571,9 +1581,10 @@
                   <name and="symbol" initialize-with=". " delimiter=", "/>
                   <label form="short" text-case="title" prefix=" (" suffix=")"/>
                 </names>
-                <!-- TODO: Split editor and translator lines once processors start to automatically
-                           create editor-translator variable. -->
-                <names variable="editor translator" delimiter=", &amp; ">
+                <!-- TODO: Translator omitted here on the assumption that editor-translators are uncommon 
+                           for chapter citations. If needed, direct entry or automatic population of
+                           `editor-translator` can produce combined labels. -->
+                <names variable="editor">
                   <name and="symbol" initialize-with=". " delimiter=", "/>
                   <label form="short" text-case="title" prefix=" (" suffix=")"/>
                 </names>

--- a/apa-with-abstract.csl
+++ b/apa-with-abstract.csl
@@ -185,8 +185,11 @@
               </choose>
             </if>
           </choose>
-          <!-- TODO: Replace `delimiter` with `collapse` to combine names variables when that becomes available. -->
-          <names variable="series-creator executive-producer" delimiter=", &amp; ">
+          <names variable="executive-producer">
+            <name name-as-sort-order="all" and="symbol" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
+            <label form="long" prefix=" (" suffix=")" text-case="title"/>
+          </names>
+          <names variable="series-creator">
             <name name-as-sort-order="all" and="symbol" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
             <label form="long" prefix=" (" suffix=")" text-case="title"/>
           </names>
@@ -310,8 +313,8 @@
                 </choose>
               </if>
             </choose>
-            <!-- TODO: Replace `delimiter` with `collapse` to combine names variables when that becomes available. -->
-            <names variable="series-creator executive-producer" delimiter=", &amp; "/>
+            <names variable="executive-producer"/>
+            <names variable="series-creator"/>
             <names variable="editor"/>
             <names variable="editorial-director"/>
             <names variable="compiler"/>
@@ -1559,10 +1562,11 @@
             </else>
           </choose>
           <group delimiter=", ">
-            <names variable="series-creator executive-producer" delimiter=", &amp; ">
+            <names variable="executive-producer">
               <name and="symbol" initialize-with=". " delimiter=", "/>
               <label form="long" text-case="title" prefix=" (" suffix=")"/>
               <substitute>
+                <names variable="series-creator"/>
                 <names variable="editor-translator">
                   <name and="symbol" initialize-with=". " delimiter=", "/>
                   <label form="short" text-case="title" prefix=" (" suffix=")"/>

--- a/apa-with-abstract.csl
+++ b/apa-with-abstract.csl
@@ -140,8 +140,17 @@
           <!-- Note: `narrator` only cited in secondary-contributors -->
           <names variable="illustrator"/>
           <!-- TODO: Replace `delimiter` with `collapse` to combine names variables when that becomes available. -->
-          <names variable="script-writer director" delimiter=", &amp; ">
-            <!-- Note: Actors/performers and producers [not executive] not cited in APA style. -->
+          <choose>
+            <if type="broadcast">
+              <names variable="script-writer director" delimiter=", &amp; ">
+                <!-- Note: Actors/performers and producers [not executive] not cited in APA style. -->
+                <name name-as-sort-order="all" and="symbol" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
+                <label form="long" prefix=" (" suffix=")" text-case="title"/>
+              </names>
+            </if>
+          </choose>
+          <names variable="director">
+            <!-- For non-broadcast items, APA only cites directors and not writers. -->
             <name name-as-sort-order="all" and="symbol" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
             <label form="long" prefix=" (" suffix=")" text-case="title"/>
           </names>
@@ -283,7 +292,12 @@
             <names variable="author"/>
             <names variable="illustrator"/>
             <!-- TODO: Replace `delimiter` with `collapse` to combine names variables when that becomes available. -->
-            <names variable="script-writer director" delimiter=", &amp; "/>
+            <choose>
+              <if type="broadcast">
+                <names variable="script-writer director" delimiter=", &amp; "/>
+              </if>
+            </choose>
+            <names variable="director"/>
             <!-- TODO: Replace `delimiter` with `collapse` to combine names variables when that becomes available. -->
             <names variable="guest host" delimiter=", &amp; "/>
             <names variable="producer"/>

--- a/apa-with-abstract.csl
+++ b/apa-with-abstract.csl
@@ -139,12 +139,14 @@
           <names variable="author"/>
           <!-- Note: `narrator` only cited in secondary-contributors -->
           <names variable="illustrator"/>
-          <names variable="script-writer director">
+          <!-- TODO: Replace `delimiter` with `collapse` to combine names variables when that becomes available. -->
+          <names variable="script-writer director" delimiter=", &amp; ">
             <!-- Note: Actors/performers and producers [not executive] not cited in APA style. -->
             <name name-as-sort-order="all" and="symbol" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
             <label form="long" prefix=" (" suffix=")" text-case="title"/>
           </names>
-          <names variable="guest host">
+          <!-- TODO: Replace `delimiter` with `collapse` to combine names variables when that becomes available. -->
+          <names variable="guest host" delimiter=", &amp; ">
             <name name-as-sort-order="all" and="symbol" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
             <label form="long" prefix=" (" suffix=")" text-case="title"/>
           </names>
@@ -174,17 +176,18 @@
               </choose>
             </if>
           </choose>
-          <names variable="series-creator executive-producer">
+          <!-- TODO: Replace `delimiter` with `collapse` to combine names variables when that becomes available. -->
+          <names variable="series-creator executive-producer" delimiter=", &amp; ">
             <name name-as-sort-order="all" and="symbol" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
             <label form="long" prefix=" (" suffix=")" text-case="title"/>
           </names>
-          <names variable="editor-translator" delimiter=", ">
+          <names variable="editor-translator">
             <name name-as-sort-order="all" and="symbol" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
             <label form="short" prefix=" (" suffix=")" text-case="title"/>
           </names>
           <!-- TODO: Split editor and translator into separate lines once processors begin to automatically create
                the editor-translator variable. -->
-          <names variable="editor translator" delimiter=", ">
+          <names variable="editor translator" delimiter=", &amp; ">
             <name name-as-sort-order="all" and="symbol" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
             <label form="short" prefix=" (" suffix=")" text-case="title"/>
           </names>
@@ -279,8 +282,10 @@
           <substitute>
             <names variable="author"/>
             <names variable="illustrator"/>
-            <names variable="script-writer director"/>
-            <names variable="guest host"/>
+            <!-- TODO: Replace `delimiter` with `collapse` to combine names variables when that becomes available. -->
+            <names variable="script-writer director" delimiter=", &amp; "/>
+            <!-- TODO: Replace `delimiter` with `collapse` to combine names variables when that becomes available. -->
+            <names variable="guest host" delimiter=", &amp; "/>
             <names variable="producer"/>
             <choose>
               <if variable="container-title">
@@ -291,7 +296,8 @@
                 </choose>
               </if>
             </choose>
-            <names variable="series-creator executive-producer"/>
+            <!-- TODO: Replace `delimiter` with `collapse` to combine names variables when that becomes available. -->
+            <names variable="series-creator executive-producer" delimiter=", &amp; "/>
             <names variable="editor"/>
             <names variable="editorial-director"/>
             <names variable="compiler"/>
@@ -1549,7 +1555,7 @@
                 </names>
                 <!-- TODO: Split editor and translator lines once processors start to automatically
                            create editor-translator variable. -->
-                <names variable="editor translator">
+                <names variable="editor translator" delimiter=", &amp; ">
                   <name and="symbol" initialize-with=". " delimiter=", "/>
                   <label form="short" text-case="title" prefix=" (" suffix=")"/>
                 </names>

--- a/apa-with-abstract.csl
+++ b/apa-with-abstract.csl
@@ -197,9 +197,8 @@
             <name name-as-sort-order="all" and="symbol" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
             <label form="short" prefix=" (" suffix=")" text-case="title"/>
           </names>
-          <!-- TODO: Split editor and translator into separate lines once processors begin to automatically create
-               the editor-translator variable. -->
-          <names variable="editor translator" delimiter=", &amp; ">
+          <!-- Note: Translator is not cited as a primary creator (only as Ed. & Trans.). -->
+          <names variable="editor">
             <name name-as-sort-order="all" and="symbol" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
             <label form="short" prefix=" (" suffix=")" text-case="title"/>
           </names>
@@ -1195,33 +1194,44 @@
           </names>
         </if>
       </choose>
-      <!-- TODO: When editor-translator becomes available in processors, add a test: 
-                 variable="editor-translator" match="none"; then print translator -->
       <choose>
         <if type="post webpage" match="none">
           <!-- Webpages treat container-title like publisher -->
-          <choose>
-            <if variable="container-title" match="none">
-              <group delimiter="; ">
-                <names variable="container-author">
-                  <label form="verb-short" suffix=" " text-case="title"/>
-                  <name and="symbol" initialize-with=". " delimiter=", "/>
-                </names>
-                <names variable="editor translator" delimiter="; ">
-                  <name and="symbol" initialize-with=". " delimiter=", "/>
-                  <label form="short" prefix=", " text-case="title"/>
-                </names>
-                <names variable="illustrator narrator" delimiter="; ">
-                  <name and="symbol" initialize-with=". " delimiter=", "/>
-                  <label form="short" prefix=", " text-case="title"/>
-                </names>
-                <names variable="compiler chair organizer curator series-creator executive-producer" delimiter="; ">
-                  <name and="symbol" initialize-with=". " delimiter=", "/>
-                  <label form="long" prefix=", " text-case="title"/>
-                </names>
-              </group>
-            </if>
-          </choose>
+          <group delimiter="; ">
+            <names variable="illustrator narrator" delimiter="; ">
+              <name and="symbol" initialize-with=". " delimiter=", "/>
+              <label form="short" prefix=", " text-case="title"/>
+            </names>
+            <choose>
+              <if variable="container-title" match="none">
+                <group delimiter="; ">
+                  <names variable="container-author">
+                    <label form="verb-short" suffix=" " text-case="title"/>
+                    <name and="symbol" initialize-with=". " delimiter=", "/>
+                  </names>
+                  <names variable="editor translator" delimiter="; ">
+                    <name and="symbol" initialize-with=". " delimiter=", "/>
+                    <label form="short" prefix=", " text-case="title"/>
+                  </names>
+                  <names variable="compiler chair organizer curator series-creator executive-producer" delimiter="; ">
+                    <name and="symbol" initialize-with=". " delimiter=", "/>
+                    <label form="long" prefix=", " text-case="title"/>
+                  </names>
+                </group>
+              </if>
+              <else>
+                <choose>
+                  <!-- TODO: Check logic once processors start to automatically populate editor-translator. -->
+                  <if variable="editor-translator" match="none">
+                    <names variable="translator" delimiter="; ">
+                      <name and="symbol" initialize-with=". " delimiter=", "/>
+                      <label form="short" prefix=", " text-case="title"/>
+                    </names>
+                  </if>
+                </choose>
+              </else>
+            </choose>
+          </group>
         </if>
         <else>
           <group delimiter="; ">
@@ -1571,9 +1581,10 @@
                   <name and="symbol" initialize-with=". " delimiter=", "/>
                   <label form="short" text-case="title" prefix=" (" suffix=")"/>
                 </names>
-                <!-- TODO: Split editor and translator lines once processors start to automatically
-                           create editor-translator variable. -->
-                <names variable="editor translator" delimiter=", &amp; ">
+                <!-- TODO: Translator omitted here on the assumption that editor-translators are uncommon 
+                           for chapter citations. If needed, direct entry or automatic population of
+                           `editor-translator` can produce combined labels. -->
+                <names variable="editor">
                   <name and="symbol" initialize-with=". " delimiter=", "/>
                   <label form="short" text-case="title" prefix=" (" suffix=")"/>
                 </names>

--- a/apa.csl
+++ b/apa.csl
@@ -1549,7 +1549,7 @@
               <name and="symbol" initialize-with=". " delimiter=", "/>
               <label form="long" text-case="title" prefix=" (" suffix=")"/>
               <substitute>
-                <names variable="editor-translator" delimiter=", &amp; ">
+                <names variable="editor-translator">
                   <name and="symbol" initialize-with=". " delimiter=", "/>
                   <label form="short" text-case="title" prefix=" (" suffix=")"/>
                 </names>

--- a/apa.csl
+++ b/apa.csl
@@ -185,8 +185,11 @@
               </choose>
             </if>
           </choose>
-          <!-- TODO: Replace `delimiter` with `collapse` to combine names variables when that becomes available. -->
-          <names variable="series-creator executive-producer" delimiter=", &amp; ">
+          <names variable="executive-producer">
+            <name name-as-sort-order="all" and="symbol" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
+            <label form="long" prefix=" (" suffix=")" text-case="title"/>
+          </names>
+          <names variable="series-creator">
             <name name-as-sort-order="all" and="symbol" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
             <label form="long" prefix=" (" suffix=")" text-case="title"/>
           </names>
@@ -310,8 +313,8 @@
                 </choose>
               </if>
             </choose>
-            <!-- TODO: Replace `delimiter` with `collapse` to combine names variables when that becomes available. -->
-            <names variable="series-creator executive-producer" delimiter=", &amp; "/>
+            <names variable="executive-producer"/>
+            <names variable="series-creator"/>
             <names variable="editor"/>
             <names variable="editorial-director"/>
             <names variable="compiler"/>
@@ -1559,10 +1562,11 @@
             </else>
           </choose>
           <group delimiter=", ">
-            <names variable="series-creator executive-producer" delimiter=", &amp; ">
+            <names variable="executive-producer">
               <name and="symbol" initialize-with=". " delimiter=", "/>
               <label form="long" text-case="title" prefix=" (" suffix=")"/>
               <substitute>
+                <names variable="series-creator"/>
                 <names variable="editor-translator">
                   <name and="symbol" initialize-with=". " delimiter=", "/>
                   <label form="short" text-case="title" prefix=" (" suffix=")"/>

--- a/apa.csl
+++ b/apa.csl
@@ -140,8 +140,17 @@
           <!-- Note: `narrator` only cited in secondary-contributors -->
           <names variable="illustrator"/>
           <!-- TODO: Replace `delimiter` with `collapse` to combine names variables when that becomes available. -->
-          <names variable="script-writer director" delimiter=", &amp; ">
-            <!-- Note: Actors/performers and producers [not executive] not cited in APA style. -->
+          <choose>
+            <if type="broadcast">
+              <names variable="script-writer director" delimiter=", &amp; ">
+                <!-- Note: Actors/performers and producers [not executive] not cited in APA style. -->
+                <name name-as-sort-order="all" and="symbol" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
+                <label form="long" prefix=" (" suffix=")" text-case="title"/>
+              </names>
+            </if>
+          </choose>
+          <names variable="director">
+            <!-- For non-broadcast items, APA only cites directors and not writers. -->
             <name name-as-sort-order="all" and="symbol" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
             <label form="long" prefix=" (" suffix=")" text-case="title"/>
           </names>
@@ -283,7 +292,12 @@
             <names variable="author"/>
             <names variable="illustrator"/>
             <!-- TODO: Replace `delimiter` with `collapse` to combine names variables when that becomes available. -->
-            <names variable="script-writer director" delimiter=", &amp; "/>
+            <choose>
+              <if type="broadcast">
+                <names variable="script-writer director" delimiter=", &amp; "/>
+              </if>
+            </choose>
+            <names variable="director"/>
             <!-- TODO: Replace `delimiter` with `collapse` to combine names variables when that becomes available. -->
             <names variable="guest host" delimiter=", &amp; "/>
             <names variable="producer"/>

--- a/apa.csl
+++ b/apa.csl
@@ -139,12 +139,14 @@
           <names variable="author"/>
           <!-- Note: `narrator` only cited in secondary-contributors -->
           <names variable="illustrator"/>
-          <names variable="script-writer director" delimiter=", ">
+          <!-- TODO: Replace `delimiter` with `collapse` to combine names variables when that becomes available. -->
+          <names variable="script-writer director" delimiter=", &amp; "> 
             <!-- Note: Actors/performers and producers [not executive] not cited in APA style. -->
             <name name-as-sort-order="all" and="symbol" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
             <label form="long" prefix=" (" suffix=")" text-case="title"/>
           </names>
-          <names variable="guest host">
+          <!-- TODO: Replace `delimiter` with `collapse` to combine names variables when that becomes available. -->
+          <names variable="guest host" delimiter=", &amp; ">
             <name name-as-sort-order="all" and="symbol" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
             <label form="long" prefix=" (" suffix=")" text-case="title"/>
           </names>
@@ -174,17 +176,18 @@
               </choose>
             </if>
           </choose>
-          <names variable="series-creator executive-producer">
+          <!-- TODO: Replace `delimiter` with `collapse` to combine names variables when that becomes available. -->
+          <names variable="series-creator executive-producer" delimiter=", &amp; ">
             <name name-as-sort-order="all" and="symbol" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
             <label form="long" prefix=" (" suffix=")" text-case="title"/>
           </names>
-          <names variable="editor-translator" delimiter=", ">
+          <names variable="editor-translator">
             <name name-as-sort-order="all" and="symbol" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
             <label form="short" prefix=" (" suffix=")" text-case="title"/>
           </names>
           <!-- TODO: Split editor and translator into separate lines once processors begin to automatically create
                the editor-translator variable. -->
-          <names variable="editor translator" delimiter=", ">
+          <names variable="editor translator" delimiter=", &amp; ">
             <name name-as-sort-order="all" and="symbol" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
             <label form="short" prefix=" (" suffix=")" text-case="title"/>
           </names>
@@ -279,8 +282,10 @@
           <substitute>
             <names variable="author"/>
             <names variable="illustrator"/>
-            <names variable="script-writer director"/>
-            <names variable="guest host"/>
+            <!-- TODO: Replace `delimiter` with `collapse` to combine names variables when that becomes available. -->
+            <names variable="script-writer director" delimiter=", &amp; "/>
+            <!-- TODO: Replace `delimiter` with `collapse` to combine names variables when that becomes available. -->
+            <names variable="guest host" delimiter=", &amp; "/>
             <names variable="producer"/>
             <choose>
               <if variable="container-title">
@@ -291,7 +296,8 @@
                 </choose>
               </if>
             </choose>
-            <names variable="series-creator executive-producer"/>
+            <!-- TODO: Replace `delimiter` with `collapse` to combine names variables when that becomes available. -->
+            <names variable="series-creator executive-producer" delimiter=", &amp; "/>
             <names variable="editor"/>
             <names variable="editorial-director"/>
             <names variable="compiler"/>
@@ -1543,13 +1549,13 @@
               <name and="symbol" initialize-with=". " delimiter=", "/>
               <label form="long" text-case="title" prefix=" (" suffix=")"/>
               <substitute>
-                <names variable="editor-translator">
+                <names variable="editor-translator" delimiter=", &amp; ">
                   <name and="symbol" initialize-with=". " delimiter=", "/>
                   <label form="short" text-case="title" prefix=" (" suffix=")"/>
                 </names>
                 <!-- TODO: Split editor and translator lines once processors start to automatically
                            create editor-translator variable. -->
-                <names variable="editor translator">
+                <names variable="editor translator" delimiter=", &amp; ">
                   <name and="symbol" initialize-with=". " delimiter=", "/>
                   <label form="short" text-case="title" prefix=" (" suffix=")"/>
                 </names>

--- a/apa.csl
+++ b/apa.csl
@@ -140,7 +140,7 @@
           <!-- Note: `narrator` only cited in secondary-contributors -->
           <names variable="illustrator"/>
           <!-- TODO: Replace `delimiter` with `collapse` to combine names variables when that becomes available. -->
-          <names variable="script-writer director" delimiter=", &amp; "> 
+          <names variable="script-writer director" delimiter=", &amp; ">
             <!-- Note: Actors/performers and producers [not executive] not cited in APA style. -->
             <name name-as-sort-order="all" and="symbol" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
             <label form="long" prefix=" (" suffix=")" text-case="title"/>

--- a/apa.csl
+++ b/apa.csl
@@ -197,9 +197,8 @@
             <name name-as-sort-order="all" and="symbol" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
             <label form="short" prefix=" (" suffix=")" text-case="title"/>
           </names>
-          <!-- TODO: Split editor and translator into separate lines once processors begin to automatically create
-               the editor-translator variable. -->
-          <names variable="editor translator" delimiter=", &amp; ">
+          <!-- Note: Translator is not cited as a primary creator (only as Ed. & Trans.). -->
+          <names variable="editor">
             <name name-as-sort-order="all" and="symbol" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
             <label form="short" prefix=" (" suffix=")" text-case="title"/>
           </names>
@@ -1195,33 +1194,44 @@
           </names>
         </if>
       </choose>
-      <!-- TODO: When editor-translator becomes available in processors, add a test: 
-                 variable="editor-translator" match="none"; then print translator -->
       <choose>
         <if type="post webpage" match="none">
           <!-- Webpages treat container-title like publisher -->
-          <choose>
-            <if variable="container-title" match="none">
-              <group delimiter="; ">
-                <names variable="container-author">
-                  <label form="verb-short" suffix=" " text-case="title"/>
-                  <name and="symbol" initialize-with=". " delimiter=", "/>
-                </names>
-                <names variable="editor translator" delimiter="; ">
-                  <name and="symbol" initialize-with=". " delimiter=", "/>
-                  <label form="short" prefix=", " text-case="title"/>
-                </names>
-                <names variable="illustrator narrator" delimiter="; ">
-                  <name and="symbol" initialize-with=". " delimiter=", "/>
-                  <label form="short" prefix=", " text-case="title"/>
-                </names>
-                <names variable="compiler chair organizer curator series-creator executive-producer" delimiter="; ">
-                  <name and="symbol" initialize-with=". " delimiter=", "/>
-                  <label form="long" prefix=", " text-case="title"/>
-                </names>
-              </group>
-            </if>
-          </choose>
+          <group delimiter="; ">
+            <names variable="illustrator narrator" delimiter="; ">
+              <name and="symbol" initialize-with=". " delimiter=", "/>
+              <label form="short" prefix=", " text-case="title"/>
+            </names>
+            <choose>
+              <if variable="container-title" match="none">
+                <group delimiter="; ">
+                  <names variable="container-author">
+                    <label form="verb-short" suffix=" " text-case="title"/>
+                    <name and="symbol" initialize-with=". " delimiter=", "/>
+                  </names>
+                  <names variable="editor translator" delimiter="; ">
+                    <name and="symbol" initialize-with=". " delimiter=", "/>
+                    <label form="short" prefix=", " text-case="title"/>
+                  </names>
+                  <names variable="compiler chair organizer curator series-creator executive-producer" delimiter="; ">
+                    <name and="symbol" initialize-with=". " delimiter=", "/>
+                    <label form="long" prefix=", " text-case="title"/>
+                  </names>
+                </group>
+              </if>
+              <else>
+                <choose>
+                  <!-- TODO: Check logic once processors start to automatically populate editor-translator. -->
+                  <if variable="editor-translator" match="none">
+                    <names variable="translator" delimiter="; ">
+                      <name and="symbol" initialize-with=". " delimiter=", "/>
+                      <label form="short" prefix=", " text-case="title"/>
+                    </names>
+                  </if>
+                </choose>
+              </else>
+            </choose>
+          </group>
         </if>
         <else>
           <group delimiter="; ">
@@ -1571,9 +1581,10 @@
                   <name and="symbol" initialize-with=". " delimiter=", "/>
                   <label form="short" text-case="title" prefix=" (" suffix=")"/>
                 </names>
-                <!-- TODO: Split editor and translator lines once processors start to automatically
-                           create editor-translator variable. -->
-                <names variable="editor translator" delimiter=", &amp; ">
+                <!-- TODO: Translator omitted here on the assumption that editor-translators are uncommon 
+                           for chapter citations. If needed, direct entry or automatic population of
+                           `editor-translator` can produce combined labels. -->
+                <names variable="editor">
                   <name and="symbol" initialize-with=". " delimiter=", "/>
                   <label form="short" text-case="title" prefix=" (" suffix=")"/>
                 </names>

--- a/apa.csl
+++ b/apa.csl
@@ -139,7 +139,7 @@
           <names variable="author"/>
           <!-- Note: `narrator` only cited in secondary-contributors -->
           <names variable="illustrator"/>
-          <names variable="script-writer director">
+          <names variable="script-writer director" delimiter=", ">
             <!-- Note: Actors/performers and producers [not executive] not cited in APA style. -->
             <name name-as-sort-order="all" and="symbol" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
             <label form="long" prefix=" (" suffix=")" text-case="title"/>


### PR DESCRIPTION
To comply with Section 10.12, the rule must support dual roles (Writer & Director) and separately list each writer and director with the appropriate role, i.e. (Writer), (Director). This may involve adding a new term "script-writer-director", similar to "editor-translator".