### PR TITLE
MHRA: Update further for 4th edition and refactor

### DIFF
--- a/modern-humanities-research-association.csl
+++ b/modern-humanities-research-association.csl
@@ -25,7 +25,7 @@
     <category field="generic-base"/>
     <category field="humanities"/>
     <summary>MHRA format with full notes and bibliography</summary>
-    <updated>2025-02-02T22:26:03+00:00</updated>
+    <updated>2025-02-02T22:54:15+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale xml:lang="en">
@@ -213,20 +213,17 @@
       </else-if>
     </choose>
   </macro>
-  <macro name="issue-note">
+  <macro name="issue-join-with-space">
     <choose>
       <if type="article-journal">
         <choose>
           <if variable="volume">
-            <text macro="issued" prefix=" (" suffix=")"/>
+            <text macro="issued" prefix="(" suffix=")"/>
           </if>
-          <else>
-            <text macro="issued" prefix=", "/>
-          </else>
         </choose>
       </if>
       <else-if match="any" variable="publisher-place publisher">
-        <group delimiter=", " prefix=" (" suffix=")">
+        <group delimiter=", " prefix="(" suffix=")">
           <group delimiter=" ">
             <choose>
               <if match="none" variable="title"/>
@@ -240,9 +237,20 @@
           <text macro="issued"/>
         </group>
       </else-if>
-      <else>
-        <text macro="issued" prefix=", "/>
-      </else>
+    </choose>
+  </macro>
+  <macro name="issue-join-with-comma">
+    <choose>
+      <if type="article-journal">
+        <choose>
+          <if match="none" variable="volume">
+            <text macro="issued"/>
+          </if>
+        </choose>
+      </if>
+      <else-if match="none" variable="publisher-place publisher">
+        <text macro="issued"/>
+      </else-if>
     </choose>
   </macro>
   <macro name="locators-specific-note">
@@ -258,7 +266,7 @@
             </else>
           </choose>
           <choose>
-            <if position="first">
+            <if match="all" position="first">
               <text font-style="italic" text-case="title" variable="volume-title"/>
             </if>
           </choose>
@@ -483,18 +491,21 @@
           </group>
         </if>
         <else>
-          <group delimiter=", ">
-            <text macro="contributors-note"/>
-            <text macro="title-note"/>
-            <text macro="secondary-contributors-note"/>
-            <text macro="container-title-note"/>
-            <text macro="container-contributors-note"/>
-            <text macro="collection-title"/>
-            <text macro="locators-note"/>
-          </group>
           <group delimiter=" ">
             <group delimiter=", ">
-              <text macro="issue-note"/>
+              <group delimiter=" ">
+                <group delimiter=", ">
+                  <text macro="contributors-note"/>
+                  <text macro="title-note"/>
+                  <text macro="secondary-contributors-note"/>
+                  <text macro="container-title-note"/>
+                  <text macro="container-contributors-note"/>
+                  <text macro="collection-title"/>
+                  <text macro="locators-note"/>
+                </group>
+                <text macro="issue-join-with-space"/>
+              </group>
+              <text macro="issue-join-with-comma"/>
               <text macro="locators-specific-note"/>
               <text macro="locators-newspaper"/>
               <text macro="point-locators"/>
@@ -512,18 +523,21 @@
       <key variable="title"/>
     </sort>
     <layout>
-      <group delimiter=", ">
-        <text macro="author"/>
-        <text macro="title-note"/>
-        <text macro="secondary-contributors-note"/>
-        <text macro="container-title-note"/>
-        <text macro="container-contributors-note"/>
-        <text macro="collection-title"/>
-        <text macro="volume"/>
-      </group>
       <group delimiter=" ">
         <group delimiter=", ">
-          <text macro="issue-note"/>
+          <group delimiter=" ">
+            <group delimiter=", ">
+              <text macro="author"/>
+              <text macro="title-note"/>
+              <text macro="secondary-contributors-note"/>
+              <text macro="container-title-note"/>
+              <text macro="container-contributors-note"/>
+              <text macro="collection-title"/>
+              <text macro="volume"/>
+            </group>
+            <text macro="issue-join-with-space"/>
+          </group>
+          <text macro="issue-join-with-comma"/>
           <text macro="locators-specific-note"/>
           <text macro="artwork"/>
           <text macro="locators-newspaper"/>

--- a/modern-humanities-research-association.csl
+++ b/modern-humanities-research-association.csl
@@ -447,7 +447,7 @@
       <text variable="archive_location"/>
     </group>
   </macro>
-  <macro name="access-note">
+  <macro name="access">
     <group delimiter=", ">
       <choose>
         <if match="none" type="article-journal bill chapter legal_case legislation paper-conference">
@@ -512,7 +512,7 @@
               <text macro="point-locators-volume-note"/>
               <text macro="locators-newspaper"/>
               <text macro="point-locators"/>
-              <text macro="access-note"/>
+              <text macro="access"/>
             </group>
             <text macro="URL"/>
           </group>
@@ -545,7 +545,7 @@
           <text macro="artwork"/>
           <text macro="locators-newspaper"/>
           <text macro="pages"/>
-          <text macro="access-note"/>
+          <text macro="access"/>
         </group>
         <text macro="URL"/>
       </group>

--- a/modern-humanities-research-association.csl
+++ b/modern-humanities-research-association.csl
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <style xmlns="http://purl.org/net/xbiblio/csl" and="text" class="note" delimiter-precedes-et-al="after-inverted-name" demote-non-dropping-particle="sort-only" et-al-min="4" et-al-use-first="1" names-delimiter=", " page-range-format="minimal-two" version="1.0" default-locale="en-GB">
   <info>
-    <title>Modern Humanities Research Association Style Guide, 4th edition (full note)</title>
-    <title-short>MHRA</title-short>
+    <title>Modern Humanities Research Association, 4th edition (full note)</title>
+    <title-short>MHRA Style Guide</title-short>
     <id>http://www.zotero.org/styles/modern-humanities-research-association</id>
     <link href="http://www.zotero.org/styles/modern-humanities-research-association" rel="self"/>
     <link href="https://www.mhra.org.uk/style/" rel="documentation"/>
@@ -25,7 +25,7 @@
     <category field="generic-base"/>
     <category field="humanities"/>
     <summary>MHRA format with full notes and bibliography</summary>
-    <updated>2025-02-02T22:59:55+00:00</updated>
+    <updated>2025-02-03T09:28:39+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale xml:lang="en">
@@ -213,6 +213,16 @@
       </else-if>
     </choose>
   </macro>
+  <macro name="volume-number-roman">
+    <choose>
+      <if is-numeric="volume">
+        <number font-variant="small-caps" form="roman" variable="volume"/>
+      </if>
+      <else>
+        <text font-variant="small-caps" variable="volume"/>
+      </else>
+    </choose>
+  </macro>
   <macro name="issue-join-with-space">
     <choose>
       <if type="article-journal">
@@ -255,21 +265,30 @@
   </macro>
   <macro name="locators-specific-note">
     <choose>
-      <if match="any" type="book legislation motion_picture report">
+      <if position="first" type="chapter entry-dictionary entry-encyclopedia paper-conference">
         <group delimiter=", ">
+          <text macro="volume-number-roman"/>
+          <text font-style="italic" text-case="title" variable="volume-title"/>
+        </group>
+      </if>
+      <else-if type="book legislation motion_picture report">
+        <group delimiter=", ">
+          <text macro="volume-number-roman"/>
           <choose>
-            <if is-numeric="volume">
-              <number font-variant="small-caps" form="roman" variable="volume"/>
-            </if>
-            <else>
-              <text font-variant="small-caps" variable="volume"/>
-            </else>
-          </choose>
-          <choose>
-            <if match="all" position="first">
+            <if position="first">
               <text font-style="italic" text-case="title" variable="volume-title"/>
             </if>
           </choose>
+        </group>
+      </else-if>
+    </choose>
+  </macro>
+  <macro name="locators-specific-bibliography">
+    <choose>
+      <if type="bill book chapter entry-dictionary entry-encyclopedia graphic legal_case legislation motion_picture paper-conference report song">
+        <group delimiter=", ">
+          <text macro="volume-number-roman"/>
+          <text font-style="italic" text-case="title" variable="volume-title"/>
         </group>
       </if>
     </choose>
@@ -384,27 +403,10 @@
     </choose>
   </macro>
   <macro name="pages">
-    <choose>
-      <if type="article-journal">
-        <group delimiter=" ">
-          <label form="short" variable="page"/>
-          <text variable="page"/>
-        </group>
-      </if>
-      <else>
-        <choose>
-          <if variable="volume">
-            <text variable="page"/>
-          </if>
-          <else>
-            <group delimiter=" ">
-              <label form="short" variable="page"/>
-              <text variable="page"/>
-            </group>
-          </else>
-        </choose>
-      </else>
-    </choose>
+    <group delimiter=" ">
+      <label form="short" variable="page"/>
+      <text variable="page"/>
+    </group>
   </macro>
   <macro name="point-locators">
     <group delimiter=" ">
@@ -538,7 +540,7 @@
             <text macro="issue-join-with-space"/>
           </group>
           <text macro="issue-join-with-comma"/>
-          <text macro="locators-specific-note"/>
+          <text macro="locators-specific-bibliography"/>
           <text macro="artwork"/>
           <text macro="locators-newspaper"/>
           <text macro="pages"/>

--- a/modern-humanities-research-association.csl
+++ b/modern-humanities-research-association.csl
@@ -94,7 +94,7 @@
     <names variable="author">
       <label form="short" prefix=", "/>
       <substitute>
-        <text macro="title-note"/>
+        <text macro="title"/>
       </substitute>
     </names>
     <text macro="recipient-note"/>
@@ -107,7 +107,7 @@
         <substitute>
           <names variable="editor"/>
           <names variable="translator"/>
-          <text macro="title-note"/>
+          <text macro="title"/>
         </substitute>
       </names>
       <text macro="recipient"/>
@@ -126,7 +126,7 @@
       </else>
     </choose>
   </macro>
