### PR TITLE
European Journal of International Law: Remove "last visited" for URLs

### DIFF
--- a/european-journal-of-international-law.csl
+++ b/european-journal-of-international-law.csl
@@ -15,7 +15,7 @@
     <category field="law"/>
     <issn>0938-5428</issn>
     <summary>Prepared according the style sheet for authors preparing texts for the Collected Courses of the Academy of European Law and/or European Journal of International Law</summary>
-    <updated>2025-08-09T12:01:55+00:00</updated>
+    <updated>2025-08-09T12:07:31+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <macro name="editor">
@@ -116,6 +116,14 @@
       </if>
     </choose>
   </macro>
+  <macro name="web">
+    <group delimiter=", ">
+      <text variable="title" text-case="title" font-style="italic" vertical-align="baseline"/>
+      <text variable="container-title" text-case="title"/>
+      <date form="text" variable="issued" vertical-align="baseline"/>
+      <text macro="URL"/>
+    </group>
+  </macro>
   <citation collapse="year">
     <sort>
       <key macro="author"/>
@@ -186,7 +194,7 @@
                 <text macro="locator"/>
               </group>
             </else-if>
-            <else-if type="webpage post-weblog" match="any">
+            <else-if type="webpage post-weblog post" match="any">
               <group vertical-align="baseline" delimiter=", ">
                 <text macro="author-long"/>
                 <text macro="web"/>
@@ -322,10 +330,7 @@
         <else-if type="webpage post-weblog post" match="any">
           <group delimiter=", ">
             <text macro="author-bibliography"/>
-            <text variable="title" text-case="title" font-style="italic" vertical-align="baseline"/>
-            <text variable="container-title" text-case="title"/>
-            <date form="text" variable="issued" vertical-align="baseline"/>
-            <text macro="URL"/>
+            <text macro="web"/>
           </group>
         </else-if>
         <else-if type="thesis" match="any">

--- a/european-journal-of-international-law.csl
+++ b/european-journal-of-international-law.csl
@@ -2,10 +2,11 @@
 <style xmlns="http://purl.org/net/xbiblio/csl" class="note" version="1.0" et-al-min="4" et-al-use-first="1" initialize-with="." demote-non-dropping-particle="sort-only" default-locale="en-GB">
   <info>
     <title>European Journal of International Law</title>
+    <title-short>EJIL</title-short>
     <id>http://www.zotero.org/styles/european-journal-of-international-law</id>
     <link href="http://www.zotero.org/styles/european-journal-of-international-law" rel="self"/>
     <link href="http://www.zotero.org/styles/vienna-legal" rel="template"/>
-    <link href="http://www.ejil.org/about/Stylesheet_EJIL_2016.pdf" rel="documentation"/>
+    <link href="https://ejil.org/about/Stylesheet_EJIL_2018.pdf" rel="documentation"/>
     <author>
       <name>Catherine Brendow</name>
       <email>catherine.brendow@graduateinstitute.ch</email>

--- a/european-journal-of-international-law.csl
+++ b/european-journal-of-international-law.csl
@@ -14,14 +14,9 @@
     <category field="law"/>
     <issn>0938-5428</issn>
     <summary>Prepared according the style sheet for authors preparing texts for the Collected Courses of the Academy of European Law and/or European Journal of International Law</summary>
-    <updated>2016-02-01T13:32:12+00:00</updated>
+    <updated>2025-08-08T13:32:12+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
-  <locale xml:lang="en">
-    <terms>
-      <term name="accessed">last visited</term>
-    </terms>
-  </locale>
   <macro name="editor">
     <names variable="editor" delimiter=", ">
       <name prefix=" " and="text" delimiter-precedes-last="never" initialize-with=". "/>
@@ -109,12 +104,6 @@
       <if match="any" variable="URL">
         <text term="available at" prefix=", " suffix=" "/>
         <text variable="URL"/>
-        <choose>
-          <if match="all" variable="accessed">
-            <text term="accessed" prefix=" ("/>
-            <date form="text" variable="accessed" prefix=" " suffix=")"/>
-          </if>
-        </choose>
       </if>
     </choose>
   </macro>

--- a/european-journal-of-international-law.csl
+++ b/european-journal-of-international-law.csl
@@ -15,13 +15,13 @@
     <category field="law"/>
     <issn>0938-5428</issn>
     <summary>Prepared according the style sheet for authors preparing texts for the Collected Courses of the Academy of European Law and/or European Journal of International Law</summary>
-    <updated>2025-08-08T13:32:12+00:00</updated>
+    <updated>2025-08-09T12:01:55+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <macro name="editor">
     <names variable="editor" delimiter=", ">
       <name prefix=" " and="text" delimiter-precedes-last="never" initialize-with=". "/>
-      <label form="short" prefix=" (" suffix="), "/>
+      <label form="short" prefix=" (" suffix=")"/>
     </names>
   </macro>
   <macro name="author">
@@ -103,18 +103,10 @@
   <macro name="URL">
     <choose>
       <if match="any" variable="URL">
-        <text term="available at" prefix=", " suffix=" "/>
+        <text term="available at" suffix=" "/>
         <text variable="URL"/>
       </if>
     </choose>
