### PR TITLE
Add “PLUS (SR V4)” style based on Jahrbuch für evangelikale Theologie (Deutsch)

### DIFF
--- a/plus-sr.csl
+++ b/plus-sr.csl
@@ -22,23 +22,23 @@
       <term name="editortranslator" form="verb-short">Hrsg. &amp; übers. von</term>
     </terms>
   </locale>
-<macro name="author">
-  <choose>
-    <if variable="author">
-      <names variable="author" suffix=", ">
-        <name delimiter="/" delimiter-precedes-last="always" name-as-sort-order="all"/>
-      </names>
-    </if>
-    <else-if variable="editor">
-      <names variable="editor" suffix=" (Hg.), ">
-        <name delimiter="/" delimiter-precedes-last="always" name-as-sort-order="all"/>
-      </names>
-    </else-if>
-    <else>
-      <text variable="title"/>
-    </else>
-  </choose>
-</macro>
+  <macro name="author">
+    <choose>
+      <if variable="author">
+        <names variable="author" suffix=", ">
+          <name delimiter="/" delimiter-precedes-last="always" name-as-sort-order="all"/>
+        </names>
+      </if>
+      <else-if variable="editor">
+        <names variable="editor" suffix=" (Hg.), ">
+          <name delimiter="/" delimiter-precedes-last="always" name-as-sort-order="all"/>
+        </names>
+      </else-if>
+      <else>
+        <text variable="title"/>
+      </else>
+    </choose>
+  </macro>
   <macro name="author-short">
     <names variable="author">
       <name form="short" delimiter="/" delimiter-precedes-last="always" name-as-sort-order="all"/>
@@ -48,20 +48,20 @@
     </names>
   </macro>
   <macro name="container-title">
-  <choose>
-    <if type="chapter entry-dictionary entry-encyclopedia" match="any">
-      <text term="in" text-case="lowercase" suffix=": "/>
-<names variable="editor" suffix=" (Hg.), ">
-  <name name-as-sort-order="all" form="long" delimiter="/" delimiter-precedes-last="always"/>
-</names>
-      <text variable="container-title" font-style="italic" suffix=","/>
-    </if>
-    <else>
-      <text term="in" text-case="lowercase" suffix=": "/>
-      <text variable="container-title" font-style="italic"/>
-    </else>
-  </choose>
-</macro>
+    <choose>
+      <if type="chapter entry-dictionary entry-encyclopedia" match="any">
+        <text term="in" text-case="lowercase" suffix=": "/>
+        <names variable="editor" suffix=" (Hg.), ">
+          <name name-as-sort-order="all" form="long" delimiter="/" delimiter-precedes-last="always"/>
+        </names>
+        <text variable="container-title" font-style="italic" suffix=","/>
+      </if>
+      <else>
+        <text term="in" text-case="lowercase" suffix=": "/>
+        <text variable="container-title" font-style="italic"/>
+      </else>
+    </choose>
+  </macro>
   <macro name="edition">
     <choose>
       <if match="any" is-numeric="edition">
@@ -69,14 +69,14 @@
       </if>
     </choose>
   </macro>
-<macro name="volumes">
-  <choose>
-    <if type="entry-dictionary entry-encyclopedia" match="any">
-      <text value="Bd. " />
-      <number variable="volume" suffix=","/>
-    </if>
-  </choose>
-</macro>
+  <macro name="volumes">
+    <choose>
+      <if type="entry-dictionary entry-encyclopedia" match="any">
+        <text value="Bd. "/>
+        <number variable="volume" suffix=","/>
+      </if>
+    </choose>
+  </macro>
   <macro name="volume-edition">
     <choose>
       <if type="book thesis" match="any"/>
@@ -128,14 +128,14 @@
   <macro name="access">
     <choose>
       <if variable="URL">
-<group>
-  <text variable="URL" prefix="Quelle: "/>
-  <date delimiter="." variable="accessed" prefix=" (Zugriff am: " suffix=")">
-    <date-part name="day"/>
-    <date-part name="month" form="numeric"/>
-    <date-part name="year"/>
-  </date>
-</group>
+        <group>
+          <text variable="URL" prefix="Quelle: "/>
+          <date delimiter="." variable="accessed" prefix=" (Zugriff am: " suffix=")">
+            <date-part name="day"/>
+            <date-part name="month" form="numeric"/>
+            <date-part name="year"/>
+          </date>
+        </group>
       </if>
     </choose>
   </macro>
@@ -191,20 +191,20 @@
               </choose>
             </group>
             <group delimiter=", ">
-<choose>
-  <if type="webpage">
-    <!-- Keine Ausgabe -->
-  </if>
-  <else>
-    <group delimiter=" ">
-      <text macro="container-title"/>
-      <text macro="volume-edition" suffix=","/>
-      <text macro="volumes"/>
-      <text macro="publisher"/>
-      <text macro="issued"/>
-    </group>
-  </else>
-</choose>
+              <choose>
+                <if type="webpage">
+                  <!-- Keine Ausgabe -->
+                </if>
+                <else>
+                  <group delimiter=" ">
+                    <text macro="container-title"/>
+                    <text macro="volume-edition" suffix=","/>
+                    <text macro="volumes"/>
+                    <text macro="publisher"/>
+                    <text macro="issued"/>
+                  </group>
+                </else>
+              </choose>
               <group delimiter=", ">
                 <text macro="access"/>
                 <group delimiter=", ">
@@ -238,20 +238,20 @@
         </group>
       </group>
       <group delimiter=", ">
-<choose>
-  <if type="webpage">
-    <!-- keine Ausgabe -->
-  </if>
-  <else>
-    <group delimiter=", ">
-  <text macro="container-title"/>
-  <text macro="volume-edition"/>
-  <text macro="volumes"/>
-  <text macro="publisher"/>
-  <text macro="issued"/>
-</group>
-  </else>
-</choose>
+        <choose>
+          <if type="webpage">
+            <!-- keine Ausgabe -->
+          </if>
+          <else>
+            <group delimiter=", ">
+              <text macro="container-title"/>
+              <text macro="volume-edition"/>
+              <text macro="volumes"/>
+              <text macro="publisher"/>
+              <text macro="issued"/>
+            </group>
+          </else>
+        </choose>
         <group delimiter=". ">
           <text macro="access"/>
           <text macro="pages"/>


### PR DESCRIPTION
This style is a modified version of the Jahrbuch für evangelikale Theologie (Deutsch) citation style, adjusted for the needs of the University of Salzburg (PLUS).
Main changes include:
	•	Adjusted formatting rules for various item types (books, journal articles, book sections).
	•	Modified punctuation and spacing in bibliography entries.
	•	Custom handling of editor and translator fields with localized abbreviations.
	•	Adjusted date formatting for issued years.
	•	Minor localization refinements for German language output.