-  <macro name="title-note">
+  <macro name="title">
     <choose>
       <if match="none" variable="title">
         <text variable="genre"/>
@@ -167,14 +167,14 @@
       </names>
     </group>
   </macro>
-  <macro name="secondary-contributors-note">
+  <macro name="secondary-contributors">
     <choose>
       <if match="none" type="chapter entry-dictionary entry-encyclopedia paper-conference">
         <text macro="editor-translator"/>
       </if>
     </choose>
   </macro>
-  <macro name="container-title-note">
+  <macro name="container-title">
     <group delimiter=" ">
       <choose>
         <if match="any" type="chapter entry-dictionary entry-encyclopedia paper-conference">
@@ -184,7 +184,7 @@
       <text font-style="italic" text-case="title" variable="container-title"/>
     </group>
   </macro>
-  <macro name="container-contributors-note">
+  <macro name="container-contributors">
     <choose>
       <if match="any" type="chapter entry-dictionary entry-encyclopedia paper-conference">
         <text macro="editor-translator"/>
@@ -499,10 +499,10 @@
               <group delimiter=" ">
                 <group delimiter=", ">
                   <text macro="contributors-note"/>
-                  <text macro="title-note"/>
-                  <text macro="secondary-contributors-note"/>
-                  <text macro="container-title-note"/>
-                  <text macro="container-contributors-note"/>
+                  <text macro="title"/>
+                  <text macro="secondary-contributors"/>
+                  <text macro="container-title"/>
+                  <text macro="container-contributors"/>
                   <text macro="collection-title"/>
                   <text macro="locators-note"/>
                 </group>
@@ -531,10 +531,10 @@
           <group delimiter=" ">
             <group delimiter=", ">
               <text macro="contributors"/>
-              <text macro="title-note"/>
-              <text macro="secondary-contributors-note"/>
-              <text macro="container-title-note"/>
-              <text macro="container-contributors-note"/>
+              <text macro="title"/>
+              <text macro="secondary-contributors"/>
+              <text macro="container-title"/>
+              <text macro="container-contributors"/>
               <text macro="collection-title"/>
               <text macro="locators"/>
             </group>

--- a/modern-humanities-research-association.csl
+++ b/modern-humanities-research-association.csl
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<style xmlns="http://purl.org/net/xbiblio/csl" and="text" class="note" demote-non-dropping-particle="sort-only" et-al-min="4" et-al-use-first="1" names-delimiter=", " page-range-format="minimal-two" version="1.0" default-locale="en-GB">
+<style xmlns="http://purl.org/net/xbiblio/csl" and="text" class="note" delimiter-precedes-et-al="after-inverted-name" demote-non-dropping-particle="sort-only" et-al-min="4" et-al-use-first="1" names-delimiter=", " page-range-format="minimal-two" version="1.0" default-locale="en-GB">
   <info>
     <title>Modern Humanities Research Association Style Guide, 4th edition (note with bibliography)</title>
     <title-short>MHRA</title-short>
@@ -25,7 +25,7 @@
     <category field="generic-base"/>
     <category field="humanities"/>
     <summary>MHRA format with full notes and bibliography</summary>
-    <updated>2025-02-02T21:52:07+00:00</updated>
+    <updated>2025-02-02T22:26:03+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale xml:lang="en">
@@ -43,7 +43,7 @@
   <macro name="author">
     <group delimiter=", ">
       <names variable="author">
-        <name delimiter-precedes-last="always" name-as-sort-order="first"/>
+        <name/>
         <label form="short" prefix=", "/>
         <substitute>
           <names variable="editor"/>
@@ -149,14 +149,14 @@
   </macro>
   <macro name="secondary-contributors-note">
     <choose>
-      <if match="none" type="chapter paper-conference">
+      <if match="none" type="chapter entry-dictionary entry-encyclopedia paper-conference">
         <text macro="editor-translator"/>
       </if>
     </choose>
   </macro>
   <macro name="container-contributors-note">
     <choose>
-      <if match="any" type="chapter paper-conference">
+      <if match="any" type="chapter entry-dictionary entry-encyclopedia paper-conference">
         <text macro="editor-translator"/>
       </if>
     </choose>
@@ -183,7 +183,7 @@
           <text variable="issue"/>
         </group>
       </if>
-      <else-if match="any" type="bill book chapter graphic legal_case legislation motion_picture paper-conference report song">
+      <else-if match="any" type="bill book chapter entry-dictionary entry-encyclopedia graphic legal_case legislation motion_picture paper-conference report song">
         <group delimiter=", ">
           <text macro="edition-note"/>
           <group delimiter=" ">
@@ -202,7 +202,7 @@
           <text variable="issue"/>
         </group>
       </if>
-      <else-if match="any" type="bill book chapter graphic legal_case legislation motion_picture paper-conference report song">
+      <else-if match="any" type="bill book chapter entry-dictionary entry-encyclopedia graphic legal_case legislation motion_picture paper-conference report song">
         <group delimiter=", ">
           <text macro="edition-note"/>
           <group delimiter=" ">
@@ -247,22 +247,29 @@
   </macro>
   <macro name="locators-specific-note">
     <choose>
-      <if match="any" type="bill book chapter graphic legal_case legislation motion_picture paper-conference report song">
-        <choose>
-          <if is-numeric="volume">
-            <number font-variant="small-caps" form="roman" variable="volume"/>
-          </if>
-          <else>
-            <text font-variant="small-caps" variable="volume"/>
-          </else>
-        </choose>
+      <if match="any" type="book legislation motion_picture report">
+        <group delimiter=", ">
+          <choose>
+            <if is-numeric="volume">
+              <number font-variant="small-caps" form="roman" variable="volume"/>
+            </if>
+            <else>
+              <text font-variant="small-caps" variable="volume"/>
+            </else>
+          </choose>
+          <choose>
+            <if position="first">
+              <text font-style="italic" text-case="title" variable="volume-title"/>
+            </if>
+          </choose>
+        </group>
       </if>
     </choose>
   </macro>
   <macro name="container-title-note">
     <group delimiter=" ">
       <choose>
-        <if match="any" type="chapter paper-conference">
+        <if match="any" type="chapter entry-dictionary entry-encyclopedia paper-conference">
           <text term="in"/>
         </if>
       </choose>
@@ -271,7 +278,7 @@
   </macro>
   <macro name="edition-note">
     <choose>
-      <if match="any" type="bill book chapter graphic legal_case legislation motion_picture paper-conference report song">
+      <if match="any" type="bill book chapter entry-dictionary entry-encyclopedia graphic legal_case legislation motion_picture paper-conference report song">
         <choose>
           <if is-numeric="edition">
             <group delimiter=" ">
@@ -499,7 +506,7 @@
       </choose>
     </layout>
   </citation>
-  <bibliography hanging-indent="true" subsequent-author-substitute="&#8212;&#8212;">
+  <bibliography delimiter-precedes-last="always" hanging-indent="true" name-as-sort-order="first" subsequent-author-substitute="&#8212;&#8212;">
     <sort>
       <key macro="author"/>
       <key variable="title"/>

--- a/modern-humanities-research-association.csl
+++ b/modern-humanities-research-association.csl
@@ -25,7 +25,7 @@
     <category field="generic-base"/>
     <category field="humanities"/>
     <summary>MHRA format with full notes and bibliography</summary>
-    <updated>2025-02-03T14:35:07+00:00</updated>
+    <updated>2025-02-03T14:38:03+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale xml:lang="en">
@@ -133,13 +133,13 @@
       <choose>
         <if match="any" variable="container-author reviewed-author">
           <names delimiter=", " variable="container-author reviewed-author">
-            <label form="verb-short" suffix=" " text-case="lowercase"/>
+            <label form="verb-short" suffix=" "/>
             <name/>
           </names>
         </if>
       </choose>
       <names delimiter=", " variable="editor translator director">
-        <label form="verb-short" suffix=" " text-case="lowercase"/>
+        <label form="verb-short" suffix=" "/>
         <name/>
       </names>
     </group>

--- a/modern-humanities-research-association.csl
+++ b/modern-humanities-research-association.csl
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <style xmlns="http://purl.org/net/xbiblio/csl" and="text" class="note" demote-non-dropping-particle="sort-only" et-al-min="4" et-al-use-first="1" names-delimiter=", " page-range-format="minimal-two" version="1.0" default-locale="en-GB">
   <info>
-    <title>Modern Humanities Research Association 4th edition (note with bibliography)</title>
+    <title>Modern Humanities Research Association Style Guide, 4th edition (note with bibliography)</title>
     <title-short>MHRA</title-short>
     <id>http://www.zotero.org/styles/modern-humanities-research-association</id>
     <link href="http://www.zotero.org/styles/modern-humanities-research-association" rel="self"/>
@@ -10,21 +10,22 @@
       <name>Rintze Zelle</name>
       <uri>https://orcid.org/0000-0003-1779-8883</uri>
     </author>
+    <author>
+      <name>Andrew Dunning</name>
+      <uri>https://orcid.org/0000-0003-0464-5036</uri>
+    </author>
     <contributor>
       <name>Sebastian Karcher</name>
       <uri>https://orcid.org/0000-0001-8249-7388</uri>
-    </contributor>
-    <contributor>
-      <name>Andrew Dunning</name>
-      <uri>https://orcid.org/0000-0003-0464-5036</uri>
     </contributor>
     <contributor>
       <name>Patrick O'Brien</name>
     </contributor>
     <category citation-format="note"/>
     <category field="generic-base"/>
+    <category field="humanities"/>
     <summary>MHRA format with full notes and bibliography</summary>
-    <updated>2025-02-02T21:12:55+00:00</updated>
+    <updated>2025-02-02T21:52:07+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale xml:lang="en">
@@ -343,16 +344,27 @@
   <macro name="issued">
     <choose>
       <if match="any" type="report article-newspaper article-magazine personal_communication">
-        <date delimiter=" " variable="issued">
-          <date-part name="day"/>
-          <date-part name="month"/>
-          <date-part name="year"/>
-        </date>
+        <date form="text" variable="issued"/>
       </if>
