### PR TITLE
Propose EN and FR styles for BMSAP

### DIFF
--- a/bulletins-et-memoires-de-la-societe-d-anthropologie-de-paris-en.csl
+++ b/bulletins-et-memoires-de-la-societe-d-anthropologie-de-paris-en.csl
@@ -1,0 +1,599 @@
+<?xml version="1.0" encoding="utf-8"?>
+<style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" demote-non-dropping-particle="never" default-locale="en-US">
+  <!-- Métadonnées générales -->
+  <info>
+    <title>Bulletins et mémoires de la Société d'Anthropologie de Paris (EN)</title>
+    <title-short>BMSAP (EN)</title-short>
+    <id>http://www.zotero.org/styles/bulletins-et-memoires-de-la-societe-d-anthropologie-de-paris-en</id>
+    <link href="http://www.zotero.org/styles/bulletins-et-memoires-de-la-societe-d-anthropologie-de-paris-en" rel="self"/>
+    <link href="https://journals.openedition.org/bmsap/6805#tocto1n2" rel="documentation"/>
+    <author>
+      <name>Frédéric Santos</name>
+      <email>frederic.santos@u-bordeaux.fr</email>
+      <uri>https://gitlab.com/f-santos</uri>
+    </author>
+    <contributor>
+      <name>Frédérique Flamerie de Lachapelle</name>
+      <email>frederique.flamerie-de-lachapelle@u-bordeaux.fr</email>
+      <uri/>
+    </contributor>
+    <category citation-format="author-date"/>
+    <category field="anthropology"/>
+    <category field="humanities"/>
+    <summary>&gt;Style sheet for BMSAP.</summary>
+    <eissn>1777-5469</eissn>
+    <updated>2024-10-23T15:00:00+00:00</updated>
+    <rights license="http://creativecommons.org/licenses/by-sa/4.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 4.0 License</rights>
+  </info>
+  <!-- Variantes linguistiques -->
+  <locale xml:lang="en">
+    <terms>
+      <term name="container-author" form="short">
+        <single>dir</single>
+        <multiple>dirs</multiple>
+      </term>
+      <term name="editor" form="short">
+        <single>ed</single>
+        <multiple>eds</multiple>
+      </term>
+      <term name="translator" form="short">
+        <single>trad</single>
+        <multiple>trads</multiple>
+      </term>
+      <term name="page" form="short">
+	<single>p</single>
+        <multiple>pp</multiple>
+      </term>
+      <term name="et-al">et al.</term>
+    </terms>
+  </locale>
+  <!-- Macros -->
+  <macro name="container-contributors">
+    <choose>
+      <if type="chapter paper-conference" match="any">
+        <names variable="container-author editor" suffix=" ">
+          <name initialize-with="" delimiter-precedes-last="never" name-as-sort-order="all" sort-separator=" "/>
+          <et-al/>
+          <label form="short" prefix=" (" suffix=")"/>
+        </names>
+      </if>
+    </choose>
+  </macro>
+  <macro name="secondary-contributors">
+    <choose>
+      <if type="article-journal chapter paper-conference" match="none">
+        <names variable="editor" delimiter=", ">
+          <label form="short" suffix=" "/>
+          <name and="text" initialize-with="" delimiter=", " delimiter-precedes-last="never"/>
+          <et-al/>
+        </names>
+      </if>
+    </choose>
+  </macro>
+  <macro name="author">
+    <choose>
+      <if variable="author">
+        <names variable="author">
+          <name delimiter-precedes-et-al="never" delimiter-precedes-last="never" initialize-with="" name-as-sort-order="all" sort-separator=" "/>
+          <et-al/>
+          <label form="short" prefix=" (" suffix=")"/>
+          <substitute>
+            <names variable="editor"/>
+            <names variable="translator"/>
+            <choose>
+              <if type="report">
+                <text variable="publisher"/>
+                <text macro="title"/>
+              </if>
+              <else>
+                <text macro="title"/>
+              </else>
+            </choose>
+          </substitute>
+        </names>
+      </if>
+      <else>
+        <choose>
+          <if type="entry-encyclopedia entry-dictionary" match="any">
+            <text macro="title"/>
+          </if>
+          <else>
+            <names variable="author">
+              <name and="text" delimiter-precedes-last="never" initialize-with=" " name-as-sort-order="all"/>
+              <et-al/>
+              <label form="short" prefix=" (" suffix=")"/>
+              <substitute>
+                <names variable="editor"/>
+                <names variable="translator"/>
+                <choose>
+                  <if type="report">
+                    <text variable="publisher"/>
+                    <text macro="title"/>
+                  </if>
+                  <else>
+                    <text macro="title"/>
+                  </else>
+                </choose>
+              </substitute>
+            </names>
+          </else>
+        </choose>
+      </else>
+    </choose>
+  </macro>
+  <macro name="author-short">
+    <names variable="author">
+      <name form="short" and="text" delimiter-precedes-last="never" et-al-min="3" et-al-use-first="1" initialize-with=". "/>
+      <substitute>
+        <names variable="editor"/>
+        <names variable="translator"/>
+        <choose>
+          <if type="report">
+            <text variable="publisher"/>
+            <text variable="title" form="short"/>
+          </if>
+          <else-if type="bill book graphic legal_case legislation motion_picture song map webpage post" match="any">
+            <text variable="title" form="short"/>
+          </else-if>
+          <else>
+            <text variable="title" form="short" quotes="true"/>
+          </else>
+        </choose>
+      </substitute>
+    </names>
+  </macro>
+  <!-- Macro pour spécifier DOI, URL, et accès divers aux ressources -->
+  <macro name="access">
+    <choose>
+      <if type="thesis">
+        <choose>
+          <if variable="archive" match="any">
+            <group>
+              <text variable="archive" suffix=". "/>
+              <text variable="archive_location" prefix=" (" suffix=")"/>
+              <text variable="URL" prefix=" [" suffix="]"/>
+            </group>
+          </if>
+          <else>
+            <text variable="URL" prefix=" [" suffix="]"/>
+          </else>
+        </choose>
+      </if>
+      <else-if type="article article-journal book chapter" match="any">
+        <choose>
+          <if variable="DOI">
+            <text variable="DOI" prefix="[https://doi.org/" suffix="]"/>
+          </if>
+	</choose>
+      </else-if>
+      <else-if type="post webpage" match="any">
+        <group delimiter=" ">
+	  <text variable="URL"/>
+          <text term="retrieved" prefix="("/>
+          <date variable="accessed" form="text" suffix=")."/>
+        </group>
+      </else-if>
+      <else>
+        <choose>
+          <if type="graphic">
+            <text variable="archive" suffix=". "/>
+            <text variable="URL"/>
+          </if>
+          <else>
+            <text variable="URL"/>
+          </else>
+        </choose>
+      </else>
+    </choose>
+  </macro>
+  <macro name="title">
+    <choose>
+      <if type="thesis" match="any">
+        <group delimiter=". " suffix=",">
+          <text variable="title"/>
+          <text variable="genre"/>
+        </group>
+      </if>
+      <else-if type="report" match="any">
+        <choose>
+          <if variable="version">
+            <group delimiter=" " suffix=", ">
+              <text variable="title"/>
+              <text variable="genre" prefix=" " suffix="." text-case="capitalize-first"/>
+              <text variable="medium" prefix=" [" suffix="]" text-case="capitalize-first"/>
+              <group delimiter=" " prefix="(" suffix=")">
+                <text term="version"/>
+                <text variable="version"/>
+              </group>
+            </group>
+          </if>
+          <else>
+            <text variable="title"/>
+            <text variable="genre" prefix=" " suffix="." text-case="capitalize-first"/>
+            <text variable="medium" prefix=" [" suffix="]" text-case="capitalize-first"/>
+          </else>
+        </choose>
+      </else-if>
+      <else-if type="book" match="any">
+	<choose>
+	  <if variable="edition translator" match="any">
+	    <text variable="title"/>
+	    <group delimiter=", " prefix=" (" suffix=").">
+	      <names variable="translator" delimiter=", ">
+		<label form="short" suffix=" "/>
+		<name and="text" initialize-with="" delimiter=", " delimiter-precedes-last="never"/>
+		<et-al/>
+              </names>
+	      <text macro="edition"/>
+	    </group>
+	  </if>
+	  <else>
+	    <text variable="title" suffix="."/>
+	  </else>
+	</choose>
+      </else-if>
+      <else-if type="post webpage" match="any">
+        <text variable="title" font-style="italic" suffix=","/>
+      </else-if>
+      <else>
+        <text variable="title" suffix="."/>
+      </else>
+    </choose>
+  </macro>
+  <!-- La macro publisher gère le groupe {éditeur, lieu, pages} pour les livres et chapitres d'ouvrages -->
+  <macro name="publisher">
+    <choose>
+      <if type="book thesis" match="any">
+        <group delimiter=", ">
+          <text variable="publisher"/>
+          <text variable="publisher-place"/>
+	  <text macro="pages-book"/>
+        </group>
+      </if>
+      <else-if type="chapter paper-conference" match="any">
+        <group delimiter=", ">
+	  <text variable="publisher"/>
+	  <text variable="publisher-place"/>
+	  <choose>
+	    <if variable="page" match="any">
+	      <group>
+		<label variable="page" form="short" suffix=" "/>
+		<text variable="page"/>
+	      </group>
+	    </if>
+	  </choose>
+        </group>
+      </else-if>
+    </choose>
+  </macro>
+  <macro name="event">
+    <choose>
+      <if variable="container-title" match="none">
+        <choose>
+          <if variable="event">
+            <choose>
+              <if variable="genre" match="none">
+                <choose>
+                  <if type="paper-conference" match="none">
+                    <text term="presented at" text-case="capitalize-first" suffix=" "/>
+                    <text variable="event"/>
+                  </if>
+                </choose>
+              </if>
+              <else>
+                <group delimiter=" ">
+                  <text variable="genre" text-case="capitalize-first"/>
+                  <text term="presented at"/>
+                  <text variable="event"/>
+                </group>
+              </else>
+            </choose>
+          </if>
+        </choose>
+      </if>
+    </choose>
+  </macro>
+  <macro name="issued">
+    <choose>
+      <if type="bill legal_case legislation" match="none">
+        <choose>
+          <if variable="issued">
+            <group prefix="(" suffix=")">
+              <date variable="issued">
+                <date-part name="year"/>
+              </date>
+              <text variable="year-suffix"/>
+              <choose>
+                <if type="article-journal bill book chapter legal_case legislation report song thesis" match="none">
+                  <date variable="issued" prefix=",">
+                    <date-part prefix=" " name="day" range-delimiter=" au "/>
+                    <date-part prefix=" " name="month"/>
+                  </date>
+                </if>
+              </choose>
+            </group>
+          </if>
+          <else>
+            <group prefix="(" suffix=")">
+              <text term="no date" form="short"/>
+              <text variable="year-suffix" prefix="-"/>
+            </group>
+          </else>
+        </choose>
+      </if>
+    </choose>
+  </macro>
+  <macro name="issued-sort">
+    <choose>
+      <if type="article-journal bill book chapter graphic legal_case legislation motion_picture paper-conference report song" match="none">
+        <date variable="issued">
+          <date-part name="year"/>
+          <date-part name="month"/>
+          <date-part name="day"/>
+        </date>
+      </if>
+      <else>
+        <date variable="issued">
+          <date-part name="year"/>
+        </date>
+      </else>
+    </choose>
+  </macro>
+  <macro name="issued-year">
+    <choose>
+      <if variable="issued">
+        <date variable="issued">
+          <date-part name="year"/>
+        </date>
+        <text variable="year-suffix"/>
+      </if>
+      <else>
+        <text term="no date" form="short"/>
+        <text variable="year-suffix" prefix="-"/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="edition">
+    <choose>
+      <if is-numeric="edition">
+        <group delimiter=" ">
+          <number variable="edition" form="ordinal"/>
+          <text term="edition" form="short"/>
+        </group>
+      </if>
+      <else>
+        <text variable="edition"/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="locators">
+    <choose>
+      <if type="article-journal article-magazine" match="any">
+        <group prefix="" delimiter="">
+	  <choose>
+            <if variable="issue">
+              <group>
+		<text variable="volume" font-style="normal"/>
+		<text variable="issue" prefix="(" suffix=")"/>
+		<text variable="page" prefix=":"/>
+              </group>
+            </if>
+            <else>
+              <text variable="volume" font-style="normal" suffix=":"/>
+	      <text variable="page"/>
+            </else>
+          </choose>
+        </group>
+      </if>
+      <else-if type="article-newspaper">
+        <group delimiter=" " prefix=", ">
+          <text variable="page"/>
+        </group>
+      </else-if>
+      <else-if type="book chapter graphic motion_picture paper-conference song" match="any">
+        <group prefix=" (" suffix=")" delimiter="; ">
+          <group delimiter=", ">
+            <group>
+              <text term="volume" form="short" plural="true" suffix=" "/>
+              <number variable="number-of-volumes" form="numeric" prefix="1-"/>
+            </group>
+            <group>
+              <text term="volume" form="short" suffix=" "/>
+              <number variable="volume" form="numeric"/>
+            </group>
+            <group>
+	      <choose>
+		<if type="chapter paper-conference" match="none">
+		  <label variable="page" form="short" suffix=" "/>
+		  <text variable="page"/>
+		</if>
+	      </choose>
+            </group>
+          </group>
+          <text macro="secondary-contributors"/>
+        </group>
+      </else-if>
+      <else-if type="legal_case">
+        <group prefix=" (" suffix=")" delimiter=" ">
+          <text variable="authority"/>
+          <date variable="issued" form="text"/>
+        </group>
+      </else-if>
+      <else-if type="bill legislation" match="any">
+        <date variable="issued" prefix=" (" suffix=")">
+          <date-part name="year"/>
+        </date>
+      </else-if>
+    </choose>
+  </macro>
+  <macro name="citation-locator">
+    <group>
+      <choose>
+        <if locator="chapter">
+          <label variable="locator" form="short"/>
+        </if>
+        <else>
+          <label variable="locator" form="short"/>
+        </else>
+      </choose>
+      <text variable="locator" prefix=" "/>
+    </group>
+  </macro>
+  <macro name="container">
+    <group>
+      <choose>
+        <if type="chapter entry-encyclopedia entry-dictionary paper-conference song" match="any">
+          <text term="in" text-case="capitalize-first" suffix=": "/>
+        </if>
+      </choose>
+      <choose>
+        <if type="entry-dictionary entry-encyclopedia" match="any">
+          <names variable="editor" suffix=", ">
+            <name and="text" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="never"/>
+            <et-al/>
+            <label form="short" prefix=" (" suffix=")"/>
+          </names>
+        </if>
+        <else-if type="song">
+          <text variable="collection-title" font-style="italic"/>
+        </else-if>
+      </choose>
+      <text macro="container-contributors"/>
+      <choose>
+        <if type="entry-dictionary">
+          <text macro="container-title"/>
+          <group prefix=" (" suffix=")">
+            <text variable="page" prefix="p. "/>
+          </group>
+        </if>
+        <else-if type="broadcast">
+          <group prefix=" (" suffix=")">
+            <choose>
+              <if is-numeric="number">
+                <text term="issue" suffix=" " form="short"/>
+                <text variable="number"/>
+              </if>
+              <else>
+                <text variable="number"/>
+              </else>
+            </choose>
+          </group>
+          <text variable="genre" prefix=" [" suffix="]" text-case="lowercase"/>
+          <text variable="medium" prefix=" [" suffix="]" text-case="lowercase"/>
+          <text macro="container-title"/>
+        </else-if>
+        <else>
+          <text macro="container-title"/>
+        </else>
+      </choose>
+      <choose>
+        <if type="entry-encyclopedia">
+          <group prefix=" (" suffix=")" delimiter=", ">
+            <text variable="volume" prefix="Vol. "/>
+            <text variable="page" prefix="p. "/>
+          </group>
+        </if>
+      </choose>
+    </group>
+    <choose>
+      <if type="manuscript">
+        <text value="Document inédit"/>
+      </if>
+    </choose>
+  </macro>
+  <macro name="container-title">
+    <choose>
+      <if type="article article-journal article-magazine article-newspaper" match="any">
+        <text variable="container-title" text-case="title" font-style="normal"/>
+      </if>
+      <else-if type="chapter">
+        <text variable="container-title" text-case="title" font-style="normal" suffix="."/>
+      </else-if>
+      <else-if type="paper-conference">
+        <text variable="container-title" text-case="title" suffix="."/>
+      </else-if>
+      <else-if type="webpage">
+        <text variable="container-title"/>
+      </else-if>
+      <else-if type="broadcast">
+        <text term="in" text-case="capitalize-first" prefix=". " suffix=" "/>
+        <text variable="collection-title"/>
+        <text variable="container-title"/>
+      </else-if>
+      <else-if type="bill legal_case legislation" match="none">
+        <text variable="container-title"/>
+      </else-if>
+      <else>
+        <group delimiter=" " prefix=", ">
+          <choose>
+            <if variable="container-title">
+              <text variable="volume"/>
+              <text variable="container-title"/>
+              <group delimiter=" ">
+                <text term="section" form="symbol"/>
+                <text variable="section"/>
+              </group>
+              <text variable="page"/>
+            </if>
+            <else>
+              <choose>
+                <if type="legal_case">
+                  <text term="issue" form="short"/>
+                  <text variable="number"/>
+                </if>
+                <else>
+                  <text term="issue" form="short"/>
+                  <text variable="number"/>
+                  <group delimiter=" ">
+                    <text term="section" form="symbol"/>
+                    <text variable="section"/>
+                  </group>
+                </else>
+              </choose>
+            </else>
+          </choose>
+        </group>
+      </else>
+    </choose>
+  </macro>
+  <macro name="pages-book">
+    <choose>
+      <if type="book thesis">
+	<text variable="number-of-pages" suffix=" p"/>
+      </if>
+    </choose>
+  </macro>
+  <!-- Instructions de citation dans le corps de texte -->
+  <citation et-al-min="3" et-al-use-first="1" disambiguate-add-year-suffix="true" disambiguate-add-names="true" disambiguate-add-givenname="true" collapse="year" givenname-disambiguation-rule="primary-name">
+    <sort>
+      <key macro="issued-sort"/>
+      <key macro="issued-year"/>
+    </sort>
+    <layout delimiter="; " prefix="(" suffix=")">
+      <group delimiter=", ">
+        <text macro="author-short"/>
+        <text macro="issued-year"/>
+        <text macro="citation-locator"/>
+      </group>
+    </layout>
+  </citation>
+  <!-- Bibliographie finale -->
+  <bibliography hanging-indent="true" et-al-min="4" et-al-use-first="3" entry-spacing="0" line-spacing="2">
+    <sort>
+      <key macro="author"/>
+      <key macro="issued-sort" sort="ascending"/>
+      <key macro="title"/>
+    </sort>
+    <layout>
+      <group delimiter=" ">
+        <text macro="author"/>
+        <text macro="issued"/>
+        <text macro="title"/>
+        <text macro="container"/>
+        <text macro="locators"/>
+        <text macro="publisher"/>
+        <text macro="access"/>
+      </group>
+    </layout>
+  </bibliography>
+</style>

