### PR TITLE
Bluebook Law Review: add court to case citations

### DIFF
--- a/bluebook-law-review.csl
+++ b/bluebook-law-review.csl
@@ -212,6 +212,14 @@
               </date>
             </group>
           </if>
+          <else-if type="legal_case">
+            <group delimiter=" ">
+              <text variable="authority"/>
+              <date variable="issued">
+                <date-part name="year"/>
+              </date>
+            </group>
+          </else-if>
           <else>
             <group delimiter=", ">
               <text macro="editor-translator"/>


### PR DESCRIPTION
Adds the court before the date of the decision in parenthesis. For example, "D. Mass" in: 

> Ward v. Reddy, 727 F. Supp. 1407, 1412 (D. Mass. 1990).

This format is shown in the ["Cases" section on the Bluebook site](https://www.legalbluebook.com/bluebook/v21/quick-style-guide#:~:text=Cases) (publicly accessible).

More specifically, the Bluebook [states in B10.1.3](https://www.legalbluebook.com/bluebook/v21/bluepages/b10-cases/b10-1-full-citation) (subscription required):

> B10.1.3 – Court and Year of Decision
> Indicate parenthetically the deciding court followed by the year of decision (immediately following the page reference). When citing decisions of the United States Supreme Court, however, do not include the name of the deciding court. [Table T1](https://www.legalbluebook.com/bluebook/v21/tables/t1-united-states-jurisdictions) lists the correct abbreviations for courts in U.S. jurisdictions.
>  
> (i) The United States Supreme Court: Cite United States Reports (U.S.) if the opinion appears therein; otherwise, cite to Supreme Court Reporter (S. Ct.):
>  
> Meritor Sav. Bank v. Vinson, 477 U.S. 57, 60 (1986).
>  
> Weyerhaeuser Co. v. U.S. Fish & Wildlife Serv., 139 S. Ct. 361, 365 (2018).
>  
> (ii) Federal Courts of Appeals: Cite Federal Reporter (F., F.2d, F.3d) and indicate the name of the court parenthetically:
>  
> Env't Def. Fund v. EPA, 465 F.2d 528, 533 (D.C. Cir. 1972).
>  
> United States v. Jardine, 364 F.3d 1200, 1203 (10th Cir. 2004).
>  
> (iii) Federal District Courts: Cite Federal Supplement (F. Supp., F. Supp. 2d, F. Supp. 3d) and indicate the name of the court parenthetically:
>  
> W. St. Grp. LLC v. Epro, 563 F. Supp. 2d 84, 91 (D. Mass. 2008).
>  
> Harris v. Roderick, 933 F. Supp. 977, 985 (D. Idaho 1996).
> 
> 

This is similarly documented in [The Indigo Book](https://law.resource.org/pub/us/code/blue/IndigoBook.html#R12)