+      <else-if match="any" type="article-journal book bill chapter legislation motion_picture paper-conference song thesis">
+        <choose>
+          <if is-uncertain-date="issued">
+            <date date-parts="year" form="numeric" prefix="[" suffix="?]" variable="issued"/>
+          </if>
+          <else>
+            <date date-parts="year" form="numeric" variable="issued"/>
+          </else>
+        </choose>
+      </else-if>
       <else>
-        <date variable="issued">
-          <date-part name="year"/>
-        </date>
+        <choose>
+          <if is-uncertain-date="issued">
+            <date form="text" prefix="[" suffix="?]" variable="issued"/>
+          </if>
+          <else>
+            <date form="text" variable="issued"/>
+          </else>
+        </choose>
       </else>
     </choose>
   </macro>
@@ -380,25 +392,27 @@
     </choose>
   </macro>
   <macro name="point-locators">
-    <text macro="pages"/>
-    <choose>
-      <if variable="page">
-        <group delimiter=" " prefix=" (" suffix=")">
-          <label form="short" variable="locator"/>
-          <text variable="locator"/>
-        </group>
-      </if>
-      <else>
-        <group delimiter=" ">
-          <label form="short" variable="locator"/>
-          <text variable="locator"/>
-        </group>
-      </else>
-    </choose>
+    <group delimiter=" ">
+      <text macro="pages"/>
+      <choose>
+        <if variable="page">
+          <group delimiter=" " prefix="(" suffix=")">
+            <label form="short" variable="locator"/>
+            <text variable="locator"/>
+          </group>
+        </if>
+        <else>
+          <group delimiter=" ">
+            <label form="short" variable="locator"/>
+            <text variable="locator"/>
+          </group>
+        </else>
+      </choose>
+    </group>
   </macro>
   <macro name="point-locators-subsequent">
     <group delimiter=" ">
-      <label variable="locator" form="short"/>
+      <label form="short" variable="locator"/>
       <text variable="locator"/>
     </group>
   </macro>
@@ -432,11 +446,7 @@
               <text prefix="&lt;" suffix="&gt;" variable="URL"/>
               <group delimiter=" " prefix="[" suffix="]">
                 <text term="accessed"/>
-                <date delimiter=" " variable="accessed">
-                  <date-part name="day"/>
-                  <date-part name="month"/>
-                  <date-part name="year"/>
-                </date>
+                <date form="text" variable="accessed"/>
               </group>
             </group>
           </if>
@@ -489,7 +499,7 @@
       </choose>
     </layout>
   </citation>
-  <bibliography hanging-indent="true" subsequent-author-substitute="&#8212;&#8212;&#8212;">
+  <bibliography hanging-indent="true" subsequent-author-substitute="&#8212;&#8212;">
     <sort>
       <key macro="author"/>
       <key variable="title"/>

--- a/modern-humanities-research-association.csl
+++ b/modern-humanities-research-association.csl
@@ -50,6 +50,12 @@
       </else>
     </choose>
   </macro>
+  <macro name="recipient-short">
+    <names variable="recipient">
+      <label form="verb" suffix=" "/>
+      <name form="short"/>
+    </names>
+  </macro>
   <macro name="recipient-note">
     <names variable="recipient">
       <label form="verb" suffix=" "/>
@@ -72,12 +78,6 @@
       </choose>
       <text macro="recipient-note"/>
     </group>
-  </macro>
-  <macro name="recipient-short">
-    <names variable="recipient">
-      <label form="verb" suffix=" "/>
-      <name form="short"/>
-    </names>
   </macro>
   <macro name="contributors-short">
     <names variable="author">

--- a/modern-humanities-research-association.csl
+++ b/modern-humanities-research-association.csl
@@ -40,19 +40,21 @@
       </term>
     </terms>
   </locale>
-  <macro name="author">
-    <group delimiter=". ">
-      <names variable="author">
-        <name delimiter-precedes-last="always" name-as-sort-order="first"/>
-        <label form="short" prefix=", "/>
-        <substitute>
-          <names variable="editor"/>
-          <names variable="translator"/>
-          <text macro="title-note"/>
-        </substitute>
-      </names>
-      <text macro="recipient"/>
-    </group>
+  <macro name="title-sort-substitute">
+    <choose>
+      <if match="any" type="bill book graphic legal_case legislation motion_picture report song">
+        <text font-style="italic" form="short" text-case="title" variable="title"/>
+      </if>
+      <else>
+        <text form="short" quotes="true" text-case="title" variable="title"/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="recipient-note">
+    <names variable="recipient">
+      <label form="verb" suffix=" "/>
+      <name/>
+    </names>
   </macro>
   <macro name="recipient">
     <group delimiter=" ">
@@ -71,6 +73,23 @@
       <text macro="recipient-note"/>
     </group>
   </macro>
+  <macro name="recipient-short">
+    <names variable="recipient">
+      <label form="verb" suffix=" "/>
+      <name form="short"/>
+    </names>
+  </macro>
+  <macro name="contributors-short">
+    <names variable="author">
+      <name form="short"/>
+      <substitute>
+        <names variable="editor"/>
+        <names variable="translator"/>
+        <text macro="title-sort-substitute"/>
+      </substitute>
+    </names>
+    <text macro="recipient-short"/>
+  </macro>
   <macro name="contributors-note">
     <names variable="author">
       <label form="short" prefix=", "/>
@@ -79,6 +98,33 @@
       </substitute>
     </names>
     <text macro="recipient-note"/>
+  </macro>
+  <macro name="contributors">
+    <group delimiter=". ">
+      <names variable="author">
+        <name delimiter-precedes-last="always" name-as-sort-order="first"/>
+        <label form="short" prefix=", "/>
+        <substitute>
+          <names variable="editor"/>
+          <names variable="translator"/>
+          <text macro="title-note"/>
+        </substitute>
+      </names>
+      <text macro="recipient"/>
+    </group>
+  </macro>
+  <macro name="title-subsequent">
+    <choose>
+      <if match="none" variable="title">
+        <text macro="issued"/>
+      </if>
+      <else-if match="any" type="bill book graphic legal_case legislation motion_picture report song">
+        <text font-style="italic" form="short" text-case="title" variable="title"/>
+      </else-if>
+      <else>
+        <text form="short" quotes="true" text-case="title" variable="title"/>
+      </else>
+    </choose>
   </macro>
   <macro name="title-note">
     <choose>
@@ -105,29 +151,6 @@
       </else>
     </choose>
   </macro>
-  <macro name="title-subsequent">
-    <choose>
-      <if match="none" variable="title">
-        <text macro="issued"/>
-      </if>
-      <else-if match="any" type="bill book graphic legal_case legislation motion_picture report song">
-        <text font-style="italic" form="short" text-case="title" variable="title"/>
-      </else-if>
-      <else>
-        <text form="short" quotes="true" text-case="title" variable="title"/>
-      </else>
-    </choose>
-  </macro>
-  <macro name="title-sort-substitute">
-    <choose>
-      <if match="any" type="bill book graphic legal_case legislation motion_picture report song">
-        <text font-style="italic" form="short" text-case="title" variable="title"/>
-      </if>
-      <else>
-        <text form="short" quotes="true" text-case="title" variable="title"/>
-      </else>
-    </choose>
-  </macro>
   <macro name="editor-translator">
     <group delimiter=", ">
       <choose>
@@ -151,6 +174,16 @@
       </if>
     </choose>
   </macro>
+  <macro name="container-title-note">
+    <group delimiter=" ">
+      <choose>
+        <if match="any" type="chapter entry-dictionary entry-encyclopedia paper-conference">
+          <text term="in"/>
+        </if>
+      </choose>
+      <text font-style="italic" text-case="title" variable="container-title"/>
+    </group>
+  </macro>
   <macro name="container-contributors-note">
     <choose>
       <if match="any" type="chapter entry-dictionary entry-encyclopedia paper-conference">
@@ -172,6 +205,23 @@
       </choose>
     </group>
   </macro>
+  <macro name="edition-note">
+    <choose>
+      <if match="any" type="bill book chapter entry-dictionary entry-encyclopedia graphic legal_case legislation motion_picture paper-conference report song">
+        <choose>
+          <if is-numeric="edition">
+            <group delimiter=" ">
+              <number form="ordinal" variable="edition"/>
+              <text form="short" term="edition"/>
+            </group>
+          </if>
+          <else>
+            <text variable="edition"/>
+          </else>
+        </choose>
+      </if>
+    </choose>
+  </macro>
   <macro name="locators-note">
     <choose>
       <if type="article-journal">
@@ -191,7 +241,7 @@
       </else-if>
     </choose>
   </macro>
-  <macro name="volume">
+  <macro name="locators">
     <choose>
       <if type="article-journal">
         <group delimiter=".">
@@ -208,152 +258,6 @@
           </group>
         </group>
       </else-if>
