### PR TITLE
Update AMA 11e styles: Remove "Published " prefix from publication date of web references

### DIFF
--- a/american-medical-association-alphabetical.csl
+++ b/american-medical-association-alphabetical.csl
@@ -66,7 +66,7 @@
             <group delimiter=". ">
               <choose>
                 <if type="webpage post post-weblog" match="any">
-                  <date variable="issued" prefix="Published " form="text"/>
+                  <date variable="issued" form="text"/>
                 </if>
               </choose>
               <group>
@@ -178,7 +178,7 @@
             <if variable="URL">
               <group delimiter=". " suffix=".">
                 <text variable="URL"/>
-                <group prefix="Published ">
+                <group>
                   <date variable="issued">
                     <date-part name="month" suffix=" "/>
                     <date-part name="day" suffix=", "/>

--- a/american-medical-association-brackets.csl
+++ b/american-medical-association-brackets.csl
@@ -66,7 +66,7 @@
             <group delimiter=". ">
               <choose>
                 <if type="webpage post post-weblog" match="any">
-                  <date variable="issued" prefix="Published " form="text"/>
+                  <date variable="issued" form="text"/>
                 </if>
               </choose>
               <group>
@@ -173,7 +173,7 @@
             <if variable="URL">
               <group delimiter=". " suffix=".">
                 <text variable="URL"/>
-                <group prefix="Published ">
+                <group>
                   <date variable="issued">
                     <date-part name="month" suffix=" "/>
                     <date-part name="day" suffix=", "/>

--- a/american-medical-association-no-et-al.csl
+++ b/american-medical-association-no-et-al.csl
@@ -66,7 +66,7 @@
             <group delimiter=". ">
               <choose>
                 <if type="webpage post post-weblog" match="any">
-                  <date variable="issued" prefix="Published " form="text"/>
+                  <date variable="issued" form="text"/>
                 </if>
               </choose>
               <group>
@@ -173,7 +173,7 @@
             <if variable="URL">
               <group delimiter=". " suffix=".">
                 <text variable="URL"/>
-                <group prefix="Published ">
+                <group>
                   <date variable="issued">
                     <date-part name="month" suffix=" "/>
                     <date-part name="day" suffix=", "/>

--- a/american-medical-association-no-url-alphabetical.csl
+++ b/american-medical-association-no-url-alphabetical.csl
@@ -148,7 +148,7 @@
             <if variable="URL">
               <group delimiter=". " suffix=".">
                 <text variable="URL"/>
-                <group prefix="Published ">
+                <group>
                   <date variable="issued">
                     <date-part name="month" suffix=" "/>
                     <date-part name="day" suffix=", "/>

--- a/american-medical-association-no-url.csl
+++ b/american-medical-association-no-url.csl
@@ -143,7 +143,7 @@
             <if variable="URL">
               <group delimiter=". " suffix=".">
                 <text variable="URL"/>
-                <group prefix="Published ">
+                <group>
                   <date variable="issued">
                     <date-part name="month" suffix=" "/>
                     <date-part name="day" suffix=", "/>

--- a/american-medical-association-parentheses.csl
+++ b/american-medical-association-parentheses.csl
@@ -53,7 +53,7 @@
             <group delimiter=". ">
               <choose>
                 <if type="webpage post post-weblog" match="any">
-                  <date variable="issued" prefix="Published " form="text"/>
+                  <date variable="issued" form="text"/>
                 </if>
               </choose>
               <group>
@@ -160,7 +160,7 @@
             <if variable="URL">
               <group delimiter=". " suffix=".">
                 <text variable="URL"/>
-                <group prefix="Published ">
+                <group>
                   <date variable="issued">
                     <date-part name="month" suffix=" "/>
                     <date-part name="day" suffix=", "/>

--- a/american-medical-association.csl
+++ b/american-medical-association.csl
@@ -66,7 +66,7 @@
             <group delimiter=". ">
               <choose>
                 <if type="webpage post post-weblog" match="any">
-                  <date variable="issued" prefix="Published " form="text"/>
+                  <date variable="issued" form="text"/>
                 </if>
               </choose>
               <group>
@@ -173,7 +173,7 @@
             <if variable="URL">
               <group delimiter=". " suffix=".">
                 <text variable="URL"/>
-                <group prefix="Published ">
+                <group>
                   <date variable="issued">
                     <date-part name="month" suffix=" "/>
                     <date-part name="day" suffix=", "/>


### PR DESCRIPTION
AMA 10e required certain web references (websites, blog posts, newspapers) to use the format "Published \[date\]" for their publication dates. However, 11e no longer requires "Published" to be present before the date.

See section 3.15.3 and example 1 in section 3.13.1 of the 11e manual:

<img width="594" alt="Screenshot 2024-08-02 at 14 26 46" src="https://github.com/user-attachments/assets/81853840-5949-4376-9807-42894685bd5a">

<img width="589" alt="Screenshot 2024-08-02 at 14 27 02" src="https://github.com/user-attachments/assets/b02605ee-1883-4fbd-b8c5-299faba404b5">