### PR TITLE
Create chicago-note-bibliography-manuscript.csl

### DIFF
--- a/chicago-note-bibliography-manuscript.csl
+++ b/chicago-note-bibliography-manuscript.csl
@@ -1,0 +1,1514 @@
+<?xml version="1.0" encoding="utf-8"?>
+<style xmlns="http://purl.org/net/xbiblio/csl" class="note" version="1.0" demote-non-dropping-particle="display-and-sort" page-range-format="chicago">
+  <info>
+    <title>Chicago Manual of Style 17th edition (note) manuscript</title>
+    <id>http://www.zotero.org/styles/chicago-note-bibliography-manuscript</id>
+    <link href="http://www.zotero.org/styles/chicago-note-bibliography-manuscript" rel="self"/>
+    <link href="http://www.zotero.org/styles/chicago-note-bibliography" rel="template"/>
+    <link href="http://www.chicagomanualofstyle.org/tools_citationguide.html" rel="documentation"/>
+    <category citation-format="note"/>
+    <category field="generic-base"/>
+    <summary>Chicago format with short notes and bibliography</summary>
+    <updated>2024-03-17T19:02:00+00:00</updated>
+    <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
+  </info>
+  <locale xml:lang="en">
+    <terms>
+      <term name="editor" form="verb-short">ed.</term>
+      <term name="translator" form="verb-short">trans.</term>
+      <term name="translator" form="short">trans.</term>
+      <term name="editortranslator" form="verb-short">ed. and trans.</term>
+      <term name="editortranslator" form="verb">Edited and translated by</term>
+      <term name="translator" form="short">trans.</term>
+    </terms>
+  </locale>
+  <macro name="editor-translator">
+    <group delimiter=", ">
+      <group delimiter=" ">
+        <choose>
+          <if variable="container-author reviewed-author" match="any">
+            <group>
+              <names variable="container-author reviewed-author">
+                <label form="verb-short" text-case="lowercase" suffix=" "/>
+                <name and="text" delimiter=", "/>
+              </names>
+            </group>
+          </if>
+        </choose>
+      </group>
+      <names variable="editor translator" delimiter=", ">
+        <label form="verb-short" text-case="lowercase" suffix=" "/>
+        <name and="text" delimiter=", "/>
+      </names>
+    </group>
+  </macro>
+  <macro name="secondary-contributors-note">
+    <choose>
+      <if type="chapter entry-dictionary entry-encyclopedia paper-conference" match="none">
+        <text macro="editor-translator"/>
+      </if>
+    </choose>
+  </macro>
+  <macro name="container-contributors-note">
+    <choose>
+      <if type="chapter entry-dictionary entry-encyclopedia paper-conference" match="any">
+        <text macro="editor-translator"/>
+      </if>
+    </choose>
+  </macro>
+  <macro name="secondary-contributors">
+    <choose>
+      <if type="chapter entry-dictionary entry-encyclopedia paper-conference" match="none">
+        <names variable="editor translator" delimiter=". ">
+          <label form="verb" text-case="capitalize-first" suffix=" "/>
+          <name and="text" delimiter=", "/>
+        </names>
+      </if>
+    </choose>
+  </macro>
+  <macro name="container-contributors">
+    <choose>
+      <if type="chapter entry-dictionary entry-encyclopedia paper-conference" match="any">
+        <group delimiter=", ">
+          <choose>
+            <if variable="author">
+              <choose>
+                <if variable="container-author" match="any">
+                  <names variable="container-author">
+                    <label form="verb-short" text-case="lowercase" suffix=" "/>
+                    <name and="text" delimiter=", "/>
+                  </names>
+                </if>
+              </choose>
+              <!--This includes page numers after the container author, e.g. for Introductions -->
+              <choose>
+                <if variable="container-author author" match="all">
+                  <group delimiter=". ">
+                    <text variable="page"/>
+                    <names variable="editor translator" delimiter=", ">
+                      <label form="verb" suffix=" "/>
+                      <name and="text" delimiter=", "/>
+                    </names>
+                  </group>
+                </if>
+                <else>
+                  <names variable="editor translator" delimiter=", ">
+                    <label form="verb" text-case="lowercase" suffix=" "/>
+                    <name and="text" delimiter=", "/>
+                  </names>
+                </else>
+              </choose>
+            </if>
+          </choose>
+        </group>
+      </if>
+    </choose>
+  </macro>
+  <macro name="recipient-note">
+    <names variable="recipient" delimiter=", ">
+      <label form="verb" text-case="lowercase" suffix=" "/>
+      <name and="text" delimiter=", "/>
+    </names>
+  </macro>
+  <macro name="contributors-note">
+    <group delimiter=" ">
+      <names variable="author">
+        <name and="text" sort-separator=", " delimiter=", "/>
+        <label form="short" prefix=", "/>
+        <substitute>
+          <names variable="editor"/>
+          <names variable="translator"/>
+        </substitute>
+      </names>
+      <text macro="recipient-note"/>
+    </group>
+  </macro>
+  <macro name="editor">
+    <names variable="editor">
+      <name name-as-sort-order="first" and="text" sort-separator=", " delimiter=", " delimiter-precedes-last="always"/>
+      <label form="short" prefix=", "/>
+    </names>
+  </macro>
+  <macro name="translator">
+    <names variable="translator">
+      <name name-as-sort-order="first" and="text" sort-separator=", " delimiter=", " delimiter-precedes-last="always"/>
+      <label form="verb-short" prefix=", "/>
+    </names>
+  </macro>
+  <macro name="recipient">
+    <group delimiter=" ">
+      <choose>
+        <if type="personal_communication">
+          <choose>
+            <if variable="genre">
+              <text variable="genre" text-case="capitalize-first"/>
+            </if>
+            <else>
+              <text term="letter" text-case="capitalize-first"/>
+            </else>
+          </choose>
+        </if>
+      </choose>
+      <text macro="recipient-note"/>
+    </group>
+  </macro>
+  <macro name="contributors">
+    <group delimiter=". ">
+      <names variable="author">
+        <name name-as-sort-order="first" and="text" sort-separator=", " delimiter=", " delimiter-precedes-last="always"/>
+        <substitute>
+          <text macro="editor"/>
+          <text macro="translator"/>
+          <choose>
+            <if type="article-magazine article-newspaper" match="any">
+              <text variable="container-title" font-style="italic"/>
+            </if>
+            <else-if type="webpage post-weblog" match="any">
+              <text variable="container-title"/>
+            </else-if>
+          </choose>
+        </substitute>
+      </names>
+      <text macro="recipient"/>
+    </group>
+  </macro>
+  <macro name="recipient-short">
+    <names variable="recipient">
+      <label form="verb" text-case="lowercase" suffix=" "/>
+      <name form="short" and="text" delimiter=", "/>
+    </names>
+  </macro>
+  <macro name="contributors-short">
+    <group delimiter=" ">
+      <names variable="author">
+        <name form="short" and="text" delimiter=", "/>
+        <substitute>
+          <names variable="editor"/>
+          <names variable="translator"/>
+        </substitute>
+      </names>
+      <text macro="recipient-short"/>
+    </group>
+  </macro>
+  <macro name="contributors-sort">
+    <names variable="author">
+      <name name-as-sort-order="all" and="text" sort-separator=", " delimiter=", " delimiter-precedes-last="always"/>
+      <substitute>
+        <names variable="editor"/>
+        <names variable="translator"/>
+        <choose>
+          <if type="article-magazine article-newspaper webpage post-weblog" match="any">
+            <text variable="container-title"/>
+          </if>
+        </choose>
+        <text macro="title"/>
+      </substitute>
+    </names>
+  </macro>
+  <macro name="interviewer-note">
+    <names variable="interviewer" delimiter=", ">
+      <label form="verb" text-case="lowercase" suffix=" "/>
+      <name and="text" delimiter=", "/>
+    </names>
+  </macro>
+  <macro name="interviewer">
+    <names variable="interviewer" delimiter=", ">
+      <label form="verb" text-case="capitalize-first" suffix=" "/>
+      <name and="text" delimiter=", "/>
+    </names>
+  </macro>
+  <macro name="title-note">
+    <choose>
+      <if variable="title" match="none">
+        <text variable="genre"/>
+      </if>
+      <else-if type="book graphic map motion_picture song" match="any">
+        <text variable="title" text-case="title" font-style="italic"/>
+        <group delimiter=" " prefix=", ">
+          <text term="version"/>
+          <text variable="version"/>
+        </group>
+      </else-if>
+      <else-if type="legal_case interview patent" match="any">
+        <text variable="title"/>
+      </else-if>
+      <else-if variable="reviewed-author">
+        <text variable="title" font-style="italic" prefix="review of "/>
+      </else-if>
+      <else-if type="manuscript">
+        <text variable="title" quotes="false" suffix=", "/>
+      </else-if>
+      <else-if type="personal_communication">
+        <text variable="title" quotes="false"/>
+      </else-if>
+      <!--The part above removes automatic quotation marks from around titles of manuscript and letter item types in footnotes.-->
+      <else>
+        <text variable="title" text-case="title" quotes="true"/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="title">
+    <choose>
+      <if variable="title" match="none">
+        <choose>
+          <if type="personal_communication" match="none">
+            <text variable="genre" text-case="capitalize-first"/>
+          </if>
+        </choose>
+      </if>
+      <else-if type="book graphic motion_picture song" match="any">
+        <text variable="title" text-case="title" font-style="italic"/>
+        <group prefix=" (" suffix=")" delimiter=" ">
+          <text term="version"/>
+          <text variable="version"/>
+        </group>
+      </else-if>
+      <else-if variable="reviewed-author">
+        <group delimiter=", ">
+          <text variable="title" font-style="italic" prefix="Review of "/>
+          <names variable="reviewed-author">
+            <label form="verb-short" text-case="lowercase" suffix=" "/>
+            <name and="text" delimiter=", "/>
+          </names>
+        </group>
+      </else-if>
+      <else-if type="bill legislation legal_case interview patent" match="any">
+        <text variable="title"/>
+      </else-if>
+      <else-if type="manuscript personal_communication">
+        <text variable="title" text-case="title" quotes="false"/>
+      </else-if>
+      <!--The part above removes automatic quotation marks from around titles of manuscript and letter item types in bibliographies.-->
+      <else>
+        <text variable="title" text-case="title" quotes="true"/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="title-short">
+    <choose>
+      <if variable="title" match="none">
+        <choose>
+          <if type="interview">
+            <text term="interview"/>
+          </if>
+          <else-if type="manuscript speech" match="any">
+            <text variable="genre" form="short"/>
+          </else-if>
+        </choose>
+      </if>
+      <else-if type="book graphic motion_picture song" match="any">
+        <text variable="title" text-case="title" form="short" font-style="italic"/>
+      </else-if>
+      <else-if type="legal_case" variable="title-short" match="all">
+        <text variable="title" font-style="italic" form="short"/>
+      </else-if>
+      <else-if type="patent interview" match="any">
+        <text variable="title" form="short"/>
+      </else-if>
+      <else-if type="legal_case bill legislation" match="any">
+        <text variable="title"/>
+      </else-if>
+      <else-if type="manuscript personal_communication" match="any">
+        <text variable="title" form="short" quotes="false"/>
+      </else-if>
+      <!--The part above removes automatic quotation marks from around the short title form of manuscript and letter item types.-->
+      <else>
+        <text variable="title" text-case="title" form="short" quotes="true"/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="date-subsequent">
+    <!--this part below is a macro that defines how dates in subsequent footnote citations for manuscripts work. I inserted the macro much later on (under the subsequent citation part), which makes the date actually appear in the subsequent citation.-->
+    <choose>
+      <if type="manuscript" variable="issued" match="any">
+        <date variable="issued">
+          <date-part name="day" suffix=" "/>
+          <date-part name="month" form="long" suffix=" "/>
+          <date-part name="year"/>
+        </date>
+      </if>
+    </choose>
+  </macro>
+  <macro name="date-disambiguate">
+    <choose>
+      <if disambiguate="true" type="personal_communication" match="any">
+        <date variable="issued">
+          <date-part name="day" suffix=" "/>
+          <date-part name="month" form="long" suffix=" "/>
+          <date-part name="year"/>
+        </date>
+        <!--this part above makes dates in subsequent footnote citations for letters appear in British style (day, month, year).-->
+      </if>
+    </choose>
+  </macro>
+  <macro name="description-note">
+    <group delimiter=", ">
+      <text macro="interviewer-note"/>
+      <text variable="medium"/>
+      <choose>
+        <if variable="title" match="none"/>
+        <else-if type="manuscript thesis speech" match="any"/>
+        <else-if type="patent">
+          <group delimiter=" ">
+            <text variable="authority"/>
+            <text variable="number"/>
+          </group>
+        </else-if>
+        <else>
+          <text variable="genre"/>
+        </else>
+      </choose>
+      <choose>
+        <if type="map">
+          <text variable="scale"/>
+        </if>
+        <else-if type="graphic">
+          <text variable="dimensions"/>
+        </else-if>
+      </choose>
+    </group>
+  </macro>
+  <macro name="description">
+    <group delimiter=", ">
+      <group delimiter=". ">
+        <text macro="interviewer"/>
+        <text variable="medium" text-case="capitalize-first"/>
+      </group>
+      <choose>
+        <if variable="title" match="none"/>
+        <else-if type="thesis speech" match="any"/>
+        <else-if type="patent">
+          <group delimiter=" ">
+            <text variable="authority"/>
+            <text variable="number"/>
+          </group>
+        </else-if>
+        <else>
+          <text variable="genre" text-case="capitalize-first"/>
+        </else>
+      </choose>
+      <choose>
+        <if type="map">
+          <text variable="scale"/>
+        </if>
+        <else-if type="graphic">
+          <text variable="dimensions"/>
+        </else-if>
+      </choose>
+    </group>
+  </macro>
+  <macro name="container-title-note">
+    <group delimiter=" ">
+      <choose>
+        <if type="chapter entry-dictionary entry-encyclopedia paper-conference" match="any">
+          <text term="in"/>
+        </if>
+      </choose>
+      <choose>
+        <if type="webpage">
+          <text variable="container-title"/>
+        </if>
+        <else-if type="post-weblog">
+          <text variable="container-title" text-case="title" font-style="italic" suffix=" (blog)"/>
+        </else-if>
+        <else-if type="bill legislation legal_case" match="none">
+          <text variable="container-title" text-case="title" font-style="italic"/>
+        </else-if>
+      </choose>
+    </group>
+  </macro>
+  <macro name="container-title">
+    <group delimiter=" ">
+      <choose>
+        <if type="chapter entry-dictionary entry-encyclopedia paper-conference" match="any">
+          <text term="in" text-case="capitalize-first"/>
+        </if>
+      </choose>
+      <choose>
+        <if type="webpage">
+          <text variable="container-title"/>
+        </if>
+        <else-if type="post-weblog">
+          <text variable="container-title" text-case="title" font-style="italic" suffix=" (blog)"/>
+        </else-if>
+        <else-if type="bill legislation legal_case" match="none">
+          <text variable="container-title" text-case="title" font-style="italic"/>
+        </else-if>
+      </choose>
+    </group>
+  </macro>
+  <macro name="collection-title">
+    <choose>
+      <if match="none" type="article-journal">
+        <choose>
+          <if match="none" is-numeric="collection-number">
+            <group delimiter=", ">
+              <text variable="collection-title" text-case="title"/>
+              <text variable="collection-number"/>
+            </group>
+          </if>
+          <else>
+            <group delimiter=" ">
+              <text variable="collection-title" text-case="title"/>
+              <text variable="collection-number"/>
+            </group>
+          </else>
+        </choose>
+      </if>
+    </choose>
+  </macro>
+  <macro name="collection-title-journal">
+    <choose>
+      <if type="article-journal">
+        <group delimiter=" ">
+          <text variable="collection-title"/>
+          <text variable="collection-number"/>
+        </group>
+      </if>
+    </choose>
+  </macro>
+  <macro name="edition-note">
+    <choose>
+      <if type="book chapter graphic motion_picture paper-conference report song" match="any">
+        <choose>
+          <if is-numeric="edition">
+            <group delimiter=" ">
+              <number variable="edition" form="ordinal"/>
+              <text term="edition" form="short"/>
+            </group>
+          </if>
+          <else>
+            <text variable="edition"/>
+          </else>
+        </choose>
+      </if>
+    </choose>
+  </macro>
+  <macro name="edition">
+    <choose>
+      <if type="book chapter graphic motion_picture paper-conference report song" match="any">
+        <choose>
+          <if is-numeric="edition">
+            <group delimiter=" ">
+              <number variable="edition" form="ordinal"/>
+              <text term="edition" form="short"/>
+            </group>
+          </if>
+          <else>
+            <text variable="edition" text-case="capitalize-first" suffix="."/>
+          </else>
+        </choose>
+      </if>
+    </choose>
+  </macro>
+  <macro name="locators-note-join-with-space">
+    <choose>
+      <if type="article-journal" variable="volume" match="all">
+        <choose>
+          <if match="none" variable="collection-title">
+            <text macro="locators-note"/>
+          </if>
+        </choose>
+      </if>
+    </choose>
+  </macro>
+  <macro name="locators-note-join-with-comma">
+    <choose>
+      <if type="article-journal" match="none">
+        <text macro="locators-note"/>
+      </if>
+      <else-if type="article-journal">
+        <choose>
+          <if variable="volume" match="none">
+            <text macro="locators-note"/>
+          </if>
+          <else-if match="any" variable="collection-title">
+            <text macro="locators-note"/>
+          </else-if>
+        </choose>
+      </else-if>
+    </choose>
+  </macro>
+  <macro name="locators-note">
+    <choose>
+      <if type="article-journal">
+        <group delimiter=", ">
+          <text macro="collection-title-journal"/>
+          <text variable="volume"/>
+          <group delimiter=" ">
+            <text term="issue" form="short"/>
+            <text variable="issue"/>
+          </group>
+        </group>
+      </if>
+      <else-if type="bill legislation legal_case" match="any">
+        <text macro="legal-cites"/>
+      </else-if>
+      <else-if type="book chapter graphic motion_picture paper-conference report song" match="any">
+        <group delimiter=", ">
+          <text macro="edition-note"/>
+          <group delimiter=", ">
+            <group delimiter=" ">
+              <text term="volume" form="short"/>
+              <number variable="volume" form="numeric"/>
+            </group>
+            <text variable="volume-title" font-style="italic"/>
+          </group>
+          <choose>
+            <if variable="locator" match="none">
+              <group delimiter=" ">
+                <number variable="number-of-volumes" form="numeric"/>
+                <text term="volume" form="short" plural="true"/>
+              </group>
+            </if>
+          </choose>
+        </group>
+      </else-if>
+    </choose>
+  </macro>
+  <macro name="legal-cites">
+    <choose>
+      <if type="legal_case" match="any">
+        <group delimiter=" ">
+          <choose>
+            <if variable="container-title">
+              <text variable="volume"/>
+              <text variable="container-title"/>
+              <group delimiter=" ">
+                <!--change to label variable="section" as that becomes available -->
+                <text term="section" form="symbol"/>
+                <text variable="section"/>
+              </group>
+              <group delimiter=", ">
+                <text variable="page"/>
+                <choose>
+                  <if locator="page" match="any">
+                    <text variable="locator"/>
+                  </if>
+                  <else>
+                    <group delimiter=" ">
+                      <label variable="locator" form="short"/>
+                      <text variable="locator"/>
+                    </group>
+                  </else>
+                </choose>
+              </group>
+            </if>
+            <else>
+              <text variable="number" prefix="No. "/>
+            </else>
+          </choose>
+        </group>
+      </if>
+      <else-if type="bill legislation" match="any">
+        <group delimiter=", ">
+          <choose>
+            <if variable="number">
+              <!--There's a public law number-->
+              <text variable="number" prefix="Pub. L. No. "/>
+              <group delimiter=" ">
+                <!--change to label variable="section" as that becomes available -->
+                <text term="section" form="symbol"/>
+                <text variable="section"/>
+              </group>
+              <group delimiter=" ">
+                <text variable="volume"/>
+                <text variable="container-title"/>
+                <text variable="page-first"/>
+              </group>
+            </if>
+            <else>
+              <group delimiter=" ">
+                <text variable="volume"/>
+                <text variable="container-title"/>
+                <!--change to label variable="section" as that becomes available -->
+                <text term="section" form="symbol"/>
+                <text variable="section"/>
+              </group>
+            </else>
+          </choose>
+        </group>
+      </else-if>
+    </choose>
+  </macro>
+  <macro name="locators-join-with-space">
+    <choose>
+      <if type="article-journal" variable="volume" match="all">
+        <choose>
+          <if match="none" variable="collection-title">
+            <text macro="locators"/>
+          </if>
+        </choose>
+      </if>
+    </choose>
+  </macro>
+  <macro name="locators-join-with-comma">
+    <choose>
+      <if type="bill chapter legislation legal_case paper-conference" match="any">
+        <text macro="locators"/>
+      </if>
+      <else-if type="article-journal">
+        <choose>
+          <if variable="volume" match="none">
+            <text macro="locators"/>
+          </if>
+          <else-if match="any" variable="collection-title">
+            <text macro="locators"/>
+          </else-if>
+        </choose>
+      </else-if>
+    </choose>
+  </macro>
+  <macro name="locators-join-with-period">
+    <choose>
+      <if type="bill legislation legal_case article-journal chapter paper-conference" match="none">
+        <text macro="locators"/>
+      </if>
+    </choose>
+  </macro>
+  <macro name="locators">
+    <choose>
+      <if type="article-journal">
+        <group delimiter=", ">
+          <text macro="collection-title-journal"/>
+          <text variable="volume"/>
+          <group delimiter=" ">
+            <text term="issue" form="short"/>
+            <text variable="issue"/>
+          </group>
+        </group>
+      </if>
+      <else-if type="bill legislation legal_case" match="any">
+        <text macro="legal-cites"/>
+      </else-if>
+      <else-if type="book graphic motion_picture report song" match="any">
+        <group delimiter=". ">
+          <text macro="edition"/>
+          <group delimiter=", ">
+            <group delimiter=" ">
+              <text term="volume" form="short" text-case="capitalize-first"/>
+              <number variable="volume" form="numeric"/>
+            </group>
+            <text variable="volume-title" font-style="italic"/>
+          </group>
+          <group delimiter=" ">
+            <number variable="number-of-volumes" form="numeric"/>
+            <text term="volume" form="short" plural="true"/>
+          </group>
+        </group>
+      </else-if>
+      <else-if type="chapter entry-dictionary entry-encyclopedia paper-conference" match="any">
+        <group delimiter=". ">
+          <text macro="edition"/>
+          <choose>
+            <if variable="page" match="none">
+              <group delimiter=" ">
+                <text term="volume" form="short" text-case="capitalize-first"/>
+                <number variable="volume" form="numeric"/>
+              </group>
+            </if>
+          </choose>
+        </group>
+      </else-if>
+    </choose>
+  </macro>
+  <macro name="locators-newspaper">
+    <choose>
+      <if type="article-newspaper">
+        <group delimiter=", ">
+          <group delimiter=" ">
+            <number variable="edition"/>
+            <text term="edition"/>
+          </group>
+          <group delimiter=" ">
+            <text term="section" form="short"/>
+            <text variable="section"/>
+          </group>
+        </group>
+      </if>
+    </choose>
+  </macro>
+  <macro name="event-note">
+    <text variable="event"/>
+  </macro>
+  <macro name="event">
+    <choose>
+      <if variable="title">
+        <group delimiter=" ">
+          <choose>
+            <if variable="genre">
+              <text term="presented at"/>
+            </if>
+            <else>
+              <text term="presented at" text-case="capitalize-first"/>
+            </else>
+          </choose>
+          <text variable="event"/>
+        </group>
+      </if>
+      <else>
+        <group delimiter=" ">
+          <text term="presented at" text-case="capitalize-first"/>
+          <text variable="event"/>
+        </group>
+      </else>
+    </choose>
+  </macro>
+  <macro name="originally-published">
+    <group delimiter=", ">
+      <group delimiter=": ">
+        <text variable="original-publisher-place"/>
+        <text variable="original-publisher"/>
+      </group>
+      <choose>
+        <if is-uncertain-date="original-date">
+          <date variable="original-date" form="numeric" date-parts="year" prefix="[" suffix="?]"/>
+        </if>
+        <else>
+          <date variable="original-date" form="numeric" date-parts="year"/>
+        </else>
+      </choose>
+    </group>
+  </macro>
+  <macro name="reprint-note">
+    <!--needs localization-->
+    <choose>
+      <if variable="original-date issued" match="all">
+        <choose>
+          <!--for whatever reason in notes, when we have both original and new publishers, reprint doesn't appear-->
+          <if variable="original-publisher original-publisher-place" match="none">
+            <text value="repr."/>
+          </if>
+        </choose>
+      </if>
+    </choose>
+  </macro>
+  <macro name="reprint">
+    <!--needs localization-->
+    <choose>
+      <if variable="original-date issued" match="all">
+        <text value="reprint" text-case="capitalize-first"/>
+      </if>
+    </choose>
+  </macro>
+  <macro name="publisher">
+    <choose>
+      <if type="thesis">
+        <text variable="publisher"/>
+      </if>
+      <else-if type="speech">
+        <text variable="event-place"/>
+      </else-if>
+      <else>
+        <group delimiter=": ">
+          <text variable="publisher-place"/>
+          <text variable="publisher"/>
+        </group>
+      </else>
+    </choose>
+  </macro>
+  <macro name="issued">
+    <choose>
+      <if variable="issued">
+        <choose>
+          <if type="legal_case">
+            <group delimiter=" ">
+              <text variable="authority"/>
+              <choose>
+                <if variable="container-title" match="any">
+                  <!--Only print year for cases published in reporters-->
+                  <date variable="issued" form="numeric" date-parts="year"/>
+                </if>
+                <else>
+                  <date variable="issued" form="text"/>
+                </else>
+              </choose>
+            </group>
+          </if>
+          <else-if type="book bill chapter  legislation motion_picture paper-conference song thesis" match="any">
+            <choose>
+              <if is-uncertain-date="issued">
+                <date variable="issued" form="numeric" date-parts="year" prefix="[" suffix="?]"/>
+              </if>
+              <else>
+                <date variable="issued" form="numeric" date-parts="year"/>
+              </else>
+            </choose>
+          </else-if>
+          <else-if type="patent">
+            <group delimiter=", ">
+              <group delimiter=" ">
+                <!--Needs Localization-->
+                <text value="filed"/>
+                <date variable="submitted" form="text"/>
+              </group>
+              <group delimiter=" ">
+                <choose>
+                  <if variable="issued submitted" match="all">
+                    <text term="and"/>
+                  </if>
+                </choose>
+                <!--Needs Localization-->
+                <text value="issued"/>
+                <date variable="issued" form="text"/>
+              </group>
+            </group>
+          </else-if>
+          <else>
+            <choose>
+              <if is-uncertain-date="issued">
+                <date variable="issued" form="text" prefix="[" suffix="?]"/>
+              </if>
+              <else>
+                <date variable="issued" form="text"/>
+              </else>
+            </choose>
+          </else>
+        </choose>
+      </if>
+      <else-if variable="status">
+        <text variable="status"/>
+      </else-if>
+      <else-if variable="accessed URL" match="all"/>
+      <else>
+        <text term="no date" form="short"/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="point-locators-subsequent">
+    <choose>
+      <if type="legal_case" variable="locator" match="all">
+        <choose>
+          <if locator="page">
+            <group delimiter=":">
+              <text variable="volume"/>
+              <text variable="locator"/>
+            </group>
+          </if>
+          <else>
+            <group delimiter=" ">
+              <label variable="locator" form="short"/>
+              <text variable="locator"/>
+            </group>
+          </else>
+        </choose>
+      </if>
+      <else-if variable="locator">
+        <choose>
+          <if locator="page" match="none">
+            <group delimiter=" ">
+              <choose>
+                <if type="book graphic motion_picture report song" match="any">
+                  <choose>
+                    <if variable="volume">
+                      <group delimiter=", ">
+                        <group delimiter=" ">
+                          <text term="volume" form="short"/>
+                          <number variable="volume" form="numeric"/>
+                        </group>
+                        <label variable="locator" form="short"/>
+                      </group>
+                    </if>
+                    <else>
+                      <label variable="locator" form="short"/>
+                    </else>
+                  </choose>
+                </if>
+                <else>
+                  <label variable="locator" form="short"/>
+                </else>
+              </choose>
+              <text variable="locator"/>
+            </group>
+          </if>
+          <else-if type="book graphic motion_picture report song" match="any">
+            <group delimiter=":">
+              <number variable="volume" form="numeric"/>
+              <text variable="locator"/>
+            </group>
+          </else-if>
+          <else>
+            <text variable="locator"/>
+          </else>
+        </choose>
+      </else-if>
+    </choose>
+  </macro>
+  <macro name="point-locators-join-with-colon">
+    <choose>
+      <if type="article-journal">
+        <choose>
+          <if variable="locator page" match="any">
+            <choose>
+              <if variable="volume issue" match="any">
+                <text macro="point-locators"/>
+              </if>
+            </choose>
+          </if>
+        </choose>
+      </if>
+    </choose>
+  </macro>
+  <macro name="point-locators-join-with-comma">
+    <choose>
+      <if type="article-journal" match="none">
+        <text macro="point-locators"/>
+      </if>
+      <else-if variable="volume issue" match="none">
+        <text macro="point-locators"/>
+      </else-if>
+    </choose>
+  </macro>
+  <macro name="point-locators">
+    <choose>
+      <if variable="locator" match="none">
+        <choose>
+          <if type="article-journal chapter paper-conference" match="any">
+            <text variable="page"/>
+          </if>
+        </choose>
+      </if>
+      <else-if type="article-journal">
+        <group delimiter=" ">
+          <choose>
+            <if locator="page" match="none">
+              <label variable="locator" form="short" suffix=" "/>
+            </if>
+          </choose>
+          <text variable="locator"/>
+        </group>
+      </else-if>
+      <else-if type="legal_case"/>
+      <else>
+        <group delimiter=" ">
+          <choose>
+            <if locator="page" match="none">
+              <label variable="locator" form="short"/>
+            </if>
+          </choose>
+          <text variable="locator"/>
+        </group>
+      </else>
+    </choose>
+  </macro>
+  <macro name="locators-chapter">
+    <choose>
+      <if type="chapter entry-dictionary entry-encyclopedia paper-conference" match="any">
+        <choose>
+          <if variable="author container-author" match="all"/>
+          <else>
+            <choose>
+              <if variable="page">
+                <text variable="volume" suffix=":"/>
+                <text variable="page"/>
+              </if>
+            </choose>
+          </else>
+        </choose>
+      </if>
+    </choose>
+  </macro>
+  <macro name="locators-journal-join-with-colon">
+    <choose>
+      <if type="article-journal">
+        <choose>
+          <if variable="volume issue" match="any">
+            <text variable="page"/>
+          </if>
+        </choose>
+      </if>
+    </choose>
+  </macro>
+  <macro name="locators-journal-join-with-comma">
+    <choose>
+      <if type="article-journal">
+        <choose>
+          <if variable="volume issue" match="none">
+            <text variable="page"/>
+          </if>
+        </choose>
+      </if>
+    </choose>
+  </macro>
+  <macro name="archive-note">
+    <choose>
+      <if type="thesis">
+        <group delimiter=" ">
+          <text variable="archive"/>
+          <text variable="archive_location" prefix="(" suffix=")"/>
+        </group>
+      </if>
+      <else>
+        <group delimiter=", ">
+          <text variable="archive_location"/>
+          <text variable="archive"/>
+          <text variable="archive-place"/>
+        </group>
+      </else>
+    </choose>
+  </macro>
+  <macro name="archive">
+    <choose>
+      <if type="thesis">
+        <group delimiter=" ">
+          <text variable="archive"/>
+          <text variable="archive_location" prefix="(" suffix=")"/>
+        </group>
+      </if>
+      <else>
+        <group delimiter=". ">
+          <text variable="archive_location" text-case="capitalize-first"/>
+          <text variable="archive"/>
+          <text variable="archive-place"/>
+        </group>
+      </else>
+    </choose>
+  </macro>
+  <macro name="issue-note-join-with-space">
+    <choose>
+      <if type="article-journal bill legislation legal_case manuscript thesis" variable="publisher-place event-place publisher" match="any">
+        <!--Chicago doesn't use publisher/place for Newspapers and we want the date delimited by a comma-->
+        <choose>
+          <if type="article-newspaper" match="none">
+            <choose>
+              <if type="article-journal" match="none">
+                <text macro="issue-note"/>
+              </if>
+              <else-if variable="issue volume" match="any">
+                <text macro="issue-note"/>
+              </else-if>
+            </choose>
+          </if>
+        </choose>
+      </if>
+    </choose>
+  </macro>
+  <macro name="issue-note-join-with-comma">
+    <choose>
+      <if type="article-journal bill legislation legal_case manuscript speech thesis" variable="publisher-place publisher" match="none">
+        <text macro="issue-note"/>
+      </if>
+      <else-if type="article-newspaper">
+        <text macro="issue-note"/>
+      </else-if>
+      <else-if type="article-journal">
+        <choose>
+          <if variable="volume issue" match="none">
+            <text macro="issue-note"/>
+          </if>
+        </choose>
+      </else-if>
+    </choose>
+  </macro>
+  <macro name="issue-map-graphic">
+    <!--See CMoS 17th ed. 14.235 and 14.237-->
+    <choose>
+      <if type="graphic map" match="any">
+        <choose>
+          <if variable="publisher publisher-place" match="none">
+            <text macro="issued"/>
+          </if>
+        </choose>
+      </if>
+    </choose>
+  </macro>
+  <macro name="issue-note">
+    <choose>
+      <if type="bill legislation legal_case" match="any">
+        <text macro="issued" prefix="(" suffix=")"/>
+      </if>
+      <else-if type="article-journal">
+        <choose>
+          <if variable="volume issue" match="any">
+            <text macro="issued" prefix="(" suffix=")"/>
+          </if>
+          <else>
+            <text macro="issued"/>
+          </else>
+        </choose>
+      </else-if>
+      <else-if type="article-newspaper">
+        <text macro="issued"/>
+      </else-if>
+      <else-if type="thesis speech" match="any">
+        <!--I removed manuscript as a type from here and added a new section below.-->
+        <group delimiter=", " prefix="(" suffix=")">
+          <choose>
+            <if variable="title" match="any">
+              <text variable="genre"/>
+            </if>
+          </choose>
+          <text variable="event"/>
+          <text variable="event-place"/>
+          <text variable="publisher"/>
+          <text macro="issued"/>
+        </group>
+      </else-if>
+      <else-if type="manuscript">
+        <choose>
+          <if variable="issued" match="any">
+            <date variable="issued">
+              <date-part name="day" suffix=" "/>
+              <date-part name="month" form="long" suffix=" "/>
+              <date-part name="year"/>
+            </date>
+          </if>
+          <else-if variable="issued" match="none">
+            <text term="no date" form="short"/>
+          </else-if>
+          <!--The part above make the dates appear in British style (day month year) in footnotes for manuscript items. It also makes the n.d. appear without parentheses around it, if no date is present, in manuscript footnotes.-->
+        </choose>
+      </else-if>
+      <!--The part immediately below makes the dates appear in British style (day month year) in footnotes for letters.-->
+      <else-if type="personal_communication">
+        <choose>
+          <if variable="issued" match="any">
+            <date variable="issued">
+              <date-part name="day" suffix=" "/>
+              <date-part name="month" form="long" suffix=" "/>
+              <date-part name="year"/>
+            </date>
+          </if>
+          <else-if variable="issued" match="none">
+            <text term="no date" form="short"/>
+            <!--I added this to make the n.d. not have parentheses around it for letter footnote entries.-->
+          </else-if>
+        </choose>
+      </else-if>
+      <else-if variable="publisher-place event-place publisher" match="any">
+        <group prefix="(" suffix=")" delimiter=", ">
+          <text macro="event-note"/>
+          <group delimiter="; ">
+            <text macro="originally-published"/>
+            <group delimiter=", ">
+              <text macro="reprint-note"/>
+              <text macro="publisher"/>
+            </group>
+          </group>
+          <text macro="issued"/>
+        </group>
+      </else-if>
+      <else>
+        <text macro="issued"/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="issue-join-with-space">
+    <choose>
+      <if type="article-journal" match="any">
+        <choose>
+          <if variable="issue volume" match="any">
+            <text macro="issue"/>
+          </if>
+        </choose>
+      </if>
+      <else-if type="bill legislation legal_case" match="any">
+        <text macro="issue"/>
+      </else-if>
+    </choose>
+  </macro>
+  <macro name="issue-join-with-period">
+    <choose>
+      <if type="article-journal bill legislation legal_case" match="none">
+        <choose>
+          <!-- We need a perdiod here when the container title gets moved up into author position, otherwise a comma (below)-->
+          <if type="article-newspaper article-magazine" match="any">
+            <choose>
+              <if variable="author editor" match="none">
+                <text macro="issue"/>
+              </if>
+            </choose>
+          </if>
+          <else-if type="speech" variable="publisher publisher-place" match="any">
+            <text macro="issue"/>
+          </else-if>
+        </choose>
+      </if>
+    </choose>
+  </macro>
+  <macro name="issue-join-with-comma">
+    <choose>
+      <if type="bill legislation legal_case" match="none">
+        <choose>
+          <if type="article-journal" match="none">
+            <choose>
+              <if type="article-newspaper article-magazine" match="any">
+                <choose>
+                  <if variable="author editor" match="any">
+                    <text macro="issue"/>
+                  </if>
+                </choose>
+              </if>
+              <else-if type="speech" variable="publisher publisher-place" match="none">
+                <text macro="issue"/>
+              </else-if>
+            </choose>
+          </if>
+          <else-if variable="volume issue" match="none">
+            <text macro="issue"/>
+          </else-if>
+        </choose>
+      </if>
+    </choose>
+  </macro>
+  <macro name="issue">
+    <choose>
+      <if type="bill legislation legal_case" match="any">
+        <text macro="issued" prefix="(" suffix=")"/>
+      </if>
+      <else-if type="manuscript personal_communication">
+        <date variable="issued">
+          <date-part name="day" suffix=" "/>
+          <date-part name="month" form="long" suffix=" "/>
+          <date-part name="year"/>
+        </date>
+        <!--above is the date formatting for bibliography entries for manuscript items and letters. -->
+      </else-if>
+      <else-if type="article-journal">
+        <choose>
+          <if variable="issue volume" match="any">
+            <text macro="issued" prefix="(" suffix=")"/>
+          </if>
+          <else>
+            <text macro="issued"/>
+          </else>
+        </choose>
+      </else-if>
+      <else-if type="speech">
+        <group delimiter=", ">
+          <group delimiter=" ">
+            <choose>
+              <if variable="title" match="none"/>
+              <else>
+                <text variable="genre" text-case="capitalize-first"/>
+              </else>
+            </choose>
+            <text macro="event"/>
+          </group>
+          <text variable="event-place"/>
+          <text macro="issued"/>
+        </group>
+      </else-if>
+      <!--Chicago doesn't use publisher/place for Newspapers -->
+      <else-if type="article-newspaper">
+        <text macro="issued"/>
+      </else-if>
+      <else-if variable="publisher-place publisher" match="any">
+        <group delimiter=", ">
+          <choose>
+            <if type="thesis">
+              <text variable="genre" text-case="capitalize-first"/>
+            </if>
+          </choose>
+          <group delimiter=". ">
+            <text macro="originally-published"/>
+            <group delimiter=", ">
+              <text macro="reprint"/>
+              <text macro="publisher"/>
+            </group>
+          </group>
+          <text macro="issued"/>
+        </group>
+      </else-if>
+      <!--location for data for maps and artwork is different-->
+      <else-if type="graphic map" match="none">
+        <text macro="issued"/>
+      </else-if>
+    </choose>
+  </macro>
+  <macro name="access-note">
+    <group delimiter=", ">
+      <choose>
+        <if type="graphic report" match="any">
+          <text macro="archive-note"/>
+        </if>
+        <else-if type="article-journal bill book chapter legal_case legislation motion_picture paper-conference" match="none">
+          <text macro="archive-note"/>
+        </else-if>
+      </choose>
+      <choose>
+        <if variable="issued" match="none">
+          <group delimiter=" ">
+            <text term="accessed"/>
+            <date variable="accessed" form="text"/>
+          </group>
+        </if>
+      </choose>
+      <choose>
+        <if type="legal_case" match="none">
+          <choose>
+            <if variable="DOI">
+              <text variable="DOI" prefix="https://doi.org/"/>
+            </if>
+            <else>
+              <text variable="URL"/>
+            </else>
+          </choose>
+        </if>
+      </choose>
+    </group>
+  </macro>
+  <macro name="access">
+    <group delimiter=". ">
+      <choose>
+        <if type="graphic report" match="any">
+          <text macro="archive"/>
+        </if>
+        <else-if type="article-journal bill book chapter legal_case legislation motion_picture paper-conference" match="none">
+          <text macro="archive"/>
+        </else-if>
+      </choose>
+      <choose>
+        <if variable="issued" match="none">
+          <group delimiter=" ">
+            <text term="accessed" text-case="capitalize-first"/>
+            <date variable="accessed" form="text"/>
+          </group>
+        </if>
+      </choose>
+      <choose>
+        <if type="legal_case" match="none">
+          <choose>
+            <if variable="DOI">
+              <text variable="DOI" prefix="https://doi.org/"/>
+            </if>
+            <else>
+              <text variable="URL"/>
+            </else>
+          </choose>
+        </if>
+      </choose>
+    </group>
+  </macro>
+  <macro name="case-locator-subsequent">
+    <choose>
+      <if type="legal_case">
+        <group delimiter=" ">
+          <text variable="volume"/>
+          <text variable="container-title"/>
+        </group>
+      </if>
+    </choose>
+  </macro>
+  <macro name="case-pinpoint-subsequent">
+    <choose>
+      <if type="legal_case">
+        <group delimiter=" ">
+          <choose>
+            <if locator="page">
+              <text term="at"/>
+              <text variable="locator"/>
+            </if>
+            <else>
+              <label variable="locator"/>
+              <text variable="locator"/>
+            </else>
+          </choose>
+        </group>
+      </if>
+    </choose>
+  </macro>
+  <citation et-al-min="4" et-al-use-first="1" disambiguate-add-names="true">
+    <layout suffix="." delimiter="; ">
+      <choose>
+        <if position="ibid ibid-with-locator" match="any">
+          <group delimiter=", ">
+            <text macro="contributors-short"/>
+            <group delimiter=" ">
+              <group delimiter=", ">
+                <choose>
+                  <if variable="author editor translator" match="none">
+                    <text macro="title-short"/>
+                  </if>
+                </choose>
+                <text macro="case-locator-subsequent"/>
+              </group>
+              <text macro="case-pinpoint-subsequent"/>
+            </group>
+            <choose>
+              <if match="none" type="legal_case">
+                <text macro="point-locators-subsequent"/>
+              </if>
+            </choose>
+          </group>
+        </if>
+        <else>
+          <group delimiter=", ">
+            <text macro="contributors-short"/>
+            <group delimiter=" ">
+              <group delimiter=", ">
+                <text macro="title-short"/>
+                <!--if title & author are the same: -->
+                <text macro="date-disambiguate"/>
+                <text macro="case-locator-subsequent"/>
+                <choose>
+                  <if type="manuscript" match="any">
+                    <text macro="date-subsequent"/>
+                    <!--I added this macro in order to make dates appear in subsequent footnote citations for manuscripts.-->
+                    <text variable="publisher-place"/>
+                    <!--I added this tag in order to make the text of the "place" field in Zotero appear in subsequent footnote citations for manuscripts.-->
+                  </if>
+                </choose>
+              </group>
+              <text macro="case-pinpoint-subsequent"/>
+            </group>
+            <choose>
+              <if match="none" type="legal_case">
+                <text macro="point-locators-subsequent"/>
+              </if>
+            </choose>
+          </group>
+        </else>
+      </choose>
+    </layout>
+  </citation>
+  <bibliography hanging-indent="true" et-al-min="11" et-al-use-first="7" subsequent-author-substitute="&#8212;&#8212;&#8212;" entry-spacing="0">
+    <sort>
+      <key macro="contributors-sort"/>
+      <key variable="title"/>
+      <key variable="genre"/>
+      <key variable="issued"/>
+    </sort>
+    <layout suffix=".">
+      <group delimiter=". ">
+        <group delimiter=": ">
+          <group delimiter=", ">
+            <group delimiter=" ">
+              <group delimiter=". ">
+                <group delimiter=" ">
+                  <group delimiter=", ">
+                    <group delimiter=". ">
+                      <group delimiter=". ">
+                        <text macro="contributors"/>
+                        <text macro="title"/>
+                        <text macro="issue-map-graphic"/>
+                      </group>
+                      <text macro="description"/>
+                      <text macro="secondary-contributors"/>
+                      <group delimiter=", ">
+                        <text macro="container-title"/>
+                        <text macro="container-contributors"/>
+                      </group>
+                      <text macro="locators-join-with-period"/>
+                    </group>
+                    <text macro="locators-join-with-comma"/>
+                    <text macro="locators-chapter"/>
+                  </group>
+                  <text macro="locators-join-with-space"/>
+                </group>
+                <text macro="collection-title"/>
+                <text macro="issue-join-with-period"/>
+              </group>
+              <text macro="issue-join-with-space"/>
+            </group>
+            <text macro="issue-join-with-comma"/>
+            <text macro="locators-journal-join-with-comma"/>
+            <text macro="locators-newspaper"/>
+          </group>
+          <text macro="locators-journal-join-with-colon"/>
+        </group>
+        <text macro="access"/>
+      </group>
+    </layout>
+  </bibliography>
+</style>

