### PR TITLE
Update instituto-brasileiro-de-informacao-em-ciencia-e-tecnologia-abn…

### DIFF
--- a/instituto-brasileiro-de-informacao-em-ciencia-e-tecnologia-abnt.csl
+++ b/instituto-brasileiro-de-informacao-em-ciencia-e-tecnologia-abnt.csl
@@ -19,7 +19,7 @@
       <name>Rebeca dos Santos de Moura</name>
       <email>rebecamoura@ibict.br</email>
     </contributor>
-        <contributor>
+    <contributor>
       <name>Bernardo Dionízio Vechi</name>
       <email>bernardovechi@ibict.br</email>
     </contributor>
@@ -64,8 +64,8 @@
         <single>ed.</single>
         <multiple>ed.</multiple>
       </term>
-        <term name="collection-editor" form="verb">editado por</term>
-        <term name="collection-editor" form="verb-short">ed.</term>
+      <term name="collection-editor" form="verb">editado por</term>
+      <term name="collection-editor" form="verb-short">ed.</term>
       <term name="organizer" form="short">org.</term>
     </terms>
   </locale>

--- a/instituto-brasileiro-de-informacao-em-ciencia-e-tecnologia-abnt.csl
+++ b/instituto-brasileiro-de-informacao-em-ciencia-e-tecnologia-abnt.csl
@@ -2,7 +2,7 @@
 <style xmlns="http://purl.org/net/xbiblio/csl" version="1.0" class="in-text" demote-non-dropping-particle="never">
   <info>
     <title>Instituto Brasileiro de Informação em Ciência e Tecnologia - ABNT (autoria completa)</title>
-    <title-short>IBICT</title-short>
+    <title-short>Ibict - Autoria completa</title-short>
     <id>http://www.zotero.org/styles/instituto-brasileiro-de-informacao-em-ciencia-e-tecnologia-abnt</id>
     <link href="http://www.zotero.org/styles/instituto-brasileiro-de-informacao-em-ciencia-e-tecnologia-abnt" rel="self"/>
     <link href="http://www.zotero.org/styles/associacao-brasileira-de-normas-tecnicas-ufmg-face-full" rel="template"/>
@@ -12,6 +12,22 @@
       <email>andreappel@ibict.br</email>
     </author>
     <contributor>
+      <name>Ingrid Torres Schiessl</name>
+      <email>ingridschiessl@ibict.br</email>
+    </contributor>
+    <contributor>
+      <name>Rebeca dos Santos de Moura</name>
+      <email>rebecamoura@ibict.br</email>
+    </contributor>
+        <contributor>
+      <name>Bernardo Dionízio Vechi</name>
+      <email>bernardovechi@ibict.br</email>
+    </contributor>
+    <contributor>
+      <name>Diego José Macêdo</name>
+      <email>diegomacedo@ibict.br</email>
+    </contributor>
+    <contributor>
       <name>Deivdy Willian Silva</name>
       <email>deivdysilva@ibict.br</email>
     </contributor>
@@ -19,14 +35,10 @@
       <name>Tiago Emmanuel Nunes Braga</name>
       <email>tiagobraga@ibict.br</email>
     </contributor>
-    <contributor>
-      <name>Diego José Macêdo</name>
-      <email>diegomacedo@ibict.br</email>
-    </contributor>
     <category citation-format="author-date"/>
     <category field="generic-base"/>
     <summary>The Brazilian Standard Style by IBICT</summary>
-    <updated>2020-04-11T15:20:00+00:00</updated>
+    <updated>2025-01-30T09:00:00+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale xml:lang="en">
@@ -50,10 +62,11 @@
       </term>
       <term name="collection-editor" form="short">
         <single>ed.</single>
-        <multiple>eds.</multiple>
+        <multiple>ed.</multiple>
       </term>
-      <term name="collection-editor" form="verb">editado por</term>
-      <term name="collection-editor" form="verb-short">ed.</term>
+        <term name="collection-editor" form="verb">editado por</term>
+        <term name="collection-editor" form="verb-short">ed.</term>
+      <term name="organizer" form="short">org.</term>
     </terms>
   </locale>
   <macro name="container-contributors">
@@ -90,8 +103,8 @@
     <text term="translator" form="verb-short" suffix=" "/>
     <names variable="translator" delimiter=", ">
       <name delimiter="; " sort-separator=" " delimiter-precedes-last="always">
-        <name-part name="given" text-case="capitalize-first"/>
-        <name-part name="family" text-case="capitalize-first"/>
+        <name-part name="given"/>
+        <name-part name="family"/>
       </name>
       <et-al font-style="italic"/>
     </names>
@@ -135,7 +148,7 @@
   <macro name="author-short">
     <names variable="author">
       <name form="short" name-as-sort-order="all" sort-separator=", " delimiter="; " delimiter-precedes-last="always">
-        <name-part name="family" text-case="uppercase"/>
+        <name-part name="family"/>
         <name-part name="given"/>
       </name>
       <et-al font-style="italic"/>
@@ -147,7 +160,7 @@
             <text variable="title" form="short"/>
           </if>
           <else>
-            <text variable="title" form="short" quotes="false" text-case="uppercase"/>
+            <text variable="title" form="short" quotes="false"/>
           </else>
         </choose>
       </substitute>
@@ -360,9 +373,12 @@
   </macro>
   <macro name="place">
     <choose>
-      <if match="any" variable="publisher-place">
+      <if variable="event-place publisher-place" match="any">
         <text variable="publisher-place"/>
       </if>
+      <else>
+        <text value="s. l." font-style="italic" prefix="[" suffix="]"/>
+      </else>
     </choose>
   </macro>
   <macro name="archive">
@@ -389,7 +405,7 @@
       </group>
     </layout>
   </citation>
-  <bibliography hanging-indent="false" et-al-min="21" et-al-use-first="19" et-al-use-last="true" entry-spacing="1" line-spacing="1">
+  <bibliography hanging-indent="false" entry-spacing="1" line-spacing="1">
     <sort>
       <key macro="author"/>
       <key macro="title"/>


### PR DESCRIPTION
…t.csl

Updated according to ABNT NBR 6023:2020 and 10520:2023:
- _name-part name="family"_ no longer _text-case="uppercase"_;
- no longer et al. on _bibliography_: 6023:2020 made it optional, so users can add it manually, as they wish;
- _term names collection-editor_ and _organizer_ are the same for _single_ and _multiple_ in _form short_, according to 6023:2020.

Some other minor improvements.