-    </choose>
-  </macro>
-  <macro name="volume-number-roman">
-    <choose>
-      <if is-numeric="volume">
-        <number font-variant="small-caps" form="roman" variable="volume"/>
-      </if>
-      <else>
-        <text font-variant="small-caps" variable="volume"/>
-      </else>
-    </choose>
-  </macro>
-  <macro name="issue-join-with-space">
-    <choose>
-      <if type="article-journal">
-        <choose>
-          <if variable="volume">
-            <text macro="issued" prefix="(" suffix=")"/>
-          </if>
-        </choose>
-      </if>
-      <else-if match="any" variable="publisher-place publisher">
-        <group delimiter=", " prefix="(" suffix=")">
-          <group delimiter=" ">
-            <choose>
-              <if match="none" variable="title"/>
-              <else-if match="any" type="thesis speech">
-                <text prefix="unpublished " variable="genre"/>
-              </else-if>
-            </choose>
-            <text macro="event"/>
-          </group>
-          <text macro="publisher"/>
-          <text macro="issued"/>
-        </group>
-      </else-if>
-    </choose>
-  </macro>
-  <macro name="issue-join-with-comma">
-    <choose>
-      <if type="article-journal">
-        <choose>
-          <if match="none" variable="volume">
-            <text macro="issued"/>
-          </if>
-        </choose>
-      </if>
-      <else-if match="none" variable="publisher-place publisher">
-        <text macro="issued"/>
-      </else-if>
-    </choose>
-  </macro>
-  <macro name="locators-specific-note">
-    <choose>
-      <if position="first" type="chapter entry-dictionary entry-encyclopedia paper-conference">
-        <group delimiter=", ">
-          <text macro="volume-number-roman"/>
-          <text font-style="italic" text-case="title" variable="volume-title"/>
-        </group>
-      </if>
-      <else-if type="book legislation motion_picture report">
-        <group delimiter=", ">
-          <text macro="volume-number-roman"/>
-          <choose>
-            <if position="first">
-              <text font-style="italic" text-case="title" variable="volume-title"/>
-            </if>
-          </choose>
-        </group>
-      </else-if>
-    </choose>
-  </macro>
-  <macro name="locators-specific-bibliography">
-    <choose>
-      <if type="bill book chapter entry-dictionary entry-encyclopedia graphic legal_case legislation motion_picture paper-conference report song">
-        <group delimiter=", ">
-          <text macro="volume-number-roman"/>
-          <text font-style="italic" text-case="title" variable="volume-title"/>
-        </group>
-      </if>
-    </choose>
-  </macro>
-  <macro name="container-title-note">
-    <group delimiter=" ">
-      <choose>
-        <if match="any" type="chapter entry-dictionary entry-encyclopedia paper-conference">
-          <text term="in"/>
-        </if>
-      </choose>
-      <text font-style="italic" text-case="title" variable="container-title"/>
-    </group>
-  </macro>
-  <macro name="edition-note">
-    <choose>
-      <if match="any" type="bill book chapter entry-dictionary entry-encyclopedia graphic legal_case legislation motion_picture paper-conference report song">
-        <choose>
-          <if is-numeric="edition">
-            <group delimiter=" ">
-              <number form="ordinal" variable="edition"/>
-              <text form="short" term="edition"/>
-            </group>
-          </if>
-          <else>
-            <text variable="edition"/>
-          </else>
-        </choose>
-      </if>
-    </choose>
-  </macro>
-  <macro name="recipient-note">
-    <names variable="recipient">
-      <label form="verb" suffix=" "/>
-      <name/>
-    </names>
-  </macro>
-  <macro name="recipient-short">
-    <names variable="recipient">
-      <label form="verb" suffix=" "/>
-      <name form="short"/>
-    </names>
-  </macro>
-  <macro name="contributors-short">
-    <names variable="author">
-      <name form="short"/>
-      <substitute>
-        <names variable="editor"/>
-        <names variable="translator"/>
-        <text macro="title-sort-substitute"/>
-      </substitute>
-    </names>
-    <text macro="recipient-short"/>
-  </macro>
-  <macro name="locators-newspaper">
-    <choose>
-      <if type="article-newspaper">
-        <group delimiter=", ">
-          <group delimiter=" ">
-            <text variable="edition"/>
-            <text term="edition"/>
-          </group>
-          <group delimiter=" ">
-            <text term="section"/>
-            <text variable="section"/>
-          </group>
-        </group>
-      </if>
     </choose>
   </macro>
   <macro name="event">
@@ -399,10 +303,122 @@
       </else>
     </choose>
   </macro>
+  <macro name="issue-join-with-space">
+    <choose>
+      <if type="article-journal">
+        <choose>
+          <if variable="volume">
+            <text macro="issued" prefix="(" suffix=")"/>
+          </if>
+        </choose>
+      </if>
+      <else-if match="any" variable="publisher-place publisher">
+        <group delimiter=", " prefix="(" suffix=")">
+          <group delimiter=" ">
+            <choose>
+              <if match="none" variable="title"/>
+              <else-if match="any" type="thesis speech">
+                <text prefix="unpublished " variable="genre"/>
+              </else-if>
+            </choose>
+            <text macro="event"/>
+          </group>
+          <text macro="publisher"/>
+          <text macro="issued"/>
+        </group>
+      </else-if>
+    </choose>
+  </macro>
+  <macro name="issue-join-with-comma">
+    <choose>
+      <if type="article-journal">
+        <choose>
+          <if match="none" variable="volume">
+            <text macro="issued"/>
+          </if>
+        </choose>
+      </if>
+      <else-if match="none" variable="publisher-place publisher">
+        <text macro="issued"/>
+      </else-if>
+    </choose>
+  </macro>
+  <macro name="artwork">
+    <choose>
+      <if match="any" type="graphic">
+        <group delimiter=", ">
+          <text variable="medium"/>
+          <text variable="dimensions"/>
+        </group>
+      </if>
+    </choose>
+  </macro>
+  <macro name="locators-newspaper">
+    <choose>
+      <if type="article-newspaper">
+        <group delimiter=", ">
+          <group delimiter=" ">
+            <text variable="edition"/>
+            <text term="edition"/>
+          </group>
+          <group delimiter=" ">
+            <text term="section"/>
+            <text variable="section"/>
+          </group>
+        </group>
+      </if>
+    </choose>
+  </macro>
   <macro name="pages">
     <group delimiter=" ">
       <label form="short" variable="page"/>
       <text variable="page"/>
+    </group>
+  </macro>
+  <macro name="volume-number-roman">
+    <choose>
+      <if is-numeric="volume">
+        <number font-variant="small-caps" form="roman" variable="volume"/>
+      </if>
+      <else>
+        <text font-variant="small-caps" variable="volume"/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="point-locators-volume-note">
+    <choose>
+      <if position="first" type="chapter entry-dictionary entry-encyclopedia paper-conference">
+        <group delimiter=", ">
+          <text macro="volume-number-roman"/>
+          <text font-style="italic" text-case="title" variable="volume-title"/>
+        </group>
+      </if>
+      <else-if type="book legislation motion_picture report">
+        <group delimiter=", ">
+          <text macro="volume-number-roman"/>
+          <choose>
+            <if position="first">
+              <text font-style="italic" text-case="title" variable="volume-title"/>
+            </if>
+          </choose>
+        </group>
+      </else-if>
+    </choose>
+  </macro>
+  <macro name="point-locators-volume">
+    <choose>
+      <if type="bill book chapter entry-dictionary entry-encyclopedia graphic legal_case legislation motion_picture paper-conference report song">
+        <group delimiter=", ">
+          <text macro="volume-number-roman"/>
+          <text font-style="italic" text-case="title" variable="volume-title"/>
+        </group>
+      </if>
+    </choose>
+  </macro>
+  <macro name="point-locators-subsequent">
+    <group delimiter=" ">
+      <label form="short" variable="locator"/>
+      <text variable="locator"/>
     </group>
   </macro>
   <macro name="point-locators">
@@ -422,12 +438,6 @@
           </group>
         </else>
       </choose>
-    </group>
-  </macro>
-  <macro name="point-locators-subsequent">
-    <group delimiter=" ">
-      <label form="short" variable="locator"/>
-      <text variable="locator"/>
     </group>
   </macro>
   <macro name="archive-note">
@@ -472,16 +482,6 @@
       </if>
     </choose>
   </macro>
-  <macro name="artwork">
-    <choose>
-      <if match="any" type="graphic">
-        <group delimiter=", ">
-          <text variable="medium"/>
-          <text variable="dimensions"/>
-        </group>
-      </if>
-    </choose>
-  </macro>
   <citation disambiguate-add-givenname="true" disambiguate-add-names="true">
     <layout delimiter="; " suffix=".">
       <choose>
@@ -489,7 +489,7 @@
           <group delimiter=", ">
             <text macro="contributors-short"/>
             <text macro="title-subsequent"/>
-            <text macro="locators-specific-note"/>
+            <text macro="point-locators-volume-note"/>
             <text macro="point-locators-subsequent"/>
           </group>
         </if>
@@ -509,7 +509,7 @@
                 <text macro="issue-join-with-space"/>
               </group>
               <text macro="issue-join-with-comma"/>
-              <text macro="locators-specific-note"/>
+              <text macro="point-locators-volume-note"/>
               <text macro="locators-newspaper"/>
               <text macro="point-locators"/>
               <text macro="access-note"/>
@@ -522,7 +522,7 @@
   </citation>
   <bibliography delimiter-precedes-et-al="after-inverted-name" hanging-indent="true" subsequent-author-substitute="&#8212;&#8212;">
     <sort>
-      <key macro="author"/>
+      <key macro="contributors"/>
       <key variable="title"/>
     </sort>
     <layout>
@@ -530,18 +530,18 @@
         <group delimiter=", ">
           <group delimiter=" ">
             <group delimiter=", ">
-              <text macro="author"/>
+              <text macro="contributors"/>
               <text macro="title-note"/>
               <text macro="secondary-contributors-note"/>
               <text macro="container-title-note"/>
               <text macro="container-contributors-note"/>
               <text macro="collection-title"/>
-              <text macro="volume"/>
+              <text macro="locators"/>
             </group>
             <text macro="issue-join-with-space"/>
           </group>
           <text macro="issue-join-with-comma"/>
-          <text macro="locators-specific-bibliography"/>
+          <text macro="point-locators-volume"/>
           <text macro="artwork"/>
           <text macro="locators-newspaper"/>
           <text macro="pages"/>

--- a/modern-humanities-research-association.csl
+++ b/modern-humanities-research-association.csl
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<style xmlns="http://purl.org/net/xbiblio/csl" and="text" class="note" default-locale="en-GB" demote-non-dropping-particle="sort-only" et-al-min="4" et-al-use-first="1" names-delimiter=", " page-range-format="minimal-two" version="1.0">
+<style xmlns="http://purl.org/net/xbiblio/csl" and="text" class="note" demote-non-dropping-particle="sort-only" et-al-min="4" et-al-use-first="1" names-delimiter=", " page-range-format="minimal-two" version="1.0" default-locale="en-GB">
   <info>
     <title>Modern Humanities Research Association 4th edition (note with bibliography)</title>
     <title-short>MHRA</title-short>
@@ -489,7 +489,7 @@
       </choose>
     </layout>
   </citation>
