### PR TITLE
MLA: Supply missing space with non-standard locator

### DIFF
--- a/modern-language-association-8th-edition.csl
+++ b/modern-language-association-8th-edition.csl
@@ -11,6 +11,8 @@
     </author>
     <category citation-format="author"/>
     <category field="generic-base"/>
+    <category field="humanities"/>
+    <category field="literature"/>
     <summary>This style adheres to the MLA 8th edition handbook. Follows the structure of references as outlined in the MLA Manual closely</summary>
     <updated>2018-12-13T20:05:10+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
@@ -286,7 +288,7 @@
         <else>
           <group delimiter=", ">
             <text macro="author-short"/>
-            <group>
+            <group delimiter=" ">
               <label variable="locator" form="short"/>
               <text variable="locator"/>
             </group>

--- a/modern-language-association.csl
+++ b/modern-language-association.csl
@@ -10,10 +10,16 @@
       <name>Sebastian Karcher</name>
     </author>
     <contributor>
+      <name>Andrew Dunning</name>
+      <uri>https://orcid.org/0000-0003-0464-5036</uri>
+    </contributor>
+    <contributor>
       <name>Patrick O'Brien</name>
     </contributor>
     <category citation-format="author"/>
     <category field="generic-base"/>
+    <category field="humanities"/>
+    <category field="literature"/>
     <summary>This style adheres to the MLA 9th edition handbook. Follows the structure of references as outlined in the MLA Manual closely</summary>
     <updated>2023-07-21T20:05:10+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
@@ -299,7 +305,7 @@
         <else>
           <group delimiter=", ">
             <text macro="author-short"/>
-            <group>
+            <group delimiter=" ">
               <label variable="locator" form="short"/>
               <text variable="locator"/>
             </group>


### PR DESCRIPTION
The missing space seems to be an accidental omission; cf. MLA 6.22–23.