### PR TITLE
Update society-of-biblical-literature-fullnote-bibliography.csl

### DIFF
--- a/society-of-biblical-literature-fullnote-bibliography.csl
+++ b/society-of-biblical-literature-fullnote-bibliography.csl
@@ -33,7 +33,7 @@
     <category citation-format="note"/>
     <category field="theology"/>
     <summary>Society of Biblical Literature format with full notes and bibliography</summary>
-    <updated>2024-05-14T14:28:04+00:00</updated>
+    <updated>2024-08-27T19:51:26+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale xml:lang="en-US">
@@ -1078,13 +1078,27 @@
               <text variable="genre" text-case="capitalize-first"/>
             </if>
           </choose>
-          <group delimiter=". ">
-            <text macro="originally-published"/>
-            <group delimiter=", ">
-              <text macro="reprint"/>
-              <text macro="publisher"/>
-            </group>
-          </group>
+          <!-- If no original-date is present, use a semicolon in the bibliography, rather than a period. Doing so allows original-publisher and original-publisher-place to be used to handle co-publication situations where both publishers are equally original. See SBLHS2 §4.1.4.4 and CMOS17 §14.140. -->
+          <choose>
+            <if variable="original-date">
+              <group delimiter=". ">
+                <text macro="originally-published"/>
+                <group delimiter=", ">
+                  <text macro="reprint"/>
+                  <text macro="publisher"/>
+                </group>
+              </group>
+            </if>
+            <else>
+              <group delimiter="; ">
+                <text macro="originally-published"/>
+                <group delimiter=", ">
+                  <text macro="reprint"/>
+                  <text macro="publisher"/>
+                </group>
+              </group>
+            </else>
+          </choose>
           <text macro="issued"/>
         </group>
       </else-if>


### PR DESCRIPTION
Adjust originally-published grouping in the bibliography so that items without original-date (i.e., co-publications where one publisher is just as original as another) get a semicolon rather than a period before the second set of publication facts.