--- a/chicago-note-bibliography-manuscript.csl
+++ b/chicago-note-bibliography-manuscript.csl
@@ -22,26 +22,7 @@
       <term name="translator" form="short">trans.</term>
     </terms>
   </locale>
-  <macro name="editor-translator">
-    <group delimiter=", ">
-      <group delimiter=" ">
-        <choose>
-          <if variable="container-author reviewed-author" match="any">
-            <group>
-              <names variable="container-author reviewed-author">
-                <label form="verb-short" text-case="lowercase" suffix=" "/>
-                <name and="text" delimiter=", "/>
-              </names>
-            </group>
-          </if>
-        </choose>
-      </group>
-      <names variable="editor translator" delimiter=", ">
-        <label form="verb-short" text-case="lowercase" suffix=" "/>
-        <name and="text" delimiter=", "/>
-      </names>
-    </group>
-  </macro>
+  <!-- Removed `editor-translator` macro as it’s not used -->
   <!-- Removed `secondary-contributors-note` macro as it’s not used -->
   <!-- Removed `container-contributors-note` macro as it’s not used -->
   <macro name="secondary-contributors">
@@ -780,23 +761,7 @@
       </if>
     </choose>
   </macro>
-  <macro name="archive-note">
-    <choose>
-      <if type="thesis">
-        <group delimiter=" ">
-          <text variable="archive"/>
-          <text variable="archive_location" prefix="(" suffix=")"/>
-        </group>
-      </if>
-      <else>
-        <group delimiter=", ">
-          <text variable="archive_location"/>
-          <text variable="archive"/>
-          <text variable="archive-place"/>
-        </group>
-      </else>
-    </choose>
-  </macro>
+  <!-- Removed `archive-note` macro as it’s not used -->
   <macro name="archive">
     <choose>
       <if type="thesis">
