### PR TITLE
Update iso690-author-date-sk.csl (according to STN ISO 690:2022)

### DIFF
--- a/iso690-author-date-sk.csl
+++ b/iso690-author-date-sk.csl
@@ -1,23 +1,27 @@
 <?xml version="1.0" encoding="utf-8"?>
 <style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" demote-non-dropping-particle="never" default-locale="sk-SK">
   <info>
-    <title>ISO-690 (author-date, Slovak)</title>
+    <title>ISO-690 (author-date, Slovenčina)</title>
     <id>http://www.zotero.org/styles/iso690-author-date-sk</id>
     <link href="http://www.zotero.org/styles/iso690-author-date-sk" rel="self"/>
     <link href="http://www.zotero.org/styles/iso690-author-date-cs" rel="template"/>
+    <link href="https://github.com/citation-style-language/styles/pull/846" rel="documentation"/>
     <author>
       <name>Tomáš Ferianc</name>
       <email>tferianc@gmail.com</email>
     </author>
     <category citation-format="author-date"/>
     <category field="generic-base"/>
-    <summary>Style based on STN ISO 690:2012</summary>
-    <updated>2014-02-18T15:01:54+00:00</updated>
+    <summary>Style based on STN ISO 690:2022</summary>
+    <updated>2024-10-29T03:41:57+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale>
     <terms>
       <term name="from">Dostupné na</term>
+      <term name="no date">s. a.</term>
+      <term name="online">Online</term>
+      <term name="accessed">citované</term>
     </terms>
   </locale>
   <macro name="author">
@@ -98,7 +102,7 @@
         </choose>
       </if>
       <else>
-        <text term="anonymous" form="short" text-case="uppercase"/>
+        <text term="anonymous" form="short" text-case="lowercase"/>
       </else>
     </choose>
   </macro>
@@ -130,14 +134,13 @@
         </names>
       </if>
       <else>
-        <text term="anonymous" form="short" text-case="uppercase"/>
+        <text term="anonymous" form="short" text-case="lowercase"/>
       </else>
     </choose>
   </macro>
   <macro name="container-author">
     <names variable="container-author">
       <name and="text" delimiter=", " delimiter-precedes-last="never">
-        <!--name and="text" name-as-sort-order="all" sort-separator=" " delimiter=", " delimiter-precedes-last="never"-->
         <name-part name="given"/>
         <name-part name="family" text-case="uppercase"/>
       </name>
@@ -159,7 +162,7 @@
         </choose>
       </if>
       <else>
-        <text term="anonymous" text-case="uppercase"/>
+        <text term="anonymous" text-case="lowercase"/>
       </else>
     </choose>
   </macro>
@@ -176,7 +179,7 @@
         </date>
       </if>
       <else>
-        <text term="no date"/>
+        <text term="no date" suffix="]" prefix="["/>
       </else>
     </choose>
   </macro>
@@ -240,7 +243,7 @@
     </choose>
     <choose>
       <if variable="DOI URL" match="any">
-        <text term="online" prefix=" [" suffix="]"/>
+        <text term="online" prefix=". " suffix=""/>
       </if>
     </choose>
   </macro>
@@ -284,7 +287,6 @@
         <date variable="issued">
           <date-part name="day" suffix="."/>
           <date-part name="month" form="numeric" suffix="."/>
-          <!--date-part name="year"/-->
         </date>
       </if>
     </choose>
@@ -298,8 +300,8 @@
   <macro name="edition">
     <choose>
       <if is-numeric="edition">
-        <number variable="edition" form="ordinal"/>
-        <label variable="edition" form="short" prefix=" "/>
+        <number suffix="." variable="edition"/>
+        <label plural="never" prefix=" " variable="edition" form="short"/>
       </if>
       <else>
         <text variable="edition" form="long"/>
@@ -321,7 +323,6 @@
             <text variable="publisher-place"/>
           </if>
           <else>
-            <!-- sine loco (s.l.)-->
             <text value="b.m." text-case="capitalize-first"/>
           </else>
         </choose>
@@ -360,7 +361,6 @@
             <text variable="publisher"/>
           </if>
           <else>
-            <!-- sine nomine (s.n.)-->
             <text value="b.n."/>
           </else>
         </choose>
@@ -381,11 +381,11 @@
     <choose>
       <if variable="URL DOI" match="any">
         <group prefix=" [" suffix="]">
