### PR TITLE
Chicago: Use title case for volume title

### DIFF
--- a/chicago-annotated-bibliography.csl
+++ b/chicago-annotated-bibliography.csl
@@ -545,7 +545,7 @@
               <text term="volume" form="short"/>
               <number variable="volume" form="numeric"/>
             </group>
-            <text variable="volume-title" font-style="italic"/>
+            <text variable="volume-title" text-case="title" font-style="italic"/>
           </group>
           <choose>
             <if variable="locator" match="none">
@@ -682,7 +682,7 @@
               <text term="volume" form="short" text-case="capitalize-first"/>
               <number variable="volume" form="numeric"/>
             </group>
-            <text variable="volume-title" font-style="italic"/>
+            <text variable="volume-title" text-case="title" font-style="italic"/>
           </group>
           <group delimiter=" ">
             <number variable="number-of-volumes" form="numeric"/>

--- a/chicago-author-date-16th-edition.csl
+++ b/chicago-author-date-16th-edition.csl
@@ -313,13 +313,17 @@
       </else-if>
       <else-if type="bill book graphic legal_case legislation motion_picture report song" match="any">
         <group prefix=". " delimiter=". ">
-          <group>
-            <text term="volume" form="short" text-case="capitalize-first" suffix=" "/>
-            <number variable="volume" form="numeric"/>
+          <text macro="edition"/>
+          <group delimiter=", ">
+            <group delimiter=" ">
+              <text term="volume" form="short" text-case="capitalize-first"/>
+              <number variable="volume" form="numeric"/>
+            </group>
+            <text variable="volume-title" text-case="title" font-style="italic"/>
           </group>
-          <group>
+          <group delimiter=" ">
             <number variable="number-of-volumes" form="numeric"/>
-            <text term="volume" form="short" prefix=" " plural="true"/>
+            <text term="volume" form="short" plural="true"/>
           </group>
         </group>
       </else-if>

--- a/chicago-author-date-basque.csl
+++ b/chicago-author-date-basque.csl
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<style xmlns="http://purl.org/net/xbiblio/csl" default-locale="eu" class="in-text" version="1.0" demote-non-dropping-particle="sort-only">
+<style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" demote-non-dropping-particle="sort-only" default-locale="eu">
   <info>
     <title>Chicago Manual of Style 16th edition (author-date, Euskara)</title>
     <id>http://www.zotero.org/styles/chicago-author-date-basque</id>
@@ -88,7 +88,6 @@
       <term name="long-ordinal-08">zortzigarren</term>
       <term name="long-ordinal-09">bederatzigarren</term>
       <term name="long-ordinal-10">hamargarren</term>
-      
       <!-- LONG LOCATOR FORMS -->
       <term name="book">
         <single>liburua</single>

--- a/chicago-author-date-basque.csl
+++ b/chicago-author-date-basque.csl
@@ -452,13 +452,17 @@
       </else-if>
       <else-if type="bill book graphic legal_case legislation motion_picture report song" match="any">
         <group prefix=". " delimiter=". ">
-          <group>
-            <text term="volume" form="short" text-case="capitalize-first" suffix=" "/>
-            <number variable="volume" form="numeric"/>
+          <text macro="edition"/>
+          <group delimiter=", ">
+            <group delimiter=" ">
+              <text term="volume" form="short" text-case="capitalize-first"/>
+              <number variable="volume" form="numeric"/>
+            </group>
+            <text variable="volume-title" text-case="title" font-style="italic"/>
           </group>
-          <group>
+          <group delimiter=" ">
             <number variable="number-of-volumes" form="numeric"/>
-            <text term="volume" form="short" prefix=" " plural="true"/>
+            <text term="volume" form="short" plural="true"/>
           </group>
         </group>
       </else-if>

--- a/chicago-author-date-de.csl
+++ b/chicago-author-date-de.csl
@@ -224,13 +224,17 @@
       </if>
       <else-if type="bill book graphic legal_case legislation motion_picture report song" match="any">
         <group prefix=". " delimiter=". ">
-          <group>
-            <text term="volume" form="short" text-case="capitalize-first" suffix=" "/>
-            <number variable="volume" form="numeric"/>
+          <text macro="edition"/>
+          <group delimiter=", ">
+            <group delimiter=" ">
+              <text term="volume" form="short" text-case="capitalize-first"/>
+              <number variable="volume" form="numeric"/>
+            </group>
+            <text variable="volume-title" text-case="title" font-style="italic"/>
           </group>
-          <group>
+          <group delimiter=" ">
             <number variable="number-of-volumes" form="numeric"/>
-            <text term="volume" form="short" prefix=" " plural="true"/>
+            <text term="volume" form="short" plural="true"/>
           </group>
         </group>
       </else-if>

