### PR TITLE
Updates to USGS citation style to conform to "USGS Suggestions to Authors 8th edition"

### DIFF
--- a/us-geological-survey.csl
+++ b/us-geological-survey.csl
@@ -4,7 +4,7 @@
     <title>U.S. Geological Survey</title>
     <id>http://www.zotero.org/styles/us-geological-survey</id>
     <link href="http://www.zotero.org/styles/us-geological-survey" rel="self"/>
-    <link href="http://www.nwrc.usgs.gov/techrpt/sta28.pdf" rel="documentation"/>
+    <link href="https://atthecore.usgs.gov/media/files/suggestions-authors-reports-us-geological-survey-official-style-guide-us-geological" rel="documentation"/>
     <author>
       <name>Rintze Zelle</name>
       <uri>http://twitter.com/rintzezelle</uri>
@@ -15,9 +15,12 @@
     <contributor>
       <name>Jason Bellino</name>
     </contributor>
+    <contributor>
+      <name>Brad Aagaard</name>
+    </contributor>
     <category citation-format="author-date"/>
     <category field="geology"/>
-    <updated>2017-05-05T11:43:00+00:00</updated>
+    <updated>2025-03-03T10:06:00+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <macro name="editor-translator">
@@ -92,13 +95,19 @@
           <group prefix=" " delimiter=", ">
             <group delimiter=" ">
               <text variable="title" suffix=":"/>
-              <text variable="publisher"/>
-              <text variable="collection-title"/>
+	      <choose>
+		<if variable="genre">
+		  <text variable="genre"/>
+		</if>
+		<else>
+		  <text variable="publisher"/>
+		  <text variable="collection-title"/>
+		</else>
+	      </choose>
               <text variable="number"/>
             </group>
             <group>
-              <text variable="page" suffix=" "/>
-              <label variable="page" form="short" plural="never"/>
+              <text variable="page" suffix=" pp."/>
             </group>
             <group prefix=" ">
               <text term="accessed"/>
@@ -114,8 +123,15 @@
                 <text variable="container-title" prefix=" "/>
               </group>
               <group prefix=" ">
-                <text term="at"/>
-                <text variable="URL" prefix=" "/>
+		<choose>
+		  <if variable="DOI">
+		    <text variable="DOI" prefix="at https://doi.org/"/>
+		  </if>
+		  <else>
+                    <text term="at"/>
+                    <text variable="URL" prefix=" "/>
+		  </else>
+		</choose>
               </group>
             </group>
           </group>
@@ -141,13 +157,14 @@
           <group prefix=" " suffix="." delimiter=", ">
             <text variable="collection-title"/>
             <text macro="publisher"/>
-            <text variable="number-of-pages" suffix=" p."/>
+            <text variable="number-of-pages" suffix=" pp."/>
           </group>
         </else-if>
         <else-if type="webpage">
-          <group prefix=" " delimiter=", ">
+          <group prefix=" ">
             <text variable="title"/>
-            <group delimiter=" ">
+            <text variable="container-title" prefix=": "/>
+            <group prefix=", " suffix=", " delimiter=" ">
               <text term="accessed"/>
               <date variable="accessed">
                 <date-part name="month" form="long" suffix=" "/>
@@ -156,14 +173,8 @@
               </date>
             </group>
             <group delimiter=" ">
-              <group delimiter=" ">
-                <text term="at"/>
-                <text variable="container-title"/>
-              </group>
-              <group delimiter=" ">
-                <text term="at"/>
-                <text variable="URL"/>
-              </group>
+              <text term="at"/>
+              <text variable="URL"/>
             </group>
           </group>
         </else-if>
@@ -195,7 +206,85 @@
           <text variable="title" prefix=" " suffix=":"/>
           <text variable="event" prefix=" "/>
           <text variable="event-place" prefix=", "/>
+	  <choose>
+	    <if variable="URL">
+              <group prefix=", ">
+		<text term="accessed"/>
+		<group prefix=" " suffix=",">
+		  <date variable="accessed">
+                    <date-part name="month" form="long" suffix=" "/>
+                    <date-part name="day" form="numeric" suffix=", "/>
+                    <date-part name="year" form="long"/>
+		  </date>
+		</group>
+		<group prefix=" ">
+		  <text variable="URL" prefix="at "/>
+		</group>
+              </group>
+	    </if>
+	  </choose>
         </else-if>
+        <else-if type="dataset">
+          <text variable="title" prefix=" " suffix=":"/>
+          <text variable="publisher" prefix=" " suffix=", "/>
+          <group prefix=" ">
+            <text term="accessed"/>
+            <group prefix=" " suffix=",">
+              <date variable="accessed">
+                <date-part name="month" form="long" suffix=" "/>
+                <date-part name="day" form="numeric" suffix=", "/>
+                <date-part name="year" form="long"/>
+              </date>
+            </group>
+            <group prefix=" ">
+              <text term="at"/>
+              <text variable="container-title" prefix=" "/>
+            </group>
+            <group prefix=" ">
+	      <choose>
+		<if variable="DOI">
+		  <text variable="DOI" prefix="at https://doi.org/"/>
+		</if>
+		<else>
+                  <text term="at"/>
+                  <text variable="URL" prefix=" "/>
+		</else>
+	      </choose>
+            </group>
+          </group>
+	</else-if>
+        <else-if type="software">
+	  <group suffix=":">
+            <text variable="title" prefix=" "/>
+	    <choose>
+	      <if variable="version">
+		<text variable="version" prefix=" (version " suffix=")"/>
+	      </if>
+	    </choose>
+	  </group>
+	  <text variable="publisher" prefix=" " suffix=", "/>
+          <group prefix=" ">
+            <text term="accessed"/>
+            <group prefix=" " suffix=",">
+              <date variable="accessed">
+                <date-part name="month" form="long" suffix=" "/>
+                <date-part name="day" form="numeric" suffix=", "/>
+                <date-part name="year" form="long"/>
+              </date>
+            </group>
+            <group prefix=" ">
+	      <choose>
+		<if variable="DOI">
+		  <text variable="DOI" prefix="at https://doi.org/"/>
+		</if>
+		<else>
+                  <text term="at"/>
+                  <text variable="URL" prefix=" "/>
+		</else>
+	      </choose>
+            </group>
+          </group>
+	</else-if>
         <else>
           <group suffix=":">
             <text variable="title" prefix=" "/>
@@ -208,6 +297,22 @@
               <text variable="issue" prefix="no. "/>
             </group>
             <text variable="page" prefix="p. "/>
+            <group prefix="accessed " suffix=",">
+              <date variable="accessed">
+                <date-part name="month" form="long" suffix=" "/>
+                <date-part name="day" form="numeric" suffix=", "/>
+                <date-part name="year" form="long"/>
+              </date>
+            </group>
+	    <choose>
+		<if variable="DOI">
+		  <text variable="DOI" prefix="at https://doi.org/"/>
+		</if>
+		<else>
+                  <text term="at"/>
+                  <text variable="URL" prefix=" "/>
+		</else>
+	      </choose>
           </group>
         </else>
       </choose>


### PR DESCRIPTION
Corrections based on "Suggestions to Authors of the Reports of the U.S. Geological Survey—The Official Style Guide of the U.S. Geological Survey, 8th Edition, Revised". This document is not yet publicly available, but I have verified that these style changes result in the correct formatting of references for datasets, software, journal articles, reports, and webpages.

- Add dataset and software types.
- Add DOIs to journal articles and reports using URL with accessed date.
- Report: Use genre when available.
- Webpage: Move institution to proper location.
