### PR TITLE
Update multidisciplinary-digital-publishing-institute.csl

### DIFF
--- a/multidisciplinary-digital-publishing-institute.csl
+++ b/multidisciplinary-digital-publishing-institute.csl
@@ -12,11 +12,11 @@
     </author>
     <contributor>
       <name>Patrick O'Brien</name>
-    </contributor>  
-    <contributor>  
+    </contributor>
+    <contributor>
       <name>Johan van der Molen Moris</name>
     </contributor>
-    <contributor>  
+    <contributor>
       <name>Szilárd Enyedi</name>
     </contributor>
     <category citation-format="numeric"/>
@@ -208,7 +208,7 @@
         <else-if type="speech">
           <group delimiter=" ">
             <text variable="title" text-case="title" suffix="."/>
-             <group delimiter=", ">
+            <group delimiter=", ">
               <group delimiter=" ">
                 <text term="presented at" text-case="capitalize-first"/>
                 <text variable="event"/>

--- a/multidisciplinary-digital-publishing-institute.csl
+++ b/multidisciplinary-digital-publishing-institute.csl
@@ -16,10 +16,13 @@
     <contributor>  
       <name>Johan van der Molen Moris</name>
     </contributor>
+    <contributor>  
+      <name>Szilárd Enyedi</name>
+    </contributor>
     <category citation-format="numeric"/>
     <category field="science"/>
     <summary>Style for the MDPI Open access journals</summary>
-    <updated>2020-12-17T13:36:58+00:00</updated>
+    <updated>2024-08-03T20:34:58+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale xml:lang="en">
@@ -224,6 +227,20 @@
               <text variable="volume" font-style="italic"/>
               <text variable="page"/>
             </group>
+          </group>
+        </else-if>
+        <else-if type="standard">
+          <group delimiter=" ">
+            <text variable="publisher" text-case="title" suffix="."/>
+            <text variable="title" font-style="italic" text-case="title" suffix=";"/>
+            <text variable="number" text-case="title" suffix=";"/>
+            <text variable="event-place" text-case="title" suffix=","/>
+            <group delimiter=", " suffix=".">
+              <text macro="issued" font-weight="bold"/>
+              <text variable="volume" font-style="italic"/>
+              <text variable="page"/>
+            </group>
+            <text variable="DOI" text-case="title" prefix="DOI: "/>
           </group>
         </else-if>
         <else>


### PR DESCRIPTION
Added formatting for "standard" type (e.g. ISO 9001). The "MDPI Reference List and Citations Style Guide" (https://mdpi-res.com/data/mdpi_references_guide_v9.pdf) does not specify it, but sends to the ACS Style Guide (https://pubs.acs.org/doi/full/10.1021/acsguide.40303). The ACS guide does give an example for formatting a "standard":

institution or publisher. italic title; number; location, year. DOI: doinumber

I kept "year" in bold, as the rest of the MDPI reference styles, although ACS does not use bold there. I also kept "volume" and "page", maybe there are standards which use that.