### PR TITLE
Fix unsupported unicode characters in two styles

### DIFF
--- a/journal-of-the-marine-biological-association-of-the-united-kingdom.csl
+++ b/journal-of-the-marine-biological-association-of-the-united-kingdom.csl
@@ -438,7 +438,7 @@
             <else>
               <group>
                 <text term="volume" form="short" plural="true" text-case="capitalize-first" suffix=" "/>
-                <number variable="number-of-volumes" form="numeric" prefix="1�"/>
+                <number variable="number-of-volumes" form="numeric" prefix="1&#8211;"/>
               </group>
             </else>
           </choose>

--- a/museum-national-dhistoire-naturelle.csl
+++ b/museum-national-dhistoire-naturelle.csl
@@ -192,7 +192,7 @@
   <macro name="genre">
     <group prefix=" " suffix=". ">
       <text variable="genre"/>
-      <text variable="number" prefix="N&ordm;"/>
+      <text variable="number" prefix="N&#xBA;"/>
     </group>
   </macro>
   <macro name="event">

--- a/museum-national-dhistoire-naturelle.csl
+++ b/museum-national-dhistoire-naturelle.csl
@@ -192,7 +192,7 @@
   <macro name="genre">
     <group prefix=" " suffix=". ">
       <text variable="genre"/>
-      <text variable="number" prefix="N&#xBA;"/>
+      <text variable="number" prefix="Nº"/>
     </group>
   </macro>
   <macro name="event">

--- a/museum-national-dhistoire-naturelle.csl
+++ b/museum-national-dhistoire-naturelle.csl
@@ -192,7 +192,7 @@
   <macro name="genre">
     <group prefix=" " suffix=". ">
       <text variable="genre"/>
-      <text variable="number" prefix=" No. "/>
+      <text variable="number" prefix="N&ordm;"/>
     </group>
   </macro>
   <macro name="event">

--- a/museum-national-dhistoire-naturelle.csl
+++ b/museum-national-dhistoire-naturelle.csl
@@ -192,7 +192,7 @@
   <macro name="genre">
     <group prefix=" " suffix=". ">
       <text variable="genre"/>
-      <text variable="number" prefix=" N�"/>
+      <text variable="number" prefix=" No. "/>
     </group>
   </macro>
   <macro name="event">


### PR DESCRIPTION
Fix invalid unicode characters in the following styles:

`journal-of-the-marine-biological-association-of-the-united-kingdom.csl`

- From PR #2547, it looks like the original style was cloned from `apa-6th-edition.csl`. The invalid character in `number-of-volumes` was updated to match that journal: `&#8211;`.

`museum-national-dhistoire-naturelle.csl`

- Replacement `"N&ordm;"` was suggested by bwiernik in review.

Fixes #7222