### PR TITLE
Fix comma with inverted names in zeitschrift-fur-religionswissenschaft-*

### DIFF
--- a/zeitschrift-fur-religionswissenschaft-author-date.csl
+++ b/zeitschrift-fur-religionswissenschaft-author-date.csl
@@ -38,7 +38,7 @@
   </macro>
   <macro name="author">
     <names variable="author">
-      <name and="text" name-as-sort-order="first" sort-separator=", " delimiter=", " delimiter-precedes-last="contextual" initialize="false" initialize-with=". "/>
+      <name and="text" name-as-sort-order="first" sort-separator=", " delimiter=", " delimiter-precedes-last="after-inverted-name" initialize="false" initialize-with=". "/>
       <label form="short" prefix=", "/>
       <substitute>
         <names variable="editor"/>

--- a/zeitschrift-fur-religionswissenschaft-note.csl
+++ b/zeitschrift-fur-religionswissenschaft-note.csl
@@ -141,13 +141,13 @@
   </macro>
   <macro name="editor">
     <names variable="editor">
-      <name name-as-sort-order="first" and="text" sort-separator=", " delimiter=", " delimiter-precedes-last="never"/>
+      <name name-as-sort-order="first" and="text" sort-separator=", " delimiter=", " delimiter-precedes-last="after-inverted-name"/>
       <label form="short" prefix=", "/>
     </names>
   </macro>
   <macro name="translator">
     <names variable="translator">
-      <name name-as-sort-order="first" and="text" sort-separator=", " delimiter=", " delimiter-precedes-last="never"/>
+      <name name-as-sort-order="first" and="text" sort-separator=", " delimiter=", " delimiter-precedes-last="after-inverted-name"/>
       <label form="verb-short" prefix=", "/>
     </names>
   </macro>
@@ -171,7 +171,7 @@
   <macro name="contributors">
     <group delimiter=". ">
       <names variable="author">
-        <name name-as-sort-order="first" and="text" sort-separator=", " delimiter=", " delimiter-precedes-last="never"/>
+        <name name-as-sort-order="first" and="text" sort-separator=", " delimiter=", " delimiter-precedes-last="after-inverted-name"/>
         <substitute>
           <text macro="editor"/>
           <text macro="translator"/>


### PR DESCRIPTION
currently,
  zeitschrift-fur-religionswissenschaft-author-date.csl
and
  zeitschrift-fur-religionswissenschaft-note.csl
do not close the comma in case of two authors:

Taddicken, Monika und Jan-Hinrik Schmidt. 2017. „Entwicklung und Verbreitung sozialer Medien“. In Handbuch Soziale Medien, hg. v. Jan-Hinrik Schmidt und Monika Taddicken, 3–22. Wiesbaden: Springer Fachmedien. Abgerufen 28. April 2025 (https://doi.org/10.1007/978-3-658-03765-9_1).

This should certainly be:

Taddicken, Monika, und Jan-Hinrik Schmidt. 2017. „Entwicklung und Verbreitung sozialer Medien“. In Handbuch Soziale Medien, hg. v. Jan-Hinrik Schmidt und Monika Taddicken, 3–22. Wiesbaden: Springer Fachmedien. Abgerufen 28. April 2025 (https://doi.org/10.1007/978-3-658-03765-9_1).

(‘close’ the comma pair).