### PR TITLE
Update harvard-university-for-the-creative-arts.csl

### DIFF
--- a/harvard-university-for-the-creative-arts.csl
+++ b/harvard-university-for-the-creative-arts.csl
@@ -14,7 +14,7 @@
     <category citation-format="author-date"/>
     <category field="generic-base"/>
     <summary>University for the Creative Arts Harvard style</summary>
-    <updated>2022-06-22T13:41:19+00:00</updated>
+    <updated>2024-12-04T15:27:19+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale>
@@ -278,7 +278,7 @@
             </group>
           </if>
         </choose>
-        <names variable="author" prefix="Directed by ">
+        <names variable="author director" prefix="Directed by " suffix=".">
           <name suffix="." and="text" delimiter-precedes-last="never" initialize-with="." name-as-sort-order="all"/>
         </names>
         <text variable="medium" prefix=" [" suffix="] "/>

--- a/harvard-university-for-the-creative-arts.csl
+++ b/harvard-university-for-the-creative-arts.csl
@@ -14,7 +14,7 @@
     <category citation-format="author-date"/>
     <category field="generic-base"/>
     <summary>University for the Creative Arts Harvard style</summary>
-    <updated>2024-12-04T15:27:19+00:00</updated>
+    <updated>2024-12-20T15:27:19+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale>


### PR DESCRIPTION
This change is to do with Directors in the CSL. Zotero is using CSL 1.0.2 and uses the Director variable and tag, this doesn't display at the moment in our current CSL when referencing with Zotero. I made a commit in the summer but withdrew it as the changes suggested by the reviewer had a knock on impact, as I've since discovered that other software that students use at UCA (Paperpile, BibGuru, myBib) don't currently use CSL 1.0.2. and won't display the director or tag if I update the code as was suggested.

Would it be possible to approve this commit, where the code will display either director or author and use a prefix instead of a label?

"The "Director" name variable was introduced last year with CSL 1.0.2. Therefore, a lot of citation styles don't include it yet."

From <https://forums.zotero.org/discussion/comment/476797/#Comment_476797>