### PR TITLE
APA: Compartmentalize macros

### DIFF
--- a/apa-annotated-bibliography.csl
+++ b/apa-annotated-bibliography.csl
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
-<style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" demote-non-dropping-particle="never" page-range-format="expanded">
+<style xmlns="http://purl.org/net/xbiblio/csl" and="symbol" class="in-text" demote-non-dropping-particle="never" initialize-with=". " names-delimiter=", " page-range-format="expanded" version="1.0">
   <info>
     <title>American Psychological Association 7th edition (annotated bibliography)</title>
-    <title-short>APA (annotated bibliography)</title-short>
+    <title-short>APA Style (annotated bibliography)</title-short>
     <id>http://www.zotero.org/styles/apa-annotated-bibliography</id>
     <link href="http://www.zotero.org/styles/apa-annotated-bibliography" rel="self"/>
     <link href="http://www.zotero.org/styles/apa" rel="template"/>
@@ -10,48 +10,53 @@
     <author>
       <name>Brenton M. Wiernik</name>
       <email>zotero@wiernik.org</email>
+      <uri>https://orcid.org/0000-0001-9560-6336</uri>
     </author>
+    <contributor>
+      <name>Andrew Dunning</name>
+      <uri>https://orcid.org/0000-0003-0464-5036</uri>
+    </contributor>
     <category citation-format="author-date"/>
     <category field="psychology"/>
     <category field="generic-base"/>
+    <summary>Author–date system of the Publication manual of the American Psychological Association: The official guide to APA style (2020)</summary>
     <updated>2024-07-09T20:08:41+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale xml:lang="en">
     <terms>
-      <term name="editortranslator" form="short">
-        <single>ed. &amp; trans.</single>
-        <multiple>eds. &amp; trans.</multiple>
-      </term>
-      <term name="editor-translator" form="short">
-        <single>ed. &amp; trans.</single>
-        <multiple>eds. &amp; trans.</multiple>
-      </term>
-      <term name="translator" form="short">trans.</term>
-      <term name="interviewer" form="short">
-        <single>interviewer</single>
-        <multiple>interviewers</multiple>
-      </term>
-      <term name="collection-editor" form="short">
+      <term name="ad"> C.E.</term>
+      <term form="long" name="at">before the</term>
+      <term name="bc"> B.C.E.</term>
+      <term form="short" name="circa">ca.</term>
+      <term name="collection">archival collection</term>
+      <term form="short" name="collection-editor">
         <single>ed.</single>
         <multiple>eds.</multiple>
       </term>
-      <term name="performer" form="verb">recorded by</term>
-      <term name="circa" form="short">ca.</term>
-      <term name="bc"> B.C.E.</term>
-      <term name="ad"> C.E.</term>
-      <term name="issue" form="long">
+      <term form="short" name="editor-translator">
+        <single>ed. &amp; trans.</single>
+        <multiple>eds. &amp; trans.</multiple>
+      </term>
+      <term form="short" name="editortranslator">
+        <single>ed. &amp; trans.</single>
+        <multiple>eds. &amp; trans.</multiple>
+      </term>
+      <term form="verb" name="hearing">testimony of</term>
+      <term form="short" name="interviewer">
+        <single>interviewer</single>
+        <multiple>interviewers</multiple>
+      </term>
+      <term form="long" name="issue">
         <single>issue</single>
         <multiple>issues</multiple>
       </term>
-      <term name="software">computer software</term>
-      <term name="at" form="long">before the</term>
-      <term name="collection">archival collection</term>
+      <term form="verb" name="performer">recorded by</term>
       <term name="post">online post</term>
-      <term name="at" form="long">before the</term>
-      <term name="hearing" form="verb">testimony of</term>
-      <term name="review-of" form="long">review of the</term>
-      <term name="review-of" form="short">review of</term>
+      <term form="long" name="review-of">review of the</term>
+      <term form="short" name="review-of">review of</term>
+      <term name="software">computer software</term>
+      <term form="short" name="translator">trans.</term>
     </terms>
   </locale>
   <locale xml:lang="da">
@@ -71,7 +76,7 @@
   </locale>
   <locale xml:lang="fr">
     <terms>
-      <term name="editor" form="short">
+      <term form="short" name="editor">
         <single>éd.</single>
         <multiple>éds.</multiple>
       </term>
@@ -97,29 +102,26 @@
       <term name="et-al">et al.</term>
     </terms>
   </locale>
-  <!-- For Indigeneous Knowledge, assume the item is stored as `document` or `speech`
-       and that Nation/Community, treaty, where the Elder lives, 
-       and topic are all stored in `title`
-       cf. https://libguides.norquest.ca/c.php?g=314831&p=5188823.
-       If the item is stored as `interview`, assume that Nation/Community, treat, and topic
-       are stored in `title`, 'Oral teaching' or similar is stored in `archive`, and where
-       the Elder lives is stored in `archive-place`. 
-  -->
-  <!-- Reviews are detected if an item has type `review` or `review-book` or if it has any of the variables
-       `reviewed-title`, `reviewed-author`, or `reviewed-genre`. For the latter case, reviews are commonly 
-       stored as types `article-journal`, `article-magazine`, `article-newspaper`, `post-weblog`, or `webpage` 
-  -->
-  <!-- General categories of item types:
-       Periodical: article-journal article-magazine article-newspaper periodical post-weblog review review-book
-       Periodical or Booklike: paper-conference
-       Booklike: article book broadcast chapter classic collection dataset document
-                 entry entry-dictionary entry-encyclopedia event figure
-                 graphic interview manuscript map motion_picture musical_score
-                 pamphlet patent performance personal_communication post report
-                 software song speech standard thesis webpage
-       Legal: bill hearing legal_case legislation regulation treaty
+  <!-- General categories of CSL item types:
+
+       Periodical
+       : article-journal article-magazine article-newspaper periodical post-weblog review review-book
+
+       Periodical or Booklike
+       : paper-conference
+
+       Booklike
+       : article book broadcast chapter classic collection dataset document
+         entry entry-dictionary entry-encyclopedia event figure
+         graphic interview manuscript map motion_picture musical_score
+         pamphlet patent performance personal_communication post report
+         software song speech standard thesis webpage
+
+       Legal
+       : bill hearing legal_case legislation regulation treaty
   -->
   <!-- Equivalencies:
+
        classic == book
        document == report, but give full date
        standard == report
@@ -128,6 +130,7 @@
        collection == book, but give full date
   -->
   <!-- Role equivalencies:
+
        compiler == editor
        organizer, curator == chair
        script-writer == director
@@ -135,128 +138,294 @@
        guest, host == director
        series-creator, executive-producer == editor
   -->
-  <!-- APA references contain four parts: author, date, title, source -->
+  <!-- Reviews are detected if an item has type `review` or `review-book` or if it has any of the variables
+       `reviewed-title`, `reviewed-author`, or `reviewed-genre`. For the latter case, reviews are commonly
+       stored as types `article-journal`, `article-magazine`, `article-newspaper`, `post-weblog`, or `webpage`
+  -->
+  <!-- For Indigeneous Knowledge, assume the item is stored as `document` or `speech`
+       and that Nation/Community, treaty, where the Elder lives,
+       and topic are all stored in `title`
+       cf. https://libguides.norquest.ca/c.php?g=314831&p=5188823.
+       If the item is stored as `interview`, assume that Nation/Community, treaty territory, and topic
+       are stored in `title`, 'Oral teaching' or similar is stored in `archive`, and where
+       the Elder lives is stored in `archive-place`.
+  -->
+  <!-- Variable labelling macros -->
+  <macro name="chapter-number-labelled">
+    <group delimiter=" ">
+      <choose>
+        <if is-numeric="chapter-number">
+          <label form="short" variable="chapter-number"/>
+        </if>
+      </choose>
+      <text variable="chapter-number"/>
+    </group>
+  </macro>
+  <macro name="edition-labelled">
+    <choose>
+      <if is-numeric="edition">
+        <group delimiter=" ">
+          <number form="ordinal" variable="edition"/>
+          <label form="short" variable="edition"/>
+        </group>
+      </if>
+      <else>
+        <text variable="edition"/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="issue-labelled">
+    <group delimiter=" ">
+      <label text-case="capitalize-first" variable="issue"/>
+      <text variable="issue"/>
+    </group>
+  </macro>
+  <macro name="locator-labelled">
+    <!-- Abbreviate page and paragraph; leave other locator labels in long form (APA 8.13) -->
+    <group delimiter=" ">
+      <choose>
+        <if locator="page paragraph" match="any">
+          <label form="short" variable="locator"/>
+        </if>
+        <else>
+          <label text-case="capitalize-first" variable="locator"/>
+        </else>
+      </choose>
+      <text variable="locator"/>
+    </group>
+  </macro>
+  <macro name="number-labelled">
+    <group delimiter=" ">
+      <choose>
+        <if is-numeric="number">
+          <label form="short" text-case="capitalize-first" variable="number"/>
+        </if>
+        <else-if match="none" type="broadcast">
+          <label form="short" text-case="capitalize-first" variable="number"/>
+        </else-if>
+      </choose>
+      <text variable="number"/>
+    </group>
+  </macro>
+  <macro name="number-article-labelled">
+    <!-- APA example 6: Journal article with article number or eLocator -->
+    <group delimiter=" ">
+      <text term="article-locator" text-case="capitalize-first"/>
+      <text variable="number"/>
+    </group>
+  </macro>
+  <macro name="number-of-volumes-labelled">
+    <choose>
+      <if is-numeric="number-of-volumes">
+        <group delimiter=" ">
+          <label form="short" text-case="capitalize-first" variable="number-of-volumes"/>
+          <text prefix="1" term="page-range-delimiter"/>
+        </group>
+      </if>
+    </choose>
+    <text variable="number-of-volumes"/>
+  </macro>
+  <macro name="page-labelled">
+    <group delimiter=" ">
+      <label form="short" variable="page"/>
+      <text variable="page"/>
+    </group>
+  </macro>
+  <macro name="part-number-labelled">
+    <group delimiter=" ">
+      <choose>
+        <if variable="part-number">
+          <!-- TODO: Replace with `part-number` label when CSL provides one -->
+          <text form="short" term="part" text-case="capitalize-first"/>
+          <text variable="part-number"/>
+        </if>
+      </choose>
+    </group>
+  </macro>
+  <macro name="section-labelled">
+    <group delimiter=" ">
+      <label form="symbol" variable="section"/>
+      <text variable="section"/>
+    </group>
+  </macro>
+  <macro name="supplement-number-labelled">
+    <group delimiter=" ">
+      <choose>
+        <if variable="supplement-number">
+          <!-- TODO: Replace with `supplement-number` label when CSL provides one -->
+          <text form="short" term="supplement" text-case="capitalize-first"/>
+          <text variable="supplement-number"/>
+        </if>
+      </choose>
+    </group>
+  </macro>
+  <macro name="version-labelled">
+    <group delimiter=" ">
+      <label text-case="capitalize-first" variable="version"/>
+      <text variable="version"/>
+    </group>
+  </macro>
+  <macro name="volume-labelled">
+    <group delimiter=" ">
+      <label form="short" text-case="capitalize-first" variable="volume"/>
+      <text variable="volume"/>
+    </group>
+  </macro>
+  <!-- Four parts in APA references:
+
+       1. Author (APA 9.7–12)
+       2. Date (APA 9.13–17)
+       3. Title (APA 9.18–22)
+       4. Source (APA 9.23–37)
+  -->
+  <!-- 1. Author -->
+  <!-- Author utility macros -->
+  <macro name="author-substitute-bib">
+    <names variable="composer">
+      <name delimiter-precedes-last="always" name-as-sort-order="all"/>
+      <label form="short" prefix=" (" suffix=")" text-case="title"/>
+      <substitute>
+        <names variable="author"/>
+        <!-- `narrator` only cited in secondary-contributors -->
+        <names variable="illustrator"/>
+        <choose>
+          <if type="broadcast">
+            <names variable="script-writer director">
+              <!-- Actors/performers and producers [not executive] not cited in APA style. -->
+              <name delimiter-precedes-last="always" name-as-sort-order="all"/>
+              <label form="long" prefix=" (" suffix=")" text-case="title"/>
+            </names>
+          </if>
+        </choose>
+        <names variable="director">
+          <!-- For non-broadcast items, APA only cites directors and not writers. -->
+          <name delimiter-precedes-last="always" name-as-sort-order="all"/>
+          <label form="long" prefix=" (" suffix=")" text-case="title"/>
+        </names>
+        <names variable="guest host">
+          <!-- TODO: Replace `delimiter` with `collapse` to combine names variables when that becomes available. -->
+          <name delimiter-precedes-last="always" name-as-sort-order="all"/>
+          <label form="long" prefix=" (" suffix=")" text-case="title"/>
+        </names>
+        <names variable="producer">
+          <!-- Producers not cited if there is a writer/director, but use if they are the principle creator. -->
+          <name delimiter-precedes-last="always" name-as-sort-order="all"/>
+          <label form="long" prefix=" (" suffix=")" text-case="title"/>
+        </names>
+        <choose>
+          <if variable="container-title">
+            <choose>
+              <if match="any" type="book classic collection entry entry-dictionary entry-encyclopedia">
+                <!-- Items with book-like container-title substitute with their title and identification,
+                     but leave description after container-title. This mimics the `container-booklike` formatting. -->
+                <text macro="title-substitute"/>
+              </if>
+            </choose>
+          </if>
+        </choose>
+        <names variable="executive-producer">
+          <name delimiter-precedes-last="always" name-as-sort-order="all"/>
+          <label form="long" prefix=" (" suffix=")" text-case="title"/>
+        </names>
+        <names variable="series-creator">
+          <name delimiter-precedes-last="always" name-as-sort-order="all"/>
+          <label form="long" prefix=" (" suffix=")" text-case="title"/>
+        </names>
+        <names variable="editor-translator"/>
+        <!-- Translator is not cited as a primary creator (only as Ed. & Trans.). -->
+        <names variable="editor"/>
+        <names variable="editorial-director"/>
+        <names variable="compiler">
+          <name delimiter-precedes-last="always" name-as-sort-order="all"/>
+          <label form="long" prefix=" (" suffix=")" text-case="title"/>
+        </names>
+        <choose>
+          <if match="any" type="event performance speech">
+            <names variable="chair">
+              <name delimiter-precedes-last="always" name-as-sort-order="all"/>
+              <label form="long" prefix=" (" suffix=")" text-case="title"/>
+            </names>
+            <names variable="organizer">
+              <name delimiter-precedes-last="always" name-as-sort-order="all"/>
+              <label form="long" prefix=" (" suffix=")" text-case="title"/>
+            </names>
+          </if>
+        </choose>
+        <names variable="curator">
+          <name delimiter-precedes-last="always" name-as-sort-order="all"/>
+          <label form="long" prefix=" (" suffix=")" text-case="title"/>
+        </names>
+        <names variable="collection-editor"/>
+        <text macro="title-substitute"/>
+      </substitute>
+    </names>
+  </macro>
+  <macro name="author-substitute-intext">
+    <names variable="composer">
+      <name form="short"/>
+      <substitute>
+        <names variable="author"/>
+        <names variable="illustrator"/>
+        <!-- TODO: Replace `delimiter` with `collapse` to combine names variables when that becomes available. -->
+        <choose>
+          <if type="broadcast">
+            <names variable="script-writer"/>
+          </if>
+        </choose>
+        <names variable="director"/>
+        <!-- TODO: Replace `delimiter` with `collapse` to combine names variables when that becomes available. -->
+        <names variable="guest host"/>
+        <names variable="producer"/>
+        <choose>
+          <if variable="container-title">
+            <choose>
+              <if match="any" type="book classic collection entry entry-dictionary entry-encyclopedia">
+                <text macro="title-intext"/>
+              </if>
+            </choose>
+          </if>
+        </choose>
+        <names variable="executive-producer"/>
+        <names variable="series-creator"/>
+        <names variable="editor"/>
+        <names variable="editorial-director"/>
+        <names variable="compiler"/>
+        <choose>
+          <if match="any" type="event performance speech">
+            <names variable="chair"/>
+            <names variable="organizer"/>
+          </if>
+        </choose>
+        <names variable="curator"/>
+        <text macro="title-intext"/>
+      </substitute>
+    </names>
+  </macro>
+  <macro name="title-substitute">
+    <choose>
+      <if variable="title">
+        <!-- If an item has a title, substitute missing author with title and identification, but leave description after the date (in the 'title' position). -->
+        <group delimiter=" ">
+          <text macro="title-bib"/>
+          <text macro="identification"/>
+        </group>
+      </if>
+      <else>
+        <!-- If an item has no title, substitute with description followed by identification. -->
+        <text macro="title-and-descriptions"/>
+      </else>
+    </choose>
+  </macro>
+  <!-- Author logic -->
   <macro name="author-bib">
     <group delimiter=" ">
-      <names variable="composer" delimiter=", &amp; ">
-        <name name-as-sort-order="all" and="symbol" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
-        <substitute>
-          <names variable="author"/>
-          <!-- Note: `narrator` only cited in secondary-contributors -->
-          <names variable="illustrator"/>
-          <!-- TODO: Replace `delimiter` with `collapse` to combine names variables when that becomes available. -->
-          <choose>
-            <if type="broadcast">
-              <names variable="script-writer director">
-                <!-- Note: Actors/performers and producers [not executive] not cited in APA style. -->
-                <name name-as-sort-order="all" and="symbol" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
-                <label form="long" prefix=" (" suffix=")" text-case="title"/>
-              </names>
-            </if>
-          </choose>
-          <names variable="director">
-            <!-- For non-broadcast items, APA only cites directors and not writers. -->
-            <name name-as-sort-order="all" and="symbol" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
-            <label form="long" prefix=" (" suffix=")" text-case="title"/>
-          </names>
-          <!-- TODO: Replace `delimiter` with `collapse` to combine names variables when that becomes available. -->
-          <names variable="guest host">
-            <name name-as-sort-order="all" and="symbol" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
-            <label form="long" prefix=" (" suffix=")" text-case="title"/>
-          </names>
-          <names variable="producer">
-            <!-- Note: Producers not cited if there is a writer/director, but use if they are the principle creator. -->
-            <name name-as-sort-order="all" and="symbol" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
-            <label form="long" prefix=" (" suffix=")" text-case="title"/>
-          </names>
-          <choose>
-            <if variable="container-title">
-              <choose>
-                <if type="book classic collection entry entry-dictionary entry-encyclopedia" match="any">
-                  <!-- Items with book-like container-title substitute with their title and parenthetical, 
-                       but leave bracketed after container-title. This mimics the `container-booklike` formatting. -->
-                  <choose>
-                    <if variable="title">
-                      <group delimiter=" ">
-                        <text macro="title"/>
-                        <text macro="parenthetical"/>
-                      </group>
-                    </if>
-                    <else>
-                      <text macro="title-and-descriptions"/>
-                    </else>
-                  </choose>
-                </if>
-              </choose>
-            </if>
-          </choose>
-          <names variable="executive-producer">
-            <name name-as-sort-order="all" and="symbol" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
-            <label form="long" prefix=" (" suffix=")" text-case="title"/>
-          </names>
-          <names variable="series-creator">
-            <name name-as-sort-order="all" and="symbol" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
-            <label form="long" prefix=" (" suffix=")" text-case="title"/>
-          </names>
-          <names variable="editor-translator">
-            <name name-as-sort-order="all" and="symbol" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
-            <label form="short" prefix=" (" suffix=")" text-case="title"/>
-          </names>
-          <!-- Note: Translator is not cited as a primary creator (only as Ed. & Trans.). -->
-          <names variable="editor">
-            <name name-as-sort-order="all" and="symbol" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
-            <label form="short" prefix=" (" suffix=")" text-case="title"/>
-          </names>
-          <names variable="editorial-director">
-            <name name-as-sort-order="all" and="symbol" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
-            <label form="short" prefix=" (" suffix=")" text-case="title"/>
-          </names>
-          <names variable="compiler">
-            <name name-as-sort-order="all" and="symbol" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
-            <label form="long" prefix=" (" suffix=")" text-case="title"/>
-          </names>
-          <choose>
-            <if type="event performance speech" match="any">
-              <names variable="chair">
-                <name name-as-sort-order="all" and="symbol" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
-                <label form="long" prefix=" (" suffix=")" text-case="title"/>
-              </names>
-              <names variable="organizer">
-                <name name-as-sort-order="all" and="symbol" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
-                <label form="long" prefix=" (" suffix=")" text-case="title"/>
-              </names>
-            </if>
-          </choose>
-          <names variable="curator">
-            <name name-as-sort-order="all" and="symbol" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
-            <label form="long" prefix=" (" suffix=")" text-case="title"/>
-          </names>
-          <names variable="collection-editor">
-            <name name-as-sort-order="all" and="symbol" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
-            <label form="short" prefix=" (" suffix=")" text-case="title"/>
-          </names>
-          <choose>
-            <if variable="title">
-              <!-- If an item has a title, substitute missing author with title and parenthetical, but leave bracketed 
-                   after the date (in the 'title' position). -->
-              <group delimiter=" ">
-                <text macro="title"/>
-                <text macro="parenthetical"/>
-              </group>
-            </if>
-            <else>
-              <!-- If an item has no title, substitute with bracketed followed by parenthetical. -->
-              <text macro="title-and-descriptions"/>
-            </else>
-          </choose>
-        </substitute>
-      </names>
+      <text macro="author-substitute-bib"/>
       <choose>
         <!-- Print "with" contributor for books, but not for other types that commonly have them (eg, thesis, software) -->
-        <if type="book classic collection" match="any">
-          <names variable="contributor" prefix="(" suffix=")">
+        <if match="any" type="book classic collection">
+          <names prefix="(" suffix=")" variable="contributor">
             <label form="verb" suffix=" "/>
-            <name name-as-sort-order="all" and="symbol" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
+            <name delimiter-precedes-last="always" name-as-sort-order="all"/>
           </names>
         </if>
       </choose>
@@ -264,80 +433,21 @@
   </macro>
   <macro name="author-intext">
     <choose>
-      <if type="bill hearing legal_case legislation regulation treaty" match="any">
+      <if match="any" type="bill hearing legal_case legislation regulation treaty">
         <text macro="title-intext"/>
       </if>
-      <else-if type="interview personal_communication" match="any">
-        <choose>
-          <!-- These variables indicate that the letter is retrievable by the reader.
-                If not, then use the APA in-text-only personal communication format -->
-          <if variable="archive container-title DOI publisher URL" match="none">
-            <group delimiter=", ">
-              <names variable="author">
-                <name and="symbol" delimiter=", " initialize-with=". "/>
-                <substitute>
-                  <text macro="title-intext"/>
-                </substitute>
-              </names>
-              <text term="personal-communication"/>
-            </group>
-          </if>
-          <else>
-            <names variable="author" delimiter=", ">
-              <name form="short" and="symbol" delimiter=", " initialize-with=". "/>
-              <substitute>
-                <text macro="title-intext"/>
-              </substitute>
-            </names>
-          </else>
-        </choose>
+      <else-if match="any" type="interview personal_communication">
+        <text macro="title-intext-interview-communication"/>
       </else-if>
       <else>
-        <names variable="composer" delimiter=" &amp; ">
-          <name form="short" and="symbol" delimiter=", " initialize-with=". "/>
-          <substitute>
-            <names variable="author"/>
-            <names variable="illustrator"/>
-            <!-- TODO: Replace `delimiter` with `collapse` to combine names variables when that becomes available. -->
-            <choose>
-              <if type="broadcast">
-                <names variable="script-writer director"/>
-              </if>
-            </choose>
-            <names variable="director"/>
-            <!-- TODO: Replace `delimiter` with `collapse` to combine names variables when that becomes available. -->
-            <names variable="guest host"/>
-            <names variable="producer"/>
-            <choose>
-              <if variable="container-title">
-                <choose>
-                  <if type="book classic collection entry entry-dictionary entry-encyclopedia" match="any">
-                    <text macro="title-intext"/>
-                  </if>
-                </choose>
-              </if>
-            </choose>
-            <names variable="executive-producer"/>
-            <names variable="series-creator"/>
-            <names variable="editor"/>
-            <names variable="editorial-director"/>
-            <names variable="compiler"/>
-            <choose>
-              <if type="event performance speech" match="any">
-                <names variable="chair"/>
-                <names variable="organizer"/>
-              </if>
-            </choose>
-            <names variable="curator"/>
-            <text macro="title-intext"/>
-          </substitute>
-        </names>
+        <text macro="author-substitute-intext"/>
       </else>
     </choose>
   </macro>
+  <!-- Author sorting -->
   <macro name="author-sort">
     <choose>
-      <if type="bill hearing legal_case legislation regulation treaty" match="any">
+      <if match="any" type="bill hearing legal_case legislation regulation treaty">
         <text macro="title-legal"/>
       </if>
       <else>
@@ -345,92 +455,161 @@
       </else>
     </choose>
   </macro>
-  <macro name="date-bib">
-    <group delimiter=" " prefix="(" suffix=")">
-      <choose>
-        <if is-uncertain-date="issued">
-          <text term="circa" form="short"/>
-        </if>
-      </choose>
-      <group>
-        <choose>
-          <if variable="issued">
-            <group delimiter=", ">
-              <group>
-                <date variable="issued" date-parts="year" form="numeric"/>
-                <text variable="year-suffix"/>
-              </group>
-              <choose>
-                <if type="article-magazine article-newspaper broadcast collection document event interview motion_picture pamphlet performance personal_communication post post-weblog song speech webpage" match="any">
-                  <!-- Many video and audio examples in manual give full dates. Err on the side of too much information. -->
-                  <date variable="issued">
-                    <date-part name="month"/>
-                    <date-part name="day" prefix=" "/>
-                  </date>
-                </if>
-                <else-if type="paper-conference">
-                  <!-- Capture 'speech' stored as 'paper-conference' -->
-                  <choose>
-                    <if variable="collection-editor compiler editor editorial-director issue page volume" match="none">
-                      <date variable="issued">
-                        <date-part name="month"/>
-                        <date-part name="day" prefix=" "/>
-                      </date>
-                    </if>
-                  </choose>
-                </else-if>
-                <!-- Only year: article article-journal book chapter classic entry entry-dictionary entry-encyclopedia dataset figure graphic
-                     manuscript map musical_score paper-conference[published] patent periodical report review review-book software standard thesis -->
-              </choose>
-            </group>
-          </if>
-          <else-if variable="status">
-            <group>
-              <!-- We print the status variable directly rather than using in-press, etc. terms. -->
-              <text variable="status" text-case="lowercase"/>
-              <text variable="year-suffix" prefix="-"/>
-            </group>
-          </else-if>
-          <else>
-            <text term="no date" form="short"/>
-            <text variable="year-suffix" prefix="-"/>
-          </else>
-        </choose>
-      </group>
+  <!-- 2. Date -->
+  <!-- Date utility macros -->
+  <macro name="date-issued-full">
+    <group delimiter=" ">
+      <text macro="uncertain-date-issued"/>
+      <date form="text" variable="issued"/>
     </group>
   </macro>
-  <macro name="date-sort">
-    <!-- This is necessary to ensure that citeproc sorts all item types chonologically in the same list. -->
+  <macro name="date-issued-leading-zeros">
+    <date delimiter="-" variable="issued">
+      <date-part form="long" name="year"/>
+      <date-part form="numeric-leading-zeros" name="month"/>
+      <date-part form="numeric-leading-zeros" name="day"/>
+    </date>
+  </macro>
+  <macro name="date-issued-month-day">
+    <date variable="issued">
+      <date-part name="month"/>
+      <date-part name="day" prefix=" "/>
+    </date>
+  </macro>
+  <macro name="date-issued-year">
+    <group delimiter=" ">
+      <text macro="uncertain-date-issued"/>
+      <date date-parts="year" form="numeric" variable="issued"/>
+    </group>
+  </macro>
+  <macro name="original-date-year">
+    <group delimiter=" ">
+      <choose>
+        <if is-uncertain-date="original-date">
+          <text form="short" term="circa"/>
+        </if>
+      </choose>
+      <date variable="original-date">
+        <date-part name="year"/>
+      </date>
+    </group>
+  </macro>
+  <macro name="uncertain-date-issued">
     <choose>
-      <if type="article article-journal book chapter entry entry-dictionary entry-encyclopedia dataset figure graphic manuscript map musical_score patent report review review-book thesis" match="any">
-        <date variable="issued" date-parts="year" form="numeric"/>
+      <if is-uncertain-date="issued">
+        <text form="short" term="circa"/>
+      </if>
+    </choose>
+  </macro>
+  <!-- Date logic -->
+  <macro name="date-bib">
+    <group prefix="(" suffix=")">
+      <choose>
+        <if variable="issued">
+          <group delimiter=", ">
+            <group>
+              <text macro="date-issued-year"/>
+              <text variable="year-suffix"/>
+            </group>
+            <choose>
+              <if match="any" type="article-magazine article-newspaper broadcast collection document event interview motion_picture pamphlet performance personal_communication post post-weblog song speech webpage">
+                <!-- Many video and audio examples in manual give full dates. Err on the side of too much information. -->
+                <text macro="date-issued-month-day"/>
+              </if>
+              <else-if type="paper-conference">
+                <!-- Capture 'speech' stored as 'paper-conference' -->
+                <choose>
+                  <if match="none" variable="collection-editor compiler editor editorial-director issue page volume">
+                    <text macro="date-issued-month-day"/>
+                  </if>
+                </choose>
+              </else-if>
+              <!-- Only year: article article-journal book chapter classic entry entry-dictionary entry-encyclopedia dataset figure graphic
+                     manuscript map musical_score paper-conference[published] patent periodical report review review-book software standard thesis -->
+            </choose>
+          </group>
+        </if>
+        <else-if variable="status">
+          <group>
+            <!-- We print the status variable directly rather than using in-press, etc. terms. -->
+            <text text-case="lowercase" variable="status"/>
+            <text prefix="-" variable="year-suffix"/>
+          </group>
+        </else-if>
+        <else>
+          <text form="short" term="no date"/>
+          <text prefix="-" variable="year-suffix"/>
+        </else>
+      </choose>
+    </group>
+  </macro>
+  <macro name="date-intext">
+    <choose>
+      <if variable="issued">
+        <group delimiter="/">
+          <text macro="original-date-year"/>
+          <group>
+            <choose>
+              <if match="any" type="interview personal_communication">
+                <choose>
+                  <if match="none" variable="archive archive-place container-title DOI publisher URL">
+                    <!-- These variables indicate that the communication is retrievable by the reader.
+                           If not, then use the in-text-only personal communication format -->
+                    <text macro="date-issued-full"/>
+                  </if>
+                  <else>
+                    <text macro="date-issued-year"/>
+                  </else>
+                </choose>
+              </if>
+              <else>
+                <text macro="date-issued-year"/>
+              </else>
+            </choose>
+            <text variable="year-suffix"/>
+          </group>
+        </group>
+      </if>
+      <else-if variable="status">
+        <!-- We print the status variable directly rather than using in-press, etc. terms. -->
+        <text text-case="lowercase" variable="status"/>
+        <text prefix="-" variable="year-suffix"/>
+      </else-if>
+      <else>
+        <text form="short" term="no date"/>
+        <text prefix="-" variable="year-suffix"/>
+      </else>
+    </choose>
+  </macro>
+  <!-- Date sorting -->
+  <macro name="date-sort">
+    <!-- Sort items by printed issue date without prefixes for original or uncertain dates -->
+    <choose>
+      <if match="any" type="article article-journal book chapter entry entry-dictionary entry-encyclopedia dataset figure graphic manuscript map musical_score patent report review review-book thesis">
+        <date date-parts="year" form="numeric" variable="issued"/>
       </if>
       <else-if type="paper-conference">
         <!-- Capture 'speech' stored as 'paper-conference' -->
         <choose>
-          <if variable="collection-editor compiler editor editorial-director issue page volume" match="any">
-            <date variable="issued" date-parts="year" form="numeric"/>
+          <if match="any" variable="collection-editor compiler editor editorial-director issue page volume">
+            <date date-parts="year" form="numeric" variable="issued"/>
           </if>
           <else>
-            <date variable="issued">
-              <date-part name="year" form="long"/>
-              <date-part name="month" form="numeric-leading-zeros"/>
-              <date-part name="day" form="numeric-leading-zeros"/>
-            </date>
+            <text macro="date-issued-leading-zeros"/>
           </else>
         </choose>
       </else-if>
       <else>
-        <date variable="issued">
-          <date-part name="year" form="long"/>
-          <date-part name="month" form="numeric-leading-zeros"/>
-          <date-part name="day" form="numeric-leading-zeros"/>
-        </date>
+        <text macro="date-issued-leading-zeros"/>
       </else>
     </choose>
   </macro>
   <macro name="date-sort-group">
-    <!-- APA sorts 1. no-date items, 2. items with dates, 3. in-press (status) items -->
+    <!-- Sorts items with and without dates:
+
+         1. no-date items (= 0)
+         2. items with dates (= 1)
+         3. in-press (status) items (= 2) -->
     <choose>
       <if variable="issued">
         <text value="1"/>
@@ -443,111 +622,185 @@
       </else>
     </choose>
   </macro>
-  <macro name="date-intext">
-    <choose>
-      <if variable="issued">
-        <group delimiter="/">
-          <group delimiter=" ">
-            <choose>
-              <if is-uncertain-date="original-date">
-                <text term="circa" form="short"/>
-              </if>
-            </choose>
-            <date variable="original-date">
-              <date-part name="year"/>
-            </date>
-          </group>
-          <group delimiter=" ">
-            <choose>
-              <if is-uncertain-date="issued">
-                <text term="circa" form="short"/>
-              </if>
-            </choose>
-            <group>
-              <choose>
-                <if type="interview personal_communication" match="any">
-                  <choose>
-                    <if variable="archive container-title DOI publisher URL" match="none">
-                      <!-- These variables indicate that the communication is retrievable by the reader.
-                           If not, then use the in-text-only personal communication format -->
-                      <date variable="issued" form="text"/>
-                    </if>
-                    <else>
-                      <date variable="issued">
-                        <date-part name="year"/>
-                      </date>
-                    </else>
-                  </choose>
-                </if>
-                <else>
-                  <date variable="issued">
-                    <date-part name="year"/>
-                  </date>
-                </else>
-              </choose>
-              <text variable="year-suffix"/>
-            </group>
-          </group>
-        </group>
-      </if>
-      <else-if variable="status">
-        <!-- We print the status variable directly rather than using in-press, etc. terms. -->
-        <text variable="status" text-case="lowercase"/>
-        <text variable="year-suffix" prefix="-"/>
-      </else-if>
-      <else>
-        <text term="no date" form="short"/>
-        <text variable="year-suffix" prefix="-"/>
-      </else>
-    </choose>
-  </macro>
-  <!-- APA has two description elements following the title:
-       title (parenthetical) [bracketed] -->
+  <!-- 3. Title and descriptions -->
+  <!-- Three parts in title element (APA 9.21):
+
+       1. Title
+       2. Identification (in parentheses)
+       3. Description [in square brackets] -->
   <macro name="title-and-descriptions">
     <choose>
       <if variable="title">
         <group delimiter=" ">
-          <text macro="title"/>
-          <text macro="parenthetical"/>
-          <text macro="bracketed"/>
+          <text macro="title-bib"/>
+          <text macro="identification"/>
+          <text macro="description-bib"/>
         </group>
       </if>
       <else>
         <choose>
-          <if type="bill report" match="any">
+          <if match="any" type="bill report">
             <!-- Bills, resolutions, and congressional reports are not italicized and substitute bill number if no title. -->
-            <!-- Can't distinguish congressional reports from other reports, 
+            <!-- Can't distinguish congressional reports from other reports,
                  but giving the genre and number seems fine for other reports too. -->
-            <text macro="number"/>
-            <text macro="bracketed"/>
-            <text macro="parenthetical"/>
+            <text macro="genre-number"/>
+            <text macro="description-bib"/>
+            <text macro="identification"/>
           </if>
           <else>
             <group delimiter=" ">
-              <text macro="bracketed"/>
-              <text macro="parenthetical"/>
+              <text macro="description-bib"/>
+              <text macro="identification"/>
             </group>
           </else>
         </choose>
       </else>
     </choose>
   </macro>
-  <macro name="title">
+  <!-- 3.1. Title -->
+  <!-- Title utility macros -->
+  <macro name="title-intext-bill-report">
+    <!-- Bills, resolutions, and congressional reports are not italicized and substitute bill number if no title. -->
+    <!-- Can't distinguish congressional reports from other reports,
+             but giving the genre and number seems fine for other reports too. -->
     <choose>
-      <if type="post webpage" match="any">
+      <if variable="title">
+        <text form="short" text-case="title" variable="title"/>
+      </if>
+      <else>
+        <group delimiter=" ">
+          <text variable="genre"/>
+          <group delimiter=" ">
+            <choose>
+              <if match="none" variable="chapter-number container-title">
+                <text macro="number-labelled"/>
+              </if>
+              <else>
+                <text variable="number"/>
+              </else>
+            </choose>
+          </group>
+        </group>
+      </else>
+    </choose>
+  </macro>
+  <macro name="title-intext-interview-communication">
+    <choose>
+      <!-- These variables indicate that the letter is retrievable by the reader.
+                If not, then use the APA in-text-only personal communication format -->
+      <if match="none" variable="archive archive-place container-title DOI publisher URL">
+        <group delimiter=", ">
+          <names variable="author">
+            <substitute>
+              <text macro="title-intext"/>
+            </substitute>
+          </names>
+          <text term="personal-communication"/>
+        </group>
+      </if>
+      <else>
+        <names variable="author">
+          <name form="short"/>
+          <substitute>
+            <text macro="title-intext"/>
+          </substitute>
+        </names>
+      </else>
+    </choose>
+  </macro>
+  <macro name="title-part">
+    <group delimiter=". ">
+      <text macro="part-number-labelled"/>
+      <text text-case="capitalize-first" variable="part-title"/>
+    </group>
+  </macro>
+  <macro name="title-plus-part-title">
+    <choose>
+      <if match="any" type="review review-book" variable="reviewed-author reviewed-genre reviewed-title">
+        <!-- If a review has no `reviewed-title`, assume that `title` contains the title of the reviewed work
+             and omit it here; it is printed in the `reviewed-item` macro. -->
+        <choose>
+          <if match="none" variable="reviewed-title"/>
+          <else>
+            <group delimiter=": ">
+              <text variable="title"/>
+              <text macro="title-part"/>
+            </group>
+          </else>
+        </choose>
+      </if>
+      <else>
+        <group delimiter=": ">
+          <text variable="title"/>
+          <text macro="title-part"/>
+        </group>
+      </else>
+    </choose>
+  </macro>
+  <macro name="title-plus-volume-title">
+    <group delimiter=": ">
+      <text variable="title"/>
+      <text macro="title-volume"/>
+    </group>
+  </macro>
+  <macro name="title-volume">
+    <group delimiter=": ">
+      <choose>
+        <if variable="volume-title">
+          <group delimiter=". ">
+            <text macro="volume-labelled"/>
+            <text variable="volume-title"/>
+          </group>
+        </if>
+        <else-if is-numeric="volume" match="none">
+          <text macro="volume-labelled"/>
+        </else-if>
+      </choose>
+      <!-- For book-like items, assume part-number and part-title refer to the book/volume. -->
+      <text macro="title-part"/>
+    </group>
+  </macro>
+  <!-- Title logic -->
+  <macro name="booklike-title">
+    <!-- For book-like items, assume part-number and part-title refer to the book/volume. -->
+    <choose>
+      <if variable="container-title">
+        <text variable="title"/>
+      </if>
+      <else>
+        <!-- For book-like items without container titles and with volume-title, append volume-title to title (APA example 30) -->
+        <text font-style="italic" macro="title-plus-volume-title"/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="periodical-title">
+    <!-- For periodicals, assume that part-number and part-title refer to the article and append to title -->
+    <choose>
+      <if variable="container-title">
+        <text macro="title-plus-part-title"/>
+      </if>
+      <else>
+        <!-- for periodical items without container titles, don't append volume-title to title -->
+        <text font-style="italic" macro="title-plus-part-title"/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="title-bib">
+    <choose>
+      <if match="any" type="post webpage">
         <!-- Webpages are always italicized -->
-        <text macro="title-plus-part-title" font-style="italic"/>
+        <text font-style="italic" macro="title-plus-part-title"/>
       </if>
       <!-- Other types are italicized based on presence of container-title.
              Assume that review and review-book are published in periodicals/blogs,
-             not just on a web page (ex. 69) -->
-      <else-if type="article-journal article-magazine article-newspaper periodical post-weblog review review-book" match="any">
+             not just on a webpage (APA example 69) -->
+      <else-if match="any" type="article-journal article-magazine article-newspaper periodical post-weblog review review-book">
         <text macro="periodical-title"/>
       </else-if>
       <else-if type="paper-conference">
         <!-- Treat paper-conference as book-like if it has an editor, otherwise as periodical-like -->
         <choose>
-          <if variable="collection-editor compiler editor editorial-director" match="any">
+          <if match="any" variable="collection-editor compiler editor editorial-director">
             <text macro="booklike-title"/>
           </if>
           <else>
@@ -560,607 +813,104 @@
       </else>
     </choose>
   </macro>
-  <macro name="periodical-title">
-    <!-- For periodicals, assume that part-number and part-title refer to the article and append to title -->
-    <choose>
-      <if variable="container-title" match="any">
-        <text macro="title-plus-part-title"/>
-      </if>
-      <else>
-        <!-- for periodical items without container titles, don't append volume-title to title -->
-        <text macro="title-plus-part-title" font-style="italic"/>
-      </else>
-    </choose>
-  </macro>
-  <macro name="booklike-title">
-    <!-- For book-like items, assume part-number and part-title refer to the book/volume. -->
-    <choose>
-      <if variable="container-title" match="any">
-        <text variable="title"/>
-      </if>
-      <else>
-        <!-- For book-like items without container titles and with volume-title, append volume-title to title (ex. 30) -->
-        <text macro="title-plus-volume-title" font-style="italic"/>
-      </else>
-    </choose>
-  </macro>
-  <macro name="title-plus-part-title">
-    <choose>
-      <if variable="reviewed-author reviewed-genre reviewed-title" type="review review-book" match="any">
-        <!-- If a review has no `reviewed-title`, assume that `title` contains the title of the reviewed work
-             and omit it here; it is printed in the `reviewed-item` macro. -->
-        <choose>
-          <if variable="reviewed-title" match="none"/>
-          <else>
-            <group delimiter=": ">
-              <text variable="title"/>
-              <text macro="part-title"/>
-            </group>
-          </else>
-        </choose>
-      </if>
-      <else>
-        <group delimiter=": ">
-          <text variable="title"/>
-          <text macro="part-title"/>
-        </group>
-      </else>
-    </choose>
-  </macro>
-  <macro name="part-title">
-    <group delimiter=". ">
-      <group delimiter=" ">
-        <label variable="part-number" form="short" text-case="capitalize-first"/>
-        <text variable="part-number"/>
-      </group>
-      <text variable="part-title" text-case="capitalize-first"/>
-    </group>
-  </macro>
-  <macro name="title-plus-volume-title">
-    <group delimiter=": ">
-      <text variable="title"/>
-      <text macro="volume-title"/>
-    </group>
-  </macro>
-  <macro name="volume-title">
-    <group delimiter=": ">
-      <choose>
-        <if variable="volume-title">
-          <group delimiter=" ">
-            <group delimiter=". ">
-              <group delimiter=" ">
-                <label variable="volume" form="short" text-case="capitalize-first"/>
-                <text variable="volume"/>
-              </group>
-              <text variable="volume-title"/>
-            </group>
-          </group>
-        </if>
-        <else-if is-numeric="volume" match="none">
-          <group delimiter=" ">
-            <label variable="volume" form="short" text-case="capitalize-first"/>
-            <text variable="volume"/>
-          </group>
-        </else-if>
-      </choose>
-      <!-- For book-like items, assume part-number and part-title refer to the book/volume. -->
-      <text macro="part-title"/>
-    </group>
-  </macro>
   <macro name="title-intext">
     <choose>
-      <if type="bill report">
-        <!-- Bills, resolutions, and congressional reports are not italicized and substitute bill number if no title. -->
-        <!-- Can't distinguish congressional reports from other reports, 
-             but giving the genre and number seems fine for other reports too. -->
-        <choose>
-          <if variable="title">
-            <text variable="title" form="short" text-case="title"/>
-          </if>
-          <else>
-            <group delimiter=" ">
-              <text variable="genre"/>
-              <group delimiter=" ">
-                <choose>
-                  <if variable="chapter-number container-title" match="none">
-                    <label variable="number" form="short" text-case="capitalize-first"/>
-                  </if>
-                </choose>
-                <text variable="number"/>
-              </group>
-            </group>
-          </else>
-        </choose>
+      <if match="any" type="bill report">
+        <text macro="title-intext-bill-report"/>
       </if>
       <else>
         <choose>
-          <if variable="title" match="none">
-            <text macro="bracketed-intext"/>
+          <if match="none" variable="title">
+            <text macro="description-intext"/>
           </if>
-          <else-if type="hearing">
-            <!-- Hearings are italicized -->
-            <text variable="title" form="short" font-style="italic" text-case="title"/>
+          <else-if type="hearing webpage">
+            <!-- Italicized with title case -->
+            <text font-style="italic" form="short" text-case="title" variable="title"/>
           </else-if>
-          <else-if type="legal_case" match="any">
-            <!-- Cases are italicized -->
-            <text variable="title" font-style="italic"/>
+          <else-if type="legal_case post">
+            <!-- Italicized -->
+            <text font-style="italic" form="short" variable="title"/>
           </else-if>
-          <else-if type="legislation regulation treaty" match="any">
-            <!-- Legislation, regulations, and treaties not italicized or quoted -->
-            <text variable="title" form="short" text-case="title"/>
+          <else-if match="any" type="legislation regulation treaty">
+            <!-- No italics or quotes -->
+            <text form="short" text-case="title" variable="title"/>
           </else-if>
-          <else-if type="post webpage" match="any">
-            <!-- Webpages are always italicized -->
-            <text variable="title" form="short" font-style="italic" text-case="title"/>
-          </else-if>
-          <else-if variable="container-title" match="any">
-            <!-- Other types are italicized or quoted based on presence of container-title. As in title macro. -->
-            <text variable="title" form="short" quotes="true" text-case="title"/>
+          <else-if variable="container-title">
+            <!-- Other types are formatted based on presence of container-title, as in title-bib macro -->
+            <text form="short" quotes="true" text-case="title" variable="title"/>
           </else-if>
           <else>
-            <text variable="title" form="short" font-style="italic" text-case="title"/>
+            <text font-style="italic" form="short" text-case="title" variable="title"/>
           </else>
         </choose>
       </else>
     </choose>
   </macro>
-  <macro name="parenthetical">
-    <!-- (Secondary contributors; Database location; Genre no. 123; Report Series 123, Version, Edition, Volume, Page) -->
-    <group prefix="(" suffix=")">
-      <choose>
-        <if type="patent">
-          <!-- authority: U.S. ; genre: patent ; number: 123,445 -->
-          <group delimiter=" ">
-            <text variable="authority" form="short"/>
-            <choose>
-              <if variable="genre">
-                <text variable="genre" text-case="capitalize-first"/>
-              </if>
-              <else>
-                <text term="patent" text-case="capitalize-first"/>
-              </else>
-            </choose>
-            <group delimiter=" ">
-              <label variable="number" form="short" text-case="capitalize-first"/>
-              <text variable="number"/>
-            </group>
-          </group>
-        </if>
-        <else-if type="post webpage" match="any">
-          <!-- For post webpage, container-title is treated as publisher -->
-          <group delimiter="; ">
-            <text macro="secondary-contributors"/>
-            <text macro="database-location"/>
-            <text macro="number"/>
-            <text macro="locators-booklike"/>
-          </group>
-        </else-if>
-        <else-if type="report" match="any">
-          <choose>
-            <if variable="title" match="none">
-              <!-- If there is no title, then genre and number are already printed as the title. -->
-              <group delimiter="; ">
-                <text macro="secondary-contributors"/>
-                <text macro="database-location"/>
-                <text macro="locators-booklike"/>
-              </group>
-            </if>
-            <!-- If the report is a chapter in a larger report, then most parenthetical information is printed after the container. -->
-            <else-if variable="container-title">
-              <text macro="secondary-contributors"/>
-            </else-if>
-            <else>
-              <group delimiter="; ">
-                <text macro="secondary-contributors"/>
-                <text macro="database-location"/>
-                <text macro="number"/>
-                <text macro="locators-booklike"/>
-              </group>
-            </else>
-          </choose>
-        </else-if>
-        <else-if variable="container-title">
-          <group delimiter="; ">
-            <text macro="secondary-contributors"/>
-            <choose>
-              <if type="broadcast graphic map motion_picture song" match="any">
-                <!-- For audiovisual media, number information comes after title, not container-title (ex. 94) -->
-                <text macro="number"/>
-              </if>
-            </choose>
-          </group>
-        </else-if>
-        <else>
-          <group delimiter="; ">
-            <text macro="secondary-contributors"/>
-            <text macro="database-location"/>
-            <text macro="number"/>
-            <text macro="locators-booklike"/>
-          </group>
-        </else>
-      </choose>
-    </group>
-  </macro>
-  <macro name="parenthetical-container">
+  <!-- 3.2. Identification (in parentheses) -->
+  <!-- Identification utility macros -->
+  <macro name="database-location">
     <choose>
-      <if variable="container-title" match="any">
-        <group prefix="(" suffix=")">
-          <group delimiter="; ">
-            <text macro="database-location"/>
-            <choose>
-              <if type="broadcast graphic map motion_picture song" match="none">
-                <!-- For audiovisual media, number information comes after title, not container-title (ex. 94) -->
-                <text macro="number"/>
-              </if>
-            </choose>
-            <text macro="locators-booklike"/>
+      <if match="none" variable="archive-place">
+        <!-- With `archive-place`: physical archives. Without: online archives. -->
+        <text variable="archive_location"/>
+      </if>
+    </choose>
+  </macro>
+  <macro name="genre-number">
+    <choose>
+      <if variable="number">
+        <group delimiter=", ">
+          <group delimiter=" ">
+            <text text-case="title" variable="genre"/>
+            <text macro="number-labelled"/>
           </group>
+          <choose>
+            <if type="thesis">
+              <choose>
+                <if match="any" variable="archive DOI URL">
+                  <!-- Include the university in brackets if thesis is published -->
+                  <text variable="publisher"/>
+                </if>
+              </choose>
+            </if>
+          </choose>
         </group>
       </if>
     </choose>
   </macro>
-  <macro name="bracketed">
-    <!-- [Descriptive information] -->
-    <!-- If there is a number, genre is already printed in macro="number" -->
-    <group prefix="[" suffix="]">
+  <macro name="locators-booklike">
+    <choose>
+      <if variable="page">
+        <text macro="page-labelled"/>
+      </if>
+      <else-if variable="chapter-number">
+        <text macro="chapter-number-labelled"/>
+      </else-if>
+    </choose>
+  </macro>
+  <macro name="patent-number">
+    <group delimiter=" ">
+      <!-- authority: U.S. ; genre: patent ; number: 123,445 -->
+      <text form="short" variable="authority"/>
       <choose>
-        <if variable="reviewed-author reviewed-genre reviewed-title" type="review review-book" match="any">
-          <text macro="reviewed-item"/>
+        <if variable="genre">
+          <text text-case="capitalize-first" variable="genre"/>
         </if>
-        <else-if type="thesis">
-          <!-- Thesis type and institution -->
-          <group delimiter="; ">
-            <choose>
-              <if variable="number" match="none">
-                <group delimiter=", ">
-                  <text variable="genre" text-case="capitalize-first"/>
-                  <choose>
-                    <if variable="archive DOI URL" match="any">
-                      <!-- Include the university in brackets if thesis is published -->
-                      <text variable="publisher"/>
-                    </if>
-                  </choose>
-                </group>
-              </if>
-            </choose>
-            <text variable="medium" text-case="capitalize-first"/>
-          </group>
-        </else-if>
-        <else-if variable="interviewer" type="interview" match="any">
-          <!-- Interview information -->
-          <choose>
-            <if variable="title">
-              <text macro="format"/>
-            </if>
-            <else-if variable="genre">
-              <group delimiter="; ">
-                <group delimiter=" ">
-                  <text variable="genre" text-case="capitalize-first"/>
-                  <group delimiter=" ">
-                    <text term="container-author" form="verb"/>
-                    <names variable="interviewer">
-                      <name and="symbol" initialize-with=". " delimiter=", "/>
-                    </names>
-                  </group>
-                </group>
-              </group>
-            </else-if>
-            <else-if variable="interviewer">
-              <group delimiter="; ">
-                <names variable="interviewer">
-                  <label form="verb" suffix=" " text-case="capitalize-first"/>
-                  <name and="symbol" initialize-with=". " delimiter=", "/>
-                </names>
-                <text variable="medium" text-case="capitalize-first"/>
-              </group>
-            </else-if>
-            <else>
-              <text macro="format"/>
-            </else>
-          </choose>
-        </else-if>
-        <else-if type="personal_communication">
-          <!-- Letter information -->
-          <choose>
-            <if variable="recipient">
-              <group delimiter="; ">
-                <group delimiter=" ">
-                  <choose>
-                    <if variable="number" match="none">
-                      <choose>
-                        <if variable="genre">
-                          <text variable="genre" text-case="capitalize-first"/>
-                        </if>
-                        <else-if variable="medium">
-                          <text variable="medium" text-case="capitalize-first"/>
-                        </else-if>
-                        <else>
-                          <text term="letter" text-case="capitalize-first"/>
-                        </else>
-                      </choose>
-                    </if>
-                    <else>
-                      <choose>
-                        <if variable="medium">
-                          <text variable="medium" text-case="capitalize-first"/>
-                        </if>
-                        <else>
-                          <text term="letter" text-case="capitalize-first"/>
-                        </else>
-                      </choose>
-                    </else>
-                  </choose>
-                  <names variable="recipient" delimiter=", ">
-                    <label form="verb" suffix=" "/>
-                    <name and="symbol" delimiter=", "/>
-                  </names>
-                </group>
-                <choose>
-                  <if variable="genre" match="any">
-                    <choose>
-                      <if variable="number" match="none">
-                        <text variable="medium" text-case="capitalize-first"/>
-                      </if>
-                    </choose>
-                  </if>
-                </choose>
-              </group>
-            </if>
-            <else>
-              <text macro="format"/>
-            </else>
-          </choose>
-        </else-if>
-        <else-if variable="composer" type="song" match="all">
-          <!-- Performer of classical music works -->
-          <group delimiter="; ">
-            <choose>
-              <if variable="number" match="none">
-                <group delimiter=" ">
-                  <choose>
-                    <if variable="genre">
-                      <text variable="genre" text-case="capitalize-first"/>
-                      <group delimiter=" ">
-                        <text term="performer" form="verb"/>
-                        <names variable="author">
-                          <name and="symbol" initialize-with=". " delimiter=", "/>
-                          <substitute>
-                            <names variable="performer"/>
-                          </substitute>
-                        </names>
-                      </group>
-                    </if>
-                    <else-if variable="medium">
-                      <text variable="medium" text-case="capitalize-first"/>
-                      <group delimiter=" ">
-                        <text term="performer" form="verb"/>
-                        <names variable="author">
-                          <name and="symbol" initialize-with=". " delimiter=", "/>
-                          <substitute>
-                            <names variable="performer"/>
-                          </substitute>
-                        </names>
-                      </group>
-                    </else-if>
-                    <else>
-                      <text term="performer" form="verb" text-case="capitalize-first"/>
-                      <names variable="author">
-                        <name and="symbol" initialize-with=". " delimiter=", "/>
-                        <substitute>
-                          <names variable="performer"/>
-                        </substitute>
-                      </names>
-                    </else>
-                  </choose>
-                </group>
-              </if>
-              <else>
-                <group delimiter=" ">
-                  <choose>
-                    <if variable="medium">
-                      <text variable="medium" text-case="capitalize-first"/>
-                      <group delimiter=" ">
-                        <text term="performer" form="verb"/>
-                        <names variable="author">
-                          <name and="symbol" initialize-with=". " delimiter=", "/>
-                          <substitute>
-                            <names variable="performer"/>
-                          </substitute>
-                        </names>
-                      </group>
-                    </if>
-                    <else>
-                      <text term="performer" form="verb" text-case="capitalize-first"/>
-                      <names variable="author">
-                        <name and="symbol" initialize-with=". " delimiter=", "/>
-                        <substitute>
-                          <names variable="performer"/>
-                        </substitute>
-                      </names>
-                    </else>
-                  </choose>
-                </group>
-              </else>
-            </choose>
-            <choose>
-              <if variable="genre" match="any">
-                <choose>
-                  <if variable="number" match="none">
-                    <text variable="medium" text-case="capitalize-first"/>
-                  </if>
-                </choose>
-              </if>
-            </choose>
-          </group>
-        </else-if>
-        <else-if variable="container-title" match="none">
-          <!-- Other description -->
-          <text macro="format"/>
-        </else-if>
         <else>
-          <!-- For conference presentations/performances/events, chapters in reports/standards/generic documents, software, 
-               place bracketed after the container title -->
-          <choose>
-            <if type="event paper-conference performance speech" match="any">
-              <choose>
-                <if variable="collection-editor compiler editor editorial-director issue page volume" match="any">
-                  <text macro="format"/>
-                </if>
-              </choose>
-            </if>
-            <else-if type="document report software standard" match="none">
-              <text macro="format"/>
-            </else-if>
-          </choose>
+          <text term="patent" text-case="capitalize-first"/>
         </else>
       </choose>
-    </group>
-  </macro>
-  <macro name="bracketed-intext">
-    <group prefix="[" suffix="]">
-      <choose>
-        <if variable="reviewed-title" match="any">
-          <group delimiter=" ">
-            <text term="review-of" text-case="capitalize-first"/>
-            <text macro="reviewed-title-intext"/>
-          </group>
-        </if>
-        <else-if variable="interviewer" type="interview" match="any">
-          <names variable="interviewer">
-            <label form="verb" suffix=" " text-case="capitalize-first"/>
-            <name and="symbol" initialize-with=". " delimiter=", "/>
-            <substitute>
-              <text macro="format-intext"/>
-            </substitute>
-          </names>
-        </else-if>
-        <else-if type="personal_communication">
-          <!-- Letter information -->
-          <choose>
-            <if variable="recipient">
-              <group delimiter=" ">
-                <choose>
-                  <if variable="number" match="none">
-                    <text variable="genre" text-case="capitalize-first"/>
-                  </if>
-                  <else>
-                    <text term="letter" text-case="capitalize-first"/>
-                  </else>
-                </choose>
-                <names variable="recipient" delimiter=", ">
-                  <label form="verb" suffix=" "/>
-                  <name and="symbol" delimiter=", "/>
-                </names>
-              </group>
-            </if>
-            <else>
-              <text macro="format-intext"/>
-            </else>
-          </choose>
-        </else-if>
-        <else>
-          <text macro="format-intext"/>
-        </else>
-      </choose>
-    </group>
-  </macro>
-  <macro name="reviewed-item">
-    <!-- Reviewed item -->
-    <group delimiter="; ">
-      <group delimiter=", ">
-        <group delimiter=" ">
-          <choose>
-            <if variable="reviewed-genre">
-              <group delimiter=" ">
-                <text term="review-of" form="long" text-case="capitalize-first"/>
-                <text variable="reviewed-genre" text-case="lowercase"/>
-              </group>
-            </if>
-            <!-- If no `reviewed-genre`, assume that `genre` or `medium` is entered as 'Review of the book' or similar -->
-            <else-if variable="number" match="none">
-              <choose>
-                <if variable="genre">
-                  <text variable="genre" text-case="capitalize-first"/>
-                </if>
-                <else-if variable="medium">
-                  <text variable="medium" text-case="capitalize-first"/>
-                </else-if>
-                <else-if type="review-book">
-                  <group delimiter=" ">
-                    <text term="review-of" form="long" text-case="capitalize-first"/>
-                    <text term="book" form="long" text-case="lowercase"/>
-                  </group>
-                </else-if>
-                <else>
-                  <text term="review-of" form="short" text-case="capitalize-first"/>
-                </else>
-              </choose>
-            </else-if>
-            <else>
-              <choose>
-                <if variable="medium">
-                  <text variable="medium" text-case="capitalize-first"/>
-                </if>
-                <else-if type="review-book">
-                  <group delimiter=" ">
-                    <text term="review-of" form="long" text-case="capitalize-first"/>
-                    <text term="book" form="long" text-case="lowercase"/>
-                  </group>
-                </else-if>
-                <else>
-                  <text term="review-of" form="short" text-case="capitalize-first"/>
-                </else>
-              </choose>
-            </else>
-          </choose>
-          <text macro="reviewed-title"/>
-        </group>
-        <names variable="reviewed-author">
-          <label form="verb-short" suffix=" "/>
-          <name and="symbol" initialize-with=". " delimiter=", "/>
-        </names>
-      </group>
-      <choose>
-        <if variable="genre" match="any">
-          <choose>
-            <if variable="number" match="none">
-              <text variable="medium" text-case="capitalize-first"/>
-            </if>
-          </choose>
-        </if>
-      </choose>
-    </group>
-  </macro>
-  <macro name="bracketed-container">
-    <group prefix="[" suffix="]">
-      <choose>
-        <if type="event paper-conference performance speech" match="any">
-          <!-- Conference presentations should describe the session [container] in bracketed unless published in a proceedings -->
-          <choose>
-            <if variable="collection-editor compiler editor editorial-director issue page volume" match="none">
-              <text macro="format"/>
-            </if>
-          </choose>
-        </if>
-        <else-if type="software" match="all">
-          <!-- For entries in mobile app reference works, place bracketed after the container-title -->
-          <text macro="format"/>
-        </else-if>
-        <else-if type="document report standard">
-          <!-- For chapters in report, standards, and generic documents, place bracketed after the container title -->
-          <text macro="format"/>
-        </else-if>
-      </choose>
+      <text macro="number-labelled"/>
     </group>
   </macro>
   <macro name="secondary-contributors">
     <choose>
-      <if type="article-journal article-magazine article-newspaper periodical post-weblog review review-book" match="any">
+      <if match="any" type="article-journal article-magazine article-newspaper periodical post-weblog review review-book">
         <text macro="secondary-contributors-periodical"/>
       </if>
       <else-if type="paper-conference">
         <choose>
-          <if variable="collection-editor compiler editor editorial-director" match="any">
+          <if match="any" variable="collection-editor compiler editor editorial-director">
             <text macro="secondary-contributors-booklike"/>
           </if>
           <else>
@@ -1173,53 +923,37 @@
       </else>
     </choose>
   </macro>
-  <macro name="secondary-contributors-periodical">
-    <group delimiter="; ">
-      <choose>
-        <if variable="title">
-          <names variable="interviewer" delimiter="; ">
-            <name and="symbol" initialize-with=". " delimiter=", "/>
-            <label form="short" prefix=", " text-case="title"/>
-          </names>
-        </if>
-      </choose>
-      <names variable="translator narrator" delimiter="; ">
-        <name and="symbol" initialize-with=". " delimiter=", "/>
-        <label form="short" prefix=", " text-case="title"/>
-      </names>
-    </group>
-  </macro>
   <macro name="secondary-contributors-booklike">
     <group delimiter="; ">
       <choose>
         <if variable="title">
           <names variable="interviewer">
-            <name and="symbol" initialize-with=". " delimiter=", "/>
+            <name/>
             <label form="short" prefix=", " text-case="title"/>
           </names>
         </if>
       </choose>
       <choose>
-        <if type="post webpage" match="none">
+        <if match="none" type="post webpage">
           <!-- Webpages treat container-title like publisher -->
           <group delimiter="; ">
-            <names variable="illustrator narrator" delimiter="; ">
-              <name and="symbol" initialize-with=". " delimiter=", "/>
+            <names delimiter="; " variable="illustrator narrator">
+              <name/>
               <label form="short" prefix=", " text-case="title"/>
             </names>
             <choose>
-              <if variable="container-title" match="none">
+              <if match="none" variable="container-title">
                 <group delimiter="; ">
                   <names variable="container-author">
                     <label form="verb-short" suffix=" " text-case="title"/>
-                    <name and="symbol" initialize-with=". " delimiter=", "/>
+                    <name/>
                   </names>
-                  <names variable="editor translator" delimiter="; ">
-                    <name and="symbol" initialize-with=". " delimiter=", "/>
+                  <names delimiter="; " variable="editor translator">
+                    <name/>
                     <label form="short" prefix=", " text-case="title"/>
                   </names>
-                  <names variable="compiler chair organizer curator series-creator executive-producer" delimiter="; ">
-                    <name and="symbol" initialize-with=". " delimiter=", "/>
+                  <names delimiter="; " variable="compiler chair organizer curator series-creator executive-producer">
+                    <name/>
                     <label form="long" prefix=", " text-case="title"/>
                   </names>
                 </group>
@@ -1227,9 +961,9 @@
               <else>
                 <choose>
                   <!-- TODO: Check logic once processors start to automatically populate editor-translator. -->
-                  <if variable="editor-translator" match="none">
-                    <names variable="translator" delimiter="; ">
-                      <name and="symbol" initialize-with=". " delimiter=", "/>
+                  <if match="none" variable="editor-translator">
+                    <names delimiter="; " variable="translator">
+                      <name/>
                       <label form="short" prefix=", " text-case="title"/>
                     </names>
                   </if>
@@ -1242,18 +976,18 @@
           <group delimiter="; ">
             <names variable="container-author">
               <label form="verb-short" suffix=" " text-case="title"/>
-              <name and="symbol" initialize-with=". " delimiter=", "/>
+              <name/>
             </names>
-            <names variable="editor translator" delimiter="; ">
-              <name and="symbol" initialize-with=". " delimiter=", "/>
+            <names delimiter="; " variable="editor translator">
+              <name/>
               <label form="short" prefix=", " text-case="title"/>
             </names>
-            <names variable="illustrator narrator" delimiter="; ">
-              <name and="symbol" initialize-with=". " delimiter=", "/>
+            <names delimiter="; " variable="illustrator narrator">
+              <name/>
               <label form="short" prefix=", " text-case="title"/>
             </names>
-            <names variable="compiler chair organizer curator series-creator executive-producer" delimiter="; ">
-              <name and="symbol" initialize-with=". " delimiter=", "/>
+            <names delimiter="; " variable="compiler chair organizer curator series-creator executive-producer">
+              <name/>
               <label form="long" prefix=", " text-case="title"/>
             </names>
           </group>
@@ -1261,166 +995,398 @@
       </choose>
     </group>
   </macro>
-  <macro name="database-location">
+  <macro name="secondary-contributors-periodical">
+    <group delimiter="; ">
+      <choose>
+        <if variable="title">
+          <names delimiter="; " variable="interviewer">
+            <name/>
+            <label form="short" prefix=", " text-case="title"/>
+          </names>
+        </if>
+      </choose>
+      <names delimiter="; " variable="translator narrator">
+        <name/>
+        <label form="short" prefix=", " text-case="title"/>
+      </names>
+    </group>
+  </macro>
+  <macro name="version-edition-volume">
+    <group delimiter=", ">
+      <text macro="version-labelled"/>
+      <text macro="edition-labelled"/>
+      <text macro="volume-booklike"/>
+    </group>
+  </macro>
+  <macro name="volume-booklike">
+    <group delimiter=", ">
+      <!-- Report series (APA example 52) -->
+      <choose>
+        <if match="any" type="document report standard">
+          <group delimiter=" ">
+            <text text-case="title" variable="collection-title"/>
+            <text variable="collection-number"/>
+          </group>
+        </if>
+      </choose>
+      <text macro="supplement-number-labelled"/>
+      <choose>
+        <if variable="volume">
+          <choose>
+            <!-- Non-numeric volumes are already printed as part of the book title -->
+            <if variable="volume-title"/>
+            <else-if is-numeric="volume">
+              <text macro="volume-labelled"/>
+            </else-if>
+          </choose>
+        </if>
+        <else>
+          <text macro="number-of-volumes-labelled"/>
+        </else>
+      </choose>
+      <text macro="issue-labelled"/>
+      <text macro="locators-booklike"/>
+    </group>
+  </macro>
+  <!-- Identification logic -->
+  <macro name="identification">
+    <group delimiter="; " prefix="(" suffix=")">
+      <!-- (Secondary contributors; Database location; Genre no. 123; Report Series 123, Version, Edition, Volume, Page) -->
+      <choose>
+        <if type="patent">
+          <text macro="patent-number"/>
+        </if>
+        <else-if match="any" type="post webpage">
+          <!-- For post webpage, container-title is treated as publisher -->
+          <text macro="identification-with-all-parts"/>
+        </else-if>
+        <else-if match="any" type="report">
+          <choose>
+            <if match="none" variable="title">
+              <!-- If there is no title, then genre and number are already printed as the title. -->
+              <text macro="secondary-contributors"/>
+              <text macro="database-location"/>
+              <text macro="identification-booklike"/>
+            </if>
+            <!-- If the report is a chapter in a larger report, then most parenthetical information is printed after the container. -->
+            <else-if variable="container-title">
+              <text macro="secondary-contributors"/>
+            </else-if>
+            <else>
+              <text macro="identification-with-all-parts"/>
+            </else>
+          </choose>
+        </else-if>
+        <else-if variable="container-title">
+          <group delimiter="; ">
+            <text macro="secondary-contributors"/>
+            <choose>
+              <if match="any" type="broadcast graphic map motion_picture song">
+                <!-- For audiovisual media, number information comes after title, not container-title (ex. 94) -->
+                <text macro="genre-number"/>
+              </if>
+            </choose>
+          </group>
+        </else-if>
+        <else>
+          <text macro="identification-with-all-parts"/>
+        </else>
+      </choose>
+    </group>
+  </macro>
+  <macro name="identification-booklike">
     <choose>
-      <if variable="archive-place" match="none">
-        <!-- With `archive-place`: physical archives. Without: online archives. -->
-        <text variable="archive_location"/>
-      </if>
+      <if match="any" type="article-journal article-magazine article-newspaper broadcast event interview patent performance periodical post post-weblog review review-book speech webpage"/>
+      <else-if type="paper-conference">
+        <choose>
+          <if match="any" variable="collection-editor compiler editor editorial-director">
+            <text macro="version-edition-volume"/>
+          </if>
+        </choose>
+      </else-if>
+      <else>
+        <text macro="version-edition-volume"/>
+      </else>
     </choose>
   </macro>
-  <macro name="number">
+  <macro name="identification-with-all-parts">
+    <group delimiter="; ">
+      <text macro="secondary-contributors"/>
+      <text macro="database-location"/>
+      <text macro="genre-number"/>
+      <text macro="identification-booklike"/>
+    </group>
+  </macro>
+  <!-- 3.3. Description [in square brackets] -->
+  <!-- Description utility macros -->
+  <macro name="description-generic">
+    <!-- For conference presentations/performances/events, chapters in reports/standards/generic documents, software, place description after the container title -->
     <choose>
-      <if variable="number">
-        <group delimiter=", ">
+      <if match="any" type="event paper-conference performance speech">
+        <choose>
+          <if match="any" variable="collection-editor compiler editor editorial-director issue page volume">
+            <text macro="format-bib"/>
+          </if>
+        </choose>
+      </if>
+      <else-if match="none" type="document report software standard">
+        <text macro="format-bib"/>
+      </else-if>
+    </choose>
+  </macro>
+  <macro name="description-interview">
+    <choose>
+      <if variable="title">
+        <text macro="format-bib"/>
+      </if>
+      <else-if variable="genre">
+        <group delimiter="; ">
           <group delimiter=" ">
-            <text variable="genre" text-case="title"/>
+            <text text-case="capitalize-first" variable="genre"/>
             <group delimiter=" ">
-              <label variable="number" form="short" text-case="capitalize-first"/>
-              <text variable="number"/>
+              <text form="verb" term="container-author"/>
+              <names variable="interviewer"/>
             </group>
           </group>
+        </group>
+      </else-if>
+      <else-if variable="interviewer">
+        <group delimiter="; ">
+          <names variable="interviewer">
+            <label form="verb" suffix=" " text-case="capitalize-first"/>
+            <name/>
+          </names>
+          <text text-case="capitalize-first" variable="medium"/>
+        </group>
+      </else-if>
+      <else>
+        <text macro="format-bib"/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="description-letter-bib">
+    <choose>
+      <if variable="recipient">
+        <group delimiter="; ">
+          <group delimiter=" ">
+            <choose>
+              <if match="none" variable="number">
+                <choose>
+                  <if variable="genre">
+                    <text text-case="capitalize-first" variable="genre"/>
+                  </if>
+                  <else-if variable="medium">
+                    <text text-case="capitalize-first" variable="medium"/>
+                  </else-if>
+                  <else>
+                    <text term="letter" text-case="capitalize-first"/>
+                  </else>
+                </choose>
+              </if>
+              <else>
+                <choose>
+                  <if variable="medium">
+                    <text text-case="capitalize-first" variable="medium"/>
+                  </if>
+                  <else>
+                    <text term="letter" text-case="capitalize-first"/>
+                  </else>
+                </choose>
+              </else>
+            </choose>
+            <names variable="recipient">
+              <label form="verb" suffix=" "/>
+              <name initialize="false"/>
+            </names>
+          </group>
           <choose>
-            <if type="thesis">
+            <if variable="genre">
               <choose>
-                <!-- Include the university in brackets if thesis is published -->
-                <if variable="archive DOI URL" match="any">
-                  <text variable="publisher"/>
+                <if match="none" variable="number">
+                  <text text-case="capitalize-first" variable="medium"/>
                 </if>
               </choose>
             </if>
           </choose>
         </group>
       </if>
-    </choose>
-  </macro>
-  <macro name="locators-booklike">
-    <choose>
-      <if type="article-journal article-magazine article-newspaper broadcast event interview patent performance periodical post post-weblog review review-book speech webpage" match="any"/>
-      <else-if type="paper-conference">
-        <choose>
-          <if variable="collection-editor compiler editor editorial-director" match="any">
-            <group delimiter=", ">
-              <text macro="version"/>
-              <text macro="edition"/>
-              <text macro="volume-booklike"/>
-            </group>
-          </if>
-        </choose>
-      </else-if>
       <else>
-        <group delimiter=", ">
-          <text macro="version"/>
-          <text macro="edition"/>
-          <text macro="volume-booklike"/>
-        </group>
+        <text macro="format-bib"/>
       </else>
     </choose>
   </macro>
-  <macro name="version">
-    <group delimiter=" ">
-      <label variable="version" text-case="capitalize-first"/>
-      <text variable="version"/>
-    </group>
-  </macro>
-  <macro name="edition">
+  <macro name="description-letter-intext">
     <choose>
-      <if is-numeric="edition">
+      <if variable="recipient">
         <group delimiter=" ">
-          <number variable="edition" form="ordinal"/>
-          <label variable="edition" form="short"/>
-        </group>
-      </if>
-      <else>
-        <text variable="edition"/>
-      </else>
-    </choose>
-  </macro>
-  <macro name="volume-booklike">
-    <group delimiter=", ">
-      <!-- Report series [ex. 52] -->
-      <choose>
-        <if type="document report standard">
-          <group delimiter=" ">
-            <text variable="collection-title" text-case="title"/>
-            <text variable="collection-number"/>
-          </group>
-        </if>
-      </choose>
-      <group delimiter=" ">
-        <label variable="supplement-number" text-case="capitalize-first"/>
-        <text variable="supplement-number"/>
-      </group>
-      <choose>
-        <if variable="volume" match="any">
           <choose>
-            <!-- Non-numeric volumes are already printed as part of the book title -->
-            <if variable="volume-title"/>
-            <else-if is-numeric="volume" match="none"/>
+            <if match="none" variable="number">
+              <text text-case="capitalize-first" variable="genre"/>
+            </if>
+            <else-if variable="medium">
+              <text text-case="capitalize-first" variable="medium"/>
+            </else-if>
             <else>
-              <group delimiter=" ">
-                <label variable="volume" form="short" text-case="capitalize-first"/>
-                <number variable="volume" form="numeric"/>
-              </group>
+              <text term="letter" text-case="capitalize-first"/>
             </else>
           </choose>
-        </if>
-        <else>
-          <group>
-            <label variable="number-of-volumes" form="short" text-case="capitalize-first" suffix=" "/>
-            <text term="page-range-delimiter" prefix="1"/>
-            <number variable="number-of-volumes" form="numeric"/>
-          </group>
-        </else>
-      </choose>
-      <group delimiter=" ">
-        <label variable="issue" text-case="capitalize-first"/>
-        <text variable="issue"/>
-      </group>
-      <group delimiter=" ">
-        <label variable="page" form="short" suffix=" "/>
-        <text variable="page"/>
-      </group>
-    </group>
-  </macro>
-  <macro name="reviewed-title">
-    <choose>
-      <if variable="reviewed-title">
-        <!-- Not possible to distinguish TV series episode from other reviewed
-             works without reviewed-container-title [Ex. 69] -->
-        <!-- Adapt for reviewed-container-title if that becomes available -->
-        <text variable="reviewed-title" font-style="italic"/>
+          <names variable="recipient">
+            <label form="verb" suffix=" "/>
+            <name/>
+          </names>
+        </group>
       </if>
       <else>
-        <!-- Assume title is title of reviewed work -->
-        <text variable="title" font-style="italic"/>
+        <text macro="format-intext"/>
       </else>
     </choose>
   </macro>
-  <macro name="reviewed-title-intext">
-    <choose>
-      <if variable="reviewed-title">
-        <!-- Not possible to distinguish TV series episode from other reviewed
-             works without reviewed-container-title [Ex. 69] -->
-        <!-- Adapt for reviewed-container-title if that becomes available -->
-        <text variable="reviewed-title" form="short" font-style="italic" text-case="title"/>
-      </if>
-      <else>
-        <!-- Assume title is title of reviewed work -->
-        <text variable="title" form="short" font-style="italic" text-case="title"/>
-      </else>
-    </choose>
-  </macro>
-  <macro name="format">
-    <choose>
-      <if variable="genre medium" match="any">
-        <group delimiter="; ">
+  <macro name="description-reviewed">
+    <!-- Reviewed item -->
+    <group delimiter="; ">
+      <group delimiter=", ">
+        <group delimiter=" ">
           <choose>
-            <if variable="number" match="none">
-              <text variable="genre" text-case="capitalize-first"/>
+            <if variable="reviewed-genre">
+              <group delimiter=" ">
+                <text form="long" term="review-of" text-case="capitalize-first"/>
+                <text text-case="lowercase" variable="reviewed-genre"/>
+              </group>
+            </if>
+            <!-- If no `reviewed-genre`, assume that `genre` or `medium` is entered as 'Review of the book' or similar -->
+            <else-if match="none" variable="number">
+              <choose>
+                <if variable="genre">
+                  <text text-case="capitalize-first" variable="genre"/>
+                </if>
+                <else-if variable="medium">
+                  <text text-case="capitalize-first" variable="medium"/>
+                </else-if>
+                <else-if type="review-book">
+                  <group delimiter=" ">
+                    <text form="long" term="review-of" text-case="capitalize-first"/>
+                    <text form="long" term="book" text-case="lowercase"/>
+                  </group>
+                </else-if>
+                <else>
+                  <text form="short" term="review-of" text-case="capitalize-first"/>
+                </else>
+              </choose>
+            </else-if>
+            <else>
+              <choose>
+                <if variable="medium">
+                  <text text-case="capitalize-first" variable="medium"/>
+                </if>
+                <else-if type="review-book">
+                  <group delimiter=" ">
+                    <text form="long" term="review-of" text-case="capitalize-first"/>
+                    <text form="long" term="book" text-case="lowercase"/>
+                  </group>
+                </else-if>
+                <else>
+                  <text form="short" term="review-of" text-case="capitalize-first"/>
+                </else>
+              </choose>
+            </else>
+          </choose>
+          <text macro="reviewed-title-bib"/>
+        </group>
+        <names variable="reviewed-author">
+          <label form="verb-short" suffix=" "/>
+          <name/>
+        </names>
+      </group>
+      <choose>
+        <if variable="genre">
+          <choose>
+            <if match="none" variable="number">
+              <text text-case="capitalize-first" variable="medium"/>
             </if>
           </choose>
-          <text variable="medium" text-case="capitalize-first"/>
+        </if>
+      </choose>
+    </group>
+  </macro>
+  <macro name="description-song">
+    <!-- Performer of classical music works -->
+    <group delimiter="; ">
+      <group delimiter=" ">
+        <choose>
+          <if match="none" variable="number">
+            <choose>
+              <if variable="genre">
+                <text text-case="capitalize-first" variable="genre"/>
+                <text form="verb" term="performer"/>
+              </if>
+              <else-if variable="medium">
+                <text text-case="capitalize-first" variable="medium"/>
+                <text form="verb" term="performer"/>
+              </else-if>
+              <else>
+                <text form="verb" term="performer" text-case="capitalize-first"/>
+              </else>
+            </choose>
+          </if>
+          <else>
+            <!-- If there is a number, genre is already printed in `genre-number` macro -->
+            <choose>
+              <if variable="medium">
+                <text text-case="capitalize-first" variable="medium"/>
+                <text form="verb" term="performer"/>
+              </if>
+              <else>
+                <text form="verb" term="performer" text-case="capitalize-first"/>
+              </else>
+            </choose>
+          </else>
+        </choose>
+        <names variable="author">
+          <substitute>
+            <names variable="performer"/>
+          </substitute>
+        </names>
+      </group>
+      <choose>
+        <if variable="genre">
+          <choose>
+            <if match="none" variable="number">
+              <text text-case="capitalize-first" variable="medium"/>
+            </if>
+          </choose>
+        </if>
+      </choose>
+    </group>
+  </macro>
+  <macro name="description-thesis">
+    <!-- Thesis type and institution -->
+    <group delimiter="; ">
+      <choose>
+        <if match="none" variable="number">
+          <group delimiter=", ">
+            <text text-case="capitalize-first" variable="genre"/>
+            <choose>
+              <if match="any" variable="archive DOI URL">
+                <!-- Include the university in brackets if thesis is published -->
+                <text variable="publisher"/>
+              </if>
+            </choose>
+          </group>
+        </if>
+      </choose>
+      <text text-case="capitalize-first" variable="medium"/>
+    </group>
+  </macro>
+  <macro name="format-bib">
+    <choose>
+      <if match="any" variable="genre medium">
+        <group delimiter="; ">
+          <choose>
+            <if match="none" variable="number">
+              <text text-case="capitalize-first" variable="genre"/>
+            </if>
+          </choose>
+          <text text-case="capitalize-first" variable="medium"/>
         </group>
       </if>
       <else>
@@ -1430,11 +1396,11 @@
   </macro>
   <macro name="format-intext">
     <choose>
-      <if variable="genre" match="any">
-        <text variable="genre" text-case="capitalize-first"/>
+      <if variable="genre">
+        <text text-case="capitalize-first" variable="genre"/>
       </if>
       <else-if variable="medium">
-        <text variable="medium" text-case="capitalize-first"/>
+        <text text-case="capitalize-first" variable="medium"/>
       </else-if>
       <else>
         <text macro="generic-type-label"/>
@@ -1450,9 +1416,9 @@
       <else-if type="software">
         <text term="software" text-case="capitalize-first"/>
       </else-if>
-      <else-if type="interview personal_communication" match="any">
+      <else-if match="any" type="interview personal_communication">
         <choose>
-          <if variable="archive container-title DOI publisher URL" match="none">
+          <if match="none" variable="archive archive-place container-title DOI publisher URL">
             <text term="personal-communication" text-case="capitalize-first"/>
           </if>
           <else-if type="interview">
@@ -1492,18 +1458,108 @@
       </else-if>
     </choose>
   </macro>
-  <!-- APA 'source' element contains four parts:
-       container, event, publisher, access -->
+  <macro name="reviewed-title-bib">
+    <choose>
+      <if variable="reviewed-title">
+        <!-- Not possible to distinguish TV series episode from other reviewed
+             works without reviewed-container-title (APA example 69) -->
+        <!-- Adapt for reviewed-container-title if that becomes available -->
+        <text font-style="italic" variable="reviewed-title"/>
+      </if>
+      <else>
+        <!-- Assume title is title of reviewed work -->
+        <text font-style="italic" variable="title"/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="reviewed-title-intext">
+    <choose>
+      <if variable="reviewed-title">
+        <!-- Not possible to distinguish TV series episode from other reviewed
+             works without reviewed-container-title (APA example 69) -->
+        <!-- Adapt for reviewed-container-title if that becomes available -->
+        <text font-style="italic" form="short" text-case="title" variable="reviewed-title"/>
+      </if>
+      <else>
+        <!-- Assume title is title of reviewed work -->
+        <text font-style="italic" form="short" text-case="title" variable="title"/>
+      </else>
+    </choose>
+  </macro>
+  <!-- Description logic -->
+  <macro name="description-bib">
+    <group prefix="[" suffix="]">
+      <choose>
+        <if match="any" type="interview" variable="interviewer">
+          <text macro="description-interview"/>
+        </if>
+        <else-if match="any" type="review review-book" variable="reviewed-author reviewed-genre reviewed-title">
+          <text macro="description-reviewed"/>
+        </else-if>
+        <else-if type="personal_communication">
+          <text macro="description-letter-bib"/>
+        </else-if>
+        <else-if type="song" variable="composer">
+          <text macro="description-song"/>
+        </else-if>
+        <else-if type="thesis">
+          <text macro="description-thesis"/>
+        </else-if>
+        <else-if match="none" variable="container-title">
+          <!-- Other description -->
+          <text macro="format-bib"/>
+        </else-if>
+        <else>
+          <text macro="description-generic"/>
+        </else>
+      </choose>
+    </group>
+  </macro>
+  <macro name="description-intext">
+    <group prefix="[" suffix="]">
+      <choose>
+        <if variable="reviewed-title">
+          <group delimiter=" ">
+            <text term="review-of" text-case="capitalize-first"/>
+            <text macro="reviewed-title-intext"/>
+          </group>
+        </if>
+        <else-if match="any" type="interview" variable="interviewer">
+          <names variable="interviewer">
+            <label form="verb" suffix=" " text-case="capitalize-first"/>
+            <name/>
+            <substitute>
+              <text macro="format-intext"/>
+            </substitute>
+          </names>
+        </else-if>
+        <else-if type="personal_communication">
+          <text macro="description-letter-intext"/>
+        </else-if>
+        <else>
+          <text macro="format-intext"/>
+        </else>
+      </choose>
+    </group>
+  </macro>
+  <!-- 4. Source -->
+  <!-- Four parts in APA 'source' element:
+
+       1. Container
+       2. Event
+       3. Publication details
+       4. Access -->
+  <!-- 4.1. Container -->
   <macro name="container">
     <choose>
-      <if type="article-journal article-magazine article-newspaper periodical post-weblog review review-book" match="any">
+      <if match="any" type="article-journal article-magazine article-newspaper periodical post-weblog review review-book">
         <!-- Periodical items -->
         <text macro="container-periodical"/>
       </if>
       <else-if type="paper-conference">
         <!-- Determine if paper-conference is a periodical- or book-like -->
         <choose>
-          <if variable="editor editorial-director collection-editor container-author" match="any">
+          <if match="any" variable="collection-editor container-author editor editorial-director">
             <text macro="container-booklike"/>
           </if>
           <else>
@@ -1511,55 +1567,15 @@
           </else>
         </choose>
       </else-if>
-      <else-if type="post webpage" match="none">
-        <!-- post and webpage treat container-title like publisher -->
+      <else-if match="none" type="post webpage">
+        <!-- Webpages treat container-title like publisher -->
         <text macro="container-booklike"/>
       </else-if>
     </choose>
   </macro>
-  <macro name="container-periodical">
-    <group delimiter=". ">
-      <group delimiter=", ">
-        <text variable="container-title" font-style="italic" text-case="title"/>
-        <choose>
-          <if variable="volume">
-            <group>
-              <text variable="volume" font-style="italic"/>
-              <text variable="issue" prefix="(" suffix=")"/>
-            </group>
-          </if>
-          <else>
-            <text variable="issue" font-style="italic"/>
-          </else>
-        </choose>
-        <choose>
-          <if variable="number">
-            <!-- Ex. 6: Journal article with article number or eLocator -->
-            <group delimiter=" ">
-              <text term="article-locator" text-case="capitalize-first"/>
-              <text variable="number"/>
-            </group>
-          </if>
-          <else>
-            <text variable="page"/>
-          </else>
-        </choose>
-      </group>
-      <choose>
-        <if variable="issued">
-          <choose>
-            <if variable="issue number page volume" match="none">
-              <!-- We print the status variable directly rather than using in-press, etc. terms. -->
-              <text variable="status" text-case="capitalize-first"/>
-            </if>
-          </choose>
-        </if>
-      </choose>
-    </group>
-  </macro>
   <macro name="container-booklike">
     <choose>
-      <if variable="container-title" match="any">
+      <if variable="container-title">
         <group delimiter=" ">
           <choose>
             <if type="song">
@@ -1570,161 +1586,167 @@
             </else>
           </choose>
           <group delimiter=", ">
-            <names variable="executive-producer">
-              <name and="symbol" initialize-with=". " delimiter=", "/>
-              <label form="long" text-case="title" prefix=" (" suffix=")"/>
-              <substitute>
-                <names variable="series-creator"/>
-                <names variable="editor-translator">
-                  <name and="symbol" initialize-with=". " delimiter=", "/>
-                  <label form="short" text-case="title" prefix=" (" suffix=")"/>
-                </names>
-                <!-- TODO: Translator omitted here on the assumption that editor-translators are uncommon 
-                           for chapter citations. If needed, direct entry or automatic population of
-                           `editor-translator` can produce combined labels. -->
-                <names variable="editor">
-                  <name and="symbol" initialize-with=". " delimiter=", "/>
-                  <label form="short" text-case="title" prefix=" (" suffix=")"/>
-                </names>
-                <names variable="editorial-director">
-                  <name and="symbol" initialize-with=". " delimiter=", "/>
-                  <label form="short" text-case="title" prefix=" (" suffix=")"/>
-                </names>
-                <names variable="compiler"/>
-                <choose>
-                  <if type="event performance speech" match="any">
-                    <names variable="chair"/>
-                    <names variable="organizer"/>
-                  </if>
-                </choose>
-                <names variable="curator"/>
-                <names variable="collection-editor">
-                  <name and="symbol" initialize-with=". " delimiter=", "/>
-                  <label form="short" text-case="title" prefix=" (" suffix=")"/>
-                </names>
-                <names variable="container-author"/>
-              </substitute>
-            </names>
-            <group delimiter=": " font-style="italic">
-              <text variable="container-title"/>
-              <text macro="volume-title"/>
-            </group>
+            <text macro="container-contributors"/>
+            <text macro="container-title-booklike"/>
           </group>
-          <text macro="parenthetical-container"/>
-          <text macro="bracketed-container"/>
+          <text macro="container-identification"/>
+          <text macro="container-description"/>
         </group>
       </if>
     </choose>
   </macro>
-  <macro name="publisher">
-    <group delimiter="; ">
+  <macro name="container-periodical">
+    <group delimiter=". ">
+      <group delimiter=", ">
+        <text font-style="italic" text-case="title" variable="container-title"/>
+        <text macro="volume-periodical"/>
+        <text macro="locators-periodical"/>
+      </group>
       <choose>
-        <if type="thesis">
+        <if variable="issued">
           <choose>
-            <if variable="archive DOI URL" match="none">
-              <text variable="publisher"/>
+            <if match="none" variable="issue number page volume">
+              <!-- We print the status variable directly rather than using in-press, etc. terms. -->
+              <text text-case="capitalize-first" variable="status"/>
             </if>
           </choose>
         </if>
-        <else-if type="post webpage" match="any">
-          <!-- For websites, treat container title like publisher -->
-          <group delimiter="; ">
-            <text variable="container-title" text-case="title"/>
-            <text variable="publisher"/>
-          </group>
-        </else-if>
-        <else-if type="paper-conference">
-          <!-- For paper-conference, don't print publisher if in a journal-like proceedings -->
-          <choose>
-            <if variable="collection-editor compiler editor editorial-director" match="any">
-              <text variable="publisher"/>
-            </if>
-          </choose>
-        </else-if>
-        <else-if type="article-journal article-magazine article-newspaper periodical post-weblog review review-book" match="none">
-          <text variable="publisher"/>
-        </else-if>
       </choose>
-      <group delimiter=", ">
-        <choose>
-          <if variable="archive-place">
-            <!-- With `archive-place`: physical archives. Without: online archives. -->
-            <!-- For physical archives, print the location before the archive name.
-                For electronic archives, these are printed in macro="description". -->
-            <!-- Must test for archive_collection:
-                With collection: archive_collection (archive_location), archive, archive-place
-                No collection: archive (archive_location), archive-place
-            -->
-            <choose>
-              <if variable="archive_collection">
-                <group delimiter=" ">
-                  <text variable="archive_collection"/>
-                  <text variable="archive_location" prefix="(" suffix=")"/>
-                </group>
-                <text variable="archive"/>
-                <text variable="archive-place"/>
-              </if>
-              <else>
-                <group delimiter=" ">
-                  <text variable="archive"/>
-                  <text variable="archive_location" prefix="(" suffix=")"/>
-                </group>
-                <text variable="archive-place"/>
-              </else>
-            </choose>
-          </if>
-          <else>
-            <text variable="archive"/>
-          </else>
-        </choose>
-      </group>
     </group>
   </macro>
-  <macro name="access">
+  <!-- Container parallels main elements -->
+  <!-- 4.1.1. Author -->
+  <macro name="container-contributors">
+    <names variable="executive-producer">
+      <name/>
+      <label form="long" prefix=" (" suffix=")" text-case="title"/>
+      <substitute>
+        <names variable="series-creator"/>
+        <names variable="editor-translator">
+          <name/>
+          <label form="short" prefix=" (" suffix=")" text-case="title"/>
+        </names>
+        <!-- TODO: Translator omitted on the assumption that editor-translators are uncommon for chapter citations.
+             If needed, direct entry or automatic population of `editor-translator` can produce combined labels. -->
+        <names delimiter="; " variable="editor">
+          <name/>
+          <label form="short" prefix=" (" suffix=")" text-case="title"/>
+        </names>
+        <names variable="editorial-director">
+          <name/>
+          <label form="short" prefix=" (" suffix=")" text-case="title"/>
+        </names>
+        <names variable="compiler"/>
+        <choose>
+          <if match="any" type="event performance speech">
+            <names variable="chair"/>
+            <names variable="organizer"/>
+          </if>
+        </choose>
+        <names variable="curator"/>
+        <names variable="collection-editor">
+          <name/>
+          <label form="short" prefix=" (" suffix=")" text-case="title"/>
+        </names>
+        <names variable="container-author"/>
+      </substitute>
+    </names>
+  </macro>
+  <!-- 4.1.3.1 Container title -->
+  <macro name="container-title-booklike">
+    <group delimiter=": " font-style="italic">
+      <text variable="container-title"/>
+      <text macro="title-volume"/>
+    </group>
+  </macro>
+  <!-- 4.1.3.1 Container identification -->
+  <macro name="container-identification">
     <choose>
-      <if variable="DOI" match="any">
-        <text variable="DOI" prefix="https://doi.org/"/>
-      </if>
-      <else-if variable="URL">
-        <group delimiter=" ">
-          <choose>
-            <if variable="issued status" match="none">
-              <group delimiter=" ">
-                <text term="retrieved" text-case="capitalize-first"/>
-                <date variable="accessed" form="text" suffix=","/>
-                <text term="from"/>
-              </group>
-            </if>
-          </choose>
-          <text variable="URL"/>
+      <if variable="container-title">
+        <group prefix="(" suffix=")">
+          <group delimiter="; ">
+            <text macro="database-location"/>
+            <choose>
+              <if match="none" type="broadcast graphic map motion_picture song">
+                <!-- For audiovisual media, number information comes after title, not container-title (APA example 94) -->
+                <text macro="genre-number"/>
+              </if>
+            </choose>
+            <text macro="identification-booklike"/>
+          </group>
         </group>
-      </else-if>
+      </if>
     </choose>
   </macro>
+  <!-- 4.1.3.2 Container description -->
+  <macro name="container-description">
+    <group prefix="[" suffix="]">
+      <choose>
+        <if match="any" type="event paper-conference performance speech">
+          <!-- Conference presentations should describe the session [container] in description unless published in a proceedings -->
+          <choose>
+            <if match="none" variable="collection-editor compiler editor editorial-director issue page volume">
+              <text macro="format-bib"/>
+            </if>
+          </choose>
+        </if>
+        <else-if type="software">
+          <!-- For entries in mobile app reference works, place description after the container-title -->
+          <text macro="format-bib"/>
+        </else-if>
+        <else-if match="any" type="document report standard">
+          <!-- For chapters in report, standards, and generic documents, place description after the container title -->
+          <text macro="format-bib"/>
+        </else-if>
+      </choose>
+    </group>
+  </macro>
+  <!-- 4.1.4. Source -->
+  <macro name="locators-periodical">
+    <choose>
+      <if variable="number">
+        <text macro="number-article-labelled"/>
+      </if>
+      <else>
+        <text variable="page"/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="volume-periodical">
+    <group delimiter=", ">
+      <text font-style="italic" text-case="title" variable="collection-title"/>
+      <choose>
+        <if variable="volume">
+          <group>
+            <text font-style="italic" variable="volume"/>
+            <text prefix="(" suffix=")" variable="issue"/>
+          </group>
+        </if>
+        <else>
+          <text font-style="italic" variable="issue"/>
+        </else>
+      </choose>
+    </group>
+  </macro>
+  <!-- 4.2. Event -->
   <macro name="event">
     <choose>
-      <if variable="event event-title" match="any">
-        <!-- To prevent Zotero from printing event-place due to its double-mapping of all 'place' to
-             both publisher-place and event-place. Remove this 'choose' when that is changed. -->
+      <if match="any" variable="event event-title">
+        <!-- To prevent Zotero from printing `event-place` due to its double-mapping of all 'place' to
+             both `publisher-place` and `event-place`. Remove this when that is changed. -->
         <choose>
           <if type="paper-conference">
             <choose>
-              <if variable="collection-editor compiler editor editorial-director issue page volume" match="none">
+              <if match="none" variable="collection-editor compiler editor editorial-director issue page volume">
                 <!-- Don't print event info for conference papers published in a proceedings -->
-                <group delimiter=", ">
-                  <text macro="event-title"/>
-                  <text variable="event-place"/>
-                </group>
+                <text macro="event-title-place"/>
               </if>
             </choose>
           </if>
           <else>
             <!-- For other item types, print event info even if published (e.g., for collection catalogs, performance programs.
                  These items aren't given explicit examples in the APA manual, so err on the side of providing too much information. -->
-            <group delimiter=", ">
-              <text macro="event-title"/>
-              <text variable="event-place"/>
-            </group>
+            <text macro="event-title-place"/>
           </else>
         </choose>
       </if>
@@ -1732,9 +1754,9 @@
   </macro>
   <macro name="event-title">
     <choose>
-      <!-- TODO: We expect "event-title" to be used,
+      <!-- TODO: We expect `event-title` to be used,
            but processors and applications may not be updated yet.
-           This macro ensures that either "event" or "event-title" can be accpeted.
+           This macro ensures that either `event` or `event-title` can be accepted.
            Remove if procesor logic and application adoption can handle this. -->
       <if variable="event-title">
         <text variable="event-title"/>
@@ -1744,11 +1766,153 @@
       </else>
     </choose>
   </macro>
-  <!-- After 'source', APA also prints publication history (original publication, reprint info, retraction info) -->
+  <macro name="event-title-place">
+    <group delimiter=", ">
+      <text macro="event-title"/>
+      <text variable="event-place"/>
+    </group>
+  </macro>
+  <!-- 4.3. Publication details -->
+  <!-- Publication utility macros -->
+  <macro name="archive">
+    <group delimiter=", ">
+      <choose>
+        <if variable="archive-place">
+          <!-- With `archive-place`: physical archives. Without: online archives. -->
+          <!-- For physical archives, print the location before the archive name.
+                For electronic archives, these are printed in macro="description". -->
+          <!-- Must test for archive_collection:
+                With collection: archive_collection (archive_location), archive, archive-place
+                No collection: archive (archive_location), archive-place
+            -->
+          <choose>
+            <if variable="archive_collection">
+              <group delimiter=" ">
+                <text variable="archive_collection"/>
+                <text prefix="(" suffix=")" variable="archive_location"/>
+              </group>
+              <text variable="archive"/>
+              <text variable="archive-place"/>
+            </if>
+            <else>
+              <group delimiter=" ">
+                <text variable="archive"/>
+                <text prefix="(" suffix=")" variable="archive_location"/>
+              </group>
+              <text variable="archive-place"/>
+            </else>
+          </choose>
+        </if>
+        <else>
+          <text variable="archive"/>
+        </else>
+      </choose>
+    </group>
+  </macro>
+  <macro name="publisher">
+    <choose>
+      <if variable="publisher">
+        <text variable="publisher"/>
+      </if>
+      <else-if match="none" variable="event-place">
+        <!-- Work around Zotero double-mapping of event/publisher place -->
+        <text variable="publisher-place"/>
+      </else-if>
+    </choose>
+  </macro>
+  <!-- Publication logic -->
+  <macro name="publication">
+    <choose>
+      <if type="thesis">
+        <choose>
+          <if match="none" variable="archive DOI URL">
+            <text macro="publisher"/>
+          </if>
+        </choose>
+      </if>
+      <else-if match="any" type="post webpage">
+        <!-- Webpages treat container-title like publisher -->
+        <group delimiter="; ">
+          <text text-case="title" variable="container-title"/>
+          <text macro="publisher"/>
+        </group>
+      </else-if>
+      <else-if type="paper-conference">
+        <!-- For paper-conference, don't print publisher if in a journal-like proceedings -->
+        <choose>
+          <if match="any" variable="collection-editor compiler editor editorial-director">
+            <text macro="publisher"/>
+          </if>
+        </choose>
+      </else-if>
+      <else-if match="none" type="article-journal article-magazine article-newspaper periodical post-weblog review review-book">
+        <text macro="publisher"/>
+      </else-if>
+    </choose>
+  </macro>
+  <macro name="publication-archive">
+    <group delimiter="; ">
+      <text macro="publication"/>
+      <text macro="archive"/>
+    </group>
+  </macro>
+  <!-- 4.4. Access -->
+  <macro name="access">
+    <choose>
+      <if variable="DOI">
+        <text prefix="https://doi.org/" variable="DOI"/>
+      </if>
+      <else-if variable="URL">
+        <group delimiter=" ">
+          <choose>
+            <if match="none" variable="issued status">
+              <group delimiter=" ">
+                <text term="retrieved" text-case="capitalize-first"/>
+                <group delimiter=", ">
+                  <date form="text" variable="accessed"/>
+                  <text term="from"/>
+                </group>
+              </group>
+            </if>
+          </choose>
+          <text variable="URL"/>
+        </group>
+      </else-if>
+    </choose>
+  </macro>
+  <!-- 5. Publication history -->
+  <!-- History utility macros -->
+  <macro name="original-publisher">
+    <choose>
+      <if variable="original-publisher">
+        <text variable="original-publisher"/>
+      </if>
+      <else>
+        <text variable="original-publisher-place"/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="original-title">
+    <choose>
+      <if variable="original-title">
+        <text value="as"/>
+        <choose>
+          <if match="any" type="article-journal article-magazine article-newspaper periodical post-weblog review review-book">
+            <text variable="original-title"/>
+          </if>
+          <else>
+            <text font-style="italic" variable="original-title"/>
+          </else>
+        </choose>
+      </if>
+    </choose>
+  </macro>
+  <!-- History logic -->
   <macro name="publication-history">
+    <!-- Information appended to 'source': original publication, reprint info, retraction info -->
     <choose>
       <if type="patent">
-        <text variable="references" prefix="(" suffix=")"/>
+        <text prefix="(" suffix=")" variable="references"/>
       </if>
       <else>
         <group delimiter="; " prefix="(" suffix=")">
@@ -1756,8 +1920,8 @@
           <choose>
             <if variable="issued">
               <choose>
-                <if variable="issue number page volume" match="any">
-                  <text variable="status" text-case="capitalize-first"/>
+                <if match="any" variable="issue number page volume">
+                  <text text-case="capitalize-first" variable="status"/>
                 </if>
               </choose>
             </if>
@@ -1766,29 +1930,31 @@
             <if variable="references">
               <!-- This provides the option for more elaborate description
                     of publication history, such as full "reprinted" references
-                    (examples 11, 43, 44) -->
+                    (APA examples 11, 43, 44) -->
               <text variable="references"/>
             </if>
             <else>
-              <group delimiter=" ">
-                <text term="original-work-published" text-case="capitalize-first"/>
-                <choose>
-                  <if is-uncertain-date="original-date">
-                    <text term="circa" form="short"/>
-                  </if>
-                </choose>
-                <date variable="original-date">
-                  <date-part name="year"/>
-                </date>
-              </group>
+              <text macro="publication-history-variables"/>
             </else>
           </choose>
         </group>
       </else>
     </choose>
   </macro>
-  <!-- Legal citations have their own rules -->
-  <macro name="legal-cites">
+  <macro name="publication-history-variables">
+    <group delimiter=" ">
+      <text term="original-work-published" text-case="capitalize-first"/>
+      <group delimiter="; ">
+        <text macro="original-title"/>
+        <group delimiter=", ">
+          <text macro="original-publisher"/>
+          <text macro="original-date-year"/>
+        </group>
+      </group>
+    </group>
+  </macro>
+  <!-- Parallel rules for legal citations -->
+  <macro name="legal-bib">
     <!-- `treaty`: for treaties -->
     <!-- `legal_case`: for all legal and court cases -->
     <!-- `bill`: for bills, resolutions, federal reports -->
@@ -1800,16 +1966,14 @@
         <if type="treaty">
           <group delimiter=", " suffix=".">
             <!-- APA generally defers to Bluebook for legal citations, but diverges without
-                explanation for treaty items. We follow the Bluebook format that was used 
+                explanation for treaty items. We follow the Bluebook format that was used
                 in APA 6th ed. -->
-            <!-- APA manual omits treaty parties/authors, but per Bluebook 
+            <!-- APA manual omits treaty parties/authors, but per Bluebook
                 they should be included at least for bilateral treaties. -->
-            <names variable="author">
-              <name initialize-with="." form="short" delimiter="-"/>
-            </names>
+            <text macro="author-legal"/>
             <text macro="date-legal"/>
-            <!-- APA manual omits treaty source/report called for by Bluebook in favor of just URL. 
-                Both are included here, following the APA style used for all other item types 
+            <!-- APA manual omits treaty source/report called for by Bluebook in favor of just URL.
+                Both are included here, following the APA style used for all other item types
                 to end the reference with a period, then give the URL afterward. -->
             <text macro="container-legal"/>
           </group>
@@ -1821,7 +1985,7 @@
               <text macro="container-legal"/>
             </group>
             <text macro="date-legal"/>
-            <text macro="parenthetical-legal"/>
+            <text macro="identification-legal"/>
           </group>
         </else>
       </choose>
@@ -1829,20 +1993,75 @@
       <text macro="access"/>
     </group>
   </macro>
+  <!-- 1. Legal author -->
+  <macro name="author-legal">
+    <names variable="author">
+      <name delimiter="-" form="short"/>
+    </names>
+  </macro>
+  <!-- 2. Legal date -->
+  <macro name="date-legal-case">
+    <group delimiter=" " prefix="(" suffix=")">
+      <text variable="authority"/>
+      <choose>
+        <if variable="container-title">
+          <!-- Print only year for cases published in reporters-->
+          <text macro="date-issued-year"/>
+        </if>
+        <else>
+          <!-- APA manual doesn't include examples of cases not yet
+                   published in a reporter, but this is Bluebook style. -->
+          <text macro="date-issued-full"/>
+        </else>
+      </choose>
+    </group>
+  </macro>
+  <macro name="date-legal">
+    <choose>
+      <if type="treaty">
+        <text macro="date-issued-full"/>
+      </if>
+      <else-if type="legal_case">
+        <text macro="date-legal-case"/>
+      </else-if>
+      <else-if match="any" type="bill hearing legislation regulation">
+        <group delimiter=" " prefix="(" suffix=")">
+          <group delimiter=" ">
+            <text macro="original-date-year"/>
+            <text form="symbol" term="and"/>
+          </group>
+          <choose>
+            <if variable="issued">
+              <!-- APA manual includes "rev." before the revision year,
+                   but this isn't part of the Bluebook rules. -->
+              <text macro="date-issued-year"/>
+            </if>
+            <else>
+              <!-- Show proposal date for uncodified regualtions.
+                   Assume date is entered literally ala "proposed May 23, 2016".
+                   TODO: Add 'proposed' term here if that becomes available -->
+              <date form="text" variable="submitted"/>
+            </else>
+          </choose>
+        </group>
+      </else-if>
+    </choose>
+  </macro>
+  <!-- 3.1. Legal title -->
   <macro name="title-legal">
     <choose>
-      <if type="bill legal_case legislation regulation treaty" match="any">
-        <text variable="title" text-case="title"/>
+      <if match="any" type="bill legal_case legislation regulation treaty">
+        <text text-case="title" variable="title"/>
       </if>
       <else-if type="hearing">
-        <!-- APA uses a comma delimiter and omits "hearing before the" for hearings with testimony, 
+        <!-- APA uses a comma delimiter and omits "hearing before the" for hearings with testimony,
              but follows Bluebook rules (colon delimiter, prefix before the committee name) for
              references to the whole hearing. We simply follow the Bluebook rules for both, but
              use APA style capitalization (not capitalizing "Before" or the title of the hearing). -->
         <group delimiter=": " font-style="italic">
-          <text variable="title" text-case="capitalize-first"/>
+          <text text-case="capitalize-first" variable="title"/>
           <group delimiter=" ">
-            <text term="hearing" form="long" text-case="capitalize-first"/>
+            <text form="long" term="hearing" text-case="capitalize-first"/>
             <group delimiter=" ">
               <group delimiter=" ">
                 <!-- APA manual omits the bill number, but it should be included per Bluebook if relevant -->
@@ -1851,7 +2070,7 @@
               </group>
               <group delimiter=" ">
                 <!-- Use the `at` term to hold "before the" -->
-                <text term="at" form="long"/>
+                <text form="long" term="at"/>
                 <text variable="section"/>
               </group>
             </group>
@@ -1860,124 +2079,95 @@
       </else-if>
     </choose>
   </macro>
-  <macro name="date-legal">
+  <!-- 3.2. Legal identification (in parentheses) -->
+  <macro name="identification-legal">
     <choose>
-      <if type="treaty">
-        <date variable="issued" form="text"/>
+      <if type="hearing">
+        <group delimiter=" " prefix="(" suffix=")">
+          <!-- Use the 'verb' form of the hearing term to hold 'testimony of' -->
+          <text form="verb" term="hearing"/>
+          <names variable="author">
+            <name initialize="false"/>
+          </names>
+        </group>
       </if>
-      <else-if type="legal_case">
-        <group prefix="(" suffix=")" delimiter=" ">
-          <text variable="authority"/>
-          <choose>
-            <if variable="container-title" match="any">
-              <!-- Print only year for cases published in reporters-->
-              <date variable="issued" form="numeric" date-parts="year"/>
-            </if>
-            <else>
-              <!-- APA manual doesn't include examples of cases not yet
-                   published in a reporter, but this is Bluebook style. -->
-              <date variable="issued" form="text"/>
-            </else>
-          </choose>
-        </group>
-      </else-if>
-      <else-if type="bill hearing legislation regulation" match="any">
-        <group prefix="(" suffix=")" delimiter=" ">
-          <group delimiter=" ">
-            <date variable="original-date">
-              <date-part name="year"/>
-            </date>
-            <text term="and" form="symbol"/>
-          </group>
-          <choose>
-            <if variable="issued">
-              <!-- APA manual includes "rev." before the revision year, 
-                   but this isn't part of the Bluebook rules. -->
-              <date variable="issued">
-                <date-part name="year"/>
-              </date>
-            </if>
-            <else>
-              <!-- Show proposal date for uncodified regualtions. 
-                   Assume date is entered literally ala "proposed May 23, 2016".
-                   TODO: Add 'proposed' term here if that becomes available -->
-              <date variable="submitted" form="text"/>
-            </else>
-          </choose>
-        </group>
+      <else-if match="any" type="bill legislation regulation">
+        <!-- For uncodified regulations, assume future code section is in `status`. -->
+        <text prefix="(" suffix=")" variable="status"/>
       </else-if>
     </choose>
   </macro>
-  <macro name="container-legal">
-    <!-- Expect legal item container-titles to be stored in short form -->
+  <!-- 4. Legal source -->
+  <!-- Legal source utility macros -->
+  <macro name="container-bill">
+    <group delimiter=", ">
+      <group delimiter=" ">
+        <text variable="genre"/>
+        <group delimiter=" ">
+          <choose>
+            <!-- If there is no session number or code/record title, assume
+                     assume the item is a congressional report and include 'No.' term. -->
+            <if match="none" variable="chapter-number container-title">
+              <!-- The item is a congressional report, rather than a bill or resultion. -->
+              <text macro="number-labelled"/>
+            </if>
+            <else>
+              <text variable="number"/>
+            </else>
+          </choose>
+        </group>
+      </group>
+      <group delimiter=" ">
+        <text variable="authority"/>
+        <!-- 'session' is `chapter-number` -->
+        <text variable="chapter-number"/>
+      </group>
+      <group delimiter=" ">
+        <text variable="volume"/>
+        <text variable="container-title"/>
+        <text variable="page-first"/>
+      </group>
+    </group>
+  </macro>
+  <macro name="container-hearing">
+    <group delimiter=" ">
+      <text variable="authority"/>
+      <!-- 'session' is `chapter-number` -->
+      <text variable="chapter-number"/>
+    </group>
+  </macro>
+  <macro name="container-legal-case">
+    <group delimiter=" ">
+      <choose>
+        <if variable="container-title">
+          <group delimiter=" ">
+            <text variable="volume"/>
+            <text variable="container-title"/>
+            <text macro="section-labelled"/>
+            <choose>
+              <if match="any" variable="page page-first">
+                <text variable="page-first"/>
+              </if>
+              <else>
+                <text value="___"/>
+              </else>
+            </choose>
+          </group>
+        </if>
+        <else>
+          <text macro="number-labelled"/>
+        </else>
+      </choose>
+    </group>
+  </macro>
+  <macro name="container-legislation">
     <choose>
-      <if type="treaty">
-        <group delimiter=" ">
-          <number variable="volume"/>
-          <text variable="container-title"/>
-          <choose>
-            <if variable="page page-first" match="any">
-              <text variable="page-first"/>
-            </if>
-            <else>
-              <group delimiter=" ">
-                <label variable="number" form="short" text-case="capitalize-first"/>
-                <text variable="number"/>
-              </group>
-            </else>
-          </choose>
-        </group>
-      </if>
-      <else-if type="legal_case">
-        <group delimiter=" ">
-          <choose>
-            <if variable="container-title">
-              <group delimiter=" ">
-                <text variable="volume"/>
-                <text variable="container-title"/>
-                <group delimiter=" ">
-                  <label variable="section" form="symbol"/>
-                  <text variable="section"/>
-                </group>
-                <choose>
-                  <if variable="page page-first" match="any">
-                    <text variable="page-first"/>
-                  </if>
-                  <else>
-                    <text value="___"/>
-                  </else>
-                </choose>
-              </group>
-            </if>
-            <else>
-              <group delimiter=" ">
-                <label variable="number" form="short" text-case="capitalize-first"/>
-                <text variable="number"/>
-              </group>
-            </else>
-          </choose>
-        </group>
-      </else-if>
-      <else-if type="bill">
+      <if variable="number">
+        <!-- There's a public law number. -->
         <group delimiter=", ">
           <group delimiter=" ">
-            <text variable="genre"/>
-            <group delimiter=" ">
-              <choose>
-                <!-- If there is no session number or code/record title, assume
-                     assume the item is a congressional report and include 'No.' term. -->
-                <if variable="chapter-number container-title" match="none">
-                  <!-- The item is a congressional report, rather than a bill or resultion. -->
-                  <label variable="number" form="short" text-case="capitalize-first"/>
-                </if>
-              </choose>
-              <text variable="number"/>
-            </group>
-          </group>
-          <group delimiter=" ">
-            <text variable="authority"/>
-            <!-- 'session' is `chapter-number` -->
-            <text variable="chapter-number"/>
+            <text value="Pub. L. No."/>
+            <text variable="number"/>
           </group>
           <group delimiter=" ">
             <text variable="volume"/>
@@ -1985,150 +2175,140 @@
             <text variable="page-first"/>
           </group>
         </group>
-      </else-if>
-      <else-if type="hearing">
+      </if>
+      <else>
         <group delimiter=" ">
-          <text variable="authority"/>
-          <!-- 'session' is `chapter-number` -->
-          <text variable="chapter-number"/>
+          <text variable="volume"/>
+          <text variable="container-title"/>
+          <choose>
+            <if variable="section">
+              <text macro="section-labelled"/>
+            </if>
+            <else>
+              <text variable="page-first"/>
+            </else>
+          </choose>
         </group>
-      </else-if>
-      <else-if type="legislation">
+      </else>
+    </choose>
+  </macro>
+  <macro name="container-regulation">
+    <group delimiter=", ">
+      <group delimiter=" ">
+        <text variable="genre"/>
+        <text macro="number-labelled"/>
+      </group>
+      <group delimiter=" ">
+        <text variable="volume"/>
+        <text variable="container-title"/>
         <choose>
-          <if variable="number">
-            <!-- There's a public law number. -->
-            <group delimiter=", ">
-              <text variable="number" prefix="Pub. L. No. "/>
-              <group delimiter=" ">
-                <text variable="volume"/>
-                <text variable="container-title"/>
-                <text variable="page-first"/>
-              </group>
-            </group>
+          <if variable="section">
+            <text macro="section-labelled"/>
           </if>
           <else>
-            <group delimiter=" ">
-              <text variable="volume"/>
-              <text variable="container-title"/>
-              <choose>
-                <if variable="section">
-                  <group delimiter=" ">
-                    <label variable="section" form="symbol"/>
-                    <text variable="section"/>
-                  </group>
-                </if>
-                <else>
-                  <text variable="page-first"/>
-                </else>
-              </choose>
-            </group>
+            <text variable="page-first"/>
           </else>
         </choose>
-      </else-if>
-      <else-if type="regulation">
-        <group delimiter=", ">
-          <group delimiter=" ">
-            <text variable="genre"/>
-            <group delimiter=" ">
-              <label variable="number" form="short" text-case="capitalize-first"/>
-              <text variable="number"/>
-            </group>
-          </group>
-          <group delimiter=" ">
-            <text variable="volume"/>
-            <text variable="container-title"/>
-            <choose>
-              <if variable="section">
-                <group delimiter=" ">
-                  <label variable="section" form="symbol"/>
-                  <text variable="section"/>
-                </group>
-              </if>
-              <else>
-                <text variable="page-first"/>
-              </else>
-            </choose>
-          </group>
-        </group>
-      </else-if>
-    </choose>
-  </macro>
-  <macro name="parenthetical-legal">
-    <choose>
-      <if type="hearing">
-        <group prefix="(" suffix=")" delimiter=" ">
-          <!-- Use the 'verb' form of the hearing term to hold 'testimony of' -->
-          <text term="hearing" form="verb"/>
-          <names variable="author">
-            <name and="symbol" delimiter=", "/>
-          </names>
-        </group>
-      </if>
-      <else-if type="bill legislation regulation" match="any">
-        <!-- For uncodified regulations, assume future code section is in `status`. -->
-        <text variable="status" prefix="(" suffix=")"/>
-      </else-if>
-    </choose>
-  </macro>
-  <macro name="citation-locator">
-    <!-- Abbreviate page and paragraph, leave other locator labels in long form, cf. Rule 8.13 -->
-    <group delimiter=" ">
-      <choose>
-        <if locator="page paragraph" match="any">
-          <label variable="locator" form="short"/>
-        </if>
-        <else>
-          <label variable="locator" text-case="capitalize-first"/>
-        </else>
-      </choose>
-      <text variable="locator"/>
+      </group>
     </group>
   </macro>
-  <citation et-al-min="3" et-al-use-first="1" disambiguate-add-year-suffix="true" disambiguate-add-names="true" disambiguate-add-givenname="true" collapse="year" givenname-disambiguation-rule="primary-name-with-initials">
+  <macro name="container-treaty">
+    <group delimiter=" ">
+      <number variable="volume"/>
+      <text variable="container-title"/>
+      <choose>
+        <if match="any" variable="page page-first">
+          <text variable="page-first"/>
+        </if>
+        <else>
+          <text macro="number-labelled"/>
+        </else>
+      </choose>
+    </group>
+  </macro>
+  <!-- Legal source logic -->
+  <macro name="container-legal">
+    <!-- Expect legal item container-titles to be stored in short form -->
+    <choose>
+      <if type="bill">
+        <text macro="container-bill"/>
+      </if>
+      <else-if type="hearing">
+        <text macro="container-hearing"/>
+      </else-if>
+      <else-if type="legal_case">
+        <text macro="container-legal-case"/>
+      </else-if>
+      <else-if type="legislation">
+        <text macro="container-legislation"/>
+      </else-if>
+      <else-if type="regulation">
+        <text macro="container-regulation"/>
+      </else-if>
+      <else-if type="treaty">
+        <text macro="container-treaty"/>
+      </else-if>
+    </choose>
+  </macro>
+  <!-- Main logic -->
+  <citation collapse="year" disambiguate-add-givenname="true" disambiguate-add-names="true" disambiguate-add-year-suffix="true" et-al-min="3" et-al-use-first="1" givenname-disambiguation-rule="primary-name-with-initials">
     <sort>
       <key macro="author-sort" names-min="3" names-use-first="1"/>
       <key macro="date-sort-group" sort="ascending"/>
       <key macro="date-sort" sort="ascending"/>
       <key variable="status"/>
     </sort>
-    <layout prefix="(" suffix=")" delimiter="; ">
+    <layout delimiter="; " prefix="(" suffix=")">
       <group delimiter=", ">
         <text macro="author-intext"/>
         <text macro="date-intext"/>
-        <text macro="citation-locator"/>
+        <text macro="locator-labelled"/>
       </group>
     </layout>
   </citation>
-  <bibliography hanging-indent="true" et-al-min="21" et-al-use-first="19" et-al-use-last="true" entry-spacing="0" line-spacing="2">
+  <macro name="bibliography">
+    <group delimiter=" ">
+      <group delimiter=". " suffix=".">
+        <text macro="author-bib"/>
+        <text macro="date-bib"/>
+        <text macro="title-and-descriptions"/>
+        <text macro="container"/>
+        <text macro="event"/>
+        <text macro="publication-archive"/>
+      </group>
+      <text macro="access"/>
+      <text macro="publication-history"/>
+    </group>
+  </macro>
+  <macro name="bibliography-filtered">
+    <choose>
+      <if match="any" type="bill hearing legal_case legislation regulation treaty">
+        <!-- Legal items have different orders and delimiters -->
+        <text macro="legal-bib"/>
+      </if>
+      <else-if type="personal_communication">
+        <choose>
+          <if match="any" variable="archive archive-place container-title DOI publisher URL">
+            <text macro="bibliography"/>
+          </if>
+        </choose>
+      </else-if>
+      <else>
+        <text macro="bibliography"/>
+      </else>
+    </choose>
+  </macro>
+  <bibliography entry-spacing="0" et-al-min="21" et-al-use-first="19" et-al-use-last="true" hanging-indent="true" line-spacing="2">
     <sort>
       <key macro="author-sort"/>
       <key macro="date-sort-group" sort="ascending"/>
       <key macro="date-sort" sort="ascending"/>
       <key variable="status"/>
-      <key macro="title"/>
+      <key macro="title-bib"/>
     </sort>
     <layout>
-      <choose>
-        <if type="bill hearing legal_case legislation regulation treaty" match="any">
-          <!-- Legal items have different orders and delimiters -->
-          <text macro="legal-cites"/>
-        </if>
-        <else>
-          <group delimiter=" ">
-            <group delimiter=". " suffix=".">
-              <text macro="author-bib"/>
-              <text macro="date-bib"/>
-              <text macro="title-and-descriptions"/>
-              <text macro="container"/>
-              <text macro="event"/>
-              <text macro="publisher"/>
-            </group>
-            <text macro="access"/>
-            <text macro="publication-history"/>
-          </group>
-        </else>
-      </choose>
-      <text variable="note" display="block"/>
+      <text macro="bibliography-filtered"/>
+      <text display="block" variable="note"/>
     </layout>
   </bibliography>
 </style>

--- a/apa-cv.csl
+++ b/apa-cv.csl
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
-<style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" demote-non-dropping-particle="never" page-range-format="expanded">
+<style xmlns="http://purl.org/net/xbiblio/csl" and="symbol" class="in-text" demote-non-dropping-particle="never" initialize-with=". " names-delimiter=", " page-range-format="expanded" version="1.0">
   <info>
     <title>American Psychological Association 7th edition (curriculum vitae, sorted by descending date)</title>
-    <title-short>APA (CV)</title-short>
+    <title-short>APA Style (CV)</title-short>
     <id>http://www.zotero.org/styles/apa-cv</id>
     <link href="http://www.zotero.org/styles/apa-cv" rel="self"/>
     <link href="http://www.zotero.org/styles/apa" rel="template"/>
@@ -10,48 +10,53 @@
     <author>
       <name>Brenton M. Wiernik</name>
       <email>zotero@wiernik.org</email>
+      <uri>https://orcid.org/0000-0001-9560-6336</uri>
     </author>
+    <contributor>
+      <name>Andrew Dunning</name>
+      <uri>https://orcid.org/0000-0003-0464-5036</uri>
+    </contributor>
     <category citation-format="author-date"/>
     <category field="psychology"/>
     <category field="generic-base"/>
+    <summary>Author–date system of the Publication manual of the American Psychological Association: The official guide to APA style (2020)</summary>
     <updated>2024-07-09T20:08:41+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale xml:lang="en">
     <terms>
-      <term name="editortranslator" form="short">
-        <single>ed. &amp; trans.</single>
-        <multiple>eds. &amp; trans.</multiple>
-      </term>
-      <term name="editor-translator" form="short">
-        <single>ed. &amp; trans.</single>
-        <multiple>eds. &amp; trans.</multiple>
-      </term>
-      <term name="translator" form="short">trans.</term>
-      <term name="interviewer" form="short">
-        <single>interviewer</single>
-        <multiple>interviewers</multiple>
-      </term>
-      <term name="collection-editor" form="short">
+      <term name="ad"> C.E.</term>
+      <term form="long" name="at">before the</term>
+      <term name="bc"> B.C.E.</term>
+      <term form="short" name="circa">ca.</term>
+      <term name="collection">archival collection</term>
+      <term form="short" name="collection-editor">
         <single>ed.</single>
         <multiple>eds.</multiple>
       </term>
-      <term name="performer" form="verb">recorded by</term>
-      <term name="circa" form="short">ca.</term>
-      <term name="bc"> B.C.E.</term>
-      <term name="ad"> C.E.</term>
-      <term name="issue" form="long">
+      <term form="short" name="editor-translator">
+        <single>ed. &amp; trans.</single>
+        <multiple>eds. &amp; trans.</multiple>
+      </term>
+      <term form="short" name="editortranslator">
+        <single>ed. &amp; trans.</single>
+        <multiple>eds. &amp; trans.</multiple>
+      </term>
+      <term form="verb" name="hearing">testimony of</term>
+      <term form="short" name="interviewer">
+        <single>interviewer</single>
+        <multiple>interviewers</multiple>
+      </term>
+      <term form="long" name="issue">
         <single>issue</single>
         <multiple>issues</multiple>
       </term>
-      <term name="software">computer software</term>
-      <term name="at" form="long">before the</term>
-      <term name="collection">archival collection</term>
+      <term form="verb" name="performer">recorded by</term>
       <term name="post">online post</term>
-      <term name="at" form="long">before the</term>
-      <term name="hearing" form="verb">testimony of</term>
-      <term name="review-of" form="long">review of the</term>
-      <term name="review-of" form="short">review of</term>
+      <term form="long" name="review-of">review of the</term>
+      <term form="short" name="review-of">review of</term>
+      <term name="software">computer software</term>
+      <term form="short" name="translator">trans.</term>
     </terms>
   </locale>
   <locale xml:lang="da">
@@ -71,7 +76,7 @@
   </locale>
   <locale xml:lang="fr">
     <terms>
-      <term name="editor" form="short">
+      <term form="short" name="editor">
         <single>éd.</single>
         <multiple>éds.</multiple>
       </term>
@@ -97,29 +102,26 @@
       <term name="et-al">et al.</term>
     </terms>
   </locale>
-  <!-- For Indigeneous Knowledge, assume the item is stored as `document` or `speech`
-       and that Nation/Community, treaty, where the Elder lives, 
-       and topic are all stored in `title`
-       cf. https://libguides.norquest.ca/c.php?g=314831&p=5188823.
-       If the item is stored as `interview`, assume that Nation/Community, treat, and topic
-       are stored in `title`, 'Oral teaching' or similar is stored in `archive`, and where
-       the Elder lives is stored in `archive-place`. 
-  -->
-  <!-- Reviews are detected if an item has type `review` or `review-book` or if it has any of the variables
-       `reviewed-title`, `reviewed-author`, or `reviewed-genre`. For the latter case, reviews are commonly 
-       stored as types `article-journal`, `article-magazine`, `article-newspaper`, `post-weblog`, or `webpage` 
-  -->
-  <!-- General categories of item types:
-       Periodical: article-journal article-magazine article-newspaper periodical post-weblog review review-book
-       Periodical or Booklike: paper-conference
-       Booklike: article book broadcast chapter classic collection dataset document
-                 entry entry-dictionary entry-encyclopedia event figure
-                 graphic interview manuscript map motion_picture musical_score
-                 pamphlet patent performance personal_communication post report
-                 software song speech standard thesis webpage
-       Legal: bill hearing legal_case legislation regulation treaty
+  <!-- General categories of CSL item types:
+
+       Periodical
+       : article-journal article-magazine article-newspaper periodical post-weblog review review-book
+
+       Periodical or Booklike
+       : paper-conference
+
+       Booklike
+       : article book broadcast chapter classic collection dataset document
+         entry entry-dictionary entry-encyclopedia event figure
+         graphic interview manuscript map motion_picture musical_score
+         pamphlet patent performance personal_communication post report
+         software song speech standard thesis webpage
+
+       Legal
+       : bill hearing legal_case legislation regulation treaty
   -->
   <!-- Equivalencies:
+
        classic == book
        document == report, but give full date
        standard == report
@@ -128,6 +130,7 @@
        collection == book, but give full date
   -->
   <!-- Role equivalencies:
+
        compiler == editor
        organizer, curator == chair
        script-writer == director
@@ -135,209 +138,248 @@
        guest, host == director
        series-creator, executive-producer == editor
   -->
-  <!-- APA references contain four parts: author, date, title, source -->
+  <!-- Reviews are detected if an item has type `review` or `review-book` or if it has any of the variables
+       `reviewed-title`, `reviewed-author`, or `reviewed-genre`. For the latter case, reviews are commonly
+       stored as types `article-journal`, `article-magazine`, `article-newspaper`, `post-weblog`, or `webpage`
+  -->
+  <!-- For Indigeneous Knowledge, assume the item is stored as `document` or `speech`
+       and that Nation/Community, treaty, where the Elder lives,
+       and topic are all stored in `title`
+       cf. https://libguides.norquest.ca/c.php?g=314831&p=5188823.
+       If the item is stored as `interview`, assume that Nation/Community, treaty territory, and topic
+       are stored in `title`, 'Oral teaching' or similar is stored in `archive`, and where
+       the Elder lives is stored in `archive-place`.
+  -->
+  <!-- Variable labelling macros -->
+  <macro name="chapter-number-labelled">
+    <group delimiter=" ">
+      <choose>
+        <if is-numeric="chapter-number">
+          <label form="short" variable="chapter-number"/>
+        </if>
+      </choose>
+      <text variable="chapter-number"/>
+    </group>
+  </macro>
+  <macro name="edition-labelled">
+    <choose>
+      <if is-numeric="edition">
+        <group delimiter=" ">
+          <number form="ordinal" variable="edition"/>
+          <label form="short" variable="edition"/>
+        </group>
+      </if>
+      <else>
+        <text variable="edition"/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="issue-labelled">
+    <group delimiter=" ">
+      <label text-case="capitalize-first" variable="issue"/>
+      <text variable="issue"/>
+    </group>
+  </macro>
+  <macro name="number-labelled">
+    <group delimiter=" ">
+      <choose>
+        <if is-numeric="number">
+          <label form="short" text-case="capitalize-first" variable="number"/>
+        </if>
+        <else-if match="none" type="broadcast">
+          <label form="short" text-case="capitalize-first" variable="number"/>
+        </else-if>
+      </choose>
+      <text variable="number"/>
+    </group>
+  </macro>
+  <macro name="number-article-labelled">
+    <!-- APA example 6: Journal article with article number or eLocator -->
+    <group delimiter=" ">
+      <text term="article-locator" text-case="capitalize-first"/>
+      <text variable="number"/>
+    </group>
+  </macro>
+  <macro name="number-of-volumes-labelled">
+    <choose>
+      <if is-numeric="number-of-volumes">
+        <group delimiter=" ">
+          <label form="short" text-case="capitalize-first" variable="number-of-volumes"/>
+          <text prefix="1" term="page-range-delimiter"/>
+        </group>
+      </if>
+    </choose>
+    <text variable="number-of-volumes"/>
+  </macro>
+  <macro name="page-labelled">
+    <group delimiter=" ">
+      <label form="short" variable="page"/>
+      <text variable="page"/>
+    </group>
+  </macro>
+  <macro name="part-number-labelled">
+    <group delimiter=" ">
+      <choose>
+        <if variable="part-number">
+          <!-- TODO: Replace with `part-number` label when CSL provides one -->
+          <text form="short" term="part" text-case="capitalize-first"/>
+          <text variable="part-number"/>
+        </if>
+      </choose>
+    </group>
+  </macro>
+  <macro name="section-labelled">
+    <group delimiter=" ">
+      <label form="symbol" variable="section"/>
+      <text variable="section"/>
+    </group>
+  </macro>
+  <macro name="supplement-number-labelled">
+    <group delimiter=" ">
+      <choose>
+        <if variable="supplement-number">
+          <!-- TODO: Replace with `supplement-number` label when CSL provides one -->
+          <text form="short" term="supplement" text-case="capitalize-first"/>
+          <text variable="supplement-number"/>
+        </if>
+      </choose>
+    </group>
+  </macro>
+  <macro name="version-labelled">
+    <group delimiter=" ">
+      <label text-case="capitalize-first" variable="version"/>
+      <text variable="version"/>
+    </group>
+  </macro>
+  <macro name="volume-labelled">
+    <group delimiter=" ">
+      <label form="short" text-case="capitalize-first" variable="volume"/>
+      <text variable="volume"/>
+    </group>
+  </macro>
+  <!-- Four parts in APA references:
+
+       1. Author (APA 9.7–12)
+       2. Date (APA 9.13–17)
+       3. Title (APA 9.18–22)
+       4. Source (APA 9.23–37)
+  -->
+  <!-- 1. Author -->
+  <!-- Author utility macros -->
+  <macro name="author-substitute-bib">
+    <names variable="composer">
+      <name delimiter-precedes-last="always" name-as-sort-order="all"/>
+      <label form="short" prefix=" (" suffix=")" text-case="title"/>
+      <substitute>
+        <names variable="author"/>
+        <!-- `narrator` only cited in secondary-contributors -->
+        <names variable="illustrator"/>
+        <choose>
+          <if type="broadcast">
+            <names variable="script-writer director">
+              <!-- Actors/performers and producers [not executive] not cited in APA style. -->
+              <name delimiter-precedes-last="always" name-as-sort-order="all"/>
+              <label form="long" prefix=" (" suffix=")" text-case="title"/>
+            </names>
+          </if>
+        </choose>
+        <names variable="director">
+          <!-- For non-broadcast items, APA only cites directors and not writers. -->
+          <name delimiter-precedes-last="always" name-as-sort-order="all"/>
+          <label form="long" prefix=" (" suffix=")" text-case="title"/>
+        </names>
+        <names variable="guest host">
+          <!-- TODO: Replace `delimiter` with `collapse` to combine names variables when that becomes available. -->
+          <name delimiter-precedes-last="always" name-as-sort-order="all"/>
+          <label form="long" prefix=" (" suffix=")" text-case="title"/>
+        </names>
+        <names variable="producer">
+          <!-- Producers not cited if there is a writer/director, but use if they are the principle creator. -->
+          <name delimiter-precedes-last="always" name-as-sort-order="all"/>
+          <label form="long" prefix=" (" suffix=")" text-case="title"/>
+        </names>
+        <choose>
+          <if variable="container-title">
+            <choose>
+              <if match="any" type="book classic collection entry entry-dictionary entry-encyclopedia">
+                <!-- Items with book-like container-title substitute with their title and identification,
+                     but leave description after container-title. This mimics the `container-booklike` formatting. -->
+                <text macro="title-substitute"/>
+              </if>
+            </choose>
+          </if>
+        </choose>
+        <names variable="executive-producer">
+          <name delimiter-precedes-last="always" name-as-sort-order="all"/>
+          <label form="long" prefix=" (" suffix=")" text-case="title"/>
+        </names>
+        <names variable="series-creator">
+          <name delimiter-precedes-last="always" name-as-sort-order="all"/>
+          <label form="long" prefix=" (" suffix=")" text-case="title"/>
+        </names>
+        <names variable="editor-translator"/>
+        <!-- Translator is not cited as a primary creator (only as Ed. & Trans.). -->
+        <names variable="editor"/>
+        <names variable="editorial-director"/>
+        <names variable="compiler">
+          <name delimiter-precedes-last="always" name-as-sort-order="all"/>
+          <label form="long" prefix=" (" suffix=")" text-case="title"/>
+        </names>
+        <choose>
+          <if match="any" type="event performance speech">
+            <names variable="chair">
+              <name delimiter-precedes-last="always" name-as-sort-order="all"/>
+              <label form="long" prefix=" (" suffix=")" text-case="title"/>
+            </names>
+            <names variable="organizer">
+              <name delimiter-precedes-last="always" name-as-sort-order="all"/>
+              <label form="long" prefix=" (" suffix=")" text-case="title"/>
+            </names>
+          </if>
+        </choose>
+        <names variable="curator">
+          <name delimiter-precedes-last="always" name-as-sort-order="all"/>
+          <label form="long" prefix=" (" suffix=")" text-case="title"/>
+        </names>
+        <names variable="collection-editor"/>
+        <text macro="title-substitute"/>
+      </substitute>
+    </names>
+  </macro>
+  <macro name="title-substitute">
+    <choose>
+      <if variable="title">
+        <!-- If an item has a title, substitute missing author with title and identification, but leave description after the date (in the 'title' position). -->
+        <group delimiter=" ">
+          <text macro="title-bib"/>
+          <text macro="identification"/>
+        </group>
+      </if>
+      <else>
+        <!-- If an item has no title, substitute with description followed by identification. -->
+        <text macro="title-and-descriptions"/>
+      </else>
+    </choose>
+  </macro>
+  <!-- Author logic -->
   <macro name="author-bib">
     <group delimiter=" ">
-      <names variable="composer" delimiter=", ">
-        <name name-as-sort-order="all" and="symbol" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
-        <substitute>
-          <names variable="author"/>
-          <!-- Note: `narrator` only cited in secondary-contributors -->
-          <names variable="illustrator"/>
-          <!-- TODO: Replace `delimiter` with `collapse` to combine names variables when that becomes available. -->
-          <choose>
-            <if type="broadcast">
-              <names variable="script-writer director" delimiter=", &amp; ">
-                <!-- Note: Actors/performers and producers [not executive] not cited in APA style. -->
-                <name name-as-sort-order="all" and="symbol" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
-                <label form="long" prefix=" (" suffix=")" text-case="title"/>
-              </names>
-            </if>
-          </choose>
-          <names variable="director">
-            <!-- For non-broadcast items, APA only cites directors and not writers. -->
-            <name name-as-sort-order="all" and="symbol" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
-            <label form="long" prefix=" (" suffix=")" text-case="title"/>
-          </names>
-          <!-- TODO: Replace `delimiter` with `collapse` to combine names variables when that becomes available. -->
-          <names variable="guest host" delimiter=", &amp; ">
-            <name name-as-sort-order="all" and="symbol" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
-            <label form="long" prefix=" (" suffix=")" text-case="title"/>
-          </names>
-          <names variable="producer">
-            <!-- Note: Producers not cited if there is a writer/director, but use if they are the principle creator. -->
-            <name name-as-sort-order="all" and="symbol" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
-            <label form="long" prefix=" (" suffix=")" text-case="title"/>
-          </names>
-          <choose>
-            <if variable="container-title">
-              <choose>
-                <if type="book classic collection entry entry-dictionary entry-encyclopedia" match="any">
-                  <!-- Items with book-like container-title substitute with their title and parenthetical, 
-                       but leave bracketed after container-title. This mimics the `container-booklike` formatting. -->
-                  <choose>
-                    <if variable="title">
-                      <group delimiter=" ">
-                        <text macro="title"/>
-                        <text macro="parenthetical"/>
-                      </group>
-                    </if>
-                    <else>
-                      <text macro="title-and-descriptions"/>
-                    </else>
-                  </choose>
-                </if>
-              </choose>
-            </if>
-          </choose>
-          <names variable="executive-producer">
-            <name name-as-sort-order="all" and="symbol" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
-            <label form="long" prefix=" (" suffix=")" text-case="title"/>
-          </names>
-          <names variable="series-creator">
-            <name name-as-sort-order="all" and="symbol" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
-            <label form="long" prefix=" (" suffix=")" text-case="title"/>
-          </names>
-          <names variable="editor-translator">
-            <name name-as-sort-order="all" and="symbol" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
-            <label form="short" prefix=" (" suffix=")" text-case="title"/>
-          </names>
-          <!-- Note: Translator is not cited as a primary creator (only as Ed. & Trans.). -->
-          <names variable="editor">
-            <name name-as-sort-order="all" and="symbol" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
-            <label form="short" prefix=" (" suffix=")" text-case="title"/>
-          </names>
-          <names variable="editorial-director">
-            <name name-as-sort-order="all" and="symbol" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
-            <label form="short" prefix=" (" suffix=")" text-case="title"/>
-          </names>
-          <names variable="compiler">
-            <name name-as-sort-order="all" and="symbol" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
-            <label form="long" prefix=" (" suffix=")" text-case="title"/>
-          </names>
-          <choose>
-            <if type="event performance speech" match="any">
-              <names variable="chair">
-                <name name-as-sort-order="all" and="symbol" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
-                <label form="long" prefix=" (" suffix=")" text-case="title"/>
-              </names>
-              <names variable="organizer">
-                <name name-as-sort-order="all" and="symbol" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
-                <label form="long" prefix=" (" suffix=")" text-case="title"/>
-              </names>
-            </if>
-          </choose>
-          <names variable="curator">
-            <name name-as-sort-order="all" and="symbol" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
-            <label form="long" prefix=" (" suffix=")" text-case="title"/>
-          </names>
-          <names variable="collection-editor">
-            <name name-as-sort-order="all" and="symbol" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
-            <label form="short" prefix=" (" suffix=")" text-case="title"/>
-          </names>
-          <choose>
-            <if variable="title">
-              <!-- If an item has a title, substitute missing author with title and parenthetical, but leave bracketed 
-                   after the date (in the 'title' position). -->
-              <group delimiter=" ">
-                <text macro="title"/>
-                <text macro="parenthetical"/>
-              </group>
-            </if>
-            <else>
-              <!-- If an item has no title, substitute with bracketed followed by parenthetical. -->
-              <text macro="title-and-descriptions"/>
-            </else>
-          </choose>
-        </substitute>
-      </names>
+      <text macro="author-substitute-bib"/>
       <choose>
         <!-- Print "with" contributor for books, but not for other types that commonly have them (eg, thesis, software) -->
-        <if type="book classic collection" match="any">
-          <names variable="contributor" prefix="(" suffix=")">
+        <if match="any" type="book classic collection">
+          <names prefix="(" suffix=")" variable="contributor">
             <label form="verb" suffix=" "/>
-            <name name-as-sort-order="all" and="symbol" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
+            <name delimiter-precedes-last="always" name-as-sort-order="all"/>
           </names>
         </if>
       </choose>
     </group>
   </macro>
-  <macro name="author-intext">
-    <choose>
-      <if type="bill hearing legal_case legislation regulation treaty" match="any">
-        <text macro="title-intext"/>
-      </if>
-      <else-if type="interview personal_communication" match="any">
-        <choose>
-          <!-- These variables indicate that the letter is retrievable by the reader.
-                If not, then use the APA in-text-only personal communication format -->
-          <if variable="archive container-title DOI publisher URL" match="none">
-            <group delimiter=", ">
-              <names variable="author">
-                <name and="symbol" delimiter=", " initialize-with=". "/>
-                <substitute>
-                  <text macro="title-intext"/>
-                </substitute>
-              </names>
-              <text term="personal-communication"/>
-            </group>
-          </if>
-          <else>
-            <names variable="author" delimiter=", ">
-              <name form="short" and="symbol" delimiter=", " initialize-with=". "/>
-              <substitute>
-                <text macro="title-intext"/>
-              </substitute>
-            </names>
-          </else>
-        </choose>
-      </else-if>
-      <else>
-        <names variable="composer" delimiter=", ">
-          <name form="short" and="symbol" delimiter=", " initialize-with=". "/>
-          <substitute>
-            <names variable="author"/>
-            <names variable="illustrator"/>
-            <!-- TODO: Replace `delimiter` with `collapse` to combine names variables when that becomes available. -->
-            <choose>
-              <if type="broadcast">
-                <names variable="script-writer director" delimiter=", &amp; "/>
-              </if>
-            </choose>
-            <names variable="director"/>
-            <!-- TODO: Replace `delimiter` with `collapse` to combine names variables when that becomes available. -->
-            <names variable="guest host" delimiter=", &amp; "/>
-            <names variable="producer"/>
-            <choose>
-              <if variable="container-title">
-                <choose>
-                  <if type="book classic collection entry entry-dictionary entry-encyclopedia" match="any">
-                    <text macro="title-intext"/>
-                  </if>
-                </choose>
-              </if>
-            </choose>
-            <names variable="executive-producer"/>
-            <names variable="series-creator"/>
-            <names variable="editor"/>
-            <names variable="editorial-director"/>
-            <names variable="compiler"/>
-            <choose>
-              <if type="event performance speech" match="any">
-                <names variable="chair"/>
-                <names variable="organizer"/>
-              </if>
-            </choose>
-            <names variable="curator"/>
-            <text macro="title-intext"/>
-          </substitute>
-        </names>
-      </else>
-    </choose>
-  </macro>
+  <!-- Author sorting -->
   <macro name="author-sort">
     <choose>
-      <if type="bill hearing legal_case legislation regulation treaty" match="any">
+      <if match="any" type="bill hearing legal_case legislation regulation treaty">
         <text macro="title-legal"/>
       </if>
       <else>
@@ -345,92 +387,123 @@
       </else>
     </choose>
   </macro>
-  <macro name="date-bib">
-    <group delimiter=" " prefix="(" suffix=")">
-      <choose>
-        <if is-uncertain-date="issued">
-          <text term="circa" form="short"/>
-        </if>
-      </choose>
-      <group>
-        <choose>
-          <if variable="issued">
-            <group delimiter=", ">
-              <group>
-                <date variable="issued" date-parts="year" form="numeric"/>
-                <text variable="year-suffix"/>
-              </group>
-              <choose>
-                <if type="article-magazine article-newspaper broadcast collection document event interview motion_picture pamphlet performance personal_communication post post-weblog song speech webpage" match="any">
-                  <!-- Many video and audio examples in manual give full dates. Err on the side of too much information. -->
-                  <date variable="issued">
-                    <date-part name="month"/>
-                    <date-part name="day" prefix=" "/>
-                  </date>
-                </if>
-                <else-if type="paper-conference">
-                  <!-- Capture 'speech' stored as 'paper-conference' -->
-                  <choose>
-                    <if variable="collection-editor compiler editor editorial-director issue page volume" match="none">
-                      <date variable="issued">
-                        <date-part name="month"/>
-                        <date-part name="day" prefix=" "/>
-                      </date>
-                    </if>
-                  </choose>
-                </else-if>
-                <!-- Only year: article article-journal book chapter classic entry entry-dictionary entry-encyclopedia dataset figure graphic
-                     manuscript map musical_score paper-conference[published] patent periodical report review review-book software standard thesis -->
-              </choose>
-            </group>
-          </if>
-          <else-if variable="status">
-            <group>
-              <!-- We print the status variable directly rather than using in-press, etc. terms. -->
-              <text variable="status" text-case="lowercase"/>
-              <text variable="year-suffix" prefix="-"/>
-            </group>
-          </else-if>
-          <else>
-            <text term="no date" form="short"/>
-            <text variable="year-suffix" prefix="-"/>
-          </else>
-        </choose>
-      </group>
+  <!-- 2. Date -->
+  <!-- Date utility macros -->
+  <macro name="date-issued-full">
+    <group delimiter=" ">
+      <text macro="uncertain-date-issued"/>
+      <date form="text" variable="issued"/>
     </group>
   </macro>
-  <macro name="date-sort">
-    <!-- This is necessary to ensure that citeproc sorts all item types chonologically in the same list. -->
+  <macro name="date-issued-leading-zeros">
+    <date delimiter="-" variable="issued">
+      <date-part form="long" name="year"/>
+      <date-part form="numeric-leading-zeros" name="month"/>
+      <date-part form="numeric-leading-zeros" name="day"/>
+    </date>
+  </macro>
+  <macro name="date-issued-month-day">
+    <date variable="issued">
+      <date-part name="month"/>
+      <date-part name="day" prefix=" "/>
+    </date>
+  </macro>
+  <macro name="date-issued-year">
+    <group delimiter=" ">
+      <text macro="uncertain-date-issued"/>
+      <date date-parts="year" form="numeric" variable="issued"/>
+    </group>
+  </macro>
+  <macro name="original-date-year">
+    <group delimiter=" ">
+      <choose>
+        <if is-uncertain-date="original-date">
+          <text form="short" term="circa"/>
+        </if>
+      </choose>
+      <date variable="original-date">
+        <date-part name="year"/>
+      </date>
+    </group>
+  </macro>
+  <macro name="uncertain-date-issued">
     <choose>
-      <if type="article article-journal book chapter entry entry-dictionary entry-encyclopedia dataset figure graphic manuscript map musical_score patent report review review-book thesis" match="any">
-        <date variable="issued" date-parts="year" form="numeric"/>
+      <if is-uncertain-date="issued">
+        <text form="short" term="circa"/>
+      </if>
+    </choose>
+  </macro>
+  <!-- Date logic -->
+  <macro name="date-bib">
+    <group prefix="(" suffix=")">
+      <choose>
+        <if variable="issued">
+          <group delimiter=", ">
+            <group>
+              <text macro="date-issued-year"/>
+              <text variable="year-suffix"/>
+            </group>
+            <choose>
+              <if match="any" type="article-magazine article-newspaper broadcast collection document event interview motion_picture pamphlet performance personal_communication post post-weblog song speech webpage">
+                <!-- Many video and audio examples in manual give full dates. Err on the side of too much information. -->
+                <text macro="date-issued-month-day"/>
+              </if>
+              <else-if type="paper-conference">
+                <!-- Capture 'speech' stored as 'paper-conference' -->
+                <choose>
+                  <if match="none" variable="collection-editor compiler editor editorial-director issue page volume">
+                    <text macro="date-issued-month-day"/>
+                  </if>
+                </choose>
+              </else-if>
+              <!-- Only year: article article-journal book chapter classic entry entry-dictionary entry-encyclopedia dataset figure graphic
+                     manuscript map musical_score paper-conference[published] patent periodical report review review-book software standard thesis -->
+            </choose>
+          </group>
+        </if>
+        <else-if variable="status">
+          <group>
+            <!-- We print the status variable directly rather than using in-press, etc. terms. -->
+            <text text-case="lowercase" variable="status"/>
+            <text prefix="-" variable="year-suffix"/>
+          </group>
+        </else-if>
+        <else>
+          <text form="short" term="no date"/>
+          <text prefix="-" variable="year-suffix"/>
+        </else>
+      </choose>
+    </group>
+  </macro>
+  <!-- Date sorting -->
+  <macro name="date-sort">
+    <!-- Sort items by printed issue date without prefixes for original or uncertain dates -->
+    <choose>
+      <if match="any" type="article article-journal book chapter entry entry-dictionary entry-encyclopedia dataset figure graphic manuscript map musical_score patent report review review-book thesis">
+        <date date-parts="year" form="numeric" variable="issued"/>
       </if>
       <else-if type="paper-conference">
         <!-- Capture 'speech' stored as 'paper-conference' -->
         <choose>
-          <if variable="collection-editor compiler editor editorial-director issue page volume" match="any">
-            <date variable="issued" date-parts="year" form="numeric"/>
+          <if match="any" variable="collection-editor compiler editor editorial-director issue page volume">
+            <date date-parts="year" form="numeric" variable="issued"/>
           </if>
           <else>
-            <date variable="issued">
-              <date-part name="year" form="long"/>
-              <date-part name="month" form="numeric-leading-zeros"/>
-              <date-part name="day" form="numeric-leading-zeros"/>
-            </date>
+            <text macro="date-issued-leading-zeros"/>
           </else>
         </choose>
       </else-if>
       <else>
-        <date variable="issued">
-          <date-part name="year" form="long"/>
-          <date-part name="month" form="numeric-leading-zeros"/>
-          <date-part name="day" form="numeric-leading-zeros"/>
-        </date>
+        <text macro="date-issued-leading-zeros"/>
       </else>
     </choose>
   </macro>
   <macro name="date-sort-group">
-    <!-- APA sorts 1. no-date items, 2. items with dates, 3. in-press (status) items -->
+    <!-- Sorts items with and without dates:
+
+         1. no-date items (= 0)
+         2. items with dates (= 1)
+         3. in-press (status) items (= 2) -->
     <choose>
       <if variable="issued">
         <text value="1"/>
@@ -443,111 +516,136 @@
       </else>
     </choose>
   </macro>
-  <macro name="date-intext">
-    <choose>
-      <if variable="issued">
-        <group delimiter="/">
-          <group delimiter=" ">
-            <choose>
-              <if is-uncertain-date="original-date">
-                <text term="circa" form="short"/>
-              </if>
-            </choose>
-            <date variable="original-date">
-              <date-part name="year"/>
-            </date>
-          </group>
-          <group delimiter=" ">
-            <choose>
-              <if is-uncertain-date="issued">
-                <text term="circa" form="short"/>
-              </if>
-            </choose>
-            <group>
-              <choose>
-                <if type="interview personal_communication" match="any">
-                  <choose>
-                    <if variable="archive container-title DOI publisher URL" match="none">
-                      <!-- These variables indicate that the communication is retrievable by the reader.
-                           If not, then use the in-text-only personal communication format -->
-                      <date variable="issued" form="text"/>
-                    </if>
-                    <else>
-                      <date variable="issued">
-                        <date-part name="year"/>
-                      </date>
-                    </else>
-                  </choose>
-                </if>
-                <else>
-                  <date variable="issued">
-                    <date-part name="year"/>
-                  </date>
-                </else>
-              </choose>
-              <text variable="year-suffix"/>
-            </group>
-          </group>
-        </group>
-      </if>
-      <else-if variable="status">
-        <!-- We print the status variable directly rather than using in-press, etc. terms. -->
-        <text variable="status" text-case="lowercase"/>
-        <text variable="year-suffix" prefix="-"/>
-      </else-if>
-      <else>
-        <text term="no date" form="short"/>
-        <text variable="year-suffix" prefix="-"/>
-      </else>
-    </choose>
-  </macro>
-  <!-- APA has two description elements following the title:
-       title (parenthetical) [bracketed] -->
+  <!-- 3. Title and descriptions -->
+  <!-- Three parts in title element (APA 9.21):
+
+       1. Title
+       2. Identification (in parentheses)
+       3. Description [in square brackets] -->
   <macro name="title-and-descriptions">
     <choose>
       <if variable="title">
         <group delimiter=" ">
-          <text macro="title"/>
-          <text macro="parenthetical"/>
-          <text macro="bracketed"/>
+          <text macro="title-bib"/>
+          <text macro="identification"/>
+          <text macro="description-bib"/>
         </group>
       </if>
       <else>
         <choose>
-          <if type="bill report" match="any">
+          <if match="any" type="bill report">
             <!-- Bills, resolutions, and congressional reports are not italicized and substitute bill number if no title. -->
-            <!-- Can't distinguish congressional reports from other reports, 
+            <!-- Can't distinguish congressional reports from other reports,
                  but giving the genre and number seems fine for other reports too. -->
-            <text macro="number"/>
-            <text macro="bracketed"/>
-            <text macro="parenthetical"/>
+            <text macro="genre-number"/>
+            <text macro="description-bib"/>
+            <text macro="identification"/>
           </if>
           <else>
             <group delimiter=" ">
-              <text macro="bracketed"/>
-              <text macro="parenthetical"/>
+              <text macro="description-bib"/>
+              <text macro="identification"/>
             </group>
           </else>
         </choose>
       </else>
     </choose>
   </macro>
-  <macro name="title">
+  <!-- 3.1. Title -->
+  <!-- Title utility macros -->
+  <macro name="title-part">
+    <group delimiter=". ">
+      <text macro="part-number-labelled"/>
+      <text text-case="capitalize-first" variable="part-title"/>
+    </group>
+  </macro>
+  <macro name="title-plus-part-title">
     <choose>
-      <if type="post webpage" match="any">
+      <if match="any" type="review review-book" variable="reviewed-author reviewed-genre reviewed-title">
+        <!-- If a review has no `reviewed-title`, assume that `title` contains the title of the reviewed work
+             and omit it here; it is printed in the `reviewed-item` macro. -->
+        <choose>
+          <if match="none" variable="reviewed-title"/>
+          <else>
+            <group delimiter=": ">
+              <text variable="title"/>
+              <text macro="title-part"/>
+            </group>
+          </else>
+        </choose>
+      </if>
+      <else>
+        <group delimiter=": ">
+          <text variable="title"/>
+          <text macro="title-part"/>
+        </group>
+      </else>
+    </choose>
+  </macro>
+  <macro name="title-plus-volume-title">
+    <group delimiter=": ">
+      <text variable="title"/>
+      <text macro="title-volume"/>
+    </group>
+  </macro>
+  <macro name="title-volume">
+    <group delimiter=": ">
+      <choose>
+        <if variable="volume-title">
+          <group delimiter=". ">
+            <text macro="volume-labelled"/>
+            <text variable="volume-title"/>
+          </group>
+        </if>
+        <else-if is-numeric="volume" match="none">
+          <text macro="volume-labelled"/>
+        </else-if>
+      </choose>
+      <!-- For book-like items, assume part-number and part-title refer to the book/volume. -->
+      <text macro="title-part"/>
+    </group>
+  </macro>
+  <!-- Title logic -->
+  <macro name="booklike-title">
+    <!-- For book-like items, assume part-number and part-title refer to the book/volume. -->
+    <choose>
+      <if variable="container-title">
+        <text variable="title"/>
+      </if>
+      <else>
+        <!-- For book-like items without container titles and with volume-title, append volume-title to title (APA example 30) -->
+        <text font-style="italic" macro="title-plus-volume-title"/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="periodical-title">
+    <!-- For periodicals, assume that part-number and part-title refer to the article and append to title -->
+    <choose>
+      <if variable="container-title">
+        <text macro="title-plus-part-title"/>
+      </if>
+      <else>
+        <!-- for periodical items without container titles, don't append volume-title to title -->
+        <text font-style="italic" macro="title-plus-part-title"/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="title-bib">
+    <choose>
+      <if match="any" type="post webpage">
         <!-- Webpages are always italicized -->
-        <text macro="title-plus-part-title" font-style="italic"/>
+        <text font-style="italic" macro="title-plus-part-title"/>
       </if>
       <!-- Other types are italicized based on presence of container-title.
              Assume that review and review-book are published in periodicals/blogs,
-             not just on a web page (ex. 69) -->
-      <else-if type="article-journal article-magazine article-newspaper periodical post-weblog review review-book" match="any">
+             not just on a webpage (APA example 69) -->
+      <else-if match="any" type="article-journal article-magazine article-newspaper periodical post-weblog review review-book">
         <text macro="periodical-title"/>
       </else-if>
       <else-if type="paper-conference">
         <!-- Treat paper-conference as book-like if it has an editor, otherwise as periodical-like -->
         <choose>
-          <if variable="collection-editor compiler editor editorial-director" match="any">
+          <if match="any" variable="collection-editor compiler editor editorial-director">
             <text macro="booklike-title"/>
           </if>
           <else>
@@ -560,607 +658,71 @@
       </else>
     </choose>
   </macro>
-  <macro name="periodical-title">
-    <!-- For periodicals, assume that part-number and part-title refer to the article and append to title -->
+  <!-- 3.2. Identification (in parentheses) -->
+  <!-- Identification utility macros -->
+  <macro name="database-location">
     <choose>
-      <if variable="container-title" match="any">
-        <text macro="title-plus-part-title"/>
+      <if match="none" variable="archive-place">
+        <!-- With `archive-place`: physical archives. Without: online archives. -->
+        <text variable="archive_location"/>
       </if>
-      <else>
-        <!-- for periodical items without container titles, don't append volume-title to title -->
-        <text macro="title-plus-part-title" font-style="italic"/>
-      </else>
     </choose>
   </macro>
-  <macro name="booklike-title">
-    <!-- For book-like items, assume part-number and part-title refer to the book/volume. -->
+  <macro name="genre-number">
     <choose>
-      <if variable="container-title" match="any">
-        <text variable="title"/>
-      </if>
-      <else>
-        <!-- For book-like items without container titles and with volume-title, append volume-title to title (ex. 30) -->
-        <text macro="title-plus-volume-title" font-style="italic"/>
-      </else>
-    </choose>
-  </macro>
-  <macro name="title-plus-part-title">
-    <choose>
-      <if variable="reviewed-author reviewed-genre reviewed-title" type="review review-book" match="any">
-        <!-- If a review has no `reviewed-title`, assume that `title` contains the title of the reviewed work
-             and omit it here; it is printed in the `reviewed-item` macro. -->
-        <choose>
-          <if variable="reviewed-title" match="none"/>
-          <else>
-            <group delimiter=": ">
-              <text variable="title"/>
-              <text macro="part-title"/>
-            </group>
-          </else>
-        </choose>
-      </if>
-      <else>
-        <group delimiter=": ">
-          <text variable="title"/>
-          <text macro="part-title"/>
-        </group>
-      </else>
-    </choose>
-  </macro>
-  <macro name="part-title">
-    <group delimiter=". ">
-      <group delimiter=" ">
-        <label variable="part-number" form="short" text-case="capitalize-first"/>
-        <text variable="part-number"/>
-      </group>
-      <text variable="part-title" text-case="capitalize-first"/>
-    </group>
-  </macro>
-  <macro name="title-plus-volume-title">
-    <group delimiter=": ">
-      <text variable="title"/>
-      <text macro="volume-title"/>
-    </group>
-  </macro>
-  <macro name="volume-title">
-    <group delimiter=": ">
-      <choose>
-        <if variable="volume-title">
+      <if variable="number">
+        <group delimiter=", ">
           <group delimiter=" ">
-            <group delimiter=". ">
-              <group delimiter=" ">
-                <label variable="volume" form="short" text-case="capitalize-first"/>
-                <text variable="volume"/>
-              </group>
-              <text variable="volume-title"/>
-            </group>
+            <text text-case="title" variable="genre"/>
+            <text macro="number-labelled"/>
           </group>
-        </if>
-        <else-if is-numeric="volume" match="none">
-          <group delimiter=" ">
-            <label variable="volume" form="short" text-case="capitalize-first"/>
-            <text variable="volume"/>
-          </group>
-        </else-if>
-      </choose>
-      <!-- For book-like items, assume part-number and part-title refer to the book/volume. -->
-      <text macro="part-title"/>
-    </group>
-  </macro>
-  <macro name="title-intext">
-    <choose>
-      <if type="bill report">
-        <!-- Bills, resolutions, and congressional reports are not italicized and substitute bill number if no title. -->
-        <!-- Can't distinguish congressional reports from other reports, 
-             but giving the genre and number seems fine for other reports too. -->
-        <choose>
-          <if variable="title">
-            <text variable="title" form="short" text-case="title"/>
-          </if>
-          <else>
-            <group delimiter=" ">
-              <text variable="genre"/>
-              <group delimiter=" ">
-                <choose>
-                  <if variable="chapter-number container-title" match="none">
-                    <label variable="number" form="short" text-case="capitalize-first"/>
-                  </if>
-                </choose>
-                <text variable="number"/>
-              </group>
-            </group>
-          </else>
-        </choose>
-      </if>
-      <else>
-        <choose>
-          <if variable="title" match="none">
-            <text macro="bracketed-intext"/>
-          </if>
-          <else-if type="hearing">
-            <!-- Hearings are italicized -->
-            <text variable="title" form="short" font-style="italic" text-case="title"/>
-          </else-if>
-          <else-if type="legal_case" match="any">
-            <!-- Cases are italicized -->
-            <text variable="title" font-style="italic"/>
-          </else-if>
-          <else-if type="legislation regulation treaty" match="any">
-            <!-- Legislation, regulations, and treaties not italicized or quoted -->
-            <text variable="title" form="short" text-case="title"/>
-          </else-if>
-          <else-if type="post webpage" match="any">
-            <!-- Webpages are always italicized -->
-            <text variable="title" form="short" font-style="italic" text-case="title"/>
-          </else-if>
-          <else-if variable="container-title" match="any">
-            <!-- Other types are italicized or quoted based on presence of container-title. As in title macro. -->
-            <text variable="title" form="short" quotes="true" text-case="title"/>
-          </else-if>
-          <else>
-            <text variable="title" form="short" font-style="italic" text-case="title"/>
-          </else>
-        </choose>
-      </else>
-    </choose>
-  </macro>
-  <macro name="parenthetical">
-    <!-- (Secondary contributors; Database location; Genre no. 123; Report Series 123, Version, Edition, Volume, Page) -->
-    <group prefix="(" suffix=")">
-      <choose>
-        <if type="patent">
-          <!-- authority: U.S. ; genre: patent ; number: 123,445 -->
-          <group delimiter=" ">
-            <text variable="authority" form="short"/>
-            <choose>
-              <if variable="genre">
-                <text variable="genre" text-case="capitalize-first"/>
-              </if>
-              <else>
-                <text term="patent" text-case="capitalize-first"/>
-              </else>
-            </choose>
-            <group delimiter=" ">
-              <label variable="number" form="short" text-case="capitalize-first"/>
-              <text variable="number"/>
-            </group>
-          </group>
-        </if>
-        <else-if type="post webpage" match="any">
-          <!-- For post webpage, container-title is treated as publisher -->
-          <group delimiter="; ">
-            <text macro="secondary-contributors"/>
-            <text macro="database-location"/>
-            <text macro="number"/>
-            <text macro="locators-booklike"/>
-          </group>
-        </else-if>
-        <else-if type="report" match="any">
           <choose>
-            <if variable="title" match="none">
-              <!-- If there is no title, then genre and number are already printed as the title. -->
-              <group delimiter="; ">
-                <text macro="secondary-contributors"/>
-                <text macro="database-location"/>
-                <text macro="locators-booklike"/>
-              </group>
+            <if type="thesis">
+              <choose>
+                <if match="any" variable="archive DOI URL">
+                  <!-- Include the university in brackets if thesis is published -->
+                  <text variable="publisher"/>
+                </if>
+              </choose>
             </if>
-            <!-- If the report is a chapter in a larger report, then most parenthetical information is printed after the container. -->
-            <else-if variable="container-title">
-              <text macro="secondary-contributors"/>
-            </else-if>
-            <else>
-              <group delimiter="; ">
-                <text macro="secondary-contributors"/>
-                <text macro="database-location"/>
-                <text macro="number"/>
-                <text macro="locators-booklike"/>
-              </group>
-            </else>
           </choose>
-        </else-if>
-        <else-if variable="container-title">
-          <group delimiter="; ">
-            <text macro="secondary-contributors"/>
-            <choose>
-              <if type="broadcast graphic map motion_picture song" match="any">
-                <!-- For audiovisual media, number information comes after title, not container-title (ex. 94) -->
-                <text macro="number"/>
-              </if>
-            </choose>
-          </group>
-        </else-if>
-        <else>
-          <group delimiter="; ">
-            <text macro="secondary-contributors"/>
-            <text macro="database-location"/>
-            <text macro="number"/>
-            <text macro="locators-booklike"/>
-          </group>
-        </else>
-      </choose>
-    </group>
-  </macro>
-  <macro name="parenthetical-container">
-    <choose>
-      <if variable="container-title" match="any">
-        <group prefix="(" suffix=")">
-          <group delimiter="; ">
-            <text macro="database-location"/>
-            <choose>
-              <if type="broadcast graphic map motion_picture song" match="none">
-                <!-- For audiovisual media, number information comes after title, not container-title (ex. 94) -->
-                <text macro="number"/>
-              </if>
-            </choose>
-            <text macro="locators-booklike"/>
-          </group>
         </group>
       </if>
     </choose>
   </macro>
-  <macro name="bracketed">
-    <!-- [Descriptive information] -->
-    <!-- If there is a number, genre is already printed in macro="number" -->
-    <group prefix="[" suffix="]">
+  <macro name="locators-booklike">
+    <choose>
+      <if variable="page">
+        <text macro="page-labelled"/>
+      </if>
+      <else-if variable="chapter-number">
+        <text macro="chapter-number-labelled"/>
+      </else-if>
+    </choose>
+  </macro>
+  <macro name="patent-number">
+    <group delimiter=" ">
+      <!-- authority: U.S. ; genre: patent ; number: 123,445 -->
+      <text form="short" variable="authority"/>
       <choose>
-        <if variable="reviewed-author reviewed-genre reviewed-title" type="review review-book" match="any">
-          <text macro="reviewed-item"/>
+        <if variable="genre">
+          <text text-case="capitalize-first" variable="genre"/>
         </if>
-        <else-if type="thesis">
-          <!-- Thesis type and institution -->
-          <group delimiter="; ">
-            <choose>
-              <if variable="number" match="none">
-                <group delimiter=", ">
-                  <text variable="genre" text-case="capitalize-first"/>
-                  <choose>
-                    <if variable="archive DOI URL" match="any">
-                      <!-- Include the university in brackets if thesis is published -->
-                      <text variable="publisher"/>
-                    </if>
-                  </choose>
-                </group>
-              </if>
-            </choose>
-            <text variable="medium" text-case="capitalize-first"/>
-          </group>
-        </else-if>
-        <else-if variable="interviewer" type="interview" match="any">
-          <!-- Interview information -->
-          <choose>
-            <if variable="title">
-              <text macro="format"/>
-            </if>
-            <else-if variable="genre">
-              <group delimiter="; ">
-                <group delimiter=" ">
-                  <text variable="genre" text-case="capitalize-first"/>
-                  <group delimiter=" ">
-                    <text term="container-author" form="verb"/>
-                    <names variable="interviewer">
-                      <name and="symbol" initialize-with=". " delimiter=", "/>
-                    </names>
-                  </group>
-                </group>
-              </group>
-            </else-if>
-            <else-if variable="interviewer">
-              <group delimiter="; ">
-                <names variable="interviewer">
-                  <label form="verb" suffix=" " text-case="capitalize-first"/>
-                  <name and="symbol" initialize-with=". " delimiter=", "/>
-                </names>
-                <text variable="medium" text-case="capitalize-first"/>
-              </group>
-            </else-if>
-            <else>
-              <text macro="format"/>
-            </else>
-          </choose>
-        </else-if>
-        <else-if type="personal_communication">
-          <!-- Letter information -->
-          <choose>
-            <if variable="recipient">
-              <group delimiter="; ">
-                <group delimiter=" ">
-                  <choose>
-                    <if variable="number" match="none">
-                      <choose>
-                        <if variable="genre">
-                          <text variable="genre" text-case="capitalize-first"/>
-                        </if>
-                        <else-if variable="medium">
-                          <text variable="medium" text-case="capitalize-first"/>
-                        </else-if>
-                        <else>
-                          <text term="letter" text-case="capitalize-first"/>
-                        </else>
-                      </choose>
-                    </if>
-                    <else>
-                      <choose>
-                        <if variable="medium">
-                          <text variable="medium" text-case="capitalize-first"/>
-                        </if>
-                        <else>
-                          <text term="letter" text-case="capitalize-first"/>
-                        </else>
-                      </choose>
-                    </else>
-                  </choose>
-                  <names variable="recipient" delimiter=", ">
-                    <label form="verb" suffix=" "/>
-                    <name and="symbol" delimiter=", "/>
-                  </names>
-                </group>
-                <choose>
-                  <if variable="genre" match="any">
-                    <choose>
-                      <if variable="number" match="none">
-                        <text variable="medium" text-case="capitalize-first"/>
-                      </if>
-                    </choose>
-                  </if>
-                </choose>
-              </group>
-            </if>
-            <else>
-              <text macro="format"/>
-            </else>
-          </choose>
-        </else-if>
-        <else-if variable="composer" type="song" match="all">
-          <!-- Performer of classical music works -->
-          <group delimiter="; ">
-            <choose>
-              <if variable="number" match="none">
-                <group delimiter=" ">
-                  <choose>
-                    <if variable="genre">
-                      <text variable="genre" text-case="capitalize-first"/>
-                      <group delimiter=" ">
-                        <text term="performer" form="verb"/>
-                        <names variable="author">
-                          <name and="symbol" initialize-with=". " delimiter=", "/>
-                          <substitute>
-                            <names variable="performer"/>
-                          </substitute>
-                        </names>
-                      </group>
-                    </if>
-                    <else-if variable="medium">
-                      <text variable="medium" text-case="capitalize-first"/>
-                      <group delimiter=" ">
-                        <text term="performer" form="verb"/>
-                        <names variable="author">
-                          <name and="symbol" initialize-with=". " delimiter=", "/>
-                          <substitute>
-                            <names variable="performer"/>
-                          </substitute>
-                        </names>
-                      </group>
-                    </else-if>
-                    <else>
-                      <text term="performer" form="verb" text-case="capitalize-first"/>
-                      <names variable="author">
-                        <name and="symbol" initialize-with=". " delimiter=", "/>
-                        <substitute>
-                          <names variable="performer"/>
-                        </substitute>
-                      </names>
-                    </else>
-                  </choose>
-                </group>
-              </if>
-              <else>
-                <group delimiter=" ">
-                  <choose>
-                    <if variable="medium">
-                      <text variable="medium" text-case="capitalize-first"/>
-                      <group delimiter=" ">
-                        <text term="performer" form="verb"/>
-                        <names variable="author">
-                          <name and="symbol" initialize-with=". " delimiter=", "/>
-                          <substitute>
-                            <names variable="performer"/>
-                          </substitute>
-                        </names>
-                      </group>
-                    </if>
-                    <else>
-                      <text term="performer" form="verb" text-case="capitalize-first"/>
-                      <names variable="author">
-                        <name and="symbol" initialize-with=". " delimiter=", "/>
-                        <substitute>
-                          <names variable="performer"/>
-                        </substitute>
-                      </names>
-                    </else>
-                  </choose>
-                </group>
-              </else>
-            </choose>
-            <choose>
-              <if variable="genre" match="any">
-                <choose>
-                  <if variable="number" match="none">
-                    <text variable="medium" text-case="capitalize-first"/>
-                  </if>
-                </choose>
-              </if>
-            </choose>
-          </group>
-        </else-if>
-        <else-if variable="container-title" match="none">
-          <!-- Other description -->
-          <text macro="format"/>
-        </else-if>
         <else>
-          <!-- For conference presentations/performances/events, chapters in reports/standards/generic documents, software, 
-               place bracketed after the container title -->
-          <choose>
-            <if type="event paper-conference performance speech" match="any">
-              <choose>
-                <if variable="collection-editor compiler editor editorial-director issue page volume" match="any">
-                  <text macro="format"/>
-                </if>
-              </choose>
-            </if>
-            <else-if type="document report software standard" match="none">
-              <text macro="format"/>
-            </else-if>
-          </choose>
+          <text term="patent" text-case="capitalize-first"/>
         </else>
       </choose>
-    </group>
-  </macro>
-  <macro name="bracketed-intext">
-    <group prefix="[" suffix="]">
-      <choose>
-        <if variable="reviewed-title" match="any">
-          <group delimiter=" ">
-            <text term="review-of" text-case="capitalize-first"/>
-            <text macro="reviewed-title-intext"/>
-          </group>
-        </if>
-        <else-if variable="interviewer" type="interview" match="any">
-          <names variable="interviewer">
-            <label form="verb" suffix=" " text-case="capitalize-first"/>
-            <name and="symbol" initialize-with=". " delimiter=", "/>
-            <substitute>
-              <text macro="format-intext"/>
-            </substitute>
-          </names>
-        </else-if>
-        <else-if type="personal_communication">
-          <!-- Letter information -->
-          <choose>
-            <if variable="recipient">
-              <group delimiter=" ">
-                <choose>
-                  <if variable="number" match="none">
-                    <text variable="genre" text-case="capitalize-first"/>
-                  </if>
-                  <else>
-                    <text term="letter" text-case="capitalize-first"/>
-                  </else>
-                </choose>
-                <names variable="recipient" delimiter=", ">
-                  <label form="verb" suffix=" "/>
-                  <name and="symbol" delimiter=", "/>
-                </names>
-              </group>
-            </if>
-            <else>
-              <text macro="format-intext"/>
-            </else>
-          </choose>
-        </else-if>
-        <else>
-          <text macro="format-intext"/>
-        </else>
-      </choose>
-    </group>
-  </macro>
-  <macro name="reviewed-item">
-    <!-- Reviewed item -->
-    <group delimiter="; ">
-      <group delimiter=", ">
-        <group delimiter=" ">
-          <choose>
-            <if variable="reviewed-genre">
-              <group delimiter=" ">
-                <text term="review-of" form="long" text-case="capitalize-first"/>
-                <text variable="reviewed-genre" text-case="lowercase"/>
-              </group>
-            </if>
-            <!-- If no `reviewed-genre`, assume that `genre` or `medium` is entered as 'Review of the book' or similar -->
-            <else-if variable="number" match="none">
-              <choose>
-                <if variable="genre">
-                  <text variable="genre" text-case="capitalize-first"/>
-                </if>
-                <else-if variable="medium">
-                  <text variable="medium" text-case="capitalize-first"/>
-                </else-if>
-                <else-if type="review-book">
-                  <group delimiter=" ">
-                    <text term="review-of" form="long" text-case="capitalize-first"/>
-                    <text term="book" form="long" text-case="lowercase"/>
-                  </group>
-                </else-if>
-                <else>
-                  <text term="review-of" form="short" text-case="capitalize-first"/>
-                </else>
-              </choose>
-            </else-if>
-            <else>
-              <choose>
-                <if variable="medium">
-                  <text variable="medium" text-case="capitalize-first"/>
-                </if>
-                <else-if type="review-book">
-                  <group delimiter=" ">
-                    <text term="review-of" form="long" text-case="capitalize-first"/>
-                    <text term="book" form="long" text-case="lowercase"/>
-                  </group>
-                </else-if>
-                <else>
-                  <text term="review-of" form="short" text-case="capitalize-first"/>
-                </else>
-              </choose>
-            </else>
-          </choose>
-          <text macro="reviewed-title"/>
-        </group>
-        <names variable="reviewed-author">
-          <label form="verb-short" suffix=" "/>
-          <name and="symbol" initialize-with=". " delimiter=", "/>
-        </names>
-      </group>
-      <choose>
-        <if variable="genre" match="any">
-          <choose>
-            <if variable="number" match="none">
-              <text variable="medium" text-case="capitalize-first"/>
-            </if>
-          </choose>
-        </if>
-      </choose>
-    </group>
-  </macro>
-  <macro name="bracketed-container">
-    <group prefix="[" suffix="]">
-      <choose>
-        <if type="event paper-conference performance speech" match="any">
-          <!-- Conference presentations should describe the session [container] in bracketed unless published in a proceedings -->
-          <choose>
-            <if variable="collection-editor compiler editor editorial-director issue page volume" match="none">
-              <text macro="format"/>
-            </if>
-          </choose>
-        </if>
-        <else-if type="software" match="all">
-          <!-- For entries in mobile app reference works, place bracketed after the container-title -->
-          <text macro="format"/>
-        </else-if>
-        <else-if type="document report standard">
-          <!-- For chapters in report, standards, and generic documents, place bracketed after the container title -->
-          <text macro="format"/>
-        </else-if>
-      </choose>
+      <text macro="number-labelled"/>
     </group>
   </macro>
   <macro name="secondary-contributors">
     <choose>
-      <if type="article-journal article-magazine article-newspaper periodical post-weblog review review-book" match="any">
+      <if match="any" type="article-journal article-magazine article-newspaper periodical post-weblog review review-book">
         <text macro="secondary-contributors-periodical"/>
       </if>
       <else-if type="paper-conference">
         <choose>
-          <if variable="collection-editor compiler editor editorial-director" match="any">
+          <if match="any" variable="collection-editor compiler editor editorial-director">
             <text macro="secondary-contributors-booklike"/>
           </if>
           <else>
@@ -1173,53 +735,37 @@
       </else>
     </choose>
   </macro>
-  <macro name="secondary-contributors-periodical">
-    <group delimiter="; ">
-      <choose>
-        <if variable="title">
-          <names variable="interviewer" delimiter="; ">
-            <name and="symbol" initialize-with=". " delimiter=", "/>
-            <label form="short" prefix=", " text-case="title"/>
-          </names>
-        </if>
-      </choose>
-      <names variable="translator narrator" delimiter="; ">
-        <name and="symbol" initialize-with=". " delimiter=", "/>
-        <label form="short" prefix=", " text-case="title"/>
-      </names>
-    </group>
-  </macro>
   <macro name="secondary-contributors-booklike">
     <group delimiter="; ">
       <choose>
         <if variable="title">
           <names variable="interviewer">
-            <name and="symbol" initialize-with=". " delimiter=", "/>
+            <name/>
             <label form="short" prefix=", " text-case="title"/>
           </names>
         </if>
       </choose>
       <choose>
-        <if type="post webpage" match="none">
+        <if match="none" type="post webpage">
           <!-- Webpages treat container-title like publisher -->
           <group delimiter="; ">
-            <names variable="illustrator narrator" delimiter="; ">
-              <name and="symbol" initialize-with=". " delimiter=", "/>
+            <names delimiter="; " variable="illustrator narrator">
+              <name/>
               <label form="short" prefix=", " text-case="title"/>
             </names>
             <choose>
-              <if variable="container-title" match="none">
+              <if match="none" variable="container-title">
                 <group delimiter="; ">
                   <names variable="container-author">
                     <label form="verb-short" suffix=" " text-case="title"/>
-                    <name and="symbol" initialize-with=". " delimiter=", "/>
+                    <name/>
                   </names>
-                  <names variable="editor translator" delimiter="; ">
-                    <name and="symbol" initialize-with=". " delimiter=", "/>
+                  <names delimiter="; " variable="editor translator">
+                    <name/>
                     <label form="short" prefix=", " text-case="title"/>
                   </names>
-                  <names variable="compiler chair organizer curator series-creator executive-producer" delimiter="; ">
-                    <name and="symbol" initialize-with=". " delimiter=", "/>
+                  <names delimiter="; " variable="compiler chair organizer curator series-creator executive-producer">
+                    <name/>
                     <label form="long" prefix=", " text-case="title"/>
                   </names>
                 </group>
@@ -1227,9 +773,9 @@
               <else>
                 <choose>
                   <!-- TODO: Check logic once processors start to automatically populate editor-translator. -->
-                  <if variable="editor-translator" match="none">
-                    <names variable="translator" delimiter="; ">
-                      <name and="symbol" initialize-with=". " delimiter=", "/>
+                  <if match="none" variable="editor-translator">
+                    <names delimiter="; " variable="translator">
+                      <name/>
                       <label form="short" prefix=", " text-case="title"/>
                     </names>
                   </if>
@@ -1242,18 +788,18 @@
           <group delimiter="; ">
             <names variable="container-author">
               <label form="verb-short" suffix=" " text-case="title"/>
-              <name and="symbol" initialize-with=". " delimiter=", "/>
+              <name/>
             </names>
-            <names variable="editor translator" delimiter="; ">
-              <name and="symbol" initialize-with=". " delimiter=", "/>
+            <names delimiter="; " variable="editor translator">
+              <name/>
               <label form="short" prefix=", " text-case="title"/>
             </names>
-            <names variable="illustrator narrator" delimiter="; ">
-              <name and="symbol" initialize-with=". " delimiter=", "/>
+            <names delimiter="; " variable="illustrator narrator">
+              <name/>
               <label form="short" prefix=", " text-case="title"/>
             </names>
-            <names variable="compiler chair organizer curator series-creator executive-producer" delimiter="; ">
-              <name and="symbol" initialize-with=". " delimiter=", "/>
+            <names delimiter="; " variable="compiler chair organizer curator series-creator executive-producer">
+              <name/>
               <label form="long" prefix=", " text-case="title"/>
             </names>
           </group>
@@ -1261,181 +807,374 @@
       </choose>
     </group>
   </macro>
-  <macro name="database-location">
+  <macro name="secondary-contributors-periodical">
+    <group delimiter="; ">
+      <choose>
+        <if variable="title">
+          <names delimiter="; " variable="interviewer">
+            <name/>
+            <label form="short" prefix=", " text-case="title"/>
+          </names>
+        </if>
+      </choose>
+      <names delimiter="; " variable="translator narrator">
+        <name/>
+        <label form="short" prefix=", " text-case="title"/>
+      </names>
+    </group>
+  </macro>
+  <macro name="version-edition-volume">
+    <group delimiter=", ">
+      <text macro="version-labelled"/>
+      <text macro="edition-labelled"/>
+      <text macro="volume-booklike"/>
+    </group>
+  </macro>
+  <macro name="volume-booklike">
+    <group delimiter=", ">
+      <!-- Report series (APA example 52) -->
+      <choose>
+        <if match="any" type="document report standard">
+          <group delimiter=" ">
+            <text text-case="title" variable="collection-title"/>
+            <text variable="collection-number"/>
+          </group>
+        </if>
+      </choose>
+      <text macro="supplement-number-labelled"/>
+      <choose>
+        <if variable="volume">
+          <choose>
+            <!-- Non-numeric volumes are already printed as part of the book title -->
+            <if variable="volume-title"/>
+            <else-if is-numeric="volume">
+              <text macro="volume-labelled"/>
+            </else-if>
+          </choose>
+        </if>
+        <else>
+          <text macro="number-of-volumes-labelled"/>
+        </else>
+      </choose>
+      <text macro="issue-labelled"/>
+      <text macro="locators-booklike"/>
+    </group>
+  </macro>
+  <!-- Identification logic -->
+  <macro name="identification">
+    <group delimiter="; " prefix="(" suffix=")">
+      <!-- (Secondary contributors; Database location; Genre no. 123; Report Series 123, Version, Edition, Volume, Page) -->
+      <choose>
+        <if type="patent">
+          <text macro="patent-number"/>
+        </if>
+        <else-if match="any" type="post webpage">
+          <!-- For post webpage, container-title is treated as publisher -->
+          <text macro="identification-with-all-parts"/>
+        </else-if>
+        <else-if match="any" type="report">
+          <choose>
+            <if match="none" variable="title">
+              <!-- If there is no title, then genre and number are already printed as the title. -->
+              <text macro="secondary-contributors"/>
+              <text macro="database-location"/>
+              <text macro="identification-booklike"/>
+            </if>
+            <!-- If the report is a chapter in a larger report, then most parenthetical information is printed after the container. -->
+            <else-if variable="container-title">
+              <text macro="secondary-contributors"/>
+            </else-if>
+            <else>
+              <text macro="identification-with-all-parts"/>
+            </else>
+          </choose>
+        </else-if>
+        <else-if variable="container-title">
+          <group delimiter="; ">
+            <text macro="secondary-contributors"/>
+            <choose>
+              <if match="any" type="broadcast graphic map motion_picture song">
+                <!-- For audiovisual media, number information comes after title, not container-title (ex. 94) -->
+                <text macro="genre-number"/>
+              </if>
+            </choose>
+          </group>
+        </else-if>
+        <else>
+          <text macro="identification-with-all-parts"/>
+        </else>
+      </choose>
+    </group>
+  </macro>
+  <macro name="identification-booklike">
     <choose>
-      <if variable="archive-place" match="none">
-        <!-- With `archive-place`: physical archives. Without: online archives. -->
-        <text variable="archive_location"/>
-      </if>
+      <if match="any" type="article-journal article-magazine article-newspaper broadcast event interview patent performance periodical post post-weblog review review-book speech webpage"/>
+      <else-if type="paper-conference">
+        <choose>
+          <if match="any" variable="collection-editor compiler editor editorial-director">
+            <text macro="version-edition-volume"/>
+          </if>
+        </choose>
+      </else-if>
+      <else>
+        <text macro="version-edition-volume"/>
+      </else>
     </choose>
   </macro>
-  <macro name="number">
+  <macro name="identification-with-all-parts">
+    <group delimiter="; ">
+      <text macro="secondary-contributors"/>
+      <text macro="database-location"/>
+      <text macro="genre-number"/>
+      <text macro="identification-booklike"/>
+    </group>
+  </macro>
+  <!-- 3.3. Description [in square brackets] -->
+  <!-- Description utility macros -->
+  <macro name="description-generic">
+    <!-- For conference presentations/performances/events, chapters in reports/standards/generic documents, software, place description after the container title -->
     <choose>
-      <if variable="number">
-        <group delimiter=", ">
+      <if match="any" type="event paper-conference performance speech">
+        <choose>
+          <if match="any" variable="collection-editor compiler editor editorial-director issue page volume">
+            <text macro="format-bib"/>
+          </if>
+        </choose>
+      </if>
+      <else-if match="none" type="document report software standard">
+        <text macro="format-bib"/>
+      </else-if>
+    </choose>
+  </macro>
+  <macro name="description-interview">
+    <choose>
+      <if variable="title">
+        <text macro="format-bib"/>
+      </if>
+      <else-if variable="genre">
+        <group delimiter="; ">
           <group delimiter=" ">
-            <text variable="genre" text-case="title"/>
+            <text text-case="capitalize-first" variable="genre"/>
             <group delimiter=" ">
-              <label variable="number" form="short" text-case="capitalize-first"/>
-              <text variable="number"/>
+              <text form="verb" term="container-author"/>
+              <names variable="interviewer"/>
             </group>
           </group>
+        </group>
+      </else-if>
+      <else-if variable="interviewer">
+        <group delimiter="; ">
+          <names variable="interviewer">
+            <label form="verb" suffix=" " text-case="capitalize-first"/>
+            <name/>
+          </names>
+          <text text-case="capitalize-first" variable="medium"/>
+        </group>
+      </else-if>
+      <else>
+        <text macro="format-bib"/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="description-letter-bib">
+    <choose>
+      <if variable="recipient">
+        <group delimiter="; ">
+          <group delimiter=" ">
+            <choose>
+              <if match="none" variable="number">
+                <choose>
+                  <if variable="genre">
+                    <text text-case="capitalize-first" variable="genre"/>
+                  </if>
+                  <else-if variable="medium">
+                    <text text-case="capitalize-first" variable="medium"/>
+                  </else-if>
+                  <else>
+                    <text term="letter" text-case="capitalize-first"/>
+                  </else>
+                </choose>
+              </if>
+              <else>
+                <choose>
+                  <if variable="medium">
+                    <text text-case="capitalize-first" variable="medium"/>
+                  </if>
+                  <else>
+                    <text term="letter" text-case="capitalize-first"/>
+                  </else>
+                </choose>
+              </else>
+            </choose>
+            <names variable="recipient">
+              <label form="verb" suffix=" "/>
+              <name initialize="false"/>
+            </names>
+          </group>
           <choose>
-            <if type="thesis">
+            <if variable="genre">
               <choose>
-                <!-- Include the university in brackets if thesis is published -->
-                <if variable="archive DOI URL" match="any">
-                  <text variable="publisher"/>
+                <if match="none" variable="number">
+                  <text text-case="capitalize-first" variable="medium"/>
                 </if>
               </choose>
             </if>
           </choose>
         </group>
       </if>
-    </choose>
-  </macro>
-  <macro name="locators-booklike">
-    <choose>
-      <if type="article-journal article-magazine article-newspaper broadcast event interview patent performance periodical post post-weblog review review-book speech webpage" match="any"/>
-      <else-if type="paper-conference">
-        <choose>
-          <if variable="collection-editor compiler editor editorial-director" match="any">
-            <group delimiter=", ">
-              <text macro="version"/>
-              <text macro="edition"/>
-              <text macro="volume-booklike"/>
-            </group>
-          </if>
-        </choose>
-      </else-if>
       <else>
-        <group delimiter=", ">
-          <text macro="version"/>
-          <text macro="edition"/>
-          <text macro="volume-booklike"/>
-        </group>
+        <text macro="format-bib"/>
       </else>
     </choose>
   </macro>
-  <macro name="version">
-    <group delimiter=" ">
-      <label variable="version" text-case="capitalize-first"/>
-      <text variable="version"/>
-    </group>
-  </macro>
-  <macro name="edition">
-    <choose>
-      <if is-numeric="edition">
+  <macro name="description-reviewed">
+    <!-- Reviewed item -->
+    <group delimiter="; ">
+      <group delimiter=", ">
         <group delimiter=" ">
-          <number variable="edition" form="ordinal"/>
-          <label variable="edition" form="short"/>
-        </group>
-      </if>
-      <else>
-        <text variable="edition"/>
-      </else>
-    </choose>
-  </macro>
-  <macro name="volume-booklike">
-    <group delimiter=", ">
-      <!-- Report series [ex. 52] -->
-      <choose>
-        <if type="document report standard">
-          <group delimiter=" ">
-            <text variable="collection-title" text-case="title"/>
-            <text variable="collection-number"/>
-          </group>
-        </if>
-      </choose>
-      <group delimiter=" ">
-        <label variable="supplement-number" text-case="capitalize-first"/>
-        <text variable="supplement-number"/>
-      </group>
-      <choose>
-        <if variable="volume" match="any">
           <choose>
-            <!-- Non-numeric volumes are already printed as part of the book title -->
-            <if variable="volume-title"/>
-            <else-if is-numeric="volume" match="none"/>
-            <else>
+            <if variable="reviewed-genre">
               <group delimiter=" ">
-                <label variable="volume" form="short" text-case="capitalize-first"/>
-                <number variable="volume" form="numeric"/>
+                <text form="long" term="review-of" text-case="capitalize-first"/>
+                <text text-case="lowercase" variable="reviewed-genre"/>
               </group>
+            </if>
+            <!-- If no `reviewed-genre`, assume that `genre` or `medium` is entered as 'Review of the book' or similar -->
+            <else-if match="none" variable="number">
+              <choose>
+                <if variable="genre">
+                  <text text-case="capitalize-first" variable="genre"/>
+                </if>
+                <else-if variable="medium">
+                  <text text-case="capitalize-first" variable="medium"/>
+                </else-if>
+                <else-if type="review-book">
+                  <group delimiter=" ">
+                    <text form="long" term="review-of" text-case="capitalize-first"/>
+                    <text form="long" term="book" text-case="lowercase"/>
+                  </group>
+                </else-if>
+                <else>
+                  <text form="short" term="review-of" text-case="capitalize-first"/>
+                </else>
+              </choose>
+            </else-if>
+            <else>
+              <choose>
+                <if variable="medium">
+                  <text text-case="capitalize-first" variable="medium"/>
+                </if>
+                <else-if type="review-book">
+                  <group delimiter=" ">
+                    <text form="long" term="review-of" text-case="capitalize-first"/>
+                    <text form="long" term="book" text-case="lowercase"/>
+                  </group>
+                </else-if>
+                <else>
+                  <text form="short" term="review-of" text-case="capitalize-first"/>
+                </else>
+              </choose>
             </else>
           </choose>
-        </if>
-        <else>
-          <group>
-            <label variable="number-of-volumes" form="short" text-case="capitalize-first" suffix=" "/>
-            <text term="page-range-delimiter" prefix="1"/>
-            <number variable="number-of-volumes" form="numeric"/>
-          </group>
-        </else>
-      </choose>
-      <group delimiter=" ">
-        <label variable="issue" text-case="capitalize-first"/>
-        <text variable="issue"/>
+          <text macro="reviewed-title-bib"/>
+        </group>
+        <names variable="reviewed-author">
+          <label form="verb-short" suffix=" "/>
+          <name/>
+        </names>
       </group>
-      <group delimiter=" ">
-        <label variable="page" form="short" suffix=" "/>
-        <text variable="page"/>
-      </group>
-    </group>
-  </macro>
-  <macro name="reviewed-title">
-    <choose>
-      <if variable="reviewed-title">
-        <!-- Not possible to distinguish TV series episode from other reviewed
-             works without reviewed-container-title [Ex. 69] -->
-        <!-- Adapt for reviewed-container-title if that becomes available -->
-        <text variable="reviewed-title" font-style="italic"/>
-      </if>
-      <else>
-        <!-- Assume title is title of reviewed work -->
-        <text variable="title" font-style="italic"/>
-      </else>
-    </choose>
-  </macro>
-  <macro name="reviewed-title-intext">
-    <choose>
-      <if variable="reviewed-title">
-        <!-- Not possible to distinguish TV series episode from other reviewed
-             works without reviewed-container-title [Ex. 69] -->
-        <!-- Adapt for reviewed-container-title if that becomes available -->
-        <text variable="reviewed-title" form="short" font-style="italic" text-case="title"/>
-      </if>
-      <else>
-        <!-- Assume title is title of reviewed work -->
-        <text variable="title" form="short" font-style="italic" text-case="title"/>
-      </else>
-    </choose>
-  </macro>
-  <macro name="format">
-    <choose>
-      <if variable="genre medium" match="any">
-        <group delimiter="; ">
+      <choose>
+        <if variable="genre">
           <choose>
-            <if variable="number" match="none">
-              <text variable="genre" text-case="capitalize-first"/>
+            <if match="none" variable="number">
+              <text text-case="capitalize-first" variable="medium"/>
             </if>
           </choose>
-          <text variable="medium" text-case="capitalize-first"/>
+        </if>
+      </choose>
+    </group>
+  </macro>
+  <macro name="description-song">
+    <!-- Performer of classical music works -->
+    <group delimiter="; ">
+      <group delimiter=" ">
+        <choose>
+          <if match="none" variable="number">
+            <choose>
+              <if variable="genre">
+                <text text-case="capitalize-first" variable="genre"/>
+                <text form="verb" term="performer"/>
+              </if>
+              <else-if variable="medium">
+                <text text-case="capitalize-first" variable="medium"/>
+                <text form="verb" term="performer"/>
+              </else-if>
+              <else>
+                <text form="verb" term="performer" text-case="capitalize-first"/>
+              </else>
+            </choose>
+          </if>
+          <else>
+            <!-- If there is a number, genre is already printed in `genre-number` macro -->
+            <choose>
+              <if variable="medium">
+                <text text-case="capitalize-first" variable="medium"/>
+                <text form="verb" term="performer"/>
+              </if>
+              <else>
+                <text form="verb" term="performer" text-case="capitalize-first"/>
+              </else>
+            </choose>
+          </else>
+        </choose>
+        <names variable="author">
+          <substitute>
+            <names variable="performer"/>
+          </substitute>
+        </names>
+      </group>
+      <choose>
+        <if variable="genre">
+          <choose>
+            <if match="none" variable="number">
+              <text text-case="capitalize-first" variable="medium"/>
+            </if>
+          </choose>
+        </if>
+      </choose>
+    </group>
+  </macro>
+  <macro name="description-thesis">
+    <!-- Thesis type and institution -->
+    <group delimiter="; ">
+      <choose>
+        <if match="none" variable="number">
+          <group delimiter=", ">
+            <text text-case="capitalize-first" variable="genre"/>
+            <choose>
+              <if match="any" variable="archive DOI URL">
+                <!-- Include the university in brackets if thesis is published -->
+                <text variable="publisher"/>
+              </if>
+            </choose>
+          </group>
+        </if>
+      </choose>
+      <text text-case="capitalize-first" variable="medium"/>
+    </group>
+  </macro>
+  <macro name="format-bib">
+    <choose>
+      <if match="any" variable="genre medium">
+        <group delimiter="; ">
+          <choose>
+            <if match="none" variable="number">
+              <text text-case="capitalize-first" variable="genre"/>
+            </if>
+          </choose>
+          <text text-case="capitalize-first" variable="medium"/>
         </group>
       </if>
-      <else>
-        <text macro="generic-type-label"/>
-      </else>
-    </choose>
-  </macro>
-  <macro name="format-intext">
-    <choose>
-      <if variable="genre" match="any">
-        <text variable="genre" text-case="capitalize-first"/>
-      </if>
-      <else-if variable="medium">
-        <text variable="medium" text-case="capitalize-first"/>
-      </else-if>
       <else>
         <text macro="generic-type-label"/>
       </else>
@@ -1450,9 +1189,9 @@
       <else-if type="software">
         <text term="software" text-case="capitalize-first"/>
       </else-if>
-      <else-if type="interview personal_communication" match="any">
+      <else-if match="any" type="interview personal_communication">
         <choose>
-          <if variable="archive container-title DOI publisher URL" match="none">
+          <if match="none" variable="archive archive-place container-title DOI publisher URL">
             <text term="personal-communication" text-case="capitalize-first"/>
           </if>
           <else-if type="interview">
@@ -1492,18 +1231,67 @@
       </else-if>
     </choose>
   </macro>
-  <!-- APA 'source' element contains four parts:
-       container, event, publisher, access -->
+  <macro name="reviewed-title-bib">
+    <choose>
+      <if variable="reviewed-title">
+        <!-- Not possible to distinguish TV series episode from other reviewed
+             works without reviewed-container-title (APA example 69) -->
+        <!-- Adapt for reviewed-container-title if that becomes available -->
+        <text font-style="italic" variable="reviewed-title"/>
+      </if>
+      <else>
+        <!-- Assume title is title of reviewed work -->
+        <text font-style="italic" variable="title"/>
+      </else>
+    </choose>
+  </macro>
+  <!-- Description logic -->
+  <macro name="description-bib">
+    <group prefix="[" suffix="]">
+      <choose>
+        <if match="any" type="interview" variable="interviewer">
+          <text macro="description-interview"/>
+        </if>
+        <else-if match="any" type="review review-book" variable="reviewed-author reviewed-genre reviewed-title">
+          <text macro="description-reviewed"/>
+        </else-if>
+        <else-if type="personal_communication">
+          <text macro="description-letter-bib"/>
+        </else-if>
+        <else-if type="song" variable="composer">
+          <text macro="description-song"/>
+        </else-if>
+        <else-if type="thesis">
+          <text macro="description-thesis"/>
+        </else-if>
+        <else-if match="none" variable="container-title">
+          <!-- Other description -->
+          <text macro="format-bib"/>
+        </else-if>
+        <else>
+          <text macro="description-generic"/>
+        </else>
+      </choose>
+    </group>
+  </macro>
+  <!-- 4. Source -->
+  <!-- Four parts in APA 'source' element:
+
+       1. Container
+       2. Event
+       3. Publication details
+       4. Access -->
+  <!-- 4.1. Container -->
   <macro name="container">
     <choose>
-      <if type="article-journal article-magazine article-newspaper periodical post-weblog review review-book" match="any">
+      <if match="any" type="article-journal article-magazine article-newspaper periodical post-weblog review review-book">
         <!-- Periodical items -->
         <text macro="container-periodical"/>
       </if>
       <else-if type="paper-conference">
         <!-- Determine if paper-conference is a periodical- or book-like -->
         <choose>
-          <if variable="editor editorial-director collection-editor container-author" match="any">
+          <if match="any" variable="collection-editor container-author editor editorial-director">
             <text macro="container-booklike"/>
           </if>
           <else>
@@ -1511,55 +1299,15 @@
           </else>
         </choose>
       </else-if>
-      <else-if type="post webpage" match="none">
-        <!-- post and webpage treat container-title like publisher -->
+      <else-if match="none" type="post webpage">
+        <!-- Webpages treat container-title like publisher -->
         <text macro="container-booklike"/>
       </else-if>
     </choose>
   </macro>
-  <macro name="container-periodical">
-    <group delimiter=". ">
-      <group delimiter=", ">
-        <text variable="container-title" font-style="italic" text-case="title"/>
-        <choose>
-          <if variable="volume">
-            <group>
-              <text variable="volume" font-style="italic"/>
-              <text variable="issue" prefix="(" suffix=")"/>
-            </group>
-          </if>
-          <else>
-            <text variable="issue" font-style="italic"/>
-          </else>
-        </choose>
-        <choose>
-          <if variable="number">
-            <!-- Ex. 6: Journal article with article number or eLocator -->
-            <group delimiter=" ">
-              <text term="article-locator" text-case="capitalize-first"/>
-              <text variable="number"/>
-            </group>
-          </if>
-          <else>
-            <text variable="page"/>
-          </else>
-        </choose>
-      </group>
-      <choose>
-        <if variable="issued">
-          <choose>
-            <if variable="issue number page volume" match="none">
-              <!-- We print the status variable directly rather than using in-press, etc. terms. -->
-              <text variable="status" text-case="capitalize-first"/>
-            </if>
-          </choose>
-        </if>
-      </choose>
-    </group>
-  </macro>
   <macro name="container-booklike">
     <choose>
-      <if variable="container-title" match="any">
+      <if variable="container-title">
         <group delimiter=" ">
           <choose>
             <if type="song">
@@ -1570,161 +1318,167 @@
             </else>
           </choose>
           <group delimiter=", ">
-            <names variable="executive-producer">
-              <name and="symbol" initialize-with=". " delimiter=", "/>
-              <label form="long" text-case="title" prefix=" (" suffix=")"/>
-              <substitute>
-                <names variable="series-creator"/>
-                <names variable="editor-translator">
-                  <name and="symbol" initialize-with=". " delimiter=", "/>
-                  <label form="short" text-case="title" prefix=" (" suffix=")"/>
-                </names>
-                <!-- TODO: Translator omitted here on the assumption that editor-translators are uncommon 
-                           for chapter citations. If needed, direct entry or automatic population of
-                           `editor-translator` can produce combined labels. -->
-                <names variable="editor">
-                  <name and="symbol" initialize-with=". " delimiter=", "/>
-                  <label form="short" text-case="title" prefix=" (" suffix=")"/>
-                </names>
-                <names variable="editorial-director">
-                  <name and="symbol" initialize-with=". " delimiter=", "/>
-                  <label form="short" text-case="title" prefix=" (" suffix=")"/>
-                </names>
-                <names variable="compiler"/>
-                <choose>
-                  <if type="event performance speech" match="any">
-                    <names variable="chair"/>
-                    <names variable="organizer"/>
-                  </if>
-                </choose>
-                <names variable="curator"/>
-                <names variable="collection-editor">
-                  <name and="symbol" initialize-with=". " delimiter=", "/>
-                  <label form="short" text-case="title" prefix=" (" suffix=")"/>
-                </names>
-                <names variable="container-author"/>
-              </substitute>
-            </names>
-            <group delimiter=": " font-style="italic">
-              <text variable="container-title"/>
-              <text macro="volume-title"/>
-            </group>
+            <text macro="container-contributors"/>
+            <text macro="container-title-booklike"/>
           </group>
-          <text macro="parenthetical-container"/>
-          <text macro="bracketed-container"/>
+          <text macro="container-identification"/>
+          <text macro="container-description"/>
         </group>
       </if>
     </choose>
   </macro>
-  <macro name="publisher">
-    <group delimiter="; ">
+  <macro name="container-periodical">
+    <group delimiter=". ">
+      <group delimiter=", ">
+        <text font-style="italic" text-case="title" variable="container-title"/>
+        <text macro="volume-periodical"/>
+        <text macro="locators-periodical"/>
+      </group>
       <choose>
-        <if type="thesis">
+        <if variable="issued">
           <choose>
-            <if variable="archive DOI URL" match="none">
-              <text variable="publisher"/>
+            <if match="none" variable="issue number page volume">
+              <!-- We print the status variable directly rather than using in-press, etc. terms. -->
+              <text text-case="capitalize-first" variable="status"/>
             </if>
           </choose>
         </if>
-        <else-if type="post webpage" match="any">
-          <!-- For websites, treat container title like publisher -->
-          <group delimiter="; ">
-            <text variable="container-title" text-case="title"/>
-            <text variable="publisher"/>
-          </group>
-        </else-if>
-        <else-if type="paper-conference">
-          <!-- For paper-conference, don't print publisher if in a journal-like proceedings -->
-          <choose>
-            <if variable="collection-editor compiler editor editorial-director" match="any">
-              <text variable="publisher"/>
-            </if>
-          </choose>
-        </else-if>
-        <else-if type="article-journal article-magazine article-newspaper periodical post-weblog review review-book" match="none">
-          <text variable="publisher"/>
-        </else-if>
       </choose>
-      <group delimiter=", ">
-        <choose>
-          <if variable="archive-place">
-            <!-- With `archive-place`: physical archives. Without: online archives. -->
-            <!-- For physical archives, print the location before the archive name.
-                For electronic archives, these are printed in macro="description". -->
-            <!-- Must test for archive_collection:
-                With collection: archive_collection (archive_location), archive, archive-place
-                No collection: archive (archive_location), archive-place
-            -->
-            <choose>
-              <if variable="archive_collection">
-                <group delimiter=" ">
-                  <text variable="archive_collection"/>
-                  <text variable="archive_location" prefix="(" suffix=")"/>
-                </group>
-                <text variable="archive"/>
-                <text variable="archive-place"/>
-              </if>
-              <else>
-                <group delimiter=" ">
-                  <text variable="archive"/>
-                  <text variable="archive_location" prefix="(" suffix=")"/>
-                </group>
-                <text variable="archive-place"/>
-              </else>
-            </choose>
-          </if>
-          <else>
-            <text variable="archive"/>
-          </else>
-        </choose>
-      </group>
     </group>
   </macro>
-  <macro name="access">
+  <!-- Container parallels main elements -->
+  <!-- 4.1.1. Author -->
+  <macro name="container-contributors">
+    <names variable="executive-producer">
+      <name/>
+      <label form="long" prefix=" (" suffix=")" text-case="title"/>
+      <substitute>
+        <names variable="series-creator"/>
+        <names variable="editor-translator">
+          <name/>
+          <label form="short" prefix=" (" suffix=")" text-case="title"/>
+        </names>
+        <!-- TODO: Translator omitted on the assumption that editor-translators are uncommon for chapter citations.
+             If needed, direct entry or automatic population of `editor-translator` can produce combined labels. -->
+        <names delimiter="; " variable="editor">
+          <name/>
+          <label form="short" prefix=" (" suffix=")" text-case="title"/>
+        </names>
+        <names variable="editorial-director">
+          <name/>
+          <label form="short" prefix=" (" suffix=")" text-case="title"/>
+        </names>
+        <names variable="compiler"/>
+        <choose>
+          <if match="any" type="event performance speech">
+            <names variable="chair"/>
+            <names variable="organizer"/>
+          </if>
+        </choose>
+        <names variable="curator"/>
+        <names variable="collection-editor">
+          <name/>
+          <label form="short" prefix=" (" suffix=")" text-case="title"/>
+        </names>
+        <names variable="container-author"/>
+      </substitute>
+    </names>
+  </macro>
+  <!-- 4.1.3.1 Container title -->
+  <macro name="container-title-booklike">
+    <group delimiter=": " font-style="italic">
+      <text variable="container-title"/>
+      <text macro="title-volume"/>
+    </group>
+  </macro>
+  <!-- 4.1.3.1 Container identification -->
+  <macro name="container-identification">
     <choose>
-      <if variable="DOI" match="any">
-        <text variable="DOI" prefix="https://doi.org/"/>
-      </if>
-      <else-if variable="URL">
-        <group delimiter=" ">
-          <choose>
-            <if variable="issued status" match="none">
-              <group delimiter=" ">
-                <text term="retrieved" text-case="capitalize-first"/>
-                <date variable="accessed" form="text" suffix=","/>
-                <text term="from"/>
-              </group>
-            </if>
-          </choose>
-          <text variable="URL"/>
+      <if variable="container-title">
+        <group prefix="(" suffix=")">
+          <group delimiter="; ">
+            <text macro="database-location"/>
+            <choose>
+              <if match="none" type="broadcast graphic map motion_picture song">
+                <!-- For audiovisual media, number information comes after title, not container-title (APA example 94) -->
+                <text macro="genre-number"/>
+              </if>
+            </choose>
+            <text macro="identification-booklike"/>
+          </group>
         </group>
-      </else-if>
+      </if>
     </choose>
   </macro>
+  <!-- 4.1.3.2 Container description -->
+  <macro name="container-description">
+    <group prefix="[" suffix="]">
+      <choose>
+        <if match="any" type="event paper-conference performance speech">
+          <!-- Conference presentations should describe the session [container] in description unless published in a proceedings -->
+          <choose>
+            <if match="none" variable="collection-editor compiler editor editorial-director issue page volume">
+              <text macro="format-bib"/>
+            </if>
+          </choose>
+        </if>
+        <else-if type="software">
+          <!-- For entries in mobile app reference works, place description after the container-title -->
+          <text macro="format-bib"/>
+        </else-if>
+        <else-if match="any" type="document report standard">
+          <!-- For chapters in report, standards, and generic documents, place description after the container title -->
+          <text macro="format-bib"/>
+        </else-if>
+      </choose>
+    </group>
+  </macro>
+  <!-- 4.1.4. Source -->
+  <macro name="locators-periodical">
+    <choose>
+      <if variable="number">
+        <text macro="number-article-labelled"/>
+      </if>
+      <else>
+        <text variable="page"/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="volume-periodical">
+    <group delimiter=", ">
+      <text font-style="italic" text-case="title" variable="collection-title"/>
+      <choose>
+        <if variable="volume">
+          <group>
+            <text font-style="italic" variable="volume"/>
+            <text prefix="(" suffix=")" variable="issue"/>
+          </group>
+        </if>
+        <else>
+          <text font-style="italic" variable="issue"/>
+        </else>
+      </choose>
+    </group>
+  </macro>
+  <!-- 4.2. Event -->
   <macro name="event">
     <choose>
-      <if variable="event event-title" match="any">
-        <!-- To prevent Zotero from printing event-place due to its double-mapping of all 'place' to
-             both publisher-place and event-place. Remove this 'choose' when that is changed. -->
+      <if match="any" variable="event event-title">
+        <!-- To prevent Zotero from printing `event-place` due to its double-mapping of all 'place' to
+             both `publisher-place` and `event-place`. Remove this when that is changed. -->
         <choose>
           <if type="paper-conference">
             <choose>
-              <if variable="collection-editor compiler editor editorial-director issue page volume" match="none">
+              <if match="none" variable="collection-editor compiler editor editorial-director issue page volume">
                 <!-- Don't print event info for conference papers published in a proceedings -->
-                <group delimiter=", ">
-                  <text macro="event-title"/>
-                  <text variable="event-place"/>
-                </group>
+                <text macro="event-title-place"/>
               </if>
             </choose>
           </if>
           <else>
             <!-- For other item types, print event info even if published (e.g., for collection catalogs, performance programs.
                  These items aren't given explicit examples in the APA manual, so err on the side of providing too much information. -->
-            <group delimiter=", ">
-              <text macro="event-title"/>
-              <text variable="event-place"/>
-            </group>
+            <text macro="event-title-place"/>
           </else>
         </choose>
       </if>
@@ -1732,9 +1486,9 @@
   </macro>
   <macro name="event-title">
     <choose>
-      <!-- TODO: We expect "event-title" to be used,
+      <!-- TODO: We expect `event-title` to be used,
            but processors and applications may not be updated yet.
-           This macro ensures that either "event" or "event-title" can be accpeted.
+           This macro ensures that either `event` or `event-title` can be accepted.
            Remove if procesor logic and application adoption can handle this. -->
       <if variable="event-title">
         <text variable="event-title"/>
@@ -1744,11 +1498,153 @@
       </else>
     </choose>
   </macro>
-  <!-- After 'source', APA also prints publication history (original publication, reprint info, retraction info) -->
+  <macro name="event-title-place">
+    <group delimiter=", ">
+      <text macro="event-title"/>
+      <text variable="event-place"/>
+    </group>
+  </macro>
+  <!-- 4.3. Publication details -->
+  <!-- Publication utility macros -->
+  <macro name="archive">
+    <group delimiter=", ">
+      <choose>
+        <if variable="archive-place">
+          <!-- With `archive-place`: physical archives. Without: online archives. -->
+          <!-- For physical archives, print the location before the archive name.
+                For electronic archives, these are printed in macro="description". -->
+          <!-- Must test for archive_collection:
+                With collection: archive_collection (archive_location), archive, archive-place
+                No collection: archive (archive_location), archive-place
+            -->
+          <choose>
+            <if variable="archive_collection">
+              <group delimiter=" ">
+                <text variable="archive_collection"/>
+                <text prefix="(" suffix=")" variable="archive_location"/>
+              </group>
+              <text variable="archive"/>
+              <text variable="archive-place"/>
+            </if>
+            <else>
+              <group delimiter=" ">
+                <text variable="archive"/>
+                <text prefix="(" suffix=")" variable="archive_location"/>
+              </group>
+              <text variable="archive-place"/>
+            </else>
+          </choose>
+        </if>
+        <else>
+          <text variable="archive"/>
+        </else>
+      </choose>
+    </group>
+  </macro>
+  <macro name="publisher">
+    <choose>
+      <if variable="publisher">
+        <text variable="publisher"/>
+      </if>
+      <else-if match="none" variable="event-place">
+        <!-- Work around Zotero double-mapping of event/publisher place -->
+        <text variable="publisher-place"/>
+      </else-if>
+    </choose>
+  </macro>
+  <!-- Publication logic -->
+  <macro name="publication">
+    <choose>
+      <if type="thesis">
+        <choose>
+          <if match="none" variable="archive DOI URL">
+            <text macro="publisher"/>
+          </if>
+        </choose>
+      </if>
+      <else-if match="any" type="post webpage">
+        <!-- Webpages treat container-title like publisher -->
+        <group delimiter="; ">
+          <text text-case="title" variable="container-title"/>
+          <text macro="publisher"/>
+        </group>
+      </else-if>
+      <else-if type="paper-conference">
+        <!-- For paper-conference, don't print publisher if in a journal-like proceedings -->
+        <choose>
+          <if match="any" variable="collection-editor compiler editor editorial-director">
+            <text macro="publisher"/>
+          </if>
+        </choose>
+      </else-if>
+      <else-if match="none" type="article-journal article-magazine article-newspaper periodical post-weblog review review-book">
+        <text macro="publisher"/>
+      </else-if>
+    </choose>
+  </macro>
+  <macro name="publication-archive">
+    <group delimiter="; ">
+      <text macro="publication"/>
+      <text macro="archive"/>
+    </group>
+  </macro>
+  <!-- 4.4. Access -->
+  <macro name="access">
+    <choose>
+      <if variable="DOI">
+        <text prefix="https://doi.org/" variable="DOI"/>
+      </if>
+      <else-if variable="URL">
+        <group delimiter=" ">
+          <choose>
+            <if match="none" variable="issued status">
+              <group delimiter=" ">
+                <text term="retrieved" text-case="capitalize-first"/>
+                <group delimiter=", ">
+                  <date form="text" variable="accessed"/>
+                  <text term="from"/>
+                </group>
+              </group>
+            </if>
+          </choose>
+          <text variable="URL"/>
+        </group>
+      </else-if>
+    </choose>
+  </macro>
+  <!-- 5. Publication history -->
+  <!-- History utility macros -->
+  <macro name="original-publisher">
+    <choose>
+      <if variable="original-publisher">
+        <text variable="original-publisher"/>
+      </if>
+      <else>
+        <text variable="original-publisher-place"/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="original-title">
+    <choose>
+      <if variable="original-title">
+        <text value="as"/>
+        <choose>
+          <if match="any" type="article-journal article-magazine article-newspaper periodical post-weblog review review-book">
+            <text variable="original-title"/>
+          </if>
+          <else>
+            <text font-style="italic" variable="original-title"/>
+          </else>
+        </choose>
+      </if>
+    </choose>
+  </macro>
+  <!-- History logic -->
   <macro name="publication-history">
+    <!-- Information appended to 'source': original publication, reprint info, retraction info -->
     <choose>
       <if type="patent">
-        <text variable="references" prefix="(" suffix=")"/>
+        <text prefix="(" suffix=")" variable="references"/>
       </if>
       <else>
         <group delimiter="; " prefix="(" suffix=")">
@@ -1756,8 +1652,8 @@
           <choose>
             <if variable="issued">
               <choose>
-                <if variable="issue number page volume" match="any">
-                  <text variable="status" text-case="capitalize-first"/>
+                <if match="any" variable="issue number page volume">
+                  <text text-case="capitalize-first" variable="status"/>
                 </if>
               </choose>
             </if>
@@ -1766,29 +1662,31 @@
             <if variable="references">
               <!-- This provides the option for more elaborate description
                     of publication history, such as full "reprinted" references
-                    (examples 11, 43, 44) -->
+                    (APA examples 11, 43, 44) -->
               <text variable="references"/>
             </if>
             <else>
-              <group delimiter=" ">
-                <text term="original-work-published" text-case="capitalize-first"/>
-                <choose>
-                  <if is-uncertain-date="original-date">
-                    <text term="circa" form="short"/>
-                  </if>
-                </choose>
-                <date variable="original-date">
-                  <date-part name="year"/>
-                </date>
-              </group>
+              <text macro="publication-history-variables"/>
             </else>
           </choose>
         </group>
       </else>
     </choose>
   </macro>
-  <!-- Legal citations have their own rules -->
-  <macro name="legal-cites">
+  <macro name="publication-history-variables">
+    <group delimiter=" ">
+      <text term="original-work-published" text-case="capitalize-first"/>
+      <group delimiter="; ">
+        <text macro="original-title"/>
+        <group delimiter=", ">
+          <text macro="original-publisher"/>
+          <text macro="original-date-year"/>
+        </group>
+      </group>
+    </group>
+  </macro>
+  <!-- Parallel rules for legal citations -->
+  <macro name="legal-bib">
     <!-- `treaty`: for treaties -->
     <!-- `legal_case`: for all legal and court cases -->
     <!-- `bill`: for bills, resolutions, federal reports -->
@@ -1800,16 +1698,14 @@
         <if type="treaty">
           <group delimiter=", " suffix=".">
             <!-- APA generally defers to Bluebook for legal citations, but diverges without
-                explanation for treaty items. We follow the Bluebook format that was used 
+                explanation for treaty items. We follow the Bluebook format that was used
                 in APA 6th ed. -->
-            <!-- APA manual omits treaty parties/authors, but per Bluebook 
+            <!-- APA manual omits treaty parties/authors, but per Bluebook
                 they should be included at least for bilateral treaties. -->
-            <names variable="author">
-              <name initialize-with="." form="short" delimiter="-"/>
-            </names>
+            <text macro="author-legal"/>
             <text macro="date-legal"/>
-            <!-- APA manual omits treaty source/report called for by Bluebook in favor of just URL. 
-                Both are included here, following the APA style used for all other item types 
+            <!-- APA manual omits treaty source/report called for by Bluebook in favor of just URL.
+                Both are included here, following the APA style used for all other item types
                 to end the reference with a period, then give the URL afterward. -->
             <text macro="container-legal"/>
           </group>
@@ -1821,7 +1717,7 @@
               <text macro="container-legal"/>
             </group>
             <text macro="date-legal"/>
-            <text macro="parenthetical-legal"/>
+            <text macro="identification-legal"/>
           </group>
         </else>
       </choose>
@@ -1829,20 +1725,75 @@
       <text macro="access"/>
     </group>
   </macro>
+  <!-- 1. Legal author -->
+  <macro name="author-legal">
+    <names variable="author">
+      <name delimiter="-" form="short"/>
+    </names>
+  </macro>
+  <!-- 2. Legal date -->
+  <macro name="date-legal-case">
+    <group delimiter=" " prefix="(" suffix=")">
+      <text variable="authority"/>
+      <choose>
+        <if variable="container-title">
+          <!-- Print only year for cases published in reporters-->
+          <text macro="date-issued-year"/>
+        </if>
+        <else>
+          <!-- APA manual doesn't include examples of cases not yet
+                   published in a reporter, but this is Bluebook style. -->
+          <text macro="date-issued-full"/>
+        </else>
+      </choose>
+    </group>
+  </macro>
+  <macro name="date-legal">
+    <choose>
+      <if type="treaty">
+        <text macro="date-issued-full"/>
+      </if>
+      <else-if type="legal_case">
+        <text macro="date-legal-case"/>
+      </else-if>
+      <else-if match="any" type="bill hearing legislation regulation">
+        <group delimiter=" " prefix="(" suffix=")">
+          <group delimiter=" ">
+            <text macro="original-date-year"/>
+            <text form="symbol" term="and"/>
+          </group>
+          <choose>
+            <if variable="issued">
+              <!-- APA manual includes "rev." before the revision year,
+                   but this isn't part of the Bluebook rules. -->
+              <text macro="date-issued-year"/>
+            </if>
+            <else>
+              <!-- Show proposal date for uncodified regualtions.
+                   Assume date is entered literally ala "proposed May 23, 2016".
+                   TODO: Add 'proposed' term here if that becomes available -->
+              <date form="text" variable="submitted"/>
+            </else>
+          </choose>
+        </group>
+      </else-if>
+    </choose>
+  </macro>
+  <!-- 3.1. Legal title -->
   <macro name="title-legal">
     <choose>
-      <if type="bill legal_case legislation regulation treaty" match="any">
-        <text variable="title" text-case="title"/>
+      <if match="any" type="bill legal_case legislation regulation treaty">
+        <text text-case="title" variable="title"/>
       </if>
       <else-if type="hearing">
-        <!-- APA uses a comma delimiter and omits "hearing before the" for hearings with testimony, 
+        <!-- APA uses a comma delimiter and omits "hearing before the" for hearings with testimony,
              but follows Bluebook rules (colon delimiter, prefix before the committee name) for
              references to the whole hearing. We simply follow the Bluebook rules for both, but
              use APA style capitalization (not capitalizing "Before" or the title of the hearing). -->
         <group delimiter=": " font-style="italic">
-          <text variable="title" text-case="capitalize-first"/>
+          <text text-case="capitalize-first" variable="title"/>
           <group delimiter=" ">
-            <text term="hearing" form="long" text-case="capitalize-first"/>
+            <text form="long" term="hearing" text-case="capitalize-first"/>
             <group delimiter=" ">
               <group delimiter=" ">
                 <!-- APA manual omits the bill number, but it should be included per Bluebook if relevant -->
@@ -1851,7 +1802,7 @@
               </group>
               <group delimiter=" ">
                 <!-- Use the `at` term to hold "before the" -->
-                <text term="at" form="long"/>
+                <text form="long" term="at"/>
                 <text variable="section"/>
               </group>
             </group>
@@ -1860,124 +1811,95 @@
       </else-if>
     </choose>
   </macro>
-  <macro name="date-legal">
+  <!-- 3.2. Legal identification (in parentheses) -->
+  <macro name="identification-legal">
     <choose>
-      <if type="treaty">
-        <date variable="issued" form="text"/>
+      <if type="hearing">
+        <group delimiter=" " prefix="(" suffix=")">
+          <!-- Use the 'verb' form of the hearing term to hold 'testimony of' -->
+          <text form="verb" term="hearing"/>
+          <names variable="author">
+            <name initialize="false"/>
+          </names>
+        </group>
       </if>
-      <else-if type="legal_case">
-        <group prefix="(" suffix=")" delimiter=" ">
-          <text variable="authority"/>
-          <choose>
-            <if variable="container-title" match="any">
-              <!-- Print only year for cases published in reporters-->
-              <date variable="issued" form="numeric" date-parts="year"/>
-            </if>
-            <else>
-              <!-- APA manual doesn't include examples of cases not yet
-                   published in a reporter, but this is Bluebook style. -->
-              <date variable="issued" form="text"/>
-            </else>
-          </choose>
-        </group>
-      </else-if>
-      <else-if type="bill hearing legislation regulation" match="any">
-        <group prefix="(" suffix=")" delimiter=" ">
-          <group delimiter=" ">
-            <date variable="original-date">
-              <date-part name="year"/>
-            </date>
-            <text term="and" form="symbol"/>
-          </group>
-          <choose>
-            <if variable="issued">
-              <!-- APA manual includes "rev." before the revision year, 
-                   but this isn't part of the Bluebook rules. -->
-              <date variable="issued">
-                <date-part name="year"/>
-              </date>
-            </if>
-            <else>
-              <!-- Show proposal date for uncodified regualtions. 
-                   Assume date is entered literally ala "proposed May 23, 2016".
-                   TODO: Add 'proposed' term here if that becomes available -->
-              <date variable="submitted" form="text"/>
-            </else>
-          </choose>
-        </group>
+      <else-if match="any" type="bill legislation regulation">
+        <!-- For uncodified regulations, assume future code section is in `status`. -->
+        <text prefix="(" suffix=")" variable="status"/>
       </else-if>
     </choose>
   </macro>
-  <macro name="container-legal">
-    <!-- Expect legal item container-titles to be stored in short form -->
+  <!-- 4. Legal source -->
+  <!-- Legal source utility macros -->
+  <macro name="container-bill">
+    <group delimiter=", ">
+      <group delimiter=" ">
+        <text variable="genre"/>
+        <group delimiter=" ">
+          <choose>
+            <!-- If there is no session number or code/record title, assume
+                     assume the item is a congressional report and include 'No.' term. -->
+            <if match="none" variable="chapter-number container-title">
+              <!-- The item is a congressional report, rather than a bill or resultion. -->
+              <text macro="number-labelled"/>
+            </if>
+            <else>
+              <text variable="number"/>
+            </else>
+          </choose>
+        </group>
+      </group>
+      <group delimiter=" ">
+        <text variable="authority"/>
+        <!-- 'session' is `chapter-number` -->
+        <text variable="chapter-number"/>
+      </group>
+      <group delimiter=" ">
+        <text variable="volume"/>
+        <text variable="container-title"/>
+        <text variable="page-first"/>
+      </group>
+    </group>
+  </macro>
+  <macro name="container-hearing">
+    <group delimiter=" ">
+      <text variable="authority"/>
+      <!-- 'session' is `chapter-number` -->
+      <text variable="chapter-number"/>
+    </group>
+  </macro>
+  <macro name="container-legal-case">
+    <group delimiter=" ">
+      <choose>
+        <if variable="container-title">
+          <group delimiter=" ">
+            <text variable="volume"/>
+            <text variable="container-title"/>
+            <text macro="section-labelled"/>
+            <choose>
+              <if match="any" variable="page page-first">
+                <text variable="page-first"/>
+              </if>
+              <else>
+                <text value="___"/>
+              </else>
+            </choose>
+          </group>
+        </if>
+        <else>
+          <text macro="number-labelled"/>
+        </else>
+      </choose>
+    </group>
+  </macro>
+  <macro name="container-legislation">
     <choose>
-      <if type="treaty">
-        <group delimiter=" ">
-          <number variable="volume"/>
-          <text variable="container-title"/>
-          <choose>
-            <if variable="page page-first" match="any">
-              <text variable="page-first"/>
-            </if>
-            <else>
-              <group delimiter=" ">
-                <label variable="number" form="short" text-case="capitalize-first"/>
-                <text variable="number"/>
-              </group>
-            </else>
-          </choose>
-        </group>
-      </if>
-      <else-if type="legal_case">
-        <group delimiter=" ">
-          <choose>
-            <if variable="container-title">
-              <group delimiter=" ">
-                <text variable="volume"/>
-                <text variable="container-title"/>
-                <group delimiter=" ">
-                  <label variable="section" form="symbol"/>
-                  <text variable="section"/>
-                </group>
-                <choose>
-                  <if variable="page page-first" match="any">
-                    <text variable="page-first"/>
-                  </if>
-                  <else>
-                    <text value="___"/>
-                  </else>
-                </choose>
-              </group>
-            </if>
-            <else>
-              <group delimiter=" ">
-                <label variable="number" form="short" text-case="capitalize-first"/>
-                <text variable="number"/>
-              </group>
-            </else>
-          </choose>
-        </group>
-      </else-if>
-      <else-if type="bill">
+      <if variable="number">
+        <!-- There's a public law number. -->
         <group delimiter=", ">
           <group delimiter=" ">
-            <text variable="genre"/>
-            <group delimiter=" ">
-              <choose>
-                <!-- If there is no session number or code/record title, assume
-                     assume the item is a congressional report and include 'No.' term. -->
-                <if variable="chapter-number container-title" match="none">
-                  <!-- The item is a congressional report, rather than a bill or resultion. -->
-                  <label variable="number" form="short" text-case="capitalize-first"/>
-                </if>
-              </choose>
-              <text variable="number"/>
-            </group>
-          </group>
-          <group delimiter=" ">
-            <text variable="authority"/>
-            <!-- 'session' is `chapter-number` -->
-            <text variable="chapter-number"/>
+            <text value="Pub. L. No."/>
+            <text variable="number"/>
           </group>
           <group delimiter=" ">
             <text variable="volume"/>
@@ -1985,170 +1907,138 @@
             <text variable="page-first"/>
           </group>
         </group>
-      </else-if>
-      <else-if type="hearing">
+      </if>
+      <else>
         <group delimiter=" ">
-          <text variable="authority"/>
-          <!-- 'session' is `chapter-number` -->
-          <text variable="chapter-number"/>
+          <text variable="volume"/>
+          <text variable="container-title"/>
+          <choose>
+            <if variable="section">
+              <text macro="section-labelled"/>
+            </if>
+            <else>
+              <text variable="page-first"/>
+            </else>
+          </choose>
         </group>
-      </else-if>
-      <else-if type="legislation">
+      </else>
+    </choose>
+  </macro>
+  <macro name="container-regulation">
+    <group delimiter=", ">
+      <group delimiter=" ">
+        <text variable="genre"/>
+        <text macro="number-labelled"/>
+      </group>
+      <group delimiter=" ">
+        <text variable="volume"/>
+        <text variable="container-title"/>
         <choose>
-          <if variable="number">
-            <!-- There's a public law number. -->
-            <group delimiter=", ">
-              <text variable="number" prefix="Pub. L. No. "/>
-              <group delimiter=" ">
-                <text variable="volume"/>
-                <text variable="container-title"/>
-                <text variable="page-first"/>
-              </group>
-            </group>
+          <if variable="section">
+            <text macro="section-labelled"/>
           </if>
           <else>
-            <group delimiter=" ">
-              <text variable="volume"/>
-              <text variable="container-title"/>
-              <choose>
-                <if variable="section">
-                  <group delimiter=" ">
-                    <label variable="section" form="symbol"/>
-                    <text variable="section"/>
-                  </group>
-                </if>
-                <else>
-                  <text variable="page-first"/>
-                </else>
-              </choose>
-            </group>
+            <text variable="page-first"/>
           </else>
         </choose>
-      </else-if>
-      <else-if type="regulation">
-        <group delimiter=", ">
-          <group delimiter=" ">
-            <text variable="genre"/>
-            <group delimiter=" ">
-              <label variable="number" form="short" text-case="capitalize-first"/>
-              <text variable="number"/>
-            </group>
-          </group>
-          <group delimiter=" ">
-            <text variable="volume"/>
-            <text variable="container-title"/>
-            <choose>
-              <if variable="section">
-                <group delimiter=" ">
-                  <label variable="section" form="symbol"/>
-                  <text variable="section"/>
-                </group>
-              </if>
-              <else>
-                <text variable="page-first"/>
-              </else>
-            </choose>
-          </group>
-        </group>
-      </else-if>
-    </choose>
-  </macro>
-  <macro name="parenthetical-legal">
-    <choose>
-      <if type="hearing">
-        <group prefix="(" suffix=")" delimiter=" ">
-          <!-- Use the 'verb' form of the hearing term to hold 'testimony of' -->
-          <text term="hearing" form="verb"/>
-          <names variable="author">
-            <name and="symbol" delimiter=", "/>
-          </names>
-        </group>
-      </if>
-      <else-if type="bill legislation regulation" match="any">
-        <!-- For uncodified regulations, assume future code section is in `status`. -->
-        <text variable="status" prefix="(" suffix=")"/>
-      </else-if>
-    </choose>
-  </macro>
-  <macro name="citation-locator">
-    <!-- Abbreviate page and paragraph, leave other locator labels in long form, cf. Rule 8.13 -->
-    <group delimiter=" ">
-      <choose>
-        <if locator="page paragraph" match="any">
-          <label variable="locator" form="short"/>
-        </if>
-        <else>
-          <label variable="locator" text-case="capitalize-first"/>
-        </else>
-      </choose>
-      <text variable="locator"/>
+      </group>
     </group>
   </macro>
-  <macro name="date-year">
-    <date variable="issued" date-parts="year" form="numeric"/>
+  <macro name="container-treaty">
+    <group delimiter=" ">
+      <number variable="volume"/>
+      <text variable="container-title"/>
+      <choose>
+        <if match="any" variable="page page-first">
+          <text variable="page-first"/>
+        </if>
+        <else>
+          <text macro="number-labelled"/>
+        </else>
+      </choose>
+    </group>
   </macro>
+  <!-- Legal source logic -->
+  <macro name="container-legal">
+    <!-- Expect legal item container-titles to be stored in short form -->
+    <choose>
+      <if type="bill">
+        <text macro="container-bill"/>
+      </if>
+      <else-if type="hearing">
+        <text macro="container-hearing"/>
+      </else-if>
+      <else-if type="legal_case">
+        <text macro="container-legal-case"/>
+      </else-if>
+      <else-if type="legislation">
+        <text macro="container-legislation"/>
+      </else-if>
+      <else-if type="regulation">
+        <text macro="container-regulation"/>
+      </else-if>
+      <else-if type="treaty">
+        <text macro="container-treaty"/>
+      </else-if>
+    </choose>
+  </macro>
+  <!-- Main logic -->
   <citation et-al-min="21" et-al-use-first="19" et-al-use-last="true">
     <sort>
       <key macro="date-sort-group" sort="descending"/>
-      <key macro="date-year" sort="descending"/>
+      <key macro="date-issued-year" sort="descending"/>
       <key macro="date-sort" sort="ascending"/>
       <key variable="status"/>
       <key macro="author-sort"/>
-      <key macro="title"/>
+      <key macro="title-bib"/>
     </sort>
     <layout delimiter="&#13;&#10;">
-      <choose>
-        <if type="bill hearing legal_case legislation regulation treaty" match="any">
-          <!-- Legal items have different orders and delimiters -->
-          <text macro="legal-cites"/>
-        </if>
-        <else>
-          <group delimiter=" ">
-            <group delimiter=". " suffix=".">
-              <text macro="author-bib"/>
-              <text macro="date-bib"/>
-              <text macro="title-and-descriptions"/>
-              <text macro="container"/>
-              <text macro="event"/>
-              <text macro="publisher"/>
-            </group>
-            <text macro="access"/>
-            <text macro="publication-history"/>
-          </group>
-        </else>
-      </choose>
+      <text macro="bibliography"/>
     </layout>
   </citation>
-  <bibliography hanging-indent="true" et-al-min="21" et-al-use-first="19" et-al-use-last="true" entry-spacing="0" line-spacing="2">
+  <macro name="bibliography">
+    <group delimiter=" ">
+      <group delimiter=". " suffix=".">
+        <text macro="author-bib"/>
+        <text macro="date-bib"/>
+        <text macro="title-and-descriptions"/>
+        <text macro="container"/>
+        <text macro="event"/>
+        <text macro="publication-archive"/>
+      </group>
+      <text macro="access"/>
+      <text macro="publication-history"/>
+    </group>
+  </macro>
+  <macro name="bibliography-filtered">
+    <choose>
+      <if match="any" type="bill hearing legal_case legislation regulation treaty">
+        <!-- Legal items have different orders and delimiters -->
+        <text macro="legal-bib"/>
+      </if>
+      <else-if type="personal_communication">
+        <choose>
+          <if match="any" variable="archive archive-place container-title DOI publisher URL">
+            <text macro="bibliography"/>
+          </if>
+        </choose>
+      </else-if>
+      <else>
+        <text macro="bibliography"/>
+      </else>
+    </choose>
+  </macro>
+  <bibliography entry-spacing="0" et-al-min="21" et-al-use-first="19" et-al-use-last="true" hanging-indent="true" line-spacing="2">
     <sort>
       <key macro="date-sort-group" sort="descending"/>
-      <key macro="date-year" sort="descending"/>
+      <key macro="date-issued-year" sort="descending"/>
       <key macro="date-sort" sort="ascending"/>
       <key variable="status"/>
       <key macro="author-sort"/>
-      <key macro="title"/>
+      <key macro="title-bib"/>
     </sort>
     <layout>
-      <choose>
-        <if type="bill hearing legal_case legislation regulation treaty" match="any">
-          <!-- Legal items have different orders and delimiters -->
-          <text macro="legal-cites"/>
-        </if>
-        <else>
-          <group delimiter=" ">
-            <group delimiter=". " suffix=".">
-              <text macro="author-bib"/>
-              <text macro="date-bib"/>
-              <text macro="title-and-descriptions"/>
-              <text macro="container"/>
-              <text macro="event"/>
-              <text macro="publisher"/>
-            </group>
-            <text macro="access"/>
-            <text macro="publication-history"/>
-          </group>
-        </else>
-      </choose>
+      <text macro="bibliography-filtered"/>
     </layout>
   </bibliography>
 </style>

--- a/apa-no-ampersand.csl
+++ b/apa-no-ampersand.csl
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
-<style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" demote-non-dropping-particle="never" page-range-format="expanded">
+<style xmlns="http://purl.org/net/xbiblio/csl" and="text" class="in-text" demote-non-dropping-particle="never" initialize-with=". " names-delimiter=", " page-range-format="expanded" version="1.0">
   <info>
     <title>American Psychological Association 7th edition (no ampersand)</title>
-    <title-short>APA (no ampersand)</title-short>
+    <title-short>APA Style (no ampersand)</title-short>
     <id>http://www.zotero.org/styles/apa-no-ampersand</id>
     <link href="http://www.zotero.org/styles/apa-no-ampersand" rel="self"/>
     <link href="http://www.zotero.org/styles/apa" rel="template"/>
@@ -10,48 +10,53 @@
     <author>
       <name>Brenton M. Wiernik</name>
       <email>zotero@wiernik.org</email>
+      <uri>https://orcid.org/0000-0001-9560-6336</uri>
     </author>
+    <contributor>
+      <name>Andrew Dunning</name>
+      <uri>https://orcid.org/0000-0003-0464-5036</uri>
+    </contributor>
     <category citation-format="author-date"/>
     <category field="psychology"/>
     <category field="generic-base"/>
+    <summary>Author–date system of the Publication manual of the American Psychological Association: The official guide to APA style (2020)</summary>
     <updated>2024-07-09T20:08:41+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale xml:lang="en">
     <terms>
-      <term name="editortranslator" form="short">
-        <single>ed. and trans.</single>
-        <multiple>eds. and trans.</multiple>
-      </term>
-      <term name="editor-translator" form="short">
-        <single>ed. and trans.</single>
-        <multiple>eds. and trans.</multiple>
-      </term>
-      <term name="translator" form="short">trans.</term>
-      <term name="interviewer" form="short">
-        <single>interviewer</single>
-        <multiple>interviewers</multiple>
-      </term>
-      <term name="collection-editor" form="short">
+      <term name="ad"> C.E.</term>
+      <term form="long" name="at">before the</term>
+      <term name="bc"> B.C.E.</term>
+      <term form="short" name="circa">ca.</term>
+      <term name="collection">archival collection</term>
+      <term form="short" name="collection-editor">
         <single>ed.</single>
         <multiple>eds.</multiple>
       </term>
-      <term name="performer" form="verb">recorded by</term>
-      <term name="circa" form="short">ca.</term>
-      <term name="bc"> B.C.E.</term>
-      <term name="ad"> C.E.</term>
-      <term name="issue" form="long">
+      <term form="short" name="editor-translator">
+        <single>ed. and trans.</single>
+        <multiple>eds. and trans.</multiple>
+      </term>
+      <term form="short" name="editortranslator">
+        <single>ed. and trans.</single>
+        <multiple>eds. and trans.</multiple>
+      </term>
+      <term form="verb" name="hearing">testimony of</term>
+      <term form="short" name="interviewer">
+        <single>interviewer</single>
+        <multiple>interviewers</multiple>
+      </term>
+      <term form="long" name="issue">
         <single>issue</single>
         <multiple>issues</multiple>
       </term>
-      <term name="software">computer software</term>
-      <term name="at" form="long">before the</term>
-      <term name="collection">archival collection</term>
+      <term form="verb" name="performer">recorded by</term>
       <term name="post">online post</term>
-      <term name="at" form="long">before the</term>
-      <term name="hearing" form="verb">testimony of</term>
-      <term name="review-of" form="long">review of the</term>
-      <term name="review-of" form="short">review of</term>
+      <term form="long" name="review-of">review of the</term>
+      <term form="short" name="review-of">review of</term>
+      <term name="software">computer software</term>
+      <term form="short" name="translator">trans.</term>
     </terms>
   </locale>
   <locale xml:lang="da">
@@ -71,7 +76,7 @@
   </locale>
   <locale xml:lang="fr">
     <terms>
-      <term name="editor" form="short">
+      <term form="short" name="editor">
         <single>éd.</single>
         <multiple>éds.</multiple>
       </term>
@@ -97,29 +102,26 @@
       <term name="et-al">et al.</term>
     </terms>
   </locale>
-  <!-- For Indigeneous Knowledge, assume the item is stored as `document` or `speech`
-       and that Nation/Community, treaty, where the Elder lives, 
-       and topic are all stored in `title`
-       cf. https://libguides.norquest.ca/c.php?g=314831&p=5188823.
-       If the item is stored as `interview`, assume that Nation/Community, treat, and topic
-       are stored in `title`, 'Oral teaching' or similar is stored in `archive`, and where
-       the Elder lives is stored in `archive-place`. 
-  -->
-  <!-- Reviews are detected if an item has type `review` or `review-book` or if it has any of the variables
-       `reviewed-title`, `reviewed-author`, or `reviewed-genre`. For the latter case, reviews are commonly 
-       stored as types `article-journal`, `article-magazine`, `article-newspaper`, `post-weblog`, or `webpage` 
-  -->
-  <!-- General categories of item types:
-       Periodical: article-journal article-magazine article-newspaper periodical post-weblog review review-book
-       Periodical or Booklike: paper-conference
-       Booklike: article book broadcast chapter classic collection dataset document
-                 entry entry-dictionary entry-encyclopedia event figure
-                 graphic interview manuscript map motion_picture musical_score
-                 pamphlet patent performance personal_communication post report
-                 software song speech standard thesis webpage
-       Legal: bill hearing legal_case legislation regulation treaty
+  <!-- General categories of CSL item types:
+
+       Periodical
+       : article-journal article-magazine article-newspaper periodical post-weblog review review-book
+
+       Periodical or Booklike
+       : paper-conference
+
+       Booklike
+       : article book broadcast chapter classic collection dataset document
+         entry entry-dictionary entry-encyclopedia event figure
+         graphic interview manuscript map motion_picture musical_score
+         pamphlet patent performance personal_communication post report
+         software song speech standard thesis webpage
+
+       Legal
+       : bill hearing legal_case legislation regulation treaty
   -->
   <!-- Equivalencies:
+
        classic == book
        document == report, but give full date
        standard == report
@@ -128,6 +130,7 @@
        collection == book, but give full date
   -->
   <!-- Role equivalencies:
+
        compiler == editor
        organizer, curator == chair
        script-writer == director
@@ -135,150 +138,294 @@
        guest, host == director
        series-creator, executive-producer == editor
   -->
-  <!-- APA references contain four parts: author, date, title, source -->
-  <macro name="author-bib">
+  <!-- Reviews are detected if an item has type `review` or `review-book` or if it has any of the variables
+       `reviewed-title`, `reviewed-author`, or `reviewed-genre`. For the latter case, reviews are commonly
+       stored as types `article-journal`, `article-magazine`, `article-newspaper`, `post-weblog`, or `webpage`
+  -->
+  <!-- For Indigeneous Knowledge, assume the item is stored as `document` or `speech`
+       and that Nation/Community, treaty, where the Elder lives,
+       and topic are all stored in `title`
+       cf. https://libguides.norquest.ca/c.php?g=314831&p=5188823.
+       If the item is stored as `interview`, assume that Nation/Community, treaty territory, and topic
+       are stored in `title`, 'Oral teaching' or similar is stored in `archive`, and where
+       the Elder lives is stored in `archive-place`.
+  -->
+  <!-- Variable labelling macros -->
+  <macro name="chapter-number-labelled">
     <group delimiter=" ">
-      <names variable="composer" delimiter=", ">
-        <name name-as-sort-order="all" and="text" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
-        <substitute>
-          <names variable="author"/>
-          <!-- Note: `narrator` only cited in secondary-contributors -->
-          <names variable="illustrator"/>
-          <!-- TODO: Replace this group with `collapse` to combine names variables when that becomes available. -->
-          <choose>
-            <if type="broadcast">
-              <!-- Note: Actors/performers and producers [not executive] not cited in APA style. -->
-              <group>
-                <names variable="script-writer" delimiter=", ">
-                  <name name-as-sort-order="all" and="text" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
-                  <label form="long" prefix=" (" suffix=")" text-case="title"/>
-                </names>
-                <choose>
-                  <if variable="script-writer director" match="all">
-                    <text term="and" prefix=", " suffix=" "/>
-                  </if>
-                </choose>
-                <names variable="director" delimiter=", ">
-                  <name name-as-sort-order="all" and="text" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
-                  <label form="long" prefix=" (" suffix=")" text-case="title"/>
-                </names>
-              </group>
-            </if>
-          </choose>
-          <names variable="director">
-            <!-- For non-broadcast items, APA only cites directors and not writers. -->
-            <name name-as-sort-order="all" and="text" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
-            <label form="long" prefix=" (" suffix=")" text-case="title"/>
-          </names>
-          <!-- TODO: Replace this group with `collapse` to combine names variables when that becomes available. -->
-          <group>
-            <names variable="guest" delimiter=", ">
-              <name name-as-sort-order="all" and="text" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
+      <choose>
+        <if is-numeric="chapter-number">
+          <label form="short" variable="chapter-number"/>
+        </if>
+      </choose>
+      <text variable="chapter-number"/>
+    </group>
+  </macro>
+  <macro name="edition-labelled">
+    <choose>
+      <if is-numeric="edition">
+        <group delimiter=" ">
+          <number form="ordinal" variable="edition"/>
+          <label form="short" variable="edition"/>
+        </group>
+      </if>
+      <else>
+        <text variable="edition"/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="issue-labelled">
+    <group delimiter=" ">
+      <label text-case="capitalize-first" variable="issue"/>
+      <text variable="issue"/>
+    </group>
+  </macro>
+  <macro name="locator-labelled">
+    <!-- Abbreviate page and paragraph; leave other locator labels in long form (APA 8.13) -->
+    <group delimiter=" ">
+      <choose>
+        <if locator="page paragraph" match="any">
+          <label form="short" variable="locator"/>
+        </if>
+        <else>
+          <label text-case="capitalize-first" variable="locator"/>
+        </else>
+      </choose>
+      <text variable="locator"/>
+    </group>
+  </macro>
+  <macro name="number-labelled">
+    <group delimiter=" ">
+      <choose>
+        <if is-numeric="number">
+          <label form="short" text-case="capitalize-first" variable="number"/>
+        </if>
+        <else-if match="none" type="broadcast">
+          <label form="short" text-case="capitalize-first" variable="number"/>
+        </else-if>
+      </choose>
+      <text variable="number"/>
+    </group>
+  </macro>
+  <macro name="number-article-labelled">
+    <!-- APA example 6: Journal article with article number or eLocator -->
+    <group delimiter=" ">
+      <text term="article-locator" text-case="capitalize-first"/>
+      <text variable="number"/>
+    </group>
+  </macro>
+  <macro name="number-of-volumes-labelled">
+    <choose>
+      <if is-numeric="number-of-volumes">
+        <group delimiter=" ">
+          <label form="short" text-case="capitalize-first" variable="number-of-volumes"/>
+          <text prefix="1" term="page-range-delimiter"/>
+        </group>
+      </if>
+    </choose>
+    <text variable="number-of-volumes"/>
+  </macro>
+  <macro name="page-labelled">
+    <group delimiter=" ">
+      <label form="short" variable="page"/>
+      <text variable="page"/>
+    </group>
+  </macro>
+  <macro name="part-number-labelled">
+    <group delimiter=" ">
+      <choose>
+        <if variable="part-number">
+          <!-- TODO: Replace with `part-number` label when CSL provides one -->
+          <text form="short" term="part" text-case="capitalize-first"/>
+          <text variable="part-number"/>
+        </if>
+      </choose>
+    </group>
+  </macro>
+  <macro name="section-labelled">
+    <group delimiter=" ">
+      <label form="symbol" variable="section"/>
+      <text variable="section"/>
+    </group>
+  </macro>
+  <macro name="supplement-number-labelled">
+    <group delimiter=" ">
+      <choose>
+        <if variable="supplement-number">
+          <!-- TODO: Replace with `supplement-number` label when CSL provides one -->
+          <text form="short" term="supplement" text-case="capitalize-first"/>
+          <text variable="supplement-number"/>
+        </if>
+      </choose>
+    </group>
+  </macro>
+  <macro name="version-labelled">
+    <group delimiter=" ">
+      <label text-case="capitalize-first" variable="version"/>
+      <text variable="version"/>
+    </group>
+  </macro>
+  <macro name="volume-labelled">
+    <group delimiter=" ">
+      <label form="short" text-case="capitalize-first" variable="volume"/>
+      <text variable="volume"/>
+    </group>
+  </macro>
+  <!-- Four parts in APA references:
+
+       1. Author (APA 9.7–12)
+       2. Date (APA 9.13–17)
+       3. Title (APA 9.18–22)
+       4. Source (APA 9.23–37)
+  -->
+  <!-- 1. Author -->
+  <!-- Author utility macros -->
+  <macro name="author-substitute-bib">
+    <names variable="composer">
+      <name delimiter-precedes-last="always" name-as-sort-order="all"/>
+      <label form="short" prefix=" (" suffix=")" text-case="title"/>
+      <substitute>
+        <names variable="author"/>
+        <!-- `narrator` only cited in secondary-contributors -->
+        <names variable="illustrator"/>
+        <choose>
+          <if type="broadcast">
+            <names variable="script-writer director">
+              <!-- Actors/performers and producers [not executive] not cited in APA style. -->
+              <name delimiter-precedes-last="always" name-as-sort-order="all"/>
               <label form="long" prefix=" (" suffix=")" text-case="title"/>
             </names>
+          </if>
+        </choose>
+        <names variable="director">
+          <!-- For non-broadcast items, APA only cites directors and not writers. -->
+          <name delimiter-precedes-last="always" name-as-sort-order="all"/>
+          <label form="long" prefix=" (" suffix=")" text-case="title"/>
+        </names>
+        <names variable="guest host">
+          <!-- TODO: Replace `delimiter` with `collapse` to combine names variables when that becomes available. -->
+          <name delimiter-precedes-last="always" name-as-sort-order="all"/>
+          <label form="long" prefix=" (" suffix=")" text-case="title"/>
+        </names>
+        <names variable="producer">
+          <!-- Producers not cited if there is a writer/director, but use if they are the principle creator. -->
+          <name delimiter-precedes-last="always" name-as-sort-order="all"/>
+          <label form="long" prefix=" (" suffix=")" text-case="title"/>
+        </names>
+        <choose>
+          <if variable="container-title">
             <choose>
-              <if variable="guest host" match="all">
-                <text term="and" prefix=", " suffix=" "/>
+              <if match="any" type="book classic collection entry entry-dictionary entry-encyclopedia">
+                <!-- Items with book-like container-title substitute with their title and identification,
+                     but leave description after container-title. This mimics the `container-booklike` formatting. -->
+                <text macro="title-substitute"/>
               </if>
             </choose>
-            <names variable="host" delimiter=", ">
-              <name name-as-sort-order="all" and="text" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
+          </if>
+        </choose>
+        <names variable="executive-producer">
+          <name delimiter-precedes-last="always" name-as-sort-order="all"/>
+          <label form="long" prefix=" (" suffix=")" text-case="title"/>
+        </names>
+        <names variable="series-creator">
+          <name delimiter-precedes-last="always" name-as-sort-order="all"/>
+          <label form="long" prefix=" (" suffix=")" text-case="title"/>
+        </names>
+        <names variable="editor-translator"/>
+        <!-- Translator is not cited as a primary creator (only as Ed. & Trans.). -->
+        <names variable="editor"/>
+        <names variable="editorial-director"/>
+        <names variable="compiler">
+          <name delimiter-precedes-last="always" name-as-sort-order="all"/>
+          <label form="long" prefix=" (" suffix=")" text-case="title"/>
+        </names>
+        <choose>
+          <if match="any" type="event performance speech">
+            <names variable="chair">
+              <name delimiter-precedes-last="always" name-as-sort-order="all"/>
               <label form="long" prefix=" (" suffix=")" text-case="title"/>
             </names>
-          </group>
-          <names variable="producer">
-            <!-- Note: Producers not cited if there is a writer/director, but use if they are the principle creator. -->
-            <name name-as-sort-order="all" and="text" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
-            <label form="long" prefix=" (" suffix=")" text-case="title"/>
-          </names>
-          <choose>
-            <if variable="container-title">
-              <choose>
-                <if type="book classic collection entry entry-dictionary entry-encyclopedia" match="any">
-                  <!-- Items with book-like container-title substitute with their title and parenthetical, 
-                       but leave bracketed after container-title. This mimics the `container-booklike` formatting. -->
-                  <choose>
-                    <if variable="title">
-                      <group delimiter=" ">
-                        <text macro="title"/>
-                        <text macro="parenthetical"/>
-                      </group>
-                    </if>
-                    <else>
-                      <text macro="title-and-descriptions"/>
-                    </else>
-                  </choose>
-                </if>
-              </choose>
-            </if>
-          </choose>
-          <names variable="series-creator" delimiter=", ">
-            <name name-as-sort-order="all" and="text" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
-            <label form="long" prefix=" (" suffix=")" text-case="title"/>
-          </names>
-          <names variable="executive-producer" delimiter=", ">
-            <name name-as-sort-order="all" and="text" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
-            <label form="long" prefix=" (" suffix=")" text-case="title"/>
-          </names>
-          <names variable="editor-translator">
-            <name name-as-sort-order="all" and="text" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
-            <label form="short" prefix=" (" suffix=")" text-case="title"/>
-          </names>
-          <!-- Note: Translator is not cited as a primary creator (only as Ed. & Trans.). -->
-          <names variable="editor">
-            <name name-as-sort-order="all" and="text" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
-            <label form="short" prefix=" (" suffix=")" text-case="title"/>
-          </names>
-          <names variable="editorial-director">
-            <name name-as-sort-order="all" and="text" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
-            <label form="short" prefix=" (" suffix=")" text-case="title"/>
-          </names>
-          <names variable="compiler">
-            <name name-as-sort-order="all" and="text" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
-            <label form="long" prefix=" (" suffix=")" text-case="title"/>
-          </names>
-          <choose>
-            <if type="event performance speech" match="any">
-              <names variable="chair">
-                <name name-as-sort-order="all" and="text" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
-                <label form="long" prefix=" (" suffix=")" text-case="title"/>
-              </names>
-              <names variable="organizer">
-                <name name-as-sort-order="all" and="text" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
-                <label form="long" prefix=" (" suffix=")" text-case="title"/>
-              </names>
-            </if>
-          </choose>
-          <names variable="curator">
-            <name name-as-sort-order="all" and="text" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
-            <label form="long" prefix=" (" suffix=")" text-case="title"/>
-          </names>
-          <names variable="collection-editor">
-            <name name-as-sort-order="all" and="text" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
-            <label form="short" prefix=" (" suffix=")" text-case="title"/>
-          </names>
-          <choose>
-            <if variable="title">
-              <!-- If an item has a title, substitute missing author with title and parenthetical, but leave bracketed 
-                   after the date (in the 'title' position). -->
-              <group delimiter=" ">
-                <text macro="title"/>
-                <text macro="parenthetical"/>
-              </group>
-            </if>
-            <else>
-              <!-- If an item has no title, substitute with bracketed followed by parenthetical. -->
-              <text macro="title-and-descriptions"/>
-            </else>
-          </choose>
-        </substitute>
-      </names>
+            <names variable="organizer">
+              <name delimiter-precedes-last="always" name-as-sort-order="all"/>
+              <label form="long" prefix=" (" suffix=")" text-case="title"/>
+            </names>
+          </if>
+        </choose>
+        <names variable="curator">
+          <name delimiter-precedes-last="always" name-as-sort-order="all"/>
+          <label form="long" prefix=" (" suffix=")" text-case="title"/>
+        </names>
+        <names variable="collection-editor"/>
+        <text macro="title-substitute"/>
+      </substitute>
+    </names>
+  </macro>
+  <macro name="author-substitute-intext">
+    <names variable="composer">
+      <name form="short"/>
+      <substitute>
+        <names variable="author"/>
+        <names variable="illustrator"/>
+        <!-- TODO: Replace `delimiter` with `collapse` to combine names variables when that becomes available. -->
+        <choose>
+          <if type="broadcast">
+            <names variable="script-writer"/>
+          </if>
+        </choose>
+        <names variable="director"/>
+        <!-- TODO: Replace `delimiter` with `collapse` to combine names variables when that becomes available. -->
+        <names variable="guest host"/>
+        <names variable="producer"/>
+        <choose>
+          <if variable="container-title">
+            <choose>
+              <if match="any" type="book classic collection entry entry-dictionary entry-encyclopedia">
+                <text macro="title-intext"/>
+              </if>
+            </choose>
+          </if>
+        </choose>
+        <names variable="executive-producer"/>
+        <names variable="series-creator"/>
+        <names variable="editor"/>
+        <names variable="editorial-director"/>
+        <names variable="compiler"/>
+        <choose>
+          <if match="any" type="event performance speech">
+            <names variable="chair"/>
+            <names variable="organizer"/>
+          </if>
+        </choose>
+        <names variable="curator"/>
+        <text macro="title-intext"/>
+      </substitute>
+    </names>
+  </macro>
+  <macro name="title-substitute">
+    <choose>
+      <if variable="title">
+        <!-- If an item has a title, substitute missing author with title and identification, but leave description after the date (in the 'title' position). -->
+        <group delimiter=" ">
+          <text macro="title-bib"/>
+          <text macro="identification"/>
+        </group>
+      </if>
+      <else>
+        <!-- If an item has no title, substitute with description followed by identification. -->
+        <text macro="title-and-descriptions"/>
+      </else>
+    </choose>
+  </macro>
+  <!-- Author logic -->
+  <macro name="author-bib">
+    <group delimiter=" ">
+      <text macro="author-substitute-bib"/>
       <choose>
         <!-- Print "with" contributor for books, but not for other types that commonly have them (eg, thesis, software) -->
-        <if type="book classic collection" match="any">
-          <names variable="contributor" prefix="(" suffix=")">
+        <if match="any" type="book classic collection">
+          <names prefix="(" suffix=")" variable="contributor">
             <label form="verb" suffix=" "/>
-            <name name-as-sort-order="all" and="text" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
+            <name delimiter-precedes-last="always" name-as-sort-order="all"/>
           </names>
         </if>
       </choose>
@@ -286,108 +433,21 @@
   </macro>
   <macro name="author-intext">
     <choose>
-      <if type="bill hearing legal_case legislation regulation treaty" match="any">
+      <if match="any" type="bill hearing legal_case legislation regulation treaty">
         <text macro="title-intext"/>
       </if>
-      <else-if type="interview personal_communication" match="any">
-        <choose>
-          <!-- These variables indicate that the letter is retrievable by the reader.
-                If not, then use the APA in-text-only personal communication format -->
-          <if variable="archive container-title DOI publisher URL" match="none">
-            <group delimiter=", ">
-              <names variable="author">
-                <name and="text" delimiter=", " initialize-with=". "/>
-                <substitute>
-                  <text macro="title-intext"/>
-                </substitute>
-              </names>
-              <text term="personal-communication"/>
-            </group>
-          </if>
-          <else>
-            <names variable="author" delimiter=", ">
-              <name form="short" and="text" delimiter=", " initialize-with=". "/>
-              <substitute>
-                <text macro="title-intext"/>
-              </substitute>
-            </names>
-          </else>
-        </choose>
+      <else-if match="any" type="interview personal_communication">
+        <text macro="title-intext-interview-communication"/>
       </else-if>
       <else>
-        <names variable="composer">
-          <name form="short" and="text" delimiter=", " initialize-with=". "/>
-          <substitute>
-            <names variable="author"/>
-            <names variable="illustrator"/>
-            <!-- TODO: Replace this group with `collapse` to combine names variables when that becomes available. -->
-            <choose>
-              <if type="broadcast">
-                <group>
-                  <names variable="script-writer" delimiter=", ">
-                    <name form="short" and="text" delimiter=", " initialize-with=". "/>
-                  </names>
-                  <choose>
-                    <if variable="script-writer director" match="all">
-                      <text term="and" prefix=" " suffix=" "/>
-                    </if>
-                  </choose>
-                  <names variable="director" delimiter=", ">
-                    <name form="short" and="text" delimiter=", " initialize-with=". "/>
-                  </names>
-                </group>
-              </if>
-            </choose>
-            <names variable="director"/>
-            <!-- TODO: Replace this group with `collapse` to combine names variables when that becomes available. -->
-            <choose>
-              <if type="broadcast">
-                <group>
-                  <names variable="guest" delimiter=", ">
-                    <name form="short" and="text" delimiter=", " initialize-with=". "/>
-                  </names>
-                  <choose>
-                    <if variable="guest host" match="all">
-                      <text term="and" prefix=", " suffix=" "/>
-                    </if>
-                  </choose>
-                  <names variable="host" delimiter=", ">
-                    <name form="short" and="text" delimiter=", " initialize-with=". "/>
-                  </names>
-                </group>
-              </if>
-            </choose>
-            <names variable="producer"/>
-            <choose>
-              <if variable="container-title">
-                <choose>
-                  <if type="book classic collection entry entry-dictionary entry-encyclopedia" match="any">
-                    <text macro="title-intext"/>
-                  </if>
-                </choose>
-              </if>
-            </choose>
-            <names variable="executive-producer"/>
-            <names variable="series-creator"/>
-            <names variable="editor"/>
-            <names variable="editorial-director"/>
-            <names variable="compiler"/>
-            <choose>
-              <if type="event performance speech" match="any">
-                <names variable="chair"/>
-                <names variable="organizer"/>
-              </if>
-            </choose>
-            <names variable="curator"/>
-            <text macro="title-intext"/>
-          </substitute>
-        </names>
+        <text macro="author-substitute-intext"/>
       </else>
     </choose>
   </macro>
+  <!-- Author sorting -->
   <macro name="author-sort">
     <choose>
-      <if type="bill hearing legal_case legislation regulation treaty" match="any">
+      <if match="any" type="bill hearing legal_case legislation regulation treaty">
         <text macro="title-legal"/>
       </if>
       <else>
@@ -395,92 +455,161 @@
       </else>
     </choose>
   </macro>
-  <macro name="date-bib">
-    <group delimiter=" " prefix="(" suffix=")">
-      <choose>
-        <if is-uncertain-date="issued">
-          <text term="circa" form="short"/>
-        </if>
-      </choose>
-      <group>
-        <choose>
-          <if variable="issued">
-            <group delimiter=", ">
-              <group>
-                <date variable="issued" date-parts="year" form="numeric"/>
-                <text variable="year-suffix"/>
-              </group>
-              <choose>
-                <if type="article-magazine article-newspaper broadcast collection document event interview motion_picture pamphlet performance personal_communication post post-weblog song speech webpage" match="any">
-                  <!-- Many video and audio examples in manual give full dates. Err on the side of too much information. -->
-                  <date variable="issued">
-                    <date-part name="month"/>
-                    <date-part name="day" prefix=" "/>
-                  </date>
-                </if>
-                <else-if type="paper-conference">
-                  <!-- Capture 'speech' stored as 'paper-conference' -->
-                  <choose>
-                    <if variable="collection-editor compiler editor editorial-director issue page volume" match="none">
-                      <date variable="issued">
-                        <date-part name="month"/>
-                        <date-part name="day" prefix=" "/>
-                      </date>
-                    </if>
-                  </choose>
-                </else-if>
-                <!-- Only year: article article-journal book chapter classic entry entry-dictionary entry-encyclopedia dataset figure graphic
-                     manuscript map musical_score paper-conference[published] patent periodical report review review-book software standard thesis -->
-              </choose>
-            </group>
-          </if>
-          <else-if variable="status">
-            <group>
-              <!-- We print the status variable directly rather than using in-press, etc. terms. -->
-              <text variable="status" text-case="lowercase"/>
-              <text variable="year-suffix" prefix="-"/>
-            </group>
-          </else-if>
-          <else>
-            <text term="no date" form="short"/>
-            <text variable="year-suffix" prefix="-"/>
-          </else>
-        </choose>
-      </group>
+  <!-- 2. Date -->
+  <!-- Date utility macros -->
+  <macro name="date-issued-full">
+    <group delimiter=" ">
+      <text macro="uncertain-date-issued"/>
+      <date form="text" variable="issued"/>
     </group>
   </macro>
-  <macro name="date-sort">
-    <!-- This is necessary to ensure that citeproc sorts all item types chonologically in the same list. -->
+  <macro name="date-issued-leading-zeros">
+    <date delimiter="-" variable="issued">
+      <date-part form="long" name="year"/>
+      <date-part form="numeric-leading-zeros" name="month"/>
+      <date-part form="numeric-leading-zeros" name="day"/>
+    </date>
+  </macro>
+  <macro name="date-issued-month-day">
+    <date variable="issued">
+      <date-part name="month"/>
+      <date-part name="day" prefix=" "/>
+    </date>
+  </macro>
+  <macro name="date-issued-year">
+    <group delimiter=" ">
+      <text macro="uncertain-date-issued"/>
+      <date date-parts="year" form="numeric" variable="issued"/>
+    </group>
+  </macro>
+  <macro name="original-date-year">
+    <group delimiter=" ">
+      <choose>
+        <if is-uncertain-date="original-date">
+          <text form="short" term="circa"/>
+        </if>
+      </choose>
+      <date variable="original-date">
+        <date-part name="year"/>
+      </date>
+    </group>
+  </macro>
+  <macro name="uncertain-date-issued">
     <choose>
-      <if type="article article-journal book chapter entry entry-dictionary entry-encyclopedia dataset figure graphic manuscript map musical_score patent report review review-book thesis" match="any">
-        <date variable="issued" date-parts="year" form="numeric"/>
+      <if is-uncertain-date="issued">
+        <text form="short" term="circa"/>
+      </if>
+    </choose>
+  </macro>
+  <!-- Date logic -->
+  <macro name="date-bib">
+    <group prefix="(" suffix=")">
+      <choose>
+        <if variable="issued">
+          <group delimiter=", ">
+            <group>
+              <text macro="date-issued-year"/>
+              <text variable="year-suffix"/>
+            </group>
+            <choose>
+              <if match="any" type="article-magazine article-newspaper broadcast collection document event interview motion_picture pamphlet performance personal_communication post post-weblog song speech webpage">
+                <!-- Many video and audio examples in manual give full dates. Err on the side of too much information. -->
+                <text macro="date-issued-month-day"/>
+              </if>
+              <else-if type="paper-conference">
+                <!-- Capture 'speech' stored as 'paper-conference' -->
+                <choose>
+                  <if match="none" variable="collection-editor compiler editor editorial-director issue page volume">
+                    <text macro="date-issued-month-day"/>
+                  </if>
+                </choose>
+              </else-if>
+              <!-- Only year: article article-journal book chapter classic entry entry-dictionary entry-encyclopedia dataset figure graphic
+                     manuscript map musical_score paper-conference[published] patent periodical report review review-book software standard thesis -->
+            </choose>
+          </group>
+        </if>
+        <else-if variable="status">
+          <group>
+            <!-- We print the status variable directly rather than using in-press, etc. terms. -->
+            <text text-case="lowercase" variable="status"/>
+            <text prefix="-" variable="year-suffix"/>
+          </group>
+        </else-if>
+        <else>
+          <text form="short" term="no date"/>
+          <text prefix="-" variable="year-suffix"/>
+        </else>
+      </choose>
+    </group>
+  </macro>
+  <macro name="date-intext">
+    <choose>
+      <if variable="issued">
+        <group delimiter="/">
+          <text macro="original-date-year"/>
+          <group>
+            <choose>
+              <if match="any" type="interview personal_communication">
+                <choose>
+                  <if match="none" variable="archive archive-place container-title DOI publisher URL">
+                    <!-- These variables indicate that the communication is retrievable by the reader.
+                           If not, then use the in-text-only personal communication format -->
+                    <text macro="date-issued-full"/>
+                  </if>
+                  <else>
+                    <text macro="date-issued-year"/>
+                  </else>
+                </choose>
+              </if>
+              <else>
+                <text macro="date-issued-year"/>
+              </else>
+            </choose>
+            <text variable="year-suffix"/>
+          </group>
+        </group>
+      </if>
+      <else-if variable="status">
+        <!-- We print the status variable directly rather than using in-press, etc. terms. -->
+        <text text-case="lowercase" variable="status"/>
+        <text prefix="-" variable="year-suffix"/>
+      </else-if>
+      <else>
+        <text form="short" term="no date"/>
+        <text prefix="-" variable="year-suffix"/>
+      </else>
+    </choose>
+  </macro>
+  <!-- Date sorting -->
+  <macro name="date-sort">
+    <!-- Sort items by printed issue date without prefixes for original or uncertain dates -->
+    <choose>
+      <if match="any" type="article article-journal book chapter entry entry-dictionary entry-encyclopedia dataset figure graphic manuscript map musical_score patent report review review-book thesis">
+        <date date-parts="year" form="numeric" variable="issued"/>
       </if>
       <else-if type="paper-conference">
         <!-- Capture 'speech' stored as 'paper-conference' -->
         <choose>
-          <if variable="collection-editor compiler editor editorial-director issue page volume" match="any">
-            <date variable="issued" date-parts="year" form="numeric"/>
+          <if match="any" variable="collection-editor compiler editor editorial-director issue page volume">
+            <date date-parts="year" form="numeric" variable="issued"/>
           </if>
           <else>
-            <date variable="issued">
-              <date-part name="year" form="long"/>
-              <date-part name="month" form="numeric-leading-zeros"/>
-              <date-part name="day" form="numeric-leading-zeros"/>
-            </date>
+            <text macro="date-issued-leading-zeros"/>
           </else>
         </choose>
       </else-if>
       <else>
-        <date variable="issued">
-          <date-part name="year" form="long"/>
-          <date-part name="month" form="numeric-leading-zeros"/>
-          <date-part name="day" form="numeric-leading-zeros"/>
-        </date>
+        <text macro="date-issued-leading-zeros"/>
       </else>
     </choose>
   </macro>
   <macro name="date-sort-group">
-    <!-- APA sorts 1. no-date items, 2. items with dates, 3. in-press (status) items -->
+    <!-- Sorts items with and without dates:
+
+         1. no-date items (= 0)
+         2. items with dates (= 1)
+         3. in-press (status) items (= 2) -->
     <choose>
       <if variable="issued">
         <text value="1"/>
@@ -493,111 +622,185 @@
       </else>
     </choose>
   </macro>
-  <macro name="date-intext">
-    <choose>
-      <if variable="issued">
-        <group delimiter="/">
-          <group delimiter=" ">
-            <choose>
-              <if is-uncertain-date="original-date">
-                <text term="circa" form="short"/>
-              </if>
-            </choose>
-            <date variable="original-date">
-              <date-part name="year"/>
-            </date>
-          </group>
-          <group delimiter=" ">
-            <choose>
-              <if is-uncertain-date="issued">
-                <text term="circa" form="short"/>
-              </if>
-            </choose>
-            <group>
-              <choose>
-                <if type="interview personal_communication" match="any">
-                  <choose>
-                    <if variable="archive container-title DOI publisher URL" match="none">
-                      <!-- These variables indicate that the communication is retrievable by the reader.
-                           If not, then use the in-text-only personal communication format -->
-                      <date variable="issued" form="text"/>
-                    </if>
-                    <else>
-                      <date variable="issued">
-                        <date-part name="year"/>
-                      </date>
-                    </else>
-                  </choose>
-                </if>
-                <else>
-                  <date variable="issued">
-                    <date-part name="year"/>
-                  </date>
-                </else>
-              </choose>
-              <text variable="year-suffix"/>
-            </group>
-          </group>
-        </group>
-      </if>
-      <else-if variable="status">
-        <!-- We print the status variable directly rather than using in-press, etc. terms. -->
-        <text variable="status" text-case="lowercase"/>
-        <text variable="year-suffix" prefix="-"/>
-      </else-if>
-      <else>
-        <text term="no date" form="short"/>
-        <text variable="year-suffix" prefix="-"/>
-      </else>
-    </choose>
-  </macro>
-  <!-- APA has two description elements following the title:
-       title (parenthetical) [bracketed] -->
+  <!-- 3. Title and descriptions -->
+  <!-- Three parts in title element (APA 9.21):
+
+       1. Title
+       2. Identification (in parentheses)
+       3. Description [in square brackets] -->
   <macro name="title-and-descriptions">
     <choose>
       <if variable="title">
         <group delimiter=" ">
-          <text macro="title"/>
-          <text macro="parenthetical"/>
-          <text macro="bracketed"/>
+          <text macro="title-bib"/>
+          <text macro="identification"/>
+          <text macro="description-bib"/>
         </group>
       </if>
       <else>
         <choose>
-          <if type="bill report" match="any">
+          <if match="any" type="bill report">
             <!-- Bills, resolutions, and congressional reports are not italicized and substitute bill number if no title. -->
-            <!-- Can't distinguish congressional reports from other reports, 
+            <!-- Can't distinguish congressional reports from other reports,
                  but giving the genre and number seems fine for other reports too. -->
-            <text macro="number"/>
-            <text macro="bracketed"/>
-            <text macro="parenthetical"/>
+            <text macro="genre-number"/>
+            <text macro="description-bib"/>
+            <text macro="identification"/>
           </if>
           <else>
             <group delimiter=" ">
-              <text macro="bracketed"/>
-              <text macro="parenthetical"/>
+              <text macro="description-bib"/>
+              <text macro="identification"/>
             </group>
           </else>
         </choose>
       </else>
     </choose>
   </macro>
-  <macro name="title">
+  <!-- 3.1. Title -->
+  <!-- Title utility macros -->
+  <macro name="title-intext-bill-report">
+    <!-- Bills, resolutions, and congressional reports are not italicized and substitute bill number if no title. -->
+    <!-- Can't distinguish congressional reports from other reports,
+             but giving the genre and number seems fine for other reports too. -->
     <choose>
-      <if type="post webpage" match="any">
+      <if variable="title">
+        <text form="short" text-case="title" variable="title"/>
+      </if>
+      <else>
+        <group delimiter=" ">
+          <text variable="genre"/>
+          <group delimiter=" ">
+            <choose>
+              <if match="none" variable="chapter-number container-title">
+                <text macro="number-labelled"/>
+              </if>
+              <else>
+                <text variable="number"/>
+              </else>
+            </choose>
+          </group>
+        </group>
+      </else>
+    </choose>
+  </macro>
+  <macro name="title-intext-interview-communication">
+    <choose>
+      <!-- These variables indicate that the letter is retrievable by the reader.
+                If not, then use the APA in-text-only personal communication format -->
+      <if match="none" variable="archive archive-place container-title DOI publisher URL">
+        <group delimiter=", ">
+          <names variable="author">
+            <substitute>
+              <text macro="title-intext"/>
+            </substitute>
+          </names>
+          <text term="personal-communication"/>
+        </group>
+      </if>
+      <else>
+        <names variable="author">
+          <name form="short"/>
+          <substitute>
+            <text macro="title-intext"/>
+          </substitute>
+        </names>
+      </else>
+    </choose>
+  </macro>
+  <macro name="title-part">
+    <group delimiter=". ">
+      <text macro="part-number-labelled"/>
+      <text text-case="capitalize-first" variable="part-title"/>
+    </group>
+  </macro>
+  <macro name="title-plus-part-title">
+    <choose>
+      <if match="any" type="review review-book" variable="reviewed-author reviewed-genre reviewed-title">
+        <!-- If a review has no `reviewed-title`, assume that `title` contains the title of the reviewed work
+             and omit it here; it is printed in the `reviewed-item` macro. -->
+        <choose>
+          <if match="none" variable="reviewed-title"/>
+          <else>
+            <group delimiter=": ">
+              <text variable="title"/>
+              <text macro="title-part"/>
+            </group>
+          </else>
+        </choose>
+      </if>
+      <else>
+        <group delimiter=": ">
+          <text variable="title"/>
+          <text macro="title-part"/>
+        </group>
+      </else>
+    </choose>
+  </macro>
+  <macro name="title-plus-volume-title">
+    <group delimiter=": ">
+      <text variable="title"/>
+      <text macro="title-volume"/>
+    </group>
+  </macro>
+  <macro name="title-volume">
+    <group delimiter=": ">
+      <choose>
+        <if variable="volume-title">
+          <group delimiter=". ">
+            <text macro="volume-labelled"/>
+            <text variable="volume-title"/>
+          </group>
+        </if>
+        <else-if is-numeric="volume" match="none">
+          <text macro="volume-labelled"/>
+        </else-if>
+      </choose>
+      <!-- For book-like items, assume part-number and part-title refer to the book/volume. -->
+      <text macro="title-part"/>
+    </group>
+  </macro>
+  <!-- Title logic -->
+  <macro name="booklike-title">
+    <!-- For book-like items, assume part-number and part-title refer to the book/volume. -->
+    <choose>
+      <if variable="container-title">
+        <text variable="title"/>
+      </if>
+      <else>
+        <!-- For book-like items without container titles and with volume-title, append volume-title to title (APA example 30) -->
+        <text font-style="italic" macro="title-plus-volume-title"/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="periodical-title">
+    <!-- For periodicals, assume that part-number and part-title refer to the article and append to title -->
+    <choose>
+      <if variable="container-title">
+        <text macro="title-plus-part-title"/>
+      </if>
+      <else>
+        <!-- for periodical items without container titles, don't append volume-title to title -->
+        <text font-style="italic" macro="title-plus-part-title"/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="title-bib">
+    <choose>
+      <if match="any" type="post webpage">
         <!-- Webpages are always italicized -->
-        <text macro="title-plus-part-title" font-style="italic"/>
+        <text font-style="italic" macro="title-plus-part-title"/>
       </if>
       <!-- Other types are italicized based on presence of container-title.
              Assume that review and review-book are published in periodicals/blogs,
-             not just on a web page (ex. 69) -->
-      <else-if type="article-journal article-magazine article-newspaper periodical post-weblog review review-book" match="any">
+             not just on a webpage (APA example 69) -->
+      <else-if match="any" type="article-journal article-magazine article-newspaper periodical post-weblog review review-book">
         <text macro="periodical-title"/>
       </else-if>
       <else-if type="paper-conference">
         <!-- Treat paper-conference as book-like if it has an editor, otherwise as periodical-like -->
         <choose>
-          <if variable="collection-editor compiler editor editorial-director" match="any">
+          <if match="any" variable="collection-editor compiler editor editorial-director">
             <text macro="booklike-title"/>
           </if>
           <else>
@@ -610,607 +813,104 @@
       </else>
     </choose>
   </macro>
-  <macro name="periodical-title">
-    <!-- For periodicals, assume that part-number and part-title refer to the article and append to title -->
-    <choose>
-      <if variable="container-title" match="any">
-        <text macro="title-plus-part-title"/>
-      </if>
-      <else>
-        <!-- for periodical items without container titles, don't append volume-title to title -->
-        <text macro="title-plus-part-title" font-style="italic"/>
-      </else>
-    </choose>
-  </macro>
-  <macro name="booklike-title">
-    <!-- For book-like items, assume part-number and part-title refer to the book/volume. -->
-    <choose>
-      <if variable="container-title" match="any">
-        <text variable="title"/>
-      </if>
-      <else>
-        <!-- For book-like items without container titles and with volume-title, append volume-title to title (ex. 30) -->
-        <text macro="title-plus-volume-title" font-style="italic"/>
-      </else>
-    </choose>
-  </macro>
-  <macro name="title-plus-part-title">
-    <choose>
-      <if variable="reviewed-author reviewed-genre reviewed-title" type="review review-book" match="any">
-        <!-- If a review has no `reviewed-title`, assume that `title` contains the title of the reviewed work
-             and omit it here; it is printed in the `reviewed-item` macro. -->
-        <choose>
-          <if variable="reviewed-title" match="none"/>
-          <else>
-            <group delimiter=": ">
-              <text variable="title"/>
-              <text macro="part-title"/>
-            </group>
-          </else>
-        </choose>
-      </if>
-      <else>
-        <group delimiter=": ">
-          <text variable="title"/>
-          <text macro="part-title"/>
-        </group>
-      </else>
-    </choose>
-  </macro>
-  <macro name="part-title">
-    <group delimiter=". ">
-      <group delimiter=" ">
-        <label variable="part-number" form="short" text-case="capitalize-first"/>
-        <text variable="part-number"/>
-      </group>
-      <text variable="part-title" text-case="capitalize-first"/>
-    </group>
-  </macro>
-  <macro name="title-plus-volume-title">
-    <group delimiter=": ">
-      <text variable="title"/>
-      <text macro="volume-title"/>
-    </group>
-  </macro>
-  <macro name="volume-title">
-    <group delimiter=": ">
-      <choose>
-        <if variable="volume-title">
-          <group delimiter=" ">
-            <group delimiter=". ">
-              <group delimiter=" ">
-                <label variable="volume" form="short" text-case="capitalize-first"/>
-                <text variable="volume"/>
-              </group>
-              <text variable="volume-title"/>
-            </group>
-          </group>
-        </if>
-        <else-if is-numeric="volume" match="none">
-          <group delimiter=" ">
-            <label variable="volume" form="short" text-case="capitalize-first"/>
-            <text variable="volume"/>
-          </group>
-        </else-if>
-      </choose>
-      <!-- For book-like items, assume part-number and part-title refer to the book/volume. -->
-      <text macro="part-title"/>
-    </group>
-  </macro>
   <macro name="title-intext">
     <choose>
-      <if type="bill report">
-        <!-- Bills, resolutions, and congressional reports are not italicized and substitute bill number if no title. -->
-        <!-- Can't distinguish congressional reports from other reports, 
-             but giving the genre and number seems fine for other reports too. -->
-        <choose>
-          <if variable="title">
-            <text variable="title" form="short" text-case="title"/>
-          </if>
-          <else>
-            <group delimiter=" ">
-              <text variable="genre"/>
-              <group delimiter=" ">
-                <choose>
-                  <if variable="chapter-number container-title" match="none">
-                    <label variable="number" form="short" text-case="capitalize-first"/>
-                  </if>
-                </choose>
-                <text variable="number"/>
-              </group>
-            </group>
-          </else>
-        </choose>
+      <if match="any" type="bill report">
+        <text macro="title-intext-bill-report"/>
       </if>
       <else>
         <choose>
-          <if variable="title" match="none">
-            <text macro="bracketed-intext"/>
+          <if match="none" variable="title">
+            <text macro="description-intext"/>
           </if>
-          <else-if type="hearing">
-            <!-- Hearings are italicized -->
-            <text variable="title" form="short" font-style="italic" text-case="title"/>
+          <else-if type="hearing webpage">
+            <!-- Italicized with title case -->
+            <text font-style="italic" form="short" text-case="title" variable="title"/>
           </else-if>
-          <else-if type="legal_case" match="any">
-            <!-- Cases are italicized -->
-            <text variable="title" font-style="italic"/>
+          <else-if type="legal_case post">
+            <!-- Italicized -->
+            <text font-style="italic" form="short" variable="title"/>
           </else-if>
-          <else-if type="legislation regulation treaty" match="any">
-            <!-- Legislation, regulations, and treaties not italicized or quoted -->
-            <text variable="title" form="short" text-case="title"/>
+          <else-if match="any" type="legislation regulation treaty">
+            <!-- No italics or quotes -->
+            <text form="short" text-case="title" variable="title"/>
           </else-if>
-          <else-if type="post webpage" match="any">
-            <!-- Webpages are always italicized -->
-            <text variable="title" form="short" font-style="italic" text-case="title"/>
-          </else-if>
-          <else-if variable="container-title" match="any">
-            <!-- Other types are italicized or quoted based on presence of container-title. As in title macro. -->
-            <text variable="title" form="short" quotes="true" text-case="title"/>
+          <else-if variable="container-title">
+            <!-- Other types are formatted based on presence of container-title, as in title-bib macro -->
+            <text form="short" quotes="true" text-case="title" variable="title"/>
           </else-if>
           <else>
-            <text variable="title" form="short" font-style="italic" text-case="title"/>
+            <text font-style="italic" form="short" text-case="title" variable="title"/>
           </else>
         </choose>
       </else>
     </choose>
   </macro>
-  <macro name="parenthetical">
-    <!-- (Secondary contributors; Database location; Genre no. 123; Report Series 123, Version, Edition, Volume, Page) -->
-    <group prefix="(" suffix=")">
-      <choose>
-        <if type="patent">
-          <!-- authority: U.S. ; genre: patent ; number: 123,445 -->
-          <group delimiter=" ">
-            <text variable="authority" form="short"/>
-            <choose>
-              <if variable="genre">
-                <text variable="genre" text-case="capitalize-first"/>
-              </if>
-              <else>
-                <text term="patent" text-case="capitalize-first"/>
-              </else>
-            </choose>
-            <group delimiter=" ">
-              <label variable="number" form="short" text-case="capitalize-first"/>
-              <text variable="number"/>
-            </group>
-          </group>
-        </if>
-        <else-if type="post webpage" match="any">
-          <!-- For post webpage, container-title is treated as publisher -->
-          <group delimiter="; ">
-            <text macro="secondary-contributors"/>
-            <text macro="database-location"/>
-            <text macro="number"/>
-            <text macro="locators-booklike"/>
-          </group>
-        </else-if>
-        <else-if type="report" match="any">
-          <choose>
-            <if variable="title" match="none">
-              <!-- If there is no title, then genre and number are already printed as the title. -->
-              <group delimiter="; ">
-                <text macro="secondary-contributors"/>
-                <text macro="database-location"/>
-                <text macro="locators-booklike"/>
-              </group>
-            </if>
-            <!-- If the report is a chapter in a larger report, then most parenthetical information is printed after the container. -->
-            <else-if variable="container-title">
-              <text macro="secondary-contributors"/>
-            </else-if>
-            <else>
-              <group delimiter="; ">
-                <text macro="secondary-contributors"/>
-                <text macro="database-location"/>
-                <text macro="number"/>
-                <text macro="locators-booklike"/>
-              </group>
-            </else>
-          </choose>
-        </else-if>
-        <else-if variable="container-title">
-          <group delimiter="; ">
-            <text macro="secondary-contributors"/>
-            <choose>
-              <if type="broadcast graphic map motion_picture song" match="any">
-                <!-- For audiovisual media, number information comes after title, not container-title (ex. 94) -->
-                <text macro="number"/>
-              </if>
-            </choose>
-          </group>
-        </else-if>
-        <else>
-          <group delimiter="; ">
-            <text macro="secondary-contributors"/>
-            <text macro="database-location"/>
-            <text macro="number"/>
-            <text macro="locators-booklike"/>
-          </group>
-        </else>
-      </choose>
-    </group>
-  </macro>
-  <macro name="parenthetical-container">
+  <!-- 3.2. Identification (in parentheses) -->
+  <!-- Identification utility macros -->
+  <macro name="database-location">
     <choose>
-      <if variable="container-title" match="any">
-        <group prefix="(" suffix=")">
-          <group delimiter="; ">
-            <text macro="database-location"/>
-            <choose>
-              <if type="broadcast graphic map motion_picture song" match="none">
-                <!-- For audiovisual media, number information comes after title, not container-title (ex. 94) -->
-                <text macro="number"/>
-              </if>
-            </choose>
-            <text macro="locators-booklike"/>
+      <if match="none" variable="archive-place">
+        <!-- With `archive-place`: physical archives. Without: online archives. -->
+        <text variable="archive_location"/>
+      </if>
+    </choose>
+  </macro>
+  <macro name="genre-number">
+    <choose>
+      <if variable="number">
+        <group delimiter=", ">
+          <group delimiter=" ">
+            <text text-case="title" variable="genre"/>
+            <text macro="number-labelled"/>
           </group>
+          <choose>
+            <if type="thesis">
+              <choose>
+                <if match="any" variable="archive DOI URL">
+                  <!-- Include the university in brackets if thesis is published -->
+                  <text variable="publisher"/>
+                </if>
+              </choose>
+            </if>
+          </choose>
         </group>
       </if>
     </choose>
   </macro>
-  <macro name="bracketed">
-    <!-- [Descriptive information] -->
-    <!-- If there is a number, genre is already printed in macro="number" -->
-    <group prefix="[" suffix="]">
+  <macro name="locators-booklike">
+    <choose>
+      <if variable="page">
+        <text macro="page-labelled"/>
+      </if>
+      <else-if variable="chapter-number">
+        <text macro="chapter-number-labelled"/>
+      </else-if>
+    </choose>
+  </macro>
+  <macro name="patent-number">
+    <group delimiter=" ">
+      <!-- authority: U.S. ; genre: patent ; number: 123,445 -->
+      <text form="short" variable="authority"/>
       <choose>
-        <if variable="reviewed-author reviewed-genre reviewed-title" type="review review-book" match="any">
-          <text macro="reviewed-item"/>
+        <if variable="genre">
+          <text text-case="capitalize-first" variable="genre"/>
         </if>
-        <else-if type="thesis">
-          <!-- Thesis type and institution -->
-          <group delimiter="; ">
-            <choose>
-              <if variable="number" match="none">
-                <group delimiter=", ">
-                  <text variable="genre" text-case="capitalize-first"/>
-                  <choose>
-                    <if variable="archive DOI URL" match="any">
-                      <!-- Include the university in brackets if thesis is published -->
-                      <text variable="publisher"/>
-                    </if>
-                  </choose>
-                </group>
-              </if>
-            </choose>
-            <text variable="medium" text-case="capitalize-first"/>
-          </group>
-        </else-if>
-        <else-if variable="interviewer" type="interview" match="any">
-          <!-- Interview information -->
-          <choose>
-            <if variable="title">
-              <text macro="format"/>
-            </if>
-            <else-if variable="genre">
-              <group delimiter="; ">
-                <group delimiter=" ">
-                  <text variable="genre" text-case="capitalize-first"/>
-                  <group delimiter=" ">
-                    <text term="container-author" form="verb"/>
-                    <names variable="interviewer">
-                      <name and="text" initialize-with=". " delimiter=", "/>
-                    </names>
-                  </group>
-                </group>
-              </group>
-            </else-if>
-            <else-if variable="interviewer">
-              <group delimiter="; ">
-                <names variable="interviewer">
-                  <label form="verb" suffix=" " text-case="capitalize-first"/>
-                  <name and="text" initialize-with=". " delimiter=", "/>
-                </names>
-                <text variable="medium" text-case="capitalize-first"/>
-              </group>
-            </else-if>
-            <else>
-              <text macro="format"/>
-            </else>
-          </choose>
-        </else-if>
-        <else-if type="personal_communication">
-          <!-- Letter information -->
-          <choose>
-            <if variable="recipient">
-              <group delimiter="; ">
-                <group delimiter=" ">
-                  <choose>
-                    <if variable="number" match="none">
-                      <choose>
-                        <if variable="genre">
-                          <text variable="genre" text-case="capitalize-first"/>
-                        </if>
-                        <else-if variable="medium">
-                          <text variable="medium" text-case="capitalize-first"/>
-                        </else-if>
-                        <else>
-                          <text term="letter" text-case="capitalize-first"/>
-                        </else>
-                      </choose>
-                    </if>
-                    <else>
-                      <choose>
-                        <if variable="medium">
-                          <text variable="medium" text-case="capitalize-first"/>
-                        </if>
-                        <else>
-                          <text term="letter" text-case="capitalize-first"/>
-                        </else>
-                      </choose>
-                    </else>
-                  </choose>
-                  <names variable="recipient" delimiter=", ">
-                    <label form="verb" suffix=" "/>
-                    <name and="text" delimiter=", "/>
-                  </names>
-                </group>
-                <choose>
-                  <if variable="genre" match="any">
-                    <choose>
-                      <if variable="number" match="none">
-                        <text variable="medium" text-case="capitalize-first"/>
-                      </if>
-                    </choose>
-                  </if>
-                </choose>
-              </group>
-            </if>
-            <else>
-              <text macro="format"/>
-            </else>
-          </choose>
-        </else-if>
-        <else-if variable="composer" type="song" match="all">
-          <!-- Performer of classical music works -->
-          <group delimiter="; ">
-            <choose>
-              <if variable="number" match="none">
-                <group delimiter=" ">
-                  <choose>
-                    <if variable="genre">
-                      <text variable="genre" text-case="capitalize-first"/>
-                      <group delimiter=" ">
-                        <text term="performer" form="verb"/>
-                        <names variable="author">
-                          <name and="text" initialize-with=". " delimiter=", "/>
-                          <substitute>
-                            <names variable="performer"/>
-                          </substitute>
-                        </names>
-                      </group>
-                    </if>
-                    <else-if variable="medium">
-                      <text variable="medium" text-case="capitalize-first"/>
-                      <group delimiter=" ">
-                        <text term="performer" form="verb"/>
-                        <names variable="author">
-                          <name and="text" initialize-with=". " delimiter=", "/>
-                          <substitute>
-                            <names variable="performer"/>
-                          </substitute>
-                        </names>
-                      </group>
-                    </else-if>
-                    <else>
-                      <text term="performer" form="verb" text-case="capitalize-first"/>
-                      <names variable="author">
-                        <name and="text" initialize-with=". " delimiter=", "/>
-                        <substitute>
-                          <names variable="performer"/>
-                        </substitute>
-                      </names>
-                    </else>
-                  </choose>
-                </group>
-              </if>
-              <else>
-                <group delimiter=" ">
-                  <choose>
-                    <if variable="medium">
-                      <text variable="medium" text-case="capitalize-first"/>
-                      <group delimiter=" ">
-                        <text term="performer" form="verb"/>
-                        <names variable="author">
-                          <name and="text" initialize-with=". " delimiter=", "/>
-                          <substitute>
-                            <names variable="performer"/>
-                          </substitute>
-                        </names>
-                      </group>
-                    </if>
-                    <else>
-                      <text term="performer" form="verb" text-case="capitalize-first"/>
-                      <names variable="author">
-                        <name and="text" initialize-with=". " delimiter=", "/>
-                        <substitute>
-                          <names variable="performer"/>
-                        </substitute>
-                      </names>
-                    </else>
-                  </choose>
-                </group>
-              </else>
-            </choose>
-            <choose>
-              <if variable="genre" match="any">
-                <choose>
-                  <if variable="number" match="none">
-                    <text variable="medium" text-case="capitalize-first"/>
-                  </if>
-                </choose>
-              </if>
-            </choose>
-          </group>
-        </else-if>
-        <else-if variable="container-title" match="none">
-          <!-- Other description -->
-          <text macro="format"/>
-        </else-if>
         <else>
-          <!-- For conference presentations/performances/events, chapters in reports/standards/generic documents, software, 
-               place bracketed after the container title -->
-          <choose>
-            <if type="event paper-conference performance speech" match="any">
-              <choose>
-                <if variable="collection-editor compiler editor editorial-director issue page volume" match="any">
-                  <text macro="format"/>
-                </if>
-              </choose>
-            </if>
-            <else-if type="document report software standard" match="none">
-              <text macro="format"/>
-            </else-if>
-          </choose>
+          <text term="patent" text-case="capitalize-first"/>
         </else>
       </choose>
-    </group>
-  </macro>
-  <macro name="bracketed-intext">
-    <group prefix="[" suffix="]">
-      <choose>
-        <if variable="reviewed-title" match="any">
-          <group delimiter=" ">
-            <text term="review-of" text-case="capitalize-first"/>
-            <text macro="reviewed-title-intext"/>
-          </group>
-        </if>
-        <else-if variable="interviewer" type="interview" match="any">
-          <names variable="interviewer">
-            <label form="verb" suffix=" " text-case="capitalize-first"/>
-            <name and="text" initialize-with=". " delimiter=", "/>
-            <substitute>
-              <text macro="format-intext"/>
-            </substitute>
-          </names>
-        </else-if>
-        <else-if type="personal_communication">
-          <!-- Letter information -->
-          <choose>
-            <if variable="recipient">
-              <group delimiter=" ">
-                <choose>
-                  <if variable="number" match="none">
-                    <text variable="genre" text-case="capitalize-first"/>
-                  </if>
-                  <else>
-                    <text term="letter" text-case="capitalize-first"/>
-                  </else>
-                </choose>
-                <names variable="recipient" delimiter=", ">
-                  <label form="verb" suffix=" "/>
-                  <name and="text" delimiter=", "/>
-                </names>
-              </group>
-            </if>
-            <else>
-              <text macro="format-intext"/>
-            </else>
-          </choose>
-        </else-if>
-        <else>
-          <text macro="format-intext"/>
-        </else>
-      </choose>
-    </group>
-  </macro>
-  <macro name="reviewed-item">
-    <!-- Reviewed item -->
-    <group delimiter="; ">
-      <group delimiter=", ">
-        <group delimiter=" ">
-          <choose>
-            <if variable="reviewed-genre">
-              <group delimiter=" ">
-                <text term="review-of" form="long" text-case="capitalize-first"/>
-                <text variable="reviewed-genre" text-case="lowercase"/>
-              </group>
-            </if>
-            <!-- If no `reviewed-genre`, assume that `genre` or `medium` is entered as 'Review of the book' or similar -->
-            <else-if variable="number" match="none">
-              <choose>
-                <if variable="genre">
-                  <text variable="genre" text-case="capitalize-first"/>
-                </if>
-                <else-if variable="medium">
-                  <text variable="medium" text-case="capitalize-first"/>
-                </else-if>
-                <else-if type="review-book">
-                  <group delimiter=" ">
-                    <text term="review-of" form="long" text-case="capitalize-first"/>
-                    <text term="book" form="long" text-case="lowercase"/>
-                  </group>
-                </else-if>
-                <else>
-                  <text term="review-of" form="short" text-case="capitalize-first"/>
-                </else>
-              </choose>
-            </else-if>
-            <else>
-              <choose>
-                <if variable="medium">
-                  <text variable="medium" text-case="capitalize-first"/>
-                </if>
-                <else-if type="review-book">
-                  <group delimiter=" ">
-                    <text term="review-of" form="long" text-case="capitalize-first"/>
-                    <text term="book" form="long" text-case="lowercase"/>
-                  </group>
-                </else-if>
-                <else>
-                  <text term="review-of" form="short" text-case="capitalize-first"/>
-                </else>
-              </choose>
-            </else>
-          </choose>
-          <text macro="reviewed-title"/>
-        </group>
-        <names variable="reviewed-author">
-          <label form="verb-short" suffix=" "/>
-          <name and="text" initialize-with=". " delimiter=", "/>
-        </names>
-      </group>
-      <choose>
-        <if variable="genre" match="any">
-          <choose>
-            <if variable="number" match="none">
-              <text variable="medium" text-case="capitalize-first"/>
-            </if>
-          </choose>
-        </if>
-      </choose>
-    </group>
-  </macro>
-  <macro name="bracketed-container">
-    <group prefix="[" suffix="]">
-      <choose>
-        <if type="event paper-conference performance speech" match="any">
-          <!-- Conference presentations should describe the session [container] in bracketed unless published in a proceedings -->
-          <choose>
-            <if variable="collection-editor compiler editor editorial-director issue page volume" match="none">
-              <text macro="format"/>
-            </if>
-          </choose>
-        </if>
-        <else-if type="software" match="all">
-          <!-- For entries in mobile app reference works, place bracketed after the container-title -->
-          <text macro="format"/>
-        </else-if>
-        <else-if type="document report standard">
-          <!-- For chapters in report, standards, and generic documents, place bracketed after the container title -->
-          <text macro="format"/>
-        </else-if>
-      </choose>
+      <text macro="number-labelled"/>
     </group>
   </macro>
   <macro name="secondary-contributors">
     <choose>
-      <if type="article-journal article-magazine article-newspaper periodical post-weblog review review-book" match="any">
+      <if match="any" type="article-journal article-magazine article-newspaper periodical post-weblog review review-book">
         <text macro="secondary-contributors-periodical"/>
       </if>
       <else-if type="paper-conference">
         <choose>
-          <if variable="collection-editor compiler editor editorial-director" match="any">
+          <if match="any" variable="collection-editor compiler editor editorial-director">
             <text macro="secondary-contributors-booklike"/>
           </if>
           <else>
@@ -1223,53 +923,37 @@
       </else>
     </choose>
   </macro>
-  <macro name="secondary-contributors-periodical">
-    <group delimiter="; ">
-      <choose>
-        <if variable="title">
-          <names variable="interviewer" delimiter="; ">
-            <name and="text" initialize-with=". " delimiter=", "/>
-            <label form="short" prefix=", " text-case="title"/>
-          </names>
-        </if>
-      </choose>
-      <names variable="translator narrator" delimiter="; ">
-        <name and="text" initialize-with=". " delimiter=", "/>
-        <label form="short" prefix=", " text-case="title"/>
-      </names>
-    </group>
-  </macro>
   <macro name="secondary-contributors-booklike">
     <group delimiter="; ">
       <choose>
         <if variable="title">
           <names variable="interviewer">
-            <name and="text" initialize-with=". " delimiter=", "/>
+            <name/>
             <label form="short" prefix=", " text-case="title"/>
           </names>
         </if>
       </choose>
       <choose>
-        <if type="post webpage" match="none">
+        <if match="none" type="post webpage">
           <!-- Webpages treat container-title like publisher -->
           <group delimiter="; ">
-            <names variable="illustrator narrator" delimiter="; ">
-              <name and="symbol" initialize-with=". " delimiter=", "/>
+            <names delimiter="; " variable="illustrator narrator">
+              <name/>
               <label form="short" prefix=", " text-case="title"/>
             </names>
             <choose>
-              <if variable="container-title" match="none">
+              <if match="none" variable="container-title">
                 <group delimiter="; ">
                   <names variable="container-author">
                     <label form="verb-short" suffix=" " text-case="title"/>
-                    <name and="symbol" initialize-with=". " delimiter=", "/>
+                    <name/>
                   </names>
-                  <names variable="editor translator" delimiter="; ">
-                    <name and="symbol" initialize-with=". " delimiter=", "/>
+                  <names delimiter="; " variable="editor translator">
+                    <name/>
                     <label form="short" prefix=", " text-case="title"/>
                   </names>
-                  <names variable="compiler chair organizer curator series-creator executive-producer" delimiter="; ">
-                    <name and="symbol" initialize-with=". " delimiter=", "/>
+                  <names delimiter="; " variable="compiler chair organizer curator series-creator executive-producer">
+                    <name/>
                     <label form="long" prefix=", " text-case="title"/>
                   </names>
                 </group>
@@ -1277,9 +961,9 @@
               <else>
                 <choose>
                   <!-- TODO: Check logic once processors start to automatically populate editor-translator. -->
-                  <if variable="editor-translator" match="none">
-                    <names variable="translator" delimiter="; ">
-                      <name and="symbol" initialize-with=". " delimiter=", "/>
+                  <if match="none" variable="editor-translator">
+                    <names delimiter="; " variable="translator">
+                      <name/>
                       <label form="short" prefix=", " text-case="title"/>
                     </names>
                   </if>
@@ -1292,18 +976,18 @@
           <group delimiter="; ">
             <names variable="container-author">
               <label form="verb-short" suffix=" " text-case="title"/>
-              <name and="text" initialize-with=". " delimiter=", "/>
+              <name/>
             </names>
-            <names variable="editor translator" delimiter="; ">
-              <name and="text" initialize-with=". " delimiter=", "/>
+            <names delimiter="; " variable="editor translator">
+              <name/>
               <label form="short" prefix=", " text-case="title"/>
             </names>
-            <names variable="illustrator narrator" delimiter="; ">
-              <name and="text" initialize-with=". " delimiter=", "/>
+            <names delimiter="; " variable="illustrator narrator">
+              <name/>
               <label form="short" prefix=", " text-case="title"/>
             </names>
-            <names variable="compiler chair organizer curator series-creator executive-producer" delimiter="; ">
-              <name and="text" initialize-with=". " delimiter=", "/>
+            <names delimiter="; " variable="compiler chair organizer curator series-creator executive-producer">
+              <name/>
               <label form="long" prefix=", " text-case="title"/>
             </names>
           </group>
@@ -1311,166 +995,398 @@
       </choose>
     </group>
   </macro>
-  <macro name="database-location">
+  <macro name="secondary-contributors-periodical">
+    <group delimiter="; ">
+      <choose>
+        <if variable="title">
+          <names delimiter="; " variable="interviewer">
+            <name/>
+            <label form="short" prefix=", " text-case="title"/>
+          </names>
+        </if>
+      </choose>
+      <names delimiter="; " variable="translator narrator">
+        <name/>
+        <label form="short" prefix=", " text-case="title"/>
+      </names>
+    </group>
+  </macro>
+  <macro name="version-edition-volume">
+    <group delimiter=", ">
+      <text macro="version-labelled"/>
+      <text macro="edition-labelled"/>
+      <text macro="volume-booklike"/>
+    </group>
+  </macro>
+  <macro name="volume-booklike">
+    <group delimiter=", ">
+      <!-- Report series (APA example 52) -->
+      <choose>
+        <if match="any" type="document report standard">
+          <group delimiter=" ">
+            <text text-case="title" variable="collection-title"/>
+            <text variable="collection-number"/>
+          </group>
+        </if>
+      </choose>
+      <text macro="supplement-number-labelled"/>
+      <choose>
+        <if variable="volume">
+          <choose>
+            <!-- Non-numeric volumes are already printed as part of the book title -->
+            <if variable="volume-title"/>
+            <else-if is-numeric="volume">
+              <text macro="volume-labelled"/>
+            </else-if>
+          </choose>
+        </if>
+        <else>
+          <text macro="number-of-volumes-labelled"/>
+        </else>
+      </choose>
+      <text macro="issue-labelled"/>
+      <text macro="locators-booklike"/>
+    </group>
+  </macro>
+  <!-- Identification logic -->
+  <macro name="identification">
+    <group delimiter="; " prefix="(" suffix=")">
+      <!-- (Secondary contributors; Database location; Genre no. 123; Report Series 123, Version, Edition, Volume, Page) -->
+      <choose>
+        <if type="patent">
+          <text macro="patent-number"/>
+        </if>
+        <else-if match="any" type="post webpage">
+          <!-- For post webpage, container-title is treated as publisher -->
+          <text macro="identification-with-all-parts"/>
+        </else-if>
+        <else-if match="any" type="report">
+          <choose>
+            <if match="none" variable="title">
+              <!-- If there is no title, then genre and number are already printed as the title. -->
+              <text macro="secondary-contributors"/>
+              <text macro="database-location"/>
+              <text macro="identification-booklike"/>
+            </if>
+            <!-- If the report is a chapter in a larger report, then most parenthetical information is printed after the container. -->
+            <else-if variable="container-title">
+              <text macro="secondary-contributors"/>
+            </else-if>
+            <else>
+              <text macro="identification-with-all-parts"/>
+            </else>
+          </choose>
+        </else-if>
+        <else-if variable="container-title">
+          <group delimiter="; ">
+            <text macro="secondary-contributors"/>
+            <choose>
+              <if match="any" type="broadcast graphic map motion_picture song">
+                <!-- For audiovisual media, number information comes after title, not container-title (ex. 94) -->
+                <text macro="genre-number"/>
+              </if>
+            </choose>
+          </group>
+        </else-if>
+        <else>
+          <text macro="identification-with-all-parts"/>
+        </else>
+      </choose>
+    </group>
+  </macro>
+  <macro name="identification-booklike">
     <choose>
-      <if variable="archive-place" match="none">
-        <!-- With `archive-place`: physical archives. Without: online archives. -->
-        <text variable="archive_location"/>
-      </if>
+      <if match="any" type="article-journal article-magazine article-newspaper broadcast event interview patent performance periodical post post-weblog review review-book speech webpage"/>
+      <else-if type="paper-conference">
+        <choose>
+          <if match="any" variable="collection-editor compiler editor editorial-director">
+            <text macro="version-edition-volume"/>
+          </if>
+        </choose>
+      </else-if>
+      <else>
+        <text macro="version-edition-volume"/>
+      </else>
     </choose>
   </macro>
-  <macro name="number">
+  <macro name="identification-with-all-parts">
+    <group delimiter="; ">
+      <text macro="secondary-contributors"/>
+      <text macro="database-location"/>
+      <text macro="genre-number"/>
+      <text macro="identification-booklike"/>
+    </group>
+  </macro>
+  <!-- 3.3. Description [in square brackets] -->
+  <!-- Description utility macros -->
+  <macro name="description-generic">
+    <!-- For conference presentations/performances/events, chapters in reports/standards/generic documents, software, place description after the container title -->
     <choose>
-      <if variable="number">
-        <group delimiter=", ">
+      <if match="any" type="event paper-conference performance speech">
+        <choose>
+          <if match="any" variable="collection-editor compiler editor editorial-director issue page volume">
+            <text macro="format-bib"/>
+          </if>
+        </choose>
+      </if>
+      <else-if match="none" type="document report software standard">
+        <text macro="format-bib"/>
+      </else-if>
+    </choose>
+  </macro>
+  <macro name="description-interview">
+    <choose>
+      <if variable="title">
+        <text macro="format-bib"/>
+      </if>
+      <else-if variable="genre">
+        <group delimiter="; ">
           <group delimiter=" ">
-            <text variable="genre" text-case="title"/>
+            <text text-case="capitalize-first" variable="genre"/>
             <group delimiter=" ">
-              <label variable="number" form="short" text-case="capitalize-first"/>
-              <text variable="number"/>
+              <text form="verb" term="container-author"/>
+              <names variable="interviewer"/>
             </group>
           </group>
+        </group>
+      </else-if>
+      <else-if variable="interviewer">
+        <group delimiter="; ">
+          <names variable="interviewer">
+            <label form="verb" suffix=" " text-case="capitalize-first"/>
+            <name/>
+          </names>
+          <text text-case="capitalize-first" variable="medium"/>
+        </group>
+      </else-if>
+      <else>
+        <text macro="format-bib"/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="description-letter-bib">
+    <choose>
+      <if variable="recipient">
+        <group delimiter="; ">
+          <group delimiter=" ">
+            <choose>
+              <if match="none" variable="number">
+                <choose>
+                  <if variable="genre">
+                    <text text-case="capitalize-first" variable="genre"/>
+                  </if>
+                  <else-if variable="medium">
+                    <text text-case="capitalize-first" variable="medium"/>
+                  </else-if>
+                  <else>
+                    <text term="letter" text-case="capitalize-first"/>
+                  </else>
+                </choose>
+              </if>
+              <else>
+                <choose>
+                  <if variable="medium">
+                    <text text-case="capitalize-first" variable="medium"/>
+                  </if>
+                  <else>
+                    <text term="letter" text-case="capitalize-first"/>
+                  </else>
+                </choose>
+              </else>
+            </choose>
+            <names variable="recipient">
+              <label form="verb" suffix=" "/>
+              <name initialize="false"/>
+            </names>
+          </group>
           <choose>
-            <if type="thesis">
+            <if variable="genre">
               <choose>
-                <!-- Include the university in brackets if thesis is published -->
-                <if variable="archive DOI URL" match="any">
-                  <text variable="publisher"/>
+                <if match="none" variable="number">
+                  <text text-case="capitalize-first" variable="medium"/>
                 </if>
               </choose>
             </if>
           </choose>
         </group>
       </if>
-    </choose>
-  </macro>
-  <macro name="locators-booklike">
-    <choose>
-      <if type="article-journal article-magazine article-newspaper broadcast event interview patent performance periodical post post-weblog review review-book speech webpage" match="any"/>
-      <else-if type="paper-conference">
-        <choose>
-          <if variable="collection-editor compiler editor editorial-director" match="any">
-            <group delimiter=", ">
-              <text macro="version"/>
-              <text macro="edition"/>
-              <text macro="volume-booklike"/>
-            </group>
-          </if>
-        </choose>
-      </else-if>
       <else>
-        <group delimiter=", ">
-          <text macro="version"/>
-          <text macro="edition"/>
-          <text macro="volume-booklike"/>
-        </group>
+        <text macro="format-bib"/>
       </else>
     </choose>
   </macro>
-  <macro name="version">
-    <group delimiter=" ">
-      <label variable="version" text-case="capitalize-first"/>
-      <text variable="version"/>
-    </group>
-  </macro>
-  <macro name="edition">
+  <macro name="description-letter-intext">
     <choose>
-      <if is-numeric="edition">
+      <if variable="recipient">
         <group delimiter=" ">
-          <number variable="edition" form="ordinal"/>
-          <label variable="edition" form="short"/>
-        </group>
-      </if>
-      <else>
-        <text variable="edition"/>
-      </else>
-    </choose>
-  </macro>
-  <macro name="volume-booklike">
-    <group delimiter=", ">
-      <!-- Report series [ex. 52] -->
-      <choose>
-        <if type="document report standard">
-          <group delimiter=" ">
-            <text variable="collection-title" text-case="title"/>
-            <text variable="collection-number"/>
-          </group>
-        </if>
-      </choose>
-      <group delimiter=" ">
-        <label variable="supplement-number" text-case="capitalize-first"/>
-        <text variable="supplement-number"/>
-      </group>
-      <choose>
-        <if variable="volume" match="any">
           <choose>
-            <!-- Non-numeric volumes are already printed as part of the book title -->
-            <if variable="volume-title"/>
-            <else-if is-numeric="volume" match="none"/>
+            <if match="none" variable="number">
+              <text text-case="capitalize-first" variable="genre"/>
+            </if>
+            <else-if variable="medium">
+              <text text-case="capitalize-first" variable="medium"/>
+            </else-if>
             <else>
-              <group delimiter=" ">
-                <label variable="volume" form="short" text-case="capitalize-first"/>
-                <number variable="volume" form="numeric"/>
-              </group>
+              <text term="letter" text-case="capitalize-first"/>
             </else>
           </choose>
-        </if>
-        <else>
-          <group>
-            <label variable="number-of-volumes" form="short" text-case="capitalize-first" suffix=" "/>
-            <text term="page-range-delimiter" prefix="1"/>
-            <number variable="number-of-volumes" form="numeric"/>
-          </group>
-        </else>
-      </choose>
-      <group delimiter=" ">
-        <label variable="issue" text-case="capitalize-first"/>
-        <text variable="issue"/>
-      </group>
-      <group delimiter=" ">
-        <label variable="page" form="short" suffix=" "/>
-        <text variable="page"/>
-      </group>
-    </group>
-  </macro>
-  <macro name="reviewed-title">
-    <choose>
-      <if variable="reviewed-title">
-        <!-- Not possible to distinguish TV series episode from other reviewed
-             works without reviewed-container-title [Ex. 69] -->
-        <!-- Adapt for reviewed-container-title if that becomes available -->
-        <text variable="reviewed-title" font-style="italic"/>
+          <names variable="recipient">
+            <label form="verb" suffix=" "/>
+            <name/>
+          </names>
+        </group>
       </if>
       <else>
-        <!-- Assume title is title of reviewed work -->
-        <text variable="title" font-style="italic"/>
+        <text macro="format-intext"/>
       </else>
     </choose>
   </macro>
-  <macro name="reviewed-title-intext">
-    <choose>
-      <if variable="reviewed-title">
-        <!-- Not possible to distinguish TV series episode from other reviewed
-             works without reviewed-container-title [Ex. 69] -->
-        <!-- Adapt for reviewed-container-title if that becomes available -->
-        <text variable="reviewed-title" form="short" font-style="italic" text-case="title"/>
-      </if>
-      <else>
-        <!-- Assume title is title of reviewed work -->
-        <text variable="title" form="short" font-style="italic" text-case="title"/>
-      </else>
-    </choose>
-  </macro>
-  <macro name="format">
-    <choose>
-      <if variable="genre medium" match="any">
-        <group delimiter="; ">
+  <macro name="description-reviewed">
+    <!-- Reviewed item -->
+    <group delimiter="; ">
+      <group delimiter=", ">
+        <group delimiter=" ">
           <choose>
-            <if variable="number" match="none">
-              <text variable="genre" text-case="capitalize-first"/>
+            <if variable="reviewed-genre">
+              <group delimiter=" ">
+                <text form="long" term="review-of" text-case="capitalize-first"/>
+                <text text-case="lowercase" variable="reviewed-genre"/>
+              </group>
+            </if>
+            <!-- If no `reviewed-genre`, assume that `genre` or `medium` is entered as 'Review of the book' or similar -->
+            <else-if match="none" variable="number">
+              <choose>
+                <if variable="genre">
+                  <text text-case="capitalize-first" variable="genre"/>
+                </if>
+                <else-if variable="medium">
+                  <text text-case="capitalize-first" variable="medium"/>
+                </else-if>
+                <else-if type="review-book">
+                  <group delimiter=" ">
+                    <text form="long" term="review-of" text-case="capitalize-first"/>
+                    <text form="long" term="book" text-case="lowercase"/>
+                  </group>
+                </else-if>
+                <else>
+                  <text form="short" term="review-of" text-case="capitalize-first"/>
+                </else>
+              </choose>
+            </else-if>
+            <else>
+              <choose>
+                <if variable="medium">
+                  <text text-case="capitalize-first" variable="medium"/>
+                </if>
+                <else-if type="review-book">
+                  <group delimiter=" ">
+                    <text form="long" term="review-of" text-case="capitalize-first"/>
+                    <text form="long" term="book" text-case="lowercase"/>
+                  </group>
+                </else-if>
+                <else>
+                  <text form="short" term="review-of" text-case="capitalize-first"/>
+                </else>
+              </choose>
+            </else>
+          </choose>
+          <text macro="reviewed-title-bib"/>
+        </group>
+        <names variable="reviewed-author">
+          <label form="verb-short" suffix=" "/>
+          <name/>
+        </names>
+      </group>
+      <choose>
+        <if variable="genre">
+          <choose>
+            <if match="none" variable="number">
+              <text text-case="capitalize-first" variable="medium"/>
             </if>
           </choose>
-          <text variable="medium" text-case="capitalize-first"/>
+        </if>
+      </choose>
+    </group>
+  </macro>
+  <macro name="description-song">
+    <!-- Performer of classical music works -->
+    <group delimiter="; ">
+      <group delimiter=" ">
+        <choose>
+          <if match="none" variable="number">
+            <choose>
+              <if variable="genre">
+                <text text-case="capitalize-first" variable="genre"/>
+                <text form="verb" term="performer"/>
+              </if>
+              <else-if variable="medium">
+                <text text-case="capitalize-first" variable="medium"/>
+                <text form="verb" term="performer"/>
+              </else-if>
+              <else>
+                <text form="verb" term="performer" text-case="capitalize-first"/>
+              </else>
+            </choose>
+          </if>
+          <else>
+            <!-- If there is a number, genre is already printed in `genre-number` macro -->
+            <choose>
+              <if variable="medium">
+                <text text-case="capitalize-first" variable="medium"/>
+                <text form="verb" term="performer"/>
+              </if>
+              <else>
+                <text form="verb" term="performer" text-case="capitalize-first"/>
+              </else>
+            </choose>
+          </else>
+        </choose>
+        <names variable="author">
+          <substitute>
+            <names variable="performer"/>
+          </substitute>
+        </names>
+      </group>
+      <choose>
+        <if variable="genre">
+          <choose>
+            <if match="none" variable="number">
+              <text text-case="capitalize-first" variable="medium"/>
+            </if>
+          </choose>
+        </if>
+      </choose>
+    </group>
+  </macro>
+  <macro name="description-thesis">
+    <!-- Thesis type and institution -->
+    <group delimiter="; ">
+      <choose>
+        <if match="none" variable="number">
+          <group delimiter=", ">
+            <text text-case="capitalize-first" variable="genre"/>
+            <choose>
+              <if match="any" variable="archive DOI URL">
+                <!-- Include the university in brackets if thesis is published -->
+                <text variable="publisher"/>
+              </if>
+            </choose>
+          </group>
+        </if>
+      </choose>
+      <text text-case="capitalize-first" variable="medium"/>
+    </group>
+  </macro>
+  <macro name="format-bib">
+    <choose>
+      <if match="any" variable="genre medium">
+        <group delimiter="; ">
+          <choose>
+            <if match="none" variable="number">
+              <text text-case="capitalize-first" variable="genre"/>
+            </if>
+          </choose>
+          <text text-case="capitalize-first" variable="medium"/>
         </group>
       </if>
       <else>
@@ -1480,11 +1396,11 @@
   </macro>
   <macro name="format-intext">
     <choose>
-      <if variable="genre" match="any">
-        <text variable="genre" text-case="capitalize-first"/>
+      <if variable="genre">
+        <text text-case="capitalize-first" variable="genre"/>
       </if>
       <else-if variable="medium">
-        <text variable="medium" text-case="capitalize-first"/>
+        <text text-case="capitalize-first" variable="medium"/>
       </else-if>
       <else>
         <text macro="generic-type-label"/>
@@ -1500,9 +1416,9 @@
       <else-if type="software">
         <text term="software" text-case="capitalize-first"/>
       </else-if>
-      <else-if type="interview personal_communication" match="any">
+      <else-if match="any" type="interview personal_communication">
         <choose>
-          <if variable="archive container-title DOI publisher URL" match="none">
+          <if match="none" variable="archive archive-place container-title DOI publisher URL">
             <text term="personal-communication" text-case="capitalize-first"/>
           </if>
           <else-if type="interview">
@@ -1542,18 +1458,108 @@
       </else-if>
     </choose>
   </macro>
-  <!-- APA 'source' element contains four parts:
-       container, event, publisher, access -->
+  <macro name="reviewed-title-bib">
+    <choose>
+      <if variable="reviewed-title">
+        <!-- Not possible to distinguish TV series episode from other reviewed
+             works without reviewed-container-title (APA example 69) -->
+        <!-- Adapt for reviewed-container-title if that becomes available -->
+        <text font-style="italic" variable="reviewed-title"/>
+      </if>
+      <else>
+        <!-- Assume title is title of reviewed work -->
+        <text font-style="italic" variable="title"/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="reviewed-title-intext">
+    <choose>
+      <if variable="reviewed-title">
+        <!-- Not possible to distinguish TV series episode from other reviewed
+             works without reviewed-container-title (APA example 69) -->
+        <!-- Adapt for reviewed-container-title if that becomes available -->
+        <text font-style="italic" form="short" text-case="title" variable="reviewed-title"/>
+      </if>
+      <else>
+        <!-- Assume title is title of reviewed work -->
+        <text font-style="italic" form="short" text-case="title" variable="title"/>
+      </else>
+    </choose>
+  </macro>
+  <!-- Description logic -->
+  <macro name="description-bib">
+    <group prefix="[" suffix="]">
+      <choose>
+        <if match="any" type="interview" variable="interviewer">
+          <text macro="description-interview"/>
+        </if>
+        <else-if match="any" type="review review-book" variable="reviewed-author reviewed-genre reviewed-title">
+          <text macro="description-reviewed"/>
+        </else-if>
+        <else-if type="personal_communication">
+          <text macro="description-letter-bib"/>
+        </else-if>
+        <else-if type="song" variable="composer">
+          <text macro="description-song"/>
+        </else-if>
+        <else-if type="thesis">
+          <text macro="description-thesis"/>
+        </else-if>
+        <else-if match="none" variable="container-title">
+          <!-- Other description -->
+          <text macro="format-bib"/>
+        </else-if>
+        <else>
+          <text macro="description-generic"/>
+        </else>
+      </choose>
+    </group>
+  </macro>
+  <macro name="description-intext">
+    <group prefix="[" suffix="]">
+      <choose>
+        <if variable="reviewed-title">
+          <group delimiter=" ">
+            <text term="review-of" text-case="capitalize-first"/>
+            <text macro="reviewed-title-intext"/>
+          </group>
+        </if>
+        <else-if match="any" type="interview" variable="interviewer">
+          <names variable="interviewer">
+            <label form="verb" suffix=" " text-case="capitalize-first"/>
+            <name/>
+            <substitute>
+              <text macro="format-intext"/>
+            </substitute>
+          </names>
+        </else-if>
+        <else-if type="personal_communication">
+          <text macro="description-letter-intext"/>
+        </else-if>
+        <else>
+          <text macro="format-intext"/>
+        </else>
+      </choose>
+    </group>
+  </macro>
+  <!-- 4. Source -->
+  <!-- Four parts in APA 'source' element:
+
+       1. Container
+       2. Event
+       3. Publication details
+       4. Access -->
+  <!-- 4.1. Container -->
   <macro name="container">
     <choose>
-      <if type="article-journal article-magazine article-newspaper periodical post-weblog review review-book" match="any">
+      <if match="any" type="article-journal article-magazine article-newspaper periodical post-weblog review review-book">
         <!-- Periodical items -->
         <text macro="container-periodical"/>
       </if>
       <else-if type="paper-conference">
         <!-- Determine if paper-conference is a periodical- or book-like -->
         <choose>
-          <if variable="editor editorial-director collection-editor container-author" match="any">
+          <if match="any" variable="collection-editor container-author editor editorial-director">
             <text macro="container-booklike"/>
           </if>
           <else>
@@ -1561,55 +1567,15 @@
           </else>
         </choose>
       </else-if>
-      <else-if type="post webpage" match="none">
-        <!-- post and webpage treat container-title like publisher -->
+      <else-if match="none" type="post webpage">
+        <!-- Webpages treat container-title like publisher -->
         <text macro="container-booklike"/>
       </else-if>
     </choose>
   </macro>
-  <macro name="container-periodical">
-    <group delimiter=". ">
-      <group delimiter=", ">
-        <text variable="container-title" font-style="italic" text-case="title"/>
-        <choose>
-          <if variable="volume">
-            <group>
-              <text variable="volume" font-style="italic"/>
-              <text variable="issue" prefix="(" suffix=")"/>
-            </group>
-          </if>
-          <else>
-            <text variable="issue" font-style="italic"/>
-          </else>
-        </choose>
-        <choose>
-          <if variable="number">
-            <!-- Ex. 6: Journal article with article number or eLocator -->
-            <group delimiter=" ">
-              <text term="article-locator" text-case="capitalize-first"/>
-              <text variable="number"/>
-            </group>
-          </if>
-          <else>
-            <text variable="page"/>
-          </else>
-        </choose>
-      </group>
-      <choose>
-        <if variable="issued">
-          <choose>
-            <if variable="issue number page volume" match="none">
-              <!-- We print the status variable directly rather than using in-press, etc. terms. -->
-              <text variable="status" text-case="capitalize-first"/>
-            </if>
-          </choose>
-        </if>
-      </choose>
-    </group>
-  </macro>
   <macro name="container-booklike">
     <choose>
-      <if variable="container-title" match="any">
+      <if variable="container-title">
         <group delimiter=" ">
           <choose>
             <if type="song">
@@ -1620,161 +1586,167 @@
             </else>
           </choose>
           <group delimiter=", ">
-            <names variable="executive-producer">
-              <name and="text" initialize-with=". " delimiter=", "/>
-              <label form="long" text-case="title" prefix=" (" suffix=")"/>
-              <substitute>
-                <names variable="series-creator"/>
-                <names variable="editor-translator">
-                  <name and="text" initialize-with=". " delimiter=", "/>
-                  <label form="short" text-case="title" prefix=" (" suffix=")"/>
-                </names>
-                <!-- TODO: Translator omitted here on the assumption that editor-translators are uncommon 
-                           for chapter citations. If needed, direct entry or automatic population of
-                           `editor-translator` can produce combined labels. -->
-                <names variable="editor">
-                  <name and="text" initialize-with=". " delimiter=", "/>
-                  <label form="short" text-case="title" prefix=" (" suffix=")"/>
-                </names>
-                <names variable="editorial-director">
-                  <name and="text" initialize-with=". " delimiter=", "/>
-                  <label form="short" text-case="title" prefix=" (" suffix=")"/>
-                </names>
-                <names variable="compiler"/>
-                <choose>
-                  <if type="event performance speech" match="any">
-                    <names variable="chair"/>
-                    <names variable="organizer"/>
-                  </if>
-                </choose>
-                <names variable="curator"/>
-                <names variable="collection-editor">
-                  <name and="text" initialize-with=". " delimiter=", "/>
-                  <label form="short" text-case="title" prefix=" (" suffix=")"/>
-                </names>
-                <names variable="container-author"/>
-              </substitute>
-            </names>
-            <group delimiter=": " font-style="italic">
-              <text variable="container-title"/>
-              <text macro="volume-title"/>
-            </group>
+            <text macro="container-contributors"/>
+            <text macro="container-title-booklike"/>
           </group>
-          <text macro="parenthetical-container"/>
-          <text macro="bracketed-container"/>
+          <text macro="container-identification"/>
+          <text macro="container-description"/>
         </group>
       </if>
     </choose>
   </macro>
-  <macro name="publisher">
-    <group delimiter="; ">
+  <macro name="container-periodical">
+    <group delimiter=". ">
+      <group delimiter=", ">
+        <text font-style="italic" text-case="title" variable="container-title"/>
+        <text macro="volume-periodical"/>
+        <text macro="locators-periodical"/>
+      </group>
       <choose>
-        <if type="thesis">
+        <if variable="issued">
           <choose>
-            <if variable="archive DOI URL" match="none">
-              <text variable="publisher"/>
+            <if match="none" variable="issue number page volume">
+              <!-- We print the status variable directly rather than using in-press, etc. terms. -->
+              <text text-case="capitalize-first" variable="status"/>
             </if>
           </choose>
         </if>
-        <else-if type="post webpage" match="any">
-          <!-- For websites, treat container title like publisher -->
-          <group delimiter="; ">
-            <text variable="container-title" text-case="title"/>
-            <text variable="publisher"/>
-          </group>
-        </else-if>
-        <else-if type="paper-conference">
-          <!-- For paper-conference, don't print publisher if in a journal-like proceedings -->
-          <choose>
-            <if variable="collection-editor compiler editor editorial-director" match="any">
-              <text variable="publisher"/>
-            </if>
-          </choose>
-        </else-if>
-        <else-if type="article-journal article-magazine article-newspaper periodical post-weblog review review-book" match="none">
-          <text variable="publisher"/>
-        </else-if>
       </choose>
-      <group delimiter=", ">
-        <choose>
-          <if variable="archive-place">
-            <!-- With `archive-place`: physical archives. Without: online archives. -->
-            <!-- For physical archives, print the location before the archive name.
-                For electronic archives, these are printed in macro="description". -->
-            <!-- Must test for archive_collection:
-                With collection: archive_collection (archive_location), archive, archive-place
-                No collection: archive (archive_location), archive-place
-            -->
-            <choose>
-              <if variable="archive_collection">
-                <group delimiter=" ">
-                  <text variable="archive_collection"/>
-                  <text variable="archive_location" prefix="(" suffix=")"/>
-                </group>
-                <text variable="archive"/>
-                <text variable="archive-place"/>
-              </if>
-              <else>
-                <group delimiter=" ">
-                  <text variable="archive"/>
-                  <text variable="archive_location" prefix="(" suffix=")"/>
-                </group>
-                <text variable="archive-place"/>
-              </else>
-            </choose>
-          </if>
-          <else>
-            <text variable="archive"/>
-          </else>
-        </choose>
-      </group>
     </group>
   </macro>
-  <macro name="access">
+  <!-- Container parallels main elements -->
+  <!-- 4.1.1. Author -->
+  <macro name="container-contributors">
+    <names variable="executive-producer">
+      <name/>
+      <label form="long" prefix=" (" suffix=")" text-case="title"/>
+      <substitute>
+        <names variable="series-creator"/>
+        <names variable="editor-translator">
+          <name/>
+          <label form="short" prefix=" (" suffix=")" text-case="title"/>
+        </names>
+        <!-- TODO: Translator omitted on the assumption that editor-translators are uncommon for chapter citations.
+             If needed, direct entry or automatic population of `editor-translator` can produce combined labels. -->
+        <names delimiter="; " variable="editor">
+          <name/>
+          <label form="short" prefix=" (" suffix=")" text-case="title"/>
+        </names>
+        <names variable="editorial-director">
+          <name/>
+          <label form="short" prefix=" (" suffix=")" text-case="title"/>
+        </names>
+        <names variable="compiler"/>
+        <choose>
+          <if match="any" type="event performance speech">
+            <names variable="chair"/>
+            <names variable="organizer"/>
+          </if>
+        </choose>
+        <names variable="curator"/>
+        <names variable="collection-editor">
+          <name/>
+          <label form="short" prefix=" (" suffix=")" text-case="title"/>
+        </names>
+        <names variable="container-author"/>
+      </substitute>
+    </names>
+  </macro>
+  <!-- 4.1.3.1 Container title -->
+  <macro name="container-title-booklike">
+    <group delimiter=": " font-style="italic">
+      <text variable="container-title"/>
+      <text macro="title-volume"/>
+    </group>
+  </macro>
+  <!-- 4.1.3.1 Container identification -->
+  <macro name="container-identification">
     <choose>
-      <if variable="DOI" match="any">
-        <text variable="DOI" prefix="https://doi.org/"/>
-      </if>
-      <else-if variable="URL">
-        <group delimiter=" ">
-          <choose>
-            <if variable="issued status" match="none">
-              <group delimiter=" ">
-                <text term="retrieved" text-case="capitalize-first"/>
-                <date variable="accessed" form="text" suffix=","/>
-                <text term="from"/>
-              </group>
-            </if>
-          </choose>
-          <text variable="URL"/>
+      <if variable="container-title">
+        <group prefix="(" suffix=")">
+          <group delimiter="; ">
+            <text macro="database-location"/>
+            <choose>
+              <if match="none" type="broadcast graphic map motion_picture song">
+                <!-- For audiovisual media, number information comes after title, not container-title (APA example 94) -->
+                <text macro="genre-number"/>
+              </if>
+            </choose>
+            <text macro="identification-booklike"/>
+          </group>
         </group>
-      </else-if>
+      </if>
     </choose>
   </macro>
+  <!-- 4.1.3.2 Container description -->
+  <macro name="container-description">
+    <group prefix="[" suffix="]">
+      <choose>
+        <if match="any" type="event paper-conference performance speech">
+          <!-- Conference presentations should describe the session [container] in description unless published in a proceedings -->
+          <choose>
+            <if match="none" variable="collection-editor compiler editor editorial-director issue page volume">
+              <text macro="format-bib"/>
+            </if>
+          </choose>
+        </if>
+        <else-if type="software">
+          <!-- For entries in mobile app reference works, place description after the container-title -->
+          <text macro="format-bib"/>
+        </else-if>
+        <else-if match="any" type="document report standard">
+          <!-- For chapters in report, standards, and generic documents, place description after the container title -->
+          <text macro="format-bib"/>
+        </else-if>
+      </choose>
+    </group>
+  </macro>
+  <!-- 4.1.4. Source -->
+  <macro name="locators-periodical">
+    <choose>
+      <if variable="number">
+        <text macro="number-article-labelled"/>
+      </if>
+      <else>
+        <text variable="page"/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="volume-periodical">
+    <group delimiter=", ">
+      <text font-style="italic" text-case="title" variable="collection-title"/>
+      <choose>
+        <if variable="volume">
+          <group>
+            <text font-style="italic" variable="volume"/>
+            <text prefix="(" suffix=")" variable="issue"/>
+          </group>
+        </if>
+        <else>
+          <text font-style="italic" variable="issue"/>
+        </else>
+      </choose>
+    </group>
+  </macro>
+  <!-- 4.2. Event -->
   <macro name="event">
     <choose>
-      <if variable="event event-title" match="any">
-        <!-- To prevent Zotero from printing event-place due to its double-mapping of all 'place' to
-             both publisher-place and event-place. Remove this 'choose' when that is changed. -->
+      <if match="any" variable="event event-title">
+        <!-- To prevent Zotero from printing `event-place` due to its double-mapping of all 'place' to
+             both `publisher-place` and `event-place`. Remove this when that is changed. -->
         <choose>
           <if type="paper-conference">
             <choose>
-              <if variable="collection-editor compiler editor editorial-director issue page volume" match="none">
+              <if match="none" variable="collection-editor compiler editor editorial-director issue page volume">
                 <!-- Don't print event info for conference papers published in a proceedings -->
-                <group delimiter=", ">
-                  <text macro="event-title"/>
-                  <text variable="event-place"/>
-                </group>
+                <text macro="event-title-place"/>
               </if>
             </choose>
           </if>
           <else>
             <!-- For other item types, print event info even if published (e.g., for collection catalogs, performance programs.
                  These items aren't given explicit examples in the APA manual, so err on the side of providing too much information. -->
-            <group delimiter=", ">
-              <text macro="event-title"/>
-              <text variable="event-place"/>
-            </group>
+            <text macro="event-title-place"/>
           </else>
         </choose>
       </if>
@@ -1782,9 +1754,9 @@
   </macro>
   <macro name="event-title">
     <choose>
-      <!-- TODO: We expect "event-title" to be used,
+      <!-- TODO: We expect `event-title` to be used,
            but processors and applications may not be updated yet.
-           This macro ensures that either "event" or "event-title" can be accpeted.
+           This macro ensures that either `event` or `event-title` can be accepted.
            Remove if procesor logic and application adoption can handle this. -->
       <if variable="event-title">
         <text variable="event-title"/>
@@ -1794,11 +1766,153 @@
       </else>
     </choose>
   </macro>
-  <!-- After 'source', APA also prints publication history (original publication, reprint info, retraction info) -->
+  <macro name="event-title-place">
+    <group delimiter=", ">
+      <text macro="event-title"/>
+      <text variable="event-place"/>
+    </group>
+  </macro>
+  <!-- 4.3. Publication details -->
+  <!-- Publication utility macros -->
+  <macro name="archive">
+    <group delimiter=", ">
+      <choose>
+        <if variable="archive-place">
+          <!-- With `archive-place`: physical archives. Without: online archives. -->
+          <!-- For physical archives, print the location before the archive name.
+                For electronic archives, these are printed in macro="description". -->
+          <!-- Must test for archive_collection:
+                With collection: archive_collection (archive_location), archive, archive-place
+                No collection: archive (archive_location), archive-place
+            -->
+          <choose>
+            <if variable="archive_collection">
+              <group delimiter=" ">
+                <text variable="archive_collection"/>
+                <text prefix="(" suffix=")" variable="archive_location"/>
+              </group>
+              <text variable="archive"/>
+              <text variable="archive-place"/>
+            </if>
+            <else>
+              <group delimiter=" ">
+                <text variable="archive"/>
+                <text prefix="(" suffix=")" variable="archive_location"/>
+              </group>
+              <text variable="archive-place"/>
+            </else>
+          </choose>
+        </if>
+        <else>
+          <text variable="archive"/>
+        </else>
+      </choose>
+    </group>
+  </macro>
+  <macro name="publisher">
+    <choose>
+      <if variable="publisher">
+        <text variable="publisher"/>
+      </if>
+      <else-if match="none" variable="event-place">
+        <!-- Work around Zotero double-mapping of event/publisher place -->
+        <text variable="publisher-place"/>
+      </else-if>
+    </choose>
+  </macro>
+  <!-- Publication logic -->
+  <macro name="publication">
+    <choose>
+      <if type="thesis">
+        <choose>
+          <if match="none" variable="archive DOI URL">
+            <text macro="publisher"/>
+          </if>
+        </choose>
+      </if>
+      <else-if match="any" type="post webpage">
+        <!-- Webpages treat container-title like publisher -->
+        <group delimiter="; ">
+          <text text-case="title" variable="container-title"/>
+          <text macro="publisher"/>
+        </group>
+      </else-if>
+      <else-if type="paper-conference">
+        <!-- For paper-conference, don't print publisher if in a journal-like proceedings -->
+        <choose>
+          <if match="any" variable="collection-editor compiler editor editorial-director">
+            <text macro="publisher"/>
+          </if>
+        </choose>
+      </else-if>
+      <else-if match="none" type="article-journal article-magazine article-newspaper periodical post-weblog review review-book">
+        <text macro="publisher"/>
+      </else-if>
+    </choose>
+  </macro>
+  <macro name="publication-archive">
+    <group delimiter="; ">
+      <text macro="publication"/>
+      <text macro="archive"/>
+    </group>
+  </macro>
+  <!-- 4.4. Access -->
+  <macro name="access">
+    <choose>
+      <if variable="DOI">
+        <text prefix="https://doi.org/" variable="DOI"/>
+      </if>
+      <else-if variable="URL">
+        <group delimiter=" ">
+          <choose>
+            <if match="none" variable="issued status">
+              <group delimiter=" ">
+                <text term="retrieved" text-case="capitalize-first"/>
+                <group delimiter=", ">
+                  <date form="text" variable="accessed"/>
+                  <text term="from"/>
+                </group>
+              </group>
+            </if>
+          </choose>
+          <text variable="URL"/>
+        </group>
+      </else-if>
+    </choose>
+  </macro>
+  <!-- 5. Publication history -->
+  <!-- History utility macros -->
+  <macro name="original-publisher">
+    <choose>
+      <if variable="original-publisher">
+        <text variable="original-publisher"/>
+      </if>
+      <else>
+        <text variable="original-publisher-place"/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="original-title">
+    <choose>
+      <if variable="original-title">
+        <text value="as"/>
+        <choose>
+          <if match="any" type="article-journal article-magazine article-newspaper periodical post-weblog review review-book">
+            <text variable="original-title"/>
+          </if>
+          <else>
+            <text font-style="italic" variable="original-title"/>
+          </else>
+        </choose>
+      </if>
+    </choose>
+  </macro>
+  <!-- History logic -->
   <macro name="publication-history">
+    <!-- Information appended to 'source': original publication, reprint info, retraction info -->
     <choose>
       <if type="patent">
-        <text variable="references" prefix="(" suffix=")"/>
+        <text prefix="(" suffix=")" variable="references"/>
       </if>
       <else>
         <group delimiter="; " prefix="(" suffix=")">
@@ -1806,8 +1920,8 @@
           <choose>
             <if variable="issued">
               <choose>
-                <if variable="issue number page volume" match="any">
-                  <text variable="status" text-case="capitalize-first"/>
+                <if match="any" variable="issue number page volume">
+                  <text text-case="capitalize-first" variable="status"/>
                 </if>
               </choose>
             </if>
@@ -1816,29 +1930,31 @@
             <if variable="references">
               <!-- This provides the option for more elaborate description
                     of publication history, such as full "reprinted" references
-                    (examples 11, 43, 44) -->
+                    (APA examples 11, 43, 44) -->
               <text variable="references"/>
             </if>
             <else>
-              <group delimiter=" ">
-                <text term="original-work-published" text-case="capitalize-first"/>
-                <choose>
-                  <if is-uncertain-date="original-date">
-                    <text term="circa" form="short"/>
-                  </if>
-                </choose>
-                <date variable="original-date">
-                  <date-part name="year"/>
-                </date>
-              </group>
+              <text macro="publication-history-variables"/>
             </else>
           </choose>
         </group>
       </else>
     </choose>
   </macro>
-  <!-- Legal citations have their own rules -->
-  <macro name="legal-cites">
+  <macro name="publication-history-variables">
+    <group delimiter=" ">
+      <text term="original-work-published" text-case="capitalize-first"/>
+      <group delimiter="; ">
+        <text macro="original-title"/>
+        <group delimiter=", ">
+          <text macro="original-publisher"/>
+          <text macro="original-date-year"/>
+        </group>
+      </group>
+    </group>
+  </macro>
+  <!-- Parallel rules for legal citations -->
+  <macro name="legal-bib">
     <!-- `treaty`: for treaties -->
     <!-- `legal_case`: for all legal and court cases -->
     <!-- `bill`: for bills, resolutions, federal reports -->
@@ -1850,16 +1966,14 @@
         <if type="treaty">
           <group delimiter=", " suffix=".">
             <!-- APA generally defers to Bluebook for legal citations, but diverges without
-                explanation for treaty items. We follow the Bluebook format that was used 
+                explanation for treaty items. We follow the Bluebook format that was used
                 in APA 6th ed. -->
-            <!-- APA manual omits treaty parties/authors, but per Bluebook 
+            <!-- APA manual omits treaty parties/authors, but per Bluebook
                 they should be included at least for bilateral treaties. -->
-            <names variable="author">
-              <name initialize-with="." form="short" delimiter="-"/>
-            </names>
+            <text macro="author-legal"/>
             <text macro="date-legal"/>
-            <!-- APA manual omits treaty source/report called for by Bluebook in favor of just URL. 
-                Both are included here, following the APA style used for all other item types 
+            <!-- APA manual omits treaty source/report called for by Bluebook in favor of just URL.
+                Both are included here, following the APA style used for all other item types
                 to end the reference with a period, then give the URL afterward. -->
             <text macro="container-legal"/>
           </group>
@@ -1871,7 +1985,7 @@
               <text macro="container-legal"/>
             </group>
             <text macro="date-legal"/>
-            <text macro="parenthetical-legal"/>
+            <text macro="identification-legal"/>
           </group>
         </else>
       </choose>
@@ -1879,20 +1993,75 @@
       <text macro="access"/>
     </group>
   </macro>
+  <!-- 1. Legal author -->
+  <macro name="author-legal">
+    <names variable="author">
+      <name delimiter="-" form="short"/>
+    </names>
+  </macro>
+  <!-- 2. Legal date -->
+  <macro name="date-legal-case">
+    <group delimiter=" " prefix="(" suffix=")">
+      <text variable="authority"/>
+      <choose>
+        <if variable="container-title">
+          <!-- Print only year for cases published in reporters-->
+          <text macro="date-issued-year"/>
+        </if>
+        <else>
+          <!-- APA manual doesn't include examples of cases not yet
+                   published in a reporter, but this is Bluebook style. -->
+          <text macro="date-issued-full"/>
+        </else>
+      </choose>
+    </group>
+  </macro>
+  <macro name="date-legal">
+    <choose>
+      <if type="treaty">
+        <text macro="date-issued-full"/>
+      </if>
+      <else-if type="legal_case">
+        <text macro="date-legal-case"/>
+      </else-if>
+      <else-if match="any" type="bill hearing legislation regulation">
+        <group delimiter=" " prefix="(" suffix=")">
+          <group delimiter=" ">
+            <text macro="original-date-year"/>
+            <text term="and"/>
+          </group>
+          <choose>
+            <if variable="issued">
+              <!-- APA manual includes "rev." before the revision year,
+                   but this isn't part of the Bluebook rules. -->
+              <text macro="date-issued-year"/>
+            </if>
+            <else>
+              <!-- Show proposal date for uncodified regualtions.
+                   Assume date is entered literally ala "proposed May 23, 2016".
+                   TODO: Add 'proposed' term here if that becomes available -->
+              <date form="text" variable="submitted"/>
+            </else>
+          </choose>
+        </group>
+      </else-if>
+    </choose>
+  </macro>
+  <!-- 3.1. Legal title -->
   <macro name="title-legal">
     <choose>
-      <if type="bill legal_case legislation regulation treaty" match="any">
-        <text variable="title" text-case="title"/>
+      <if match="any" type="bill legal_case legislation regulation treaty">
+        <text text-case="title" variable="title"/>
       </if>
       <else-if type="hearing">
-        <!-- APA uses a comma delimiter and omits "hearing before the" for hearings with testimony, 
+        <!-- APA uses a comma delimiter and omits "hearing before the" for hearings with testimony,
              but follows Bluebook rules (colon delimiter, prefix before the committee name) for
              references to the whole hearing. We simply follow the Bluebook rules for both, but
              use APA style capitalization (not capitalizing "Before" or the title of the hearing). -->
         <group delimiter=": " font-style="italic">
-          <text variable="title" text-case="capitalize-first"/>
+          <text text-case="capitalize-first" variable="title"/>
           <group delimiter=" ">
-            <text term="hearing" form="long" text-case="capitalize-first"/>
+            <text form="long" term="hearing" text-case="capitalize-first"/>
             <group delimiter=" ">
               <group delimiter=" ">
                 <!-- APA manual omits the bill number, but it should be included per Bluebook if relevant -->
@@ -1901,7 +2070,7 @@
               </group>
               <group delimiter=" ">
                 <!-- Use the `at` term to hold "before the" -->
-                <text term="at" form="long"/>
+                <text form="long" term="at"/>
                 <text variable="section"/>
               </group>
             </group>
@@ -1910,124 +2079,95 @@
       </else-if>
     </choose>
   </macro>
-  <macro name="date-legal">
+  <!-- 3.2. Legal identification (in parentheses) -->
+  <macro name="identification-legal">
     <choose>
-      <if type="treaty">
-        <date variable="issued" form="text"/>
+      <if type="hearing">
+        <group delimiter=" " prefix="(" suffix=")">
+          <!-- Use the 'verb' form of the hearing term to hold 'testimony of' -->
+          <text form="verb" term="hearing"/>
+          <names variable="author">
+            <name initialize="false"/>
+          </names>
+        </group>
       </if>
-      <else-if type="legal_case">
-        <group prefix="(" suffix=")" delimiter=" ">
-          <text variable="authority"/>
-          <choose>
-            <if variable="container-title" match="any">
-              <!-- Print only year for cases published in reporters-->
-              <date variable="issued" form="numeric" date-parts="year"/>
-            </if>
-            <else>
-              <!-- APA manual doesn't include examples of cases not yet
-                   published in a reporter, but this is Bluebook style. -->
-              <date variable="issued" form="text"/>
-            </else>
-          </choose>
-        </group>
-      </else-if>
-      <else-if type="bill hearing legislation regulation" match="any">
-        <group prefix="(" suffix=")" delimiter=" ">
-          <group delimiter=" ">
-            <date variable="original-date">
-              <date-part name="year"/>
-            </date>
-            <text term="and" form="symbol"/>
-          </group>
-          <choose>
-            <if variable="issued">
-              <!-- APA manual includes "rev." before the revision year, 
-                   but this isn't part of the Bluebook rules. -->
-              <date variable="issued">
-                <date-part name="year"/>
-              </date>
-            </if>
-            <else>
-              <!-- Show proposal date for uncodified regualtions. 
-                   Assume date is entered literally ala "proposed May 23, 2016".
-                   TODO: Add 'proposed' term here if that becomes available -->
-              <date variable="submitted" form="text"/>
-            </else>
-          </choose>
-        </group>
+      <else-if match="any" type="bill legislation regulation">
+        <!-- For uncodified regulations, assume future code section is in `status`. -->
+        <text prefix="(" suffix=")" variable="status"/>
       </else-if>
     </choose>
   </macro>
-  <macro name="container-legal">
-    <!-- Expect legal item container-titles to be stored in short form -->
+  <!-- 4. Legal source -->
+  <!-- Legal source utility macros -->
+  <macro name="container-bill">
+    <group delimiter=", ">
+      <group delimiter=" ">
+        <text variable="genre"/>
+        <group delimiter=" ">
+          <choose>
+            <!-- If there is no session number or code/record title, assume
+                     assume the item is a congressional report and include 'No.' term. -->
+            <if match="none" variable="chapter-number container-title">
+              <!-- The item is a congressional report, rather than a bill or resultion. -->
+              <text macro="number-labelled"/>
+            </if>
+            <else>
+              <text variable="number"/>
+            </else>
+          </choose>
+        </group>
+      </group>
+      <group delimiter=" ">
+        <text variable="authority"/>
+        <!-- 'session' is `chapter-number` -->
+        <text variable="chapter-number"/>
+      </group>
+      <group delimiter=" ">
+        <text variable="volume"/>
+        <text variable="container-title"/>
+        <text variable="page-first"/>
+      </group>
+    </group>
+  </macro>
+  <macro name="container-hearing">
+    <group delimiter=" ">
+      <text variable="authority"/>
+      <!-- 'session' is `chapter-number` -->
+      <text variable="chapter-number"/>
+    </group>
+  </macro>
+  <macro name="container-legal-case">
+    <group delimiter=" ">
+      <choose>
+        <if variable="container-title">
+          <group delimiter=" ">
+            <text variable="volume"/>
+            <text variable="container-title"/>
+            <text macro="section-labelled"/>
+            <choose>
+              <if match="any" variable="page page-first">
+                <text variable="page-first"/>
+              </if>
+              <else>
+                <text value="___"/>
+              </else>
+            </choose>
+          </group>
+        </if>
+        <else>
+          <text macro="number-labelled"/>
+        </else>
+      </choose>
+    </group>
+  </macro>
+  <macro name="container-legislation">
     <choose>
-      <if type="treaty">
-        <group delimiter=" ">
-          <number variable="volume"/>
-          <text variable="container-title"/>
-          <choose>
-            <if variable="page page-first" match="any">
-              <text variable="page-first"/>
-            </if>
-            <else>
-              <group delimiter=" ">
-                <label variable="number" form="short" text-case="capitalize-first"/>
-                <text variable="number"/>
-              </group>
-            </else>
-          </choose>
-        </group>
-      </if>
-      <else-if type="legal_case">
-        <group delimiter=" ">
-          <choose>
-            <if variable="container-title">
-              <group delimiter=" ">
-                <text variable="volume"/>
-                <text variable="container-title"/>
-                <group delimiter=" ">
-                  <label variable="section" form="symbol"/>
-                  <text variable="section"/>
-                </group>
-                <choose>
-                  <if variable="page page-first" match="any">
-                    <text variable="page-first"/>
-                  </if>
-                  <else>
-                    <text value="___"/>
-                  </else>
-                </choose>
-              </group>
-            </if>
-            <else>
-              <group delimiter=" ">
-                <label variable="number" form="short" text-case="capitalize-first"/>
-                <text variable="number"/>
-              </group>
-            </else>
-          </choose>
-        </group>
-      </else-if>
-      <else-if type="bill">
+      <if variable="number">
+        <!-- There's a public law number. -->
         <group delimiter=", ">
           <group delimiter=" ">
-            <text variable="genre"/>
-            <group delimiter=" ">
-              <choose>
-                <!-- If there is no session number or code/record title, assume
-                     assume the item is a congressional report and include 'No.' term. -->
-                <if variable="chapter-number container-title" match="none">
-                  <!-- The item is a congressional report, rather than a bill or resultion. -->
-                  <label variable="number" form="short" text-case="capitalize-first"/>
-                </if>
-              </choose>
-              <text variable="number"/>
-            </group>
-          </group>
-          <group delimiter=" ">
-            <text variable="authority"/>
-            <!-- 'session' is `chapter-number` -->
-            <text variable="chapter-number"/>
+            <text value="Pub. L. No."/>
+            <text variable="number"/>
           </group>
           <group delimiter=" ">
             <text variable="volume"/>
@@ -2035,149 +2175,139 @@
             <text variable="page-first"/>
           </group>
         </group>
-      </else-if>
-      <else-if type="hearing">
+      </if>
+      <else>
         <group delimiter=" ">
-          <text variable="authority"/>
-          <!-- 'session' is `chapter-number` -->
-          <text variable="chapter-number"/>
+          <text variable="volume"/>
+          <text variable="container-title"/>
+          <choose>
+            <if variable="section">
+              <text macro="section-labelled"/>
+            </if>
+            <else>
+              <text variable="page-first"/>
+            </else>
+          </choose>
         </group>
-      </else-if>
-      <else-if type="legislation">
+      </else>
+    </choose>
+  </macro>
+  <macro name="container-regulation">
+    <group delimiter=", ">
+      <group delimiter=" ">
+        <text variable="genre"/>
+        <text macro="number-labelled"/>
+      </group>
+      <group delimiter=" ">
+        <text variable="volume"/>
+        <text variable="container-title"/>
         <choose>
-          <if variable="number">
-            <!-- There's a public law number. -->
-            <group delimiter=", ">
-              <text variable="number" prefix="Pub. L. No. "/>
-              <group delimiter=" ">
-                <text variable="volume"/>
-                <text variable="container-title"/>
-                <text variable="page-first"/>
-              </group>
-            </group>
+          <if variable="section">
+            <text macro="section-labelled"/>
           </if>
           <else>
-            <group delimiter=" ">
-              <text variable="volume"/>
-              <text variable="container-title"/>
-              <choose>
-                <if variable="section">
-                  <group delimiter=" ">
-                    <label variable="section" form="symbol"/>
-                    <text variable="section"/>
-                  </group>
-                </if>
-                <else>
-                  <text variable="page-first"/>
-                </else>
-              </choose>
-            </group>
+            <text variable="page-first"/>
           </else>
         </choose>
-      </else-if>
-      <else-if type="regulation">
-        <group delimiter=", ">
-          <group delimiter=" ">
-            <text variable="genre"/>
-            <group delimiter=" ">
-              <label variable="number" form="short" text-case="capitalize-first"/>
-              <text variable="number"/>
-            </group>
-          </group>
-          <group delimiter=" ">
-            <text variable="volume"/>
-            <text variable="container-title"/>
-            <choose>
-              <if variable="section">
-                <group delimiter=" ">
-                  <label variable="section" form="symbol"/>
-                  <text variable="section"/>
-                </group>
-              </if>
-              <else>
-                <text variable="page-first"/>
-              </else>
-            </choose>
-          </group>
-        </group>
-      </else-if>
-    </choose>
-  </macro>
-  <macro name="parenthetical-legal">
-    <choose>
-      <if type="hearing">
-        <group prefix="(" suffix=")" delimiter=" ">
-          <!-- Use the 'verb' form of the hearing term to hold 'testimony of' -->
-          <text term="hearing" form="verb"/>
-          <names variable="author">
-            <name and="text" delimiter=", "/>
-          </names>
-        </group>
-      </if>
-      <else-if type="bill legislation regulation" match="any">
-        <!-- For uncodified regulations, assume future code section is in `status`. -->
-        <text variable="status" prefix="(" suffix=")"/>
-      </else-if>
-    </choose>
-  </macro>
-  <macro name="citation-locator">
-    <!-- Abbreviate page and paragraph, leave other locator labels in long form, cf. Rule 8.13 -->
-    <group delimiter=" ">
-      <choose>
-        <if locator="page paragraph" match="any">
-          <label variable="locator" form="short"/>
-        </if>
-        <else>
-          <label variable="locator" text-case="capitalize-first"/>
-        </else>
-      </choose>
-      <text variable="locator"/>
+      </group>
     </group>
   </macro>
-  <citation et-al-min="3" et-al-use-first="1" disambiguate-add-year-suffix="true" disambiguate-add-names="true" disambiguate-add-givenname="true" collapse="year" givenname-disambiguation-rule="primary-name-with-initials">
+  <macro name="container-treaty">
+    <group delimiter=" ">
+      <number variable="volume"/>
+      <text variable="container-title"/>
+      <choose>
+        <if match="any" variable="page page-first">
+          <text variable="page-first"/>
+        </if>
+        <else>
+          <text macro="number-labelled"/>
+        </else>
+      </choose>
+    </group>
+  </macro>
+  <!-- Legal source logic -->
+  <macro name="container-legal">
+    <!-- Expect legal item container-titles to be stored in short form -->
+    <choose>
+      <if type="bill">
+        <text macro="container-bill"/>
+      </if>
+      <else-if type="hearing">
+        <text macro="container-hearing"/>
+      </else-if>
+      <else-if type="legal_case">
+        <text macro="container-legal-case"/>
+      </else-if>
+      <else-if type="legislation">
+        <text macro="container-legislation"/>
+      </else-if>
+      <else-if type="regulation">
+        <text macro="container-regulation"/>
+      </else-if>
+      <else-if type="treaty">
+        <text macro="container-treaty"/>
+      </else-if>
+    </choose>
+  </macro>
+  <!-- Main logic -->
+  <citation collapse="year" disambiguate-add-givenname="true" disambiguate-add-names="true" disambiguate-add-year-suffix="true" et-al-min="3" et-al-use-first="1" givenname-disambiguation-rule="primary-name-with-initials">
     <sort>
       <key macro="author-sort" names-min="3" names-use-first="1"/>
       <key macro="date-sort-group" sort="ascending"/>
       <key macro="date-sort" sort="ascending"/>
       <key variable="status"/>
     </sort>
-    <layout prefix="(" suffix=")" delimiter="; ">
+    <layout delimiter="; " prefix="(" suffix=")">
       <group delimiter=", ">
         <text macro="author-intext"/>
         <text macro="date-intext"/>
-        <text macro="citation-locator"/>
+        <text macro="locator-labelled"/>
       </group>
     </layout>
   </citation>
-  <bibliography hanging-indent="true" et-al-min="21" et-al-use-first="19" et-al-use-last="true" entry-spacing="0" line-spacing="2">
+  <macro name="bibliography">
+    <group delimiter=" ">
+      <group delimiter=". " suffix=".">
+        <text macro="author-bib"/>
+        <text macro="date-bib"/>
+        <text macro="title-and-descriptions"/>
+        <text macro="container"/>
+        <text macro="event"/>
+        <text macro="publication-archive"/>
+      </group>
+      <text macro="access"/>
+      <text macro="publication-history"/>
+    </group>
+  </macro>
+  <macro name="bibliography-filtered">
+    <choose>
+      <if match="any" type="bill hearing legal_case legislation regulation treaty">
+        <!-- Legal items have different orders and delimiters -->
+        <text macro="legal-bib"/>
+      </if>
+      <else-if type="personal_communication">
+        <choose>
+          <if match="any" variable="archive archive-place container-title DOI publisher URL">
+            <text macro="bibliography"/>
+          </if>
+        </choose>
+      </else-if>
+      <else>
+        <text macro="bibliography"/>
+      </else>
+    </choose>
+  </macro>
+  <bibliography entry-spacing="0" et-al-min="21" et-al-use-first="19" et-al-use-last="true" hanging-indent="true" line-spacing="2">
     <sort>
       <key macro="author-sort"/>
       <key macro="date-sort-group" sort="ascending"/>
       <key macro="date-sort" sort="ascending"/>
       <key variable="status"/>
-      <key macro="title"/>
+      <key macro="title-bib"/>
     </sort>
     <layout>
-      <choose>
-        <if type="bill hearing legal_case legislation regulation treaty" match="any">
-          <!-- Legal items have different orders and delimiters -->
-          <text macro="legal-cites"/>
-        </if>
-        <else>
-          <group delimiter=" ">
-            <group delimiter=". " suffix=".">
-              <text macro="author-bib"/>
-              <text macro="date-bib"/>
-              <text macro="title-and-descriptions"/>
-              <text macro="container"/>
-              <text macro="event"/>
-              <text macro="publisher"/>
-            </group>
-            <text macro="access"/>
-            <text macro="publication-history"/>
-          </group>
-        </else>
-      </choose>
+      <text macro="bibliography-filtered"/>
     </layout>
   </bibliography>
 </style>

--- a/apa-no-initials.csl
+++ b/apa-no-initials.csl
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
-<style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" demote-non-dropping-particle="never" page-range-format="expanded">
+<style xmlns="http://purl.org/net/xbiblio/csl" and="symbol" class="in-text" demote-non-dropping-particle="never" names-delimiter=", " page-range-format="expanded" version="1.0">
   <info>
     <title>American Psychological Association 7th edition (no initials)</title>
-    <title-short>APA (no initials)</title-short>
+    <title-short>APA Style (no initials)</title-short>
     <id>http://www.zotero.org/styles/apa-no-initials</id>
     <link href="http://www.zotero.org/styles/apa-no-initials" rel="self"/>
     <link href="http://www.zotero.org/styles/apa" rel="template"/>
@@ -10,48 +10,53 @@
     <author>
       <name>Brenton M. Wiernik</name>
       <email>zotero@wiernik.org</email>
+      <uri>https://orcid.org/0000-0001-9560-6336</uri>
     </author>
+    <contributor>
+      <name>Andrew Dunning</name>
+      <uri>https://orcid.org/0000-0003-0464-5036</uri>
+    </contributor>
     <category citation-format="author-date"/>
     <category field="psychology"/>
     <category field="generic-base"/>
+    <summary>Author–date system of the Publication manual of the American Psychological Association: The official guide to APA style (2020)</summary>
     <updated>2024-07-09T20:08:41+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale xml:lang="en">
     <terms>
-      <term name="editortranslator" form="short">
-        <single>ed. &amp; trans.</single>
-        <multiple>eds. &amp; trans.</multiple>
-      </term>
-      <term name="editor-translator" form="short">
-        <single>ed. &amp; trans.</single>
-        <multiple>eds. &amp; trans.</multiple>
-      </term>
-      <term name="translator" form="short">trans.</term>
-      <term name="interviewer" form="short">
-        <single>interviewer</single>
-        <multiple>interviewers</multiple>
-      </term>
-      <term name="collection-editor" form="short">
+      <term name="ad"> C.E.</term>
+      <term form="long" name="at">before the</term>
+      <term name="bc"> B.C.E.</term>
+      <term form="short" name="circa">ca.</term>
+      <term name="collection">archival collection</term>
+      <term form="short" name="collection-editor">
         <single>ed.</single>
         <multiple>eds.</multiple>
       </term>
-      <term name="performer" form="verb">recorded by</term>
-      <term name="circa" form="short">ca.</term>
-      <term name="bc"> B.C.E.</term>
-      <term name="ad"> C.E.</term>
-      <term name="issue" form="long">
+      <term form="short" name="editor-translator">
+        <single>ed. &amp; trans.</single>
+        <multiple>eds. &amp; trans.</multiple>
+      </term>
+      <term form="short" name="editortranslator">
+        <single>ed. &amp; trans.</single>
+        <multiple>eds. &amp; trans.</multiple>
+      </term>
+      <term form="verb" name="hearing">testimony of</term>
+      <term form="short" name="interviewer">
+        <single>interviewer</single>
+        <multiple>interviewers</multiple>
+      </term>
+      <term form="long" name="issue">
         <single>issue</single>
         <multiple>issues</multiple>
       </term>
-      <term name="software">computer software</term>
-      <term name="at" form="long">before the</term>
-      <term name="collection">archival collection</term>
+      <term form="verb" name="performer">recorded by</term>
       <term name="post">online post</term>
-      <term name="at" form="long">before the</term>
-      <term name="hearing" form="verb">testimony of</term>
-      <term name="review-of" form="long">review of the</term>
-      <term name="review-of" form="short">review of</term>
+      <term form="long" name="review-of">review of the</term>
+      <term form="short" name="review-of">review of</term>
+      <term name="software">computer software</term>
+      <term form="short" name="translator">trans.</term>
     </terms>
   </locale>
   <locale xml:lang="da">
@@ -71,7 +76,7 @@
   </locale>
   <locale xml:lang="fr">
     <terms>
-      <term name="editor" form="short">
+      <term form="short" name="editor">
         <single>éd.</single>
         <multiple>éds.</multiple>
       </term>
@@ -97,29 +102,26 @@
       <term name="et-al">et al.</term>
     </terms>
   </locale>
-  <!-- For Indigeneous Knowledge, assume the item is stored as `document` or `speech`
-       and that Nation/Community, treaty, where the Elder lives, 
-       and topic are all stored in `title`
-       cf. https://libguides.norquest.ca/c.php?g=314831&p=5188823.
-       If the item is stored as `interview`, assume that Nation/Community, treat, and topic
-       are stored in `title`, 'Oral teaching' or similar is stored in `archive`, and where
-       the Elder lives is stored in `archive-place`. 
-  -->
-  <!-- Reviews are detected if an item has type `review` or `review-book` or if it has any of the variables
-       `reviewed-title`, `reviewed-author`, or `reviewed-genre`. For the latter case, reviews are commonly 
-       stored as types `article-journal`, `article-magazine`, `article-newspaper`, `post-weblog`, or `webpage` 
-  -->
-  <!-- General categories of item types:
-       Periodical: article-journal article-magazine article-newspaper periodical post-weblog review review-book
-       Periodical or Booklike: paper-conference
-       Booklike: article book broadcast chapter classic collection dataset document
-                 entry entry-dictionary entry-encyclopedia event figure
-                 graphic interview manuscript map motion_picture musical_score
-                 pamphlet patent performance personal_communication post report
-                 software song speech standard thesis webpage
-       Legal: bill hearing legal_case legislation regulation treaty
+  <!-- General categories of CSL item types:
+
+       Periodical
+       : article-journal article-magazine article-newspaper periodical post-weblog review review-book
+
+       Periodical or Booklike
+       : paper-conference
+
+       Booklike
+       : article book broadcast chapter classic collection dataset document
+         entry entry-dictionary entry-encyclopedia event figure
+         graphic interview manuscript map motion_picture musical_score
+         pamphlet patent performance personal_communication post report
+         software song speech standard thesis webpage
+
+       Legal
+       : bill hearing legal_case legislation regulation treaty
   -->
   <!-- Equivalencies:
+
        classic == book
        document == report, but give full date
        standard == report
@@ -128,6 +130,7 @@
        collection == book, but give full date
   -->
   <!-- Role equivalencies:
+
        compiler == editor
        organizer, curator == chair
        script-writer == director
@@ -135,128 +138,294 @@
        guest, host == director
        series-creator, executive-producer == editor
   -->
-  <!-- APA references contain four parts: author, date, title, source -->
+  <!-- Reviews are detected if an item has type `review` or `review-book` or if it has any of the variables
+       `reviewed-title`, `reviewed-author`, or `reviewed-genre`. For the latter case, reviews are commonly
+       stored as types `article-journal`, `article-magazine`, `article-newspaper`, `post-weblog`, or `webpage`
+  -->
+  <!-- For Indigeneous Knowledge, assume the item is stored as `document` or `speech`
+       and that Nation/Community, treaty, where the Elder lives,
+       and topic are all stored in `title`
+       cf. https://libguides.norquest.ca/c.php?g=314831&p=5188823.
+       If the item is stored as `interview`, assume that Nation/Community, treaty territory, and topic
+       are stored in `title`, 'Oral teaching' or similar is stored in `archive`, and where
+       the Elder lives is stored in `archive-place`.
+  -->
+  <!-- Variable labelling macros -->
+  <macro name="chapter-number-labelled">
+    <group delimiter=" ">
+      <choose>
+        <if is-numeric="chapter-number">
+          <label form="short" variable="chapter-number"/>
+        </if>
+      </choose>
+      <text variable="chapter-number"/>
+    </group>
+  </macro>
+  <macro name="edition-labelled">
+    <choose>
+      <if is-numeric="edition">
+        <group delimiter=" ">
+          <number form="ordinal" variable="edition"/>
+          <label form="short" variable="edition"/>
+        </group>
+      </if>
+      <else>
+        <text variable="edition"/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="issue-labelled">
+    <group delimiter=" ">
+      <label text-case="capitalize-first" variable="issue"/>
+      <text variable="issue"/>
+    </group>
+  </macro>
+  <macro name="locator-labelled">
+    <!-- Abbreviate page and paragraph; leave other locator labels in long form (APA 8.13) -->
+    <group delimiter=" ">
+      <choose>
+        <if locator="page paragraph" match="any">
+          <label form="short" variable="locator"/>
+        </if>
+        <else>
+          <label text-case="capitalize-first" variable="locator"/>
+        </else>
+      </choose>
+      <text variable="locator"/>
+    </group>
+  </macro>
+  <macro name="number-labelled">
+    <group delimiter=" ">
+      <choose>
+        <if is-numeric="number">
+          <label form="short" text-case="capitalize-first" variable="number"/>
+        </if>
+        <else-if match="none" type="broadcast">
+          <label form="short" text-case="capitalize-first" variable="number"/>
+        </else-if>
+      </choose>
+      <text variable="number"/>
+    </group>
+  </macro>
+  <macro name="number-article-labelled">
+    <!-- APA example 6: Journal article with article number or eLocator -->
+    <group delimiter=" ">
+      <text term="article-locator" text-case="capitalize-first"/>
+      <text variable="number"/>
+    </group>
+  </macro>
+  <macro name="number-of-volumes-labelled">
+    <choose>
+      <if is-numeric="number-of-volumes">
+        <group delimiter=" ">
+          <label form="short" text-case="capitalize-first" variable="number-of-volumes"/>
+          <text prefix="1" term="page-range-delimiter"/>
+        </group>
+      </if>
+    </choose>
+    <text variable="number-of-volumes"/>
+  </macro>
+  <macro name="page-labelled">
+    <group delimiter=" ">
+      <label form="short" variable="page"/>
+      <text variable="page"/>
+    </group>
+  </macro>
+  <macro name="part-number-labelled">
+    <group delimiter=" ">
+      <choose>
+        <if variable="part-number">
+          <!-- TODO: Replace with `part-number` label when CSL provides one -->
+          <text form="short" term="part" text-case="capitalize-first"/>
+          <text variable="part-number"/>
+        </if>
+      </choose>
+    </group>
+  </macro>
+  <macro name="section-labelled">
+    <group delimiter=" ">
+      <label form="symbol" variable="section"/>
+      <text variable="section"/>
+    </group>
+  </macro>
+  <macro name="supplement-number-labelled">
+    <group delimiter=" ">
+      <choose>
+        <if variable="supplement-number">
+          <!-- TODO: Replace with `supplement-number` label when CSL provides one -->
+          <text form="short" term="supplement" text-case="capitalize-first"/>
+          <text variable="supplement-number"/>
+        </if>
+      </choose>
+    </group>
+  </macro>
+  <macro name="version-labelled">
+    <group delimiter=" ">
+      <label text-case="capitalize-first" variable="version"/>
+      <text variable="version"/>
+    </group>
+  </macro>
+  <macro name="volume-labelled">
+    <group delimiter=" ">
+      <label form="short" text-case="capitalize-first" variable="volume"/>
+      <text variable="volume"/>
+    </group>
+  </macro>
+  <!-- Four parts in APA references:
+
+       1. Author (APA 9.7–12)
+       2. Date (APA 9.13–17)
+       3. Title (APA 9.18–22)
+       4. Source (APA 9.23–37)
+  -->
+  <!-- 1. Author -->
+  <!-- Author utility macros -->
+  <macro name="author-substitute-bib">
+    <names variable="composer">
+      <name delimiter-precedes-last="always" name-as-sort-order="all"/>
+      <label form="short" prefix=" (" suffix=")" text-case="title"/>
+      <substitute>
+        <names variable="author"/>
+        <!-- `narrator` only cited in secondary-contributors -->
+        <names variable="illustrator"/>
+        <choose>
+          <if type="broadcast">
+            <names variable="script-writer director">
+              <!-- Actors/performers and producers [not executive] not cited in APA style. -->
+              <name delimiter-precedes-last="always" name-as-sort-order="all"/>
+              <label form="long" prefix=" (" suffix=")" text-case="title"/>
+            </names>
+          </if>
+        </choose>
+        <names variable="director">
+          <!-- For non-broadcast items, APA only cites directors and not writers. -->
+          <name delimiter-precedes-last="always" name-as-sort-order="all"/>
+          <label form="long" prefix=" (" suffix=")" text-case="title"/>
+        </names>
+        <names variable="guest host">
+          <!-- TODO: Replace `delimiter` with `collapse` to combine names variables when that becomes available. -->
+          <name delimiter-precedes-last="always" name-as-sort-order="all"/>
+          <label form="long" prefix=" (" suffix=")" text-case="title"/>
+        </names>
+        <names variable="producer">
+          <!-- Producers not cited if there is a writer/director, but use if they are the principle creator. -->
+          <name delimiter-precedes-last="always" name-as-sort-order="all"/>
+          <label form="long" prefix=" (" suffix=")" text-case="title"/>
+        </names>
+        <choose>
+          <if variable="container-title">
+            <choose>
+              <if match="any" type="book classic collection entry entry-dictionary entry-encyclopedia">
+                <!-- Items with book-like container-title substitute with their title and identification,
+                     but leave description after container-title. This mimics the `container-booklike` formatting. -->
+                <text macro="title-substitute"/>
+              </if>
+            </choose>
+          </if>
+        </choose>
+        <names variable="executive-producer">
+          <name delimiter-precedes-last="always" name-as-sort-order="all"/>
+          <label form="long" prefix=" (" suffix=")" text-case="title"/>
+        </names>
+        <names variable="series-creator">
+          <name delimiter-precedes-last="always" name-as-sort-order="all"/>
+          <label form="long" prefix=" (" suffix=")" text-case="title"/>
+        </names>
+        <names variable="editor-translator"/>
+        <!-- Translator is not cited as a primary creator (only as Ed. & Trans.). -->
+        <names variable="editor"/>
+        <names variable="editorial-director"/>
+        <names variable="compiler">
+          <name delimiter-precedes-last="always" name-as-sort-order="all"/>
+          <label form="long" prefix=" (" suffix=")" text-case="title"/>
+        </names>
+        <choose>
+          <if match="any" type="event performance speech">
+            <names variable="chair">
+              <name delimiter-precedes-last="always" name-as-sort-order="all"/>
+              <label form="long" prefix=" (" suffix=")" text-case="title"/>
+            </names>
+            <names variable="organizer">
+              <name delimiter-precedes-last="always" name-as-sort-order="all"/>
+              <label form="long" prefix=" (" suffix=")" text-case="title"/>
+            </names>
+          </if>
+        </choose>
+        <names variable="curator">
+          <name delimiter-precedes-last="always" name-as-sort-order="all"/>
+          <label form="long" prefix=" (" suffix=")" text-case="title"/>
+        </names>
+        <names variable="collection-editor"/>
+        <text macro="title-substitute"/>
+      </substitute>
+    </names>
+  </macro>
+  <macro name="author-substitute-intext">
+    <names variable="composer">
+      <name form="short"/>
+      <substitute>
+        <names variable="author"/>
+        <names variable="illustrator"/>
+        <!-- TODO: Replace `delimiter` with `collapse` to combine names variables when that becomes available. -->
+        <choose>
+          <if type="broadcast">
+            <names variable="script-writer"/>
+          </if>
+        </choose>
+        <names variable="director"/>
+        <!-- TODO: Replace `delimiter` with `collapse` to combine names variables when that becomes available. -->
+        <names variable="guest host"/>
+        <names variable="producer"/>
+        <choose>
+          <if variable="container-title">
+            <choose>
+              <if match="any" type="book classic collection entry entry-dictionary entry-encyclopedia">
+                <text macro="title-intext"/>
+              </if>
+            </choose>
+          </if>
+        </choose>
+        <names variable="executive-producer"/>
+        <names variable="series-creator"/>
+        <names variable="editor"/>
+        <names variable="editorial-director"/>
+        <names variable="compiler"/>
+        <choose>
+          <if match="any" type="event performance speech">
+            <names variable="chair"/>
+            <names variable="organizer"/>
+          </if>
+        </choose>
+        <names variable="curator"/>
+        <text macro="title-intext"/>
+      </substitute>
+    </names>
+  </macro>
+  <macro name="title-substitute">
+    <choose>
+      <if variable="title">
+        <!-- If an item has a title, substitute missing author with title and identification, but leave description after the date (in the 'title' position). -->
+        <group delimiter=" ">
+          <text macro="title-bib"/>
+          <text macro="identification"/>
+        </group>
+      </if>
+      <else>
+        <!-- If an item has no title, substitute with description followed by identification. -->
+        <text macro="title-and-descriptions"/>
+      </else>
+    </choose>
+  </macro>
+  <!-- Author logic -->
   <macro name="author-bib">
     <group delimiter=" ">
-      <names variable="composer" delimiter=", &amp; ">
-        <name name-as-sort-order="all" and="symbol" sort-separator=", " initialize="false" initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
-        <substitute>
-          <names variable="author"/>
-          <!-- Note: `narrator` only cited in secondary-contributors -->
-          <names variable="illustrator"/>
-          <!-- TODO: Replace `delimiter` with `collapse` to combine names variables when that becomes available. -->
-          <choose>
-            <if type="broadcast">
-              <names variable="script-writer director">
-                <!-- Note: Actors/performers and producers [not executive] not cited in APA style. -->
-                <name name-as-sort-order="all" and="symbol" sort-separator=", " initialize="false" initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
-                <label form="long" prefix=" (" suffix=")" text-case="title"/>
-              </names>
-            </if>
-          </choose>
-          <names variable="director">
-            <!-- For non-broadcast items, APA only cites directors and not writers. -->
-            <name name-as-sort-order="all" and="symbol" sort-separator=", " initialize="false" initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
-            <label form="long" prefix=" (" suffix=")" text-case="title"/>
-          </names>
-          <!-- TODO: Replace `delimiter` with `collapse` to combine names variables when that becomes available. -->
-          <names variable="guest host">
-            <name name-as-sort-order="all" and="symbol" sort-separator=", " initialize="false" initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
-            <label form="long" prefix=" (" suffix=")" text-case="title"/>
-          </names>
-          <names variable="producer">
-            <!-- Note: Producers not cited if there is a writer/director, but use if they are the principle creator. -->
-            <name name-as-sort-order="all" and="symbol" sort-separator=", " initialize="false" initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
-            <label form="long" prefix=" (" suffix=")" text-case="title"/>
-          </names>
-          <choose>
-            <if variable="container-title">
-              <choose>
-                <if type="book classic collection entry entry-dictionary entry-encyclopedia" match="any">
-                  <!-- Items with book-like container-title substitute with their title and parenthetical, 
-                       but leave bracketed after container-title. This mimics the `container-booklike` formatting. -->
-                  <choose>
-                    <if variable="title">
-                      <group delimiter=" ">
-                        <text macro="title"/>
-                        <text macro="parenthetical"/>
-                      </group>
-                    </if>
-                    <else>
-                      <text macro="title-and-descriptions"/>
-                    </else>
-                  </choose>
-                </if>
-              </choose>
-            </if>
-          </choose>
-          <names variable="executive-producer">
-            <name name-as-sort-order="all" and="symbol" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
-            <label form="long" prefix=" (" suffix=")" text-case="title"/>
-          </names>
-          <names variable="series-creator">
-            <name name-as-sort-order="all" and="symbol" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
-            <label form="long" prefix=" (" suffix=")" text-case="title"/>
-          </names>
-          <names variable="editor-translator">
-            <name name-as-sort-order="all" and="symbol" sort-separator=", " initialize="false" initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
-            <label form="short" prefix=" (" suffix=")" text-case="title"/>
-          </names>
-          <!-- Note: Translator is not cited as a primary creator (only as Ed. & Trans.). -->
-          <names variable="editor">
-            <name name-as-sort-order="all" and="symbol" sort-separator=", " initialize="false" initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
-            <label form="short" prefix=" (" suffix=")" text-case="title"/>
-          </names>
-          <names variable="editorial-director">
-            <name name-as-sort-order="all" and="symbol" sort-separator=", " initialize="false" initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
-            <label form="short" prefix=" (" suffix=")" text-case="title"/>
-          </names>
-          <names variable="compiler">
-            <name name-as-sort-order="all" and="symbol" sort-separator=", " initialize="false" initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
-            <label form="long" prefix=" (" suffix=")" text-case="title"/>
-          </names>
-          <choose>
-            <if type="event performance speech" match="any">
-              <names variable="chair">
-                <name name-as-sort-order="all" and="symbol" sort-separator=", " initialize="false" initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
-                <label form="long" prefix=" (" suffix=")" text-case="title"/>
-              </names>
-              <names variable="organizer">
-                <name name-as-sort-order="all" and="symbol" sort-separator=", " initialize="false" initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
-                <label form="long" prefix=" (" suffix=")" text-case="title"/>
-              </names>
-            </if>
-          </choose>
-          <names variable="curator">
-            <name name-as-sort-order="all" and="symbol" sort-separator=", " initialize="false" initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
-            <label form="long" prefix=" (" suffix=")" text-case="title"/>
-          </names>
-          <names variable="collection-editor">
-            <name name-as-sort-order="all" and="symbol" sort-separator=", " initialize="false" initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
-            <label form="short" prefix=" (" suffix=")" text-case="title"/>
-          </names>
-          <choose>
-            <if variable="title">
-              <!-- If an item has a title, substitute missing author with title and parenthetical, but leave bracketed 
-                   after the date (in the 'title' position). -->
-              <group delimiter=" ">
-                <text macro="title"/>
-                <text macro="parenthetical"/>
-              </group>
-            </if>
-            <else>
-              <!-- If an item has no title, substitute with bracketed followed by parenthetical. -->
-              <text macro="title-and-descriptions"/>
-            </else>
-          </choose>
-        </substitute>
-      </names>
+      <text macro="author-substitute-bib"/>
       <choose>
         <!-- Print "with" contributor for books, but not for other types that commonly have them (eg, thesis, software) -->
-        <if type="book classic collection" match="any">
-          <names variable="contributor" prefix="(" suffix=")">
+        <if match="any" type="book classic collection">
+          <names prefix="(" suffix=")" variable="contributor">
             <label form="verb" suffix=" "/>
-            <name name-as-sort-order="all" and="symbol" sort-separator=", " initialize="false" initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
+            <name delimiter-precedes-last="always" name-as-sort-order="all"/>
           </names>
         </if>
       </choose>
@@ -264,80 +433,21 @@
   </macro>
   <macro name="author-intext">
     <choose>
-      <if type="bill hearing legal_case legislation regulation treaty" match="any">
+      <if match="any" type="bill hearing legal_case legislation regulation treaty">
         <text macro="title-intext"/>
       </if>
-      <else-if type="interview personal_communication" match="any">
-        <choose>
-          <!-- These variables indicate that the letter is retrievable by the reader.
-                If not, then use the APA in-text-only personal communication format -->
-          <if variable="archive container-title DOI publisher URL" match="none">
-            <group delimiter=", ">
-              <names variable="author">
-                <name and="symbol" delimiter=", " initialize="false" initialize-with=". "/>
-                <substitute>
-                  <text macro="title-intext"/>
-                </substitute>
-              </names>
-              <text term="personal-communication"/>
-            </group>
-          </if>
-          <else>
-            <names variable="author" delimiter=", ">
-              <name form="short" and="symbol" delimiter=", " initialize="false" initialize-with=". "/>
-              <substitute>
-                <text macro="title-intext"/>
-              </substitute>
-            </names>
-          </else>
-        </choose>
+      <else-if match="any" type="interview personal_communication">
+        <text macro="title-intext-interview-communication"/>
       </else-if>
       <else>
-        <names variable="composer" delimiter=" &amp; ">
-          <name form="short" and="symbol" delimiter=", " initialize="false" initialize-with=". "/>
-          <substitute>
-            <names variable="author"/>
-            <names variable="illustrator"/>
-            <!-- TODO: Replace `delimiter` with `collapse` to combine names variables when that becomes available. -->
-            <choose>
-              <if type="broadcast">
-                <names variable="script-writer director"/>
-              </if>
-            </choose>
-            <names variable="director"/>
-            <!-- TODO: Replace `delimiter` with `collapse` to combine names variables when that becomes available. -->
-            <names variable="guest host"/>
-            <names variable="producer"/>
-            <choose>
-              <if variable="container-title">
-                <choose>
-                  <if type="book classic collection entry entry-dictionary entry-encyclopedia" match="any">
-                    <text macro="title-intext"/>
-                  </if>
-                </choose>
-              </if>
-            </choose>
-            <names variable="executive-producer"/>
-            <names variable="series-creator"/>
-            <names variable="editor"/>
-            <names variable="editorial-director"/>
-            <names variable="compiler"/>
-            <choose>
-              <if type="event performance speech" match="any">
-                <names variable="chair"/>
-                <names variable="organizer"/>
-              </if>
-            </choose>
-            <names variable="curator"/>
-            <text macro="title-intext"/>
-          </substitute>
-        </names>
+        <text macro="author-substitute-intext"/>
       </else>
     </choose>
   </macro>
+  <!-- Author sorting -->
   <macro name="author-sort">
     <choose>
-      <if type="bill hearing legal_case legislation regulation treaty" match="any">
+      <if match="any" type="bill hearing legal_case legislation regulation treaty">
         <text macro="title-legal"/>
       </if>
       <else>
@@ -345,92 +455,161 @@
       </else>
     </choose>
   </macro>
-  <macro name="date-bib">
-    <group delimiter=" " prefix="(" suffix=")">
-      <choose>
-        <if is-uncertain-date="issued">
-          <text term="circa" form="short"/>
-        </if>
-      </choose>
-      <group>
-        <choose>
-          <if variable="issued">
-            <group delimiter=", ">
-              <group>
-                <date variable="issued" date-parts="year" form="numeric"/>
-                <text variable="year-suffix"/>
-              </group>
-              <choose>
-                <if type="article-magazine article-newspaper broadcast collection document event interview motion_picture pamphlet performance personal_communication post post-weblog song speech webpage" match="any">
-                  <!-- Many video and audio examples in manual give full dates. Err on the side of too much information. -->
-                  <date variable="issued">
-                    <date-part name="month"/>
-                    <date-part name="day" prefix=" "/>
-                  </date>
-                </if>
-                <else-if type="paper-conference">
-                  <!-- Capture 'speech' stored as 'paper-conference' -->
-                  <choose>
-                    <if variable="collection-editor compiler editor editorial-director issue page volume" match="none">
-                      <date variable="issued">
-                        <date-part name="month"/>
-                        <date-part name="day" prefix=" "/>
-                      </date>
-                    </if>
-                  </choose>
-                </else-if>
-                <!-- Only year: article article-journal book chapter classic entry entry-dictionary entry-encyclopedia dataset figure graphic
-                     manuscript map musical_score paper-conference[published] patent periodical report review review-book software standard thesis -->
-              </choose>
-            </group>
-          </if>
-          <else-if variable="status">
-            <group>
-              <!-- We print the status variable directly rather than using in-press, etc. terms. -->
-              <text variable="status" text-case="lowercase"/>
-              <text variable="year-suffix" prefix="-"/>
-            </group>
-          </else-if>
-          <else>
-            <text term="no date" form="short"/>
-            <text variable="year-suffix" prefix="-"/>
-          </else>
-        </choose>
-      </group>
+  <!-- 2. Date -->
+  <!-- Date utility macros -->
+  <macro name="date-issued-full">
+    <group delimiter=" ">
+      <text macro="uncertain-date-issued"/>
+      <date form="text" variable="issued"/>
     </group>
   </macro>
-  <macro name="date-sort">
-    <!-- This is necessary to ensure that citeproc sorts all item types chonologically in the same list. -->
+  <macro name="date-issued-leading-zeros">
+    <date delimiter="-" variable="issued">
+      <date-part form="long" name="year"/>
+      <date-part form="numeric-leading-zeros" name="month"/>
+      <date-part form="numeric-leading-zeros" name="day"/>
+    </date>
+  </macro>
+  <macro name="date-issued-month-day">
+    <date variable="issued">
+      <date-part name="month"/>
+      <date-part name="day" prefix=" "/>
+    </date>
+  </macro>
+  <macro name="date-issued-year">
+    <group delimiter=" ">
+      <text macro="uncertain-date-issued"/>
+      <date date-parts="year" form="numeric" variable="issued"/>
+    </group>
+  </macro>
+  <macro name="original-date-year">
+    <group delimiter=" ">
+      <choose>
+        <if is-uncertain-date="original-date">
+          <text form="short" term="circa"/>
+        </if>
+      </choose>
+      <date variable="original-date">
+        <date-part name="year"/>
+      </date>
+    </group>
+  </macro>
+  <macro name="uncertain-date-issued">
     <choose>
-      <if type="article article-journal book chapter entry entry-dictionary entry-encyclopedia dataset figure graphic manuscript map musical_score patent report review review-book thesis" match="any">
-        <date variable="issued" date-parts="year" form="numeric"/>
+      <if is-uncertain-date="issued">
+        <text form="short" term="circa"/>
+      </if>
+    </choose>
+  </macro>
+  <!-- Date logic -->
+  <macro name="date-bib">
+    <group prefix="(" suffix=")">
+      <choose>
+        <if variable="issued">
+          <group delimiter=", ">
+            <group>
+              <text macro="date-issued-year"/>
+              <text variable="year-suffix"/>
+            </group>
+            <choose>
+              <if match="any" type="article-magazine article-newspaper broadcast collection document event interview motion_picture pamphlet performance personal_communication post post-weblog song speech webpage">
+                <!-- Many video and audio examples in manual give full dates. Err on the side of too much information. -->
+                <text macro="date-issued-month-day"/>
+              </if>
+              <else-if type="paper-conference">
+                <!-- Capture 'speech' stored as 'paper-conference' -->
+                <choose>
+                  <if match="none" variable="collection-editor compiler editor editorial-director issue page volume">
+                    <text macro="date-issued-month-day"/>
+                  </if>
+                </choose>
+              </else-if>
+              <!-- Only year: article article-journal book chapter classic entry entry-dictionary entry-encyclopedia dataset figure graphic
+                     manuscript map musical_score paper-conference[published] patent periodical report review review-book software standard thesis -->
+            </choose>
+          </group>
+        </if>
+        <else-if variable="status">
+          <group>
+            <!-- We print the status variable directly rather than using in-press, etc. terms. -->
+            <text text-case="lowercase" variable="status"/>
+            <text prefix="-" variable="year-suffix"/>
+          </group>
+        </else-if>
+        <else>
+          <text form="short" term="no date"/>
+          <text prefix="-" variable="year-suffix"/>
+        </else>
+      </choose>
+    </group>
+  </macro>
+  <macro name="date-intext">
+    <choose>
+      <if variable="issued">
+        <group delimiter="/">
+          <text macro="original-date-year"/>
+          <group>
+            <choose>
+              <if match="any" type="interview personal_communication">
+                <choose>
+                  <if match="none" variable="archive archive-place container-title DOI publisher URL">
+                    <!-- These variables indicate that the communication is retrievable by the reader.
+                           If not, then use the in-text-only personal communication format -->
+                    <text macro="date-issued-full"/>
+                  </if>
+                  <else>
+                    <text macro="date-issued-year"/>
+                  </else>
+                </choose>
+              </if>
+              <else>
+                <text macro="date-issued-year"/>
+              </else>
+            </choose>
+            <text variable="year-suffix"/>
+          </group>
+        </group>
+      </if>
+      <else-if variable="status">
+        <!-- We print the status variable directly rather than using in-press, etc. terms. -->
+        <text text-case="lowercase" variable="status"/>
+        <text prefix="-" variable="year-suffix"/>
+      </else-if>
+      <else>
+        <text form="short" term="no date"/>
+        <text prefix="-" variable="year-suffix"/>
+      </else>
+    </choose>
+  </macro>
+  <!-- Date sorting -->
+  <macro name="date-sort">
+    <!-- Sort items by printed issue date without prefixes for original or uncertain dates -->
+    <choose>
+      <if match="any" type="article article-journal book chapter entry entry-dictionary entry-encyclopedia dataset figure graphic manuscript map musical_score patent report review review-book thesis">
+        <date date-parts="year" form="numeric" variable="issued"/>
       </if>
       <else-if type="paper-conference">
         <!-- Capture 'speech' stored as 'paper-conference' -->
         <choose>
-          <if variable="collection-editor compiler editor editorial-director issue page volume" match="any">
-            <date variable="issued" date-parts="year" form="numeric"/>
+          <if match="any" variable="collection-editor compiler editor editorial-director issue page volume">
+            <date date-parts="year" form="numeric" variable="issued"/>
           </if>
           <else>
-            <date variable="issued">
-              <date-part name="year" form="long"/>
-              <date-part name="month" form="numeric-leading-zeros"/>
-              <date-part name="day" form="numeric-leading-zeros"/>
-            </date>
+            <text macro="date-issued-leading-zeros"/>
           </else>
         </choose>
       </else-if>
       <else>
-        <date variable="issued">
-          <date-part name="year" form="long"/>
-          <date-part name="month" form="numeric-leading-zeros"/>
-          <date-part name="day" form="numeric-leading-zeros"/>
-        </date>
+        <text macro="date-issued-leading-zeros"/>
       </else>
     </choose>
   </macro>
   <macro name="date-sort-group">
-    <!-- APA sorts 1. no-date items, 2. items with dates, 3. in-press (status) items -->
+    <!-- Sorts items with and without dates:
+
+         1. no-date items (= 0)
+         2. items with dates (= 1)
+         3. in-press (status) items (= 2) -->
     <choose>
       <if variable="issued">
         <text value="1"/>
@@ -443,111 +622,185 @@
       </else>
     </choose>
   </macro>
-  <macro name="date-intext">
-    <choose>
-      <if variable="issued">
-        <group delimiter="/">
-          <group delimiter=" ">
-            <choose>
-              <if is-uncertain-date="original-date">
-                <text term="circa" form="short"/>
-              </if>
-            </choose>
-            <date variable="original-date">
-              <date-part name="year"/>
-            </date>
-          </group>
-          <group delimiter=" ">
-            <choose>
-              <if is-uncertain-date="issued">
-                <text term="circa" form="short"/>
-              </if>
-            </choose>
-            <group>
-              <choose>
-                <if type="interview personal_communication" match="any">
-                  <choose>
-                    <if variable="archive container-title DOI publisher URL" match="none">
-                      <!-- These variables indicate that the communication is retrievable by the reader.
-                           If not, then use the in-text-only personal communication format -->
-                      <date variable="issued" form="text"/>
-                    </if>
-                    <else>
-                      <date variable="issued">
-                        <date-part name="year"/>
-                      </date>
-                    </else>
-                  </choose>
-                </if>
-                <else>
-                  <date variable="issued">
-                    <date-part name="year"/>
-                  </date>
-                </else>
-              </choose>
-              <text variable="year-suffix"/>
-            </group>
-          </group>
-        </group>
-      </if>
-      <else-if variable="status">
-        <!-- We print the status variable directly rather than using in-press, etc. terms. -->
-        <text variable="status" text-case="lowercase"/>
-        <text variable="year-suffix" prefix="-"/>
-      </else-if>
-      <else>
-        <text term="no date" form="short"/>
-        <text variable="year-suffix" prefix="-"/>
-      </else>
-    </choose>
-  </macro>
-  <!-- APA has two description elements following the title:
-       title (parenthetical) [bracketed] -->
+  <!-- 3. Title and descriptions -->
+  <!-- Three parts in title element (APA 9.21):
+
+       1. Title
+       2. Identification (in parentheses)
+       3. Description [in square brackets] -->
   <macro name="title-and-descriptions">
     <choose>
       <if variable="title">
         <group delimiter=" ">
-          <text macro="title"/>
-          <text macro="parenthetical"/>
-          <text macro="bracketed"/>
+          <text macro="title-bib"/>
+          <text macro="identification"/>
+          <text macro="description-bib"/>
         </group>
       </if>
       <else>
         <choose>
-          <if type="bill report" match="any">
+          <if match="any" type="bill report">
             <!-- Bills, resolutions, and congressional reports are not italicized and substitute bill number if no title. -->
-            <!-- Can't distinguish congressional reports from other reports, 
+            <!-- Can't distinguish congressional reports from other reports,
                  but giving the genre and number seems fine for other reports too. -->
-            <text macro="number"/>
-            <text macro="bracketed"/>
-            <text macro="parenthetical"/>
+            <text macro="genre-number"/>
+            <text macro="description-bib"/>
+            <text macro="identification"/>
           </if>
           <else>
             <group delimiter=" ">
-              <text macro="bracketed"/>
-              <text macro="parenthetical"/>
+              <text macro="description-bib"/>
+              <text macro="identification"/>
             </group>
           </else>
         </choose>
       </else>
     </choose>
   </macro>
-  <macro name="title">
+  <!-- 3.1. Title -->
+  <!-- Title utility macros -->
+  <macro name="title-intext-bill-report">
+    <!-- Bills, resolutions, and congressional reports are not italicized and substitute bill number if no title. -->
+    <!-- Can't distinguish congressional reports from other reports,
+             but giving the genre and number seems fine for other reports too. -->
     <choose>
-      <if type="post webpage" match="any">
+      <if variable="title">
+        <text form="short" text-case="title" variable="title"/>
+      </if>
+      <else>
+        <group delimiter=" ">
+          <text variable="genre"/>
+          <group delimiter=" ">
+            <choose>
+              <if match="none" variable="chapter-number container-title">
+                <text macro="number-labelled"/>
+              </if>
+              <else>
+                <text variable="number"/>
+              </else>
+            </choose>
+          </group>
+        </group>
+      </else>
+    </choose>
+  </macro>
+  <macro name="title-intext-interview-communication">
+    <choose>
+      <!-- These variables indicate that the letter is retrievable by the reader.
+                If not, then use the APA in-text-only personal communication format -->
+      <if match="none" variable="archive archive-place container-title DOI publisher URL">
+        <group delimiter=", ">
+          <names variable="author">
+            <substitute>
+              <text macro="title-intext"/>
+            </substitute>
+          </names>
+          <text term="personal-communication"/>
+        </group>
+      </if>
+      <else>
+        <names variable="author">
+          <name form="short"/>
+          <substitute>
+            <text macro="title-intext"/>
+          </substitute>
+        </names>
+      </else>
+    </choose>
+  </macro>
+  <macro name="title-part">
+    <group delimiter=". ">
+      <text macro="part-number-labelled"/>
+      <text text-case="capitalize-first" variable="part-title"/>
+    </group>
+  </macro>
+  <macro name="title-plus-part-title">
+    <choose>
+      <if match="any" type="review review-book" variable="reviewed-author reviewed-genre reviewed-title">
+        <!-- If a review has no `reviewed-title`, assume that `title` contains the title of the reviewed work
+             and omit it here; it is printed in the `reviewed-item` macro. -->
+        <choose>
+          <if match="none" variable="reviewed-title"/>
+          <else>
+            <group delimiter=": ">
+              <text variable="title"/>
+              <text macro="title-part"/>
+            </group>
+          </else>
+        </choose>
+      </if>
+      <else>
+        <group delimiter=": ">
+          <text variable="title"/>
+          <text macro="title-part"/>
+        </group>
+      </else>
+    </choose>
+  </macro>
+  <macro name="title-plus-volume-title">
+    <group delimiter=": ">
+      <text variable="title"/>
+      <text macro="title-volume"/>
+    </group>
+  </macro>
+  <macro name="title-volume">
+    <group delimiter=": ">
+      <choose>
+        <if variable="volume-title">
+          <group delimiter=". ">
+            <text macro="volume-labelled"/>
+            <text variable="volume-title"/>
+          </group>
+        </if>
+        <else-if is-numeric="volume" match="none">
+          <text macro="volume-labelled"/>
+        </else-if>
+      </choose>
+      <!-- For book-like items, assume part-number and part-title refer to the book/volume. -->
+      <text macro="title-part"/>
+    </group>
+  </macro>
+  <!-- Title logic -->
+  <macro name="booklike-title">
+    <!-- For book-like items, assume part-number and part-title refer to the book/volume. -->
+    <choose>
+      <if variable="container-title">
+        <text variable="title"/>
+      </if>
+      <else>
+        <!-- For book-like items without container titles and with volume-title, append volume-title to title (APA example 30) -->
+        <text font-style="italic" macro="title-plus-volume-title"/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="periodical-title">
+    <!-- For periodicals, assume that part-number and part-title refer to the article and append to title -->
+    <choose>
+      <if variable="container-title">
+        <text macro="title-plus-part-title"/>
+      </if>
+      <else>
+        <!-- for periodical items without container titles, don't append volume-title to title -->
+        <text font-style="italic" macro="title-plus-part-title"/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="title-bib">
+    <choose>
+      <if match="any" type="post webpage">
         <!-- Webpages are always italicized -->
-        <text macro="title-plus-part-title" font-style="italic"/>
+        <text font-style="italic" macro="title-plus-part-title"/>
       </if>
       <!-- Other types are italicized based on presence of container-title.
              Assume that review and review-book are published in periodicals/blogs,
-             not just on a web page (ex. 69) -->
-      <else-if type="article-journal article-magazine article-newspaper periodical post-weblog review review-book" match="any">
+             not just on a webpage (APA example 69) -->
+      <else-if match="any" type="article-journal article-magazine article-newspaper periodical post-weblog review review-book">
         <text macro="periodical-title"/>
       </else-if>
       <else-if type="paper-conference">
         <!-- Treat paper-conference as book-like if it has an editor, otherwise as periodical-like -->
         <choose>
-          <if variable="collection-editor compiler editor editorial-director" match="any">
+          <if match="any" variable="collection-editor compiler editor editorial-director">
             <text macro="booklike-title"/>
           </if>
           <else>
@@ -560,607 +813,104 @@
       </else>
     </choose>
   </macro>
-  <macro name="periodical-title">
-    <!-- For periodicals, assume that part-number and part-title refer to the article and append to title -->
-    <choose>
-      <if variable="container-title" match="any">
-        <text macro="title-plus-part-title"/>
-      </if>
-      <else>
-        <!-- for periodical items without container titles, don't append volume-title to title -->
-        <text macro="title-plus-part-title" font-style="italic"/>
-      </else>
-    </choose>
-  </macro>
-  <macro name="booklike-title">
-    <!-- For book-like items, assume part-number and part-title refer to the book/volume. -->
-    <choose>
-      <if variable="container-title" match="any">
-        <text variable="title"/>
-      </if>
-      <else>
-        <!-- For book-like items without container titles and with volume-title, append volume-title to title (ex. 30) -->
-        <text macro="title-plus-volume-title" font-style="italic"/>
-      </else>
-    </choose>
-  </macro>
-  <macro name="title-plus-part-title">
-    <choose>
-      <if variable="reviewed-author reviewed-genre reviewed-title" type="review review-book" match="any">
-        <!-- If a review has no `reviewed-title`, assume that `title` contains the title of the reviewed work
-             and omit it here; it is printed in the `reviewed-item` macro. -->
-        <choose>
-          <if variable="reviewed-title" match="none"/>
-          <else>
-            <group delimiter=": ">
-              <text variable="title"/>
-              <text macro="part-title"/>
-            </group>
-          </else>
-        </choose>
-      </if>
-      <else>
-        <group delimiter=": ">
-          <text variable="title"/>
-          <text macro="part-title"/>
-        </group>
-      </else>
-    </choose>
-  </macro>
-  <macro name="part-title">
-    <group delimiter=". ">
-      <group delimiter=" ">
-        <label variable="part-number" form="short" text-case="capitalize-first"/>
-        <text variable="part-number"/>
-      </group>
-      <text variable="part-title" text-case="capitalize-first"/>
-    </group>
-  </macro>
-  <macro name="title-plus-volume-title">
-    <group delimiter=": ">
-      <text variable="title"/>
-      <text macro="volume-title"/>
-    </group>
-  </macro>
-  <macro name="volume-title">
-    <group delimiter=": ">
-      <choose>
-        <if variable="volume-title">
-          <group delimiter=" ">
-            <group delimiter=". ">
-              <group delimiter=" ">
-                <label variable="volume" form="short" text-case="capitalize-first"/>
-                <text variable="volume"/>
-              </group>
-              <text variable="volume-title"/>
-            </group>
-          </group>
-        </if>
-        <else-if is-numeric="volume" match="none">
-          <group delimiter=" ">
-            <label variable="volume" form="short" text-case="capitalize-first"/>
-            <text variable="volume"/>
-          </group>
-        </else-if>
-      </choose>
-      <!-- For book-like items, assume part-number and part-title refer to the book/volume. -->
-      <text macro="part-title"/>
-    </group>
-  </macro>
   <macro name="title-intext">
     <choose>
-      <if type="bill report">
-        <!-- Bills, resolutions, and congressional reports are not italicized and substitute bill number if no title. -->
-        <!-- Can't distinguish congressional reports from other reports, 
-             but giving the genre and number seems fine for other reports too. -->
-        <choose>
-          <if variable="title">
-            <text variable="title" form="short" text-case="title"/>
-          </if>
-          <else>
-            <group delimiter=" ">
-              <text variable="genre"/>
-              <group delimiter=" ">
-                <choose>
-                  <if variable="chapter-number container-title" match="none">
-                    <label variable="number" form="short" text-case="capitalize-first"/>
-                  </if>
-                </choose>
-                <text variable="number"/>
-              </group>
-            </group>
-          </else>
-        </choose>
+      <if match="any" type="bill report">
+        <text macro="title-intext-bill-report"/>
       </if>
       <else>
         <choose>
-          <if variable="title" match="none">
-            <text macro="bracketed-intext"/>
+          <if match="none" variable="title">
+            <text macro="description-intext"/>
           </if>
-          <else-if type="hearing">
-            <!-- Hearings are italicized -->
-            <text variable="title" form="short" font-style="italic" text-case="title"/>
+          <else-if type="hearing webpage">
+            <!-- Italicized with title case -->
+            <text font-style="italic" form="short" text-case="title" variable="title"/>
           </else-if>
-          <else-if type="legal_case" match="any">
-            <!-- Cases are italicized -->
-            <text variable="title" font-style="italic"/>
+          <else-if type="legal_case post">
+            <!-- Italicized -->
+            <text font-style="italic" form="short" variable="title"/>
           </else-if>
-          <else-if type="legislation regulation treaty" match="any">
-            <!-- Legislation, regulations, and treaties not italicized or quoted -->
-            <text variable="title" form="short" text-case="title"/>
+          <else-if match="any" type="legislation regulation treaty">
+            <!-- No italics or quotes -->
+            <text form="short" text-case="title" variable="title"/>
           </else-if>
-          <else-if type="post webpage" match="any">
-            <!-- Webpages are always italicized -->
-            <text variable="title" form="short" font-style="italic" text-case="title"/>
-          </else-if>
-          <else-if variable="container-title" match="any">
-            <!-- Other types are italicized or quoted based on presence of container-title. As in title macro. -->
-            <text variable="title" form="short" quotes="true" text-case="title"/>
+          <else-if variable="container-title">
+            <!-- Other types are formatted based on presence of container-title, as in title-bib macro -->
+            <text form="short" quotes="true" text-case="title" variable="title"/>
           </else-if>
           <else>
-            <text variable="title" form="short" font-style="italic" text-case="title"/>
+            <text font-style="italic" form="short" text-case="title" variable="title"/>
           </else>
         </choose>
       </else>
     </choose>
   </macro>
-  <macro name="parenthetical">
-    <!-- (Secondary contributors; Database location; Genre no. 123; Report Series 123, Version, Edition, Volume, Page) -->
-    <group prefix="(" suffix=")">
-      <choose>
-        <if type="patent">
-          <!-- authority: U.S. ; genre: patent ; number: 123,445 -->
-          <group delimiter=" ">
-            <text variable="authority" form="short"/>
-            <choose>
-              <if variable="genre">
-                <text variable="genre" text-case="capitalize-first"/>
-              </if>
-              <else>
-                <text term="patent" text-case="capitalize-first"/>
-              </else>
-            </choose>
-            <group delimiter=" ">
-              <label variable="number" form="short" text-case="capitalize-first"/>
-              <text variable="number"/>
-            </group>
-          </group>
-        </if>
-        <else-if type="post webpage" match="any">
-          <!-- For post webpage, container-title is treated as publisher -->
-          <group delimiter="; ">
-            <text macro="secondary-contributors"/>
-            <text macro="database-location"/>
-            <text macro="number"/>
-            <text macro="locators-booklike"/>
-          </group>
-        </else-if>
-        <else-if type="report" match="any">
-          <choose>
-            <if variable="title" match="none">
-              <!-- If there is no title, then genre and number are already printed as the title. -->
-              <group delimiter="; ">
-                <text macro="secondary-contributors"/>
-                <text macro="database-location"/>
-                <text macro="locators-booklike"/>
-              </group>
-            </if>
-            <!-- If the report is a chapter in a larger report, then most parenthetical information is printed after the container. -->
-            <else-if variable="container-title">
-              <text macro="secondary-contributors"/>
-            </else-if>
-            <else>
-              <group delimiter="; ">
-                <text macro="secondary-contributors"/>
-                <text macro="database-location"/>
-                <text macro="number"/>
-                <text macro="locators-booklike"/>
-              </group>
-            </else>
-          </choose>
-        </else-if>
-        <else-if variable="container-title">
-          <group delimiter="; ">
-            <text macro="secondary-contributors"/>
-            <choose>
-              <if type="broadcast graphic map motion_picture song" match="any">
-                <!-- For audiovisual media, number information comes after title, not container-title (ex. 94) -->
-                <text macro="number"/>
-              </if>
-            </choose>
-          </group>
-        </else-if>
-        <else>
-          <group delimiter="; ">
-            <text macro="secondary-contributors"/>
-            <text macro="database-location"/>
-            <text macro="number"/>
-            <text macro="locators-booklike"/>
-          </group>
-        </else>
-      </choose>
-    </group>
-  </macro>
-  <macro name="parenthetical-container">
+  <!-- 3.2. Identification (in parentheses) -->
+  <!-- Identification utility macros -->
+  <macro name="database-location">
     <choose>
-      <if variable="container-title" match="any">
-        <group prefix="(" suffix=")">
-          <group delimiter="; ">
-            <text macro="database-location"/>
-            <choose>
-              <if type="broadcast graphic map motion_picture song" match="none">
-                <!-- For audiovisual media, number information comes after title, not container-title (ex. 94) -->
-                <text macro="number"/>
-              </if>
-            </choose>
-            <text macro="locators-booklike"/>
+      <if match="none" variable="archive-place">
+        <!-- With `archive-place`: physical archives. Without: online archives. -->
+        <text variable="archive_location"/>
+      </if>
+    </choose>
+  </macro>
+  <macro name="genre-number">
+    <choose>
+      <if variable="number">
+        <group delimiter=", ">
+          <group delimiter=" ">
+            <text text-case="title" variable="genre"/>
+            <text macro="number-labelled"/>
           </group>
+          <choose>
+            <if type="thesis">
+              <choose>
+                <if match="any" variable="archive DOI URL">
+                  <!-- Include the university in brackets if thesis is published -->
+                  <text variable="publisher"/>
+                </if>
+              </choose>
+            </if>
+          </choose>
         </group>
       </if>
     </choose>
   </macro>
-  <macro name="bracketed">
-    <!-- [Descriptive information] -->
-    <!-- If there is a number, genre is already printed in macro="number" -->
-    <group prefix="[" suffix="]">
+  <macro name="locators-booklike">
+    <choose>
+      <if variable="page">
+        <text macro="page-labelled"/>
+      </if>
+      <else-if variable="chapter-number">
+        <text macro="chapter-number-labelled"/>
+      </else-if>
+    </choose>
+  </macro>
+  <macro name="patent-number">
+    <group delimiter=" ">
+      <!-- authority: U.S. ; genre: patent ; number: 123,445 -->
+      <text form="short" variable="authority"/>
       <choose>
-        <if variable="reviewed-author reviewed-genre reviewed-title" type="review review-book" match="any">
-          <text macro="reviewed-item"/>
+        <if variable="genre">
+          <text text-case="capitalize-first" variable="genre"/>
         </if>
-        <else-if type="thesis">
-          <!-- Thesis type and institution -->
-          <group delimiter="; ">
-            <choose>
-              <if variable="number" match="none">
-                <group delimiter=", ">
-                  <text variable="genre" text-case="capitalize-first"/>
-                  <choose>
-                    <if variable="archive DOI URL" match="any">
-                      <!-- Include the university in brackets if thesis is published -->
-                      <text variable="publisher"/>
-                    </if>
-                  </choose>
-                </group>
-              </if>
-            </choose>
-            <text variable="medium" text-case="capitalize-first"/>
-          </group>
-        </else-if>
-        <else-if variable="interviewer" type="interview" match="any">
-          <!-- Interview information -->
-          <choose>
-            <if variable="title">
-              <text macro="format"/>
-            </if>
-            <else-if variable="genre">
-              <group delimiter="; ">
-                <group delimiter=" ">
-                  <text variable="genre" text-case="capitalize-first"/>
-                  <group delimiter=" ">
-                    <text term="container-author" form="verb"/>
-                    <names variable="interviewer">
-                      <name and="symbol" initialize="false" initialize-with=". " delimiter=", "/>
-                    </names>
-                  </group>
-                </group>
-              </group>
-            </else-if>
-            <else-if variable="interviewer">
-              <group delimiter="; ">
-                <names variable="interviewer">
-                  <label form="verb" suffix=" " text-case="capitalize-first"/>
-                  <name and="symbol" initialize="false" initialize-with=". " delimiter=", "/>
-                </names>
-                <text variable="medium" text-case="capitalize-first"/>
-              </group>
-            </else-if>
-            <else>
-              <text macro="format"/>
-            </else>
-          </choose>
-        </else-if>
-        <else-if type="personal_communication">
-          <!-- Letter information -->
-          <choose>
-            <if variable="recipient">
-              <group delimiter="; ">
-                <group delimiter=" ">
-                  <choose>
-                    <if variable="number" match="none">
-                      <choose>
-                        <if variable="genre">
-                          <text variable="genre" text-case="capitalize-first"/>
-                        </if>
-                        <else-if variable="medium">
-                          <text variable="medium" text-case="capitalize-first"/>
-                        </else-if>
-                        <else>
-                          <text term="letter" text-case="capitalize-first"/>
-                        </else>
-                      </choose>
-                    </if>
-                    <else>
-                      <choose>
-                        <if variable="medium">
-                          <text variable="medium" text-case="capitalize-first"/>
-                        </if>
-                        <else>
-                          <text term="letter" text-case="capitalize-first"/>
-                        </else>
-                      </choose>
-                    </else>
-                  </choose>
-                  <names variable="recipient" delimiter=", ">
-                    <label form="verb" suffix=" "/>
-                    <name and="symbol" delimiter=", "/>
-                  </names>
-                </group>
-                <choose>
-                  <if variable="genre" match="any">
-                    <choose>
-                      <if variable="number" match="none">
-                        <text variable="medium" text-case="capitalize-first"/>
-                      </if>
-                    </choose>
-                  </if>
-                </choose>
-              </group>
-            </if>
-            <else>
-              <text macro="format"/>
-            </else>
-          </choose>
-        </else-if>
-        <else-if variable="composer" type="song" match="all">
-          <!-- Performer of classical music works -->
-          <group delimiter="; ">
-            <choose>
-              <if variable="number" match="none">
-                <group delimiter=" ">
-                  <choose>
-                    <if variable="genre">
-                      <text variable="genre" text-case="capitalize-first"/>
-                      <group delimiter=" ">
-                        <text term="performer" form="verb"/>
-                        <names variable="author">
-                          <name and="symbol" initialize="false" initialize-with=". " delimiter=", "/>
-                          <substitute>
-                            <names variable="performer"/>
-                          </substitute>
-                        </names>
-                      </group>
-                    </if>
-                    <else-if variable="medium">
-                      <text variable="medium" text-case="capitalize-first"/>
-                      <group delimiter=" ">
-                        <text term="performer" form="verb"/>
-                        <names variable="author">
-                          <name and="symbol" initialize="false" initialize-with=". " delimiter=", "/>
-                          <substitute>
-                            <names variable="performer"/>
-                          </substitute>
-                        </names>
-                      </group>
-                    </else-if>
-                    <else>
-                      <text term="performer" form="verb" text-case="capitalize-first"/>
-                      <names variable="author">
-                        <name and="symbol" initialize="false" initialize-with=". " delimiter=", "/>
-                        <substitute>
-                          <names variable="performer"/>
-                        </substitute>
-                      </names>
-                    </else>
-                  </choose>
-                </group>
-              </if>
-              <else>
-                <group delimiter=" ">
-                  <choose>
-                    <if variable="medium">
-                      <text variable="medium" text-case="capitalize-first"/>
-                      <group delimiter=" ">
-                        <text term="performer" form="verb"/>
-                        <names variable="author">
-                          <name and="symbol" initialize="false" initialize-with=". " delimiter=", "/>
-                          <substitute>
-                            <names variable="performer"/>
-                          </substitute>
-                        </names>
-                      </group>
-                    </if>
-                    <else>
-                      <text term="performer" form="verb" text-case="capitalize-first"/>
-                      <names variable="author">
-                        <name and="symbol" initialize="false" initialize-with=". " delimiter=", "/>
-                        <substitute>
-                          <names variable="performer"/>
-                        </substitute>
-                      </names>
-                    </else>
-                  </choose>
-                </group>
-              </else>
-            </choose>
-            <choose>
-              <if variable="genre" match="any">
-                <choose>
-                  <if variable="number" match="none">
-                    <text variable="medium" text-case="capitalize-first"/>
-                  </if>
-                </choose>
-              </if>
-            </choose>
-          </group>
-        </else-if>
-        <else-if variable="container-title" match="none">
-          <!-- Other description -->
-          <text macro="format"/>
-        </else-if>
         <else>
-          <!-- For conference presentations/performances/events, chapters in reports/standards/generic documents, software, 
-               place bracketed after the container title -->
-          <choose>
-            <if type="event paper-conference performance speech" match="any">
-              <choose>
-                <if variable="collection-editor compiler editor editorial-director issue page volume" match="any">
-                  <text macro="format"/>
-                </if>
-              </choose>
-            </if>
-            <else-if type="document report software standard" match="none">
-              <text macro="format"/>
-            </else-if>
-          </choose>
+          <text term="patent" text-case="capitalize-first"/>
         </else>
       </choose>
-    </group>
-  </macro>
-  <macro name="bracketed-intext">
-    <group prefix="[" suffix="]">
-      <choose>
-        <if variable="reviewed-title" match="any">
-          <group delimiter=" ">
-            <text term="review-of" text-case="capitalize-first"/>
-            <text macro="reviewed-title-intext"/>
-          </group>
-        </if>
-        <else-if variable="interviewer" type="interview" match="any">
-          <names variable="interviewer">
-            <label form="verb" suffix=" " text-case="capitalize-first"/>
-            <name and="symbol" initialize="false" initialize-with=". " delimiter=", "/>
-            <substitute>
-              <text macro="format-intext"/>
-            </substitute>
-          </names>
-        </else-if>
-        <else-if type="personal_communication">
-          <!-- Letter information -->
-          <choose>
-            <if variable="recipient">
-              <group delimiter=" ">
-                <choose>
-                  <if variable="number" match="none">
-                    <text variable="genre" text-case="capitalize-first"/>
-                  </if>
-                  <else>
-                    <text term="letter" text-case="capitalize-first"/>
-                  </else>
-                </choose>
-                <names variable="recipient" delimiter=", ">
-                  <label form="verb" suffix=" "/>
-                  <name and="symbol" delimiter=", "/>
-                </names>
-              </group>
-            </if>
-            <else>
-              <text macro="format-intext"/>
-            </else>
-          </choose>
-        </else-if>
-        <else>
-          <text macro="format-intext"/>
-        </else>
-      </choose>
-    </group>
-  </macro>
-  <macro name="reviewed-item">
-    <!-- Reviewed item -->
-    <group delimiter="; ">
-      <group delimiter=", ">
-        <group delimiter=" ">
-          <choose>
-            <if variable="reviewed-genre">
-              <group delimiter=" ">
-                <text term="review-of" form="long" text-case="capitalize-first"/>
-                <text variable="reviewed-genre" text-case="lowercase"/>
-              </group>
-            </if>
-            <!-- If no `reviewed-genre`, assume that `genre` or `medium` is entered as 'Review of the book' or similar -->
-            <else-if variable="number" match="none">
-              <choose>
-                <if variable="genre">
-                  <text variable="genre" text-case="capitalize-first"/>
-                </if>
-                <else-if variable="medium">
-                  <text variable="medium" text-case="capitalize-first"/>
-                </else-if>
-                <else-if type="review-book">
-                  <group delimiter=" ">
-                    <text term="review-of" form="long" text-case="capitalize-first"/>
-                    <text term="book" form="long" text-case="lowercase"/>
-                  </group>
-                </else-if>
-                <else>
-                  <text term="review-of" form="short" text-case="capitalize-first"/>
-                </else>
-              </choose>
-            </else-if>
-            <else>
-              <choose>
-                <if variable="medium">
-                  <text variable="medium" text-case="capitalize-first"/>
-                </if>
-                <else-if type="review-book">
-                  <group delimiter=" ">
-                    <text term="review-of" form="long" text-case="capitalize-first"/>
-                    <text term="book" form="long" text-case="lowercase"/>
-                  </group>
-                </else-if>
-                <else>
-                  <text term="review-of" form="short" text-case="capitalize-first"/>
-                </else>
-              </choose>
-            </else>
-          </choose>
-          <text macro="reviewed-title"/>
-        </group>
-        <names variable="reviewed-author">
-          <label form="verb-short" suffix=" "/>
-          <name and="symbol" initialize="false" initialize-with=". " delimiter=", "/>
-        </names>
-      </group>
-      <choose>
-        <if variable="genre" match="any">
-          <choose>
-            <if variable="number" match="none">
-              <text variable="medium" text-case="capitalize-first"/>
-            </if>
-          </choose>
-        </if>
-      </choose>
-    </group>
-  </macro>
-  <macro name="bracketed-container">
-    <group prefix="[" suffix="]">
-      <choose>
-        <if type="event paper-conference performance speech" match="any">
-          <!-- Conference presentations should describe the session [container] in bracketed unless published in a proceedings -->
-          <choose>
-            <if variable="collection-editor compiler editor editorial-director issue page volume" match="none">
-              <text macro="format"/>
-            </if>
-          </choose>
-        </if>
-        <else-if type="software" match="all">
-          <!-- For entries in mobile app reference works, place bracketed after the container-title -->
-          <text macro="format"/>
-        </else-if>
-        <else-if type="document report standard">
-          <!-- For chapters in report, standards, and generic documents, place bracketed after the container title -->
-          <text macro="format"/>
-        </else-if>
-      </choose>
+      <text macro="number-labelled"/>
     </group>
   </macro>
   <macro name="secondary-contributors">
     <choose>
-      <if type="article-journal article-magazine article-newspaper periodical post-weblog review review-book" match="any">
+      <if match="any" type="article-journal article-magazine article-newspaper periodical post-weblog review review-book">
         <text macro="secondary-contributors-periodical"/>
       </if>
       <else-if type="paper-conference">
         <choose>
-          <if variable="collection-editor compiler editor editorial-director" match="any">
+          <if match="any" variable="collection-editor compiler editor editorial-director">
             <text macro="secondary-contributors-booklike"/>
           </if>
           <else>
@@ -1173,53 +923,37 @@
       </else>
     </choose>
   </macro>
-  <macro name="secondary-contributors-periodical">
-    <group delimiter="; ">
-      <choose>
-        <if variable="title">
-          <names variable="interviewer" delimiter="; ">
-            <name and="symbol" initialize="false" initialize-with=". " delimiter=", "/>
-            <label form="short" prefix=", " text-case="title"/>
-          </names>
-        </if>
-      </choose>
-      <names variable="translator narrator" delimiter="; ">
-        <name and="symbol" initialize="false" initialize-with=". " delimiter=", "/>
-        <label form="short" prefix=", " text-case="title"/>
-      </names>
-    </group>
-  </macro>
   <macro name="secondary-contributors-booklike">
     <group delimiter="; ">
       <choose>
         <if variable="title">
           <names variable="interviewer">
-            <name and="symbol" initialize="false" initialize-with=". " delimiter=", "/>
+            <name/>
             <label form="short" prefix=", " text-case="title"/>
           </names>
         </if>
       </choose>
       <choose>
-        <if type="post webpage" match="none">
+        <if match="none" type="post webpage">
           <!-- Webpages treat container-title like publisher -->
           <group delimiter="; ">
-            <names variable="illustrator narrator" delimiter="; ">
-              <name and="symbol" initialize="false" initialize-with=". " delimiter=", "/>
+            <names delimiter="; " variable="illustrator narrator">
+              <name/>
               <label form="short" prefix=", " text-case="title"/>
             </names>
             <choose>
-              <if variable="container-title" match="none">
+              <if match="none" variable="container-title">
                 <group delimiter="; ">
                   <names variable="container-author">
                     <label form="verb-short" suffix=" " text-case="title"/>
-                    <name and="symbol" initialize="false" initialize-with=". " delimiter=", "/>
+                    <name/>
                   </names>
-                  <names variable="editor translator" delimiter="; ">
-                    <name and="symbol" initialize="false" initialize-with=". " delimiter=", "/>
+                  <names delimiter="; " variable="editor translator">
+                    <name/>
                     <label form="short" prefix=", " text-case="title"/>
                   </names>
-                  <names variable="compiler chair organizer curator series-creator executive-producer" delimiter="; ">
-                    <name and="symbol" initialize="false" initialize-with=". " delimiter=", "/>
+                  <names delimiter="; " variable="compiler chair organizer curator series-creator executive-producer">
+                    <name/>
                     <label form="long" prefix=", " text-case="title"/>
                   </names>
                 </group>
@@ -1227,9 +961,9 @@
               <else>
                 <choose>
                   <!-- TODO: Check logic once processors start to automatically populate editor-translator. -->
-                  <if variable="editor-translator" match="none">
-                    <names variable="translator" delimiter="; ">
-                      <name and="symbol" initialize="false" initialize-with=". " delimiter=", "/>
+                  <if match="none" variable="editor-translator">
+                    <names delimiter="; " variable="translator">
+                      <name/>
                       <label form="short" prefix=", " text-case="title"/>
                     </names>
                   </if>
@@ -1242,18 +976,18 @@
           <group delimiter="; ">
             <names variable="container-author">
               <label form="verb-short" suffix=" " text-case="title"/>
-              <name and="symbol" initialize="false" initialize-with=". " delimiter=", "/>
+              <name/>
             </names>
-            <names variable="editor translator" delimiter="; ">
-              <name and="symbol" initialize="false" initialize-with=". " delimiter=", "/>
+            <names delimiter="; " variable="editor translator">
+              <name/>
               <label form="short" prefix=", " text-case="title"/>
             </names>
-            <names variable="illustrator narrator" delimiter="; ">
-              <name and="symbol" initialize="false" initialize-with=". " delimiter=", "/>
+            <names delimiter="; " variable="illustrator narrator">
+              <name/>
               <label form="short" prefix=", " text-case="title"/>
             </names>
-            <names variable="compiler chair organizer curator series-creator executive-producer" delimiter="; ">
-              <name and="symbol" initialize="false" initialize-with=". " delimiter=", "/>
+            <names delimiter="; " variable="compiler chair organizer curator series-creator executive-producer">
+              <name/>
               <label form="long" prefix=", " text-case="title"/>
             </names>
           </group>
@@ -1261,166 +995,398 @@
       </choose>
     </group>
   </macro>
-  <macro name="database-location">
+  <macro name="secondary-contributors-periodical">
+    <group delimiter="; ">
+      <choose>
+        <if variable="title">
+          <names delimiter="; " variable="interviewer">
+            <name/>
+            <label form="short" prefix=", " text-case="title"/>
+          </names>
+        </if>
+      </choose>
+      <names delimiter="; " variable="translator narrator">
+        <name/>
+        <label form="short" prefix=", " text-case="title"/>
+      </names>
+    </group>
+  </macro>
+  <macro name="version-edition-volume">
+    <group delimiter=", ">
+      <text macro="version-labelled"/>
+      <text macro="edition-labelled"/>
+      <text macro="volume-booklike"/>
+    </group>
+  </macro>
+  <macro name="volume-booklike">
+    <group delimiter=", ">
+      <!-- Report series (APA example 52) -->
+      <choose>
+        <if match="any" type="document report standard">
+          <group delimiter=" ">
+            <text text-case="title" variable="collection-title"/>
+            <text variable="collection-number"/>
+          </group>
+        </if>
+      </choose>
+      <text macro="supplement-number-labelled"/>
+      <choose>
+        <if variable="volume">
+          <choose>
+            <!-- Non-numeric volumes are already printed as part of the book title -->
+            <if variable="volume-title"/>
+            <else-if is-numeric="volume">
+              <text macro="volume-labelled"/>
+            </else-if>
+          </choose>
+        </if>
+        <else>
+          <text macro="number-of-volumes-labelled"/>
+        </else>
+      </choose>
+      <text macro="issue-labelled"/>
+      <text macro="locators-booklike"/>
+    </group>
+  </macro>
+  <!-- Identification logic -->
+  <macro name="identification">
+    <group delimiter="; " prefix="(" suffix=")">
+      <!-- (Secondary contributors; Database location; Genre no. 123; Report Series 123, Version, Edition, Volume, Page) -->
+      <choose>
+        <if type="patent">
+          <text macro="patent-number"/>
+        </if>
+        <else-if match="any" type="post webpage">
+          <!-- For post webpage, container-title is treated as publisher -->
+          <text macro="identification-with-all-parts"/>
+        </else-if>
+        <else-if match="any" type="report">
+          <choose>
+            <if match="none" variable="title">
+              <!-- If there is no title, then genre and number are already printed as the title. -->
+              <text macro="secondary-contributors"/>
+              <text macro="database-location"/>
+              <text macro="identification-booklike"/>
+            </if>
+            <!-- If the report is a chapter in a larger report, then most parenthetical information is printed after the container. -->
+            <else-if variable="container-title">
+              <text macro="secondary-contributors"/>
+            </else-if>
+            <else>
+              <text macro="identification-with-all-parts"/>
+            </else>
+          </choose>
+        </else-if>
+        <else-if variable="container-title">
+          <group delimiter="; ">
+            <text macro="secondary-contributors"/>
+            <choose>
+              <if match="any" type="broadcast graphic map motion_picture song">
+                <!-- For audiovisual media, number information comes after title, not container-title (ex. 94) -->
+                <text macro="genre-number"/>
+              </if>
+            </choose>
+          </group>
+        </else-if>
+        <else>
+          <text macro="identification-with-all-parts"/>
+        </else>
+      </choose>
+    </group>
+  </macro>
+  <macro name="identification-booklike">
     <choose>
-      <if variable="archive-place" match="none">
-        <!-- With `archive-place`: physical archives. Without: online archives. -->
-        <text variable="archive_location"/>
-      </if>
+      <if match="any" type="article-journal article-magazine article-newspaper broadcast event interview patent performance periodical post post-weblog review review-book speech webpage"/>
+      <else-if type="paper-conference">
+        <choose>
+          <if match="any" variable="collection-editor compiler editor editorial-director">
+            <text macro="version-edition-volume"/>
+          </if>
+        </choose>
+      </else-if>
+      <else>
+        <text macro="version-edition-volume"/>
+      </else>
     </choose>
   </macro>
-  <macro name="number">
+  <macro name="identification-with-all-parts">
+    <group delimiter="; ">
+      <text macro="secondary-contributors"/>
+      <text macro="database-location"/>
+      <text macro="genre-number"/>
+      <text macro="identification-booklike"/>
+    </group>
+  </macro>
+  <!-- 3.3. Description [in square brackets] -->
+  <!-- Description utility macros -->
+  <macro name="description-generic">
+    <!-- For conference presentations/performances/events, chapters in reports/standards/generic documents, software, place description after the container title -->
     <choose>
-      <if variable="number">
-        <group delimiter=", ">
+      <if match="any" type="event paper-conference performance speech">
+        <choose>
+          <if match="any" variable="collection-editor compiler editor editorial-director issue page volume">
+            <text macro="format-bib"/>
+          </if>
+        </choose>
+      </if>
+      <else-if match="none" type="document report software standard">
+        <text macro="format-bib"/>
+      </else-if>
+    </choose>
+  </macro>
+  <macro name="description-interview">
+    <choose>
+      <if variable="title">
+        <text macro="format-bib"/>
+      </if>
+      <else-if variable="genre">
+        <group delimiter="; ">
           <group delimiter=" ">
-            <text variable="genre" text-case="title"/>
+            <text text-case="capitalize-first" variable="genre"/>
             <group delimiter=" ">
-              <label variable="number" form="short" text-case="capitalize-first"/>
-              <text variable="number"/>
+              <text form="verb" term="container-author"/>
+              <names variable="interviewer"/>
             </group>
           </group>
+        </group>
+      </else-if>
+      <else-if variable="interviewer">
+        <group delimiter="; ">
+          <names variable="interviewer">
+            <label form="verb" suffix=" " text-case="capitalize-first"/>
+            <name/>
+          </names>
+          <text text-case="capitalize-first" variable="medium"/>
+        </group>
+      </else-if>
+      <else>
+        <text macro="format-bib"/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="description-letter-bib">
+    <choose>
+      <if variable="recipient">
+        <group delimiter="; ">
+          <group delimiter=" ">
+            <choose>
+              <if match="none" variable="number">
+                <choose>
+                  <if variable="genre">
+                    <text text-case="capitalize-first" variable="genre"/>
+                  </if>
+                  <else-if variable="medium">
+                    <text text-case="capitalize-first" variable="medium"/>
+                  </else-if>
+                  <else>
+                    <text term="letter" text-case="capitalize-first"/>
+                  </else>
+                </choose>
+              </if>
+              <else>
+                <choose>
+                  <if variable="medium">
+                    <text text-case="capitalize-first" variable="medium"/>
+                  </if>
+                  <else>
+                    <text term="letter" text-case="capitalize-first"/>
+                  </else>
+                </choose>
+              </else>
+            </choose>
+            <names variable="recipient">
+              <label form="verb" suffix=" "/>
+              <name initialize="false"/>
+            </names>
+          </group>
           <choose>
-            <if type="thesis">
+            <if variable="genre">
               <choose>
-                <!-- Include the university in brackets if thesis is published -->
-                <if variable="archive DOI URL" match="any">
-                  <text variable="publisher"/>
+                <if match="none" variable="number">
+                  <text text-case="capitalize-first" variable="medium"/>
                 </if>
               </choose>
             </if>
           </choose>
         </group>
       </if>
-    </choose>
-  </macro>
-  <macro name="locators-booklike">
-    <choose>
-      <if type="article-journal article-magazine article-newspaper broadcast event interview patent performance periodical post post-weblog review review-book speech webpage" match="any"/>
-      <else-if type="paper-conference">
-        <choose>
-          <if variable="collection-editor compiler editor editorial-director" match="any">
-            <group delimiter=", ">
-              <text macro="version"/>
-              <text macro="edition"/>
-              <text macro="volume-booklike"/>
-            </group>
-          </if>
-        </choose>
-      </else-if>
       <else>
-        <group delimiter=", ">
-          <text macro="version"/>
-          <text macro="edition"/>
-          <text macro="volume-booklike"/>
-        </group>
+        <text macro="format-bib"/>
       </else>
     </choose>
   </macro>
-  <macro name="version">
-    <group delimiter=" ">
-      <label variable="version" text-case="capitalize-first"/>
-      <text variable="version"/>
-    </group>
-  </macro>
-  <macro name="edition">
+  <macro name="description-letter-intext">
     <choose>
-      <if is-numeric="edition">
+      <if variable="recipient">
         <group delimiter=" ">
-          <number variable="edition" form="ordinal"/>
-          <label variable="edition" form="short"/>
-        </group>
-      </if>
-      <else>
-        <text variable="edition"/>
-      </else>
-    </choose>
-  </macro>
-  <macro name="volume-booklike">
-    <group delimiter=", ">
-      <!-- Report series [ex. 52] -->
-      <choose>
-        <if type="document report standard">
-          <group delimiter=" ">
-            <text variable="collection-title" text-case="title"/>
-            <text variable="collection-number"/>
-          </group>
-        </if>
-      </choose>
-      <group delimiter=" ">
-        <label variable="supplement-number" text-case="capitalize-first"/>
-        <text variable="supplement-number"/>
-      </group>
-      <choose>
-        <if variable="volume" match="any">
           <choose>
-            <!-- Non-numeric volumes are already printed as part of the book title -->
-            <if variable="volume-title"/>
-            <else-if is-numeric="volume" match="none"/>
+            <if match="none" variable="number">
+              <text text-case="capitalize-first" variable="genre"/>
+            </if>
+            <else-if variable="medium">
+              <text text-case="capitalize-first" variable="medium"/>
+            </else-if>
             <else>
-              <group delimiter=" ">
-                <label variable="volume" form="short" text-case="capitalize-first"/>
-                <number variable="volume" form="numeric"/>
-              </group>
+              <text term="letter" text-case="capitalize-first"/>
             </else>
           </choose>
-        </if>
-        <else>
-          <group>
-            <label variable="number-of-volumes" form="short" text-case="capitalize-first" suffix=" "/>
-            <text term="page-range-delimiter" prefix="1"/>
-            <number variable="number-of-volumes" form="numeric"/>
-          </group>
-        </else>
-      </choose>
-      <group delimiter=" ">
-        <label variable="issue" text-case="capitalize-first"/>
-        <text variable="issue"/>
-      </group>
-      <group delimiter=" ">
-        <label variable="page" form="short" suffix=" "/>
-        <text variable="page"/>
-      </group>
-    </group>
-  </macro>
-  <macro name="reviewed-title">
-    <choose>
-      <if variable="reviewed-title">
-        <!-- Not possible to distinguish TV series episode from other reviewed
-             works without reviewed-container-title [Ex. 69] -->
-        <!-- Adapt for reviewed-container-title if that becomes available -->
-        <text variable="reviewed-title" font-style="italic"/>
+          <names variable="recipient">
+            <label form="verb" suffix=" "/>
+            <name/>
+          </names>
+        </group>
       </if>
       <else>
-        <!-- Assume title is title of reviewed work -->
-        <text variable="title" font-style="italic"/>
+        <text macro="format-intext"/>
       </else>
     </choose>
   </macro>
-  <macro name="reviewed-title-intext">
-    <choose>
-      <if variable="reviewed-title">
-        <!-- Not possible to distinguish TV series episode from other reviewed
-             works without reviewed-container-title [Ex. 69] -->
-        <!-- Adapt for reviewed-container-title if that becomes available -->
-        <text variable="reviewed-title" form="short" font-style="italic" text-case="title"/>
-      </if>
-      <else>
-        <!-- Assume title is title of reviewed work -->
-        <text variable="title" form="short" font-style="italic" text-case="title"/>
-      </else>
-    </choose>
-  </macro>
-  <macro name="format">
-    <choose>
-      <if variable="genre medium" match="any">
-        <group delimiter="; ">
+  <macro name="description-reviewed">
+    <!-- Reviewed item -->
+    <group delimiter="; ">
+      <group delimiter=", ">
+        <group delimiter=" ">
           <choose>
-            <if variable="number" match="none">
-              <text variable="genre" text-case="capitalize-first"/>
+            <if variable="reviewed-genre">
+              <group delimiter=" ">
+                <text form="long" term="review-of" text-case="capitalize-first"/>
+                <text text-case="lowercase" variable="reviewed-genre"/>
+              </group>
+            </if>
+            <!-- If no `reviewed-genre`, assume that `genre` or `medium` is entered as 'Review of the book' or similar -->
+            <else-if match="none" variable="number">
+              <choose>
+                <if variable="genre">
+                  <text text-case="capitalize-first" variable="genre"/>
+                </if>
+                <else-if variable="medium">
+                  <text text-case="capitalize-first" variable="medium"/>
+                </else-if>
+                <else-if type="review-book">
+                  <group delimiter=" ">
+                    <text form="long" term="review-of" text-case="capitalize-first"/>
+                    <text form="long" term="book" text-case="lowercase"/>
+                  </group>
+                </else-if>
+                <else>
+                  <text form="short" term="review-of" text-case="capitalize-first"/>
+                </else>
+              </choose>
+            </else-if>
+            <else>
+              <choose>
+                <if variable="medium">
+                  <text text-case="capitalize-first" variable="medium"/>
+                </if>
+                <else-if type="review-book">
+                  <group delimiter=" ">
+                    <text form="long" term="review-of" text-case="capitalize-first"/>
+                    <text form="long" term="book" text-case="lowercase"/>
+                  </group>
+                </else-if>
+                <else>
+                  <text form="short" term="review-of" text-case="capitalize-first"/>
+                </else>
+              </choose>
+            </else>
+          </choose>
+          <text macro="reviewed-title-bib"/>
+        </group>
+        <names variable="reviewed-author">
+          <label form="verb-short" suffix=" "/>
+          <name/>
+        </names>
+      </group>
+      <choose>
+        <if variable="genre">
+          <choose>
+            <if match="none" variable="number">
+              <text text-case="capitalize-first" variable="medium"/>
             </if>
           </choose>
-          <text variable="medium" text-case="capitalize-first"/>
+        </if>
+      </choose>
+    </group>
+  </macro>
+  <macro name="description-song">
+    <!-- Performer of classical music works -->
+    <group delimiter="; ">
+      <group delimiter=" ">
+        <choose>
+          <if match="none" variable="number">
+            <choose>
+              <if variable="genre">
+                <text text-case="capitalize-first" variable="genre"/>
+                <text form="verb" term="performer"/>
+              </if>
+              <else-if variable="medium">
+                <text text-case="capitalize-first" variable="medium"/>
+                <text form="verb" term="performer"/>
+              </else-if>
+              <else>
+                <text form="verb" term="performer" text-case="capitalize-first"/>
+              </else>
+            </choose>
+          </if>
+          <else>
+            <!-- If there is a number, genre is already printed in `genre-number` macro -->
+            <choose>
+              <if variable="medium">
+                <text text-case="capitalize-first" variable="medium"/>
+                <text form="verb" term="performer"/>
+              </if>
+              <else>
+                <text form="verb" term="performer" text-case="capitalize-first"/>
+              </else>
+            </choose>
+          </else>
+        </choose>
+        <names variable="author">
+          <substitute>
+            <names variable="performer"/>
+          </substitute>
+        </names>
+      </group>
+      <choose>
+        <if variable="genre">
+          <choose>
+            <if match="none" variable="number">
+              <text text-case="capitalize-first" variable="medium"/>
+            </if>
+          </choose>
+        </if>
+      </choose>
+    </group>
+  </macro>
+  <macro name="description-thesis">
+    <!-- Thesis type and institution -->
+    <group delimiter="; ">
+      <choose>
+        <if match="none" variable="number">
+          <group delimiter=", ">
+            <text text-case="capitalize-first" variable="genre"/>
+            <choose>
+              <if match="any" variable="archive DOI URL">
+                <!-- Include the university in brackets if thesis is published -->
+                <text variable="publisher"/>
+              </if>
+            </choose>
+          </group>
+        </if>
+      </choose>
+      <text text-case="capitalize-first" variable="medium"/>
+    </group>
+  </macro>
+  <macro name="format-bib">
+    <choose>
+      <if match="any" variable="genre medium">
+        <group delimiter="; ">
+          <choose>
+            <if match="none" variable="number">
+              <text text-case="capitalize-first" variable="genre"/>
+            </if>
+          </choose>
+          <text text-case="capitalize-first" variable="medium"/>
         </group>
       </if>
       <else>
@@ -1430,11 +1396,11 @@
   </macro>
   <macro name="format-intext">
     <choose>
-      <if variable="genre" match="any">
-        <text variable="genre" text-case="capitalize-first"/>
+      <if variable="genre">
+        <text text-case="capitalize-first" variable="genre"/>
       </if>
       <else-if variable="medium">
-        <text variable="medium" text-case="capitalize-first"/>
+        <text text-case="capitalize-first" variable="medium"/>
       </else-if>
       <else>
         <text macro="generic-type-label"/>
@@ -1450,9 +1416,9 @@
       <else-if type="software">
         <text term="software" text-case="capitalize-first"/>
       </else-if>
-      <else-if type="interview personal_communication" match="any">
+      <else-if match="any" type="interview personal_communication">
         <choose>
-          <if variable="archive container-title DOI publisher URL" match="none">
+          <if match="none" variable="archive archive-place container-title DOI publisher URL">
             <text term="personal-communication" text-case="capitalize-first"/>
           </if>
           <else-if type="interview">
@@ -1492,18 +1458,108 @@
       </else-if>
     </choose>
   </macro>
-  <!-- APA 'source' element contains four parts:
-       container, event, publisher, access -->
+  <macro name="reviewed-title-bib">
+    <choose>
+      <if variable="reviewed-title">
+        <!-- Not possible to distinguish TV series episode from other reviewed
+             works without reviewed-container-title (APA example 69) -->
+        <!-- Adapt for reviewed-container-title if that becomes available -->
+        <text font-style="italic" variable="reviewed-title"/>
+      </if>
+      <else>
+        <!-- Assume title is title of reviewed work -->
+        <text font-style="italic" variable="title"/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="reviewed-title-intext">
+    <choose>
+      <if variable="reviewed-title">
+        <!-- Not possible to distinguish TV series episode from other reviewed
+             works without reviewed-container-title (APA example 69) -->
+        <!-- Adapt for reviewed-container-title if that becomes available -->
+        <text font-style="italic" form="short" text-case="title" variable="reviewed-title"/>
+      </if>
+      <else>
+        <!-- Assume title is title of reviewed work -->
+        <text font-style="italic" form="short" text-case="title" variable="title"/>
+      </else>
+    </choose>
+  </macro>
+  <!-- Description logic -->
+  <macro name="description-bib">
+    <group prefix="[" suffix="]">
+      <choose>
+        <if match="any" type="interview" variable="interviewer">
+          <text macro="description-interview"/>
+        </if>
+        <else-if match="any" type="review review-book" variable="reviewed-author reviewed-genre reviewed-title">
+          <text macro="description-reviewed"/>
+        </else-if>
+        <else-if type="personal_communication">
+          <text macro="description-letter-bib"/>
+        </else-if>
+        <else-if type="song" variable="composer">
+          <text macro="description-song"/>
+        </else-if>
+        <else-if type="thesis">
+          <text macro="description-thesis"/>
+        </else-if>
+        <else-if match="none" variable="container-title">
+          <!-- Other description -->
+          <text macro="format-bib"/>
+        </else-if>
+        <else>
+          <text macro="description-generic"/>
+        </else>
+      </choose>
+    </group>
+  </macro>
+  <macro name="description-intext">
+    <group prefix="[" suffix="]">
+      <choose>
+        <if variable="reviewed-title">
+          <group delimiter=" ">
+            <text term="review-of" text-case="capitalize-first"/>
+            <text macro="reviewed-title-intext"/>
+          </group>
+        </if>
+        <else-if match="any" type="interview" variable="interviewer">
+          <names variable="interviewer">
+            <label form="verb" suffix=" " text-case="capitalize-first"/>
+            <name/>
+            <substitute>
+              <text macro="format-intext"/>
+            </substitute>
+          </names>
+        </else-if>
+        <else-if type="personal_communication">
+          <text macro="description-letter-intext"/>
+        </else-if>
+        <else>
+          <text macro="format-intext"/>
+        </else>
+      </choose>
+    </group>
+  </macro>
+  <!-- 4. Source -->
+  <!-- Four parts in APA 'source' element:
+
+       1. Container
+       2. Event
+       3. Publication details
+       4. Access -->
+  <!-- 4.1. Container -->
   <macro name="container">
     <choose>
-      <if type="article-journal article-magazine article-newspaper periodical post-weblog review review-book" match="any">
+      <if match="any" type="article-journal article-magazine article-newspaper periodical post-weblog review review-book">
         <!-- Periodical items -->
         <text macro="container-periodical"/>
       </if>
       <else-if type="paper-conference">
         <!-- Determine if paper-conference is a periodical- or book-like -->
         <choose>
-          <if variable="editor editorial-director collection-editor container-author" match="any">
+          <if match="any" variable="collection-editor container-author editor editorial-director">
             <text macro="container-booklike"/>
           </if>
           <else>
@@ -1511,55 +1567,15 @@
           </else>
         </choose>
       </else-if>
-      <else-if type="post webpage" match="none">
-        <!-- post and webpage treat container-title like publisher -->
+      <else-if match="none" type="post webpage">
+        <!-- Webpages treat container-title like publisher -->
         <text macro="container-booklike"/>
       </else-if>
     </choose>
   </macro>
-  <macro name="container-periodical">
-    <group delimiter=". ">
-      <group delimiter=", ">
-        <text variable="container-title" font-style="italic" text-case="title"/>
-        <choose>
-          <if variable="volume">
-            <group>
-              <text variable="volume" font-style="italic"/>
-              <text variable="issue" prefix="(" suffix=")"/>
-            </group>
-          </if>
-          <else>
-            <text variable="issue" font-style="italic"/>
-          </else>
-        </choose>
-        <choose>
-          <if variable="number">
-            <!-- Ex. 6: Journal article with article number or eLocator -->
-            <group delimiter=" ">
-              <text term="article-locator" text-case="capitalize-first"/>
-              <text variable="number"/>
-            </group>
-          </if>
-          <else>
-            <text variable="page"/>
-          </else>
-        </choose>
-      </group>
-      <choose>
-        <if variable="issued">
-          <choose>
-            <if variable="issue number page volume" match="none">
-              <!-- We print the status variable directly rather than using in-press, etc. terms. -->
-              <text variable="status" text-case="capitalize-first"/>
-            </if>
-          </choose>
-        </if>
-      </choose>
-    </group>
-  </macro>
   <macro name="container-booklike">
     <choose>
-      <if variable="container-title" match="any">
+      <if variable="container-title">
         <group delimiter=" ">
           <choose>
             <if type="song">
@@ -1570,161 +1586,167 @@
             </else>
           </choose>
           <group delimiter=", ">
-            <names variable="executive-producer">
-              <name and="symbol" initialize="false" initialize-with=". " delimiter=", "/>
-              <label form="long" text-case="title" prefix=" (" suffix=")"/>
-              <substitute>
-                <names variable="series-creator"/>
-                <names variable="editor-translator">
-                  <name and="symbol" initialize="false" initialize-with=". " delimiter=", "/>
-                  <label form="short" text-case="title" prefix=" (" suffix=")"/>
-                </names>
-                <!-- TODO: Translator omitted here on the assumption that editor-translators are uncommon 
-                           for chapter citations. If needed, direct entry or automatic population of
-                           `editor-translator` can produce combined labels. -->
-                <names variable="editor">
-                  <name and="symbol" initialize="false" initialize-with=". " delimiter=", "/>
-                  <label form="short" text-case="title" prefix=" (" suffix=")"/>
-                </names>
-                <names variable="editorial-director">
-                  <name and="symbol" initialize="false" initialize-with=". " delimiter=", "/>
-                  <label form="short" text-case="title" prefix=" (" suffix=")"/>
-                </names>
-                <names variable="compiler"/>
-                <choose>
-                  <if type="event performance speech" match="any">
-                    <names variable="chair"/>
-                    <names variable="organizer"/>
-                  </if>
-                </choose>
-                <names variable="curator"/>
-                <names variable="collection-editor">
-                  <name and="symbol" initialize="false" initialize-with=". " delimiter=", "/>
-                  <label form="short" text-case="title" prefix=" (" suffix=")"/>
-                </names>
-                <names variable="container-author"/>
-              </substitute>
-            </names>
-            <group delimiter=": " font-style="italic">
-              <text variable="container-title"/>
-              <text macro="volume-title"/>
-            </group>
+            <text macro="container-contributors"/>
+            <text macro="container-title-booklike"/>
           </group>
-          <text macro="parenthetical-container"/>
-          <text macro="bracketed-container"/>
+          <text macro="container-identification"/>
+          <text macro="container-description"/>
         </group>
       </if>
     </choose>
   </macro>
-  <macro name="publisher">
-    <group delimiter="; ">
+  <macro name="container-periodical">
+    <group delimiter=". ">
+      <group delimiter=", ">
+        <text font-style="italic" text-case="title" variable="container-title"/>
+        <text macro="volume-periodical"/>
+        <text macro="locators-periodical"/>
+      </group>
       <choose>
-        <if type="thesis">
+        <if variable="issued">
           <choose>
-            <if variable="archive DOI URL" match="none">
-              <text variable="publisher"/>
+            <if match="none" variable="issue number page volume">
+              <!-- We print the status variable directly rather than using in-press, etc. terms. -->
+              <text text-case="capitalize-first" variable="status"/>
             </if>
           </choose>
         </if>
-        <else-if type="post webpage" match="any">
-          <!-- For websites, treat container title like publisher -->
-          <group delimiter="; ">
-            <text variable="container-title" text-case="title"/>
-            <text variable="publisher"/>
-          </group>
-        </else-if>
-        <else-if type="paper-conference">
-          <!-- For paper-conference, don't print publisher if in a journal-like proceedings -->
-          <choose>
-            <if variable="collection-editor compiler editor editorial-director" match="any">
-              <text variable="publisher"/>
-            </if>
-          </choose>
-        </else-if>
-        <else-if type="article-journal article-magazine article-newspaper periodical post-weblog review review-book" match="none">
-          <text variable="publisher"/>
-        </else-if>
       </choose>
-      <group delimiter=", ">
-        <choose>
-          <if variable="archive-place">
-            <!-- With `archive-place`: physical archives. Without: online archives. -->
-            <!-- For physical archives, print the location before the archive name.
-                For electronic archives, these are printed in macro="description". -->
-            <!-- Must test for archive_collection:
-                With collection: archive_collection (archive_location), archive, archive-place
-                No collection: archive (archive_location), archive-place
-            -->
-            <choose>
-              <if variable="archive_collection">
-                <group delimiter=" ">
-                  <text variable="archive_collection"/>
-                  <text variable="archive_location" prefix="(" suffix=")"/>
-                </group>
-                <text variable="archive"/>
-                <text variable="archive-place"/>
-              </if>
-              <else>
-                <group delimiter=" ">
-                  <text variable="archive"/>
-                  <text variable="archive_location" prefix="(" suffix=")"/>
-                </group>
-                <text variable="archive-place"/>
-              </else>
-            </choose>
-          </if>
-          <else>
-            <text variable="archive"/>
-          </else>
-        </choose>
-      </group>
     </group>
   </macro>
-  <macro name="access">
+  <!-- Container parallels main elements -->
+  <!-- 4.1.1. Author -->
+  <macro name="container-contributors">
+    <names variable="executive-producer">
+      <name/>
+      <label form="long" prefix=" (" suffix=")" text-case="title"/>
+      <substitute>
+        <names variable="series-creator"/>
+        <names variable="editor-translator">
+          <name/>
+          <label form="short" prefix=" (" suffix=")" text-case="title"/>
+        </names>
+        <!-- TODO: Translator omitted on the assumption that editor-translators are uncommon for chapter citations.
+             If needed, direct entry or automatic population of `editor-translator` can produce combined labels. -->
+        <names delimiter="; " variable="editor">
+          <name/>
+          <label form="short" prefix=" (" suffix=")" text-case="title"/>
+        </names>
+        <names variable="editorial-director">
+          <name/>
+          <label form="short" prefix=" (" suffix=")" text-case="title"/>
+        </names>
+        <names variable="compiler"/>
+        <choose>
+          <if match="any" type="event performance speech">
+            <names variable="chair"/>
+            <names variable="organizer"/>
+          </if>
+        </choose>
+        <names variable="curator"/>
+        <names variable="collection-editor">
+          <name/>
+          <label form="short" prefix=" (" suffix=")" text-case="title"/>
+        </names>
+        <names variable="container-author"/>
+      </substitute>
+    </names>
+  </macro>
+  <!-- 4.1.3.1 Container title -->
+  <macro name="container-title-booklike">
+    <group delimiter=": " font-style="italic">
+      <text variable="container-title"/>
+      <text macro="title-volume"/>
+    </group>
+  </macro>
+  <!-- 4.1.3.1 Container identification -->
+  <macro name="container-identification">
     <choose>
-      <if variable="DOI" match="any">
-        <text variable="DOI" prefix="https://doi.org/"/>
-      </if>
-      <else-if variable="URL">
-        <group delimiter=" ">
-          <choose>
-            <if variable="issued status" match="none">
-              <group delimiter=" ">
-                <text term="retrieved" text-case="capitalize-first"/>
-                <date variable="accessed" form="text" suffix=","/>
-                <text term="from"/>
-              </group>
-            </if>
-          </choose>
-          <text variable="URL"/>
+      <if variable="container-title">
+        <group prefix="(" suffix=")">
+          <group delimiter="; ">
+            <text macro="database-location"/>
+            <choose>
+              <if match="none" type="broadcast graphic map motion_picture song">
+                <!-- For audiovisual media, number information comes after title, not container-title (APA example 94) -->
+                <text macro="genre-number"/>
+              </if>
+            </choose>
+            <text macro="identification-booklike"/>
+          </group>
         </group>
-      </else-if>
+      </if>
     </choose>
   </macro>
+  <!-- 4.1.3.2 Container description -->
+  <macro name="container-description">
+    <group prefix="[" suffix="]">
+      <choose>
+        <if match="any" type="event paper-conference performance speech">
+          <!-- Conference presentations should describe the session [container] in description unless published in a proceedings -->
+          <choose>
+            <if match="none" variable="collection-editor compiler editor editorial-director issue page volume">
+              <text macro="format-bib"/>
+            </if>
+          </choose>
+        </if>
+        <else-if type="software">
+          <!-- For entries in mobile app reference works, place description after the container-title -->
+          <text macro="format-bib"/>
+        </else-if>
+        <else-if match="any" type="document report standard">
+          <!-- For chapters in report, standards, and generic documents, place description after the container title -->
+          <text macro="format-bib"/>
+        </else-if>
+      </choose>
+    </group>
+  </macro>
+  <!-- 4.1.4. Source -->
+  <macro name="locators-periodical">
+    <choose>
+      <if variable="number">
+        <text macro="number-article-labelled"/>
+      </if>
+      <else>
+        <text variable="page"/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="volume-periodical">
+    <group delimiter=", ">
+      <text font-style="italic" text-case="title" variable="collection-title"/>
+      <choose>
+        <if variable="volume">
+          <group>
+            <text font-style="italic" variable="volume"/>
+            <text prefix="(" suffix=")" variable="issue"/>
+          </group>
+        </if>
+        <else>
+          <text font-style="italic" variable="issue"/>
+        </else>
+      </choose>
+    </group>
+  </macro>
+  <!-- 4.2. Event -->
   <macro name="event">
     <choose>
-      <if variable="event event-title" match="any">
-        <!-- To prevent Zotero from printing event-place due to its double-mapping of all 'place' to
-             both publisher-place and event-place. Remove this 'choose' when that is changed. -->
+      <if match="any" variable="event event-title">
+        <!-- To prevent Zotero from printing `event-place` due to its double-mapping of all 'place' to
+             both `publisher-place` and `event-place`. Remove this when that is changed. -->
         <choose>
           <if type="paper-conference">
             <choose>
-              <if variable="collection-editor compiler editor editorial-director issue page volume" match="none">
+              <if match="none" variable="collection-editor compiler editor editorial-director issue page volume">
                 <!-- Don't print event info for conference papers published in a proceedings -->
-                <group delimiter=", ">
-                  <text macro="event-title"/>
-                  <text variable="event-place"/>
-                </group>
+                <text macro="event-title-place"/>
               </if>
             </choose>
           </if>
           <else>
             <!-- For other item types, print event info even if published (e.g., for collection catalogs, performance programs.
                  These items aren't given explicit examples in the APA manual, so err on the side of providing too much information. -->
-            <group delimiter=", ">
-              <text macro="event-title"/>
-              <text variable="event-place"/>
-            </group>
+            <text macro="event-title-place"/>
           </else>
         </choose>
       </if>
@@ -1732,9 +1754,9 @@
   </macro>
   <macro name="event-title">
     <choose>
-      <!-- TODO: We expect "event-title" to be used,
+      <!-- TODO: We expect `event-title` to be used,
            but processors and applications may not be updated yet.
-           This macro ensures that either "event" or "event-title" can be accpeted.
+           This macro ensures that either `event` or `event-title` can be accepted.
            Remove if procesor logic and application adoption can handle this. -->
       <if variable="event-title">
         <text variable="event-title"/>
@@ -1744,11 +1766,153 @@
       </else>
     </choose>
   </macro>
-  <!-- After 'source', APA also prints publication history (original publication, reprint info, retraction info) -->
+  <macro name="event-title-place">
+    <group delimiter=", ">
+      <text macro="event-title"/>
+      <text variable="event-place"/>
+    </group>
+  </macro>
+  <!-- 4.3. Publication details -->
+  <!-- Publication utility macros -->
+  <macro name="archive">
+    <group delimiter=", ">
+      <choose>
+        <if variable="archive-place">
+          <!-- With `archive-place`: physical archives. Without: online archives. -->
+          <!-- For physical archives, print the location before the archive name.
+                For electronic archives, these are printed in macro="description". -->
+          <!-- Must test for archive_collection:
+                With collection: archive_collection (archive_location), archive, archive-place
+                No collection: archive (archive_location), archive-place
+            -->
+          <choose>
+            <if variable="archive_collection">
+              <group delimiter=" ">
+                <text variable="archive_collection"/>
+                <text prefix="(" suffix=")" variable="archive_location"/>
+              </group>
+              <text variable="archive"/>
+              <text variable="archive-place"/>
+            </if>
+            <else>
+              <group delimiter=" ">
+                <text variable="archive"/>
+                <text prefix="(" suffix=")" variable="archive_location"/>
+              </group>
+              <text variable="archive-place"/>
+            </else>
+          </choose>
+        </if>
+        <else>
+          <text variable="archive"/>
+        </else>
+      </choose>
+    </group>
+  </macro>
+  <macro name="publisher">
+    <choose>
+      <if variable="publisher">
+        <text variable="publisher"/>
+      </if>
+      <else-if match="none" variable="event-place">
+        <!-- Work around Zotero double-mapping of event/publisher place -->
+        <text variable="publisher-place"/>
+      </else-if>
+    </choose>
+  </macro>
+  <!-- Publication logic -->
+  <macro name="publication">
+    <choose>
+      <if type="thesis">
+        <choose>
+          <if match="none" variable="archive DOI URL">
+            <text macro="publisher"/>
+          </if>
+        </choose>
+      </if>
+      <else-if match="any" type="post webpage">
+        <!-- Webpages treat container-title like publisher -->
+        <group delimiter="; ">
+          <text text-case="title" variable="container-title"/>
+          <text macro="publisher"/>
+        </group>
+      </else-if>
+      <else-if type="paper-conference">
+        <!-- For paper-conference, don't print publisher if in a journal-like proceedings -->
+        <choose>
+          <if match="any" variable="collection-editor compiler editor editorial-director">
+            <text macro="publisher"/>
+          </if>
+        </choose>
+      </else-if>
+      <else-if match="none" type="article-journal article-magazine article-newspaper periodical post-weblog review review-book">
+        <text macro="publisher"/>
+      </else-if>
+    </choose>
+  </macro>
+  <macro name="publication-archive">
+    <group delimiter="; ">
+      <text macro="publication"/>
+      <text macro="archive"/>
+    </group>
+  </macro>
+  <!-- 4.4. Access -->
+  <macro name="access">
+    <choose>
+      <if variable="DOI">
+        <text prefix="https://doi.org/" variable="DOI"/>
+      </if>
+      <else-if variable="URL">
+        <group delimiter=" ">
+          <choose>
+            <if match="none" variable="issued status">
+              <group delimiter=" ">
+                <text term="retrieved" text-case="capitalize-first"/>
+                <group delimiter=", ">
+                  <date form="text" variable="accessed"/>
+                  <text term="from"/>
+                </group>
+              </group>
+            </if>
+          </choose>
+          <text variable="URL"/>
+        </group>
+      </else-if>
+    </choose>
+  </macro>
+  <!-- 5. Publication history -->
+  <!-- History utility macros -->
+  <macro name="original-publisher">
+    <choose>
+      <if variable="original-publisher">
+        <text variable="original-publisher"/>
+      </if>
+      <else>
+        <text variable="original-publisher-place"/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="original-title">
+    <choose>
+      <if variable="original-title">
+        <text value="as"/>
+        <choose>
+          <if match="any" type="article-journal article-magazine article-newspaper periodical post-weblog review review-book">
+            <text variable="original-title"/>
+          </if>
+          <else>
+            <text font-style="italic" variable="original-title"/>
+          </else>
+        </choose>
+      </if>
+    </choose>
+  </macro>
+  <!-- History logic -->
   <macro name="publication-history">
+    <!-- Information appended to 'source': original publication, reprint info, retraction info -->
     <choose>
       <if type="patent">
-        <text variable="references" prefix="(" suffix=")"/>
+        <text prefix="(" suffix=")" variable="references"/>
       </if>
       <else>
         <group delimiter="; " prefix="(" suffix=")">
@@ -1756,8 +1920,8 @@
           <choose>
             <if variable="issued">
               <choose>
-                <if variable="issue number page volume" match="any">
-                  <text variable="status" text-case="capitalize-first"/>
+                <if match="any" variable="issue number page volume">
+                  <text text-case="capitalize-first" variable="status"/>
                 </if>
               </choose>
             </if>
@@ -1766,29 +1930,31 @@
             <if variable="references">
               <!-- This provides the option for more elaborate description
                     of publication history, such as full "reprinted" references
-                    (examples 11, 43, 44) -->
+                    (APA examples 11, 43, 44) -->
               <text variable="references"/>
             </if>
             <else>
-              <group delimiter=" ">
-                <text term="original-work-published" text-case="capitalize-first"/>
-                <choose>
-                  <if is-uncertain-date="original-date">
-                    <text term="circa" form="short"/>
-                  </if>
-                </choose>
-                <date variable="original-date">
-                  <date-part name="year"/>
-                </date>
-              </group>
+              <text macro="publication-history-variables"/>
             </else>
           </choose>
         </group>
       </else>
     </choose>
   </macro>
-  <!-- Legal citations have their own rules -->
-  <macro name="legal-cites">
+  <macro name="publication-history-variables">
+    <group delimiter=" ">
+      <text term="original-work-published" text-case="capitalize-first"/>
+      <group delimiter="; ">
+        <text macro="original-title"/>
+        <group delimiter=", ">
+          <text macro="original-publisher"/>
+          <text macro="original-date-year"/>
+        </group>
+      </group>
+    </group>
+  </macro>
+  <!-- Parallel rules for legal citations -->
+  <macro name="legal-bib">
     <!-- `treaty`: for treaties -->
     <!-- `legal_case`: for all legal and court cases -->
     <!-- `bill`: for bills, resolutions, federal reports -->
@@ -1800,16 +1966,14 @@
         <if type="treaty">
           <group delimiter=", " suffix=".">
             <!-- APA generally defers to Bluebook for legal citations, but diverges without
-                explanation for treaty items. We follow the Bluebook format that was used 
+                explanation for treaty items. We follow the Bluebook format that was used
                 in APA 6th ed. -->
-            <!-- APA manual omits treaty parties/authors, but per Bluebook 
+            <!-- APA manual omits treaty parties/authors, but per Bluebook
                 they should be included at least for bilateral treaties. -->
-            <names variable="author">
-              <name initialize-with="." form="short" delimiter="-"/>
-            </names>
+            <text macro="author-legal"/>
             <text macro="date-legal"/>
-            <!-- APA manual omits treaty source/report called for by Bluebook in favor of just URL. 
-                Both are included here, following the APA style used for all other item types 
+            <!-- APA manual omits treaty source/report called for by Bluebook in favor of just URL.
+                Both are included here, following the APA style used for all other item types
                 to end the reference with a period, then give the URL afterward. -->
             <text macro="container-legal"/>
           </group>
@@ -1821,7 +1985,7 @@
               <text macro="container-legal"/>
             </group>
             <text macro="date-legal"/>
-            <text macro="parenthetical-legal"/>
+            <text macro="identification-legal"/>
           </group>
         </else>
       </choose>
@@ -1829,20 +1993,75 @@
       <text macro="access"/>
     </group>
   </macro>
+  <!-- 1. Legal author -->
+  <macro name="author-legal">
+    <names variable="author">
+      <name delimiter="-" form="short"/>
+    </names>
+  </macro>
+  <!-- 2. Legal date -->
+  <macro name="date-legal-case">
+    <group delimiter=" " prefix="(" suffix=")">
+      <text variable="authority"/>
+      <choose>
+        <if variable="container-title">
+          <!-- Print only year for cases published in reporters-->
+          <text macro="date-issued-year"/>
+        </if>
+        <else>
+          <!-- APA manual doesn't include examples of cases not yet
+                   published in a reporter, but this is Bluebook style. -->
+          <text macro="date-issued-full"/>
+        </else>
+      </choose>
+    </group>
+  </macro>
+  <macro name="date-legal">
+    <choose>
+      <if type="treaty">
+        <text macro="date-issued-full"/>
+      </if>
+      <else-if type="legal_case">
+        <text macro="date-legal-case"/>
+      </else-if>
+      <else-if match="any" type="bill hearing legislation regulation">
+        <group delimiter=" " prefix="(" suffix=")">
+          <group delimiter=" ">
+            <text macro="original-date-year"/>
+            <text form="symbol" term="and"/>
+          </group>
+          <choose>
+            <if variable="issued">
+              <!-- APA manual includes "rev." before the revision year,
+                   but this isn't part of the Bluebook rules. -->
+              <text macro="date-issued-year"/>
+            </if>
+            <else>
+              <!-- Show proposal date for uncodified regualtions.
+                   Assume date is entered literally ala "proposed May 23, 2016".
+                   TODO: Add 'proposed' term here if that becomes available -->
+              <date form="text" variable="submitted"/>
+            </else>
+          </choose>
+        </group>
+      </else-if>
+    </choose>
+  </macro>
+  <!-- 3.1. Legal title -->
   <macro name="title-legal">
     <choose>
-      <if type="bill legal_case legislation regulation treaty" match="any">
-        <text variable="title" text-case="title"/>
+      <if match="any" type="bill legal_case legislation regulation treaty">
+        <text text-case="title" variable="title"/>
       </if>
       <else-if type="hearing">
-        <!-- APA uses a comma delimiter and omits "hearing before the" for hearings with testimony, 
+        <!-- APA uses a comma delimiter and omits "hearing before the" for hearings with testimony,
              but follows Bluebook rules (colon delimiter, prefix before the committee name) for
              references to the whole hearing. We simply follow the Bluebook rules for both, but
              use APA style capitalization (not capitalizing "Before" or the title of the hearing). -->
         <group delimiter=": " font-style="italic">
-          <text variable="title" text-case="capitalize-first"/>
+          <text text-case="capitalize-first" variable="title"/>
           <group delimiter=" ">
-            <text term="hearing" form="long" text-case="capitalize-first"/>
+            <text form="long" term="hearing" text-case="capitalize-first"/>
             <group delimiter=" ">
               <group delimiter=" ">
                 <!-- APA manual omits the bill number, but it should be included per Bluebook if relevant -->
@@ -1851,7 +2070,7 @@
               </group>
               <group delimiter=" ">
                 <!-- Use the `at` term to hold "before the" -->
-                <text term="at" form="long"/>
+                <text form="long" term="at"/>
                 <text variable="section"/>
               </group>
             </group>
@@ -1860,124 +2079,95 @@
       </else-if>
     </choose>
   </macro>
-  <macro name="date-legal">
+  <!-- 3.2. Legal identification (in parentheses) -->
+  <macro name="identification-legal">
     <choose>
-      <if type="treaty">
-        <date variable="issued" form="text"/>
+      <if type="hearing">
+        <group delimiter=" " prefix="(" suffix=")">
+          <!-- Use the 'verb' form of the hearing term to hold 'testimony of' -->
+          <text form="verb" term="hearing"/>
+          <names variable="author">
+            <name initialize="false"/>
+          </names>
+        </group>
       </if>
-      <else-if type="legal_case">
-        <group prefix="(" suffix=")" delimiter=" ">
-          <text variable="authority"/>
-          <choose>
-            <if variable="container-title" match="any">
-              <!-- Print only year for cases published in reporters-->
-              <date variable="issued" form="numeric" date-parts="year"/>
-            </if>
-            <else>
-              <!-- APA manual doesn't include examples of cases not yet
-                   published in a reporter, but this is Bluebook style. -->
-              <date variable="issued" form="text"/>
-            </else>
-          </choose>
-        </group>
-      </else-if>
-      <else-if type="bill hearing legislation regulation" match="any">
-        <group prefix="(" suffix=")" delimiter=" ">
-          <group delimiter=" ">
-            <date variable="original-date">
-              <date-part name="year"/>
-            </date>
-            <text term="and" form="symbol"/>
-          </group>
-          <choose>
-            <if variable="issued">
-              <!-- APA manual includes "rev." before the revision year, 
-                   but this isn't part of the Bluebook rules. -->
-              <date variable="issued">
-                <date-part name="year"/>
-              </date>
-            </if>
-            <else>
-              <!-- Show proposal date for uncodified regualtions. 
-                   Assume date is entered literally ala "proposed May 23, 2016".
-                   TODO: Add 'proposed' term here if that becomes available -->
-              <date variable="submitted" form="text"/>
-            </else>
-          </choose>
-        </group>
+      <else-if match="any" type="bill legislation regulation">
+        <!-- For uncodified regulations, assume future code section is in `status`. -->
+        <text prefix="(" suffix=")" variable="status"/>
       </else-if>
     </choose>
   </macro>
-  <macro name="container-legal">
-    <!-- Expect legal item container-titles to be stored in short form -->
+  <!-- 4. Legal source -->
+  <!-- Legal source utility macros -->
+  <macro name="container-bill">
+    <group delimiter=", ">
+      <group delimiter=" ">
+        <text variable="genre"/>
+        <group delimiter=" ">
+          <choose>
+            <!-- If there is no session number or code/record title, assume
+                     assume the item is a congressional report and include 'No.' term. -->
+            <if match="none" variable="chapter-number container-title">
+              <!-- The item is a congressional report, rather than a bill or resultion. -->
+              <text macro="number-labelled"/>
+            </if>
+            <else>
+              <text variable="number"/>
+            </else>
+          </choose>
+        </group>
+      </group>
+      <group delimiter=" ">
+        <text variable="authority"/>
+        <!-- 'session' is `chapter-number` -->
+        <text variable="chapter-number"/>
+      </group>
+      <group delimiter=" ">
+        <text variable="volume"/>
+        <text variable="container-title"/>
+        <text variable="page-first"/>
+      </group>
+    </group>
+  </macro>
+  <macro name="container-hearing">
+    <group delimiter=" ">
+      <text variable="authority"/>
+      <!-- 'session' is `chapter-number` -->
+      <text variable="chapter-number"/>
+    </group>
+  </macro>
+  <macro name="container-legal-case">
+    <group delimiter=" ">
+      <choose>
+        <if variable="container-title">
+          <group delimiter=" ">
+            <text variable="volume"/>
+            <text variable="container-title"/>
+            <text macro="section-labelled"/>
+            <choose>
+              <if match="any" variable="page page-first">
+                <text variable="page-first"/>
+              </if>
+              <else>
+                <text value="___"/>
+              </else>
+            </choose>
+          </group>
+        </if>
+        <else>
+          <text macro="number-labelled"/>
+        </else>
+      </choose>
+    </group>
+  </macro>
+  <macro name="container-legislation">
     <choose>
-      <if type="treaty">
-        <group delimiter=" ">
-          <number variable="volume"/>
-          <text variable="container-title"/>
-          <choose>
-            <if variable="page page-first" match="any">
-              <text variable="page-first"/>
-            </if>
-            <else>
-              <group delimiter=" ">
-                <label variable="number" form="short" text-case="capitalize-first"/>
-                <text variable="number"/>
-              </group>
-            </else>
-          </choose>
-        </group>
-      </if>
-      <else-if type="legal_case">
-        <group delimiter=" ">
-          <choose>
-            <if variable="container-title">
-              <group delimiter=" ">
-                <text variable="volume"/>
-                <text variable="container-title"/>
-                <group delimiter=" ">
-                  <label variable="section" form="symbol"/>
-                  <text variable="section"/>
-                </group>
-                <choose>
-                  <if variable="page page-first" match="any">
-                    <text variable="page-first"/>
-                  </if>
-                  <else>
-                    <text value="___"/>
-                  </else>
-                </choose>
-              </group>
-            </if>
-            <else>
-              <group delimiter=" ">
-                <label variable="number" form="short" text-case="capitalize-first"/>
-                <text variable="number"/>
-              </group>
-            </else>
-          </choose>
-        </group>
-      </else-if>
-      <else-if type="bill">
+      <if variable="number">
+        <!-- There's a public law number. -->
         <group delimiter=", ">
           <group delimiter=" ">
-            <text variable="genre"/>
-            <group delimiter=" ">
-              <choose>
-                <!-- If there is no session number or code/record title, assume
-                     assume the item is a congressional report and include 'No.' term. -->
-                <if variable="chapter-number container-title" match="none">
-                  <!-- The item is a congressional report, rather than a bill or resultion. -->
-                  <label variable="number" form="short" text-case="capitalize-first"/>
-                </if>
-              </choose>
-              <text variable="number"/>
-            </group>
-          </group>
-          <group delimiter=" ">
-            <text variable="authority"/>
-            <!-- 'session' is `chapter-number` -->
-            <text variable="chapter-number"/>
+            <text value="Pub. L. No."/>
+            <text variable="number"/>
           </group>
           <group delimiter=" ">
             <text variable="volume"/>
@@ -1985,149 +2175,139 @@
             <text variable="page-first"/>
           </group>
         </group>
-      </else-if>
-      <else-if type="hearing">
+      </if>
+      <else>
         <group delimiter=" ">
-          <text variable="authority"/>
-          <!-- 'session' is `chapter-number` -->
-          <text variable="chapter-number"/>
+          <text variable="volume"/>
+          <text variable="container-title"/>
+          <choose>
+            <if variable="section">
+              <text macro="section-labelled"/>
+            </if>
+            <else>
+              <text variable="page-first"/>
+            </else>
+          </choose>
         </group>
-      </else-if>
-      <else-if type="legislation">
+      </else>
+    </choose>
+  </macro>
+  <macro name="container-regulation">
+    <group delimiter=", ">
+      <group delimiter=" ">
+        <text variable="genre"/>
+        <text macro="number-labelled"/>
+      </group>
+      <group delimiter=" ">
+        <text variable="volume"/>
+        <text variable="container-title"/>
         <choose>
-          <if variable="number">
-            <!-- There's a public law number. -->
-            <group delimiter=", ">
-              <text variable="number" prefix="Pub. L. No. "/>
-              <group delimiter=" ">
-                <text variable="volume"/>
-                <text variable="container-title"/>
-                <text variable="page-first"/>
-              </group>
-            </group>
+          <if variable="section">
+            <text macro="section-labelled"/>
           </if>
           <else>
-            <group delimiter=" ">
-              <text variable="volume"/>
-              <text variable="container-title"/>
-              <choose>
-                <if variable="section">
-                  <group delimiter=" ">
-                    <label variable="section" form="symbol"/>
-                    <text variable="section"/>
-                  </group>
-                </if>
-                <else>
-                  <text variable="page-first"/>
-                </else>
-              </choose>
-            </group>
+            <text variable="page-first"/>
           </else>
         </choose>
-      </else-if>
-      <else-if type="regulation">
-        <group delimiter=", ">
-          <group delimiter=" ">
-            <text variable="genre"/>
-            <group delimiter=" ">
-              <label variable="number" form="short" text-case="capitalize-first"/>
-              <text variable="number"/>
-            </group>
-          </group>
-          <group delimiter=" ">
-            <text variable="volume"/>
-            <text variable="container-title"/>
-            <choose>
-              <if variable="section">
-                <group delimiter=" ">
-                  <label variable="section" form="symbol"/>
-                  <text variable="section"/>
-                </group>
-              </if>
-              <else>
-                <text variable="page-first"/>
-              </else>
-            </choose>
-          </group>
-        </group>
-      </else-if>
-    </choose>
-  </macro>
-  <macro name="parenthetical-legal">
-    <choose>
-      <if type="hearing">
-        <group prefix="(" suffix=")" delimiter=" ">
-          <!-- Use the 'verb' form of the hearing term to hold 'testimony of' -->
-          <text term="hearing" form="verb"/>
-          <names variable="author">
-            <name and="symbol" delimiter=", "/>
-          </names>
-        </group>
-      </if>
-      <else-if type="bill legislation regulation" match="any">
-        <!-- For uncodified regulations, assume future code section is in `status`. -->
-        <text variable="status" prefix="(" suffix=")"/>
-      </else-if>
-    </choose>
-  </macro>
-  <macro name="citation-locator">
-    <!-- Abbreviate page and paragraph, leave other locator labels in long form, cf. Rule 8.13 -->
-    <group delimiter=" ">
-      <choose>
-        <if locator="page paragraph" match="any">
-          <label variable="locator" form="short"/>
-        </if>
-        <else>
-          <label variable="locator" text-case="capitalize-first"/>
-        </else>
-      </choose>
-      <text variable="locator"/>
+      </group>
     </group>
   </macro>
-  <citation et-al-min="3" et-al-use-first="1" disambiguate-add-year-suffix="true" disambiguate-add-names="true" disambiguate-add-givenname="true" collapse="year" givenname-disambiguation-rule="primary-name-with-initials">
+  <macro name="container-treaty">
+    <group delimiter=" ">
+      <number variable="volume"/>
+      <text variable="container-title"/>
+      <choose>
+        <if match="any" variable="page page-first">
+          <text variable="page-first"/>
+        </if>
+        <else>
+          <text macro="number-labelled"/>
+        </else>
+      </choose>
+    </group>
+  </macro>
+  <!-- Legal source logic -->
+  <macro name="container-legal">
+    <!-- Expect legal item container-titles to be stored in short form -->
+    <choose>
+      <if type="bill">
+        <text macro="container-bill"/>
+      </if>
+      <else-if type="hearing">
+        <text macro="container-hearing"/>
+      </else-if>
+      <else-if type="legal_case">
+        <text macro="container-legal-case"/>
+      </else-if>
+      <else-if type="legislation">
+        <text macro="container-legislation"/>
+      </else-if>
+      <else-if type="regulation">
+        <text macro="container-regulation"/>
+      </else-if>
+      <else-if type="treaty">
+        <text macro="container-treaty"/>
+      </else-if>
+    </choose>
+  </macro>
+  <!-- Main logic -->
+  <citation collapse="year" disambiguate-add-givenname="true" disambiguate-add-names="true" disambiguate-add-year-suffix="true" et-al-min="3" et-al-use-first="1" givenname-disambiguation-rule="primary-name-with-initials">
     <sort>
       <key macro="author-sort" names-min="3" names-use-first="1"/>
       <key macro="date-sort-group" sort="ascending"/>
       <key macro="date-sort" sort="ascending"/>
       <key variable="status"/>
     </sort>
-    <layout prefix="(" suffix=")" delimiter="; ">
+    <layout delimiter="; " prefix="(" suffix=")">
       <group delimiter=", ">
         <text macro="author-intext"/>
         <text macro="date-intext"/>
-        <text macro="citation-locator"/>
+        <text macro="locator-labelled"/>
       </group>
     </layout>
   </citation>
-  <bibliography hanging-indent="true" et-al-min="21" et-al-use-first="19" et-al-use-last="true" entry-spacing="0" line-spacing="2">
+  <macro name="bibliography">
+    <group delimiter=" ">
+      <group delimiter=". " suffix=".">
+        <text macro="author-bib"/>
+        <text macro="date-bib"/>
+        <text macro="title-and-descriptions"/>
+        <text macro="container"/>
+        <text macro="event"/>
+        <text macro="publication-archive"/>
+      </group>
+      <text macro="access"/>
+      <text macro="publication-history"/>
+    </group>
+  </macro>
+  <macro name="bibliography-filtered">
+    <choose>
+      <if match="any" type="bill hearing legal_case legislation regulation treaty">
+        <!-- Legal items have different orders and delimiters -->
+        <text macro="legal-bib"/>
+      </if>
+      <else-if type="personal_communication">
+        <choose>
+          <if match="any" variable="archive archive-place container-title DOI publisher URL">
+            <text macro="bibliography"/>
+          </if>
+        </choose>
+      </else-if>
+      <else>
+        <text macro="bibliography"/>
+      </else>
+    </choose>
+  </macro>
+  <bibliography entry-spacing="0" et-al-min="21" et-al-use-first="19" et-al-use-last="true" hanging-indent="true" line-spacing="2">
     <sort>
       <key macro="author-sort"/>
       <key macro="date-sort-group" sort="ascending"/>
       <key macro="date-sort" sort="ascending"/>
       <key variable="status"/>
-      <key macro="title"/>
+      <key macro="title-bib"/>
     </sort>
     <layout>
-      <choose>
-        <if type="bill hearing legal_case legislation regulation treaty" match="any">
-          <!-- Legal items have different orders and delimiters -->
-          <text macro="legal-cites"/>
-        </if>
-        <else>
-          <group delimiter=" ">
-            <group delimiter=". " suffix=".">
-              <text macro="author-bib"/>
-              <text macro="date-bib"/>
-              <text macro="title-and-descriptions"/>
-              <text macro="container"/>
-              <text macro="event"/>
-              <text macro="publisher"/>
-            </group>
-            <text macro="access"/>
-            <text macro="publication-history"/>
-          </group>
-        </else>
-      </choose>
+      <text macro="bibliography-filtered"/>
     </layout>
   </bibliography>
 </style>

--- a/apa-numeric-superscript-brackets.csl
+++ b/apa-numeric-superscript-brackets.csl
@@ -1,16 +1,21 @@
 <?xml version="1.0" encoding="utf-8"?>
-<style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" demote-non-dropping-particle="never" page-range-format="expanded">
+<style xmlns="http://purl.org/net/xbiblio/csl" and="symbol" class="in-text" demote-non-dropping-particle="never" initialize-with=". " names-delimiter=", " page-range-format="expanded" version="1.0">
   <info>
-    <title>American Psychological Association 7th edition (numeric, brackets)</title>
-    <title-short>APA (numeric, superscript, brackets)</title-short>
-    <id>http://www.zotero.org/styles/apa-numeric-superscript-brackets</id>
-    <link href="http://www.zotero.org/styles/apa-numeric-superscript-brackets" rel="self"/>
+    <title>American Psychological Association 7th edition (numeric, superscript, brackets)</title>
+    <title-short>APA Style (numeric, superscript, brackets)</title-short>
+    <id>http://www.zotero.org/styles/apa-superscript-brackets</id>
+    <link href="http://www.zotero.org/styles/apa-superscript-brackets" rel="self"/>
     <link href="http://www.zotero.org/styles/apa" rel="template"/>
     <link href="https://apastyle.apa.org/style-grammar-guidelines/references/examples" rel="documentation"/>
     <author>
       <name>Brenton M. Wiernik</name>
       <email>zotero@wiernik.org</email>
+      <uri>https://orcid.org/0000-0001-9560-6336</uri>
     </author>
+    <contributor>
+      <name>Andrew Dunning</name>
+      <uri>https://orcid.org/0000-0003-0464-5036</uri>
+    </contributor>
     <category citation-format="numeric"/>
     <category field="psychology"/>
     <category field="generic-base"/>
@@ -20,39 +25,38 @@
   </info>
   <locale xml:lang="en">
     <terms>
-      <term name="editortranslator" form="short">
-        <single>ed. &amp; trans.</single>
-        <multiple>eds. &amp; trans.</multiple>
-      </term>
-      <term name="editor-translator" form="short">
-        <single>ed. &amp; trans.</single>
-        <multiple>eds. &amp; trans.</multiple>
-      </term>
-      <term name="translator" form="short">trans.</term>
-      <term name="interviewer" form="short">
-        <single>interviewer</single>
-        <multiple>interviewers</multiple>
-      </term>
-      <term name="collection-editor" form="short">
+      <term name="ad"> C.E.</term>
+      <term form="long" name="at">before the</term>
+      <term name="bc"> B.C.E.</term>
+      <term form="short" name="circa">ca.</term>
+      <term name="collection">archival collection</term>
+      <term form="short" name="collection-editor">
         <single>ed.</single>
         <multiple>eds.</multiple>
       </term>
-      <term name="performer" form="verb">recorded by</term>
-      <term name="circa" form="short">ca.</term>
-      <term name="bc"> B.C.E.</term>
-      <term name="ad"> C.E.</term>
-      <term name="issue" form="long">
+      <term form="short" name="editor-translator">
+        <single>ed. &amp; trans.</single>
+        <multiple>eds. &amp; trans.</multiple>
+      </term>
+      <term form="short" name="editortranslator">
+        <single>ed. &amp; trans.</single>
+        <multiple>eds. &amp; trans.</multiple>
+      </term>
+      <term form="verb" name="hearing">testimony of</term>
+      <term form="short" name="interviewer">
+        <single>interviewer</single>
+        <multiple>interviewers</multiple>
+      </term>
+      <term form="long" name="issue">
         <single>issue</single>
         <multiple>issues</multiple>
       </term>
-      <term name="software">computer software</term>
-      <term name="at" form="long">before the</term>
-      <term name="collection">archival collection</term>
+      <term form="verb" name="performer">recorded by</term>
       <term name="post">online post</term>
-      <term name="at" form="long">before the</term>
-      <term name="hearing" form="verb">testimony of</term>
-      <term name="review-of" form="long">review of the</term>
-      <term name="review-of" form="short">review of</term>
+      <term form="long" name="review-of">review of the</term>
+      <term form="short" name="review-of">review of</term>
+      <term name="software">computer software</term>
+      <term form="short" name="translator">trans.</term>
     </terms>
   </locale>
   <locale xml:lang="da">
@@ -72,7 +76,7 @@
   </locale>
   <locale xml:lang="fr">
     <terms>
-      <term name="editor" form="short">
+      <term form="short" name="editor">
         <single>éd.</single>
         <multiple>éds.</multiple>
       </term>
@@ -98,29 +102,26 @@
       <term name="et-al">et al.</term>
     </terms>
   </locale>
-  <!-- For Indigeneous Knowledge, assume the item is stored as `document` or `speech`
-       and that Nation/Community, treaty, where the Elder lives, 
-       and topic are all stored in `title`
-       cf. https://libguides.norquest.ca/c.php?g=314831&p=5188823.
-       If the item is stored as `interview`, assume that Nation/Community, treat, and topic
-       are stored in `title`, 'Oral teaching' or similar is stored in `archive`, and where
-       the Elder lives is stored in `archive-place`. 
-  -->
-  <!-- Reviews are detected if an item has type `review` or `review-book` or if it has any of the variables
-       `reviewed-title`, `reviewed-author`, or `reviewed-genre`. For the latter case, reviews are commonly 
-       stored as types `article-journal`, `article-magazine`, `article-newspaper`, `post-weblog`, or `webpage` 
-  -->
-  <!-- General categories of item types:
-       Periodical: article-journal article-magazine article-newspaper periodical post-weblog review review-book
-       Periodical or Booklike: paper-conference
-       Booklike: article book broadcast chapter classic collection dataset document
-                 entry entry-dictionary entry-encyclopedia event figure
-                 graphic interview manuscript map motion_picture musical_score
-                 pamphlet patent performance personal_communication post report
-                 software song speech standard thesis webpage
-       Legal: bill hearing legal_case legislation regulation treaty
+  <!-- General categories of CSL item types:
+
+       Periodical
+       : article-journal article-magazine article-newspaper periodical post-weblog review review-book
+
+       Periodical or Booklike
+       : paper-conference
+
+       Booklike
+       : article book broadcast chapter classic collection dataset document
+         entry entry-dictionary entry-encyclopedia event figure
+         graphic interview manuscript map motion_picture musical_score
+         pamphlet patent performance personal_communication post report
+         software song speech standard thesis webpage
+
+       Legal
+       : bill hearing legal_case legislation regulation treaty
   -->
   <!-- Equivalencies:
+
        classic == book
        document == report, but give full date
        standard == report
@@ -129,6 +130,7 @@
        collection == book, but give full date
   -->
   <!-- Role equivalencies:
+
        compiler == editor
        organizer, curator == chair
        script-writer == director
@@ -136,419 +138,471 @@
        guest, host == director
        series-creator, executive-producer == editor
   -->
-  <!-- APA references contain four parts: author, date, title, source -->
-  <macro name="author-bib">
+  <!-- Reviews are detected if an item has type `review` or `review-book` or if it has any of the variables
+       `reviewed-title`, `reviewed-author`, or `reviewed-genre`. For the latter case, reviews are commonly
+       stored as types `article-journal`, `article-magazine`, `article-newspaper`, `post-weblog`, or `webpage`
+  -->
+  <!-- For Indigeneous Knowledge, assume the item is stored as `document` or `speech`
+       and that Nation/Community, treaty, where the Elder lives,
+       and topic are all stored in `title`
+       cf. https://libguides.norquest.ca/c.php?g=314831&p=5188823.
+       If the item is stored as `interview`, assume that Nation/Community, treaty territory, and topic
+       are stored in `title`, 'Oral teaching' or similar is stored in `archive`, and where
+       the Elder lives is stored in `archive-place`.
+  -->
+  <!-- Variable labelling macros -->
+  <macro name="chapter-number-labelled">
     <group delimiter=" ">
-      <names variable="composer" delimiter=", &amp; ">
-        <name name-as-sort-order="all" and="symbol" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
-        <substitute>
-          <names variable="author"/>
-          <!-- Note: `narrator` only cited in secondary-contributors -->
-          <names variable="illustrator"/>
-          <!-- TODO: Replace `delimiter` with `collapse` to combine names variables when that becomes available. -->
-          <choose>
-            <if type="broadcast">
-              <names variable="script-writer director">
-                <!-- Note: Actors/performers and producers [not executive] not cited in APA style. -->
-                <name name-as-sort-order="all" and="symbol" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
-                <label form="long" prefix=" (" suffix=")" text-case="title"/>
-              </names>
-            </if>
-          </choose>
-          <names variable="director">
-            <!-- For non-broadcast items, APA only cites directors and not writers. -->
-            <name name-as-sort-order="all" and="symbol" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
-            <label form="long" prefix=" (" suffix=")" text-case="title"/>
-          </names>
-          <!-- TODO: Replace `delimiter` with `collapse` to combine names variables when that becomes available. -->
-          <names variable="guest host">
-            <name name-as-sort-order="all" and="symbol" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
-            <label form="long" prefix=" (" suffix=")" text-case="title"/>
-          </names>
-          <names variable="producer">
-            <!-- Note: Producers not cited if there is a writer/director, but use if they are the principle creator. -->
-            <name name-as-sort-order="all" and="symbol" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
-            <label form="long" prefix=" (" suffix=")" text-case="title"/>
-          </names>
-          <choose>
-            <if variable="container-title">
-              <choose>
-                <if type="book classic collection entry entry-dictionary entry-encyclopedia" match="any">
-                  <!-- Items with book-like container-title substitute with their title and parenthetical, 
-                       but leave bracketed after container-title. This mimics the `container-booklike` formatting. -->
-                  <choose>
-                    <if variable="title">
-                      <group delimiter=" ">
-                        <text macro="title"/>
-                        <text macro="parenthetical"/>
-                      </group>
-                    </if>
-                    <else>
-                      <text macro="title-and-descriptions"/>
-                    </else>
-                  </choose>
-                </if>
-              </choose>
-            </if>
-          </choose>
-          <names variable="executive-producer">
-            <name name-as-sort-order="all" and="symbol" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
-            <label form="long" prefix=" (" suffix=")" text-case="title"/>
-          </names>
-          <names variable="series-creator">
-            <name name-as-sort-order="all" and="symbol" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
-            <label form="long" prefix=" (" suffix=")" text-case="title"/>
-          </names>
-          <names variable="editor-translator">
-            <name name-as-sort-order="all" and="symbol" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
-            <label form="short" prefix=" (" suffix=")" text-case="title"/>
-          </names>
-          <!-- Note: Translator is not cited as a primary creator (only as Ed. & Trans.). -->
-          <names variable="editor">
-            <name name-as-sort-order="all" and="symbol" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
-            <label form="short" prefix=" (" suffix=")" text-case="title"/>
-          </names>
-          <names variable="editorial-director">
-            <name name-as-sort-order="all" and="symbol" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
-            <label form="short" prefix=" (" suffix=")" text-case="title"/>
-          </names>
-          <names variable="compiler">
-            <name name-as-sort-order="all" and="symbol" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
-            <label form="long" prefix=" (" suffix=")" text-case="title"/>
-          </names>
-          <choose>
-            <if type="event performance speech" match="any">
-              <names variable="chair">
-                <name name-as-sort-order="all" and="symbol" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
-                <label form="long" prefix=" (" suffix=")" text-case="title"/>
-              </names>
-              <names variable="organizer">
-                <name name-as-sort-order="all" and="symbol" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
-                <label form="long" prefix=" (" suffix=")" text-case="title"/>
-              </names>
-            </if>
-          </choose>
-          <names variable="curator">
-            <name name-as-sort-order="all" and="symbol" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
-            <label form="long" prefix=" (" suffix=")" text-case="title"/>
-          </names>
-          <names variable="collection-editor">
-            <name name-as-sort-order="all" and="symbol" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
-            <label form="short" prefix=" (" suffix=")" text-case="title"/>
-          </names>
-          <choose>
-            <if variable="title">
-              <!-- If an item has a title, substitute missing author with title and parenthetical, but leave bracketed 
-                   after the date (in the 'title' position). -->
-              <group delimiter=" ">
-                <text macro="title"/>
-                <text macro="parenthetical"/>
-              </group>
-            </if>
-            <else>
-              <!-- If an item has no title, substitute with bracketed followed by parenthetical. -->
-              <text macro="title-and-descriptions"/>
-            </else>
-          </choose>
-        </substitute>
-      </names>
       <choose>
-        <!-- Print "with" contributor for books, but not for other types that commonly have them (eg, thesis, software) -->
-        <if type="book classic collection" match="any">
-          <names variable="contributor" prefix="(" suffix=")">
-            <label form="verb" suffix=" "/>
-            <name name-as-sort-order="all" and="symbol" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
-          </names>
+        <if is-numeric="chapter-number">
+          <label form="short" variable="chapter-number"/>
         </if>
       </choose>
+      <text variable="chapter-number"/>
     </group>
   </macro>
-  <macro name="author-intext">
+  <macro name="edition-labelled">
     <choose>
-      <if type="bill hearing legal_case legislation regulation treaty" match="any">
-        <text macro="title-intext"/>
-      </if>
-      <else-if type="interview personal_communication" match="any">
-        <choose>
-          <!-- These variables indicate that the letter is retrievable by the reader.
-                If not, then use the APA in-text-only personal communication format -->
-          <if variable="archive container-title DOI publisher URL" match="none">
-            <group delimiter=", ">
-              <names variable="author">
-                <name and="symbol" delimiter=", " initialize-with=". "/>
-                <substitute>
-                  <text macro="title-intext"/>
-                </substitute>
-              </names>
-              <text term="personal-communication"/>
-            </group>
-          </if>
-          <else>
-            <names variable="author" delimiter=", ">
-              <name form="short" and="symbol" delimiter=", " initialize-with=". "/>
-              <substitute>
-                <text macro="title-intext"/>
-              </substitute>
-            </names>
-          </else>
-        </choose>
-      </else-if>
-      <else>
-        <names variable="composer" delimiter=" &amp; ">
-          <name form="short" and="symbol" delimiter=", " initialize-with=". "/>
-          <substitute>
-            <names variable="author"/>
-            <names variable="illustrator"/>
-            <!-- TODO: Replace `delimiter` with `collapse` to combine names variables when that becomes available. -->
-            <choose>
-              <if type="broadcast">
-                <names variable="script-writer director"/>
-              </if>
-            </choose>
-            <names variable="director"/>
-            <!-- TODO: Replace `delimiter` with `collapse` to combine names variables when that becomes available. -->
-            <names variable="guest host"/>
-            <names variable="producer"/>
-            <choose>
-              <if variable="container-title">
-                <choose>
-                  <if type="book classic collection entry entry-dictionary entry-encyclopedia" match="any">
-                    <text macro="title-intext"/>
-                  </if>
-                </choose>
-              </if>
-            </choose>
-            <names variable="executive-producer"/>
-            <names variable="series-creator"/>
-            <names variable="editor"/>
-            <names variable="editorial-director"/>
-            <names variable="compiler"/>
-            <choose>
-              <if type="event performance speech" match="any">
-                <names variable="chair"/>
-                <names variable="organizer"/>
-              </if>
-            </choose>
-            <names variable="curator"/>
-            <text macro="title-intext"/>
-          </substitute>
-        </names>
-      </else>
-    </choose>
-  </macro>
-  <macro name="author-sort">
-    <choose>
-      <if type="bill hearing legal_case legislation regulation treaty" match="any">
-        <text macro="title-legal"/>
-      </if>
-      <else>
-        <text macro="author-bib"/>
-      </else>
-    </choose>
-  </macro>
-  <macro name="date-bib">
-    <group delimiter=" " prefix="(" suffix=")">
-      <choose>
-        <if is-uncertain-date="issued">
-          <text term="circa" form="short"/>
-        </if>
-      </choose>
-      <group>
-        <choose>
-          <if variable="issued">
-            <group delimiter=", ">
-              <group>
-                <date variable="issued" date-parts="year" form="numeric"/>
-                <text variable="year-suffix"/>
-              </group>
-              <choose>
-                <if type="article-magazine article-newspaper broadcast collection document event interview motion_picture pamphlet performance personal_communication post post-weblog song speech webpage" match="any">
-                  <!-- Many video and audio examples in manual give full dates. Err on the side of too much information. -->
-                  <date variable="issued">
-                    <date-part name="month"/>
-                    <date-part name="day" prefix=" "/>
-                  </date>
-                </if>
-                <else-if type="paper-conference">
-                  <!-- Capture 'speech' stored as 'paper-conference' -->
-                  <choose>
-                    <if variable="collection-editor compiler editor editorial-director issue page volume" match="none">
-                      <date variable="issued">
-                        <date-part name="month"/>
-                        <date-part name="day" prefix=" "/>
-                      </date>
-                    </if>
-                  </choose>
-                </else-if>
-                <!-- Only year: article article-journal book chapter classic entry entry-dictionary entry-encyclopedia dataset figure graphic
-                     manuscript map musical_score paper-conference[published] patent periodical report review review-book software standard thesis -->
-              </choose>
-            </group>
-          </if>
-          <else-if variable="status">
-            <group>
-              <!-- We print the status variable directly rather than using in-press, etc. terms. -->
-              <text variable="status" text-case="lowercase"/>
-              <text variable="year-suffix" prefix="-"/>
-            </group>
-          </else-if>
-          <else>
-            <text term="no date" form="short"/>
-            <text variable="year-suffix" prefix="-"/>
-          </else>
-        </choose>
-      </group>
-    </group>
-  </macro>
-  <macro name="date-sort">
-    <!-- This is necessary to ensure that citeproc sorts all item types chonologically in the same list. -->
-    <choose>
-      <if type="article article-journal book chapter entry entry-dictionary entry-encyclopedia dataset figure graphic manuscript map musical_score patent report review review-book thesis" match="any">
-        <date variable="issued" date-parts="year" form="numeric"/>
-      </if>
-      <else-if type="paper-conference">
-        <!-- Capture 'speech' stored as 'paper-conference' -->
-        <choose>
-          <if variable="collection-editor compiler editor editorial-director issue page volume" match="any">
-            <date variable="issued" date-parts="year" form="numeric"/>
-          </if>
-          <else>
-            <date variable="issued">
-              <date-part name="year" form="long"/>
-              <date-part name="month" form="numeric-leading-zeros"/>
-              <date-part name="day" form="numeric-leading-zeros"/>
-            </date>
-          </else>
-        </choose>
-      </else-if>
-      <else>
-        <date variable="issued">
-          <date-part name="year" form="long"/>
-          <date-part name="month" form="numeric-leading-zeros"/>
-          <date-part name="day" form="numeric-leading-zeros"/>
-        </date>
-      </else>
-    </choose>
-  </macro>
-  <macro name="date-sort-group">
-    <!-- APA sorts 1. no-date items, 2. items with dates, 3. in-press (status) items -->
-    <choose>
-      <if variable="issued">
-        <text value="1"/>
-      </if>
-      <else-if variable="status">
-        <text value="2"/>
-      </else-if>
-      <else>
-        <text value="0"/>
-      </else>
-    </choose>
-  </macro>
-  <macro name="date-intext">
-    <choose>
-      <if variable="issued">
-        <group delimiter="/">
-          <group delimiter=" ">
-            <choose>
-              <if is-uncertain-date="original-date">
-                <text term="circa" form="short"/>
-              </if>
-            </choose>
-            <date variable="original-date">
-              <date-part name="year"/>
-            </date>
-          </group>
-          <group delimiter=" ">
-            <choose>
-              <if is-uncertain-date="issued">
-                <text term="circa" form="short"/>
-              </if>
-            </choose>
-            <group>
-              <choose>
-                <if type="interview personal_communication" match="any">
-                  <choose>
-                    <if variable="archive container-title DOI publisher URL" match="none">
-                      <!-- These variables indicate that the communication is retrievable by the reader.
-                           If not, then use the in-text-only personal communication format -->
-                      <date variable="issued" form="text"/>
-                    </if>
-                    <else>
-                      <date variable="issued">
-                        <date-part name="year"/>
-                      </date>
-                    </else>
-                  </choose>
-                </if>
-                <else>
-                  <date variable="issued">
-                    <date-part name="year"/>
-                  </date>
-                </else>
-              </choose>
-              <text variable="year-suffix"/>
-            </group>
-          </group>
+      <if is-numeric="edition">
+        <group delimiter=" ">
+          <number form="ordinal" variable="edition"/>
+          <label form="short" variable="edition"/>
         </group>
       </if>
-      <else-if variable="status">
-        <!-- We print the status variable directly rather than using in-press, etc. terms. -->
-        <text variable="status" text-case="lowercase"/>
-        <text variable="year-suffix" prefix="-"/>
-      </else-if>
       <else>
-        <text term="no date" form="short"/>
-        <text variable="year-suffix" prefix="-"/>
+        <text variable="edition"/>
       </else>
     </choose>
   </macro>
-  <!-- APA has two description elements following the title:
-       title (parenthetical) [bracketed] -->
+  <macro name="issue-labelled">
+    <group delimiter=" ">
+      <label text-case="capitalize-first" variable="issue"/>
+      <text variable="issue"/>
+    </group>
+  </macro>
+  <macro name="locator-labelled">
+    <!-- Abbreviate page and paragraph; leave other locator labels in long form (APA 8.13) -->
+    <group delimiter=" ">
+      <choose>
+        <if locator="page paragraph" match="any">
+          <label form="short" variable="locator"/>
+        </if>
+        <else>
+          <label text-case="capitalize-first" variable="locator"/>
+        </else>
+      </choose>
+      <text variable="locator"/>
+    </group>
+  </macro>
+  <macro name="number-labelled">
+    <group delimiter=" ">
+      <choose>
+        <if is-numeric="number">
+          <label form="short" text-case="capitalize-first" variable="number"/>
+        </if>
+        <else-if match="none" type="broadcast">
+          <label form="short" text-case="capitalize-first" variable="number"/>
+        </else-if>
+      </choose>
+      <text variable="number"/>
+    </group>
+  </macro>
+  <macro name="number-article-labelled">
+    <!-- APA example 6: Journal article with article number or eLocator -->
+    <group delimiter=" ">
+      <text term="article-locator" text-case="capitalize-first"/>
+      <text variable="number"/>
+    </group>
+  </macro>
+  <macro name="number-of-volumes-labelled">
+    <choose>
+      <if is-numeric="number-of-volumes">
+        <group delimiter=" ">
+          <label form="short" text-case="capitalize-first" variable="number-of-volumes"/>
+          <text prefix="1" term="page-range-delimiter"/>
+        </group>
+      </if>
+    </choose>
+    <text variable="number-of-volumes"/>
+  </macro>
+  <macro name="page-labelled">
+    <group delimiter=" ">
+      <label form="short" variable="page"/>
+      <text variable="page"/>
+    </group>
+  </macro>
+  <macro name="part-number-labelled">
+    <group delimiter=" ">
+      <choose>
+        <if variable="part-number">
+          <!-- TODO: Replace with `part-number` label when CSL provides one -->
+          <text form="short" term="part" text-case="capitalize-first"/>
+          <text variable="part-number"/>
+        </if>
+      </choose>
+    </group>
+  </macro>
+  <macro name="section-labelled">
+    <group delimiter=" ">
+      <label form="symbol" variable="section"/>
+      <text variable="section"/>
+    </group>
+  </macro>
+  <macro name="supplement-number-labelled">
+    <group delimiter=" ">
+      <choose>
+        <if variable="supplement-number">
+          <!-- TODO: Replace with `supplement-number` label when CSL provides one -->
+          <text form="short" term="supplement" text-case="capitalize-first"/>
+          <text variable="supplement-number"/>
+        </if>
+      </choose>
+    </group>
+  </macro>
+  <macro name="version-labelled">
+    <group delimiter=" ">
+      <label text-case="capitalize-first" variable="version"/>
+      <text variable="version"/>
+    </group>
+  </macro>
+  <macro name="volume-labelled">
+    <group delimiter=" ">
+      <label form="short" text-case="capitalize-first" variable="volume"/>
+      <text variable="volume"/>
+    </group>
+  </macro>
+  <!-- Four parts in APA references:
+
+       1. Author (APA 9.7–12)
+       2. Date (APA 9.13–17)
+       3. Title (APA 9.18–22)
+       4. Source (APA 9.23–37)
+  -->
+  <!-- 1. Author -->
+  <!-- Author utility macros -->
+  <macro name="author-substitute-bib">
+    <names variable="composer">
+      <name delimiter-precedes-last="always" name-as-sort-order="all"/>
+      <label form="short" prefix=" (" suffix=")" text-case="title"/>
+      <substitute>
+        <names variable="author"/>
+        <!-- `narrator` only cited in secondary-contributors -->
+        <names variable="illustrator"/>
+        <choose>
+          <if type="broadcast">
+            <names variable="script-writer director">
+              <!-- Actors/performers and producers [not executive] not cited in APA style. -->
+              <name delimiter-precedes-last="always" name-as-sort-order="all"/>
+              <label form="long" prefix=" (" suffix=")" text-case="title"/>
+            </names>
+          </if>
+        </choose>
+        <names variable="director">
+          <!-- For non-broadcast items, APA only cites directors and not writers. -->
+          <name delimiter-precedes-last="always" name-as-sort-order="all"/>
+          <label form="long" prefix=" (" suffix=")" text-case="title"/>
+        </names>
+        <names variable="guest host">
+          <!-- TODO: Replace `delimiter` with `collapse` to combine names variables when that becomes available. -->
+          <name delimiter-precedes-last="always" name-as-sort-order="all"/>
+          <label form="long" prefix=" (" suffix=")" text-case="title"/>
+        </names>
+        <names variable="producer">
+          <!-- Producers not cited if there is a writer/director, but use if they are the principle creator. -->
+          <name delimiter-precedes-last="always" name-as-sort-order="all"/>
+          <label form="long" prefix=" (" suffix=")" text-case="title"/>
+        </names>
+        <choose>
+          <if variable="container-title">
+            <choose>
+              <if match="any" type="book classic collection entry entry-dictionary entry-encyclopedia">
+                <!-- Items with book-like container-title substitute with their title and identification,
+                     but leave description after container-title. This mimics the `container-booklike` formatting. -->
+                <text macro="title-substitute"/>
+              </if>
+            </choose>
+          </if>
+        </choose>
+        <names variable="executive-producer">
+          <name delimiter-precedes-last="always" name-as-sort-order="all"/>
+          <label form="long" prefix=" (" suffix=")" text-case="title"/>
+        </names>
+        <names variable="series-creator">
+          <name delimiter-precedes-last="always" name-as-sort-order="all"/>
+          <label form="long" prefix=" (" suffix=")" text-case="title"/>
+        </names>
+        <names variable="editor-translator"/>
+        <!-- Translator is not cited as a primary creator (only as Ed. & Trans.). -->
+        <names variable="editor"/>
+        <names variable="editorial-director"/>
+        <names variable="compiler">
+          <name delimiter-precedes-last="always" name-as-sort-order="all"/>
+          <label form="long" prefix=" (" suffix=")" text-case="title"/>
+        </names>
+        <choose>
+          <if match="any" type="event performance speech">
+            <names variable="chair">
+              <name delimiter-precedes-last="always" name-as-sort-order="all"/>
+              <label form="long" prefix=" (" suffix=")" text-case="title"/>
+            </names>
+            <names variable="organizer">
+              <name delimiter-precedes-last="always" name-as-sort-order="all"/>
+              <label form="long" prefix=" (" suffix=")" text-case="title"/>
+            </names>
+          </if>
+        </choose>
+        <names variable="curator">
+          <name delimiter-precedes-last="always" name-as-sort-order="all"/>
+          <label form="long" prefix=" (" suffix=")" text-case="title"/>
+        </names>
+        <names variable="collection-editor"/>
+        <text macro="title-substitute"/>
+      </substitute>
+    </names>
+  </macro>
+  <macro name="title-substitute">
+    <choose>
+      <if variable="title">
+        <!-- If an item has a title, substitute missing author with title and identification, but leave description after the date (in the 'title' position). -->
+        <group delimiter=" ">
+          <text macro="title-bib"/>
+          <text macro="identification"/>
+        </group>
+      </if>
+      <else>
+        <!-- If an item has no title, substitute with description followed by identification. -->
+        <text macro="title-and-descriptions"/>
+      </else>
+    </choose>
+  </macro>
+  <!-- Author logic -->
+  <macro name="author-bib">
+    <group delimiter=" ">
+      <text macro="author-substitute-bib"/>
+      <choose>
+        <!-- Print "with" contributor for books, but not for other types that commonly have them (eg, thesis, software) -->
+        <if match="any" type="book classic collection">
+          <names prefix="(" suffix=")" variable="contributor">
+            <label form="verb" suffix=" "/>
+            <name delimiter-precedes-last="always" name-as-sort-order="all"/>
+          </names>
+        </if>
+      </choose>
+    </group>
+  </macro>
+  <!-- Author sorting -->
+  <!-- 2. Date -->
+  <!-- Date utility macros -->
+  <macro name="date-issued-full">
+    <group delimiter=" ">
+      <text macro="uncertain-date-issued"/>
+      <date form="text" variable="issued"/>
+    </group>
+  </macro>
+  <macro name="date-issued-month-day">
+    <date variable="issued">
+      <date-part name="month"/>
+      <date-part name="day" prefix=" "/>
+    </date>
+  </macro>
+  <macro name="date-issued-year">
+    <group delimiter=" ">
+      <text macro="uncertain-date-issued"/>
+      <date date-parts="year" form="numeric" variable="issued"/>
+    </group>
+  </macro>
+  <macro name="original-date-year">
+    <group delimiter=" ">
+      <choose>
+        <if is-uncertain-date="original-date">
+          <text form="short" term="circa"/>
+        </if>
+      </choose>
+      <date variable="original-date">
+        <date-part name="year"/>
+      </date>
+    </group>
+  </macro>
+  <macro name="uncertain-date-issued">
+    <choose>
+      <if is-uncertain-date="issued">
+        <text form="short" term="circa"/>
+      </if>
+    </choose>
+  </macro>
+  <!-- Date logic -->
+  <macro name="date-bib">
+    <group prefix="(" suffix=")">
+      <choose>
+        <if variable="issued">
+          <group delimiter=", ">
+            <group>
+              <text macro="date-issued-year"/>
+              <text variable="year-suffix"/>
+            </group>
+            <choose>
+              <if match="any" type="article-magazine article-newspaper broadcast collection document event interview motion_picture pamphlet performance personal_communication post post-weblog song speech webpage">
+                <!-- Many video and audio examples in manual give full dates. Err on the side of too much information. -->
+                <text macro="date-issued-month-day"/>
+              </if>
+              <else-if type="paper-conference">
+                <!-- Capture 'speech' stored as 'paper-conference' -->
+                <choose>
+                  <if match="none" variable="collection-editor compiler editor editorial-director issue page volume">
+                    <text macro="date-issued-month-day"/>
+                  </if>
+                </choose>
+              </else-if>
+              <!-- Only year: article article-journal book chapter classic entry entry-dictionary entry-encyclopedia dataset figure graphic
+                     manuscript map musical_score paper-conference[published] patent periodical report review review-book software standard thesis -->
+            </choose>
+          </group>
+        </if>
+        <else-if variable="status">
+          <group>
+            <!-- We print the status variable directly rather than using in-press, etc. terms. -->
+            <text text-case="lowercase" variable="status"/>
+            <text prefix="-" variable="year-suffix"/>
+          </group>
+        </else-if>
+        <else>
+          <text form="short" term="no date"/>
+          <text prefix="-" variable="year-suffix"/>
+        </else>
+      </choose>
+    </group>
+  </macro>
+  <!-- Date sorting -->
+  <!-- 3. Title and descriptions -->
+  <!-- Three parts in title element (APA 9.21):
+
+       1. Title
+       2. Identification (in parentheses)
+       3. Description [in square brackets] -->
   <macro name="title-and-descriptions">
     <choose>
       <if variable="title">
         <group delimiter=" ">
-          <text macro="title"/>
-          <text macro="parenthetical"/>
-          <text macro="bracketed"/>
+          <text macro="title-bib"/>
+          <text macro="identification"/>
+          <text macro="description-bib"/>
         </group>
       </if>
       <else>
         <choose>
-          <if type="bill report" match="any">
+          <if match="any" type="bill report">
             <!-- Bills, resolutions, and congressional reports are not italicized and substitute bill number if no title. -->
-            <!-- Can't distinguish congressional reports from other reports, 
+            <!-- Can't distinguish congressional reports from other reports,
                  but giving the genre and number seems fine for other reports too. -->
-            <text macro="number"/>
-            <text macro="bracketed"/>
-            <text macro="parenthetical"/>
+            <text macro="genre-number"/>
+            <text macro="description-bib"/>
+            <text macro="identification"/>
           </if>
           <else>
             <group delimiter=" ">
-              <text macro="bracketed"/>
-              <text macro="parenthetical"/>
+              <text macro="description-bib"/>
+              <text macro="identification"/>
             </group>
           </else>
         </choose>
       </else>
     </choose>
   </macro>
-  <macro name="title">
+  <!-- 3.1. Title -->
+  <!-- Title utility macros -->
+  <macro name="title-part">
+    <group delimiter=". ">
+      <text macro="part-number-labelled"/>
+      <text text-case="capitalize-first" variable="part-title"/>
+    </group>
+  </macro>
+  <macro name="title-plus-part-title">
     <choose>
-      <if type="post webpage" match="any">
+      <if match="any" type="review review-book" variable="reviewed-author reviewed-genre reviewed-title">
+        <!-- If a review has no `reviewed-title`, assume that `title` contains the title of the reviewed work
+             and omit it here; it is printed in the `reviewed-item` macro. -->
+        <choose>
+          <if match="none" variable="reviewed-title"/>
+          <else>
+            <group delimiter=": ">
+              <text variable="title"/>
+              <text macro="title-part"/>
+            </group>
+          </else>
+        </choose>
+      </if>
+      <else>
+        <group delimiter=": ">
+          <text variable="title"/>
+          <text macro="title-part"/>
+        </group>
+      </else>
+    </choose>
+  </macro>
+  <macro name="title-plus-volume-title">
+    <group delimiter=": ">
+      <text variable="title"/>
+      <text macro="title-volume"/>
+    </group>
+  </macro>
+  <macro name="title-volume">
+    <group delimiter=": ">
+      <choose>
+        <if variable="volume-title">
+          <group delimiter=". ">
+            <text macro="volume-labelled"/>
+            <text variable="volume-title"/>
+          </group>
+        </if>
+        <else-if is-numeric="volume" match="none">
+          <text macro="volume-labelled"/>
+        </else-if>
+      </choose>
+      <!-- For book-like items, assume part-number and part-title refer to the book/volume. -->
+      <text macro="title-part"/>
+    </group>
+  </macro>
+  <!-- Title logic -->
+  <macro name="booklike-title">
+    <!-- For book-like items, assume part-number and part-title refer to the book/volume. -->
+    <choose>
+      <if variable="container-title">
+        <text variable="title"/>
+      </if>
+      <else>
+        <!-- For book-like items without container titles and with volume-title, append volume-title to title (APA example 30) -->
+        <text font-style="italic" macro="title-plus-volume-title"/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="periodical-title">
+    <!-- For periodicals, assume that part-number and part-title refer to the article and append to title -->
+    <choose>
+      <if variable="container-title">
+        <text macro="title-plus-part-title"/>
+      </if>
+      <else>
+        <!-- for periodical items without container titles, don't append volume-title to title -->
+        <text font-style="italic" macro="title-plus-part-title"/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="title-bib">
+    <choose>
+      <if match="any" type="post webpage">
         <!-- Webpages are always italicized -->
-        <text macro="title-plus-part-title" font-style="italic"/>
+        <text font-style="italic" macro="title-plus-part-title"/>
       </if>
       <!-- Other types are italicized based on presence of container-title.
              Assume that review and review-book are published in periodicals/blogs,
-             not just on a web page (ex. 69) -->
-      <else-if type="article-journal article-magazine article-newspaper periodical post-weblog review review-book" match="any">
+             not just on a webpage (APA example 69) -->
+      <else-if match="any" type="article-journal article-magazine article-newspaper periodical post-weblog review review-book">
         <text macro="periodical-title"/>
       </else-if>
       <else-if type="paper-conference">
         <!-- Treat paper-conference as book-like if it has an editor, otherwise as periodical-like -->
         <choose>
-          <if variable="collection-editor compiler editor editorial-director" match="any">
+          <if match="any" variable="collection-editor compiler editor editorial-director">
             <text macro="booklike-title"/>
           </if>
           <else>
@@ -561,607 +615,71 @@
       </else>
     </choose>
   </macro>
-  <macro name="periodical-title">
-    <!-- For periodicals, assume that part-number and part-title refer to the article and append to title -->
+  <!-- 3.2. Identification (in parentheses) -->
+  <!-- Identification utility macros -->
+  <macro name="database-location">
     <choose>
-      <if variable="container-title" match="any">
-        <text macro="title-plus-part-title"/>
+      <if match="none" variable="archive-place">
+        <!-- With `archive-place`: physical archives. Without: online archives. -->
+        <text variable="archive_location"/>
       </if>
-      <else>
-        <!-- for periodical items without container titles, don't append volume-title to title -->
-        <text macro="title-plus-part-title" font-style="italic"/>
-      </else>
     </choose>
   </macro>
-  <macro name="booklike-title">
-    <!-- For book-like items, assume part-number and part-title refer to the book/volume. -->
+  <macro name="genre-number">
     <choose>
-      <if variable="container-title" match="any">
-        <text variable="title"/>
-      </if>
-      <else>
-        <!-- For book-like items without container titles and with volume-title, append volume-title to title (ex. 30) -->
-        <text macro="title-plus-volume-title" font-style="italic"/>
-      </else>
-    </choose>
-  </macro>
-  <macro name="title-plus-part-title">
-    <choose>
-      <if variable="reviewed-author reviewed-genre reviewed-title" type="review review-book" match="any">
-        <!-- If a review has no `reviewed-title`, assume that `title` contains the title of the reviewed work
-             and omit it here; it is printed in the `reviewed-item` macro. -->
-        <choose>
-          <if variable="reviewed-title" match="none"/>
-          <else>
-            <group delimiter=": ">
-              <text variable="title"/>
-              <text macro="part-title"/>
-            </group>
-          </else>
-        </choose>
-      </if>
-      <else>
-        <group delimiter=": ">
-          <text variable="title"/>
-          <text macro="part-title"/>
-        </group>
-      </else>
-    </choose>
-  </macro>
-  <macro name="part-title">
-    <group delimiter=". ">
-      <group delimiter=" ">
-        <label variable="part-number" form="short" text-case="capitalize-first"/>
-        <text variable="part-number"/>
-      </group>
-      <text variable="part-title" text-case="capitalize-first"/>
-    </group>
-  </macro>
-  <macro name="title-plus-volume-title">
-    <group delimiter=": ">
-      <text variable="title"/>
-      <text macro="volume-title"/>
-    </group>
-  </macro>
-  <macro name="volume-title">
-    <group delimiter=": ">
-      <choose>
-        <if variable="volume-title">
+      <if variable="number">
+        <group delimiter=", ">
           <group delimiter=" ">
-            <group delimiter=". ">
-              <group delimiter=" ">
-                <label variable="volume" form="short" text-case="capitalize-first"/>
-                <text variable="volume"/>
-              </group>
-              <text variable="volume-title"/>
-            </group>
+            <text text-case="title" variable="genre"/>
+            <text macro="number-labelled"/>
           </group>
-        </if>
-        <else-if is-numeric="volume" match="none">
-          <group delimiter=" ">
-            <label variable="volume" form="short" text-case="capitalize-first"/>
-            <text variable="volume"/>
-          </group>
-        </else-if>
-      </choose>
-      <!-- For book-like items, assume part-number and part-title refer to the book/volume. -->
-      <text macro="part-title"/>
-    </group>
-  </macro>
-  <macro name="title-intext">
-    <choose>
-      <if type="bill report">
-        <!-- Bills, resolutions, and congressional reports are not italicized and substitute bill number if no title. -->
-        <!-- Can't distinguish congressional reports from other reports, 
-             but giving the genre and number seems fine for other reports too. -->
-        <choose>
-          <if variable="title">
-            <text variable="title" form="short" text-case="title"/>
-          </if>
-          <else>
-            <group delimiter=" ">
-              <text variable="genre"/>
-              <group delimiter=" ">
-                <choose>
-                  <if variable="chapter-number container-title" match="none">
-                    <label variable="number" form="short" text-case="capitalize-first"/>
-                  </if>
-                </choose>
-                <text variable="number"/>
-              </group>
-            </group>
-          </else>
-        </choose>
-      </if>
-      <else>
-        <choose>
-          <if variable="title" match="none">
-            <text macro="bracketed-intext"/>
-          </if>
-          <else-if type="hearing">
-            <!-- Hearings are italicized -->
-            <text variable="title" form="short" font-style="italic" text-case="title"/>
-          </else-if>
-          <else-if type="legal_case" match="any">
-            <!-- Cases are italicized -->
-            <text variable="title" font-style="italic"/>
-          </else-if>
-          <else-if type="legislation regulation treaty" match="any">
-            <!-- Legislation, regulations, and treaties not italicized or quoted -->
-            <text variable="title" form="short" text-case="title"/>
-          </else-if>
-          <else-if type="post webpage" match="any">
-            <!-- Webpages are always italicized -->
-            <text variable="title" form="short" font-style="italic" text-case="title"/>
-          </else-if>
-          <else-if variable="container-title" match="any">
-            <!-- Other types are italicized or quoted based on presence of container-title. As in title macro. -->
-            <text variable="title" form="short" quotes="true" text-case="title"/>
-          </else-if>
-          <else>
-            <text variable="title" form="short" font-style="italic" text-case="title"/>
-          </else>
-        </choose>
-      </else>
-    </choose>
-  </macro>
-  <macro name="parenthetical">
-    <!-- (Secondary contributors; Database location; Genre no. 123; Report Series 123, Version, Edition, Volume, Page) -->
-    <group prefix="(" suffix=")">
-      <choose>
-        <if type="patent">
-          <!-- authority: U.S. ; genre: patent ; number: 123,445 -->
-          <group delimiter=" ">
-            <text variable="authority" form="short"/>
-            <choose>
-              <if variable="genre">
-                <text variable="genre" text-case="capitalize-first"/>
-              </if>
-              <else>
-                <text term="patent" text-case="capitalize-first"/>
-              </else>
-            </choose>
-            <group delimiter=" ">
-              <label variable="number" form="short" text-case="capitalize-first"/>
-              <text variable="number"/>
-            </group>
-          </group>
-        </if>
-        <else-if type="post webpage" match="any">
-          <!-- For post webpage, container-title is treated as publisher -->
-          <group delimiter="; ">
-            <text macro="secondary-contributors"/>
-            <text macro="database-location"/>
-            <text macro="number"/>
-            <text macro="locators-booklike"/>
-          </group>
-        </else-if>
-        <else-if type="report" match="any">
           <choose>
-            <if variable="title" match="none">
-              <!-- If there is no title, then genre and number are already printed as the title. -->
-              <group delimiter="; ">
-                <text macro="secondary-contributors"/>
-                <text macro="database-location"/>
-                <text macro="locators-booklike"/>
-              </group>
+            <if type="thesis">
+              <choose>
+                <if match="any" variable="archive DOI URL">
+                  <!-- Include the university in brackets if thesis is published -->
+                  <text variable="publisher"/>
+                </if>
+              </choose>
             </if>
-            <!-- If the report is a chapter in a larger report, then most parenthetical information is printed after the container. -->
-            <else-if variable="container-title">
-              <text macro="secondary-contributors"/>
-            </else-if>
-            <else>
-              <group delimiter="; ">
-                <text macro="secondary-contributors"/>
-                <text macro="database-location"/>
-                <text macro="number"/>
-                <text macro="locators-booklike"/>
-              </group>
-            </else>
           </choose>
-        </else-if>
-        <else-if variable="container-title">
-          <group delimiter="; ">
-            <text macro="secondary-contributors"/>
-            <choose>
-              <if type="broadcast graphic map motion_picture song" match="any">
-                <!-- For audiovisual media, number information comes after title, not container-title (ex. 94) -->
-                <text macro="number"/>
-              </if>
-            </choose>
-          </group>
-        </else-if>
-        <else>
-          <group delimiter="; ">
-            <text macro="secondary-contributors"/>
-            <text macro="database-location"/>
-            <text macro="number"/>
-            <text macro="locators-booklike"/>
-          </group>
-        </else>
-      </choose>
-    </group>
-  </macro>
-  <macro name="parenthetical-container">
-    <choose>
-      <if variable="container-title" match="any">
-        <group prefix="(" suffix=")">
-          <group delimiter="; ">
-            <text macro="database-location"/>
-            <choose>
-              <if type="broadcast graphic map motion_picture song" match="none">
-                <!-- For audiovisual media, number information comes after title, not container-title (ex. 94) -->
-                <text macro="number"/>
-              </if>
-            </choose>
-            <text macro="locators-booklike"/>
-          </group>
         </group>
       </if>
     </choose>
   </macro>
-  <macro name="bracketed">
-    <!-- [Descriptive information] -->
-    <!-- If there is a number, genre is already printed in macro="number" -->
-    <group prefix="[" suffix="]">
+  <macro name="locators-booklike">
+    <choose>
+      <if variable="page">
+        <text macro="page-labelled"/>
+      </if>
+      <else-if variable="chapter-number">
+        <text macro="chapter-number-labelled"/>
+      </else-if>
+    </choose>
+  </macro>
+  <macro name="patent-number">
+    <group delimiter=" ">
+      <!-- authority: U.S. ; genre: patent ; number: 123,445 -->
+      <text form="short" variable="authority"/>
       <choose>
-        <if variable="reviewed-author reviewed-genre reviewed-title" type="review review-book" match="any">
-          <text macro="reviewed-item"/>
+        <if variable="genre">
+          <text text-case="capitalize-first" variable="genre"/>
         </if>
-        <else-if type="thesis">
-          <!-- Thesis type and institution -->
-          <group delimiter="; ">
-            <choose>
-              <if variable="number" match="none">
-                <group delimiter=", ">
-                  <text variable="genre" text-case="capitalize-first"/>
-                  <choose>
-                    <if variable="archive DOI URL" match="any">
-                      <!-- Include the university in brackets if thesis is published -->
-                      <text variable="publisher"/>
-                    </if>
-                  </choose>
-                </group>
-              </if>
-            </choose>
-            <text variable="medium" text-case="capitalize-first"/>
-          </group>
-        </else-if>
-        <else-if variable="interviewer" type="interview" match="any">
-          <!-- Interview information -->
-          <choose>
-            <if variable="title">
-              <text macro="format"/>
-            </if>
-            <else-if variable="genre">
-              <group delimiter="; ">
-                <group delimiter=" ">
-                  <text variable="genre" text-case="capitalize-first"/>
-                  <group delimiter=" ">
-                    <text term="container-author" form="verb"/>
-                    <names variable="interviewer">
-                      <name and="symbol" initialize-with=". " delimiter=", "/>
-                    </names>
-                  </group>
-                </group>
-              </group>
-            </else-if>
-            <else-if variable="interviewer">
-              <group delimiter="; ">
-                <names variable="interviewer">
-                  <label form="verb" suffix=" " text-case="capitalize-first"/>
-                  <name and="symbol" initialize-with=". " delimiter=", "/>
-                </names>
-                <text variable="medium" text-case="capitalize-first"/>
-              </group>
-            </else-if>
-            <else>
-              <text macro="format"/>
-            </else>
-          </choose>
-        </else-if>
-        <else-if type="personal_communication">
-          <!-- Letter information -->
-          <choose>
-            <if variable="recipient">
-              <group delimiter="; ">
-                <group delimiter=" ">
-                  <choose>
-                    <if variable="number" match="none">
-                      <choose>
-                        <if variable="genre">
-                          <text variable="genre" text-case="capitalize-first"/>
-                        </if>
-                        <else-if variable="medium">
-                          <text variable="medium" text-case="capitalize-first"/>
-                        </else-if>
-                        <else>
-                          <text term="letter" text-case="capitalize-first"/>
-                        </else>
-                      </choose>
-                    </if>
-                    <else>
-                      <choose>
-                        <if variable="medium">
-                          <text variable="medium" text-case="capitalize-first"/>
-                        </if>
-                        <else>
-                          <text term="letter" text-case="capitalize-first"/>
-                        </else>
-                      </choose>
-                    </else>
-                  </choose>
-                  <names variable="recipient" delimiter=", ">
-                    <label form="verb" suffix=" "/>
-                    <name and="symbol" delimiter=", "/>
-                  </names>
-                </group>
-                <choose>
-                  <if variable="genre" match="any">
-                    <choose>
-                      <if variable="number" match="none">
-                        <text variable="medium" text-case="capitalize-first"/>
-                      </if>
-                    </choose>
-                  </if>
-                </choose>
-              </group>
-            </if>
-            <else>
-              <text macro="format"/>
-            </else>
-          </choose>
-        </else-if>
-        <else-if variable="composer" type="song" match="all">
-          <!-- Performer of classical music works -->
-          <group delimiter="; ">
-            <choose>
-              <if variable="number" match="none">
-                <group delimiter=" ">
-                  <choose>
-                    <if variable="genre">
-                      <text variable="genre" text-case="capitalize-first"/>
-                      <group delimiter=" ">
-                        <text term="performer" form="verb"/>
-                        <names variable="author">
-                          <name and="symbol" initialize-with=". " delimiter=", "/>
-                          <substitute>
-                            <names variable="performer"/>
-                          </substitute>
-                        </names>
-                      </group>
-                    </if>
-                    <else-if variable="medium">
-                      <text variable="medium" text-case="capitalize-first"/>
-                      <group delimiter=" ">
-                        <text term="performer" form="verb"/>
-                        <names variable="author">
-                          <name and="symbol" initialize-with=". " delimiter=", "/>
-                          <substitute>
-                            <names variable="performer"/>
-                          </substitute>
-                        </names>
-                      </group>
-                    </else-if>
-                    <else>
-                      <text term="performer" form="verb" text-case="capitalize-first"/>
-                      <names variable="author">
-                        <name and="symbol" initialize-with=". " delimiter=", "/>
-                        <substitute>
-                          <names variable="performer"/>
-                        </substitute>
-                      </names>
-                    </else>
-                  </choose>
-                </group>
-              </if>
-              <else>
-                <group delimiter=" ">
-                  <choose>
-                    <if variable="medium">
-                      <text variable="medium" text-case="capitalize-first"/>
-                      <group delimiter=" ">
-                        <text term="performer" form="verb"/>
-                        <names variable="author">
-                          <name and="symbol" initialize-with=". " delimiter=", "/>
-                          <substitute>
-                            <names variable="performer"/>
-                          </substitute>
-                        </names>
-                      </group>
-                    </if>
-                    <else>
-                      <text term="performer" form="verb" text-case="capitalize-first"/>
-                      <names variable="author">
-                        <name and="symbol" initialize-with=". " delimiter=", "/>
-                        <substitute>
-                          <names variable="performer"/>
-                        </substitute>
-                      </names>
-                    </else>
-                  </choose>
-                </group>
-              </else>
-            </choose>
-            <choose>
-              <if variable="genre" match="any">
-                <choose>
-                  <if variable="number" match="none">
-                    <text variable="medium" text-case="capitalize-first"/>
-                  </if>
-                </choose>
-              </if>
-            </choose>
-          </group>
-        </else-if>
-        <else-if variable="container-title" match="none">
-          <!-- Other description -->
-          <text macro="format"/>
-        </else-if>
         <else>
-          <!-- For conference presentations/performances/events, chapters in reports/standards/generic documents, software, 
-               place bracketed after the container title -->
-          <choose>
-            <if type="event paper-conference performance speech" match="any">
-              <choose>
-                <if variable="collection-editor compiler editor editorial-director issue page volume" match="any">
-                  <text macro="format"/>
-                </if>
-              </choose>
-            </if>
-            <else-if type="document report software standard" match="none">
-              <text macro="format"/>
-            </else-if>
-          </choose>
+          <text term="patent" text-case="capitalize-first"/>
         </else>
       </choose>
-    </group>
-  </macro>
-  <macro name="bracketed-intext">
-    <group prefix="[" suffix="]">
-      <choose>
-        <if variable="reviewed-title" match="any">
-          <group delimiter=" ">
-            <text term="review-of" text-case="capitalize-first"/>
-            <text macro="reviewed-title-intext"/>
-          </group>
-        </if>
-        <else-if variable="interviewer" type="interview" match="any">
-          <names variable="interviewer">
-            <label form="verb" suffix=" " text-case="capitalize-first"/>
-            <name and="symbol" initialize-with=". " delimiter=", "/>
-            <substitute>
-              <text macro="format-intext"/>
-            </substitute>
-          </names>
-        </else-if>
-        <else-if type="personal_communication">
-          <!-- Letter information -->
-          <choose>
-            <if variable="recipient">
-              <group delimiter=" ">
-                <choose>
-                  <if variable="number" match="none">
-                    <text variable="genre" text-case="capitalize-first"/>
-                  </if>
-                  <else>
-                    <text term="letter" text-case="capitalize-first"/>
-                  </else>
-                </choose>
-                <names variable="recipient" delimiter=", ">
-                  <label form="verb" suffix=" "/>
-                  <name and="symbol" delimiter=", "/>
-                </names>
-              </group>
-            </if>
-            <else>
-              <text macro="format-intext"/>
-            </else>
-          </choose>
-        </else-if>
-        <else>
-          <text macro="format-intext"/>
-        </else>
-      </choose>
-    </group>
-  </macro>
-  <macro name="reviewed-item">
-    <!-- Reviewed item -->
-    <group delimiter="; ">
-      <group delimiter=", ">
-        <group delimiter=" ">
-          <choose>
-            <if variable="reviewed-genre">
-              <group delimiter=" ">
-                <text term="review-of" form="long" text-case="capitalize-first"/>
-                <text variable="reviewed-genre" text-case="lowercase"/>
-              </group>
-            </if>
-            <!-- If no `reviewed-genre`, assume that `genre` or `medium` is entered as 'Review of the book' or similar -->
-            <else-if variable="number" match="none">
-              <choose>
-                <if variable="genre">
-                  <text variable="genre" text-case="capitalize-first"/>
-                </if>
-                <else-if variable="medium">
-                  <text variable="medium" text-case="capitalize-first"/>
-                </else-if>
-                <else-if type="review-book">
-                  <group delimiter=" ">
-                    <text term="review-of" form="long" text-case="capitalize-first"/>
-                    <text term="book" form="long" text-case="lowercase"/>
-                  </group>
-                </else-if>
-                <else>
-                  <text term="review-of" form="short" text-case="capitalize-first"/>
-                </else>
-              </choose>
-            </else-if>
-            <else>
-              <choose>
-                <if variable="medium">
-                  <text variable="medium" text-case="capitalize-first"/>
-                </if>
-                <else-if type="review-book">
-                  <group delimiter=" ">
-                    <text term="review-of" form="long" text-case="capitalize-first"/>
-                    <text term="book" form="long" text-case="lowercase"/>
-                  </group>
-                </else-if>
-                <else>
-                  <text term="review-of" form="short" text-case="capitalize-first"/>
-                </else>
-              </choose>
-            </else>
-          </choose>
-          <text macro="reviewed-title"/>
-        </group>
-        <names variable="reviewed-author">
-          <label form="verb-short" suffix=" "/>
-          <name and="symbol" initialize-with=". " delimiter=", "/>
-        </names>
-      </group>
-      <choose>
-        <if variable="genre" match="any">
-          <choose>
-            <if variable="number" match="none">
-              <text variable="medium" text-case="capitalize-first"/>
-            </if>
-          </choose>
-        </if>
-      </choose>
-    </group>
-  </macro>
-  <macro name="bracketed-container">
-    <group prefix="[" suffix="]">
-      <choose>
-        <if type="event paper-conference performance speech" match="any">
-          <!-- Conference presentations should describe the session [container] in bracketed unless published in a proceedings -->
-          <choose>
-            <if variable="collection-editor compiler editor editorial-director issue page volume" match="none">
-              <text macro="format"/>
-            </if>
-          </choose>
-        </if>
-        <else-if type="software" match="all">
-          <!-- For entries in mobile app reference works, place bracketed after the container-title -->
-          <text macro="format"/>
-        </else-if>
-        <else-if type="document report standard">
-          <!-- For chapters in report, standards, and generic documents, place bracketed after the container title -->
-          <text macro="format"/>
-        </else-if>
-      </choose>
+      <text macro="number-labelled"/>
     </group>
   </macro>
   <macro name="secondary-contributors">
     <choose>
-      <if type="article-journal article-magazine article-newspaper periodical post-weblog review review-book" match="any">
+      <if match="any" type="article-journal article-magazine article-newspaper periodical post-weblog review review-book">
         <text macro="secondary-contributors-periodical"/>
       </if>
       <else-if type="paper-conference">
         <choose>
-          <if variable="collection-editor compiler editor editorial-director" match="any">
+          <if match="any" variable="collection-editor compiler editor editorial-director">
             <text macro="secondary-contributors-booklike"/>
           </if>
           <else>
@@ -1174,53 +692,37 @@
       </else>
     </choose>
   </macro>
-  <macro name="secondary-contributors-periodical">
-    <group delimiter="; ">
-      <choose>
-        <if variable="title">
-          <names variable="interviewer" delimiter="; ">
-            <name and="symbol" initialize-with=". " delimiter=", "/>
-            <label form="short" prefix=", " text-case="title"/>
-          </names>
-        </if>
-      </choose>
-      <names variable="translator narrator" delimiter="; ">
-        <name and="symbol" initialize-with=". " delimiter=", "/>
-        <label form="short" prefix=", " text-case="title"/>
-      </names>
-    </group>
-  </macro>
   <macro name="secondary-contributors-booklike">
     <group delimiter="; ">
       <choose>
         <if variable="title">
           <names variable="interviewer">
-            <name and="symbol" initialize-with=". " delimiter=", "/>
+            <name/>
             <label form="short" prefix=", " text-case="title"/>
           </names>
         </if>
       </choose>
       <choose>
-        <if type="post webpage" match="none">
+        <if match="none" type="post webpage">
           <!-- Webpages treat container-title like publisher -->
           <group delimiter="; ">
-            <names variable="illustrator narrator" delimiter="; ">
-              <name and="symbol" initialize-with=". " delimiter=", "/>
+            <names delimiter="; " variable="illustrator narrator">
+              <name/>
               <label form="short" prefix=", " text-case="title"/>
             </names>
             <choose>
-              <if variable="container-title" match="none">
+              <if match="none" variable="container-title">
                 <group delimiter="; ">
                   <names variable="container-author">
                     <label form="verb-short" suffix=" " text-case="title"/>
-                    <name and="symbol" initialize-with=". " delimiter=", "/>
+                    <name/>
                   </names>
-                  <names variable="editor translator" delimiter="; ">
-                    <name and="symbol" initialize-with=". " delimiter=", "/>
+                  <names delimiter="; " variable="editor translator">
+                    <name/>
                     <label form="short" prefix=", " text-case="title"/>
                   </names>
-                  <names variable="compiler chair organizer curator series-creator executive-producer" delimiter="; ">
-                    <name and="symbol" initialize-with=". " delimiter=", "/>
+                  <names delimiter="; " variable="compiler chair organizer curator series-creator executive-producer">
+                    <name/>
                     <label form="long" prefix=", " text-case="title"/>
                   </names>
                 </group>
@@ -1228,9 +730,9 @@
               <else>
                 <choose>
                   <!-- TODO: Check logic once processors start to automatically populate editor-translator. -->
-                  <if variable="editor-translator" match="none">
-                    <names variable="translator" delimiter="; ">
-                      <name and="symbol" initialize-with=". " delimiter=", "/>
+                  <if match="none" variable="editor-translator">
+                    <names delimiter="; " variable="translator">
+                      <name/>
                       <label form="short" prefix=", " text-case="title"/>
                     </names>
                   </if>
@@ -1243,18 +745,18 @@
           <group delimiter="; ">
             <names variable="container-author">
               <label form="verb-short" suffix=" " text-case="title"/>
-              <name and="symbol" initialize-with=". " delimiter=", "/>
+              <name/>
             </names>
-            <names variable="editor translator" delimiter="; ">
-              <name and="symbol" initialize-with=". " delimiter=", "/>
+            <names delimiter="; " variable="editor translator">
+              <name/>
               <label form="short" prefix=", " text-case="title"/>
             </names>
-            <names variable="illustrator narrator" delimiter="; ">
-              <name and="symbol" initialize-with=". " delimiter=", "/>
+            <names delimiter="; " variable="illustrator narrator">
+              <name/>
               <label form="short" prefix=", " text-case="title"/>
             </names>
-            <names variable="compiler chair organizer curator series-creator executive-producer" delimiter="; ">
-              <name and="symbol" initialize-with=". " delimiter=", "/>
+            <names delimiter="; " variable="compiler chair organizer curator series-creator executive-producer">
+              <name/>
               <label form="long" prefix=", " text-case="title"/>
             </names>
           </group>
@@ -1262,181 +764,374 @@
       </choose>
     </group>
   </macro>
-  <macro name="database-location">
+  <macro name="secondary-contributors-periodical">
+    <group delimiter="; ">
+      <choose>
+        <if variable="title">
+          <names delimiter="; " variable="interviewer">
+            <name/>
+            <label form="short" prefix=", " text-case="title"/>
+          </names>
+        </if>
+      </choose>
+      <names delimiter="; " variable="translator narrator">
+        <name/>
+        <label form="short" prefix=", " text-case="title"/>
+      </names>
+    </group>
+  </macro>
+  <macro name="version-edition-volume">
+    <group delimiter=", ">
+      <text macro="version-labelled"/>
+      <text macro="edition-labelled"/>
+      <text macro="volume-booklike"/>
+    </group>
+  </macro>
+  <macro name="volume-booklike">
+    <group delimiter=", ">
+      <!-- Report series (APA example 52) -->
+      <choose>
+        <if match="any" type="document report standard">
+          <group delimiter=" ">
+            <text text-case="title" variable="collection-title"/>
+            <text variable="collection-number"/>
+          </group>
+        </if>
+      </choose>
+      <text macro="supplement-number-labelled"/>
+      <choose>
+        <if variable="volume">
+          <choose>
+            <!-- Non-numeric volumes are already printed as part of the book title -->
+            <if variable="volume-title"/>
+            <else-if is-numeric="volume">
+              <text macro="volume-labelled"/>
+            </else-if>
+          </choose>
+        </if>
+        <else>
+          <text macro="number-of-volumes-labelled"/>
+        </else>
+      </choose>
+      <text macro="issue-labelled"/>
+      <text macro="locators-booklike"/>
+    </group>
+  </macro>
+  <!-- Identification logic -->
+  <macro name="identification">
+    <group delimiter="; " prefix="(" suffix=")">
+      <!-- (Secondary contributors; Database location; Genre no. 123; Report Series 123, Version, Edition, Volume, Page) -->
+      <choose>
+        <if type="patent">
+          <text macro="patent-number"/>
+        </if>
+        <else-if match="any" type="post webpage">
+          <!-- For post webpage, container-title is treated as publisher -->
+          <text macro="identification-with-all-parts"/>
+        </else-if>
+        <else-if match="any" type="report">
+          <choose>
+            <if match="none" variable="title">
+              <!-- If there is no title, then genre and number are already printed as the title. -->
+              <text macro="secondary-contributors"/>
+              <text macro="database-location"/>
+              <text macro="identification-booklike"/>
+            </if>
+            <!-- If the report is a chapter in a larger report, then most parenthetical information is printed after the container. -->
+            <else-if variable="container-title">
+              <text macro="secondary-contributors"/>
+            </else-if>
+            <else>
+              <text macro="identification-with-all-parts"/>
+            </else>
+          </choose>
+        </else-if>
+        <else-if variable="container-title">
+          <group delimiter="; ">
+            <text macro="secondary-contributors"/>
+            <choose>
+              <if match="any" type="broadcast graphic map motion_picture song">
+                <!-- For audiovisual media, number information comes after title, not container-title (ex. 94) -->
+                <text macro="genre-number"/>
+              </if>
+            </choose>
+          </group>
+        </else-if>
+        <else>
+          <text macro="identification-with-all-parts"/>
+        </else>
+      </choose>
+    </group>
+  </macro>
+  <macro name="identification-booklike">
     <choose>
-      <if variable="archive-place" match="none">
-        <!-- With `archive-place`: physical archives. Without: online archives. -->
-        <text variable="archive_location"/>
-      </if>
+      <if match="any" type="article-journal article-magazine article-newspaper broadcast event interview patent performance periodical post post-weblog review review-book speech webpage"/>
+      <else-if type="paper-conference">
+        <choose>
+          <if match="any" variable="collection-editor compiler editor editorial-director">
+            <text macro="version-edition-volume"/>
+          </if>
+        </choose>
+      </else-if>
+      <else>
+        <text macro="version-edition-volume"/>
+      </else>
     </choose>
   </macro>
-  <macro name="number">
+  <macro name="identification-with-all-parts">
+    <group delimiter="; ">
+      <text macro="secondary-contributors"/>
+      <text macro="database-location"/>
+      <text macro="genre-number"/>
+      <text macro="identification-booklike"/>
+    </group>
+  </macro>
+  <!-- 3.3. Description [in square brackets] -->
+  <!-- Description utility macros -->
+  <macro name="description-generic">
+    <!-- For conference presentations/performances/events, chapters in reports/standards/generic documents, software, place description after the container title -->
     <choose>
-      <if variable="number">
-        <group delimiter=", ">
+      <if match="any" type="event paper-conference performance speech">
+        <choose>
+          <if match="any" variable="collection-editor compiler editor editorial-director issue page volume">
+            <text macro="format-bib"/>
+          </if>
+        </choose>
+      </if>
+      <else-if match="none" type="document report software standard">
+        <text macro="format-bib"/>
+      </else-if>
+    </choose>
+  </macro>
+  <macro name="description-interview">
+    <choose>
+      <if variable="title">
+        <text macro="format-bib"/>
+      </if>
+      <else-if variable="genre">
+        <group delimiter="; ">
           <group delimiter=" ">
-            <text variable="genre" text-case="title"/>
+            <text text-case="capitalize-first" variable="genre"/>
             <group delimiter=" ">
-              <label variable="number" form="short" text-case="capitalize-first"/>
-              <text variable="number"/>
+              <text form="verb" term="container-author"/>
+              <names variable="interviewer"/>
             </group>
           </group>
+        </group>
+      </else-if>
+      <else-if variable="interviewer">
+        <group delimiter="; ">
+          <names variable="interviewer">
+            <label form="verb" suffix=" " text-case="capitalize-first"/>
+            <name/>
+          </names>
+          <text text-case="capitalize-first" variable="medium"/>
+        </group>
+      </else-if>
+      <else>
+        <text macro="format-bib"/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="description-letter-bib">
+    <choose>
+      <if variable="recipient">
+        <group delimiter="; ">
+          <group delimiter=" ">
+            <choose>
+              <if match="none" variable="number">
+                <choose>
+                  <if variable="genre">
+                    <text text-case="capitalize-first" variable="genre"/>
+                  </if>
+                  <else-if variable="medium">
+                    <text text-case="capitalize-first" variable="medium"/>
+                  </else-if>
+                  <else>
+                    <text term="letter" text-case="capitalize-first"/>
+                  </else>
+                </choose>
+              </if>
+              <else>
+                <choose>
+                  <if variable="medium">
+                    <text text-case="capitalize-first" variable="medium"/>
+                  </if>
+                  <else>
+                    <text term="letter" text-case="capitalize-first"/>
+                  </else>
+                </choose>
+              </else>
+            </choose>
+            <names variable="recipient">
+              <label form="verb" suffix=" "/>
+              <name initialize="false"/>
+            </names>
+          </group>
           <choose>
-            <if type="thesis">
+            <if variable="genre">
               <choose>
-                <!-- Include the university in brackets if thesis is published -->
-                <if variable="archive DOI URL" match="any">
-                  <text variable="publisher"/>
+                <if match="none" variable="number">
+                  <text text-case="capitalize-first" variable="medium"/>
                 </if>
               </choose>
             </if>
           </choose>
         </group>
       </if>
-    </choose>
-  </macro>
-  <macro name="locators-booklike">
-    <choose>
-      <if type="article-journal article-magazine article-newspaper broadcast event interview patent performance periodical post post-weblog review review-book speech webpage" match="any"/>
-      <else-if type="paper-conference">
-        <choose>
-          <if variable="collection-editor compiler editor editorial-director" match="any">
-            <group delimiter=", ">
-              <text macro="version"/>
-              <text macro="edition"/>
-              <text macro="volume-booklike"/>
-            </group>
-          </if>
-        </choose>
-      </else-if>
       <else>
-        <group delimiter=", ">
-          <text macro="version"/>
-          <text macro="edition"/>
-          <text macro="volume-booklike"/>
-        </group>
+        <text macro="format-bib"/>
       </else>
     </choose>
   </macro>
-  <macro name="version">
-    <group delimiter=" ">
-      <label variable="version" text-case="capitalize-first"/>
-      <text variable="version"/>
-    </group>
-  </macro>
-  <macro name="edition">
-    <choose>
-      <if is-numeric="edition">
+  <macro name="description-reviewed">
+    <!-- Reviewed item -->
+    <group delimiter="; ">
+      <group delimiter=", ">
         <group delimiter=" ">
-          <number variable="edition" form="ordinal"/>
-          <label variable="edition" form="short"/>
-        </group>
-      </if>
-      <else>
-        <text variable="edition"/>
-      </else>
-    </choose>
-  </macro>
-  <macro name="volume-booklike">
-    <group delimiter=", ">
-      <!-- Report series [ex. 52] -->
-      <choose>
-        <if type="document report standard">
-          <group delimiter=" ">
-            <text variable="collection-title" text-case="title"/>
-            <text variable="collection-number"/>
-          </group>
-        </if>
-      </choose>
-      <group delimiter=" ">
-        <label variable="supplement-number" text-case="capitalize-first"/>
-        <text variable="supplement-number"/>
-      </group>
-      <choose>
-        <if variable="volume" match="any">
           <choose>
-            <!-- Non-numeric volumes are already printed as part of the book title -->
-            <if variable="volume-title"/>
-            <else-if is-numeric="volume" match="none"/>
-            <else>
+            <if variable="reviewed-genre">
               <group delimiter=" ">
-                <label variable="volume" form="short" text-case="capitalize-first"/>
-                <number variable="volume" form="numeric"/>
+                <text form="long" term="review-of" text-case="capitalize-first"/>
+                <text text-case="lowercase" variable="reviewed-genre"/>
               </group>
+            </if>
+            <!-- If no `reviewed-genre`, assume that `genre` or `medium` is entered as 'Review of the book' or similar -->
+            <else-if match="none" variable="number">
+              <choose>
+                <if variable="genre">
+                  <text text-case="capitalize-first" variable="genre"/>
+                </if>
+                <else-if variable="medium">
+                  <text text-case="capitalize-first" variable="medium"/>
+                </else-if>
+                <else-if type="review-book">
+                  <group delimiter=" ">
+                    <text form="long" term="review-of" text-case="capitalize-first"/>
+                    <text form="long" term="book" text-case="lowercase"/>
+                  </group>
+                </else-if>
+                <else>
+                  <text form="short" term="review-of" text-case="capitalize-first"/>
+                </else>
+              </choose>
+            </else-if>
+            <else>
+              <choose>
+                <if variable="medium">
+                  <text text-case="capitalize-first" variable="medium"/>
+                </if>
+                <else-if type="review-book">
+                  <group delimiter=" ">
+                    <text form="long" term="review-of" text-case="capitalize-first"/>
+                    <text form="long" term="book" text-case="lowercase"/>
+                  </group>
+                </else-if>
+                <else>
+                  <text form="short" term="review-of" text-case="capitalize-first"/>
+                </else>
+              </choose>
             </else>
           </choose>
-        </if>
-        <else>
-          <group>
-            <label variable="number-of-volumes" form="short" text-case="capitalize-first" suffix=" "/>
-            <text term="page-range-delimiter" prefix="1"/>
-            <number variable="number-of-volumes" form="numeric"/>
-          </group>
-        </else>
-      </choose>
-      <group delimiter=" ">
-        <label variable="issue" text-case="capitalize-first"/>
-        <text variable="issue"/>
+          <text macro="reviewed-title-bib"/>
+        </group>
+        <names variable="reviewed-author">
+          <label form="verb-short" suffix=" "/>
+          <name/>
+        </names>
       </group>
-      <group delimiter=" ">
-        <label variable="page" form="short" suffix=" "/>
-        <text variable="page"/>
-      </group>
-    </group>
-  </macro>
-  <macro name="reviewed-title">
-    <choose>
-      <if variable="reviewed-title">
-        <!-- Not possible to distinguish TV series episode from other reviewed
-             works without reviewed-container-title [Ex. 69] -->
-        <!-- Adapt for reviewed-container-title if that becomes available -->
-        <text variable="reviewed-title" font-style="italic"/>
-      </if>
-      <else>
-        <!-- Assume title is title of reviewed work -->
-        <text variable="title" font-style="italic"/>
-      </else>
-    </choose>
-  </macro>
-  <macro name="reviewed-title-intext">
-    <choose>
-      <if variable="reviewed-title">
-        <!-- Not possible to distinguish TV series episode from other reviewed
-             works without reviewed-container-title [Ex. 69] -->
-        <!-- Adapt for reviewed-container-title if that becomes available -->
-        <text variable="reviewed-title" form="short" font-style="italic" text-case="title"/>
-      </if>
-      <else>
-        <!-- Assume title is title of reviewed work -->
-        <text variable="title" form="short" font-style="italic" text-case="title"/>
-      </else>
-    </choose>
-  </macro>
-  <macro name="format">
-    <choose>
-      <if variable="genre medium" match="any">
-        <group delimiter="; ">
+      <choose>
+        <if variable="genre">
           <choose>
-            <if variable="number" match="none">
-              <text variable="genre" text-case="capitalize-first"/>
+            <if match="none" variable="number">
+              <text text-case="capitalize-first" variable="medium"/>
             </if>
           </choose>
-          <text variable="medium" text-case="capitalize-first"/>
+        </if>
+      </choose>
+    </group>
+  </macro>
+  <macro name="description-song">
+    <!-- Performer of classical music works -->
+    <group delimiter="; ">
+      <group delimiter=" ">
+        <choose>
+          <if match="none" variable="number">
+            <choose>
+              <if variable="genre">
+                <text text-case="capitalize-first" variable="genre"/>
+                <text form="verb" term="performer"/>
+              </if>
+              <else-if variable="medium">
+                <text text-case="capitalize-first" variable="medium"/>
+                <text form="verb" term="performer"/>
+              </else-if>
+              <else>
+                <text form="verb" term="performer" text-case="capitalize-first"/>
+              </else>
+            </choose>
+          </if>
+          <else>
+            <!-- If there is a number, genre is already printed in `genre-number` macro -->
+            <choose>
+              <if variable="medium">
+                <text text-case="capitalize-first" variable="medium"/>
+                <text form="verb" term="performer"/>
+              </if>
+              <else>
+                <text form="verb" term="performer" text-case="capitalize-first"/>
+              </else>
+            </choose>
+          </else>
+        </choose>
+        <names variable="author">
+          <substitute>
+            <names variable="performer"/>
+          </substitute>
+        </names>
+      </group>
+      <choose>
+        <if variable="genre">
+          <choose>
+            <if match="none" variable="number">
+              <text text-case="capitalize-first" variable="medium"/>
+            </if>
+          </choose>
+        </if>
+      </choose>
+    </group>
+  </macro>
+  <macro name="description-thesis">
+    <!-- Thesis type and institution -->
+    <group delimiter="; ">
+      <choose>
+        <if match="none" variable="number">
+          <group delimiter=", ">
+            <text text-case="capitalize-first" variable="genre"/>
+            <choose>
+              <if match="any" variable="archive DOI URL">
+                <!-- Include the university in brackets if thesis is published -->
+                <text variable="publisher"/>
+              </if>
+            </choose>
+          </group>
+        </if>
+      </choose>
+      <text text-case="capitalize-first" variable="medium"/>
+    </group>
+  </macro>
+  <macro name="format-bib">
+    <choose>
+      <if match="any" variable="genre medium">
+        <group delimiter="; ">
+          <choose>
+            <if match="none" variable="number">
+              <text text-case="capitalize-first" variable="genre"/>
+            </if>
+          </choose>
+          <text text-case="capitalize-first" variable="medium"/>
         </group>
       </if>
-      <else>
-        <text macro="generic-type-label"/>
-      </else>
-    </choose>
-  </macro>
-  <macro name="format-intext">
-    <choose>
-      <if variable="genre" match="any">
-        <text variable="genre" text-case="capitalize-first"/>
-      </if>
-      <else-if variable="medium">
-        <text variable="medium" text-case="capitalize-first"/>
-      </else-if>
       <else>
         <text macro="generic-type-label"/>
       </else>
@@ -1451,9 +1146,9 @@
       <else-if type="software">
         <text term="software" text-case="capitalize-first"/>
       </else-if>
-      <else-if type="interview personal_communication" match="any">
+      <else-if match="any" type="interview personal_communication">
         <choose>
-          <if variable="archive container-title DOI publisher URL" match="none">
+          <if match="none" variable="archive archive-place container-title DOI publisher URL">
             <text term="personal-communication" text-case="capitalize-first"/>
           </if>
           <else-if type="interview">
@@ -1493,18 +1188,67 @@
       </else-if>
     </choose>
   </macro>
-  <!-- APA 'source' element contains four parts:
-       container, event, publisher, access -->
+  <macro name="reviewed-title-bib">
+    <choose>
+      <if variable="reviewed-title">
+        <!-- Not possible to distinguish TV series episode from other reviewed
+             works without reviewed-container-title (APA example 69) -->
+        <!-- Adapt for reviewed-container-title if that becomes available -->
+        <text font-style="italic" variable="reviewed-title"/>
+      </if>
+      <else>
+        <!-- Assume title is title of reviewed work -->
+        <text font-style="italic" variable="title"/>
+      </else>
+    </choose>
+  </macro>
+  <!-- Description logic -->
+  <macro name="description-bib">
+    <group prefix="[" suffix="]">
+      <choose>
+        <if match="any" type="interview" variable="interviewer">
+          <text macro="description-interview"/>
+        </if>
+        <else-if match="any" type="review review-book" variable="reviewed-author reviewed-genre reviewed-title">
+          <text macro="description-reviewed"/>
+        </else-if>
+        <else-if type="personal_communication">
+          <text macro="description-letter-bib"/>
+        </else-if>
+        <else-if type="song" variable="composer">
+          <text macro="description-song"/>
+        </else-if>
+        <else-if type="thesis">
+          <text macro="description-thesis"/>
+        </else-if>
+        <else-if match="none" variable="container-title">
+          <!-- Other description -->
+          <text macro="format-bib"/>
+        </else-if>
+        <else>
+          <text macro="description-generic"/>
+        </else>
+      </choose>
+    </group>
+  </macro>
+  <!-- 4. Source -->
+  <!-- Four parts in APA 'source' element:
+
+       1. Container
+       2. Event
+       3. Publication details
+       4. Access -->
+  <!-- 4.1. Container -->
   <macro name="container">
     <choose>
-      <if type="article-journal article-magazine article-newspaper periodical post-weblog review review-book" match="any">
+      <if match="any" type="article-journal article-magazine article-newspaper periodical post-weblog review review-book">
         <!-- Periodical items -->
         <text macro="container-periodical"/>
       </if>
       <else-if type="paper-conference">
         <!-- Determine if paper-conference is a periodical- or book-like -->
         <choose>
-          <if variable="editor editorial-director collection-editor container-author" match="any">
+          <if match="any" variable="collection-editor container-author editor editorial-director">
             <text macro="container-booklike"/>
           </if>
           <else>
@@ -1512,55 +1256,15 @@
           </else>
         </choose>
       </else-if>
-      <else-if type="post webpage" match="none">
-        <!-- post and webpage treat container-title like publisher -->
+      <else-if match="none" type="post webpage">
+        <!-- Webpages treat container-title like publisher -->
         <text macro="container-booklike"/>
       </else-if>
     </choose>
   </macro>
-  <macro name="container-periodical">
-    <group delimiter=". ">
-      <group delimiter=", ">
-        <text variable="container-title" font-style="italic" text-case="title"/>
-        <choose>
-          <if variable="volume">
-            <group>
-              <text variable="volume" font-style="italic"/>
-              <text variable="issue" prefix="(" suffix=")"/>
-            </group>
-          </if>
-          <else>
-            <text variable="issue" font-style="italic"/>
-          </else>
-        </choose>
-        <choose>
-          <if variable="number">
-            <!-- Ex. 6: Journal article with article number or eLocator -->
-            <group delimiter=" ">
-              <text term="article-locator" text-case="capitalize-first"/>
-              <text variable="number"/>
-            </group>
-          </if>
-          <else>
-            <text variable="page"/>
-          </else>
-        </choose>
-      </group>
-      <choose>
-        <if variable="issued">
-          <choose>
-            <if variable="issue number page volume" match="none">
-              <!-- We print the status variable directly rather than using in-press, etc. terms. -->
-              <text variable="status" text-case="capitalize-first"/>
-            </if>
-          </choose>
-        </if>
-      </choose>
-    </group>
-  </macro>
   <macro name="container-booklike">
     <choose>
-      <if variable="container-title" match="any">
+      <if variable="container-title">
         <group delimiter=" ">
           <choose>
             <if type="song">
@@ -1571,161 +1275,167 @@
             </else>
           </choose>
           <group delimiter=", ">
-            <names variable="executive-producer">
-              <name and="symbol" initialize-with=". " delimiter=", "/>
-              <label form="long" text-case="title" prefix=" (" suffix=")"/>
-              <substitute>
-                <names variable="series-creator"/>
-                <names variable="editor-translator">
-                  <name and="symbol" initialize-with=". " delimiter=", "/>
-                  <label form="short" text-case="title" prefix=" (" suffix=")"/>
-                </names>
-                <!-- TODO: Translator omitted here on the assumption that editor-translators are uncommon 
-                           for chapter citations. If needed, direct entry or automatic population of
-                           `editor-translator` can produce combined labels. -->
-                <names variable="editor">
-                  <name and="symbol" initialize-with=". " delimiter=", "/>
-                  <label form="short" text-case="title" prefix=" (" suffix=")"/>
-                </names>
-                <names variable="editorial-director">
-                  <name and="symbol" initialize-with=". " delimiter=", "/>
-                  <label form="short" text-case="title" prefix=" (" suffix=")"/>
-                </names>
-                <names variable="compiler"/>
-                <choose>
-                  <if type="event performance speech" match="any">
-                    <names variable="chair"/>
-                    <names variable="organizer"/>
-                  </if>
-                </choose>
-                <names variable="curator"/>
-                <names variable="collection-editor">
-                  <name and="symbol" initialize-with=". " delimiter=", "/>
-                  <label form="short" text-case="title" prefix=" (" suffix=")"/>
-                </names>
-                <names variable="container-author"/>
-              </substitute>
-            </names>
-            <group delimiter=": " font-style="italic">
-              <text variable="container-title"/>
-              <text macro="volume-title"/>
-            </group>
+            <text macro="container-contributors"/>
+            <text macro="container-title-booklike"/>
           </group>
-          <text macro="parenthetical-container"/>
-          <text macro="bracketed-container"/>
+          <text macro="container-identification"/>
+          <text macro="container-description"/>
         </group>
       </if>
     </choose>
   </macro>
-  <macro name="publisher">
-    <group delimiter="; ">
+  <macro name="container-periodical">
+    <group delimiter=". ">
+      <group delimiter=", ">
+        <text font-style="italic" text-case="title" variable="container-title"/>
+        <text macro="volume-periodical"/>
+        <text macro="locators-periodical"/>
+      </group>
       <choose>
-        <if type="thesis">
+        <if variable="issued">
           <choose>
-            <if variable="archive DOI URL" match="none">
-              <text variable="publisher"/>
+            <if match="none" variable="issue number page volume">
+              <!-- We print the status variable directly rather than using in-press, etc. terms. -->
+              <text text-case="capitalize-first" variable="status"/>
             </if>
           </choose>
         </if>
-        <else-if type="post webpage" match="any">
-          <!-- For websites, treat container title like publisher -->
-          <group delimiter="; ">
-            <text variable="container-title" text-case="title"/>
-            <text variable="publisher"/>
-          </group>
-        </else-if>
-        <else-if type="paper-conference">
-          <!-- For paper-conference, don't print publisher if in a journal-like proceedings -->
-          <choose>
-            <if variable="collection-editor compiler editor editorial-director" match="any">
-              <text variable="publisher"/>
-            </if>
-          </choose>
-        </else-if>
-        <else-if type="article-journal article-magazine article-newspaper periodical post-weblog review review-book" match="none">
-          <text variable="publisher"/>
-        </else-if>
       </choose>
-      <group delimiter=", ">
-        <choose>
-          <if variable="archive-place">
-            <!-- With `archive-place`: physical archives. Without: online archives. -->
-            <!-- For physical archives, print the location before the archive name.
-                For electronic archives, these are printed in macro="description". -->
-            <!-- Must test for archive_collection:
-                With collection: archive_collection (archive_location), archive, archive-place
-                No collection: archive (archive_location), archive-place
-            -->
-            <choose>
-              <if variable="archive_collection">
-                <group delimiter=" ">
-                  <text variable="archive_collection"/>
-                  <text variable="archive_location" prefix="(" suffix=")"/>
-                </group>
-                <text variable="archive"/>
-                <text variable="archive-place"/>
-              </if>
-              <else>
-                <group delimiter=" ">
-                  <text variable="archive"/>
-                  <text variable="archive_location" prefix="(" suffix=")"/>
-                </group>
-                <text variable="archive-place"/>
-              </else>
-            </choose>
-          </if>
-          <else>
-            <text variable="archive"/>
-          </else>
-        </choose>
-      </group>
     </group>
   </macro>
-  <macro name="access">
+  <!-- Container parallels main elements -->
+  <!-- 4.1.1. Author -->
+  <macro name="container-contributors">
+    <names variable="executive-producer">
+      <name/>
+      <label form="long" prefix=" (" suffix=")" text-case="title"/>
+      <substitute>
+        <names variable="series-creator"/>
+        <names variable="editor-translator">
+          <name/>
+          <label form="short" prefix=" (" suffix=")" text-case="title"/>
+        </names>
+        <!-- TODO: Translator omitted on the assumption that editor-translators are uncommon for chapter citations.
+             If needed, direct entry or automatic population of `editor-translator` can produce combined labels. -->
+        <names delimiter="; " variable="editor">
+          <name/>
+          <label form="short" prefix=" (" suffix=")" text-case="title"/>
+        </names>
+        <names variable="editorial-director">
+          <name/>
+          <label form="short" prefix=" (" suffix=")" text-case="title"/>
+        </names>
+        <names variable="compiler"/>
+        <choose>
+          <if match="any" type="event performance speech">
+            <names variable="chair"/>
+            <names variable="organizer"/>
+          </if>
+        </choose>
+        <names variable="curator"/>
+        <names variable="collection-editor">
+          <name/>
+          <label form="short" prefix=" (" suffix=")" text-case="title"/>
+        </names>
+        <names variable="container-author"/>
+      </substitute>
+    </names>
+  </macro>
+  <!-- 4.1.3.1 Container title -->
+  <macro name="container-title-booklike">
+    <group delimiter=": " font-style="italic">
+      <text variable="container-title"/>
+      <text macro="title-volume"/>
+    </group>
+  </macro>
+  <!-- 4.1.3.1 Container identification -->
+  <macro name="container-identification">
     <choose>
-      <if variable="DOI" match="any">
-        <text variable="DOI" prefix="https://doi.org/"/>
-      </if>
-      <else-if variable="URL">
-        <group delimiter=" ">
-          <choose>
-            <if variable="issued status" match="none">
-              <group delimiter=" ">
-                <text term="retrieved" text-case="capitalize-first"/>
-                <date variable="accessed" form="text" suffix=","/>
-                <text term="from"/>
-              </group>
-            </if>
-          </choose>
-          <text variable="URL"/>
+      <if variable="container-title">
+        <group prefix="(" suffix=")">
+          <group delimiter="; ">
+            <text macro="database-location"/>
+            <choose>
+              <if match="none" type="broadcast graphic map motion_picture song">
+                <!-- For audiovisual media, number information comes after title, not container-title (APA example 94) -->
+                <text macro="genre-number"/>
+              </if>
+            </choose>
+            <text macro="identification-booklike"/>
+          </group>
         </group>
-      </else-if>
+      </if>
     </choose>
   </macro>
+  <!-- 4.1.3.2 Container description -->
+  <macro name="container-description">
+    <group prefix="[" suffix="]">
+      <choose>
+        <if match="any" type="event paper-conference performance speech">
+          <!-- Conference presentations should describe the session [container] in description unless published in a proceedings -->
+          <choose>
+            <if match="none" variable="collection-editor compiler editor editorial-director issue page volume">
+              <text macro="format-bib"/>
+            </if>
+          </choose>
+        </if>
+        <else-if type="software">
+          <!-- For entries in mobile app reference works, place description after the container-title -->
+          <text macro="format-bib"/>
+        </else-if>
+        <else-if match="any" type="document report standard">
+          <!-- For chapters in report, standards, and generic documents, place description after the container title -->
+          <text macro="format-bib"/>
+        </else-if>
+      </choose>
+    </group>
+  </macro>
+  <!-- 4.1.4. Source -->
+  <macro name="locators-periodical">
+    <choose>
+      <if variable="number">
+        <text macro="number-article-labelled"/>
+      </if>
+      <else>
+        <text variable="page"/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="volume-periodical">
+    <group delimiter=", ">
+      <text font-style="italic" text-case="title" variable="collection-title"/>
+      <choose>
+        <if variable="volume">
+          <group>
+            <text font-style="italic" variable="volume"/>
+            <text prefix="(" suffix=")" variable="issue"/>
+          </group>
+        </if>
+        <else>
+          <text font-style="italic" variable="issue"/>
+        </else>
+      </choose>
+    </group>
+  </macro>
+  <!-- 4.2. Event -->
   <macro name="event">
     <choose>
-      <if variable="event event-title" match="any">
-        <!-- To prevent Zotero from printing event-place due to its double-mapping of all 'place' to
-             both publisher-place and event-place. Remove this 'choose' when that is changed. -->
+      <if match="any" variable="event event-title">
+        <!-- To prevent Zotero from printing `event-place` due to its double-mapping of all 'place' to
+             both `publisher-place` and `event-place`. Remove this when that is changed. -->
         <choose>
           <if type="paper-conference">
             <choose>
-              <if variable="collection-editor compiler editor editorial-director issue page volume" match="none">
+              <if match="none" variable="collection-editor compiler editor editorial-director issue page volume">
                 <!-- Don't print event info for conference papers published in a proceedings -->
-                <group delimiter=", ">
-                  <text macro="event-title"/>
-                  <text variable="event-place"/>
-                </group>
+                <text macro="event-title-place"/>
               </if>
             </choose>
           </if>
           <else>
             <!-- For other item types, print event info even if published (e.g., for collection catalogs, performance programs.
                  These items aren't given explicit examples in the APA manual, so err on the side of providing too much information. -->
-            <group delimiter=", ">
-              <text macro="event-title"/>
-              <text variable="event-place"/>
-            </group>
+            <text macro="event-title-place"/>
           </else>
         </choose>
       </if>
@@ -1733,9 +1443,9 @@
   </macro>
   <macro name="event-title">
     <choose>
-      <!-- TODO: We expect "event-title" to be used,
+      <!-- TODO: We expect `event-title` to be used,
            but processors and applications may not be updated yet.
-           This macro ensures that either "event" or "event-title" can be accpeted.
+           This macro ensures that either `event` or `event-title` can be accepted.
            Remove if procesor logic and application adoption can handle this. -->
       <if variable="event-title">
         <text variable="event-title"/>
@@ -1745,11 +1455,153 @@
       </else>
     </choose>
   </macro>
-  <!-- After 'source', APA also prints publication history (original publication, reprint info, retraction info) -->
+  <macro name="event-title-place">
+    <group delimiter=", ">
+      <text macro="event-title"/>
+      <text variable="event-place"/>
+    </group>
+  </macro>
+  <!-- 4.3. Publication details -->
+  <!-- Publication utility macros -->
+  <macro name="archive">
+    <group delimiter=", ">
+      <choose>
+        <if variable="archive-place">
+          <!-- With `archive-place`: physical archives. Without: online archives. -->
+          <!-- For physical archives, print the location before the archive name.
+                For electronic archives, these are printed in macro="description". -->
+          <!-- Must test for archive_collection:
+                With collection: archive_collection (archive_location), archive, archive-place
+                No collection: archive (archive_location), archive-place
+            -->
+          <choose>
+            <if variable="archive_collection">
+              <group delimiter=" ">
+                <text variable="archive_collection"/>
+                <text prefix="(" suffix=")" variable="archive_location"/>
+              </group>
+              <text variable="archive"/>
+              <text variable="archive-place"/>
+            </if>
+            <else>
+              <group delimiter=" ">
+                <text variable="archive"/>
+                <text prefix="(" suffix=")" variable="archive_location"/>
+              </group>
+              <text variable="archive-place"/>
+            </else>
+          </choose>
+        </if>
+        <else>
+          <text variable="archive"/>
+        </else>
+      </choose>
+    </group>
+  </macro>
+  <macro name="publisher">
+    <choose>
+      <if variable="publisher">
+        <text variable="publisher"/>
+      </if>
+      <else-if match="none" variable="event-place">
+        <!-- Work around Zotero double-mapping of event/publisher place -->
+        <text variable="publisher-place"/>
+      </else-if>
+    </choose>
+  </macro>
+  <!-- Publication logic -->
+  <macro name="publication">
+    <choose>
+      <if type="thesis">
+        <choose>
+          <if match="none" variable="archive DOI URL">
+            <text macro="publisher"/>
+          </if>
+        </choose>
+      </if>
+      <else-if match="any" type="post webpage">
+        <!-- Webpages treat container-title like publisher -->
+        <group delimiter="; ">
+          <text text-case="title" variable="container-title"/>
+          <text macro="publisher"/>
+        </group>
+      </else-if>
+      <else-if type="paper-conference">
+        <!-- For paper-conference, don't print publisher if in a journal-like proceedings -->
+        <choose>
+          <if match="any" variable="collection-editor compiler editor editorial-director">
+            <text macro="publisher"/>
+          </if>
+        </choose>
+      </else-if>
+      <else-if match="none" type="article-journal article-magazine article-newspaper periodical post-weblog review review-book">
+        <text macro="publisher"/>
+      </else-if>
+    </choose>
+  </macro>
+  <macro name="publication-archive">
+    <group delimiter="; ">
+      <text macro="publication"/>
+      <text macro="archive"/>
+    </group>
+  </macro>
+  <!-- 4.4. Access -->
+  <macro name="access">
+    <choose>
+      <if variable="DOI">
+        <text prefix="https://doi.org/" variable="DOI"/>
+      </if>
+      <else-if variable="URL">
+        <group delimiter=" ">
+          <choose>
+            <if match="none" variable="issued status">
+              <group delimiter=" ">
+                <text term="retrieved" text-case="capitalize-first"/>
+                <group delimiter=", ">
+                  <date form="text" variable="accessed"/>
+                  <text term="from"/>
+                </group>
+              </group>
+            </if>
+          </choose>
+          <text variable="URL"/>
+        </group>
+      </else-if>
+    </choose>
+  </macro>
+  <!-- 5. Publication history -->
+  <!-- History utility macros -->
+  <macro name="original-publisher">
+    <choose>
+      <if variable="original-publisher">
+        <text variable="original-publisher"/>
+      </if>
+      <else>
+        <text variable="original-publisher-place"/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="original-title">
+    <choose>
+      <if variable="original-title">
+        <text value="as"/>
+        <choose>
+          <if match="any" type="article-journal article-magazine article-newspaper periodical post-weblog review review-book">
+            <text variable="original-title"/>
+          </if>
+          <else>
+            <text font-style="italic" variable="original-title"/>
+          </else>
+        </choose>
+      </if>
+    </choose>
+  </macro>
+  <!-- History logic -->
   <macro name="publication-history">
+    <!-- Information appended to 'source': original publication, reprint info, retraction info -->
     <choose>
       <if type="patent">
-        <text variable="references" prefix="(" suffix=")"/>
+        <text prefix="(" suffix=")" variable="references"/>
       </if>
       <else>
         <group delimiter="; " prefix="(" suffix=")">
@@ -1757,8 +1609,8 @@
           <choose>
             <if variable="issued">
               <choose>
-                <if variable="issue number page volume" match="any">
-                  <text variable="status" text-case="capitalize-first"/>
+                <if match="any" variable="issue number page volume">
+                  <text text-case="capitalize-first" variable="status"/>
                 </if>
               </choose>
             </if>
@@ -1767,29 +1619,31 @@
             <if variable="references">
               <!-- This provides the option for more elaborate description
                     of publication history, such as full "reprinted" references
-                    (examples 11, 43, 44) -->
+                    (APA examples 11, 43, 44) -->
               <text variable="references"/>
             </if>
             <else>
-              <group delimiter=" ">
-                <text term="original-work-published" text-case="capitalize-first"/>
-                <choose>
-                  <if is-uncertain-date="original-date">
-                    <text term="circa" form="short"/>
-                  </if>
-                </choose>
-                <date variable="original-date">
-                  <date-part name="year"/>
-                </date>
-              </group>
+              <text macro="publication-history-variables"/>
             </else>
           </choose>
         </group>
       </else>
     </choose>
   </macro>
-  <!-- Legal citations have their own rules -->
-  <macro name="legal-cites">
+  <macro name="publication-history-variables">
+    <group delimiter=" ">
+      <text term="original-work-published" text-case="capitalize-first"/>
+      <group delimiter="; ">
+        <text macro="original-title"/>
+        <group delimiter=", ">
+          <text macro="original-publisher"/>
+          <text macro="original-date-year"/>
+        </group>
+      </group>
+    </group>
+  </macro>
+  <!-- Parallel rules for legal citations -->
+  <macro name="legal-bib">
     <!-- `treaty`: for treaties -->
     <!-- `legal_case`: for all legal and court cases -->
     <!-- `bill`: for bills, resolutions, federal reports -->
@@ -1801,16 +1655,14 @@
         <if type="treaty">
           <group delimiter=", " suffix=".">
             <!-- APA generally defers to Bluebook for legal citations, but diverges without
-                explanation for treaty items. We follow the Bluebook format that was used 
+                explanation for treaty items. We follow the Bluebook format that was used
                 in APA 6th ed. -->
-            <!-- APA manual omits treaty parties/authors, but per Bluebook 
+            <!-- APA manual omits treaty parties/authors, but per Bluebook
                 they should be included at least for bilateral treaties. -->
-            <names variable="author">
-              <name initialize-with="." form="short" delimiter="-"/>
-            </names>
+            <text macro="author-legal"/>
             <text macro="date-legal"/>
-            <!-- APA manual omits treaty source/report called for by Bluebook in favor of just URL. 
-                Both are included here, following the APA style used for all other item types 
+            <!-- APA manual omits treaty source/report called for by Bluebook in favor of just URL.
+                Both are included here, following the APA style used for all other item types
                 to end the reference with a period, then give the URL afterward. -->
             <text macro="container-legal"/>
           </group>
@@ -1822,7 +1674,7 @@
               <text macro="container-legal"/>
             </group>
             <text macro="date-legal"/>
-            <text macro="parenthetical-legal"/>
+            <text macro="identification-legal"/>
           </group>
         </else>
       </choose>
@@ -1830,20 +1682,75 @@
       <text macro="access"/>
     </group>
   </macro>
+  <!-- 1. Legal author -->
+  <macro name="author-legal">
+    <names variable="author">
+      <name delimiter="-" form="short"/>
+    </names>
+  </macro>
+  <!-- 2. Legal date -->
+  <macro name="date-legal-case">
+    <group delimiter=" " prefix="(" suffix=")">
+      <text variable="authority"/>
+      <choose>
+        <if variable="container-title">
+          <!-- Print only year for cases published in reporters-->
+          <text macro="date-issued-year"/>
+        </if>
+        <else>
+          <!-- APA manual doesn't include examples of cases not yet
+                   published in a reporter, but this is Bluebook style. -->
+          <text macro="date-issued-full"/>
+        </else>
+      </choose>
+    </group>
+  </macro>
+  <macro name="date-legal">
+    <choose>
+      <if type="treaty">
+        <text macro="date-issued-full"/>
+      </if>
+      <else-if type="legal_case">
+        <text macro="date-legal-case"/>
+      </else-if>
+      <else-if match="any" type="bill hearing legislation regulation">
+        <group delimiter=" " prefix="(" suffix=")">
+          <group delimiter=" ">
+            <text macro="original-date-year"/>
+            <text form="symbol" term="and"/>
+          </group>
+          <choose>
+            <if variable="issued">
+              <!-- APA manual includes "rev." before the revision year,
+                   but this isn't part of the Bluebook rules. -->
+              <text macro="date-issued-year"/>
+            </if>
+            <else>
+              <!-- Show proposal date for uncodified regualtions.
+                   Assume date is entered literally ala "proposed May 23, 2016".
+                   TODO: Add 'proposed' term here if that becomes available -->
+              <date form="text" variable="submitted"/>
+            </else>
+          </choose>
+        </group>
+      </else-if>
+    </choose>
+  </macro>
+  <!-- 3.1. Legal title -->
   <macro name="title-legal">
     <choose>
-      <if type="bill legal_case legislation regulation treaty" match="any">
-        <text variable="title" text-case="title"/>
+      <if match="any" type="bill legal_case legislation regulation treaty">
+        <text text-case="title" variable="title"/>
       </if>
       <else-if type="hearing">
-        <!-- APA uses a comma delimiter and omits "hearing before the" for hearings with testimony, 
+        <!-- APA uses a comma delimiter and omits "hearing before the" for hearings with testimony,
              but follows Bluebook rules (colon delimiter, prefix before the committee name) for
              references to the whole hearing. We simply follow the Bluebook rules for both, but
              use APA style capitalization (not capitalizing "Before" or the title of the hearing). -->
         <group delimiter=": " font-style="italic">
-          <text variable="title" text-case="capitalize-first"/>
+          <text text-case="capitalize-first" variable="title"/>
           <group delimiter=" ">
-            <text term="hearing" form="long" text-case="capitalize-first"/>
+            <text form="long" term="hearing" text-case="capitalize-first"/>
             <group delimiter=" ">
               <group delimiter=" ">
                 <!-- APA manual omits the bill number, but it should be included per Bluebook if relevant -->
@@ -1852,7 +1759,7 @@
               </group>
               <group delimiter=" ">
                 <!-- Use the `at` term to hold "before the" -->
-                <text term="at" form="long"/>
+                <text form="long" term="at"/>
                 <text variable="section"/>
               </group>
             </group>
@@ -1861,124 +1768,95 @@
       </else-if>
     </choose>
   </macro>
-  <macro name="date-legal">
+  <!-- 3.2. Legal identification (in parentheses) -->
+  <macro name="identification-legal">
     <choose>
-      <if type="treaty">
-        <date variable="issued" form="text"/>
+      <if type="hearing">
+        <group delimiter=" " prefix="(" suffix=")">
+          <!-- Use the 'verb' form of the hearing term to hold 'testimony of' -->
+          <text form="verb" term="hearing"/>
+          <names variable="author">
+            <name initialize="false"/>
+          </names>
+        </group>
       </if>
-      <else-if type="legal_case">
-        <group prefix="(" suffix=")" delimiter=" ">
-          <text variable="authority"/>
-          <choose>
-            <if variable="container-title" match="any">
-              <!-- Print only year for cases published in reporters-->
-              <date variable="issued" form="numeric" date-parts="year"/>
-            </if>
-            <else>
-              <!-- APA manual doesn't include examples of cases not yet
-                   published in a reporter, but this is Bluebook style. -->
-              <date variable="issued" form="text"/>
-            </else>
-          </choose>
-        </group>
-      </else-if>
-      <else-if type="bill hearing legislation regulation" match="any">
-        <group prefix="(" suffix=")" delimiter=" ">
-          <group delimiter=" ">
-            <date variable="original-date">
-              <date-part name="year"/>
-            </date>
-            <text term="and" form="symbol"/>
-          </group>
-          <choose>
-            <if variable="issued">
-              <!-- APA manual includes "rev." before the revision year, 
-                   but this isn't part of the Bluebook rules. -->
-              <date variable="issued">
-                <date-part name="year"/>
-              </date>
-            </if>
-            <else>
-              <!-- Show proposal date for uncodified regualtions. 
-                   Assume date is entered literally ala "proposed May 23, 2016".
-                   TODO: Add 'proposed' term here if that becomes available -->
-              <date variable="submitted" form="text"/>
-            </else>
-          </choose>
-        </group>
+      <else-if match="any" type="bill legislation regulation">
+        <!-- For uncodified regulations, assume future code section is in `status`. -->
+        <text prefix="(" suffix=")" variable="status"/>
       </else-if>
     </choose>
   </macro>
-  <macro name="container-legal">
-    <!-- Expect legal item container-titles to be stored in short form -->
+  <!-- 4. Legal source -->
+  <!-- Legal source utility macros -->
+  <macro name="container-bill">
+    <group delimiter=", ">
+      <group delimiter=" ">
+        <text variable="genre"/>
+        <group delimiter=" ">
+          <choose>
+            <!-- If there is no session number or code/record title, assume
+                     assume the item is a congressional report and include 'No.' term. -->
+            <if match="none" variable="chapter-number container-title">
+              <!-- The item is a congressional report, rather than a bill or resultion. -->
+              <text macro="number-labelled"/>
+            </if>
+            <else>
+              <text variable="number"/>
+            </else>
+          </choose>
+        </group>
+      </group>
+      <group delimiter=" ">
+        <text variable="authority"/>
+        <!-- 'session' is `chapter-number` -->
+        <text variable="chapter-number"/>
+      </group>
+      <group delimiter=" ">
+        <text variable="volume"/>
+        <text variable="container-title"/>
+        <text variable="page-first"/>
+      </group>
+    </group>
+  </macro>
+  <macro name="container-hearing">
+    <group delimiter=" ">
+      <text variable="authority"/>
+      <!-- 'session' is `chapter-number` -->
+      <text variable="chapter-number"/>
+    </group>
+  </macro>
+  <macro name="container-legal-case">
+    <group delimiter=" ">
+      <choose>
+        <if variable="container-title">
+          <group delimiter=" ">
+            <text variable="volume"/>
+            <text variable="container-title"/>
+            <text macro="section-labelled"/>
+            <choose>
+              <if match="any" variable="page page-first">
+                <text variable="page-first"/>
+              </if>
+              <else>
+                <text value="___"/>
+              </else>
+            </choose>
+          </group>
+        </if>
+        <else>
+          <text macro="number-labelled"/>
+        </else>
+      </choose>
+    </group>
+  </macro>
+  <macro name="container-legislation">
     <choose>
-      <if type="treaty">
-        <group delimiter=" ">
-          <number variable="volume"/>
-          <text variable="container-title"/>
-          <choose>
-            <if variable="page page-first" match="any">
-              <text variable="page-first"/>
-            </if>
-            <else>
-              <group delimiter=" ">
-                <label variable="number" form="short" text-case="capitalize-first"/>
-                <text variable="number"/>
-              </group>
-            </else>
-          </choose>
-        </group>
-      </if>
-      <else-if type="legal_case">
-        <group delimiter=" ">
-          <choose>
-            <if variable="container-title">
-              <group delimiter=" ">
-                <text variable="volume"/>
-                <text variable="container-title"/>
-                <group delimiter=" ">
-                  <label variable="section" form="symbol"/>
-                  <text variable="section"/>
-                </group>
-                <choose>
-                  <if variable="page page-first" match="any">
-                    <text variable="page-first"/>
-                  </if>
-                  <else>
-                    <text value="___"/>
-                  </else>
-                </choose>
-              </group>
-            </if>
-            <else>
-              <group delimiter=" ">
-                <label variable="number" form="short" text-case="capitalize-first"/>
-                <text variable="number"/>
-              </group>
-            </else>
-          </choose>
-        </group>
-      </else-if>
-      <else-if type="bill">
+      <if variable="number">
+        <!-- There's a public law number. -->
         <group delimiter=", ">
           <group delimiter=" ">
-            <text variable="genre"/>
-            <group delimiter=" ">
-              <choose>
-                <!-- If there is no session number or code/record title, assume
-                     assume the item is a congressional report and include 'No.' term. -->
-                <if variable="chapter-number container-title" match="none">
-                  <!-- The item is a congressional report, rather than a bill or resultion. -->
-                  <label variable="number" form="short" text-case="capitalize-first"/>
-                </if>
-              </choose>
-              <text variable="number"/>
-            </group>
-          </group>
-          <group delimiter=" ">
-            <text variable="authority"/>
-            <!-- 'session' is `chapter-number` -->
-            <text variable="chapter-number"/>
+            <text value="Pub. L. No."/>
+            <text variable="number"/>
           </group>
           <group delimiter=" ">
             <text variable="volume"/>
@@ -1986,105 +1864,82 @@
             <text variable="page-first"/>
           </group>
         </group>
-      </else-if>
-      <else-if type="hearing">
+      </if>
+      <else>
         <group delimiter=" ">
-          <text variable="authority"/>
-          <!-- 'session' is `chapter-number` -->
-          <text variable="chapter-number"/>
+          <text variable="volume"/>
+          <text variable="container-title"/>
+          <choose>
+            <if variable="section">
+              <text macro="section-labelled"/>
+            </if>
+            <else>
+              <text variable="page-first"/>
+            </else>
+          </choose>
         </group>
-      </else-if>
-      <else-if type="legislation">
+      </else>
+    </choose>
+  </macro>
+  <macro name="container-regulation">
+    <group delimiter=", ">
+      <group delimiter=" ">
+        <text variable="genre"/>
+        <text macro="number-labelled"/>
+      </group>
+      <group delimiter=" ">
+        <text variable="volume"/>
+        <text variable="container-title"/>
         <choose>
-          <if variable="number">
-            <!-- There's a public law number. -->
-            <group delimiter=", ">
-              <text variable="number" prefix="Pub. L. No. "/>
-              <group delimiter=" ">
-                <text variable="volume"/>
-                <text variable="container-title"/>
-                <text variable="page-first"/>
-              </group>
-            </group>
+          <if variable="section">
+            <text macro="section-labelled"/>
           </if>
           <else>
-            <group delimiter=" ">
-              <text variable="volume"/>
-              <text variable="container-title"/>
-              <choose>
-                <if variable="section">
-                  <group delimiter=" ">
-                    <label variable="section" form="symbol"/>
-                    <text variable="section"/>
-                  </group>
-                </if>
-                <else>
-                  <text variable="page-first"/>
-                </else>
-              </choose>
-            </group>
+            <text variable="page-first"/>
           </else>
         </choose>
-      </else-if>
-      <else-if type="regulation">
-        <group delimiter=", ">
-          <group delimiter=" ">
-            <text variable="genre"/>
-            <group delimiter=" ">
-              <label variable="number" form="short" text-case="capitalize-first"/>
-              <text variable="number"/>
-            </group>
-          </group>
-          <group delimiter=" ">
-            <text variable="volume"/>
-            <text variable="container-title"/>
-            <choose>
-              <if variable="section">
-                <group delimiter=" ">
-                  <label variable="section" form="symbol"/>
-                  <text variable="section"/>
-                </group>
-              </if>
-              <else>
-                <text variable="page-first"/>
-              </else>
-            </choose>
-          </group>
-        </group>
-      </else-if>
-    </choose>
-  </macro>
-  <macro name="parenthetical-legal">
-    <choose>
-      <if type="hearing">
-        <group prefix="(" suffix=")" delimiter=" ">
-          <!-- Use the 'verb' form of the hearing term to hold 'testimony of' -->
-          <text term="hearing" form="verb"/>
-          <names variable="author">
-            <name and="symbol" delimiter=", "/>
-          </names>
-        </group>
-      </if>
-      <else-if type="bill legislation regulation" match="any">
-        <!-- For uncodified regulations, assume future code section is in `status`. -->
-        <text variable="status" prefix="(" suffix=")"/>
-      </else-if>
-    </choose>
-  </macro>
-  <macro name="citation-locator">
-    <!-- Abbreviate page and paragraph, leave other locator labels in long form, cf. Rule 8.13 -->
-    <group delimiter=" ">
-      <choose>
-        <if locator="page paragraph" match="any">
-          <label variable="locator" form="short"/>
-        </if>
-        <else>
-          <label variable="locator" text-case="capitalize-first"/>
-        </else>
-      </choose>
-      <text variable="locator"/>
+      </group>
     </group>
   </macro>
+  <macro name="container-treaty">
+    <group delimiter=" ">
+      <number variable="volume"/>
+      <text variable="container-title"/>
+      <choose>
+        <if match="any" variable="page page-first">
+          <text variable="page-first"/>
+        </if>
+        <else>
+          <text macro="number-labelled"/>
+        </else>
+      </choose>
+    </group>
+  </macro>
+  <!-- Legal source logic -->
+  <macro name="container-legal">
+    <!-- Expect legal item container-titles to be stored in short form -->
+    <choose>
+      <if type="bill">
+        <text macro="container-bill"/>
+      </if>
+      <else-if type="hearing">
+        <text macro="container-hearing"/>
+      </else-if>
+      <else-if type="legal_case">
+        <text macro="container-legal-case"/>
+      </else-if>
+      <else-if type="legislation">
+        <text macro="container-legislation"/>
+      </else-if>
+      <else-if type="regulation">
+        <text macro="container-regulation"/>
+      </else-if>
+      <else-if type="treaty">
+        <text macro="container-treaty"/>
+      </else-if>
+    </choose>
+  </macro>
+  <!-- Main logic -->
   <citation collapse="citation-number">
     <sort>
       <key variable="citation-number"/>
@@ -2092,34 +1947,47 @@
     <layout delimiter="," prefix="[" suffix="]" vertical-align="sup">
       <group>
         <text variable="citation-number"/>
-        <text macro="citation-locator" prefix="(" suffix=")"/>
+        <text macro="locator-labelled" prefix="(" suffix=")"/>
       </group>
     </layout>
   </citation>
-  <bibliography hanging-indent="true" et-al-min="21" et-al-use-first="19" et-al-use-last="true" entry-spacing="0" line-spacing="2">
+  <macro name="bibliography">
+    <group delimiter=" ">
+      <group delimiter=". " suffix=".">
+        <text macro="author-bib"/>
+        <text macro="date-bib"/>
+        <text macro="title-and-descriptions"/>
+        <text macro="container"/>
+        <text macro="event"/>
+        <text macro="publication-archive"/>
+      </group>
+      <text macro="access"/>
+      <text macro="publication-history"/>
+    </group>
+  </macro>
+  <macro name="bibliography-filtered">
+    <choose>
+      <if match="any" type="bill hearing legal_case legislation regulation treaty">
+        <!-- Legal items have different orders and delimiters -->
+        <text macro="legal-bib"/>
+      </if>
+      <else-if type="personal_communication">
+        <choose>
+          <if match="any" variable="archive archive-place container-title DOI publisher URL">
+            <text macro="bibliography"/>
+          </if>
+        </choose>
+      </else-if>
+      <else>
+        <text macro="bibliography"/>
+      </else>
+    </choose>
+  </macro>
+  <bibliography entry-spacing="0" et-al-min="21" et-al-use-first="19" et-al-use-last="true" hanging-indent="true" line-spacing="2">
     <layout>
       <group delimiter=". ">
         <text variable="citation-number"/>
-        <choose>
-          <if type="bill hearing legal_case legislation regulation treaty" match="any">
-            <!-- Legal items have different orders and delimiters -->
-            <text macro="legal-cites"/>
-          </if>
-          <else>
-            <group delimiter=" ">
-              <group delimiter=". " suffix=".">
-                <text macro="author-bib"/>
-                <text macro="date-bib"/>
-                <text macro="title-and-descriptions"/>
-                <text macro="container"/>
-                <text macro="event"/>
-                <text macro="publisher"/>
-              </group>
-              <text macro="access"/>
-              <text macro="publication-history"/>
-            </group>
-          </else>
-        </choose>
+        <text macro="bibliography-filtered"/>
       </group>
     </layout>
   </bibliography>

--- a/apa-numeric-superscript.csl
+++ b/apa-numeric-superscript.csl
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
-<style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" demote-non-dropping-particle="never" page-range-format="expanded">
+<style xmlns="http://purl.org/net/xbiblio/csl" and="symbol" class="in-text" demote-non-dropping-particle="never" initialize-with=". " names-delimiter=", " page-range-format="expanded" version="1.0">
   <info>
     <title>American Psychological Association 7th edition (numeric, superscript)</title>
-    <title-short>APA (numeric)</title-short>
+    <title-short>APA Style (numeric, superscript)</title-short>
     <id>http://www.zotero.org/styles/apa-numeric-superscript</id>
     <link href="http://www.zotero.org/styles/apa-numeric-superscript" rel="self"/>
     <link href="http://www.zotero.org/styles/apa" rel="template"/>
@@ -10,7 +10,12 @@
     <author>
       <name>Brenton M. Wiernik</name>
       <email>zotero@wiernik.org</email>
+      <uri>https://orcid.org/0000-0001-9560-6336</uri>
     </author>
+    <contributor>
+      <name>Andrew Dunning</name>
+      <uri>https://orcid.org/0000-0003-0464-5036</uri>
+    </contributor>
     <category citation-format="numeric"/>
     <category field="psychology"/>
     <category field="generic-base"/>
@@ -20,39 +25,38 @@
   </info>
   <locale xml:lang="en">
     <terms>
-      <term name="editortranslator" form="short">
-        <single>ed. &amp; trans.</single>
-        <multiple>eds. &amp; trans.</multiple>
-      </term>
-      <term name="editor-translator" form="short">
-        <single>ed. &amp; trans.</single>
-        <multiple>eds. &amp; trans.</multiple>
-      </term>
-      <term name="translator" form="short">trans.</term>
-      <term name="interviewer" form="short">
-        <single>interviewer</single>
-        <multiple>interviewers</multiple>
-      </term>
-      <term name="collection-editor" form="short">
+      <term name="ad"> C.E.</term>
+      <term form="long" name="at">before the</term>
+      <term name="bc"> B.C.E.</term>
+      <term form="short" name="circa">ca.</term>
+      <term name="collection">archival collection</term>
+      <term form="short" name="collection-editor">
         <single>ed.</single>
         <multiple>eds.</multiple>
       </term>
-      <term name="performer" form="verb">recorded by</term>
-      <term name="circa" form="short">ca.</term>
-      <term name="bc"> B.C.E.</term>
-      <term name="ad"> C.E.</term>
-      <term name="issue" form="long">
+      <term form="short" name="editor-translator">
+        <single>ed. &amp; trans.</single>
+        <multiple>eds. &amp; trans.</multiple>
+      </term>
+      <term form="short" name="editortranslator">
+        <single>ed. &amp; trans.</single>
+        <multiple>eds. &amp; trans.</multiple>
+      </term>
+      <term form="verb" name="hearing">testimony of</term>
+      <term form="short" name="interviewer">
+        <single>interviewer</single>
+        <multiple>interviewers</multiple>
+      </term>
+      <term form="long" name="issue">
         <single>issue</single>
         <multiple>issues</multiple>
       </term>
-      <term name="software">computer software</term>
-      <term name="at" form="long">before the</term>
-      <term name="collection">archival collection</term>
+      <term form="verb" name="performer">recorded by</term>
       <term name="post">online post</term>
-      <term name="at" form="long">before the</term>
-      <term name="hearing" form="verb">testimony of</term>
-      <term name="review-of" form="long">review of the</term>
-      <term name="review-of" form="short">review of</term>
+      <term form="long" name="review-of">review of the</term>
+      <term form="short" name="review-of">review of</term>
+      <term name="software">computer software</term>
+      <term form="short" name="translator">trans.</term>
     </terms>
   </locale>
   <locale xml:lang="da">
@@ -72,7 +76,7 @@
   </locale>
   <locale xml:lang="fr">
     <terms>
-      <term name="editor" form="short">
+      <term form="short" name="editor">
         <single>éd.</single>
         <multiple>éds.</multiple>
       </term>
@@ -98,29 +102,26 @@
       <term name="et-al">et al.</term>
     </terms>
   </locale>
-  <!-- For Indigeneous Knowledge, assume the item is stored as `document` or `speech`
-       and that Nation/Community, treaty, where the Elder lives, 
-       and topic are all stored in `title`
-       cf. https://libguides.norquest.ca/c.php?g=314831&p=5188823.
-       If the item is stored as `interview`, assume that Nation/Community, treat, and topic
-       are stored in `title`, 'Oral teaching' or similar is stored in `archive`, and where
-       the Elder lives is stored in `archive-place`. 
-  -->
-  <!-- Reviews are detected if an item has type `review` or `review-book` or if it has any of the variables
-       `reviewed-title`, `reviewed-author`, or `reviewed-genre`. For the latter case, reviews are commonly 
-       stored as types `article-journal`, `article-magazine`, `article-newspaper`, `post-weblog`, or `webpage` 
-  -->
-  <!-- General categories of item types:
-       Periodical: article-journal article-magazine article-newspaper periodical post-weblog review review-book
-       Periodical or Booklike: paper-conference
-       Booklike: article book broadcast chapter classic collection dataset document
-                 entry entry-dictionary entry-encyclopedia event figure
-                 graphic interview manuscript map motion_picture musical_score
-                 pamphlet patent performance personal_communication post report
-                 software song speech standard thesis webpage
-       Legal: bill hearing legal_case legislation regulation treaty
+  <!-- General categories of CSL item types:
+
+       Periodical
+       : article-journal article-magazine article-newspaper periodical post-weblog review review-book
+
+       Periodical or Booklike
+       : paper-conference
+
+       Booklike
+       : article book broadcast chapter classic collection dataset document
+         entry entry-dictionary entry-encyclopedia event figure
+         graphic interview manuscript map motion_picture musical_score
+         pamphlet patent performance personal_communication post report
+         software song speech standard thesis webpage
+
+       Legal
+       : bill hearing legal_case legislation regulation treaty
   -->
   <!-- Equivalencies:
+
        classic == book
        document == report, but give full date
        standard == report
@@ -129,6 +130,7 @@
        collection == book, but give full date
   -->
   <!-- Role equivalencies:
+
        compiler == editor
        organizer, curator == chair
        script-writer == director
@@ -136,419 +138,471 @@
        guest, host == director
        series-creator, executive-producer == editor
   -->
-  <!-- APA references contain four parts: author, date, title, source -->
-  <macro name="author-bib">
+  <!-- Reviews are detected if an item has type `review` or `review-book` or if it has any of the variables
+       `reviewed-title`, `reviewed-author`, or `reviewed-genre`. For the latter case, reviews are commonly
+       stored as types `article-journal`, `article-magazine`, `article-newspaper`, `post-weblog`, or `webpage`
+  -->
+  <!-- For Indigeneous Knowledge, assume the item is stored as `document` or `speech`
+       and that Nation/Community, treaty, where the Elder lives,
+       and topic are all stored in `title`
+       cf. https://libguides.norquest.ca/c.php?g=314831&p=5188823.
+       If the item is stored as `interview`, assume that Nation/Community, treaty territory, and topic
+       are stored in `title`, 'Oral teaching' or similar is stored in `archive`, and where
+       the Elder lives is stored in `archive-place`.
+  -->
+  <!-- Variable labelling macros -->
+  <macro name="chapter-number-labelled">
     <group delimiter=" ">
-      <names variable="composer" delimiter=", &amp; ">
-        <name name-as-sort-order="all" and="symbol" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
-        <substitute>
-          <names variable="author"/>
-          <!-- Note: `narrator` only cited in secondary-contributors -->
-          <names variable="illustrator"/>
-          <!-- TODO: Replace `delimiter` with `collapse` to combine names variables when that becomes available. -->
-          <choose>
-            <if type="broadcast">
-              <names variable="script-writer director">
-                <!-- Note: Actors/performers and producers [not executive] not cited in APA style. -->
-                <name name-as-sort-order="all" and="symbol" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
-                <label form="long" prefix=" (" suffix=")" text-case="title"/>
-              </names>
-            </if>
-          </choose>
-          <names variable="director">
-            <!-- For non-broadcast items, APA only cites directors and not writers. -->
-            <name name-as-sort-order="all" and="symbol" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
-            <label form="long" prefix=" (" suffix=")" text-case="title"/>
-          </names>
-          <!-- TODO: Replace `delimiter` with `collapse` to combine names variables when that becomes available. -->
-          <names variable="guest host">
-            <name name-as-sort-order="all" and="symbol" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
-            <label form="long" prefix=" (" suffix=")" text-case="title"/>
-          </names>
-          <names variable="producer">
-            <!-- Note: Producers not cited if there is a writer/director, but use if they are the principle creator. -->
-            <name name-as-sort-order="all" and="symbol" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
-            <label form="long" prefix=" (" suffix=")" text-case="title"/>
-          </names>
-          <choose>
-            <if variable="container-title">
-              <choose>
-                <if type="book classic collection entry entry-dictionary entry-encyclopedia" match="any">
-                  <!-- Items with book-like container-title substitute with their title and parenthetical, 
-                       but leave bracketed after container-title. This mimics the `container-booklike` formatting. -->
-                  <choose>
-                    <if variable="title">
-                      <group delimiter=" ">
-                        <text macro="title"/>
-                        <text macro="parenthetical"/>
-                      </group>
-                    </if>
-                    <else>
-                      <text macro="title-and-descriptions"/>
-                    </else>
-                  </choose>
-                </if>
-              </choose>
-            </if>
-          </choose>
-          <names variable="executive-producer">
-            <name name-as-sort-order="all" and="symbol" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
-            <label form="long" prefix=" (" suffix=")" text-case="title"/>
-          </names>
-          <names variable="series-creator">
-            <name name-as-sort-order="all" and="symbol" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
-            <label form="long" prefix=" (" suffix=")" text-case="title"/>
-          </names>
-          <names variable="editor-translator">
-            <name name-as-sort-order="all" and="symbol" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
-            <label form="short" prefix=" (" suffix=")" text-case="title"/>
-          </names>
-          <!-- Note: Translator is not cited as a primary creator (only as Ed. & Trans.). -->
-          <names variable="editor">
-            <name name-as-sort-order="all" and="symbol" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
-            <label form="short" prefix=" (" suffix=")" text-case="title"/>
-          </names>
-          <names variable="editorial-director">
-            <name name-as-sort-order="all" and="symbol" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
-            <label form="short" prefix=" (" suffix=")" text-case="title"/>
-          </names>
-          <names variable="compiler">
-            <name name-as-sort-order="all" and="symbol" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
-            <label form="long" prefix=" (" suffix=")" text-case="title"/>
-          </names>
-          <choose>
-            <if type="event performance speech" match="any">
-              <names variable="chair">
-                <name name-as-sort-order="all" and="symbol" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
-                <label form="long" prefix=" (" suffix=")" text-case="title"/>
-              </names>
-              <names variable="organizer">
-                <name name-as-sort-order="all" and="symbol" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
-                <label form="long" prefix=" (" suffix=")" text-case="title"/>
-              </names>
-            </if>
-          </choose>
-          <names variable="curator">
-            <name name-as-sort-order="all" and="symbol" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
-            <label form="long" prefix=" (" suffix=")" text-case="title"/>
-          </names>
-          <names variable="collection-editor">
-            <name name-as-sort-order="all" and="symbol" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
-            <label form="short" prefix=" (" suffix=")" text-case="title"/>
-          </names>
-          <choose>
-            <if variable="title">
-              <!-- If an item has a title, substitute missing author with title and parenthetical, but leave bracketed 
-                   after the date (in the 'title' position). -->
-              <group delimiter=" ">
-                <text macro="title"/>
-                <text macro="parenthetical"/>
-              </group>
-            </if>
-            <else>
-              <!-- If an item has no title, substitute with bracketed followed by parenthetical. -->
-              <text macro="title-and-descriptions"/>
-            </else>
-          </choose>
-        </substitute>
-      </names>
       <choose>
-        <!-- Print "with" contributor for books, but not for other types that commonly have them (eg, thesis, software) -->
-        <if type="book classic collection" match="any">
-          <names variable="contributor" prefix="(" suffix=")">
-            <label form="verb" suffix=" "/>
-            <name name-as-sort-order="all" and="symbol" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
-          </names>
+        <if is-numeric="chapter-number">
+          <label form="short" variable="chapter-number"/>
         </if>
       </choose>
+      <text variable="chapter-number"/>
     </group>
   </macro>
-  <macro name="author-intext">
+  <macro name="edition-labelled">
     <choose>
-      <if type="bill hearing legal_case legislation regulation treaty" match="any">
-        <text macro="title-intext"/>
-      </if>
-      <else-if type="interview personal_communication" match="any">
-        <choose>
-          <!-- These variables indicate that the letter is retrievable by the reader.
-                If not, then use the APA in-text-only personal communication format -->
-          <if variable="archive container-title DOI publisher URL" match="none">
-            <group delimiter=", ">
-              <names variable="author">
-                <name and="symbol" delimiter=", " initialize-with=". "/>
-                <substitute>
-                  <text macro="title-intext"/>
-                </substitute>
-              </names>
-              <text term="personal-communication"/>
-            </group>
-          </if>
-          <else>
-            <names variable="author" delimiter=", ">
-              <name form="short" and="symbol" delimiter=", " initialize-with=". "/>
-              <substitute>
-                <text macro="title-intext"/>
-              </substitute>
-            </names>
-          </else>
-        </choose>
-      </else-if>
-      <else>
-        <names variable="composer" delimiter=" &amp; ">
-          <name form="short" and="symbol" delimiter=", " initialize-with=". "/>
-          <substitute>
-            <names variable="author"/>
-            <names variable="illustrator"/>
-            <!-- TODO: Replace `delimiter` with `collapse` to combine names variables when that becomes available. -->
-            <choose>
-              <if type="broadcast">
-                <names variable="script-writer director"/>
-              </if>
-            </choose>
-            <names variable="director"/>
-            <!-- TODO: Replace `delimiter` with `collapse` to combine names variables when that becomes available. -->
-            <names variable="guest host"/>
-            <names variable="producer"/>
-            <choose>
-              <if variable="container-title">
-                <choose>
-                  <if type="book classic collection entry entry-dictionary entry-encyclopedia" match="any">
-                    <text macro="title-intext"/>
-                  </if>
-                </choose>
-              </if>
-            </choose>
-            <names variable="executive-producer"/>
-            <names variable="series-creator"/>
-            <names variable="editor"/>
-            <names variable="editorial-director"/>
-            <names variable="compiler"/>
-            <choose>
-              <if type="event performance speech" match="any">
-                <names variable="chair"/>
-                <names variable="organizer"/>
-              </if>
-            </choose>
-            <names variable="curator"/>
-            <text macro="title-intext"/>
-          </substitute>
-        </names>
-      </else>
-    </choose>
-  </macro>
-  <macro name="author-sort">
-    <choose>
-      <if type="bill hearing legal_case legislation regulation treaty" match="any">
-        <text macro="title-legal"/>
-      </if>
-      <else>
-        <text macro="author-bib"/>
-      </else>
-    </choose>
-  </macro>
-  <macro name="date-bib">
-    <group delimiter=" " prefix="(" suffix=")">
-      <choose>
-        <if is-uncertain-date="issued">
-          <text term="circa" form="short"/>
-        </if>
-      </choose>
-      <group>
-        <choose>
-          <if variable="issued">
-            <group delimiter=", ">
-              <group>
-                <date variable="issued" date-parts="year" form="numeric"/>
-                <text variable="year-suffix"/>
-              </group>
-              <choose>
-                <if type="article-magazine article-newspaper broadcast collection document event interview motion_picture pamphlet performance personal_communication post post-weblog song speech webpage" match="any">
-                  <!-- Many video and audio examples in manual give full dates. Err on the side of too much information. -->
-                  <date variable="issued">
-                    <date-part name="month"/>
-                    <date-part name="day" prefix=" "/>
-                  </date>
-                </if>
-                <else-if type="paper-conference">
-                  <!-- Capture 'speech' stored as 'paper-conference' -->
-                  <choose>
-                    <if variable="collection-editor compiler editor editorial-director issue page volume" match="none">
-                      <date variable="issued">
-                        <date-part name="month"/>
-                        <date-part name="day" prefix=" "/>
-                      </date>
-                    </if>
-                  </choose>
-                </else-if>
-                <!-- Only year: article article-journal book chapter classic entry entry-dictionary entry-encyclopedia dataset figure graphic
-                     manuscript map musical_score paper-conference[published] patent periodical report review review-book software standard thesis -->
-              </choose>
-            </group>
-          </if>
-          <else-if variable="status">
-            <group>
-              <!-- We print the status variable directly rather than using in-press, etc. terms. -->
-              <text variable="status" text-case="lowercase"/>
-              <text variable="year-suffix" prefix="-"/>
-            </group>
-          </else-if>
-          <else>
-            <text term="no date" form="short"/>
-            <text variable="year-suffix" prefix="-"/>
-          </else>
-        </choose>
-      </group>
-    </group>
-  </macro>
-  <macro name="date-sort">
-    <!-- This is necessary to ensure that citeproc sorts all item types chonologically in the same list. -->
-    <choose>
-      <if type="article article-journal book chapter entry entry-dictionary entry-encyclopedia dataset figure graphic manuscript map musical_score patent report review review-book thesis" match="any">
-        <date variable="issued" date-parts="year" form="numeric"/>
-      </if>
-      <else-if type="paper-conference">
-        <!-- Capture 'speech' stored as 'paper-conference' -->
-        <choose>
-          <if variable="collection-editor compiler editor editorial-director issue page volume" match="any">
-            <date variable="issued" date-parts="year" form="numeric"/>
-          </if>
-          <else>
-            <date variable="issued">
-              <date-part name="year" form="long"/>
-              <date-part name="month" form="numeric-leading-zeros"/>
-              <date-part name="day" form="numeric-leading-zeros"/>
-            </date>
-          </else>
-        </choose>
-      </else-if>
-      <else>
-        <date variable="issued">
-          <date-part name="year" form="long"/>
-          <date-part name="month" form="numeric-leading-zeros"/>
-          <date-part name="day" form="numeric-leading-zeros"/>
-        </date>
-      </else>
-    </choose>
-  </macro>
-  <macro name="date-sort-group">
-    <!-- APA sorts 1. no-date items, 2. items with dates, 3. in-press (status) items -->
-    <choose>
-      <if variable="issued">
-        <text value="1"/>
-      </if>
-      <else-if variable="status">
-        <text value="2"/>
-      </else-if>
-      <else>
-        <text value="0"/>
-      </else>
-    </choose>
-  </macro>
-  <macro name="date-intext">
-    <choose>
-      <if variable="issued">
-        <group delimiter="/">
-          <group delimiter=" ">
-            <choose>
-              <if is-uncertain-date="original-date">
-                <text term="circa" form="short"/>
-              </if>
-            </choose>
-            <date variable="original-date">
-              <date-part name="year"/>
-            </date>
-          </group>
-          <group delimiter=" ">
-            <choose>
-              <if is-uncertain-date="issued">
-                <text term="circa" form="short"/>
-              </if>
-            </choose>
-            <group>
-              <choose>
-                <if type="interview personal_communication" match="any">
-                  <choose>
-                    <if variable="archive container-title DOI publisher URL" match="none">
-                      <!-- These variables indicate that the communication is retrievable by the reader.
-                           If not, then use the in-text-only personal communication format -->
-                      <date variable="issued" form="text"/>
-                    </if>
-                    <else>
-                      <date variable="issued">
-                        <date-part name="year"/>
-                      </date>
-                    </else>
-                  </choose>
-                </if>
-                <else>
-                  <date variable="issued">
-                    <date-part name="year"/>
-                  </date>
-                </else>
-              </choose>
-              <text variable="year-suffix"/>
-            </group>
-          </group>
+      <if is-numeric="edition">
+        <group delimiter=" ">
+          <number form="ordinal" variable="edition"/>
+          <label form="short" variable="edition"/>
         </group>
       </if>
-      <else-if variable="status">
-        <!-- We print the status variable directly rather than using in-press, etc. terms. -->
-        <text variable="status" text-case="lowercase"/>
-        <text variable="year-suffix" prefix="-"/>
-      </else-if>
       <else>
-        <text term="no date" form="short"/>
-        <text variable="year-suffix" prefix="-"/>
+        <text variable="edition"/>
       </else>
     </choose>
   </macro>
-  <!-- APA has two description elements following the title:
-       title (parenthetical) [bracketed] -->
+  <macro name="issue-labelled">
+    <group delimiter=" ">
+      <label text-case="capitalize-first" variable="issue"/>
+      <text variable="issue"/>
+    </group>
+  </macro>
+  <macro name="locator-labelled">
+    <!-- Abbreviate page and paragraph; leave other locator labels in long form (APA 8.13) -->
+    <group delimiter=" ">
+      <choose>
+        <if locator="page paragraph" match="any">
+          <label form="short" variable="locator"/>
+        </if>
+        <else>
+          <label text-case="capitalize-first" variable="locator"/>
+        </else>
+      </choose>
+      <text variable="locator"/>
+    </group>
+  </macro>
+  <macro name="number-labelled">
+    <group delimiter=" ">
+      <choose>
+        <if is-numeric="number">
+          <label form="short" text-case="capitalize-first" variable="number"/>
+        </if>
+        <else-if match="none" type="broadcast">
+          <label form="short" text-case="capitalize-first" variable="number"/>
+        </else-if>
+      </choose>
+      <text variable="number"/>
+    </group>
+  </macro>
+  <macro name="number-article-labelled">
+    <!-- APA example 6: Journal article with article number or eLocator -->
+    <group delimiter=" ">
+      <text term="article-locator" text-case="capitalize-first"/>
+      <text variable="number"/>
+    </group>
+  </macro>
+  <macro name="number-of-volumes-labelled">
+    <choose>
+      <if is-numeric="number-of-volumes">
+        <group delimiter=" ">
+          <label form="short" text-case="capitalize-first" variable="number-of-volumes"/>
+          <text prefix="1" term="page-range-delimiter"/>
+        </group>
+      </if>
+    </choose>
+    <text variable="number-of-volumes"/>
+  </macro>
+  <macro name="page-labelled">
+    <group delimiter=" ">
+      <label form="short" variable="page"/>
+      <text variable="page"/>
+    </group>
+  </macro>
+  <macro name="part-number-labelled">
+    <group delimiter=" ">
+      <choose>
+        <if variable="part-number">
+          <!-- TODO: Replace with `part-number` label when CSL provides one -->
+          <text form="short" term="part" text-case="capitalize-first"/>
+          <text variable="part-number"/>
+        </if>
+      </choose>
+    </group>
+  </macro>
+  <macro name="section-labelled">
+    <group delimiter=" ">
+      <label form="symbol" variable="section"/>
+      <text variable="section"/>
+    </group>
+  </macro>
+  <macro name="supplement-number-labelled">
+    <group delimiter=" ">
+      <choose>
+        <if variable="supplement-number">
+          <!-- TODO: Replace with `supplement-number` label when CSL provides one -->
+          <text form="short" term="supplement" text-case="capitalize-first"/>
+          <text variable="supplement-number"/>
+        </if>
+      </choose>
+    </group>
+  </macro>
+  <macro name="version-labelled">
+    <group delimiter=" ">
+      <label text-case="capitalize-first" variable="version"/>
+      <text variable="version"/>
+    </group>
+  </macro>
+  <macro name="volume-labelled">
+    <group delimiter=" ">
+      <label form="short" text-case="capitalize-first" variable="volume"/>
+      <text variable="volume"/>
+    </group>
+  </macro>
+  <!-- Four parts in APA references:
+
+       1. Author (APA 9.7–12)
+       2. Date (APA 9.13–17)
+       3. Title (APA 9.18–22)
+       4. Source (APA 9.23–37)
+  -->
+  <!-- 1. Author -->
+  <!-- Author utility macros -->
+  <macro name="author-substitute-bib">
+    <names variable="composer">
+      <name delimiter-precedes-last="always" name-as-sort-order="all"/>
+      <label form="short" prefix=" (" suffix=")" text-case="title"/>
+      <substitute>
+        <names variable="author"/>
+        <!-- `narrator` only cited in secondary-contributors -->
+        <names variable="illustrator"/>
+        <choose>
+          <if type="broadcast">
+            <names variable="script-writer director">
+              <!-- Actors/performers and producers [not executive] not cited in APA style. -->
+              <name delimiter-precedes-last="always" name-as-sort-order="all"/>
+              <label form="long" prefix=" (" suffix=")" text-case="title"/>
+            </names>
+          </if>
+        </choose>
+        <names variable="director">
+          <!-- For non-broadcast items, APA only cites directors and not writers. -->
+          <name delimiter-precedes-last="always" name-as-sort-order="all"/>
+          <label form="long" prefix=" (" suffix=")" text-case="title"/>
+        </names>
+        <names variable="guest host">
+          <!-- TODO: Replace `delimiter` with `collapse` to combine names variables when that becomes available. -->
+          <name delimiter-precedes-last="always" name-as-sort-order="all"/>
+          <label form="long" prefix=" (" suffix=")" text-case="title"/>
+        </names>
+        <names variable="producer">
+          <!-- Producers not cited if there is a writer/director, but use if they are the principle creator. -->
+          <name delimiter-precedes-last="always" name-as-sort-order="all"/>
+          <label form="long" prefix=" (" suffix=")" text-case="title"/>
+        </names>
+        <choose>
+          <if variable="container-title">
+            <choose>
+              <if match="any" type="book classic collection entry entry-dictionary entry-encyclopedia">
+                <!-- Items with book-like container-title substitute with their title and identification,
+                     but leave description after container-title. This mimics the `container-booklike` formatting. -->
+                <text macro="title-substitute"/>
+              </if>
+            </choose>
+          </if>
+        </choose>
+        <names variable="executive-producer">
+          <name delimiter-precedes-last="always" name-as-sort-order="all"/>
+          <label form="long" prefix=" (" suffix=")" text-case="title"/>
+        </names>
+        <names variable="series-creator">
+          <name delimiter-precedes-last="always" name-as-sort-order="all"/>
+          <label form="long" prefix=" (" suffix=")" text-case="title"/>
+        </names>
+        <names variable="editor-translator"/>
+        <!-- Translator is not cited as a primary creator (only as Ed. & Trans.). -->
+        <names variable="editor"/>
+        <names variable="editorial-director"/>
+        <names variable="compiler">
+          <name delimiter-precedes-last="always" name-as-sort-order="all"/>
+          <label form="long" prefix=" (" suffix=")" text-case="title"/>
+        </names>
+        <choose>
+          <if match="any" type="event performance speech">
+            <names variable="chair">
+              <name delimiter-precedes-last="always" name-as-sort-order="all"/>
+              <label form="long" prefix=" (" suffix=")" text-case="title"/>
+            </names>
+            <names variable="organizer">
+              <name delimiter-precedes-last="always" name-as-sort-order="all"/>
+              <label form="long" prefix=" (" suffix=")" text-case="title"/>
+            </names>
+          </if>
+        </choose>
+        <names variable="curator">
+          <name delimiter-precedes-last="always" name-as-sort-order="all"/>
+          <label form="long" prefix=" (" suffix=")" text-case="title"/>
+        </names>
+        <names variable="collection-editor"/>
+        <text macro="title-substitute"/>
+      </substitute>
+    </names>
+  </macro>
+  <macro name="title-substitute">
+    <choose>
+      <if variable="title">
+        <!-- If an item has a title, substitute missing author with title and identification, but leave description after the date (in the 'title' position). -->
+        <group delimiter=" ">
+          <text macro="title-bib"/>
+          <text macro="identification"/>
+        </group>
+      </if>
+      <else>
+        <!-- If an item has no title, substitute with description followed by identification. -->
+        <text macro="title-and-descriptions"/>
+      </else>
+    </choose>
+  </macro>
+  <!-- Author logic -->
+  <macro name="author-bib">
+    <group delimiter=" ">
+      <text macro="author-substitute-bib"/>
+      <choose>
+        <!-- Print "with" contributor for books, but not for other types that commonly have them (eg, thesis, software) -->
+        <if match="any" type="book classic collection">
+          <names prefix="(" suffix=")" variable="contributor">
+            <label form="verb" suffix=" "/>
+            <name delimiter-precedes-last="always" name-as-sort-order="all"/>
+          </names>
+        </if>
+      </choose>
+    </group>
+  </macro>
+  <!-- Author sorting -->
+  <!-- 2. Date -->
+  <!-- Date utility macros -->
+  <macro name="date-issued-full">
+    <group delimiter=" ">
+      <text macro="uncertain-date-issued"/>
+      <date form="text" variable="issued"/>
+    </group>
+  </macro>
+  <macro name="date-issued-month-day">
+    <date variable="issued">
+      <date-part name="month"/>
+      <date-part name="day" prefix=" "/>
+    </date>
+  </macro>
+  <macro name="date-issued-year">
+    <group delimiter=" ">
+      <text macro="uncertain-date-issued"/>
+      <date date-parts="year" form="numeric" variable="issued"/>
+    </group>
+  </macro>
+  <macro name="original-date-year">
+    <group delimiter=" ">
+      <choose>
+        <if is-uncertain-date="original-date">
+          <text form="short" term="circa"/>
+        </if>
+      </choose>
+      <date variable="original-date">
+        <date-part name="year"/>
+      </date>
+    </group>
+  </macro>
+  <macro name="uncertain-date-issued">
+    <choose>
+      <if is-uncertain-date="issued">
+        <text form="short" term="circa"/>
+      </if>
+    </choose>
+  </macro>
+  <!-- Date logic -->
+  <macro name="date-bib">
+    <group prefix="(" suffix=")">
+      <choose>
+        <if variable="issued">
+          <group delimiter=", ">
+            <group>
+              <text macro="date-issued-year"/>
+              <text variable="year-suffix"/>
+            </group>
+            <choose>
+              <if match="any" type="article-magazine article-newspaper broadcast collection document event interview motion_picture pamphlet performance personal_communication post post-weblog song speech webpage">
+                <!-- Many video and audio examples in manual give full dates. Err on the side of too much information. -->
+                <text macro="date-issued-month-day"/>
+              </if>
+              <else-if type="paper-conference">
+                <!-- Capture 'speech' stored as 'paper-conference' -->
+                <choose>
+                  <if match="none" variable="collection-editor compiler editor editorial-director issue page volume">
+                    <text macro="date-issued-month-day"/>
+                  </if>
+                </choose>
+              </else-if>
+              <!-- Only year: article article-journal book chapter classic entry entry-dictionary entry-encyclopedia dataset figure graphic
+                     manuscript map musical_score paper-conference[published] patent periodical report review review-book software standard thesis -->
+            </choose>
+          </group>
+        </if>
+        <else-if variable="status">
+          <group>
+            <!-- We print the status variable directly rather than using in-press, etc. terms. -->
+            <text text-case="lowercase" variable="status"/>
+            <text prefix="-" variable="year-suffix"/>
+          </group>
+        </else-if>
+        <else>
+          <text form="short" term="no date"/>
+          <text prefix="-" variable="year-suffix"/>
+        </else>
+      </choose>
+    </group>
+  </macro>
+  <!-- Date sorting -->
+  <!-- 3. Title and descriptions -->
+  <!-- Three parts in title element (APA 9.21):
+
+       1. Title
+       2. Identification (in parentheses)
+       3. Description [in square brackets] -->
   <macro name="title-and-descriptions">
     <choose>
       <if variable="title">
         <group delimiter=" ">
-          <text macro="title"/>
-          <text macro="parenthetical"/>
-          <text macro="bracketed"/>
+          <text macro="title-bib"/>
+          <text macro="identification"/>
+          <text macro="description-bib"/>
         </group>
       </if>
       <else>
         <choose>
-          <if type="bill report" match="any">
+          <if match="any" type="bill report">
             <!-- Bills, resolutions, and congressional reports are not italicized and substitute bill number if no title. -->
-            <!-- Can't distinguish congressional reports from other reports, 
+            <!-- Can't distinguish congressional reports from other reports,
                  but giving the genre and number seems fine for other reports too. -->
-            <text macro="number"/>
-            <text macro="bracketed"/>
-            <text macro="parenthetical"/>
+            <text macro="genre-number"/>
+            <text macro="description-bib"/>
+            <text macro="identification"/>
           </if>
           <else>
             <group delimiter=" ">
-              <text macro="bracketed"/>
-              <text macro="parenthetical"/>
+              <text macro="description-bib"/>
+              <text macro="identification"/>
             </group>
           </else>
         </choose>
       </else>
     </choose>
   </macro>
-  <macro name="title">
+  <!-- 3.1. Title -->
+  <!-- Title utility macros -->
+  <macro name="title-part">
+    <group delimiter=". ">
+      <text macro="part-number-labelled"/>
+      <text text-case="capitalize-first" variable="part-title"/>
+    </group>
+  </macro>
+  <macro name="title-plus-part-title">
     <choose>
-      <if type="post webpage" match="any">
+      <if match="any" type="review review-book" variable="reviewed-author reviewed-genre reviewed-title">
+        <!-- If a review has no `reviewed-title`, assume that `title` contains the title of the reviewed work
+             and omit it here; it is printed in the `reviewed-item` macro. -->
+        <choose>
+          <if match="none" variable="reviewed-title"/>
+          <else>
+            <group delimiter=": ">
+              <text variable="title"/>
+              <text macro="title-part"/>
+            </group>
+          </else>
+        </choose>
+      </if>
+      <else>
+        <group delimiter=": ">
+          <text variable="title"/>
+          <text macro="title-part"/>
+        </group>
+      </else>
+    </choose>
+  </macro>
+  <macro name="title-plus-volume-title">
+    <group delimiter=": ">
+      <text variable="title"/>
+      <text macro="title-volume"/>
+    </group>
+  </macro>
+  <macro name="title-volume">
+    <group delimiter=": ">
+      <choose>
+        <if variable="volume-title">
+          <group delimiter=". ">
+            <text macro="volume-labelled"/>
+            <text variable="volume-title"/>
+          </group>
+        </if>
+        <else-if is-numeric="volume" match="none">
+          <text macro="volume-labelled"/>
+        </else-if>
+      </choose>
+      <!-- For book-like items, assume part-number and part-title refer to the book/volume. -->
+      <text macro="title-part"/>
+    </group>
+  </macro>
+  <!-- Title logic -->
+  <macro name="booklike-title">
+    <!-- For book-like items, assume part-number and part-title refer to the book/volume. -->
+    <choose>
+      <if variable="container-title">
+        <text variable="title"/>
+      </if>
+      <else>
+        <!-- For book-like items without container titles and with volume-title, append volume-title to title (APA example 30) -->
+        <text font-style="italic" macro="title-plus-volume-title"/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="periodical-title">
+    <!-- For periodicals, assume that part-number and part-title refer to the article and append to title -->
+    <choose>
+      <if variable="container-title">
+        <text macro="title-plus-part-title"/>
+      </if>
+      <else>
+        <!-- for periodical items without container titles, don't append volume-title to title -->
+        <text font-style="italic" macro="title-plus-part-title"/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="title-bib">
+    <choose>
+      <if match="any" type="post webpage">
         <!-- Webpages are always italicized -->
-        <text macro="title-plus-part-title" font-style="italic"/>
+        <text font-style="italic" macro="title-plus-part-title"/>
       </if>
       <!-- Other types are italicized based on presence of container-title.
              Assume that review and review-book are published in periodicals/blogs,
-             not just on a web page (ex. 69) -->
-      <else-if type="article-journal article-magazine article-newspaper periodical post-weblog review review-book" match="any">
+             not just on a webpage (APA example 69) -->
+      <else-if match="any" type="article-journal article-magazine article-newspaper periodical post-weblog review review-book">
         <text macro="periodical-title"/>
       </else-if>
       <else-if type="paper-conference">
         <!-- Treat paper-conference as book-like if it has an editor, otherwise as periodical-like -->
         <choose>
-          <if variable="collection-editor compiler editor editorial-director" match="any">
+          <if match="any" variable="collection-editor compiler editor editorial-director">
             <text macro="booklike-title"/>
           </if>
           <else>
@@ -561,607 +615,71 @@
       </else>
     </choose>
   </macro>
-  <macro name="periodical-title">
-    <!-- For periodicals, assume that part-number and part-title refer to the article and append to title -->
+  <!-- 3.2. Identification (in parentheses) -->
+  <!-- Identification utility macros -->
+  <macro name="database-location">
     <choose>
-      <if variable="container-title" match="any">
-        <text macro="title-plus-part-title"/>
+      <if match="none" variable="archive-place">
+        <!-- With `archive-place`: physical archives. Without: online archives. -->
+        <text variable="archive_location"/>
       </if>
-      <else>
-        <!-- for periodical items without container titles, don't append volume-title to title -->
-        <text macro="title-plus-part-title" font-style="italic"/>
-      </else>
     </choose>
   </macro>
-  <macro name="booklike-title">
-    <!-- For book-like items, assume part-number and part-title refer to the book/volume. -->
+  <macro name="genre-number">
     <choose>
-      <if variable="container-title" match="any">
-        <text variable="title"/>
-      </if>
-      <else>
-        <!-- For book-like items without container titles and with volume-title, append volume-title to title (ex. 30) -->
-        <text macro="title-plus-volume-title" font-style="italic"/>
-      </else>
-    </choose>
-  </macro>
-  <macro name="title-plus-part-title">
-    <choose>
-      <if variable="reviewed-author reviewed-genre reviewed-title" type="review review-book" match="any">
-        <!-- If a review has no `reviewed-title`, assume that `title` contains the title of the reviewed work
-             and omit it here; it is printed in the `reviewed-item` macro. -->
-        <choose>
-          <if variable="reviewed-title" match="none"/>
-          <else>
-            <group delimiter=": ">
-              <text variable="title"/>
-              <text macro="part-title"/>
-            </group>
-          </else>
-        </choose>
-      </if>
-      <else>
-        <group delimiter=": ">
-          <text variable="title"/>
-          <text macro="part-title"/>
-        </group>
-      </else>
-    </choose>
-  </macro>
-  <macro name="part-title">
-    <group delimiter=". ">
-      <group delimiter=" ">
-        <label variable="part-number" form="short" text-case="capitalize-first"/>
-        <text variable="part-number"/>
-      </group>
-      <text variable="part-title" text-case="capitalize-first"/>
-    </group>
-  </macro>
-  <macro name="title-plus-volume-title">
-    <group delimiter=": ">
-      <text variable="title"/>
-      <text macro="volume-title"/>
-    </group>
-  </macro>
-  <macro name="volume-title">
-    <group delimiter=": ">
-      <choose>
-        <if variable="volume-title">
+      <if variable="number">
+        <group delimiter=", ">
           <group delimiter=" ">
-            <group delimiter=". ">
-              <group delimiter=" ">
-                <label variable="volume" form="short" text-case="capitalize-first"/>
-                <text variable="volume"/>
-              </group>
-              <text variable="volume-title"/>
-            </group>
+            <text text-case="title" variable="genre"/>
+            <text macro="number-labelled"/>
           </group>
-        </if>
-        <else-if is-numeric="volume" match="none">
-          <group delimiter=" ">
-            <label variable="volume" form="short" text-case="capitalize-first"/>
-            <text variable="volume"/>
-          </group>
-        </else-if>
-      </choose>
-      <!-- For book-like items, assume part-number and part-title refer to the book/volume. -->
-      <text macro="part-title"/>
-    </group>
-  </macro>
-  <macro name="title-intext">
-    <choose>
-      <if type="bill report">
-        <!-- Bills, resolutions, and congressional reports are not italicized and substitute bill number if no title. -->
-        <!-- Can't distinguish congressional reports from other reports, 
-             but giving the genre and number seems fine for other reports too. -->
-        <choose>
-          <if variable="title">
-            <text variable="title" form="short" text-case="title"/>
-          </if>
-          <else>
-            <group delimiter=" ">
-              <text variable="genre"/>
-              <group delimiter=" ">
-                <choose>
-                  <if variable="chapter-number container-title" match="none">
-                    <label variable="number" form="short" text-case="capitalize-first"/>
-                  </if>
-                </choose>
-                <text variable="number"/>
-              </group>
-            </group>
-          </else>
-        </choose>
-      </if>
-      <else>
-        <choose>
-          <if variable="title" match="none">
-            <text macro="bracketed-intext"/>
-          </if>
-          <else-if type="hearing">
-            <!-- Hearings are italicized -->
-            <text variable="title" form="short" font-style="italic" text-case="title"/>
-          </else-if>
-          <else-if type="legal_case" match="any">
-            <!-- Cases are italicized -->
-            <text variable="title" font-style="italic"/>
-          </else-if>
-          <else-if type="legislation regulation treaty" match="any">
-            <!-- Legislation, regulations, and treaties not italicized or quoted -->
-            <text variable="title" form="short" text-case="title"/>
-          </else-if>
-          <else-if type="post webpage" match="any">
-            <!-- Webpages are always italicized -->
-            <text variable="title" form="short" font-style="italic" text-case="title"/>
-          </else-if>
-          <else-if variable="container-title" match="any">
-            <!-- Other types are italicized or quoted based on presence of container-title. As in title macro. -->
-            <text variable="title" form="short" quotes="true" text-case="title"/>
-          </else-if>
-          <else>
-            <text variable="title" form="short" font-style="italic" text-case="title"/>
-          </else>
-        </choose>
-      </else>
-    </choose>
-  </macro>
-  <macro name="parenthetical">
-    <!-- (Secondary contributors; Database location; Genre no. 123; Report Series 123, Version, Edition, Volume, Page) -->
-    <group prefix="(" suffix=")">
-      <choose>
-        <if type="patent">
-          <!-- authority: U.S. ; genre: patent ; number: 123,445 -->
-          <group delimiter=" ">
-            <text variable="authority" form="short"/>
-            <choose>
-              <if variable="genre">
-                <text variable="genre" text-case="capitalize-first"/>
-              </if>
-              <else>
-                <text term="patent" text-case="capitalize-first"/>
-              </else>
-            </choose>
-            <group delimiter=" ">
-              <label variable="number" form="short" text-case="capitalize-first"/>
-              <text variable="number"/>
-            </group>
-          </group>
-        </if>
-        <else-if type="post webpage" match="any">
-          <!-- For post webpage, container-title is treated as publisher -->
-          <group delimiter="; ">
-            <text macro="secondary-contributors"/>
-            <text macro="database-location"/>
-            <text macro="number"/>
-            <text macro="locators-booklike"/>
-          </group>
-        </else-if>
-        <else-if type="report" match="any">
           <choose>
-            <if variable="title" match="none">
-              <!-- If there is no title, then genre and number are already printed as the title. -->
-              <group delimiter="; ">
-                <text macro="secondary-contributors"/>
-                <text macro="database-location"/>
-                <text macro="locators-booklike"/>
-              </group>
+            <if type="thesis">
+              <choose>
+                <if match="any" variable="archive DOI URL">
+                  <!-- Include the university in brackets if thesis is published -->
+                  <text variable="publisher"/>
+                </if>
+              </choose>
             </if>
-            <!-- If the report is a chapter in a larger report, then most parenthetical information is printed after the container. -->
-            <else-if variable="container-title">
-              <text macro="secondary-contributors"/>
-            </else-if>
-            <else>
-              <group delimiter="; ">
-                <text macro="secondary-contributors"/>
-                <text macro="database-location"/>
-                <text macro="number"/>
-                <text macro="locators-booklike"/>
-              </group>
-            </else>
           </choose>
-        </else-if>
-        <else-if variable="container-title">
-          <group delimiter="; ">
-            <text macro="secondary-contributors"/>
-            <choose>
-              <if type="broadcast graphic map motion_picture song" match="any">
-                <!-- For audiovisual media, number information comes after title, not container-title (ex. 94) -->
-                <text macro="number"/>
-              </if>
-            </choose>
-          </group>
-        </else-if>
-        <else>
-          <group delimiter="; ">
-            <text macro="secondary-contributors"/>
-            <text macro="database-location"/>
-            <text macro="number"/>
-            <text macro="locators-booklike"/>
-          </group>
-        </else>
-      </choose>
-    </group>
-  </macro>
-  <macro name="parenthetical-container">
-    <choose>
-      <if variable="container-title" match="any">
-        <group prefix="(" suffix=")">
-          <group delimiter="; ">
-            <text macro="database-location"/>
-            <choose>
-              <if type="broadcast graphic map motion_picture song" match="none">
-                <!-- For audiovisual media, number information comes after title, not container-title (ex. 94) -->
-                <text macro="number"/>
-              </if>
-            </choose>
-            <text macro="locators-booklike"/>
-          </group>
         </group>
       </if>
     </choose>
   </macro>
-  <macro name="bracketed">
-    <!-- [Descriptive information] -->
-    <!-- If there is a number, genre is already printed in macro="number" -->
-    <group prefix="[" suffix="]">
+  <macro name="locators-booklike">
+    <choose>
+      <if variable="page">
+        <text macro="page-labelled"/>
+      </if>
+      <else-if variable="chapter-number">
+        <text macro="chapter-number-labelled"/>
+      </else-if>
+    </choose>
+  </macro>
+  <macro name="patent-number">
+    <group delimiter=" ">
+      <!-- authority: U.S. ; genre: patent ; number: 123,445 -->
+      <text form="short" variable="authority"/>
       <choose>
-        <if variable="reviewed-author reviewed-genre reviewed-title" type="review review-book" match="any">
-          <text macro="reviewed-item"/>
+        <if variable="genre">
+          <text text-case="capitalize-first" variable="genre"/>
         </if>
-        <else-if type="thesis">
-          <!-- Thesis type and institution -->
-          <group delimiter="; ">
-            <choose>
-              <if variable="number" match="none">
-                <group delimiter=", ">
-                  <text variable="genre" text-case="capitalize-first"/>
-                  <choose>
-                    <if variable="archive DOI URL" match="any">
-                      <!-- Include the university in brackets if thesis is published -->
-                      <text variable="publisher"/>
-                    </if>
-                  </choose>
-                </group>
-              </if>
-            </choose>
-            <text variable="medium" text-case="capitalize-first"/>
-          </group>
-        </else-if>
-        <else-if variable="interviewer" type="interview" match="any">
-          <!-- Interview information -->
-          <choose>
-            <if variable="title">
-              <text macro="format"/>
-            </if>
-            <else-if variable="genre">
-              <group delimiter="; ">
-                <group delimiter=" ">
-                  <text variable="genre" text-case="capitalize-first"/>
-                  <group delimiter=" ">
-                    <text term="container-author" form="verb"/>
-                    <names variable="interviewer">
-                      <name and="symbol" initialize-with=". " delimiter=", "/>
-                    </names>
-                  </group>
-                </group>
-              </group>
-            </else-if>
-            <else-if variable="interviewer">
-              <group delimiter="; ">
-                <names variable="interviewer">
-                  <label form="verb" suffix=" " text-case="capitalize-first"/>
-                  <name and="symbol" initialize-with=". " delimiter=", "/>
-                </names>
-                <text variable="medium" text-case="capitalize-first"/>
-              </group>
-            </else-if>
-            <else>
-              <text macro="format"/>
-            </else>
-          </choose>
-        </else-if>
-        <else-if type="personal_communication">
-          <!-- Letter information -->
-          <choose>
-            <if variable="recipient">
-              <group delimiter="; ">
-                <group delimiter=" ">
-                  <choose>
-                    <if variable="number" match="none">
-                      <choose>
-                        <if variable="genre">
-                          <text variable="genre" text-case="capitalize-first"/>
-                        </if>
-                        <else-if variable="medium">
-                          <text variable="medium" text-case="capitalize-first"/>
-                        </else-if>
-                        <else>
-                          <text term="letter" text-case="capitalize-first"/>
-                        </else>
-                      </choose>
-                    </if>
-                    <else>
-                      <choose>
-                        <if variable="medium">
-                          <text variable="medium" text-case="capitalize-first"/>
-                        </if>
-                        <else>
-                          <text term="letter" text-case="capitalize-first"/>
-                        </else>
-                      </choose>
-                    </else>
-                  </choose>
-                  <names variable="recipient" delimiter=", ">
-                    <label form="verb" suffix=" "/>
-                    <name and="symbol" delimiter=", "/>
-                  </names>
-                </group>
-                <choose>
-                  <if variable="genre" match="any">
-                    <choose>
-                      <if variable="number" match="none">
-                        <text variable="medium" text-case="capitalize-first"/>
-                      </if>
-                    </choose>
-                  </if>
-                </choose>
-              </group>
-            </if>
-            <else>
-              <text macro="format"/>
-            </else>
-          </choose>
-        </else-if>
-        <else-if variable="composer" type="song" match="all">
-          <!-- Performer of classical music works -->
-          <group delimiter="; ">
-            <choose>
-              <if variable="number" match="none">
-                <group delimiter=" ">
-                  <choose>
-                    <if variable="genre">
-                      <text variable="genre" text-case="capitalize-first"/>
-                      <group delimiter=" ">
-                        <text term="performer" form="verb"/>
-                        <names variable="author">
-                          <name and="symbol" initialize-with=". " delimiter=", "/>
-                          <substitute>
-                            <names variable="performer"/>
-                          </substitute>
-                        </names>
-                      </group>
-                    </if>
-                    <else-if variable="medium">
-                      <text variable="medium" text-case="capitalize-first"/>
-                      <group delimiter=" ">
-                        <text term="performer" form="verb"/>
-                        <names variable="author">
-                          <name and="symbol" initialize-with=". " delimiter=", "/>
-                          <substitute>
-                            <names variable="performer"/>
-                          </substitute>
-                        </names>
-                      </group>
-                    </else-if>
-                    <else>
-                      <text term="performer" form="verb" text-case="capitalize-first"/>
-                      <names variable="author">
-                        <name and="symbol" initialize-with=". " delimiter=", "/>
-                        <substitute>
-                          <names variable="performer"/>
-                        </substitute>
-                      </names>
-                    </else>
-                  </choose>
-                </group>
-              </if>
-              <else>
-                <group delimiter=" ">
-                  <choose>
-                    <if variable="medium">
-                      <text variable="medium" text-case="capitalize-first"/>
-                      <group delimiter=" ">
-                        <text term="performer" form="verb"/>
-                        <names variable="author">
-                          <name and="symbol" initialize-with=". " delimiter=", "/>
-                          <substitute>
-                            <names variable="performer"/>
-                          </substitute>
-                        </names>
-                      </group>
-                    </if>
-                    <else>
-                      <text term="performer" form="verb" text-case="capitalize-first"/>
-                      <names variable="author">
-                        <name and="symbol" initialize-with=". " delimiter=", "/>
-                        <substitute>
-                          <names variable="performer"/>
-                        </substitute>
-                      </names>
-                    </else>
-                  </choose>
-                </group>
-              </else>
-            </choose>
-            <choose>
-              <if variable="genre" match="any">
-                <choose>
-                  <if variable="number" match="none">
-                    <text variable="medium" text-case="capitalize-first"/>
-                  </if>
-                </choose>
-              </if>
-            </choose>
-          </group>
-        </else-if>
-        <else-if variable="container-title" match="none">
-          <!-- Other description -->
-          <text macro="format"/>
-        </else-if>
         <else>
-          <!-- For conference presentations/performances/events, chapters in reports/standards/generic documents, software, 
-               place bracketed after the container title -->
-          <choose>
-            <if type="event paper-conference performance speech" match="any">
-              <choose>
-                <if variable="collection-editor compiler editor editorial-director issue page volume" match="any">
-                  <text macro="format"/>
-                </if>
-              </choose>
-            </if>
-            <else-if type="document report software standard" match="none">
-              <text macro="format"/>
-            </else-if>
-          </choose>
+          <text term="patent" text-case="capitalize-first"/>
         </else>
       </choose>
-    </group>
-  </macro>
-  <macro name="bracketed-intext">
-    <group prefix="[" suffix="]">
-      <choose>
-        <if variable="reviewed-title" match="any">
-          <group delimiter=" ">
-            <text term="review-of" text-case="capitalize-first"/>
-            <text macro="reviewed-title-intext"/>
-          </group>
-        </if>
-        <else-if variable="interviewer" type="interview" match="any">
-          <names variable="interviewer">
-            <label form="verb" suffix=" " text-case="capitalize-first"/>
-            <name and="symbol" initialize-with=". " delimiter=", "/>
-            <substitute>
-              <text macro="format-intext"/>
-            </substitute>
-          </names>
-        </else-if>
-        <else-if type="personal_communication">
-          <!-- Letter information -->
-          <choose>
-            <if variable="recipient">
-              <group delimiter=" ">
-                <choose>
-                  <if variable="number" match="none">
-                    <text variable="genre" text-case="capitalize-first"/>
-                  </if>
-                  <else>
-                    <text term="letter" text-case="capitalize-first"/>
-                  </else>
-                </choose>
-                <names variable="recipient" delimiter=", ">
-                  <label form="verb" suffix=" "/>
-                  <name and="symbol" delimiter=", "/>
-                </names>
-              </group>
-            </if>
-            <else>
-              <text macro="format-intext"/>
-            </else>
-          </choose>
-        </else-if>
-        <else>
-          <text macro="format-intext"/>
-        </else>
-      </choose>
-    </group>
-  </macro>
-  <macro name="reviewed-item">
-    <!-- Reviewed item -->
-    <group delimiter="; ">
-      <group delimiter=", ">
-        <group delimiter=" ">
-          <choose>
-            <if variable="reviewed-genre">
-              <group delimiter=" ">
-                <text term="review-of" form="long" text-case="capitalize-first"/>
-                <text variable="reviewed-genre" text-case="lowercase"/>
-              </group>
-            </if>
-            <!-- If no `reviewed-genre`, assume that `genre` or `medium` is entered as 'Review of the book' or similar -->
-            <else-if variable="number" match="none">
-              <choose>
-                <if variable="genre">
-                  <text variable="genre" text-case="capitalize-first"/>
-                </if>
-                <else-if variable="medium">
-                  <text variable="medium" text-case="capitalize-first"/>
-                </else-if>
-                <else-if type="review-book">
-                  <group delimiter=" ">
-                    <text term="review-of" form="long" text-case="capitalize-first"/>
-                    <text term="book" form="long" text-case="lowercase"/>
-                  </group>
-                </else-if>
-                <else>
-                  <text term="review-of" form="short" text-case="capitalize-first"/>
-                </else>
-              </choose>
-            </else-if>
-            <else>
-              <choose>
-                <if variable="medium">
-                  <text variable="medium" text-case="capitalize-first"/>
-                </if>
-                <else-if type="review-book">
-                  <group delimiter=" ">
-                    <text term="review-of" form="long" text-case="capitalize-first"/>
-                    <text term="book" form="long" text-case="lowercase"/>
-                  </group>
-                </else-if>
-                <else>
-                  <text term="review-of" form="short" text-case="capitalize-first"/>
-                </else>
-              </choose>
-            </else>
-          </choose>
-          <text macro="reviewed-title"/>
-        </group>
-        <names variable="reviewed-author">
-          <label form="verb-short" suffix=" "/>
-          <name and="symbol" initialize-with=". " delimiter=", "/>
-        </names>
-      </group>
-      <choose>
-        <if variable="genre" match="any">
-          <choose>
-            <if variable="number" match="none">
-              <text variable="medium" text-case="capitalize-first"/>
-            </if>
-          </choose>
-        </if>
-      </choose>
-    </group>
-  </macro>
-  <macro name="bracketed-container">
-    <group prefix="[" suffix="]">
-      <choose>
-        <if type="event paper-conference performance speech" match="any">
-          <!-- Conference presentations should describe the session [container] in bracketed unless published in a proceedings -->
-          <choose>
-            <if variable="collection-editor compiler editor editorial-director issue page volume" match="none">
-              <text macro="format"/>
-            </if>
-          </choose>
-        </if>
-        <else-if type="software" match="all">
-          <!-- For entries in mobile app reference works, place bracketed after the container-title -->
-          <text macro="format"/>
-        </else-if>
-        <else-if type="document report standard">
-          <!-- For chapters in report, standards, and generic documents, place bracketed after the container title -->
-          <text macro="format"/>
-        </else-if>
-      </choose>
+      <text macro="number-labelled"/>
     </group>
   </macro>
   <macro name="secondary-contributors">
     <choose>
-      <if type="article-journal article-magazine article-newspaper periodical post-weblog review review-book" match="any">
+      <if match="any" type="article-journal article-magazine article-newspaper periodical post-weblog review review-book">
         <text macro="secondary-contributors-periodical"/>
       </if>
       <else-if type="paper-conference">
         <choose>
-          <if variable="collection-editor compiler editor editorial-director" match="any">
+          <if match="any" variable="collection-editor compiler editor editorial-director">
             <text macro="secondary-contributors-booklike"/>
           </if>
           <else>
@@ -1174,53 +692,37 @@
       </else>
     </choose>
   </macro>
-  <macro name="secondary-contributors-periodical">
-    <group delimiter="; ">
-      <choose>
-        <if variable="title">
-          <names variable="interviewer" delimiter="; ">
-            <name and="symbol" initialize-with=". " delimiter=", "/>
-            <label form="short" prefix=", " text-case="title"/>
-          </names>
-        </if>
-      </choose>
-      <names variable="translator narrator" delimiter="; ">
-        <name and="symbol" initialize-with=". " delimiter=", "/>
-        <label form="short" prefix=", " text-case="title"/>
-      </names>
-    </group>
-  </macro>
   <macro name="secondary-contributors-booklike">
     <group delimiter="; ">
       <choose>
         <if variable="title">
           <names variable="interviewer">
-            <name and="symbol" initialize-with=". " delimiter=", "/>
+            <name/>
             <label form="short" prefix=", " text-case="title"/>
           </names>
         </if>
       </choose>
       <choose>
-        <if type="post webpage" match="none">
+        <if match="none" type="post webpage">
           <!-- Webpages treat container-title like publisher -->
           <group delimiter="; ">
-            <names variable="illustrator narrator" delimiter="; ">
-              <name and="symbol" initialize-with=". " delimiter=", "/>
+            <names delimiter="; " variable="illustrator narrator">
+              <name/>
               <label form="short" prefix=", " text-case="title"/>
             </names>
             <choose>
-              <if variable="container-title" match="none">
+              <if match="none" variable="container-title">
                 <group delimiter="; ">
                   <names variable="container-author">
                     <label form="verb-short" suffix=" " text-case="title"/>
-                    <name and="symbol" initialize-with=". " delimiter=", "/>
+                    <name/>
                   </names>
-                  <names variable="editor translator" delimiter="; ">
-                    <name and="symbol" initialize-with=". " delimiter=", "/>
+                  <names delimiter="; " variable="editor translator">
+                    <name/>
                     <label form="short" prefix=", " text-case="title"/>
                   </names>
-                  <names variable="compiler chair organizer curator series-creator executive-producer" delimiter="; ">
-                    <name and="symbol" initialize-with=". " delimiter=", "/>
+                  <names delimiter="; " variable="compiler chair organizer curator series-creator executive-producer">
+                    <name/>
                     <label form="long" prefix=", " text-case="title"/>
                   </names>
                 </group>
@@ -1228,9 +730,9 @@
               <else>
                 <choose>
                   <!-- TODO: Check logic once processors start to automatically populate editor-translator. -->
-                  <if variable="editor-translator" match="none">
-                    <names variable="translator" delimiter="; ">
-                      <name and="symbol" initialize-with=". " delimiter=", "/>
+                  <if match="none" variable="editor-translator">
+                    <names delimiter="; " variable="translator">
+                      <name/>
                       <label form="short" prefix=", " text-case="title"/>
                     </names>
                   </if>
@@ -1243,18 +745,18 @@
           <group delimiter="; ">
             <names variable="container-author">
               <label form="verb-short" suffix=" " text-case="title"/>
-              <name and="symbol" initialize-with=". " delimiter=", "/>
+              <name/>
             </names>
-            <names variable="editor translator" delimiter="; ">
-              <name and="symbol" initialize-with=". " delimiter=", "/>
+            <names delimiter="; " variable="editor translator">
+              <name/>
               <label form="short" prefix=", " text-case="title"/>
             </names>
-            <names variable="illustrator narrator" delimiter="; ">
-              <name and="symbol" initialize-with=". " delimiter=", "/>
+            <names delimiter="; " variable="illustrator narrator">
+              <name/>
               <label form="short" prefix=", " text-case="title"/>
             </names>
-            <names variable="compiler chair organizer curator series-creator executive-producer" delimiter="; ">
-              <name and="symbol" initialize-with=". " delimiter=", "/>
+            <names delimiter="; " variable="compiler chair organizer curator series-creator executive-producer">
+              <name/>
               <label form="long" prefix=", " text-case="title"/>
             </names>
           </group>
@@ -1262,181 +764,374 @@
       </choose>
     </group>
   </macro>
-  <macro name="database-location">
+  <macro name="secondary-contributors-periodical">
+    <group delimiter="; ">
+      <choose>
+        <if variable="title">
+          <names delimiter="; " variable="interviewer">
+            <name/>
+            <label form="short" prefix=", " text-case="title"/>
+          </names>
+        </if>
+      </choose>
+      <names delimiter="; " variable="translator narrator">
+        <name/>
+        <label form="short" prefix=", " text-case="title"/>
+      </names>
+    </group>
+  </macro>
+  <macro name="version-edition-volume">
+    <group delimiter=", ">
+      <text macro="version-labelled"/>
+      <text macro="edition-labelled"/>
+      <text macro="volume-booklike"/>
+    </group>
+  </macro>
+  <macro name="volume-booklike">
+    <group delimiter=", ">
+      <!-- Report series (APA example 52) -->
+      <choose>
+        <if match="any" type="document report standard">
+          <group delimiter=" ">
+            <text text-case="title" variable="collection-title"/>
+            <text variable="collection-number"/>
+          </group>
+        </if>
+      </choose>
+      <text macro="supplement-number-labelled"/>
+      <choose>
+        <if variable="volume">
+          <choose>
+            <!-- Non-numeric volumes are already printed as part of the book title -->
+            <if variable="volume-title"/>
+            <else-if is-numeric="volume">
+              <text macro="volume-labelled"/>
+            </else-if>
+          </choose>
+        </if>
+        <else>
+          <text macro="number-of-volumes-labelled"/>
+        </else>
+      </choose>
+      <text macro="issue-labelled"/>
+      <text macro="locators-booklike"/>
+    </group>
+  </macro>
+  <!-- Identification logic -->
+  <macro name="identification">
+    <group delimiter="; " prefix="(" suffix=")">
+      <!-- (Secondary contributors; Database location; Genre no. 123; Report Series 123, Version, Edition, Volume, Page) -->
+      <choose>
+        <if type="patent">
+          <text macro="patent-number"/>
+        </if>
+        <else-if match="any" type="post webpage">
+          <!-- For post webpage, container-title is treated as publisher -->
+          <text macro="identification-with-all-parts"/>
+        </else-if>
+        <else-if match="any" type="report">
+          <choose>
+            <if match="none" variable="title">
+              <!-- If there is no title, then genre and number are already printed as the title. -->
+              <text macro="secondary-contributors"/>
+              <text macro="database-location"/>
+              <text macro="identification-booklike"/>
+            </if>
+            <!-- If the report is a chapter in a larger report, then most parenthetical information is printed after the container. -->
+            <else-if variable="container-title">
+              <text macro="secondary-contributors"/>
+            </else-if>
+            <else>
+              <text macro="identification-with-all-parts"/>
+            </else>
+          </choose>
+        </else-if>
+        <else-if variable="container-title">
+          <group delimiter="; ">
+            <text macro="secondary-contributors"/>
+            <choose>
+              <if match="any" type="broadcast graphic map motion_picture song">
+                <!-- For audiovisual media, number information comes after title, not container-title (ex. 94) -->
+                <text macro="genre-number"/>
+              </if>
+            </choose>
+          </group>
+        </else-if>
+        <else>
+          <text macro="identification-with-all-parts"/>
+        </else>
+      </choose>
+    </group>
+  </macro>
+  <macro name="identification-booklike">
     <choose>
-      <if variable="archive-place" match="none">
-        <!-- With `archive-place`: physical archives. Without: online archives. -->
-        <text variable="archive_location"/>
-      </if>
+      <if match="any" type="article-journal article-magazine article-newspaper broadcast event interview patent performance periodical post post-weblog review review-book speech webpage"/>
+      <else-if type="paper-conference">
+        <choose>
+          <if match="any" variable="collection-editor compiler editor editorial-director">
+            <text macro="version-edition-volume"/>
+          </if>
+        </choose>
+      </else-if>
+      <else>
+        <text macro="version-edition-volume"/>
+      </else>
     </choose>
   </macro>
-  <macro name="number">
+  <macro name="identification-with-all-parts">
+    <group delimiter="; ">
+      <text macro="secondary-contributors"/>
+      <text macro="database-location"/>
+      <text macro="genre-number"/>
+      <text macro="identification-booklike"/>
+    </group>
+  </macro>
+  <!-- 3.3. Description [in square brackets] -->
+  <!-- Description utility macros -->
+  <macro name="description-generic">
+    <!-- For conference presentations/performances/events, chapters in reports/standards/generic documents, software, place description after the container title -->
     <choose>
-      <if variable="number">
-        <group delimiter=", ">
+      <if match="any" type="event paper-conference performance speech">
+        <choose>
+          <if match="any" variable="collection-editor compiler editor editorial-director issue page volume">
+            <text macro="format-bib"/>
+          </if>
+        </choose>
+      </if>
+      <else-if match="none" type="document report software standard">
+        <text macro="format-bib"/>
+      </else-if>
+    </choose>
+  </macro>
+  <macro name="description-interview">
+    <choose>
+      <if variable="title">
+        <text macro="format-bib"/>
+      </if>
+      <else-if variable="genre">
+        <group delimiter="; ">
           <group delimiter=" ">
-            <text variable="genre" text-case="title"/>
+            <text text-case="capitalize-first" variable="genre"/>
             <group delimiter=" ">
-              <label variable="number" form="short" text-case="capitalize-first"/>
-              <text variable="number"/>
+              <text form="verb" term="container-author"/>
+              <names variable="interviewer"/>
             </group>
           </group>
+        </group>
+      </else-if>
+      <else-if variable="interviewer">
+        <group delimiter="; ">
+          <names variable="interviewer">
+            <label form="verb" suffix=" " text-case="capitalize-first"/>
+            <name/>
+          </names>
+          <text text-case="capitalize-first" variable="medium"/>
+        </group>
+      </else-if>
+      <else>
+        <text macro="format-bib"/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="description-letter-bib">
+    <choose>
+      <if variable="recipient">
+        <group delimiter="; ">
+          <group delimiter=" ">
+            <choose>
+              <if match="none" variable="number">
+                <choose>
+                  <if variable="genre">
+                    <text text-case="capitalize-first" variable="genre"/>
+                  </if>
+                  <else-if variable="medium">
+                    <text text-case="capitalize-first" variable="medium"/>
+                  </else-if>
+                  <else>
+                    <text term="letter" text-case="capitalize-first"/>
+                  </else>
+                </choose>
+              </if>
+              <else>
+                <choose>
+                  <if variable="medium">
+                    <text text-case="capitalize-first" variable="medium"/>
+                  </if>
+                  <else>
+                    <text term="letter" text-case="capitalize-first"/>
+                  </else>
+                </choose>
+              </else>
+            </choose>
+            <names variable="recipient">
+              <label form="verb" suffix=" "/>
+              <name initialize="false"/>
+            </names>
+          </group>
           <choose>
-            <if type="thesis">
+            <if variable="genre">
               <choose>
-                <!-- Include the university in brackets if thesis is published -->
-                <if variable="archive DOI URL" match="any">
-                  <text variable="publisher"/>
+                <if match="none" variable="number">
+                  <text text-case="capitalize-first" variable="medium"/>
                 </if>
               </choose>
             </if>
           </choose>
         </group>
       </if>
-    </choose>
-  </macro>
-  <macro name="locators-booklike">
-    <choose>
-      <if type="article-journal article-magazine article-newspaper broadcast event interview patent performance periodical post post-weblog review review-book speech webpage" match="any"/>
-      <else-if type="paper-conference">
-        <choose>
-          <if variable="collection-editor compiler editor editorial-director" match="any">
-            <group delimiter=", ">
-              <text macro="version"/>
-              <text macro="edition"/>
-              <text macro="volume-booklike"/>
-            </group>
-          </if>
-        </choose>
-      </else-if>
       <else>
-        <group delimiter=", ">
-          <text macro="version"/>
-          <text macro="edition"/>
-          <text macro="volume-booklike"/>
-        </group>
+        <text macro="format-bib"/>
       </else>
     </choose>
   </macro>
-  <macro name="version">
-    <group delimiter=" ">
-      <label variable="version" text-case="capitalize-first"/>
-      <text variable="version"/>
-    </group>
-  </macro>
-  <macro name="edition">
-    <choose>
-      <if is-numeric="edition">
+  <macro name="description-reviewed">
+    <!-- Reviewed item -->
+    <group delimiter="; ">
+      <group delimiter=", ">
         <group delimiter=" ">
-          <number variable="edition" form="ordinal"/>
-          <label variable="edition" form="short"/>
-        </group>
-      </if>
-      <else>
-        <text variable="edition"/>
-      </else>
-    </choose>
-  </macro>
-  <macro name="volume-booklike">
-    <group delimiter=", ">
-      <!-- Report series [ex. 52] -->
-      <choose>
-        <if type="document report standard">
-          <group delimiter=" ">
-            <text variable="collection-title" text-case="title"/>
-            <text variable="collection-number"/>
-          </group>
-        </if>
-      </choose>
-      <group delimiter=" ">
-        <label variable="supplement-number" text-case="capitalize-first"/>
-        <text variable="supplement-number"/>
-      </group>
-      <choose>
-        <if variable="volume" match="any">
           <choose>
-            <!-- Non-numeric volumes are already printed as part of the book title -->
-            <if variable="volume-title"/>
-            <else-if is-numeric="volume" match="none"/>
-            <else>
+            <if variable="reviewed-genre">
               <group delimiter=" ">
-                <label variable="volume" form="short" text-case="capitalize-first"/>
-                <number variable="volume" form="numeric"/>
+                <text form="long" term="review-of" text-case="capitalize-first"/>
+                <text text-case="lowercase" variable="reviewed-genre"/>
               </group>
+            </if>
+            <!-- If no `reviewed-genre`, assume that `genre` or `medium` is entered as 'Review of the book' or similar -->
+            <else-if match="none" variable="number">
+              <choose>
+                <if variable="genre">
+                  <text text-case="capitalize-first" variable="genre"/>
+                </if>
+                <else-if variable="medium">
+                  <text text-case="capitalize-first" variable="medium"/>
+                </else-if>
+                <else-if type="review-book">
+                  <group delimiter=" ">
+                    <text form="long" term="review-of" text-case="capitalize-first"/>
+                    <text form="long" term="book" text-case="lowercase"/>
+                  </group>
+                </else-if>
+                <else>
+                  <text form="short" term="review-of" text-case="capitalize-first"/>
+                </else>
+              </choose>
+            </else-if>
+            <else>
+              <choose>
+                <if variable="medium">
+                  <text text-case="capitalize-first" variable="medium"/>
+                </if>
+                <else-if type="review-book">
+                  <group delimiter=" ">
+                    <text form="long" term="review-of" text-case="capitalize-first"/>
+                    <text form="long" term="book" text-case="lowercase"/>
+                  </group>
+                </else-if>
+                <else>
+                  <text form="short" term="review-of" text-case="capitalize-first"/>
+                </else>
+              </choose>
             </else>
           </choose>
-        </if>
-        <else>
-          <group>
-            <label variable="number-of-volumes" form="short" text-case="capitalize-first" suffix=" "/>
-            <text term="page-range-delimiter" prefix="1"/>
-            <number variable="number-of-volumes" form="numeric"/>
-          </group>
-        </else>
-      </choose>
-      <group delimiter=" ">
-        <label variable="issue" text-case="capitalize-first"/>
-        <text variable="issue"/>
+          <text macro="reviewed-title-bib"/>
+        </group>
+        <names variable="reviewed-author">
+          <label form="verb-short" suffix=" "/>
+          <name/>
+        </names>
       </group>
-      <group delimiter=" ">
-        <label variable="page" form="short" suffix=" "/>
-        <text variable="page"/>
-      </group>
-    </group>
-  </macro>
-  <macro name="reviewed-title">
-    <choose>
-      <if variable="reviewed-title">
-        <!-- Not possible to distinguish TV series episode from other reviewed
-             works without reviewed-container-title [Ex. 69] -->
-        <!-- Adapt for reviewed-container-title if that becomes available -->
-        <text variable="reviewed-title" font-style="italic"/>
-      </if>
-      <else>
-        <!-- Assume title is title of reviewed work -->
-        <text variable="title" font-style="italic"/>
-      </else>
-    </choose>
-  </macro>
-  <macro name="reviewed-title-intext">
-    <choose>
-      <if variable="reviewed-title">
-        <!-- Not possible to distinguish TV series episode from other reviewed
-             works without reviewed-container-title [Ex. 69] -->
-        <!-- Adapt for reviewed-container-title if that becomes available -->
-        <text variable="reviewed-title" form="short" font-style="italic" text-case="title"/>
-      </if>
-      <else>
-        <!-- Assume title is title of reviewed work -->
-        <text variable="title" form="short" font-style="italic" text-case="title"/>
-      </else>
-    </choose>
-  </macro>
-  <macro name="format">
-    <choose>
-      <if variable="genre medium" match="any">
-        <group delimiter="; ">
+      <choose>
+        <if variable="genre">
           <choose>
-            <if variable="number" match="none">
-              <text variable="genre" text-case="capitalize-first"/>
+            <if match="none" variable="number">
+              <text text-case="capitalize-first" variable="medium"/>
             </if>
           </choose>
-          <text variable="medium" text-case="capitalize-first"/>
+        </if>
+      </choose>
+    </group>
+  </macro>
+  <macro name="description-song">
+    <!-- Performer of classical music works -->
+    <group delimiter="; ">
+      <group delimiter=" ">
+        <choose>
+          <if match="none" variable="number">
+            <choose>
+              <if variable="genre">
+                <text text-case="capitalize-first" variable="genre"/>
+                <text form="verb" term="performer"/>
+              </if>
+              <else-if variable="medium">
+                <text text-case="capitalize-first" variable="medium"/>
+                <text form="verb" term="performer"/>
+              </else-if>
+              <else>
+                <text form="verb" term="performer" text-case="capitalize-first"/>
+              </else>
+            </choose>
+          </if>
+          <else>
+            <!-- If there is a number, genre is already printed in `genre-number` macro -->
+            <choose>
+              <if variable="medium">
+                <text text-case="capitalize-first" variable="medium"/>
+                <text form="verb" term="performer"/>
+              </if>
+              <else>
+                <text form="verb" term="performer" text-case="capitalize-first"/>
+              </else>
+            </choose>
+          </else>
+        </choose>
+        <names variable="author">
+          <substitute>
+            <names variable="performer"/>
+          </substitute>
+        </names>
+      </group>
+      <choose>
+        <if variable="genre">
+          <choose>
+            <if match="none" variable="number">
+              <text text-case="capitalize-first" variable="medium"/>
+            </if>
+          </choose>
+        </if>
+      </choose>
+    </group>
+  </macro>
+  <macro name="description-thesis">
+    <!-- Thesis type and institution -->
+    <group delimiter="; ">
+      <choose>
+        <if match="none" variable="number">
+          <group delimiter=", ">
+            <text text-case="capitalize-first" variable="genre"/>
+            <choose>
+              <if match="any" variable="archive DOI URL">
+                <!-- Include the university in brackets if thesis is published -->
+                <text variable="publisher"/>
+              </if>
+            </choose>
+          </group>
+        </if>
+      </choose>
+      <text text-case="capitalize-first" variable="medium"/>
+    </group>
+  </macro>
+  <macro name="format-bib">
+    <choose>
+      <if match="any" variable="genre medium">
+        <group delimiter="; ">
+          <choose>
+            <if match="none" variable="number">
+              <text text-case="capitalize-first" variable="genre"/>
+            </if>
+          </choose>
+          <text text-case="capitalize-first" variable="medium"/>
         </group>
       </if>
-      <else>
-        <text macro="generic-type-label"/>
-      </else>
-    </choose>
-  </macro>
-  <macro name="format-intext">
-    <choose>
-      <if variable="genre" match="any">
-        <text variable="genre" text-case="capitalize-first"/>
-      </if>
-      <else-if variable="medium">
-        <text variable="medium" text-case="capitalize-first"/>
-      </else-if>
       <else>
         <text macro="generic-type-label"/>
       </else>
@@ -1451,9 +1146,9 @@
       <else-if type="software">
         <text term="software" text-case="capitalize-first"/>
       </else-if>
-      <else-if type="interview personal_communication" match="any">
+      <else-if match="any" type="interview personal_communication">
         <choose>
-          <if variable="archive container-title DOI publisher URL" match="none">
+          <if match="none" variable="archive archive-place container-title DOI publisher URL">
             <text term="personal-communication" text-case="capitalize-first"/>
           </if>
           <else-if type="interview">
@@ -1493,18 +1188,67 @@
       </else-if>
     </choose>
   </macro>
-  <!-- APA 'source' element contains four parts:
-       container, event, publisher, access -->
+  <macro name="reviewed-title-bib">
+    <choose>
+      <if variable="reviewed-title">
+        <!-- Not possible to distinguish TV series episode from other reviewed
+             works without reviewed-container-title (APA example 69) -->
+        <!-- Adapt for reviewed-container-title if that becomes available -->
+        <text font-style="italic" variable="reviewed-title"/>
+      </if>
+      <else>
+        <!-- Assume title is title of reviewed work -->
+        <text font-style="italic" variable="title"/>
+      </else>
+    </choose>
+  </macro>
+  <!-- Description logic -->
+  <macro name="description-bib">
+    <group prefix="[" suffix="]">
+      <choose>
+        <if match="any" type="interview" variable="interviewer">
+          <text macro="description-interview"/>
+        </if>
+        <else-if match="any" type="review review-book" variable="reviewed-author reviewed-genre reviewed-title">
+          <text macro="description-reviewed"/>
+        </else-if>
+        <else-if type="personal_communication">
+          <text macro="description-letter-bib"/>
+        </else-if>
+        <else-if type="song" variable="composer">
+          <text macro="description-song"/>
+        </else-if>
+        <else-if type="thesis">
+          <text macro="description-thesis"/>
+        </else-if>
+        <else-if match="none" variable="container-title">
+          <!-- Other description -->
+          <text macro="format-bib"/>
+        </else-if>
+        <else>
+          <text macro="description-generic"/>
+        </else>
+      </choose>
+    </group>
+  </macro>
+  <!-- 4. Source -->
+  <!-- Four parts in APA 'source' element:
+
+       1. Container
+       2. Event
+       3. Publication details
+       4. Access -->
+  <!-- 4.1. Container -->
   <macro name="container">
     <choose>
-      <if type="article-journal article-magazine article-newspaper periodical post-weblog review review-book" match="any">
+      <if match="any" type="article-journal article-magazine article-newspaper periodical post-weblog review review-book">
         <!-- Periodical items -->
         <text macro="container-periodical"/>
       </if>
       <else-if type="paper-conference">
         <!-- Determine if paper-conference is a periodical- or book-like -->
         <choose>
-          <if variable="editor editorial-director collection-editor container-author" match="any">
+          <if match="any" variable="collection-editor container-author editor editorial-director">
             <text macro="container-booklike"/>
           </if>
           <else>
@@ -1512,55 +1256,15 @@
           </else>
         </choose>
       </else-if>
-      <else-if type="post webpage" match="none">
-        <!-- post and webpage treat container-title like publisher -->
+      <else-if match="none" type="post webpage">
+        <!-- Webpages treat container-title like publisher -->
         <text macro="container-booklike"/>
       </else-if>
     </choose>
   </macro>
-  <macro name="container-periodical">
-    <group delimiter=". ">
-      <group delimiter=", ">
-        <text variable="container-title" font-style="italic" text-case="title"/>
-        <choose>
-          <if variable="volume">
-            <group>
-              <text variable="volume" font-style="italic"/>
-              <text variable="issue" prefix="(" suffix=")"/>
-            </group>
-          </if>
-          <else>
-            <text variable="issue" font-style="italic"/>
-          </else>
-        </choose>
-        <choose>
-          <if variable="number">
-            <!-- Ex. 6: Journal article with article number or eLocator -->
-            <group delimiter=" ">
-              <text term="article-locator" text-case="capitalize-first"/>
-              <text variable="number"/>
-            </group>
-          </if>
-          <else>
-            <text variable="page"/>
-          </else>
-        </choose>
-      </group>
-      <choose>
-        <if variable="issued">
-          <choose>
-            <if variable="issue number page volume" match="none">
-              <!-- We print the status variable directly rather than using in-press, etc. terms. -->
-              <text variable="status" text-case="capitalize-first"/>
-            </if>
-          </choose>
-        </if>
-      </choose>
-    </group>
-  </macro>
   <macro name="container-booklike">
     <choose>
-      <if variable="container-title" match="any">
+      <if variable="container-title">
         <group delimiter=" ">
           <choose>
             <if type="song">
@@ -1571,161 +1275,167 @@
             </else>
           </choose>
           <group delimiter=", ">
-            <names variable="executive-producer">
-              <name and="symbol" initialize-with=". " delimiter=", "/>
-              <label form="long" text-case="title" prefix=" (" suffix=")"/>
-              <substitute>
-                <names variable="series-creator"/>
-                <names variable="editor-translator">
-                  <name and="symbol" initialize-with=". " delimiter=", "/>
-                  <label form="short" text-case="title" prefix=" (" suffix=")"/>
-                </names>
-                <!-- TODO: Translator omitted here on the assumption that editor-translators are uncommon 
-                           for chapter citations. If needed, direct entry or automatic population of
-                           `editor-translator` can produce combined labels. -->
-                <names variable="editor">
-                  <name and="symbol" initialize-with=". " delimiter=", "/>
-                  <label form="short" text-case="title" prefix=" (" suffix=")"/>
-                </names>
-                <names variable="editorial-director">
-                  <name and="symbol" initialize-with=". " delimiter=", "/>
-                  <label form="short" text-case="title" prefix=" (" suffix=")"/>
-                </names>
-                <names variable="compiler"/>
-                <choose>
-                  <if type="event performance speech" match="any">
-                    <names variable="chair"/>
-                    <names variable="organizer"/>
-                  </if>
-                </choose>
-                <names variable="curator"/>
-                <names variable="collection-editor">
-                  <name and="symbol" initialize-with=". " delimiter=", "/>
-                  <label form="short" text-case="title" prefix=" (" suffix=")"/>
-                </names>
-                <names variable="container-author"/>
-              </substitute>
-            </names>
-            <group delimiter=": " font-style="italic">
-              <text variable="container-title"/>
-              <text macro="volume-title"/>
-            </group>
+            <text macro="container-contributors"/>
+            <text macro="container-title-booklike"/>
           </group>
-          <text macro="parenthetical-container"/>
-          <text macro="bracketed-container"/>
+          <text macro="container-identification"/>
+          <text macro="container-description"/>
         </group>
       </if>
     </choose>
   </macro>
-  <macro name="publisher">
-    <group delimiter="; ">
+  <macro name="container-periodical">
+    <group delimiter=". ">
+      <group delimiter=", ">
+        <text font-style="italic" text-case="title" variable="container-title"/>
+        <text macro="volume-periodical"/>
+        <text macro="locators-periodical"/>
+      </group>
       <choose>
-        <if type="thesis">
+        <if variable="issued">
           <choose>
-            <if variable="archive DOI URL" match="none">
-              <text variable="publisher"/>
+            <if match="none" variable="issue number page volume">
+              <!-- We print the status variable directly rather than using in-press, etc. terms. -->
+              <text text-case="capitalize-first" variable="status"/>
             </if>
           </choose>
         </if>
-        <else-if type="post webpage" match="any">
-          <!-- For websites, treat container title like publisher -->
-          <group delimiter="; ">
-            <text variable="container-title" text-case="title"/>
-            <text variable="publisher"/>
-          </group>
-        </else-if>
-        <else-if type="paper-conference">
-          <!-- For paper-conference, don't print publisher if in a journal-like proceedings -->
-          <choose>
-            <if variable="collection-editor compiler editor editorial-director" match="any">
-              <text variable="publisher"/>
-            </if>
-          </choose>
-        </else-if>
-        <else-if type="article-journal article-magazine article-newspaper periodical post-weblog review review-book" match="none">
-          <text variable="publisher"/>
-        </else-if>
       </choose>
-      <group delimiter=", ">
-        <choose>
-          <if variable="archive-place">
-            <!-- With `archive-place`: physical archives. Without: online archives. -->
-            <!-- For physical archives, print the location before the archive name.
-                For electronic archives, these are printed in macro="description". -->
-            <!-- Must test for archive_collection:
-                With collection: archive_collection (archive_location), archive, archive-place
-                No collection: archive (archive_location), archive-place
-            -->
-            <choose>
-              <if variable="archive_collection">
-                <group delimiter=" ">
-                  <text variable="archive_collection"/>
-                  <text variable="archive_location" prefix="(" suffix=")"/>
-                </group>
-                <text variable="archive"/>
-                <text variable="archive-place"/>
-              </if>
-              <else>
-                <group delimiter=" ">
-                  <text variable="archive"/>
-                  <text variable="archive_location" prefix="(" suffix=")"/>
-                </group>
-                <text variable="archive-place"/>
-              </else>
-            </choose>
-          </if>
-          <else>
-            <text variable="archive"/>
-          </else>
-        </choose>
-      </group>
     </group>
   </macro>
-  <macro name="access">
+  <!-- Container parallels main elements -->
+  <!-- 4.1.1. Author -->
+  <macro name="container-contributors">
+    <names variable="executive-producer">
+      <name/>
+      <label form="long" prefix=" (" suffix=")" text-case="title"/>
+      <substitute>
+        <names variable="series-creator"/>
+        <names variable="editor-translator">
+          <name/>
+          <label form="short" prefix=" (" suffix=")" text-case="title"/>
+        </names>
+        <!-- TODO: Translator omitted on the assumption that editor-translators are uncommon for chapter citations.
+             If needed, direct entry or automatic population of `editor-translator` can produce combined labels. -->
+        <names delimiter="; " variable="editor">
+          <name/>
+          <label form="short" prefix=" (" suffix=")" text-case="title"/>
+        </names>
+        <names variable="editorial-director">
+          <name/>
+          <label form="short" prefix=" (" suffix=")" text-case="title"/>
+        </names>
+        <names variable="compiler"/>
+        <choose>
+          <if match="any" type="event performance speech">
+            <names variable="chair"/>
+            <names variable="organizer"/>
+          </if>
+        </choose>
+        <names variable="curator"/>
+        <names variable="collection-editor">
+          <name/>
+          <label form="short" prefix=" (" suffix=")" text-case="title"/>
+        </names>
+        <names variable="container-author"/>
+      </substitute>
+    </names>
+  </macro>
+  <!-- 4.1.3.1 Container title -->
+  <macro name="container-title-booklike">
+    <group delimiter=": " font-style="italic">
+      <text variable="container-title"/>
+      <text macro="title-volume"/>
+    </group>
+  </macro>
+  <!-- 4.1.3.1 Container identification -->
+  <macro name="container-identification">
     <choose>
-      <if variable="DOI" match="any">
-        <text variable="DOI" prefix="https://doi.org/"/>
-      </if>
-      <else-if variable="URL">
-        <group delimiter=" ">
-          <choose>
-            <if variable="issued status" match="none">
-              <group delimiter=" ">
-                <text term="retrieved" text-case="capitalize-first"/>
-                <date variable="accessed" form="text" suffix=","/>
-                <text term="from"/>
-              </group>
-            </if>
-          </choose>
-          <text variable="URL"/>
+      <if variable="container-title">
+        <group prefix="(" suffix=")">
+          <group delimiter="; ">
+            <text macro="database-location"/>
+            <choose>
+              <if match="none" type="broadcast graphic map motion_picture song">
+                <!-- For audiovisual media, number information comes after title, not container-title (APA example 94) -->
+                <text macro="genre-number"/>
+              </if>
+            </choose>
+            <text macro="identification-booklike"/>
+          </group>
         </group>
-      </else-if>
+      </if>
     </choose>
   </macro>
+  <!-- 4.1.3.2 Container description -->
+  <macro name="container-description">
+    <group prefix="[" suffix="]">
+      <choose>
+        <if match="any" type="event paper-conference performance speech">
+          <!-- Conference presentations should describe the session [container] in description unless published in a proceedings -->
+          <choose>
+            <if match="none" variable="collection-editor compiler editor editorial-director issue page volume">
+              <text macro="format-bib"/>
+            </if>
+          </choose>
+        </if>
+        <else-if type="software">
+          <!-- For entries in mobile app reference works, place description after the container-title -->
+          <text macro="format-bib"/>
+        </else-if>
+        <else-if match="any" type="document report standard">
+          <!-- For chapters in report, standards, and generic documents, place description after the container title -->
+          <text macro="format-bib"/>
+        </else-if>
+      </choose>
+    </group>
+  </macro>
+  <!-- 4.1.4. Source -->
+  <macro name="locators-periodical">
+    <choose>
+      <if variable="number">
+        <text macro="number-article-labelled"/>
+      </if>
+      <else>
+        <text variable="page"/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="volume-periodical">
+    <group delimiter=", ">
+      <text font-style="italic" text-case="title" variable="collection-title"/>
+      <choose>
+        <if variable="volume">
+          <group>
+            <text font-style="italic" variable="volume"/>
+            <text prefix="(" suffix=")" variable="issue"/>
+          </group>
+        </if>
+        <else>
+          <text font-style="italic" variable="issue"/>
+        </else>
+      </choose>
+    </group>
+  </macro>
+  <!-- 4.2. Event -->
   <macro name="event">
     <choose>
-      <if variable="event event-title" match="any">
-        <!-- To prevent Zotero from printing event-place due to its double-mapping of all 'place' to
-             both publisher-place and event-place. Remove this 'choose' when that is changed. -->
+      <if match="any" variable="event event-title">
+        <!-- To prevent Zotero from printing `event-place` due to its double-mapping of all 'place' to
+             both `publisher-place` and `event-place`. Remove this when that is changed. -->
         <choose>
           <if type="paper-conference">
             <choose>
-              <if variable="collection-editor compiler editor editorial-director issue page volume" match="none">
+              <if match="none" variable="collection-editor compiler editor editorial-director issue page volume">
                 <!-- Don't print event info for conference papers published in a proceedings -->
-                <group delimiter=", ">
-                  <text macro="event-title"/>
-                  <text variable="event-place"/>
-                </group>
+                <text macro="event-title-place"/>
               </if>
             </choose>
           </if>
           <else>
             <!-- For other item types, print event info even if published (e.g., for collection catalogs, performance programs.
                  These items aren't given explicit examples in the APA manual, so err on the side of providing too much information. -->
-            <group delimiter=", ">
-              <text macro="event-title"/>
-              <text variable="event-place"/>
-            </group>
+            <text macro="event-title-place"/>
           </else>
         </choose>
       </if>
@@ -1733,9 +1443,9 @@
   </macro>
   <macro name="event-title">
     <choose>
-      <!-- TODO: We expect "event-title" to be used,
+      <!-- TODO: We expect `event-title` to be used,
            but processors and applications may not be updated yet.
-           This macro ensures that either "event" or "event-title" can be accpeted.
+           This macro ensures that either `event` or `event-title` can be accepted.
            Remove if procesor logic and application adoption can handle this. -->
       <if variable="event-title">
         <text variable="event-title"/>
@@ -1745,11 +1455,153 @@
       </else>
     </choose>
   </macro>
-  <!-- After 'source', APA also prints publication history (original publication, reprint info, retraction info) -->
+  <macro name="event-title-place">
+    <group delimiter=", ">
+      <text macro="event-title"/>
+      <text variable="event-place"/>
+    </group>
+  </macro>
+  <!-- 4.3. Publication details -->
+  <!-- Publication utility macros -->
+  <macro name="archive">
+    <group delimiter=", ">
+      <choose>
+        <if variable="archive-place">
+          <!-- With `archive-place`: physical archives. Without: online archives. -->
+          <!-- For physical archives, print the location before the archive name.
+                For electronic archives, these are printed in macro="description". -->
+          <!-- Must test for archive_collection:
+                With collection: archive_collection (archive_location), archive, archive-place
+                No collection: archive (archive_location), archive-place
+            -->
+          <choose>
+            <if variable="archive_collection">
+              <group delimiter=" ">
+                <text variable="archive_collection"/>
+                <text prefix="(" suffix=")" variable="archive_location"/>
+              </group>
+              <text variable="archive"/>
+              <text variable="archive-place"/>
+            </if>
+            <else>
+              <group delimiter=" ">
+                <text variable="archive"/>
+                <text prefix="(" suffix=")" variable="archive_location"/>
+              </group>
+              <text variable="archive-place"/>
+            </else>
+          </choose>
+        </if>
+        <else>
+          <text variable="archive"/>
+        </else>
+      </choose>
+    </group>
+  </macro>
+  <macro name="publisher">
+    <choose>
+      <if variable="publisher">
+        <text variable="publisher"/>
+      </if>
+      <else-if match="none" variable="event-place">
+        <!-- Work around Zotero double-mapping of event/publisher place -->
+        <text variable="publisher-place"/>
+      </else-if>
+    </choose>
+  </macro>
+  <!-- Publication logic -->
+  <macro name="publication">
+    <choose>
+      <if type="thesis">
+        <choose>
+          <if match="none" variable="archive DOI URL">
+            <text macro="publisher"/>
+          </if>
+        </choose>
+      </if>
+      <else-if match="any" type="post webpage">
+        <!-- Webpages treat container-title like publisher -->
+        <group delimiter="; ">
+          <text text-case="title" variable="container-title"/>
+          <text macro="publisher"/>
+        </group>
+      </else-if>
+      <else-if type="paper-conference">
+        <!-- For paper-conference, don't print publisher if in a journal-like proceedings -->
+        <choose>
+          <if match="any" variable="collection-editor compiler editor editorial-director">
+            <text macro="publisher"/>
+          </if>
+        </choose>
+      </else-if>
+      <else-if match="none" type="article-journal article-magazine article-newspaper periodical post-weblog review review-book">
+        <text macro="publisher"/>
+      </else-if>
+    </choose>
+  </macro>
+  <macro name="publication-archive">
+    <group delimiter="; ">
+      <text macro="publication"/>
+      <text macro="archive"/>
+    </group>
+  </macro>
+  <!-- 4.4. Access -->
+  <macro name="access">
+    <choose>
+      <if variable="DOI">
+        <text prefix="https://doi.org/" variable="DOI"/>
+      </if>
+      <else-if variable="URL">
+        <group delimiter=" ">
+          <choose>
+            <if match="none" variable="issued status">
+              <group delimiter=" ">
+                <text term="retrieved" text-case="capitalize-first"/>
+                <group delimiter=", ">
+                  <date form="text" variable="accessed"/>
+                  <text term="from"/>
+                </group>
+              </group>
+            </if>
+          </choose>
+          <text variable="URL"/>
+        </group>
+      </else-if>
+    </choose>
+  </macro>
+  <!-- 5. Publication history -->
+  <!-- History utility macros -->
+  <macro name="original-publisher">
+    <choose>
+      <if variable="original-publisher">
+        <text variable="original-publisher"/>
+      </if>
+      <else>
+        <text variable="original-publisher-place"/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="original-title">
+    <choose>
+      <if variable="original-title">
+        <text value="as"/>
+        <choose>
+          <if match="any" type="article-journal article-magazine article-newspaper periodical post-weblog review review-book">
+            <text variable="original-title"/>
+          </if>
+          <else>
+            <text font-style="italic" variable="original-title"/>
+          </else>
+        </choose>
+      </if>
+    </choose>
+  </macro>
+  <!-- History logic -->
   <macro name="publication-history">
+    <!-- Information appended to 'source': original publication, reprint info, retraction info -->
     <choose>
       <if type="patent">
-        <text variable="references" prefix="(" suffix=")"/>
+        <text prefix="(" suffix=")" variable="references"/>
       </if>
       <else>
         <group delimiter="; " prefix="(" suffix=")">
@@ -1757,8 +1609,8 @@
           <choose>
             <if variable="issued">
               <choose>
-                <if variable="issue number page volume" match="any">
-                  <text variable="status" text-case="capitalize-first"/>
+                <if match="any" variable="issue number page volume">
+                  <text text-case="capitalize-first" variable="status"/>
                 </if>
               </choose>
             </if>
@@ -1767,29 +1619,31 @@
             <if variable="references">
               <!-- This provides the option for more elaborate description
                     of publication history, such as full "reprinted" references
-                    (examples 11, 43, 44) -->
+                    (APA examples 11, 43, 44) -->
               <text variable="references"/>
             </if>
             <else>
-              <group delimiter=" ">
-                <text term="original-work-published" text-case="capitalize-first"/>
-                <choose>
-                  <if is-uncertain-date="original-date">
-                    <text term="circa" form="short"/>
-                  </if>
-                </choose>
-                <date variable="original-date">
-                  <date-part name="year"/>
-                </date>
-              </group>
+              <text macro="publication-history-variables"/>
             </else>
           </choose>
         </group>
       </else>
     </choose>
   </macro>
-  <!-- Legal citations have their own rules -->
-  <macro name="legal-cites">
+  <macro name="publication-history-variables">
+    <group delimiter=" ">
+      <text term="original-work-published" text-case="capitalize-first"/>
+      <group delimiter="; ">
+        <text macro="original-title"/>
+        <group delimiter=", ">
+          <text macro="original-publisher"/>
+          <text macro="original-date-year"/>
+        </group>
+      </group>
+    </group>
+  </macro>
+  <!-- Parallel rules for legal citations -->
+  <macro name="legal-bib">
     <!-- `treaty`: for treaties -->
     <!-- `legal_case`: for all legal and court cases -->
     <!-- `bill`: for bills, resolutions, federal reports -->
@@ -1801,16 +1655,14 @@
         <if type="treaty">
           <group delimiter=", " suffix=".">
             <!-- APA generally defers to Bluebook for legal citations, but diverges without
-                explanation for treaty items. We follow the Bluebook format that was used 
+                explanation for treaty items. We follow the Bluebook format that was used
                 in APA 6th ed. -->
-            <!-- APA manual omits treaty parties/authors, but per Bluebook 
+            <!-- APA manual omits treaty parties/authors, but per Bluebook
                 they should be included at least for bilateral treaties. -->
-            <names variable="author">
-              <name initialize-with="." form="short" delimiter="-"/>
-            </names>
+            <text macro="author-legal"/>
             <text macro="date-legal"/>
-            <!-- APA manual omits treaty source/report called for by Bluebook in favor of just URL. 
-                Both are included here, following the APA style used for all other item types 
+            <!-- APA manual omits treaty source/report called for by Bluebook in favor of just URL.
+                Both are included here, following the APA style used for all other item types
                 to end the reference with a period, then give the URL afterward. -->
             <text macro="container-legal"/>
           </group>
@@ -1822,7 +1674,7 @@
               <text macro="container-legal"/>
             </group>
             <text macro="date-legal"/>
-            <text macro="parenthetical-legal"/>
+            <text macro="identification-legal"/>
           </group>
         </else>
       </choose>
@@ -1830,20 +1682,75 @@
       <text macro="access"/>
     </group>
   </macro>
+  <!-- 1. Legal author -->
+  <macro name="author-legal">
+    <names variable="author">
+      <name delimiter="-" form="short"/>
+    </names>
+  </macro>
+  <!-- 2. Legal date -->
+  <macro name="date-legal-case">
+    <group delimiter=" " prefix="(" suffix=")">
+      <text variable="authority"/>
+      <choose>
+        <if variable="container-title">
+          <!-- Print only year for cases published in reporters-->
+          <text macro="date-issued-year"/>
+        </if>
+        <else>
+          <!-- APA manual doesn't include examples of cases not yet
+                   published in a reporter, but this is Bluebook style. -->
+          <text macro="date-issued-full"/>
+        </else>
+      </choose>
+    </group>
+  </macro>
+  <macro name="date-legal">
+    <choose>
+      <if type="treaty">
+        <text macro="date-issued-full"/>
+      </if>
+      <else-if type="legal_case">
+        <text macro="date-legal-case"/>
+      </else-if>
+      <else-if match="any" type="bill hearing legislation regulation">
+        <group delimiter=" " prefix="(" suffix=")">
+          <group delimiter=" ">
+            <text macro="original-date-year"/>
+            <text form="symbol" term="and"/>
+          </group>
+          <choose>
+            <if variable="issued">
+              <!-- APA manual includes "rev." before the revision year,
+                   but this isn't part of the Bluebook rules. -->
+              <text macro="date-issued-year"/>
+            </if>
+            <else>
+              <!-- Show proposal date for uncodified regualtions.
+                   Assume date is entered literally ala "proposed May 23, 2016".
+                   TODO: Add 'proposed' term here if that becomes available -->
+              <date form="text" variable="submitted"/>
+            </else>
+          </choose>
+        </group>
+      </else-if>
+    </choose>
+  </macro>
+  <!-- 3.1. Legal title -->
   <macro name="title-legal">
     <choose>
-      <if type="bill legal_case legislation regulation treaty" match="any">
-        <text variable="title" text-case="title"/>
+      <if match="any" type="bill legal_case legislation regulation treaty">
+        <text text-case="title" variable="title"/>
       </if>
       <else-if type="hearing">
-        <!-- APA uses a comma delimiter and omits "hearing before the" for hearings with testimony, 
+        <!-- APA uses a comma delimiter and omits "hearing before the" for hearings with testimony,
              but follows Bluebook rules (colon delimiter, prefix before the committee name) for
              references to the whole hearing. We simply follow the Bluebook rules for both, but
              use APA style capitalization (not capitalizing "Before" or the title of the hearing). -->
         <group delimiter=": " font-style="italic">
-          <text variable="title" text-case="capitalize-first"/>
+          <text text-case="capitalize-first" variable="title"/>
           <group delimiter=" ">
-            <text term="hearing" form="long" text-case="capitalize-first"/>
+            <text form="long" term="hearing" text-case="capitalize-first"/>
             <group delimiter=" ">
               <group delimiter=" ">
                 <!-- APA manual omits the bill number, but it should be included per Bluebook if relevant -->
@@ -1852,7 +1759,7 @@
               </group>
               <group delimiter=" ">
                 <!-- Use the `at` term to hold "before the" -->
-                <text term="at" form="long"/>
+                <text form="long" term="at"/>
                 <text variable="section"/>
               </group>
             </group>
@@ -1861,124 +1768,95 @@
       </else-if>
     </choose>
   </macro>
-  <macro name="date-legal">
+  <!-- 3.2. Legal identification (in parentheses) -->
+  <macro name="identification-legal">
     <choose>
-      <if type="treaty">
-        <date variable="issued" form="text"/>
+      <if type="hearing">
+        <group delimiter=" " prefix="(" suffix=")">
+          <!-- Use the 'verb' form of the hearing term to hold 'testimony of' -->
+          <text form="verb" term="hearing"/>
+          <names variable="author">
+            <name initialize="false"/>
+          </names>
+        </group>
       </if>
-      <else-if type="legal_case">
-        <group prefix="(" suffix=")" delimiter=" ">
-          <text variable="authority"/>
-          <choose>
-            <if variable="container-title" match="any">
-              <!-- Print only year for cases published in reporters-->
-              <date variable="issued" form="numeric" date-parts="year"/>
-            </if>
-            <else>
-              <!-- APA manual doesn't include examples of cases not yet
-                   published in a reporter, but this is Bluebook style. -->
-              <date variable="issued" form="text"/>
-            </else>
-          </choose>
-        </group>
-      </else-if>
-      <else-if type="bill hearing legislation regulation" match="any">
-        <group prefix="(" suffix=")" delimiter=" ">
-          <group delimiter=" ">
-            <date variable="original-date">
-              <date-part name="year"/>
-            </date>
-            <text term="and" form="symbol"/>
-          </group>
-          <choose>
-            <if variable="issued">
-              <!-- APA manual includes "rev." before the revision year, 
-                   but this isn't part of the Bluebook rules. -->
-              <date variable="issued">
-                <date-part name="year"/>
-              </date>
-            </if>
-            <else>
-              <!-- Show proposal date for uncodified regualtions. 
-                   Assume date is entered literally ala "proposed May 23, 2016".
-                   TODO: Add 'proposed' term here if that becomes available -->
-              <date variable="submitted" form="text"/>
-            </else>
-          </choose>
-        </group>
+      <else-if match="any" type="bill legislation regulation">
+        <!-- For uncodified regulations, assume future code section is in `status`. -->
+        <text prefix="(" suffix=")" variable="status"/>
       </else-if>
     </choose>
   </macro>
-  <macro name="container-legal">
-    <!-- Expect legal item container-titles to be stored in short form -->
+  <!-- 4. Legal source -->
+  <!-- Legal source utility macros -->
+  <macro name="container-bill">
+    <group delimiter=", ">
+      <group delimiter=" ">
+        <text variable="genre"/>
+        <group delimiter=" ">
+          <choose>
+            <!-- If there is no session number or code/record title, assume
+                     assume the item is a congressional report and include 'No.' term. -->
+            <if match="none" variable="chapter-number container-title">
+              <!-- The item is a congressional report, rather than a bill or resultion. -->
+              <text macro="number-labelled"/>
+            </if>
+            <else>
+              <text variable="number"/>
+            </else>
+          </choose>
+        </group>
+      </group>
+      <group delimiter=" ">
+        <text variable="authority"/>
+        <!-- 'session' is `chapter-number` -->
+        <text variable="chapter-number"/>
+      </group>
+      <group delimiter=" ">
+        <text variable="volume"/>
+        <text variable="container-title"/>
+        <text variable="page-first"/>
+      </group>
+    </group>
+  </macro>
+  <macro name="container-hearing">
+    <group delimiter=" ">
+      <text variable="authority"/>
+      <!-- 'session' is `chapter-number` -->
+      <text variable="chapter-number"/>
+    </group>
+  </macro>
+  <macro name="container-legal-case">
+    <group delimiter=" ">
+      <choose>
+        <if variable="container-title">
+          <group delimiter=" ">
+            <text variable="volume"/>
+            <text variable="container-title"/>
+            <text macro="section-labelled"/>
+            <choose>
+              <if match="any" variable="page page-first">
+                <text variable="page-first"/>
+              </if>
+              <else>
+                <text value="___"/>
+              </else>
+            </choose>
+          </group>
+        </if>
+        <else>
+          <text macro="number-labelled"/>
+        </else>
+      </choose>
+    </group>
+  </macro>
+  <macro name="container-legislation">
     <choose>
-      <if type="treaty">
-        <group delimiter=" ">
-          <number variable="volume"/>
-          <text variable="container-title"/>
-          <choose>
-            <if variable="page page-first" match="any">
-              <text variable="page-first"/>
-            </if>
-            <else>
-              <group delimiter=" ">
-                <label variable="number" form="short" text-case="capitalize-first"/>
-                <text variable="number"/>
-              </group>
-            </else>
-          </choose>
-        </group>
-      </if>
-      <else-if type="legal_case">
-        <group delimiter=" ">
-          <choose>
-            <if variable="container-title">
-              <group delimiter=" ">
-                <text variable="volume"/>
-                <text variable="container-title"/>
-                <group delimiter=" ">
-                  <label variable="section" form="symbol"/>
-                  <text variable="section"/>
-                </group>
-                <choose>
-                  <if variable="page page-first" match="any">
-                    <text variable="page-first"/>
-                  </if>
-                  <else>
-                    <text value="___"/>
-                  </else>
-                </choose>
-              </group>
-            </if>
-            <else>
-              <group delimiter=" ">
-                <label variable="number" form="short" text-case="capitalize-first"/>
-                <text variable="number"/>
-              </group>
-            </else>
-          </choose>
-        </group>
-      </else-if>
-      <else-if type="bill">
+      <if variable="number">
+        <!-- There's a public law number. -->
         <group delimiter=", ">
           <group delimiter=" ">
-            <text variable="genre"/>
-            <group delimiter=" ">
-              <choose>
-                <!-- If there is no session number or code/record title, assume
-                     assume the item is a congressional report and include 'No.' term. -->
-                <if variable="chapter-number container-title" match="none">
-                  <!-- The item is a congressional report, rather than a bill or resultion. -->
-                  <label variable="number" form="short" text-case="capitalize-first"/>
-                </if>
-              </choose>
-              <text variable="number"/>
-            </group>
-          </group>
-          <group delimiter=" ">
-            <text variable="authority"/>
-            <!-- 'session' is `chapter-number` -->
-            <text variable="chapter-number"/>
+            <text value="Pub. L. No."/>
+            <text variable="number"/>
           </group>
           <group delimiter=" ">
             <text variable="volume"/>
@@ -1986,105 +1864,82 @@
             <text variable="page-first"/>
           </group>
         </group>
-      </else-if>
-      <else-if type="hearing">
+      </if>
+      <else>
         <group delimiter=" ">
-          <text variable="authority"/>
-          <!-- 'session' is `chapter-number` -->
-          <text variable="chapter-number"/>
+          <text variable="volume"/>
+          <text variable="container-title"/>
+          <choose>
+            <if variable="section">
+              <text macro="section-labelled"/>
+            </if>
+            <else>
+              <text variable="page-first"/>
+            </else>
+          </choose>
         </group>
-      </else-if>
-      <else-if type="legislation">
+      </else>
+    </choose>
+  </macro>
+  <macro name="container-regulation">
+    <group delimiter=", ">
+      <group delimiter=" ">
+        <text variable="genre"/>
+        <text macro="number-labelled"/>
+      </group>
+      <group delimiter=" ">
+        <text variable="volume"/>
+        <text variable="container-title"/>
         <choose>
-          <if variable="number">
-            <!-- There's a public law number. -->
-            <group delimiter=", ">
-              <text variable="number" prefix="Pub. L. No. "/>
-              <group delimiter=" ">
-                <text variable="volume"/>
-                <text variable="container-title"/>
-                <text variable="page-first"/>
-              </group>
-            </group>
+          <if variable="section">
+            <text macro="section-labelled"/>
           </if>
           <else>
-            <group delimiter=" ">
-              <text variable="volume"/>
-              <text variable="container-title"/>
-              <choose>
-                <if variable="section">
-                  <group delimiter=" ">
-                    <label variable="section" form="symbol"/>
-                    <text variable="section"/>
-                  </group>
-                </if>
-                <else>
-                  <text variable="page-first"/>
-                </else>
-              </choose>
-            </group>
+            <text variable="page-first"/>
           </else>
         </choose>
-      </else-if>
-      <else-if type="regulation">
-        <group delimiter=", ">
-          <group delimiter=" ">
-            <text variable="genre"/>
-            <group delimiter=" ">
-              <label variable="number" form="short" text-case="capitalize-first"/>
-              <text variable="number"/>
-            </group>
-          </group>
-          <group delimiter=" ">
-            <text variable="volume"/>
-            <text variable="container-title"/>
-            <choose>
-              <if variable="section">
-                <group delimiter=" ">
-                  <label variable="section" form="symbol"/>
-                  <text variable="section"/>
-                </group>
-              </if>
-              <else>
-                <text variable="page-first"/>
-              </else>
-            </choose>
-          </group>
-        </group>
-      </else-if>
-    </choose>
-  </macro>
-  <macro name="parenthetical-legal">
-    <choose>
-      <if type="hearing">
-        <group prefix="(" suffix=")" delimiter=" ">
-          <!-- Use the 'verb' form of the hearing term to hold 'testimony of' -->
-          <text term="hearing" form="verb"/>
-          <names variable="author">
-            <name and="symbol" delimiter=", "/>
-          </names>
-        </group>
-      </if>
-      <else-if type="bill legislation regulation" match="any">
-        <!-- For uncodified regulations, assume future code section is in `status`. -->
-        <text variable="status" prefix="(" suffix=")"/>
-      </else-if>
-    </choose>
-  </macro>
-  <macro name="citation-locator">
-    <!-- Abbreviate page and paragraph, leave other locator labels in long form, cf. Rule 8.13 -->
-    <group delimiter=" ">
-      <choose>
-        <if locator="page paragraph" match="any">
-          <label variable="locator" form="short"/>
-        </if>
-        <else>
-          <label variable="locator" text-case="capitalize-first"/>
-        </else>
-      </choose>
-      <text variable="locator"/>
+      </group>
     </group>
   </macro>
+  <macro name="container-treaty">
+    <group delimiter=" ">
+      <number variable="volume"/>
+      <text variable="container-title"/>
+      <choose>
+        <if match="any" variable="page page-first">
+          <text variable="page-first"/>
+        </if>
+        <else>
+          <text macro="number-labelled"/>
+        </else>
+      </choose>
+    </group>
+  </macro>
+  <!-- Legal source logic -->
+  <macro name="container-legal">
+    <!-- Expect legal item container-titles to be stored in short form -->
+    <choose>
+      <if type="bill">
+        <text macro="container-bill"/>
+      </if>
+      <else-if type="hearing">
+        <text macro="container-hearing"/>
+      </else-if>
+      <else-if type="legal_case">
+        <text macro="container-legal-case"/>
+      </else-if>
+      <else-if type="legislation">
+        <text macro="container-legislation"/>
+      </else-if>
+      <else-if type="regulation">
+        <text macro="container-regulation"/>
+      </else-if>
+      <else-if type="treaty">
+        <text macro="container-treaty"/>
+      </else-if>
+    </choose>
+  </macro>
+  <!-- Main logic -->
   <citation collapse="citation-number">
     <sort>
       <key variable="citation-number"/>
@@ -2092,34 +1947,47 @@
     <layout delimiter="," vertical-align="sup">
       <group>
         <text variable="citation-number"/>
-        <text macro="citation-locator" prefix="(" suffix=")"/>
+        <text macro="locator-labelled" prefix="(" suffix=")"/>
       </group>
     </layout>
   </citation>
-  <bibliography hanging-indent="true" et-al-min="21" et-al-use-first="19" et-al-use-last="true" entry-spacing="0" line-spacing="2">
+  <macro name="bibliography">
+    <group delimiter=" ">
+      <group delimiter=". " suffix=".">
+        <text macro="author-bib"/>
+        <text macro="date-bib"/>
+        <text macro="title-and-descriptions"/>
+        <text macro="container"/>
+        <text macro="event"/>
+        <text macro="publication-archive"/>
+      </group>
+      <text macro="access"/>
+      <text macro="publication-history"/>
+    </group>
+  </macro>
+  <macro name="bibliography-filtered">
+    <choose>
+      <if match="any" type="bill hearing legal_case legislation regulation treaty">
+        <!-- Legal items have different orders and delimiters -->
+        <text macro="legal-bib"/>
+      </if>
+      <else-if type="personal_communication">
+        <choose>
+          <if match="any" variable="archive archive-place container-title DOI publisher URL">
+            <text macro="bibliography"/>
+          </if>
+        </choose>
+      </else-if>
+      <else>
+        <text macro="bibliography"/>
+      </else>
+    </choose>
+  </macro>
+  <bibliography entry-spacing="0" et-al-min="21" et-al-use-first="19" et-al-use-last="true" hanging-indent="true" line-spacing="2">
     <layout>
       <group delimiter=". ">
         <text variable="citation-number"/>
-        <choose>
-          <if type="bill hearing legal_case legislation regulation treaty" match="any">
-            <!-- Legal items have different orders and delimiters -->
-            <text macro="legal-cites"/>
-          </if>
-          <else>
-            <group delimiter=" ">
-              <group delimiter=". " suffix=".">
-                <text macro="author-bib"/>
-                <text macro="date-bib"/>
-                <text macro="title-and-descriptions"/>
-                <text macro="container"/>
-                <text macro="event"/>
-                <text macro="publisher"/>
-              </group>
-              <text macro="access"/>
-              <text macro="publication-history"/>
-            </group>
-          </else>
-        </choose>
+        <text macro="bibliography-filtered"/>
       </group>
     </layout>
   </bibliography>

--- a/apa-single-spaced.csl
+++ b/apa-single-spaced.csl
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
-<style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" demote-non-dropping-particle="never" page-range-format="expanded">
+<style xmlns="http://purl.org/net/xbiblio/csl" and="symbol" class="in-text" demote-non-dropping-particle="never" initialize-with=". " names-delimiter=", " page-range-format="expanded" version="1.0">
   <info>
     <title>American Psychological Association 7th edition (single-spaced bibliography)</title>
-    <title-short>APA (single-spaced)</title-short>
+    <title-short>APA Style (single-spaced bibliography)</title-short>
     <id>http://www.zotero.org/styles/apa-single-spaced</id>
     <link href="http://www.zotero.org/styles/apa-single-spaced" rel="self"/>
     <link href="http://www.zotero.org/styles/apa" rel="template"/>
@@ -10,48 +10,53 @@
     <author>
       <name>Brenton M. Wiernik</name>
       <email>zotero@wiernik.org</email>
+      <uri>https://orcid.org/0000-0001-9560-6336</uri>
     </author>
+    <contributor>
+      <name>Andrew Dunning</name>
+      <uri>https://orcid.org/0000-0003-0464-5036</uri>
+    </contributor>
     <category citation-format="author-date"/>
     <category field="psychology"/>
     <category field="generic-base"/>
+    <summary>Author–date system of the Publication manual of the American Psychological Association: The official guide to APA style (2020)</summary>
     <updated>2024-07-09T20:08:41+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale xml:lang="en">
     <terms>
-      <term name="editortranslator" form="short">
-        <single>ed. &amp; trans.</single>
-        <multiple>eds. &amp; trans.</multiple>
-      </term>
-      <term name="editor-translator" form="short">
-        <single>ed. &amp; trans.</single>
-        <multiple>eds. &amp; trans.</multiple>
-      </term>
-      <term name="translator" form="short">trans.</term>
-      <term name="interviewer" form="short">
-        <single>interviewer</single>
-        <multiple>interviewers</multiple>
-      </term>
-      <term name="collection-editor" form="short">
+      <term name="ad"> C.E.</term>
+      <term form="long" name="at">before the</term>
+      <term name="bc"> B.C.E.</term>
+      <term form="short" name="circa">ca.</term>
+      <term name="collection">archival collection</term>
+      <term form="short" name="collection-editor">
         <single>ed.</single>
         <multiple>eds.</multiple>
       </term>
-      <term name="performer" form="verb">recorded by</term>
-      <term name="circa" form="short">ca.</term>
-      <term name="bc"> B.C.E.</term>
-      <term name="ad"> C.E.</term>
-      <term name="issue" form="long">
+      <term form="short" name="editor-translator">
+        <single>ed. &amp; trans.</single>
+        <multiple>eds. &amp; trans.</multiple>
+      </term>
+      <term form="short" name="editortranslator">
+        <single>ed. &amp; trans.</single>
+        <multiple>eds. &amp; trans.</multiple>
+      </term>
+      <term form="verb" name="hearing">testimony of</term>
+      <term form="short" name="interviewer">
+        <single>interviewer</single>
+        <multiple>interviewers</multiple>
+      </term>
+      <term form="long" name="issue">
         <single>issue</single>
         <multiple>issues</multiple>
       </term>
-      <term name="software">computer software</term>
-      <term name="at" form="long">before the</term>
-      <term name="collection">archival collection</term>
+      <term form="verb" name="performer">recorded by</term>
       <term name="post">online post</term>
-      <term name="at" form="long">before the</term>
-      <term name="hearing" form="verb">testimony of</term>
-      <term name="review-of" form="long">review of the</term>
-      <term name="review-of" form="short">review of</term>
+      <term form="long" name="review-of">review of the</term>
+      <term form="short" name="review-of">review of</term>
+      <term name="software">computer software</term>
+      <term form="short" name="translator">trans.</term>
     </terms>
   </locale>
   <locale xml:lang="da">
@@ -71,7 +76,7 @@
   </locale>
   <locale xml:lang="fr">
     <terms>
-      <term name="editor" form="short">
+      <term form="short" name="editor">
         <single>éd.</single>
         <multiple>éds.</multiple>
       </term>
@@ -97,29 +102,26 @@
       <term name="et-al">et al.</term>
     </terms>
   </locale>
-  <!-- For Indigeneous Knowledge, assume the item is stored as `document` or `speech`
-       and that Nation/Community, treaty, where the Elder lives, 
-       and topic are all stored in `title`
-       cf. https://libguides.norquest.ca/c.php?g=314831&p=5188823.
-       If the item is stored as `interview`, assume that Nation/Community, treat, and topic
-       are stored in `title`, 'Oral teaching' or similar is stored in `archive`, and where
-       the Elder lives is stored in `archive-place`. 
-  -->
-  <!-- Reviews are detected if an item has type `review` or `review-book` or if it has any of the variables
-       `reviewed-title`, `reviewed-author`, or `reviewed-genre`. For the latter case, reviews are commonly 
-       stored as types `article-journal`, `article-magazine`, `article-newspaper`, `post-weblog`, or `webpage` 
-  -->
-  <!-- General categories of item types:
-       Periodical: article-journal article-magazine article-newspaper periodical post-weblog review review-book
-       Periodical or Booklike: paper-conference
-       Booklike: article book broadcast chapter classic collection dataset document
-                 entry entry-dictionary entry-encyclopedia event figure
-                 graphic interview manuscript map motion_picture musical_score
-                 pamphlet patent performance personal_communication post report
-                 software song speech standard thesis webpage
-       Legal: bill hearing legal_case legislation regulation treaty
+  <!-- General categories of CSL item types:
+
+       Periodical
+       : article-journal article-magazine article-newspaper periodical post-weblog review review-book
+
+       Periodical or Booklike
+       : paper-conference
+
+       Booklike
+       : article book broadcast chapter classic collection dataset document
+         entry entry-dictionary entry-encyclopedia event figure
+         graphic interview manuscript map motion_picture musical_score
+         pamphlet patent performance personal_communication post report
+         software song speech standard thesis webpage
+
+       Legal
+       : bill hearing legal_case legislation regulation treaty
   -->
   <!-- Equivalencies:
+
        classic == book
        document == report, but give full date
        standard == report
@@ -128,6 +130,7 @@
        collection == book, but give full date
   -->
   <!-- Role equivalencies:
+
        compiler == editor
        organizer, curator == chair
        script-writer == director
@@ -135,128 +138,294 @@
        guest, host == director
        series-creator, executive-producer == editor
   -->
-  <!-- APA references contain four parts: author, date, title, source -->
+  <!-- Reviews are detected if an item has type `review` or `review-book` or if it has any of the variables
+       `reviewed-title`, `reviewed-author`, or `reviewed-genre`. For the latter case, reviews are commonly
+       stored as types `article-journal`, `article-magazine`, `article-newspaper`, `post-weblog`, or `webpage`
+  -->
+  <!-- For Indigeneous Knowledge, assume the item is stored as `document` or `speech`
+       and that Nation/Community, treaty, where the Elder lives,
+       and topic are all stored in `title`
+       cf. https://libguides.norquest.ca/c.php?g=314831&p=5188823.
+       If the item is stored as `interview`, assume that Nation/Community, treaty territory, and topic
+       are stored in `title`, 'Oral teaching' or similar is stored in `archive`, and where
+       the Elder lives is stored in `archive-place`.
+  -->
+  <!-- Variable labelling macros -->
+  <macro name="chapter-number-labelled">
+    <group delimiter=" ">
+      <choose>
+        <if is-numeric="chapter-number">
+          <label form="short" variable="chapter-number"/>
+        </if>
+      </choose>
+      <text variable="chapter-number"/>
+    </group>
+  </macro>
+  <macro name="edition-labelled">
+    <choose>
+      <if is-numeric="edition">
+        <group delimiter=" ">
+          <number form="ordinal" variable="edition"/>
+          <label form="short" variable="edition"/>
+        </group>
+      </if>
+      <else>
+        <text variable="edition"/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="issue-labelled">
+    <group delimiter=" ">
+      <label text-case="capitalize-first" variable="issue"/>
+      <text variable="issue"/>
+    </group>
+  </macro>
+  <macro name="locator-labelled">
+    <!-- Abbreviate page and paragraph; leave other locator labels in long form (APA 8.13) -->
+    <group delimiter=" ">
+      <choose>
+        <if locator="page paragraph" match="any">
+          <label form="short" variable="locator"/>
+        </if>
+        <else>
+          <label text-case="capitalize-first" variable="locator"/>
+        </else>
+      </choose>
+      <text variable="locator"/>
+    </group>
+  </macro>
+  <macro name="number-labelled">
+    <group delimiter=" ">
+      <choose>
+        <if is-numeric="number">
+          <label form="short" text-case="capitalize-first" variable="number"/>
+        </if>
+        <else-if match="none" type="broadcast">
+          <label form="short" text-case="capitalize-first" variable="number"/>
+        </else-if>
+      </choose>
+      <text variable="number"/>
+    </group>
+  </macro>
+  <macro name="number-article-labelled">
+    <!-- APA example 6: Journal article with article number or eLocator -->
+    <group delimiter=" ">
+      <text term="article-locator" text-case="capitalize-first"/>
+      <text variable="number"/>
+    </group>
+  </macro>
+  <macro name="number-of-volumes-labelled">
+    <choose>
+      <if is-numeric="number-of-volumes">
+        <group delimiter=" ">
+          <label form="short" text-case="capitalize-first" variable="number-of-volumes"/>
+          <text prefix="1" term="page-range-delimiter"/>
+        </group>
+      </if>
+    </choose>
+    <text variable="number-of-volumes"/>
+  </macro>
+  <macro name="page-labelled">
+    <group delimiter=" ">
+      <label form="short" variable="page"/>
+      <text variable="page"/>
+    </group>
+  </macro>
+  <macro name="part-number-labelled">
+    <group delimiter=" ">
+      <choose>
+        <if variable="part-number">
+          <!-- TODO: Replace with `part-number` label when CSL provides one -->
+          <text form="short" term="part" text-case="capitalize-first"/>
+          <text variable="part-number"/>
+        </if>
+      </choose>
+    </group>
+  </macro>
+  <macro name="section-labelled">
+    <group delimiter=" ">
+      <label form="symbol" variable="section"/>
+      <text variable="section"/>
+    </group>
+  </macro>
+  <macro name="supplement-number-labelled">
+    <group delimiter=" ">
+      <choose>
+        <if variable="supplement-number">
+          <!-- TODO: Replace with `supplement-number` label when CSL provides one -->
+          <text form="short" term="supplement" text-case="capitalize-first"/>
+          <text variable="supplement-number"/>
+        </if>
+      </choose>
+    </group>
+  </macro>
+  <macro name="version-labelled">
+    <group delimiter=" ">
+      <label text-case="capitalize-first" variable="version"/>
+      <text variable="version"/>
+    </group>
+  </macro>
+  <macro name="volume-labelled">
+    <group delimiter=" ">
+      <label form="short" text-case="capitalize-first" variable="volume"/>
+      <text variable="volume"/>
+    </group>
+  </macro>
+  <!-- Four parts in APA references:
+
+       1. Author (APA 9.7–12)
+       2. Date (APA 9.13–17)
+       3. Title (APA 9.18–22)
+       4. Source (APA 9.23–37)
+  -->
+  <!-- 1. Author -->
+  <!-- Author utility macros -->
+  <macro name="author-substitute-bib">
+    <names variable="composer">
+      <name delimiter-precedes-last="always" name-as-sort-order="all"/>
+      <label form="short" prefix=" (" suffix=")" text-case="title"/>
+      <substitute>
+        <names variable="author"/>
+        <!-- `narrator` only cited in secondary-contributors -->
+        <names variable="illustrator"/>
+        <choose>
+          <if type="broadcast">
+            <names variable="script-writer director">
+              <!-- Actors/performers and producers [not executive] not cited in APA style. -->
+              <name delimiter-precedes-last="always" name-as-sort-order="all"/>
+              <label form="long" prefix=" (" suffix=")" text-case="title"/>
+            </names>
+          </if>
+        </choose>
+        <names variable="director">
+          <!-- For non-broadcast items, APA only cites directors and not writers. -->
+          <name delimiter-precedes-last="always" name-as-sort-order="all"/>
+          <label form="long" prefix=" (" suffix=")" text-case="title"/>
+        </names>
+        <names variable="guest host">
+          <!-- TODO: Replace `delimiter` with `collapse` to combine names variables when that becomes available. -->
+          <name delimiter-precedes-last="always" name-as-sort-order="all"/>
+          <label form="long" prefix=" (" suffix=")" text-case="title"/>
+        </names>
+        <names variable="producer">
+          <!-- Producers not cited if there is a writer/director, but use if they are the principle creator. -->
+          <name delimiter-precedes-last="always" name-as-sort-order="all"/>
+          <label form="long" prefix=" (" suffix=")" text-case="title"/>
+        </names>
+        <choose>
+          <if variable="container-title">
+            <choose>
+              <if match="any" type="book classic collection entry entry-dictionary entry-encyclopedia">
+                <!-- Items with book-like container-title substitute with their title and identification,
+                     but leave description after container-title. This mimics the `container-booklike` formatting. -->
+                <text macro="title-substitute"/>
+              </if>
+            </choose>
+          </if>
+        </choose>
+        <names variable="executive-producer">
+          <name delimiter-precedes-last="always" name-as-sort-order="all"/>
+          <label form="long" prefix=" (" suffix=")" text-case="title"/>
+        </names>
+        <names variable="series-creator">
+          <name delimiter-precedes-last="always" name-as-sort-order="all"/>
+          <label form="long" prefix=" (" suffix=")" text-case="title"/>
+        </names>
+        <names variable="editor-translator"/>
+        <!-- Translator is not cited as a primary creator (only as Ed. & Trans.). -->
+        <names variable="editor"/>
+        <names variable="editorial-director"/>
+        <names variable="compiler">
+          <name delimiter-precedes-last="always" name-as-sort-order="all"/>
+          <label form="long" prefix=" (" suffix=")" text-case="title"/>
+        </names>
+        <choose>
+          <if match="any" type="event performance speech">
+            <names variable="chair">
+              <name delimiter-precedes-last="always" name-as-sort-order="all"/>
+              <label form="long" prefix=" (" suffix=")" text-case="title"/>
+            </names>
+            <names variable="organizer">
+              <name delimiter-precedes-last="always" name-as-sort-order="all"/>
+              <label form="long" prefix=" (" suffix=")" text-case="title"/>
+            </names>
+          </if>
+        </choose>
+        <names variable="curator">
+          <name delimiter-precedes-last="always" name-as-sort-order="all"/>
+          <label form="long" prefix=" (" suffix=")" text-case="title"/>
+        </names>
+        <names variable="collection-editor"/>
+        <text macro="title-substitute"/>
+      </substitute>
+    </names>
+  </macro>
+  <macro name="author-substitute-intext">
+    <names variable="composer">
+      <name form="short"/>
+      <substitute>
+        <names variable="author"/>
+        <names variable="illustrator"/>
+        <!-- TODO: Replace `delimiter` with `collapse` to combine names variables when that becomes available. -->
+        <choose>
+          <if type="broadcast">
+            <names variable="script-writer"/>
+          </if>
+        </choose>
+        <names variable="director"/>
+        <!-- TODO: Replace `delimiter` with `collapse` to combine names variables when that becomes available. -->
+        <names variable="guest host"/>
+        <names variable="producer"/>
+        <choose>
+          <if variable="container-title">
+            <choose>
+              <if match="any" type="book classic collection entry entry-dictionary entry-encyclopedia">
+                <text macro="title-intext"/>
+              </if>
+            </choose>
+          </if>
+        </choose>
+        <names variable="executive-producer"/>
+        <names variable="series-creator"/>
+        <names variable="editor"/>
+        <names variable="editorial-director"/>
+        <names variable="compiler"/>
+        <choose>
+          <if match="any" type="event performance speech">
+            <names variable="chair"/>
+            <names variable="organizer"/>
+          </if>
+        </choose>
+        <names variable="curator"/>
+        <text macro="title-intext"/>
+      </substitute>
+    </names>
+  </macro>
+  <macro name="title-substitute">
+    <choose>
+      <if variable="title">
+        <!-- If an item has a title, substitute missing author with title and identification, but leave description after the date (in the 'title' position). -->
+        <group delimiter=" ">
+          <text macro="title-bib"/>
+          <text macro="identification"/>
+        </group>
+      </if>
+      <else>
+        <!-- If an item has no title, substitute with description followed by identification. -->
+        <text macro="title-and-descriptions"/>
+      </else>
+    </choose>
+  </macro>
+  <!-- Author logic -->
   <macro name="author-bib">
     <group delimiter=" ">
-      <names variable="composer" delimiter=", &amp; ">
-        <name name-as-sort-order="all" and="symbol" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
-        <substitute>
-          <names variable="author"/>
-          <!-- Note: `narrator` only cited in secondary-contributors -->
-          <names variable="illustrator"/>
-          <!-- TODO: Replace `delimiter` with `collapse` to combine names variables when that becomes available. -->
-          <choose>
-            <if type="broadcast">
-              <names variable="script-writer director">
-                <!-- Note: Actors/performers and producers [not executive] not cited in APA style. -->
-                <name name-as-sort-order="all" and="symbol" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
-                <label form="long" prefix=" (" suffix=")" text-case="title"/>
-              </names>
-            </if>
-          </choose>
-          <names variable="director">
-            <!-- For non-broadcast items, APA only cites directors and not writers. -->
-            <name name-as-sort-order="all" and="symbol" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
-            <label form="long" prefix=" (" suffix=")" text-case="title"/>
-          </names>
-          <!-- TODO: Replace `delimiter` with `collapse` to combine names variables when that becomes available. -->
-          <names variable="guest host">
-            <name name-as-sort-order="all" and="symbol" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
-            <label form="long" prefix=" (" suffix=")" text-case="title"/>
-          </names>
-          <names variable="producer">
-            <!-- Note: Producers not cited if there is a writer/director, but use if they are the principle creator. -->
-            <name name-as-sort-order="all" and="symbol" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
-            <label form="long" prefix=" (" suffix=")" text-case="title"/>
-          </names>
-          <choose>
-            <if variable="container-title">
-              <choose>
-                <if type="book classic collection entry entry-dictionary entry-encyclopedia" match="any">
-                  <!-- Items with book-like container-title substitute with their title and parenthetical, 
-                       but leave bracketed after container-title. This mimics the `container-booklike` formatting. -->
-                  <choose>
-                    <if variable="title">
-                      <group delimiter=" ">
-                        <text macro="title"/>
-                        <text macro="parenthetical"/>
-                      </group>
-                    </if>
-                    <else>
-                      <text macro="title-and-descriptions"/>
-                    </else>
-                  </choose>
-                </if>
-              </choose>
-            </if>
-          </choose>
-          <names variable="executive-producer">
-            <name name-as-sort-order="all" and="symbol" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
-            <label form="long" prefix=" (" suffix=")" text-case="title"/>
-          </names>
-          <names variable="series-creator">
-            <name name-as-sort-order="all" and="symbol" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
-            <label form="long" prefix=" (" suffix=")" text-case="title"/>
-          </names>
-          <names variable="editor-translator">
-            <name name-as-sort-order="all" and="symbol" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
-            <label form="short" prefix=" (" suffix=")" text-case="title"/>
-          </names>
-          <!-- Note: Translator is not cited as a primary creator (only as Ed. & Trans.). -->
-          <names variable="editor">
-            <name name-as-sort-order="all" and="symbol" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
-            <label form="short" prefix=" (" suffix=")" text-case="title"/>
-          </names>
-          <names variable="editorial-director">
-            <name name-as-sort-order="all" and="symbol" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
-            <label form="short" prefix=" (" suffix=")" text-case="title"/>
-          </names>
-          <names variable="compiler">
-            <name name-as-sort-order="all" and="symbol" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
-            <label form="long" prefix=" (" suffix=")" text-case="title"/>
-          </names>
-          <choose>
-            <if type="event performance speech" match="any">
-              <names variable="chair">
-                <name name-as-sort-order="all" and="symbol" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
-                <label form="long" prefix=" (" suffix=")" text-case="title"/>
-              </names>
-              <names variable="organizer">
-                <name name-as-sort-order="all" and="symbol" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
-                <label form="long" prefix=" (" suffix=")" text-case="title"/>
-              </names>
-            </if>
-          </choose>
-          <names variable="curator">
-            <name name-as-sort-order="all" and="symbol" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
-            <label form="long" prefix=" (" suffix=")" text-case="title"/>
-          </names>
-          <names variable="collection-editor">
-            <name name-as-sort-order="all" and="symbol" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
-            <label form="short" prefix=" (" suffix=")" text-case="title"/>
-          </names>
-          <choose>
-            <if variable="title">
-              <!-- If an item has a title, substitute missing author with title and parenthetical, but leave bracketed 
-                   after the date (in the 'title' position). -->
-              <group delimiter=" ">
-                <text macro="title"/>
-                <text macro="parenthetical"/>
-              </group>
-            </if>
-            <else>
-              <!-- If an item has no title, substitute with bracketed followed by parenthetical. -->
-              <text macro="title-and-descriptions"/>
-            </else>
-          </choose>
-        </substitute>
-      </names>
+      <text macro="author-substitute-bib"/>
       <choose>
         <!-- Print "with" contributor for books, but not for other types that commonly have them (eg, thesis, software) -->
-        <if type="book classic collection" match="any">
-          <names variable="contributor" prefix="(" suffix=")">
+        <if match="any" type="book classic collection">
+          <names prefix="(" suffix=")" variable="contributor">
             <label form="verb" suffix=" "/>
-            <name name-as-sort-order="all" and="symbol" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
+            <name delimiter-precedes-last="always" name-as-sort-order="all"/>
           </names>
         </if>
       </choose>
@@ -264,80 +433,21 @@
   </macro>
   <macro name="author-intext">
     <choose>
-      <if type="bill hearing legal_case legislation regulation treaty" match="any">
+      <if match="any" type="bill hearing legal_case legislation regulation treaty">
         <text macro="title-intext"/>
       </if>
-      <else-if type="interview personal_communication" match="any">
-        <choose>
-          <!-- These variables indicate that the letter is retrievable by the reader.
-                If not, then use the APA in-text-only personal communication format -->
-          <if variable="archive container-title DOI publisher URL" match="none">
-            <group delimiter=", ">
-              <names variable="author">
-                <name and="symbol" delimiter=", " initialize-with=". "/>
-                <substitute>
-                  <text macro="title-intext"/>
-                </substitute>
-              </names>
-              <text term="personal-communication"/>
-            </group>
-          </if>
-          <else>
-            <names variable="author" delimiter=", ">
-              <name form="short" and="symbol" delimiter=", " initialize-with=". "/>
-              <substitute>
-                <text macro="title-intext"/>
-              </substitute>
-            </names>
-          </else>
-        </choose>
+      <else-if match="any" type="interview personal_communication">
+        <text macro="title-intext-interview-communication"/>
       </else-if>
       <else>
-        <names variable="composer" delimiter=" &amp; ">
-          <name form="short" and="symbol" delimiter=", " initialize-with=". "/>
-          <substitute>
-            <names variable="author"/>
-            <names variable="illustrator"/>
-            <!-- TODO: Replace `delimiter` with `collapse` to combine names variables when that becomes available. -->
-            <choose>
-              <if type="broadcast">
-                <names variable="script-writer director"/>
-              </if>
-            </choose>
-            <names variable="director"/>
-            <!-- TODO: Replace `delimiter` with `collapse` to combine names variables when that becomes available. -->
-            <names variable="guest host"/>
-            <names variable="producer"/>
-            <choose>
-              <if variable="container-title">
-                <choose>
-                  <if type="book classic collection entry entry-dictionary entry-encyclopedia" match="any">
-                    <text macro="title-intext"/>
-                  </if>
-                </choose>
-              </if>
-            </choose>
-            <names variable="executive-producer"/>
-            <names variable="series-creator"/>
-            <names variable="editor"/>
-            <names variable="editorial-director"/>
-            <names variable="compiler"/>
-            <choose>
-              <if type="event performance speech" match="any">
-                <names variable="chair"/>
-                <names variable="organizer"/>
-              </if>
-            </choose>
-            <names variable="curator"/>
-            <text macro="title-intext"/>
-          </substitute>
-        </names>
+        <text macro="author-substitute-intext"/>
       </else>
     </choose>
   </macro>
+  <!-- Author sorting -->
   <macro name="author-sort">
     <choose>
-      <if type="bill hearing legal_case legislation regulation treaty" match="any">
+      <if match="any" type="bill hearing legal_case legislation regulation treaty">
         <text macro="title-legal"/>
       </if>
       <else>
@@ -345,92 +455,161 @@
       </else>
     </choose>
   </macro>
-  <macro name="date-bib">
-    <group delimiter=" " prefix="(" suffix=")">
-      <choose>
-        <if is-uncertain-date="issued">
-          <text term="circa" form="short"/>
-        </if>
-      </choose>
-      <group>
-        <choose>
-          <if variable="issued">
-            <group delimiter=", ">
-              <group>
-                <date variable="issued" date-parts="year" form="numeric"/>
-                <text variable="year-suffix"/>
-              </group>
-              <choose>
-                <if type="article-magazine article-newspaper broadcast collection document event interview motion_picture pamphlet performance personal_communication post post-weblog song speech webpage" match="any">
-                  <!-- Many video and audio examples in manual give full dates. Err on the side of too much information. -->
-                  <date variable="issued">
-                    <date-part name="month"/>
-                    <date-part name="day" prefix=" "/>
-                  </date>
-                </if>
-                <else-if type="paper-conference">
-                  <!-- Capture 'speech' stored as 'paper-conference' -->
-                  <choose>
-                    <if variable="collection-editor compiler editor editorial-director issue page volume" match="none">
-                      <date variable="issued">
-                        <date-part name="month"/>
-                        <date-part name="day" prefix=" "/>
-                      </date>
-                    </if>
-                  </choose>
-                </else-if>
-                <!-- Only year: article article-journal book chapter classic entry entry-dictionary entry-encyclopedia dataset figure graphic
-                     manuscript map musical_score paper-conference[published] patent periodical report review review-book software standard thesis -->
-              </choose>
-            </group>
-          </if>
-          <else-if variable="status">
-            <group>
-              <!-- We print the status variable directly rather than using in-press, etc. terms. -->
-              <text variable="status" text-case="lowercase"/>
-              <text variable="year-suffix" prefix="-"/>
-            </group>
-          </else-if>
-          <else>
-            <text term="no date" form="short"/>
-            <text variable="year-suffix" prefix="-"/>
-          </else>
-        </choose>
-      </group>
+  <!-- 2. Date -->
+  <!-- Date utility macros -->
+  <macro name="date-issued-full">
+    <group delimiter=" ">
+      <text macro="uncertain-date-issued"/>
+      <date form="text" variable="issued"/>
     </group>
   </macro>
-  <macro name="date-sort">
-    <!-- This is necessary to ensure that citeproc sorts all item types chonologically in the same list. -->
+  <macro name="date-issued-leading-zeros">
+    <date delimiter="-" variable="issued">
+      <date-part form="long" name="year"/>
+      <date-part form="numeric-leading-zeros" name="month"/>
+      <date-part form="numeric-leading-zeros" name="day"/>
+    </date>
+  </macro>
+  <macro name="date-issued-month-day">
+    <date variable="issued">
+      <date-part name="month"/>
+      <date-part name="day" prefix=" "/>
+    </date>
+  </macro>
+  <macro name="date-issued-year">
+    <group delimiter=" ">
+      <text macro="uncertain-date-issued"/>
+      <date date-parts="year" form="numeric" variable="issued"/>
+    </group>
+  </macro>
+  <macro name="original-date-year">
+    <group delimiter=" ">
+      <choose>
+        <if is-uncertain-date="original-date">
+          <text form="short" term="circa"/>
+        </if>
+      </choose>
+      <date variable="original-date">
+        <date-part name="year"/>
+      </date>
+    </group>
+  </macro>
+  <macro name="uncertain-date-issued">
     <choose>
-      <if type="article article-journal book chapter entry entry-dictionary entry-encyclopedia dataset figure graphic manuscript map musical_score patent report review review-book thesis" match="any">
-        <date variable="issued" date-parts="year" form="numeric"/>
+      <if is-uncertain-date="issued">
+        <text form="short" term="circa"/>
+      </if>
+    </choose>
+  </macro>
+  <!-- Date logic -->
+  <macro name="date-bib">
+    <group prefix="(" suffix=")">
+      <choose>
+        <if variable="issued">
+          <group delimiter=", ">
+            <group>
+              <text macro="date-issued-year"/>
+              <text variable="year-suffix"/>
+            </group>
+            <choose>
+              <if match="any" type="article-magazine article-newspaper broadcast collection document event interview motion_picture pamphlet performance personal_communication post post-weblog song speech webpage">
+                <!-- Many video and audio examples in manual give full dates. Err on the side of too much information. -->
+                <text macro="date-issued-month-day"/>
+              </if>
+              <else-if type="paper-conference">
+                <!-- Capture 'speech' stored as 'paper-conference' -->
+                <choose>
+                  <if match="none" variable="collection-editor compiler editor editorial-director issue page volume">
+                    <text macro="date-issued-month-day"/>
+                  </if>
+                </choose>
+              </else-if>
+              <!-- Only year: article article-journal book chapter classic entry entry-dictionary entry-encyclopedia dataset figure graphic
+                     manuscript map musical_score paper-conference[published] patent periodical report review review-book software standard thesis -->
+            </choose>
+          </group>
+        </if>
+        <else-if variable="status">
+          <group>
+            <!-- We print the status variable directly rather than using in-press, etc. terms. -->
+            <text text-case="lowercase" variable="status"/>
+            <text prefix="-" variable="year-suffix"/>
+          </group>
+        </else-if>
+        <else>
+          <text form="short" term="no date"/>
+          <text prefix="-" variable="year-suffix"/>
+        </else>
+      </choose>
+    </group>
+  </macro>
+  <macro name="date-intext">
+    <choose>
+      <if variable="issued">
+        <group delimiter="/">
+          <text macro="original-date-year"/>
+          <group>
+            <choose>
+              <if match="any" type="interview personal_communication">
+                <choose>
+                  <if match="none" variable="archive archive-place container-title DOI publisher URL">
+                    <!-- These variables indicate that the communication is retrievable by the reader.
+                           If not, then use the in-text-only personal communication format -->
+                    <text macro="date-issued-full"/>
+                  </if>
+                  <else>
+                    <text macro="date-issued-year"/>
+                  </else>
+                </choose>
+              </if>
+              <else>
+                <text macro="date-issued-year"/>
+              </else>
+            </choose>
+            <text variable="year-suffix"/>
+          </group>
+        </group>
+      </if>
+      <else-if variable="status">
+        <!-- We print the status variable directly rather than using in-press, etc. terms. -->
+        <text text-case="lowercase" variable="status"/>
+        <text prefix="-" variable="year-suffix"/>
+      </else-if>
+      <else>
+        <text form="short" term="no date"/>
+        <text prefix="-" variable="year-suffix"/>
+      </else>
+    </choose>
+  </macro>
+  <!-- Date sorting -->
+  <macro name="date-sort">
+    <!-- Sort items by printed issue date without prefixes for original or uncertain dates -->
+    <choose>
+      <if match="any" type="article article-journal book chapter entry entry-dictionary entry-encyclopedia dataset figure graphic manuscript map musical_score patent report review review-book thesis">
+        <date date-parts="year" form="numeric" variable="issued"/>
       </if>
       <else-if type="paper-conference">
         <!-- Capture 'speech' stored as 'paper-conference' -->
         <choose>
-          <if variable="collection-editor compiler editor editorial-director issue page volume" match="any">
-            <date variable="issued" date-parts="year" form="numeric"/>
+          <if match="any" variable="collection-editor compiler editor editorial-director issue page volume">
+            <date date-parts="year" form="numeric" variable="issued"/>
           </if>
           <else>
-            <date variable="issued">
-              <date-part name="year" form="long"/>
-              <date-part name="month" form="numeric-leading-zeros"/>
-              <date-part name="day" form="numeric-leading-zeros"/>
-            </date>
+            <text macro="date-issued-leading-zeros"/>
           </else>
         </choose>
       </else-if>
       <else>
-        <date variable="issued">
-          <date-part name="year" form="long"/>
-          <date-part name="month" form="numeric-leading-zeros"/>
-          <date-part name="day" form="numeric-leading-zeros"/>
-        </date>
+        <text macro="date-issued-leading-zeros"/>
       </else>
     </choose>
   </macro>
   <macro name="date-sort-group">
-    <!-- APA sorts 1. no-date items, 2. items with dates, 3. in-press (status) items -->
+    <!-- Sorts items with and without dates:
+
+         1. no-date items (= 0)
+         2. items with dates (= 1)
+         3. in-press (status) items (= 2) -->
     <choose>
       <if variable="issued">
         <text value="1"/>
@@ -443,111 +622,185 @@
       </else>
     </choose>
   </macro>
-  <macro name="date-intext">
-    <choose>
-      <if variable="issued">
-        <group delimiter="/">
-          <group delimiter=" ">
-            <choose>
-              <if is-uncertain-date="original-date">
-                <text term="circa" form="short"/>
-              </if>
-            </choose>
-            <date variable="original-date">
-              <date-part name="year"/>
-            </date>
-          </group>
-          <group delimiter=" ">
-            <choose>
-              <if is-uncertain-date="issued">
-                <text term="circa" form="short"/>
-              </if>
-            </choose>
-            <group>
-              <choose>
-                <if type="interview personal_communication" match="any">
-                  <choose>
-                    <if variable="archive container-title DOI publisher URL" match="none">
-                      <!-- These variables indicate that the communication is retrievable by the reader.
-                           If not, then use the in-text-only personal communication format -->
-                      <date variable="issued" form="text"/>
-                    </if>
-                    <else>
-                      <date variable="issued">
-                        <date-part name="year"/>
-                      </date>
-                    </else>
-                  </choose>
-                </if>
-                <else>
-                  <date variable="issued">
-                    <date-part name="year"/>
-                  </date>
-                </else>
-              </choose>
-              <text variable="year-suffix"/>
-            </group>
-          </group>
-        </group>
-      </if>
-      <else-if variable="status">
-        <!-- We print the status variable directly rather than using in-press, etc. terms. -->
-        <text variable="status" text-case="lowercase"/>
-        <text variable="year-suffix" prefix="-"/>
-      </else-if>
-      <else>
-        <text term="no date" form="short"/>
-        <text variable="year-suffix" prefix="-"/>
-      </else>
-    </choose>
-  </macro>
-  <!-- APA has two description elements following the title:
-       title (parenthetical) [bracketed] -->
+  <!-- 3. Title and descriptions -->
+  <!-- Three parts in title element (APA 9.21):
+
+       1. Title
+       2. Identification (in parentheses)
+       3. Description [in square brackets] -->
   <macro name="title-and-descriptions">
     <choose>
       <if variable="title">
         <group delimiter=" ">
-          <text macro="title"/>
-          <text macro="parenthetical"/>
-          <text macro="bracketed"/>
+          <text macro="title-bib"/>
+          <text macro="identification"/>
+          <text macro="description-bib"/>
         </group>
       </if>
       <else>
         <choose>
-          <if type="bill report" match="any">
+          <if match="any" type="bill report">
             <!-- Bills, resolutions, and congressional reports are not italicized and substitute bill number if no title. -->
-            <!-- Can't distinguish congressional reports from other reports, 
+            <!-- Can't distinguish congressional reports from other reports,
                  but giving the genre and number seems fine for other reports too. -->
-            <text macro="number"/>
-            <text macro="bracketed"/>
-            <text macro="parenthetical"/>
+            <text macro="genre-number"/>
+            <text macro="description-bib"/>
+            <text macro="identification"/>
           </if>
           <else>
             <group delimiter=" ">
-              <text macro="bracketed"/>
-              <text macro="parenthetical"/>
+              <text macro="description-bib"/>
+              <text macro="identification"/>
             </group>
           </else>
         </choose>
       </else>
     </choose>
   </macro>
-  <macro name="title">
+  <!-- 3.1. Title -->
+  <!-- Title utility macros -->
+  <macro name="title-intext-bill-report">
+    <!-- Bills, resolutions, and congressional reports are not italicized and substitute bill number if no title. -->
+    <!-- Can't distinguish congressional reports from other reports,
+             but giving the genre and number seems fine for other reports too. -->
     <choose>
-      <if type="post webpage" match="any">
+      <if variable="title">
+        <text form="short" text-case="title" variable="title"/>
+      </if>
+      <else>
+        <group delimiter=" ">
+          <text variable="genre"/>
+          <group delimiter=" ">
+            <choose>
+              <if match="none" variable="chapter-number container-title">
+                <text macro="number-labelled"/>
+              </if>
+              <else>
+                <text variable="number"/>
+              </else>
+            </choose>
+          </group>
+        </group>
+      </else>
+    </choose>
+  </macro>
+  <macro name="title-intext-interview-communication">
+    <choose>
+      <!-- These variables indicate that the letter is retrievable by the reader.
+                If not, then use the APA in-text-only personal communication format -->
+      <if match="none" variable="archive archive-place container-title DOI publisher URL">
+        <group delimiter=", ">
+          <names variable="author">
+            <substitute>
+              <text macro="title-intext"/>
+            </substitute>
+          </names>
+          <text term="personal-communication"/>
+        </group>
+      </if>
+      <else>
+        <names variable="author">
+          <name form="short"/>
+          <substitute>
+            <text macro="title-intext"/>
+          </substitute>
+        </names>
+      </else>
+    </choose>
+  </macro>
+  <macro name="title-part">
+    <group delimiter=". ">
+      <text macro="part-number-labelled"/>
+      <text text-case="capitalize-first" variable="part-title"/>
+    </group>
+  </macro>
+  <macro name="title-plus-part-title">
+    <choose>
+      <if match="any" type="review review-book" variable="reviewed-author reviewed-genre reviewed-title">
+        <!-- If a review has no `reviewed-title`, assume that `title` contains the title of the reviewed work
+             and omit it here; it is printed in the `reviewed-item` macro. -->
+        <choose>
+          <if match="none" variable="reviewed-title"/>
+          <else>
+            <group delimiter=": ">
+              <text variable="title"/>
+              <text macro="title-part"/>
+            </group>
+          </else>
+        </choose>
+      </if>
+      <else>
+        <group delimiter=": ">
+          <text variable="title"/>
+          <text macro="title-part"/>
+        </group>
+      </else>
+    </choose>
+  </macro>
+  <macro name="title-plus-volume-title">
+    <group delimiter=": ">
+      <text variable="title"/>
+      <text macro="title-volume"/>
+    </group>
+  </macro>
+  <macro name="title-volume">
+    <group delimiter=": ">
+      <choose>
+        <if variable="volume-title">
+          <group delimiter=". ">
+            <text macro="volume-labelled"/>
+            <text variable="volume-title"/>
+          </group>
+        </if>
+        <else-if is-numeric="volume" match="none">
+          <text macro="volume-labelled"/>
+        </else-if>
+      </choose>
+      <!-- For book-like items, assume part-number and part-title refer to the book/volume. -->
+      <text macro="title-part"/>
+    </group>
+  </macro>
+  <!-- Title logic -->
+  <macro name="booklike-title">
+    <!-- For book-like items, assume part-number and part-title refer to the book/volume. -->
+    <choose>
+      <if variable="container-title">
+        <text variable="title"/>
+      </if>
+      <else>
+        <!-- For book-like items without container titles and with volume-title, append volume-title to title (APA example 30) -->
+        <text font-style="italic" macro="title-plus-volume-title"/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="periodical-title">
+    <!-- For periodicals, assume that part-number and part-title refer to the article and append to title -->
+    <choose>
+      <if variable="container-title">
+        <text macro="title-plus-part-title"/>
+      </if>
+      <else>
+        <!-- for periodical items without container titles, don't append volume-title to title -->
+        <text font-style="italic" macro="title-plus-part-title"/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="title-bib">
+    <choose>
+      <if match="any" type="post webpage">
         <!-- Webpages are always italicized -->
-        <text macro="title-plus-part-title" font-style="italic"/>
+        <text font-style="italic" macro="title-plus-part-title"/>
       </if>
       <!-- Other types are italicized based on presence of container-title.
              Assume that review and review-book are published in periodicals/blogs,
-             not just on a web page (ex. 69) -->
-      <else-if type="article-journal article-magazine article-newspaper periodical post-weblog review review-book" match="any">
+             not just on a webpage (APA example 69) -->
+      <else-if match="any" type="article-journal article-magazine article-newspaper periodical post-weblog review review-book">
         <text macro="periodical-title"/>
       </else-if>
       <else-if type="paper-conference">
         <!-- Treat paper-conference as book-like if it has an editor, otherwise as periodical-like -->
         <choose>
-          <if variable="collection-editor compiler editor editorial-director" match="any">
+          <if match="any" variable="collection-editor compiler editor editorial-director">
             <text macro="booklike-title"/>
           </if>
           <else>
@@ -560,607 +813,104 @@
       </else>
     </choose>
   </macro>
-  <macro name="periodical-title">
-    <!-- For periodicals, assume that part-number and part-title refer to the article and append to title -->
-    <choose>
-      <if variable="container-title" match="any">
-        <text macro="title-plus-part-title"/>
-      </if>
-      <else>
-        <!-- for periodical items without container titles, don't append volume-title to title -->
-        <text macro="title-plus-part-title" font-style="italic"/>
-      </else>
-    </choose>
-  </macro>
-  <macro name="booklike-title">
-    <!-- For book-like items, assume part-number and part-title refer to the book/volume. -->
-    <choose>
-      <if variable="container-title" match="any">
-        <text variable="title"/>
-      </if>
-      <else>
-        <!-- For book-like items without container titles and with volume-title, append volume-title to title (ex. 30) -->
-        <text macro="title-plus-volume-title" font-style="italic"/>
-      </else>
-    </choose>
-  </macro>
-  <macro name="title-plus-part-title">
-    <choose>
-      <if variable="reviewed-author reviewed-genre reviewed-title" type="review review-book" match="any">
-        <!-- If a review has no `reviewed-title`, assume that `title` contains the title of the reviewed work
-             and omit it here; it is printed in the `reviewed-item` macro. -->
-        <choose>
-          <if variable="reviewed-title" match="none"/>
-          <else>
-            <group delimiter=": ">
-              <text variable="title"/>
-              <text macro="part-title"/>
-            </group>
-          </else>
-        </choose>
-      </if>
-      <else>
-        <group delimiter=": ">
-          <text variable="title"/>
-          <text macro="part-title"/>
-        </group>
-      </else>
-    </choose>
-  </macro>
-  <macro name="part-title">
-    <group delimiter=". ">
-      <group delimiter=" ">
-        <label variable="part-number" form="short" text-case="capitalize-first"/>
-        <text variable="part-number"/>
-      </group>
-      <text variable="part-title" text-case="capitalize-first"/>
-    </group>
-  </macro>
-  <macro name="title-plus-volume-title">
-    <group delimiter=": ">
-      <text variable="title"/>
-      <text macro="volume-title"/>
-    </group>
-  </macro>
-  <macro name="volume-title">
-    <group delimiter=": ">
-      <choose>
-        <if variable="volume-title">
-          <group delimiter=" ">
-            <group delimiter=". ">
-              <group delimiter=" ">
-                <label variable="volume" form="short" text-case="capitalize-first"/>
-                <text variable="volume"/>
-              </group>
-              <text variable="volume-title"/>
-            </group>
-          </group>
-        </if>
-        <else-if is-numeric="volume" match="none">
-          <group delimiter=" ">
-            <label variable="volume" form="short" text-case="capitalize-first"/>
-            <text variable="volume"/>
-          </group>
-        </else-if>
-      </choose>
-      <!-- For book-like items, assume part-number and part-title refer to the book/volume. -->
-      <text macro="part-title"/>
-    </group>
-  </macro>
   <macro name="title-intext">
     <choose>
-      <if type="bill report">
-        <!-- Bills, resolutions, and congressional reports are not italicized and substitute bill number if no title. -->
-        <!-- Can't distinguish congressional reports from other reports, 
-             but giving the genre and number seems fine for other reports too. -->
-        <choose>
-          <if variable="title">
-            <text variable="title" form="short" text-case="title"/>
-          </if>
-          <else>
-            <group delimiter=" ">
-              <text variable="genre"/>
-              <group delimiter=" ">
-                <choose>
-                  <if variable="chapter-number container-title" match="none">
-                    <label variable="number" form="short" text-case="capitalize-first"/>
-                  </if>
-                </choose>
-                <text variable="number"/>
-              </group>
-            </group>
-          </else>
-        </choose>
+      <if match="any" type="bill report">
+        <text macro="title-intext-bill-report"/>
       </if>
       <else>
         <choose>
-          <if variable="title" match="none">
-            <text macro="bracketed-intext"/>
+          <if match="none" variable="title">
+            <text macro="description-intext"/>
           </if>
-          <else-if type="hearing">
-            <!-- Hearings are italicized -->
-            <text variable="title" form="short" font-style="italic" text-case="title"/>
+          <else-if type="hearing webpage">
+            <!-- Italicized with title case -->
+            <text font-style="italic" form="short" text-case="title" variable="title"/>
           </else-if>
-          <else-if type="legal_case" match="any">
-            <!-- Cases are italicized -->
-            <text variable="title" font-style="italic"/>
+          <else-if type="legal_case post">
+            <!-- Italicized -->
+            <text font-style="italic" form="short" variable="title"/>
           </else-if>
-          <else-if type="legislation regulation treaty" match="any">
-            <!-- Legislation, regulations, and treaties not italicized or quoted -->
-            <text variable="title" form="short" text-case="title"/>
+          <else-if match="any" type="legislation regulation treaty">
+            <!-- No italics or quotes -->
+            <text form="short" text-case="title" variable="title"/>
           </else-if>
-          <else-if type="post webpage" match="any">
-            <!-- Webpages are always italicized -->
-            <text variable="title" form="short" font-style="italic" text-case="title"/>
-          </else-if>
-          <else-if variable="container-title" match="any">
-            <!-- Other types are italicized or quoted based on presence of container-title. As in title macro. -->
-            <text variable="title" form="short" quotes="true" text-case="title"/>
+          <else-if variable="container-title">
+            <!-- Other types are formatted based on presence of container-title, as in title-bib macro -->
+            <text form="short" quotes="true" text-case="title" variable="title"/>
           </else-if>
           <else>
-            <text variable="title" form="short" font-style="italic" text-case="title"/>
+            <text font-style="italic" form="short" text-case="title" variable="title"/>
           </else>
         </choose>
       </else>
     </choose>
   </macro>
-  <macro name="parenthetical">
-    <!-- (Secondary contributors; Database location; Genre no. 123; Report Series 123, Version, Edition, Volume, Page) -->
-    <group prefix="(" suffix=")">
-      <choose>
-        <if type="patent">
-          <!-- authority: U.S. ; genre: patent ; number: 123,445 -->
-          <group delimiter=" ">
-            <text variable="authority" form="short"/>
-            <choose>
-              <if variable="genre">
-                <text variable="genre" text-case="capitalize-first"/>
-              </if>
-              <else>
-                <text term="patent" text-case="capitalize-first"/>
-              </else>
-            </choose>
-            <group delimiter=" ">
-              <label variable="number" form="short" text-case="capitalize-first"/>
-              <text variable="number"/>
-            </group>
-          </group>
-        </if>
-        <else-if type="post webpage" match="any">
-          <!-- For post webpage, container-title is treated as publisher -->
-          <group delimiter="; ">
-            <text macro="secondary-contributors"/>
-            <text macro="database-location"/>
-            <text macro="number"/>
-            <text macro="locators-booklike"/>
-          </group>
-        </else-if>
-        <else-if type="report" match="any">
-          <choose>
-            <if variable="title" match="none">
-              <!-- If there is no title, then genre and number are already printed as the title. -->
-              <group delimiter="; ">
-                <text macro="secondary-contributors"/>
-                <text macro="database-location"/>
-                <text macro="locators-booklike"/>
-              </group>
-            </if>
-            <!-- If the report is a chapter in a larger report, then most parenthetical information is printed after the container. -->
-            <else-if variable="container-title">
-              <text macro="secondary-contributors"/>
-            </else-if>
-            <else>
-              <group delimiter="; ">
-                <text macro="secondary-contributors"/>
-                <text macro="database-location"/>
-                <text macro="number"/>
-                <text macro="locators-booklike"/>
-              </group>
-            </else>
-          </choose>
-        </else-if>
-        <else-if variable="container-title">
-          <group delimiter="; ">
-            <text macro="secondary-contributors"/>
-            <choose>
-              <if type="broadcast graphic map motion_picture song" match="any">
-                <!-- For audiovisual media, number information comes after title, not container-title (ex. 94) -->
-                <text macro="number"/>
-              </if>
-            </choose>
-          </group>
-        </else-if>
-        <else>
-          <group delimiter="; ">
-            <text macro="secondary-contributors"/>
-            <text macro="database-location"/>
-            <text macro="number"/>
-            <text macro="locators-booklike"/>
-          </group>
-        </else>
-      </choose>
-    </group>
-  </macro>
-  <macro name="parenthetical-container">
+  <!-- 3.2. Identification (in parentheses) -->
+  <!-- Identification utility macros -->
+  <macro name="database-location">
     <choose>
-      <if variable="container-title" match="any">
-        <group prefix="(" suffix=")">
-          <group delimiter="; ">
-            <text macro="database-location"/>
-            <choose>
-              <if type="broadcast graphic map motion_picture song" match="none">
-                <!-- For audiovisual media, number information comes after title, not container-title (ex. 94) -->
-                <text macro="number"/>
-              </if>
-            </choose>
-            <text macro="locators-booklike"/>
+      <if match="none" variable="archive-place">
+        <!-- With `archive-place`: physical archives. Without: online archives. -->
+        <text variable="archive_location"/>
+      </if>
+    </choose>
+  </macro>
+  <macro name="genre-number">
+    <choose>
+      <if variable="number">
+        <group delimiter=", ">
+          <group delimiter=" ">
+            <text text-case="title" variable="genre"/>
+            <text macro="number-labelled"/>
           </group>
+          <choose>
+            <if type="thesis">
+              <choose>
+                <if match="any" variable="archive DOI URL">
+                  <!-- Include the university in brackets if thesis is published -->
+                  <text variable="publisher"/>
+                </if>
+              </choose>
+            </if>
+          </choose>
         </group>
       </if>
     </choose>
   </macro>
-  <macro name="bracketed">
-    <!-- [Descriptive information] -->
-    <!-- If there is a number, genre is already printed in macro="number" -->
-    <group prefix="[" suffix="]">
+  <macro name="locators-booklike">
+    <choose>
+      <if variable="page">
+        <text macro="page-labelled"/>
+      </if>
+      <else-if variable="chapter-number">
+        <text macro="chapter-number-labelled"/>
+      </else-if>
+    </choose>
+  </macro>
+  <macro name="patent-number">
+    <group delimiter=" ">
+      <!-- authority: U.S. ; genre: patent ; number: 123,445 -->
+      <text form="short" variable="authority"/>
       <choose>
-        <if variable="reviewed-author reviewed-genre reviewed-title" type="review review-book" match="any">
-          <text macro="reviewed-item"/>
+        <if variable="genre">
+          <text text-case="capitalize-first" variable="genre"/>
         </if>
-        <else-if type="thesis">
-          <!-- Thesis type and institution -->
-          <group delimiter="; ">
-            <choose>
-              <if variable="number" match="none">
-                <group delimiter=", ">
-                  <text variable="genre" text-case="capitalize-first"/>
-                  <choose>
-                    <if variable="archive DOI URL" match="any">
-                      <!-- Include the university in brackets if thesis is published -->
-                      <text variable="publisher"/>
-                    </if>
-                  </choose>
-                </group>
-              </if>
-            </choose>
-            <text variable="medium" text-case="capitalize-first"/>
-          </group>
-        </else-if>
-        <else-if variable="interviewer" type="interview" match="any">
-          <!-- Interview information -->
-          <choose>
-            <if variable="title">
-              <text macro="format"/>
-            </if>
-            <else-if variable="genre">
-              <group delimiter="; ">
-                <group delimiter=" ">
-                  <text variable="genre" text-case="capitalize-first"/>
-                  <group delimiter=" ">
-                    <text term="container-author" form="verb"/>
-                    <names variable="interviewer">
-                      <name and="symbol" initialize-with=". " delimiter=", "/>
-                    </names>
-                  </group>
-                </group>
-              </group>
-            </else-if>
-            <else-if variable="interviewer">
-              <group delimiter="; ">
-                <names variable="interviewer">
-                  <label form="verb" suffix=" " text-case="capitalize-first"/>
-                  <name and="symbol" initialize-with=". " delimiter=", "/>
-                </names>
-                <text variable="medium" text-case="capitalize-first"/>
-              </group>
-            </else-if>
-            <else>
-              <text macro="format"/>
-            </else>
-          </choose>
-        </else-if>
-        <else-if type="personal_communication">
-          <!-- Letter information -->
-          <choose>
-            <if variable="recipient">
-              <group delimiter="; ">
-                <group delimiter=" ">
-                  <choose>
-                    <if variable="number" match="none">
-                      <choose>
-                        <if variable="genre">
-                          <text variable="genre" text-case="capitalize-first"/>
-                        </if>
-                        <else-if variable="medium">
-                          <text variable="medium" text-case="capitalize-first"/>
-                        </else-if>
-                        <else>
-                          <text term="letter" text-case="capitalize-first"/>
-                        </else>
-                      </choose>
-                    </if>
-                    <else>
-                      <choose>
-                        <if variable="medium">
-                          <text variable="medium" text-case="capitalize-first"/>
-                        </if>
-                        <else>
-                          <text term="letter" text-case="capitalize-first"/>
-                        </else>
-                      </choose>
-                    </else>
-                  </choose>
-                  <names variable="recipient" delimiter=", ">
-                    <label form="verb" suffix=" "/>
-                    <name and="symbol" delimiter=", "/>
-                  </names>
-                </group>
-                <choose>
-                  <if variable="genre" match="any">
-                    <choose>
-                      <if variable="number" match="none">
-                        <text variable="medium" text-case="capitalize-first"/>
-                      </if>
-                    </choose>
-                  </if>
-                </choose>
-              </group>
-            </if>
-            <else>
-              <text macro="format"/>
-            </else>
-          </choose>
-        </else-if>
-        <else-if variable="composer" type="song" match="all">
-          <!-- Performer of classical music works -->
-          <group delimiter="; ">
-            <choose>
-              <if variable="number" match="none">
-                <group delimiter=" ">
-                  <choose>
-                    <if variable="genre">
-                      <text variable="genre" text-case="capitalize-first"/>
-                      <group delimiter=" ">
-                        <text term="performer" form="verb"/>
-                        <names variable="author">
-                          <name and="symbol" initialize-with=". " delimiter=", "/>
-                          <substitute>
-                            <names variable="performer"/>
-                          </substitute>
-                        </names>
-                      </group>
-                    </if>
-                    <else-if variable="medium">
-                      <text variable="medium" text-case="capitalize-first"/>
-                      <group delimiter=" ">
-                        <text term="performer" form="verb"/>
-                        <names variable="author">
-                          <name and="symbol" initialize-with=". " delimiter=", "/>
-                          <substitute>
-                            <names variable="performer"/>
-                          </substitute>
-                        </names>
-                      </group>
-                    </else-if>
-                    <else>
-                      <text term="performer" form="verb" text-case="capitalize-first"/>
-                      <names variable="author">
-                        <name and="symbol" initialize-with=". " delimiter=", "/>
-                        <substitute>
-                          <names variable="performer"/>
-                        </substitute>
-                      </names>
-                    </else>
-                  </choose>
-                </group>
-              </if>
-              <else>
-                <group delimiter=" ">
-                  <choose>
-                    <if variable="medium">
-                      <text variable="medium" text-case="capitalize-first"/>
-                      <group delimiter=" ">
-                        <text term="performer" form="verb"/>
-                        <names variable="author">
-                          <name and="symbol" initialize-with=". " delimiter=", "/>
-                          <substitute>
-                            <names variable="performer"/>
-                          </substitute>
-                        </names>
-                      </group>
-                    </if>
-                    <else>
-                      <text term="performer" form="verb" text-case="capitalize-first"/>
-                      <names variable="author">
-                        <name and="symbol" initialize-with=". " delimiter=", "/>
-                        <substitute>
-                          <names variable="performer"/>
-                        </substitute>
-                      </names>
-                    </else>
-                  </choose>
-                </group>
-              </else>
-            </choose>
-            <choose>
-              <if variable="genre" match="any">
-                <choose>
-                  <if variable="number" match="none">
-                    <text variable="medium" text-case="capitalize-first"/>
-                  </if>
-                </choose>
-              </if>
-            </choose>
-          </group>
-        </else-if>
-        <else-if variable="container-title" match="none">
-          <!-- Other description -->
-          <text macro="format"/>
-        </else-if>
         <else>
-          <!-- For conference presentations/performances/events, chapters in reports/standards/generic documents, software, 
-               place bracketed after the container title -->
-          <choose>
-            <if type="event paper-conference performance speech" match="any">
-              <choose>
-                <if variable="collection-editor compiler editor editorial-director issue page volume" match="any">
-                  <text macro="format"/>
-                </if>
-              </choose>
-            </if>
-            <else-if type="document report software standard" match="none">
-              <text macro="format"/>
-            </else-if>
-          </choose>
+          <text term="patent" text-case="capitalize-first"/>
         </else>
       </choose>
-    </group>
-  </macro>
-  <macro name="bracketed-intext">
-    <group prefix="[" suffix="]">
-      <choose>
-        <if variable="reviewed-title" match="any">
-          <group delimiter=" ">
-            <text term="review-of" text-case="capitalize-first"/>
-            <text macro="reviewed-title-intext"/>
-          </group>
-        </if>
-        <else-if variable="interviewer" type="interview" match="any">
-          <names variable="interviewer">
-            <label form="verb" suffix=" " text-case="capitalize-first"/>
-            <name and="symbol" initialize-with=". " delimiter=", "/>
-            <substitute>
-              <text macro="format-intext"/>
-            </substitute>
-          </names>
-        </else-if>
-        <else-if type="personal_communication">
-          <!-- Letter information -->
-          <choose>
-            <if variable="recipient">
-              <group delimiter=" ">
-                <choose>
-                  <if variable="number" match="none">
-                    <text variable="genre" text-case="capitalize-first"/>
-                  </if>
-                  <else>
-                    <text term="letter" text-case="capitalize-first"/>
-                  </else>
-                </choose>
-                <names variable="recipient" delimiter=", ">
-                  <label form="verb" suffix=" "/>
-                  <name and="symbol" delimiter=", "/>
-                </names>
-              </group>
-            </if>
-            <else>
-              <text macro="format-intext"/>
-            </else>
-          </choose>
-        </else-if>
-        <else>
-          <text macro="format-intext"/>
-        </else>
-      </choose>
-    </group>
-  </macro>
-  <macro name="reviewed-item">
-    <!-- Reviewed item -->
-    <group delimiter="; ">
-      <group delimiter=", ">
-        <group delimiter=" ">
-          <choose>
-            <if variable="reviewed-genre">
-              <group delimiter=" ">
-                <text term="review-of" form="long" text-case="capitalize-first"/>
-                <text variable="reviewed-genre" text-case="lowercase"/>
-              </group>
-            </if>
-            <!-- If no `reviewed-genre`, assume that `genre` or `medium` is entered as 'Review of the book' or similar -->
-            <else-if variable="number" match="none">
-              <choose>
-                <if variable="genre">
-                  <text variable="genre" text-case="capitalize-first"/>
-                </if>
-                <else-if variable="medium">
-                  <text variable="medium" text-case="capitalize-first"/>
-                </else-if>
-                <else-if type="review-book">
-                  <group delimiter=" ">
-                    <text term="review-of" form="long" text-case="capitalize-first"/>
-                    <text term="book" form="long" text-case="lowercase"/>
-                  </group>
-                </else-if>
-                <else>
-                  <text term="review-of" form="short" text-case="capitalize-first"/>
-                </else>
-              </choose>
-            </else-if>
-            <else>
-              <choose>
-                <if variable="medium">
-                  <text variable="medium" text-case="capitalize-first"/>
-                </if>
-                <else-if type="review-book">
-                  <group delimiter=" ">
-                    <text term="review-of" form="long" text-case="capitalize-first"/>
-                    <text term="book" form="long" text-case="lowercase"/>
-                  </group>
-                </else-if>
-                <else>
-                  <text term="review-of" form="short" text-case="capitalize-first"/>
-                </else>
-              </choose>
-            </else>
-          </choose>
-          <text macro="reviewed-title"/>
-        </group>
-        <names variable="reviewed-author">
-          <label form="verb-short" suffix=" "/>
-          <name and="symbol" initialize-with=". " delimiter=", "/>
-        </names>
-      </group>
-      <choose>
-        <if variable="genre" match="any">
-          <choose>
-            <if variable="number" match="none">
-              <text variable="medium" text-case="capitalize-first"/>
-            </if>
-          </choose>
-        </if>
-      </choose>
-    </group>
-  </macro>
-  <macro name="bracketed-container">
-    <group prefix="[" suffix="]">
-      <choose>
-        <if type="event paper-conference performance speech" match="any">
-          <!-- Conference presentations should describe the session [container] in bracketed unless published in a proceedings -->
-          <choose>
-            <if variable="collection-editor compiler editor editorial-director issue page volume" match="none">
-              <text macro="format"/>
-            </if>
-          </choose>
-        </if>
-        <else-if type="software" match="all">
-          <!-- For entries in mobile app reference works, place bracketed after the container-title -->
-          <text macro="format"/>
-        </else-if>
-        <else-if type="document report standard">
-          <!-- For chapters in report, standards, and generic documents, place bracketed after the container title -->
-          <text macro="format"/>
-        </else-if>
-      </choose>
+      <text macro="number-labelled"/>
     </group>
   </macro>
   <macro name="secondary-contributors">
     <choose>
-      <if type="article-journal article-magazine article-newspaper periodical post-weblog review review-book" match="any">
+      <if match="any" type="article-journal article-magazine article-newspaper periodical post-weblog review review-book">
         <text macro="secondary-contributors-periodical"/>
       </if>
       <else-if type="paper-conference">
         <choose>
-          <if variable="collection-editor compiler editor editorial-director" match="any">
+          <if match="any" variable="collection-editor compiler editor editorial-director">
             <text macro="secondary-contributors-booklike"/>
           </if>
           <else>
@@ -1173,53 +923,37 @@
       </else>
     </choose>
   </macro>
-  <macro name="secondary-contributors-periodical">
-    <group delimiter="; ">
-      <choose>
-        <if variable="title">
-          <names variable="interviewer" delimiter="; ">
-            <name and="symbol" initialize-with=". " delimiter=", "/>
-            <label form="short" prefix=", " text-case="title"/>
-          </names>
-        </if>
-      </choose>
-      <names variable="translator narrator" delimiter="; ">
-        <name and="symbol" initialize-with=". " delimiter=", "/>
-        <label form="short" prefix=", " text-case="title"/>
-      </names>
-    </group>
-  </macro>
   <macro name="secondary-contributors-booklike">
     <group delimiter="; ">
       <choose>
         <if variable="title">
           <names variable="interviewer">
-            <name and="symbol" initialize-with=". " delimiter=", "/>
+            <name/>
             <label form="short" prefix=", " text-case="title"/>
           </names>
         </if>
       </choose>
       <choose>
-        <if type="post webpage" match="none">
+        <if match="none" type="post webpage">
           <!-- Webpages treat container-title like publisher -->
           <group delimiter="; ">
-            <names variable="illustrator narrator" delimiter="; ">
-              <name and="symbol" initialize-with=". " delimiter=", "/>
+            <names delimiter="; " variable="illustrator narrator">
+              <name/>
               <label form="short" prefix=", " text-case="title"/>
             </names>
             <choose>
-              <if variable="container-title" match="none">
+              <if match="none" variable="container-title">
                 <group delimiter="; ">
                   <names variable="container-author">
                     <label form="verb-short" suffix=" " text-case="title"/>
-                    <name and="symbol" initialize-with=". " delimiter=", "/>
+                    <name/>
                   </names>
-                  <names variable="editor translator" delimiter="; ">
-                    <name and="symbol" initialize-with=". " delimiter=", "/>
+                  <names delimiter="; " variable="editor translator">
+                    <name/>
                     <label form="short" prefix=", " text-case="title"/>
                   </names>
-                  <names variable="compiler chair organizer curator series-creator executive-producer" delimiter="; ">
-                    <name and="symbol" initialize-with=". " delimiter=", "/>
+                  <names delimiter="; " variable="compiler chair organizer curator series-creator executive-producer">
+                    <name/>
                     <label form="long" prefix=", " text-case="title"/>
                   </names>
                 </group>
@@ -1227,9 +961,9 @@
               <else>
                 <choose>
                   <!-- TODO: Check logic once processors start to automatically populate editor-translator. -->
-                  <if variable="editor-translator" match="none">
-                    <names variable="translator" delimiter="; ">
-                      <name and="symbol" initialize-with=". " delimiter=", "/>
+                  <if match="none" variable="editor-translator">
+                    <names delimiter="; " variable="translator">
+                      <name/>
                       <label form="short" prefix=", " text-case="title"/>
                     </names>
                   </if>
@@ -1242,18 +976,18 @@
           <group delimiter="; ">
             <names variable="container-author">
               <label form="verb-short" suffix=" " text-case="title"/>
-              <name and="symbol" initialize-with=". " delimiter=", "/>
+              <name/>
             </names>
-            <names variable="editor translator" delimiter="; ">
-              <name and="symbol" initialize-with=". " delimiter=", "/>
+            <names delimiter="; " variable="editor translator">
+              <name/>
               <label form="short" prefix=", " text-case="title"/>
             </names>
-            <names variable="illustrator narrator" delimiter="; ">
-              <name and="symbol" initialize-with=". " delimiter=", "/>
+            <names delimiter="; " variable="illustrator narrator">
+              <name/>
               <label form="short" prefix=", " text-case="title"/>
             </names>
-            <names variable="compiler chair organizer curator series-creator executive-producer" delimiter="; ">
-              <name and="symbol" initialize-with=". " delimiter=", "/>
+            <names delimiter="; " variable="compiler chair organizer curator series-creator executive-producer">
+              <name/>
               <label form="long" prefix=", " text-case="title"/>
             </names>
           </group>
@@ -1261,166 +995,398 @@
       </choose>
     </group>
   </macro>
-  <macro name="database-location">
+  <macro name="secondary-contributors-periodical">
+    <group delimiter="; ">
+      <choose>
+        <if variable="title">
+          <names delimiter="; " variable="interviewer">
+            <name/>
+            <label form="short" prefix=", " text-case="title"/>
+          </names>
+        </if>
+      </choose>
+      <names delimiter="; " variable="translator narrator">
+        <name/>
+        <label form="short" prefix=", " text-case="title"/>
+      </names>
+    </group>
+  </macro>
+  <macro name="version-edition-volume">
+    <group delimiter=", ">
+      <text macro="version-labelled"/>
+      <text macro="edition-labelled"/>
+      <text macro="volume-booklike"/>
+    </group>
+  </macro>
+  <macro name="volume-booklike">
+    <group delimiter=", ">
+      <!-- Report series (APA example 52) -->
+      <choose>
+        <if match="any" type="document report standard">
+          <group delimiter=" ">
+            <text text-case="title" variable="collection-title"/>
+            <text variable="collection-number"/>
+          </group>
+        </if>
+      </choose>
+      <text macro="supplement-number-labelled"/>
+      <choose>
+        <if variable="volume">
+          <choose>
+            <!-- Non-numeric volumes are already printed as part of the book title -->
+            <if variable="volume-title"/>
+            <else-if is-numeric="volume">
+              <text macro="volume-labelled"/>
+            </else-if>
+          </choose>
+        </if>
+        <else>
+          <text macro="number-of-volumes-labelled"/>
+        </else>
+      </choose>
+      <text macro="issue-labelled"/>
+      <text macro="locators-booklike"/>
+    </group>
+  </macro>
+  <!-- Identification logic -->
+  <macro name="identification">
+    <group delimiter="; " prefix="(" suffix=")">
+      <!-- (Secondary contributors; Database location; Genre no. 123; Report Series 123, Version, Edition, Volume, Page) -->
+      <choose>
+        <if type="patent">
+          <text macro="patent-number"/>
+        </if>
+        <else-if match="any" type="post webpage">
+          <!-- For post webpage, container-title is treated as publisher -->
+          <text macro="identification-with-all-parts"/>
+        </else-if>
+        <else-if match="any" type="report">
+          <choose>
+            <if match="none" variable="title">
+              <!-- If there is no title, then genre and number are already printed as the title. -->
+              <text macro="secondary-contributors"/>
+              <text macro="database-location"/>
+              <text macro="identification-booklike"/>
+            </if>
+            <!-- If the report is a chapter in a larger report, then most parenthetical information is printed after the container. -->
+            <else-if variable="container-title">
+              <text macro="secondary-contributors"/>
+            </else-if>
+            <else>
+              <text macro="identification-with-all-parts"/>
+            </else>
+          </choose>
+        </else-if>
+        <else-if variable="container-title">
+          <group delimiter="; ">
+            <text macro="secondary-contributors"/>
+            <choose>
+              <if match="any" type="broadcast graphic map motion_picture song">
+                <!-- For audiovisual media, number information comes after title, not container-title (ex. 94) -->
+                <text macro="genre-number"/>
+              </if>
+            </choose>
+          </group>
+        </else-if>
+        <else>
+          <text macro="identification-with-all-parts"/>
+        </else>
+      </choose>
+    </group>
+  </macro>
+  <macro name="identification-booklike">
     <choose>
-      <if variable="archive-place" match="none">
-        <!-- With `archive-place`: physical archives. Without: online archives. -->
-        <text variable="archive_location"/>
-      </if>
+      <if match="any" type="article-journal article-magazine article-newspaper broadcast event interview patent performance periodical post post-weblog review review-book speech webpage"/>
+      <else-if type="paper-conference">
+        <choose>
+          <if match="any" variable="collection-editor compiler editor editorial-director">
+            <text macro="version-edition-volume"/>
+          </if>
+        </choose>
+      </else-if>
+      <else>
+        <text macro="version-edition-volume"/>
+      </else>
     </choose>
   </macro>
-  <macro name="number">
+  <macro name="identification-with-all-parts">
+    <group delimiter="; ">
+      <text macro="secondary-contributors"/>
+      <text macro="database-location"/>
+      <text macro="genre-number"/>
+      <text macro="identification-booklike"/>
+    </group>
+  </macro>
+  <!-- 3.3. Description [in square brackets] -->
+  <!-- Description utility macros -->
+  <macro name="description-generic">
+    <!-- For conference presentations/performances/events, chapters in reports/standards/generic documents, software, place description after the container title -->
     <choose>
-      <if variable="number">
-        <group delimiter=", ">
+      <if match="any" type="event paper-conference performance speech">
+        <choose>
+          <if match="any" variable="collection-editor compiler editor editorial-director issue page volume">
+            <text macro="format-bib"/>
+          </if>
+        </choose>
+      </if>
+      <else-if match="none" type="document report software standard">
+        <text macro="format-bib"/>
+      </else-if>
+    </choose>
+  </macro>
+  <macro name="description-interview">
+    <choose>
+      <if variable="title">
+        <text macro="format-bib"/>
+      </if>
+      <else-if variable="genre">
+        <group delimiter="; ">
           <group delimiter=" ">
-            <text variable="genre" text-case="title"/>
+            <text text-case="capitalize-first" variable="genre"/>
             <group delimiter=" ">
-              <label variable="number" form="short" text-case="capitalize-first"/>
-              <text variable="number"/>
+              <text form="verb" term="container-author"/>
+              <names variable="interviewer"/>
             </group>
           </group>
+        </group>
+      </else-if>
+      <else-if variable="interviewer">
+        <group delimiter="; ">
+          <names variable="interviewer">
+            <label form="verb" suffix=" " text-case="capitalize-first"/>
+            <name/>
+          </names>
+          <text text-case="capitalize-first" variable="medium"/>
+        </group>
+      </else-if>
+      <else>
+        <text macro="format-bib"/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="description-letter-bib">
+    <choose>
+      <if variable="recipient">
+        <group delimiter="; ">
+          <group delimiter=" ">
+            <choose>
+              <if match="none" variable="number">
+                <choose>
+                  <if variable="genre">
+                    <text text-case="capitalize-first" variable="genre"/>
+                  </if>
+                  <else-if variable="medium">
+                    <text text-case="capitalize-first" variable="medium"/>
+                  </else-if>
+                  <else>
+                    <text term="letter" text-case="capitalize-first"/>
+                  </else>
+                </choose>
+              </if>
+              <else>
+                <choose>
+                  <if variable="medium">
+                    <text text-case="capitalize-first" variable="medium"/>
+                  </if>
+                  <else>
+                    <text term="letter" text-case="capitalize-first"/>
+                  </else>
+                </choose>
+              </else>
+            </choose>
+            <names variable="recipient">
+              <label form="verb" suffix=" "/>
+              <name initialize="false"/>
+            </names>
+          </group>
           <choose>
-            <if type="thesis">
+            <if variable="genre">
               <choose>
-                <!-- Include the university in brackets if thesis is published -->
-                <if variable="archive DOI URL" match="any">
-                  <text variable="publisher"/>
+                <if match="none" variable="number">
+                  <text text-case="capitalize-first" variable="medium"/>
                 </if>
               </choose>
             </if>
           </choose>
         </group>
       </if>
-    </choose>
-  </macro>
-  <macro name="locators-booklike">
-    <choose>
-      <if type="article-journal article-magazine article-newspaper broadcast event interview patent performance periodical post post-weblog review review-book speech webpage" match="any"/>
-      <else-if type="paper-conference">
-        <choose>
-          <if variable="collection-editor compiler editor editorial-director" match="any">
-            <group delimiter=", ">
-              <text macro="version"/>
-              <text macro="edition"/>
-              <text macro="volume-booklike"/>
-            </group>
-          </if>
-        </choose>
-      </else-if>
       <else>
-        <group delimiter=", ">
-          <text macro="version"/>
-          <text macro="edition"/>
-          <text macro="volume-booklike"/>
-        </group>
+        <text macro="format-bib"/>
       </else>
     </choose>
   </macro>
-  <macro name="version">
-    <group delimiter=" ">
-      <label variable="version" text-case="capitalize-first"/>
-      <text variable="version"/>
-    </group>
-  </macro>
-  <macro name="edition">
+  <macro name="description-letter-intext">
     <choose>
-      <if is-numeric="edition">
+      <if variable="recipient">
         <group delimiter=" ">
-          <number variable="edition" form="ordinal"/>
-          <label variable="edition" form="short"/>
-        </group>
-      </if>
-      <else>
-        <text variable="edition"/>
-      </else>
-    </choose>
-  </macro>
-  <macro name="volume-booklike">
-    <group delimiter=", ">
-      <!-- Report series [ex. 52] -->
-      <choose>
-        <if type="document report standard">
-          <group delimiter=" ">
-            <text variable="collection-title" text-case="title"/>
-            <text variable="collection-number"/>
-          </group>
-        </if>
-      </choose>
-      <group delimiter=" ">
-        <label variable="supplement-number" text-case="capitalize-first"/>
-        <text variable="supplement-number"/>
-      </group>
-      <choose>
-        <if variable="volume" match="any">
           <choose>
-            <!-- Non-numeric volumes are already printed as part of the book title -->
-            <if variable="volume-title"/>
-            <else-if is-numeric="volume" match="none"/>
+            <if match="none" variable="number">
+              <text text-case="capitalize-first" variable="genre"/>
+            </if>
+            <else-if variable="medium">
+              <text text-case="capitalize-first" variable="medium"/>
+            </else-if>
             <else>
-              <group delimiter=" ">
-                <label variable="volume" form="short" text-case="capitalize-first"/>
-                <number variable="volume" form="numeric"/>
-              </group>
+              <text term="letter" text-case="capitalize-first"/>
             </else>
           </choose>
-        </if>
-        <else>
-          <group>
-            <label variable="number-of-volumes" form="short" text-case="capitalize-first" suffix=" "/>
-            <text term="page-range-delimiter" prefix="1"/>
-            <number variable="number-of-volumes" form="numeric"/>
-          </group>
-        </else>
-      </choose>
-      <group delimiter=" ">
-        <label variable="issue" text-case="capitalize-first"/>
-        <text variable="issue"/>
-      </group>
-      <group delimiter=" ">
-        <label variable="page" form="short" suffix=" "/>
-        <text variable="page"/>
-      </group>
-    </group>
-  </macro>
-  <macro name="reviewed-title">
-    <choose>
-      <if variable="reviewed-title">
-        <!-- Not possible to distinguish TV series episode from other reviewed
-             works without reviewed-container-title [Ex. 69] -->
-        <!-- Adapt for reviewed-container-title if that becomes available -->
-        <text variable="reviewed-title" font-style="italic"/>
+          <names variable="recipient">
+            <label form="verb" suffix=" "/>
+            <name/>
+          </names>
+        </group>
       </if>
       <else>
-        <!-- Assume title is title of reviewed work -->
-        <text variable="title" font-style="italic"/>
+        <text macro="format-intext"/>
       </else>
     </choose>
   </macro>
-  <macro name="reviewed-title-intext">
-    <choose>
-      <if variable="reviewed-title">
-        <!-- Not possible to distinguish TV series episode from other reviewed
-             works without reviewed-container-title [Ex. 69] -->
-        <!-- Adapt for reviewed-container-title if that becomes available -->
-        <text variable="reviewed-title" form="short" font-style="italic" text-case="title"/>
-      </if>
-      <else>
-        <!-- Assume title is title of reviewed work -->
-        <text variable="title" form="short" font-style="italic" text-case="title"/>
-      </else>
-    </choose>
-  </macro>
-  <macro name="format">
-    <choose>
-      <if variable="genre medium" match="any">
-        <group delimiter="; ">
+  <macro name="description-reviewed">
+    <!-- Reviewed item -->
+    <group delimiter="; ">
+      <group delimiter=", ">
+        <group delimiter=" ">
           <choose>
-            <if variable="number" match="none">
-              <text variable="genre" text-case="capitalize-first"/>
+            <if variable="reviewed-genre">
+              <group delimiter=" ">
+                <text form="long" term="review-of" text-case="capitalize-first"/>
+                <text text-case="lowercase" variable="reviewed-genre"/>
+              </group>
+            </if>
+            <!-- If no `reviewed-genre`, assume that `genre` or `medium` is entered as 'Review of the book' or similar -->
+            <else-if match="none" variable="number">
+              <choose>
+                <if variable="genre">
+                  <text text-case="capitalize-first" variable="genre"/>
+                </if>
+                <else-if variable="medium">
+                  <text text-case="capitalize-first" variable="medium"/>
+                </else-if>
+                <else-if type="review-book">
+                  <group delimiter=" ">
+                    <text form="long" term="review-of" text-case="capitalize-first"/>
+                    <text form="long" term="book" text-case="lowercase"/>
+                  </group>
+                </else-if>
+                <else>
+                  <text form="short" term="review-of" text-case="capitalize-first"/>
+                </else>
+              </choose>
+            </else-if>
+            <else>
+              <choose>
+                <if variable="medium">
+                  <text text-case="capitalize-first" variable="medium"/>
+                </if>
+                <else-if type="review-book">
+                  <group delimiter=" ">
+                    <text form="long" term="review-of" text-case="capitalize-first"/>
+                    <text form="long" term="book" text-case="lowercase"/>
+                  </group>
+                </else-if>
+                <else>
+                  <text form="short" term="review-of" text-case="capitalize-first"/>
+                </else>
+              </choose>
+            </else>
+          </choose>
+          <text macro="reviewed-title-bib"/>
+        </group>
+        <names variable="reviewed-author">
+          <label form="verb-short" suffix=" "/>
+          <name/>
+        </names>
+      </group>
+      <choose>
+        <if variable="genre">
+          <choose>
+            <if match="none" variable="number">
+              <text text-case="capitalize-first" variable="medium"/>
             </if>
           </choose>
-          <text variable="medium" text-case="capitalize-first"/>
+        </if>
+      </choose>
+    </group>
+  </macro>
+  <macro name="description-song">
+    <!-- Performer of classical music works -->
+    <group delimiter="; ">
+      <group delimiter=" ">
+        <choose>
+          <if match="none" variable="number">
+            <choose>
+              <if variable="genre">
+                <text text-case="capitalize-first" variable="genre"/>
+                <text form="verb" term="performer"/>
+              </if>
+              <else-if variable="medium">
+                <text text-case="capitalize-first" variable="medium"/>
+                <text form="verb" term="performer"/>
+              </else-if>
+              <else>
+                <text form="verb" term="performer" text-case="capitalize-first"/>
+              </else>
+            </choose>
+          </if>
+          <else>
+            <!-- If there is a number, genre is already printed in `genre-number` macro -->
+            <choose>
+              <if variable="medium">
+                <text text-case="capitalize-first" variable="medium"/>
+                <text form="verb" term="performer"/>
+              </if>
+              <else>
+                <text form="verb" term="performer" text-case="capitalize-first"/>
+              </else>
+            </choose>
+          </else>
+        </choose>
+        <names variable="author">
+          <substitute>
+            <names variable="performer"/>
+          </substitute>
+        </names>
+      </group>
+      <choose>
+        <if variable="genre">
+          <choose>
+            <if match="none" variable="number">
+              <text text-case="capitalize-first" variable="medium"/>
+            </if>
+          </choose>
+        </if>
+      </choose>
+    </group>
+  </macro>
+  <macro name="description-thesis">
+    <!-- Thesis type and institution -->
+    <group delimiter="; ">
+      <choose>
+        <if match="none" variable="number">
+          <group delimiter=", ">
+            <text text-case="capitalize-first" variable="genre"/>
+            <choose>
+              <if match="any" variable="archive DOI URL">
+                <!-- Include the university in brackets if thesis is published -->
+                <text variable="publisher"/>
+              </if>
+            </choose>
+          </group>
+        </if>
+      </choose>
+      <text text-case="capitalize-first" variable="medium"/>
+    </group>
+  </macro>
+  <macro name="format-bib">
+    <choose>
+      <if match="any" variable="genre medium">
+        <group delimiter="; ">
+          <choose>
+            <if match="none" variable="number">
+              <text text-case="capitalize-first" variable="genre"/>
+            </if>
+          </choose>
+          <text text-case="capitalize-first" variable="medium"/>
         </group>
       </if>
       <else>
@@ -1430,11 +1396,11 @@
   </macro>
   <macro name="format-intext">
     <choose>
-      <if variable="genre" match="any">
-        <text variable="genre" text-case="capitalize-first"/>
+      <if variable="genre">
+        <text text-case="capitalize-first" variable="genre"/>
       </if>
       <else-if variable="medium">
-        <text variable="medium" text-case="capitalize-first"/>
+        <text text-case="capitalize-first" variable="medium"/>
       </else-if>
       <else>
         <text macro="generic-type-label"/>
@@ -1450,9 +1416,9 @@
       <else-if type="software">
         <text term="software" text-case="capitalize-first"/>
       </else-if>
-      <else-if type="interview personal_communication" match="any">
+      <else-if match="any" type="interview personal_communication">
         <choose>
-          <if variable="archive container-title DOI publisher URL" match="none">
+          <if match="none" variable="archive archive-place container-title DOI publisher URL">
             <text term="personal-communication" text-case="capitalize-first"/>
           </if>
           <else-if type="interview">
@@ -1492,18 +1458,108 @@
       </else-if>
     </choose>
   </macro>
-  <!-- APA 'source' element contains four parts:
-       container, event, publisher, access -->
+  <macro name="reviewed-title-bib">
+    <choose>
+      <if variable="reviewed-title">
+        <!-- Not possible to distinguish TV series episode from other reviewed
+             works without reviewed-container-title (APA example 69) -->
+        <!-- Adapt for reviewed-container-title if that becomes available -->
+        <text font-style="italic" variable="reviewed-title"/>
+      </if>
+      <else>
+        <!-- Assume title is title of reviewed work -->
+        <text font-style="italic" variable="title"/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="reviewed-title-intext">
+    <choose>
+      <if variable="reviewed-title">
+        <!-- Not possible to distinguish TV series episode from other reviewed
+             works without reviewed-container-title (APA example 69) -->
+        <!-- Adapt for reviewed-container-title if that becomes available -->
+        <text font-style="italic" form="short" text-case="title" variable="reviewed-title"/>
+      </if>
+      <else>
+        <!-- Assume title is title of reviewed work -->
+        <text font-style="italic" form="short" text-case="title" variable="title"/>
+      </else>
+    </choose>
+  </macro>
+  <!-- Description logic -->
+  <macro name="description-bib">
+    <group prefix="[" suffix="]">
+      <choose>
+        <if match="any" type="interview" variable="interviewer">
+          <text macro="description-interview"/>
+        </if>
+        <else-if match="any" type="review review-book" variable="reviewed-author reviewed-genre reviewed-title">
+          <text macro="description-reviewed"/>
+        </else-if>
+        <else-if type="personal_communication">
+          <text macro="description-letter-bib"/>
+        </else-if>
+        <else-if type="song" variable="composer">
+          <text macro="description-song"/>
+        </else-if>
+        <else-if type="thesis">
+          <text macro="description-thesis"/>
+        </else-if>
+        <else-if match="none" variable="container-title">
+          <!-- Other description -->
+          <text macro="format-bib"/>
+        </else-if>
+        <else>
+          <text macro="description-generic"/>
+        </else>
+      </choose>
+    </group>
+  </macro>
+  <macro name="description-intext">
+    <group prefix="[" suffix="]">
+      <choose>
+        <if variable="reviewed-title">
+          <group delimiter=" ">
+            <text term="review-of" text-case="capitalize-first"/>
+            <text macro="reviewed-title-intext"/>
+          </group>
+        </if>
+        <else-if match="any" type="interview" variable="interviewer">
+          <names variable="interviewer">
+            <label form="verb" suffix=" " text-case="capitalize-first"/>
+            <name/>
+            <substitute>
+              <text macro="format-intext"/>
+            </substitute>
+          </names>
+        </else-if>
+        <else-if type="personal_communication">
+          <text macro="description-letter-intext"/>
+        </else-if>
+        <else>
+          <text macro="format-intext"/>
+        </else>
+      </choose>
+    </group>
+  </macro>
+  <!-- 4. Source -->
+  <!-- Four parts in APA 'source' element:
+
+       1. Container
+       2. Event
+       3. Publication details
+       4. Access -->
+  <!-- 4.1. Container -->
   <macro name="container">
     <choose>
-      <if type="article-journal article-magazine article-newspaper periodical post-weblog review review-book" match="any">
+      <if match="any" type="article-journal article-magazine article-newspaper periodical post-weblog review review-book">
         <!-- Periodical items -->
         <text macro="container-periodical"/>
       </if>
       <else-if type="paper-conference">
         <!-- Determine if paper-conference is a periodical- or book-like -->
         <choose>
-          <if variable="editor editorial-director collection-editor container-author" match="any">
+          <if match="any" variable="collection-editor container-author editor editorial-director">
             <text macro="container-booklike"/>
           </if>
           <else>
@@ -1511,55 +1567,15 @@
           </else>
         </choose>
       </else-if>
-      <else-if type="post webpage" match="none">
-        <!-- post and webpage treat container-title like publisher -->
+      <else-if match="none" type="post webpage">
+        <!-- Webpages treat container-title like publisher -->
         <text macro="container-booklike"/>
       </else-if>
     </choose>
   </macro>
-  <macro name="container-periodical">
-    <group delimiter=". ">
-      <group delimiter=", ">
-        <text variable="container-title" font-style="italic" text-case="title"/>
-        <choose>
-          <if variable="volume">
-            <group>
-              <text variable="volume" font-style="italic"/>
-              <text variable="issue" prefix="(" suffix=")"/>
-            </group>
-          </if>
-          <else>
-            <text variable="issue" font-style="italic"/>
-          </else>
-        </choose>
-        <choose>
-          <if variable="number">
-            <!-- Ex. 6: Journal article with article number or eLocator -->
-            <group delimiter=" ">
-              <text term="article-locator" text-case="capitalize-first"/>
-              <text variable="number"/>
-            </group>
-          </if>
-          <else>
-            <text variable="page"/>
-          </else>
-        </choose>
-      </group>
-      <choose>
-        <if variable="issued">
-          <choose>
-            <if variable="issue number page volume" match="none">
-              <!-- We print the status variable directly rather than using in-press, etc. terms. -->
-              <text variable="status" text-case="capitalize-first"/>
-            </if>
-          </choose>
-        </if>
-      </choose>
-    </group>
-  </macro>
   <macro name="container-booklike">
     <choose>
-      <if variable="container-title" match="any">
+      <if variable="container-title">
         <group delimiter=" ">
           <choose>
             <if type="song">
@@ -1570,161 +1586,167 @@
             </else>
           </choose>
           <group delimiter=", ">
-            <names variable="executive-producer">
-              <name and="symbol" initialize-with=". " delimiter=", "/>
-              <label form="long" text-case="title" prefix=" (" suffix=")"/>
-              <substitute>
-                <names variable="series-creator"/>
-                <names variable="editor-translator">
-                  <name and="symbol" initialize-with=". " delimiter=", "/>
-                  <label form="short" text-case="title" prefix=" (" suffix=")"/>
-                </names>
-                <!-- TODO: Translator omitted here on the assumption that editor-translators are uncommon 
-                           for chapter citations. If needed, direct entry or automatic population of
-                           `editor-translator` can produce combined labels. -->
-                <names variable="editor">
-                  <name and="symbol" initialize-with=". " delimiter=", "/>
-                  <label form="short" text-case="title" prefix=" (" suffix=")"/>
-                </names>
-                <names variable="editorial-director">
-                  <name and="symbol" initialize-with=". " delimiter=", "/>
-                  <label form="short" text-case="title" prefix=" (" suffix=")"/>
-                </names>
-                <names variable="compiler"/>
-                <choose>
-                  <if type="event performance speech" match="any">
-                    <names variable="chair"/>
-                    <names variable="organizer"/>
-                  </if>
-                </choose>
-                <names variable="curator"/>
-                <names variable="collection-editor">
-                  <name and="symbol" initialize-with=". " delimiter=", "/>
-                  <label form="short" text-case="title" prefix=" (" suffix=")"/>
-                </names>
-                <names variable="container-author"/>
-              </substitute>
-            </names>
-            <group delimiter=": " font-style="italic">
-              <text variable="container-title"/>
-              <text macro="volume-title"/>
-            </group>
+            <text macro="container-contributors"/>
+            <text macro="container-title-booklike"/>
           </group>
-          <text macro="parenthetical-container"/>
-          <text macro="bracketed-container"/>
+          <text macro="container-identification"/>
+          <text macro="container-description"/>
         </group>
       </if>
     </choose>
   </macro>
-  <macro name="publisher">
-    <group delimiter="; ">
+  <macro name="container-periodical">
+    <group delimiter=". ">
+      <group delimiter=", ">
+        <text font-style="italic" text-case="title" variable="container-title"/>
+        <text macro="volume-periodical"/>
+        <text macro="locators-periodical"/>
+      </group>
       <choose>
-        <if type="thesis">
+        <if variable="issued">
           <choose>
-            <if variable="archive DOI URL" match="none">
-              <text variable="publisher"/>
+            <if match="none" variable="issue number page volume">
+              <!-- We print the status variable directly rather than using in-press, etc. terms. -->
+              <text text-case="capitalize-first" variable="status"/>
             </if>
           </choose>
         </if>
-        <else-if type="post webpage" match="any">
-          <!-- For websites, treat container title like publisher -->
-          <group delimiter="; ">
-            <text variable="container-title" text-case="title"/>
-            <text variable="publisher"/>
-          </group>
-        </else-if>
-        <else-if type="paper-conference">
-          <!-- For paper-conference, don't print publisher if in a journal-like proceedings -->
-          <choose>
-            <if variable="collection-editor compiler editor editorial-director" match="any">
-              <text variable="publisher"/>
-            </if>
-          </choose>
-        </else-if>
-        <else-if type="article-journal article-magazine article-newspaper periodical post-weblog review review-book" match="none">
-          <text variable="publisher"/>
-        </else-if>
       </choose>
-      <group delimiter=", ">
-        <choose>
-          <if variable="archive-place">
-            <!-- With `archive-place`: physical archives. Without: online archives. -->
-            <!-- For physical archives, print the location before the archive name.
-                For electronic archives, these are printed in macro="description". -->
-            <!-- Must test for archive_collection:
-                With collection: archive_collection (archive_location), archive, archive-place
-                No collection: archive (archive_location), archive-place
-            -->
-            <choose>
-              <if variable="archive_collection">
-                <group delimiter=" ">
-                  <text variable="archive_collection"/>
-                  <text variable="archive_location" prefix="(" suffix=")"/>
-                </group>
-                <text variable="archive"/>
-                <text variable="archive-place"/>
-              </if>
-              <else>
-                <group delimiter=" ">
-                  <text variable="archive"/>
-                  <text variable="archive_location" prefix="(" suffix=")"/>
-                </group>
-                <text variable="archive-place"/>
-              </else>
-            </choose>
-          </if>
-          <else>
-            <text variable="archive"/>
-          </else>
-        </choose>
-      </group>
     </group>
   </macro>
-  <macro name="access">
+  <!-- Container parallels main elements -->
+  <!-- 4.1.1. Author -->
+  <macro name="container-contributors">
+    <names variable="executive-producer">
+      <name/>
+      <label form="long" prefix=" (" suffix=")" text-case="title"/>
+      <substitute>
+        <names variable="series-creator"/>
+        <names variable="editor-translator">
+          <name/>
+          <label form="short" prefix=" (" suffix=")" text-case="title"/>
+        </names>
+        <!-- TODO: Translator omitted on the assumption that editor-translators are uncommon for chapter citations.
+             If needed, direct entry or automatic population of `editor-translator` can produce combined labels. -->
+        <names delimiter="; " variable="editor">
+          <name/>
+          <label form="short" prefix=" (" suffix=")" text-case="title"/>
+        </names>
+        <names variable="editorial-director">
+          <name/>
+          <label form="short" prefix=" (" suffix=")" text-case="title"/>
+        </names>
+        <names variable="compiler"/>
+        <choose>
+          <if match="any" type="event performance speech">
+            <names variable="chair"/>
+            <names variable="organizer"/>
+          </if>
+        </choose>
+        <names variable="curator"/>
+        <names variable="collection-editor">
+          <name/>
+          <label form="short" prefix=" (" suffix=")" text-case="title"/>
+        </names>
+        <names variable="container-author"/>
+      </substitute>
+    </names>
+  </macro>
+  <!-- 4.1.3.1 Container title -->
+  <macro name="container-title-booklike">
+    <group delimiter=": " font-style="italic">
+      <text variable="container-title"/>
+      <text macro="title-volume"/>
+    </group>
+  </macro>
+  <!-- 4.1.3.1 Container identification -->
+  <macro name="container-identification">
     <choose>
-      <if variable="DOI" match="any">
-        <text variable="DOI" prefix="https://doi.org/"/>
-      </if>
-      <else-if variable="URL">
-        <group delimiter=" ">
-          <choose>
-            <if variable="issued status" match="none">
-              <group delimiter=" ">
-                <text term="retrieved" text-case="capitalize-first"/>
-                <date variable="accessed" form="text" suffix=","/>
-                <text term="from"/>
-              </group>
-            </if>
-          </choose>
-          <text variable="URL"/>
+      <if variable="container-title">
+        <group prefix="(" suffix=")">
+          <group delimiter="; ">
+            <text macro="database-location"/>
+            <choose>
+              <if match="none" type="broadcast graphic map motion_picture song">
+                <!-- For audiovisual media, number information comes after title, not container-title (APA example 94) -->
+                <text macro="genre-number"/>
+              </if>
+            </choose>
+            <text macro="identification-booklike"/>
+          </group>
         </group>
-      </else-if>
+      </if>
     </choose>
   </macro>
+  <!-- 4.1.3.2 Container description -->
+  <macro name="container-description">
+    <group prefix="[" suffix="]">
+      <choose>
+        <if match="any" type="event paper-conference performance speech">
+          <!-- Conference presentations should describe the session [container] in description unless published in a proceedings -->
+          <choose>
+            <if match="none" variable="collection-editor compiler editor editorial-director issue page volume">
+              <text macro="format-bib"/>
+            </if>
+          </choose>
+        </if>
+        <else-if type="software">
+          <!-- For entries in mobile app reference works, place description after the container-title -->
+          <text macro="format-bib"/>
+        </else-if>
+        <else-if match="any" type="document report standard">
+          <!-- For chapters in report, standards, and generic documents, place description after the container title -->
+          <text macro="format-bib"/>
+        </else-if>
+      </choose>
+    </group>
+  </macro>
+  <!-- 4.1.4. Source -->
+  <macro name="locators-periodical">
+    <choose>
+      <if variable="number">
+        <text macro="number-article-labelled"/>
+      </if>
+      <else>
+        <text variable="page"/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="volume-periodical">
+    <group delimiter=", ">
+      <text font-style="italic" text-case="title" variable="collection-title"/>
+      <choose>
+        <if variable="volume">
+          <group>
+            <text font-style="italic" variable="volume"/>
+            <text prefix="(" suffix=")" variable="issue"/>
+          </group>
+        </if>
+        <else>
+          <text font-style="italic" variable="issue"/>
+        </else>
+      </choose>
+    </group>
+  </macro>
+  <!-- 4.2. Event -->
   <macro name="event">
     <choose>
-      <if variable="event event-title" match="any">
-        <!-- To prevent Zotero from printing event-place due to its double-mapping of all 'place' to
-             both publisher-place and event-place. Remove this 'choose' when that is changed. -->
+      <if match="any" variable="event event-title">
+        <!-- To prevent Zotero from printing `event-place` due to its double-mapping of all 'place' to
+             both `publisher-place` and `event-place`. Remove this when that is changed. -->
         <choose>
           <if type="paper-conference">
             <choose>
-              <if variable="collection-editor compiler editor editorial-director issue page volume" match="none">
+              <if match="none" variable="collection-editor compiler editor editorial-director issue page volume">
                 <!-- Don't print event info for conference papers published in a proceedings -->
-                <group delimiter=", ">
-                  <text macro="event-title"/>
-                  <text variable="event-place"/>
-                </group>
+                <text macro="event-title-place"/>
               </if>
             </choose>
           </if>
           <else>
             <!-- For other item types, print event info even if published (e.g., for collection catalogs, performance programs.
                  These items aren't given explicit examples in the APA manual, so err on the side of providing too much information. -->
-            <group delimiter=", ">
-              <text macro="event-title"/>
-              <text variable="event-place"/>
-            </group>
+            <text macro="event-title-place"/>
           </else>
         </choose>
       </if>
@@ -1732,9 +1754,9 @@
   </macro>
   <macro name="event-title">
     <choose>
-      <!-- TODO: We expect "event-title" to be used,
+      <!-- TODO: We expect `event-title` to be used,
            but processors and applications may not be updated yet.
-           This macro ensures that either "event" or "event-title" can be accpeted.
+           This macro ensures that either `event` or `event-title` can be accepted.
            Remove if procesor logic and application adoption can handle this. -->
       <if variable="event-title">
         <text variable="event-title"/>
@@ -1744,11 +1766,153 @@
       </else>
     </choose>
   </macro>
-  <!-- After 'source', APA also prints publication history (original publication, reprint info, retraction info) -->
+  <macro name="event-title-place">
+    <group delimiter=", ">
+      <text macro="event-title"/>
+      <text variable="event-place"/>
+    </group>
+  </macro>
+  <!-- 4.3. Publication details -->
+  <!-- Publication utility macros -->
+  <macro name="archive">
+    <group delimiter=", ">
+      <choose>
+        <if variable="archive-place">
+          <!-- With `archive-place`: physical archives. Without: online archives. -->
+          <!-- For physical archives, print the location before the archive name.
+                For electronic archives, these are printed in macro="description". -->
+          <!-- Must test for archive_collection:
+                With collection: archive_collection (archive_location), archive, archive-place
+                No collection: archive (archive_location), archive-place
+            -->
+          <choose>
+            <if variable="archive_collection">
+              <group delimiter=" ">
+                <text variable="archive_collection"/>
+                <text prefix="(" suffix=")" variable="archive_location"/>
+              </group>
+              <text variable="archive"/>
+              <text variable="archive-place"/>
+            </if>
+            <else>
+              <group delimiter=" ">
+                <text variable="archive"/>
+                <text prefix="(" suffix=")" variable="archive_location"/>
+              </group>
+              <text variable="archive-place"/>
+            </else>
+          </choose>
+        </if>
+        <else>
+          <text variable="archive"/>
+        </else>
+      </choose>
+    </group>
+  </macro>
+  <macro name="publisher">
+    <choose>
+      <if variable="publisher">
+        <text variable="publisher"/>
+      </if>
+      <else-if match="none" variable="event-place">
+        <!-- Work around Zotero double-mapping of event/publisher place -->
+        <text variable="publisher-place"/>
+      </else-if>
+    </choose>
+  </macro>
+  <!-- Publication logic -->
+  <macro name="publication">
+    <choose>
+      <if type="thesis">
+        <choose>
+          <if match="none" variable="archive DOI URL">
+            <text macro="publisher"/>
+          </if>
+        </choose>
+      </if>
+      <else-if match="any" type="post webpage">
+        <!-- Webpages treat container-title like publisher -->
+        <group delimiter="; ">
+          <text text-case="title" variable="container-title"/>
+          <text macro="publisher"/>
+        </group>
+      </else-if>
+      <else-if type="paper-conference">
+        <!-- For paper-conference, don't print publisher if in a journal-like proceedings -->
+        <choose>
+          <if match="any" variable="collection-editor compiler editor editorial-director">
+            <text macro="publisher"/>
+          </if>
+        </choose>
+      </else-if>
+      <else-if match="none" type="article-journal article-magazine article-newspaper periodical post-weblog review review-book">
+        <text macro="publisher"/>
+      </else-if>
+    </choose>
+  </macro>
+  <macro name="publication-archive">
+    <group delimiter="; ">
+      <text macro="publication"/>
+      <text macro="archive"/>
+    </group>
+  </macro>
+  <!-- 4.4. Access -->
+  <macro name="access">
+    <choose>
+      <if variable="DOI">
+        <text prefix="https://doi.org/" variable="DOI"/>
+      </if>
+      <else-if variable="URL">
+        <group delimiter=" ">
+          <choose>
+            <if match="none" variable="issued status">
+              <group delimiter=" ">
+                <text term="retrieved" text-case="capitalize-first"/>
+                <group delimiter=", ">
+                  <date form="text" variable="accessed"/>
+                  <text term="from"/>
+                </group>
+              </group>
+            </if>
+          </choose>
+          <text variable="URL"/>
+        </group>
+      </else-if>
+    </choose>
+  </macro>
+  <!-- 5. Publication history -->
+  <!-- History utility macros -->
+  <macro name="original-publisher">
+    <choose>
+      <if variable="original-publisher">
+        <text variable="original-publisher"/>
+      </if>
+      <else>
+        <text variable="original-publisher-place"/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="original-title">
+    <choose>
+      <if variable="original-title">
+        <text value="as"/>
+        <choose>
+          <if match="any" type="article-journal article-magazine article-newspaper periodical post-weblog review review-book">
+            <text variable="original-title"/>
+          </if>
+          <else>
+            <text font-style="italic" variable="original-title"/>
+          </else>
+        </choose>
+      </if>
+    </choose>
+  </macro>
+  <!-- History logic -->
   <macro name="publication-history">
+    <!-- Information appended to 'source': original publication, reprint info, retraction info -->
     <choose>
       <if type="patent">
-        <text variable="references" prefix="(" suffix=")"/>
+        <text prefix="(" suffix=")" variable="references"/>
       </if>
       <else>
         <group delimiter="; " prefix="(" suffix=")">
@@ -1756,8 +1920,8 @@
           <choose>
             <if variable="issued">
               <choose>
-                <if variable="issue number page volume" match="any">
-                  <text variable="status" text-case="capitalize-first"/>
+                <if match="any" variable="issue number page volume">
+                  <text text-case="capitalize-first" variable="status"/>
                 </if>
               </choose>
             </if>
@@ -1766,29 +1930,31 @@
             <if variable="references">
               <!-- This provides the option for more elaborate description
                     of publication history, such as full "reprinted" references
-                    (examples 11, 43, 44) -->
+                    (APA examples 11, 43, 44) -->
               <text variable="references"/>
             </if>
             <else>
-              <group delimiter=" ">
-                <text term="original-work-published" text-case="capitalize-first"/>
-                <choose>
-                  <if is-uncertain-date="original-date">
-                    <text term="circa" form="short"/>
-                  </if>
-                </choose>
-                <date variable="original-date">
-                  <date-part name="year"/>
-                </date>
-              </group>
+              <text macro="publication-history-variables"/>
             </else>
           </choose>
         </group>
       </else>
     </choose>
   </macro>
-  <!-- Legal citations have their own rules -->
-  <macro name="legal-cites">
+  <macro name="publication-history-variables">
+    <group delimiter=" ">
+      <text term="original-work-published" text-case="capitalize-first"/>
+      <group delimiter="; ">
+        <text macro="original-title"/>
+        <group delimiter=", ">
+          <text macro="original-publisher"/>
+          <text macro="original-date-year"/>
+        </group>
+      </group>
+    </group>
+  </macro>
+  <!-- Parallel rules for legal citations -->
+  <macro name="legal-bib">
     <!-- `treaty`: for treaties -->
     <!-- `legal_case`: for all legal and court cases -->
     <!-- `bill`: for bills, resolutions, federal reports -->
@@ -1800,16 +1966,14 @@
         <if type="treaty">
           <group delimiter=", " suffix=".">
             <!-- APA generally defers to Bluebook for legal citations, but diverges without
-                explanation for treaty items. We follow the Bluebook format that was used 
+                explanation for treaty items. We follow the Bluebook format that was used
                 in APA 6th ed. -->
-            <!-- APA manual omits treaty parties/authors, but per Bluebook 
+            <!-- APA manual omits treaty parties/authors, but per Bluebook
                 they should be included at least for bilateral treaties. -->
-            <names variable="author">
-              <name initialize-with="." form="short" delimiter="-"/>
-            </names>
+            <text macro="author-legal"/>
             <text macro="date-legal"/>
-            <!-- APA manual omits treaty source/report called for by Bluebook in favor of just URL. 
-                Both are included here, following the APA style used for all other item types 
+            <!-- APA manual omits treaty source/report called for by Bluebook in favor of just URL.
+                Both are included here, following the APA style used for all other item types
                 to end the reference with a period, then give the URL afterward. -->
             <text macro="container-legal"/>
           </group>
@@ -1821,7 +1985,7 @@
               <text macro="container-legal"/>
             </group>
             <text macro="date-legal"/>
-            <text macro="parenthetical-legal"/>
+            <text macro="identification-legal"/>
           </group>
         </else>
       </choose>
@@ -1829,20 +1993,75 @@
       <text macro="access"/>
     </group>
   </macro>
+  <!-- 1. Legal author -->
+  <macro name="author-legal">
+    <names variable="author">
+      <name delimiter="-" form="short"/>
+    </names>
+  </macro>
+  <!-- 2. Legal date -->
+  <macro name="date-legal-case">
+    <group delimiter=" " prefix="(" suffix=")">
+      <text variable="authority"/>
+      <choose>
+        <if variable="container-title">
+          <!-- Print only year for cases published in reporters-->
+          <text macro="date-issued-year"/>
+        </if>
+        <else>
+          <!-- APA manual doesn't include examples of cases not yet
+                   published in a reporter, but this is Bluebook style. -->
+          <text macro="date-issued-full"/>
+        </else>
+      </choose>
+    </group>
+  </macro>
+  <macro name="date-legal">
+    <choose>
+      <if type="treaty">
+        <text macro="date-issued-full"/>
+      </if>
+      <else-if type="legal_case">
+        <text macro="date-legal-case"/>
+      </else-if>
+      <else-if match="any" type="bill hearing legislation regulation">
+        <group delimiter=" " prefix="(" suffix=")">
+          <group delimiter=" ">
+            <text macro="original-date-year"/>
+            <text form="symbol" term="and"/>
+          </group>
+          <choose>
+            <if variable="issued">
+              <!-- APA manual includes "rev." before the revision year,
+                   but this isn't part of the Bluebook rules. -->
+              <text macro="date-issued-year"/>
+            </if>
+            <else>
+              <!-- Show proposal date for uncodified regualtions.
+                   Assume date is entered literally ala "proposed May 23, 2016".
+                   TODO: Add 'proposed' term here if that becomes available -->
+              <date form="text" variable="submitted"/>
+            </else>
+          </choose>
+        </group>
+      </else-if>
+    </choose>
+  </macro>
+  <!-- 3.1. Legal title -->
   <macro name="title-legal">
     <choose>
-      <if type="bill legal_case legislation regulation treaty" match="any">
-        <text variable="title" text-case="title"/>
+      <if match="any" type="bill legal_case legislation regulation treaty">
+        <text text-case="title" variable="title"/>
       </if>
       <else-if type="hearing">
-        <!-- APA uses a comma delimiter and omits "hearing before the" for hearings with testimony, 
+        <!-- APA uses a comma delimiter and omits "hearing before the" for hearings with testimony,
              but follows Bluebook rules (colon delimiter, prefix before the committee name) for
              references to the whole hearing. We simply follow the Bluebook rules for both, but
              use APA style capitalization (not capitalizing "Before" or the title of the hearing). -->
         <group delimiter=": " font-style="italic">
-          <text variable="title" text-case="capitalize-first"/>
+          <text text-case="capitalize-first" variable="title"/>
           <group delimiter=" ">
-            <text term="hearing" form="long" text-case="capitalize-first"/>
+            <text form="long" term="hearing" text-case="capitalize-first"/>
             <group delimiter=" ">
               <group delimiter=" ">
                 <!-- APA manual omits the bill number, but it should be included per Bluebook if relevant -->
@@ -1851,7 +2070,7 @@
               </group>
               <group delimiter=" ">
                 <!-- Use the `at` term to hold "before the" -->
-                <text term="at" form="long"/>
+                <text form="long" term="at"/>
                 <text variable="section"/>
               </group>
             </group>
@@ -1860,124 +2079,95 @@
       </else-if>
     </choose>
   </macro>
-  <macro name="date-legal">
+  <!-- 3.2. Legal identification (in parentheses) -->
+  <macro name="identification-legal">
     <choose>
-      <if type="treaty">
-        <date variable="issued" form="text"/>
+      <if type="hearing">
+        <group delimiter=" " prefix="(" suffix=")">
+          <!-- Use the 'verb' form of the hearing term to hold 'testimony of' -->
+          <text form="verb" term="hearing"/>
+          <names variable="author">
+            <name initialize="false"/>
+          </names>
+        </group>
       </if>
-      <else-if type="legal_case">
-        <group prefix="(" suffix=")" delimiter=" ">
-          <text variable="authority"/>
-          <choose>
-            <if variable="container-title" match="any">
-              <!-- Print only year for cases published in reporters-->
-              <date variable="issued" form="numeric" date-parts="year"/>
-            </if>
-            <else>
-              <!-- APA manual doesn't include examples of cases not yet
-                   published in a reporter, but this is Bluebook style. -->
-              <date variable="issued" form="text"/>
-            </else>
-          </choose>
-        </group>
-      </else-if>
-      <else-if type="bill hearing legislation regulation" match="any">
-        <group prefix="(" suffix=")" delimiter=" ">
-          <group delimiter=" ">
-            <date variable="original-date">
-              <date-part name="year"/>
-            </date>
-            <text term="and" form="symbol"/>
-          </group>
-          <choose>
-            <if variable="issued">
-              <!-- APA manual includes "rev." before the revision year, 
-                   but this isn't part of the Bluebook rules. -->
-              <date variable="issued">
-                <date-part name="year"/>
-              </date>
-            </if>
-            <else>
-              <!-- Show proposal date for uncodified regualtions. 
-                   Assume date is entered literally ala "proposed May 23, 2016".
-                   TODO: Add 'proposed' term here if that becomes available -->
-              <date variable="submitted" form="text"/>
-            </else>
-          </choose>
-        </group>
+      <else-if match="any" type="bill legislation regulation">
+        <!-- For uncodified regulations, assume future code section is in `status`. -->
+        <text prefix="(" suffix=")" variable="status"/>
       </else-if>
     </choose>
   </macro>
-  <macro name="container-legal">
-    <!-- Expect legal item container-titles to be stored in short form -->
+  <!-- 4. Legal source -->
+  <!-- Legal source utility macros -->
+  <macro name="container-bill">
+    <group delimiter=", ">
+      <group delimiter=" ">
+        <text variable="genre"/>
+        <group delimiter=" ">
+          <choose>
+            <!-- If there is no session number or code/record title, assume
+                     assume the item is a congressional report and include 'No.' term. -->
+            <if match="none" variable="chapter-number container-title">
+              <!-- The item is a congressional report, rather than a bill or resultion. -->
+              <text macro="number-labelled"/>
+            </if>
+            <else>
+              <text variable="number"/>
+            </else>
+          </choose>
+        </group>
+      </group>
+      <group delimiter=" ">
+        <text variable="authority"/>
+        <!-- 'session' is `chapter-number` -->
+        <text variable="chapter-number"/>
+      </group>
+      <group delimiter=" ">
+        <text variable="volume"/>
+        <text variable="container-title"/>
+        <text variable="page-first"/>
+      </group>
+    </group>
+  </macro>
+  <macro name="container-hearing">
+    <group delimiter=" ">
+      <text variable="authority"/>
+      <!-- 'session' is `chapter-number` -->
+      <text variable="chapter-number"/>
+    </group>
+  </macro>
+  <macro name="container-legal-case">
+    <group delimiter=" ">
+      <choose>
+        <if variable="container-title">
+          <group delimiter=" ">
+            <text variable="volume"/>
+            <text variable="container-title"/>
+            <text macro="section-labelled"/>
+            <choose>
+              <if match="any" variable="page page-first">
+                <text variable="page-first"/>
+              </if>
+              <else>
+                <text value="___"/>
+              </else>
+            </choose>
+          </group>
+        </if>
+        <else>
+          <text macro="number-labelled"/>
+        </else>
+      </choose>
+    </group>
+  </macro>
+  <macro name="container-legislation">
     <choose>
-      <if type="treaty">
-        <group delimiter=" ">
-          <number variable="volume"/>
-          <text variable="container-title"/>
-          <choose>
-            <if variable="page page-first" match="any">
-              <text variable="page-first"/>
-            </if>
-            <else>
-              <group delimiter=" ">
-                <label variable="number" form="short" text-case="capitalize-first"/>
-                <text variable="number"/>
-              </group>
-            </else>
-          </choose>
-        </group>
-      </if>
-      <else-if type="legal_case">
-        <group delimiter=" ">
-          <choose>
-            <if variable="container-title">
-              <group delimiter=" ">
-                <text variable="volume"/>
-                <text variable="container-title"/>
-                <group delimiter=" ">
-                  <label variable="section" form="symbol"/>
-                  <text variable="section"/>
-                </group>
-                <choose>
-                  <if variable="page page-first" match="any">
-                    <text variable="page-first"/>
-                  </if>
-                  <else>
-                    <text value="___"/>
-                  </else>
-                </choose>
-              </group>
-            </if>
-            <else>
-              <group delimiter=" ">
-                <label variable="number" form="short" text-case="capitalize-first"/>
-                <text variable="number"/>
-              </group>
-            </else>
-          </choose>
-        </group>
-      </else-if>
-      <else-if type="bill">
+      <if variable="number">
+        <!-- There's a public law number. -->
         <group delimiter=", ">
           <group delimiter=" ">
-            <text variable="genre"/>
-            <group delimiter=" ">
-              <choose>
-                <!-- If there is no session number or code/record title, assume
-                     assume the item is a congressional report and include 'No.' term. -->
-                <if variable="chapter-number container-title" match="none">
-                  <!-- The item is a congressional report, rather than a bill or resultion. -->
-                  <label variable="number" form="short" text-case="capitalize-first"/>
-                </if>
-              </choose>
-              <text variable="number"/>
-            </group>
-          </group>
-          <group delimiter=" ">
-            <text variable="authority"/>
-            <!-- 'session' is `chapter-number` -->
-            <text variable="chapter-number"/>
+            <text value="Pub. L. No."/>
+            <text variable="number"/>
           </group>
           <group delimiter=" ">
             <text variable="volume"/>
@@ -1985,149 +2175,139 @@
             <text variable="page-first"/>
           </group>
         </group>
-      </else-if>
-      <else-if type="hearing">
+      </if>
+      <else>
         <group delimiter=" ">
-          <text variable="authority"/>
-          <!-- 'session' is `chapter-number` -->
-          <text variable="chapter-number"/>
+          <text variable="volume"/>
+          <text variable="container-title"/>
+          <choose>
+            <if variable="section">
+              <text macro="section-labelled"/>
+            </if>
+            <else>
+              <text variable="page-first"/>
+            </else>
+          </choose>
         </group>
-      </else-if>
-      <else-if type="legislation">
+      </else>
+    </choose>
+  </macro>
+  <macro name="container-regulation">
+    <group delimiter=", ">
+      <group delimiter=" ">
+        <text variable="genre"/>
+        <text macro="number-labelled"/>
+      </group>
+      <group delimiter=" ">
+        <text variable="volume"/>
+        <text variable="container-title"/>
         <choose>
-          <if variable="number">
-            <!-- There's a public law number. -->
-            <group delimiter=", ">
-              <text variable="number" prefix="Pub. L. No. "/>
-              <group delimiter=" ">
-                <text variable="volume"/>
-                <text variable="container-title"/>
-                <text variable="page-first"/>
-              </group>
-            </group>
+          <if variable="section">
+            <text macro="section-labelled"/>
           </if>
           <else>
-            <group delimiter=" ">
-              <text variable="volume"/>
-              <text variable="container-title"/>
-              <choose>
-                <if variable="section">
-                  <group delimiter=" ">
-                    <label variable="section" form="symbol"/>
-                    <text variable="section"/>
-                  </group>
-                </if>
-                <else>
-                  <text variable="page-first"/>
-                </else>
-              </choose>
-            </group>
+            <text variable="page-first"/>
           </else>
         </choose>
-      </else-if>
-      <else-if type="regulation">
-        <group delimiter=", ">
-          <group delimiter=" ">
-            <text variable="genre"/>
-            <group delimiter=" ">
-              <label variable="number" form="short" text-case="capitalize-first"/>
-              <text variable="number"/>
-            </group>
-          </group>
-          <group delimiter=" ">
-            <text variable="volume"/>
-            <text variable="container-title"/>
-            <choose>
-              <if variable="section">
-                <group delimiter=" ">
-                  <label variable="section" form="symbol"/>
-                  <text variable="section"/>
-                </group>
-              </if>
-              <else>
-                <text variable="page-first"/>
-              </else>
-            </choose>
-          </group>
-        </group>
-      </else-if>
-    </choose>
-  </macro>
-  <macro name="parenthetical-legal">
-    <choose>
-      <if type="hearing">
-        <group prefix="(" suffix=")" delimiter=" ">
-          <!-- Use the 'verb' form of the hearing term to hold 'testimony of' -->
-          <text term="hearing" form="verb"/>
-          <names variable="author">
-            <name and="symbol" delimiter=", "/>
-          </names>
-        </group>
-      </if>
-      <else-if type="bill legislation regulation" match="any">
-        <!-- For uncodified regulations, assume future code section is in `status`. -->
-        <text variable="status" prefix="(" suffix=")"/>
-      </else-if>
-    </choose>
-  </macro>
-  <macro name="citation-locator">
-    <!-- Abbreviate page and paragraph, leave other locator labels in long form, cf. Rule 8.13 -->
-    <group delimiter=" ">
-      <choose>
-        <if locator="page paragraph" match="any">
-          <label variable="locator" form="short"/>
-        </if>
-        <else>
-          <label variable="locator" text-case="capitalize-first"/>
-        </else>
-      </choose>
-      <text variable="locator"/>
+      </group>
     </group>
   </macro>
-  <citation et-al-min="3" et-al-use-first="1" disambiguate-add-year-suffix="true" disambiguate-add-names="true" disambiguate-add-givenname="true" collapse="year" givenname-disambiguation-rule="primary-name-with-initials">
+  <macro name="container-treaty">
+    <group delimiter=" ">
+      <number variable="volume"/>
+      <text variable="container-title"/>
+      <choose>
+        <if match="any" variable="page page-first">
+          <text variable="page-first"/>
+        </if>
+        <else>
+          <text macro="number-labelled"/>
+        </else>
+      </choose>
+    </group>
+  </macro>
+  <!-- Legal source logic -->
+  <macro name="container-legal">
+    <!-- Expect legal item container-titles to be stored in short form -->
+    <choose>
+      <if type="bill">
+        <text macro="container-bill"/>
+      </if>
+      <else-if type="hearing">
+        <text macro="container-hearing"/>
+      </else-if>
+      <else-if type="legal_case">
+        <text macro="container-legal-case"/>
+      </else-if>
+      <else-if type="legislation">
+        <text macro="container-legislation"/>
+      </else-if>
+      <else-if type="regulation">
+        <text macro="container-regulation"/>
+      </else-if>
+      <else-if type="treaty">
+        <text macro="container-treaty"/>
+      </else-if>
+    </choose>
+  </macro>
+  <!-- Main logic -->
+  <citation collapse="year" disambiguate-add-givenname="true" disambiguate-add-names="true" disambiguate-add-year-suffix="true" et-al-min="3" et-al-use-first="1" givenname-disambiguation-rule="primary-name-with-initials">
     <sort>
       <key macro="author-sort" names-min="3" names-use-first="1"/>
       <key macro="date-sort-group" sort="ascending"/>
       <key macro="date-sort" sort="ascending"/>
       <key variable="status"/>
     </sort>
-    <layout prefix="(" suffix=")" delimiter="; ">
+    <layout delimiter="; " prefix="(" suffix=")">
       <group delimiter=", ">
         <text macro="author-intext"/>
         <text macro="date-intext"/>
-        <text macro="citation-locator"/>
+        <text macro="locator-labelled"/>
       </group>
     </layout>
   </citation>
-  <bibliography hanging-indent="true" et-al-min="21" et-al-use-first="19" et-al-use-last="true" entry-spacing="0" line-spacing="1">
+  <macro name="bibliography">
+    <group delimiter=" ">
+      <group delimiter=". " suffix=".">
+        <text macro="author-bib"/>
+        <text macro="date-bib"/>
+        <text macro="title-and-descriptions"/>
+        <text macro="container"/>
+        <text macro="event"/>
+        <text macro="publication-archive"/>
+      </group>
+      <text macro="access"/>
+      <text macro="publication-history"/>
+    </group>
+  </macro>
+  <macro name="bibliography-filtered">
+    <choose>
+      <if match="any" type="bill hearing legal_case legislation regulation treaty">
+        <!-- Legal items have different orders and delimiters -->
+        <text macro="legal-bib"/>
+      </if>
+      <else-if type="personal_communication">
+        <choose>
+          <if match="any" variable="archive archive-place container-title DOI publisher URL">
+            <text macro="bibliography"/>
+          </if>
+        </choose>
+      </else-if>
+      <else>
+        <text macro="bibliography"/>
+      </else>
+    </choose>
+  </macro>
+  <bibliography entry-spacing="0" et-al-min="21" et-al-use-first="19" et-al-use-last="true" hanging-indent="true" line-spacing="1">
     <sort>
       <key macro="author-sort"/>
       <key macro="date-sort-group" sort="ascending"/>
       <key macro="date-sort" sort="ascending"/>
       <key variable="status"/>
-      <key macro="title"/>
+      <key macro="title-bib"/>
     </sort>
     <layout>
-      <choose>
-        <if type="bill hearing legal_case legislation regulation treaty" match="any">
-          <!-- Legal items have different orders and delimiters -->
-          <text macro="legal-cites"/>
-        </if>
-        <else>
-          <group delimiter=" ">
-            <group delimiter=". " suffix=".">
-              <text macro="author-bib"/>
-              <text macro="date-bib"/>
-              <text macro="title-and-descriptions"/>
-              <text macro="container"/>
-              <text macro="event"/>
-              <text macro="publisher"/>
-            </group>
-            <text macro="access"/>
-            <text macro="publication-history"/>
-          </group>
-        </else>
-      </choose>
+      <text macro="bibliography-filtered"/>
     </layout>
   </bibliography>
 </style>

--- a/apa-with-abstract.csl
+++ b/apa-with-abstract.csl
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
-<style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" demote-non-dropping-particle="never" page-range-format="expanded">
+<style xmlns="http://purl.org/net/xbiblio/csl" and="symbol" class="in-text" demote-non-dropping-particle="never" initialize-with=". " names-delimiter=", " page-range-format="expanded" version="1.0">
   <info>
     <title>American Psychological Association 7th edition (with abstract)</title>
-    <title-short>APA (with abstract)</title-short>
+    <title-short>APA Style (with abstract)</title-short>
     <id>http://www.zotero.org/styles/apa-with-abstract</id>
     <link href="http://www.zotero.org/styles/apa-with-abstract" rel="self"/>
     <link href="http://www.zotero.org/styles/apa" rel="template"/>
@@ -10,48 +10,53 @@
     <author>
       <name>Brenton M. Wiernik</name>
       <email>zotero@wiernik.org</email>
+      <uri>https://orcid.org/0000-0001-9560-6336</uri>
     </author>
+    <contributor>
+      <name>Andrew Dunning</name>
+      <uri>https://orcid.org/0000-0003-0464-5036</uri>
+    </contributor>
     <category citation-format="author-date"/>
     <category field="psychology"/>
     <category field="generic-base"/>
+    <summary>Author–date system of the Publication manual of the American Psychological Association: The official guide to APA style (2020)</summary>
     <updated>2024-07-09T20:08:41+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale xml:lang="en">
     <terms>
-      <term name="editortranslator" form="short">
-        <single>ed. &amp; trans.</single>
-        <multiple>eds. &amp; trans.</multiple>
-      </term>
-      <term name="editor-translator" form="short">
-        <single>ed. &amp; trans.</single>
-        <multiple>eds. &amp; trans.</multiple>
-      </term>
-      <term name="translator" form="short">trans.</term>
-      <term name="interviewer" form="short">
-        <single>interviewer</single>
-        <multiple>interviewers</multiple>
-      </term>
-      <term name="collection-editor" form="short">
+      <term name="ad"> C.E.</term>
+      <term form="long" name="at">before the</term>
+      <term name="bc"> B.C.E.</term>
+      <term form="short" name="circa">ca.</term>
+      <term name="collection">archival collection</term>
+      <term form="short" name="collection-editor">
         <single>ed.</single>
         <multiple>eds.</multiple>
       </term>
-      <term name="performer" form="verb">recorded by</term>
-      <term name="circa" form="short">ca.</term>
-      <term name="bc"> B.C.E.</term>
-      <term name="ad"> C.E.</term>
-      <term name="issue" form="long">
+      <term form="short" name="editor-translator">
+        <single>ed. &amp; trans.</single>
+        <multiple>eds. &amp; trans.</multiple>
+      </term>
+      <term form="short" name="editortranslator">
+        <single>ed. &amp; trans.</single>
+        <multiple>eds. &amp; trans.</multiple>
+      </term>
+      <term form="verb" name="hearing">testimony of</term>
+      <term form="short" name="interviewer">
+        <single>interviewer</single>
+        <multiple>interviewers</multiple>
+      </term>
+      <term form="long" name="issue">
         <single>issue</single>
         <multiple>issues</multiple>
       </term>
-      <term name="software">computer software</term>
-      <term name="at" form="long">before the</term>
-      <term name="collection">archival collection</term>
+      <term form="verb" name="performer">recorded by</term>
       <term name="post">online post</term>
-      <term name="at" form="long">before the</term>
-      <term name="hearing" form="verb">testimony of</term>
-      <term name="review-of" form="long">review of the</term>
-      <term name="review-of" form="short">review of</term>
+      <term form="long" name="review-of">review of the</term>
+      <term form="short" name="review-of">review of</term>
+      <term name="software">computer software</term>
+      <term form="short" name="translator">trans.</term>
     </terms>
   </locale>
   <locale xml:lang="da">
@@ -71,7 +76,7 @@
   </locale>
   <locale xml:lang="fr">
     <terms>
-      <term name="editor" form="short">
+      <term form="short" name="editor">
         <single>éd.</single>
         <multiple>éds.</multiple>
       </term>
@@ -97,29 +102,26 @@
       <term name="et-al">et al.</term>
     </terms>
   </locale>
-  <!-- For Indigeneous Knowledge, assume the item is stored as `document` or `speech`
-       and that Nation/Community, treaty, where the Elder lives, 
-       and topic are all stored in `title`
-       cf. https://libguides.norquest.ca/c.php?g=314831&p=5188823.
-       If the item is stored as `interview`, assume that Nation/Community, treat, and topic
-       are stored in `title`, 'Oral teaching' or similar is stored in `archive`, and where
-       the Elder lives is stored in `archive-place`. 
-  -->
-  <!-- Reviews are detected if an item has type `review` or `review-book` or if it has any of the variables
-       `reviewed-title`, `reviewed-author`, or `reviewed-genre`. For the latter case, reviews are commonly 
-       stored as types `article-journal`, `article-magazine`, `article-newspaper`, `post-weblog`, or `webpage` 
-  -->
-  <!-- General categories of item types:
-       Periodical: article-journal article-magazine article-newspaper periodical post-weblog review review-book
-       Periodical or Booklike: paper-conference
-       Booklike: article book broadcast chapter classic collection dataset document
-                 entry entry-dictionary entry-encyclopedia event figure
-                 graphic interview manuscript map motion_picture musical_score
-                 pamphlet patent performance personal_communication post report
-                 software song speech standard thesis webpage
-       Legal: bill hearing legal_case legislation regulation treaty
+  <!-- General categories of CSL item types:
+
+       Periodical
+       : article-journal article-magazine article-newspaper periodical post-weblog review review-book
+
+       Periodical or Booklike
+       : paper-conference
+
+       Booklike
+       : article book broadcast chapter classic collection dataset document
+         entry entry-dictionary entry-encyclopedia event figure
+         graphic interview manuscript map motion_picture musical_score
+         pamphlet patent performance personal_communication post report
+         software song speech standard thesis webpage
+
+       Legal
+       : bill hearing legal_case legislation regulation treaty
   -->
   <!-- Equivalencies:
+
        classic == book
        document == report, but give full date
        standard == report
@@ -128,6 +130,7 @@
        collection == book, but give full date
   -->
   <!-- Role equivalencies:
+
        compiler == editor
        organizer, curator == chair
        script-writer == director
@@ -135,128 +138,294 @@
        guest, host == director
        series-creator, executive-producer == editor
   -->
-  <!-- APA references contain four parts: author, date, title, source -->
+  <!-- Reviews are detected if an item has type `review` or `review-book` or if it has any of the variables
+       `reviewed-title`, `reviewed-author`, or `reviewed-genre`. For the latter case, reviews are commonly
+       stored as types `article-journal`, `article-magazine`, `article-newspaper`, `post-weblog`, or `webpage`
+  -->
+  <!-- For Indigeneous Knowledge, assume the item is stored as `document` or `speech`
+       and that Nation/Community, treaty, where the Elder lives,
+       and topic are all stored in `title`
+       cf. https://libguides.norquest.ca/c.php?g=314831&p=5188823.
+       If the item is stored as `interview`, assume that Nation/Community, treaty territory, and topic
+       are stored in `title`, 'Oral teaching' or similar is stored in `archive`, and where
+       the Elder lives is stored in `archive-place`.
+  -->
+  <!-- Variable labelling macros -->
+  <macro name="chapter-number-labelled">
+    <group delimiter=" ">
+      <choose>
+        <if is-numeric="chapter-number">
+          <label form="short" variable="chapter-number"/>
+        </if>
+      </choose>
+      <text variable="chapter-number"/>
+    </group>
+  </macro>
+  <macro name="edition-labelled">
+    <choose>
+      <if is-numeric="edition">
+        <group delimiter=" ">
+          <number form="ordinal" variable="edition"/>
+          <label form="short" variable="edition"/>
+        </group>
+      </if>
+      <else>
+        <text variable="edition"/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="issue-labelled">
+    <group delimiter=" ">
+      <label text-case="capitalize-first" variable="issue"/>
+      <text variable="issue"/>
+    </group>
+  </macro>
+  <macro name="locator-labelled">
+    <!-- Abbreviate page and paragraph; leave other locator labels in long form (APA 8.13) -->
+    <group delimiter=" ">
+      <choose>
+        <if locator="page paragraph" match="any">
+          <label form="short" variable="locator"/>
+        </if>
+        <else>
+          <label text-case="capitalize-first" variable="locator"/>
+        </else>
+      </choose>
+      <text variable="locator"/>
+    </group>
+  </macro>
+  <macro name="number-labelled">
+    <group delimiter=" ">
+      <choose>
+        <if is-numeric="number">
+          <label form="short" text-case="capitalize-first" variable="number"/>
+        </if>
+        <else-if match="none" type="broadcast">
+          <label form="short" text-case="capitalize-first" variable="number"/>
+        </else-if>
+      </choose>
+      <text variable="number"/>
+    </group>
+  </macro>
+  <macro name="number-article-labelled">
+    <!-- APA example 6: Journal article with article number or eLocator -->
+    <group delimiter=" ">
+      <text term="article-locator" text-case="capitalize-first"/>
+      <text variable="number"/>
+    </group>
+  </macro>
+  <macro name="number-of-volumes-labelled">
+    <choose>
+      <if is-numeric="number-of-volumes">
+        <group delimiter=" ">
+          <label form="short" text-case="capitalize-first" variable="number-of-volumes"/>
+          <text prefix="1" term="page-range-delimiter"/>
+        </group>
+      </if>
+    </choose>
+    <text variable="number-of-volumes"/>
+  </macro>
+  <macro name="page-labelled">
+    <group delimiter=" ">
+      <label form="short" variable="page"/>
+      <text variable="page"/>
+    </group>
+  </macro>
+  <macro name="part-number-labelled">
+    <group delimiter=" ">
+      <choose>
+        <if variable="part-number">
+          <!-- TODO: Replace with `part-number` label when CSL provides one -->
+          <text form="short" term="part" text-case="capitalize-first"/>
+          <text variable="part-number"/>
+        </if>
+      </choose>
+    </group>
+  </macro>
+  <macro name="section-labelled">
+    <group delimiter=" ">
+      <label form="symbol" variable="section"/>
+      <text variable="section"/>
+    </group>
+  </macro>
+  <macro name="supplement-number-labelled">
+    <group delimiter=" ">
+      <choose>
+        <if variable="supplement-number">
+          <!-- TODO: Replace with `supplement-number` label when CSL provides one -->
+          <text form="short" term="supplement" text-case="capitalize-first"/>
+          <text variable="supplement-number"/>
+        </if>
+      </choose>
+    </group>
+  </macro>
+  <macro name="version-labelled">
+    <group delimiter=" ">
+      <label text-case="capitalize-first" variable="version"/>
+      <text variable="version"/>
+    </group>
+  </macro>
+  <macro name="volume-labelled">
+    <group delimiter=" ">
+      <label form="short" text-case="capitalize-first" variable="volume"/>
+      <text variable="volume"/>
+    </group>
+  </macro>
+  <!-- Four parts in APA references:
+
+       1. Author (APA 9.7–12)
+       2. Date (APA 9.13–17)
+       3. Title (APA 9.18–22)
+       4. Source (APA 9.23–37)
+  -->
+  <!-- 1. Author -->
+  <!-- Author utility macros -->
+  <macro name="author-substitute-bib">
+    <names variable="composer">
+      <name delimiter-precedes-last="always" name-as-sort-order="all"/>
+      <label form="short" prefix=" (" suffix=")" text-case="title"/>
+      <substitute>
+        <names variable="author"/>
+        <!-- `narrator` only cited in secondary-contributors -->
+        <names variable="illustrator"/>
+        <choose>
+          <if type="broadcast">
+            <names variable="script-writer director">
+              <!-- Actors/performers and producers [not executive] not cited in APA style. -->
+              <name delimiter-precedes-last="always" name-as-sort-order="all"/>
+              <label form="long" prefix=" (" suffix=")" text-case="title"/>
+            </names>
+          </if>
+        </choose>
+        <names variable="director">
+          <!-- For non-broadcast items, APA only cites directors and not writers. -->
+          <name delimiter-precedes-last="always" name-as-sort-order="all"/>
+          <label form="long" prefix=" (" suffix=")" text-case="title"/>
+        </names>
+        <names variable="guest host">
+          <!-- TODO: Replace `delimiter` with `collapse` to combine names variables when that becomes available. -->
+          <name delimiter-precedes-last="always" name-as-sort-order="all"/>
+          <label form="long" prefix=" (" suffix=")" text-case="title"/>
+        </names>
+        <names variable="producer">
+          <!-- Producers not cited if there is a writer/director, but use if they are the principle creator. -->
+          <name delimiter-precedes-last="always" name-as-sort-order="all"/>
+          <label form="long" prefix=" (" suffix=")" text-case="title"/>
+        </names>
+        <choose>
+          <if variable="container-title">
+            <choose>
+              <if match="any" type="book classic collection entry entry-dictionary entry-encyclopedia">
+                <!-- Items with book-like container-title substitute with their title and identification,
+                     but leave description after container-title. This mimics the `container-booklike` formatting. -->
+                <text macro="title-substitute"/>
+              </if>
+            </choose>
+          </if>
+        </choose>
+        <names variable="executive-producer">
+          <name delimiter-precedes-last="always" name-as-sort-order="all"/>
+          <label form="long" prefix=" (" suffix=")" text-case="title"/>
+        </names>
+        <names variable="series-creator">
+          <name delimiter-precedes-last="always" name-as-sort-order="all"/>
+          <label form="long" prefix=" (" suffix=")" text-case="title"/>
+        </names>
+        <names variable="editor-translator"/>
+        <!-- Translator is not cited as a primary creator (only as Ed. & Trans.). -->
+        <names variable="editor"/>
+        <names variable="editorial-director"/>
+        <names variable="compiler">
+          <name delimiter-precedes-last="always" name-as-sort-order="all"/>
+          <label form="long" prefix=" (" suffix=")" text-case="title"/>
+        </names>
+        <choose>
+          <if match="any" type="event performance speech">
+            <names variable="chair">
+              <name delimiter-precedes-last="always" name-as-sort-order="all"/>
+              <label form="long" prefix=" (" suffix=")" text-case="title"/>
+            </names>
+            <names variable="organizer">
+              <name delimiter-precedes-last="always" name-as-sort-order="all"/>
+              <label form="long" prefix=" (" suffix=")" text-case="title"/>
+            </names>
+          </if>
+        </choose>
+        <names variable="curator">
+          <name delimiter-precedes-last="always" name-as-sort-order="all"/>
+          <label form="long" prefix=" (" suffix=")" text-case="title"/>
+        </names>
+        <names variable="collection-editor"/>
+        <text macro="title-substitute"/>
+      </substitute>
+    </names>
+  </macro>
+  <macro name="author-substitute-intext">
+    <names variable="composer">
+      <name form="short"/>
+      <substitute>
+        <names variable="author"/>
+        <names variable="illustrator"/>
+        <!-- TODO: Replace `delimiter` with `collapse` to combine names variables when that becomes available. -->
+        <choose>
+          <if type="broadcast">
+            <names variable="script-writer"/>
+          </if>
+        </choose>
+        <names variable="director"/>
+        <!-- TODO: Replace `delimiter` with `collapse` to combine names variables when that becomes available. -->
+        <names variable="guest host"/>
+        <names variable="producer"/>
+        <choose>
+          <if variable="container-title">
+            <choose>
+              <if match="any" type="book classic collection entry entry-dictionary entry-encyclopedia">
+                <text macro="title-intext"/>
+              </if>
+            </choose>
+          </if>
+        </choose>
+        <names variable="executive-producer"/>
+        <names variable="series-creator"/>
+        <names variable="editor"/>
+        <names variable="editorial-director"/>
+        <names variable="compiler"/>
+        <choose>
+          <if match="any" type="event performance speech">
+            <names variable="chair"/>
+            <names variable="organizer"/>
+          </if>
+        </choose>
+        <names variable="curator"/>
+        <text macro="title-intext"/>
+      </substitute>
+    </names>
+  </macro>
+  <macro name="title-substitute">
+    <choose>
+      <if variable="title">
+        <!-- If an item has a title, substitute missing author with title and identification, but leave description after the date (in the 'title' position). -->
+        <group delimiter=" ">
+          <text macro="title-bib"/>
+          <text macro="identification"/>
+        </group>
+      </if>
+      <else>
+        <!-- If an item has no title, substitute with description followed by identification. -->
+        <text macro="title-and-descriptions"/>
+      </else>
+    </choose>
+  </macro>
+  <!-- Author logic -->
   <macro name="author-bib">
     <group delimiter=" ">
-      <names variable="composer" delimiter=", &amp; ">
-        <name name-as-sort-order="all" and="symbol" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
-        <substitute>
-          <names variable="author"/>
-          <!-- Note: `narrator` only cited in secondary-contributors -->
-          <names variable="illustrator"/>
-          <!-- TODO: Replace `delimiter` with `collapse` to combine names variables when that becomes available. -->
-          <choose>
-            <if type="broadcast">
-              <names variable="script-writer director">
-                <!-- Note: Actors/performers and producers [not executive] not cited in APA style. -->
-                <name name-as-sort-order="all" and="symbol" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
-                <label form="long" prefix=" (" suffix=")" text-case="title"/>
-              </names>
-            </if>
-          </choose>
-          <names variable="director">
-            <!-- For non-broadcast items, APA only cites directors and not writers. -->
-            <name name-as-sort-order="all" and="symbol" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
-            <label form="long" prefix=" (" suffix=")" text-case="title"/>
-          </names>
-          <!-- TODO: Replace `delimiter` with `collapse` to combine names variables when that becomes available. -->
-          <names variable="guest host">
-            <name name-as-sort-order="all" and="symbol" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
-            <label form="long" prefix=" (" suffix=")" text-case="title"/>
-          </names>
-          <names variable="producer">
-            <!-- Note: Producers not cited if there is a writer/director, but use if they are the principle creator. -->
-            <name name-as-sort-order="all" and="symbol" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
-            <label form="long" prefix=" (" suffix=")" text-case="title"/>
-          </names>
-          <choose>
-            <if variable="container-title">
-              <choose>
-                <if type="book classic collection entry entry-dictionary entry-encyclopedia" match="any">
-                  <!-- Items with book-like container-title substitute with their title and parenthetical, 
-                       but leave bracketed after container-title. This mimics the `container-booklike` formatting. -->
-                  <choose>
-                    <if variable="title">
-                      <group delimiter=" ">
-                        <text macro="title"/>
-                        <text macro="parenthetical"/>
-                      </group>
-                    </if>
-                    <else>
-                      <text macro="title-and-descriptions"/>
-                    </else>
-                  </choose>
-                </if>
-              </choose>
-            </if>
-          </choose>
-          <names variable="executive-producer">
-            <name name-as-sort-order="all" and="symbol" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
-            <label form="long" prefix=" (" suffix=")" text-case="title"/>
-          </names>
-          <names variable="series-creator">
-            <name name-as-sort-order="all" and="symbol" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
-            <label form="long" prefix=" (" suffix=")" text-case="title"/>
-          </names>
-          <names variable="editor-translator">
-            <name name-as-sort-order="all" and="symbol" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
-            <label form="short" prefix=" (" suffix=")" text-case="title"/>
-          </names>
-          <!-- Note: Translator is not cited as a primary creator (only as Ed. & Trans.). -->
-          <names variable="editor">
-            <name name-as-sort-order="all" and="symbol" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
-            <label form="short" prefix=" (" suffix=")" text-case="title"/>
-          </names>
-          <names variable="editorial-director">
-            <name name-as-sort-order="all" and="symbol" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
-            <label form="short" prefix=" (" suffix=")" text-case="title"/>
-          </names>
-          <names variable="compiler">
-            <name name-as-sort-order="all" and="symbol" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
-            <label form="long" prefix=" (" suffix=")" text-case="title"/>
-          </names>
-          <choose>
-            <if type="event performance speech" match="any">
-              <names variable="chair">
-                <name name-as-sort-order="all" and="symbol" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
-                <label form="long" prefix=" (" suffix=")" text-case="title"/>
-              </names>
-              <names variable="organizer">
-                <name name-as-sort-order="all" and="symbol" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
-                <label form="long" prefix=" (" suffix=")" text-case="title"/>
-              </names>
-            </if>
-          </choose>
-          <names variable="curator">
-            <name name-as-sort-order="all" and="symbol" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
-            <label form="long" prefix=" (" suffix=")" text-case="title"/>
-          </names>
-          <names variable="collection-editor">
-            <name name-as-sort-order="all" and="symbol" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
-            <label form="short" prefix=" (" suffix=")" text-case="title"/>
-          </names>
-          <choose>
-            <if variable="title">
-              <!-- If an item has a title, substitute missing author with title and parenthetical, but leave bracketed 
-                   after the date (in the 'title' position). -->
-              <group delimiter=" ">
-                <text macro="title"/>
-                <text macro="parenthetical"/>
-              </group>
-            </if>
-            <else>
-              <!-- If an item has no title, substitute with bracketed followed by parenthetical. -->
-              <text macro="title-and-descriptions"/>
-            </else>
-          </choose>
-        </substitute>
-      </names>
+      <text macro="author-substitute-bib"/>
       <choose>
         <!-- Print "with" contributor for books, but not for other types that commonly have them (eg, thesis, software) -->
-        <if type="book classic collection" match="any">
-          <names variable="contributor" prefix="(" suffix=")">
+        <if match="any" type="book classic collection">
+          <names prefix="(" suffix=")" variable="contributor">
             <label form="verb" suffix=" "/>
-            <name name-as-sort-order="all" and="symbol" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
+            <name delimiter-precedes-last="always" name-as-sort-order="all"/>
           </names>
         </if>
       </choose>
@@ -264,80 +433,21 @@
   </macro>
   <macro name="author-intext">
     <choose>
-      <if type="bill hearing legal_case legislation regulation treaty" match="any">
+      <if match="any" type="bill hearing legal_case legislation regulation treaty">
         <text macro="title-intext"/>
       </if>
-      <else-if type="interview personal_communication" match="any">
-        <choose>
-          <!-- These variables indicate that the letter is retrievable by the reader.
-                If not, then use the APA in-text-only personal communication format -->
-          <if variable="archive container-title DOI publisher URL" match="none">
-            <group delimiter=", ">
-              <names variable="author">
-                <name and="symbol" delimiter=", " initialize-with=". "/>
-                <substitute>
-                  <text macro="title-intext"/>
-                </substitute>
-              </names>
-              <text term="personal-communication"/>
-            </group>
-          </if>
-          <else>
-            <names variable="author" delimiter=", ">
-              <name form="short" and="symbol" delimiter=", " initialize-with=". "/>
-              <substitute>
-                <text macro="title-intext"/>
-              </substitute>
-            </names>
-          </else>
-        </choose>
+      <else-if match="any" type="interview personal_communication">
+        <text macro="title-intext-interview-communication"/>
       </else-if>
       <else>
-        <names variable="composer" delimiter=" &amp; ">
-          <name form="short" and="symbol" delimiter=", " initialize-with=". "/>
-          <substitute>
-            <names variable="author"/>
-            <names variable="illustrator"/>
-            <!-- TODO: Replace `delimiter` with `collapse` to combine names variables when that becomes available. -->
-            <choose>
-              <if type="broadcast">
-                <names variable="script-writer director"/>
-              </if>
-            </choose>
-            <names variable="director"/>
-            <!-- TODO: Replace `delimiter` with `collapse` to combine names variables when that becomes available. -->
-            <names variable="guest host"/>
-            <names variable="producer"/>
-            <choose>
-              <if variable="container-title">
-                <choose>
-                  <if type="book classic collection entry entry-dictionary entry-encyclopedia" match="any">
-                    <text macro="title-intext"/>
-                  </if>
-                </choose>
-              </if>
-            </choose>
-            <names variable="executive-producer"/>
-            <names variable="series-creator"/>
-            <names variable="editor"/>
-            <names variable="editorial-director"/>
-            <names variable="compiler"/>
-            <choose>
-              <if type="event performance speech" match="any">
-                <names variable="chair"/>
-                <names variable="organizer"/>
-              </if>
-            </choose>
-            <names variable="curator"/>
-            <text macro="title-intext"/>
-          </substitute>
-        </names>
+        <text macro="author-substitute-intext"/>
       </else>
     </choose>
   </macro>
+  <!-- Author sorting -->
   <macro name="author-sort">
     <choose>
-      <if type="bill hearing legal_case legislation regulation treaty" match="any">
+      <if match="any" type="bill hearing legal_case legislation regulation treaty">
         <text macro="title-legal"/>
       </if>
       <else>
@@ -345,92 +455,161 @@
       </else>
     </choose>
   </macro>
-  <macro name="date-bib">
-    <group delimiter=" " prefix="(" suffix=")">
-      <choose>
-        <if is-uncertain-date="issued">
-          <text term="circa" form="short"/>
-        </if>
-      </choose>
-      <group>
-        <choose>
-          <if variable="issued">
-            <group delimiter=", ">
-              <group>
-                <date variable="issued" date-parts="year" form="numeric"/>
-                <text variable="year-suffix"/>
-              </group>
-              <choose>
-                <if type="article-magazine article-newspaper broadcast collection document event interview motion_picture pamphlet performance personal_communication post post-weblog song speech webpage" match="any">
-                  <!-- Many video and audio examples in manual give full dates. Err on the side of too much information. -->
-                  <date variable="issued">
-                    <date-part name="month"/>
-                    <date-part name="day" prefix=" "/>
-                  </date>
-                </if>
-                <else-if type="paper-conference">
-                  <!-- Capture 'speech' stored as 'paper-conference' -->
-                  <choose>
-                    <if variable="collection-editor compiler editor editorial-director issue page volume" match="none">
-                      <date variable="issued">
-                        <date-part name="month"/>
-                        <date-part name="day" prefix=" "/>
-                      </date>
-                    </if>
-                  </choose>
-                </else-if>
-                <!-- Only year: article article-journal book chapter classic entry entry-dictionary entry-encyclopedia dataset figure graphic
-                     manuscript map musical_score paper-conference[published] patent periodical report review review-book software standard thesis -->
-              </choose>
-            </group>
-          </if>
-          <else-if variable="status">
-            <group>
-              <!-- We print the status variable directly rather than using in-press, etc. terms. -->
-              <text variable="status" text-case="lowercase"/>
-              <text variable="year-suffix" prefix="-"/>
-            </group>
-          </else-if>
-          <else>
-            <text term="no date" form="short"/>
-            <text variable="year-suffix" prefix="-"/>
-          </else>
-        </choose>
-      </group>
+  <!-- 2. Date -->
+  <!-- Date utility macros -->
+  <macro name="date-issued-full">
+    <group delimiter=" ">
+      <text macro="uncertain-date-issued"/>
+      <date form="text" variable="issued"/>
     </group>
   </macro>
-  <macro name="date-sort">
-    <!-- This is necessary to ensure that citeproc sorts all item types chonologically in the same list. -->
+  <macro name="date-issued-leading-zeros">
+    <date delimiter="-" variable="issued">
+      <date-part form="long" name="year"/>
+      <date-part form="numeric-leading-zeros" name="month"/>
+      <date-part form="numeric-leading-zeros" name="day"/>
+    </date>
+  </macro>
+  <macro name="date-issued-month-day">
+    <date variable="issued">
+      <date-part name="month"/>
+      <date-part name="day" prefix=" "/>
+    </date>
+  </macro>
+  <macro name="date-issued-year">
+    <group delimiter=" ">
+      <text macro="uncertain-date-issued"/>
+      <date date-parts="year" form="numeric" variable="issued"/>
+    </group>
+  </macro>
+  <macro name="original-date-year">
+    <group delimiter=" ">
+      <choose>
+        <if is-uncertain-date="original-date">
+          <text form="short" term="circa"/>
+        </if>
+      </choose>
+      <date variable="original-date">
+        <date-part name="year"/>
+      </date>
+    </group>
+  </macro>
+  <macro name="uncertain-date-issued">
     <choose>
-      <if type="article article-journal book chapter entry entry-dictionary entry-encyclopedia dataset figure graphic manuscript map musical_score patent report review review-book thesis" match="any">
-        <date variable="issued" date-parts="year" form="numeric"/>
+      <if is-uncertain-date="issued">
+        <text form="short" term="circa"/>
+      </if>
+    </choose>
+  </macro>
+  <!-- Date logic -->
+  <macro name="date-bib">
+    <group prefix="(" suffix=")">
+      <choose>
+        <if variable="issued">
+          <group delimiter=", ">
+            <group>
+              <text macro="date-issued-year"/>
+              <text variable="year-suffix"/>
+            </group>
+            <choose>
+              <if match="any" type="article-magazine article-newspaper broadcast collection document event interview motion_picture pamphlet performance personal_communication post post-weblog song speech webpage">
+                <!-- Many video and audio examples in manual give full dates. Err on the side of too much information. -->
+                <text macro="date-issued-month-day"/>
+              </if>
+              <else-if type="paper-conference">
+                <!-- Capture 'speech' stored as 'paper-conference' -->
+                <choose>
+                  <if match="none" variable="collection-editor compiler editor editorial-director issue page volume">
+                    <text macro="date-issued-month-day"/>
+                  </if>
+                </choose>
+              </else-if>
+              <!-- Only year: article article-journal book chapter classic entry entry-dictionary entry-encyclopedia dataset figure graphic
+                     manuscript map musical_score paper-conference[published] patent periodical report review review-book software standard thesis -->
+            </choose>
+          </group>
+        </if>
+        <else-if variable="status">
+          <group>
+            <!-- We print the status variable directly rather than using in-press, etc. terms. -->
+            <text text-case="lowercase" variable="status"/>
+            <text prefix="-" variable="year-suffix"/>
+          </group>
+        </else-if>
+        <else>
+          <text form="short" term="no date"/>
+          <text prefix="-" variable="year-suffix"/>
+        </else>
+      </choose>
+    </group>
+  </macro>
+  <macro name="date-intext">
+    <choose>
+      <if variable="issued">
+        <group delimiter="/">
+          <text macro="original-date-year"/>
+          <group>
+            <choose>
+              <if match="any" type="interview personal_communication">
+                <choose>
+                  <if match="none" variable="archive archive-place container-title DOI publisher URL">
+                    <!-- These variables indicate that the communication is retrievable by the reader.
+                           If not, then use the in-text-only personal communication format -->
+                    <text macro="date-issued-full"/>
+                  </if>
+                  <else>
+                    <text macro="date-issued-year"/>
+                  </else>
+                </choose>
+              </if>
+              <else>
+                <text macro="date-issued-year"/>
+              </else>
+            </choose>
+            <text variable="year-suffix"/>
+          </group>
+        </group>
+      </if>
+      <else-if variable="status">
+        <!-- We print the status variable directly rather than using in-press, etc. terms. -->
+        <text text-case="lowercase" variable="status"/>
+        <text prefix="-" variable="year-suffix"/>
+      </else-if>
+      <else>
+        <text form="short" term="no date"/>
+        <text prefix="-" variable="year-suffix"/>
+      </else>
+    </choose>
+  </macro>
+  <!-- Date sorting -->
+  <macro name="date-sort">
+    <!-- Sort items by printed issue date without prefixes for original or uncertain dates -->
+    <choose>
+      <if match="any" type="article article-journal book chapter entry entry-dictionary entry-encyclopedia dataset figure graphic manuscript map musical_score patent report review review-book thesis">
+        <date date-parts="year" form="numeric" variable="issued"/>
       </if>
       <else-if type="paper-conference">
         <!-- Capture 'speech' stored as 'paper-conference' -->
         <choose>
-          <if variable="collection-editor compiler editor editorial-director issue page volume" match="any">
-            <date variable="issued" date-parts="year" form="numeric"/>
+          <if match="any" variable="collection-editor compiler editor editorial-director issue page volume">
+            <date date-parts="year" form="numeric" variable="issued"/>
           </if>
           <else>
-            <date variable="issued">
-              <date-part name="year" form="long"/>
-              <date-part name="month" form="numeric-leading-zeros"/>
-              <date-part name="day" form="numeric-leading-zeros"/>
-            </date>
+            <text macro="date-issued-leading-zeros"/>
           </else>
         </choose>
       </else-if>
       <else>
-        <date variable="issued">
-          <date-part name="year" form="long"/>
-          <date-part name="month" form="numeric-leading-zeros"/>
-          <date-part name="day" form="numeric-leading-zeros"/>
-        </date>
+        <text macro="date-issued-leading-zeros"/>
       </else>
     </choose>
   </macro>
   <macro name="date-sort-group">
-    <!-- APA sorts 1. no-date items, 2. items with dates, 3. in-press (status) items -->
+    <!-- Sorts items with and without dates:
+
+         1. no-date items (= 0)
+         2. items with dates (= 1)
+         3. in-press (status) items (= 2) -->
     <choose>
       <if variable="issued">
         <text value="1"/>
@@ -443,111 +622,185 @@
       </else>
     </choose>
   </macro>
-  <macro name="date-intext">
-    <choose>
-      <if variable="issued">
-        <group delimiter="/">
-          <group delimiter=" ">
-            <choose>
-              <if is-uncertain-date="original-date">
-                <text term="circa" form="short"/>
-              </if>
-            </choose>
-            <date variable="original-date">
-              <date-part name="year"/>
-            </date>
-          </group>
-          <group delimiter=" ">
-            <choose>
-              <if is-uncertain-date="issued">
-                <text term="circa" form="short"/>
-              </if>
-            </choose>
-            <group>
-              <choose>
-                <if type="interview personal_communication" match="any">
-                  <choose>
-                    <if variable="archive container-title DOI publisher URL" match="none">
-                      <!-- These variables indicate that the communication is retrievable by the reader.
-                           If not, then use the in-text-only personal communication format -->
-                      <date variable="issued" form="text"/>
-                    </if>
-                    <else>
-                      <date variable="issued">
-                        <date-part name="year"/>
-                      </date>
-                    </else>
-                  </choose>
-                </if>
-                <else>
-                  <date variable="issued">
-                    <date-part name="year"/>
-                  </date>
-                </else>
-              </choose>
-              <text variable="year-suffix"/>
-            </group>
-          </group>
-        </group>
-      </if>
-      <else-if variable="status">
-        <!-- We print the status variable directly rather than using in-press, etc. terms. -->
-        <text variable="status" text-case="lowercase"/>
-        <text variable="year-suffix" prefix="-"/>
-      </else-if>
-      <else>
-        <text term="no date" form="short"/>
-        <text variable="year-suffix" prefix="-"/>
-      </else>
-    </choose>
-  </macro>
-  <!-- APA has two description elements following the title:
-       title (parenthetical) [bracketed] -->
+  <!-- 3. Title and descriptions -->
+  <!-- Three parts in title element (APA 9.21):
+
+       1. Title
+       2. Identification (in parentheses)
+       3. Description [in square brackets] -->
   <macro name="title-and-descriptions">
     <choose>
       <if variable="title">
         <group delimiter=" ">
-          <text macro="title"/>
-          <text macro="parenthetical"/>
-          <text macro="bracketed"/>
+          <text macro="title-bib"/>
+          <text macro="identification"/>
+          <text macro="description-bib"/>
         </group>
       </if>
       <else>
         <choose>
-          <if type="bill report" match="any">
+          <if match="any" type="bill report">
             <!-- Bills, resolutions, and congressional reports are not italicized and substitute bill number if no title. -->
-            <!-- Can't distinguish congressional reports from other reports, 
+            <!-- Can't distinguish congressional reports from other reports,
                  but giving the genre and number seems fine for other reports too. -->
-            <text macro="number"/>
-            <text macro="bracketed"/>
-            <text macro="parenthetical"/>
+            <text macro="genre-number"/>
+            <text macro="description-bib"/>
+            <text macro="identification"/>
           </if>
           <else>
             <group delimiter=" ">
-              <text macro="bracketed"/>
-              <text macro="parenthetical"/>
+              <text macro="description-bib"/>
+              <text macro="identification"/>
             </group>
           </else>
         </choose>
       </else>
     </choose>
   </macro>
-  <macro name="title">
+  <!-- 3.1. Title -->
+  <!-- Title utility macros -->
+  <macro name="title-intext-bill-report">
+    <!-- Bills, resolutions, and congressional reports are not italicized and substitute bill number if no title. -->
+    <!-- Can't distinguish congressional reports from other reports,
+             but giving the genre and number seems fine for other reports too. -->
     <choose>
-      <if type="post webpage" match="any">
+      <if variable="title">
+        <text form="short" text-case="title" variable="title"/>
+      </if>
+      <else>
+        <group delimiter=" ">
+          <text variable="genre"/>
+          <group delimiter=" ">
+            <choose>
+              <if match="none" variable="chapter-number container-title">
+                <text macro="number-labelled"/>
+              </if>
+              <else>
+                <text variable="number"/>
+              </else>
+            </choose>
+          </group>
+        </group>
+      </else>
+    </choose>
+  </macro>
+  <macro name="title-intext-interview-communication">
+    <choose>
+      <!-- These variables indicate that the letter is retrievable by the reader.
+                If not, then use the APA in-text-only personal communication format -->
+      <if match="none" variable="archive archive-place container-title DOI publisher URL">
+        <group delimiter=", ">
+          <names variable="author">
+            <substitute>
+              <text macro="title-intext"/>
+            </substitute>
+          </names>
+          <text term="personal-communication"/>
+        </group>
+      </if>
+      <else>
+        <names variable="author">
+          <name form="short"/>
+          <substitute>
+            <text macro="title-intext"/>
+          </substitute>
+        </names>
+      </else>
+    </choose>
+  </macro>
+  <macro name="title-part">
+    <group delimiter=". ">
+      <text macro="part-number-labelled"/>
+      <text text-case="capitalize-first" variable="part-title"/>
+    </group>
+  </macro>
+  <macro name="title-plus-part-title">
+    <choose>
+      <if match="any" type="review review-book" variable="reviewed-author reviewed-genre reviewed-title">
+        <!-- If a review has no `reviewed-title`, assume that `title` contains the title of the reviewed work
+             and omit it here; it is printed in the `reviewed-item` macro. -->
+        <choose>
+          <if match="none" variable="reviewed-title"/>
+          <else>
+            <group delimiter=": ">
+              <text variable="title"/>
+              <text macro="title-part"/>
+            </group>
+          </else>
+        </choose>
+      </if>
+      <else>
+        <group delimiter=": ">
+          <text variable="title"/>
+          <text macro="title-part"/>
+        </group>
+      </else>
+    </choose>
+  </macro>
+  <macro name="title-plus-volume-title">
+    <group delimiter=": ">
+      <text variable="title"/>
+      <text macro="title-volume"/>
+    </group>
+  </macro>
+  <macro name="title-volume">
+    <group delimiter=": ">
+      <choose>
+        <if variable="volume-title">
+          <group delimiter=". ">
+            <text macro="volume-labelled"/>
+            <text variable="volume-title"/>
+          </group>
+        </if>
+        <else-if is-numeric="volume" match="none">
+          <text macro="volume-labelled"/>
+        </else-if>
+      </choose>
+      <!-- For book-like items, assume part-number and part-title refer to the book/volume. -->
+      <text macro="title-part"/>
+    </group>
+  </macro>
+  <!-- Title logic -->
+  <macro name="booklike-title">
+    <!-- For book-like items, assume part-number and part-title refer to the book/volume. -->
+    <choose>
+      <if variable="container-title">
+        <text variable="title"/>
+      </if>
+      <else>
+        <!-- For book-like items without container titles and with volume-title, append volume-title to title (APA example 30) -->
+        <text font-style="italic" macro="title-plus-volume-title"/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="periodical-title">
+    <!-- For periodicals, assume that part-number and part-title refer to the article and append to title -->
+    <choose>
+      <if variable="container-title">
+        <text macro="title-plus-part-title"/>
+      </if>
+      <else>
+        <!-- for periodical items without container titles, don't append volume-title to title -->
+        <text font-style="italic" macro="title-plus-part-title"/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="title-bib">
+    <choose>
+      <if match="any" type="post webpage">
         <!-- Webpages are always italicized -->
-        <text macro="title-plus-part-title" font-style="italic"/>
+        <text font-style="italic" macro="title-plus-part-title"/>
       </if>
       <!-- Other types are italicized based on presence of container-title.
              Assume that review and review-book are published in periodicals/blogs,
-             not just on a web page (ex. 69) -->
-      <else-if type="article-journal article-magazine article-newspaper periodical post-weblog review review-book" match="any">
+             not just on a webpage (APA example 69) -->
+      <else-if match="any" type="article-journal article-magazine article-newspaper periodical post-weblog review review-book">
         <text macro="periodical-title"/>
       </else-if>
       <else-if type="paper-conference">
         <!-- Treat paper-conference as book-like if it has an editor, otherwise as periodical-like -->
         <choose>
-          <if variable="collection-editor compiler editor editorial-director" match="any">
+          <if match="any" variable="collection-editor compiler editor editorial-director">
             <text macro="booklike-title"/>
           </if>
           <else>
@@ -560,607 +813,104 @@
       </else>
     </choose>
   </macro>
-  <macro name="periodical-title">
-    <!-- For periodicals, assume that part-number and part-title refer to the article and append to title -->
-    <choose>
-      <if variable="container-title" match="any">
-        <text macro="title-plus-part-title"/>
-      </if>
-      <else>
-        <!-- for periodical items without container titles, don't append volume-title to title -->
-        <text macro="title-plus-part-title" font-style="italic"/>
-      </else>
-    </choose>
-  </macro>
-  <macro name="booklike-title">
-    <!-- For book-like items, assume part-number and part-title refer to the book/volume. -->
-    <choose>
-      <if variable="container-title" match="any">
-        <text variable="title"/>
-      </if>
-      <else>
-        <!-- For book-like items without container titles and with volume-title, append volume-title to title (ex. 30) -->
-        <text macro="title-plus-volume-title" font-style="italic"/>
-      </else>
-    </choose>
-  </macro>
-  <macro name="title-plus-part-title">
-    <choose>
-      <if variable="reviewed-author reviewed-genre reviewed-title" type="review review-book" match="any">
-        <!-- If a review has no `reviewed-title`, assume that `title` contains the title of the reviewed work
-             and omit it here; it is printed in the `reviewed-item` macro. -->
-        <choose>
-          <if variable="reviewed-title" match="none"/>
-          <else>
-            <group delimiter=": ">
-              <text variable="title"/>
-              <text macro="part-title"/>
-            </group>
-          </else>
-        </choose>
-      </if>
-      <else>
-        <group delimiter=": ">
-          <text variable="title"/>
-          <text macro="part-title"/>
-        </group>
-      </else>
-    </choose>
-  </macro>
-  <macro name="part-title">
-    <group delimiter=". ">
-      <group delimiter=" ">
-        <label variable="part-number" form="short" text-case="capitalize-first"/>
-        <text variable="part-number"/>
-      </group>
-      <text variable="part-title" text-case="capitalize-first"/>
-    </group>
-  </macro>
-  <macro name="title-plus-volume-title">
-    <group delimiter=": ">
-      <text variable="title"/>
-      <text macro="volume-title"/>
-    </group>
-  </macro>
-  <macro name="volume-title">
-    <group delimiter=": ">
-      <choose>
-        <if variable="volume-title">
-          <group delimiter=" ">
-            <group delimiter=". ">
-              <group delimiter=" ">
-                <label variable="volume" form="short" text-case="capitalize-first"/>
-                <text variable="volume"/>
-              </group>
-              <text variable="volume-title"/>
-            </group>
-          </group>
-        </if>
-        <else-if is-numeric="volume" match="none">
-          <group delimiter=" ">
-            <label variable="volume" form="short" text-case="capitalize-first"/>
-            <text variable="volume"/>
-          </group>
-        </else-if>
-      </choose>
-      <!-- For book-like items, assume part-number and part-title refer to the book/volume. -->
-      <text macro="part-title"/>
-    </group>
-  </macro>
   <macro name="title-intext">
     <choose>
-      <if type="bill report">
-        <!-- Bills, resolutions, and congressional reports are not italicized and substitute bill number if no title. -->
-        <!-- Can't distinguish congressional reports from other reports, 
-             but giving the genre and number seems fine for other reports too. -->
-        <choose>
-          <if variable="title">
-            <text variable="title" form="short" text-case="title"/>
-          </if>
-          <else>
-            <group delimiter=" ">
-              <text variable="genre"/>
-              <group delimiter=" ">
-                <choose>
-                  <if variable="chapter-number container-title" match="none">
-                    <label variable="number" form="short" text-case="capitalize-first"/>
-                  </if>
-                </choose>
-                <text variable="number"/>
-              </group>
-            </group>
-          </else>
-        </choose>
+      <if match="any" type="bill report">
+        <text macro="title-intext-bill-report"/>
       </if>
       <else>
         <choose>
-          <if variable="title" match="none">
-            <text macro="bracketed-intext"/>
+          <if match="none" variable="title">
+            <text macro="description-intext"/>
           </if>
-          <else-if type="hearing">
-            <!-- Hearings are italicized -->
-            <text variable="title" form="short" font-style="italic" text-case="title"/>
+          <else-if type="hearing webpage">
+            <!-- Italicized with title case -->
+            <text font-style="italic" form="short" text-case="title" variable="title"/>
           </else-if>
-          <else-if type="legal_case" match="any">
-            <!-- Cases are italicized -->
-            <text variable="title" font-style="italic"/>
+          <else-if type="legal_case post">
+            <!-- Italicized -->
+            <text font-style="italic" form="short" variable="title"/>
           </else-if>
-          <else-if type="legislation regulation treaty" match="any">
-            <!-- Legislation, regulations, and treaties not italicized or quoted -->
-            <text variable="title" form="short" text-case="title"/>
+          <else-if match="any" type="legislation regulation treaty">
+            <!-- No italics or quotes -->
+            <text form="short" text-case="title" variable="title"/>
           </else-if>
-          <else-if type="post webpage" match="any">
-            <!-- Webpages are always italicized -->
-            <text variable="title" form="short" font-style="italic" text-case="title"/>
-          </else-if>
-          <else-if variable="container-title" match="any">
-            <!-- Other types are italicized or quoted based on presence of container-title. As in title macro. -->
-            <text variable="title" form="short" quotes="true" text-case="title"/>
+          <else-if variable="container-title">
+            <!-- Other types are formatted based on presence of container-title, as in title-bib macro -->
+            <text form="short" quotes="true" text-case="title" variable="title"/>
           </else-if>
           <else>
-            <text variable="title" form="short" font-style="italic" text-case="title"/>
+            <text font-style="italic" form="short" text-case="title" variable="title"/>
           </else>
         </choose>
       </else>
     </choose>
   </macro>
-  <macro name="parenthetical">
-    <!-- (Secondary contributors; Database location; Genre no. 123; Report Series 123, Version, Edition, Volume, Page) -->
-    <group prefix="(" suffix=")">
-      <choose>
-        <if type="patent">
-          <!-- authority: U.S. ; genre: patent ; number: 123,445 -->
-          <group delimiter=" ">
-            <text variable="authority" form="short"/>
-            <choose>
-              <if variable="genre">
-                <text variable="genre" text-case="capitalize-first"/>
-              </if>
-              <else>
-                <text term="patent" text-case="capitalize-first"/>
-              </else>
-            </choose>
-            <group delimiter=" ">
-              <label variable="number" form="short" text-case="capitalize-first"/>
-              <text variable="number"/>
-            </group>
-          </group>
-        </if>
-        <else-if type="post webpage" match="any">
-          <!-- For post webpage, container-title is treated as publisher -->
-          <group delimiter="; ">
-            <text macro="secondary-contributors"/>
-            <text macro="database-location"/>
-            <text macro="number"/>
-            <text macro="locators-booklike"/>
-          </group>
-        </else-if>
-        <else-if type="report" match="any">
-          <choose>
-            <if variable="title" match="none">
-              <!-- If there is no title, then genre and number are already printed as the title. -->
-              <group delimiter="; ">
-                <text macro="secondary-contributors"/>
-                <text macro="database-location"/>
-                <text macro="locators-booklike"/>
-              </group>
-            </if>
-            <!-- If the report is a chapter in a larger report, then most parenthetical information is printed after the container. -->
-            <else-if variable="container-title">
-              <text macro="secondary-contributors"/>
-            </else-if>
-            <else>
-              <group delimiter="; ">
-                <text macro="secondary-contributors"/>
-                <text macro="database-location"/>
-                <text macro="number"/>
-                <text macro="locators-booklike"/>
-              </group>
-            </else>
-          </choose>
-        </else-if>
-        <else-if variable="container-title">
-          <group delimiter="; ">
-            <text macro="secondary-contributors"/>
-            <choose>
-              <if type="broadcast graphic map motion_picture song" match="any">
-                <!-- For audiovisual media, number information comes after title, not container-title (ex. 94) -->
-                <text macro="number"/>
-              </if>
-            </choose>
-          </group>
-        </else-if>
-        <else>
-          <group delimiter="; ">
-            <text macro="secondary-contributors"/>
-            <text macro="database-location"/>
-            <text macro="number"/>
-            <text macro="locators-booklike"/>
-          </group>
-        </else>
-      </choose>
-    </group>
-  </macro>
-  <macro name="parenthetical-container">
+  <!-- 3.2. Identification (in parentheses) -->
+  <!-- Identification utility macros -->
+  <macro name="database-location">
     <choose>
-      <if variable="container-title" match="any">
-        <group prefix="(" suffix=")">
-          <group delimiter="; ">
-            <text macro="database-location"/>
-            <choose>
-              <if type="broadcast graphic map motion_picture song" match="none">
-                <!-- For audiovisual media, number information comes after title, not container-title (ex. 94) -->
-                <text macro="number"/>
-              </if>
-            </choose>
-            <text macro="locators-booklike"/>
+      <if match="none" variable="archive-place">
+        <!-- With `archive-place`: physical archives. Without: online archives. -->
+        <text variable="archive_location"/>
+      </if>
+    </choose>
+  </macro>
+  <macro name="genre-number">
+    <choose>
+      <if variable="number">
+        <group delimiter=", ">
+          <group delimiter=" ">
+            <text text-case="title" variable="genre"/>
+            <text macro="number-labelled"/>
           </group>
+          <choose>
+            <if type="thesis">
+              <choose>
+                <if match="any" variable="archive DOI URL">
+                  <!-- Include the university in brackets if thesis is published -->
+                  <text variable="publisher"/>
+                </if>
+              </choose>
+            </if>
+          </choose>
         </group>
       </if>
     </choose>
   </macro>
-  <macro name="bracketed">
-    <!-- [Descriptive information] -->
-    <!-- If there is a number, genre is already printed in macro="number" -->
-    <group prefix="[" suffix="]">
+  <macro name="locators-booklike">
+    <choose>
+      <if variable="page">
+        <text macro="page-labelled"/>
+      </if>
+      <else-if variable="chapter-number">
+        <text macro="chapter-number-labelled"/>
+      </else-if>
+    </choose>
+  </macro>
+  <macro name="patent-number">
+    <group delimiter=" ">
+      <!-- authority: U.S. ; genre: patent ; number: 123,445 -->
+      <text form="short" variable="authority"/>
       <choose>
-        <if variable="reviewed-author reviewed-genre reviewed-title" type="review review-book" match="any">
-          <text macro="reviewed-item"/>
+        <if variable="genre">
+          <text text-case="capitalize-first" variable="genre"/>
         </if>
-        <else-if type="thesis">
-          <!-- Thesis type and institution -->
-          <group delimiter="; ">
-            <choose>
-              <if variable="number" match="none">
-                <group delimiter=", ">
-                  <text variable="genre" text-case="capitalize-first"/>
-                  <choose>
-                    <if variable="archive DOI URL" match="any">
-                      <!-- Include the university in brackets if thesis is published -->
-                      <text variable="publisher"/>
-                    </if>
-                  </choose>
-                </group>
-              </if>
-            </choose>
-            <text variable="medium" text-case="capitalize-first"/>
-          </group>
-        </else-if>
-        <else-if variable="interviewer" type="interview" match="any">
-          <!-- Interview information -->
-          <choose>
-            <if variable="title">
-              <text macro="format"/>
-            </if>
-            <else-if variable="genre">
-              <group delimiter="; ">
-                <group delimiter=" ">
-                  <text variable="genre" text-case="capitalize-first"/>
-                  <group delimiter=" ">
-                    <text term="container-author" form="verb"/>
-                    <names variable="interviewer">
-                      <name and="symbol" initialize-with=". " delimiter=", "/>
-                    </names>
-                  </group>
-                </group>
-              </group>
-            </else-if>
-            <else-if variable="interviewer">
-              <group delimiter="; ">
-                <names variable="interviewer">
-                  <label form="verb" suffix=" " text-case="capitalize-first"/>
-                  <name and="symbol" initialize-with=". " delimiter=", "/>
-                </names>
-                <text variable="medium" text-case="capitalize-first"/>
-              </group>
-            </else-if>
-            <else>
-              <text macro="format"/>
-            </else>
-          </choose>
-        </else-if>
-        <else-if type="personal_communication">
-          <!-- Letter information -->
-          <choose>
-            <if variable="recipient">
-              <group delimiter="; ">
-                <group delimiter=" ">
-                  <choose>
-                    <if variable="number" match="none">
-                      <choose>
-                        <if variable="genre">
-                          <text variable="genre" text-case="capitalize-first"/>
-                        </if>
-                        <else-if variable="medium">
-                          <text variable="medium" text-case="capitalize-first"/>
-                        </else-if>
-                        <else>
-                          <text term="letter" text-case="capitalize-first"/>
-                        </else>
-                      </choose>
-                    </if>
-                    <else>
-                      <choose>
-                        <if variable="medium">
-                          <text variable="medium" text-case="capitalize-first"/>
-                        </if>
-                        <else>
-                          <text term="letter" text-case="capitalize-first"/>
-                        </else>
-                      </choose>
-                    </else>
-                  </choose>
-                  <names variable="recipient" delimiter=", ">
-                    <label form="verb" suffix=" "/>
-                    <name and="symbol" delimiter=", "/>
-                  </names>
-                </group>
-                <choose>
-                  <if variable="genre" match="any">
-                    <choose>
-                      <if variable="number" match="none">
-                        <text variable="medium" text-case="capitalize-first"/>
-                      </if>
-                    </choose>
-                  </if>
-                </choose>
-              </group>
-            </if>
-            <else>
-              <text macro="format"/>
-            </else>
-          </choose>
-        </else-if>
-        <else-if variable="composer" type="song" match="all">
-          <!-- Performer of classical music works -->
-          <group delimiter="; ">
-            <choose>
-              <if variable="number" match="none">
-                <group delimiter=" ">
-                  <choose>
-                    <if variable="genre">
-                      <text variable="genre" text-case="capitalize-first"/>
-                      <group delimiter=" ">
-                        <text term="performer" form="verb"/>
-                        <names variable="author">
-                          <name and="symbol" initialize-with=". " delimiter=", "/>
-                          <substitute>
-                            <names variable="performer"/>
-                          </substitute>
-                        </names>
-                      </group>
-                    </if>
-                    <else-if variable="medium">
-                      <text variable="medium" text-case="capitalize-first"/>
-                      <group delimiter=" ">
-                        <text term="performer" form="verb"/>
-                        <names variable="author">
-                          <name and="symbol" initialize-with=". " delimiter=", "/>
-                          <substitute>
-                            <names variable="performer"/>
-                          </substitute>
-                        </names>
-                      </group>
-                    </else-if>
-                    <else>
-                      <text term="performer" form="verb" text-case="capitalize-first"/>
-                      <names variable="author">
-                        <name and="symbol" initialize-with=". " delimiter=", "/>
-                        <substitute>
-                          <names variable="performer"/>
-                        </substitute>
-                      </names>
-                    </else>
-                  </choose>
-                </group>
-              </if>
-              <else>
-                <group delimiter=" ">
-                  <choose>
-                    <if variable="medium">
-                      <text variable="medium" text-case="capitalize-first"/>
-                      <group delimiter=" ">
-                        <text term="performer" form="verb"/>
-                        <names variable="author">
-                          <name and="symbol" initialize-with=". " delimiter=", "/>
-                          <substitute>
-                            <names variable="performer"/>
-                          </substitute>
-                        </names>
-                      </group>
-                    </if>
-                    <else>
-                      <text term="performer" form="verb" text-case="capitalize-first"/>
-                      <names variable="author">
-                        <name and="symbol" initialize-with=". " delimiter=", "/>
-                        <substitute>
-                          <names variable="performer"/>
-                        </substitute>
-                      </names>
-                    </else>
-                  </choose>
-                </group>
-              </else>
-            </choose>
-            <choose>
-              <if variable="genre" match="any">
-                <choose>
-                  <if variable="number" match="none">
-                    <text variable="medium" text-case="capitalize-first"/>
-                  </if>
-                </choose>
-              </if>
-            </choose>
-          </group>
-        </else-if>
-        <else-if variable="container-title" match="none">
-          <!-- Other description -->
-          <text macro="format"/>
-        </else-if>
         <else>
-          <!-- For conference presentations/performances/events, chapters in reports/standards/generic documents, software, 
-               place bracketed after the container title -->
-          <choose>
-            <if type="event paper-conference performance speech" match="any">
-              <choose>
-                <if variable="collection-editor compiler editor editorial-director issue page volume" match="any">
-                  <text macro="format"/>
-                </if>
-              </choose>
-            </if>
-            <else-if type="document report software standard" match="none">
-              <text macro="format"/>
-            </else-if>
-          </choose>
+          <text term="patent" text-case="capitalize-first"/>
         </else>
       </choose>
-    </group>
-  </macro>
-  <macro name="bracketed-intext">
-    <group prefix="[" suffix="]">
-      <choose>
-        <if variable="reviewed-title" match="any">
-          <group delimiter=" ">
-            <text term="review-of" text-case="capitalize-first"/>
-            <text macro="reviewed-title-intext"/>
-          </group>
-        </if>
-        <else-if variable="interviewer" type="interview" match="any">
-          <names variable="interviewer">
-            <label form="verb" suffix=" " text-case="capitalize-first"/>
-            <name and="symbol" initialize-with=". " delimiter=", "/>
-            <substitute>
-              <text macro="format-intext"/>
-            </substitute>
-          </names>
-        </else-if>
-        <else-if type="personal_communication">
-          <!-- Letter information -->
-          <choose>
-            <if variable="recipient">
-              <group delimiter=" ">
-                <choose>
-                  <if variable="number" match="none">
-                    <text variable="genre" text-case="capitalize-first"/>
-                  </if>
-                  <else>
-                    <text term="letter" text-case="capitalize-first"/>
-                  </else>
-                </choose>
-                <names variable="recipient" delimiter=", ">
-                  <label form="verb" suffix=" "/>
-                  <name and="symbol" delimiter=", "/>
-                </names>
-              </group>
-            </if>
-            <else>
-              <text macro="format-intext"/>
-            </else>
-          </choose>
-        </else-if>
-        <else>
-          <text macro="format-intext"/>
-        </else>
-      </choose>
-    </group>
-  </macro>
-  <macro name="reviewed-item">
-    <!-- Reviewed item -->
-    <group delimiter="; ">
-      <group delimiter=", ">
-        <group delimiter=" ">
-          <choose>
-            <if variable="reviewed-genre">
-              <group delimiter=" ">
-                <text term="review-of" form="long" text-case="capitalize-first"/>
-                <text variable="reviewed-genre" text-case="lowercase"/>
-              </group>
-            </if>
-            <!-- If no `reviewed-genre`, assume that `genre` or `medium` is entered as 'Review of the book' or similar -->
-            <else-if variable="number" match="none">
-              <choose>
-                <if variable="genre">
-                  <text variable="genre" text-case="capitalize-first"/>
-                </if>
-                <else-if variable="medium">
-                  <text variable="medium" text-case="capitalize-first"/>
-                </else-if>
-                <else-if type="review-book">
-                  <group delimiter=" ">
-                    <text term="review-of" form="long" text-case="capitalize-first"/>
-                    <text term="book" form="long" text-case="lowercase"/>
-                  </group>
-                </else-if>
-                <else>
-                  <text term="review-of" form="short" text-case="capitalize-first"/>
-                </else>
-              </choose>
-            </else-if>
-            <else>
-              <choose>
-                <if variable="medium">
-                  <text variable="medium" text-case="capitalize-first"/>
-                </if>
-                <else-if type="review-book">
-                  <group delimiter=" ">
-                    <text term="review-of" form="long" text-case="capitalize-first"/>
-                    <text term="book" form="long" text-case="lowercase"/>
-                  </group>
-                </else-if>
-                <else>
-                  <text term="review-of" form="short" text-case="capitalize-first"/>
-                </else>
-              </choose>
-            </else>
-          </choose>
-          <text macro="reviewed-title"/>
-        </group>
-        <names variable="reviewed-author">
-          <label form="verb-short" suffix=" "/>
-          <name and="symbol" initialize-with=". " delimiter=", "/>
-        </names>
-      </group>
-      <choose>
-        <if variable="genre" match="any">
-          <choose>
-            <if variable="number" match="none">
-              <text variable="medium" text-case="capitalize-first"/>
-            </if>
-          </choose>
-        </if>
-      </choose>
-    </group>
-  </macro>
-  <macro name="bracketed-container">
-    <group prefix="[" suffix="]">
-      <choose>
-        <if type="event paper-conference performance speech" match="any">
-          <!-- Conference presentations should describe the session [container] in bracketed unless published in a proceedings -->
-          <choose>
-            <if variable="collection-editor compiler editor editorial-director issue page volume" match="none">
-              <text macro="format"/>
-            </if>
-          </choose>
-        </if>
-        <else-if type="software" match="all">
-          <!-- For entries in mobile app reference works, place bracketed after the container-title -->
-          <text macro="format"/>
-        </else-if>
-        <else-if type="document report standard">
-          <!-- For chapters in report, standards, and generic documents, place bracketed after the container title -->
-          <text macro="format"/>
-        </else-if>
-      </choose>
+      <text macro="number-labelled"/>
     </group>
   </macro>
   <macro name="secondary-contributors">
     <choose>
-      <if type="article-journal article-magazine article-newspaper periodical post-weblog review review-book" match="any">
+      <if match="any" type="article-journal article-magazine article-newspaper periodical post-weblog review review-book">
         <text macro="secondary-contributors-periodical"/>
       </if>
       <else-if type="paper-conference">
         <choose>
-          <if variable="collection-editor compiler editor editorial-director" match="any">
+          <if match="any" variable="collection-editor compiler editor editorial-director">
             <text macro="secondary-contributors-booklike"/>
           </if>
           <else>
@@ -1173,53 +923,37 @@
       </else>
     </choose>
   </macro>
-  <macro name="secondary-contributors-periodical">
-    <group delimiter="; ">
-      <choose>
-        <if variable="title">
-          <names variable="interviewer" delimiter="; ">
-            <name and="symbol" initialize-with=". " delimiter=", "/>
-            <label form="short" prefix=", " text-case="title"/>
-          </names>
-        </if>
-      </choose>
-      <names variable="translator narrator" delimiter="; ">
-        <name and="symbol" initialize-with=". " delimiter=", "/>
-        <label form="short" prefix=", " text-case="title"/>
-      </names>
-    </group>
-  </macro>
   <macro name="secondary-contributors-booklike">
     <group delimiter="; ">
       <choose>
         <if variable="title">
           <names variable="interviewer">
-            <name and="symbol" initialize-with=". " delimiter=", "/>
+            <name/>
             <label form="short" prefix=", " text-case="title"/>
           </names>
         </if>
       </choose>
       <choose>
-        <if type="post webpage" match="none">
+        <if match="none" type="post webpage">
           <!-- Webpages treat container-title like publisher -->
           <group delimiter="; ">
-            <names variable="illustrator narrator" delimiter="; ">
-              <name and="symbol" initialize-with=". " delimiter=", "/>
+            <names delimiter="; " variable="illustrator narrator">
+              <name/>
               <label form="short" prefix=", " text-case="title"/>
             </names>
             <choose>
-              <if variable="container-title" match="none">
+              <if match="none" variable="container-title">
                 <group delimiter="; ">
                   <names variable="container-author">
                     <label form="verb-short" suffix=" " text-case="title"/>
-                    <name and="symbol" initialize-with=". " delimiter=", "/>
+                    <name/>
                   </names>
-                  <names variable="editor translator" delimiter="; ">
-                    <name and="symbol" initialize-with=". " delimiter=", "/>
+                  <names delimiter="; " variable="editor translator">
+                    <name/>
                     <label form="short" prefix=", " text-case="title"/>
                   </names>
-                  <names variable="compiler chair organizer curator series-creator executive-producer" delimiter="; ">
-                    <name and="symbol" initialize-with=". " delimiter=", "/>
+                  <names delimiter="; " variable="compiler chair organizer curator series-creator executive-producer">
+                    <name/>
                     <label form="long" prefix=", " text-case="title"/>
                   </names>
                 </group>
@@ -1227,9 +961,9 @@
               <else>
                 <choose>
                   <!-- TODO: Check logic once processors start to automatically populate editor-translator. -->
-                  <if variable="editor-translator" match="none">
-                    <names variable="translator" delimiter="; ">
-                      <name and="symbol" initialize-with=". " delimiter=", "/>
+                  <if match="none" variable="editor-translator">
+                    <names delimiter="; " variable="translator">
+                      <name/>
                       <label form="short" prefix=", " text-case="title"/>
                     </names>
                   </if>
@@ -1242,18 +976,18 @@
           <group delimiter="; ">
             <names variable="container-author">
               <label form="verb-short" suffix=" " text-case="title"/>
-              <name and="symbol" initialize-with=". " delimiter=", "/>
+              <name/>
             </names>
-            <names variable="editor translator" delimiter="; ">
-              <name and="symbol" initialize-with=". " delimiter=", "/>
+            <names delimiter="; " variable="editor translator">
+              <name/>
               <label form="short" prefix=", " text-case="title"/>
             </names>
-            <names variable="illustrator narrator" delimiter="; ">
-              <name and="symbol" initialize-with=". " delimiter=", "/>
+            <names delimiter="; " variable="illustrator narrator">
+              <name/>
               <label form="short" prefix=", " text-case="title"/>
             </names>
-            <names variable="compiler chair organizer curator series-creator executive-producer" delimiter="; ">
-              <name and="symbol" initialize-with=". " delimiter=", "/>
+            <names delimiter="; " variable="compiler chair organizer curator series-creator executive-producer">
+              <name/>
               <label form="long" prefix=", " text-case="title"/>
             </names>
           </group>
@@ -1261,166 +995,398 @@
       </choose>
     </group>
   </macro>
-  <macro name="database-location">
+  <macro name="secondary-contributors-periodical">
+    <group delimiter="; ">
+      <choose>
+        <if variable="title">
+          <names delimiter="; " variable="interviewer">
+            <name/>
+            <label form="short" prefix=", " text-case="title"/>
+          </names>
+        </if>
+      </choose>
+      <names delimiter="; " variable="translator narrator">
+        <name/>
+        <label form="short" prefix=", " text-case="title"/>
+      </names>
+    </group>
+  </macro>
+  <macro name="version-edition-volume">
+    <group delimiter=", ">
+      <text macro="version-labelled"/>
+      <text macro="edition-labelled"/>
+      <text macro="volume-booklike"/>
+    </group>
+  </macro>
+  <macro name="volume-booklike">
+    <group delimiter=", ">
+      <!-- Report series (APA example 52) -->
+      <choose>
+        <if match="any" type="document report standard">
+          <group delimiter=" ">
+            <text text-case="title" variable="collection-title"/>
+            <text variable="collection-number"/>
+          </group>
+        </if>
+      </choose>
+      <text macro="supplement-number-labelled"/>
+      <choose>
+        <if variable="volume">
+          <choose>
+            <!-- Non-numeric volumes are already printed as part of the book title -->
+            <if variable="volume-title"/>
+            <else-if is-numeric="volume">
+              <text macro="volume-labelled"/>
+            </else-if>
+          </choose>
+        </if>
+        <else>
+          <text macro="number-of-volumes-labelled"/>
+        </else>
+      </choose>
+      <text macro="issue-labelled"/>
+      <text macro="locators-booklike"/>
+    </group>
+  </macro>
+  <!-- Identification logic -->
+  <macro name="identification">
+    <group delimiter="; " prefix="(" suffix=")">
+      <!-- (Secondary contributors; Database location; Genre no. 123; Report Series 123, Version, Edition, Volume, Page) -->
+      <choose>
+        <if type="patent">
+          <text macro="patent-number"/>
+        </if>
+        <else-if match="any" type="post webpage">
+          <!-- For post webpage, container-title is treated as publisher -->
+          <text macro="identification-with-all-parts"/>
+        </else-if>
+        <else-if match="any" type="report">
+          <choose>
+            <if match="none" variable="title">
+              <!-- If there is no title, then genre and number are already printed as the title. -->
+              <text macro="secondary-contributors"/>
+              <text macro="database-location"/>
+              <text macro="identification-booklike"/>
+            </if>
+            <!-- If the report is a chapter in a larger report, then most parenthetical information is printed after the container. -->
+            <else-if variable="container-title">
+              <text macro="secondary-contributors"/>
+            </else-if>
+            <else>
+              <text macro="identification-with-all-parts"/>
+            </else>
+          </choose>
+        </else-if>
+        <else-if variable="container-title">
+          <group delimiter="; ">
+            <text macro="secondary-contributors"/>
+            <choose>
+              <if match="any" type="broadcast graphic map motion_picture song">
+                <!-- For audiovisual media, number information comes after title, not container-title (ex. 94) -->
+                <text macro="genre-number"/>
+              </if>
+            </choose>
+          </group>
+        </else-if>
+        <else>
+          <text macro="identification-with-all-parts"/>
+        </else>
+      </choose>
+    </group>
+  </macro>
+  <macro name="identification-booklike">
     <choose>
-      <if variable="archive-place" match="none">
-        <!-- With `archive-place`: physical archives. Without: online archives. -->
-        <text variable="archive_location"/>
-      </if>
+      <if match="any" type="article-journal article-magazine article-newspaper broadcast event interview patent performance periodical post post-weblog review review-book speech webpage"/>
+      <else-if type="paper-conference">
+        <choose>
+          <if match="any" variable="collection-editor compiler editor editorial-director">
+            <text macro="version-edition-volume"/>
+          </if>
+        </choose>
+      </else-if>
+      <else>
+        <text macro="version-edition-volume"/>
+      </else>
     </choose>
   </macro>
-  <macro name="number">
+  <macro name="identification-with-all-parts">
+    <group delimiter="; ">
+      <text macro="secondary-contributors"/>
+      <text macro="database-location"/>
+      <text macro="genre-number"/>
+      <text macro="identification-booklike"/>
+    </group>
+  </macro>
+  <!-- 3.3. Description [in square brackets] -->
+  <!-- Description utility macros -->
+  <macro name="description-generic">
+    <!-- For conference presentations/performances/events, chapters in reports/standards/generic documents, software, place description after the container title -->
     <choose>
-      <if variable="number">
-        <group delimiter=", ">
+      <if match="any" type="event paper-conference performance speech">
+        <choose>
+          <if match="any" variable="collection-editor compiler editor editorial-director issue page volume">
+            <text macro="format-bib"/>
+          </if>
+        </choose>
+      </if>
+      <else-if match="none" type="document report software standard">
+        <text macro="format-bib"/>
+      </else-if>
+    </choose>
+  </macro>
+  <macro name="description-interview">
+    <choose>
+      <if variable="title">
+        <text macro="format-bib"/>
+      </if>
+      <else-if variable="genre">
+        <group delimiter="; ">
           <group delimiter=" ">
-            <text variable="genre" text-case="title"/>
+            <text text-case="capitalize-first" variable="genre"/>
             <group delimiter=" ">
-              <label variable="number" form="short" text-case="capitalize-first"/>
-              <text variable="number"/>
+              <text form="verb" term="container-author"/>
+              <names variable="interviewer"/>
             </group>
           </group>
+        </group>
+      </else-if>
+      <else-if variable="interviewer">
+        <group delimiter="; ">
+          <names variable="interviewer">
+            <label form="verb" suffix=" " text-case="capitalize-first"/>
+            <name/>
+          </names>
+          <text text-case="capitalize-first" variable="medium"/>
+        </group>
+      </else-if>
+      <else>
+        <text macro="format-bib"/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="description-letter-bib">
+    <choose>
+      <if variable="recipient">
+        <group delimiter="; ">
+          <group delimiter=" ">
+            <choose>
+              <if match="none" variable="number">
+                <choose>
+                  <if variable="genre">
+                    <text text-case="capitalize-first" variable="genre"/>
+                  </if>
+                  <else-if variable="medium">
+                    <text text-case="capitalize-first" variable="medium"/>
+                  </else-if>
+                  <else>
+                    <text term="letter" text-case="capitalize-first"/>
+                  </else>
+                </choose>
+              </if>
+              <else>
+                <choose>
+                  <if variable="medium">
+                    <text text-case="capitalize-first" variable="medium"/>
+                  </if>
+                  <else>
+                    <text term="letter" text-case="capitalize-first"/>
+                  </else>
+                </choose>
+              </else>
+            </choose>
+            <names variable="recipient">
+              <label form="verb" suffix=" "/>
+              <name initialize="false"/>
+            </names>
+          </group>
           <choose>
-            <if type="thesis">
+            <if variable="genre">
               <choose>
-                <!-- Include the university in brackets if thesis is published -->
-                <if variable="archive DOI URL" match="any">
-                  <text variable="publisher"/>
+                <if match="none" variable="number">
+                  <text text-case="capitalize-first" variable="medium"/>
                 </if>
               </choose>
             </if>
           </choose>
         </group>
       </if>
-    </choose>
-  </macro>
-  <macro name="locators-booklike">
-    <choose>
-      <if type="article-journal article-magazine article-newspaper broadcast event interview patent performance periodical post post-weblog review review-book speech webpage" match="any"/>
-      <else-if type="paper-conference">
-        <choose>
-          <if variable="collection-editor compiler editor editorial-director" match="any">
-            <group delimiter=", ">
-              <text macro="version"/>
-              <text macro="edition"/>
-              <text macro="volume-booklike"/>
-            </group>
-          </if>
-        </choose>
-      </else-if>
       <else>
-        <group delimiter=", ">
-          <text macro="version"/>
-          <text macro="edition"/>
-          <text macro="volume-booklike"/>
-        </group>
+        <text macro="format-bib"/>
       </else>
     </choose>
   </macro>
-  <macro name="version">
-    <group delimiter=" ">
-      <label variable="version" text-case="capitalize-first"/>
-      <text variable="version"/>
-    </group>
-  </macro>
-  <macro name="edition">
+  <macro name="description-letter-intext">
     <choose>
-      <if is-numeric="edition">
+      <if variable="recipient">
         <group delimiter=" ">
-          <number variable="edition" form="ordinal"/>
-          <label variable="edition" form="short"/>
-        </group>
-      </if>
-      <else>
-        <text variable="edition"/>
-      </else>
-    </choose>
-  </macro>
-  <macro name="volume-booklike">
-    <group delimiter=", ">
-      <!-- Report series [ex. 52] -->
-      <choose>
-        <if type="document report standard">
-          <group delimiter=" ">
-            <text variable="collection-title" text-case="title"/>
-            <text variable="collection-number"/>
-          </group>
-        </if>
-      </choose>
-      <group delimiter=" ">
-        <label variable="supplement-number" text-case="capitalize-first"/>
-        <text variable="supplement-number"/>
-      </group>
-      <choose>
-        <if variable="volume" match="any">
           <choose>
-            <!-- Non-numeric volumes are already printed as part of the book title -->
-            <if variable="volume-title"/>
-            <else-if is-numeric="volume" match="none"/>
+            <if match="none" variable="number">
+              <text text-case="capitalize-first" variable="genre"/>
+            </if>
+            <else-if variable="medium">
+              <text text-case="capitalize-first" variable="medium"/>
+            </else-if>
             <else>
-              <group delimiter=" ">
-                <label variable="volume" form="short" text-case="capitalize-first"/>
-                <number variable="volume" form="numeric"/>
-              </group>
+              <text term="letter" text-case="capitalize-first"/>
             </else>
           </choose>
-        </if>
-        <else>
-          <group>
-            <label variable="number-of-volumes" form="short" text-case="capitalize-first" suffix=" "/>
-            <text term="page-range-delimiter" prefix="1"/>
-            <number variable="number-of-volumes" form="numeric"/>
-          </group>
-        </else>
-      </choose>
-      <group delimiter=" ">
-        <label variable="issue" text-case="capitalize-first"/>
-        <text variable="issue"/>
-      </group>
-      <group delimiter=" ">
-        <label variable="page" form="short" suffix=" "/>
-        <text variable="page"/>
-      </group>
-    </group>
-  </macro>
-  <macro name="reviewed-title">
-    <choose>
-      <if variable="reviewed-title">
-        <!-- Not possible to distinguish TV series episode from other reviewed
-             works without reviewed-container-title [Ex. 69] -->
-        <!-- Adapt for reviewed-container-title if that becomes available -->
-        <text variable="reviewed-title" font-style="italic"/>
+          <names variable="recipient">
+            <label form="verb" suffix=" "/>
+            <name/>
+          </names>
+        </group>
       </if>
       <else>
-        <!-- Assume title is title of reviewed work -->
-        <text variable="title" font-style="italic"/>
+        <text macro="format-intext"/>
       </else>
     </choose>
   </macro>
-  <macro name="reviewed-title-intext">
-    <choose>
-      <if variable="reviewed-title">
-        <!-- Not possible to distinguish TV series episode from other reviewed
-             works without reviewed-container-title [Ex. 69] -->
-        <!-- Adapt for reviewed-container-title if that becomes available -->
-        <text variable="reviewed-title" form="short" font-style="italic" text-case="title"/>
-      </if>
-      <else>
-        <!-- Assume title is title of reviewed work -->
-        <text variable="title" form="short" font-style="italic" text-case="title"/>
-      </else>
-    </choose>
-  </macro>
-  <macro name="format">
-    <choose>
-      <if variable="genre medium" match="any">
-        <group delimiter="; ">
+  <macro name="description-reviewed">
+    <!-- Reviewed item -->
+    <group delimiter="; ">
+      <group delimiter=", ">
+        <group delimiter=" ">
           <choose>
-            <if variable="number" match="none">
-              <text variable="genre" text-case="capitalize-first"/>
+            <if variable="reviewed-genre">
+              <group delimiter=" ">
+                <text form="long" term="review-of" text-case="capitalize-first"/>
+                <text text-case="lowercase" variable="reviewed-genre"/>
+              </group>
+            </if>
+            <!-- If no `reviewed-genre`, assume that `genre` or `medium` is entered as 'Review of the book' or similar -->
+            <else-if match="none" variable="number">
+              <choose>
+                <if variable="genre">
+                  <text text-case="capitalize-first" variable="genre"/>
+                </if>
+                <else-if variable="medium">
+                  <text text-case="capitalize-first" variable="medium"/>
+                </else-if>
+                <else-if type="review-book">
+                  <group delimiter=" ">
+                    <text form="long" term="review-of" text-case="capitalize-first"/>
+                    <text form="long" term="book" text-case="lowercase"/>
+                  </group>
+                </else-if>
+                <else>
+                  <text form="short" term="review-of" text-case="capitalize-first"/>
+                </else>
+              </choose>
+            </else-if>
+            <else>
+              <choose>
+                <if variable="medium">
+                  <text text-case="capitalize-first" variable="medium"/>
+                </if>
+                <else-if type="review-book">
+                  <group delimiter=" ">
+                    <text form="long" term="review-of" text-case="capitalize-first"/>
+                    <text form="long" term="book" text-case="lowercase"/>
+                  </group>
+                </else-if>
+                <else>
+                  <text form="short" term="review-of" text-case="capitalize-first"/>
+                </else>
+              </choose>
+            </else>
+          </choose>
+          <text macro="reviewed-title-bib"/>
+        </group>
+        <names variable="reviewed-author">
+          <label form="verb-short" suffix=" "/>
+          <name/>
+        </names>
+      </group>
+      <choose>
+        <if variable="genre">
+          <choose>
+            <if match="none" variable="number">
+              <text text-case="capitalize-first" variable="medium"/>
             </if>
           </choose>
-          <text variable="medium" text-case="capitalize-first"/>
+        </if>
+      </choose>
+    </group>
+  </macro>
+  <macro name="description-song">
+    <!-- Performer of classical music works -->
+    <group delimiter="; ">
+      <group delimiter=" ">
+        <choose>
+          <if match="none" variable="number">
+            <choose>
+              <if variable="genre">
+                <text text-case="capitalize-first" variable="genre"/>
+                <text form="verb" term="performer"/>
+              </if>
+              <else-if variable="medium">
+                <text text-case="capitalize-first" variable="medium"/>
+                <text form="verb" term="performer"/>
+              </else-if>
+              <else>
+                <text form="verb" term="performer" text-case="capitalize-first"/>
+              </else>
+            </choose>
+          </if>
+          <else>
+            <!-- If there is a number, genre is already printed in `genre-number` macro -->
+            <choose>
+              <if variable="medium">
+                <text text-case="capitalize-first" variable="medium"/>
+                <text form="verb" term="performer"/>
+              </if>
+              <else>
+                <text form="verb" term="performer" text-case="capitalize-first"/>
+              </else>
+            </choose>
+          </else>
+        </choose>
+        <names variable="author">
+          <substitute>
+            <names variable="performer"/>
+          </substitute>
+        </names>
+      </group>
+      <choose>
+        <if variable="genre">
+          <choose>
+            <if match="none" variable="number">
+              <text text-case="capitalize-first" variable="medium"/>
+            </if>
+          </choose>
+        </if>
+      </choose>
+    </group>
+  </macro>
+  <macro name="description-thesis">
+    <!-- Thesis type and institution -->
+    <group delimiter="; ">
+      <choose>
+        <if match="none" variable="number">
+          <group delimiter=", ">
+            <text text-case="capitalize-first" variable="genre"/>
+            <choose>
+              <if match="any" variable="archive DOI URL">
+                <!-- Include the university in brackets if thesis is published -->
+                <text variable="publisher"/>
+              </if>
+            </choose>
+          </group>
+        </if>
+      </choose>
+      <text text-case="capitalize-first" variable="medium"/>
+    </group>
+  </macro>
+  <macro name="format-bib">
+    <choose>
+      <if match="any" variable="genre medium">
+        <group delimiter="; ">
+          <choose>
+            <if match="none" variable="number">
+              <text text-case="capitalize-first" variable="genre"/>
+            </if>
+          </choose>
+          <text text-case="capitalize-first" variable="medium"/>
         </group>
       </if>
       <else>
@@ -1430,11 +1396,11 @@
   </macro>
   <macro name="format-intext">
     <choose>
-      <if variable="genre" match="any">
-        <text variable="genre" text-case="capitalize-first"/>
+      <if variable="genre">
+        <text text-case="capitalize-first" variable="genre"/>
       </if>
       <else-if variable="medium">
-        <text variable="medium" text-case="capitalize-first"/>
+        <text text-case="capitalize-first" variable="medium"/>
       </else-if>
       <else>
         <text macro="generic-type-label"/>
@@ -1450,9 +1416,9 @@
       <else-if type="software">
         <text term="software" text-case="capitalize-first"/>
       </else-if>
-      <else-if type="interview personal_communication" match="any">
+      <else-if match="any" type="interview personal_communication">
         <choose>
-          <if variable="archive container-title DOI publisher URL" match="none">
+          <if match="none" variable="archive archive-place container-title DOI publisher URL">
             <text term="personal-communication" text-case="capitalize-first"/>
           </if>
           <else-if type="interview">
@@ -1492,18 +1458,108 @@
       </else-if>
     </choose>
   </macro>
-  <!-- APA 'source' element contains four parts:
-       container, event, publisher, access -->
+  <macro name="reviewed-title-bib">
+    <choose>
+      <if variable="reviewed-title">
+        <!-- Not possible to distinguish TV series episode from other reviewed
+             works without reviewed-container-title (APA example 69) -->
+        <!-- Adapt for reviewed-container-title if that becomes available -->
+        <text font-style="italic" variable="reviewed-title"/>
+      </if>
+      <else>
+        <!-- Assume title is title of reviewed work -->
+        <text font-style="italic" variable="title"/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="reviewed-title-intext">
+    <choose>
+      <if variable="reviewed-title">
+        <!-- Not possible to distinguish TV series episode from other reviewed
+             works without reviewed-container-title (APA example 69) -->
+        <!-- Adapt for reviewed-container-title if that becomes available -->
+        <text font-style="italic" form="short" text-case="title" variable="reviewed-title"/>
+      </if>
+      <else>
+        <!-- Assume title is title of reviewed work -->
+        <text font-style="italic" form="short" text-case="title" variable="title"/>
+      </else>
+    </choose>
+  </macro>
+  <!-- Description logic -->
+  <macro name="description-bib">
+    <group prefix="[" suffix="]">
+      <choose>
+        <if match="any" type="interview" variable="interviewer">
+          <text macro="description-interview"/>
+        </if>
+        <else-if match="any" type="review review-book" variable="reviewed-author reviewed-genre reviewed-title">
+          <text macro="description-reviewed"/>
+        </else-if>
+        <else-if type="personal_communication">
+          <text macro="description-letter-bib"/>
+        </else-if>
+        <else-if type="song" variable="composer">
+          <text macro="description-song"/>
+        </else-if>
+        <else-if type="thesis">
+          <text macro="description-thesis"/>
+        </else-if>
+        <else-if match="none" variable="container-title">
+          <!-- Other description -->
+          <text macro="format-bib"/>
+        </else-if>
+        <else>
+          <text macro="description-generic"/>
+        </else>
+      </choose>
+    </group>
+  </macro>
+  <macro name="description-intext">
+    <group prefix="[" suffix="]">
+      <choose>
+        <if variable="reviewed-title">
+          <group delimiter=" ">
+            <text term="review-of" text-case="capitalize-first"/>
+            <text macro="reviewed-title-intext"/>
+          </group>
+        </if>
+        <else-if match="any" type="interview" variable="interviewer">
+          <names variable="interviewer">
+            <label form="verb" suffix=" " text-case="capitalize-first"/>
+            <name/>
+            <substitute>
+              <text macro="format-intext"/>
+            </substitute>
+          </names>
+        </else-if>
+        <else-if type="personal_communication">
+          <text macro="description-letter-intext"/>
+        </else-if>
+        <else>
+          <text macro="format-intext"/>
+        </else>
+      </choose>
+    </group>
+  </macro>
+  <!-- 4. Source -->
+  <!-- Four parts in APA 'source' element:
+
+       1. Container
+       2. Event
+       3. Publication details
+       4. Access -->
+  <!-- 4.1. Container -->
   <macro name="container">
     <choose>
-      <if type="article-journal article-magazine article-newspaper periodical post-weblog review review-book" match="any">
+      <if match="any" type="article-journal article-magazine article-newspaper periodical post-weblog review review-book">
         <!-- Periodical items -->
         <text macro="container-periodical"/>
       </if>
       <else-if type="paper-conference">
         <!-- Determine if paper-conference is a periodical- or book-like -->
         <choose>
-          <if variable="editor editorial-director collection-editor container-author" match="any">
+          <if match="any" variable="collection-editor container-author editor editorial-director">
             <text macro="container-booklike"/>
           </if>
           <else>
@@ -1511,55 +1567,15 @@
           </else>
         </choose>
       </else-if>
-      <else-if type="post webpage" match="none">
-        <!-- post and webpage treat container-title like publisher -->
+      <else-if match="none" type="post webpage">
+        <!-- Webpages treat container-title like publisher -->
         <text macro="container-booklike"/>
       </else-if>
     </choose>
   </macro>
-  <macro name="container-periodical">
-    <group delimiter=". ">
-      <group delimiter=", ">
-        <text variable="container-title" font-style="italic" text-case="title"/>
-        <choose>
-          <if variable="volume">
-            <group>
-              <text variable="volume" font-style="italic"/>
-              <text variable="issue" prefix="(" suffix=")"/>
-            </group>
-          </if>
-          <else>
-            <text variable="issue" font-style="italic"/>
-          </else>
-        </choose>
-        <choose>
-          <if variable="number">
-            <!-- Ex. 6: Journal article with article number or eLocator -->
-            <group delimiter=" ">
-              <text term="article-locator" text-case="capitalize-first"/>
-              <text variable="number"/>
-            </group>
-          </if>
-          <else>
-            <text variable="page"/>
-          </else>
-        </choose>
-      </group>
-      <choose>
-        <if variable="issued">
-          <choose>
-            <if variable="issue number page volume" match="none">
-              <!-- We print the status variable directly rather than using in-press, etc. terms. -->
-              <text variable="status" text-case="capitalize-first"/>
-            </if>
-          </choose>
-        </if>
-      </choose>
-    </group>
-  </macro>
   <macro name="container-booklike">
     <choose>
-      <if variable="container-title" match="any">
+      <if variable="container-title">
         <group delimiter=" ">
           <choose>
             <if type="song">
@@ -1570,161 +1586,167 @@
             </else>
           </choose>
           <group delimiter=", ">
-            <names variable="executive-producer">
-              <name and="symbol" initialize-with=". " delimiter=", "/>
-              <label form="long" text-case="title" prefix=" (" suffix=")"/>
-              <substitute>
-                <names variable="series-creator"/>
-                <names variable="editor-translator">
-                  <name and="symbol" initialize-with=". " delimiter=", "/>
-                  <label form="short" text-case="title" prefix=" (" suffix=")"/>
-                </names>
-                <!-- TODO: Translator omitted here on the assumption that editor-translators are uncommon 
-                           for chapter citations. If needed, direct entry or automatic population of
-                           `editor-translator` can produce combined labels. -->
-                <names variable="editor">
-                  <name and="symbol" initialize-with=". " delimiter=", "/>
-                  <label form="short" text-case="title" prefix=" (" suffix=")"/>
-                </names>
-                <names variable="editorial-director">
-                  <name and="symbol" initialize-with=". " delimiter=", "/>
-                  <label form="short" text-case="title" prefix=" (" suffix=")"/>
-                </names>
-                <names variable="compiler"/>
-                <choose>
-                  <if type="event performance speech" match="any">
-                    <names variable="chair"/>
-                    <names variable="organizer"/>
-                  </if>
-                </choose>
-                <names variable="curator"/>
-                <names variable="collection-editor">
-                  <name and="symbol" initialize-with=". " delimiter=", "/>
-                  <label form="short" text-case="title" prefix=" (" suffix=")"/>
-                </names>
-                <names variable="container-author"/>
-              </substitute>
-            </names>
-            <group delimiter=": " font-style="italic">
-              <text variable="container-title"/>
-              <text macro="volume-title"/>
-            </group>
+            <text macro="container-contributors"/>
+            <text macro="container-title-booklike"/>
           </group>
-          <text macro="parenthetical-container"/>
-          <text macro="bracketed-container"/>
+          <text macro="container-identification"/>
+          <text macro="container-description"/>
         </group>
       </if>
     </choose>
   </macro>
-  <macro name="publisher">
-    <group delimiter="; ">
+  <macro name="container-periodical">
+    <group delimiter=". ">
+      <group delimiter=", ">
+        <text font-style="italic" text-case="title" variable="container-title"/>
+        <text macro="volume-periodical"/>
+        <text macro="locators-periodical"/>
+      </group>
       <choose>
-        <if type="thesis">
+        <if variable="issued">
           <choose>
-            <if variable="archive DOI URL" match="none">
-              <text variable="publisher"/>
+            <if match="none" variable="issue number page volume">
+              <!-- We print the status variable directly rather than using in-press, etc. terms. -->
+              <text text-case="capitalize-first" variable="status"/>
             </if>
           </choose>
         </if>
-        <else-if type="post webpage" match="any">
-          <!-- For websites, treat container title like publisher -->
-          <group delimiter="; ">
-            <text variable="container-title" text-case="title"/>
-            <text variable="publisher"/>
-          </group>
-        </else-if>
-        <else-if type="paper-conference">
-          <!-- For paper-conference, don't print publisher if in a journal-like proceedings -->
-          <choose>
-            <if variable="collection-editor compiler editor editorial-director" match="any">
-              <text variable="publisher"/>
-            </if>
-          </choose>
-        </else-if>
-        <else-if type="article-journal article-magazine article-newspaper periodical post-weblog review review-book" match="none">
-          <text variable="publisher"/>
-        </else-if>
       </choose>
-      <group delimiter=", ">
-        <choose>
-          <if variable="archive-place">
-            <!-- With `archive-place`: physical archives. Without: online archives. -->
-            <!-- For physical archives, print the location before the archive name.
-                For electronic archives, these are printed in macro="description". -->
-            <!-- Must test for archive_collection:
-                With collection: archive_collection (archive_location), archive, archive-place
-                No collection: archive (archive_location), archive-place
-            -->
-            <choose>
-              <if variable="archive_collection">
-                <group delimiter=" ">
-                  <text variable="archive_collection"/>
-                  <text variable="archive_location" prefix="(" suffix=")"/>
-                </group>
-                <text variable="archive"/>
-                <text variable="archive-place"/>
-              </if>
-              <else>
-                <group delimiter=" ">
-                  <text variable="archive"/>
-                  <text variable="archive_location" prefix="(" suffix=")"/>
-                </group>
-                <text variable="archive-place"/>
-              </else>
-            </choose>
-          </if>
-          <else>
-            <text variable="archive"/>
-          </else>
-        </choose>
-      </group>
     </group>
   </macro>
-  <macro name="access">
+  <!-- Container parallels main elements -->
+  <!-- 4.1.1. Author -->
+  <macro name="container-contributors">
+    <names variable="executive-producer">
+      <name/>
+      <label form="long" prefix=" (" suffix=")" text-case="title"/>
+      <substitute>
+        <names variable="series-creator"/>
+        <names variable="editor-translator">
+          <name/>
+          <label form="short" prefix=" (" suffix=")" text-case="title"/>
+        </names>
+        <!-- TODO: Translator omitted on the assumption that editor-translators are uncommon for chapter citations.
+             If needed, direct entry or automatic population of `editor-translator` can produce combined labels. -->
+        <names delimiter="; " variable="editor">
+          <name/>
+          <label form="short" prefix=" (" suffix=")" text-case="title"/>
+        </names>
+        <names variable="editorial-director">
+          <name/>
+          <label form="short" prefix=" (" suffix=")" text-case="title"/>
+        </names>
+        <names variable="compiler"/>
+        <choose>
+          <if match="any" type="event performance speech">
+            <names variable="chair"/>
+            <names variable="organizer"/>
+          </if>
+        </choose>
+        <names variable="curator"/>
+        <names variable="collection-editor">
+          <name/>
+          <label form="short" prefix=" (" suffix=")" text-case="title"/>
+        </names>
+        <names variable="container-author"/>
+      </substitute>
+    </names>
+  </macro>
+  <!-- 4.1.3.1 Container title -->
+  <macro name="container-title-booklike">
+    <group delimiter=": " font-style="italic">
+      <text variable="container-title"/>
+      <text macro="title-volume"/>
+    </group>
+  </macro>
+  <!-- 4.1.3.1 Container identification -->
+  <macro name="container-identification">
     <choose>
-      <if variable="DOI" match="any">
-        <text variable="DOI" prefix="https://doi.org/"/>
-      </if>
-      <else-if variable="URL">
-        <group delimiter=" ">
-          <choose>
-            <if variable="issued status" match="none">
-              <group delimiter=" ">
-                <text term="retrieved" text-case="capitalize-first"/>
-                <date variable="accessed" form="text" suffix=","/>
-                <text term="from"/>
-              </group>
-            </if>
-          </choose>
-          <text variable="URL"/>
+      <if variable="container-title">
+        <group prefix="(" suffix=")">
+          <group delimiter="; ">
+            <text macro="database-location"/>
+            <choose>
+              <if match="none" type="broadcast graphic map motion_picture song">
+                <!-- For audiovisual media, number information comes after title, not container-title (APA example 94) -->
+                <text macro="genre-number"/>
+              </if>
+            </choose>
+            <text macro="identification-booklike"/>
+          </group>
         </group>
-      </else-if>
+      </if>
     </choose>
   </macro>
+  <!-- 4.1.3.2 Container description -->
+  <macro name="container-description">
+    <group prefix="[" suffix="]">
+      <choose>
+        <if match="any" type="event paper-conference performance speech">
+          <!-- Conference presentations should describe the session [container] in description unless published in a proceedings -->
+          <choose>
+            <if match="none" variable="collection-editor compiler editor editorial-director issue page volume">
+              <text macro="format-bib"/>
+            </if>
+          </choose>
+        </if>
+        <else-if type="software">
+          <!-- For entries in mobile app reference works, place description after the container-title -->
+          <text macro="format-bib"/>
+        </else-if>
+        <else-if match="any" type="document report standard">
+          <!-- For chapters in report, standards, and generic documents, place description after the container title -->
+          <text macro="format-bib"/>
+        </else-if>
+      </choose>
+    </group>
+  </macro>
+  <!-- 4.1.4. Source -->
+  <macro name="locators-periodical">
+    <choose>
+      <if variable="number">
+        <text macro="number-article-labelled"/>
+      </if>
+      <else>
+        <text variable="page"/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="volume-periodical">
+    <group delimiter=", ">
+      <text font-style="italic" text-case="title" variable="collection-title"/>
+      <choose>
+        <if variable="volume">
+          <group>
+            <text font-style="italic" variable="volume"/>
+            <text prefix="(" suffix=")" variable="issue"/>
+          </group>
+        </if>
+        <else>
+          <text font-style="italic" variable="issue"/>
+        </else>
+      </choose>
+    </group>
+  </macro>
+  <!-- 4.2. Event -->
   <macro name="event">
     <choose>
-      <if variable="event event-title" match="any">
-        <!-- To prevent Zotero from printing event-place due to its double-mapping of all 'place' to
-             both publisher-place and event-place. Remove this 'choose' when that is changed. -->
+      <if match="any" variable="event event-title">
+        <!-- To prevent Zotero from printing `event-place` due to its double-mapping of all 'place' to
+             both `publisher-place` and `event-place`. Remove this when that is changed. -->
         <choose>
           <if type="paper-conference">
             <choose>
-              <if variable="collection-editor compiler editor editorial-director issue page volume" match="none">
+              <if match="none" variable="collection-editor compiler editor editorial-director issue page volume">
                 <!-- Don't print event info for conference papers published in a proceedings -->
-                <group delimiter=", ">
-                  <text macro="event-title"/>
-                  <text variable="event-place"/>
-                </group>
+                <text macro="event-title-place"/>
               </if>
             </choose>
           </if>
           <else>
             <!-- For other item types, print event info even if published (e.g., for collection catalogs, performance programs.
                  These items aren't given explicit examples in the APA manual, so err on the side of providing too much information. -->
-            <group delimiter=", ">
-              <text macro="event-title"/>
-              <text variable="event-place"/>
-            </group>
+            <text macro="event-title-place"/>
           </else>
         </choose>
       </if>
@@ -1732,9 +1754,9 @@
   </macro>
   <macro name="event-title">
     <choose>
-      <!-- TODO: We expect "event-title" to be used,
+      <!-- TODO: We expect `event-title` to be used,
            but processors and applications may not be updated yet.
-           This macro ensures that either "event" or "event-title" can be accpeted.
+           This macro ensures that either `event` or `event-title` can be accepted.
            Remove if procesor logic and application adoption can handle this. -->
       <if variable="event-title">
         <text variable="event-title"/>
@@ -1744,11 +1766,153 @@
       </else>
     </choose>
   </macro>
-  <!-- After 'source', APA also prints publication history (original publication, reprint info, retraction info) -->
+  <macro name="event-title-place">
+    <group delimiter=", ">
+      <text macro="event-title"/>
+      <text variable="event-place"/>
+    </group>
+  </macro>
+  <!-- 4.3. Publication details -->
+  <!-- Publication utility macros -->
+  <macro name="archive">
+    <group delimiter=", ">
+      <choose>
+        <if variable="archive-place">
+          <!-- With `archive-place`: physical archives. Without: online archives. -->
+          <!-- For physical archives, print the location before the archive name.
+                For electronic archives, these are printed in macro="description". -->
+          <!-- Must test for archive_collection:
+                With collection: archive_collection (archive_location), archive, archive-place
+                No collection: archive (archive_location), archive-place
+            -->
+          <choose>
+            <if variable="archive_collection">
+              <group delimiter=" ">
+                <text variable="archive_collection"/>
+                <text prefix="(" suffix=")" variable="archive_location"/>
+              </group>
+              <text variable="archive"/>
+              <text variable="archive-place"/>
+            </if>
+            <else>
+              <group delimiter=" ">
+                <text variable="archive"/>
+                <text prefix="(" suffix=")" variable="archive_location"/>
+              </group>
+              <text variable="archive-place"/>
+            </else>
+          </choose>
+        </if>
+        <else>
+          <text variable="archive"/>
+        </else>
+      </choose>
+    </group>
+  </macro>
+  <macro name="publisher">
+    <choose>
+      <if variable="publisher">
+        <text variable="publisher"/>
+      </if>
+      <else-if match="none" variable="event-place">
+        <!-- Work around Zotero double-mapping of event/publisher place -->
+        <text variable="publisher-place"/>
+      </else-if>
+    </choose>
+  </macro>
+  <!-- Publication logic -->
+  <macro name="publication">
+    <choose>
+      <if type="thesis">
+        <choose>
+          <if match="none" variable="archive DOI URL">
+            <text macro="publisher"/>
+          </if>
+        </choose>
+      </if>
+      <else-if match="any" type="post webpage">
+        <!-- Webpages treat container-title like publisher -->
+        <group delimiter="; ">
+          <text text-case="title" variable="container-title"/>
+          <text macro="publisher"/>
+        </group>
+      </else-if>
+      <else-if type="paper-conference">
+        <!-- For paper-conference, don't print publisher if in a journal-like proceedings -->
+        <choose>
+          <if match="any" variable="collection-editor compiler editor editorial-director">
+            <text macro="publisher"/>
+          </if>
+        </choose>
+      </else-if>
+      <else-if match="none" type="article-journal article-magazine article-newspaper periodical post-weblog review review-book">
+        <text macro="publisher"/>
+      </else-if>
+    </choose>
+  </macro>
+  <macro name="publication-archive">
+    <group delimiter="; ">
+      <text macro="publication"/>
+      <text macro="archive"/>
+    </group>
+  </macro>
+  <!-- 4.4. Access -->
+  <macro name="access">
+    <choose>
+      <if variable="DOI">
+        <text prefix="https://doi.org/" variable="DOI"/>
+      </if>
+      <else-if variable="URL">
+        <group delimiter=" ">
+          <choose>
+            <if match="none" variable="issued status">
+              <group delimiter=" ">
+                <text term="retrieved" text-case="capitalize-first"/>
+                <group delimiter=", ">
+                  <date form="text" variable="accessed"/>
+                  <text term="from"/>
+                </group>
+              </group>
+            </if>
+          </choose>
+          <text variable="URL"/>
+        </group>
+      </else-if>
+    </choose>
+  </macro>
+  <!-- 5. Publication history -->
+  <!-- History utility macros -->
+  <macro name="original-publisher">
+    <choose>
+      <if variable="original-publisher">
+        <text variable="original-publisher"/>
+      </if>
+      <else>
+        <text variable="original-publisher-place"/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="original-title">
+    <choose>
+      <if variable="original-title">
+        <text value="as"/>
+        <choose>
+          <if match="any" type="article-journal article-magazine article-newspaper periodical post-weblog review review-book">
+            <text variable="original-title"/>
+          </if>
+          <else>
+            <text font-style="italic" variable="original-title"/>
+          </else>
+        </choose>
+      </if>
+    </choose>
+  </macro>
+  <!-- History logic -->
   <macro name="publication-history">
+    <!-- Information appended to 'source': original publication, reprint info, retraction info -->
     <choose>
       <if type="patent">
-        <text variable="references" prefix="(" suffix=")"/>
+        <text prefix="(" suffix=")" variable="references"/>
       </if>
       <else>
         <group delimiter="; " prefix="(" suffix=")">
@@ -1756,8 +1920,8 @@
           <choose>
             <if variable="issued">
               <choose>
-                <if variable="issue number page volume" match="any">
-                  <text variable="status" text-case="capitalize-first"/>
+                <if match="any" variable="issue number page volume">
+                  <text text-case="capitalize-first" variable="status"/>
                 </if>
               </choose>
             </if>
@@ -1766,29 +1930,31 @@
             <if variable="references">
               <!-- This provides the option for more elaborate description
                     of publication history, such as full "reprinted" references
-                    (examples 11, 43, 44) -->
+                    (APA examples 11, 43, 44) -->
               <text variable="references"/>
             </if>
             <else>
-              <group delimiter=" ">
-                <text term="original-work-published" text-case="capitalize-first"/>
-                <choose>
-                  <if is-uncertain-date="original-date">
-                    <text term="circa" form="short"/>
-                  </if>
-                </choose>
-                <date variable="original-date">
-                  <date-part name="year"/>
-                </date>
-              </group>
+              <text macro="publication-history-variables"/>
             </else>
           </choose>
         </group>
       </else>
     </choose>
   </macro>
-  <!-- Legal citations have their own rules -->
-  <macro name="legal-cites">
+  <macro name="publication-history-variables">
+    <group delimiter=" ">
+      <text term="original-work-published" text-case="capitalize-first"/>
+      <group delimiter="; ">
+        <text macro="original-title"/>
+        <group delimiter=", ">
+          <text macro="original-publisher"/>
+          <text macro="original-date-year"/>
+        </group>
+      </group>
+    </group>
+  </macro>
+  <!-- Parallel rules for legal citations -->
+  <macro name="legal-bib">
     <!-- `treaty`: for treaties -->
     <!-- `legal_case`: for all legal and court cases -->
     <!-- `bill`: for bills, resolutions, federal reports -->
@@ -1800,16 +1966,14 @@
         <if type="treaty">
           <group delimiter=", " suffix=".">
             <!-- APA generally defers to Bluebook for legal citations, but diverges without
-                explanation for treaty items. We follow the Bluebook format that was used 
+                explanation for treaty items. We follow the Bluebook format that was used
                 in APA 6th ed. -->
-            <!-- APA manual omits treaty parties/authors, but per Bluebook 
+            <!-- APA manual omits treaty parties/authors, but per Bluebook
                 they should be included at least for bilateral treaties. -->
-            <names variable="author">
-              <name initialize-with="." form="short" delimiter="-"/>
-            </names>
+            <text macro="author-legal"/>
             <text macro="date-legal"/>
-            <!-- APA manual omits treaty source/report called for by Bluebook in favor of just URL. 
-                Both are included here, following the APA style used for all other item types 
+            <!-- APA manual omits treaty source/report called for by Bluebook in favor of just URL.
+                Both are included here, following the APA style used for all other item types
                 to end the reference with a period, then give the URL afterward. -->
             <text macro="container-legal"/>
           </group>
@@ -1821,7 +1985,7 @@
               <text macro="container-legal"/>
             </group>
             <text macro="date-legal"/>
-            <text macro="parenthetical-legal"/>
+            <text macro="identification-legal"/>
           </group>
         </else>
       </choose>
@@ -1829,20 +1993,75 @@
       <text macro="access"/>
     </group>
   </macro>
+  <!-- 1. Legal author -->
+  <macro name="author-legal">
+    <names variable="author">
+      <name delimiter="-" form="short"/>
+    </names>
+  </macro>
+  <!-- 2. Legal date -->
+  <macro name="date-legal-case">
+    <group delimiter=" " prefix="(" suffix=")">
+      <text variable="authority"/>
+      <choose>
+        <if variable="container-title">
+          <!-- Print only year for cases published in reporters-->
+          <text macro="date-issued-year"/>
+        </if>
+        <else>
+          <!-- APA manual doesn't include examples of cases not yet
+                   published in a reporter, but this is Bluebook style. -->
+          <text macro="date-issued-full"/>
+        </else>
+      </choose>
+    </group>
+  </macro>
+  <macro name="date-legal">
+    <choose>
+      <if type="treaty">
+        <text macro="date-issued-full"/>
+      </if>
+      <else-if type="legal_case">
+        <text macro="date-legal-case"/>
+      </else-if>
+      <else-if match="any" type="bill hearing legislation regulation">
+        <group delimiter=" " prefix="(" suffix=")">
+          <group delimiter=" ">
+            <text macro="original-date-year"/>
+            <text form="symbol" term="and"/>
+          </group>
+          <choose>
+            <if variable="issued">
+              <!-- APA manual includes "rev." before the revision year,
+                   but this isn't part of the Bluebook rules. -->
+              <text macro="date-issued-year"/>
+            </if>
+            <else>
+              <!-- Show proposal date for uncodified regualtions.
+                   Assume date is entered literally ala "proposed May 23, 2016".
+                   TODO: Add 'proposed' term here if that becomes available -->
+              <date form="text" variable="submitted"/>
+            </else>
+          </choose>
+        </group>
+      </else-if>
+    </choose>
+  </macro>
+  <!-- 3.1. Legal title -->
   <macro name="title-legal">
     <choose>
-      <if type="bill legal_case legislation regulation treaty" match="any">
-        <text variable="title" text-case="title"/>
+      <if match="any" type="bill legal_case legislation regulation treaty">
+        <text text-case="title" variable="title"/>
       </if>
       <else-if type="hearing">
-        <!-- APA uses a comma delimiter and omits "hearing before the" for hearings with testimony, 
+        <!-- APA uses a comma delimiter and omits "hearing before the" for hearings with testimony,
              but follows Bluebook rules (colon delimiter, prefix before the committee name) for
              references to the whole hearing. We simply follow the Bluebook rules for both, but
              use APA style capitalization (not capitalizing "Before" or the title of the hearing). -->
         <group delimiter=": " font-style="italic">
-          <text variable="title" text-case="capitalize-first"/>
+          <text text-case="capitalize-first" variable="title"/>
           <group delimiter=" ">
-            <text term="hearing" form="long" text-case="capitalize-first"/>
+            <text form="long" term="hearing" text-case="capitalize-first"/>
             <group delimiter=" ">
               <group delimiter=" ">
                 <!-- APA manual omits the bill number, but it should be included per Bluebook if relevant -->
@@ -1851,7 +2070,7 @@
               </group>
               <group delimiter=" ">
                 <!-- Use the `at` term to hold "before the" -->
-                <text term="at" form="long"/>
+                <text form="long" term="at"/>
                 <text variable="section"/>
               </group>
             </group>
@@ -1860,124 +2079,95 @@
       </else-if>
     </choose>
   </macro>
-  <macro name="date-legal">
+  <!-- 3.2. Legal identification (in parentheses) -->
+  <macro name="identification-legal">
     <choose>
-      <if type="treaty">
-        <date variable="issued" form="text"/>
+      <if type="hearing">
+        <group delimiter=" " prefix="(" suffix=")">
+          <!-- Use the 'verb' form of the hearing term to hold 'testimony of' -->
+          <text form="verb" term="hearing"/>
+          <names variable="author">
+            <name initialize="false"/>
+          </names>
+        </group>
       </if>
-      <else-if type="legal_case">
-        <group prefix="(" suffix=")" delimiter=" ">
-          <text variable="authority"/>
-          <choose>
-            <if variable="container-title" match="any">
-              <!-- Print only year for cases published in reporters-->
-              <date variable="issued" form="numeric" date-parts="year"/>
-            </if>
-            <else>
-              <!-- APA manual doesn't include examples of cases not yet
-                   published in a reporter, but this is Bluebook style. -->
-              <date variable="issued" form="text"/>
-            </else>
-          </choose>
-        </group>
-      </else-if>
-      <else-if type="bill hearing legislation regulation" match="any">
-        <group prefix="(" suffix=")" delimiter=" ">
-          <group delimiter=" ">
-            <date variable="original-date">
-              <date-part name="year"/>
-            </date>
-            <text term="and" form="symbol"/>
-          </group>
-          <choose>
-            <if variable="issued">
-              <!-- APA manual includes "rev." before the revision year, 
-                   but this isn't part of the Bluebook rules. -->
-              <date variable="issued">
-                <date-part name="year"/>
-              </date>
-            </if>
-            <else>
-              <!-- Show proposal date for uncodified regualtions. 
-                   Assume date is entered literally ala "proposed May 23, 2016".
-                   TODO: Add 'proposed' term here if that becomes available -->
-              <date variable="submitted" form="text"/>
-            </else>
-          </choose>
-        </group>
+      <else-if match="any" type="bill legislation regulation">
+        <!-- For uncodified regulations, assume future code section is in `status`. -->
+        <text prefix="(" suffix=")" variable="status"/>
       </else-if>
     </choose>
   </macro>
-  <macro name="container-legal">
-    <!-- Expect legal item container-titles to be stored in short form -->
+  <!-- 4. Legal source -->
+  <!-- Legal source utility macros -->
+  <macro name="container-bill">
+    <group delimiter=", ">
+      <group delimiter=" ">
+        <text variable="genre"/>
+        <group delimiter=" ">
+          <choose>
+            <!-- If there is no session number or code/record title, assume
+                     assume the item is a congressional report and include 'No.' term. -->
+            <if match="none" variable="chapter-number container-title">
+              <!-- The item is a congressional report, rather than a bill or resultion. -->
+              <text macro="number-labelled"/>
+            </if>
+            <else>
+              <text variable="number"/>
+            </else>
+          </choose>
+        </group>
+      </group>
+      <group delimiter=" ">
+        <text variable="authority"/>
+        <!-- 'session' is `chapter-number` -->
+        <text variable="chapter-number"/>
+      </group>
+      <group delimiter=" ">
+        <text variable="volume"/>
+        <text variable="container-title"/>
+        <text variable="page-first"/>
+      </group>
+    </group>
+  </macro>
+  <macro name="container-hearing">
+    <group delimiter=" ">
+      <text variable="authority"/>
+      <!-- 'session' is `chapter-number` -->
+      <text variable="chapter-number"/>
+    </group>
+  </macro>
+  <macro name="container-legal-case">
+    <group delimiter=" ">
+      <choose>
+        <if variable="container-title">
+          <group delimiter=" ">
+            <text variable="volume"/>
+            <text variable="container-title"/>
+            <text macro="section-labelled"/>
+            <choose>
+              <if match="any" variable="page page-first">
+                <text variable="page-first"/>
+              </if>
+              <else>
+                <text value="___"/>
+              </else>
+            </choose>
+          </group>
+        </if>
+        <else>
+          <text macro="number-labelled"/>
+        </else>
+      </choose>
+    </group>
+  </macro>
+  <macro name="container-legislation">
     <choose>
-      <if type="treaty">
-        <group delimiter=" ">
-          <number variable="volume"/>
-          <text variable="container-title"/>
-          <choose>
-            <if variable="page page-first" match="any">
-              <text variable="page-first"/>
-            </if>
-            <else>
-              <group delimiter=" ">
-                <label variable="number" form="short" text-case="capitalize-first"/>
-                <text variable="number"/>
-              </group>
-            </else>
-          </choose>
-        </group>
-      </if>
-      <else-if type="legal_case">
-        <group delimiter=" ">
-          <choose>
-            <if variable="container-title">
-              <group delimiter=" ">
-                <text variable="volume"/>
-                <text variable="container-title"/>
-                <group delimiter=" ">
-                  <label variable="section" form="symbol"/>
-                  <text variable="section"/>
-                </group>
-                <choose>
-                  <if variable="page page-first" match="any">
-                    <text variable="page-first"/>
-                  </if>
-                  <else>
-                    <text value="___"/>
-                  </else>
-                </choose>
-              </group>
-            </if>
-            <else>
-              <group delimiter=" ">
-                <label variable="number" form="short" text-case="capitalize-first"/>
-                <text variable="number"/>
-              </group>
-            </else>
-          </choose>
-        </group>
-      </else-if>
-      <else-if type="bill">
+      <if variable="number">
+        <!-- There's a public law number. -->
         <group delimiter=", ">
           <group delimiter=" ">
-            <text variable="genre"/>
-            <group delimiter=" ">
-              <choose>
-                <!-- If there is no session number or code/record title, assume
-                     assume the item is a congressional report and include 'No.' term. -->
-                <if variable="chapter-number container-title" match="none">
-                  <!-- The item is a congressional report, rather than a bill or resultion. -->
-                  <label variable="number" form="short" text-case="capitalize-first"/>
-                </if>
-              </choose>
-              <text variable="number"/>
-            </group>
-          </group>
-          <group delimiter=" ">
-            <text variable="authority"/>
-            <!-- 'session' is `chapter-number` -->
-            <text variable="chapter-number"/>
+            <text value="Pub. L. No."/>
+            <text variable="number"/>
           </group>
           <group delimiter=" ">
             <text variable="volume"/>
@@ -1985,150 +2175,140 @@
             <text variable="page-first"/>
           </group>
         </group>
-      </else-if>
-      <else-if type="hearing">
+      </if>
+      <else>
         <group delimiter=" ">
-          <text variable="authority"/>
-          <!-- 'session' is `chapter-number` -->
-          <text variable="chapter-number"/>
+          <text variable="volume"/>
+          <text variable="container-title"/>
+          <choose>
+            <if variable="section">
+              <text macro="section-labelled"/>
+            </if>
+            <else>
+              <text variable="page-first"/>
+            </else>
+          </choose>
         </group>
-      </else-if>
-      <else-if type="legislation">
+      </else>
+    </choose>
+  </macro>
+  <macro name="container-regulation">
+    <group delimiter=", ">
+      <group delimiter=" ">
+        <text variable="genre"/>
+        <text macro="number-labelled"/>
+      </group>
+      <group delimiter=" ">
+        <text variable="volume"/>
+        <text variable="container-title"/>
         <choose>
-          <if variable="number">
-            <!-- There's a public law number. -->
-            <group delimiter=", ">
-              <text variable="number" prefix="Pub. L. No. "/>
-              <group delimiter=" ">
-                <text variable="volume"/>
-                <text variable="container-title"/>
-                <text variable="page-first"/>
-              </group>
-            </group>
+          <if variable="section">
+            <text macro="section-labelled"/>
           </if>
           <else>
-            <group delimiter=" ">
-              <text variable="volume"/>
-              <text variable="container-title"/>
-              <choose>
-                <if variable="section">
-                  <group delimiter=" ">
-                    <label variable="section" form="symbol"/>
-                    <text variable="section"/>
-                  </group>
-                </if>
-                <else>
-                  <text variable="page-first"/>
-                </else>
-              </choose>
-            </group>
+            <text variable="page-first"/>
           </else>
         </choose>
-      </else-if>
-      <else-if type="regulation">
-        <group delimiter=", ">
-          <group delimiter=" ">
-            <text variable="genre"/>
-            <group delimiter=" ">
-              <label variable="number" form="short" text-case="capitalize-first"/>
-              <text variable="number"/>
-            </group>
-          </group>
-          <group delimiter=" ">
-            <text variable="volume"/>
-            <text variable="container-title"/>
-            <choose>
-              <if variable="section">
-                <group delimiter=" ">
-                  <label variable="section" form="symbol"/>
-                  <text variable="section"/>
-                </group>
-              </if>
-              <else>
-                <text variable="page-first"/>
-              </else>
-            </choose>
-          </group>
-        </group>
-      </else-if>
-    </choose>
-  </macro>
-  <macro name="parenthetical-legal">
-    <choose>
-      <if type="hearing">
-        <group prefix="(" suffix=")" delimiter=" ">
-          <!-- Use the 'verb' form of the hearing term to hold 'testimony of' -->
-          <text term="hearing" form="verb"/>
-          <names variable="author">
-            <name and="symbol" delimiter=", "/>
-          </names>
-        </group>
-      </if>
-      <else-if type="bill legislation regulation" match="any">
-        <!-- For uncodified regulations, assume future code section is in `status`. -->
-        <text variable="status" prefix="(" suffix=")"/>
-      </else-if>
-    </choose>
-  </macro>
-  <macro name="citation-locator">
-    <!-- Abbreviate page and paragraph, leave other locator labels in long form, cf. Rule 8.13 -->
-    <group delimiter=" ">
-      <choose>
-        <if locator="page paragraph" match="any">
-          <label variable="locator" form="short"/>
-        </if>
-        <else>
-          <label variable="locator" text-case="capitalize-first"/>
-        </else>
-      </choose>
-      <text variable="locator"/>
+      </group>
     </group>
   </macro>
-  <citation et-al-min="3" et-al-use-first="1" disambiguate-add-year-suffix="true" disambiguate-add-names="true" disambiguate-add-givenname="true" collapse="year" givenname-disambiguation-rule="primary-name-with-initials">
+  <macro name="container-treaty">
+    <group delimiter=" ">
+      <number variable="volume"/>
+      <text variable="container-title"/>
+      <choose>
+        <if match="any" variable="page page-first">
+          <text variable="page-first"/>
+        </if>
+        <else>
+          <text macro="number-labelled"/>
+        </else>
+      </choose>
+    </group>
+  </macro>
+  <!-- Legal source logic -->
+  <macro name="container-legal">
+    <!-- Expect legal item container-titles to be stored in short form -->
+    <choose>
+      <if type="bill">
+        <text macro="container-bill"/>
+      </if>
+      <else-if type="hearing">
+        <text macro="container-hearing"/>
+      </else-if>
+      <else-if type="legal_case">
+        <text macro="container-legal-case"/>
+      </else-if>
+      <else-if type="legislation">
+        <text macro="container-legislation"/>
+      </else-if>
+      <else-if type="regulation">
+        <text macro="container-regulation"/>
+      </else-if>
+      <else-if type="treaty">
+        <text macro="container-treaty"/>
+      </else-if>
+    </choose>
+  </macro>
+  <!-- Main logic -->
+  <citation collapse="year" disambiguate-add-givenname="true" disambiguate-add-names="true" disambiguate-add-year-suffix="true" et-al-min="3" et-al-use-first="1" givenname-disambiguation-rule="primary-name-with-initials">
     <sort>
       <key macro="author-sort" names-min="3" names-use-first="1"/>
       <key macro="date-sort-group" sort="ascending"/>
       <key macro="date-sort" sort="ascending"/>
       <key variable="status"/>
     </sort>
-    <layout prefix="(" suffix=")" delimiter="; ">
+    <layout delimiter="; " prefix="(" suffix=")">
       <group delimiter=", ">
         <text macro="author-intext"/>
         <text macro="date-intext"/>
-        <text macro="citation-locator"/>
+        <text macro="locator-labelled"/>
       </group>
     </layout>
   </citation>
-  <bibliography hanging-indent="true" et-al-min="21" et-al-use-first="19" et-al-use-last="true" entry-spacing="0" line-spacing="2">
+  <macro name="bibliography">
+    <group delimiter=" ">
+      <group delimiter=". " suffix=".">
+        <text macro="author-bib"/>
+        <text macro="date-bib"/>
+        <text macro="title-and-descriptions"/>
+        <text macro="container"/>
+        <text macro="event"/>
+        <text macro="publication-archive"/>
+      </group>
+      <text macro="access"/>
+      <text macro="publication-history"/>
+    </group>
+  </macro>
+  <macro name="bibliography-filtered">
+    <choose>
+      <if match="any" type="bill hearing legal_case legislation regulation treaty">
+        <!-- Legal items have different orders and delimiters -->
+        <text macro="legal-bib"/>
+      </if>
+      <else-if type="personal_communication">
+        <choose>
+          <if match="any" variable="archive archive-place container-title DOI publisher URL">
+            <text macro="bibliography"/>
+          </if>
+        </choose>
+      </else-if>
+      <else>
+        <text macro="bibliography"/>
+      </else>
+    </choose>
+  </macro>
+  <bibliography entry-spacing="0" et-al-min="21" et-al-use-first="19" et-al-use-last="true" hanging-indent="true" line-spacing="2">
     <sort>
       <key macro="author-sort"/>
       <key macro="date-sort-group" sort="ascending"/>
       <key macro="date-sort" sort="ascending"/>
       <key variable="status"/>
-      <key macro="title"/>
+      <key macro="title-bib"/>
     </sort>
     <layout>
-      <choose>
-        <if type="bill hearing legal_case legislation regulation treaty" match="any">
-          <!-- Legal items have different orders and delimiters -->
-          <text macro="legal-cites"/>
-        </if>
-        <else>
-          <group delimiter=" ">
-            <group delimiter=". " suffix=".">
-              <text macro="author-bib"/>
-              <text macro="date-bib"/>
-              <text macro="title-and-descriptions"/>
-              <text macro="container"/>
-              <text macro="event"/>
-              <text macro="publisher"/>
-            </group>
-            <text macro="access"/>
-            <text macro="publication-history"/>
-          </group>
-        </else>
-      </choose>
-      <text variable="abstract" display="block"/>
+      <text macro="bibliography-filtered"/>
+      <text display="block" variable="abstract"/>
     </layout>
   </bibliography>
 </style>

--- a/apa.csl
+++ b/apa.csl
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
-<style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" demote-non-dropping-particle="never" page-range-format="expanded">
+<style xmlns="http://purl.org/net/xbiblio/csl" and="symbol" class="in-text" demote-non-dropping-particle="never" initialize-with=". " names-delimiter=", " page-range-format="expanded" version="1.0">
   <info>
     <title>American Psychological Association 7th edition</title>
-    <title-short>APA</title-short>
+    <title-short>APA Style</title-short>
     <id>http://www.zotero.org/styles/apa</id>
     <link href="http://www.zotero.org/styles/apa" rel="self"/>
     <link href="http://www.zotero.org/styles/apa-6th-edition" rel="template"/>
@@ -10,48 +10,53 @@
     <author>
       <name>Brenton M. Wiernik</name>
       <email>zotero@wiernik.org</email>
+      <uri>https://orcid.org/0000-0001-9560-6336</uri>
     </author>
+    <contributor>
+      <name>Andrew Dunning</name>
+      <uri>https://orcid.org/0000-0003-0464-5036</uri>
+    </contributor>
     <category citation-format="author-date"/>
     <category field="psychology"/>
     <category field="generic-base"/>
+    <summary>Author–date system of the Publication manual of the American Psychological Association: The official guide to APA style (2020)</summary>
     <updated>2024-07-09T20:08:41+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale xml:lang="en">
     <terms>
-      <term name="editortranslator" form="short">
-        <single>ed. &amp; trans.</single>
-        <multiple>eds. &amp; trans.</multiple>
-      </term>
-      <term name="editor-translator" form="short">
-        <single>ed. &amp; trans.</single>
-        <multiple>eds. &amp; trans.</multiple>
-      </term>
-      <term name="translator" form="short">trans.</term>
-      <term name="interviewer" form="short">
-        <single>interviewer</single>
-        <multiple>interviewers</multiple>
-      </term>
-      <term name="collection-editor" form="short">
+      <term name="ad"> C.E.</term>
+      <term form="long" name="at">before the</term>
+      <term name="bc"> B.C.E.</term>
+      <term form="short" name="circa">ca.</term>
+      <term name="collection">archival collection</term>
+      <term form="short" name="collection-editor">
         <single>ed.</single>
         <multiple>eds.</multiple>
       </term>
-      <term name="performer" form="verb">recorded by</term>
-      <term name="circa" form="short">ca.</term>
-      <term name="bc"> B.C.E.</term>
-      <term name="ad"> C.E.</term>
-      <term name="issue" form="long">
+      <term form="short" name="editor-translator">
+        <single>ed. &amp; trans.</single>
+        <multiple>eds. &amp; trans.</multiple>
+      </term>
+      <term form="short" name="editortranslator">
+        <single>ed. &amp; trans.</single>
+        <multiple>eds. &amp; trans.</multiple>
+      </term>
+      <term form="verb" name="hearing">testimony of</term>
+      <term form="short" name="interviewer">
+        <single>interviewer</single>
+        <multiple>interviewers</multiple>
+      </term>
+      <term form="long" name="issue">
         <single>issue</single>
         <multiple>issues</multiple>
       </term>
-      <term name="software">computer software</term>
-      <term name="at" form="long">before the</term>
-      <term name="collection">archival collection</term>
+      <term form="verb" name="performer">recorded by</term>
       <term name="post">online post</term>
-      <term name="at" form="long">before the</term>
-      <term name="hearing" form="verb">testimony of</term>
-      <term name="review-of" form="long">review of the</term>
-      <term name="review-of" form="short">review of</term>
+      <term form="long" name="review-of">review of the</term>
+      <term form="short" name="review-of">review of</term>
+      <term name="software">computer software</term>
+      <term form="short" name="translator">trans.</term>
     </terms>
   </locale>
   <locale xml:lang="da">
@@ -71,7 +76,7 @@
   </locale>
   <locale xml:lang="fr">
     <terms>
-      <term name="editor" form="short">
+      <term form="short" name="editor">
         <single>éd.</single>
         <multiple>éds.</multiple>
       </term>
@@ -97,29 +102,26 @@
       <term name="et-al">et al.</term>
     </terms>
   </locale>
-  <!-- For Indigeneous Knowledge, assume the item is stored as `document` or `speech`
-       and that Nation/Community, treaty, where the Elder lives, 
-       and topic are all stored in `title`
-       cf. https://libguides.norquest.ca/c.php?g=314831&p=5188823.
-       If the item is stored as `interview`, assume that Nation/Community, treat, and topic
-       are stored in `title`, 'Oral teaching' or similar is stored in `archive`, and where
-       the Elder lives is stored in `archive-place`. 
-  -->
-  <!-- Reviews are detected if an item has type `review` or `review-book` or if it has any of the variables
-       `reviewed-title`, `reviewed-author`, or `reviewed-genre`. For the latter case, reviews are commonly 
-       stored as types `article-journal`, `article-magazine`, `article-newspaper`, `post-weblog`, or `webpage` 
-  -->
-  <!-- General categories of item types:
-       Periodical: article-journal article-magazine article-newspaper periodical post-weblog review review-book
-       Periodical or Booklike: paper-conference
-       Booklike: article book broadcast chapter classic collection dataset document
-                 entry entry-dictionary entry-encyclopedia event figure
-                 graphic interview manuscript map motion_picture musical_score
-                 pamphlet patent performance personal_communication post report
-                 software song speech standard thesis webpage
-       Legal: bill hearing legal_case legislation regulation treaty
+  <!-- General categories of CSL item types:
+
+       Periodical
+       : article-journal article-magazine article-newspaper periodical post-weblog review review-book
+
+       Periodical or Booklike
+       : paper-conference
+
+       Booklike
+       : article book broadcast chapter classic collection dataset document
+         entry entry-dictionary entry-encyclopedia event figure
+         graphic interview manuscript map motion_picture musical_score
+         pamphlet patent performance personal_communication post report
+         software song speech standard thesis webpage
+
+       Legal
+       : bill hearing legal_case legislation regulation treaty
   -->
   <!-- Equivalencies:
+
        classic == book
        document == report, but give full date
        standard == report
@@ -128,6 +130,7 @@
        collection == book, but give full date
   -->
   <!-- Role equivalencies:
+
        compiler == editor
        organizer, curator == chair
        script-writer == director
@@ -135,128 +138,294 @@
        guest, host == director
        series-creator, executive-producer == editor
   -->
-  <!-- APA references contain four parts: author, date, title, source -->
+  <!-- Reviews are detected if an item has type `review` or `review-book` or if it has any of the variables
+       `reviewed-title`, `reviewed-author`, or `reviewed-genre`. For the latter case, reviews are commonly
+       stored as types `article-journal`, `article-magazine`, `article-newspaper`, `post-weblog`, or `webpage`
+  -->
+  <!-- For Indigeneous Knowledge, assume the item is stored as `document` or `speech`
+       and that Nation/Community, treaty, where the Elder lives,
+       and topic are all stored in `title`
+       cf. https://libguides.norquest.ca/c.php?g=314831&p=5188823.
+       If the item is stored as `interview`, assume that Nation/Community, treaty territory, and topic
+       are stored in `title`, 'Oral teaching' or similar is stored in `archive`, and where
+       the Elder lives is stored in `archive-place`.
+  -->
+  <!-- Variable labelling macros -->
+  <macro name="chapter-number-labelled">
+    <group delimiter=" ">
+      <choose>
+        <if is-numeric="chapter-number">
+          <label form="short" variable="chapter-number"/>
+        </if>
+      </choose>
+      <text variable="chapter-number"/>
+    </group>
+  </macro>
+  <macro name="edition-labelled">
+    <choose>
+      <if is-numeric="edition">
+        <group delimiter=" ">
+          <number form="ordinal" variable="edition"/>
+          <label form="short" variable="edition"/>
+        </group>
+      </if>
+      <else>
+        <text variable="edition"/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="issue-labelled">
+    <group delimiter=" ">
+      <label text-case="capitalize-first" variable="issue"/>
+      <text variable="issue"/>
+    </group>
+  </macro>
+  <macro name="locator-labelled">
+    <!-- Abbreviate page and paragraph; leave other locator labels in long form (APA 8.13) -->
+    <group delimiter=" ">
+      <choose>
+        <if locator="page paragraph" match="any">
+          <label form="short" variable="locator"/>
+        </if>
+        <else>
+          <label text-case="capitalize-first" variable="locator"/>
+        </else>
+      </choose>
+      <text variable="locator"/>
+    </group>
+  </macro>
+  <macro name="number-labelled">
+    <group delimiter=" ">
+      <choose>
+        <if is-numeric="number">
+          <label form="short" text-case="capitalize-first" variable="number"/>
+        </if>
+        <else-if match="none" type="broadcast">
+          <label form="short" text-case="capitalize-first" variable="number"/>
+        </else-if>
+      </choose>
+      <text variable="number"/>
+    </group>
+  </macro>
+  <macro name="number-article-labelled">
+    <!-- APA example 6: Journal article with article number or eLocator -->
+    <group delimiter=" ">
+      <text term="article-locator" text-case="capitalize-first"/>
+      <text variable="number"/>
+    </group>
+  </macro>
+  <macro name="number-of-volumes-labelled">
+    <choose>
+      <if is-numeric="number-of-volumes">
+        <group delimiter=" ">
+          <label form="short" text-case="capitalize-first" variable="number-of-volumes"/>
+          <text prefix="1" term="page-range-delimiter"/>
+        </group>
+      </if>
+    </choose>
+    <text variable="number-of-volumes"/>
+  </macro>
+  <macro name="page-labelled">
+    <group delimiter=" ">
+      <label form="short" variable="page"/>
+      <text variable="page"/>
+    </group>
+  </macro>
+  <macro name="part-number-labelled">
+    <group delimiter=" ">
+      <choose>
+        <if variable="part-number">
+          <!-- TODO: Replace with `part-number` label when CSL provides one -->
+          <text form="short" term="part" text-case="capitalize-first"/>
+          <text variable="part-number"/>
+        </if>
+      </choose>
+    </group>
+  </macro>
+  <macro name="section-labelled">
+    <group delimiter=" ">
+      <label form="symbol" variable="section"/>
+      <text variable="section"/>
+    </group>
+  </macro>
+  <macro name="supplement-number-labelled">
+    <group delimiter=" ">
+      <choose>
+        <if variable="supplement-number">
+          <!-- TODO: Replace with `supplement-number` label when CSL provides one -->
+          <text form="short" term="supplement" text-case="capitalize-first"/>
+          <text variable="supplement-number"/>
+        </if>
+      </choose>
+    </group>
+  </macro>
+  <macro name="version-labelled">
+    <group delimiter=" ">
+      <label text-case="capitalize-first" variable="version"/>
+      <text variable="version"/>
+    </group>
+  </macro>
+  <macro name="volume-labelled">
+    <group delimiter=" ">
+      <label form="short" text-case="capitalize-first" variable="volume"/>
+      <text variable="volume"/>
+    </group>
+  </macro>
+  <!-- Four parts in APA references:
+
+       1. Author (APA 9.7–12)
+       2. Date (APA 9.13–17)
+       3. Title (APA 9.18–22)
+       4. Source (APA 9.23–37)
+  -->
+  <!-- 1. Author -->
+  <!-- Author utility macros -->
+  <macro name="author-substitute-bib">
+    <names variable="composer">
+      <name delimiter-precedes-last="always" name-as-sort-order="all"/>
+      <label form="short" prefix=" (" suffix=")" text-case="title"/>
+      <substitute>
+        <names variable="author"/>
+        <!-- `narrator` only cited in secondary-contributors -->
+        <names variable="illustrator"/>
+        <choose>
+          <if type="broadcast">
+            <names variable="script-writer director">
+              <!-- Actors/performers and producers [not executive] not cited in APA style. -->
+              <name delimiter-precedes-last="always" name-as-sort-order="all"/>
+              <label form="long" prefix=" (" suffix=")" text-case="title"/>
+            </names>
+          </if>
+        </choose>
+        <names variable="director">
+          <!-- For non-broadcast items, APA only cites directors and not writers. -->
+          <name delimiter-precedes-last="always" name-as-sort-order="all"/>
+          <label form="long" prefix=" (" suffix=")" text-case="title"/>
+        </names>
+        <names variable="guest host">
+          <!-- TODO: Replace `delimiter` with `collapse` to combine names variables when that becomes available. -->
+          <name delimiter-precedes-last="always" name-as-sort-order="all"/>
+          <label form="long" prefix=" (" suffix=")" text-case="title"/>
+        </names>
+        <names variable="producer">
+          <!-- Producers not cited if there is a writer/director, but use if they are the principle creator. -->
+          <name delimiter-precedes-last="always" name-as-sort-order="all"/>
+          <label form="long" prefix=" (" suffix=")" text-case="title"/>
+        </names>
+        <choose>
+          <if variable="container-title">
+            <choose>
+              <if match="any" type="book classic collection entry entry-dictionary entry-encyclopedia">
+                <!-- Items with book-like container-title substitute with their title and identification,
+                     but leave description after container-title. This mimics the `container-booklike` formatting. -->
+                <text macro="title-substitute"/>
+              </if>
+            </choose>
+          </if>
+        </choose>
+        <names variable="executive-producer">
+          <name delimiter-precedes-last="always" name-as-sort-order="all"/>
+          <label form="long" prefix=" (" suffix=")" text-case="title"/>
+        </names>
+        <names variable="series-creator">
+          <name delimiter-precedes-last="always" name-as-sort-order="all"/>
+          <label form="long" prefix=" (" suffix=")" text-case="title"/>
+        </names>
+        <names variable="editor-translator"/>
+        <!-- Translator is not cited as a primary creator (only as Ed. & Trans.). -->
+        <names variable="editor"/>
+        <names variable="editorial-director"/>
+        <names variable="compiler">
+          <name delimiter-precedes-last="always" name-as-sort-order="all"/>
+          <label form="long" prefix=" (" suffix=")" text-case="title"/>
+        </names>
+        <choose>
+          <if match="any" type="event performance speech">
+            <names variable="chair">
+              <name delimiter-precedes-last="always" name-as-sort-order="all"/>
+              <label form="long" prefix=" (" suffix=")" text-case="title"/>
+            </names>
+            <names variable="organizer">
+              <name delimiter-precedes-last="always" name-as-sort-order="all"/>
+              <label form="long" prefix=" (" suffix=")" text-case="title"/>
+            </names>
+          </if>
+        </choose>
+        <names variable="curator">
+          <name delimiter-precedes-last="always" name-as-sort-order="all"/>
+          <label form="long" prefix=" (" suffix=")" text-case="title"/>
+        </names>
+        <names variable="collection-editor"/>
+        <text macro="title-substitute"/>
+      </substitute>
+    </names>
+  </macro>
+  <macro name="author-substitute-intext">
+    <names variable="composer">
+      <name form="short"/>
+      <substitute>
+        <names variable="author"/>
+        <names variable="illustrator"/>
+        <!-- TODO: Replace `delimiter` with `collapse` to combine names variables when that becomes available. -->
+        <choose>
+          <if type="broadcast">
+            <names variable="script-writer"/>
+          </if>
+        </choose>
+        <names variable="director"/>
+        <!-- TODO: Replace `delimiter` with `collapse` to combine names variables when that becomes available. -->
+        <names variable="guest host"/>
+        <names variable="producer"/>
+        <choose>
+          <if variable="container-title">
+            <choose>
+              <if match="any" type="book classic collection entry entry-dictionary entry-encyclopedia">
+                <text macro="title-intext"/>
+              </if>
+            </choose>
+          </if>
+        </choose>
+        <names variable="executive-producer"/>
+        <names variable="series-creator"/>
+        <names variable="editor"/>
+        <names variable="editorial-director"/>
+        <names variable="compiler"/>
+        <choose>
+          <if match="any" type="event performance speech">
+            <names variable="chair"/>
+            <names variable="organizer"/>
+          </if>
+        </choose>
+        <names variable="curator"/>
+        <text macro="title-intext"/>
+      </substitute>
+    </names>
+  </macro>
+  <macro name="title-substitute">
+    <choose>
+      <if variable="title">
+        <!-- If an item has a title, substitute missing author with title and identification, but leave description after the date (in the 'title' position). -->
+        <group delimiter=" ">
+          <text macro="title-bib"/>
+          <text macro="identification"/>
+        </group>
+      </if>
+      <else>
+        <!-- If an item has no title, substitute with description followed by identification. -->
+        <text macro="title-and-descriptions"/>
+      </else>
+    </choose>
+  </macro>
+  <!-- Author logic -->
   <macro name="author-bib">
     <group delimiter=" ">
-      <names variable="composer" delimiter=", &amp; ">
-        <name name-as-sort-order="all" and="symbol" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
-        <substitute>
-          <names variable="author"/>
-          <!-- Note: `narrator` only cited in secondary-contributors -->
-          <names variable="illustrator"/>
-          <!-- TODO: Replace `delimiter` with `collapse` to combine names variables when that becomes available. -->
-          <choose>
-            <if type="broadcast">
-              <names variable="script-writer director">
-                <!-- Note: Actors/performers and producers [not executive] not cited in APA style. -->
-                <name name-as-sort-order="all" and="symbol" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
-                <label form="long" prefix=" (" suffix=")" text-case="title"/>
-              </names>
-            </if>
-          </choose>
-          <names variable="director">
-            <!-- For non-broadcast items, APA only cites directors and not writers. -->
-            <name name-as-sort-order="all" and="symbol" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
-            <label form="long" prefix=" (" suffix=")" text-case="title"/>
-          </names>
-          <!-- TODO: Replace `delimiter` with `collapse` to combine names variables when that becomes available. -->
-          <names variable="guest host">
-            <name name-as-sort-order="all" and="symbol" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
-            <label form="long" prefix=" (" suffix=")" text-case="title"/>
-          </names>
-          <names variable="producer">
-            <!-- Note: Producers not cited if there is a writer/director, but use if they are the principle creator. -->
-            <name name-as-sort-order="all" and="symbol" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
-            <label form="long" prefix=" (" suffix=")" text-case="title"/>
-          </names>
-          <choose>
-            <if variable="container-title">
-              <choose>
-                <if type="book classic collection entry entry-dictionary entry-encyclopedia" match="any">
-                  <!-- Items with book-like container-title substitute with their title and parenthetical, 
-                       but leave bracketed after container-title. This mimics the `container-booklike` formatting. -->
-                  <choose>
-                    <if variable="title">
-                      <group delimiter=" ">
-                        <text macro="title"/>
-                        <text macro="parenthetical"/>
-                      </group>
-                    </if>
-                    <else>
-                      <text macro="title-and-descriptions"/>
-                    </else>
-                  </choose>
-                </if>
-              </choose>
-            </if>
-          </choose>
-          <names variable="executive-producer">
-            <name name-as-sort-order="all" and="symbol" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
-            <label form="long" prefix=" (" suffix=")" text-case="title"/>
-          </names>
-          <names variable="series-creator">
-            <name name-as-sort-order="all" and="symbol" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
-            <label form="long" prefix=" (" suffix=")" text-case="title"/>
-          </names>
-          <names variable="editor-translator">
-            <name name-as-sort-order="all" and="symbol" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
-            <label form="short" prefix=" (" suffix=")" text-case="title"/>
-          </names>
-          <!-- Note: Translator is not cited as a primary creator (only as Ed. & Trans.). -->
-          <names variable="editor">
-            <name name-as-sort-order="all" and="symbol" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
-            <label form="short" prefix=" (" suffix=")" text-case="title"/>
-          </names>
-          <names variable="editorial-director">
-            <name name-as-sort-order="all" and="symbol" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
-            <label form="short" prefix=" (" suffix=")" text-case="title"/>
-          </names>
-          <names variable="compiler">
-            <name name-as-sort-order="all" and="symbol" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
-            <label form="long" prefix=" (" suffix=")" text-case="title"/>
-          </names>
-          <choose>
-            <if type="event performance speech" match="any">
-              <names variable="chair">
-                <name name-as-sort-order="all" and="symbol" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
-                <label form="long" prefix=" (" suffix=")" text-case="title"/>
-              </names>
-              <names variable="organizer">
-                <name name-as-sort-order="all" and="symbol" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
-                <label form="long" prefix=" (" suffix=")" text-case="title"/>
-              </names>
-            </if>
-          </choose>
-          <names variable="curator">
-            <name name-as-sort-order="all" and="symbol" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
-            <label form="long" prefix=" (" suffix=")" text-case="title"/>
-          </names>
-          <names variable="collection-editor">
-            <name name-as-sort-order="all" and="symbol" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
-            <label form="short" prefix=" (" suffix=")" text-case="title"/>
-          </names>
-          <choose>
-            <if variable="title">
-              <!-- If an item has a title, substitute missing author with title and parenthetical, but leave bracketed 
-                   after the date (in the 'title' position). -->
-              <group delimiter=" ">
-                <text macro="title"/>
-                <text macro="parenthetical"/>
-              </group>
-            </if>
-            <else>
-              <!-- If an item has no title, substitute with bracketed followed by parenthetical. -->
-              <text macro="title-and-descriptions"/>
-            </else>
-          </choose>
-        </substitute>
-      </names>
+      <text macro="author-substitute-bib"/>
       <choose>
         <!-- Print "with" contributor for books, but not for other types that commonly have them (eg, thesis, software) -->
-        <if type="book classic collection" match="any">
-          <names variable="contributor" prefix="(" suffix=")">
+        <if match="any" type="book classic collection">
+          <names prefix="(" suffix=")" variable="contributor">
             <label form="verb" suffix=" "/>
-            <name name-as-sort-order="all" and="symbol" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
+            <name delimiter-precedes-last="always" name-as-sort-order="all"/>
           </names>
         </if>
       </choose>
@@ -264,80 +433,21 @@
   </macro>
   <macro name="author-intext">
     <choose>
-      <if type="bill hearing legal_case legislation regulation treaty" match="any">
+      <if match="any" type="bill hearing legal_case legislation regulation treaty">
         <text macro="title-intext"/>
       </if>
-      <else-if type="interview personal_communication" match="any">
-        <choose>
-          <!-- These variables indicate that the letter is retrievable by the reader.
-                If not, then use the APA in-text-only personal communication format -->
-          <if variable="archive container-title DOI publisher URL" match="none">
-            <group delimiter=", ">
-              <names variable="author">
-                <name and="symbol" delimiter=", " initialize-with=". "/>
-                <substitute>
-                  <text macro="title-intext"/>
-                </substitute>
-              </names>
-              <text term="personal-communication"/>
-            </group>
-          </if>
-          <else>
-            <names variable="author" delimiter=", ">
-              <name form="short" and="symbol" delimiter=", " initialize-with=". "/>
-              <substitute>
-                <text macro="title-intext"/>
-              </substitute>
-            </names>
-          </else>
-        </choose>
+      <else-if match="any" type="interview personal_communication">
+        <text macro="title-intext-interview-communication"/>
       </else-if>
       <else>
-        <names variable="composer" delimiter=" &amp; ">
-          <name form="short" and="symbol" delimiter=", " initialize-with=". "/>
-          <substitute>
-            <names variable="author"/>
-            <names variable="illustrator"/>
-            <!-- TODO: Replace `delimiter` with `collapse` to combine names variables when that becomes available. -->
-            <choose>
-              <if type="broadcast">
-                <names variable="script-writer director"/>
-              </if>
-            </choose>
-            <names variable="director"/>
-            <!-- TODO: Replace `delimiter` with `collapse` to combine names variables when that becomes available. -->
-            <names variable="guest host"/>
-            <names variable="producer"/>
-            <choose>
-              <if variable="container-title">
-                <choose>
-                  <if type="book classic collection entry entry-dictionary entry-encyclopedia" match="any">
-                    <text macro="title-intext"/>
-                  </if>
-                </choose>
-              </if>
-            </choose>
-            <names variable="executive-producer"/>
-            <names variable="series-creator"/>
-            <names variable="editor"/>
-            <names variable="editorial-director"/>
-            <names variable="compiler"/>
-            <choose>
-              <if type="event performance speech" match="any">
-                <names variable="chair"/>
-                <names variable="organizer"/>
-              </if>
-            </choose>
-            <names variable="curator"/>
-            <text macro="title-intext"/>
-          </substitute>
-        </names>
+        <text macro="author-substitute-intext"/>
       </else>
     </choose>
   </macro>
+  <!-- Author sorting -->
   <macro name="author-sort">
     <choose>
-      <if type="bill hearing legal_case legislation regulation treaty" match="any">
+      <if match="any" type="bill hearing legal_case legislation regulation treaty">
         <text macro="title-legal"/>
       </if>
       <else>
@@ -345,92 +455,161 @@
       </else>
     </choose>
   </macro>
-  <macro name="date-bib">
-    <group delimiter=" " prefix="(" suffix=")">
-      <choose>
-        <if is-uncertain-date="issued">
-          <text term="circa" form="short"/>
-        </if>
-      </choose>
-      <group>
-        <choose>
-          <if variable="issued">
-            <group delimiter=", ">
-              <group>
-                <date variable="issued" date-parts="year" form="numeric"/>
-                <text variable="year-suffix"/>
-              </group>
-              <choose>
-                <if type="article-magazine article-newspaper broadcast collection document event interview motion_picture pamphlet performance personal_communication post post-weblog song speech webpage" match="any">
-                  <!-- Many video and audio examples in manual give full dates. Err on the side of too much information. -->
-                  <date variable="issued">
-                    <date-part name="month"/>
-                    <date-part name="day" prefix=" "/>
-                  </date>
-                </if>
-                <else-if type="paper-conference">
-                  <!-- Capture 'speech' stored as 'paper-conference' -->
-                  <choose>
-                    <if variable="collection-editor compiler editor editorial-director issue page volume" match="none">
-                      <date variable="issued">
-                        <date-part name="month"/>
-                        <date-part name="day" prefix=" "/>
-                      </date>
-                    </if>
-                  </choose>
-                </else-if>
-                <!-- Only year: article article-journal book chapter classic entry entry-dictionary entry-encyclopedia dataset figure graphic
-                     manuscript map musical_score paper-conference[published] patent periodical report review review-book software standard thesis -->
-              </choose>
-            </group>
-          </if>
-          <else-if variable="status">
-            <group>
-              <!-- We print the status variable directly rather than using in-press, etc. terms. -->
-              <text variable="status" text-case="lowercase"/>
-              <text variable="year-suffix" prefix="-"/>
-            </group>
-          </else-if>
-          <else>
-            <text term="no date" form="short"/>
-            <text variable="year-suffix" prefix="-"/>
-          </else>
-        </choose>
-      </group>
+  <!-- 2. Date -->
+  <!-- Date utility macros -->
+  <macro name="date-issued-full">
+    <group delimiter=" ">
+      <text macro="uncertain-date-issued"/>
+      <date form="text" variable="issued"/>
     </group>
   </macro>
-  <macro name="date-sort">
-    <!-- This is necessary to ensure that citeproc sorts all item types chonologically in the same list. -->
+  <macro name="date-issued-leading-zeros">
+    <date delimiter="-" variable="issued">
+      <date-part form="long" name="year"/>
+      <date-part form="numeric-leading-zeros" name="month"/>
+      <date-part form="numeric-leading-zeros" name="day"/>
+    </date>
+  </macro>
+  <macro name="date-issued-month-day">
+    <date variable="issued">
+      <date-part name="month"/>
+      <date-part name="day" prefix=" "/>
+    </date>
+  </macro>
+  <macro name="date-issued-year">
+    <group delimiter=" ">
+      <text macro="uncertain-date-issued"/>
+      <date date-parts="year" form="numeric" variable="issued"/>
+    </group>
+  </macro>
+  <macro name="original-date-year">
+    <group delimiter=" ">
+      <choose>
+        <if is-uncertain-date="original-date">
+          <text form="short" term="circa"/>
+        </if>
+      </choose>
+      <date variable="original-date">
+        <date-part name="year"/>
+      </date>
+    </group>
+  </macro>
+  <macro name="uncertain-date-issued">
     <choose>
-      <if type="article article-journal book chapter entry entry-dictionary entry-encyclopedia dataset figure graphic manuscript map musical_score patent report review review-book thesis" match="any">
-        <date variable="issued" date-parts="year" form="numeric"/>
+      <if is-uncertain-date="issued">
+        <text form="short" term="circa"/>
+      </if>
+    </choose>
+  </macro>
+  <!-- Date logic -->
+  <macro name="date-bib">
+    <group prefix="(" suffix=")">
+      <choose>
+        <if variable="issued">
+          <group delimiter=", ">
+            <group>
+              <text macro="date-issued-year"/>
+              <text variable="year-suffix"/>
+            </group>
+            <choose>
+              <if match="any" type="article-magazine article-newspaper broadcast collection document event interview motion_picture pamphlet performance personal_communication post post-weblog song speech webpage">
+                <!-- Many video and audio examples in manual give full dates. Err on the side of too much information. -->
+                <text macro="date-issued-month-day"/>
+              </if>
+              <else-if type="paper-conference">
+                <!-- Capture 'speech' stored as 'paper-conference' -->
+                <choose>
+                  <if match="none" variable="collection-editor compiler editor editorial-director issue page volume">
+                    <text macro="date-issued-month-day"/>
+                  </if>
+                </choose>
+              </else-if>
+              <!-- Only year: article article-journal book chapter classic entry entry-dictionary entry-encyclopedia dataset figure graphic
+                     manuscript map musical_score paper-conference[published] patent periodical report review review-book software standard thesis -->
+            </choose>
+          </group>
+        </if>
+        <else-if variable="status">
+          <group>
+            <!-- We print the status variable directly rather than using in-press, etc. terms. -->
+            <text text-case="lowercase" variable="status"/>
+            <text prefix="-" variable="year-suffix"/>
+          </group>
+        </else-if>
+        <else>
+          <text form="short" term="no date"/>
+          <text prefix="-" variable="year-suffix"/>
+        </else>
+      </choose>
+    </group>
+  </macro>
+  <macro name="date-intext">
+    <choose>
+      <if variable="issued">
+        <group delimiter="/">
+          <text macro="original-date-year"/>
+          <group>
+            <choose>
+              <if match="any" type="interview personal_communication">
+                <choose>
+                  <if match="none" variable="archive archive-place container-title DOI publisher URL">
+                    <!-- These variables indicate that the communication is retrievable by the reader.
+                           If not, then use the in-text-only personal communication format -->
+                    <text macro="date-issued-full"/>
+                  </if>
+                  <else>
+                    <text macro="date-issued-year"/>
+                  </else>
+                </choose>
+              </if>
+              <else>
+                <text macro="date-issued-year"/>
+              </else>
+            </choose>
+            <text variable="year-suffix"/>
+          </group>
+        </group>
+      </if>
+      <else-if variable="status">
+        <!-- We print the status variable directly rather than using in-press, etc. terms. -->
+        <text text-case="lowercase" variable="status"/>
+        <text prefix="-" variable="year-suffix"/>
+      </else-if>
+      <else>
+        <text form="short" term="no date"/>
+        <text prefix="-" variable="year-suffix"/>
+      </else>
+    </choose>
+  </macro>
+  <!-- Date sorting -->
+  <macro name="date-sort">
+    <!-- Sort items by printed issue date without prefixes for original or uncertain dates -->
+    <choose>
+      <if match="any" type="article article-journal book chapter entry entry-dictionary entry-encyclopedia dataset figure graphic manuscript map musical_score patent report review review-book thesis">
+        <date date-parts="year" form="numeric" variable="issued"/>
       </if>
       <else-if type="paper-conference">
         <!-- Capture 'speech' stored as 'paper-conference' -->
         <choose>
-          <if variable="collection-editor compiler editor editorial-director issue page volume" match="any">
-            <date variable="issued" date-parts="year" form="numeric"/>
+          <if match="any" variable="collection-editor compiler editor editorial-director issue page volume">
+            <date date-parts="year" form="numeric" variable="issued"/>
           </if>
           <else>
-            <date variable="issued">
-              <date-part name="year" form="long"/>
-              <date-part name="month" form="numeric-leading-zeros"/>
-              <date-part name="day" form="numeric-leading-zeros"/>
-            </date>
+            <text macro="date-issued-leading-zeros"/>
           </else>
         </choose>
       </else-if>
       <else>
-        <date variable="issued">
-          <date-part name="year" form="long"/>
-          <date-part name="month" form="numeric-leading-zeros"/>
-          <date-part name="day" form="numeric-leading-zeros"/>
-        </date>
+        <text macro="date-issued-leading-zeros"/>
       </else>
     </choose>
   </macro>
   <macro name="date-sort-group">
-    <!-- APA sorts 1. no-date items, 2. items with dates, 3. in-press (status) items -->
+    <!-- Sorts items with and without dates:
+
+         1. no-date items (= 0)
+         2. items with dates (= 1)
+         3. in-press (status) items (= 2) -->
     <choose>
       <if variable="issued">
         <text value="1"/>
@@ -443,111 +622,185 @@
       </else>
     </choose>
   </macro>
-  <macro name="date-intext">
-    <choose>
-      <if variable="issued">
-        <group delimiter="/">
-          <group delimiter=" ">
-            <choose>
-              <if is-uncertain-date="original-date">
-                <text term="circa" form="short"/>
-              </if>
-            </choose>
-            <date variable="original-date">
-              <date-part name="year"/>
-            </date>
-          </group>
-          <group delimiter=" ">
-            <choose>
-              <if is-uncertain-date="issued">
-                <text term="circa" form="short"/>
-              </if>
-            </choose>
-            <group>
-              <choose>
-                <if type="interview personal_communication" match="any">
-                  <choose>
-                    <if variable="archive container-title DOI publisher URL" match="none">
-                      <!-- These variables indicate that the communication is retrievable by the reader.
-                           If not, then use the in-text-only personal communication format -->
-                      <date variable="issued" form="text"/>
-                    </if>
-                    <else>
-                      <date variable="issued">
-                        <date-part name="year"/>
-                      </date>
-                    </else>
-                  </choose>
-                </if>
-                <else>
-                  <date variable="issued">
-                    <date-part name="year"/>
-                  </date>
-                </else>
-              </choose>
-              <text variable="year-suffix"/>
-            </group>
-          </group>
-        </group>
-      </if>
-      <else-if variable="status">
-        <!-- We print the status variable directly rather than using in-press, etc. terms. -->
-        <text variable="status" text-case="lowercase"/>
-        <text variable="year-suffix" prefix="-"/>
-      </else-if>
-      <else>
-        <text term="no date" form="short"/>
-        <text variable="year-suffix" prefix="-"/>
-      </else>
-    </choose>
-  </macro>
-  <!-- APA has two description elements following the title:
-       title (parenthetical) [bracketed] -->
+  <!-- 3. Title and descriptions -->
+  <!-- Three parts in title element (APA 9.21):
+
+       1. Title
+       2. Identification (in parentheses)
+       3. Description [in square brackets] -->
   <macro name="title-and-descriptions">
     <choose>
       <if variable="title">
         <group delimiter=" ">
-          <text macro="title"/>
-          <text macro="parenthetical"/>
-          <text macro="bracketed"/>
+          <text macro="title-bib"/>
+          <text macro="identification"/>
+          <text macro="description-bib"/>
         </group>
       </if>
       <else>
         <choose>
-          <if type="bill report" match="any">
+          <if match="any" type="bill report">
             <!-- Bills, resolutions, and congressional reports are not italicized and substitute bill number if no title. -->
-            <!-- Can't distinguish congressional reports from other reports, 
+            <!-- Can't distinguish congressional reports from other reports,
                  but giving the genre and number seems fine for other reports too. -->
-            <text macro="number"/>
-            <text macro="bracketed"/>
-            <text macro="parenthetical"/>
+            <text macro="genre-number"/>
+            <text macro="description-bib"/>
+            <text macro="identification"/>
           </if>
           <else>
             <group delimiter=" ">
-              <text macro="bracketed"/>
-              <text macro="parenthetical"/>
+              <text macro="description-bib"/>
+              <text macro="identification"/>
             </group>
           </else>
         </choose>
       </else>
     </choose>
   </macro>
-  <macro name="title">
+  <!-- 3.1. Title -->
+  <!-- Title utility macros -->
+  <macro name="title-intext-bill-report">
+    <!-- Bills, resolutions, and congressional reports are not italicized and substitute bill number if no title. -->
+    <!-- Can't distinguish congressional reports from other reports,
+             but giving the genre and number seems fine for other reports too. -->
     <choose>
-      <if type="post webpage" match="any">
+      <if variable="title">
+        <text form="short" text-case="title" variable="title"/>
+      </if>
+      <else>
+        <group delimiter=" ">
+          <text variable="genre"/>
+          <group delimiter=" ">
+            <choose>
+              <if match="none" variable="chapter-number container-title">
+                <text macro="number-labelled"/>
+              </if>
+              <else>
+                <text variable="number"/>
+              </else>
+            </choose>
+          </group>
+        </group>
+      </else>
+    </choose>
+  </macro>
+  <macro name="title-intext-interview-communication">
+    <choose>
+      <!-- These variables indicate that the letter is retrievable by the reader.
+                If not, then use the APA in-text-only personal communication format -->
+      <if match="none" variable="archive archive-place container-title DOI publisher URL">
+        <group delimiter=", ">
+          <names variable="author">
+            <substitute>
+              <text macro="title-intext"/>
+            </substitute>
+          </names>
+          <text term="personal-communication"/>
+        </group>
+      </if>
+      <else>
+        <names variable="author">
+          <name form="short"/>
+          <substitute>
+            <text macro="title-intext"/>
+          </substitute>
+        </names>
+      </else>
+    </choose>
+  </macro>
+  <macro name="title-part">
+    <group delimiter=". ">
+      <text macro="part-number-labelled"/>
+      <text text-case="capitalize-first" variable="part-title"/>
+    </group>
+  </macro>
+  <macro name="title-plus-part-title">
+    <choose>
+      <if match="any" type="review review-book" variable="reviewed-author reviewed-genre reviewed-title">
+        <!-- If a review has no `reviewed-title`, assume that `title` contains the title of the reviewed work
+             and omit it here; it is printed in the `reviewed-item` macro. -->
+        <choose>
+          <if match="none" variable="reviewed-title"/>
+          <else>
+            <group delimiter=": ">
+              <text variable="title"/>
+              <text macro="title-part"/>
+            </group>
+          </else>
+        </choose>
+      </if>
+      <else>
+        <group delimiter=": ">
+          <text variable="title"/>
+          <text macro="title-part"/>
+        </group>
+      </else>
+    </choose>
+  </macro>
+  <macro name="title-plus-volume-title">
+    <group delimiter=": ">
+      <text variable="title"/>
+      <text macro="title-volume"/>
+    </group>
+  </macro>
+  <macro name="title-volume">
+    <group delimiter=": ">
+      <choose>
+        <if variable="volume-title">
+          <group delimiter=". ">
+            <text macro="volume-labelled"/>
+            <text variable="volume-title"/>
+          </group>
+        </if>
+        <else-if is-numeric="volume" match="none">
+          <text macro="volume-labelled"/>
+        </else-if>
+      </choose>
+      <!-- For book-like items, assume part-number and part-title refer to the book/volume. -->
+      <text macro="title-part"/>
+    </group>
+  </macro>
+  <!-- Title logic -->
+  <macro name="booklike-title">
+    <!-- For book-like items, assume part-number and part-title refer to the book/volume. -->
+    <choose>
+      <if variable="container-title">
+        <text variable="title"/>
+      </if>
+      <else>
+        <!-- For book-like items without container titles and with volume-title, append volume-title to title (APA example 30) -->
+        <text font-style="italic" macro="title-plus-volume-title"/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="periodical-title">
+    <!-- For periodicals, assume that part-number and part-title refer to the article and append to title -->
+    <choose>
+      <if variable="container-title">
+        <text macro="title-plus-part-title"/>
+      </if>
+      <else>
+        <!-- for periodical items without container titles, don't append volume-title to title -->
+        <text font-style="italic" macro="title-plus-part-title"/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="title-bib">
+    <choose>
+      <if match="any" type="post webpage">
         <!-- Webpages are always italicized -->
-        <text macro="title-plus-part-title" font-style="italic"/>
+        <text font-style="italic" macro="title-plus-part-title"/>
       </if>
       <!-- Other types are italicized based on presence of container-title.
              Assume that review and review-book are published in periodicals/blogs,
-             not just on a web page (ex. 69) -->
-      <else-if type="article-journal article-magazine article-newspaper periodical post-weblog review review-book" match="any">
+             not just on a webpage (APA example 69) -->
+      <else-if match="any" type="article-journal article-magazine article-newspaper periodical post-weblog review review-book">
         <text macro="periodical-title"/>
       </else-if>
       <else-if type="paper-conference">
         <!-- Treat paper-conference as book-like if it has an editor, otherwise as periodical-like -->
         <choose>
-          <if variable="collection-editor compiler editor editorial-director" match="any">
+          <if match="any" variable="collection-editor compiler editor editorial-director">
             <text macro="booklike-title"/>
           </if>
           <else>
@@ -560,607 +813,104 @@
       </else>
     </choose>
   </macro>
-  <macro name="periodical-title">
-    <!-- For periodicals, assume that part-number and part-title refer to the article and append to title -->
-    <choose>
-      <if variable="container-title" match="any">
-        <text macro="title-plus-part-title"/>
-      </if>
-      <else>
-        <!-- for periodical items without container titles, don't append volume-title to title -->
-        <text macro="title-plus-part-title" font-style="italic"/>
-      </else>
-    </choose>
-  </macro>
-  <macro name="booklike-title">
-    <!-- For book-like items, assume part-number and part-title refer to the book/volume. -->
-    <choose>
-      <if variable="container-title" match="any">
-        <text variable="title"/>
-      </if>
-      <else>
-        <!-- For book-like items without container titles and with volume-title, append volume-title to title (ex. 30) -->
-        <text macro="title-plus-volume-title" font-style="italic"/>
-      </else>
-    </choose>
-  </macro>
-  <macro name="title-plus-part-title">
-    <choose>
-      <if variable="reviewed-author reviewed-genre reviewed-title" type="review review-book" match="any">
-        <!-- If a review has no `reviewed-title`, assume that `title` contains the title of the reviewed work
-             and omit it here; it is printed in the `reviewed-item` macro. -->
-        <choose>
-          <if variable="reviewed-title" match="none"/>
-          <else>
-            <group delimiter=": ">
-              <text variable="title"/>
-              <text macro="part-title"/>
-            </group>
-          </else>
-        </choose>
-      </if>
-      <else>
-        <group delimiter=": ">
-          <text variable="title"/>
-          <text macro="part-title"/>
-        </group>
-      </else>
-    </choose>
-  </macro>
-  <macro name="part-title">
-    <group delimiter=". ">
-      <group delimiter=" ">
-        <label variable="part-number" form="short" text-case="capitalize-first"/>
-        <text variable="part-number"/>
-      </group>
-      <text variable="part-title" text-case="capitalize-first"/>
-    </group>
-  </macro>
-  <macro name="title-plus-volume-title">
-    <group delimiter=": ">
-      <text variable="title"/>
-      <text macro="volume-title"/>
-    </group>
-  </macro>
-  <macro name="volume-title">
-    <group delimiter=": ">
-      <choose>
-        <if variable="volume-title">
-          <group delimiter=" ">
-            <group delimiter=". ">
-              <group delimiter=" ">
-                <label variable="volume" form="short" text-case="capitalize-first"/>
-                <text variable="volume"/>
-              </group>
-              <text variable="volume-title"/>
-            </group>
-          </group>
-        </if>
-        <else-if is-numeric="volume" match="none">
-          <group delimiter=" ">
-            <label variable="volume" form="short" text-case="capitalize-first"/>
-            <text variable="volume"/>
-          </group>
-        </else-if>
-      </choose>
-      <!-- For book-like items, assume part-number and part-title refer to the book/volume. -->
-      <text macro="part-title"/>
-    </group>
-  </macro>
   <macro name="title-intext">
     <choose>
-      <if type="bill report">
-        <!-- Bills, resolutions, and congressional reports are not italicized and substitute bill number if no title. -->
-        <!-- Can't distinguish congressional reports from other reports, 
-             but giving the genre and number seems fine for other reports too. -->
-        <choose>
-          <if variable="title">
-            <text variable="title" form="short" text-case="title"/>
-          </if>
-          <else>
-            <group delimiter=" ">
-              <text variable="genre"/>
-              <group delimiter=" ">
-                <choose>
-                  <if variable="chapter-number container-title" match="none">
-                    <label variable="number" form="short" text-case="capitalize-first"/>
-                  </if>
-                </choose>
-                <text variable="number"/>
-              </group>
-            </group>
-          </else>
-        </choose>
+      <if match="any" type="bill report">
+        <text macro="title-intext-bill-report"/>
       </if>
       <else>
         <choose>
-          <if variable="title" match="none">
-            <text macro="bracketed-intext"/>
+          <if match="none" variable="title">
+            <text macro="description-intext"/>
           </if>
-          <else-if type="hearing">
-            <!-- Hearings are italicized -->
-            <text variable="title" form="short" font-style="italic" text-case="title"/>
+          <else-if type="hearing webpage">
+            <!-- Italicized with title case -->
+            <text font-style="italic" form="short" text-case="title" variable="title"/>
           </else-if>
-          <else-if type="legal_case" match="any">
-            <!-- Cases are italicized -->
-            <text variable="title" font-style="italic"/>
+          <else-if type="legal_case post">
+            <!-- Italicized -->
+            <text font-style="italic" form="short" variable="title"/>
           </else-if>
-          <else-if type="legislation regulation treaty" match="any">
-            <!-- Legislation, regulations, and treaties not italicized or quoted -->
-            <text variable="title" form="short" text-case="title"/>
+          <else-if match="any" type="legislation regulation treaty">
+            <!-- No italics or quotes -->
+            <text form="short" text-case="title" variable="title"/>
           </else-if>
-          <else-if type="post webpage" match="any">
-            <!-- Webpages are always italicized -->
-            <text variable="title" form="short" font-style="italic" text-case="title"/>
-          </else-if>
-          <else-if variable="container-title" match="any">
-            <!-- Other types are italicized or quoted based on presence of container-title. As in title macro. -->
-            <text variable="title" form="short" quotes="true" text-case="title"/>
+          <else-if variable="container-title">
+            <!-- Other types are formatted based on presence of container-title, as in title-bib macro -->
+            <text form="short" quotes="true" text-case="title" variable="title"/>
           </else-if>
           <else>
-            <text variable="title" form="short" font-style="italic" text-case="title"/>
+            <text font-style="italic" form="short" text-case="title" variable="title"/>
           </else>
         </choose>
       </else>
     </choose>
   </macro>
-  <macro name="parenthetical">
-    <!-- (Secondary contributors; Database location; Genre no. 123; Report Series 123, Version, Edition, Volume, Page) -->
-    <group prefix="(" suffix=")">
-      <choose>
-        <if type="patent">
-          <!-- authority: U.S. ; genre: patent ; number: 123,445 -->
-          <group delimiter=" ">
-            <text variable="authority" form="short"/>
-            <choose>
-              <if variable="genre">
-                <text variable="genre" text-case="capitalize-first"/>
-              </if>
-              <else>
-                <text term="patent" text-case="capitalize-first"/>
-              </else>
-            </choose>
-            <group delimiter=" ">
-              <label variable="number" form="short" text-case="capitalize-first"/>
-              <text variable="number"/>
-            </group>
-          </group>
-        </if>
-        <else-if type="post webpage" match="any">
-          <!-- For post webpage, container-title is treated as publisher -->
-          <group delimiter="; ">
-            <text macro="secondary-contributors"/>
-            <text macro="database-location"/>
-            <text macro="number"/>
-            <text macro="locators-booklike"/>
-          </group>
-        </else-if>
-        <else-if type="report" match="any">
-          <choose>
-            <if variable="title" match="none">
-              <!-- If there is no title, then genre and number are already printed as the title. -->
-              <group delimiter="; ">
-                <text macro="secondary-contributors"/>
-                <text macro="database-location"/>
-                <text macro="locators-booklike"/>
-              </group>
-            </if>
-            <!-- If the report is a chapter in a larger report, then most parenthetical information is printed after the container. -->
-            <else-if variable="container-title">
-              <text macro="secondary-contributors"/>
-            </else-if>
-            <else>
-              <group delimiter="; ">
-                <text macro="secondary-contributors"/>
-                <text macro="database-location"/>
-                <text macro="number"/>
-                <text macro="locators-booklike"/>
-              </group>
-            </else>
-          </choose>
-        </else-if>
-        <else-if variable="container-title">
-          <group delimiter="; ">
-            <text macro="secondary-contributors"/>
-            <choose>
-              <if type="broadcast graphic map motion_picture song" match="any">
-                <!-- For audiovisual media, number information comes after title, not container-title (ex. 94) -->
-                <text macro="number"/>
-              </if>
-            </choose>
-          </group>
-        </else-if>
-        <else>
-          <group delimiter="; ">
-            <text macro="secondary-contributors"/>
-            <text macro="database-location"/>
-            <text macro="number"/>
-            <text macro="locators-booklike"/>
-          </group>
-        </else>
-      </choose>
-    </group>
-  </macro>
-  <macro name="parenthetical-container">
+  <!-- 3.2. Identification (in parentheses) -->
+  <!-- Identification utility macros -->
+  <macro name="database-location">
     <choose>
-      <if variable="container-title" match="any">
-        <group prefix="(" suffix=")">
-          <group delimiter="; ">
-            <text macro="database-location"/>
-            <choose>
-              <if type="broadcast graphic map motion_picture song" match="none">
-                <!-- For audiovisual media, number information comes after title, not container-title (ex. 94) -->
-                <text macro="number"/>
-              </if>
-            </choose>
-            <text macro="locators-booklike"/>
+      <if match="none" variable="archive-place">
+        <!-- With `archive-place`: physical archives. Without: online archives. -->
+        <text variable="archive_location"/>
+      </if>
+    </choose>
+  </macro>
+  <macro name="genre-number">
+    <choose>
+      <if variable="number">
+        <group delimiter=", ">
+          <group delimiter=" ">
+            <text text-case="title" variable="genre"/>
+            <text macro="number-labelled"/>
           </group>
+          <choose>
+            <if type="thesis">
+              <choose>
+                <if match="any" variable="archive DOI URL">
+                  <!-- Include the university in brackets if thesis is published -->
+                  <text variable="publisher"/>
+                </if>
+              </choose>
+            </if>
+          </choose>
         </group>
       </if>
     </choose>
   </macro>
-  <macro name="bracketed">
-    <!-- [Descriptive information] -->
-    <!-- If there is a number, genre is already printed in macro="number" -->
-    <group prefix="[" suffix="]">
+  <macro name="locators-booklike">
+    <choose>
+      <if variable="page">
+        <text macro="page-labelled"/>
+      </if>
+      <else-if variable="chapter-number">
+        <text macro="chapter-number-labelled"/>
+      </else-if>
+    </choose>
+  </macro>
+  <macro name="patent-number">
+    <group delimiter=" ">
+      <!-- authority: U.S. ; genre: patent ; number: 123,445 -->
+      <text form="short" variable="authority"/>
       <choose>
-        <if variable="reviewed-author reviewed-genre reviewed-title" type="review review-book" match="any">
-          <text macro="reviewed-item"/>
+        <if variable="genre">
+          <text text-case="capitalize-first" variable="genre"/>
         </if>
-        <else-if type="thesis">
-          <!-- Thesis type and institution -->
-          <group delimiter="; ">
-            <choose>
-              <if variable="number" match="none">
-                <group delimiter=", ">
-                  <text variable="genre" text-case="capitalize-first"/>
-                  <choose>
-                    <if variable="archive DOI URL" match="any">
-                      <!-- Include the university in brackets if thesis is published -->
-                      <text variable="publisher"/>
-                    </if>
-                  </choose>
-                </group>
-              </if>
-            </choose>
-            <text variable="medium" text-case="capitalize-first"/>
-          </group>
-        </else-if>
-        <else-if variable="interviewer" type="interview" match="any">
-          <!-- Interview information -->
-          <choose>
-            <if variable="title">
-              <text macro="format"/>
-            </if>
-            <else-if variable="genre">
-              <group delimiter="; ">
-                <group delimiter=" ">
-                  <text variable="genre" text-case="capitalize-first"/>
-                  <group delimiter=" ">
-                    <text term="container-author" form="verb"/>
-                    <names variable="interviewer">
-                      <name and="symbol" initialize-with=". " delimiter=", "/>
-                    </names>
-                  </group>
-                </group>
-              </group>
-            </else-if>
-            <else-if variable="interviewer">
-              <group delimiter="; ">
-                <names variable="interviewer">
-                  <label form="verb" suffix=" " text-case="capitalize-first"/>
-                  <name and="symbol" initialize-with=". " delimiter=", "/>
-                </names>
-                <text variable="medium" text-case="capitalize-first"/>
-              </group>
-            </else-if>
-            <else>
-              <text macro="format"/>
-            </else>
-          </choose>
-        </else-if>
-        <else-if type="personal_communication">
-          <!-- Letter information -->
-          <choose>
-            <if variable="recipient">
-              <group delimiter="; ">
-                <group delimiter=" ">
-                  <choose>
-                    <if variable="number" match="none">
-                      <choose>
-                        <if variable="genre">
-                          <text variable="genre" text-case="capitalize-first"/>
-                        </if>
-                        <else-if variable="medium">
-                          <text variable="medium" text-case="capitalize-first"/>
-                        </else-if>
-                        <else>
-                          <text term="letter" text-case="capitalize-first"/>
-                        </else>
-                      </choose>
-                    </if>
-                    <else>
-                      <choose>
-                        <if variable="medium">
-                          <text variable="medium" text-case="capitalize-first"/>
-                        </if>
-                        <else>
-                          <text term="letter" text-case="capitalize-first"/>
-                        </else>
-                      </choose>
-                    </else>
-                  </choose>
-                  <names variable="recipient" delimiter=", ">
-                    <label form="verb" suffix=" "/>
-                    <name and="symbol" delimiter=", "/>
-                  </names>
-                </group>
-                <choose>
-                  <if variable="genre" match="any">
-                    <choose>
-                      <if variable="number" match="none">
-                        <text variable="medium" text-case="capitalize-first"/>
-                      </if>
-                    </choose>
-                  </if>
-                </choose>
-              </group>
-            </if>
-            <else>
-              <text macro="format"/>
-            </else>
-          </choose>
-        </else-if>
-        <else-if variable="composer" type="song" match="all">
-          <!-- Performer of classical music works -->
-          <group delimiter="; ">
-            <choose>
-              <if variable="number" match="none">
-                <group delimiter=" ">
-                  <choose>
-                    <if variable="genre">
-                      <text variable="genre" text-case="capitalize-first"/>
-                      <group delimiter=" ">
-                        <text term="performer" form="verb"/>
-                        <names variable="author">
-                          <name and="symbol" initialize-with=". " delimiter=", "/>
-                          <substitute>
-                            <names variable="performer"/>
-                          </substitute>
-                        </names>
-                      </group>
-                    </if>
-                    <else-if variable="medium">
-                      <text variable="medium" text-case="capitalize-first"/>
-                      <group delimiter=" ">
-                        <text term="performer" form="verb"/>
-                        <names variable="author">
-                          <name and="symbol" initialize-with=". " delimiter=", "/>
-                          <substitute>
-                            <names variable="performer"/>
-                          </substitute>
-                        </names>
-                      </group>
-                    </else-if>
-                    <else>
-                      <text term="performer" form="verb" text-case="capitalize-first"/>
-                      <names variable="author">
-                        <name and="symbol" initialize-with=". " delimiter=", "/>
-                        <substitute>
-                          <names variable="performer"/>
-                        </substitute>
-                      </names>
-                    </else>
-                  </choose>
-                </group>
-              </if>
-              <else>
-                <group delimiter=" ">
-                  <choose>
-                    <if variable="medium">
-                      <text variable="medium" text-case="capitalize-first"/>
-                      <group delimiter=" ">
-                        <text term="performer" form="verb"/>
-                        <names variable="author">
-                          <name and="symbol" initialize-with=". " delimiter=", "/>
-                          <substitute>
-                            <names variable="performer"/>
-                          </substitute>
-                        </names>
-                      </group>
-                    </if>
-                    <else>
-                      <text term="performer" form="verb" text-case="capitalize-first"/>
-                      <names variable="author">
-                        <name and="symbol" initialize-with=". " delimiter=", "/>
-                        <substitute>
-                          <names variable="performer"/>
-                        </substitute>
-                      </names>
-                    </else>
-                  </choose>
-                </group>
-              </else>
-            </choose>
-            <choose>
-              <if variable="genre" match="any">
-                <choose>
-                  <if variable="number" match="none">
-                    <text variable="medium" text-case="capitalize-first"/>
-                  </if>
-                </choose>
-              </if>
-            </choose>
-          </group>
-        </else-if>
-        <else-if variable="container-title" match="none">
-          <!-- Other description -->
-          <text macro="format"/>
-        </else-if>
         <else>
-          <!-- For conference presentations/performances/events, chapters in reports/standards/generic documents, software, 
-               place bracketed after the container title -->
-          <choose>
-            <if type="event paper-conference performance speech" match="any">
-              <choose>
-                <if variable="collection-editor compiler editor editorial-director issue page volume" match="any">
-                  <text macro="format"/>
-                </if>
-              </choose>
-            </if>
-            <else-if type="document report software standard" match="none">
-              <text macro="format"/>
-            </else-if>
-          </choose>
+          <text term="patent" text-case="capitalize-first"/>
         </else>
       </choose>
-    </group>
-  </macro>
-  <macro name="bracketed-intext">
-    <group prefix="[" suffix="]">
-      <choose>
-        <if variable="reviewed-title" match="any">
-          <group delimiter=" ">
-            <text term="review-of" text-case="capitalize-first"/>
-            <text macro="reviewed-title-intext"/>
-          </group>
-        </if>
-        <else-if variable="interviewer" type="interview" match="any">
-          <names variable="interviewer">
-            <label form="verb" suffix=" " text-case="capitalize-first"/>
-            <name and="symbol" initialize-with=". " delimiter=", "/>
-            <substitute>
-              <text macro="format-intext"/>
-            </substitute>
-          </names>
-        </else-if>
-        <else-if type="personal_communication">
-          <!-- Letter information -->
-          <choose>
-            <if variable="recipient">
-              <group delimiter=" ">
-                <choose>
-                  <if variable="number" match="none">
-                    <text variable="genre" text-case="capitalize-first"/>
-                  </if>
-                  <else>
-                    <text term="letter" text-case="capitalize-first"/>
-                  </else>
-                </choose>
-                <names variable="recipient" delimiter=", ">
-                  <label form="verb" suffix=" "/>
-                  <name and="symbol" delimiter=", "/>
-                </names>
-              </group>
-            </if>
-            <else>
-              <text macro="format-intext"/>
-            </else>
-          </choose>
-        </else-if>
-        <else>
-          <text macro="format-intext"/>
-        </else>
-      </choose>
-    </group>
-  </macro>
-  <macro name="reviewed-item">
-    <!-- Reviewed item -->
-    <group delimiter="; ">
-      <group delimiter=", ">
-        <group delimiter=" ">
-          <choose>
-            <if variable="reviewed-genre">
-              <group delimiter=" ">
-                <text term="review-of" form="long" text-case="capitalize-first"/>
-                <text variable="reviewed-genre" text-case="lowercase"/>
-              </group>
-            </if>
-            <!-- If no `reviewed-genre`, assume that `genre` or `medium` is entered as 'Review of the book' or similar -->
-            <else-if variable="number" match="none">
-              <choose>
-                <if variable="genre">
-                  <text variable="genre" text-case="capitalize-first"/>
-                </if>
-                <else-if variable="medium">
-                  <text variable="medium" text-case="capitalize-first"/>
-                </else-if>
-                <else-if type="review-book">
-                  <group delimiter=" ">
-                    <text term="review-of" form="long" text-case="capitalize-first"/>
-                    <text term="book" form="long" text-case="lowercase"/>
-                  </group>
-                </else-if>
-                <else>
-                  <text term="review-of" form="short" text-case="capitalize-first"/>
-                </else>
-              </choose>
-            </else-if>
-            <else>
-              <choose>
-                <if variable="medium">
-                  <text variable="medium" text-case="capitalize-first"/>
-                </if>
-                <else-if type="review-book">
-                  <group delimiter=" ">
-                    <text term="review-of" form="long" text-case="capitalize-first"/>
-                    <text term="book" form="long" text-case="lowercase"/>
-                  </group>
-                </else-if>
-                <else>
-                  <text term="review-of" form="short" text-case="capitalize-first"/>
-                </else>
-              </choose>
-            </else>
-          </choose>
-          <text macro="reviewed-title"/>
-        </group>
-        <names variable="reviewed-author">
-          <label form="verb-short" suffix=" "/>
-          <name and="symbol" initialize-with=". " delimiter=", "/>
-        </names>
-      </group>
-      <choose>
-        <if variable="genre" match="any">
-          <choose>
-            <if variable="number" match="none">
-              <text variable="medium" text-case="capitalize-first"/>
-            </if>
-          </choose>
-        </if>
-      </choose>
-    </group>
-  </macro>
-  <macro name="bracketed-container">
-    <group prefix="[" suffix="]">
-      <choose>
-        <if type="event paper-conference performance speech" match="any">
-          <!-- Conference presentations should describe the session [container] in bracketed unless published in a proceedings -->
-          <choose>
-            <if variable="collection-editor compiler editor editorial-director issue page volume" match="none">
-              <text macro="format"/>
-            </if>
-          </choose>
-        </if>
-        <else-if type="software" match="all">
-          <!-- For entries in mobile app reference works, place bracketed after the container-title -->
-          <text macro="format"/>
-        </else-if>
-        <else-if type="document report standard">
-          <!-- For chapters in report, standards, and generic documents, place bracketed after the container title -->
-          <text macro="format"/>
-        </else-if>
-      </choose>
+      <text macro="number-labelled"/>
     </group>
   </macro>
   <macro name="secondary-contributors">
     <choose>
-      <if type="article-journal article-magazine article-newspaper periodical post-weblog review review-book" match="any">
+      <if match="any" type="article-journal article-magazine article-newspaper periodical post-weblog review review-book">
         <text macro="secondary-contributors-periodical"/>
       </if>
       <else-if type="paper-conference">
         <choose>
-          <if variable="collection-editor compiler editor editorial-director" match="any">
+          <if match="any" variable="collection-editor compiler editor editorial-director">
             <text macro="secondary-contributors-booklike"/>
           </if>
           <else>
@@ -1173,53 +923,37 @@
       </else>
     </choose>
   </macro>
-  <macro name="secondary-contributors-periodical">
-    <group delimiter="; ">
-      <choose>
-        <if variable="title">
-          <names variable="interviewer" delimiter="; ">
-            <name and="symbol" initialize-with=". " delimiter=", "/>
-            <label form="short" prefix=", " text-case="title"/>
-          </names>
-        </if>
-      </choose>
-      <names variable="translator narrator" delimiter="; ">
-        <name and="symbol" initialize-with=". " delimiter=", "/>
-        <label form="short" prefix=", " text-case="title"/>
-      </names>
-    </group>
-  </macro>
   <macro name="secondary-contributors-booklike">
     <group delimiter="; ">
       <choose>
         <if variable="title">
           <names variable="interviewer">
-            <name and="symbol" initialize-with=". " delimiter=", "/>
+            <name/>
             <label form="short" prefix=", " text-case="title"/>
           </names>
         </if>
       </choose>
       <choose>
-        <if type="post webpage" match="none">
+        <if match="none" type="post webpage">
           <!-- Webpages treat container-title like publisher -->
           <group delimiter="; ">
-            <names variable="illustrator narrator" delimiter="; ">
-              <name and="symbol" initialize-with=". " delimiter=", "/>
+            <names delimiter="; " variable="illustrator narrator">
+              <name/>
               <label form="short" prefix=", " text-case="title"/>
             </names>
             <choose>
-              <if variable="container-title" match="none">
+              <if match="none" variable="container-title">
                 <group delimiter="; ">
                   <names variable="container-author">
                     <label form="verb-short" suffix=" " text-case="title"/>
-                    <name and="symbol" initialize-with=". " delimiter=", "/>
+                    <name/>
                   </names>
-                  <names variable="editor translator" delimiter="; ">
-                    <name and="symbol" initialize-with=". " delimiter=", "/>
+                  <names delimiter="; " variable="editor translator">
+                    <name/>
                     <label form="short" prefix=", " text-case="title"/>
                   </names>
-                  <names variable="compiler chair organizer curator series-creator executive-producer" delimiter="; ">
-                    <name and="symbol" initialize-with=". " delimiter=", "/>
+                  <names delimiter="; " variable="compiler chair organizer curator series-creator executive-producer">
+                    <name/>
                     <label form="long" prefix=", " text-case="title"/>
                   </names>
                 </group>
@@ -1227,9 +961,9 @@
               <else>
                 <choose>
                   <!-- TODO: Check logic once processors start to automatically populate editor-translator. -->
-                  <if variable="editor-translator" match="none">
-                    <names variable="translator" delimiter="; ">
-                      <name and="symbol" initialize-with=". " delimiter=", "/>
+                  <if match="none" variable="editor-translator">
+                    <names delimiter="; " variable="translator">
+                      <name/>
                       <label form="short" prefix=", " text-case="title"/>
                     </names>
                   </if>
@@ -1242,18 +976,18 @@
           <group delimiter="; ">
             <names variable="container-author">
               <label form="verb-short" suffix=" " text-case="title"/>
-              <name and="symbol" initialize-with=". " delimiter=", "/>
+              <name/>
             </names>
-            <names variable="editor translator" delimiter="; ">
-              <name and="symbol" initialize-with=". " delimiter=", "/>
+            <names delimiter="; " variable="editor translator">
+              <name/>
               <label form="short" prefix=", " text-case="title"/>
             </names>
-            <names variable="illustrator narrator" delimiter="; ">
-              <name and="symbol" initialize-with=". " delimiter=", "/>
+            <names delimiter="; " variable="illustrator narrator">
+              <name/>
               <label form="short" prefix=", " text-case="title"/>
             </names>
-            <names variable="compiler chair organizer curator series-creator executive-producer" delimiter="; ">
-              <name and="symbol" initialize-with=". " delimiter=", "/>
+            <names delimiter="; " variable="compiler chair organizer curator series-creator executive-producer">
+              <name/>
               <label form="long" prefix=", " text-case="title"/>
             </names>
           </group>
@@ -1261,166 +995,398 @@
       </choose>
     </group>
   </macro>
-  <macro name="database-location">
+  <macro name="secondary-contributors-periodical">
+    <group delimiter="; ">
+      <choose>
+        <if variable="title">
+          <names delimiter="; " variable="interviewer">
+            <name/>
+            <label form="short" prefix=", " text-case="title"/>
+          </names>
+        </if>
+      </choose>
+      <names delimiter="; " variable="translator narrator">
+        <name/>
+        <label form="short" prefix=", " text-case="title"/>
+      </names>
+    </group>
+  </macro>
+  <macro name="version-edition-volume">
+    <group delimiter=", ">
+      <text macro="version-labelled"/>
+      <text macro="edition-labelled"/>
+      <text macro="volume-booklike"/>
+    </group>
+  </macro>
+  <macro name="volume-booklike">
+    <group delimiter=", ">
+      <!-- Report series (APA example 52) -->
+      <choose>
+        <if match="any" type="document report standard">
+          <group delimiter=" ">
+            <text text-case="title" variable="collection-title"/>
+            <text variable="collection-number"/>
+          </group>
+        </if>
+      </choose>
+      <text macro="supplement-number-labelled"/>
+      <choose>
+        <if variable="volume">
+          <choose>
+            <!-- Non-numeric volumes are already printed as part of the book title -->
+            <if variable="volume-title"/>
+            <else-if is-numeric="volume">
+              <text macro="volume-labelled"/>
+            </else-if>
+          </choose>
+        </if>
+        <else>
+          <text macro="number-of-volumes-labelled"/>
+        </else>
+      </choose>
+      <text macro="issue-labelled"/>
+      <text macro="locators-booklike"/>
+    </group>
+  </macro>
+  <!-- Identification logic -->
+  <macro name="identification">
+    <group delimiter="; " prefix="(" suffix=")">
+      <!-- (Secondary contributors; Database location; Genre no. 123; Report Series 123, Version, Edition, Volume, Page) -->
+      <choose>
+        <if type="patent">
+          <text macro="patent-number"/>
+        </if>
+        <else-if match="any" type="post webpage">
+          <!-- For post webpage, container-title is treated as publisher -->
+          <text macro="identification-with-all-parts"/>
+        </else-if>
+        <else-if match="any" type="report">
+          <choose>
+            <if match="none" variable="title">
+              <!-- If there is no title, then genre and number are already printed as the title. -->
+              <text macro="secondary-contributors"/>
+              <text macro="database-location"/>
+              <text macro="identification-booklike"/>
+            </if>
+            <!-- If the report is a chapter in a larger report, then most parenthetical information is printed after the container. -->
+            <else-if variable="container-title">
+              <text macro="secondary-contributors"/>
+            </else-if>
+            <else>
+              <text macro="identification-with-all-parts"/>
+            </else>
+          </choose>
+        </else-if>
+        <else-if variable="container-title">
+          <group delimiter="; ">
+            <text macro="secondary-contributors"/>
+            <choose>
+              <if match="any" type="broadcast graphic map motion_picture song">
+                <!-- For audiovisual media, number information comes after title, not container-title (ex. 94) -->
+                <text macro="genre-number"/>
+              </if>
+            </choose>
+          </group>
+        </else-if>
+        <else>
+          <text macro="identification-with-all-parts"/>
+        </else>
+      </choose>
+    </group>
+  </macro>
+  <macro name="identification-booklike">
     <choose>
-      <if variable="archive-place" match="none">
-        <!-- With `archive-place`: physical archives. Without: online archives. -->
-        <text variable="archive_location"/>
-      </if>
+      <if match="any" type="article-journal article-magazine article-newspaper broadcast event interview patent performance periodical post post-weblog review review-book speech webpage"/>
+      <else-if type="paper-conference">
+        <choose>
+          <if match="any" variable="collection-editor compiler editor editorial-director">
+            <text macro="version-edition-volume"/>
+          </if>
+        </choose>
+      </else-if>
+      <else>
+        <text macro="version-edition-volume"/>
+      </else>
     </choose>
   </macro>
-  <macro name="number">
+  <macro name="identification-with-all-parts">
+    <group delimiter="; ">
+      <text macro="secondary-contributors"/>
+      <text macro="database-location"/>
+      <text macro="genre-number"/>
+      <text macro="identification-booklike"/>
+    </group>
+  </macro>
+  <!-- 3.3. Description [in square brackets] -->
+  <!-- Description utility macros -->
+  <macro name="description-generic">
+    <!-- For conference presentations/performances/events, chapters in reports/standards/generic documents, software, place description after the container title -->
     <choose>
-      <if variable="number">
-        <group delimiter=", ">
+      <if match="any" type="event paper-conference performance speech">
+        <choose>
+          <if match="any" variable="collection-editor compiler editor editorial-director issue page volume">
+            <text macro="format-bib"/>
+          </if>
+        </choose>
+      </if>
+      <else-if match="none" type="document report software standard">
+        <text macro="format-bib"/>
+      </else-if>
+    </choose>
+  </macro>
+  <macro name="description-interview">
+    <choose>
+      <if variable="title">
+        <text macro="format-bib"/>
+      </if>
+      <else-if variable="genre">
+        <group delimiter="; ">
           <group delimiter=" ">
-            <text variable="genre" text-case="title"/>
+            <text text-case="capitalize-first" variable="genre"/>
             <group delimiter=" ">
-              <label variable="number" form="short" text-case="capitalize-first"/>
-              <text variable="number"/>
+              <text form="verb" term="container-author"/>
+              <names variable="interviewer"/>
             </group>
           </group>
+        </group>
+      </else-if>
+      <else-if variable="interviewer">
+        <group delimiter="; ">
+          <names variable="interviewer">
+            <label form="verb" suffix=" " text-case="capitalize-first"/>
+            <name/>
+          </names>
+          <text text-case="capitalize-first" variable="medium"/>
+        </group>
+      </else-if>
+      <else>
+        <text macro="format-bib"/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="description-letter-bib">
+    <choose>
+      <if variable="recipient">
+        <group delimiter="; ">
+          <group delimiter=" ">
+            <choose>
+              <if match="none" variable="number">
+                <choose>
+                  <if variable="genre">
+                    <text text-case="capitalize-first" variable="genre"/>
+                  </if>
+                  <else-if variable="medium">
+                    <text text-case="capitalize-first" variable="medium"/>
+                  </else-if>
+                  <else>
+                    <text term="letter" text-case="capitalize-first"/>
+                  </else>
+                </choose>
+              </if>
+              <else>
+                <choose>
+                  <if variable="medium">
+                    <text text-case="capitalize-first" variable="medium"/>
+                  </if>
+                  <else>
+                    <text term="letter" text-case="capitalize-first"/>
+                  </else>
+                </choose>
+              </else>
+            </choose>
+            <names variable="recipient">
+              <label form="verb" suffix=" "/>
+              <name initialize="false"/>
+            </names>
+          </group>
           <choose>
-            <if type="thesis">
+            <if variable="genre">
               <choose>
-                <!-- Include the university in brackets if thesis is published -->
-                <if variable="archive DOI URL" match="any">
-                  <text variable="publisher"/>
+                <if match="none" variable="number">
+                  <text text-case="capitalize-first" variable="medium"/>
                 </if>
               </choose>
             </if>
           </choose>
         </group>
       </if>
-    </choose>
-  </macro>
-  <macro name="locators-booklike">
-    <choose>
-      <if type="article-journal article-magazine article-newspaper broadcast event interview patent performance periodical post post-weblog review review-book speech webpage" match="any"/>
-      <else-if type="paper-conference">
-        <choose>
-          <if variable="collection-editor compiler editor editorial-director" match="any">
-            <group delimiter=", ">
-              <text macro="version"/>
-              <text macro="edition"/>
-              <text macro="volume-booklike"/>
-            </group>
-          </if>
-        </choose>
-      </else-if>
       <else>
-        <group delimiter=", ">
-          <text macro="version"/>
-          <text macro="edition"/>
-          <text macro="volume-booklike"/>
-        </group>
+        <text macro="format-bib"/>
       </else>
     </choose>
   </macro>
-  <macro name="version">
-    <group delimiter=" ">
-      <label variable="version" text-case="capitalize-first"/>
-      <text variable="version"/>
-    </group>
-  </macro>
-  <macro name="edition">
+  <macro name="description-letter-intext">
     <choose>
-      <if is-numeric="edition">
+      <if variable="recipient">
         <group delimiter=" ">
-          <number variable="edition" form="ordinal"/>
-          <label variable="edition" form="short"/>
-        </group>
-      </if>
-      <else>
-        <text variable="edition"/>
-      </else>
-    </choose>
-  </macro>
-  <macro name="volume-booklike">
-    <group delimiter=", ">
-      <!-- Report series [ex. 52] -->
-      <choose>
-        <if type="document report standard">
-          <group delimiter=" ">
-            <text variable="collection-title" text-case="title"/>
-            <text variable="collection-number"/>
-          </group>
-        </if>
-      </choose>
-      <group delimiter=" ">
-        <label variable="supplement-number" text-case="capitalize-first"/>
-        <text variable="supplement-number"/>
-      </group>
-      <choose>
-        <if variable="volume" match="any">
           <choose>
-            <!-- Non-numeric volumes are already printed as part of the book title -->
-            <if variable="volume-title"/>
-            <else-if is-numeric="volume" match="none"/>
+            <if match="none" variable="number">
+              <text text-case="capitalize-first" variable="genre"/>
+            </if>
+            <else-if variable="medium">
+              <text text-case="capitalize-first" variable="medium"/>
+            </else-if>
             <else>
-              <group delimiter=" ">
-                <label variable="volume" form="short" text-case="capitalize-first"/>
-                <number variable="volume" form="numeric"/>
-              </group>
+              <text term="letter" text-case="capitalize-first"/>
             </else>
           </choose>
-        </if>
-        <else>
-          <group>
-            <label variable="number-of-volumes" form="short" text-case="capitalize-first" suffix=" "/>
-            <text term="page-range-delimiter" prefix="1"/>
-            <number variable="number-of-volumes" form="numeric"/>
-          </group>
-        </else>
-      </choose>
-      <group delimiter=" ">
-        <label variable="issue" text-case="capitalize-first"/>
-        <text variable="issue"/>
-      </group>
-      <group delimiter=" ">
-        <label variable="page" form="short" suffix=" "/>
-        <text variable="page"/>
-      </group>
-    </group>
-  </macro>
-  <macro name="reviewed-title">
-    <choose>
-      <if variable="reviewed-title">
-        <!-- Not possible to distinguish TV series episode from other reviewed
-             works without reviewed-container-title [Ex. 69] -->
-        <!-- Adapt for reviewed-container-title if that becomes available -->
-        <text variable="reviewed-title" font-style="italic"/>
+          <names variable="recipient">
+            <label form="verb" suffix=" "/>
+            <name/>
+          </names>
+        </group>
       </if>
       <else>
-        <!-- Assume title is title of reviewed work -->
-        <text variable="title" font-style="italic"/>
+        <text macro="format-intext"/>
       </else>
     </choose>
   </macro>
-  <macro name="reviewed-title-intext">
-    <choose>
-      <if variable="reviewed-title">
-        <!-- Not possible to distinguish TV series episode from other reviewed
-             works without reviewed-container-title [Ex. 69] -->
-        <!-- Adapt for reviewed-container-title if that becomes available -->
-        <text variable="reviewed-title" form="short" font-style="italic" text-case="title"/>
-      </if>
-      <else>
-        <!-- Assume title is title of reviewed work -->
-        <text variable="title" form="short" font-style="italic" text-case="title"/>
-      </else>
-    </choose>
-  </macro>
-  <macro name="format">
-    <choose>
-      <if variable="genre medium" match="any">
-        <group delimiter="; ">
+  <macro name="description-reviewed">
+    <!-- Reviewed item -->
+    <group delimiter="; ">
+      <group delimiter=", ">
+        <group delimiter=" ">
           <choose>
-            <if variable="number" match="none">
-              <text variable="genre" text-case="capitalize-first"/>
+            <if variable="reviewed-genre">
+              <group delimiter=" ">
+                <text form="long" term="review-of" text-case="capitalize-first"/>
+                <text text-case="lowercase" variable="reviewed-genre"/>
+              </group>
+            </if>
+            <!-- If no `reviewed-genre`, assume that `genre` or `medium` is entered as 'Review of the book' or similar -->
+            <else-if match="none" variable="number">
+              <choose>
+                <if variable="genre">
+                  <text text-case="capitalize-first" variable="genre"/>
+                </if>
+                <else-if variable="medium">
+                  <text text-case="capitalize-first" variable="medium"/>
+                </else-if>
+                <else-if type="review-book">
+                  <group delimiter=" ">
+                    <text form="long" term="review-of" text-case="capitalize-first"/>
+                    <text form="long" term="book" text-case="lowercase"/>
+                  </group>
+                </else-if>
+                <else>
+                  <text form="short" term="review-of" text-case="capitalize-first"/>
+                </else>
+              </choose>
+            </else-if>
+            <else>
+              <choose>
+                <if variable="medium">
+                  <text text-case="capitalize-first" variable="medium"/>
+                </if>
+                <else-if type="review-book">
+                  <group delimiter=" ">
+                    <text form="long" term="review-of" text-case="capitalize-first"/>
+                    <text form="long" term="book" text-case="lowercase"/>
+                  </group>
+                </else-if>
+                <else>
+                  <text form="short" term="review-of" text-case="capitalize-first"/>
+                </else>
+              </choose>
+            </else>
+          </choose>
+          <text macro="reviewed-title-bib"/>
+        </group>
+        <names variable="reviewed-author">
+          <label form="verb-short" suffix=" "/>
+          <name/>
+        </names>
+      </group>
+      <choose>
+        <if variable="genre">
+          <choose>
+            <if match="none" variable="number">
+              <text text-case="capitalize-first" variable="medium"/>
             </if>
           </choose>
-          <text variable="medium" text-case="capitalize-first"/>
+        </if>
+      </choose>
+    </group>
+  </macro>
+  <macro name="description-song">
+    <!-- Performer of classical music works -->
+    <group delimiter="; ">
+      <group delimiter=" ">
+        <choose>
+          <if match="none" variable="number">
+            <choose>
+              <if variable="genre">
+                <text text-case="capitalize-first" variable="genre"/>
+                <text form="verb" term="performer"/>
+              </if>
+              <else-if variable="medium">
+                <text text-case="capitalize-first" variable="medium"/>
+                <text form="verb" term="performer"/>
+              </else-if>
+              <else>
+                <text form="verb" term="performer" text-case="capitalize-first"/>
+              </else>
+            </choose>
+          </if>
+          <else>
+            <!-- If there is a number, genre is already printed in `genre-number` macro -->
+            <choose>
+              <if variable="medium">
+                <text text-case="capitalize-first" variable="medium"/>
+                <text form="verb" term="performer"/>
+              </if>
+              <else>
+                <text form="verb" term="performer" text-case="capitalize-first"/>
+              </else>
+            </choose>
+          </else>
+        </choose>
+        <names variable="author">
+          <substitute>
+            <names variable="performer"/>
+          </substitute>
+        </names>
+      </group>
+      <choose>
+        <if variable="genre">
+          <choose>
+            <if match="none" variable="number">
+              <text text-case="capitalize-first" variable="medium"/>
+            </if>
+          </choose>
+        </if>
+      </choose>
+    </group>
+  </macro>
+  <macro name="description-thesis">
+    <!-- Thesis type and institution -->
+    <group delimiter="; ">
+      <choose>
+        <if match="none" variable="number">
+          <group delimiter=", ">
+            <text text-case="capitalize-first" variable="genre"/>
+            <choose>
+              <if match="any" variable="archive DOI URL">
+                <!-- Include the university in brackets if thesis is published -->
+                <text variable="publisher"/>
+              </if>
+            </choose>
+          </group>
+        </if>
+      </choose>
+      <text text-case="capitalize-first" variable="medium"/>
+    </group>
+  </macro>
+  <macro name="format-bib">
+    <choose>
+      <if match="any" variable="genre medium">
+        <group delimiter="; ">
+          <choose>
+            <if match="none" variable="number">
+              <text text-case="capitalize-first" variable="genre"/>
+            </if>
+          </choose>
+          <text text-case="capitalize-first" variable="medium"/>
         </group>
       </if>
       <else>
@@ -1430,11 +1396,11 @@
   </macro>
   <macro name="format-intext">
     <choose>
-      <if variable="genre" match="any">
-        <text variable="genre" text-case="capitalize-first"/>
+      <if variable="genre">
+        <text text-case="capitalize-first" variable="genre"/>
       </if>
       <else-if variable="medium">
-        <text variable="medium" text-case="capitalize-first"/>
+        <text text-case="capitalize-first" variable="medium"/>
       </else-if>
       <else>
         <text macro="generic-type-label"/>
@@ -1450,9 +1416,9 @@
       <else-if type="software">
         <text term="software" text-case="capitalize-first"/>
       </else-if>
-      <else-if type="interview personal_communication" match="any">
+      <else-if match="any" type="interview personal_communication">
         <choose>
-          <if variable="archive container-title DOI publisher URL" match="none">
+          <if match="none" variable="archive archive-place container-title DOI publisher URL">
             <text term="personal-communication" text-case="capitalize-first"/>
           </if>
           <else-if type="interview">
@@ -1492,18 +1458,108 @@
       </else-if>
     </choose>
   </macro>
-  <!-- APA 'source' element contains four parts:
-       container, event, publisher, access -->
+  <macro name="reviewed-title-bib">
+    <choose>
+      <if variable="reviewed-title">
+        <!-- Not possible to distinguish TV series episode from other reviewed
+             works without reviewed-container-title (APA example 69) -->
+        <!-- Adapt for reviewed-container-title if that becomes available -->
+        <text font-style="italic" variable="reviewed-title"/>
+      </if>
+      <else>
+        <!-- Assume title is title of reviewed work -->
+        <text font-style="italic" variable="title"/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="reviewed-title-intext">
+    <choose>
+      <if variable="reviewed-title">
+        <!-- Not possible to distinguish TV series episode from other reviewed
+             works without reviewed-container-title (APA example 69) -->
+        <!-- Adapt for reviewed-container-title if that becomes available -->
+        <text font-style="italic" form="short" text-case="title" variable="reviewed-title"/>
+      </if>
+      <else>
+        <!-- Assume title is title of reviewed work -->
+        <text font-style="italic" form="short" text-case="title" variable="title"/>
+      </else>
+    </choose>
+  </macro>
+  <!-- Description logic -->
+  <macro name="description-bib">
+    <group prefix="[" suffix="]">
+      <choose>
+        <if match="any" type="interview" variable="interviewer">
+          <text macro="description-interview"/>
+        </if>
+        <else-if match="any" type="review review-book" variable="reviewed-author reviewed-genre reviewed-title">
+          <text macro="description-reviewed"/>
+        </else-if>
+        <else-if type="personal_communication">
+          <text macro="description-letter-bib"/>
+        </else-if>
+        <else-if type="song" variable="composer">
+          <text macro="description-song"/>
+        </else-if>
+        <else-if type="thesis">
+          <text macro="description-thesis"/>
+        </else-if>
+        <else-if match="none" variable="container-title">
+          <!-- Other description -->
+          <text macro="format-bib"/>
+        </else-if>
+        <else>
+          <text macro="description-generic"/>
+        </else>
+      </choose>
+    </group>
+  </macro>
+  <macro name="description-intext">
+    <group prefix="[" suffix="]">
+      <choose>
+        <if variable="reviewed-title">
+          <group delimiter=" ">
+            <text term="review-of" text-case="capitalize-first"/>
+            <text macro="reviewed-title-intext"/>
+          </group>
+        </if>
+        <else-if match="any" type="interview" variable="interviewer">
+          <names variable="interviewer">
+            <label form="verb" suffix=" " text-case="capitalize-first"/>
+            <name/>
+            <substitute>
+              <text macro="format-intext"/>
+            </substitute>
+          </names>
+        </else-if>
+        <else-if type="personal_communication">
+          <text macro="description-letter-intext"/>
+        </else-if>
+        <else>
+          <text macro="format-intext"/>
+        </else>
+      </choose>
+    </group>
+  </macro>
+  <!-- 4. Source -->
+  <!-- Four parts in APA 'source' element:
+
+       1. Container
+       2. Event
+       3. Publication details
+       4. Access -->
+  <!-- 4.1. Container -->
   <macro name="container">
     <choose>
-      <if type="article-journal article-magazine article-newspaper periodical post-weblog review review-book" match="any">
+      <if match="any" type="article-journal article-magazine article-newspaper periodical post-weblog review review-book">
         <!-- Periodical items -->
         <text macro="container-periodical"/>
       </if>
       <else-if type="paper-conference">
         <!-- Determine if paper-conference is a periodical- or book-like -->
         <choose>
-          <if variable="editor editorial-director collection-editor container-author" match="any">
+          <if match="any" variable="collection-editor container-author editor editorial-director">
             <text macro="container-booklike"/>
           </if>
           <else>
@@ -1511,55 +1567,15 @@
           </else>
         </choose>
       </else-if>
-      <else-if type="post webpage" match="none">
-        <!-- post and webpage treat container-title like publisher -->
+      <else-if match="none" type="post webpage">
+        <!-- Webpages treat container-title like publisher -->
         <text macro="container-booklike"/>
       </else-if>
     </choose>
   </macro>
-  <macro name="container-periodical">
-    <group delimiter=". ">
-      <group delimiter=", ">
-        <text variable="container-title" font-style="italic" text-case="title"/>
-        <choose>
-          <if variable="volume">
-            <group>
-              <text variable="volume" font-style="italic"/>
-              <text variable="issue" prefix="(" suffix=")"/>
-            </group>
-          </if>
-          <else>
-            <text variable="issue" font-style="italic"/>
-          </else>
-        </choose>
-        <choose>
-          <if variable="number">
-            <!-- Ex. 6: Journal article with article number or eLocator -->
-            <group delimiter=" ">
-              <text term="article-locator" text-case="capitalize-first"/>
-              <text variable="number"/>
-            </group>
-          </if>
-          <else>
-            <text variable="page"/>
-          </else>
-        </choose>
-      </group>
-      <choose>
-        <if variable="issued">
-          <choose>
-            <if variable="issue number page volume" match="none">
-              <!-- We print the status variable directly rather than using in-press, etc. terms. -->
-              <text variable="status" text-case="capitalize-first"/>
-            </if>
-          </choose>
-        </if>
-      </choose>
-    </group>
-  </macro>
   <macro name="container-booklike">
     <choose>
-      <if variable="container-title" match="any">
+      <if variable="container-title">
         <group delimiter=" ">
           <choose>
             <if type="song">
@@ -1570,161 +1586,167 @@
             </else>
           </choose>
           <group delimiter=", ">
-            <names variable="executive-producer">
-              <name and="symbol" initialize-with=". " delimiter=", "/>
-              <label form="long" text-case="title" prefix=" (" suffix=")"/>
-              <substitute>
-                <names variable="series-creator"/>
-                <names variable="editor-translator">
-                  <name and="symbol" initialize-with=". " delimiter=", "/>
-                  <label form="short" text-case="title" prefix=" (" suffix=")"/>
-                </names>
-                <!-- TODO: Translator omitted here on the assumption that editor-translators are uncommon 
-                           for chapter citations. If needed, direct entry or automatic population of
-                           `editor-translator` can produce combined labels. -->
-                <names variable="editor">
-                  <name and="symbol" initialize-with=". " delimiter=", "/>
-                  <label form="short" text-case="title" prefix=" (" suffix=")"/>
-                </names>
-                <names variable="editorial-director">
-                  <name and="symbol" initialize-with=". " delimiter=", "/>
-                  <label form="short" text-case="title" prefix=" (" suffix=")"/>
-                </names>
-                <names variable="compiler"/>
-                <choose>
-                  <if type="event performance speech" match="any">
-                    <names variable="chair"/>
-                    <names variable="organizer"/>
-                  </if>
-                </choose>
-                <names variable="curator"/>
-                <names variable="collection-editor">
-                  <name and="symbol" initialize-with=". " delimiter=", "/>
-                  <label form="short" text-case="title" prefix=" (" suffix=")"/>
-                </names>
-                <names variable="container-author"/>
-              </substitute>
-            </names>
-            <group delimiter=": " font-style="italic">
-              <text variable="container-title"/>
-              <text macro="volume-title"/>
-            </group>
+            <text macro="container-contributors"/>
+            <text macro="container-title-booklike"/>
           </group>
-          <text macro="parenthetical-container"/>
-          <text macro="bracketed-container"/>
+          <text macro="container-identification"/>
+          <text macro="container-description"/>
         </group>
       </if>
     </choose>
   </macro>
-  <macro name="publisher">
-    <group delimiter="; ">
+  <macro name="container-periodical">
+    <group delimiter=". ">
+      <group delimiter=", ">
+        <text font-style="italic" text-case="title" variable="container-title"/>
+        <text macro="volume-periodical"/>
+        <text macro="locators-periodical"/>
+      </group>
       <choose>
-        <if type="thesis">
+        <if variable="issued">
           <choose>
-            <if variable="archive DOI URL" match="none">
-              <text variable="publisher"/>
+            <if match="none" variable="issue number page volume">
+              <!-- We print the status variable directly rather than using in-press, etc. terms. -->
+              <text text-case="capitalize-first" variable="status"/>
             </if>
           </choose>
         </if>
-        <else-if type="post webpage" match="any">
-          <!-- For websites, treat container title like publisher -->
-          <group delimiter="; ">
-            <text variable="container-title" text-case="title"/>
-            <text variable="publisher"/>
-          </group>
-        </else-if>
-        <else-if type="paper-conference">
-          <!-- For paper-conference, don't print publisher if in a journal-like proceedings -->
-          <choose>
-            <if variable="collection-editor compiler editor editorial-director" match="any">
-              <text variable="publisher"/>
-            </if>
-          </choose>
-        </else-if>
-        <else-if type="article-journal article-magazine article-newspaper periodical post-weblog review review-book" match="none">
-          <text variable="publisher"/>
-        </else-if>
       </choose>
-      <group delimiter=", ">
-        <choose>
-          <if variable="archive-place">
-            <!-- With `archive-place`: physical archives. Without: online archives. -->
-            <!-- For physical archives, print the location before the archive name.
-                For electronic archives, these are printed in macro="description". -->
-            <!-- Must test for archive_collection:
-                With collection: archive_collection (archive_location), archive, archive-place
-                No collection: archive (archive_location), archive-place
-            -->
-            <choose>
-              <if variable="archive_collection">
-                <group delimiter=" ">
-                  <text variable="archive_collection"/>
-                  <text variable="archive_location" prefix="(" suffix=")"/>
-                </group>
-                <text variable="archive"/>
-                <text variable="archive-place"/>
-              </if>
-              <else>
-                <group delimiter=" ">
-                  <text variable="archive"/>
-                  <text variable="archive_location" prefix="(" suffix=")"/>
-                </group>
-                <text variable="archive-place"/>
-              </else>
-            </choose>
-          </if>
-          <else>
-            <text variable="archive"/>
-          </else>
-        </choose>
-      </group>
     </group>
   </macro>
-  <macro name="access">
+  <!-- Container parallels main elements -->
+  <!-- 4.1.1. Author -->
+  <macro name="container-contributors">
+    <names variable="executive-producer">
+      <name/>
+      <label form="long" prefix=" (" suffix=")" text-case="title"/>
+      <substitute>
+        <names variable="series-creator"/>
+        <names variable="editor-translator">
+          <name/>
+          <label form="short" prefix=" (" suffix=")" text-case="title"/>
+        </names>
+        <!-- TODO: Translator omitted on the assumption that editor-translators are uncommon for chapter citations.
+             If needed, direct entry or automatic population of `editor-translator` can produce combined labels. -->
+        <names delimiter="; " variable="editor">
+          <name/>
+          <label form="short" prefix=" (" suffix=")" text-case="title"/>
+        </names>
+        <names variable="editorial-director">
+          <name/>
+          <label form="short" prefix=" (" suffix=")" text-case="title"/>
+        </names>
+        <names variable="compiler"/>
+        <choose>
+          <if match="any" type="event performance speech">
+            <names variable="chair"/>
+            <names variable="organizer"/>
+          </if>
+        </choose>
+        <names variable="curator"/>
+        <names variable="collection-editor">
+          <name/>
+          <label form="short" prefix=" (" suffix=")" text-case="title"/>
+        </names>
+        <names variable="container-author"/>
+      </substitute>
+    </names>
+  </macro>
+  <!-- 4.1.3.1 Container title -->
+  <macro name="container-title-booklike">
+    <group delimiter=": " font-style="italic">
+      <text variable="container-title"/>
+      <text macro="title-volume"/>
+    </group>
+  </macro>
+  <!-- 4.1.3.1 Container identification -->
+  <macro name="container-identification">
     <choose>
-      <if variable="DOI" match="any">
-        <text variable="DOI" prefix="https://doi.org/"/>
-      </if>
-      <else-if variable="URL">
-        <group delimiter=" ">
-          <choose>
-            <if variable="issued status" match="none">
-              <group delimiter=" ">
-                <text term="retrieved" text-case="capitalize-first"/>
-                <date variable="accessed" form="text" suffix=","/>
-                <text term="from"/>
-              </group>
-            </if>
-          </choose>
-          <text variable="URL"/>
+      <if variable="container-title">
+        <group prefix="(" suffix=")">
+          <group delimiter="; ">
+            <text macro="database-location"/>
+            <choose>
+              <if match="none" type="broadcast graphic map motion_picture song">
+                <!-- For audiovisual media, number information comes after title, not container-title (APA example 94) -->
+                <text macro="genre-number"/>
+              </if>
+            </choose>
+            <text macro="identification-booklike"/>
+          </group>
         </group>
-      </else-if>
+      </if>
     </choose>
   </macro>
+  <!-- 4.1.3.2 Container description -->
+  <macro name="container-description">
+    <group prefix="[" suffix="]">
+      <choose>
+        <if match="any" type="event paper-conference performance speech">
+          <!-- Conference presentations should describe the session [container] in description unless published in a proceedings -->
+          <choose>
+            <if match="none" variable="collection-editor compiler editor editorial-director issue page volume">
+              <text macro="format-bib"/>
+            </if>
+          </choose>
+        </if>
+        <else-if type="software">
+          <!-- For entries in mobile app reference works, place description after the container-title -->
+          <text macro="format-bib"/>
+        </else-if>
+        <else-if match="any" type="document report standard">
+          <!-- For chapters in report, standards, and generic documents, place description after the container title -->
+          <text macro="format-bib"/>
+        </else-if>
+      </choose>
+    </group>
+  </macro>
+  <!-- 4.1.4. Source -->
+  <macro name="locators-periodical">
+    <choose>
+      <if variable="number">
+        <text macro="number-article-labelled"/>
+      </if>
+      <else>
+        <text variable="page"/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="volume-periodical">
+    <group delimiter=", ">
+      <text font-style="italic" text-case="title" variable="collection-title"/>
+      <choose>
+        <if variable="volume">
+          <group>
+            <text font-style="italic" variable="volume"/>
+            <text prefix="(" suffix=")" variable="issue"/>
+          </group>
+        </if>
+        <else>
+          <text font-style="italic" variable="issue"/>
+        </else>
+      </choose>
+    </group>
+  </macro>
+  <!-- 4.2. Event -->
   <macro name="event">
     <choose>
-      <if variable="event event-title" match="any">
-        <!-- To prevent Zotero from printing event-place due to its double-mapping of all 'place' to
-             both publisher-place and event-place. Remove this 'choose' when that is changed. -->
+      <if match="any" variable="event event-title">
+        <!-- To prevent Zotero from printing `event-place` due to its double-mapping of all 'place' to
+             both `publisher-place` and `event-place`. Remove this when that is changed. -->
         <choose>
           <if type="paper-conference">
             <choose>
-              <if variable="collection-editor compiler editor editorial-director issue page volume" match="none">
+              <if match="none" variable="collection-editor compiler editor editorial-director issue page volume">
                 <!-- Don't print event info for conference papers published in a proceedings -->
-                <group delimiter=", ">
-                  <text macro="event-title"/>
-                  <text variable="event-place"/>
-                </group>
+                <text macro="event-title-place"/>
               </if>
             </choose>
           </if>
           <else>
             <!-- For other item types, print event info even if published (e.g., for collection catalogs, performance programs.
                  These items aren't given explicit examples in the APA manual, so err on the side of providing too much information. -->
-            <group delimiter=", ">
-              <text macro="event-title"/>
-              <text variable="event-place"/>
-            </group>
+            <text macro="event-title-place"/>
           </else>
         </choose>
       </if>
@@ -1732,9 +1754,9 @@
   </macro>
   <macro name="event-title">
     <choose>
-      <!-- TODO: We expect "event-title" to be used,
+      <!-- TODO: We expect `event-title` to be used,
            but processors and applications may not be updated yet.
-           This macro ensures that either "event" or "event-title" can be accpeted.
+           This macro ensures that either `event` or `event-title` can be accepted.
            Remove if procesor logic and application adoption can handle this. -->
       <if variable="event-title">
         <text variable="event-title"/>
@@ -1744,11 +1766,153 @@
       </else>
     </choose>
   </macro>
-  <!-- After 'source', APA also prints publication history (original publication, reprint info, retraction info) -->
+  <macro name="event-title-place">
+    <group delimiter=", ">
+      <text macro="event-title"/>
+      <text variable="event-place"/>
+    </group>
+  </macro>
+  <!-- 4.3. Publication details -->
+  <!-- Publication utility macros -->
+  <macro name="archive">
+    <group delimiter=", ">
+      <choose>
+        <if variable="archive-place">
+          <!-- With `archive-place`: physical archives. Without: online archives. -->
+          <!-- For physical archives, print the location before the archive name.
+                For electronic archives, these are printed in macro="description". -->
+          <!-- Must test for archive_collection:
+                With collection: archive_collection (archive_location), archive, archive-place
+                No collection: archive (archive_location), archive-place
+            -->
+          <choose>
+            <if variable="archive_collection">
+              <group delimiter=" ">
+                <text variable="archive_collection"/>
+                <text prefix="(" suffix=")" variable="archive_location"/>
+              </group>
+              <text variable="archive"/>
+              <text variable="archive-place"/>
+            </if>
+            <else>
+              <group delimiter=" ">
+                <text variable="archive"/>
+                <text prefix="(" suffix=")" variable="archive_location"/>
+              </group>
+              <text variable="archive-place"/>
+            </else>
+          </choose>
+        </if>
+        <else>
+          <text variable="archive"/>
+        </else>
+      </choose>
+    </group>
+  </macro>
+  <macro name="publisher">
+    <choose>
+      <if variable="publisher">
+        <text variable="publisher"/>
+      </if>
+      <else-if match="none" variable="event-place">
+        <!-- Work around Zotero double-mapping of event/publisher place -->
+        <text variable="publisher-place"/>
+      </else-if>
+    </choose>
+  </macro>
+  <!-- Publication logic -->
+  <macro name="publication">
+    <choose>
+      <if type="thesis">
+        <choose>
+          <if match="none" variable="archive DOI URL">
+            <text macro="publisher"/>
+          </if>
+        </choose>
+      </if>
+      <else-if match="any" type="post webpage">
+        <!-- Webpages treat container-title like publisher -->
+        <group delimiter="; ">
+          <text text-case="title" variable="container-title"/>
+          <text macro="publisher"/>
+        </group>
+      </else-if>
+      <else-if type="paper-conference">
+        <!-- For paper-conference, don't print publisher if in a journal-like proceedings -->
+        <choose>
+          <if match="any" variable="collection-editor compiler editor editorial-director">
+            <text macro="publisher"/>
+          </if>
+        </choose>
+      </else-if>
+      <else-if match="none" type="article-journal article-magazine article-newspaper periodical post-weblog review review-book">
+        <text macro="publisher"/>
+      </else-if>
+    </choose>
+  </macro>
+  <macro name="publication-archive">
+    <group delimiter="; ">
+      <text macro="publication"/>
+      <text macro="archive"/>
+    </group>
+  </macro>
+  <!-- 4.4. Access -->
+  <macro name="access">
+    <choose>
+      <if variable="DOI">
+        <text prefix="https://doi.org/" variable="DOI"/>
+      </if>
+      <else-if variable="URL">
+        <group delimiter=" ">
+          <choose>
+            <if match="none" variable="issued status">
+              <group delimiter=" ">
+                <text term="retrieved" text-case="capitalize-first"/>
+                <group delimiter=", ">
+                  <date form="text" variable="accessed"/>
+                  <text term="from"/>
+                </group>
+              </group>
+            </if>
+          </choose>
+          <text variable="URL"/>
+        </group>
+      </else-if>
+    </choose>
+  </macro>
+  <!-- 5. Publication history -->
+  <!-- History utility macros -->
+  <macro name="original-publisher">
+    <choose>
+      <if variable="original-publisher">
+        <text variable="original-publisher"/>
+      </if>
+      <else>
+        <text variable="original-publisher-place"/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="original-title">
+    <choose>
+      <if variable="original-title">
+        <text value="as"/>
+        <choose>
+          <if match="any" type="article-journal article-magazine article-newspaper periodical post-weblog review review-book">
+            <text variable="original-title"/>
+          </if>
+          <else>
+            <text font-style="italic" variable="original-title"/>
+          </else>
+        </choose>
+      </if>
+    </choose>
+  </macro>
+  <!-- History logic -->
   <macro name="publication-history">
+    <!-- Information appended to 'source': original publication, reprint info, retraction info -->
     <choose>
       <if type="patent">
-        <text variable="references" prefix="(" suffix=")"/>
+        <text prefix="(" suffix=")" variable="references"/>
       </if>
       <else>
         <group delimiter="; " prefix="(" suffix=")">
@@ -1756,8 +1920,8 @@
           <choose>
             <if variable="issued">
               <choose>
-                <if variable="issue number page volume" match="any">
-                  <text variable="status" text-case="capitalize-first"/>
+                <if match="any" variable="issue number page volume">
+                  <text text-case="capitalize-first" variable="status"/>
                 </if>
               </choose>
             </if>
@@ -1766,29 +1930,31 @@
             <if variable="references">
               <!-- This provides the option for more elaborate description
                     of publication history, such as full "reprinted" references
-                    (examples 11, 43, 44) -->
+                    (APA examples 11, 43, 44) -->
               <text variable="references"/>
             </if>
             <else>
-              <group delimiter=" ">
-                <text term="original-work-published" text-case="capitalize-first"/>
-                <choose>
-                  <if is-uncertain-date="original-date">
-                    <text term="circa" form="short"/>
-                  </if>
-                </choose>
-                <date variable="original-date">
-                  <date-part name="year"/>
-                </date>
-              </group>
+              <text macro="publication-history-variables"/>
             </else>
           </choose>
         </group>
       </else>
     </choose>
   </macro>
-  <!-- Legal citations have their own rules -->
-  <macro name="legal-cites">
+  <macro name="publication-history-variables">
+    <group delimiter=" ">
+      <text term="original-work-published" text-case="capitalize-first"/>
+      <group delimiter="; ">
+        <text macro="original-title"/>
+        <group delimiter=", ">
+          <text macro="original-publisher"/>
+          <text macro="original-date-year"/>
+        </group>
+      </group>
+    </group>
+  </macro>
+  <!-- Parallel rules for legal citations -->
+  <macro name="legal-bib">
     <!-- `treaty`: for treaties -->
     <!-- `legal_case`: for all legal and court cases -->
     <!-- `bill`: for bills, resolutions, federal reports -->
@@ -1800,16 +1966,14 @@
         <if type="treaty">
           <group delimiter=", " suffix=".">
             <!-- APA generally defers to Bluebook for legal citations, but diverges without
-                explanation for treaty items. We follow the Bluebook format that was used 
+                explanation for treaty items. We follow the Bluebook format that was used
                 in APA 6th ed. -->
-            <!-- APA manual omits treaty parties/authors, but per Bluebook 
+            <!-- APA manual omits treaty parties/authors, but per Bluebook
                 they should be included at least for bilateral treaties. -->
-            <names variable="author">
-              <name initialize-with="." form="short" delimiter="-"/>
-            </names>
+            <text macro="author-legal"/>
             <text macro="date-legal"/>
-            <!-- APA manual omits treaty source/report called for by Bluebook in favor of just URL. 
-                Both are included here, following the APA style used for all other item types 
+            <!-- APA manual omits treaty source/report called for by Bluebook in favor of just URL.
+                Both are included here, following the APA style used for all other item types
                 to end the reference with a period, then give the URL afterward. -->
             <text macro="container-legal"/>
           </group>
@@ -1821,7 +1985,7 @@
               <text macro="container-legal"/>
             </group>
             <text macro="date-legal"/>
-            <text macro="parenthetical-legal"/>
+            <text macro="identification-legal"/>
           </group>
         </else>
       </choose>
@@ -1829,20 +1993,75 @@
       <text macro="access"/>
     </group>
   </macro>
+  <!-- 1. Legal author -->
+  <macro name="author-legal">
+    <names variable="author">
+      <name delimiter="-" form="short"/>
+    </names>
+  </macro>
+  <!-- 2. Legal date -->
+  <macro name="date-legal-case">
+    <group delimiter=" " prefix="(" suffix=")">
+      <text variable="authority"/>
+      <choose>
+        <if variable="container-title">
+          <!-- Print only year for cases published in reporters-->
+          <text macro="date-issued-year"/>
+        </if>
+        <else>
+          <!-- APA manual doesn't include examples of cases not yet
+                   published in a reporter, but this is Bluebook style. -->
+          <text macro="date-issued-full"/>
+        </else>
+      </choose>
+    </group>
+  </macro>
+  <macro name="date-legal">
+    <choose>
+      <if type="treaty">
+        <text macro="date-issued-full"/>
+      </if>
+      <else-if type="legal_case">
+        <text macro="date-legal-case"/>
+      </else-if>
+      <else-if match="any" type="bill hearing legislation regulation">
+        <group delimiter=" " prefix="(" suffix=")">
+          <group delimiter=" ">
+            <text macro="original-date-year"/>
+            <text form="symbol" term="and"/>
+          </group>
+          <choose>
+            <if variable="issued">
+              <!-- APA manual includes "rev." before the revision year,
+                   but this isn't part of the Bluebook rules. -->
+              <text macro="date-issued-year"/>
+            </if>
+            <else>
+              <!-- Show proposal date for uncodified regualtions.
+                   Assume date is entered literally ala "proposed May 23, 2016".
+                   TODO: Add 'proposed' term here if that becomes available -->
+              <date form="text" variable="submitted"/>
+            </else>
+          </choose>
+        </group>
+      </else-if>
+    </choose>
+  </macro>
+  <!-- 3.1. Legal title -->
   <macro name="title-legal">
     <choose>
-      <if type="bill legal_case legislation regulation treaty" match="any">
-        <text variable="title" text-case="title"/>
+      <if match="any" type="bill legal_case legislation regulation treaty">
+        <text text-case="title" variable="title"/>
       </if>
       <else-if type="hearing">
-        <!-- APA uses a comma delimiter and omits "hearing before the" for hearings with testimony, 
+        <!-- APA uses a comma delimiter and omits "hearing before the" for hearings with testimony,
              but follows Bluebook rules (colon delimiter, prefix before the committee name) for
              references to the whole hearing. We simply follow the Bluebook rules for both, but
              use APA style capitalization (not capitalizing "Before" or the title of the hearing). -->
         <group delimiter=": " font-style="italic">
-          <text variable="title" text-case="capitalize-first"/>
+          <text text-case="capitalize-first" variable="title"/>
           <group delimiter=" ">
-            <text term="hearing" form="long" text-case="capitalize-first"/>
+            <text form="long" term="hearing" text-case="capitalize-first"/>
             <group delimiter=" ">
               <group delimiter=" ">
                 <!-- APA manual omits the bill number, but it should be included per Bluebook if relevant -->
@@ -1851,7 +2070,7 @@
               </group>
               <group delimiter=" ">
                 <!-- Use the `at` term to hold "before the" -->
-                <text term="at" form="long"/>
+                <text form="long" term="at"/>
                 <text variable="section"/>
               </group>
             </group>
@@ -1860,124 +2079,95 @@
       </else-if>
     </choose>
   </macro>
-  <macro name="date-legal">
+  <!-- 3.2. Legal identification (in parentheses) -->
+  <macro name="identification-legal">
     <choose>
-      <if type="treaty">
-        <date variable="issued" form="text"/>
+      <if type="hearing">
+        <group delimiter=" " prefix="(" suffix=")">
+          <!-- Use the 'verb' form of the hearing term to hold 'testimony of' -->
+          <text form="verb" term="hearing"/>
+          <names variable="author">
+            <name initialize="false"/>
+          </names>
+        </group>
       </if>
-      <else-if type="legal_case">
-        <group prefix="(" suffix=")" delimiter=" ">
-          <text variable="authority"/>
-          <choose>
-            <if variable="container-title" match="any">
-              <!-- Print only year for cases published in reporters-->
-              <date variable="issued" form="numeric" date-parts="year"/>
-            </if>
-            <else>
-              <!-- APA manual doesn't include examples of cases not yet
-                   published in a reporter, but this is Bluebook style. -->
-              <date variable="issued" form="text"/>
-            </else>
-          </choose>
-        </group>
-      </else-if>
-      <else-if type="bill hearing legislation regulation" match="any">
-        <group prefix="(" suffix=")" delimiter=" ">
-          <group delimiter=" ">
-            <date variable="original-date">
-              <date-part name="year"/>
-            </date>
-            <text term="and" form="symbol"/>
-          </group>
-          <choose>
-            <if variable="issued">
-              <!-- APA manual includes "rev." before the revision year, 
-                   but this isn't part of the Bluebook rules. -->
-              <date variable="issued">
-                <date-part name="year"/>
-              </date>
-            </if>
-            <else>
-              <!-- Show proposal date for uncodified regualtions. 
-                   Assume date is entered literally ala "proposed May 23, 2016".
-                   TODO: Add 'proposed' term here if that becomes available -->
-              <date variable="submitted" form="text"/>
-            </else>
-          </choose>
-        </group>
+      <else-if match="any" type="bill legislation regulation">
+        <!-- For uncodified regulations, assume future code section is in `status`. -->
+        <text prefix="(" suffix=")" variable="status"/>
       </else-if>
     </choose>
   </macro>
-  <macro name="container-legal">
-    <!-- Expect legal item container-titles to be stored in short form -->
+  <!-- 4. Legal source -->
+  <!-- Legal source utility macros -->
+  <macro name="container-bill">
+    <group delimiter=", ">
+      <group delimiter=" ">
+        <text variable="genre"/>
+        <group delimiter=" ">
+          <choose>
+            <!-- If there is no session number or code/record title, assume
+                     assume the item is a congressional report and include 'No.' term. -->
+            <if match="none" variable="chapter-number container-title">
+              <!-- The item is a congressional report, rather than a bill or resultion. -->
+              <text macro="number-labelled"/>
+            </if>
+            <else>
+              <text variable="number"/>
+            </else>
+          </choose>
+        </group>
+      </group>
+      <group delimiter=" ">
+        <text variable="authority"/>
+        <!-- 'session' is `chapter-number` -->
+        <text variable="chapter-number"/>
+      </group>
+      <group delimiter=" ">
+        <text variable="volume"/>
+        <text variable="container-title"/>
+        <text variable="page-first"/>
+      </group>
+    </group>
+  </macro>
+  <macro name="container-hearing">
+    <group delimiter=" ">
+      <text variable="authority"/>
+      <!-- 'session' is `chapter-number` -->
+      <text variable="chapter-number"/>
+    </group>
+  </macro>
+  <macro name="container-legal-case">
+    <group delimiter=" ">
+      <choose>
+        <if variable="container-title">
+          <group delimiter=" ">
+            <text variable="volume"/>
+            <text variable="container-title"/>
+            <text macro="section-labelled"/>
+            <choose>
+              <if match="any" variable="page page-first">
+                <text variable="page-first"/>
+              </if>
+              <else>
+                <text value="___"/>
+              </else>
+            </choose>
+          </group>
+        </if>
+        <else>
+          <text macro="number-labelled"/>
+        </else>
+      </choose>
+    </group>
+  </macro>
+  <macro name="container-legislation">
     <choose>
-      <if type="treaty">
-        <group delimiter=" ">
-          <number variable="volume"/>
-          <text variable="container-title"/>
-          <choose>
-            <if variable="page page-first" match="any">
-              <text variable="page-first"/>
-            </if>
-            <else>
-              <group delimiter=" ">
-                <label variable="number" form="short" text-case="capitalize-first"/>
-                <text variable="number"/>
-              </group>
-            </else>
-          </choose>
-        </group>
-      </if>
-      <else-if type="legal_case">
-        <group delimiter=" ">
-          <choose>
-            <if variable="container-title">
-              <group delimiter=" ">
-                <text variable="volume"/>
-                <text variable="container-title"/>
-                <group delimiter=" ">
-                  <label variable="section" form="symbol"/>
-                  <text variable="section"/>
-                </group>
-                <choose>
-                  <if variable="page page-first" match="any">
-                    <text variable="page-first"/>
-                  </if>
-                  <else>
-                    <text value="___"/>
-                  </else>
-                </choose>
-              </group>
-            </if>
-            <else>
-              <group delimiter=" ">
-                <label variable="number" form="short" text-case="capitalize-first"/>
-                <text variable="number"/>
-              </group>
-            </else>
-          </choose>
-        </group>
-      </else-if>
-      <else-if type="bill">
+      <if variable="number">
+        <!-- There's a public law number. -->
         <group delimiter=", ">
           <group delimiter=" ">
-            <text variable="genre"/>
-            <group delimiter=" ">
-              <choose>
-                <!-- If there is no session number or code/record title, assume
-                     assume the item is a congressional report and include 'No.' term. -->
-                <if variable="chapter-number container-title" match="none">
-                  <!-- The item is a congressional report, rather than a bill or resultion. -->
-                  <label variable="number" form="short" text-case="capitalize-first"/>
-                </if>
-              </choose>
-              <text variable="number"/>
-            </group>
-          </group>
-          <group delimiter=" ">
-            <text variable="authority"/>
-            <!-- 'session' is `chapter-number` -->
-            <text variable="chapter-number"/>
+            <text value="Pub. L. No."/>
+            <text variable="number"/>
           </group>
           <group delimiter=" ">
             <text variable="volume"/>
@@ -1985,149 +2175,139 @@
             <text variable="page-first"/>
           </group>
         </group>
-      </else-if>
-      <else-if type="hearing">
+      </if>
+      <else>
         <group delimiter=" ">
-          <text variable="authority"/>
-          <!-- 'session' is `chapter-number` -->
-          <text variable="chapter-number"/>
+          <text variable="volume"/>
+          <text variable="container-title"/>
+          <choose>
+            <if variable="section">
+              <text macro="section-labelled"/>
+            </if>
+            <else>
+              <text variable="page-first"/>
+            </else>
+          </choose>
         </group>
-      </else-if>
-      <else-if type="legislation">
+      </else>
+    </choose>
+  </macro>
+  <macro name="container-regulation">
+    <group delimiter=", ">
+      <group delimiter=" ">
+        <text variable="genre"/>
+        <text macro="number-labelled"/>
+      </group>
+      <group delimiter=" ">
+        <text variable="volume"/>
+        <text variable="container-title"/>
         <choose>
-          <if variable="number">
-            <!-- There's a public law number. -->
-            <group delimiter=", ">
-              <text variable="number" prefix="Pub. L. No. "/>
-              <group delimiter=" ">
-                <text variable="volume"/>
-                <text variable="container-title"/>
-                <text variable="page-first"/>
-              </group>
-            </group>
+          <if variable="section">
+            <text macro="section-labelled"/>
           </if>
           <else>
-            <group delimiter=" ">
-              <text variable="volume"/>
-              <text variable="container-title"/>
-              <choose>
-                <if variable="section">
-                  <group delimiter=" ">
-                    <label variable="section" form="symbol"/>
-                    <text variable="section"/>
-                  </group>
-                </if>
-                <else>
-                  <text variable="page-first"/>
-                </else>
-              </choose>
-            </group>
+            <text variable="page-first"/>
           </else>
         </choose>
-      </else-if>
-      <else-if type="regulation">
-        <group delimiter=", ">
-          <group delimiter=" ">
-            <text variable="genre"/>
-            <group delimiter=" ">
-              <label variable="number" form="short" text-case="capitalize-first"/>
-              <text variable="number"/>
-            </group>
-          </group>
-          <group delimiter=" ">
-            <text variable="volume"/>
-            <text variable="container-title"/>
-            <choose>
-              <if variable="section">
-                <group delimiter=" ">
-                  <label variable="section" form="symbol"/>
-                  <text variable="section"/>
-                </group>
-              </if>
-              <else>
-                <text variable="page-first"/>
-              </else>
-            </choose>
-          </group>
-        </group>
-      </else-if>
-    </choose>
-  </macro>
-  <macro name="parenthetical-legal">
-    <choose>
-      <if type="hearing">
-        <group prefix="(" suffix=")" delimiter=" ">
-          <!-- Use the 'verb' form of the hearing term to hold 'testimony of' -->
-          <text term="hearing" form="verb"/>
-          <names variable="author">
-            <name and="symbol" delimiter=", "/>
-          </names>
-        </group>
-      </if>
-      <else-if type="bill legislation regulation" match="any">
-        <!-- For uncodified regulations, assume future code section is in `status`. -->
-        <text variable="status" prefix="(" suffix=")"/>
-      </else-if>
-    </choose>
-  </macro>
-  <macro name="citation-locator">
-    <!-- Abbreviate page and paragraph, leave other locator labels in long form, cf. Rule 8.13 -->
-    <group delimiter=" ">
-      <choose>
-        <if locator="page paragraph" match="any">
-          <label variable="locator" form="short"/>
-        </if>
-        <else>
-          <label variable="locator" text-case="capitalize-first"/>
-        </else>
-      </choose>
-      <text variable="locator"/>
+      </group>
     </group>
   </macro>
-  <citation et-al-min="3" et-al-use-first="1" disambiguate-add-year-suffix="true" disambiguate-add-names="true" disambiguate-add-givenname="true" collapse="year" givenname-disambiguation-rule="primary-name-with-initials">
+  <macro name="container-treaty">
+    <group delimiter=" ">
+      <number variable="volume"/>
+      <text variable="container-title"/>
+      <choose>
+        <if match="any" variable="page page-first">
+          <text variable="page-first"/>
+        </if>
+        <else>
+          <text macro="number-labelled"/>
+        </else>
+      </choose>
+    </group>
+  </macro>
+  <!-- Legal source logic -->
+  <macro name="container-legal">
+    <!-- Expect legal item container-titles to be stored in short form -->
+    <choose>
+      <if type="bill">
+        <text macro="container-bill"/>
+      </if>
+      <else-if type="hearing">
+        <text macro="container-hearing"/>
+      </else-if>
+      <else-if type="legal_case">
+        <text macro="container-legal-case"/>
+      </else-if>
+      <else-if type="legislation">
+        <text macro="container-legislation"/>
+      </else-if>
+      <else-if type="regulation">
+        <text macro="container-regulation"/>
+      </else-if>
+      <else-if type="treaty">
+        <text macro="container-treaty"/>
+      </else-if>
+    </choose>
+  </macro>
+  <!-- Main logic -->
+  <citation collapse="year" disambiguate-add-givenname="true" disambiguate-add-names="true" disambiguate-add-year-suffix="true" et-al-min="3" et-al-use-first="1" givenname-disambiguation-rule="primary-name-with-initials">
     <sort>
       <key macro="author-sort" names-min="3" names-use-first="1"/>
       <key macro="date-sort-group" sort="ascending"/>
       <key macro="date-sort" sort="ascending"/>
       <key variable="status"/>
     </sort>
-    <layout prefix="(" suffix=")" delimiter="; ">
+    <layout delimiter="; " prefix="(" suffix=")">
       <group delimiter=", ">
         <text macro="author-intext"/>
         <text macro="date-intext"/>
-        <text macro="citation-locator"/>
+        <text macro="locator-labelled"/>
       </group>
     </layout>
   </citation>
-  <bibliography hanging-indent="true" et-al-min="21" et-al-use-first="19" et-al-use-last="true" entry-spacing="0" line-spacing="2">
+  <macro name="bibliography">
+    <group delimiter=" ">
+      <group delimiter=". " suffix=".">
+        <text macro="author-bib"/>
+        <text macro="date-bib"/>
+        <text macro="title-and-descriptions"/>
+        <text macro="container"/>
+        <text macro="event"/>
+        <text macro="publication-archive"/>
+      </group>
+      <text macro="access"/>
+      <text macro="publication-history"/>
+    </group>
+  </macro>
+  <macro name="bibliography-filtered">
+    <choose>
+      <if match="any" type="bill hearing legal_case legislation regulation treaty">
+        <!-- Legal items have different orders and delimiters -->
+        <text macro="legal-bib"/>
+      </if>
+      <else-if type="personal_communication">
+        <choose>
+          <if match="any" variable="archive archive-place container-title DOI publisher URL">
+            <text macro="bibliography"/>
+          </if>
+        </choose>
+      </else-if>
+      <else>
+        <text macro="bibliography"/>
+      </else>
+    </choose>
+  </macro>
+  <bibliography entry-spacing="0" et-al-min="21" et-al-use-first="19" et-al-use-last="true" hanging-indent="true" line-spacing="2">
     <sort>
       <key macro="author-sort"/>
       <key macro="date-sort-group" sort="ascending"/>
       <key macro="date-sort" sort="ascending"/>
       <key variable="status"/>
-      <key macro="title"/>
+      <key macro="title-bib"/>
     </sort>
     <layout>
-      <choose>
-        <if type="bill hearing legal_case legislation regulation treaty" match="any">
-          <!-- Legal items have different orders and delimiters -->
-          <text macro="legal-cites"/>
-        </if>
-        <else>
-          <group delimiter=" ">
-            <group delimiter=". " suffix=".">
-              <text macro="author-bib"/>
-              <text macro="date-bib"/>
-              <text macro="title-and-descriptions"/>
-              <text macro="container"/>
-              <text macro="event"/>
-              <text macro="publisher"/>
-            </group>
-            <text macro="access"/>
-            <text macro="publication-history"/>
-          </group>
-        </else>
-      </choose>
+      <text macro="bibliography-filtered"/>
     </layout>
   </bibliography>
 </style>


### PR DESCRIPTION
Facilitate the sharing of macros between APA and other styles by compartmentalizing macro functionality, separating the logic as much as possible. Provide additional headings to make the file arrangement more explicit.

Changes:

- Filter out personal correspondence without a means of access from the bibliography (based on #3005)
- Provide missing delimiter in author listing and simplify using default CSL settings (APA example 87)
- Do not combine script-writer and director in-text, providing slightly less broken results with APA example 87 (now matching at least one of the examples, though not both)
- Do not provide 'no.' label with a non-numeric `number` on a broadcast (APA example 87)
- Provide an alternative for the missing CSL `part-number` and `supplement-number` labels
- Support `chapter-number` in case of missing chapter page numbers
- Apply criteria for unpublished letters consistently; fixes example 402
- Provide `collection-title` for periodicals (e.g. new series, 2nd series)
- Provide `publisher-place` as a fallback in case of missing publisher (not specified in APA but necessary for pre-1900 books)

Tested against the APA 7th ed. collection in the Test Items Library at <https://www.zotero.org/groups/2205533/test_items_library/collections/MR2N872S> using Zotero, by generating HTML citations and bibliography using both the previous version and these files and comparing the results.

Variants generated using <https://github.com/adunning/csl-builder>.