### PR TITLE
Update palaeontology.csl

### DIFF
--- a/palaeontology.csl
+++ b/palaeontology.csl
@@ -5,7 +5,7 @@
     <id>http://www.zotero.org/styles/palaeontology</id>
     <link href="http://www.zotero.org/styles/palaeontology" rel="self"/>
     <link href="http://www.zotero.org/styles/journal-of-vertebrate-paleontology" rel="template"/>
-    <link href="https://www.palass.org/sites/default/files/media/publications/for_authors/ITA_2016_v1.pdf" rel="documentation"/>
+    <link href="https://www.palass.org/sites/default/files/media/publications/for_authors/RefExamples_2021_v1.pdf" rel="documentation"/>
     <author>
       <name>Benjamin C. Moon</name>
       <email>benjamin.moon@bristol.ac.uk</email>
@@ -15,11 +15,16 @@
       <email>martin.smith@durham.ac.uk</email>
       <uri>https://smithlabdurham.github.io/</uri>
     </contributor>
+    <contributor>
+      <name>Peter L. Falkingham</name>
+      <email>p.l.falkingham@ljmu.ac.uk</email>
+      <uri>https://peterfalkingham.com/</uri>
+    </contributor>
     <category citation-format="author-date"/>
     <category field="biology"/>
     <issn>0031-0239</issn>
     <eissn>1475-4983</eissn>
-    <updated>2019-05-03T08:35:38+00:00</updated>
+    <updated>2025-05-07T14:58:31+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <macro name="author">
@@ -94,7 +99,7 @@
       </group>
     </layout>
   </citation>
-  <bibliography entry-spacing="0" hanging-indent="true" subsequent-author-substitute-rule="partial-each" subsequent-author-substitute="&#8212;&#8212;&#8212;">
+  <bibliography entry-spacing="0" hanging-indent="true">
     <sort>
       <key macro="author" names-min="1" names-use-first="1"/>
       <key macro="author-count"/>


### PR DESCRIPTION
updated to remove quotes/emdashes for repeated authors.

Just had paper accepted into palaeontology, and technical editor told me style has changed:

"Please do not use ditto marks (———) in your references. Include all author names in full."

After querying, technical editor (Sally Thomas) said:

"I am aware that there is a Palaeontology style sheet around but don’t know how we can either have this adjusted (as it has been out of date for many years) or taken down. "

So, I've changed it to not use the --- quotes for duplicate authors in the list.