### PR TITLE
Create nature-single-spaced-no-et-al.csl

### DIFF
--- a/dependent/nature-single-spaced-no-et-al.csl
+++ b/dependent/nature-single-spaced-no-et-al.csl
@@ -4,6 +4,7 @@
     <title>Nature Single Spaced (no "et al.")</title>
     <id>http://www.zotero.org/styles/nature-single-spaced-no-et-al</id>
     <link href="http://www.zotero.org/styles/nature-single-spaced-no-et-al" rel="self"/>
+    <link href="http://www.zotero.org/styles/nature" rel="independent-parent"/>
     <link href="http://mts-am.nature.com/cgi-bin/main.plex?form_type=display_auth_instructions#format" rel="documentation"/>
     <author>
       <name>Avik Dutt</name>

--- a/dependent/nature-single-spaced-no-et-al.csl
+++ b/dependent/nature-single-spaced-no-et-al.csl
@@ -2,7 +2,7 @@
 <style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" demote-non-dropping-particle="sort-only" default-locale="en-GB">
   <info>
     <title>Nature Single Spaced (no "et al.")</title>
-    <id>http://www.zotero.org/styles/nature-no-et-al</id>
+    <id>http://www.zotero.org/styles/nature-single-spaced-no-et-al</id>
     <link href="http://www.zotero.org/styles/nature-no-et-al" rel="self"/>
     <link href="http://mts-am.nature.com/cgi-bin/main.plex?form_type=display_auth_instructions#format" rel="documentation"/>
     <author>

--- a/dependent/nature-single-spaced-no-et-al.csl
+++ b/dependent/nature-single-spaced-no-et-al.csl
@@ -3,7 +3,7 @@
   <info>
     <title>Nature Single Spaced (no "et al.")</title>
     <id>http://www.zotero.org/styles/nature-single-spaced-no-et-al</id>
-    <link href="http://www.zotero.org/styles/nature-no-et-al" rel="self"/>
+    <link href="http://www.zotero.org/styles/nature-single-spaced-no-et-al" rel="self"/>
     <link href="http://mts-am.nature.com/cgi-bin/main.plex?form_type=display_auth_instructions#format" rel="documentation"/>
     <author>
       <name>Avik Dutt</name>

--- a/dependent/nature-single-spaced-no-et-al.csl
+++ b/dependent/nature-single-spaced-no-et-al.csl
@@ -1,0 +1,127 @@
+<?xml version="1.0" encoding="utf-8"?>
+<style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" demote-non-dropping-particle="sort-only" default-locale="en-GB">
+  <info>
+    <title>Nature Single Spaced (no "et al.")</title>
+    <id>http://www.zotero.org/styles/nature-no-et-al</id>
+    <link href="http://www.zotero.org/styles/nature-no-et-al" rel="self"/>
+    <link href="http://mts-am.nature.com/cgi-bin/main.plex?form_type=display_auth_instructions#format" rel="documentation"/>
+    <author>
+      <name>Avik Dutt</name>
+      <email>avikdutt@umd.edu</email>
+    </author>
+    <category citation-format="numeric"/>
+    <category field="science"/>
+    <category field="generic-base"/>
+    <updated>2024-11-16T13:18:26+00:00</updated>
+    <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
+  </info>
+  <macro name="title">
+    <choose>
+      <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
+        <text variable="title" font-style="italic"/>
+      </if>
+      <else-if type="chapter" match="any"/>
+      <else>
+        <text variable="title"/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="author">
+    <names variable="author">
+      <name sort-separator=", " delimiter=", " and="symbol" initialize-with=". " delimiter-precedes-last="never" name-as-sort-order="all"/>
+      <label form="short" prefix=", "/>
+      <et-al font-style="italic"/>
+    </names>
+  </macro>
+  <macro name="access">
+    <choose>
+      <if variable="volume" type="article" match="any"/>
+      <else-if variable="DOI">
+        <text variable="DOI" prefix="doi:"/>
+      </else-if>
+      <else-if variable="URL">
+        <text term="at"/>
+        <text variable="URL" prefix=" &lt;" suffix="&gt;"/>
+      </else-if>
+    </choose>
+  </macro>
+  <macro name="issuance">
+    <choose>
+      <if type="bill book graphic legal_case legislation motion_picture report song chapter paper-conference" match="any">
+        <group delimiter=", " prefix="(" suffix=").">
+          <text variable="publisher" form="long"/>
+          <date variable="issued">
+            <date-part name="year"/>
+          </date>
+        </group>
+      </if>
+      <else-if type="article">
+        <group delimiter=" ">
+          <choose>
+            <if variable="genre" match="any">
+              <text variable="genre" text-case="capitalize-first"/>
+            </if>
+            <else>
+              <text term="article" text-case="capitalize-first"/>
+            </else>
+          </choose>
+          <text term="at"/>
+          <choose>
+            <if variable="DOI" match="any">
+              <text variable="DOI" prefix="https://doi.org/"/>
+            </if>
+            <else>
+              <text variable="URL"/>
+            </else>
+          </choose>
+          <date date-parts="year" form="text" variable="issued" prefix="(" suffix=")"/>
+        </group>
+      </else-if>
+      <else>
+        <date prefix="(" suffix=")." variable="issued">
+          <date-part name="year"/>
+        </date>
+      </else>
+    </choose>
+  </macro>
+  <macro name="editor">
+    <choose>
+      <if type="chapter paper-conference" match="any">
+        <names variable="editor" prefix="(" suffix=")">
+          <label form="short" suffix=" "/>
+          <name and="symbol" delimiter-precedes-last="never" initialize-with=". " name-as-sort-order="all"/>
+        </names>
+      </if>
+    </choose>
+  </macro>
+  <citation collapse="citation-number">
+    <sort>
+      <key variable="citation-number"/>
+    </sort>
+    <layout vertical-align="sup" delimiter=",">
+      <text variable="citation-number"/>
+    </layout>
+  </citation>
+  <bibliography second-field-align="flush" entry-spacing="0" line-spacing="1">
+    <layout>
+      <text variable="citation-number" suffix="."/>
+      <group delimiter=" ">
+        <text macro="author" suffix="."/>
+        <text macro="title" suffix="."/>
+        <choose>
+          <if type="chapter paper-conference" match="any">
+            <text term="in" form="long" plural="false"/>
+          </if>
+        </choose>
+        <text variable="container-title" font-style="italic" form="short"/>
+        <text macro="editor"/>
+        <group font-weight="bold">
+          <text variable="volume" suffix=","/>
+        </group>
+        <text variable="page"/>
+        <text macro="issuance"/>
+        <text macro="access"/>
+      </group>
+    </layout>
+  </bibliography>
+</style>


### PR DESCRIPTION

![Screenshot 2024-11-16 231157](https://github.com/user-attachments/assets/ab3f9ad0-7e35-43fe-8868-23b4dcbbca7d)
To create single-spaced reference list. Default Nature CSL style file produces double-spaced reference list in Word