### PR TITLE
Create Revista-Derecho-Universidad-Austral-de-Chile.csl

### DIFF
--- a/Revista-Derecho-Universidad-Austral-de-Chile.csl
+++ b/Revista-Derecho-Universidad-Austral-de-Chile.csl
@@ -1,0 +1,233 @@
+<?xml version="1.0" encoding="utf-8"?>
+<style xmlns="http://purl.org/net/xbiblio/csl" class="note" version="1.0" demote-non-dropping-particle="sort-only" default-locale="es-ES">
+  <!-- This style was edited with the Visual CSL Editor (https://editor.citationstyles.org/visualEditor/) -->
+  <info>
+    <title>Revista Derecho Universidad Austral de Chile</title>
+    <title-short>Revista Derecho UACh</title-short> 
+    <id> http://www.zotero.org/styles/universidad-austral-de-chile-revista-de-derecho</id>
+    <link href="http://www.zotero.org/styles/universidad-austral-de-chile-revista-de-derecho" rel="self"/>
+    <link href="http://www.zotero.org/styles/spanish-legal" rel="template"/>
+    <link href="https://derecho.uach.cl/revista/instrucciones-a-los-autores" rel="documentation"/>
+    <author>
+      <name>Claudio Agüero San Juan</name>
+      <email>aguero.claudio@gmail.com</email>
+    </author>
+    <category citation-format="note"/>
+    <category field="law"/>
+    <updated>2025-07-03T00:00:00+00:00</updated>
+    <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
+  </info>
+  <locale>
+    <terms>
+      <term name="editor" form="short">
+        <single>ed.</single>
+        <multiple>eds.</multiple>
+      </term>
+      <term name="editor">
+        <single>ed.</single>
+        <multiple>eds.</multiple>
+      </term>
+      <term name="et-al">y otros</term>
+      <term name="and">y</term>
+      <term name="page" form="short">
+        <single>p.</single>
+        <multiple>pp.</multiple>
+      </term>
+      <term name="page">
+        <single>pág.</single>
+        <multiple>págs.</multiple>
+      </term>
+      <term name="chapter" form="short">
+        <single>cap.</single>
+        <multiple>caps.</multiple>
+      </term>
+      <term name="chapter">
+        <single>cap.</single>
+        <multiple>caps.</multiple>
+      </term>
+      <term name="accessed">fecha de consulta</term>
+      <term name="in">en</term>
+      <term name="forthcoming">en prensa</term>
+      <term name="no date">sin fecha</term>
+      <term name="no date" form="short">s/f</term>
+      <term name="month-01">Enero</term>
+      <term name="month-02">Febrero</term>
+      <term name="month-03">Marzo</term>
+      <term name="month-04">Abril</term>
+      <term name="month-05">Mayo</term>
+      <term name="month-06">Junio</term>
+      <term name="month-07">Julio</term>
+      <term name="month-08">Agosto</term>
+      <term name="month-09">Septiembre</term>
+      <term name="month-10">Octubre</term>
+      <term name="month-11">Noviembre</term>
+      <term name="month-12">Diciembre</term>
+      <term name="at">en</term>
+    </terms>
+  </locale>
+  <macro name="editor-translator">
+    <names variable="editor translator" delimiter=", ">
+      <label form="verb"/>
+      <name and="text" delimiter=", " prefix=" " delimiter-precedes-last="never"/>
+    </names>
+  </macro>
+  <macro name="author">
+    <names variable="author">
+      <name form="long" initialize-with=". " delimiter="; " delimiter-precedes-last="always" sort-separator=", "/>
+      <label form="short" prefix=" (" suffix=")"/>
+      <substitute>
+        <names variable="editor"/>
+        <names variable="translator"/>
+        <text macro="title"/>
+      </substitute>
+    </names>
+  </macro>
+  <macro name="author-bibliography">
+    <names variable="author">
+      <name name-as-sort-order="all" form="long" initialize-with=". " delimiter="; " delimiter-precedes-last="always" sort-separator=", " font-variant="small-caps"/>
+      <label form="short" prefix=" (" suffix=")"/>
+      <substitute>
+        <names variable="editor"/>
+        <names variable="translator"/>
+        <text macro="title"/>
+      </substitute>
+    </names>
+  </macro>
+  <macro name="access">
+    <group>
+      <text term="accessed" suffix=" "/>
+      <date variable="accessed" suffix=", ">
+        <date-part name="day" suffix=" "/>
+        <date-part name="month" suffix=" " text-case="lowercase"/>
+        <date-part name="year"/>
+      </date>
+      <group>
+        <text term="at" suffix=" "/>
+        <text variable="URL"/>
+      </group>
+    </group>
+  </macro>
+  <macro name="title">
+    <choose>
+      <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
+        <text variable="title" text-case="capitalize-first" font-style="italic"/>
+      </if>
+      <else>
+        <text variable="title" text-case="capitalize-first" quotes="true"/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="title-short">
+    <choose>
+      <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
+        <text variable="title" text-case="capitalize-first" font-style="italic" suffix=", cit." form="short"/>
+      </if>
+      <else>
+        <text variable="title" text-case="capitalize-first" quotes="true" suffix=", cit." form="short"/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="publisher">
+    <group delimiter=", ">
+      <text variable="publisher"/>
+      <text variable="publisher-place"/>
+    </group>
+  </macro>
+<citation
+  et-al-min="3"
+  et-al-use-first="1"
+  disambiguate-add-year-suffix="true"
+  collapse="year">
+  <layout delimiter="; " suffix=".">
+    <group delimiter=", ">
+      <names variable="author" delimiter=" y ">
+        <name and="text" form="short" font-variant="small-caps"/>
+      </names>
+      <date variable="issued">
+        <date-part name="year"/>
+      </date>
+      <group>
+        <label variable="locator" form="short" prefix=", "/>
+        <text variable="locator" prefix=" "/>
+      </group>
+    </group>
+  </layout>
+</citation>
+<bibliography et-al-min="4" et-al-use-first="1" hanging-indent="true">
+  <sort>
+    <key macro="author-bibliography"/>
+    <key variable="issued"/>
+  </sort>
+  <layout suffix=".">
+      <group delimiter=", ">
+      <names variable="author">
+        <name name-as-sort-order="all" form="long" delimiter=", " font-variant="small-caps"/> 
+   </names>
+      <date variable="issued">
+        <date-part name="year" suffix=":"/>
+      </date>
+    </group>
+    <choose>
+      <if type="book">
+        <group delimiter=", ">
+          <text variable="title" font-style="italic"/>
+          <text variable="edition" suffix=" ed."/>
+          <text variable="publisher-place"/>
+          <text variable="publisher"/>
+        </group>
+      </if>
+      <else-if type="chapter">
+        <group delimiter=", ">
+          <text variable="title" quotes="true"/>
+          <group delimiter=", ">
+            <text term="in" text-case="lowercase"/>
+            <names variable="editor">
+              <name form="long" delimiter=", "/>
+              <label form="short" prefix=" (" suffix=".)"/>
+            </names>
+            <text variable="container-title" font-style="italic"/>
+          </group>
+          <text variable="publisher-place"/>
+          <text variable="publisher"/>
+          <group delimiter=" ">
+            <label variable="page" form="short"/>
+            <text variable="page"/>
+          </group>
+        </group>
+      </else-if>
+      <else-if type="article-journal article-magazine article-newspaper">
+        <group delimiter=", ">
+          <text variable="title" quotes="true"/>
+          <text variable="container-title" font-style="italic"/>
+          <group delimiter=", ">
+            <group delimiter=" ">
+              <text term="volume"/>
+              <text variable="volume"/>
+            </group>
+            <group delimiter=" ">
+              <text term="issue"/>
+              <text variable="issue"/>
+            </group>
+            <group delimiter=" ">
+              <label variable="page" form="short"/>
+              <text variable="page"/>
+            </group>
+          </group>
+          <text variable="DOI" prefix="doi:"/>
+        </group>
+      </else-if>
+      <else-if type="webpage thesis report">
+        <group delimiter=", ">
+          <text variable="title" quotes="true"/>
+          <text variable="genre"/>
+          <text variable="publisher"/>
+          <text variable="URL"/>
+        </group>
+      </else-if>
+      <else>
+        <text variable="title" font-style="italic"/>
+      </else>
+    </choose>
+  </layout>
+</bibliography>
+</style>


### PR DESCRIPTION
>
This citation style is designed for use with the *Revista de Derecho* of the Universidad Austral de Chile. It formats footnotes with small caps for author surnames, the year of publication (with disambiguation suffixes), and page numbers. The bibliography is alphabetized and includes full first names, publication year followed by a colon, italicized titles for monographs, and quotation marks for articles and book chapters. It also handles editions, translations, volumes, institutional authors, and DOIs according to the journal’s editorial guidelines. Note: This style does not include formatting for legal norms or case law, as Zotero does not currently support multiple bibliography sections (e.g., separate sections for "Bibliografía", "Normas jurídicas", and "Jurisprudencia"). See style guidelines and examples: https://revistaderechovaldivia.cl/