-  <bibliography hanging-indent="true" subsequent-author-substitute="———">
+  <bibliography hanging-indent="true" subsequent-author-substitute="&#8212;&#8212;&#8212;">
     <sort>
       <key macro="author"/>
       <key variable="title"/>

--- a/modern-humanities-research-association.csl
+++ b/modern-humanities-research-association.csl
@@ -189,20 +189,6 @@
       </if>
     </choose>
   </macro>
-  <macro name="collection-title">
-    <group delimiter=", ">
-      <choose>
-        <if type="article-journal">
-          <text variable="collection-title"/>
-          <text variable="collection-number"/>
-        </if>
-        <else>
-          <text text-case="title" variable="collection-title"/>
-          <text variable="collection-number"/>
-        </else>
-      </choose>
-    </group>
-  </macro>
   <macro name="edition">
     <choose>
       <if match="any" type="bill book chapter entry-dictionary entry-encyclopedia graphic legal_case legislation motion_picture paper-conference report song">
@@ -223,23 +209,30 @@
   <macro name="locators">
     <choose>
       <if type="article-journal">
-        <choose>
-          <if variable="volume">
-            <group delimiter=".">
-              <text variable="volume"/>
-              <text variable="issue"/>
-            </group>
-          </if>
-          <else>
-            <group delimiter=" ">
-              <text form="short" term="issue"/>
-              <text variable="issue"/>
-            </group>
-          </else>
-        </choose>
+        <group delimiter=", ">
+          <text variable="collection-title"/>
+          <choose>
+            <if variable="volume">
+              <group delimiter=".">
+                <text variable="volume"/>
+                <text variable="issue"/>
+              </group>
+            </if>
+            <else>
+              <group delimiter=" ">
+                <text form="short" term="issue"/>
+                <text variable="issue"/>
+              </group>
+            </else>
+          </choose>
+        </group>
       </if>
       <else-if match="any" type="bill book chapter entry-dictionary entry-encyclopedia graphic legal_case legislation motion_picture paper-conference report song">
         <group delimiter=", ">
+          <group delimiter=", ">
+            <text text-case="title" variable="collection-title"/>
+            <text variable="collection-number"/>
+          </group>
           <text macro="edition"/>
           <group delimiter=" ">
             <number form="numeric" variable="number-of-volumes"/>
@@ -514,7 +507,6 @@
                   <text macro="secondary-contributors"/>
                   <text macro="container-title"/>
                   <text macro="container-contributors"/>
-                  <text macro="collection-title"/>
                   <text macro="locators"/>
                 </group>
                 <text macro="issue-join-with-space"/>
@@ -546,7 +538,6 @@
               <text macro="secondary-contributors"/>
               <text macro="container-title"/>
               <text macro="container-contributors"/>
-              <text macro="collection-title"/>
               <text macro="locators"/>
             </group>
             <text macro="issue-join-with-space"/>

--- a/modern-humanities-research-association.csl
+++ b/modern-humanities-research-association.csl
@@ -56,13 +56,13 @@
       <name form="short"/>
     </names>
   </macro>
-  <macro name="recipient-note">
+  <macro name="recipient">
     <names variable="recipient">
       <label form="verb" suffix=" "/>
       <name/>
     </names>
   </macro>
-  <macro name="recipient">
+  <macro name="communication-recipient">
     <group delimiter=" ">
       <choose>
         <if type="personal_communication">
@@ -76,7 +76,7 @@
           </choose>
         </if>
       </choose>
-      <text macro="recipient-note"/>
+      <text macro="recipient"/>
     </group>
   </macro>
   <macro name="contributors-short">
@@ -97,7 +97,7 @@
         <text macro="title"/>
       </substitute>
     </names>
-    <text macro="recipient-note"/>
+    <text macro="recipient"/>
   </macro>
   <macro name="contributors">
     <group delimiter=". ">
@@ -110,7 +110,7 @@
           <text macro="title"/>
         </substitute>
       </names>
-      <text macro="recipient"/>
+      <text macro="communication-recipient"/>
     </group>
   </macro>
   <macro name="title-subsequent">
@@ -205,7 +205,7 @@
       </choose>
     </group>
   </macro>
-  <macro name="edition-note">
+  <macro name="edition">
     <choose>
       <if match="any" type="bill book chapter entry-dictionary entry-encyclopedia graphic legal_case legislation motion_picture paper-conference report song">
         <choose>
@@ -222,36 +222,27 @@
       </if>
     </choose>
   </macro>
-  <macro name="locators-note">
-    <choose>
-      <if type="article-journal">
-        <group delimiter=".">
-          <text variable="volume"/>
-          <text variable="issue"/>
-        </group>
-      </if>
-      <else-if match="any" type="bill book chapter entry-dictionary entry-encyclopedia graphic legal_case legislation motion_picture paper-conference report song">
-        <group delimiter=", ">
-          <text macro="edition-note"/>
-          <group delimiter=" ">
-            <number form="numeric" variable="number-of-volumes"/>
-            <text form="short" plural="true" term="volume"/>
-          </group>
-        </group>
-      </else-if>
-    </choose>
-  </macro>
   <macro name="locators">
     <choose>
       <if type="article-journal">
-        <group delimiter=".">
-          <text variable="volume"/>
-          <text variable="issue"/>
-        </group>
+        <choose>
+          <if variable="volume">
+            <group delimiter=".">
+              <text variable="volume"/>
+              <text variable="issue"/>
+            </group>
+          </if>
+          <else>
+            <group delimiter=" ">
+              <text form="short" term="issue"/>
+              <text variable="issue"/>
+            </group>
+          </else>
+        </choose>
       </if>
       <else-if match="any" type="bill book chapter entry-dictionary entry-encyclopedia graphic legal_case legislation motion_picture paper-conference report song">
         <group delimiter=", ">
-          <text macro="edition-note"/>
+          <text macro="edition"/>
           <group delimiter=" ">
             <number form="numeric" variable="number-of-volumes"/>
             <text form="short" plural="true" term="volume"/>
@@ -305,11 +296,41 @@
   </macro>
   <macro name="issue-join-with-space">
     <choose>
+      <if type="article-journal" variable="volume">
+        <text macro="issue"/>
+      </if>
+      <else-if type="article-journal" variable="issue">
+        <text macro="issue"/>
+      </else-if>
+      <else-if match="any" variable="publisher-place publisher">
+        <text macro="issue"/>
+      </else-if>
+    </choose>
+  </macro>
+  <macro name="issue-join-with-comma">
+    <choose>
       <if type="article-journal">
         <choose>
-          <if variable="volume">
+          <if match="none" variable="volume issue">
+            <text macro="issue"/>
+          </if>
+        </choose>
+      </if>
+      <else-if match="none" variable="publisher-place publisher">
+        <text macro="issue"/>
+      </else-if>
+    </choose>
+  </macro>
+  <macro name="issue">
+    <choose>
+      <if type="article-journal">
+        <choose>
+          <if match="any" variable="volume issue">
             <text macro="issued" prefix="(" suffix=")"/>
           </if>
+          <else>
+            <text macro="issued"/>
+          </else>
         </choose>
       </if>
       <else-if match="any" variable="publisher-place publisher">
@@ -327,20 +348,9 @@
           <text macro="issued"/>
         </group>
       </else-if>
-    </choose>
-  </macro>
-  <macro name="issue-join-with-comma">
-    <choose>
-      <if type="article-journal">
-        <choose>
-          <if match="none" variable="volume">
-            <text macro="issued"/>
-          </if>
-        </choose>
-      </if>
-      <else-if match="none" variable="publisher-place publisher">
+      <else>
         <text macro="issued"/>
-      </else-if>
+      </else>
     </choose>
   </macro>
   <macro name="artwork">
@@ -440,7 +450,7 @@
       </choose>
     </group>
   </macro>
-  <macro name="archive-note">
+  <macro name="archive">
     <group delimiter=", ">
       <text variable="archive-place"/>
       <text variable="archive"/>
@@ -451,7 +461,7 @@
     <group delimiter=", ">
       <choose>
         <if match="none" type="article-journal bill chapter legal_case legislation paper-conference">
-          <text macro="archive-note"/>
+          <text macro="archive"/>
         </if>
       </choose>
       <choose>
@@ -504,7 +514,7 @@
                   <text macro="container-title"/>
                   <text macro="container-contributors"/>
                   <text macro="collection-title"/>
-                  <text macro="locators-note"/>
+                  <text macro="locators"/>
                 </group>
                 <text macro="issue-join-with-space"/>
               </group>

--- a/modern-humanities-research-association.csl
+++ b/modern-humanities-research-association.csl
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <style xmlns="http://purl.org/net/xbiblio/csl" and="text" class="note" demote-non-dropping-particle="sort-only" et-al-min="4" et-al-use-first="1" page-range-format="minimal-two" version="1.0" default-locale="en-GB">
   <info>
-    <title>Modern Humanities Research Association, 4th edition (full note)</title>
+    <title>Modern Humanities Research Association, 4th edition (note with bibliography)</title>
     <title-short>MHRA</title-short>
     <id>http://www.zotero.org/styles/modern-humanities-research-association</id>
     <link href="http://www.zotero.org/styles/modern-humanities-research-association" rel="self"/>
@@ -31,9 +31,7 @@
   <locale xml:lang="en">
     <terms>
       <term name="et-al">and others</term>
-      <term form="verb-short" name="editor">ed. by</term>
       <term form="short" name="edition">edn</term>
-      <term form="verb-short" name="translator">trans. by</term>
       <term name="folio">
         <single>fol.</single>
         <multiple>fols</multiple>

--- a/modern-humanities-research-association.csl
+++ b/modern-humanities-research-association.csl
@@ -25,7 +25,7 @@
     <category field="generic-base"/>
     <category field="humanities"/>
     <summary>MHRA format with full notes and bibliography</summary>
-    <updated>2025-02-02T22:54:15+00:00</updated>
+    <updated>2025-02-02T22:59:55+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale xml:lang="en">
@@ -43,7 +43,7 @@
   <macro name="author">
     <group delimiter=", ">
       <names variable="author">