-  </macro>
-  <macro name="web">
-    <group>
-      <text variable="title" text-case="title" font-style="italic" vertical-align="baseline"/>
-      <date form="text" variable="issued" vertical-align="baseline" prefix=", "/>
-      <text variable="container-title" text-case="title" prefix=", "/>
-      <text macro="URL"/>
-    </group>
   </macro>
   <macro name="locator">
     <choose>
@@ -213,7 +205,7 @@
                 <text variable="title" text-case="title"/>
                 <number variable="number"/>
                 <group delimiter=", ">
-                  <text variable="container-title" text-case="title" font-style="normal" prefix=" "/>
+                  <text variable="container-title" text-case="title" prefix=" "/>
                   <group delimiter=" ">
                     <text term="volume" form="short"/>
                     <text variable="volume"/>
@@ -245,7 +237,7 @@
           <text macro="author"/>
           <text value="supra" font-style="italic" prefix=", " suffix=" "/>
           <text value="note" suffix=" "/>
-          <text variable="first-reference-note-number" font-style="normal"/>
+          <text variable="first-reference-note-number"/>
           <choose>
             <if match="any" variable="locator">
               <text term="at" prefix=", " suffix=" "/>
@@ -286,22 +278,22 @@
           </group>
         </if>
         <else-if type="chapter paper-conference" match="any">
-          <group delimiter=" ">
+          <group delimiter=", ">
             <names variable="author">
-              <name form="short" suffix=", "/>
+              <name form="short"/>
             </names>
-            <text variable="title" text-case="title" prefix="'" suffix="',"/>
+            <text variable="title" text-case="title" quotes="true"/>
             <group delimiter=" ">
               <text term="in"/>
               <text macro="editor"/>
-              <text variable="container-title" text-case="title" font-style="italic"/>
             </group>
             <group delimiter=" ">
               <text term="volume" form="short"/>
               <text variable="volume"/>
             </group>
             <text variable="edition"/>
-            <group>
+            <group delimiter=" ">
+              <text variable="container-title" text-case="title" font-style="italic"/>
               <date variable="issued">
                 <date-part name="year" prefix="(" suffix=")"/>
               </date>
@@ -310,43 +302,50 @@
           </group>
         </else-if>
         <else-if type="article-journal article-magazine article-newspaper interview manuscript map personal_communication speech" match="any">
-          <group delimiter=" ">
-            <names variable="author" suffix=", ">
+          <group delimiter=", ">
+            <names variable="author">
               <name form="short" and="text"/>
             </names>
-            <text variable="title" text-case="title" prefix="'" suffix="', "/>
-            <text variable="volume"/>
-            <text variable="container-title" text-case="title" font-style="italic"/>
+            <text variable="title" text-case="title" quotes="true"/>
             <group delimiter=" ">
+              <text variable="volume"/>
+              <text variable="container-title" text-case="title" font-style="italic"/>
               <date variable="issued" prefix="(" suffix=")">
                 <date-part name="year"/>
               </date>
+              <text variable="page-first"/>
             </group>
-            <text variable="page-first"/>
             <text variable="edition"/>
             <text macro="URL"/>
           </group>
         </else-if>
-        <else-if type="webpage post-weblog" match="any">
+        <else-if type="webpage post-weblog post" match="any">
           <group delimiter=", ">
             <text macro="author-bibliography"/>
-            <text macro="web"/>
+            <text variable="title" text-case="title" font-style="italic" vertical-align="baseline"/>
+            <text variable="container-title" text-case="title"/>
+            <date form="text" variable="issued" vertical-align="baseline"/>
+            <text macro="URL"/>
           </group>
         </else-if>
         <else-if type="thesis" match="any">
-          <text macro="author-bibliography" suffix=", "/>
-          <text variable="title" text-case="title" prefix="'" suffix="' "/>
-          <date date-parts="year" form="text" variable="issued" prefix="(" suffix=") "/>
-          <text macro="thesis"/>
-          <text macro="locator"/>
+          <group delimiter=", ">
+            <text macro="author-bibliography"/>
+            <group delimiter=" ">
+              <text variable="title" text-case="title" quotes="true"/>
+              <date date-parts="year" form="text" variable="issued" prefix="(" suffix=") "/>
+              <text macro="thesis"/>
+            </group>
+            <text macro="locator"/>
+          </group>
         </else-if>
         <else>
           <group delimiter=", ">
             <text macro="author-bibliography"/>
-            <text variable="title" text-case="title" font-style="normal"/>
+            <text variable="title" text-case="title"/>
             <number variable="number"/>
             <group delimiter=", ">
-              <text variable="container-title" text-case="title" font-style="normal"/>
+              <text variable="container-title" text-case="title"/>
               <group delimiter=" ">
                 <text term="volume" form="short"/>
                 <text variable="volume"/>


### PR DESCRIPTION
"last visited" is not required for Internet sources according to the official EJIL stylesheet: https://ejil.org/about/Stylesheet_EJIL_2018.pdf#page=7

Also, the current version did not work flawlessly and created a closing square bracket.