### PR TITLE
Adding style for L'Homme *for English-language manuscripts*

### DIFF
--- a/lhomme-english.csl
+++ b/lhomme-english.csl
@@ -61,13 +61,6 @@
     <text variable="container-title" font-style="italic"/>
   </macro>
 
-  <macro name="collection-title">
-    <group delimiter=", ">
-      <text variable="collection-title"/>
-      <text variable="collection-number"/>
-    </group>
-  </macro>
-
   <citation>
     <layout prefix="(" suffix=")" delimiter=", ">
       <text macro="author"/>

--- a/lhomme-english.csl
+++ b/lhomme-english.csl
@@ -12,10 +12,7 @@
     <category citation-format="author-date"/>
     <category field="anthropology"/>
     <summary>Style for English-language submissions to the anthropology journal "L'Homme"</summary>
-    <rights license="http://creativecommons.org/licenses/by-sa/3.0/">
-    This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License.
-</rights>
-
+    <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
     <updated>2025-05-06T00:00:00+00:00</updated>
   </info>
 

--- a/lhomme-english.csl
+++ b/lhomme-english.csl
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
-<style xmlns="http://purl.org/net/xbiblio/csl" version="1.0" class="in-text" demote-non-dropping-particle="sort-only" default-locale="en" page-range-format="expanded">
+<style xmlns="http://purl.org/net/xbiblio/csl" version="1.0" class="in-text" demote-non-dropping-particle="sort-only" page-range-format="expanded" default-locale="en">
   <info>
-    <title>L'Homme – Revue française d’anthropologie (English)</title>
+    <title>L'Homme &#8211; Revue française d’anthropologie (English)</title>
     <id>http://www.zotero.org/styles/lhomme-english</id>
     <link href="http://www.zotero.org/styles/lhomme-english" rel="self"/>
     <link href="http://www.editions.ehess.fr/revues/lhomme/" rel="documentation"/>
@@ -12,36 +12,31 @@
     <category citation-format="author-date"/>
     <category field="anthropology"/>
     <summary>Style for English-language submissions to the anthropology journal "L'Homme"</summary>
-    <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
     <updated>2025-05-06T00:00:00+00:00</updated>
+    <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
-
   <macro name="author">
     <names variable="author">
       <name and="text" name-as-sort-order="all" sort-separator=", " delimiter=", "/>
     </names>
   </macro>
-
   <macro name="editor">
     <names variable="editor">
       <label form="short" prefix="(" suffix=")" text-case="lowercase"/>
       <name and="text" name-as-sort-order="all" sort-separator=", " delimiter=", "/>
     </names>
   </macro>
-
   <macro name="issued">
     <date variable="issued">
       <date-part name="year"/>
     </date>
   </macro>
-
   <macro name="publisher">
     <group delimiter=", ">
       <text variable="publisher-place"/>
       <text variable="publisher"/>
     </group>
   </macro>
-
   <macro name="pages">
     <choose>
       <if variable="page">
@@ -49,22 +44,18 @@
       </if>
     </choose>
   </macro>
-
   <macro name="title">
     <text variable="title"/>
   </macro>
-
   <macro name="container-title">
     <text variable="container-title" font-style="italic"/>
   </macro>
-
   <citation>
     <layout prefix="(" suffix=")" delimiter=", ">
       <text macro="author"/>
       <text macro="issued"/>
     </layout>
   </citation>
-
   <bibliography hanging-indent="true" line-spacing="2" entry-spacing="1">
     <sort>
       <key macro="author"/>
@@ -73,13 +64,11 @@
     <layout suffix=".">
       <text macro="author" suffix=" "/>
       <text macro="issued" prefix="(" suffix=") "/>
-
       <choose>
         <if type="book" match="any">
           <text macro="title" font-style="italic" suffix=". "/>
           <text macro="publisher"/>
         </if>
-
         <else-if type="chapter paper-conference" match="any">
           <text macro="title" quotes="true" suffix=". "/>
           <group delimiter=" " suffix=", ">
@@ -94,7 +83,6 @@
             </group>
           </group>
         </else-if>
-
         <else-if type="article-journal article-magazine article-newspaper">
           <text macro="title" quotes="true" suffix=", "/>
           <text macro="container-title" suffix=" "/>
@@ -104,7 +92,6 @@
             <text variable="page" prefix=": "/>
           </group>
         </else-if>
-
         <else>
           <text macro="title"/>
         </else>

--- a/lhomme-english.csl
+++ b/lhomme-english.csl
@@ -2,8 +2,8 @@
 <style xmlns="http://purl.org/net/xbiblio/csl" version="1.0" class="in-text" demote-non-dropping-particle="sort-only" default-locale="en" page-range-format="expanded">
   <info>
     <title>L'Homme – Revue française d’anthropologie (English)</title>
-    <id>http://www.zotero.org/styles/l-homme-english</id>
-    <link href="http://www.zotero.org/styles/l-homme-english" rel="self"/>
+    <id>http://www.zotero.org/styles/lhomme-english</id>
+    <link href="http://www.zotero.org/styles/lhomme-english" rel="self"/>
     <link href="http://www.editions.ehess.fr/revues/lhomme/" rel="documentation"/>
     <author>
       <name>Mark Collins (English adaptation by Alexis Michaud, with help from Perplexity.ai and ChatGPT)</name>
