### PR TITLE
Create apa-single-spaced-no-url.csl

### DIFF
--- a/apa-single-spaced-no-url.csl
+++ b/apa-single-spaced-no-url.csl
@@ -1681,27 +1681,7 @@
     </group>
   </macro>
   <!--
-  <macro name="access">
-    <choose>
-      <if variable="DOI" match="any">
-        <text variable="DOI" prefix="https://doi.org/"/>
-      </if>
-      <else-if variable="URL">
-        <group delimiter=" ">
-          <choose>
-            <if variable="issued status" match="none">
-              <group delimiter=" ">
-                <text term="retrieved" text-case="capitalize-first"/>
-                <date variable="accessed" form="text" suffix=","/>
-                <text term="from"/>
-              </group>
-            </if>
-          </choose>
-          <text variable="URL"/>
-        </group>
-      </else-if>
-    </choose>
-  </macro>
+  <macro name="access"><choose><if variable="DOI" match="any"><text variable="DOI" prefix="https://doi.org/"/></if><else-if variable="URL"><group delimiter=" "><choose><if variable="issued status" match="none"><group delimiter=" "><text term="retrieved" text-case="capitalize-first"/><date variable="accessed" form="text" suffix=","/><text term="from"/></group></if></choose><text variable="URL"/></group></else-if></choose></macro>
   -->
   <macro name="access">
     <text value=""/>


### PR DESCRIPTION
This is modified from `apa-single-spaced.csl`. No URLs are shown with this style (to save more space).