### PR TITLE
Update royal-society-of-chemistry-with-titles.csl

### DIFF
--- a/royal-society-of-chemistry-with-titles.csl
+++ b/royal-society-of-chemistry-with-titles.csl
@@ -20,7 +20,7 @@
     <category citation-format="numeric"/>
     <category field="chemistry"/>
     <summary>The Royal Society of Chemistry journal style.</summary>
-    <updated>2017-06-12T22:42:45+00:00</updated>
+    <updated>2024-10-31T19:05:03+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <macro name="editor">
@@ -152,7 +152,7 @@
                 <text variable="page"/>
               </if>
               <else>
-                <text variable="DOI" prefix=", DOI:"/>
+                <text variable="DOI" prefix="DOI:"/>
               </else>
             </choose>
           </group>

--- a/royal-society-of-chemistry.csl
+++ b/royal-society-of-chemistry.csl
@@ -21,7 +21,7 @@
     <category citation-format="numeric"/>
     <category field="chemistry"/>
     <summary>The Royal Society of Chemistry journal style.</summary>
-    <updated>2022-12-05T05:15:00+00:00</updated>
+    <updated>2024-10-31T19:06:49+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <macro name="editor">
@@ -165,7 +165,7 @@
                 <text variable="page"/>
               </if>
               <else>
-                <text variable="DOI" prefix=", DOI:"/>
+                <text variable="DOI" prefix="DOI:"/>
               </else>
             </choose>
           </group>


### PR DESCRIPTION
Closes https://github.com/citation-style-language/styles/issues/7070

While the described issue was a non-issue as the group above the mentioned part sets the delimiter correclty.
However, while checking I noticed an error for the DOI adding a double ", ".