### PR TITLE
Create japan-journal-of-stuttering-and-other-fluency-disorders.csl

### DIFF
--- a/japan-journal-of-stuttering-and-other-fluency-disorders.csl
+++ b/japan-journal-of-stuttering-and-other-fluency-disorders.csl
@@ -1,0 +1,1695 @@
+<?xml version="1.0" encoding="utf-8"?>
+<style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" demote-non-dropping-particle="never" page-range-format="expanded">
+  <info>
+    <!-- title xml:lang="en">Japan Journal of Stuttering and Other Fluency Disorders Style</title -->
+    <title xml:lang="ja">吃音・流暢性障害学研究</title>
+    <title-short>JJSFD</title-short>
+    <!-- summary xml:lang="en">This Citation Style Language (CSL) file is for the Japan Journal of Stuttering and Other Fluency Disorders (JJSFD), which is an official journal of the Japan Society of Stuttering and Other Fluency Disorders (www.jssfd.org). In order to fulfil the required sort order of Japanese author names in the transliterated alphabetic order, it introduces a variable "author-yomi" in the Extra field, which generates a validation error against CSL 1.0.2 strict. Because it is essential to have this variable in this CSL, the user should override the error alert in installing it into their bibliography managing program.</summary -->
+    <id>http://www.zotero.org/styles/japan-journal-of-stuttering-and-other-fluency-disorders</id>
+    <link href="http://www.zotero.org/styles/japan-journal-of-stuttering-and-other-fluency-disorders" rel="self"/>
+    <link href="http://www.zotero.org/styles/apa-6th-edition-no-ampersand" rel="template"/>
+    <link href="https://www.jssfd.org/gakkaishi.html" rel="documentation"/>
+    <author>
+      <name>Koichi Mori</name>
+    </author>
+    <category citation-format="author-date"/>
+    <category field="communications"/>
+    <category field="engineering"/>
+    <category field="humanities"/>
+    <category field="linguistics"/>
+    <category field="medicine"/>
+    <category field="psychology"/>
+    <category field="science"/>
+    <category field="social_science"/>
+    <category field="sociology"/>
+    <eissn>2760-1749</eissn>
+    <summary xml:lang="ja">この文献引用スタイルファイルは、日本吃音・流暢性障害学会の公式論文誌である吃音・流暢性障害学研究(JSSFD)のために、引用スタイル言語 (CSL) で書かれたものです。日本語の著者名のソート順については、Extra (その他)のフィールド内に"author-yomi: "という項目を作り、ローマ字化した著者名を";"で区切って記入すれば、それがソートに使われます（順序以外の引用文献の表示には影響しません）。"author-yomi"は元来のCSL 1.0.2 (strict) にはないキーワードのため、スタイル・マネージャーに登録する時に「有効なCSL引用スタイルファイルではない」という警告が出ますが、OKをクリックして登録してください。なお、多人数著者の論文等で省略に「et al.」が使われるか「他」が使われるかは、「エクスポート」の設定の「言語：」の設定を「English (US)」にするか「日本語」にするかによって決まります。文献ごとに自動的に切りかえることはできません。</summary>
+    <published>2025-05-02T09:00:00+09:00</published>
+    <updated>2025-08-13T19:00:00+09:00</updated>
+    <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
+  </info>
+  <locale xml:lang="en">
+    <terms>
+      <term name="et-al">et al.</term>
+      <term name="and"/>
+      <term name="at"/>
+      <term name="in"/>
+    </terms>
+  </locale>
+  <locale xml:lang="ja">
+    <!-- defaultのjaのlocaleでは「年」「月」「日」が表示されることがあるのを防止するための修正 -->
+    <date form="text">
+      <date-part name="year" suffix="-"/>
+      <date-part name="month" form="numeric-leading-zeros" suffix="-"/>
+      <date-part name="day" form="numeric-leading-zeros" suffix=""/>
+    </date>
+    <date form="numeric">
+      <date-part name="year" suffix="/"/>
+      <date-part name="month" form="numeric-leading-zeros" suffix="/"/>
+      <date-part name="day" form="numeric-leading-zeros" suffix=""/>
+    </date>
+    <terms>
+      <!-- defaultのjaのlocale設定では"et-al"が「ほか」になるので、「他」とする等の修正。 -->
+      <term name="et-al"> 他</term>
+      <term name="personal-communication">バーソナル・コミュニケーション</term>
+      <term name="podcast">ポドキャスト</term>
+      <term name="album">アルバム</term>
+      <term name="film">映画</term>
+      <term name="circa" form="short">ca.</term>
+      <term name="issue" form="long">
+        <single>号</single>
+        <multiple>号</multiple>
+      </term>
+      <term name="at"/>
+      <term name="in"/>
+      <term name="retrieved"/>
+      <term name="from"/>
+      <term name="and"/>
+      <term name="and others">他</term>
+    </terms>
+  </locale>
+  <macro name="container-contributors-booklike">
+    <choose>
+      <if variable="container-title">
+        <names variable="editor translator director" delimiter=", ">
+          <label form="short" prefix=" (" text-case="title" suffix=")"/>
+          <substitute>
+            <names variable="editorial-director"/>
+            <names variable="collection-editor"/>
+            <names variable="container-author"/>
+            <names variable="director"/>
+          </substitute>
+        </names>
+      </if>
+    </choose>
+  </macro>
+  <macro name="container-contributors">
+    <choose>
+      <!-- book is here to catch software with container titles -->
+      <if type="book broadcast chapter entry entry-dictionary entry-encyclopedia graphic map personal_communication report speech post-weblog webpage paper-conference" match="any">
+        <text macro="container-contributors-booklike"/>
+      </if>
+      <else>
+        <choose>
+          <if variable="collection-editor container-author editor" match="any">
+            <text macro="container-contributors-booklike"/>
+          </if>
+        </choose>
+      </else>
+    </choose>
+  </macro>
+  <macro name="secondary-contributors-booklike">
+    <group delimiter="; ">
+      <choose>
+        <if variable="title">
+          <names variable="interviewer">
+            <label form="short" prefix=", " text-case="title"/>
+          </names>
+        </if>
+      </choose>
+      <choose>
+        <if variable="container-title" match="none">
+          <group delimiter="; ">
+            <names variable="container-author">
+              <label form="verb-short" suffix=" " text-case="title"/>
+            </names>
+            <names variable="editor translator" delimiter="; ">
+              <label form="short" prefix=", " text-case="title"/>
+            </names>
+          </group>
+        </if>
+      </choose>
+    </group>
+  </macro>
+  <!-- end of "secondary-contributors-booklike" -->
+  <macro name="secondary-contributors">
+    <choose>
+      <!-- book is here to catch software with container titles -->
+      <if type="book broadcast chapter entry entry-dictionary entry-encyclopedia graphic map report" match="any">
+        <text macro="secondary-contributors-booklike"/>
+      </if>
+      <else-if type="personal_communication">
+        <group delimiter="; ">
+          <group delimiter=" ">
+            <choose>
+              <if variable="genre" match="any">
+                <text variable="genre" text-case="capitalize-first"/>
+              </if>
+              <else>
+                <text term="letter" text-case="capitalize-first"/>
+              </else>
+            </choose>
+            <names variable="recipient" delimiter=", ">
+              <label form="verb" suffix=" "/>
+            </names>
+          </group>
+          <text variable="medium" text-case="capitalize-first"/>
+          <choose>
+            <if variable="container-title" match="none">
+              <names variable="editor translator" delimiter="; ">
+                <label form="short" prefix=", " text-case="title"/>
+              </names>
+            </if>
+          </choose>
+        </group>
+      </else-if>
+      <else-if type="song">
+        <choose>
+          <if variable="original-author composer" match="any">
+            <group delimiter="; ">
+              <!-- Replace prefix with performer label as that becomes available -->
+              <names variable="author" prefix="Recorded by ">
+                <label form="verb" text-case="title"/>
+              </names>
+              <names variable="translator">
+                <label form="short" prefix=", " text-case="title"/>
+              </names>
+            </group>
+          </if>
+        </choose>
+      </else-if>
+      <else-if type="article-journal article-magazine article-newspaper" match="any">
+        <group delimiter="; ">
+          <choose>
+            <if variable="title">
+              <names variable="interviewer" delimiter="; ">
+                <label form="short" prefix=", " text-case="title"/>
+              </names>
+            </if>
+          </choose>
+          <names variable="translator" delimiter="; ">
+            <label form="short" prefix=", " text-case="title"/>
+          </names>
+        </group>
+      </else-if>
+      <else>
+        <group delimiter="; ">
+          <choose>
+            <if variable="title">
+              <names variable="interviewer">
+                <label form="short" prefix=", " text-case="title"/>
+              </names>
+            </if>
+          </choose>
+          <names variable="editor translator" delimiter="; ">
+            <label form="short" prefix=", " text-case="title"/>
+          </names>
+        </group>
+      </else>
+    </choose>
+  </macro>
+  <!-- end of "secondary-contributors-booklike" -->
+  <macro name="author">
+    <choose>
+      <if type="song">
+        <names variable="composer" delimiter=", ">
+          <name name-as-sort-order="all" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
+          <substitute>
+            <names variable="original-author"/>
+            <names variable="author"/>
+            <names variable="performer"/>
+            <names variable="director"/>
+            <names variable="translator">
+              <name name-as-sort-order="all" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
+              <label form="short" prefix=" (" suffix=")" text-case="title"/>
+            </names>
+            <group delimiter=" ">
+              <text macro="title"/>
+              <text macro="description"/>
+              <text macro="format"/>
+            </group>
+          </substitute>
+        </names>
+      </if>
+      <else-if type="treaty"/>
+      <else>
+        <names variable="author" delimiter=", ">
+          <name name-as-sort-order="all" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
+          <substitute>
+            <names variable="illustrator"/>
+            <names variable="composer"/>
+            <names variable="guest"/>
+            <names variable="contributor"/>
+            <names variable="performer"/>
+            <names variable="director"/>
+            <names variable="script-writer"/>
+            <!-- 脚本家 -->
+            <names variable="producer"/>
+            <names variable="interviewer"/>
+            <choose>
+              <if variable="container-title">
+                <choose>
+                  <if type="book entry entry-dictionary entry-encyclopedia" match="any">
+                    <text macro="title"/>
+                  </if>
+                  <else>
+                    <names variable="translator"/>
+                  </else>
+                </choose>
+                <names variable="translator">
+                  <name name-as-sort-order="all" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
+                  <label form="short" prefix=" (" suffix=")" text-case="title"/>
+                </names>
+              </if>
+            </choose>
+            <names variable="editor translator" delimiter=", ">
+              <name name-as-sort-order="all" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
+              <label form="short" prefix=" (" suffix=")" text-case="title"/>
+            </names>
+            <names variable="editorial-director">
+              <name name-as-sort-order="all" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
+              <label form="short" prefix=" (" suffix=")" text-case="title"/>
+            </names>
+            <names variable="collection-editor">
+              <name name-as-sort-order="all" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
+              <label form="short" prefix=" (" suffix=")" text-case="title"/>
+            </names>
+            <names variable="interviewer">
+              <name name-as-sort-order="all" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
+              <label form="short" prefix=" (" suffix=")" text-case="title"/>
+            </names>
+            <names variable="director">
+              <!-- 監督 -->
+              <name name-as-sort-order="all" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
+              <label form="short" prefix=" (" suffix=")" text-case="title"/>
+            </names>
+            <names variable="producer">
+              <name name-as-sort-order="all" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
+              <label form="short" prefix=" (" suffix=")" text-case="title"/>
+            </names>
+            <names variable="recipient">
+              <name name-as-sort-order="all" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
+              <label form="short" prefix=" (" suffix=")" text-case="title"/>
+            </names>
+            <choose>
+              <if type="report">
+                <text variable="publisher"/>
+              </if>
+            </choose>
+            <group delimiter=" ">
+              <text macro="title"/>
+              <text macro="description"/>
+              <text macro="format"/>
+            </group>
+          </substitute>
+        </names>
+      </else>
+    </choose>
+  </macro>
+  <!-- end of name="author" -->
+  <macro name="author-short">
+    <choose>
+      <if type="patent" variable="number" match="all">
+        <text macro="patent-number"/>
+      </if>
+      <else-if type="treaty">
+        <text variable="title" form="short" text-case="title"/>
+      </else-if>
+      <else-if type="personal_communication">
+        <choose>
+          <if variable="archive DOI publisher URL" match="none">
+            <group delimiter=", ">
+              <names variable="author">
+                <substitute>
+                  <text variable="title" form="short" text-case="title" quotes="true"/>
+                </substitute>
+              </names>
+              <!-- This should be localized -->
+              <text value="personal communication"/>
+            </group>
+          </if>
+          <else>
+            <names variable="author" delimiter=", ">
+              <name>
+                <name-part name="family" text-case="capitalize-first"/>
+              </name>
+              <substitute>
+                <names variable="editor"/>
+                <names variable="translator"/>
+                <choose>
+                  <if variable="container-title">
+                    <text variable="title" form="short" text-case="title" quotes="false"/>
+                  </if>
+                  <else>
+                    <text variable="title" form="short" text-case="title"/>
+                  </else>
+                </choose>
+                <text macro="format-short" prefix="[" suffix="]"/>
+              </substitute>
+            </names>
+          </else>
+        </choose>
+      </else-if>
+      <!-- type="personal_communication" -->
+      <else-if type="song">
+        <names variable="composer" delimiter=", ">
+          <substitute>
+            <names variable="original-author"/>
+            <names variable="author"/>
+            <names variable="performer"/>
+            <names variable="director"/>
+            <names variable="translator"/>
+            <choose>
+              <if variable="container-title">
+                <text variable="title" form="short" text-case="title" quotes="false"/>
+              </if>
+              <else>
+                <text variable="title" form="short" text-case="title"/>
+              </else>
+            </choose>
+            <text macro="format-short" prefix="[" suffix="]"/>
+          </substitute>
+        </names>
+      </else-if>
+      <!-- type="song" -->
+      <else>
+        <names variable="author" delimiter=", ">
+          <name form="short">
+            <name-part name="family" text-case="capitalize-first"/>
+          </name>
+          <substitute>
+            <names variable="illustrator"/>
+            <names variable="composer"/>
+            <!-- names variable="cartographer"/ -->
+            <!-- 地図作成者, not in the namespace of purl.org/net/xbiblio/csl -->
+            <!-- names variable="programmer"/ -->
+            <!-- not in the namespace of purl.org/net/xbiblio/csl -->
+            <!-- names variable="presenter"/ -->
+            <!-- not in the namespace of purl.org/net/xbiblio/csl -->
+            <!-- names variable="interview-with"/ -->
+            <!-- not in the namespace of purl.org/net/xbiblio/csl -->
+            <!-- names variable="commenter"/ -->
+            <!-- not in the namespace of purl.org/net/xbiblio/csl -->
+            <names variable="guest"/>
+            <!-- ゲスト -->
+            <names variable="contributor"/>
+            <!-- 寄稿者名 -->
+            <!-- names variable="cast member"/ -->
+            <!-- キャスト, not in the namespace of purl.org/net/xbiblio/csl -->
+            <!-- names variable="artist"/ -->
+            <!-- not in the namespace of purl.org/net/xbiblio/csl -->
+            <names variable="performer"/>
+            <names variable="script-writer"/>
+            <!-- 脚本家 -->
+            <choose>
+              <if variable="container-title">
+                <choose>
+                  <if type="book entry entry-dictionary entry-encyclopedia" match="any">
+                    <text variable="title" form="short" text-case="title" quotes="false"/>
+                  </if>
+                  <else>
+                    <names variable="translator"/>
+                  </else>
+                </choose>
+              </if>
+            </choose>
+            <names variable="editor"/>
+            <names variable="editorial-director"/>
+            <names variable="translator"/>
+            <names variable="interviewer"/>
+            <names variable="director"/>
+            <!-- 監督 -->
+            <names variable="producer"/>
+            <names variable="recipient"/>
+            <choose>
+              <if type="report" variable="publisher" match="all">
+                <text variable="publisher"/>
+              </if>
+              <else-if type="legal_case">
+                <text variable="title"/>
+              </else-if>
+              <else-if type="bill legislation" match="any">
+                <text variable="title" form="short" text-case="title"/>
+              </else-if>
+              <else-if variable="reviewed-author" type="review review-book" match="any">
+                <text macro="format-short" prefix="[" suffix="]"/>
+              </else-if>
+              <else-if type="post post-weblog webpage" variable="container-title" match="any">
+                <text variable="title" form="short" text-case="title" quotes="false"/>
+              </else-if>
+              <else>
+                <text variable="title" form="short" text-case="title"/>
+              </else>
+            </choose>
+            <text macro="format-short" prefix="[" suffix="]"/>
+          </substitute>
+        </names>
+      </else>
+    </choose>
+  </macro>
+  <!-- end of name="author-short" -->
+  <macro name="patent-number">
+    <!-- authority: U.S. ; genre: patent ; number: 123,445 -->
+    <group delimiter=" ">
+      <text variable="authority"/>
+      <choose>
+        <if variable="genre">
+          <text variable="genre" text-case="capitalize-first"/>
+        </if>
+        <else>
+          <!-- This should be localized -->
+          <text value="patent" text-case="capitalize-first"/>
+        </else>
+      </choose>
+      <group delimiter=" ">
+        <text term="issue" form="short" text-case="capitalize-first"/>
+        <text variable="number"/>
+      </group>
+    </group>
+  </macro>
+  <!-- end of name="patent-number" -->
+  <macro name="access">
+    <choose>
+      <if type="bill legal_case legislation" match="any"/>
+      <else-if variable="DOI" match="any">
+        <text variable="DOI" prefix="https://doi.org/"/>
+      </else-if>
+      <else-if variable="URL">
+        <group delimiter=" ">
+          <text term="retrieved" text-case="capitalize-first"/>
+          <choose>
+            <if type="post post-weblog webpage" match="any">
+              <date variable="accessed" form="text" suffix=","/>
+            </if>
+          </choose>
+          <text term="from"/>
+          <choose>
+            <if type="report">
+              <choose>
+                <if variable="author editor translator" match="any">
+                  <!-- This should be localized -->
+                  <text variable="publisher" suffix=" website:"/>
+                </if>
+              </choose>
+            </if>
+            <else-if type="post post-weblog webpage" match="any">
+              <!-- This should be localized -->
+              <text variable="container-title" suffix=" website:"/>
+            </else-if>
+          </choose>
+          <text variable="URL"/>
+        </group>
+      </else-if>
+      <else-if variable="archive">
+        <choose>
+          <if type="article article-journal article-magazine article-newspaper dataset report speech thesis" match="any">
+            <!-- This section is for electronic database locations. Physical archives for these and other item types are called in 'publisher' macro -->
+            <choose>
+              <if variable="archive-place" match="none">
+                <group delimiter=" ">
+                  <text term="retrieved" text-case="capitalize-first"/>
+                  <text term="from"/>
+                  <text variable="archive" suffix="."/>
+                  <text variable="archive_location" prefix="(" suffix=")"/>
+                </group>
+              </if>
+            </choose>
+          </if>
+        </choose>
+      </else-if>
+    </choose>
+  </macro>
+  <!-- end of name="access" -->
+  <macro name="title">
+    <choose>
+      <if type="treaty">
+        <group delimiter=", ">
+          <text variable="title" text-case="title"/>
+          <names variable="author">
+            <name initialize-with="." form="short" delimiter="-"/>
+          </names>
+        </group>
+      </if>
+      <else-if type="patent" variable="number" match="all">
+        <text macro="patent-number"/>
+      </else-if>
+      <else-if variable="title">
+        <choose>
+          <if variable="version" type="book" match="all">
+            <!---This is a hack until we have a software type -->
+            <text variable="title"/>
+          </if>
+          <else-if variable="reviewed-author reviewed-title" type="review review-book" match="any">
+            <choose>
+              <if variable="reviewed-title">
+                <choose>
+                  <if type="post post-weblog webpage" variable="container-title" match="any">
+                    <text variable="title"/>
+                  </if>
+                  <else>
+                    <text variable="title"/>
+                  </else>
+                </choose>
+              </if>
+            </choose>
+          </else-if>
+          <else-if type="post post-weblog webpage" variable="container-title" match="any">
+            <text variable="title"/>
+          </else-if>
+          <else>
+            <text variable="title"/>
+          </else>
+        </choose>
+      </else-if>
+      <else-if variable="interviewer" type="interview" match="any">
+        <names variable="interviewer">
+          <label form="verb-short" suffix=" " text-case="capitalize-first"/>
+        </names>
+      </else-if>
+    </choose>
+  </macro>
+  <!-- end of name="title" -->
+  <!-- APA has four descriptive sections following the title: -->
+  <!-- (description), [format], container, event -->
+  <macro name="description">
+    <group prefix="(" suffix=")">
+      <choose>
+        <!-- book is here to catch software with container titles -->
+        <if type="book report" match="any">
+          <choose>
+            <if variable="container-title">
+              <text macro="secondary-contributors"/>
+            </if>
+            <else>
+              <group delimiter="; ">
+                <text macro="description-report"/>
+                <text macro="secondary-contributors"/>
+              </group>
+            </else>
+          </choose>
+        </if>
+        <else-if type="thesis">
+          <group delimiter="; ">
+            <group delimiter=", ">
+              <text variable="genre" text-case="capitalize-first"/>
+              <choose>
+                <!-- In APA journals, the university (variable="publisher") of a thesis is always cited, even if another locator is given -->
+                <if variable="DOI URL archive" match="any">
+                  <text variable="publisher"/>
+                </if>
+              </choose>
+            </group>
+            <text macro="locators"/>
+            <text macro="secondary-contributors"/>
+          </group>
+        </else-if>
+        <else-if type="book interview manuscript motion_picture musical_score pamphlet post-weblog speech webpage" match="any">
+          <group delimiter="; ">
+            <text macro="locators"/>
+            <text macro="secondary-contributors"/>
+          </group>
+        </else-if>
+        <else-if type="song">
+          <choose>
+            <if variable="container-title" match="none">
+              <text macro="locators"/>
+            </if>
+          </choose>
+        </else-if>
+        <else-if type="article dataset figure" match="any">
+          <choose>
+            <if variable="container-title">
+              <text macro="secondary-contributors"/>
+            </if>
+            <else>
+              <group delimiter="; ">
+                <text macro="locators"/>
+                <text macro="secondary-contributors"/>
+              </group>
+            </else>
+          </choose>
+        </else-if>
+        <else-if type="bill legislation legal_case patent treaty personal_communication" match="none">
+          <text macro="secondary-contributors"/>
+        </else-if>
+      </choose>
+    </group>
+  </macro>
+  <!-- end of name="description" -->
+  <macro name="format">
+    <group prefix="[" suffix="]">
+      <choose>
+        <if variable="reviewed-author reviewed-title" type="review review-book" match="any">
+          <group delimiter=", ">
+            <choose>
+              <if variable="genre">
+                <!-- Delimiting by , rather than "of" to avoid incorrect grammar -->
+                <group delimiter=", ">
+                  <text variable="genre" text-case="capitalize-first"/>
+                  <choose>
+                    <if variable="reviewed-title">
+                      <text variable="reviewed-title"/>
+                    </if>
+                    <else>
+                      <!-- Assume `title` is title of reviewed work -->
+                      <text variable="title"/>
+                    </else>
+                  </choose>
+                </group>
+              </if>
+              <else>
+                <!-- This should be localized -->
+                <group delimiter=" ">
+                  <text value="Review of"/>
+                  <choose>
+                    <if variable="reviewed-title">
+                      <text variable="reviewed-title"/>
+                    </if>
+                    <else>
+                      <!-- Assume `title` is title of reviewed work -->
+                      <text variable="title"/>
+                    </else>
+                  </choose>
+                </group>
+              </else>
+            </choose>
+            <names variable="reviewed-author">
+              <label form="verb-short" suffix=" "/>
+            </names>
+          </group>
+        </if>
+        <else>
+          <text macro="format-short"/>
+        </else>
+      </choose>
+    </group>
+  </macro>
+  <!-- end of name="format" -->
+  <macro name="format-short">
+    <choose>
+      <if variable="reviewed-author reviewed-title" type="review review-book" match="any">
+        <choose>
+          <if variable="reviewed-title" match="none">
+            <choose>
+              <if variable="genre">
+                <!-- Delimiting by , rather than "of" to avoid incorrect grammar -->
+                <group delimiter=", ">
+                  <text variable="genre" text-case="capitalize-first"/>
+                  <text variable="title" form="short" text-case="title"/>
+                </group>
+              </if>
+              <else>
+                <!-- This should be localized -->
+                <group delimiter=" ">
+                  <text value="Review of"/>
+                  <text variable="title" form="short" text-case="title"/>
+                </group>
+              </else>
+            </choose>
+          </if>
+          <else>
+            <text variable="title" form="short" text-case="title" quotes="true"/>
+          </else>
+        </choose>
+      </if>
+      <else-if type="speech thesis" match="any">
+        <text variable="medium" text-case="capitalize-first"/>
+      </else-if>
+      <!-- book is here to catch software with container titles -->
+      <else-if type="book report" match="any">
+        <choose>
+          <if variable="container-title" match="none">
+            <text macro="format-report"/>
+          </if>
+        </choose>
+      </else-if>
+      <else-if type="manuscript pamphlet" match="any">
+        <text variable="medium" text-case="capitalize-first"/>
+      </else-if>
+      <else-if type="personal_communication">
+        <text macro="secondary-contributors"/>
+      </else-if>
+      <else-if type="song">
+        <group delimiter="; ">
+          <text macro="secondary-contributors"/>
+          <choose>
+            <if variable="container-title" match="none">
+              <group delimiter=", ">
+                <text variable="genre" text-case="capitalize-first"/>
+                <text variable="medium" text-case="capitalize-first"/>
+              </group>
+            </if>
+          </choose>
+        </group>
+      </else-if>
+      <else-if type="paper-conference speech broadcast" match="any">
+        <group delimiter=", ">
+          <choose>
+            <if variable="collection-editor editor issue page volume" match="any">
+              <text variable="genre" text-case="capitalize-first"/>
+            </if>
+          </choose>
+          <text variable="medium" text-case="capitalize-first"/>
+        </group>
+      </else-if>
+      <else-if type="bill legislation legal_case patent treaty" match="none">
+        <choose>
+          <if variable="genre medium" match="any">
+            <group delimiter=", ">
+              <text variable="genre" text-case="capitalize-first"/>
+              <text variable="medium" text-case="capitalize-first"/>
+            </group>
+          </if>
+          <else-if type="dataset">
+            <!-- This should be localized -->
+            <text value="Data set"/>
+          </else-if>
+        </choose>
+      </else-if>
+    </choose>
+  </macro>
+  <!-- end of name="format-short" -->
+  <macro name="description-report">
+    <choose>
+      <if variable="number">
+        <group delimiter="; ">
+          <group delimiter=" ">
+            <text variable="genre" text-case="title"/>
+            <!-- Replace with term="number" if that becomes available -->
+            <text term="issue" form="short" text-case="capitalize-first"/>
+            <text variable="number"/>
+          </group>
+          <text macro="locators"/>
+        </group>
+      </if>
+      <else>
+        <text macro="locators"/>
+      </else>
+    </choose>
+  </macro>
+  <!-- end of name="description-report" -->
+  <macro name="format-report">
+    <choose>
+      <if variable="number">
+        <text variable="medium" text-case="capitalize-first"/>
+      </if>
+      <else>
+        <group delimiter=", ">
+          <text variable="genre" text-case="capitalize-first"/>
+          <text variable="medium" text-case="capitalize-first"/>
+        </group>
+      </else>
+    </choose>
+  </macro>
+  <!-- end of name="format-report" -->
+  <macro name="title-and-descriptions">
+    <group delimiter=" ">
+      <text macro="title"/>
+      <choose>
+        <if variable="title interviewer" type="interview" match="any">
+          <group delimiter=" ">
+            <text macro="description"/>
+            <text macro="format"/>
+          </group>
+        </if>
+        <else>
+          <group delimiter=" ">
+            <text macro="format"/>
+            <text macro="description"/>
+          </group>
+        </else>
+      </choose>
+    </group>
+  </macro>
+  <!-- end of name="title-and-descriptions" -->
+  <macro name="archive">
+    <group delimiter=". ">
+      <group delimiter=", ">
+        <choose>
+          <if type="manuscript">
+            <text variable="genre"/>
+          </if>
+        </choose>
+        <group delimiter=" ">
+          <!-- Replace "archive" with "archive_collection" as that becomes available -->
+          <text variable="archive"/>
+          <text variable="archive_location" prefix="(" suffix=")"/>
+        </group>
+      </group>
+      <group delimiter=", ">
+        <!-- Move "archive" here when "archive_collection" becomes available -->
+        <text variable="archive-place"/>
+      </group>
+    </group>
+  </macro>
+  <!-- end of name="archive" -->
+  <macro name="publisher">
+    <choose>
+      <if type="manuscript pamphlet" match="any">
+        <choose>
+          <if variable="archive archive_location archive-place" match="any">
+            <group delimiter=". ">
+              <group delimiter=": ">
+                <text variable="publisher-place"/>
+                <text variable="publisher"/>
+              </group>
+              <text macro="archive"/>
+            </group>
+          </if>
+          <else>
+            <group delimiter=", ">
+              <text variable="genre"/>
+              <text variable="publisher"/>
+              <text variable="publisher-place"/>
+            </group>
+          </else>
+        </choose>
+      </if>
+      <else-if type="thesis" match="any">
+        <group delimiter=". ">
+          <group delimiter=", ">
+            <text variable="publisher"/>
+            <text variable="publisher-place"/>
+          </group>
+          <text macro="archive"/>
+        </group>
+      </else-if>
+      <else-if type="patent">
+        <group delimiter=". ">
+          <group delimiter=": ">
+            <text variable="publisher-place"/>
+            <text variable="publisher"/>
+          </group>
+          <text macro="archive"/>
+        </group>
+      </else-if>
+      <else-if type="article-journal article-magazine article-newspaper" match="any">
+        <text macro="archive"/>
+      </else-if>
+      <else-if type="post post-weblog webpage" match="none">
+        <group delimiter=". ">
+          <choose>
+            <if variable="event">
+              <choose>
+                <!-- Only print publisher info if published in a proceedings -->
+                <if variable="collection-editor editor issue page volume" match="any">
+                  <group delimiter=": ">
+                    <text variable="publisher-place"/>
+                    <text variable="publisher"/>
+                  </group>
+                </if>
+              </choose>
+            </if>
+            <else-if type="speech paper-conference" match="any">
+              <!-- publisher-place removed to avoide duplicate place -->
+              <text variable="publisher"/>
+            </else-if>
+            <else>
+              <group delimiter=": ">
+                <text variable="publisher-place"/>
+                <text variable="publisher"/>
+              </group>
+            </else>
+          </choose>
+          <text macro="archive"/>
+        </group>
+      </else-if>
+    </choose>
+  </macro>
+  <!-- end of name="publisher" -->
+  <macro name="event">
+    <choose>
+      <if type="speech" match="any">
+        <!-- To prevent Zotero from printing event-place due to its double-mapping of all 'place' to
+             both publisher-place and event-place. Remove this 'choose' when that is changed. -->
+        <choose>
+          <if type="speech" match="any">
+            <choose>
+              <!-- Don't print event info if published in a proceedings -->
+              <if variable="collection-editor" match="none">
+                <!-- editor issue page volume excluded -->
+                <group delimiter=" ">
+                  <text variable="genre" text-case="capitalize-first"/>
+                  <group delimiter=" ">
+                    <group delimiter=", ">
+                      <text macro="event-title"/>
+                      <text variable="event-place"/>
+                    </group>
+                  </group>
+                </group>
+              </if>
+            </choose>
+          </if>
+        </choose>
+      </if>
+    </choose>
+  </macro>
+  <!-- end of name="event" -->
+  <macro name="event-title">
+    <choose>
+      <!-- TODO: We expect "event-title" to be used,
+           but processors and applications may not be updated yet.
+           This macro ensures that either "event" or "event-title" can be accpeted.
+           Remove if procesor logic and application adoption can handle this. -->
+      <if variable="event-title">
+        <text variable="event-title"/>
+      </if>
+      <else>
+        <text variable="event"/>
+      </else>
+    </choose>
+  </macro>
+  <!-- end of name="event-title" -->
+  <macro name="issued">
+    <choose>
+      <if type="bill legal_case legislation" match="any"/>
+      <else-if variable="issued">
+        <group>
+          <date variable="issued">
+            <date-part name="year"/>
+          </date>
+          <text variable="year-suffix"/>
+        </group>
+      </else-if>
+      <else-if variable="status">
+        <group>
+          <text variable="status" text-case="lowercase"/>
+          <text variable="year-suffix" prefix="-"/>
+        </group>
+      </else-if>
+      <else>
+        <text term="no date" form="short"/>
+        <text variable="year-suffix" prefix="-"/>
+      </else>
+    </choose>
+  </macro>
+  <!-- end of name="issued" -->
+  <macro name="issued-sort">
+    <choose>
+      <if type="article article-magazine article-newspaper broadcast interview pamphlet personal_communication post post-weblog speech treaty webpage paper-conference speech" match="any">
+        <date variable="issued" form="numeric">
+          <date-part name="year"/>
+          <date-part name="month" form="numeric-leading-zeros"/>
+          <date-part name="day" form="numeric-leading-zeros"/>
+        </date>
+      </if>
+      <else>
+        <date variable="issued">
+          <date-part name="year"/>
+        </date>
+      </else>
+    </choose>
+  </macro>
+  <!-- end of name="issued-sort" -->
+  <macro name="issued-year">
+    <group>
+      <choose>
+        <if type="personal_communication">
+          <choose>
+            <if variable="archive DOI publisher URL" match="none">
+              <!-- These variables indicate that the letter is retrievable by the reader. If not, then use the APA in-text-only personal communication format -->
+              <date variable="issued" form="text"/>
+            </if>
+            <else>
+              <date variable="issued">
+                <date-part name="year" form="long"/>
+              </date>
+            </else>
+          </choose>
+        </if>
+        <else>
+          <date variable="issued" form="numeric">
+            <date-part name="year" form="long"/>
+            <!-- "long" to avoid month and day appearing even if only year is specified -->
+          </date>
+        </else>
+      </choose>
+      <text variable="year-suffix"/>
+    </group>
+  </macro>
+  <!-- end of name="issued-year" -->
+  <macro name="issued-citation">
+    <choose>
+      <if variable="issued">
+        <group delimiter="-">
+          <choose>
+            <if is-uncertain-date="original-date">
+              <group prefix="[" suffix="]" delimiter=" ">
+                <text term="circa" form="short"/>
+                <date variable="original-date">
+                  <date-part name="year"/>
+                </date>
+              </group>
+            </if>
+            <else>
+              <date variable="original-date">
+                <date-part name="year"/>
+              </date>
+            </else>
+          </choose>
+          <choose>
+            <if is-uncertain-date="issued">
+              <group prefix="[" suffix="]" delimiter=" ">
+                <text term="circa" form="short"/>
+                <text macro="issued-year"/>
+              </group>
+            </if>
+            <else>
+              <text macro="issued-year"/>
+            </else>
+          </choose>
+        </group>
+      </if>
+      <else-if variable="status">
+        <text variable="status" text-case="lowercase"/>
+        <text variable="year-suffix" prefix="-"/>
+      </else-if>
+      <else>
+        <text term="no date" form="short"/>
+        <text variable="year-suffix" prefix="-"/>
+      </else>
+    </choose>
+  </macro>
+  <!-- end of name="issued-citation" -->
+  <macro name="accessed">
+    <group suffix=", " delimiter="-">
+      <date variable="accessed" form="numeric">
+        <date-part name="year" form="long"/>
+        <!-- "long" to avoid month and day appearing even if only year is specified -->
+        <date-part name="month" form="numeric-leading-zeros"/>
+        <date-part name="day" form="numeric-leading-zeros"/>
+      </date>
+    </group>
+  </macro>
+  <macro name="original-date">
+    <choose>
+      <if type="bill legal_case legislation" match="any"/>
+      <else-if type="speech">
+        <group delimiter="-">
+          <date variable="original-date">
+            <date-part name="year" form="long"/>
+            <!-- "long" to avoid month and day appearing even if only year is specified -->
+            <date-part name="month" form="numeric-leading-zeros"/>
+            <date-part name="day" form="numeric-leading-zeros"/>
+          </date>
+        </group>
+      </else-if>
+      <else-if type="article article-magazine article-newspaper broadcast interview pamphlet personal_communication post post-weblog treaty webpage" match="any">
+        <date variable="original-date" form="text"/>
+      </else-if>
+      <else>
+        <date variable="original-date">
+          <date-part name="year" form="long"/>
+          <!-- "long" to avoid month and day appearing even if only year is specified -->
+        </date>
+      </else>
+    </choose>
+  </macro>
+  <macro name="original-published">
+    <!--This should be localized -->
+    <choose>
+      <if type="bill legal_case legislation" match="any"/>
+      <else>
+        <text term="original-work-published" text-case="capitalize-first"/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="edition">
+    <choose>
+      <if is-numeric="edition">
+        <group delimiter=" ">
+          <number variable="edition" form="ordinal"/>
+          <text term="edition" form="short"/>
+        </group>
+      </if>
+      <else>
+        <text variable="edition"/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="locators">
+    <choose>
+      <if type="article-journal article-magazine figure review review-book" match="any">
+        <group delimiter=", ">
+          <group>
+            <text variable="volume"/>
+            <text variable="issue" prefix="(" suffix=")"/>
+          </group>
+          <text variable="page"/>
+        </group>
+      </if>
+      <else-if type="article-newspaper">
+        <group delimiter=" ">
+          <label variable="page" form="short"/>
+          <text variable="page"/>
+        </group>
+      </else-if>
+      <else-if type="paper-conference speech" match="any">
+        <choose>
+          <if variable="collection-editor editor" match="any">
+            <text macro="locators-booklike"/>
+          </if>
+          <else>
+            <group delimiter=", ">
+              <group>
+                <text variable="volume"/>
+                <text variable="issue" prefix="(" suffix=") "/>
+              </group>
+              <text variable="page"/>
+            </group>
+          </else>
+        </choose>
+      </else-if>
+      <else-if type="bill broadcast interview legal_case legislation patent post post-weblog treaty webpage" match="none">
+        <text macro="locators-booklike"/>
+      </else-if>
+    </choose>
+  </macro>
+  <!-- end of name="locators" -->
+  <macro name="locators-booklike">
+    <group delimiter=", ">
+      <text macro="edition"/>
+      <group delimiter=" ">
+        <text term="version" text-case="capitalize-first"/>
+        <text variable="version"/>
+      </group>
+      <choose>
+        <if variable="volume" match="any">
+          <choose>
+            <if is-numeric="volume" match="none"/>
+            <else-if variable="collection-title">
+              <choose>
+                <if variable="editor translator" match="none">
+                  <choose>
+                    <if variable="collection-number">
+                      <group>
+                        <text term="volume" form="short" text-case="capitalize-first" suffix=" "/>
+                        <number variable="volume" form="numeric"/>
+                      </group>
+                    </if>
+                  </choose>
+                </if>
+              </choose>
+            </else-if>
+            <else>
+              <group>
+                <text term="volume" form="short" text-case="capitalize-first" suffix=" "/>
+                <number variable="volume" form="numeric"/>
+              </group>
+            </else>
+          </choose>
+        </if>
+        <else>
+          <group>
+            <text term="volume" form="short" plural="true" text-case="capitalize-first" suffix=" "/>
+            <number variable="number-of-volumes" form="numeric" prefix="1&#8211;"/>
+            <!-- the code is for en-dash -->
+          </group>
+        </else>
+      </choose>
+      <group>
+        <label variable="page" form="short" suffix=" "/>
+        <text variable="page"/>
+      </group>
+    </group>
+  </macro>
+  <!-- end of name="locators-booklike" -->
+  <macro name="citation-locator">
+    <group>
+      <choose>
+        <if locator="chapter">
+          <label variable="locator" text-case="capitalize-first"/>
+        </if>
+        <else>
+          <label variable="locator" form="short"/>
+        </else>
+      </choose>
+      <text variable="locator" prefix=" "/>
+    </group>
+  </macro>
+  <macro name="container">
+    <choose>
+      <if type="article article-journal article-magazine article-newspaper review review-book" match="any">
+        <group delimiter=", ">
+          <text macro="container-title"/>
+          <text macro="locators"/>
+        </group>
+        <choose>
+          <!--for advance online publication-->
+          <if variable="issued">
+            <choose>
+              <if variable="page issue" match="none">
+                <text variable="status" text-case="capitalize-first" prefix=". "/>
+              </if>
+            </choose>
+          </if>
+        </choose>
+      </if>
+      <else-if type="article dataset figure" match="any">
+        <choose>
+          <if variable="container-title">
+            <group delimiter=", ">
+              <text macro="container-title"/>
+              <text macro="locators"/>
+            </group>
+            <choose>
+              <!--for advance online publication-->
+              <if variable="issued">
+                <choose>
+                  <if variable="page issue" match="none">
+                    <text variable="status" text-case="capitalize-first" prefix=". "/>
+                  </if>
+                </choose>
+              </if>
+            </choose>
+          </if>
+        </choose>
+      </else-if>
+      <!-- book is here to catch software with container titles -->
+      <else-if type="book" variable="container-title" match="all">
+        <group delimiter=", ">
+          <text term="in" text-case="capitalize-first" suffix=" "/>
+          <group delimiter=", ">
+            <text macro="container-contributors"/>
+            <group delimiter=" ">
+              <text macro="container-title"/>
+              <text macro="description-report" prefix="(" suffix=")"/>
+              <text macro="format-report" prefix="[" suffix="]"/>
+            </group>
+          </group>
+        </group>
+      </else-if>
+      <else-if type="report" variable="container-title" match="all">
+        <group delimiter=" ">
+          <text term="in" text-case="capitalize-first" suffix=" "/>
+          <group delimiter=", ">
+            <text macro="container-contributors"/>
+            <group delimiter=" ">
+              <text macro="container-title"/>
+              <text macro="description-report" prefix="(" suffix=")"/>
+              <text macro="format-report" prefix="[" suffix="]"/>
+            </group>
+          </group>
+        </group>
+      </else-if>
+      <else-if type="song" variable="container-title" match="all">
+        <group delimiter=" ">
+          <text term="in" text-case="capitalize-first" suffix=" "/>
+          <group delimiter=", ">
+            <text macro="container-contributors"/>
+            <group delimiter=" ">
+              <text macro="container-title"/>
+              <text macro="locators" prefix="(" suffix=")"/>
+              <group delimiter=", " prefix="[" suffix="]">
+                <text variable="genre" text-case="capitalize-first"/>
+                <text variable="medium" text-case="capitalize-first"/>
+              </group>
+            </group>
+          </group>
+        </group>
+      </else-if>
+      <else-if type="paper-conference speech broadcast post post-weblog webpage" match="any">
+        <choose>
+          <if variable="editor collection-editor container-author" match="any">
+            <text macro="container-booklike"/>
+          </if>
+          <else>
+            <group delimiter=", " suffix=", ">
+              <text macro="container-title"/>
+              <text macro="locators"/>
+            </group>
+          </else>
+        </choose>
+        <choose>
+          <if type="broadcast" match="any">
+            <text variable="publisher" suffix=", "/>
+            <!-- broadcasting network name -->
+          </if>
+          <else>
+            <text variable="event-place" suffix=", "/>
+          </else>
+        </choose>
+        <choose>
+          <if variable="event-date" match="any">
+            <date variable="event-date" form="text" suffix="-">
+              <date-part name="year" form="long"/>
+            </date>
+            <date variable="event-date" delimiter="-">
+              <date-part name="month" form="numeric-leading-zeros"/>
+              <date-part name="day" form="numeric-leading-zeros"/>
+            </date>
+          </if>
+          <else>
+            <date variable="issued" suffix="-">
+              <date-part name="year" form="long"/>
+              <!-- "long" to avoid month and day appearing even if only year is specified -->
+            </date>
+            <date variable="issued" delimiter="-">
+              <date-part name="month" form="numeric-leading-zeros"/>
+              <date-part name="day" form="numeric-leading-zeros"/>
+            </date>
+          </else>
+        </choose>
+      </else-if>
+      <else-if type="book">
+        <choose>
+          <!-- book and software should not cite collection-title, only container-title -->
+          <if variable="container-title">
+            <text macro="container-booklike"/>
+          </if>
+        </choose>
+      </else-if>
+      <else-if type="chapter entry entry-dictionary entry-encyclopedia graphic map" match="any">
+        <text macro="container-booklike"/>
+      </else-if>
+      <else-if type="bill legal_case legislation treaty" match="any">
+        <text macro="legal-cites"/>
+      </else-if>
+    </choose>
+  </macro>
+  <!-- end of macro name="container" -->
+  <macro name="container-booklike">
+    <choose>
+      <if variable="container-title collection-title" match="any">
+        <group delimiter=", ">
+          <text term="in" text-case="capitalize-first"/>
+          <group delimiter=", ">
+            <text macro="container-contributors"/>
+            <choose>
+              <if variable="container-author editor translator" match="none">
+                <group delimiter=". ">
+                  <group delimiter=": ">
+                    <text variable="collection-title" text-case="title"/>
+                    <choose>
+                      <if variable="collection-title">
+                        <group delimiter=" ">
+                          <text term="volume" form="short" text-case="capitalize-first"/>
+                          <number variable="collection-number" form="numeric"/>
+                          <choose>
+                            <if variable="collection-number" match="none">
+                              <number variable="volume" form="numeric"/>
+                            </if>
+                          </choose>
+                        </group>
+                      </if>
+                    </choose>
+                  </group>
+                  <!-- Replace with volume-title as that becomes available -->
+                  <group delimiter=": ">
+                    <text macro="container-title"/>
+                    <choose>
+                      <if variable="collection-title" is-numeric="volume" match="none">
+                        <group delimiter=" ">
+                          <text term="volume" form="short" text-case="capitalize-first"/>
+                          <text variable="volume"/>
+                        </group>
+                      </if>
+                    </choose>
+                  </group>
+                </group>
+              </if>
+              <else>
+                <!-- Replace with volume-title as that becomes available -->
+                <group delimiter=": ">
+                  <text macro="container-title"/>
+                  <choose>
+                    <if is-numeric="volume" match="none">
+                      <group delimiter=" ">
+                        <text term="volume" form="short" text-case="capitalize-first"/>
+                        <text variable="volume"/>
+                      </group>
+                    </if>
+                  </choose>
+                </group>
+              </else>
+            </choose>
+          </group>
+          <group delimiter="; " prefix="(" suffix=")">
+            <text macro="locators"/>
+            <names variable="container-author">
+              <label form="verb-short" suffix=" " text-case="title"/>
+            </names>
+          </group>
+        </group>
+      </if>
+    </choose>
+  </macro>
+  <!-- end of macro name="container-booklike" -->
+  <macro name="container-title">
+    <choose>
+      <if type="article article-journal article-magazine article-newspaper dataset" match="any">
+        <text variable="container-title" text-case="title"/>
+      </if>
+      <else-if type="speech" match="any">
+        <choose>
+          <if variable="collection-editor container-author editor" match="any">
+            <text variable="container-title"/>
+          </if>
+          <else>
+            <text variable="container-title" text-case="title"/>
+          </else>
+        </choose>
+      </else-if>
+      <else-if type="bill legal_case legislation post-weblog webpage" match="none">
+        <text variable="container-title"/>
+      </else-if>
+      <else-if type="paper-conference broadcast post post-weblog webpage" match="any">
+        <text variable="event-title" suffix=", "/>
+      </else-if>
+    </choose>
+  </macro>
+  <!-- After 'source', APA also prints publication history (original publication, reprint info, retraction info) -->
+  <macro name="publication-history">
+    <choose>
+      <if type="patent" match="none">
+        <group prefix="(" suffix=")">
+          <choose>
+            <if variable="references">
+              <!-- This provides the option for more elaborate description
+                   of publication history, such as full "reprinted" references
+                   (example 26) or retracted references -->
+              <text variable="references"/>
+            </if>
+            <else>
+              <choose>
+                <if variable="original-date">
+                  <group delimiter=" ">
+                    <text macro="original-published"/>
+                    <choose>
+                      <if is-uncertain-date="original-date">
+                        <group prefix="[" suffix="]" delimiter=" ">
+                          <text term="circa" form="short"/>
+                          <text macro="original-date"/>
+                        </group>
+                      </if>
+                      <else>
+                        <text macro="original-date"/>
+                      </else>
+                    </choose>
+                  </group>
+                </if>
+              </choose>
+            </else>
+          </choose>
+        </group>
+      </if>
+      <else>
+        <text variable="references" prefix="(" suffix=")"/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="legal-cites">
+    <choose>
+      <if type="legal_case">
+        <group prefix=", " delimiter=" ">
+          <group delimiter=" ">
+            <choose>
+              <if variable="container-title">
+                <text variable="volume"/>
+                <text variable="container-title"/>
+                <group delimiter=" ">
+                  <!--change to label variable="section" as that becomes available -->
+                  <text term="section" form="symbol"/>
+                  <text variable="section"/>
+                </group>
+                <text variable="page"/>
+              </if>
+              <else>
+                <group delimiter=" ">
+                  <choose>
+                    <if is-numeric="number">
+                      <!-- Replace with term="number" if that becomes available -->
+                      <text term="issue" form="short" text-case="capitalize-first"/>
+                    </if>
+                  </choose>
+                  <text variable="number"/>
+                </group>
+              </else>
+            </choose>
+          </group>
+          <group prefix="(" suffix=")" delimiter=" ">
+            <text variable="authority"/>
+            <choose>
+              <if variable="container-title" match="any">
+                <!--Only print year for cases published in reporters-->
+                <date variable="issued" form="numeric" date-parts="year"/>
+              </if>
+              <else>
+                <date variable="issued" form="text"/>
+              </else>
+            </choose>
+          </group>
+        </group>
+      </if>
+      <else-if type="bill legislation" match="any">
+        <group prefix=", " delimiter=" ">
+          <group delimiter=", ">
+            <choose>
+              <if variable="number">
+                <!--There's a public law number-->
+                <text variable="number" prefix="Pub. L. No. "/>
+                <group delimiter=" ">
+                  <!--change to label variable="section" as that becomes available -->
+                  <text term="section" form="symbol"/>
+                  <text variable="section"/>
+                </group>
+                <group delimiter=" ">
+                  <text variable="volume"/>
+                  <text variable="container-title"/>
+                  <text variable="page-first"/>
+                </group>
+              </if>
+              <else>
+                <group delimiter=" ">
+                  <text variable="volume"/>
+                  <text variable="container-title"/>
+                  <!--change to label variable="section" as that becomes available -->
+                  <text term="section" form="symbol"/>
+                  <text variable="section"/>
+                </group>
+              </else>
+            </choose>
+          </group>
+          <date variable="issued" prefix="(" suffix=")">
+            <date-part name="year"/>
+          </date>
+        </group>
+      </else-if>
+      <else-if type="treaty">
+        <group delimiter=" ">
+          <number variable="volume"/>
+          <text variable="container-title"/>
+          <text variable="page"/>
+        </group>
+      </else-if>
+    </choose>
+  </macro>
+  <!-- end of macro name="legal-cites" -->
+  <macro name="author-sort">
+    <!-- for sorting Japanese authors accoding to romanized name (variable name="author-yomi") in the Extra field instead of the Japanese Kanji names in the author field. e.g. author-yomi: Suzuki, Hanako; Yamada, Jiro -->
+    <names variable="author">
+      <name name-as-sort-order="all" sort-separator=", " delimiter="; " delimiter-precedes-last="always">
+        <name-part name="family" text-case="capitalize-first"/>
+        <name-part name="given" text-case="capitalize-first"/>
+      </name>
+      <substitute>
+        <names variable="editor"/>
+        <names variable="translator"/>
+        <text macro="title"/>
+      </substitute>
+    </names>
+  </macro>
+  <!-- ソート優先度の決定： extra (proxy for author-yomi) がない場合は"0"、ある場合は"1"を返す -->
+  <macro name="sort-priority">
+    <choose>
+      <if variable="author-yomi">
+        <!-- "note" maps to Extra field, which is a proxy for author-yomi -->
+        <text value="1"/>
+      </if>
+      <else>
+        <text value="0"/>
+      </else>
+    </choose>
+  </macro>
+  <!-- ソート用文字列の生成 -->
+  <macro name="author-yomi-sort-string">
+    <choose>
+      <if variable="author-yomi">
+        <!-- "author-yomi: " prepended to the Romanized Japanese names (FamilyName, GivenName; ...) in Extra field -->
+        <text variable="author-yomi"/>
+      </if>
+      <else>
+        <!-- author-yomiがない場合は通常の著者名を使用 -->
+        <text macro="author-sort"/>
+      </else>
+    </choose>
+  </macro>
+  <!-- end of macro name="author-sort-string" -->
+  <macro name="year-date">
+    <choose>
+      <if variable="issued">
+        <date variable="issued">
+          <date-part name="year"/>
+        </date>
+      </if>
+      <else>
+        <text term="no date" form="short"/>
+      </else>
+    </choose>
+  </macro>
+  <!-- 引用形式 -->
+  <citation et-al-min="3" et-al-use-first="1" et-al-subsequent-min="3" et-al-subsequent-use-first="1" disambiguate-add-year-suffix="true" disambiguate-add-names="false" disambiguate-add-givenname="false" collapse="year-suffix-ranged" givenname-disambiguation-rule="primary-name">
+    <sort>
+      <!-- まず優先度でソート（0=author-yomiなし、1=author-yomiあり） -->
+      <key macro="sort-priority"/>
+      <!-- 次に著者名またはauthor-yomiでソート -->
+      <key macro="author-yomi-sort-string"/>
+      <key macro="issued-sort" sort="ascending"/>
+    </sort>
+    <layout prefix="(" suffix=")" delimiter="; ">
+      <group delimiter=", ">
+        <text macro="author-short"/>
+        <text macro="year-date"/>
+        <!-- issued-citation in APA 6 removed -->
+        <text macro="citation-locator"/>
+      </group>
+    </layout>
+  </citation>
+  <bibliography hanging-indent="true" et-al-min="8" et-al-use-first="7" et-al-use-last="false" entry-spacing="0" line-spacing="2">
+    <sort>
+      <!-- まず優先度でソート（0=author-yomiなし、1=author-yomiあり） -->
+      <key macro="sort-priority" sort="ascending"/>
+      <!-- 次に著者名またはauthor-yomiでソート -->
+      <key macro="author-yomi-sort-string"/>
+      <!-- 年でソート -->
+      <key macro="year-date" sort="ascending"/>
+      <!-- タイトルでソート -->
+      <key variable="title"/>
+    </sort>
+    <layout>
+      <group delimiter=" " suffix=".">
+        <group delimiter=" ">
+          <!-- for debugging: -->
+          <!-- text value="["/><text macro="sort-priority"/><text macro="author-yomi-sort-string"/><text value="] "/ -->
+          <text macro="author"/>
+          <choose>
+            <if is-uncertain-date="issued">
+              <group prefix="[" suffix="]" delimiter=" ">
+                <text term="circa" form="short"/>
+                <text macro="issued"/>
+              </group>
+            </if>
+            <else>
+              <group prefix="(" suffix=")">
+                <text macro="year-date"/>
+                <text variable="year-suffix"/>
+              </group>
+            </else>
+          </choose>
+          <group delimiter=", ">
+            <text macro="title-and-descriptions"/>
+            <text macro="event-title"/>
+            <text macro="container"/>
+            <choose>
+              <if type="book review-book" match="any">
+                <text macro="publisher"/>
+              </if>
+            </choose>
+          </group>
+        </group>
+        <text macro="access"/>
+        <text macro="publication-history"/>
+      </group>
+    </layout>
+  </bibliography>
+</style>


### PR DESCRIPTION
Creation of the CSL for the "Japan Journal of Stuttering and Other Fluency Disorders," a journal in Japanese and English. Validated with 1.0.2 strict, with an error with the variable "author-yomi" (appearing on three lines), which is required for sorting bibliography in Japanese, and should be overridden when registering in Zotero.