### PR TITLE
Update anesthesiology.csl

### DIFF
--- a/anesthesiology.csl
+++ b/anesthesiology.csl
@@ -137,8 +137,6 @@
     <layout>
       <text variable="citation-number" suffix="."/>
       <text macro="author" suffix=":"/>
-        <citation et-al-min="6" et-al-use-first="3">
-        </citation>
       <text macro="title" prefix=" "/>
       <text macro="container-title"/>
       <text macro="editor" suffix="."/>

--- a/anesthesiology.csl
+++ b/anesthesiology.csl
@@ -13,6 +13,8 @@
     </author>
     <contributor>
       <name>Sebastian Karcher</name>
+    </contributor>
+    <contributor>
       <name>Matthew Ning</name>
     </contributor>
     <category citation-format="numeric"/>

--- a/anesthesiology.csl
+++ b/anesthesiology.csl
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" default-locale="en-US" page-range-format="minimal">
+<style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" page-range-format="minimal" default-locale="en-US">
   <info>
     <title>Anesthesiology</title>
     <id>http://www.zotero.org/styles/anesthesiology</id>

--- a/anesthesiology.csl
+++ b/anesthesiology.csl
@@ -5,7 +5,7 @@
     <id>http://www.zotero.org/styles/anesthesiology</id>
     <link href="http://www.zotero.org/styles/anesthesiology" rel="self"/>
     <link href="http://www.zotero.org/styles/anesthesia-and-analgesia" rel="template"/>
-    <link href="http://journals.lww.com/anesthesiology/Pages/completeinstructionsforauthors.aspx#references" rel="documentation"/>
+    <link href="https://pubs.asahq.org/anesthesiology/pages/instructions-for-authors-general#references" rel="documentation"/>
     <author>
       <name>Matt Levin</name>
       <email>mlevin@mlevin.net</email>
@@ -13,12 +13,13 @@
     </author>
     <contributor>
       <name>Sebastian Karcher</name>
+      <name>Matthew Ning</name>
     </contributor>
     <category citation-format="numeric"/>
     <category field="medicine"/>
     <issn>0003-3022</issn>
     <eissn>1528-1175</eissn>
-    <updated>2015-12-22T17:55:08+00:00</updated>
+    <updated>2024-10-09T11:44:00+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <macro name="title">
@@ -132,10 +133,12 @@
       <text variable="citation-number"/>
     </layout>
   </citation>
-  <bibliography et-al-min="31" et-al-use-first="30" second-field-align="flush" entry-spacing="0">
+  <bibliography et-al-min="7" et-al-use-first="3" second-field-align="flush" entry-spacing="0">
     <layout>
       <text variable="citation-number" suffix="."/>
       <text macro="author" suffix=":"/>
+        <citation et-al-min="6" et-al-use-first="3">
+        </citation>
       <text macro="title" prefix=" "/>
       <text macro="container-title"/>
       <text macro="editor" suffix="."/>


### PR DESCRIPTION
Update Anesthesiology bibliography style to reflect the following rule: "If there are 7 or more authors in a reference, list the first 3 authors’ names, followed by et al.” When there are 6 or fewer authors in a reference, all names should be listed."

https://pubs.asahq.org/anesthesiology/pages/instructions-for-authors-general#references