### PR TITLE
Create istanbul-bilgi-universitesi-lisansustu-programlar-enstitusu-hukuk.csl

### DIFF
--- a/istanbul-bilgi-universitesi-lisansustu-programlar-enstitusu-hukuk.csl
+++ b/istanbul-bilgi-universitesi-lisansustu-programlar-enstitusu-hukuk.csl
@@ -12,20 +12,14 @@
     <category citation-format="note"/>
     <category field="law"/>
     <summary>İstanbul Bilgi Üniversitesi Lisansüstü Programlar Enstitüsü'nün hukuk için hazırladığı yönergeye uygun hazırlanmıştır.</summary>
-    <updated>2025-09-16T09:27:59+00:00</updated>
+    <updated>2025-09-18T15:30:38+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale xml:lang="tr">
     <terms>
-      <term name="et-al">vd.</term>
       <term name="editor" form="short">edt.</term>
-      <term name="page" form="short">s.</term>
       <term name="accessed">e.t.</term>
-      <term name="volume" form="long">Cilt</term>
-      <term name="volume" form="short">C</term>
-      <term name="issue" form="long">Sayı</term>
       <term name="issue" form="short">S</term>
-      <term name="translator" form="short">Çev.</term>
       <term name="edition" form="long">bası</term>
     </terms>
   </locale>
@@ -80,7 +74,7 @@
   </macro>
   <macro name="translator">
     <names variable="translator" prefix="(" suffix=")">
-      <label form="short" suffix=": "/>
+      <label form="short" text-case="capitalize-first" suffix=": "/>
       <name font-weight="bold" delimiter=" / " initialize="false"/>
     </names>
   </macro>
@@ -139,7 +133,7 @@
     <choose>
       <if variable="volume">
         <group delimiter=": ">
-          <text value="C"/>
+          <label text-case="capitalize-first" strip-periods="true" variable="volume" form="short"/>
           <text variable="volume"/>
         </group>
       </if>
@@ -172,7 +166,7 @@
   </macro>
   <macro name="cite-locator">
     <group delimiter=" ">
-      <label variable="locator" form="short"/>
+      <label plural="never" variable="locator" form="short"/>
       <text variable="locator"/>
     </group>
   </macro>
@@ -205,6 +199,7 @@
       </else-if>
       <else-if type="article-journal">
         <group delimiter=", ">
+          <text macro="translator"/>
           <text macro="container-title"/>
           <text macro="volume-issue"/>
           <text macro="year"/>


### PR DESCRIPTION
This style implements the official citation format required by İstanbul Bilgi Üniversitesi's Lisanüstü Programlar Enstitüsü (Graduate Programs Institute) for law students and researchers.

Key Features:
- Turkish localization: All terms (editor, page, volume, etc.) are properly translated
- Intelligent disambiguation: Short titles only appear when multiple works by the same author are cited
- Comprehensive source support: Books, journal articles, theses, book chapters, web pages, and conference papers
- Proper formatting: Bold author names, correct punctuation, and Turkish academic conventions
- Online source handling: Includes URLs and access dates for web sources

Source Types Supported:
- Books (with translator, editor, edition, and volume support)
- Journal articles (with volume/issue formatting)
- Theses (with degree type indication)
- Book chapters and conference papers
- Web pages and blog posts

Special Formatting:
- Author names in bold
- Titles in quotes for articles, plain text for books
- Turkish abbreviations (C: for volume, S: for issue, s. for page)
- Proper handling of translators with "Çev.:" prefix

This style has been developed in accordance with İstanbul Bilgi Üniversitesi's official guidelines for legal academic writing.