### PR TITLE
Update bluebook-law-review.csl

### DIFF
--- a/bluebook-law-review.csl
+++ b/bluebook-law-review.csl
@@ -16,10 +16,14 @@
     <contributor>
       <name>Patrick O'Brien</name>
     </contributor>
+    <contributor>
+      <name>Shay Elbaum</name>
+      <email>selbaum@law.harvard.edu</email>
+    </contributor>
     <category citation-format="note"/>
     <category field="law"/>
     <summary>The Bluebook legal citation style for law reviews.</summary>
-    <updated>2023-06-28T09:05:37+00:00</updated>
+    <updated>2025-05-06T00:00:00+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale>
@@ -33,9 +37,6 @@
     <names variable="author">
       <name and="symbol" delimiter=", " delimiter-precedes-last="never"/>
       <label form="short" prefix=" "/>
-      <substitute>
-        <text variable="title"/>
-      </substitute>
     </names>
   </macro>
   <macro name="author-short">
@@ -93,14 +94,18 @@
       <if variable="URL">
         <group delimiter=" ">
           <text variable="URL"/>
-          <group delimiter=" " prefix="(" suffix=")">
-            <text value="last visited"/>
-            <date variable="accessed">
-              <date-part name="month" form="short" suffix=" " strip-periods="true"/>
-              <date-part name="day" suffix=", "/>
-              <date-part name="year"/>
-            </date>
-          </group>
+          <choose>
+            <if variable="issued" match="none">
+              <group delimiter=" " prefix="(" suffix=")">
+                <text value="last visited"/>
+                <date variable="accessed">
+                  <date-part name="month" form="short" suffix=" "/>
+                  <date-part name="day" suffix=", "/>
+                  <date-part name="year"/>
+                </date>
+              </group>
+            </if>
+          </choose>
         </group>
       </if>
     </choose>
@@ -135,7 +140,7 @@
           <text macro="issuance" prefix="(" suffix=")"/>
         </group>
       </else-if>
-      <else-if type="article-newspaper article-magazine thesis" match="any">
+      <else-if type="article-newspaper article-magazine" match="any">
         <group delimiter=", ">
           <text variable="title" text-case="title" font-style="italic"/>
           <group delimiter=" ">
@@ -149,6 +154,21 @@
           </group>
         </group>
       </else-if>
+      <else-if type="article thesis" match="any">
+        <group delimiter=", ">
+          <text variable="title" text-case="title"/>
+          <text macro="container"/>  
+        </group>
+        <text macro="issuance" prefix=" (" suffix=")"/>
+        <choose>
+          <if type="thesis">
+            <group delimiter=", " prefix=" (" suffix=")">
+              <text variable="genre" suffix=" dissertation"/>
+              <text variable="publisher"/> 
+            </group>
+          </if>
+        </choose> 
+      </else-if>
       <else-if type="chapter paper-conference" match="any">
         <text variable="title" text-case="title" font-style="italic"/>
         <group prefix=", " delimiter=" " suffix=" ">
@@ -159,7 +179,7 @@
         <text variable="locator" prefix=", "/>
         <text macro="issuance" prefix=" (" suffix=")"/>
       </else-if>
-      <else-if type="book" match="any">
+      <else-if type="book report" match="any">
         <text variable="title" text-case="title" font-variant="small-caps"/>
         <text variable="locator" prefix=" "/>
         <text macro="issuance" prefix=" (" suffix=")"/>
@@ -190,14 +210,14 @@
       </if>
       <else>
         <choose>
-          <if type="article-journal article-magazine article-newspaper broadcast interview manuscript map patent personal_communication song speech thesis webpage post-weblog" match="any">
+          <if type="article article-journal article-magazine article-newspaper broadcast interview manuscript map patent personal_communication song speech thesis webpage post-weblog" match="any">
             <group>
               <choose>
-                <if type="article-newspaper thesis post-weblog" match="any">
-                  <group suffix=", ">
+                <if type="article article-newspaper thesis webpage post-weblog" match="any">
+                  <group>
                     <date variable="issued">
-                      <date-part name="month" form="short"/>
-                      <date-part name="day" prefix=" "/>
+                      <date-part name="month" form="short" suffix=" "/>
+                      <date-part name="day" prefix=" " suffix=", "/>
                     </date>
                   </group>
                 </if>

--- a/bluebook-law-review.csl
+++ b/bluebook-law-review.csl
@@ -157,17 +157,17 @@
       <else-if type="article thesis" match="any">
         <group delimiter=", ">
           <text variable="title" text-case="title"/>
-          <text macro="container"/>  
+          <text macro="container"/>
         </group>
         <text macro="issuance" prefix=" (" suffix=")"/>
         <choose>
           <if type="thesis">
             <group delimiter=", " prefix=" (" suffix=")">
               <text variable="genre" suffix=" dissertation"/>
-              <text variable="publisher"/> 
+              <text variable="publisher"/>
             </group>
           </if>
-        </choose> 
+        </choose>
       </else-if>
       <else-if type="chapter paper-conference" match="any">
         <text variable="title" text-case="title" font-style="italic"/>


### PR DESCRIPTION
Include (last visited) parenthetical only if issuance date not provided; put theses and unpublished manuscript titles in roman type and include type and institution for theses; treat reports like books, with small caps author and title; don't include comma after month if no day provided; include month and day for webpages if available; keep title formatting even if no author provided.