-        <name/>
+        <name delimiter-precedes-last="always" name-as-sort-order="first"/>
         <label form="short" prefix=", "/>
         <substitute>
           <names variable="editor"/>
@@ -517,7 +517,7 @@
       </choose>
     </layout>
   </citation>
-  <bibliography delimiter-precedes-last="always" hanging-indent="true" name-as-sort-order="first" subsequent-author-substitute="&#8212;&#8212;">
+  <bibliography hanging-indent="true" subsequent-author-substitute="&#8212;&#8212;">
     <sort>
       <key macro="author"/>
       <key variable="title"/>

--- a/modern-humanities-research-association.csl
+++ b/modern-humanities-research-association.csl
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <style xmlns="http://purl.org/net/xbiblio/csl" and="text" class="note" delimiter-precedes-et-al="after-inverted-name" demote-non-dropping-particle="sort-only" et-al-min="4" et-al-use-first="1" names-delimiter=", " page-range-format="minimal-two" version="1.0" default-locale="en-GB">
   <info>
-    <title>Modern Humanities Research Association Style Guide, 4th edition (note with bibliography)</title>
+    <title>Modern Humanities Research Association Style Guide, 4th edition (full note)</title>
     <title-short>MHRA</title-short>
     <id>http://www.zotero.org/styles/modern-humanities-research-association</id>
     <link href="http://www.zotero.org/styles/modern-humanities-research-association" rel="self"/>

--- a/modern-humanities-research-association.csl
+++ b/modern-humanities-research-association.csl
@@ -25,7 +25,7 @@
     <category field="generic-base"/>
     <category field="humanities"/>
     <summary>MHRA format with full notes and bibliography</summary>
-    <updated>2025-02-03T14:38:03+00:00</updated>
+    <updated>2025-02-03T14:44:03+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale xml:lang="en">
@@ -444,12 +444,12 @@
           <text macro="archive-note"/>
         </if>
       </choose>
+      <choose>
+        <if variable="DOI">
+          <text prefix="doi:" variable="DOI"/>
+        </if>
+      </choose>
     </group>
-    <choose>
-      <if variable="DOI">
-        <text prefix="doi:" variable="DOI"/>
-      </if>
-    </choose>
   </macro>
   <macro name="URL">
     <choose>

--- a/modern-humanities-research-association.csl
+++ b/modern-humanities-research-association.csl
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<style xmlns="http://purl.org/net/xbiblio/csl" and="text" class="note" delimiter-precedes-et-al="after-inverted-name" demote-non-dropping-particle="sort-only" et-al-min="4" et-al-use-first="1" page-range-format="minimal-two" version="1.0" default-locale="en-GB">
+<style xmlns="http://purl.org/net/xbiblio/csl" and="text" class="note" demote-non-dropping-particle="sort-only" et-al-min="4" et-al-use-first="1" page-range-format="minimal-two" version="1.0" default-locale="en-GB">
   <info>
     <title>Modern Humanities Research Association, 4th edition (full note)</title>
     <title-short>MHRA Style Guide</title-short>
@@ -25,7 +25,7 @@
     <category field="generic-base"/>
     <category field="humanities"/>
     <summary>MHRA format with full notes and bibliography</summary>
-    <updated>2025-02-03T09:53:36+00:00</updated>
+    <updated>2025-02-03T10:00:18+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale xml:lang="en">
@@ -522,7 +522,7 @@
       </choose>
     </layout>
   </citation>
-  <bibliography hanging-indent="true" subsequent-author-substitute="&#8212;&#8212;">
+  <bibliography delimiter-precedes-et-al="after-inverted-name" hanging-indent="true" subsequent-author-substitute="&#8212;&#8212;">
     <sort>
       <key macro="author"/>
       <key variable="title"/>

--- a/modern-humanities-research-association.csl
+++ b/modern-humanities-research-association.csl
@@ -41,7 +41,7 @@
     </terms>
   </locale>
   <macro name="author">
-    <group delimiter=", ">
+    <group delimiter=". ">
       <names variable="author">
         <name delimiter-precedes-last="always" name-as-sort-order="first"/>
         <label form="short" prefix=", "/>

--- a/modern-humanities-research-association.csl
+++ b/modern-humanities-research-association.csl
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<style xmlns="http://purl.org/net/xbiblio/csl" and="text" class="note" delimiter-precedes-et-al="after-inverted-name" demote-non-dropping-particle="sort-only" et-al-min="4" et-al-use-first="1" names-delimiter=", " page-range-format="minimal-two" version="1.0" default-locale="en-GB">
+<style xmlns="http://purl.org/net/xbiblio/csl" and="text" class="note" delimiter-precedes-et-al="after-inverted-name" demote-non-dropping-particle="sort-only" et-al-min="4" et-al-use-first="1" page-range-format="minimal-two" version="1.0" default-locale="en-GB">
   <info>
     <title>Modern Humanities Research Association, 4th edition (full note)</title>
     <title-short>MHRA Style Guide</title-short>
@@ -25,7 +25,7 @@
     <category field="generic-base"/>
     <category field="humanities"/>
     <summary>MHRA format with full notes and bibliography</summary>
-    <updated>2025-02-03T09:28:39+00:00</updated>
+    <updated>2025-02-03T09:53:36+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale xml:lang="en">
@@ -73,7 +73,6 @@
   </macro>
   <macro name="contributors-note">
     <names variable="author">
-      <name/>
       <label form="short" prefix=", "/>
       <substitute>
         <text macro="title-note"/>
@@ -134,13 +133,13 @@
       <group delimiter=" ">
         <choose>
           <if match="any" variable="container-author reviewed-author">
-            <names variable="container-author reviewed-author">
+            <names variable="container-author reviewed-author" delimiter=", ">
               <label form="verb-short" suffix=" " text-case="lowercase"/>
               <name/>
             </names>
           </if>
         </choose>
-        <names variable="editor translator director">
+        <names variable="editor translator director" delimiter=", ">
           <label form="verb-short" suffix=" " text-case="lowercase"/>
           <name/>
         </names>
@@ -461,10 +460,14 @@
           <if variable="URL">
             <group delimiter=" ">
               <text prefix="&lt;" suffix="&gt;" variable="URL"/>
-              <group delimiter=" " prefix="[" suffix="]">
-                <text term="accessed"/>
-                <date form="text" variable="accessed"/>
-              </group>
+              <choose>
+                <if match="none" variable="issued">
+                  <group delimiter=" " prefix="[" suffix="]">
+                    <text term="accessed"/>
+                    <date form="text" variable="accessed"/>
+                  </group>
+                </if>
+              </choose>
             </group>
           </if>
         </choose>

--- a/modern-humanities-research-association.csl
+++ b/modern-humanities-research-association.csl
@@ -2,7 +2,7 @@
 <style xmlns="http://purl.org/net/xbiblio/csl" and="text" class="note" demote-non-dropping-particle="sort-only" et-al-min="4" et-al-use-first="1" page-range-format="minimal-two" version="1.0" default-locale="en-GB">
   <info>
     <title>Modern Humanities Research Association, 4th edition (full note)</title>
-    <title-short>MHRA Style Guide</title-short>
+    <title-short>MHRA</title-short>
     <id>http://www.zotero.org/styles/modern-humanities-research-association</id>
     <link href="http://www.zotero.org/styles/modern-humanities-research-association" rel="self"/>
     <link href="https://www.mhra.org.uk/style/" rel="documentation"/>
@@ -24,7 +24,7 @@
     <category citation-format="note"/>
     <category field="generic-base"/>
     <category field="humanities"/>
-    <summary>MHRA format with full notes and bibliography</summary>
+    <summary>MHRA Style Guide full notes and bibliography</summary>
     <updated>2025-02-03T14:44:03+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
@@ -263,7 +263,10 @@
         <text variable="publisher"/>
       </if>
       <else>
-        <text variable="publisher"/>
+        <group delimiter=": ">
+          <!-- <text variable="publisher-place"/> -->
+          <text variable="publisher"/>
+        </group>
       </else>
     </choose>
   </macro>

--- a/modern-humanities-research-association.csl
+++ b/modern-humanities-research-association.csl
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<style xmlns="http://purl.org/net/xbiblio/csl" class="note" version="1.0" demote-non-dropping-particle="sort-only" page-range-format="minimal-two" default-locale="en-GB">
+<style xmlns="http://purl.org/net/xbiblio/csl" and="text" class="note" default-locale="en-GB" demote-non-dropping-particle="sort-only" et-al-min="4" et-al-use-first="1" names-delimiter=", " page-range-format="minimal-two" version="1.0">
   <info>
     <title>Modern Humanities Research Association 4th edition (note with bibliography)</title>
     <title-short>MHRA</title-short>
@@ -8,10 +8,11 @@
     <link href="https://www.mhra.org.uk/style/" rel="documentation"/>
     <author>
       <name>Rintze Zelle</name>
-      <uri>http://twitter.com/rintzezelle</uri>
+      <uri>https://orcid.org/0000-0003-1779-8883</uri>
     </author>
     <contributor>
       <name>Sebastian Karcher</name>
+      <uri>https://orcid.org/0000-0001-8249-7388</uri>
     </contributor>
     <contributor>
       <name>Andrew Dunning</name>
@@ -23,15 +24,15 @@
     <category citation-format="note"/>
     <category field="generic-base"/>
     <summary>MHRA format with full notes and bibliography</summary>
-    <updated>2025-01-31T00:46:42+00:00</updated>
+    <updated>2025-02-02T21:12:55+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale xml:lang="en">
     <terms>
       <term name="et-al">and others</term>
-      <term name="editor" form="verb-short">ed. by</term>
-      <term name="edition" form="short">edn</term>
-      <term name="translator" form="verb-short">trans. by</term>
+      <term form="verb-short" name="editor">ed. by</term>
+      <term form="short" name="edition">edn</term>
+      <term form="verb-short" name="translator">trans. by</term>
       <term name="folio">
         <single>fol.</single>
         <multiple>fols</multiple>
@@ -39,10 +40,10 @@
     </terms>
   </locale>
   <macro name="author">
