### PR TITLE
Create etudes-chinoises.csl

### DIFF
--- a/etudes-chinoises.csl
+++ b/etudes-chinoises.csl
@@ -1,0 +1,679 @@
+<?xml version="1.0" encoding="utf-8"?>
+<style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" and="symbol" delimiter-precedes-et-al="never" delimiter-precedes-last="never" et-al-min="4" et-al-use-first="1" page-range-format="expanded">
+  <info>
+    <title>Études chinoises</title>
+    <id>http://www.zotero.org/styles/etudes-chinoises</id>
+    <link rel="self" href="http://www.zotero.org/styles/etudes-chinoises"/>
+    <author>
+      <name>Association française d'études chinoises</name>
+    </author>
+    <category citation-format="author-date"/>
+    <category field="generic-base"/>
+    <summary>Modification du fichier CSL des Presses de l'Inalco par Daniel Patrick Morgan</summary>
+    <updated>2025-01-27T15:17:01+00:00</updated>
+    <rights license="https://creativecommons.org/licenses/by-sa/4.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 4.0 License</rights>
+  </info>
+  <locale xml:lang="en">
+    <terms>
+      <term name="editor" form="verb-short">ed.</term>
+      <term name="container-author" form="verb">by</term>
+      <term name="translator" form="verb-short">trans.</term>
+      <term name="editortranslator" form="verb">edited and translated by</term>
+      <term name="translator" form="short">trans.</term>
+    </terms>
+  </locale>
+  <macro name="secondary-contributors">
+    <choose>
+      <if type="chapter entry-dictionary entry-encyclopedia paper-conference" match="none">
+        <group delimiter=", ">
+          <names variable="illustrator performer collection-editor compiler composer translator">
+            <label form="short" text-case="lowercase" suffix=" "/>
+            <name and="symbol" delimiter-precedes-et-al="never" delimiter-precedes-last="never" et-al-min="11" et-al-use-first="7" name-as-sort-order="all" sort-separator=" ">
+              <name-part name="family" font-variant="small-caps"/>
+              <name-part name="given"/>
+            </name>
+          </names>
+        </group>
+      </if>
+    </choose>
+  </macro>
+  <macro name="container-contributors">
+    <choose>
+      <if type="entry-dictionary entry-encyclopedia paper-conference article-journal" match="any">
+        <group delimiter=" ">
+          <text term="in" font-style="normal" prefix=" "/>
+          <text variable="container-title" font-style="italic" suffix=", "/>
+        </group>
+      </if>
+      <else-if type="article-newspaper article-magazine" match="any">
+        <text variable="container-title" font-style="italic" suffix=", "/>
+        <date form="text" variable="issued" suffix=", "/>
+        <text variable="title" strip-periods="false" quotes="true"/>
+        <names variable="author" delimiter=" " prefix=", ">
+          <name sort-separator="">
+            <name-part name="given" font-variant="normal"/>
+            <name-part name="family" font-variant="small-caps"/>
+          </name>
+        </names>
+      </else-if>
+      <else-if type="webpage" match="any"/>
+      <else-if type="chapter" match="none" variable="container-author">
+        <text term="in" font-style="normal" suffix=" "/>
+        <text variable="container-title" font-style="italic"/>
+      </else-if>
+      <else-if type="chapter" match="any">
+        <text term="in" font-style="italic" prefix=" " suffix=" "/>
+        <names variable="container-author" delimiter=", " suffix=", ">
+          <name name-as-sort-order="all" sort-separator=" ">
+            <name-part name="family" font-variant="small-caps"/>
+            <name-part name="given"/>
+          </name>
+        </names>
+        <names variable="editor director" suffix=" (dir.),">
+          <name name-as-sort-order="all" sort-separator=" ">
+            <name-part name="family" font-variant="small-caps"/>
+            <name-part name="given"/>
+          </name>
+        </names>
+        <text variable="container-title" font-style="italic" prefix=" "/>
+      </else-if>
+    </choose>
+  </macro>
+  <macro name="recipient">
+    <choose>
+      <if type="personal_communication">
+        <choose>
+          <if variable="genre">
+            <text variable="genre" text-case="capitalize-first"/>
+          </if>
+          <else>
+            <text term="letter" text-case="capitalize-first"/>
+          </else>
+        </choose>
+      </if>
+    </choose>
+    <names variable="recipient" delimiter=", ">
+      <label form="verb" prefix=" " text-case="lowercase" suffix=" "/>
+      <name and="text" delimiter=", "/>
+    </names>
+  </macro>
+  <macro name="substitute-title">
+    <choose>
+      <if type="article-magazine article-newspaper review review-book" match="any">
+        <text variable="container-title"/>
+      </if>
+    </choose>
+  </macro>
+  <macro name="contributors">
+    <choose>
+      <if type="webpage article-newspaper article-magazine motion_picture" match="none">
+        <group>
+          <names variable="author">
+            <name and="symbol" delimiter-precedes-et-al="never" delimiter-precedes-last="never" et-al-min="11" et-al-use-first="7" name-as-sort-order="all" sort-separator=" ">
+              <name-part name="family" font-variant="small-caps" suffix=" "/>
+              <name-part name="given" prefix=" "/>
+            </name>
+            <label form="short" prefix="(" suffix=")"/>
+            <substitute>
+              <names variable="editor" suffix=" (dir.),">
+                <name et-al-min="11" et-al-use-first="7" name-as-sort-order="all" sort-separator=" ">
+                  <name-part name="family" font-variant="small-caps"/>
+                  <name-part name="given"/>
+                </name>
+              </names>
+              <names variable="translator">
+                <label form="short" prefix=" (" suffix=")"/>
+              </names>
+              <names variable="director">
+                <label form="short" prefix=" (" suffix=")"/>
+              </names>
+              <text macro="substitute-title"/>
+              <text macro="title"/>
+            </substitute>
+            <et-al font-style="italic"/>
+          </names>
+          <text macro="recipient"/>
+        </group>
+      </if>
+      <else-if type="motion_picture broadcast" match="any">
+        <group>
+          <names variable="author">
+            <name font-variant="small-caps" suffix=" (réal.)" and="symbol" delimiter-precedes-et-al="never" delimiter-precedes-last="never" et-al-min="11" et-al-use-first="7" name-as-sort-order="all">
+              <name-part name="family" font-variant="small-caps"/>
+              <name-part name="given"/>
+            </name>
+          </names>
+        </group>
+      </else-if>
+    </choose>
+  </macro>
+  <macro name="contributors-short">
+    <names variable="author" font-variant="normal">
+      <name form="short" and="symbol" delimiter-precedes-et-al="never" initialize-with=". ">
+        <name-part name="family" font-variant="small-caps"/>
+      </name>
+      <substitute>
+        <names variable="editor"/>
+        <names variable="translator"/>
+        <names variable="director" suffix=" (réal.)"/>
+        <text macro="substitute-title"/>
+        <text macro="title"/>
+      </substitute>
+      <et-al font-style="italic"/>
+    </names>
+  </macro>
+  <macro name="interviewer">
+    <names variable="interviewer" delimiter=", ">
+      <label form="verb" prefix=" " text-case="capitalize-first" suffix=" "/>
+      <name and="text" delimiter=", "/>
+    </names>
+  </macro>
+  <macro name="archive">
+    <group delimiter=",">
+      <text variable="archive_location" text-case="capitalize-first"/>
+      <text variable="archive"/>
+      <text variable="archive-place"/>
+    </group>
+  </macro>
+  <macro name="access">
+    <group delimiter=" ">
+      <choose>
+        <if type="graphic report" match="any">
+          <text macro="archive"/>
+        </if>
+        <else-if type="article-journal bill book chapter legal_case legislation motion_picture paper-conference" match="none">
+          <text macro="archive"/>
+        </else-if>
+      </choose>
+      <choose>
+        <if type="legal_case" match="none">
+          <choose>
+            <if variable="DOI">
+              <text variable="DOI" prefix="DOI : "/>
+            </if>
+            <else>
+              <text variable="URL" prefix="URL : "/>
+              <date form="numeric" variable="accessed" prefix="(consulté le " suffix=")"/>
+            </else>
+          </choose>
+        </if>
+      </choose>
+    </group>
+  </macro>
+  <macro name="title">
+    <choose>
+      <if variable="title" match="none">
+        <choose>
+          <if type="personal_communication" match="none">
+            <text variable="genre" text-case="capitalize-first"/>
+          </if>
+        </choose>
+      </if>
+      <else-if type="article-newspaper article-magazine" match="any"/>
+      <else-if type="bill book graphic legislation motion_picture thesis" match="any">
+        <text variable="title" text-case="title" font-style="italic"/>
+        <group prefix=" (" suffix=")" delimiter=" ">
+          <text term="version"/>
+          <text variable="version"/>
+        </group>
+      </else-if>
+      <else-if variable="reviewed-author">
+        <choose>
+          <if variable="reviewed-title">
+            <group delimiter=". ">
+              <text variable="title" text-case="title" quotes="true"/>
+              <group delimiter=", ">
+                <text variable="reviewed-title" text-case="title" font-style="italic" prefix="Review of "/>
+                <names variable="reviewed-author">
+                  <label form="verb-short" text-case="lowercase" suffix=" "/>
+                  <name and="text" delimiter=", "/>
+                </names>
+              </group>
+            </group>
+          </if>
+          <else>
+            <group delimiter=", ">
+              <text variable="title" text-case="title" font-style="italic" prefix="Review of "/>
+              <names variable="reviewed-author">
+                <label form="verb-short" text-case="lowercase" suffix=" "/>
+                <name and="text" delimiter=", "/>
+              </names>
+            </group>
+          </else>
+        </choose>
+      </else-if>
+      <else-if type="legal_case interview patent" match="any">
+        <text variable="title" quotes="false" font-style="italic"/>
+      </else-if>
+      <else-if type="article-journal chapter paper-conference" match="any">
+        <text variable="title" quotes="true"/>
+      </else-if>
+      <else-if type="webpage" match="any">
+        <text variable="title" font-variant="normal"/>
+      </else-if>
+      <else-if type="song" match="any">
+        <text variable="title" quotes="true"/>
+      </else-if>
+      <else>
+        <text variable="title" text-case="title" quotes="true" font-style="normal"/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="edition">
+    <choose>
+      <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
+        <choose>
+          <if is-numeric="edition">
+            <group delimiter=" " prefix=", ">
+              <number variable="edition" form="ordinal"/>
+              <text term="edition" strip-periods="true"/>
+            </group>
+          </if>
+          <else>
+            <text variable="edition" text-case="capitalize-first" prefix=", "/>
+          </else>
+        </choose>
+      </if>
+      <else-if type="chapter entry-dictionary entry-encyclopedia paper-conference" match="any">
+        <choose>
+          <if is-numeric="edition">
+            <group delimiter=" " prefix=", ">
+              <number variable="edition" form="ordinal"/>
+              <text term="edition" form="short"/>
+            </group>
+          </if>
+          <else>
+            <text variable="edition" prefix=", "/>
+          </else>
+        </choose>
+      </else-if>
+    </choose>
+  </macro>
+  <macro name="locators">
+    <choose>
+      <if type="article-journal">
+        <choose>
+          <if variable="volume" match="none">
+            <group>
+              <choose>
+                <if variable="issue">
+                  <text term="issue" form="short" suffix=" "/>
+                  <text variable="issue" vertical-align="baseline"/>
+                </if>
+              </choose>
+            </group>
+          </if>
+          <else-if variable="issue volume">
+            <text variable="volume" prefix="vol.&amp;#160;" suffix=", "/>
+            <group delimiter=" ">
+              <text term="issue" form="short"/>
+              <text variable="issue"/>
+            </group>
+          </else-if>
+          <else-if match="any" variable="issue">
+            <choose>
+              <if match="none" variable="volume">
+                <text term="issue" suffix=" "/>
+                <text variable="issue"/>
+              </if>
+            </choose>
+          </else-if>
+          <else>
+            <date variable="issued" prefix=", ">
+              <date-part name="month"/>
+            </date>
+          </else>
+        </choose>
+      </if>
+      <else-if type="legal_case">
+        <text variable="volume" prefix=", "/>
+        <text variable="container-title" prefix=" "/>
+        <text variable="page" prefix=" "/>
+      </else-if>
+      <else-if type="bill book graphic legal_case legislation motion_picture report song" match="any">
+        <group delimiter=", " prefix=", ">
+          <group>
+            <text term="volume" text-case="capitalize-first" suffix=" "/>
+            <number variable="volume" form="numeric"/>
+          </group>
+          <group>
+            <number variable="number-of-volumes" form="numeric"/>
+            <text term="volume" plural="true" prefix=" "/>
+          </group>
+        </group>
+      </else-if>
+      <else-if type="chapter entry-dictionary entry-encyclopedia paper-conference" match="any">
+        <choose>
+          <if variable="page" match="none">
+            <group prefix=". ">
+              <text term="volume" form="short" text-case="capitalize-first" suffix=" "/>
+              <number variable="volume" form="numeric"/>
+            </group>
+          </if>
+        </choose>
+      </else-if>
+    </choose>
+  </macro>
+  <macro name="locators-chapter">
+    <choose>
+      <if type="chapter entry-dictionary entry-encyclopedia paper-conference" match="any">
+        <choose>
+          <if variable="page">
+            <group prefix=", ">
+              <text variable="volume" suffix=", "/>
+              <text variable="page" prefix="p.&amp;#160;"/>
+            </group>
+          </if>
+        </choose>
+      </if>
+    </choose>
+  </macro>
+  <macro name="locators-article">
+    <choose>
+      <if type="article-newspaper">
+        <group prefix=", " delimiter=", ">
+          <group delimiter=" ">
+            <text variable="edition"/>
+            <text term="edition"/>
+          </group>
+          <group>
+            <text term="section" form="short" suffix=" "/>
+            <text variable="section"/>
+          </group>
+        </group>
+      </if>
+      <else-if type="article-journal">
+        <choose>
+          <if variable="volume issue" match="any">
+            <text variable="page" prefix=", p. "/>
+          </if>
+          <else>
+            <text variable="page" prefix=", "/>
+          </else>
+        </choose>
+      </else-if>
+    </choose>
+  </macro>
+  <macro name="point-locators">
+    <choose>
+      <if variable="locator">
+        <choose>
+          <if locator="page" match="none">
+            <choose>
+              <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
+                <choose>
+                  <if variable="volume">
+                    <group>
+                      <text term="volume" form="short" suffix=" "/>
+                      <number variable="volume" form="numeric"/>
+                      <label variable="locator" form="short" prefix=", " suffix=" "/>
+                    </group>
+                  </if>
+                  <else>
+                    <label variable="locator" form="short" suffix=" "/>
+                  </else>
+                </choose>
+              </if>
+              <else>
+                <label variable="locator" form="short" suffix=" "/>
+              </else>
+            </choose>
+          </if>
+          <else-if type="bill book graphic legal_case legislation motion_picture report song" match="any">
+            <number variable="volume" form="numeric" suffix=":"/>
+          </else-if>
+        </choose>
+        <text variable="locator" prefix=", p.&amp;#160;"/>
+      </if>
+    </choose>
+  </macro>
+  <macro name="publisher">
+    <group delimiter=", ">
+      <text variable="publisher" prefix=", "/>
+    </group>
+  </macro>
+  <macro name="date">
+    <choose>
+      <if type="webpage article-newspaper article-magazine" match="any"/>
+      <else-if match="all" variable="issued">
+        <group delimiter=" ">
+          <date variable="original-date" form="text" date-parts="year" prefix="(" suffix=")"/>
+          <date variable="issued">
+            <date-part name="year"/>
+          </date>
+        </group>
+      </else-if>
+      <else-if variable="status">
+        <text variable="status" text-case="capitalize-first"/>
+      </else-if>
+      <else-if type="article" match="any"/>
+      <else>
+        <text term="no date" form="short"/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="date-in-text">
+    <choose>
+      <if variable="issued">
+        <group delimiter=" ">
+          <date variable="original-date" form="text" date-parts="year" prefix="[" suffix="]"/>
+          <date variable="issued">
+            <date-part name="year"/>
+          </date>
+        </group>
+      </if>
+      <else-if variable="status">
+        <text variable="status" quotes="false"/>
+      </else-if>
+      <else>
+        <text term="no date" form="short"/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="day-month">
+    <date variable="issued">
+      <date-part name="month"/>
+      <date-part name="day" prefix=" "/>
+    </date>
+  </macro>
+  <macro name="collection-title">
+    <choose>
+      <if match="none" type="article-journal"/>
+    </choose>
+  </macro>
+  <macro name="collection-title-journal">
+    <choose>
+      <if type="article-journal">
+        <group delimiter=" ">
+          <text variable="collection-title"/>
+          <text variable="collection-number"/>
+        </group>
+      </if>
+    </choose>
+  </macro>
+  <macro name="event">
+    <group delimiter=" ">
+      <choose>
+        <if variable="genre">
+          <text term="presented at"/>
+        </if>
+        <else>
+          <text term="presented at" text-case="capitalize-first"/>
+        </else>
+      </choose>
+      <text variable="event"/>
+    </group>
+  </macro>
+  <macro name="description">
+    <choose>
+      <if variable="interviewer" type="interview" match="any">
+        <group delimiter=". ">
+          <text macro="interviewer"/>
+          <text variable="medium" text-case="capitalize-first"/>
+        </group>
+      </if>
+      <else-if type="patent">
+        <group delimiter=" " prefix=", ">
+          <text variable="authority"/>
+          <text variable="number" prefix=" Brevet "/>
+        </group>
+      </else-if>
+      <else>
+        <text variable="medium" text-case="capitalize-first" prefix=". "/>
+      </else>
+    </choose>
+    <choose>
+      <if variable="title" match="none"/>
+      <else-if type="thesis personal_communication speech" match="any"/>
+      <else>
+        <group delimiter=" ">
+          <text variable="genre" text-case="capitalize-first" suffix=", "/>
+          <choose>
+            <if type="report">
+              <text variable="number" prefix="no "/>
+            </if>
+          </choose>
+        </group>
+      </else>
+    </choose>
+  </macro>
+  <macro name="issue">
+    <choose>
+      <if type="legal_case">
+        <text variable="authority" prefix=", "/>
+      </if>
+      <else-if type="paper-conference">
+        <group delimiter=", " prefix=", ">
+          <group delimiter=" ">
+            <text variable="genre" text-case="capitalize-first"/>
+            <text macro="event"/>
+          </group>
+          <text variable="event-title"/>
+          <text variable="authority"/>
+          <text variable="event-place"/>
+          <text macro="day-month"/>
+        </group>
+      </else-if>
+      <else-if type="personal_communication" match="any">
+        <date form="text" variable="issued" prefix=", "/>
+      </else-if>
+      <else-if type="patent">
+        <group delimiter=", " prefix=", ">
+          <group delimiter=", ">
+            <date variable="issued" form="text"/>
+          </group>
+        </group>
+      </else-if>
+      <else-if type="article-journal" match="any"/>
+      <else-if type="article-newspaper article-magazine" match="any"/>
+      <else>
+        <group>
+          <choose>
+            <if type="thesis">
+              <text variable="genre" text-case="capitalize-first" prefix=", "/>
+            </if>
+          </choose>
+          <text macro="publisher"/>
+          <choose>
+            <if match="none" is-numeric="collection-number">
+              <group delimiter=", " prefix=" (coll. " suffix="),">
+                <text variable="collection-title" text-case="title"/>
+                <text variable="collection-number"/>
+              </group>
+            </if>
+            <else>
+              <group delimiter=" " prefix=" (coll. " suffix=")">
+                <text variable="collection-title" text-case="title" prefix=" "/>
+                <text variable="collection-number"/>
+              </group>
+            </else>
+          </choose>
+          <text variable="publisher-place" prefix=", "/>
+        </group>
+      </else>
+    </choose>
+  </macro>
+  <macro name="Nb_pages">
+    <choose>
+      <if match="any" variable="number-of-pages">
+        <text variable="number-of-pages" prefix=", " suffix=" p."/>
+      </if>
+    </choose>
+  </macro>
+  <macro name="film_minutes">
+    <choose>
+      <if type="motion_picture broadcast" match="any">
+        <text variable="dimensions" prefix=", " suffix=" min"/>
+      </if>
+    </choose>
+  </macro>
+  <citation et-al-min="4" et-al-use-first="1" disambiguate-add-year-suffix="true" disambiguate-add-names="true" disambiguate-add-givenname="true" givenname-disambiguation-rule="primary-name" collapse="year" after-collapse-delimiter="; ">
+    <layout delimiter="&amp;#160;; ">
+      <group>
+        <choose>
+          <if type="webpage" match="any">
+            <names variable="author">
+              <name font-variant="normal" sort-separator="">
+                <name-part name="family" font-variant="small-caps"/>
+                <name-part name="given"/>
+              </name>
+            </names>
+            <text variable="title"/>
+            <text variable="URL" prefix=", URL : "/>
+          </if>
+          <else-if type="article-magazine article-newspaper" match="any">
+            <text variable="container-title" font-style="italic" suffix=", "/>
+            <text variable="title" quotes="true"/>
+          </else-if>
+          <else-if type="motion_picture broadcast" match="any">
+            <group>
+              <text macro="contributors-short" suffix=" (réal.), "/>
+              <text macro="date-in-text"/>
+            </group>
+          </else-if>
+          <else-if match="any" variable="issued accessed">
+            <group delimiter=" ">
+              <text macro="contributors-short" suffix=", "/>
+              <text macro="date-in-text"/>
+            </group>
+          </else-if>
+          <else>
+            <group delimiter=", ">
+              <text macro="contributors-short"/>
+              <text macro="date-in-text"/>
+            </group>
+          </else>
+        </choose>
+        <text macro="point-locators"/>
+      </group>
+    </layout>
+  </citation>
+  <bibliography hanging-indent="true" et-al-min="11" et-al-use-first="7" entry-spacing="0">
+    <sort>
+      <key macro="contributors"/>
+      <key variable="issued"/>
+      <key variable="title"/>
+    </sort>
+    <layout suffix=".">
+      <group delimiter=", ">
+        <text macro="contributors"/>
+        <text macro="date"/>
+        <text macro="title"/>
+      </group>
+      <text macro="description"/>
+      <text macro="secondary-contributors" prefix=", "/>
+      <text macro="container-contributors"/>
+      <text macro="edition"/>
+      <text macro="collection-title-journal" prefix=", " suffix=", "/>
+      <text macro="locators"/>
+      <text macro="issue"/>
+      <text macro="collection-title" prefix=", "/>
+      <text macro="locators-chapter"/>
+      <text macro="locators-article"/>
+      <text macro="Nb_pages"/>
+      <text macro="access" prefix=", "/>
+      <text macro="film_minutes"/>
+      <text variable="ISBN" prefix=" [" suffix="]"/>
+    </layout>
+  </bibliography>
+</style>


### PR DESCRIPTION
Create CSL for journal Études chinoises, published by les Press de l'INALCO.

NOTE: CSL 1.0.2 documentation instructs to italicize et-al by adding it to <names> (see https://docs.citationstyles.org/en/stable/specification.html#et-al), and that works, but the CSL style validator does not like it.