--- a/chicago-author-date-fr.csl
+++ b/chicago-author-date-fr.csl
@@ -352,13 +352,17 @@
       </else-if>
       <else-if type="bill book graphic legal_case legislation motion_picture report song" match="any">
         <group prefix=". " delimiter=". ">
-          <group>
-            <text term="volume" form="short" text-case="capitalize-first" suffix=" "/>
-            <number variable="volume" form="numeric"/>
+          <text macro="edition"/>
+          <group delimiter=", ">
+            <group delimiter=" ">
+              <text term="volume" form="short" text-case="capitalize-first"/>
+              <number variable="volume" form="numeric"/>
+            </group>
+            <text variable="volume-title" text-case="title" font-style="italic"/>
           </group>
-          <group>
+          <group delimiter=" ">
             <number variable="number-of-volumes" form="numeric"/>
-            <text term="volume" form="short" prefix=" " plural="true"/>
+            <text term="volume" form="short" plural="true"/>
           </group>
         </group>
       </else-if>

--- a/chicago-author-date-no-em-dash.csl
+++ b/chicago-author-date-no-em-dash.csl
@@ -337,13 +337,17 @@
       </else-if>
       <else-if type="bill book graphic legal_case legislation motion_picture report song" match="any">
         <group prefix=". " delimiter=". ">
-          <group>
-            <text term="volume" form="short" text-case="capitalize-first" suffix=" "/>
-            <number variable="volume" form="numeric"/>
+          <text macro="edition"/>
+          <group delimiter=", ">
+            <group delimiter=" ">
+              <text term="volume" form="short" text-case="capitalize-first"/>
+              <number variable="volume" form="numeric"/>
+            </group>
+            <text variable="volume-title" text-case="title" font-style="italic"/>
           </group>
-          <group>
+          <group delimiter=" ">
             <number variable="number-of-volumes" form="numeric"/>
-            <text term="volume" form="short" prefix=" " plural="true"/>
+            <text term="volume" form="short" plural="true"/>
           </group>
         </group>
       </else-if>

--- a/chicago-author-date.csl
+++ b/chicago-author-date.csl
@@ -337,13 +337,17 @@
       </else-if>
       <else-if type="bill book graphic legal_case legislation motion_picture report song" match="any">
         <group prefix=". " delimiter=". ">
-          <group>
-            <text term="volume" form="short" text-case="capitalize-first" suffix=" "/>
-            <number variable="volume" form="numeric"/>
+          <text macro="edition"/>
+          <group delimiter=", ">
+            <group delimiter=" ">
+              <text term="volume" form="short" text-case="capitalize-first"/>
+              <number variable="volume" form="numeric"/>
+            </group>
+            <text variable="volume-title" text-case="title" font-style="italic"/>
           </group>
-          <group>
+          <group delimiter=" ">
             <number variable="number-of-volumes" form="numeric"/>
-            <text term="volume" form="short" prefix=" " plural="true"/>
+            <text term="volume" form="short" plural="true"/>
           </group>
         </group>
       </else-if>

--- a/chicago-fullnote-bibliography-no-em-dash.csl
+++ b/chicago-fullnote-bibliography-no-em-dash.csl
@@ -545,7 +545,7 @@
               <text term="volume" form="short"/>
               <number variable="volume" form="numeric"/>
             </group>
-            <text variable="volume-title" font-style="italic"/>
+            <text variable="volume-title" text-case="title" font-style="italic"/>
           </group>
           <choose>
             <if variable="locator" match="none">
@@ -682,7 +682,7 @@
               <text term="volume" form="short" text-case="capitalize-first"/>
               <number variable="volume" form="numeric"/>
             </group>
-            <text variable="volume-title" font-style="italic"/>
+            <text variable="volume-title" text-case="title" font-style="italic"/>
           </group>
           <group delimiter=" ">
             <number variable="number-of-volumes" form="numeric"/>

--- a/chicago-fullnote-bibliography-short-title-subsequent.csl
+++ b/chicago-fullnote-bibliography-short-title-subsequent.csl
@@ -546,7 +546,7 @@
               <text term="volume" form="short"/>
               <number variable="volume" form="numeric"/>
             </group>
-            <text variable="volume-title" font-style="italic"/>
+            <text variable="volume-title" text-case="title" font-style="italic"/>
           </group>
           <choose>
             <if variable="locator" match="none">
@@ -683,7 +683,7 @@
               <text term="volume" form="short" text-case="capitalize-first"/>
               <number variable="volume" form="numeric"/>
             </group>
-            <text variable="volume-title" font-style="italic"/>
+            <text variable="volume-title" text-case="title" font-style="italic"/>
           </group>
           <group delimiter=" ">
             <number variable="number-of-volumes" form="numeric"/>

