### PR TITLE
Add homeopathy-thieme.csl

### DIFF
--- a/Homeopathy  Thieme.csl
+++ b/Homeopathy  Thieme.csl
@@ -1,0 +1,128 @@
+<?xml version="1.0" encoding="utf-8"?>
+<style xmlns="http://purl.org/net/xbiblio/csl" version="1.0" class="in-text" default-locale="en-US">
+  <info>
+    <title>Homeopathy Thieme</title>
+    <id>http://www.zotero.org/styles/homeopathy-thieme</id>
+    <link href="http://www.zotero.org/styles/homeopathy-thieme" rel="self"/>
+    <author>
+      <name>Dr. Kurian Poruthukaren</name>
+    </author>
+    <category citation-format="numeric"/>
+    <updated>2025-07-07T12:00:00+05:30</updated>
+  </info>
+
+  <macro name="author">
+    <names variable="author">
+      <name form="long"
+            name-as-sort-order="all"
+            initialize-with="."
+            delimiter=", "
+            and="text"
+            et-al-min="7"
+            et-al-use-first="3"
+            sort-separator=" "/>
+      <et-al/>
+    </names>
+  </macro>
+
+  <macro name="title">
+    <group>
+      <text variable="title"/>
+      <choose>
+        <if type="thesis">
+          <text value=" [PhD dissertation]"/>
+        </if>
+      </choose>
+    </group>
+  </macro>
+
+  <macro name="access">
+    <choose>
+      <if type="article-journal">
+        <text value=" [serial online]"/>
+      </if>
+    </choose>
+    <text variable="URL" prefix=" Available at: "/>
+    <date variable="accessed" prefix=" Accessed " form="text"/>
+  </macro>
+
+  <macro name="issued">
+    <date variable="issued">
+      <date-part name="year"/>
+    </date>
+  </macro>
+
+  <macro name="volume-pages">
+    <group delimiter=":">
+      <text variable="volume"/>
+      <text variable="page"/>
+    </group>
+  </macro>
+
+  <macro name="publisher">
+    <group delimiter=": ">
+      <text variable="publisher-place"/>
+      <text variable="publisher"/>
+    </group>
+    <date variable="issued" prefix="; " form="text"/>
+    <text variable="number" prefix=". "/>
+  </macro>
+
+  <macro name="container-title">
+    <text variable="container-title" font-style="normal" text-case="title"/>
+  </macro>
+
+  <macro name="editor">
+    <names variable="editor">
+      <label form="short" suffix=" "/>
+      <name form="long" initialize-with="." delimiter=", " and="text"/>
+    </names>
+  </macro>
+
+  <citation>
+    <layout vertical-align="sup" delimiter=",">
+      <text variable="citation-number"/>
+    </layout>
+  </citation>
+
+  <bibliography hanging-indent="false">
+    <layout>
+      <text variable="citation-number" suffix=". "/>
+      <text macro="author" suffix=". "/>
+      <text macro="title" suffix=". "/>
+      <choose>
+        <if type="article-journal">
+          <text macro="container-title" suffix=". "/>
+          <text macro="issued" suffix=";"/>
+          <text macro="volume-pages"/>
+        </if>
+        <else-if type="chapter">
+          <text value="In: " />
+          <text macro="editor" suffix=". "/>
+          <text variable="container-title" suffix=". "/>
+          <text macro="publisher"/>
+        </else-if>
+        <else-if type="book">
+          <text macro="publisher"/>
+        </else-if>
+        <else-if type="thesis">
+          <text macro="publisher"/>
+        </else-if>
+        <else-if type="report">
+          <text macro="publisher"/>
+        </else-if>
+        <else>
+          <text macro="container-title" suffix=". "/>
+          <text macro="publisher"/>
+        </else>
+      </choose>
+      <text macro="access"/>
+      <choose>
+        <if variable="issued" match="none">
+          <text variable="DOI" prefix=" https://doi.org/"/>
+        </if>
+      </choose>
+    </layout>
+  </bibliography>
+</style>
+


### PR DESCRIPTION
This style is based on AMA and modified to meet the formatting guidelines of the journal Homeopathy (Thieme):

        Superscript in-text citations

        No italics for journal or book titles

        Author formatting: surname first, initials after

        Year-only for publication dates (no month or issue)

        Conditional DOI for in-press

        [serial online] + access info for online-only

    Prepared by Dr. Kurian Poruthukaren John for publication in Homeopathy.
    Validated using https://validator.citationstyles.org/