### PR TITLE
Add Vancouver with subscript parentheses citation style

### DIFF
--- a/vancouver-subscript-parentheses.csl
+++ b/vancouver-subscript-parentheses.csl
@@ -1,0 +1,1 @@
+<style xmlns="http://purl.org/net/xbiblio/csl" version="1.0"><info><title>Vancouver with Subscript Parentheses</title></info><citation et-al-min="6" et-al-use-first="3" disambiguate-add-names="true"><layout prefix="₍" suffix="₎" vertical-align="sub"><text variable="citation-number" /></layout></citation></style>


### PR DESCRIPTION
This CSL style presents Vancouver numeric references as subscript numbers enclosed in parentheses, e.g. ₍₁₎.

It was developed to meet formatting preferences requested by health researchers in Chile.

Validated locally using CSL validator.

Author: Macarena Hirmas