### PR TITLE
Updated OSCOLA CSL style that uses journal abbreviations, if they are…

### DIFF
--- a/oscola-no-ibid.csl
+++ b/oscola-no-ibid.csl
@@ -10,10 +10,13 @@
     <author>
       <name>Sebastian Karcher</name>
     </author>
+    <contributor>
+      <name>Brenton M. Wiernik</name>
+    </contributor>
     <category citation-format="note"/>
     <category field="law"/>
     <summary>The OSCOLA Standards with no ibid. For a Zotero Group showing data-entry in Zotero see: https://www.zotero.org/groups/oscola_samples/items/order/itemType</summary>
-    <updated>2013-11-15T01:14:57+00:00</updated>
+    <updated>2025-08-26T01:14:57+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale>
@@ -414,6 +417,16 @@
                   </if>
                 </choose>
               </if>
+              <else-if type="article-journal" match="any">
+                <choose>
+                  <if match="any" variable="container-title-short">
+                    <text variable="container-title-short" form="short" strip-periods="true"/>
+                  </if>
+                  <else>
+                    <text variable="container-title" strip-periods="true"/>
+                  </else>
+                </choose>
+              </else-if>
               <else-if type="article-magazine article-newspaper" match="any">
                 <text variable="container-title" font-style="italic"/>
               </else-if>

--- a/oscola.csl
+++ b/oscola.csl
@@ -1,4 +1,5 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+﻿
+<?xml version="1.0" encoding="utf-8"?>
 <style xmlns="http://purl.org/net/xbiblio/csl" class="note" version="1.0" demote-non-dropping-particle="never" default-locale="en-GB">
   <info>
     <title>OSCOLA (Oxford University Standard for Citation of Legal Authorities)</title>

