### PR TITLE
Add support for Original Title in extra field

### DIFF
--- a/apa.csl
+++ b/apa.csl
@@ -8,13 +8,17 @@
     <link href="http://www.zotero.org/styles/apa-6th-edition" rel="template"/>
     <link href="https://apastyle.apa.org/style-grammar-guidelines/references/examples" rel="documentation"/>
     <author>
+      <name>Stef Kors</name>
+      <email>stef.kors@gmail.com</email>
+    </author>
+    <author>
       <name>Brenton M. Wiernik</name>
       <email>zotero@wiernik.org</email>
     </author>
     <category citation-format="author-date"/>
     <category field="psychology"/>
     <category field="generic-base"/>
-    <updated>2024-07-09T20:08:41+00:00</updated>
+    <updated>2025-06-09T08:45:37+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale xml:lang="en">
@@ -576,7 +580,10 @@
     <!-- For book-like items, assume part-number and part-title refer to the book/volume. -->
     <choose>
       <if variable="container-title" match="any">
-        <text variable="title"/>
+        <group delimiter=" ">
+          <text variable="title"/>
+          <text variable="original-title" prefix="[" suffix="]"/>
+        </group>
       </if>
       <else>
         <!-- For book-like items without container titles and with volume-title, append volume-title to title (ex. 30) -->
@@ -593,7 +600,10 @@
           <if variable="reviewed-title" match="none"/>
           <else>
             <group delimiter=": ">
-              <text variable="title"/>
+              <group delimiter=" ">
+                <text variable="title"/>
+                <text variable="original-title" prefix="[" suffix="]"/>
+              </group>
               <text macro="part-title"/>
             </group>
           </else>
@@ -601,7 +611,10 @@
       </if>
       <else>
         <group delimiter=": ">
-          <text variable="title"/>
+          <group delimiter=" ">
+            <text variable="title"/>
+            <text variable="original-title" prefix="[" suffix="]"/>
+          </group>
           <text macro="part-title"/>
         </group>
       </else>
@@ -618,7 +631,10 @@
   </macro>
   <macro name="title-plus-volume-title">
     <group delimiter=": ">
-      <text variable="title"/>
+      <group delimiter=" ">
+        <text variable="title"/>
+        <text variable="original-title" prefix="[" suffix="]"/>
+      </group>
       <text macro="volume-title"/>
     </group>
   </macro>
@@ -1389,11 +1405,17 @@
         <!-- Not possible to distinguish TV series episode from other reviewed
              works without reviewed-container-title [Ex. 69] -->
         <!-- Adapt for reviewed-container-title if that becomes available -->
-        <text variable="reviewed-title" font-style="italic"/>
+        <group delimiter=" ">
+          <text variable="reviewed-title" font-style="italic"/>
+          <text variable="original-title" prefix="[" suffix="]"/>
+        </group>
       </if>
       <else>
         <!-- Assume title is title of reviewed work -->
-        <text variable="title" font-style="italic"/>
+        <group delimiter=" ">
+          <text variable="title" font-style="italic"/>
+          <text variable="original-title" prefix="[" suffix="]"/>
+        </group>
       </else>
     </choose>
   </macro>


### PR DESCRIPTION
This change adds support for Original Title in the extra field.

By default the Original Title would be displayed in the in-text citations. However APA 7th does not require the translated title to appear in the in-text citation.

## In-Text
| Before | After |
|--------|--------|
| (‘Haagsche Verkeersweek [The Hague Traffic Week]’, 1941) | (‘Haagsche Verkeersweek’, 1941) |

## References
| Before | After |
|--------|--------|
| Haagsche Verkeersweek [The Hague Traffic Week]. (1941, March 9). Algemeen Handelsblad. https://resolver.kb.nl/resolve? urn=KBNRC01:000059083:mpeg21:p004 (https://resolver.kb.nl/resolve?%20urn=KBNRC01:000059083:mpeg21:p004) | Haagsche Verkeersweek [The Hague Traffic Week]. (1941, March 9). Algemeen Handelsblad. https://resolver.kb.nl/resolve? urn=KBNRC01:000059083:mpeg21:p004 (https://resolver.kb.nl/resolve?%20urn=KBNRC01:000059083:mpeg21:p004) | 