-          <text term="accessed" form="short"/>
+          <text term="accessed" form="short" suffix=" "/>
           <date variable="accessed">
-            <date-part name="day" prefix=". "/>
-            <date-part name="month" prefix=". "/>
-            <date-part name="year" prefix=" "/>
+            <date-part name="year"/>
+            <date-part name="month" form="numeric-leading-zeros" prefix="-"/>
+            <date-part name="day" form="numeric-leading-zeros" prefix="-"/>
           </date>
         </group>
       </if>
@@ -429,9 +429,6 @@
   <macro name="issn">
     <text variable="ISSN" prefix="ISSN "/>
   </macro>
-  <macro name="doi">
-    <text variable="DOI" prefix="doi "/>
-  </macro>
   <macro name="url">
     <choose>
       <if variable="DOI">
@@ -447,30 +444,6 @@
         </group>
       </else-if>
     </choose>
-  </macro>
-  <macro name="archive">
-    <text variable="archive"/>
-    <choose>
-      <if variable="archive_location">
-        <text value=": "/>
-      </if>
-    </choose>
-  </macro>
-  <macro name="archive_location">
-    <choose>
-      <if variable="archive_location">
-        <text variable="archive_location"/>
-      </if>
-      <else>
-        <text variable="call-number"/>
-      </else>
-    </choose>
-  </macro>
-  <macro name="abstract">
-    <text variable="abstract"/>
-  </macro>
-  <macro name="note">
-    <text variable="note"/>
   </macro>
   <citation disambiguate-add-year-suffix="true" collapse="year" year-suffix-delimiter=", " after-collapse-delimiter="; " et-al-min="3" et-al-use-first="1" and="text">
     <layout prefix="(" suffix=")" delimiter="; ">
@@ -494,14 +467,10 @@
     </sort>
     <layout>
       <group delimiter=", " suffix=". ">
-        <!-- Author(s) -->
         <text macro="responsability"/>
-        <!-- Citation Year -->
         <text macro="year-date"/>
       </group>
-      <!-- Rest of Citation -->
       <choose>
-        <!-- Specific Formats -->
         <if type="book" match="any">
           <group delimiter=". " suffix=". ">
             <group delimiter=" ">
@@ -511,7 +480,6 @@
                 <text macro="edition"/>
                 <text macro="secondary-responsability"/>
                 <text macro="publisher-info"/>
-                <!--text macro="page"/-->
                 <text macro="collection"/>
               </group>
               <text macro="accessed"/>
@@ -528,7 +496,6 @@
             <text macro="edition"/>
             <text macro="secondary-responsability"/>
             <text macro="publisher-info"/>
-            <!--text macro="page"/-->
             <group delimiter=" ">
               <text macro="collection"/>
               <text macro="accessed"/>
@@ -554,8 +521,7 @@
             <text macro="edition"/>
             <group delimiter=" ">
               <group delimiter=", ">
-                <text macro="publisher-info"/>
-                <text macro="date-day-month"/>
+                <text macro="year-date"/>
                 <text macro="issue"/>
               </group>
               <text macro="accessed"/>
@@ -571,10 +537,6 @@
             <group delimiter=" ">
               <group delimiter=", ">
                 <text macro="publisher-info"/>
-                <!--group delimiter=": ">
-                    <text macro="publisher-place"/>
-                    <text macro="publisher"/>
-                  </group-->
                 <text macro="collection"/>
                 <text macro="page"/>
               </group>
@@ -636,7 +598,7 @@
         </else-if>
         <else-if type="motion_picture" match="any">
           <text macro="title" suffix=". "/>
-          <text macro="medium" prefix=" [" suffix="]. "/>
+          <text macro="medium" prefix="[" suffix="]. "/>
           <text macro="year-date" suffix=". "/>
           <text macro="responsability" suffix=". "/>
           <text macro="publisher-place" suffix=": "/>
@@ -709,7 +671,6 @@
           <group delimiter=". " suffix=". ">
             <text macro="title"/>
             <text macro="interviewer"/>
-            <!--text macro="event"/-->
             <text macro="date-day-month"/>
           </group>
         </else-if>


### PR DESCRIPTION
Replaced "no date" with the preferred "s. a."
Adjusted date format to "yyyy-mm-dd" and updated text "cit." to "citované" 
Changed "[online]" to the preferred "Online" form