### PR TITLE
Create wikipedia-fr-templates.csl

### DIFF
--- a/wikipedia-fr-templates.csl
+++ b/wikipedia-fr-templates.csl
@@ -1,0 +1,265 @@
+<?xml version="1.0" encoding="utf-8"?>
+<style class="in-text" version="1.0" initialize="false" default-locale="fr-FR" xmlns="http://purl.org/net/xbiblio/csl">
+  <info>
+    <title>Wikipedia-fr templates</title>
+    <title-short>Wikipedia-fr templates</title-short>
+    <id>http://www.zotero.org/styles/wikipedia-fr-templates</id>
+    <link href="http://www.zotero.org/styles/wikipedia-fr-templates" rel="self"/>
+    <link href="https://fr.wikipedia.org/wiki/Mod%C3%A8le:Ouvrage" rel="documentation"/>
+    <link href="https://fr.wikipedia.org/wiki/Mod%C3%A8le:Chapitre" rel="documentation"/>
+    <link href="https://fr.wikipedia.org/wiki/Mod%C3%A8le:Article" rel="documentation"/>
+    <link href="https://fr.wikipedia.org/wiki/Mod%C3%A8le:Lien_web" rel="documentation"/>
+    <link href="http://www.zotero.org/styles/wikipedia-templates" rel="template"/>
+    <author>
+      <name>Jules*</name>
+    </author>
+    <category citation-format="numeric"/>
+    <category field="generic-base"/>
+    <updated>2025-01-03T19:43:47+00:00</updated>
+    <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
+  </info>
+  <macro name="citations">
+    <choose>
+      <if type="book">
+        <text macro="book-citation"/>
+      </if>
+      <else-if type="chapter">
+        <text macro="chapter-citation"/>
+      </else-if>
+      <else-if type="article-journal">
+        <text macro="journal-citation"/>
+      </else-if>
+      <else-if type="article-newspaper article-magazine" match="any">
+        <text macro="news-citation"/>
+      </else-if>
+      <else-if type="webpage post-weblog" match="any">
+        <text macro="web-citation"/>
+      </else-if>
+    </choose>
+  </macro>
+  <macro name="inline-citation">
+    <text macro="citations" prefix="&lt;ref&gt;" suffix="&lt;/ref&gt;"/>
+  </macro>
+  <macro name="book-citation">
+    <group prefix="{{ouvrage" suffix="}}">
+      <text macro="language"/>
+      <text macro="contributor-statements"/>
+      <text macro="title-statements"/>
+      <text macro="volume"/>
+      <text macro="place"/>
+      <text macro="publisher"/>
+      <text macro="date"/>
+      <text macro="series"/>
+      <text macro="edition"/>
+      <text macro="total-pages"/>
+      <text macro="pagination"/>
+      <text macro="url"/>
+      <text macro="doi"/>
+      <text macro="isbn"/>
+    </group>
+  </macro>
+  <macro name="chapter-citation">
+    <group prefix="{{chapitre" suffix="}}">
+      <text macro="language"/>
+      <text macro="contributor-statements"/>
+      <text macro="title-statements"/>
+      <text macro="volume"/>
+      <text macro="place"/>
+      <text macro="publisher"/>
+      <text macro="date"/>
+      <text macro="series"/>
+      <text macro="edition"/>
+      <text macro="total-pages"/>
+      <text macro="pagination"/>
+      <text macro="url"/>
+      <text macro="doi"/>
+      <text macro="isbn"/>
+    </group>
+  </macro>
+  <macro name="journal-citation">
+    <group prefix="{{article" suffix="}}">
+      <text macro="language"/>
+      <text macro="contributor-statements"/>
+      <text macro="title-statements"/>
+      <text macro="place"/>
+      <text macro="publisher"/>
+      <text macro="volume"/>
+      <text macro="issue"/>
+      <text macro="date"/>
+      <text macro="url"/>
+      <text macro="issn"/>
+      <text macro="doi"/>
+      <text macro="pagination"/>
+    </group>
+  </macro>
+  <macro name="news-citation">
+    <group prefix="{{article" suffix="}}">
+      <text macro="language"/>
+      <text macro="contributor-statements"/>
+      <text macro="title-statements"/>
+      <text macro="issue"/>
+      <text macro="newspaper"/>
+      <text macro="date"/>
+      <text macro="url"/>
+      <text macro="issn"/>
+      <text macro="pagination"/>
+    </group>
+  </macro>
+  <macro name="web-citation">
+    <group prefix="{{lien web" suffix="}}">
+      <text macro="language"/>
+      <text macro="url"/>
+      <text macro="contributor-statements"/>
+      <text macro="title-statements"/>
+      <text macro="website"/>
+      <text macro="publisher"/>
+      <text macro="date"/>
+      <text macro="place"/>
+      <text macro="access-date"/>
+    </group>
+  </macro>
+  <macro name="contributor-statements">
+    <choose>
+      <if type="chapter">
+        <choose>
+          <if match="any" variable="editor">
+            <names variable="editor" prefix=" |auteurs ouvrage=">
+              <name suffix=" ({{dir.}})" et-al-min="10" et-al-use-first="10" initialize-with=". "/>
+            </names>
+            <choose>
+              <if match="any" variable="author">
+                <names variable="author" prefix=" |auteurs="/>
+              </if>
+            </choose>
+          </if>
+          <else>
+            <names variable="author" prefix=" |auteurs=">
+              <name et-al-min="10" initialize-with=". "/>
+            </names>
+          </else>
+        </choose>
+      </if>
+      <else>
+        <choose>
+          <if match="any" variable="editor">
+            <names variable="editor" prefix=" |auteurs=">
+              <name suffix=" ({{dir.}})" et-al-min="10" et-al-use-first="10" initialize-with=". "/>
+            </names>
+            <choose>
+              <if match="any" variable="author">
+                <names variable="author" prefix=", "/>
+              </if>
+            </choose>
+          </if>
+          <else>
+            <names variable="author" prefix=" |auteurs=">
+              <name et-al-min="10" initialize-with=". "/>
+            </names>
+          </else>
+        </choose>
+      </else>
+    </choose>
+  </macro>
+  <macro name="date">
+    <choose>
+      <if type="book chapter" match="any">
+        <date variable="issued" prefix=" |année=">
+          <date-part name="month" form="long"/>
+          <date-part name="year" form="long" prefix=" "/>
+        </date>
+      </if>
+      <else>
+        <date variable="issued" prefix=" |date=">
+          <date-part name="day" form="numeric"/>
+          <date-part name="month" form="long" prefix=" "/>
+          <date-part name="year" form="long" prefix=" "/>
+        </date>
+      </else>
+    </choose>
+  </macro>
+  <macro name="title-statements">
+    <choose>
+      <if type="chapter">
+        <text variable="title" prefix=" |titre ouvrage="/>
+        <text variable="container-title" prefix=" |titre chapitre="/>
+      </if>
+      <else-if type="article-journal">
+        <text variable="container-title" prefix=" |périodique="/>
+        <text variable="title" prefix=" |titre="/>
+      </else-if>
+      <else>
+        <text variable="title" prefix=" |titre="/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="publisher">
+    <text variable="publisher" prefix=" |éditeur="/>
+  </macro>
+  <macro name="newspaper">
+    <text variable="source" prefix=" |périodique="/>
+  </macro>
+  <macro name="website">
+    <text variable="container-title" prefix=" |site="/>
+  </macro>
+  <macro name="place">
+    <text variable="publisher-place" prefix=" |lieu="/>
+  </macro>
+  <macro name="series">
+    <text variable="collection-title" prefix=" |collection="/>
+  </macro>
+  <macro name="volume">
+    <number variable="volume" prefix=" |volume="/>
+  </macro>
+  <macro name="edition">
+    <number prefix=" |numéro édition=" variable="edition" form="ordinal"/>
+  </macro>
+  <macro name="doi">
+    <text variable="DOI" prefix=" |doi="/>
+  </macro>
+  <macro name="isbn">
+    <text variable="ISBN" prefix=" |isbn="/>
+  </macro>
+  <macro name="issn">
+    <text variable="ISSN" prefix=" |issn="/>
+  </macro>
+  <macro name="pagination">
+    <text variable="page" prefix=" |passage="/>
+  </macro>
+  <macro name="url">
+    <text variable="URL" prefix=" |url="/>
+  </macro>
+  <macro name="access-date">
+    <date variable="accessed" prefix=" |consulté le=">
+      <date-part name="day" form="numeric" suffix=" "/>
+      <date-part name="month" form="long" suffix=" "/>
+      <date-part name="year" form="long"/>
+    </date>
+  </macro>
+  <macro name="issue">
+    <number prefix=" | numéro=" variable="issue"/>
+  </macro>
+  <macro name="language">
+    <choose>
+      <if match="any" variable="language">
+        <text variable="language" prefix=" |langue="/>
+      </if>
+    </choose>
+  </macro>
+  <macro name="total-pages">
+    <number prefix=" |pages totales=" variable="number-of-pages"/>
+  </macro>
+  <citation>
+    <layout>
+      <text macro="inline-citation"/>
+    </layout>
+  </citation>
+  <bibliography>
+    <sort>
+      <key macro="contributor-statements"/>
+      <key macro="date"/>
+    </sort>
+    <layout>
+      <text macro="citations"/>
+    </layout>
+  </bibliography>
+</style>


### PR DESCRIPTION
New CSL style for Wikipedia in french. See also [discussions on fr.wikipedia.org about it](https://fr.wikipedia.org/wiki/Projet:Sources/Chez_Manon#Export_de_sources_via_Zotero). Thanks.