-    <group delimiter=". ">
+    <group delimiter=", ">
       <names variable="author">
-        <name name-as-sort-order="first" and="text" sort-separator=", " delimiter=", " delimiter-precedes-last="always"/>
-        <label form="short" prefix=", " suffix="."/>
+        <name delimiter-precedes-last="always" name-as-sort-order="first"/>
+        <label form="short" prefix=", "/>
         <substitute>
           <names variable="editor"/>
           <names variable="translator"/>
@@ -58,7 +59,7 @@
         <if type="personal_communication">
           <choose>
             <if variable="genre">
-              <text variable="genre" text-case="capitalize-first"/>
+              <text text-case="capitalize-first" variable="genre"/>
             </if>
             <else>
               <text term="letter" text-case="capitalize-first"/>
@@ -71,7 +72,7 @@
   </macro>
   <macro name="contributors-note">
     <names variable="author">
-      <name and="text" sort-separator=", " delimiter=", "/>
+      <name/>
       <label form="short" prefix=", "/>
       <substitute>
         <text macro="title-note"/>
@@ -81,47 +82,49 @@
   </macro>
   <macro name="title-note">
     <choose>
-      <if variable="title" match="none">
+      <if match="none" variable="title">
         <text variable="genre"/>
       </if>
-      <else-if type="bill book graphic legislation motion_picture report song" match="any">
-        <text variable="title" text-case="title" font-style="italic"/>
-        <group delimiter=" " prefix=", ">
-          <text term="version"/>
-          <text variable="version"/>
+      <else-if match="any" type="bill book graphic legislation motion_picture report song">
+        <group delimiter=", ">
+          <text font-style="italic" text-case="title" variable="title"/>
+          <group delimiter=" ">
+            <text term="version"/>
+            <text variable="version"/>
+          </group>
         </group>
       </else-if>
-      <else-if type="legal_case interview" match="any">
+      <else-if match="any" type="legal_case interview">
         <text variable="title"/>
       </else-if>
       <else-if variable="reviewed-author">
-        <text variable="title" font-style="italic" prefix="review of "/>
+        <text font-style="italic" prefix="review of " variable="title"/>
       </else-if>
       <else>
-        <text variable="title" text-case="title" quotes="true"/>
+        <text quotes="true" text-case="title" variable="title"/>
       </else>
     </choose>
   </macro>
   <macro name="title-subsequent">
     <choose>
-      <if variable="title" match="none">
+      <if match="none" variable="title">
         <text macro="issued"/>
       </if>
-      <else-if type="bill book graphic legal_case legislation motion_picture report song" match="any">
-        <text variable="title" font-style="italic" text-case="title" form="short"/>
+      <else-if match="any" type="bill book graphic legal_case legislation motion_picture report song">
+        <text font-style="italic" form="short" text-case="title" variable="title"/>
       </else-if>
       <else>
-        <text variable="title" quotes="true" text-case="title" form="short"/>
+        <text form="short" quotes="true" text-case="title" variable="title"/>
       </else>
     </choose>
   </macro>
   <macro name="title-sort-substitute">
     <choose>
-      <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
-        <text variable="title" font-style="italic" text-case="title" form="short"/>
+      <if match="any" type="bill book graphic legal_case legislation motion_picture report song">
+        <text font-style="italic" form="short" text-case="title" variable="title"/>
       </if>
       <else>
-        <text variable="title" quotes="true" text-case="title" form="short"/>
+        <text form="short" quotes="true" text-case="title" variable="title"/>
       </else>
     </choose>
   </macro>
@@ -129,32 +132,30 @@
     <group delimiter=", ">
       <group delimiter=" ">
         <choose>
-          <if variable="container-author reviewed-author" match="any">
-            <group>
-              <names variable="container-author reviewed-author">
-                <label form="verb-short" text-case="lowercase" suffix=" "/>
-                <name and="text" delimiter=", "/>
-              </names>
-            </group>
+          <if match="any" variable="container-author reviewed-author">
+            <names variable="container-author reviewed-author">
+              <label form="verb-short" suffix=" " text-case="lowercase"/>
+              <name/>
+            </names>
           </if>
         </choose>
+        <names variable="editor translator director">
+          <label form="verb-short" suffix=" " text-case="lowercase"/>
+          <name/>
+        </names>
       </group>
-      <names variable="editor translator director" delimiter=", ">
-        <label form="verb-short" text-case="lowercase" suffix=" "/>
-        <name and="text" delimiter=", "/>
-      </names>
     </group>
   </macro>
   <macro name="secondary-contributors-note">
     <choose>
-      <if type="chapter paper-conference" match="none">
+      <if match="none" type="chapter paper-conference">
         <text macro="editor-translator"/>
       </if>
     </choose>
   </macro>
   <macro name="container-contributors-note">
     <choose>
-      <if type="chapter paper-conference" match="any">
+      <if match="any" type="chapter paper-conference">
         <text macro="editor-translator"/>
       </if>
     </choose>
@@ -167,7 +168,7 @@
           <text variable="collection-number"/>
         </if>
         <else>
-          <text variable="collection-title" text-case="title"/>
+          <text text-case="title" variable="collection-title"/>
           <text variable="collection-number"/>
         </else>
       </choose>
@@ -181,12 +182,12 @@
           <text variable="issue"/>
         </group>
       </if>
-      <else-if type="bill book chapter graphic legal_case legislation motion_picture paper-conference report song" match="any">
+      <else-if match="any" type="bill book chapter graphic legal_case legislation motion_picture paper-conference report song">
         <group delimiter=", ">
           <text macro="edition-note"/>
-          <group>
-            <number variable="number-of-volumes" form="numeric"/>
-            <text term="volume" form="short" prefix=" " plural="true"/>
+          <group delimiter=" ">
+            <number form="numeric" variable="number-of-volumes"/>
+            <text form="short" plural="true" term="volume"/>
           </group>
         </group>
       </else-if>
@@ -200,12 +201,12 @@
           <text variable="issue"/>
         </group>
       </if>
-      <else-if type="bill book chapter graphic legal_case legislation motion_picture paper-conference report song" match="any">
+      <else-if match="any" type="bill book chapter graphic legal_case legislation motion_picture paper-conference report song">
         <group delimiter=", ">
           <text macro="edition-note"/>
-          <group>
-            <number variable="number-of-volumes" form="numeric"/>
-            <text term="volume" form="short" prefix=" " plural="true"/>
+          <group delimiter=" ">
+            <number form="numeric" variable="number-of-volumes"/>
+            <text form="short" plural="true" term="volume"/>
           </group>
         </group>
       </else-if>
@@ -223,13 +224,13 @@
           </else>
         </choose>
       </if>
-      <else-if variable="publisher-place publisher" match="any">
-        <group prefix=" (" suffix=")" delimiter=", ">
+      <else-if match="any" variable="publisher-place publisher">
+        <group delimiter=", " prefix=" (" suffix=")">
           <group delimiter=" ">
             <choose>
-              <if variable="title" match="none"/>
-              <else-if type="thesis speech" match="any">
-                <text variable="genre" prefix="unpublished "/>
+              <if match="none" variable="title"/>
+              <else-if match="any" type="thesis speech">
+                <text prefix="unpublished " variable="genre"/>
               </else-if>
             </choose>
             <text macro="event"/>
@@ -245,34 +246,36 @@
   </macro>
   <macro name="locators-specific-note">
     <choose>
-      <if type="bill book chapter graphic legal_case legislation motion_picture paper-conference report song" match="any">
+      <if match="any" type="bill book chapter graphic legal_case legislation motion_picture paper-conference report song">
         <choose>
           <if is-numeric="volume">
-            <number variable="volume" form="roman" font-variant="small-caps"/>
+            <number font-variant="small-caps" form="roman" variable="volume"/>
           </if>
           <else>
-            <text variable="volume" font-variant="small-caps"/>
+            <text font-variant="small-caps" variable="volume"/>
           </else>
         </choose>
       </if>
     </choose>
   </macro>
   <macro name="container-title-note">
-    <choose>
-      <if type="chapter paper-conference" match="any">
-        <text term="in" suffix=" "/>
-      </if>
-    </choose>
-    <text variable="container-title" text-case="title" font-style="italic"/>
+    <group delimiter=" ">
+      <choose>
+        <if match="any" type="chapter paper-conference">
+          <text term="in"/>
+        </if>
+      </choose>
+      <text font-style="italic" text-case="title" variable="container-title"/>
+    </group>
   </macro>
   <macro name="edition-note">
     <choose>
-      <if type="bill book chapter graphic legal_case legislation motion_picture paper-conference report song" match="any">
+      <if match="any" type="bill book chapter graphic legal_case legislation motion_picture paper-conference report song">
         <choose>
           <if is-numeric="edition">
             <group delimiter=" ">
-              <number variable="edition" form="ordinal"/>
-              <text term="edition" form="short"/>
+              <number form="ordinal" variable="edition"/>
+              <text form="short" term="edition"/>
             </group>
           </if>
           <else>
@@ -283,20 +286,20 @@
     </choose>
   </macro>
   <macro name="recipient-note">
-    <names variable="recipient" delimiter=", ">
-      <label form="verb" prefix=" " suffix=" "/>
-      <name and="text" delimiter=", "/>
+    <names variable="recipient">
+      <label form="verb" suffix=" "/>
+      <name/>
     </names>
   </macro>
   <macro name="recipient-short">
     <names variable="recipient">
-      <label form="verb" prefix=" " suffix=" "/>
-      <name form="short" and="text" delimiter=", "/>
+      <label form="verb" suffix=" "/>
+      <name form="short"/>
     </names>
   </macro>
   <macro name="contributors-short">
     <names variable="author">
-      <name form="short" and="text" sort-separator=", " delimiter=", "/>
+      <name form="short"/>
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
@@ -313,8 +316,8 @@
             <text variable="edition"/>
             <text term="edition"/>
           </group>
-          <group>
-            <text term="section" suffix=" "/>
+          <group delimiter=" ">
+            <text term="section"/>
             <text variable="section"/>
           </group>
         </group>
