### PR TITLE
Update cardiff-university-vancouver.csl

### DIFF
--- a/cardiff-university-vancouver.csl
+++ b/cardiff-university-vancouver.csl
@@ -177,9 +177,16 @@
   <macro name="date">
     <choose>
       <if type="article-journal article-magazine article-newspaper review review-book" match="any">
+<choose>
+<if match="none" variable="volume page">
         <group suffix=";" delimiter=" ">
           <date variable="issued" form="text"/>
         </group>
+      </if>
+<else>
+            <date date-parts="year" form="text" variable="issued" suffix=";"/>
+          </else>
+        </choose>
       </if>
       <else-if type="bill legislation" match="any">
         <group delimiter=", ">

--- a/cardiff-university-vancouver.csl
+++ b/cardiff-university-vancouver.csl
@@ -177,13 +177,13 @@
   <macro name="date">
     <choose>
       <if type="article-journal article-magazine article-newspaper review review-book" match="any">
-<choose>
-<if match="none" variable="volume page">
-        <group suffix=";" delimiter=" ">
-          <date variable="issued" form="text"/>
-        </group>
-      </if>
-<else>
+        <choose>
+          <if match="none" variable="volume page">
+            <group suffix=";" delimiter=" ">
+              <date variable="issued" form="text"/>
+            </group>
+          </if>
+          <else>
             <date date-parts="year" form="text" variable="issued" suffix=";"/>
           </else>
         </choose>


### PR DESCRIPTION
I have altered the macro name = date so that if a journal article has a volume and pages then only the year of publication appears but if that information is missing then we assume it is a preprint and the month and day also appear with year.