### PR TITLE
Update elsevier-harvard-without-titles.csl

### DIFF
--- a/elsevier-harvard-without-titles.csl
+++ b/elsevier-harvard-without-titles.csl
@@ -31,7 +31,7 @@
     <category citation-format="author-date"/>
     <category field="biology"/>
     <category field="generic-base"/>
-    <updated>2012-09-27T22:06:38+00:00</updated>
+    <updated>2024-09-27T22:06:38+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <macro name="container">
@@ -119,7 +119,7 @@
         <text variable="title"/>
         <group prefix=" (" suffix=")">
           <text variable="genre"/>
-          <text variable="number" prefix=" No. "/>
+          <text variable="number" prefix="No. "/>
         </group>
       </if>
       <else-if type="bill book graphic legal_case legislation motion_picture report song speech" match="any">


### PR DESCRIPTION
Just came across this discrepancy between `elsevier-harvard-without-titles.csl` and `elsevier-harvard.csl` and think it's an error.
Funny enough, this style was not updated in exactly 12 years. To the day.