### PR TITLE
Create studia-historiae-scientiarum-1.0

### DIFF
--- a/studia-historiae-scientiarum-1.0
+++ b/studia-historiae-scientiarum-1.0
@@ -1,0 +1,408 @@
+<?xml version="1.0" encoding="utf-8"?>
+<style
+	xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" demote-non-dropping-particle="sort-only" page-range-format="expanded" default-locale="en">
+	<info>
+		<title>Studia Historiae Scientiarum - English version 1.0</title>
+		<title-short>Stud. Hist. Sci. - EN 1.0</title-short>
+		<id>https://www.zotero.org/styles/studia-historiae-scientiarum-en-1.0</id>
+		<link href="https://www.zotero.org/styles/studia-historiae-scientiarum-en-1.0" rel="self"/>
+		<link href="https://www.zotero.org/styles/studia-historiae-scientiarum-en-1.0" rel="template"/>
+		<link href="https://ejournals.eu/en/media/01954b4a-c281-72f9-a0e3-b2a874071dd5/download" rel="documentation"/>
+		<author>
+			<name>Artur Górka</name>
+			<email>shs@pau.krakow.pl</email>
+			<uri>https://atforge.pl/</uri>
+		</author>
+		<contributor>
+			<name>Michal Kokowski</name>
+			<email>shs@pau.krakow.pl</email>
+			<uri>https://www.cyfronet.krakow.pl/~n1kokows/home.html</uri>
+		</contributor>
+		<category citation-format="author-date"/>
+		<category field="science"/>
+		<category field="history"/>
+		<issn>2451-3202</issn>
+		<eissn>2543-702X</eissn>
+		<summary>The Studia Historiae Scientiarum in-text citation style and full bibliography style - version 1.0.</summary>
+		<published>2022-12-30T00:00:00+00:00</published>
+		<rights license="http://creativecommons.org/licenses/by-sa/4.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 4.0 License. </rights>
+		<updated>2022-12-30T18:39:38+00:00</updated>
+	</info>
+	<locale xml:lang="en-US">
+		<date form="text">
+			<date-part name="day" suffix=" "/>
+			<date-part name="month" suffix=" "/>
+			<date-part name="year"/>
+		</date>
+		<terms>
+			<term name="volume" form="short">vol.</term>
+			<term name="page" form="short">
+				<single>p.</single>
+				<multiple>pp.</multiple>
+			</term>
+			<term name="available at" form="short">URL:</term>
+			<term name="ordinal-00" form="short">DOI:</term>
+			<term name="ordinal-01" form="short">ISBN</term>
+			<term name="accessed" form="short">accessed on</term>
+			<term name="anonymous" form="short">N.N.</term>
+			<term name="open-quote" form="short">“</term>
+			<term name="close-quote" form="short">”</term>
+			<term name="editor" form="verb">Edited by</term>
+			<term name="translator" form="verb">Translated by</term>
+		</terms>
+	</locale>
+	<locale xml:lang="pl-PL">
+		<date form="text">
+			<date-part name="day" form="numeric-leading-zeros" suffix="."/>
+			<date-part name="month" form="numeric" suffix="."/>
+			<date-part name="year"/>
+		</date>
+		<terms>
+			<term name="volume" form="short">t.</term>
+			<term name="page" form="short">
+				<single>s.</single>
+				<multiple>ss.</multiple>
+			</term>
+			<term name="available at" form="short">URL:</term>
+			<term name="ordinal-00" form="short">DOI:</term>
+			<term name="ordinal-01" form="short">ISBN</term>
+			<term name="accessed" form="short">dostęp:</term>
+			<term name="anonymous" form="short">N.N.</term>
+			<term name="open-quote" form="short">„</term>
+			<term name="close-quote" form="short">”</term>
+			<term name="editor" form="verb">Redakcja:</term>
+			<term name="translator" form="verb">Tłumaczenie:</term>
+		</terms>
+	</locale>
+	<macro name="author">
+		<names variable="author" suffix="">
+			<name sort-separator=", " name-as-sort-order="all" delimiter="; "/>
+			<label form="short" prefix=" (" suffix=")"/>
+			<substitute>
+				<names variable="editor"/>
+				<names variable="translator"/>
+			</substitute>
+		</names>
+	</macro>
+	<macro name="translator">
+		<names variable="translator">
+			<label form="verb" suffix=" "/>
+			<name delimiter=", "/>
+		</names>
+	</macro>
+	<macro name="editor-chapter">
+		<names variable="editor">
+			<name delimiter=", "/>
+			<label form="short" prefix=" (" suffix=")"/>
+		</names>
+	</macro>
+	<macro name="editor">
+		<names variable="editor">
+			<label  form="verb" suffix=" "/>
+			<name delimiter=", "/>
+		</names>
+	</macro>
+	<macro name="author-short">
+		<names variable="author">
+			<name form="short" delimiter=", " initialize-with="."/>
+			<substitute>
+				<names variable="editor"/>
+				<names variable="translator"/>
+			</substitute>
+		</names>
+	</macro>
+	<macro name="author-count">
+		<names variable="author">
+			<name form="count"/>
+			<substitute>
+				<names variable="editor"/>
+			</substitute>
+		</names>
+	</macro>
+	<macro name="year-date">
+		<choose>
+			<if variable="issued">
+				<date variable="issued">
+					<date-part name="year"/>
+				</date>
+			</if>
+			<else-if type="book chapter webpage" variable="container-title volume page" match="none">
+				<text term="forthcoming"/>
+			</else-if>
+			<else-if type="book chapter webpage" variable="volume page" match="none">
+				<text term="in press"/>
+			</else-if>
+			<else>
+				<text term="no date" form="short"/>
+			</else>
+		</choose>
+	</macro>
+	<macro name="publisher">
+		<choose>
+			<if variable="publisher-place publisher" match="all">
+				<text variable="publisher-place" suffix=": "/>
+				<text variable="publisher"/>
+			</if>
+			<else-if variable="publisher">
+				<text variable="publisher"/>
+			</else-if>
+			<else-if variable="publisher-place">
+				<text variable="publisher-place"/>
+			</else-if>
+		</choose>
+	</macro>
+	<macro name="container-title">
+		<choose>
+			<if variable="edition">
+				<text variable="container-title"/>
+			</if>
+			<else>
+				<text variable="container-title"/>
+			</else>
+		</choose>
+	</macro>
+	<macro name="edition">
+		<choose>
+			<if is-numeric="edition">
+				<group delimiter=" ">
+					<number variable="edition" form="ordinal"/>
+					<text term="edition" form="short"/>
+				</group>
+			</if>
+			<else>
+				<text variable="edition" suffix="."/>
+			</else>
+		</choose>
+	</macro>
+	<macro name="doi">
+		<choose>
+			<if variable="DOI">
+				<text term="ordinal-00" form="short" suffix=" "/>
+				<text variable="DOI"/>
+			</if>
+			<else-if variable="ISBN">
+				<text term="ordinal-01" form="short" suffix=" "/>
+				<text variable="ISBN" />
+			</else-if>
+		</choose>
+	</macro>
+	<macro name="url">
+		<choose>
+			<if variable="DOI">
+				<text term="available at" form="short" suffix=" "/>
+				<text variable="DOI" prefix="https://doi.org/"/>
+			</if>
+			<else-if variable="URL">
+				<text term="available at" form="short" suffix=" "/>
+				<text variable="URL"/>
+			</else-if>
+		</choose>
+		<choose>
+			<if variable="accessed">
+				<text term="accessed" form="short" prefix=" (" suffix=" "/>
+				<date variable="accessed" form="text" suffix=")"/>
+			</if>
+		</choose>
+	</macro>
+	<citation disambiguate-add-names="true" disambiguate-add-givenname="true" disambiguate-add-year-suffix="true" givenname-disambiguation-rule="all-names-with-initials" collapse="year">
+		<sort>
+			<key macro="year-date"/>
+			<key macro="author-short"/>
+		</sort>
+		<layout prefix="" suffix="." delimiter="; ">
+			<choose>
+				<if variable="author editor" match="any">
+					<text macro="author-short"/>
+				</if>
+				<else>
+					<text term="anonymous" form="short"/>
+				</else>
+			</choose>
+			<group prefix=" " delimiter=", ">
+				<text macro="year-date"/>
+				<group delimiter=" ">
+					<label variable="page" form="short"/>
+					<text variable="page"/>
+				</group>
+			</group>
+			<text variable="locator"/>
+		</layout>
+	</citation>
+	<bibliography entry-spacing="0" hanging-indent="true">
+		<sort>
+			<key macro="author" names-min="1" names-use-first="1"/>
+			<key macro="author-count"/>
+			<key macro="year-date"/>
+		</sort>
+		<layout suffix=".">
+			<group delimiter=" ">
+				<choose>
+					<if variable="author editor" match="any">
+						<text macro="author"/>
+					</if>
+					<else>
+						<text term="anonymous" form="short"/>
+					</else>
+				</choose>
+				<group suffix=": ">
+					<choose>
+						<if variable="issued">
+							<date variable="issued">
+								<date-part name="year"/>
+							</date>
+						</if>
+						<else-if type="book chapter webpage" variable="container-title volume page" match="none">
+							<text term="forthcoming" />
+						</else-if>
+						<else-if type="book chapter webpage" variable="volume page" match="none">
+							<text term="in press" />
+						</else-if>
+						<else>
+							<text term="no date" form="short"/>
+						</else>
+					</choose>
+				</group>
+				<choose>
+					<if type="book graphic motion_picture report song thesis" match="any">
+						<group >
+							<group suffix=". ">
+								<text variable="title" font-style="italic" />
+							</group>
+							<group delimiter=" ">
+								<text macro="edition"/>
+								<text macro="translator" suffix="."/>
+								<text macro="editor" suffix="."/>
+							</group>
+						</group>
+						<group delimiter=". ">
+							<text prefix=" " macro="publisher"/>
+							<group delimiter=" ">
+								<group delimiter=" ">
+									<text variable="number-of-pages"/>
+									<label plural="always" variable="number-of-pages" form="short" suffix=","/>
+								</group>
+								<group suffix="." delimiter=" ">
+									<text macro="doi"/>
+									<group delimiter=", ">
+										<choose>
+											<if variable="collection-title">
+												<group delimiter=", " prefix="(" suffix=")">
+													<group delimiter="">
+														<text term="open-quote" form="short" />
+														<text variable="collection-title" />
+														<text term="close-quote" form="short" />
+													</group>
+													<choose>
+														<if variable="volume">
+															<group delimiter=" ">
+																<text term="volume" form="short" />
+																<text variable="volume"/>
+															</group>
+														</if>
+													</choose>
+												</group>
+											</if>
+										</choose>
+										<group delimiter=" ">
+											<label variable="page" form="short"/>
+											<text variable="page"/>
+										</group>
+									</group>
+								</group>
+								<text macro="url"/>
+							</group>
+						</group>
+					</if>
+					<else-if type="chapter entry-dictionary entry-encyclopedia" match="any">
+						<group suffix=". ">
+							<text variable="title" />
+						</group>
+						<text term="in" form="short" text-case="title" prefix="[" suffix=":]"/>
+						<group delimiter=". " suffix=".">
+							<group delimiter=", ">
+								<text macro="editor-chapter"/>
+								<text variable="container-title" font-style="italic"/>
+							</group>
+							<text macro="translator"/>
+						</group>
+						<group delimiter=", ">
+							<text prefix=" " macro="publisher"/>
+							<group delimiter=" ">
+								<group delimiter=" ">
+									<text variable="number-of-pages"/>
+									<label plural="never" variable="number-of-pages" form="short"/>
+								</group>
+								<group suffix="." delimiter=" ">
+									<text macro="doi"/>
+									<group delimiter=", ">
+										<choose>
+											<if variable="collection-title">
+												<group delimiter=", " prefix="(" suffix=")">
+													<group delimiter="">
+														<text term="open-quote" form="short" />
+														<text variable="collection-title" />
+														<text term="close-quote" form="short" />
+													</group>
+													<choose>
+														<if variable="volume">
+															<group delimiter=" ">
+																<text term="volume" form="short" />
+																<text variable="volume"/>
+															</group>
+														</if>
+													</choose>
+												</group>
+											</if>
+										</choose>
+										<group delimiter=" ">
+											<label variable="page" form="short"/>
+											<text variable="page"/>
+										</group>
+									</group>
+								</group>
+								<text macro="url"/>
+							</group>
+						</group>
+					</else-if>
+					<else>
+						<group delimiter=" ">
+							<text variable="title" suffix="."/>
+							<choose>
+								<if variable="archive archive_location" match="any">
+									<group delimiter=". " suffix=".">
+										<text variable="archive"/>
+										<text variable="archive_location"/>
+									</group>
+								</if>
+								<else-if variable="container-title volume issue" match="any">
+									<group delimiter=" " suffix=",">
+										<text variable="container-title" form="long" font-style="italic"/>
+										<group delimiter="">
+											<text variable="volume"/>
+											<text variable="issue" prefix="(" suffix=")"/>
+										</group>
+									</group>
+								</else-if>
+								<else-if variable="number authority" match="any">
+									<group delimiter=". " suffix=".">
+										<text variable="authority"/>
+										<text variable="number"/>
+									</group>
+								</else-if>
+							</choose>
+						</group>
+						<text prefix=" " macro="publisher"/>
+						<group delimiter=", " suffix=".">
+							<group delimiter=" ">
+								<label variable="page" form="short"/>
+								<text variable="page"/>
+							</group>
+						</group>
+						<text prefix=" " suffix="." macro="doi"/>
+						<text prefix=" " macro="url"/>
+					</else>
+				</choose>
+			</group>
+		</layout>
+	</bibliography>
+</style>


### PR DESCRIPTION
Dear colleagues,
I am adding a new English version of csl for the journal Studia Historiae Scientiarum (e-ISSN: 2543-702X, p-ISSN: 2451-3202).

Professor Michal Kokowski, PhD, Dsc
Studia Historiae Scientiarum (editor-in-chief)