### PR TITLE
Add style CSL éditions Entremonde

### DIFF
--- a/ed_entremonde-style-cit.csl
+++ b/ed_entremonde-style-cit.csl
@@ -1,0 +1,552 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<style xmlns="http://purl.org/net/xbiblio/csl" class="note" version="1.0" page-range-format="expanded" default-locale="fr-FR">
+  <!-- This style was edited with the Visual CSL Editor (https://editor.citationstyles.org/visualEditor/) -->
+  <info>
+    <title>Entremonde</title>
+    <title-short>entremonde</title-short>
+    <id>http://www.zotero.org/styles/entremonde</id>
+    <link rel="self" href="http://www.zotero.org/styles/entremonde"/>
+    <link href="https://doc.entremonde.net" rel="documentation" xml:lang="fr"/>
+    <author>
+      <name>entremonde</name>
+      <uri>https://doc.entremonde.net</uri>
+    </author>
+    <category citation-format="note"/>
+    <category field="humanities"/>
+    <category field="philosophy"/>
+    <category field="social_science"/>
+    <summary>Version 1.0</summary>
+    <updated>2025-04-20T22:27:21+00:00</updated>
+    <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work
+    is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
+  </info>
+  <locale xml:lang="fr">
+    <terms>
+      <term name="in">in</term>
+      <term name="cited">op. cit.</term>
+      <term name="page" form="short">
+        <single>p.</single>
+        <multiple>p.</multiple>
+      </term>
+      <term name="editor" form="short">
+        <single>éd.</single>
+        <multiple>éds.</multiple>
+      </term>
+      <term name="online">[en ligne]</term>
+    </terms>
+  </locale>
+  <macro name="author">
+    <choose>
+      <if variable="author">
+        <names variable="author" suffix=", ">
+          <name delimiter-precedes-et-al="always" delimiter-precedes-last="always" et-al-min="4" et-al-use-first="3" et-al-subsequent-min="3" et-al-subsequent-use-first="1" initialize-with=". " sort-separator=" ">
+            <name-part name="family" text-case="sentence" font-variant="normal"/>
+          </name>
+          <et-al font-style="italic"/>
+        </names>
+      </if>
+      <else-if variable="editor">
+        <names variable="editor" suffix=", ">
+          <name delimiter-precedes-last="never" et-al-min="4" et-al-use-first="3" et-al-subsequent-min="3" et-al-subsequent-use-first="1" initialize-with=". " sort-separator=" ">
+            <name-part name="family" font-variant="normal"/>
+          </name>
+          <label form="short" prefix=" (" suffix=".)"/>
+        </names>
+      </else-if>
+    </choose>
+  </macro>
+  <macro name="author-bib">
+    <choose>
+      <if variable="author">
+        <names variable="author" suffix=" ">
+          <name font-style="normal" suffix=":" delimiter-precedes-et-al="always" delimiter-precedes-last="always" et-al-min="4" et-al-use-first="3" et-al-subsequent-min="3" et-al-subsequent-use-first="1" initialize="false" initialize-with="." name-as-sort-order="all" sort-separator=" ">
+            <name-part name="family" text-case="sentence" font-variant="normal" suffix=","/>
+          </name>
+          <et-al font-style="italic"/>
+        </names>
+      </if>
+      <else-if variable="editor">
+        <names variable="editor" suffix=", ">
+          <name font-style="normal" delimiter-precedes-last="never" et-al-min="4" et-al-use-first="3" et-al-subsequent-min="3" et-al-subsequent-use-first="1" name-as-sort-order="all" sort-separator=" ">
+            <name-part name="family" font-variant="normal"/>
+          </name>
+          <label form="short" prefix=" (" suffix=".)"/>
+        </names>
+      </else-if>
+    </choose>
+  </macro>
+  <macro name="editor">
+    <names variable="editor">
+      <name font-style="normal" and="text" delimiter-precedes-last="never" initialize-with=". " sort-separator=" ">
+        <name-part name="family" font-variant="normal"/>
+      </name>
+      <label form="short" prefix=" (" suffix=".)"/>
+    </names>
+  </macro>
+  <macro name="title">
+    <choose>
+      <if type="book report" match="any">
+        <group>
+          <text variable="title" text-case="capitalize-first" quotes="false" font-style="italic"/>
+          <choose>
+            <if variable="original-date" match="any">
+              <date variable="original-date" prefix=" (" suffix=")">
+                <date-part name="year"/>
+              </date>
+            </if>
+          </choose>
+        </group>
+      </if>
+      <else-if type="graphic personal_communication interview" match="any">
+        <group>
+          <text variable="title" text-case="capitalize-first" font-style="italic"/>
+        </group>
+        <text macro="date"/>
+        <group delimiter=", " prefix=", " suffix=".">
+          <text macro="interviewer"/>
+          <text variable="medium"/>
+          <text variable="genre"/>
+          <text variable="issue"/>
+        </group>
+      </else-if>
+      <else-if type="motion_picture" match="any">
+        <group delimiter=", ">
+          <text variable="title" text-case="capitalize-first" font-style="italic"/>
+          <text variable="medium"/>
+        </group>
+      </else-if>
+      <else-if type="thesis broadcast" match="any">
+        <group delimiter=", ">
+          <group>
+            <text variable="title" text-case="capitalize-first" font-style="italic"/>
+          </group>
+          <text variable="genre"/>
+          <text variable="container-title" font-style="italic"/>
+        </group>
+      </else-if>
+      <else-if type="manuscript" match="any">
+        <group delimiter="">
+          <group suffix=",">
+            <text variable="title" text-case="capitalize-first" quotes="true" font-style="normal"/>
+          </group>
+          <text variable="genre" prefix=" "/>
+        </group>
+      </else-if>
+      <else-if type="chapter paper-conference article-journal article-magazine article-newspaper article" match="any">
+        <group>
+          <group>
+            <text variable="title" text-case="capitalize-first" quotes="true"/>
+            <choose>
+              <if variable="original-date" match="any">
+                <text value=" "/>
+                <date variable="original-date" prefix="(" suffix=")">
+                  <date-part name="year"/>
+                </date>
+              </if>
+            </choose>
+          </group>
+          <text value="in" prefix=" " suffix=" "/>
+          <text macro="editor" suffix=", "/>
+          <text variable="container-title" text-case="capitalize-first" font-style="italic"/>
+        </group>
+      </else-if>
+      <else-if type="entry-dictionary entry-encyclopedia paper-conference chapter" match="any">
+        <group delimiter="">
+          <group suffix=",">
+            <text variable="title" text-case="capitalize-first" quotes="true" prefix="article "/>
+          </group>
+          <text value="in" font-style="normal" prefix=" " suffix=" "/>
+          <text macro="editor" suffix=", "/>
+          <text variable="container-title" text-case="capitalize-first" font-style="italic"/>
+        </group>
+      </else-if>
+      <else-if type="webpage" match="any">
+        <group delimiter=", ">
+          <group>
+            <text variable="title" text-case="capitalize-first" quotes="true" font-style="normal"/>
+          </group>
+          <text variable="genre"/>
+          <text variable="container-title" font-style="italic"/>
+        </group>
+      </else-if>
+      <else-if type="map" match="any">
+        <group delimiter=", ">
+          <group>
+            <text variable="title" text-case="capitalize-first" font-style="italic"/>
+          </group>
+          <text variable="genre"/>
+          <text variable="edition"/>
+        </group>
+      </else-if>
+      <else>
+        <group>
+          <text variable="title" text-case="capitalize-first" quotes="true" font-style="normal"/>
+        </group>
+      </else>
+    </choose>
+  </macro>
+  <macro name="translator-bib">
+    <names variable="translator" prefix=", trad. ">
+      <name initialize-with=". " sort-separator=" ">
+        <name-part name="family" font-variant="normal"/>
+      </name>
+    </names>
+  </macro>
+  <macro name="translator">
+    <names variable="translator" prefix=", trad. ">
+      <name initialize-with=". " sort-separator=" ">
+        <name-part name="family" font-variant="normal"/>
+      </name>
+    </names>
+  </macro>
+  <macro name="edition">
+    <choose>
+      <if type="book graphic report entry-dictionary entry-encyclopedia chapter speech paper-conference" match="any">
+        <choose>
+          <if is-numeric="edition">
+            <group delimiter=" " prefix=", ">
+              <number variable="edition" form="ordinal"/>
+              <text term="edition" form="short"/>
+            </group>
+          </if>
+          <else>
+            <text variable="edition" prefix=", "/>
+          </else>
+        </choose>
+      </if>
+      <else-if type="article-journal article-magazine" match="any">
+        <group font-style="normal">
+          <choose>
+            <if variable="issued">
+              <group prefix=", ">
+                <text macro="issue" text-decoration="none" prefix="n° " suffix=", "/>
+                <date date-parts="year" form="text" variable="issued"/>
+              </group>
+            </if>
+            <else>
+              <text macro="volume" prefix=", "/>
+            </else>
+          </choose>
+        </group>
+      </else-if>
+    </choose>
+  </macro>
+  <macro name="newspaper-edition">
+    <choose>
+      <if type="article-newspaper">
+        <group delimiter=", ">
+          <group>
+            <text term="edition" prefix=" "/>
+            <text variable="edition" prefix=" "/>
+          </group>
+          <group>
+            <text term="section" form="short" font-weight="normal" suffix=". "/>
+            <text variable="section" font-weight="normal"/>
+          </group>
+        </group>
+      </if>
+    </choose>
+  </macro>
+  <macro name="event">
+    <choose>
+      <if variable="event">
+        <choose>
+          <if variable="genre" match="none">
+            <group delimiter=" " prefix=", ">
+              <text term="presented at" suffix=" "/>
+              <text variable="event"/>
+            </group>
+          </if>
+          <else>
+            <group delimiter=" " prefix=", ">
+              <text variable="genre"/>
+              <text term="presented at"/>
+              <text variable="event"/>
+            </group>
+          </else>
+        </choose>
+      </if>
+    </choose>
+  </macro>
+  <macro name="place">
+    <choose>
+      <if type="article-newspaper paper-conference" match="any">
+        <choose>
+          <if variable="publisher-place">
+            <text variable="publisher-place" prefix=", "/>
+          </if>
+          <else>
+            <text value="" prefix=", "/>
+          </else>
+        </choose>
+      </if>
+      <else-if type="speech manuscript thesis broadcast" match="any">
+        <choose>
+          <if variable="publisher-place">
+            <text variable="publisher-place" prefix=", "/>
+          </if>
+          <else>
+            <text value="" prefix=", "/>
+          </else>
+        </choose>
+      </else-if>
+      <else-if type="article-magazine article-journal personal_communication interview graphic webpage" match="any"/>
+      <else-if type="book chapter motion_picture report entry-dictionary entry-encyclopedia map" match="any">
+        <choose>
+          <if variable="publisher-place">
+            <text variable="publisher-place" prefix=", "/>
+          </if>
+          <else>
+            <text value="" prefix=", "/>
+          </else>
+        </choose>
+      </else-if>
+    </choose>
+  </macro>
+  <macro name="publisher">
+    <choose>
+      <if type="motion_picture map book paper-conference entry-dictionary entry-encyclopedia chapter report thesis article" match="any">
+        <choose>
+          <if variable="publisher">
+            <text variable="publisher" font-weight="normal" prefix=", "/>
+          </if>
+          <else>
+            <text value=""/>
+          </else>
+        </choose>
+      </if>
+      <else-if type="thesis broadcast" match="any"/>
+      <else>
+        <text variable="publisher" font-weight="normal" prefix=", "/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="collection">
+    <choose>
+      <if type="motion_picture map entry-dictionary entry-encyclopedia speech paper-conference chapter" match="any">
+        <group prefix=", ">
+          <group text-decoration="none">
+            <text variable="collection-title" quotes="false" prefix="coll. "/>
+            <text variable="collection-number" prefix=" n°"/>
+          </group>
+        </group>
+      </if>
+      <else-if type="article-journal">
+        <text variable="collection-title" font-style="normal" prefix=", "/>
+      </else-if>
+      <else-if type="book" match="any"/>
+      <else>
+        <text variable="collection-title" suffix=", " font-style="italic"/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="date">
+    <choose>
+      <if variable="issued">
+        <date date-parts="year" form="text" variable="issued" prefix=", "/>
+      </if>
+      <else>
+        <text value="" prefix=", "/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="yearpage-bib">
+    <choose>
+      <if type="book" match="any">
+        <group>
+          <text macro="date"/>
+        </group>
+      </if>
+      <else-if type="map manuscript thesis motion_picture broadcast" match="any">
+        <group>
+          <text macro="date"/>
+          <text variable="number-of-pages" prefix=", " suffix=" p"/>
+        </group>
+      </else-if>
+      <else-if type="report entry-dictionary entry-encyclopedia chapter" match="any">
+        <group>
+          <text macro="date"/>
+          <group delimiter=" " prefix=", ">
+            <label variable="page" form="short"/>
+            <text variable="page"/>
+          </group>
+        </group>
+      </else-if>
+      <else-if type="graphic personal_communication interview" match="any"/>
+      <else-if type="article-journal article-magazine" match="any">
+        <group delimiter=" " font-style="normal" prefix=", ">
+          <group delimiter=" ">
+            <label variable="page" form="short"/>
+            <text variable="page"/>
+          </group>
+        </group>
+      </else-if>
+      <else-if type="article-newspaper speech paper-conference" match="any">
+        <group delimiter="" font-style="normal">
+          <text macro="newspaper-edition"/>
+          <text macro="date"/>
+          <group delimiter=" " prefix=", ">
+            <label variable="page" form="short"/>
+            <text variable="page" font-weight="normal"/>
+          </group>
+        </group>
+      </else-if>
+      <else-if type="webpage" match="any">
+        <group delimiter=" " font-style="normal">
+          <text value="le" prefix=", "/>
+          <date form="text" variable="issued" suffix="">
+            <date-part name="day"/>
+            <date-part name="month"/>
+            <date-part name="year"/>
+          </date>
+        </group>
+      </else-if>
+      <else>
+        <group>
+          <text macro="date"/>
+          <text variable="number-of-pages" prefix=", " suffix=" p."/>
+        </group>
+      </else>
+    </choose>
+  </macro>
+  <macro name="archive">
+    <group suffix="." prefix=". ">
+      <group delimiter=", ">
+        <text variable="archive"/>
+        <text variable="archive_location"/>
+        <text variable="call-number"/>
+      </group>
+    </group>
+  </macro>
+  <macro name="volume">
+    <choose>
+      <if type="article-journal article-newspaper" match="any">
+        <choose>
+          <if is-numeric="volume">
+            <text variable="volume" prefix=", vol. "/>
+          </if>
+          <else>
+            <text variable="number-of-volumes" suffix="vol.,"/>
+          </else>
+        </choose>
+      </if>
+      <else>
+        <choose>
+          <if match="any" variable="volume">
+            <text variable="volume" prefix=", t. "/>
+          </if>
+          <else>
+            <text variable="number-of-volumes" prefix=", " suffix=" vol."/>
+          </else>
+        </choose>
+      </else>
+    </choose>
+  </macro>
+  <macro name="issue">
+    <choose>
+      <if is-numeric="issue">
+        <text variable="issue"/>
+      </if>
+      <else>
+        <text variable="issue"/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="interviewer">
+    <group>
+      <names variable="interviewer">
+        <label form="verb" prefix=" " suffix=" "/>
+        <name form="long" and="text" delimiter=", ">
+          <name-part name="family" font-variant="small-caps"/>
+        </name>
+      </names>
+    </group>
+  </macro>
+  <macro name="accessed">
+    <group delimiter=" ">
+      <text variable="URL" text-decoration="none" prefix=", [" suffix="]"/>
+    </group>
+  </macro>
+  <macro name="pages-citation">
+    <label plural="never" suffix=" " variable="page" form="short"/>
+    <text variable="locator" form="short"/>
+  </macro>
+  <citation et-al-min="4" et-al-use-first="1">
+    <layout delimiter=" ; ">
+      <choose>
+        <if position="ibid-with-locator">
+          <group delimiter=", ">
+            <text term="ibid" text-case="capitalize-first" font-style="italic" suffix="."/>
+            <text macro="pages-citation"/>
+          </group>
+        </if>
+        <else-if position="ibid">
+          <text term="ibid" text-case="capitalize-first" font-style="italic"/>
+        </else-if>
+        <else-if position="subsequent">
+          <text macro="author"/>
+          <group delimiter=", ">
+            <choose>
+              <if type="book graphic report" match="any">
+                <text macro="title"/>
+                <text term="cited" font-style="italic" suffix="."/>
+              </if>
+              <else-if type="article-journal article-newspaper article-magazine" match="any">
+                <text variable="title" text-case="capitalize-first" form="short" quotes="true"/>
+                <text value="art. cit."/>
+              </else-if>
+              <else>
+                <text macro="title" text-case="capitalize-first"/>
+                <text term="cited" font-style="italic" suffix="."/>
+              </else>
+            </choose>
+            <group delimiter=" ">
+              <text macro="pages-citation"/>
+            </group>
+          </group>
+        </else-if>
+        <else>
+          <text macro="author"/>
+          <text macro="title"/>
+          <text macro="collection"/>
+          <text macro="volume"/>
+          <text macro="edition"/>
+          <text macro="event"/>
+          <text macro="place"/>
+          <text macro="publisher"/>
+          <text macro="yearpage-bib"/>
+          <text macro="pages-citation" prefix=", "/>
+        </else>
+      </choose>
+      <text value="." suffix=" "/>
+    </layout>
+  </citation>
+  <bibliography hanging-indent="true" entry-spacing="1" subsequent-author-substitute="—" subsequent-author-substitute-rule="complete-all">
+    <sort>
+      <key macro="author"/>
+      <key variable="issued" sort="descending"/>
+    </sort>
+    <layout suffix=".">
+      <group>
+        <group>
+          <text macro="author-bib"/>
+          <choose>
+            <if position="first">
+              <text value=":"/>
+            </if>
+          </choose>
+        </group>
+        <text macro="title"/>
+        <text macro="translator-bib"/>
+        <text macro="collection"/>
+        <text macro="volume"/>
+        <text macro="edition"/>
+        <text macro="event"/>
+        <text macro="place"/>
+        <text macro="publisher"/>
+        <text macro="yearpage-bib"/>
+        <text macro="archive"/>
+      </group>
+    </layout>
+  </bibliography>
+</style>


### PR DESCRIPTION
Bibliographic style of the publishing house [Éditions Entremonde](https://entremonde.net), based on the recommendations of its [typographical guide](https://doc.entremonde.net/guide_ortho-typographique). Supports op. cit., ibid., and em dash substitution for repeated authors.