@@ -322,8 +325,8 @@
     </choose>
   </macro>
   <macro name="event">
-    <group>
-      <text term="presented at" suffix=" "/>
+    <group delimiter=" ">
+      <text term="presented at"/>
       <text variable="event"/>
     </group>
   </macro>
@@ -339,10 +342,10 @@
   </macro>
   <macro name="issued">
     <choose>
-      <if type="report article-newspaper article-magazine personal_communication" match="any">
-        <date variable="issued">
-          <date-part name="day" suffix=" "/>
-          <date-part name="month" suffix=" "/>
+      <if match="any" type="report article-newspaper article-magazine personal_communication">
+        <date delimiter=" " variable="issued">
+          <date-part name="day"/>
+          <date-part name="month"/>
           <date-part name="year"/>
         </date>
       </if>
@@ -356,19 +359,21 @@
   <macro name="pages">
     <choose>
       <if type="article-journal">
-        <group delimiter=" " prefix=", ">
-          <label variable="page" form="short"/>
+        <group delimiter=" ">
+          <label form="short" variable="page"/>
           <text variable="page"/>
         </group>
       </if>
       <else>
         <choose>
           <if variable="volume">
-            <text variable="page" prefix=", "/>
+            <text variable="page"/>
           </if>
           <else>
-            <label variable="page" form="short" prefix=", " suffix=" "/>
-            <text variable="page"/>
+            <group delimiter=" ">
+              <label form="short" variable="page"/>
+              <text variable="page"/>
+            </group>
           </else>
         </choose>
       </else>
@@ -378,20 +383,24 @@
     <text macro="pages"/>
     <choose>
       <if variable="page">
-        <group prefix=" (" suffix=")">
-          <label variable="locator" form="short" suffix=" "/>
+        <group delimiter=" " prefix=" (" suffix=")">
+          <label form="short" variable="locator"/>
           <text variable="locator"/>
         </group>
       </if>
       <else>
-        <label variable="locator" form="short" prefix=", " suffix=" "/>
-        <text variable="locator"/>
+        <group delimiter=" ">
+          <label form="short" variable="locator"/>
+          <text variable="locator"/>
+        </group>
       </else>
     </choose>
   </macro>
   <macro name="point-locators-subsequent">
-    <label variable="locator" form="short" prefix=", " suffix=" "/>
-    <text variable="locator"/>
+    <group delimiter=" ">
+      <label variable="locator" form="short"/>
+      <text variable="locator"/>
+    </group>
   </macro>
   <macro name="archive-note">
     <group delimiter=", ">
@@ -403,35 +412,41 @@
   <macro name="access-note">
     <group delimiter=", ">
       <choose>
-        <if type="article-journal bill chapter legal_case legislation paper-conference" match="none">
-          <text macro="archive-note" prefix=", "/>
+        <if match="none" type="article-journal bill chapter legal_case legislation paper-conference">
+          <text macro="archive-note"/>
         </if>
       </choose>
     </group>
     <choose>
       <if variable="DOI">
-        <text variable="DOI" prefix=", doi:"/>
+        <text prefix="doi:" variable="DOI"/>
       </if>
-      <else>
+    </choose>
+  </macro>
+  <macro name="URL">
+    <choose>
+      <if match="none" variable="DOI">
         <choose>
           <if variable="URL">
-            <text variable="URL" prefix=" &lt;" suffix="&gt;"/>
-            <group prefix=" [" suffix="]">
-              <text term="accessed"/>
-              <date variable="accessed">
-                <date-part name="day" prefix=" "/>
-                <date-part name="month" prefix=" "/>
-                <date-part name="year" prefix=" "/>
-              </date>
+            <group delimiter=" ">
+              <text prefix="&lt;" suffix="&gt;" variable="URL"/>
+              <group delimiter=" " prefix="[" suffix="]">
+                <text term="accessed"/>
+                <date delimiter=" " variable="accessed">
+                  <date-part name="day"/>
+                  <date-part name="month"/>
+                  <date-part name="year"/>
+                </date>
+              </group>
             </group>
           </if>
         </choose>
-      </else>
+      </if>
     </choose>
   </macro>
   <macro name="artwork">
     <choose>
-      <if type="graphic" match="any">
+      <if match="any" type="graphic">
         <group delimiter=", ">
           <text variable="medium"/>
           <text variable="dimensions"/>
@@ -439,16 +454,16 @@
       </if>
     </choose>
   </macro>
-  <citation et-al-min="4" et-al-use-first="1" disambiguate-add-names="true" disambiguate-add-givenname="true">
-    <layout suffix="." delimiter="; ">
+  <citation disambiguate-add-givenname="true" disambiguate-add-names="true">
+    <layout delimiter="; " suffix=".">
       <choose>
         <if position="subsequent">
           <group delimiter=", ">
             <text macro="contributors-short"/>
             <text macro="title-subsequent"/>
             <text macro="locators-specific-note"/>
+            <text macro="point-locators-subsequent"/>
           </group>
-          <text macro="point-locators-subsequent"/>
         </if>
         <else>
           <group delimiter=", ">
@@ -460,16 +475,21 @@
             <text macro="collection-title"/>
             <text macro="locators-note"/>
           </group>
-          <text macro="issue-note"/>
-          <text macro="locators-specific-note" prefix=", "/>
-          <text macro="locators-newspaper" prefix=", "/>
-          <text macro="point-locators"/>
-          <text macro="access-note"/>
+          <group delimiter=" ">
+            <group delimiter=", ">
+              <text macro="issue-note"/>
+              <text macro="locators-specific-note"/>
+              <text macro="locators-newspaper"/>
+              <text macro="point-locators"/>
+              <text macro="access-note"/>
+            </group>
+            <text macro="URL"/>
+          </group>
         </else>
       </choose>
     </layout>
   </citation>
-  <bibliography hanging-indent="true" et-al-min="7" et-al-use-first="6" subsequent-author-substitute="&#8212;&#8212;&#8212;">
+  <bibliography hanging-indent="true" subsequent-author-substitute="———">
     <sort>
       <key macro="author"/>
       <key variable="title"/>
@@ -484,12 +504,17 @@
         <text macro="collection-title"/>
         <text macro="volume"/>
       </group>
-      <text macro="issue-note"/>
-      <text macro="locators-specific-note" prefix=", "/>
-      <text macro="artwork" prefix=", "/>
-      <text macro="locators-newspaper" prefix=", "/>
-      <text macro="pages"/>
-      <text macro="access-note"/>
+      <group delimiter=" ">
+        <group delimiter=", ">
+          <text macro="issue-note"/>
+          <text macro="locators-specific-note"/>
+          <text macro="artwork"/>
+          <text macro="locators-newspaper"/>
+          <text macro="pages"/>
+          <text macro="access-note"/>
+        </group>
+        <text macro="URL"/>
+      </group>
     </layout>
   </bibliography>
 </style>

--- a/modern-humanities-research-association.csl
+++ b/modern-humanities-research-association.csl
@@ -25,7 +25,7 @@
     <category field="generic-base"/>
     <category field="humanities"/>
     <summary>MHRA format with full notes and bibliography</summary>
-    <updated>2025-02-03T10:00:18+00:00</updated>
+    <updated>2025-02-03T14:35:07+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale xml:lang="en">
@@ -130,20 +130,18 @@
   </macro>
   <macro name="editor-translator">
     <group delimiter=", ">
-      <group delimiter=" ">
-        <choose>
-          <if match="any" variable="container-author reviewed-author">
-            <names variable="container-author reviewed-author" delimiter=", ">
-              <label form="verb-short" suffix=" " text-case="lowercase"/>
-              <name/>
-            </names>
-          </if>
-        </choose>
-        <names variable="editor translator director" delimiter=", ">
-          <label form="verb-short" suffix=" " text-case="lowercase"/>
-          <name/>
-        </names>
-      </group>
+      <choose>
+        <if match="any" variable="container-author reviewed-author">
+          <names delimiter=", " variable="container-author reviewed-author">
+            <label form="verb-short" suffix=" " text-case="lowercase"/>
+            <name/>
+          </names>
+        </if>
+      </choose>
+      <names delimiter=", " variable="editor translator director">
+        <label form="verb-short" suffix=" " text-case="lowercase"/>
+        <name/>
+      </names>
     </group>
   </macro>
   <macro name="secondary-contributors-note">

--- a/modern-humanities-research-association.csl
+++ b/modern-humanities-research-association.csl
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
-<style xmlns="http://purl.org/net/xbiblio/csl" class="note" version="1.0" demote-non-dropping-particle="sort-only" page-range-format="chicago" default-locale="en-GB">
+<style xmlns="http://purl.org/net/xbiblio/csl" class="note" version="1.0" demote-non-dropping-particle="sort-only" page-range-format="minimal-two" default-locale="en-GB">
   <info>
     <title>Modern Humanities Research Association 4th edition (note with bibliography)</title>
     <title-short>MHRA</title-short>
     <id>http://www.zotero.org/styles/modern-humanities-research-association</id>
     <link href="http://www.zotero.org/styles/modern-humanities-research-association" rel="self"/>
-    <link href="http://www.mhra.org.uk/Publications/Books/StyleGuide/download.shtml" rel="documentation"/>
+    <link href="https://www.mhra.org.uk/style/" rel="documentation"/>
     <author>
       <name>Rintze Zelle</name>
       <uri>http://twitter.com/rintzezelle</uri>
@@ -23,7 +23,7 @@
     <category citation-format="note"/>
     <category field="generic-base"/>
     <summary>MHRA format with full notes and bibliography</summary>
-    <updated>2024-10-30T15:33:25+00:00</updated>
+    <updated>2025-01-31T00:46:42+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale xml:lang="en">


### PR DESCRIPTION
- Implement further changes from the MHRA Style Guide, 4th edition, notably the number of authors used for et-al abbreviation and the number range abbreviation format.
- Improve the naming of macros for better consistency and clarity: macros appear in the order of the bibliography, with dependent macros appearing immediately before their first usage.
- Enhance the handling of contributors, titles, and publication details.
- Convert all affixes where possible to delimiters.