@@ -828,87 +793,7 @@
       </if>
     </choose>
   </macro>
-  <macro name="issue-note">
-    <choose>
-      <if type="bill legislation legal_case" match="any">
-        <text macro="issued" prefix="(" suffix=")"/>
-      </if>
-      <else-if type="article-journal">
-        <choose>
-          <if variable="volume issue" match="any">
-            <text macro="issued" prefix="(" suffix=")"/>
-          </if>
-          <else>
-            <text macro="issued"/>
-          </else>
-        </choose>
-      </else-if>
-      <else-if type="article-newspaper">
-        <text macro="issued"/>
-      </else-if>
-      <else-if type="thesis speech" match="any">
-        <!--I removed manuscript as a type from here and added a new section below.-->
-        <group delimiter=", " prefix="(" suffix=")">
-          <choose>
-            <if variable="title" match="any">
-              <text variable="genre"/>
-            </if>
-          </choose>
-          <text variable="event"/>
-          <text variable="event-place"/>
-          <text variable="publisher"/>
-          <text macro="issued"/>
-        </group>
-      </else-if>
-      <else-if type="manuscript">
-        <choose>
-          <if variable="issued" match="any">
-            <date variable="issued">
-              <date-part name="day" suffix=" "/>
-              <date-part name="month" form="long" suffix=" "/>
-              <date-part name="year"/>
-            </date>
-          </if>
-          <else-if variable="issued" match="none">
-            <text term="no date" form="short"/>
-          </else-if>
-          <!--The part above make the dates appear in British style (day month year) in footnotes for manuscript items. It also makes the n.d. appear without parentheses around it, if no date is present, in manuscript footnotes.-->
-        </choose>
-      </else-if>
-      <!--The part immediately below makes the dates appear in British style (day month year) in footnotes for letters.-->
-      <else-if type="personal_communication">
-        <choose>
-          <if variable="issued" match="any">
-            <date variable="issued">
-              <date-part name="day" suffix=" "/>
-              <date-part name="month" form="long" suffix=" "/>
-              <date-part name="year"/>
-            </date>
-          </if>
-          <else-if variable="issued" match="none">
-            <text term="no date" form="short"/>
-            <!--I added this to make the n.d. not have parentheses around it for letter footnote entries.-->
-          </else-if>
-        </choose>
-      </else-if>
-      <else-if variable="publisher-place event-place publisher" match="any">
-        <group prefix="(" suffix=")" delimiter=", ">
-          <text macro="event-note"/>
-          <group delimiter="; ">
-            <text macro="originally-published"/>
-            <group delimiter=", ">
-              <text macro="reprint-note"/>
-              <text macro="publisher"/>
-            </group>
-          </group>
-          <text macro="issued"/>
-        </group>
-      </else-if>
-      <else>
-        <text macro="issued"/>
-      </else>
-    </choose>
-  </macro>
+  <!-- Removed `issue-note` macro as it’s not used -->
   <macro name="issue-join-with-space">
     <choose>
       <if type="article-journal" match="any">

