### PR TITLE
infoclio.ch: add mention of editor and translator

### DIFF
--- a/infoclio-de-kurzbelege.csl
+++ b/infoclio-de-kurzbelege.csl
@@ -33,7 +33,7 @@
       <term name="editor" form="short">Hg.</term>
       <term name="editor" form="verb-short">hg. v.</term>
       <term name="translator" form="verb-short">übers. v.</term>
-      <term name="editortranslator" form="verb-short">hg. &#38; übers. v.</term>
+      <term name="editortranslator" form="verb-short">hg. &amp; übers. v.</term>
       <term name="interviewer" form="verb">Interview geführt von</term>
       <term name="accessed">Stand</term>
       <term name="letter">Schreiben</term>

--- a/infoclio-de-kurzbelege.csl
+++ b/infoclio-de-kurzbelege.csl
@@ -25,12 +25,15 @@
     <category citation-format="note"/>
     <category field="history"/>
     <category field="social_science"/>
-    <updated>2024-01-04T12:30:00+02:00</updated>
+    <updated>2024-09-04T12:30:00+02:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale xml:lang="de">
     <terms>
       <term name="editor" form="short">Hg.</term>
+      <term name="editor" form="verb-short">hg. v.</term>
+      <term name="translator" form="verb-short">übers. v.</term>
+      <term name="editortranslator" form="verb-short">hg. &#38; übers. v.</term>
       <term name="interviewer" form="verb">Interview geführt von</term>
       <term name="accessed">Stand</term>
       <term name="letter">Schreiben</term>
@@ -72,6 +75,7 @@
           <text macro="creator"/>
           <group delimiter=", ">
             <text macro="title"/>
+            <text macro="scientific-editor"/>
             <group delimiter=": ">
               <text macro="in"/>
               <text macro="container-creator"/>
@@ -177,6 +181,18 @@
         <text variable="collection-title"/>
         <text variable="container-title"/>
       </else-if>
+    </choose>
+  </macro>
+  <macro name="scientific-editor">
+    <choose>
+      <if type="book">
+        <group delimiter=" ">
+          <names variable="editor translator">
+            <label form="verb-short" suffix=" "/>
+            <name sort-separator=", " name-as-sort-order="all" et-al-min="4" et-al-use-first="3"/>
+          </names>
+        </group>
+      </if>
     </choose>
   </macro>
   <macro name="in">

--- a/infoclio-de.csl
+++ b/infoclio-de.csl
@@ -33,7 +33,7 @@
       <term name="editor" form="short">Hg.</term>
       <term name="editor" form="verb-short">hg. v.</term>
       <term name="translator" form="verb-short">übers. v.</term>
-      <term name="editortranslator" form="verb-short">hg. &#38; übers. v.</term>
+      <term name="editortranslator" form="verb-short">hg. &amp; übers. v.</term>
       <term name="interviewer" form="verb">Interview geführt von</term>
       <term name="accessed">Stand</term>
       <term name="letter">Schreiben</term>

--- a/infoclio-de.csl
+++ b/infoclio-de.csl
@@ -25,12 +25,15 @@
     <category citation-format="note"/>
     <category field="history"/>
     <category field="social_science"/>
-    <updated>2024-01-04T12:30:00+02:00</updated>
+    <updated>2024-09-04T12:30:00+02:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale xml:lang="de">
     <terms>
       <term name="editor" form="short">Hg.</term>
+      <term name="editor" form="verb-short">hg. v.</term>
+      <term name="translator" form="verb-short">übers. v.</term>
+      <term name="editortranslator" form="verb-short">hg. &#38; übers. v.</term>
       <term name="interviewer" form="verb">Interview geführt von</term>
       <term name="accessed">Stand</term>
       <term name="letter">Schreiben</term>
@@ -75,6 +78,7 @@
           <text macro="creator"/>
           <group delimiter=", ">
             <text macro="title"/>
+            <text macro="scientific-editor"/>
             <group delimiter=": ">
               <text macro="in"/>
               <text macro="container-creator"/>
@@ -180,6 +184,18 @@
         <text variable="collection-title"/>
         <text variable="container-title"/>
       </else-if>
+    </choose>
+  </macro>
+  <macro name="scientific-editor">
+    <choose>
+      <if type="book">
+        <group delimiter=" ">
+          <names variable="editor translator">
+            <label form="verb-short" suffix=" "/>
+            <name sort-separator=", " name-as-sort-order="all" et-al-min="4" et-al-use-first="3"/>
+          </names>
+        </group>
+      </if>
     </choose>
   </macro>
   <macro name="in">

--- a/infoclio-fr-nocaps.csl
+++ b/infoclio-fr-nocaps.csl
@@ -25,7 +25,7 @@
     <category citation-format="note"/>
     <category field="history"/>
     <category field="social_science"/>
-    <updated>2024-01-04T12:30:00+02:00</updated>
+    <updated>2024-09-04T12:30:00+02:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale xml:lang="fr">
@@ -84,6 +84,7 @@
       <group delimiter=", ">
         <text macro="creator"/>
         <text macro="title"/>
+        <text macro="scientific-editor"/>
         <group delimiter=": ">
           <text macro="in"/>
           <group delimiter=", ">
@@ -245,6 +246,16 @@
       </choose>
       <text term="cited" form="short"/>
     </group>
+  </macro>
+  <macro name="scientific-editor">
+    <choose>
+      <if type="book">
+        <names variable="editor translator">
+          <label form="verb-short" suffix=" "/>
+          <name sort-separator=" " name-as-sort-order="all" et-al-min="4" et-al-use-first="3"/>
+        </names>
+      </if>
+    </choose>
   </macro>
   <macro name="in">
     <choose>

--- a/infoclio-fr-smallcaps.csl
+++ b/infoclio-fr-smallcaps.csl
@@ -24,7 +24,7 @@
     <category citation-format="note"/>
     <category field="history"/>
     <category field="social_science"/>
-    <updated>2024-01-04T12:30:00+02:00</updated>
+    <updated>2024-09-04T12:30:00+02:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale xml:lang="fr">
@@ -83,6 +83,7 @@
       <group delimiter=", ">
         <text macro="creator"/>
         <text macro="title"/>
+        <text macro="scientific-editor"/>
         <group delimiter=": ">
           <text macro="in"/>
           <group delimiter=", ">
@@ -250,6 +251,18 @@
       </choose>
       <text term="cited" form="short"/>
     </group>
+  </macro>
+  <macro name="scientific-editor">
+    <choose>
+      <if type="book">
+        <names variable="editor translator">
+          <label form="verb-short" suffix=" "/>
+          <name sort-separator=" " name-as-sort-order="all" et-al-min="4" et-al-use-first="3">
+            <name-part name="family" font-variant="small-caps"/>
+          </name>
+        </names>
+      </if>
+    </choose>
   </macro>
   <macro name="in">
     <choose>


### PR DESCRIPTION
A small update to the infoclio.ch styles, for history students (and scholars) - originally submitted in #234 and last updated in #6833.

Responding to a request of users, we add the mention of editors of a book after its title. The use case is for critical editions of an author's work (say, Adam Smith), where we want to mention both the author and the scientific editors. We also display the translator in the same place.

As usual, thanks so much for the volunteer work of maintaining the styles! :clap: 

By the way, may I draw attention to my other PR #6787 ? The journal editors, who commissioned the style, have asked me again about the status.

cc @janbaumanninfoclio 