### PR TITLE
Remove erroneous "by" for subsequent in bluebook-law-review.csl

### DIFF
--- a/bluebook-law-review.csl
+++ b/bluebook-law-review.csl
@@ -64,7 +64,6 @@
   <macro name="name-short-macro">
     <names variable="author">
       <name form="short" and="text" delimiter=", "/>
-      <label form="verb-short" prefix=", "/>
       <substitute>
         <text variable="title" form="short"/>
       </substitute>


### PR DESCRIPTION
https://forums.zotero.org/discussion/116905/cross-references-in-bluebook-format-coming-out-with-a-superfluous-by#latest

Nota bene, there is another PR open for bluebook> https://github.com/citation-style-language/styles/pull/6634