--- a/chicago-note-bibliography-manuscript.csl
+++ b/chicago-note-bibliography-manuscript.csl
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <style xmlns="http://purl.org/net/xbiblio/csl" class="note" version="1.0" demote-non-dropping-particle="display-and-sort" page-range-format="chicago">
   <info>
-    <title>Chicago Manual of Style 17th edition (note, with Ibid.) manuscript</title>
-    <id>http://www.zotero.org/styles/chicago-note-bibliography-with-ibid-manuscript</id>
-    <link href="http://www.zotero.org/styles/chicago-note-bibliography-with-ibid-manuscript" rel="self"/>
-    <link href="http://www.zotero.org/styles/chicago-note-bibliography-with-ibid" rel="template"/>
+    <title>Chicago Manual of Style 17th edition (note) manuscript</title>
+    <id>http://www.zotero.org/styles/chicago-note-bibliography-manuscript</id>
+    <link href="http://www.zotero.org/styles/chicago-note-bibliography-manuscript" rel="self"/>
+    <link href="http://www.zotero.org/styles/chicago-note-bibliography" rel="template"/>
     <link href="http://www.chicagomanualofstyle.org/tools_citationguide.html" rel="documentation"/>
     <category citation-format="note"/>
     <category field="generic-base"/>
@@ -42,7 +42,8 @@
       </names>
     </group>
   </macro>
