### PR TITLE
Some fixes for #7702 (EJIL)

### DIFF
--- a/european-journal-of-international-law.csl
+++ b/european-journal-of-international-law.csl
@@ -309,7 +309,7 @@
             <text macro="URL"/>
           </group>
         </if>
-        <if type="legal_case" match="any">
+        <else-if type="legal_case" match="any">
           <group delimiter=", ">
             <text variable="authority"/>
             <text macro="author-bibliography"/>
@@ -323,7 +323,7 @@
             <text macro="edition"/>
             <text macro="URL"/>
           </group>
-        </if>
+        </else-if>
         <else-if type="chapter paper-conference" match="any">
           <group delimiter=", ">
             <names variable="author">


### PR DESCRIPTION
Fixes comma issues with newspaper articles and removes the URL for journal articles.

Does not remove the URL for legal_cases, as the stylesheet mentions the possibility to include them under certain circumstances, but it still needs fixing (comma and a space are missing before "available at").

Closes https://github.com/citation-style-language/styles/issues/7702