### PR TITLE
Update revue-francaise-de-gestion.csl

### DIFF
--- a/revue-francaise-de-gestion.csl
+++ b/revue-francaise-de-gestion.csl
@@ -15,9 +15,9 @@
     <category field="humanities"/>
     <issn>0338-4551</issn>
     <eissn>1777-5663</eissn>
-    <summary>Le style utilisé en 2018 par la Revue française de gestion.</summary>
-    <updated>2018-07-15T19:23:47+00:00</updated>
-    <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
+    <summary>Le style utilisé en 2024 par la Revue française de gestion.</summary>
+    <updated>2024-10-28T11:38:47+00:00</updated>
+    <rights license="http://creativecommons.org/licenses/by-sa/4.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 4.0 License</rights>
   </info>
   <locale xml:lang="fr">
     <terms>
@@ -145,7 +145,7 @@
       <text variable="number-of-pages" suffix="&#160;p"/>
     </group>
   </macro>
-  <citation et-al-min="4" et-al-use-first="1" disambiguate-add-year-suffix="true" disambiguate-add-names="true" collapse="year">
+  <citation et-al-min="3" et-al-use-first="1" disambiguate-add-year-suffix="true" disambiguate-add-names="true" collapse="year">
     <sort>
       <key macro="author-last"/>
       <key macro="year-date-short"/>


### PR DESCRIPTION
At the request of the journal, change in the number of authors from which the ‘et al’ is used (from 4 to 3). Update of the licence version.