-  <!-- Removed `secondary-contributors-note` macro as it’s not used-->
+  <!-- Removed `secondary-contributors-note` macro as it’s not used -->
+  <!-- Removed `container-contributors-note` macro as it’s not used -->
   <macro name="secondary-contributors">
     <choose>
       <if type="chapter entry-dictionary entry-encyclopedia paper-conference" match="none">
@@ -97,7 +98,7 @@
       <name and="text" delimiter=", "/>
     </names>
   </macro>
-  <!-- Removed `contributors-note` macro as it’s not used-->
+  <!-- Removed `contributors-note` macro as it’s not used -->
   <macro name="editor">
     <names variable="editor">
       <name name-as-sort-order="first" and="text" sort-separator=", " delimiter=", " delimiter-precedes-last="always"/>
@@ -180,7 +181,7 @@
       </substitute>
     </names>
   </macro>
-  <!-- Removed `interviewer-note` macro as it’s not used-->
+  <!-- Removed `interviewer-note` macro as it’s not used -->
   <macro name="interviewer">
     <names variable="interviewer" delimiter=", ">
       <label form="verb" text-case="capitalize-first" suffix=" "/>
@@ -282,7 +283,7 @@
       </if>
     </choose>
   </macro>
-  <!-- Removed `description-note` macro as it’s not used-->
+  <!-- Removed `description-note` macro as it’s not used -->
   <macro name="description">
     <group delimiter=", ">
       <group delimiter=". ">
