### PR TITLE
Update nephrology-dialysis-transplantation.csl

### DIFF
--- a/nephrology-dialysis-transplantation.csl
+++ b/nephrology-dialysis-transplantation.csl
@@ -125,7 +125,7 @@
     <sort>
       <key variable="citation-number"/>
     </sort>
-    <layout delimiter="," prefix="(" suffix=")">
+    <layout delimiter=", " prefix="[" suffix="]">
       <text variable="citation-number"/>
     </layout>
   </citation>

--- a/nephrology-dialysis-transplantation.csl
+++ b/nephrology-dialysis-transplantation.csl
@@ -15,7 +15,7 @@
     <category field="medicine"/>
     <issn>0931-0509</issn>
     <eissn>1460-2385</eissn>
-    <updated>2013-11-21T01:12:52+00:00</updated>
+    <updated>2025-08-01T20:15:00+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <macro name="author">


### PR DESCRIPTION
NDT (Nephrology, Dialysis, Transplantation) currently uses square brackets for citations, and the delimiter is a comma followed by a space. This also applies for dependent styles, e.g. Clinical Kidney Journal.

For reference, here is a current article in NDT:

https://academic.oup.com/ndt/article/40/7/1284/7929884