### PR TITLE
Turabian 8th: Redirect to CMOS16

### DIFF
--- a/renamed-styles.json
+++ b/renamed-styles.json
@@ -86,7 +86,7 @@
     "chicago-note-bibliography-with-ibid": "chicago-shortened-notes-bibliography-subsequent-ibid",
     "turabian-fullnote-bibliography": "turabian-notes-bibliography",
     "turabian-fullnote-bibliography-no-ibid": "turabian-notes-bibliography",
-    "turabian-fullnote-bibliography-8th-edition": "turabian-notes-bibliography",
+    "turabian-fullnote-bibliography-8th-edition": "chicago-notes-bibliography-16th-edition",
     "chinese-journal-of-geochemistry": "acta-geochimica",
     "chronic-diseases-in-canada": "chronic-diseases-and-injuries-in-canada",
     "college-of-physicians-and-surgeons-pakistan": "journal-of-the-college-of-physicians-and-surgeons-pakistan",


### PR DESCRIPTION
Chicago 16th edition is a more accurate redirect for the 8th edition than current Turabian.