@@ -312,7 +313,7 @@
       </choose>
     </group>
   </macro>
-  <!-- Removed `containter-title-note` macro as it’s not used-->
+  <!-- Removed `container-title-note` macro as it’s not used -->
   <macro name="container-title">
     <group delimiter=" ">
       <choose>
@@ -363,7 +364,7 @@
       </if>
     </choose>
   </macro>
-  <!-- Removed `edition-note` macro as it’s not used-->
+  <!-- Removed `edition-note` macro as it’s not used -->
   <macro name="edition">
     <choose>
       <if type="book chapter graphic motion_picture paper-conference report song" match="any">
@@ -381,8 +382,9 @@
       </if>
     </choose>
   </macro>
-  <!-- Removed `locators-note-join-with-space` macro as it’s not used-->
-  <!-- Removed `locators-note` macro as it’s not used-->
+  <!-- Removed `locators-note-join-with-space` macro as it’s not used -->
+  <!-- Removed `locators-note-join-with-comma` macro as it’s not used -->
+  <!-- Removed `locators-note` macro as it’s not used -->
   <macro name="legal-cites">
     <choose>
       <if type="legal_case" match="any">
@@ -529,7 +531,7 @@
       </else-if>
     </choose>
   </macro>
-  <!-- Removed `locators-newspaper` macro as it’s not used-->
+  <!-- Removed `locators-newspaper` macro as it’s not used -->
   <macro name="event-note">
     <text variable="event"/>
   </macro>
@@ -736,9 +738,9 @@
       </else-if>
     </choose>
   </macro>
-  <!-- Removed `point-locators-join-with-colon` macro as it’s not used-->
-  <!-- Removed `point-locators-join-with-comma` macro as it’s not used-->
-  <!-- Removed `point-locators` macro as it’s not used-->
+  <!-- Removed `point-locators-join-with-colon` macro as it’s not used -->
+  <!-- Removed `point-locators-join-with-comma` macro as it’s not used -->
+  <!-- Removed `point-locators` macro as it’s not used -->
   <macro name="locators-chapter">
     <choose>
       <if type="chapter entry-dictionary entry-encyclopedia paper-conference" match="any">
@@ -812,27 +814,8 @@
       </else>
     </choose>
   </macro>
-  <!-- Removed `access-note` macro as it’s not used-->
-  <macro name="issue-note-join-with-space">
-    <choose>
-      <if type="article-journal bill legislation legal_case manuscript thesis" variable="publisher-place event-place publisher" match="any">
-        <!--Chicago doesn't use publisher/place for Newspapers and we want the date delimited by a comma-->
-        <choose>
-          <if type="article-newspaper" match="none">
-            <choose>
-              <if type="article-journal" match="none">
-                <text macro="issue-note"/>
-              </if>
-              <else-if variable="issue volume" match="any">
-                <text macro="issue-note"/>
-              </else-if>
-            </choose>
-          </if>
-        </choose>
-      </if>
-    </choose>
-  </macro>
-  <!-- Removed `issue-note-join-with-comma` macro as it’s not used-->
+  <!-- Removed `issue-note-join-with-space` macro as it’s not used -->
+  <!-- Removed `issue-note-join-with-comma` macro as it’s not used -->
   <macro name="issue-map-graphic">
     <!--See CMoS 17th ed. 14.235 and 14.237-->
     <choose>
@@ -1049,7 +1032,7 @@
       </else-if>
     </choose>
   </macro>
-  <!-- Removed `access-note` macro as it’s not used-->
+  <!-- Removed `access-note` macro as it’s not used -->
   <macro name="access">
     <group delimiter=". ">
       <choose>
@@ -1113,15 +1096,27 @@
   <citation et-al-min="4" et-al-use-first="1" disambiguate-add-names="true">
     <layout suffix="." delimiter="; ">
       <choose>
-        <if position="ibid-with-locator">
+        <if position="ibid ibid-with-locator" match="any">
           <group delimiter=", ">
-            <text term="ibid"/>
-            <text macro="point-locators-subsequent"/>
+            <text macro="contributors-short"/>
+            <group delimiter=" ">
+              <group delimiter=", ">
+                <choose>
+                  <if variable="author editor translator" match="none">
+                    <text macro="title-short"/>
+                  </if>
+                </choose>
+                <text macro="case-locator-subsequent"/>
+              </group>
+              <text macro="case-pinpoint-subsequent"/>
+            </group>
+            <choose>
+              <if match="none" type="legal_case">
+                <text macro="point-locators-subsequent"/>
+              </if>
+            </choose>
           </group>
         </if>
