### PR TITLE
Update glossa.csl

### DIFF
--- a/glossa.csl
+++ b/glossa.csl
@@ -1,3 +1,7 @@
+How can I suppress the author middle initials in the bibliography citation. Example = Portes, Alejandro & Alex Stepick (1993). City on the Edge: The Transformation of Miami. Berkeley, CA: University of 
+California Press.
+
+
 <?xml version="1.0" encoding="utf-8"?>
 <style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" demote-non-dropping-particle="never" default-locale="en-US">
   <info>


### PR DESCRIPTION
This is an attempt to suppress the author middle initials in the bibliography citation in the style called glossa. How can I do it?