### PR TITLE
Update american-journal-of-agricultural-economics.csl

### DIFF
--- a/american-journal-of-agricultural-economics.csl
+++ b/american-journal-of-agricultural-economics.csl
@@ -110,7 +110,7 @@
       <text variable="page"/>
     </group>
   </macro>
-  <citation et-al-min="4" et-al-use-first="1" et-al-subsequent-min="3" et-al-subsequent-use-first="1" disambiguate-add-year-suffix="true" disambiguate-add-names="true" disambiguate-add-givenname="true">
+  <citation et-al-min="5" et-al-use-first="1" et-al-subsequent-min="5" et-al-subsequent-use-first="1" disambiguate-add-year-suffix="true" disambiguate-add-names="true" disambiguate-add-givenname="true">
     <layout prefix="(" suffix=")" delimiter="; ">
       <group delimiter=", ">
         <group delimiter=" ">


### PR DESCRIPTION
Chenged style so citations with more than for authors use et al. Eg.  Michler, Tjernström, Verkaart, and Mausch (2019) should be cited as Michler et al. (2019). As per May 2020 AJAE checklist.