### PR TITLE
Hotfix for uniwersytet-gdanski-kulturoznawstwo

### DIFF
--- a/uniwersytet-gdanski-kulturoznawstwo-autor-rok.csl
+++ b/uniwersytet-gdanski-kulturoznawstwo-autor-rok.csl
@@ -16,7 +16,7 @@
     <category field="sociology"/>
     <category field="anthropology"/>
     <summary>A Polish in-text citation style with wide use range for cultural studies, digital humanities. Based on Uni. of Gdansk guildelines</summary>
-    <updated>2025-08-10T12:13:28+00:00</updated>
+    <updated>2025-08-10T17:26:29+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale xml:lang="pl">
@@ -132,7 +132,7 @@
     <group delimiter=" ">
       <choose>
         <if match="none" locator="page">
-          <label suffix="." variable="locator" form="short"/>
+          <label variable="locator" form="short"/>
         </if>
       </choose>
       <text variable="locator"/>

--- a/uniwersytet-gdanski-kulturoznawstwo-przypis.csl
+++ b/uniwersytet-gdanski-kulturoznawstwo-przypis.csl
@@ -16,7 +16,7 @@
     <category field="sociology"/>
     <category field="anthropology"/>
     <summary>A Polish note citation style with wide use range for cultural studies, digital humanities. Based on Uni. of Gdansk guildelines</summary>
-    <updated>2025-08-03T19:37:23+00:00</updated>
+    <updated>2025-08-10T17:26:07+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale xml:lang="pl">
@@ -170,7 +170,7 @@
   </macro>
   <macro name="locator">
     <group delimiter=" ">
-      <label variable="locator" form="short" suffix="."/>
+      <label variable="locator" form="short"/>
       <text variable="locator"/>
     </group>
   </macro>


### PR DESCRIPTION
Removed '.' suffix from locator (label) variable in locator macro.

It breaks some locators like nr, which - according to Polish grammar - shouldn't have '.' at the end at all, or timestamps, which are empty in Polish locale and will be unwanted '.'...

It's also redundant as '.' are defined in short terms in locale files.

It was a last minute change in #7549 before merge 5 hours ago and I missed it. (sorry @POBrien333).

See: https://sjp.pwn.pl/poradnia/haslo/skrot-nr;13368.html