-        <else-if position="ibid">
-          <text term="ibid"/>
-        </else-if>
         <else>
           <group delimiter=", ">
             <text macro="contributors-short"/>

--- a/chicago-note-bibliography-manuscript.csl
+++ b/chicago-note-bibliography-manuscript.csl
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <style xmlns="http://purl.org/net/xbiblio/csl" class="note" version="1.0" demote-non-dropping-particle="display-and-sort" page-range-format="chicago">
   <info>
-    <title>Chicago Manual of Style 17th edition (note) manuscript</title>
-    <id>http://www.zotero.org/styles/chicago-note-bibliography-manuscript</id>
-    <link href="http://www.zotero.org/styles/chicago-note-bibliography-manuscript" rel="self"/>
-    <link href="http://www.zotero.org/styles/chicago-note-bibliography" rel="template"/>
+    <title>Chicago Manual of Style 17th edition (note, with Ibid.) manuscript</title>
+    <id>http://www.zotero.org/styles/chicago-note-bibliography-with-ibid-manuscript</id>
+    <link href="http://www.zotero.org/styles/chicago-note-bibliography-with-ibid-manuscript" rel="self"/>
+    <link href="http://www.zotero.org/styles/chicago-note-bibliography-with-ibid" rel="template"/>
     <link href="http://www.chicagomanualofstyle.org/tools_citationguide.html" rel="documentation"/>
     <category citation-format="note"/>
     <category field="generic-base"/>
@@ -42,20 +42,7 @@
       </names>
     </group>
   </macro>
-  <macro name="secondary-contributors-note">
-    <choose>
-      <if type="chapter entry-dictionary entry-encyclopedia paper-conference" match="none">
-        <text macro="editor-translator"/>
-      </if>
-    </choose>
-  </macro>
-  <macro name="container-contributors-note">
-    <choose>
-      <if type="chapter entry-dictionary entry-encyclopedia paper-conference" match="any">
-        <text macro="editor-translator"/>
-      </if>
-    </choose>
-  </macro>
+  <!-- Removed `secondary-contributors-note` macro as it’s not used-->
   <macro name="secondary-contributors">
     <choose>
       <if type="chapter entry-dictionary entry-encyclopedia paper-conference" match="none">
@@ -110,19 +97,7 @@
       <name and="text" delimiter=", "/>
     </names>
   </macro>
-  <macro name="contributors-note">
-    <group delimiter=" ">
-      <names variable="author">
-        <name and="text" sort-separator=", " delimiter=", "/>
-        <label form="short" prefix=", "/>
-        <substitute>
-          <names variable="editor"/>
-          <names variable="translator"/>
-        </substitute>
-      </names>
-      <text macro="recipient-note"/>
-    </group>
-  </macro>
+  <!-- Removed `contributors-note` macro as it’s not used-->
   <macro name="editor">
     <names variable="editor">
       <name name-as-sort-order="first" and="text" sort-separator=", " delimiter=", " delimiter-precedes-last="always"/>
@@ -205,48 +180,14 @@
       </substitute>
     </names>
   </macro>
-  <macro name="interviewer-note">
-    <names variable="interviewer" delimiter=", ">
-      <label form="verb" text-case="lowercase" suffix=" "/>
-      <name and="text" delimiter=", "/>
-    </names>
-  </macro>
+  <!-- Removed `interviewer-note` macro as it’s not used-->
   <macro name="interviewer">
     <names variable="interviewer" delimiter=", ">
       <label form="verb" text-case="capitalize-first" suffix=" "/>
       <name and="text" delimiter=", "/>
     </names>
   </macro>
-  <macro name="title-note">
-    <choose>
-      <if variable="title" match="none">
-        <text variable="genre"/>
-      </if>
-      <else-if type="book graphic map motion_picture song" match="any">
-        <text variable="title" text-case="title" font-style="italic"/>
-        <group delimiter=" " prefix=", ">
-          <text term="version"/>
-          <text variable="version"/>
-        </group>
-      </else-if>
-      <else-if type="legal_case interview patent" match="any">
-        <text variable="title"/>
-      </else-if>
-      <else-if variable="reviewed-author">
-        <text variable="title" font-style="italic" prefix="review of "/>
-      </else-if>
-      <else-if type="manuscript">
-        <text variable="title" quotes="false" suffix=", "/>
-      </else-if>
-      <else-if type="personal_communication">
-        <text variable="title" quotes="false"/>
-      </else-if>
-      <!--The part above removes automatic quotation marks from around titles of manuscript and letter item types in footnotes.-->
-      <else>
-        <text variable="title" text-case="title" quotes="true"/>
-      </else>
-    </choose>
-  </macro>
+  <!-- Removed `title-note` macro as it’s not used -->
   <macro name="title">
     <choose>
       <if variable="title" match="none">
@@ -341,33 +282,7 @@
       </if>
     </choose>
   </macro>
-  <macro name="description-note">
-    <group delimiter=", ">
-      <text macro="interviewer-note"/>
-      <text variable="medium"/>
-      <choose>
-        <if variable="title" match="none"/>
-        <else-if type="manuscript thesis speech" match="any"/>
-        <else-if type="patent">
-          <group delimiter=" ">
-            <text variable="authority"/>
-            <text variable="number"/>
-          </group>
-        </else-if>
-        <else>
-          <text variable="genre"/>
-        </else>
-      </choose>
-      <choose>
-        <if type="map">
-          <text variable="scale"/>
-        </if>
-        <else-if type="graphic">
-          <text variable="dimensions"/>
-        </else-if>
-      </choose>
-    </group>
-  </macro>
+  <!-- Removed `description-note` macro as it’s not used-->
   <macro name="description">
     <group delimiter=", ">
       <group delimiter=". ">
@@ -397,26 +312,7 @@
       </choose>
     </group>
   </macro>
-  <macro name="container-title-note">
-    <group delimiter=" ">
-      <choose>
-        <if type="chapter entry-dictionary entry-encyclopedia paper-conference" match="any">
-          <text term="in"/>
-        </if>
-      </choose>
-      <choose>
-        <if type="webpage">
-          <text variable="container-title"/>
-        </if>
-        <else-if type="post-weblog">
-          <text variable="container-title" text-case="title" font-style="italic" suffix=" (blog)"/>
-        </else-if>
-        <else-if type="bill legislation legal_case" match="none">
-          <text variable="container-title" text-case="title" font-style="italic"/>
-        </else-if>
-      </choose>
-    </group>
-  </macro>
+  <!-- Removed `containter-title-note` macro as it’s not used-->
   <macro name="container-title">
     <group delimiter=" ">
       <choose>
@@ -467,23 +363,7 @@
       </if>
     </choose>
   </macro>
-  <macro name="edition-note">
-    <choose>
-      <if type="book chapter graphic motion_picture paper-conference report song" match="any">
-        <choose>
-          <if is-numeric="edition">
-            <group delimiter=" ">
-              <number variable="edition" form="ordinal"/>
-              <text term="edition" form="short"/>
-            </group>
-          </if>
-          <else>
-            <text variable="edition"/>
-          </else>
-        </choose>
-      </if>
-    </choose>
-  </macro>
+  <!-- Removed `edition-note` macro as it’s not used-->
   <macro name="edition">
     <choose>
       <if type="book chapter graphic motion_picture paper-conference report song" match="any">
@@ -501,71 +381,8 @@
       </if>
     </choose>
   </macro>
-  <macro name="locators-note-join-with-space">
-    <choose>
-      <if type="article-journal" variable="volume" match="all">
-        <choose>
-          <if match="none" variable="collection-title">
-            <text macro="locators-note"/>
-          </if>
-        </choose>
-      </if>
-    </choose>
-  </macro>
-  <macro name="locators-note-join-with-comma">
-    <choose>
-      <if type="article-journal" match="none">
-        <text macro="locators-note"/>
-      </if>
-      <else-if type="article-journal">
-        <choose>
-          <if variable="volume" match="none">
-            <text macro="locators-note"/>
-          </if>
-          <else-if match="any" variable="collection-title">
-            <text macro="locators-note"/>
-          </else-if>
-        </choose>
-      </else-if>
-    </choose>
-  </macro>
-  <macro name="locators-note">
-    <choose>
-      <if type="article-journal">
-        <group delimiter=", ">
-          <text macro="collection-title-journal"/>
-          <text variable="volume"/>
-          <group delimiter=" ">
-            <text term="issue" form="short"/>
-            <text variable="issue"/>
-          </group>
-        </group>
-      </if>
-      <else-if type="bill legislation legal_case" match="any">
-        <text macro="legal-cites"/>
-      </else-if>
-      <else-if type="book chapter graphic motion_picture paper-conference report song" match="any">
-        <group delimiter=", ">
-          <text macro="edition-note"/>
-          <group delimiter=", ">
-            <group delimiter=" ">
-              <text term="volume" form="short"/>
-              <number variable="volume" form="numeric"/>
-            </group>
-            <text variable="volume-title" font-style="italic"/>
-          </group>
-          <choose>
-            <if variable="locator" match="none">
-              <group delimiter=" ">
-                <number variable="number-of-volumes" form="numeric"/>
-                <text term="volume" form="short" plural="true"/>
-              </group>
-            </if>
-          </choose>
-        </group>
-      </else-if>
-    </choose>
-  </macro>
+  <!-- Removed `locators-note-join-with-space` macro as it’s not used-->
+  <!-- Removed `locators-note` macro as it’s not used-->
   <macro name="legal-cites">
     <choose>
       <if type="legal_case" match="any">
@@ -712,22 +529,7 @@
       </else-if>
     </choose>
   </macro>
