### PR TITLE
Update duale-hochschule-baden-wurttemberg-villingen-schwenningen-rote…

### DIFF
--- a/duale-hochschule-baden-wurttemberg-villingen-schwenningen-roter-grubert-mattern.csl
+++ b/duale-hochschule-baden-wurttemberg-villingen-schwenningen-roter-grubert-mattern.csl
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <style xmlns="http://purl.org/net/xbiblio/csl" class="note" version="1.0" demote-non-dropping-particle="never" default-locale="de-DE">
   <info>
-    <title>Duale Hochschule Baden Württemberg Villingen-Schwenningen - Roter Grubert/Mattern (Deutsch)</title>
+    <title>Duale Hochschule Baden-Württemberg Villingen-Schwenningen - Roter Grubert/Mattern (Deutsch)</title>
     <title-short>DHBW-VS-Roter-Grubert/Mattern</title-short>
     <id>http://www.zotero.org/styles/duale-hochschule-baden-wurttemberg-villingen-schwenningen-roter-grubert-mattern</id>
     <link href="http://www.zotero.org/styles/duale-hochschule-baden-wurttemberg-villingen-schwenningen-roter-grubert-mattern" rel="self"/>
@@ -13,8 +13,8 @@
     </author>
     <category citation-format="note"/>
     <category field="humanities"/>
-    <summary>Die Zielgruppe für diesen Zitierstil sind BWL-Studierende an der DHBW-VS. Erstellt 2025-07-17</summary>
-    <updated>2025-04-10T05:28:52+00:00</updated>
+    <summary>Die Zielgruppe für diesen Zitierstil sind BWL-Studierende an der DHBW-VS. Erstellt 2025-07-29</summary>
+    <updated>2025-07-17T09:26:48+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <macro name="container-contributors">
@@ -386,7 +386,7 @@
       </else-if>
     </choose>
   </macro>
-  <citation et-al-min="4" et-al-use-first="1" et-al-subsequent-min="3" et-al-subsequent-use-first="1" disambiguate-add-year-suffix="true" disambiguate-add-names="true" disambiguate-add-givenname="true" collapse="year" givenname-disambiguation-rule="primary-name">
+  <citation et-al-min="4" et-al-use-first="1" disambiguate-add-year-suffix="true" disambiguate-add-names="true" disambiguate-add-givenname="true">
     <sort>
       <key macro="author"/>
       <key macro="issued-sort"/>


### PR DESCRIPTION
…r-grubert-mattern.csl

Changes:
Line 4: Title: Added missing hyphen between "Baden" and "Württemberg" 
Line 389: Less "Citation" - Rules