--- a/oscola.csl
+++ b/oscola.csl
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <style xmlns="http://purl.org/net/xbiblio/csl" class="note" version="1.0" demote-non-dropping-particle="never" default-locale="en-GB">
   <!-- This style was edited with the Visual CSL Editor (https://editor.citationstyles.org/visualEditor/) -->
   <info>

--- a/oscola.csl
+++ b/oscola.csl
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <style xmlns="http://purl.org/net/xbiblio/csl" class="note" version="1.0" demote-non-dropping-particle="never" default-locale="en-GB">
+  <!-- This style was edited with the Visual CSL Editor (https://editor.citationstyles.org/visualEditor/) -->
   <info>
     <title>OSCOLA (Oxford University Standard for Citation of Legal Authorities)</title>
     <title-short>OSCOLA</title-short>
@@ -10,10 +11,13 @@
     <author>
       <name>Sebastian Karcher</name>
     </author>
+    <contributor>
+      <name>Aaron Timoshanko</name>
+    </contributor>
     <category citation-format="note"/>
     <category field="law"/>
     <summary>The OSCOLA Standards. For a Zotero Group showing data-entry in Zotero see: https://www.zotero.org/groups/oscola_samples/items/order/itemType</summary>
-    <updated>2024-08-30T01:14:57+00:00</updated>
+    <updated>2025-02-23T10:56:32+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale>
@@ -38,9 +42,7 @@
       <term name="et-al">and others</term>
     </terms>
   </locale>
-  <!--Authors and Persons-->
   <macro name="author-note">
-    <!--for bills & hearing this should start with jurisdiction once available-->
     <choose>
       <if type="interview">
         <group delimiter=", ">
@@ -123,7 +125,6 @@
     </choose>
   </macro>
   <macro name="author">
-    <!--for bills & hearing this should start with jurisdiction once available-->
     <choose>
       <if type="interview">
         <group delimiter=", ">
@@ -184,7 +185,6 @@
       </names>
     </group>
   </macro>
-  <!-- Titles -->
   <macro name="title">
     <choose>
       <if type="book motion_picture treaty" match="any">
@@ -224,7 +224,6 @@
       </else>
     </choose>
   </macro>
-  <!--Dates-->
   <macro name="issued-year">
     <date variable="issued" form="text" date-parts="year"/>
   </macro>
@@ -242,7 +241,6 @@
             <text macro="issued-year" prefix="(" suffix=")"/>
           </else-if>
           <else-if variable="container-title volume number" match="any">
-            <!--no year in square brackets for unreported case w/o medium neutral citation-->
             <text macro="issued-year" prefix="[" suffix="]"/>
           </else-if>
         </choose>
@@ -252,7 +250,6 @@
       </else-if>
     </choose>
   </macro>
-  <!--publication info -->
   <macro name="publisher">
     <choose>
       <if type="book chapter broadcast personal_communication manuscript paper-conference article-newspaper report legislation motion_picture speech interview thesis entry-encyclopedia webpage post-weblog article" match="any">
@@ -267,18 +264,15 @@
                 <date variable="issued" form="text"/>
               </else-if>
               <else-if type="legislation bill" match="any">
-                <!--this should be jurisdiction we use code instead-->
                 <text variable="container-title" strip-periods="true"/>
               </else-if>
               <else>
-                <!--this won't work in Zotero yet, but does no harm -->
                 <names variable="director">
                   <label form="verb" text-case="capitalize-first" suffix=" "/>
                   <name delimiter-precedes-last="never" and="text" delimiter=", " initialize="false" initialize-with=""/>
                 </names>
                 <text macro="editor"/>
                 <choose>
-                  <!--if none of these, this we don't want edition either. Might be Loose-Leaf-->
                   <if variable="publisher issued genre container-title" match="any">
                     <text macro="edition"/>
                   </if>
@@ -399,7 +393,6 @@
     <choose>
       <if type="article-journal article-magazine article-newspaper legal_case" match="any">
         <group delimiter=", ">
-          <!--Assume that only cases with a Medium Neutral Citation have a docket number -->
           <choose>
             <if variable="authority number" match="all">
               <group delimiter=" ">
@@ -418,6 +411,16 @@
                   </if>
                 </choose>
               </if>
+              <else-if type="article-journal" match="any">
+                <choose>
+                  <if match="any" variable="container-title-short">
+                    <text variable="container-title-short" form="short" strip-periods="true"/>
+                  </if>
+                  <else>
+                    <text variable="container-title" strip-periods="true"/>
+                  </else>
+                </choose>
+              </else-if>
               <else-if type="article-magazine article-newspaper" match="any">
                 <text variable="container-title" font-style="italic"/>
               </else-if>
@@ -519,7 +522,6 @@
       </else-if>
     </choose>
   </macro>
-  <!--Others -->
   <macro name="treaty-catchall">
     <choose>
       <if type="treaty">
@@ -553,7 +555,6 @@
     </names>
   </macro>
   <macro name="sort-type">
-    <!--This should just sort secondary sources first. I'm leaving the rest from AGLC for simplicity-->
     <choose>
       <if type="book chapter paper-conference article-magazine article-newspaper article-journal manuscript report speech entry-encyclopedia" match="any">
         <text value="1"/>
@@ -593,7 +594,6 @@
         <else-if position="subsequent">
           <choose>
             <if type="legal_case bill legislation treaty" match="any">
-              <!--don't use short form and above note for legal citations -->
               <group delimiter=" ">
                 <text macro="author-note"/>
                 <text macro="title-short"/>
@@ -623,7 +623,6 @@
           </choose>
         </else-if>
         <else>
-          <!--general whole citation -->
           <group delimiter=" ">
             <group delimiter=", ">
               <group delimiter=" ">
@@ -660,7 +659,7 @@
       </choose>
     </layout>
   </citation>
-  <bibliography et-al-min="4" et-al-use-first="1" subsequent-author-substitute="&#8212;&#8212;">
+  <bibliography et-al-min="4" et-al-use-first="1" subsequent-author-substitute="——">
     <sort>
       <key macro="sort-type"/>
       <key macro="author" names-min="1" names-use-first="1"/>

--- a/oscola.csl
+++ b/oscola.csl
@@ -1,7 +1,6 @@
 ﻿
 <?xml version="1.0" encoding="utf-8"?>
 <style xmlns="http://purl.org/net/xbiblio/csl" class="note" version="1.0" demote-non-dropping-particle="never" default-locale="en-GB">
-  <!-- This style was edited with the Visual CSL Editor (https://editor.citationstyles.org/visualEditor/) -->
   <info>
     <title>OSCOLA (Oxford University Standard for Citation of Legal Authorities)</title>
     <title-short>OSCOLA</title-short>
@@ -43,7 +42,9 @@
       <term name="et-al">and others</term>
     </terms>
   </locale>
+  <!--Authors and Persons-->
   <macro name="author-note">
+    <!--for bills & hearing this should start with jurisdiction once available-->
     <choose>
       <if type="interview">
         <group delimiter=", ">
@@ -126,6 +127,7 @@
     </choose>
   </macro>
   <macro name="author">
+    <!--for bills & hearing this should start with jurisdiction once available-->
     <choose>
       <if type="interview">
         <group delimiter=", ">
@@ -186,6 +188,7 @@
       </names>
     </group>
   </macro>
+  <!-- Titles -->
   <macro name="title">
     <choose>
       <if type="book motion_picture treaty" match="any">
@@ -225,6 +228,7 @@
       </else>
     </choose>
   </macro>
+  <!--Dates-->
   <macro name="issued-year">
     <date variable="issued" form="text" date-parts="year"/>
   </macro>
@@ -242,6 +246,7 @@
             <text macro="issued-year" prefix="(" suffix=")"/>
           </else-if>
           <else-if variable="container-title volume number" match="any">
+            <!--no year in square brackets for unreported case w/o medium neutral citation-->
             <text macro="issued-year" prefix="[" suffix="]"/>
           </else-if>
         </choose>
@@ -251,6 +256,7 @@
       </else-if>
     </choose>
   </macro>
+  <!--publication info -->
   <macro name="publisher">
     <choose>
       <if type="book chapter broadcast personal_communication manuscript paper-conference article-newspaper report legislation motion_picture speech interview thesis entry-encyclopedia webpage post-weblog article" match="any">
@@ -265,15 +271,18 @@
                 <date variable="issued" form="text"/>
               </else-if>
               <else-if type="legislation bill" match="any">
+                <!--this should be jurisdiction we use code instead-->
                 <text variable="container-title" strip-periods="true"/>
               </else-if>
               <else>
                 <names variable="director">
+                  <!--this won't work in Zotero yet, but does no harm -->
                   <label form="verb" text-case="capitalize-first" suffix=" "/>
                   <name delimiter-precedes-last="never" and="text" delimiter=", " initialize="false" initialize-with=""/>
                 </names>
                 <text macro="editor"/>
                 <choose>
+                  <!--if none of these, this we don't want edition either. Might be Loose-Leaf-->
                   <if variable="publisher issued genre container-title" match="any">
                     <text macro="edition"/>
                   </if>
@@ -394,6 +403,7 @@
     <choose>
       <if type="article-journal article-magazine article-newspaper legal_case" match="any">
         <group delimiter=", ">
+          <!--Assume that only cases with a Medium Neutral Citation have a docket number -->
           <choose>
             <if variable="authority number" match="all">
               <group delimiter=" ">
@@ -523,6 +533,7 @@
       </else-if>
     </choose>
   </macro>
+  <!--Others -->
   <macro name="treaty-catchall">
     <choose>
       <if type="treaty">
@@ -556,6 +567,7 @@
     </names>
   </macro>
   <macro name="sort-type">
+    <!--This should just sort secondary sources first. I'm leaving the rest from AGLC for simplicity-->
     <choose>
       <if type="book chapter paper-conference article-magazine article-newspaper article-journal manuscript report speech entry-encyclopedia" match="any">
         <text value="1"/>
@@ -595,6 +607,7 @@
         <else-if position="subsequent">
           <choose>
             <if type="legal_case bill legislation treaty" match="any">
+              <!--don't use short form and above note for legal citations -->
               <group delimiter=" ">
                 <text macro="author-note"/>
                 <text macro="title-short"/>
@@ -608,6 +621,7 @@
               </group>
             </if>
             <else>
+              <!--general whole citation -->
               <group delimiter=" ">
                 <group delimiter=", ">
                   <text macro="author-short"/>

--- a/oscola.csl
+++ b/oscola.csl
@@ -1,5 +1,4 @@
-﻿
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <style xmlns="http://purl.org/net/xbiblio/csl" class="note" version="1.0" demote-non-dropping-particle="never" default-locale="en-GB">
   <info>
     <title>OSCOLA (Oxford University Standard for Citation of Legal Authorities)</title>

--- a/oscola.csl
+++ b/oscola.csl
@@ -1,4 +1,5 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+﻿
+<?xml version="1.0" encoding="utf-8"?>
 <style xmlns="http://purl.org/net/xbiblio/csl" class="note" version="1.0" demote-non-dropping-particle="never" default-locale="en-GB">
   <!-- This style was edited with the Visual CSL Editor (https://editor.citationstyles.org/visualEditor/) -->
   <info>
@@ -659,7 +660,7 @@
       </choose>
     </layout>
   </citation>
-  <bibliography et-al-min="4" et-al-use-first="1" subsequent-author-substitute="——">
+  <bibliography et-al-min="4" et-al-use-first="1" subsequent-author-substitute="&#8212;&#8212;">
     <sort>
       <key macro="sort-type"/>
       <key macro="author" names-min="1" names-use-first="1"/>


### PR DESCRIPTION
… available. If no journal abbreviation is present, then the full title appears.