### PR TITLE
Space with locators in MLA (sect.1 => sect. 1)

### DIFF
--- a/modern-language-association.csl
+++ b/modern-language-association.csl
@@ -299,7 +299,7 @@
         <else>
           <group delimiter=", ">
             <text macro="author-short"/>
-            <group>
+            <group delimiter=" ">
               <label variable="locator" form="short"/>
               <text variable="locator"/>
             </group>


### PR DESCRIPTION
Currently, locators in MLA are joined without intervening space, in my case "Absch.1" for "Absch. 1" ("sect.1" instead of "sect. 1"). This commit fixes this.