### PR TITLE
Create hofmannsthal-jahrbuch-zur-europaischen-moderne.csl

### DIFF
--- a/hofmannsthal-jahrbuch-zur-europaischen-moderne.csl
+++ b/hofmannsthal-jahrbuch-zur-europaischen-moderne.csl
@@ -1,0 +1,251 @@
+<?xml version="1.0" encoding="utf-8"?>
+<style xmlns="http://purl.org/net/xbiblio/csl" class="note" version="1.0" demote-non-dropping-particle="sort-only" default-locale="de-DE">
+  <info>
+    <title>Hofmannsthal. Jahrbuch zur europäischen Moderne (Deutsch)</title>
+    <title-short>HJb</title-short>
+    <id>http://www.zotero.org/styles/hofmannsthal-jahrbuch-zur-europaischen-moderne</id>
+    <link href="http://www.zotero.org/styles/hofmannsthal-jahrbuch-zur-europaischen-moderne" rel="self"/>
+    <link href="http://www.zotero.org/styles/zeitschrift-fur-deutsche-philologie" rel="template"/>
+    <author>
+      <name>Julia Jennifer Beine</name>
+    </author>
+    <category citation-format="note"/>
+    <category field="humanities"/>
+    <category field="literature"/>
+    <issn>0946-4018</issn>
+    <eissn>2510-7305</eissn>
+    <summary>Zitierstil des Periodikums »Hofmannsthal. Jahrbuch zur europäischen Moderne«</summary>
+    <updated>2025-01-29T11:07:24+00:00</updated>
+    <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
+  </info>
+  <locale xml:lang="de">
+    <terms>
+      <term name="editor" form="verb-short">Hg. von</term>
+      <term name="translator" form="verb-short">Übers. von</term>
+      <term name="editortranslator" form="verb-short">Hg. und übers. von</term>
+      <term name="open-quote">»</term>
+      <term name="close-quote">«</term>
+      <term name="open-inner-quote">›</term>
+      <term name="close-inner-quote">‹</term>
+      <term name="et-al">u.a.</term>
+      <term name="no date" form="long">o.J.</term>
+      <term name="no date" form="short">o.J.</term>
+    </terms>
+  </locale>
+  <macro name="author">
+    <names variable="author">
+      <name and="text" delimiter-precedes-last="never"/>
+    </names>
+  </macro>
+  <macro name="container-title">
+    <group delimiter=": ">
+      <text term="in" text-case="capitalize-first" prefix=". "/>
+      <text variable="container-title"/>
+    </group>
+  </macro>
+  <macro name="editor">
+    <choose>
+      <if type="entry-encyclopedia" match="all" variable="author editor"/>
+      <else>
+        <names variable="editor translator" delimiter=", " prefix=". ">
+          <label form="verb-short" suffix=" "/>
+          <name and="text" delimiter-precedes-et-al="never" delimiter-precedes-last="never"/>
+        </names>
+      </else>
+    </choose>
+  </macro>
+  <macro name="volume-for-books">
+    <choose>
+      <if variable="volume">
+        <group delimiter=" ">
+          <text term="volume" form="short" text-case="capitalize-first" prefix=", "/>
+          <number text-case="capitalize-first" variable="volume"/>
+        </group>
+      </if>
+      <else>
+        <group prefix=". ">
+          <number variable="number-of-volumes" form="numeric"/>
+          <text term="volume" form="short" prefix=" " plural="true"/>
+        </group>
+      </else>
+    </choose>
+  </macro>
+  <macro name="point-locators-subsequent">
+    <choose>
+      <if variable="page">
+        <choose>
+          <if match="all" locator="page">
+            <label plural="never" variable="locator" form="short"/>
+            <text variable="locator" prefix=" "/>
+          </if>
+          <else>
+            <text variable="locator" prefix=" "/>
+          </else>
+        </choose>
+      </if>
+      <else>
+        <choose>
+          <if match="all" locator="page">
+            <label plural="never" variable="locator" form="short"/>
+            <text variable="locator" prefix=" "/>
+          </if>
+          <else>
+            <text variable="locator" prefix=" "/>
+          </else>
+        </choose>
+      </else>
+    </choose>
+  </macro>
+  <macro name="point-locators">
+    <choose>
+      <if variable="page">
+        <choose>
+          <if match="all" locator="page">
+            <label plural="never" prefix="hier " variable="locator" form="short"/>
+            <text variable="locator" prefix=" "/>
+          </if>
+          <else>
+            <text variable="locator" prefix=" "/>
+          </else>
+        </choose>
+      </if>
+      <else>
+        <choose>
+          <if match="all" locator="page">
+            <label plural="never" variable="locator" form="short"/>
+            <text variable="locator" prefix=" "/>
+          </if>
+          <else>
+            <text variable="locator" prefix=" "/>
+          </else>
+        </choose>
+      </else>
+    </choose>
+  </macro>
+  <macro name="pages">
+    <label plural="never" text-case="capitalize-first" variable="page" form="short"/>
+    <text variable="page" prefix=" "/>
+  </macro>
+  <macro name="edition-if-unveraendert">
+    <choose>
+      <if match="any" is-numeric="edition">
+        <text variable="edition" vertical-align="baseline" prefix=". " suffix=". Aufl"/>
+      </if>
+    </choose>
+  </macro>
+  <macro name="edition-if-not-unveraendert">
+    <choose>
+      <if match="none" is-numeric="edition">
+        <text variable="edition"/>
+      </if>
+    </choose>
+  </macro>
+  <macro name="author-short">
+    <names variable="author">
+      <name form="short"/>
+    </names>
+  </macro>
+  <macro name="serie-with-number">
+    <group delimiter=", ">
+      <text variable="collection-title"/>
+      <text variable="collection-number" prefix="Bd. "/>
+    </group>
+  </macro>
+  <macro name="url-with-date">
+    <group delimiter=" ">
+      <text variable="URL" prefix=" "/>
+      <date form="numeric" variable="accessed" prefix="(" suffix=")"/>
+    </group>
+  </macro>
+  <citation et-al-min="4" et-al-use-first="3" disambiguate-add-names="true">
+    <layout delimiter="; " suffix=".">
+      <choose>
+        <if position="ibid-with-locator">
+          <group delimiter=", ">
+            <text term="ibid"/>
+            <text macro="point-locators-subsequent"/>
+          </group>
+        </if>
+        <else-if position="ibid">
+          <text term="ibid"/>
+        </else-if>
+        <else-if position="subsequent">
+          <text macro="author-short" suffix=", "/>
+          <text variable="title" form="short"/>
+          <text variable="first-reference-note-number" prefix=" (wie Anm. " suffix=")"/>
+          <text macro="point-locators-subsequent" prefix=", "/>
+        </else-if>
+        <else>
+          <group delimiter=", ">
+            <text macro="author"/>
+            <text variable="title"/>
+          </group>
+          <text macro="container-title"/>
+          <choose>
+            <if type="article article-journal article-magazine article-newspaper" match="any">
+              <choose>
+                <if match="all" variable="volume">
+                  <group delimiter="/" prefix=" ">
+                    <choose>
+                      <if match="all" variable="issue">
+                        <text variable="volume" prefix=" "/>
+                        <text variable="issue" suffix=", "/>
+                      </if>
+                      <else>
+                        <text variable="volume" suffix=", "/>
+                      </else>
+                    </choose>
+                  </group>
+                  <date form="text" variable="issued">
+                    <date-part name="year"/>
+                  </date>
+                </if>
+                <else>
+                  <date form="numeric" variable="issued" prefix=", ">
+                    <date-part name="year"/>
+                  </date>
+                </else>
+              </choose>
+            </if>
+            <else>
+              <text macro="editor"/>
+              <text macro="volume-for-books"/>
+              <text macro="edition-if-not-unveraendert"/>
+              <text macro="edition-if-unveraendert" vertical-align="baseline"/>
+              <group delimiter=" " prefix=". ">
+                <text variable="publisher-place"/>
+                <group>
+                  <choose>
+                    <if match="all" variable="issued">
+                      <date variable="issued">
+                        <date-part name="year"/>
+                      </date>
+                    </if>
+                    <else-if match="none" variable="issued">
+                      <text term="no date" form="short"/>
+                    </else-if>
+                  </choose>
+                </group>
+              </group>
+            </else>
+          </choose>
+          <group delimiter=", " prefix=", ">
+            <text macro="pages" prefix=" "/>
+            <text macro="point-locators"/>
+            <text macro="url-with-date"/>
+            <group delimiter=", " prefix=" ">
+              <choose>
+                <if match="all" variable="archive">
+                  <text variable="archive"/>
+                  <text variable="archive_collection"/>
+                  <text variable="archive_location"/>
+                  <text variable="call-number"/>
+                </if>
+              </choose>
+            </group>
+          </group>
+        </else>
+      </choose>
+    </layout>
+  </citation>
+</style>


### PR DESCRIPTION
I propose this new citation style for the yearbook “Hofmannsthal. Jahrbuch zur europäischen Moderne”. The yearbook does not provide a submission or style guide online. Moreover, some elements of the citation style have varied from article to article. Therefore, I have adapted the citation style in consultation with Sara Landa (Ruprecht-Karls-Universität Heidelberg) from the yearbook team.