### PR TITLE
Adding PMID macro to AMA.csl

### DIFF
--- a/american-medical-association.csl
+++ b/american-medical-association.csl
@@ -84,6 +84,14 @@
       </if>
     </choose>
   </macro>
+<macro name="pmid">
+  <choose>
+    <if variable="PMID">
+      <text value="PMID: "/>
+      <text variable="PMID"/>
+    </if>
+  </choose>
+</macro>  
   <macro name="title">
     <choose>
       <if type="bill book graphic legal_case legislation motion_picture report song thesis" match="any">
@@ -284,6 +292,7 @@
         </else>
       </choose>
       <text prefix=" " macro="access"/>
+      <text prefix=". " macro="pmid"/>
     </layout>
   </bibliography>
 </style>

--- a/american-medical-association.csl
+++ b/american-medical-association.csl
@@ -84,14 +84,14 @@
       </if>
     </choose>
   </macro>
-<macro name="pmid">
-  <choose>
-    <if variable="PMID">
-      <text value="PMID: "/>
-      <text variable="PMID"/>
-    </if>
-  </choose>
-</macro>  
+  <macro name="pmid">
+    <choose>
+      <if variable="PMID">
+        <text value="PMID: "/>
+        <text variable="PMID"/>
+      </if>
+    </choose>
+  </macro>
   <macro name="title">
     <choose>
       <if type="bill book graphic legal_case legislation motion_picture report song thesis" match="any">


### PR DESCRIPTION
AMA allows PMIDs to be included in references when desired.

This PR attempts to add a PMID to the end of the reference when a PMID is present.

In Zotero, this works as expected:

<img width="1288" alt="Screenshot 2025-03-19 at 3 47 51 PM" src="https://github.com/user-attachments/assets/9317f8cc-be8c-4d12-a1b7-1e1c07c2b72b" />