-  <macro name="locators-newspaper">
-    <choose>
-      <if type="article-newspaper">
-        <group delimiter=", ">
-          <group delimiter=" ">
-            <number variable="edition"/>
-            <text term="edition"/>
-          </group>
-          <group delimiter=" ">
-            <text term="section" form="short"/>
-            <text variable="section"/>
-          </group>
-        </group>
-      </if>
-    </choose>
-  </macro>
+  <!-- Removed `locators-newspaper` macro as it’s not used-->
   <macro name="event-note">
     <text variable="event"/>
   </macro>
@@ -934,63 +736,9 @@
       </else-if>
     </choose>
   </macro>
-  <macro name="point-locators-join-with-colon">
-    <choose>
-      <if type="article-journal">
-        <choose>
-          <if variable="locator page" match="any">
-            <choose>
-              <if variable="volume issue" match="any">
-                <text macro="point-locators"/>
-              </if>
-            </choose>
-          </if>
-        </choose>
-      </if>
-    </choose>
-  </macro>
-  <macro name="point-locators-join-with-comma">
-    <choose>
-      <if type="article-journal" match="none">
-        <text macro="point-locators"/>
-      </if>
-      <else-if variable="volume issue" match="none">
-        <text macro="point-locators"/>
-      </else-if>
-    </choose>
-  </macro>
-  <macro name="point-locators">
-    <choose>
-      <if variable="locator" match="none">
-        <choose>
-          <if type="article-journal chapter paper-conference" match="any">
-            <text variable="page"/>
-          </if>
-        </choose>
-      </if>
-      <else-if type="article-journal">
-        <group delimiter=" ">
-          <choose>
-            <if locator="page" match="none">
-              <label variable="locator" form="short" suffix=" "/>
-            </if>
-          </choose>
-          <text variable="locator"/>
-        </group>
-      </else-if>
-      <else-if type="legal_case"/>
-      <else>
-        <group delimiter=" ">
-          <choose>
-            <if locator="page" match="none">
-              <label variable="locator" form="short"/>
-            </if>
-          </choose>
-          <text variable="locator"/>
-        </group>
-      </else>
-    </choose>
-  </macro>
+  <!-- Removed `point-locators-join-with-colon` macro as it’s not used-->
+  <!-- Removed `point-locators-join-with-comma` macro as it’s not used-->
+  <!-- Removed `point-locators` macro as it’s not used-->
   <macro name="locators-chapter">
     <choose>
       <if type="chapter entry-dictionary entry-encyclopedia paper-conference" match="any">
@@ -1064,6 +812,7 @@
       </else>
     </choose>
   </macro>
+  <!-- Removed `access-note` macro as it’s not used-->
   <macro name="issue-note-join-with-space">
     <choose>
       <if type="article-journal bill legislation legal_case manuscript thesis" variable="publisher-place event-place publisher" match="any">
@@ -1083,23 +832,7 @@
       </if>
     </choose>
   </macro>
-  <macro name="issue-note-join-with-comma">
-    <choose>
-      <if type="article-journal bill legislation legal_case manuscript speech thesis" variable="publisher-place publisher" match="none">
-        <text macro="issue-note"/>
-      </if>
-      <else-if type="article-newspaper">
-        <text macro="issue-note"/>
-      </else-if>
-      <else-if type="article-journal">
-        <choose>
-          <if variable="volume issue" match="none">
-            <text macro="issue-note"/>
-          </if>
-        </choose>
-      </else-if>
-    </choose>
-  </macro>
+  <!-- Removed `issue-note-join-with-comma` macro as it’s not used-->
   <macro name="issue-map-graphic">
     <!--See CMoS 17th ed. 14.235 and 14.237-->
     <choose>
@@ -1316,38 +1049,7 @@
       </else-if>
     </choose>
   </macro>
-  <macro name="access-note">
-    <group delimiter=", ">
-      <choose>
-        <if type="graphic report" match="any">
-          <text macro="archive-note"/>
-        </if>
-        <else-if type="article-journal bill book chapter legal_case legislation motion_picture paper-conference" match="none">
-          <text macro="archive-note"/>
-        </else-if>
-      </choose>
-      <choose>
-        <if variable="issued" match="none">
-          <group delimiter=" ">
-            <text term="accessed"/>
-            <date variable="accessed" form="text"/>
-          </group>
-        </if>
-      </choose>
-      <choose>
-        <if type="legal_case" match="none">
-          <choose>
-            <if variable="DOI">
-              <text variable="DOI" prefix="https://doi.org/"/>
-            </if>
-            <else>
-              <text variable="URL"/>
-            </else>
-          </choose>
-        </if>
-      </choose>
-    </group>
-  </macro>
+  <!-- Removed `access-note` macro as it’s not used-->
   <macro name="access">
     <group delimiter=". ">
       <choose>
@@ -1411,27 +1113,15 @@
   <citation et-al-min="4" et-al-use-first="1" disambiguate-add-names="true">
     <layout suffix="." delimiter="; ">
       <choose>
-        <if position="ibid ibid-with-locator" match="any">
+        <if position="ibid-with-locator">
           <group delimiter=", ">
-            <text macro="contributors-short"/>
-            <group delimiter=" ">
-              <group delimiter=", ">
-                <choose>
-                  <if variable="author editor translator" match="none">
-                    <text macro="title-short"/>
-                  </if>
-                </choose>
-                <text macro="case-locator-subsequent"/>
-              </group>
-              <text macro="case-pinpoint-subsequent"/>
-            </group>
-            <choose>
-              <if match="none" type="legal_case">
-                <text macro="point-locators-subsequent"/>
-              </if>
-            </choose>
+            <text term="ibid"/>
+            <text macro="point-locators-subsequent"/>
           </group>
         </if>
+        <else-if position="ibid">
+          <text term="ibid"/>
+        </else-if>
         <else>
           <group delimiter=", ">
             <text macro="contributors-short"/>
@@ -1503,7 +1193,6 @@
             </group>
             <text macro="issue-join-with-comma"/>
             <text macro="locators-journal-join-with-comma"/>
-            <text macro="locators-newspaper"/>
           </group>
           <text macro="locators-journal-join-with-colon"/>
         </group>

--- a/chicago-note-bibliography-manuscript.csl
+++ b/chicago-note-bibliography-manuscript.csl
@@ -513,9 +513,7 @@
     </choose>
   </macro>
   <!-- Removed `locators-newspaper` macro as it’s not used -->
-  <macro name="event-note">
-    <text variable="event"/>
-  </macro>
+  <!-- Removed `event-note` macro as it’s not used -->
   <macro name="event">
     <choose>
       <if variable="title">
@@ -555,19 +553,7 @@
       </choose>
     </group>
   </macro>
-  <macro name="reprint-note">
-    <!--needs localization-->
-    <choose>
-      <if variable="original-date issued" match="all">
-        <choose>
-          <!--for whatever reason in notes, when we have both original and new publishers, reprint doesn't appear-->
-          <if variable="original-publisher original-publisher-place" match="none">
-            <text value="repr."/>
-          </if>
-        </choose>
-      </if>
-    </choose>
-  </macro>
+  <!-- Removed `reprint-note` macro as it’s not used -->
   <macro name="reprint">
     <!--needs localization-->
     <choose>


### PR DESCRIPTION
A variant of Chicago 17th Notes & Bibliography note style with changes to manuscript and letter item types that better match Chicago guidance.

The specific edits I made are detailed below, with my rationale following each bullet point:

Titles:

- Removal of the quotation marks around manuscript and letter item types and manuscript collection titles. If you want an item to have quotation marks around the title, you can add curly quotation marks to the Zotero title field. This allows users to decide for themselves whether or not the item at hand requires quotation marks around the title.
- Removal of default title casing for manuscript and letter titles in footnotes. Manuscript and letter titles will appear as entered in the Zotero field. Chicago guidance is nuanced; users can decide for themselves whether title or sentence casing is most appropriate for the item at hand.

Dates:

- Removal of the parentheses around a date or “n.d.” in a manuscript item footnote. Chicago guidance does not contain parentheses around dates in manuscript citations.
- Removal of the “n.d.” from manuscript collection bibliography entries. If dates are associated with a manuscript collection, they typically appear as part of the title. The indication of “no date” is not needed for the collection as a whole.
- The date format for manuscript and letter citations has been changed from month-day-year to day-month-year. Chicago guidance accepts both formats, but their examples employ day-month-year.

Subsequent citations:

- If a date is present in the Zotero date field, it will appear in subsequent shortened citations for manuscript and letter item types. If no date is present in Zotero, the “n.d.” will not appear in subsequent shortened citations. Chicago guidance indicates that more information than just the title may be useful in subsequent citations. Dates can be useful to distinguish between multiple similar documents.
- If the user enters text into the Place field in manuscript item types, that text will appear at the end of the shortened citation. This can be used for names of manuscript collections or repositories, if needed (e.g., if you have documents with similar titles across multiple collections or repositories). It may be useful to distinguish multiple similar documents by the collection or holding repository.

A few notes about how to best use this edited citation style:

- Use separate manuscript item and collection records: Create separate Zotero records for each individual manuscript item that you cite from the archival collection, plus another Zotero record for the collection as a whole. Use the individual manuscript item records to create footnote citations. Use the collection record for the bibliography. Note that when you put together the bibliography, you can use the functionality of the Zotero plugin in Word to edit the bibliography: specifically, you can remove the individual manuscript items from the bibliography and add in the collection record.

- Additional editing needed for letters that are part of manuscript collections:

- Instead of using the “Author”, “Contributor”, and “Recipient” options in Zotero’s creator field, write [sender’s name] to [recipient’s name] in the title field, as you’d like it to appear in the citation.

- For shortened subsequent citations, enter the shortened version of the title into the “Short Title” field in Zotero (e.g., Smith to Williams).