### PR TITLE
Update ieee.csl to use non-breaking space in author initials

### DIFF
--- a/ieee.csl
+++ b/ieee.csl
@@ -115,7 +115,7 @@
   </macro>
   <macro name="author">
     <names variable="author">
-      <name and="text" et-al-min="7" et-al-use-first="1" initialize-with=". "/>
+      <name and="text" et-al-min="7" et-al-use-first="1" initialize-with=".&#160;"/>
       <label form="short" prefix=", " text-case="capitalize-first"/>
       <et-al font-style="italic"/>
       <substitute>
@@ -127,13 +127,13 @@
   </macro>
   <macro name="editor">
     <names variable="editor">
-      <name initialize-with=". " delimiter=", " and="text"/>
+      <name initialize-with=".&#160;" delimiter=", " and="text"/>
       <label form="short" prefix=", " text-case="capitalize-first"/>
     </names>
   </macro>
   <macro name="director">
     <names variable="director">
-      <name and="text" et-al-min="7" et-al-use-first="1" initialize-with=". "/>
+      <name and="text" et-al-min="7" et-al-use-first="1" initialize-with=".&#160;"/>
       <et-al font-style="italic"/>
     </names>
   </macro>


### PR DESCRIPTION
Avoids unfortunate breaking, i.e. produces
> A. Author, B. Author and
> C. Author, "A paper", ...

instead of
> A. Author, B. Author and C.
> Author, "A paper", ...

----

PS: Currently, only about 1% of the styles use non-breaking space and as such will suffer from the issue above.
- [11 styles using non-breaking space](https://github.com/search?q=repo%3Acitation-style-language%2Fstyles+%22initialize-with%3D%5C%22.%26%23160%3B%5C%22%22&type=code)
- [964 styles using plain space](https://github.com/search?q=repo%3Acitation-style-language%2Fstyles+%22initialize-with%3D%5C%22.+%5C%22%22&type=code)