### PR TITLE
Update chinese-journal-of-aeronautics.csl

### DIFF
--- a/chinese-journal-of-aeronautics.csl
+++ b/chinese-journal-of-aeronautics.csl
@@ -11,13 +11,24 @@
       <name>Ramanathan</name>
       <email>Ra.Ganapathi@elsevier.com</email>
     </author>
+    <contributor>
+      <name>YZW</name>
+      <email>yzw.19951004@outlook.com</email>
+    </contributor>
     <category citation-format="numeric"/>
     <category field="engineering"/>
     <issn>1000-9361</issn>
     <summary>A style for some Elsevier journals, resembles Vancouver style</summary>
-    <updated>2014-09-26T17:00:10+00:00</updated>
+    <updated>2025-05-03 10:42:58</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
+
+   <locale xml:lang="zh">
+    <terms>
+      <term name="lang-suffix">[Chinese]</term>
+    </terms>
+  </locale>
+ 
   <macro name="access">
     <choose>
       <if variable="DOI">
@@ -37,7 +48,7 @@
   </macro>
   <macro name="author">
     <names variable="author">
-      <name form="long" initialize="false" delimiter=", " delimiter-precedes-last="always" name-as-sort-order="all" sort-separator=" "/>
+      <name form="long" initialize="true" initialize-with="" delimiter=", " delimiter-precedes-last="always" name-as-sort-order="all" sort-separator=" "/>
       <label form="long" prefix=", "/>
       <substitute>
         <names variable="editor"/>
@@ -112,6 +123,16 @@
       </else>
     </choose>
   </macro>
+
+  <!-- 若条目处于 zh locale，则在条目末尾加空格+[Chinese] -->
+  <macro name="lang-note">
+    <choose>
+      
+      <if locale="zh">
+        <text term="lang-suffix" prefix=" "/>
+      </if>
+    </choose>
+  </macro>
   <citation collapse="citation-number">
     <sort>
       <key variable="citation-number" sort="ascending"/>
@@ -122,7 +143,7 @@
   </citation>
   <bibliography entry-spacing="0" second-field-align="flush" et-al-min="7" et-al-use-first="6">
     <layout suffix=".">
-      <text variable="citation-number"/>
+      <text variable="citation-number" suffix=". "/>
       <text macro="author" suffix=". "/>
       <choose>
         <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
@@ -189,7 +210,10 @@
         </else-if>
         <else-if type="webpage">
           <group delimiter=" ">
-            <text variable="title" form="long" suffix="."/>
+            <!-- 题名后不加句点，避免出现双句点 -->
+            <text variable="title"/>
+            <!-- 插入“ [Internet].” -->
+            <text value="[Internet]" prefix=" " suffix="."/>
             <text variable="container-title" form="long" suffix="." text-case="title"/>
             <text macro="access"/>
             <text macro="year-date"/>
@@ -212,6 +236,7 @@
           <text macro="access" prefix=". "/>
         </else>
       </choose>
+      <text macro="lang-note"/>
     </layout>
   </bibliography>
 </style>


### PR DESCRIPTION
1. add <contributor> YZW and refresh <updated> timestamp
2. introduce zh locale with custom term lang-suffix → “[Chinese]” create new lang-note macro; append it to bibliography layout for Chinese items
3. switch author macro to use initials (initialize="true", empty initialize-with)
4. output citation number as “N. ” (number + dot + space) in bibliography
5. revise webpage layout: remove extra period after title, inject “ [Internet].” token for correct punctuation