### PR TITLE
MHRA: Options for place of publication

### DIFF
--- a/modern-humanities-research-association-author-date.csl
+++ b/modern-humanities-research-association-author-date.csl
@@ -194,10 +194,14 @@
         <text variable="publisher"/>
       </if>
       <else>
-        <group delimiter=": ">
-          <!-- <text variable="publisher-place"/> -->
-          <text variable="publisher"/>
-        </group>
+        <choose>
+          <if match="none" variable="publisher">
+            <text variable="publisher-place"/>
+          </if>
+          <else>
+            <text variable="publisher"/>
+          </else>
+        </choose>
       </else>
     </choose>
   </macro>

--- a/modern-humanities-research-association-publisher-place.csl
+++ b/modern-humanities-research-association-publisher-place.csl
@@ -1,0 +1,561 @@
+<?xml version="1.0" encoding="utf-8"?>
+<style xmlns="http://purl.org/net/xbiblio/csl" and="text" class="note" demote-non-dropping-particle="sort-only" et-al-min="4" et-al-use-first="1" page-range-format="minimal-two" version="1.0" default-locale="en-GB">
+  <info>
+    <title>Modern Humanities Research Association, 4th edition (note with bibliography, with place of publication)</title>
+    <title-short>MHRA</title-short>
+    <id>http://www.zotero.org/styles/modern-humanities-research-association-publisher-place</id>
+    <link href="http://www.zotero.org/styles/modern-humanities-research-association-publisher-place" rel="self"/>
+    <link href="http://www.zotero.org/styles/modern-humanities-research-association" rel="template"/>
+    <link href="https://www.mhra.org.uk/style/" rel="documentation"/>
+    <author>
+      <name>Rintze Zelle</name>
+      <uri>https://orcid.org/0000-0003-1779-8883</uri>
+    </author>
+    <author>
+      <name>Andrew Dunning</name>
+      <uri>https://orcid.org/0000-0003-0464-5036</uri>
+    </author>
+    <contributor>
+      <name>Sebastian Karcher</name>
+      <uri>https://orcid.org/0000-0001-8249-7388</uri>
+    </contributor>
+    <contributor>
+      <name>Patrick O'Brien</name>
+    </contributor>
+    <category citation-format="note"/>
+    <category field="generic-base"/>
+    <category field="humanities"/>
+    <summary>MHRA Style Guide full notes and bibliography, with place of publication</summary>
+    <updated>2025-02-03T14:44:03+00:00</updated>
+    <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
+  </info>
+  <locale xml:lang="en">
+    <terms>
+      <term name="et-al">and others</term>
+      <term form="short" name="edition">edn</term>
+      <term name="folio">
+        <single>fol.</single>
+        <multiple>fols</multiple>
+      </term>
+    </terms>
+  </locale>
+  <macro name="title-sort-substitute">
+    <choose>
+      <if match="any" type="bill book graphic legal_case legislation motion_picture report song">
+        <text font-style="italic" form="short" text-case="title" variable="title"/>
+      </if>
+      <else>
+        <text form="short" quotes="true" text-case="title" variable="title"/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="recipient-short">
+    <names variable="recipient">
+      <label form="verb" suffix=" "/>
+      <name form="short"/>
+    </names>
+  </macro>
+  <macro name="recipient">
+    <names variable="recipient">
+      <label form="verb" suffix=" "/>
+      <name/>
+    </names>
+  </macro>
+  <macro name="communication-recipient">
+    <group delimiter=" ">
+      <choose>
+        <if type="personal_communication">
+          <choose>
+            <if variable="genre">
+              <text text-case="capitalize-first" variable="genre"/>
+            </if>
+            <else>
+              <text term="letter" text-case="capitalize-first"/>
+            </else>
+          </choose>
+        </if>
+      </choose>
+      <text macro="recipient"/>
+    </group>
+  </macro>
+  <macro name="contributors-short">
+    <group delimiter=" ">
+      <names variable="author">
+        <name form="short"/>
+        <substitute>
+          <names variable="editor"/>
+          <names variable="translator"/>
+          <text macro="title-sort-substitute"/>
+        </substitute>
+      </names>
+      <text macro="recipient-short"/>
+    </group>
+  </macro>
+  <macro name="contributors-note">
+    <group delimiter=" ">
+      <names variable="author">
+        <label form="short" prefix=", "/>
+        <substitute>
+          <text macro="title"/>
+        </substitute>
+      </names>
+      <text macro="recipient"/>
+    </group>
+  </macro>
+  <macro name="contributors">
+    <group delimiter=". ">
+      <names variable="author">
+        <name delimiter-precedes-last="always" name-as-sort-order="first"/>
+        <label form="short" prefix=", "/>
+        <substitute>
+          <names variable="editor"/>
+          <names variable="translator"/>
+          <text macro="title"/>
+        </substitute>
+      </names>
+      <text macro="communication-recipient"/>
+    </group>
+  </macro>
+  <macro name="title-subsequent">
+    <choose>
+      <if match="none" variable="title">
+        <text macro="issued"/>
+      </if>
+      <else-if match="any" type="bill book graphic legal_case legislation motion_picture report song">
+        <text font-style="italic" form="short" text-case="title" variable="title"/>
+      </else-if>
+      <else>
+        <text form="short" quotes="true" text-case="title" variable="title"/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="title">
+    <choose>
+      <if match="none" variable="title">
+        <text variable="genre"/>
+      </if>
+      <else-if match="any" type="bill book graphic legislation motion_picture report song">
+        <group delimiter=", ">
+          <text font-style="italic" text-case="title" variable="title"/>
+          <group delimiter=" ">
+            <text term="version"/>
+            <text variable="version"/>
+          </group>
+        </group>
+      </else-if>
+      <else-if match="any" type="legal_case interview">
+        <text variable="title"/>
+      </else-if>
+      <else-if variable="reviewed-author">
+        <text font-style="italic" prefix="review of " variable="title"/>
+      </else-if>
+      <else>
+        <text quotes="true" text-case="title" variable="title"/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="editor-translator">
+    <group delimiter=", ">
+      <choose>
+        <if match="any" variable="container-author reviewed-author">
+          <names delimiter=", " variable="container-author reviewed-author">
+            <label form="verb-short" suffix=" "/>
+            <name/>
+          </names>
+        </if>
+      </choose>
+      <names delimiter=", " variable="editor translator director">
+        <label form="verb-short" suffix=" "/>
+        <name/>
+      </names>
+    </group>
+  </macro>
+  <macro name="secondary-contributors">
+    <choose>
+      <if match="none" type="chapter entry-dictionary entry-encyclopedia paper-conference">
+        <text macro="editor-translator"/>
+      </if>
+    </choose>
+  </macro>
+  <macro name="container-title">
+    <group delimiter=" ">
+      <choose>
+        <if match="any" type="chapter entry-dictionary entry-encyclopedia paper-conference">
+          <text term="in"/>
+        </if>
+      </choose>
+      <text font-style="italic" text-case="title" variable="container-title"/>
+    </group>
+  </macro>
+  <macro name="container-contributors">
+    <choose>
+      <if match="any" type="chapter entry-dictionary entry-encyclopedia paper-conference">
+        <text macro="editor-translator"/>
+      </if>
+    </choose>
+  </macro>
+  <macro name="edition">
+    <choose>
+      <if match="any" type="bill book chapter entry-dictionary entry-encyclopedia graphic legal_case legislation motion_picture paper-conference report song">
+        <choose>
+          <if is-numeric="edition">
+            <group delimiter=" ">
+              <number form="ordinal" variable="edition"/>
+              <text form="short" term="edition"/>
+            </group>
+          </if>
+          <else>
+            <text variable="edition"/>
+          </else>
+        </choose>
+      </if>
+    </choose>
+  </macro>
+  <macro name="locators">
+    <choose>
+      <if type="article-journal">
+        <group delimiter=", ">
+          <text variable="collection-title"/>
+          <choose>
+            <if variable="volume">
+              <group delimiter=".">
+                <text variable="volume"/>
+                <text variable="issue"/>
+              </group>
+            </if>
+            <else>
+              <group delimiter=" ">
+                <text form="short" term="issue"/>
+                <text variable="issue"/>
+              </group>
+            </else>
+          </choose>
+        </group>
+      </if>
+      <else-if match="any" type="bill book chapter entry-dictionary entry-encyclopedia graphic legal_case legislation motion_picture paper-conference report song">
+        <group delimiter=", ">
+          <group delimiter=", ">
+            <text text-case="title" variable="collection-title"/>
+            <text variable="collection-number"/>
+          </group>
+          <text macro="edition"/>
+          <group delimiter=" ">
+            <number form="numeric" variable="number-of-volumes"/>
+            <text form="short" plural="true" term="volume"/>
+          </group>
+        </group>
+      </else-if>
+    </choose>
+  </macro>
+  <macro name="event">
+    <group delimiter=" ">
+      <text term="presented at"/>
+      <text variable="event"/>
+    </group>
+  </macro>
+  <macro name="publisher">
+    <choose>
+      <if type="thesis">
+        <text variable="publisher"/>
+      </if>
+      <else>
+        <group delimiter=": ">
+          <text variable="publisher-place"/>
+          <text variable="publisher"/>
+        </group>
+      </else>
+    </choose>
+  </macro>
+  <macro name="issued">
+    <choose>
+      <if match="any" type="report article-newspaper article-magazine personal_communication">
+        <date form="text" variable="issued"/>
+      </if>
+      <else-if match="any" type="article-journal book bill chapter legislation motion_picture paper-conference song thesis">
+        <choose>
+          <if is-uncertain-date="issued">
+            <date date-parts="year" form="numeric" prefix="[" suffix="?]" variable="issued"/>
+          </if>
+          <else>
+            <date date-parts="year" form="numeric" variable="issued"/>
+          </else>
+        </choose>
+      </else-if>
+      <else>
+        <choose>
+          <if is-uncertain-date="issued">
+            <date form="text" prefix="[" suffix="?]" variable="issued"/>
+          </if>
+          <else>
+            <date form="text" variable="issued"/>
+          </else>
+        </choose>
+      </else>
+    </choose>
+  </macro>
+  <macro name="issue-join-with-space">
+    <choose>
+      <if type="article-journal" variable="volume">
+        <text macro="issue"/>
+      </if>
+      <else-if type="article-journal" variable="issue">
+        <text macro="issue"/>
+      </else-if>
+      <else-if match="any" variable="publisher-place publisher">
+        <text macro="issue"/>
+      </else-if>
+    </choose>
+  </macro>
+  <macro name="issue-join-with-comma">
+    <choose>
+      <if type="article-journal">
+        <choose>
+          <if match="none" variable="volume issue">
+            <text macro="issue"/>
+          </if>
+        </choose>
+      </if>
+      <else-if match="none" variable="publisher-place publisher">
+        <text macro="issue"/>
+      </else-if>
+    </choose>
+  </macro>
+  <macro name="issue">
+    <choose>
+      <if type="article-journal">
+        <choose>
+          <if match="any" variable="volume issue">
+            <text macro="issued" prefix="(" suffix=")"/>
+          </if>
+          <else>
+            <text macro="issued"/>
+          </else>
+        </choose>
+      </if>
+      <else-if match="any" variable="publisher-place publisher">
+        <group delimiter=", " prefix="(" suffix=")">
+          <group delimiter=" ">
+            <choose>
+              <if match="none" variable="title"/>
+              <else-if match="any" type="thesis speech">
+                <text prefix="unpublished " variable="genre"/>
+              </else-if>
+            </choose>
+            <text macro="event"/>
+          </group>
+          <text macro="publisher"/>
+          <text macro="issued"/>
+        </group>
+      </else-if>
+      <else>
+        <text macro="issued"/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="artwork">
+    <choose>
+      <if match="any" type="graphic">
+        <group delimiter=", ">
+          <text variable="medium"/>
+          <text variable="dimensions"/>
+        </group>
+      </if>
+    </choose>
+  </macro>
+  <macro name="locators-newspaper">
+    <choose>
+      <if type="article-newspaper">
+        <group delimiter=", ">
+          <group delimiter=" ">
+            <text variable="edition"/>
+            <text term="edition"/>
+          </group>
+          <group delimiter=" ">
+            <text term="section"/>
+            <text variable="section"/>
+          </group>
+        </group>
+      </if>
+    </choose>
+  </macro>
+  <macro name="pages">
+    <group delimiter=" ">
+      <label form="short" variable="page"/>
+      <text variable="page"/>
+    </group>
+  </macro>
+  <macro name="volume-number-roman">
+    <choose>
+      <if is-numeric="volume">
+        <number font-variant="small-caps" form="roman" variable="volume"/>
+      </if>
+      <else>
+        <text font-variant="small-caps" variable="volume"/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="point-locators-volume-note">
+    <choose>
+      <if position="first" type="chapter entry-dictionary entry-encyclopedia paper-conference">
+        <group delimiter=", ">
+          <text macro="volume-number-roman"/>
+          <text font-style="italic" text-case="title" variable="volume-title"/>
+        </group>
+      </if>
+      <else-if type="book legislation motion_picture report">
+        <group delimiter=", ">
+          <text macro="volume-number-roman"/>
+          <choose>
+            <if position="first">
+              <text font-style="italic" text-case="title" variable="volume-title"/>
+            </if>
+          </choose>
+        </group>
+      </else-if>
+    </choose>
+  </macro>
+  <macro name="point-locators-volume">
+    <choose>
+      <if type="bill book chapter entry-dictionary entry-encyclopedia graphic legal_case legislation motion_picture paper-conference report song">
+        <group delimiter=", ">
+          <text macro="volume-number-roman"/>
+          <text font-style="italic" text-case="title" variable="volume-title"/>
+        </group>
+      </if>
+    </choose>
+  </macro>
+  <macro name="point-locators-subsequent">
+    <group delimiter=" ">
+      <label form="short" variable="locator"/>
+      <text variable="locator"/>
+    </group>
+  </macro>
+  <macro name="point-locators">
+    <group delimiter=" ">
+      <text macro="pages"/>
+      <choose>
+        <if variable="page">
+          <group delimiter=" " prefix="(" suffix=")">
+            <label form="short" variable="locator"/>
+            <text variable="locator"/>
+          </group>
+        </if>
+        <else>
+          <group delimiter=" ">
+            <label form="short" variable="locator"/>
+            <text variable="locator"/>
+          </group>
+        </else>
+      </choose>
+    </group>
+  </macro>
+  <macro name="archive">
+    <group delimiter=", ">
+      <text variable="archive-place"/>
+      <text variable="archive"/>
+      <text variable="archive_location"/>
+    </group>
+  </macro>
+  <macro name="access">
+    <group delimiter=", ">
+      <choose>
+        <if match="none" type="article-journal bill chapter legal_case legislation paper-conference">
+          <text macro="archive"/>
+        </if>
+      </choose>
+      <choose>
+        <if variable="DOI">
+          <text prefix="doi:" variable="DOI"/>
+        </if>
+      </choose>
+    </group>
+  </macro>
+  <macro name="URL">
+    <choose>
+      <if match="none" variable="DOI">
+        <choose>
+          <if variable="URL">
+            <group delimiter=" ">
+              <text prefix="&lt;" suffix="&gt;" variable="URL"/>
+              <choose>
+                <if match="none" variable="issued">
+                  <group delimiter=" " prefix="[" suffix="]">
+                    <text term="accessed"/>
+                    <date form="text" variable="accessed"/>
+                  </group>
+                </if>
+              </choose>
+            </group>
+          </if>
+        </choose>
+      </if>
+    </choose>
+  </macro>
+  <citation disambiguate-add-givenname="true" disambiguate-add-names="true">
+    <layout delimiter="; " suffix=".">
+      <choose>
+        <if position="subsequent">
+          <group delimiter=", ">
+            <text macro="contributors-short"/>
+            <text macro="title-subsequent"/>
+            <text macro="point-locators-volume-note"/>
+            <text macro="point-locators-subsequent"/>
+          </group>
+        </if>
+        <else>
+          <group delimiter=" ">
+            <group delimiter=", ">
+              <group delimiter=" ">
+                <group delimiter=", ">
+                  <text macro="contributors-note"/>
+                  <text macro="title"/>
+                  <text macro="secondary-contributors"/>
+                  <text macro="container-title"/>
+                  <text macro="container-contributors"/>
+                  <text macro="locators"/>
+                </group>
+                <text macro="issue-join-with-space"/>
+              </group>
+              <text macro="issue-join-with-comma"/>
+              <text macro="point-locators-volume-note"/>
+              <text macro="locators-newspaper"/>
+              <text macro="point-locators"/>
+              <text macro="access"/>
+            </group>
+            <text macro="URL"/>
+          </group>
+        </else>
+      </choose>
+    </layout>
+  </citation>
+  <bibliography delimiter-precedes-et-al="after-inverted-name" hanging-indent="true" subsequent-author-substitute="&#8212;&#8212;">
+    <sort>
+      <key macro="contributors"/>
+      <key variable="title"/>
+    </sort>
+    <layout>
+      <group delimiter=" ">
+        <group delimiter=", ">
+          <group delimiter=" ">
+            <group delimiter=", ">
+              <text macro="contributors"/>
+              <text macro="title"/>
+              <text macro="secondary-contributors"/>
+              <text macro="container-title"/>
+              <text macro="container-contributors"/>
+              <text macro="locators"/>
+            </group>
+            <text macro="issue-join-with-space"/>
+          </group>
+          <text macro="issue-join-with-comma"/>
+          <text macro="point-locators-volume"/>
+          <text macro="artwork"/>
+          <text macro="locators-newspaper"/>
+          <text macro="pages"/>
+          <text macro="access"/>
+        </group>
+        <text macro="URL"/>
+      </group>
+    </layout>
+  </bibliography>
+</style>

--- a/modern-humanities-research-association.csl
+++ b/modern-humanities-research-association.csl
@@ -258,10 +258,14 @@
         <text variable="publisher"/>
       </if>
       <else>
-        <group delimiter=": ">
-          <!-- <text variable="publisher-place"/> -->
-          <text variable="publisher"/>
-        </group>
+        <choose>
+          <if match="none" variable="publisher">
+            <text variable="publisher-place"/>
+          </if>
+          <else>
+            <text variable="publisher"/>
+          </else>
+        </choose>
       </else>
     </choose>
   </macro>


### PR DESCRIPTION
Provide the place of publication if there is no publisher and add a variant style with the place of publication. This reflects [MHRA 7.3](https://www.mhra.org.uk/style/chapter7.html), in which the exclusion of the place of publication is ambiguous:

> While MHRA style does not require the place of publication to be given, scholars writing about the early era of printing may wish to include the place of publication of historical texts where this information is of use to readers in their field. Similarly, in some print cultures there is no publisher in the modern sense but it may be useful to give the name of a printer, where this is known.