### PR TITLE
Remove default locale from Harvard Cite Them Right 

### DIFF
--- a/eu-interinstitutional-style-1st-edition.csl
+++ b/eu-interinstitutional-style-1st-edition.csl
@@ -1,4 +1,5 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+﻿
+<?xml version="1.0" encoding="utf-8"?>
 <style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" and="text" delimiter-precedes-et-al="never" delimiter-precedes-last="never" initialize-with=". " page-range-format="expanded" demote-non-dropping-particle="never" default-locale="en-GB">
   <!-- This style was edited with the Visual CSL Editor (https://editor.citationstyles.org/visualEditor/) -->
   <info>

--- a/oscola-journal-abbreviations.csl
+++ b/oscola-journal-abbreviations.csl
@@ -1,4 +1,5 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+﻿
+<?xml version="1.0" encoding="utf-8"?>
 <style xmlns="http://purl.org/net/xbiblio/csl" class="note" version="1.0" demote-non-dropping-particle="never" default-locale="en-GB">
   <info>
     <title>OSCOLA (Oxford University Standard for Citation of Legal Authorities, with journal abbreviations)</title>


### PR DESCRIPTION
Modified from Cite Them Right to use "dkk." instead of "et al."
