### PR TITLE
Create canadian-journal-of-mineralogy-and-petrology.csl

### DIFF
--- a/canadian-journal-of-mineralogy-and-petrology.csl
+++ b/canadian-journal-of-mineralogy-and-petrology.csl
@@ -1,0 +1,182 @@
+<?xml version="1.0" encoding="utf-8"?>
+<style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" demote-non-dropping-particle="sort-only" default-locale="en-US">
+  <!-- This style was edited with the Visual CSL Editor (https://editor.citationstyles.org/visualEditor/) -->
+  <info>
+    <title>Canadian Journal of Mineralogy and Petrology</title>
+    <title-short>CJMP</title-short>
+    <id>http://www.zotero.org/styles/canadian-journal-of-mineralogy-and-petrology</id>
+    <link rel="self" href="http://www.zotero.org/styles/canadian-journal-of-mineralogy-and-petrology"/>
+	<link href="https://mac-amc.myshopify.com/pages/submit-author-information" rel="documentation"/>
+    <author>
+      <name>Derek D.V. Leung</name>
+      <email>derekdvleung@gmail.com</email>
+    </author>
+    <category citation-format="author-date"/>
+    <category field="geology"/>
+    <issn>2817-1713</issn>
+    <eissn>2817-1713</eissn>
+    <summary>Style for the Canadian Journal of Mineralogy and Petrology</summary>
+    <updated>2024-03-26T22:00:20+00:00</updated>
+    <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
+  </info>
+  <locale>
+    <terms>
+      <term name="edition" form="short">edn.</term>
+      <term name="edition" form="long">Edition</term>
+      <term name="editor" form="short">
+        <single>ed.</single>
+        <multiple>eds.</multiple>
+      </term>
+      <term name="in">In</term>
+	  <term name="available at">available from</term>
+    </terms>
+  </locale>
+  <macro name="editor">
+    <names variable="editor">
+      <name and="symbol" sort-separator=" " initialize-with="." delimiter=", " delimiter-precedes-last="never"/>
+	  <label form="short" prefix=", " suffix=""/>
+    </names>
+  </macro>
+  <macro name="author">
+    <names variable="author" font-variant="small-caps">
+      <name and="symbol" delimiter-precedes-last="contextual" initialize-with="." name-as-sort-order="all"/>
+      <label form="short" prefix=" "/>
+      <et-al term="et-al" font-style="italic"/>
+      <substitute>
+        <names variable="editor"/>
+        <names variable="translator"/>
+        <text variable="title"/>
+      </substitute>
+    </names>
+  </macro>
+  <macro name="author-short">
+    <names variable="author">
+      <name form="short" and="symbol" delimiter-precedes-last="never" initialize-with=". "/>
+      <et-al font-style="italic"/>
+      <substitute>
+        <names variable="editor"/>
+        <names variable="translator"/>
+        <text variable="title"/>
+      </substitute>
+    </names>
+  </macro>
+  <macro name="title">
+    <text variable="title"/>
+  </macro>
+  <macro name="publisher">
+    <group delimiter=", ">
+      <text variable="publisher"/>
+      <text variable="publisher-place"/>
+    </group>
+  </macro>
+  <macro name="year-date">
+    <date variable="issued">
+      <date-part name="year"/>
+    </date>
+  </macro>
+  <macro name="edition">
+    <choose>
+      <if is-numeric="edition">
+        <group delimiter=" ">
+          <number variable="edition" form="ordinal"/>
+          <text term="edition" form="short" strip-periods="true"/>
+        </group>
+      </if>
+      <else>
+        <text variable="edition"/>
+      </else>
+    </choose>
+  </macro>
+   <macro name="access">
+    <choose>
+      <if variable="URL">
+        <group delimiter=". ">
+          <group delimiter=" ">
+            <text term="available at" text-case="capitalize-first"/>
+            <text variable="URL" prefix="&lt;" suffix="&gt;"/>
+          </group>
+          <date variable="accessed" prefix="[Date accessed: " suffix="]">
+            <date-part name="month" form="short" strip-periods="true" suffix=" "/>
+			<date-part name="day" suffix=", "/>
+            <date-part name="year"/>
+          </date>
+        </group>
+      </if>
+    </choose>
+  </macro>
+  <citation et-al-min="3" et-al-use-first="1" disambiguate-add-year-suffix="true" disambiguate-add-names="false" disambiguate-add-givenname="false" collapse="year-suffix" year-suffix-delimiter=" ">
+    <sort>
+      <key variable="issued" sort="ascending"/>
+      <key macro="author-short"/>
+    </sort>
+    <layout delimiter=", ">
+      <group delimiter=" ">
+        <text macro="author-short"/>
+        <text macro="year-date"/>
+        <text variable="locator"/>
+      </group>
+    </layout>
+  </citation>
+  <bibliography hanging-indent="true" entry-spacing="0">
+    <sort>
+      <key macro="author" names-min="1" names-use-first="1"/>
+      <!-- <key macro="author-count" names-min="3" names-use-first="3"/> -->
+      <key macro="author" names-min="3" names-use-first="1"/>
+      <key macro="year-date" sort="ascending"/>
+    </sort>
+    <layout suffix=".">
+      <text macro="author"/>
+      <date variable="issued" prefix=" (" suffix=")">
+        <date-part name="year"/>
+      </date>
+      <choose>
+        <if type="bill book graphic legal_case legislation motion_picture report song thesis" match="any">
+          <group delimiter=" " prefix=" ">
+            <group delimiter=", " prefix=" " suffix=".">
+              <text macro="title"/>
+              <text macro="edition"/>
+            </group>
+            <text macro="editor" prefix=" (" suffix="),"/>
+            <text macro="publisher" prefix=" "/>
+			<text variable = "number" prefix=" "/>
+          </group>
+        </if>
+        <else-if type="chapter paper-conference" match="any">
+          <text macro="title" prefix=" " suffix="." font-style="normal"/>
+          <group prefix=" " suffix=" ">
+            <text term="in" suffix=" " font-style="italic"/>
+            <group delimiter=", " suffix=".">
+              <text variable="container-title" font-style="normal"/>
+              <text macro="edition"/>
+            </group>
+            <text variable="collection-title" font-style="normal" prefix=" " suffix=","/>
+          </group>
+          <text macro="editor" prefix=" (" suffix=")."/>
+          <group suffix=".">
+		    <text macro="publisher" prefix=" "/>
+            <group prefix=" (" suffix=").">
+              <text variable="page"/>
+            </group>
+          </group>
+        </else-if>
+		<else-if type="webpage" match="any">
+		    <text macro="title" prefix=" " suffix="."/>
+			<text macro="access" prefix=". "/>
+		</else-if>
+        <else>
+          <text macro="title" prefix=" " suffix="."/>
+          <group delimiter=" " prefix=" " suffix=".">
+            <group delimiter=", ">
+				<text variable="container-title" font-style="italic"/>
+				<group delimiter="">
+					<text variable="volume" form="short" font-weight="bold"/>
+					<text variable="issue" form="short" prefix="(" suffix=")"/>
+				</group>
+				<text variable="page"/>
+			</group>
+          </group>
+        </else>
+      </choose>
+    </layout>
+  </bibliography>
+</style>


### PR DESCRIPTION
Added a new csl file for the Canadian Journal of Mineralogy and Petrology (https://pubs.geoscienceworld.org/cjmp) with plans to update some of the more obscure reference formats.