--- a/bulletins-et-memoires-de-la-societe-d-anthropologie-de-paris-fr.csl
+++ b/bulletins-et-memoires-de-la-societe-d-anthropologie-de-paris-fr.csl
@@ -1,0 +1,599 @@
+<?xml version="1.0" encoding="utf-8"?>
+<style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" demote-non-dropping-particle="never" default-locale="fr-FR">
+  <!-- Métadonnées générales -->
+  <info>
+    <title>Bulletins et mémoires de la Société d'Anthropologie de Paris (FR)</title>
+    <title-short>BMSAP (FR)</title-short>
+    <id>http://www.zotero.org/styles/bulletins-et-memoires-de-la-societe-d-anthropologie-de-paris-fr</id>
+    <link href="http://www.zotero.org/styles/bulletins-et-memoires-de-la-societe-d-anthropologie-de-paris-fr" rel="self"/>
+    <link href="https://journals.openedition.org/bmsap/6805#tocto1n2" rel="documentation"/>
+    <author>
+      <name>Frédéric Santos</name>
+      <email>frederic.santos@u-bordeaux.fr</email>
+      <uri>https://gitlab.com/f-santos</uri>
+    </author>
+    <contributor>
+      <name>Frédérique Flamerie de Lachapelle</name>
+      <email>frederique.flamerie-de-lachapelle@u-bordeaux.fr</email>
+      <uri/>
+    </contributor>
+    <category citation-format="author-date"/>
+    <category field="anthropology"/>
+    <category field="humanities"/>
+    <summary>&gt;Style bibliographique des BMSAP.</summary>
+    <eissn>1777-5469</eissn>
+    <updated>2024-10-23T15:00:00+00:00</updated>
+    <rights license="http://creativecommons.org/licenses/by-sa/4.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 4.0 License</rights>
+  </info>
+  <!-- Variantes linguistiques -->
+  <locale xml:lang="fr">
+    <terms>
+      <term name="container-author" form="short">
+        <single>dir</single>
+        <multiple>dirs</multiple>
+      </term>
+      <term name="editor" form="short">
+        <single>éd</single>
+        <multiple>éds</multiple>
+      </term>
+      <term name="translator" form="short">
+        <single>trad</single>
+        <multiple>trads</multiple>
+      </term>
+      <term name="page" form="short">
+	<single>p</single>
+        <multiple>pp</multiple>
+      </term>
+      <term name="et-al">et al.</term>
+    </terms>
+  </locale>
+  <!-- Macros -->
+  <macro name="container-contributors">
+    <choose>
+      <if type="chapter paper-conference" match="any">
+        <names variable="container-author editor" suffix=" ">
+          <name initialize-with="" delimiter-precedes-last="never" name-as-sort-order="all" sort-separator=" "/>
+          <et-al/>
+          <label form="short" prefix=" (" suffix=")"/>
+        </names>
+      </if>
+    </choose>
+  </macro>
+  <macro name="secondary-contributors">
+    <choose>
+      <if type="article-journal chapter paper-conference" match="none">
+        <names variable="editor" delimiter=", ">
+          <label form="short" suffix=" "/>
+          <name and="text" initialize-with="" delimiter=", " delimiter-precedes-last="never"/>
+          <et-al/>
+        </names>
+      </if>
+    </choose>
+  </macro>
+  <macro name="author">
+    <choose>
+      <if variable="author">
+        <names variable="author">
+          <name delimiter-precedes-et-al="never" delimiter-precedes-last="never" initialize-with="" name-as-sort-order="all" sort-separator=" "/>
+          <et-al/>
+          <label form="short" prefix=" (" suffix=")"/>
+          <substitute>
+            <names variable="editor"/>
+            <names variable="translator"/>
+            <choose>
+              <if type="report">
+                <text variable="publisher"/>
+                <text macro="title"/>
+              </if>
+              <else>
+                <text macro="title"/>
+              </else>
+            </choose>
+          </substitute>
+        </names>
+      </if>
+      <else>
+        <choose>
+          <if type="entry-encyclopedia entry-dictionary" match="any">
+            <text macro="title"/>
+          </if>
+          <else>
+            <names variable="author">
+              <name and="text" delimiter-precedes-last="never" initialize-with=" " name-as-sort-order="all"/>
+              <et-al/>
+              <label form="short" prefix=" (" suffix=")"/>
+              <substitute>
+                <names variable="editor"/>
+                <names variable="translator"/>
+                <choose>
+                  <if type="report">
+                    <text variable="publisher"/>
+                    <text macro="title"/>
+                  </if>
+                  <else>
+                    <text macro="title"/>
+                  </else>
+                </choose>
+              </substitute>
+            </names>
+          </else>
+        </choose>
+      </else>
+    </choose>
+  </macro>
+  <macro name="author-short">
+    <names variable="author">
+      <name form="short" and="text" delimiter-precedes-last="never" et-al-min="3" et-al-use-first="1" initialize-with=". "/>
+      <substitute>
+        <names variable="editor"/>
+        <names variable="translator"/>
+        <choose>
+          <if type="report">
+            <text variable="publisher"/>
+            <text variable="title" form="short"/>
+          </if>
+          <else-if type="bill book graphic legal_case legislation motion_picture song map webpage post" match="any">
+            <text variable="title" form="short"/>
+          </else-if>
+          <else>
+            <text variable="title" form="short" quotes="true"/>
+          </else>
+        </choose>
+      </substitute>
+    </names>
+  </macro>
+  <!-- Macro pour spécifier DOI, URL, et accès divers aux ressources -->
+  <macro name="access">
+    <choose>
+      <if type="thesis">
+        <choose>
+          <if variable="archive" match="any">
+            <group>
+              <text variable="archive" suffix=". "/>
+              <text variable="archive_location" prefix=" (" suffix=")"/>
+              <text variable="URL" prefix=" [" suffix="]"/>
+            </group>
+          </if>
+          <else>
+            <text variable="URL" prefix=" [" suffix="]"/>
+          </else>
+        </choose>
+      </if>
+      <else-if type="article article-journal book chapter" match="any">
+        <choose>
+          <if variable="DOI">
+            <text variable="DOI" prefix="[https://doi.org/" suffix="]"/>
+          </if>
+	</choose>
+      </else-if>
+      <else-if type="post webpage" match="any">
+        <group delimiter=" ">
+	  <text variable="URL"/>
+          <text term="retrieved" prefix="("/>
+          <date variable="accessed" form="text" suffix=")."/>
+        </group>
+      </else-if>
+      <else>
+        <choose>
+          <if type="graphic">
+            <text variable="archive" suffix=". "/>
+            <text variable="URL"/>
+          </if>
+          <else>
+            <text variable="URL"/>
+          </else>
+        </choose>
+      </else>
+    </choose>
+  </macro>
+  <macro name="title">
+    <choose>
+      <if type="thesis" match="any">
+        <group delimiter=". " suffix=",">
+          <text variable="title"/>
+          <text variable="genre"/>
+        </group>
+      </if>
+      <else-if type="report" match="any">
+        <choose>
+          <if variable="version">
+            <group delimiter=" " suffix=", ">
+              <text variable="title"/>
+              <text variable="genre" prefix=" " suffix="." text-case="capitalize-first"/>
+              <text variable="medium" prefix=" [" suffix="]" text-case="capitalize-first"/>
+              <group delimiter=" " prefix="(" suffix=")">
+                <text term="version"/>
+                <text variable="version"/>
+              </group>
+            </group>
+          </if>
+          <else>
+            <text variable="title"/>
+            <text variable="genre" prefix=" " suffix="." text-case="capitalize-first"/>
+            <text variable="medium" prefix=" [" suffix="]" text-case="capitalize-first"/>
+          </else>
+        </choose>
+      </else-if>
+      <else-if type="book" match="any">
+	<choose>
+	  <if variable="edition translator" match="any">
+	    <text variable="title"/>
+	    <group delimiter=", " prefix=" (" suffix=").">
+	      <names variable="translator" delimiter=", ">
+		<label form="short" suffix=" "/>
+		<name and="text" initialize-with="" delimiter=", " delimiter-precedes-last="never"/>
+		<et-al/>
+              </names>
+	      <text macro="edition"/>
+	    </group>
+	  </if>
+	  <else>
+	    <text variable="title" suffix="."/>
+	  </else>
+	</choose>
+      </else-if>
+      <else-if type="post webpage" match="any">
+        <text variable="title" font-style="italic" suffix=","/>
+      </else-if>
+      <else>
+        <text variable="title" suffix="."/>
+      </else>
+    </choose>
+  </macro>
+  <!-- La macro publisher gère le groupe {éditeur, lieu, pages} pour les livres et chapitres d'ouvrages -->
+  <macro name="publisher">
+    <choose>
+      <if type="book thesis" match="any">
+        <group delimiter=", ">
+          <text variable="publisher"/>
+          <text variable="publisher-place"/>
+	  <text macro="pages-book"/>
+        </group>
+      </if>
+      <else-if type="chapter paper-conference" match="any">
+        <group delimiter=", ">
+	  <text variable="publisher"/>
+	  <text variable="publisher-place"/>
+	  <choose>
+	    <if variable="page" match="any">
+	      <group>
+		<label variable="page" form="short" suffix=" "/>
+		<text variable="page"/>
+	      </group>
+	    </if>
+	  </choose>
+        </group>
+      </else-if>
+    </choose>
+  </macro>
+  <macro name="event">
+    <choose>
+      <if variable="container-title" match="none">
+        <choose>
+          <if variable="event">
+            <choose>
+              <if variable="genre" match="none">
+                <choose>
+                  <if type="paper-conference" match="none">
+                    <text term="presented at" text-case="capitalize-first" suffix=" "/>
+                    <text variable="event"/>
+                  </if>
+                </choose>
+              </if>
+              <else>
+                <group delimiter=" ">
+                  <text variable="genre" text-case="capitalize-first"/>
+                  <text term="presented at"/>
+                  <text variable="event"/>
+                </group>
+              </else>
+            </choose>
+          </if>
+        </choose>
+      </if>
+    </choose>
+  </macro>
+  <macro name="issued">
+    <choose>
+      <if type="bill legal_case legislation" match="none">
+        <choose>
+          <if variable="issued">
+            <group prefix="(" suffix=")">
+              <date variable="issued">
+                <date-part name="year"/>
+              </date>
+              <text variable="year-suffix"/>
+              <choose>
+                <if type="article-journal bill book chapter legal_case legislation report song thesis" match="none">
+                  <date variable="issued" prefix=",">
+                    <date-part prefix=" " name="day" range-delimiter=" au "/>
+                    <date-part prefix=" " name="month"/>
+                  </date>
+                </if>
+              </choose>
+            </group>
+          </if>
+          <else>
+            <group prefix="(" suffix=")">
+              <text term="no date" form="short"/>
+              <text variable="year-suffix" prefix="-"/>
+            </group>
+          </else>
+        </choose>
+      </if>
+    </choose>
+  </macro>
+  <macro name="issued-sort">
+    <choose>
+      <if type="article-journal bill book chapter graphic legal_case legislation motion_picture paper-conference report song" match="none">
+        <date variable="issued">
+          <date-part name="year"/>
+          <date-part name="month"/>
+          <date-part name="day"/>
+        </date>
+      </if>
+      <else>
+        <date variable="issued">
+          <date-part name="year"/>
+        </date>
+      </else>
+    </choose>
+  </macro>
+  <macro name="issued-year">
+    <choose>
+      <if variable="issued">
+        <date variable="issued">
+          <date-part name="year"/>
+        </date>
+        <text variable="year-suffix"/>
+      </if>
+      <else>
+        <text term="no date" form="short"/>
+        <text variable="year-suffix" prefix="-"/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="edition">
+    <choose>
+      <if is-numeric="edition">
+        <group delimiter=" ">
+          <number variable="edition" form="ordinal"/>
+          <text term="edition" form="short"/>
+        </group>
+      </if>
+      <else>
+        <text variable="edition"/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="locators">
+    <choose>
+      <if type="article-journal article-magazine" match="any">
+        <group prefix="" delimiter="">
+	  <choose>
+            <if variable="issue">
+              <group>
+		<text variable="volume" font-style="normal"/>
+		<text variable="issue" prefix="(" suffix=")"/>
+		<text variable="page" prefix=":"/>
+              </group>
+            </if>
+            <else>
+              <text variable="volume" font-style="normal" suffix=":"/>
+	      <text variable="page"/>
+            </else>
+          </choose>
+        </group>
+      </if>
+      <else-if type="article-newspaper">
+        <group delimiter=" " prefix=", ">
+          <text variable="page"/>
+        </group>
+      </else-if>
+      <else-if type="book chapter graphic motion_picture paper-conference song" match="any">
+        <group prefix=" (" suffix=")" delimiter="; ">
+          <group delimiter=", ">
+            <group>
+              <text term="volume" form="short" plural="true" suffix=" "/>
+              <number variable="number-of-volumes" form="numeric" prefix="1-"/>
+            </group>
+            <group>
+              <text term="volume" form="short" suffix=" "/>
+              <number variable="volume" form="numeric"/>
+            </group>
+            <group>
+	      <choose>
+		<if type="chapter paper-conference" match="none">
+		  <label variable="page" form="short" suffix=" "/>
+		  <text variable="page"/>
+		</if>
+	      </choose>
+            </group>
+          </group>
+          <text macro="secondary-contributors"/>
+        </group>
+      </else-if>
+      <else-if type="legal_case">
+        <group prefix=" (" suffix=")" delimiter=" ">
+          <text variable="authority"/>
+          <date variable="issued" form="text"/>
+        </group>
+      </else-if>
+      <else-if type="bill legislation" match="any">
+        <date variable="issued" prefix=" (" suffix=")">
+          <date-part name="year"/>
+        </date>
+      </else-if>
+    </choose>
+  </macro>
+  <macro name="citation-locator">
+    <group>
+      <choose>
+        <if locator="chapter">
+          <label variable="locator" form="short"/>
+        </if>
+        <else>
+          <label variable="locator" form="short"/>
+        </else>
+      </choose>
+      <text variable="locator" prefix=" "/>
+    </group>
+  </macro>
+  <macro name="container">
+    <group>
+      <choose>
+        <if type="chapter entry-encyclopedia entry-dictionary paper-conference song" match="any">
+          <text term="in" text-case="capitalize-first" suffix=" : "/>
+        </if>
+      </choose>
+      <choose>
+        <if type="entry-dictionary entry-encyclopedia" match="any">
+          <names variable="editor" suffix=", ">
+            <name and="text" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="never"/>
+            <et-al/>
+            <label form="short" prefix=" (" suffix=")"/>
+          </names>
+        </if>
+        <else-if type="song">
+          <text variable="collection-title" font-style="italic"/>
+        </else-if>
+      </choose>
+      <text macro="container-contributors"/>
+      <choose>
+        <if type="entry-dictionary">
+          <text macro="container-title"/>
+          <group prefix=" (" suffix=")">
+            <text variable="page" prefix="p. "/>
+          </group>
+        </if>
+        <else-if type="broadcast">
+          <group prefix=" (" suffix=")">
+            <choose>
+              <if is-numeric="number">
+                <text term="issue" suffix=" " form="short"/>
+                <text variable="number"/>
+              </if>
+              <else>
+                <text variable="number"/>
+              </else>
+            </choose>
+          </group>
+          <text variable="genre" prefix=" [" suffix="]" text-case="lowercase"/>
+          <text variable="medium" prefix=" [" suffix="]" text-case="lowercase"/>
+          <text macro="container-title"/>
+        </else-if>
+        <else>
+          <text macro="container-title"/>
+        </else>
+      </choose>
+      <choose>
+        <if type="entry-encyclopedia">
+          <group prefix=" (" suffix=")" delimiter=", ">
+            <text variable="volume" prefix="Vol. "/>
+            <text variable="page" prefix="p. "/>
+          </group>
+        </if>
+      </choose>
+    </group>
+    <choose>
+      <if type="manuscript">
+        <text value="Document inédit"/>
+      </if>
+    </choose>
+  </macro>
+  <macro name="container-title">
+    <choose>
+      <if type="article article-journal article-magazine article-newspaper" match="any">
+        <text variable="container-title" text-case="title" font-style="normal"/>
+      </if>
+      <else-if type="chapter">
+        <text variable="container-title" text-case="title" font-style="normal" suffix="."/>
+      </else-if>
+      <else-if type="paper-conference">
+        <text variable="container-title" text-case="title" suffix="."/>
+      </else-if>
+      <else-if type="webpage">
+        <text variable="container-title"/>
+      </else-if>
+      <else-if type="broadcast">
+        <text term="in" text-case="capitalize-first" prefix=". " suffix=" "/>
+        <text variable="collection-title"/>
+        <text variable="container-title"/>
+      </else-if>
+      <else-if type="bill legal_case legislation" match="none">
+        <text variable="container-title"/>
+      </else-if>
+      <else>
+        <group delimiter=" " prefix=", ">
+          <choose>
+            <if variable="container-title">
+              <text variable="volume"/>
+              <text variable="container-title"/>
+              <group delimiter=" ">
+                <text term="section" form="symbol"/>
+                <text variable="section"/>
+              </group>
+              <text variable="page"/>
+            </if>
+            <else>
+              <choose>
+                <if type="legal_case">
+                  <text term="issue" form="short"/>
+                  <text variable="number"/>
+                </if>
+                <else>
+                  <text term="issue" form="short"/>
+                  <text variable="number"/>
+                  <group delimiter=" ">
+                    <text term="section" form="symbol"/>
+                    <text variable="section"/>
+                  </group>
+                </else>
+              </choose>
+            </else>
+          </choose>
+        </group>
+      </else>
+    </choose>
+  </macro>
+  <macro name="pages-book">
+    <choose>
+      <if type="book thesis">
+	<text variable="number-of-pages" suffix=" p"/>
+      </if>
+    </choose>
+  </macro>
+  <!-- Instructions de citation dans le corps de texte -->
+  <citation et-al-min="3" et-al-use-first="1" disambiguate-add-year-suffix="true" disambiguate-add-names="true" disambiguate-add-givenname="true" collapse="year" givenname-disambiguation-rule="primary-name">
+    <sort>
+      <key macro="issued-sort"/>
+      <key macro="issued-year"/>
+    </sort>
+    <layout delimiter=" ; " prefix="(" suffix=")">
+      <group delimiter=", ">
+        <text macro="author-short"/>
+        <text macro="issued-year"/>
+        <text macro="citation-locator"/>
+      </group>
+    </layout>
+  </citation>
+  <!-- Bibliographie finale -->
+  <bibliography hanging-indent="true" et-al-min="4" et-al-use-first="3" entry-spacing="0" line-spacing="2">
+    <sort>
+      <key macro="author"/>
+      <key macro="issued-sort" sort="ascending"/>
+      <key macro="title"/>
+    </sort>
+    <layout>
+      <group delimiter=" ">
+        <text macro="author"/>
+        <text macro="issued"/>
+        <text macro="title"/>
+        <text macro="container"/>
+        <text macro="locators"/>
+        <text macro="publisher"/>
+        <text macro="access"/>
+      </group>
+    </layout>
+  </bibliography>
+</style>


### PR DESCRIPTION
Hi,

This PR proposes two CSL files (one per language) for the journal [Bulletins et Mémoires de la Société d’Anthropologie de Paris](https://journals.openedition.org/bmsap/).
The rationale for the two separate files instead of one multi-lang file has been discussed [on Zotero's forum](https://forums.zotero.org/discussion/119030/style-request-bulletins-et-memoires-de-la-societe-danthropologie-de-paris#latest).

Thanks!