### PR TITLE
Update pediatric-research.csl

### DIFF
--- a/pediatric-research.csl
+++ b/pediatric-research.csl
@@ -5,7 +5,7 @@
     <id>http://www.zotero.org/styles/pediatric-research</id>
     <link href="http://www.zotero.org/styles/pediatric-research" rel="self"/>
     <link href="http://www.zotero.org/styles/the-new-england-journal-of-medicine" rel="template"/>
-    <link href="http://www.nature.com/pr/pr_instructions_to_authors.pdf" rel="documentation"/>
+    <link href="https://www.nature.com/pr/authors-and-referees/preparation-of-articles" rel="documentation"/>
     <author>
       <name>Dallas Card</name>
       <email>dallas.card@gmail.com</email>
@@ -14,8 +14,8 @@
     <category field="medicine"/>
     <issn>0031-3998</issn>
     <eissn>1530-0447</eissn>
-    <summary>Pediatric Research style - based on NEJM with no issue numbers and double-spaced bibliography</summary>
-    <updated>2012-11-30T00:00:00+00:00</updated>
+    <summary>Pediatric Research style, updated July 2025</summary>
+    <updated>2025-07-02T00:00:00+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <macro name="author">
@@ -111,11 +111,11 @@
     <sort>
       <key variable="citation-number"/>
     </sort>
-    <layout prefix="(" suffix=")" delimiter=",">
+    <layout delimiter=",", vertical-align="sup">
       <text variable="citation-number"/>
     </layout>
   </citation>
-  <bibliography et-al-min="7" et-al-use-first="3" second-field-align="flush" line-spacing="2">
+  <bibliography et-al-min="5" et-al-use-first="1" second-field-align="flush" line-spacing="2">
     <layout>
       <text variable="citation-number" suffix=". "/>
       <text macro="author"/>

--- a/pediatric-research.csl
+++ b/pediatric-research.csl
@@ -111,7 +111,7 @@
     <sort>
       <key variable="citation-number"/>
     </sort>
-    <layout delimiter=",", vertical-align="sup">
+    <layout delimiter="," vertical-align="sup">
       <text variable="citation-number"/>
     </layout>
   </citation>


### PR DESCRIPTION
- updated instructions for authors link
- changed to superscript in text citations
- change "et al" criteria to more than 5 authors with only a single author listed per journal style