@@ -11,7 +11,11 @@
     </author>
     <category citation-format="author-date"/>
     <category field="anthropology"/>
-    <summary>Fixes punctuation issues in chapter and container grouping</summary>
+    <summary>Style for English-language submissions to the anthropology journal "L'Homme"</summary>
+    <rights license="http://creativecommons.org/licenses/by-sa/3.0/">
+    This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License.
+</rights>
+
     <updated>2025-05-06T00:00:00+00:00</updated>
   </info>
 

--- a/lhomme-english.csl
+++ b/lhomme-english.csl
@@ -1,0 +1,120 @@
+<?xml version="1.0" encoding="utf-8"?>
+<style xmlns="http://purl.org/net/xbiblio/csl" version="1.0" class="in-text" demote-non-dropping-particle="sort-only" default-locale="en" page-range-format="expanded">
+  <info>
+    <title>L'Homme – Revue française d’anthropologie (English)</title>
+    <id>http://www.zotero.org/styles/l-homme-english</id>
+    <link href="http://www.zotero.org/styles/l-homme-english" rel="self"/>
+    <link href="http://www.editions.ehess.fr/revues/lhomme/" rel="documentation"/>
+    <author>
+      <name>Mark Collins (English adaptation by Alexis Michaud, with help from Perplexity.ai and ChatGPT)</name>
+      <email>alexis.michaud@cnrs.fr</email>
+    </author>
+    <category citation-format="author-date"/>
+    <category field="anthropology"/>
+    <summary>Fixes punctuation issues in chapter and container grouping</summary>
+    <updated>2025-05-06T00:00:00+00:00</updated>
+  </info>
+
+  <macro name="author">
+    <names variable="author">
+      <name and="text" name-as-sort-order="all" sort-separator=", " delimiter=", "/>
+    </names>
+  </macro>
+
+  <macro name="editor">
+    <names variable="editor">
+      <label form="short" prefix="(" suffix=")" text-case="lowercase"/>
+      <name and="text" name-as-sort-order="all" sort-separator=", " delimiter=", "/>
+    </names>
+  </macro>
+
+  <macro name="issued">
+    <date variable="issued">
+      <date-part name="year"/>
+    </date>
+  </macro>
+
+  <macro name="publisher">
+    <group delimiter=", ">
+      <text variable="publisher-place"/>
+      <text variable="publisher"/>
+    </group>
+  </macro>
+
+  <macro name="pages">
+    <choose>
+      <if variable="page">
+        <text variable="page" prefix=": "/>
+      </if>
+    </choose>
+  </macro>
+
+  <macro name="title">
+    <text variable="title"/>
+  </macro>
+
+  <macro name="container-title">
+    <text variable="container-title" font-style="italic"/>
+  </macro>
+
+  <macro name="collection-title">
+    <group delimiter=", ">
+      <text variable="collection-title"/>
+      <text variable="collection-number"/>
+    </group>
+  </macro>
+
+  <citation>
+    <layout prefix="(" suffix=")" delimiter=", ">
+      <text macro="author"/>
+      <text macro="issued"/>
+    </layout>
+  </citation>
+
+  <bibliography hanging-indent="true" line-spacing="2" entry-spacing="1">
+    <sort>
+      <key macro="author"/>
+      <key variable="issued"/>
+    </sort>
+    <layout suffix=".">
+      <text macro="author" suffix=" "/>
+      <text macro="issued" prefix="(" suffix=") "/>
+
+      <choose>
+        <if type="book" match="any">
+          <text macro="title" font-style="italic" suffix=". "/>
+          <text macro="publisher"/>
+        </if>
+
+        <else-if type="chapter paper-conference" match="any">
+          <text macro="title" quotes="true" suffix=". "/>
+          <group delimiter=" " suffix=", ">
+            <text value="in" font-style="italic"/>
+            <text macro="editor"/>
+          </group>
+          <group delimiter=", ">
+            <text macro="container-title"/>
+            <group delimiter=", ">
+              <text macro="publisher"/>
+              <text macro="pages"/>
+            </group>
+          </group>
+        </else-if>
+
+        <else-if type="article-journal article-magazine article-newspaper">
+          <text macro="title" quotes="true" suffix=", "/>
+          <text macro="container-title" suffix=" "/>
+          <group delimiter=", ">
+            <text variable="volume"/>
+            <text variable="issue"/>
+            <text variable="page" prefix=": "/>
+          </group>
+        </else-if>
+
+        <else>
+          <text macro="title"/>
+        </else>
+      </choose>
+    </layout>
+  </bibliography>
+</style>


### PR DESCRIPTION
This style is based on the style for _L'Homme_ already present in the repo. 
The reason for producing an English-language version is that the journal accepts manuscripts written in English, and the reference stylesheet needed to be adapted accordingly (using "and" instead of "et", and so on). 

I have checked it locally and it works (but I'm happy to chisel further if useful). Needless to say it's error-free against the [CSL Validator](https://validator.citationstyles.org/).

Credit is given to the author of the original file. I provide my own e-mail in the `email` field so the author of the original (French-language) version won't get unsolicited e-mail about someone else's adaptation of his work. 

```
    <author>
      <name>Mark Collins (English adaptation by Alexis Michaud, with help from Perplexity.ai and ChatGPT)</name>
      <email>alexis.michaud@cnrs.fr</email>
    </author>
```

Looking forward, 
With appreciation of Zotero & CSL