--- a/chicago-fullnote-bibliography-with-ibid.csl
+++ b/chicago-fullnote-bibliography-with-ibid.csl
@@ -545,7 +545,7 @@
               <text term="volume" form="short"/>
               <number variable="volume" form="numeric"/>
             </group>
-            <text variable="volume-title" font-style="italic"/>
+            <text variable="volume-title" text-case="title" font-style="italic"/>
           </group>
           <choose>
             <if variable="locator" match="none">
@@ -682,7 +682,7 @@
               <text term="volume" form="short" text-case="capitalize-first"/>
               <number variable="volume" form="numeric"/>
             </group>
-            <text variable="volume-title" font-style="italic"/>
+            <text variable="volume-title" text-case="title" font-style="italic"/>
           </group>
           <group delimiter=" ">
             <number variable="number-of-volumes" form="numeric"/>

--- a/chicago-fullnote-bibliography.csl
+++ b/chicago-fullnote-bibliography.csl
@@ -545,7 +545,7 @@
               <text term="volume" form="short"/>
               <number variable="volume" form="numeric"/>
             </group>
-            <text variable="volume-title" font-style="italic"/>
+            <text variable="volume-title" text-case="title" font-style="italic"/>
           </group>
           <choose>
             <if variable="locator" match="none">
@@ -682,7 +682,7 @@
               <text term="volume" form="short" text-case="capitalize-first"/>
               <number variable="volume" form="numeric"/>
             </group>
-            <text variable="volume-title" font-style="italic"/>
+            <text variable="volume-title" text-case="title" font-style="italic"/>
           </group>
           <group delimiter=" ">
             <number variable="number-of-volumes" form="numeric"/>

--- a/chicago-library-list.csl
+++ b/chicago-library-list.csl
@@ -545,7 +545,7 @@
               <text term="volume" form="short"/>
               <number variable="volume" form="numeric"/>
             </group>
-            <text variable="volume-title" font-style="italic"/>
+            <text variable="volume-title" text-case="title" font-style="italic"/>
           </group>
           <choose>
             <if variable="locator" match="none">
@@ -682,7 +682,7 @@
               <text term="volume" form="short" text-case="capitalize-first"/>
               <number variable="volume" form="numeric"/>
             </group>
-            <text variable="volume-title" font-style="italic"/>
+            <text variable="volume-title" text-case="title" font-style="italic"/>
           </group>
           <group delimiter=" ">
             <number variable="number-of-volumes" form="numeric"/>

--- a/chicago-note-bibliography-with-ibid.csl
+++ b/chicago-note-bibliography-with-ibid.csl
@@ -545,7 +545,7 @@
               <text term="volume" form="short"/>
               <number variable="volume" form="numeric"/>
             </group>
-            <text variable="volume-title" font-style="italic"/>
+            <text variable="volume-title" text-case="title" font-style="italic"/>
           </group>
           <choose>
             <if variable="locator" match="none">
@@ -682,7 +682,7 @@
               <text term="volume" form="short" text-case="capitalize-first"/>
               <number variable="volume" form="numeric"/>
             </group>
-            <text variable="volume-title" font-style="italic"/>
+            <text variable="volume-title" text-case="title" font-style="italic"/>
           </group>
           <group delimiter=" ">
             <number variable="number-of-volumes" form="numeric"/>

--- a/chicago-note-bibliography.csl
+++ b/chicago-note-bibliography.csl
@@ -545,7 +545,7 @@
               <text term="volume" form="short"/>
               <number variable="volume" form="numeric"/>
             </group>
-            <text variable="volume-title" font-style="italic"/>
+            <text variable="volume-title" text-case="title" font-style="italic"/>
           </group>
           <choose>
             <if variable="locator" match="none">
@@ -682,7 +682,7 @@
               <text term="volume" form="short" text-case="capitalize-first"/>
               <number variable="volume" form="numeric"/>
             </group>
-            <text variable="volume-title" font-style="italic"/>
+            <text variable="volume-title" text-case="title" font-style="italic"/>
           </group>
           <group delimiter=" ">
             <number variable="number-of-volumes" form="numeric"/>


### PR DESCRIPTION
This ensures the correct capitalization of a volume title stored in sentence case, such as:

> Knowles, David. *The Religious Orders in England.* Vol. 3, *The Tudor Age.* 3 vols. Cambridge: Cambridge University Press, 1959. <https://doi.org/10.1017/CBO9780511560668>.

I observe when testing with Zotero that, if the language is not set to English, the volume title is not set to sentence case as I would expect. I cannot however seem to find a way to control this in the CSL file: is this a bug in citeproc-js?