### PR TITLE
MLA: Expand CSL support

### DIFF
--- a/modern-language-association-annotated-bibliography.csl
+++ b/modern-language-association-annotated-bibliography.csl
@@ -43,10 +43,21 @@
         <single>general editor</single>
         <multiple>general editors</multiple>
       </term>
+      <term name="editor-translator">
+        <single>editor and translator</single>
+        <multiple>editors and translators</multiple>
+      </term>
+      <term name="editortranslator">
+        <single>editor and translator</single>
+        <multiple>editors and translators</multiple>
+      </term>
+      <term form="verb" name="editor-translator">edited and translated by</term>
+      <term form="verb" name="editortranslator">edited and translated by</term>
       <term form="short" name="note">
         <single>n</single>
         <multiple>nn</multiple>
       </term>
+      <term name="original-work-published">originally published</term>
       <term form="short" name="paragraph">
         <single>par.</single>
         <multiple>pars.</multiple>
@@ -220,11 +231,14 @@
       <label form="long" prefix=", "/>
       <substitute>
         <names variable="author"/>
+        <names variable="guest">
+          <name delimiter-precedes-et-al="always" delimiter-precedes-last="always" name-as-sort-order="first"/>
+          <!-- `guest` has no label (see MLA 'Interview by podcast host') -->
+        </names>
         <names variable="editor-translator"/>
         <names variable="editor"/>
         <names variable="translator"/>
         <text macro="title"/>
-        <text macro="supplemental-generic-label"/>
       </substitute>
     </names>
   </macro>
@@ -234,11 +248,11 @@
         <name form="short" initialize-with=". "/>
         <substitute>
           <names variable="author"/>
+          <names variable="guest"/>
           <names variable="editor-translator"/>
           <names variable="editor"/>
           <names variable="translator"/>
           <text macro="title-short"/>
-          <text macro="supplemental-generic-label"/>
         </substitute>
       </names>
       <choose>
@@ -433,7 +447,7 @@
   </macro>
   <!-- 3. Supplemental Element after Title of Source (MLA 5.106-109) -->
   <macro name="supplemental-element-after-title">
-    <group delimiter=". ">
+    <group delimiter=", ">
       <text macro="supplemental-contributor"/>
       <text macro="supplemental-original-date"/>
       <text macro="supplemental-generic-label"/>
@@ -445,32 +459,14 @@
       <label form="verb" suffix=" " text-case="capitalize-first"/>
       <name/>
     </names>
-    <choose>
-      <if variable="container-title"/>
-      <else>
-        <group delimiter=", ">
-          <names delimiter=", " variable="editor-translator">
-            <label form="verb" suffix=" " text-case="capitalize-first"/>
-            <name/>
-          </names>
-          <names delimiter=", " variable="editor translator">
-            <label form="verb" suffix=" " text-case="capitalize-first"/>
-            <name/>
-          </names>
-          <names delimiter=", " variable="director illustrator contributor">
-            <label form="verb" suffix=" " text-case="capitalize-first"/>
-            <name/>
-          </names>
-        </group>
-      </else>
-    </choose>
   </macro>
   <!-- 3.2. Original publication date (MLA 5.108) -->
   <macro name="supplemental-original-date">
     <choose>
-      <if is-uncertain-date="original-date">
+      <if match="any" variable="original-publisher original-publisher-place"/>
+      <else-if is-uncertain-date="original-date">
         <date form="text" prefix="[" suffix="?]" variable="original-date"/>
-      </if>
+      </else-if>
       <else>
         <date form="text" variable="original-date"/>
       </else>
@@ -623,32 +619,16 @@
             <text term="supplement" text-case="capitalize-first"/>
             <text value="to"/>
           </else-if>
-          <else-if type="periodical">
-            <choose>
-              <if variable="genre">
-                <text text-case="capitalize-first" variable="genre"/>
-              </if>
-              <else-if variable="volume-title">
-                <text term="special-issue" text-case="capitalize-first"/>
-              </else-if>
-              <else-if type="periodical" variable="title">
-                <text term="special-issue" text-case="capitalize-first"/>
-              </else-if>
-            </choose>
+          <else-if type="periodical" variable="volume-title">
+            <text term="special-issue" text-case="capitalize-first"/>
+            <text value="of"/>
+          </else-if>
+          <else-if type="periodical" variable="title">
+            <text term="special-issue" text-case="capitalize-first"/>
             <text value="of"/>
           </else-if>
           <else-if variable="volume-title">
-            <choose>
-              <if variable="genre">
-                <text variable="genre"/>
-              </if>
-              <else-if variable="volume-title">
-                <text term="special-issue"/>
-              </else-if>
-              <else-if type="periodical" variable="title">
-                <text term="special-issue"/>
-              </else-if>
-            </choose>
+            <text term="special-issue"/>
             <text value="of"/>
           </else-if>
         </choose>
@@ -679,21 +659,33 @@
       </names>
       <choose>
         <if variable="container-title">
-          <group delimiter=", ">
-            <names delimiter=", " variable="editor-translator">
-              <label form="verb" suffix=" "/>
-              <name/>
-            </names>
-            <names delimiter=", " variable="editor translator">
-              <label form="verb" suffix=" "/>
-              <name/>
-            </names>
-            <names delimiter=", " variable="director illustrator contributor">
-              <label form="verb" suffix=" "/>
-              <name/>
-            </names>
-          </group>
+          <names delimiter=", " variable="editor-translator">
+            <label form="verb" suffix=" "/>
+            <name/>
+          </names>
+          <names delimiter=", " variable="editor translator">
+            <label form="verb" suffix=" "/>
+            <name/>
+          </names>
+          <names delimiter=", " variable="director series-creator illustrator host narrator contributor">
+            <label form="verb" suffix=" "/>
+            <name/>
+          </names>
         </if>
+        <else>
+          <names delimiter=", " variable="editor-translator">
+            <label form="verb" suffix=" " text-case="capitalize-first"/>
+            <name/>
+          </names>
+          <names delimiter=", " variable="editor translator">
+            <label form="verb" suffix=" " text-case="capitalize-first"/>
+            <name/>
+          </names>
+          <names delimiter=", " variable="director series-creator illustrator host narrator contributor">
+            <label form="verb" suffix=" " text-case="capitalize-first"/>
+            <name/>
+          </names>
+        </else>
       </choose>
     </group>
   </macro>
@@ -911,7 +903,7 @@
   </macro>
   <!-- 7. Supplemental Element at End of Entry (MLA 5.110-118) -->
   <macro name="supplemental-element-end">
-    <group delimiter=". ">
+    <group delimiter=", ">
       <text macro="supplemental-date-access"/>
       <text macro="supplemental-medium"/>
       <choose>
@@ -924,7 +916,7 @@
   </macro>
   <macro name="supplemental-element-movable">
     <!-- information relevant only to one container appears either in `supplemental-element-between` or `supplemental-element-end` depending on the presence of `source` -->
-    <group delimiter=". ">
+    <group delimiter=", ">
       <choose>
         <if match="any" type="article-journal article-magazine article-newspaper periodical post-weblog review review-book">
           <!-- serial usage -->
@@ -984,7 +976,11 @@
   <!-- 7.4. Publication history (MLA 5.114) -->
   <macro name="supplemental-publication-history">
     <group delimiter=" ">
-      <text term="original-work-published" text-case="capitalize-first"/>
+      <choose>
+        <if match="any" variable="original-publisher original-publisher-place original-title">
+          <text term="original-work-published" text-case="capitalize-first"/>
+        </if>
+      </choose>
       <group delimiter=", ">
         <choose>
           <if variable="original-title">
@@ -992,16 +988,42 @@
               <text value="as"/>
               <choose>
                 <if match="any" type="article-journal article-magazine article-newspaper periodical post-weblog review review-book">
-                  <text variable="original-title"/>
+                  <text quotes="true" text-case="title" variable="original-title"/>
                 </if>
                 <else>
-                  <text font-style="italic" variable="original-title"/>
+                  <text font-style="italic" text-case="title" variable="original-title"/>
                 </else>
               </choose>
             </group>
           </if>
         </choose>
-        <text variable="original-publisher"/>
+        <choose>
+          <if match="any" variable="original-publisher original-publisher-place">
+            <choose>
+              <if variable="original-publisher">
+                <group delimiter=" ">
+                  <choose>
+                    <if match="none" variable="original-title">
+                      <text term="by"/>
+                    </if>
+                  </choose>
+                  <text variable="original-publisher"/>
+                </group>
+              </if>
+              <else>
+                <text variable="original-publisher-place"/>
+              </else>
+            </choose>
+            <choose>
+              <if is-uncertain-date="original-date">
+                <date date-parts="year" form="text" prefix="[" suffix="?]" variable="original-date"/>
+              </if>
+              <else>
+                <date date-parts="year" form="text" variable="original-date"/>
+              </else>
+            </choose>
+          </if>
+        </choose>
       </group>
     </group>
   </macro>
@@ -1091,18 +1113,13 @@
             </group>
           </group>
         </else-if>
-        <else-if variable="part-number volume">
-          <text macro="label-volume-capitalized"/>
-          <text macro="label-part-number"/>
-        </else-if>
-        <else-if variable="part-number">
-          <text macro="label-part-number-capitalized"/>
-        </else-if>
-        <else-if variable="volume">
-          <text macro="label-volume-capitalized"/>
-        </else-if>
+        <!-- numbers without a volume title appear in `container1-number` -->
       </choose>
-      <text macro="label-number-of-volumes"/>
+      <choose>
+        <if match="none" variable="volume">
+          <text macro="label-number-of-volumes"/>
+        </if>
+      </choose>
       <!-- TODO: provide container date here when available -->
     </group>
   </macro>

--- a/modern-language-association-no-url.csl
+++ b/modern-language-association-no-url.csl
@@ -57,6 +57,7 @@
         <single>n</single>
         <multiple>nn</multiple>
       </term>
+      <term name="original-work-published">originally published</term>
       <term form="short" name="paragraph">
         <single>par.</single>
         <multiple>pars.</multiple>
@@ -230,11 +231,14 @@
       <label form="long" prefix=", "/>
       <substitute>
         <names variable="author"/>
+        <names variable="guest">
+          <name delimiter-precedes-et-al="always" delimiter-precedes-last="always" name-as-sort-order="first"/>
+          <!-- `guest` has no label (see MLA 'Interview by podcast host') -->
+        </names>
         <names variable="editor-translator"/>
         <names variable="editor"/>
         <names variable="translator"/>
         <text macro="title"/>
-        <text macro="supplemental-generic-label"/>
       </substitute>
     </names>
   </macro>
@@ -244,11 +248,11 @@
         <name form="short" initialize-with=". "/>
         <substitute>
           <names variable="author"/>
+          <names variable="guest"/>
           <names variable="editor-translator"/>
           <names variable="editor"/>
           <names variable="translator"/>
           <text macro="title-short"/>
-          <text macro="supplemental-generic-label"/>
         </substitute>
       </names>
       <choose>
@@ -459,9 +463,10 @@
   <!-- 3.2. Original publication date (MLA 5.108) -->
   <macro name="supplemental-original-date">
     <choose>
-      <if is-uncertain-date="original-date">
+      <if match="any" variable="original-publisher original-publisher-place"/>
+      <else-if is-uncertain-date="original-date">
         <date form="text" prefix="[" suffix="?]" variable="original-date"/>
-      </if>
+      </else-if>
       <else>
         <date form="text" variable="original-date"/>
       </else>
@@ -614,32 +619,16 @@
             <text term="supplement" text-case="capitalize-first"/>
             <text value="to"/>
           </else-if>
-          <else-if type="periodical">
-            <choose>
-              <if variable="genre">
-                <text text-case="capitalize-first" variable="genre"/>
-              </if>
-              <else-if variable="volume-title">
-                <text term="special-issue" text-case="capitalize-first"/>
-              </else-if>
-              <else-if type="periodical" variable="title">
-                <text term="special-issue" text-case="capitalize-first"/>
-              </else-if>
-            </choose>
+          <else-if type="periodical" variable="volume-title">
+            <text term="special-issue" text-case="capitalize-first"/>
+            <text value="of"/>
+          </else-if>
+          <else-if type="periodical" variable="title">
+            <text term="special-issue" text-case="capitalize-first"/>
             <text value="of"/>
           </else-if>
           <else-if variable="volume-title">
-            <choose>
-              <if variable="genre">
-                <text variable="genre"/>
-              </if>
-              <else-if variable="volume-title">
-                <text term="special-issue"/>
-              </else-if>
-              <else-if type="periodical" variable="title">
-                <text term="special-issue"/>
-              </else-if>
-            </choose>
+            <text term="special-issue"/>
             <text value="of"/>
           </else-if>
         </choose>
@@ -670,36 +659,32 @@
       </names>
       <choose>
         <if variable="container-title">
-          <group delimiter=", ">
-            <names delimiter=", " variable="editor-translator">
-              <label form="verb" suffix=" "/>
-              <name/>
-            </names>
-            <names delimiter=", " variable="editor translator">
-              <label form="verb" suffix=" "/>
-              <name/>
-            </names>
-            <names delimiter=", " variable="director illustrator host series-creator contributor">
-              <label form="verb" suffix=" "/>
-              <name/>
-            </names>
-          </group>
+          <names delimiter=", " variable="editor-translator">
+            <label form="verb" suffix=" "/>
+            <name/>
+          </names>
+          <names delimiter=", " variable="editor translator">
+            <label form="verb" suffix=" "/>
+            <name/>
+          </names>
+          <names delimiter=", " variable="director series-creator illustrator host narrator contributor">
+            <label form="verb" suffix=" "/>
+            <name/>
+          </names>
         </if>
         <else>
-          <group delimiter=", ">
-            <names delimiter=", " variable="editor-translator">
-              <label form="verb" suffix=" " text-case="capitalize-first"/>
-              <name/>
-            </names>
-            <names delimiter=", " variable="editor translator">
-              <label form="verb" suffix=" " text-case="capitalize-first"/>
-              <name/>
-            </names>
-            <names delimiter=", " variable="director illustrator host series-creator contributor">
-              <label form="verb" suffix=" " text-case="capitalize-first"/>
-              <name/>
-            </names>
-          </group>
+          <names delimiter=", " variable="editor-translator">
+            <label form="verb" suffix=" " text-case="capitalize-first"/>
+            <name/>
+          </names>
+          <names delimiter=", " variable="editor translator">
+            <label form="verb" suffix=" " text-case="capitalize-first"/>
+            <name/>
+          </names>
+          <names delimiter=", " variable="director series-creator illustrator host narrator contributor">
+            <label form="verb" suffix=" " text-case="capitalize-first"/>
+            <name/>
+          </names>
         </else>
       </choose>
     </group>
@@ -964,7 +949,11 @@
   <!-- 7.4. Publication history (MLA 5.114) -->
   <macro name="supplemental-publication-history">
     <group delimiter=" ">
-      <text term="original-work-published" text-case="capitalize-first"/>
+      <choose>
+        <if match="any" variable="original-publisher original-publisher-place original-title">
+          <text term="original-work-published" text-case="capitalize-first"/>
+        </if>
+      </choose>
       <group delimiter=", ">
         <choose>
           <if variable="original-title">
@@ -972,16 +961,42 @@
               <text value="as"/>
               <choose>
                 <if match="any" type="article-journal article-magazine article-newspaper periodical post-weblog review review-book">
-                  <text variable="original-title"/>
+                  <text quotes="true" text-case="title" variable="original-title"/>
                 </if>
                 <else>
-                  <text font-style="italic" variable="original-title"/>
+                  <text font-style="italic" text-case="title" variable="original-title"/>
                 </else>
               </choose>
             </group>
           </if>
         </choose>
-        <text variable="original-publisher"/>
+        <choose>
+          <if match="any" variable="original-publisher original-publisher-place">
+            <choose>
+              <if variable="original-publisher">
+                <group delimiter=" ">
+                  <choose>
+                    <if match="none" variable="original-title">
+                      <text term="by"/>
+                    </if>
+                  </choose>
+                  <text variable="original-publisher"/>
+                </group>
+              </if>
+              <else>
+                <text variable="original-publisher-place"/>
+              </else>
+            </choose>
+            <choose>
+              <if is-uncertain-date="original-date">
+                <date date-parts="year" form="text" prefix="[" suffix="?]" variable="original-date"/>
+              </if>
+              <else>
+                <date date-parts="year" form="text" variable="original-date"/>
+              </else>
+            </choose>
+          </if>
+        </choose>
       </group>
     </group>
   </macro>

--- a/modern-language-association-notes-no-url.csl
+++ b/modern-language-association-notes-no-url.csl
@@ -57,6 +57,7 @@
         <single>n</single>
         <multiple>nn</multiple>
       </term>
+      <term name="original-work-published">originally published</term>
       <term form="short" name="paragraph">
         <single>par.</single>
         <multiple>pars.</multiple>
@@ -230,11 +231,14 @@
       <label form="long" prefix=", "/>
       <substitute>
         <names variable="author"/>
+        <names variable="guest">
+          <name delimiter-precedes-et-al="always" delimiter-precedes-last="always" name-as-sort-order="first"/>
+          <!-- `guest` has no label (see MLA 'Interview by podcast host') -->
+        </names>
         <names variable="editor-translator"/>
         <names variable="editor"/>
         <names variable="translator"/>
         <text macro="title"/>
-        <text macro="supplemental-generic-label"/>
       </substitute>
     </names>
   </macro>
@@ -244,11 +248,11 @@
         <name form="short" initialize-with=". "/>
         <substitute>
           <names variable="author"/>
+          <names variable="guest"/>
           <names variable="editor-translator"/>
           <names variable="editor"/>
           <names variable="translator"/>
           <text macro="title-short"/>
-          <text macro="supplemental-generic-label"/>
         </substitute>
       </names>
       <choose>
@@ -459,9 +463,10 @@
   <!-- 3.2. Original publication date (MLA 5.108) -->
   <macro name="supplemental-original-date">
     <choose>
-      <if is-uncertain-date="original-date">
+      <if match="any" variable="original-publisher original-publisher-place"/>
+      <else-if is-uncertain-date="original-date">
         <date form="text" prefix="[" suffix="?]" variable="original-date"/>
-      </if>
+      </else-if>
       <else>
         <date form="text" variable="original-date"/>
       </else>
@@ -614,32 +619,16 @@
             <text term="supplement" text-case="capitalize-first"/>
             <text value="to"/>
           </else-if>
-          <else-if type="periodical">
-            <choose>
-              <if variable="genre">
-                <text text-case="capitalize-first" variable="genre"/>
-              </if>
-              <else-if variable="volume-title">
-                <text term="special-issue" text-case="capitalize-first"/>
-              </else-if>
-              <else-if type="periodical" variable="title">
-                <text term="special-issue" text-case="capitalize-first"/>
-              </else-if>
-            </choose>
+          <else-if type="periodical" variable="volume-title">
+            <text term="special-issue" text-case="capitalize-first"/>
+            <text value="of"/>
+          </else-if>
+          <else-if type="periodical" variable="title">
+            <text term="special-issue" text-case="capitalize-first"/>
             <text value="of"/>
           </else-if>
           <else-if variable="volume-title">
-            <choose>
-              <if variable="genre">
-                <text variable="genre"/>
-              </if>
-              <else-if variable="volume-title">
-                <text term="special-issue"/>
-              </else-if>
-              <else-if type="periodical" variable="title">
-                <text term="special-issue"/>
-              </else-if>
-            </choose>
+            <text term="special-issue"/>
             <text value="of"/>
           </else-if>
         </choose>
@@ -670,36 +659,32 @@
       </names>
       <choose>
         <if variable="container-title">
-          <group delimiter=", ">
-            <names delimiter=", " variable="editor-translator">
-              <label form="verb" suffix=" "/>
-              <name/>
-            </names>
-            <names delimiter=", " variable="editor translator">
-              <label form="verb" suffix=" "/>
-              <name/>
-            </names>
-            <names delimiter=", " variable="director illustrator host series-creator contributor">
-              <label form="verb" suffix=" "/>
-              <name/>
-            </names>
-          </group>
+          <names delimiter=", " variable="editor-translator">
+            <label form="verb" suffix=" "/>
+            <name/>
+          </names>
+          <names delimiter=", " variable="editor translator">
+            <label form="verb" suffix=" "/>
+            <name/>
+          </names>
+          <names delimiter=", " variable="director series-creator illustrator host narrator contributor">
+            <label form="verb" suffix=" "/>
+            <name/>
+          </names>
         </if>
         <else>
-          <group delimiter=", ">
-            <names delimiter=", " variable="editor-translator">
-              <label form="verb" suffix=" " text-case="capitalize-first"/>
-              <name/>
-            </names>
-            <names delimiter=", " variable="editor translator">
-              <label form="verb" suffix=" " text-case="capitalize-first"/>
-              <name/>
-            </names>
-            <names delimiter=", " variable="director illustrator host series-creator contributor">
-              <label form="verb" suffix=" " text-case="capitalize-first"/>
-              <name/>
-            </names>
-          </group>
+          <names delimiter=", " variable="editor-translator">
+            <label form="verb" suffix=" " text-case="capitalize-first"/>
+            <name/>
+          </names>
+          <names delimiter=", " variable="editor translator">
+            <label form="verb" suffix=" " text-case="capitalize-first"/>
+            <name/>
+          </names>
+          <names delimiter=", " variable="director series-creator illustrator host narrator contributor">
+            <label form="verb" suffix=" " text-case="capitalize-first"/>
+            <name/>
+          </names>
         </else>
       </choose>
     </group>
@@ -964,7 +949,11 @@
   <!-- 7.4. Publication history (MLA 5.114) -->
   <macro name="supplemental-publication-history">
     <group delimiter=" ">
-      <text term="original-work-published" text-case="capitalize-first"/>
+      <choose>
+        <if match="any" variable="original-publisher original-publisher-place original-title">
+          <text term="original-work-published" text-case="capitalize-first"/>
+        </if>
+      </choose>
       <group delimiter=", ">
         <choose>
           <if variable="original-title">
@@ -972,16 +961,42 @@
               <text value="as"/>
               <choose>
                 <if match="any" type="article-journal article-magazine article-newspaper periodical post-weblog review review-book">
-                  <text variable="original-title"/>
+                  <text quotes="true" text-case="title" variable="original-title"/>
                 </if>
                 <else>
-                  <text font-style="italic" variable="original-title"/>
+                  <text font-style="italic" text-case="title" variable="original-title"/>
                 </else>
               </choose>
             </group>
           </if>
         </choose>
-        <text variable="original-publisher"/>
+        <choose>
+          <if match="any" variable="original-publisher original-publisher-place">
+            <choose>
+              <if variable="original-publisher">
+                <group delimiter=" ">
+                  <choose>
+                    <if match="none" variable="original-title">
+                      <text term="by"/>
+                    </if>
+                  </choose>
+                  <text variable="original-publisher"/>
+                </group>
+              </if>
+              <else>
+                <text variable="original-publisher-place"/>
+              </else>
+            </choose>
+            <choose>
+              <if is-uncertain-date="original-date">
+                <date date-parts="year" form="text" prefix="[" suffix="?]" variable="original-date"/>
+              </if>
+              <else>
+                <date date-parts="year" form="text" variable="original-date"/>
+              </else>
+            </choose>
+          </if>
+        </choose>
       </group>
     </group>
   </macro>

--- a/modern-language-association-notes.csl
+++ b/modern-language-association-notes.csl
@@ -57,6 +57,7 @@
         <single>n</single>
         <multiple>nn</multiple>
       </term>
+      <term name="original-work-published">originally published</term>
       <term form="short" name="paragraph">
         <single>par.</single>
         <multiple>pars.</multiple>
@@ -230,11 +231,14 @@
       <label form="long" prefix=", "/>
       <substitute>
         <names variable="author"/>
+        <names variable="guest">
+          <name delimiter-precedes-et-al="always" delimiter-precedes-last="always" name-as-sort-order="first"/>
+          <!-- `guest` has no label (see MLA 'Interview by podcast host') -->
+        </names>
         <names variable="editor-translator"/>
         <names variable="editor"/>
         <names variable="translator"/>
         <text macro="title"/>
-        <text macro="supplemental-generic-label"/>
       </substitute>
     </names>
   </macro>
@@ -244,11 +248,11 @@
         <name form="short" initialize-with=". "/>
         <substitute>
           <names variable="author"/>
+          <names variable="guest"/>
           <names variable="editor-translator"/>
           <names variable="editor"/>
           <names variable="translator"/>
           <text macro="title-short"/>
-          <text macro="supplemental-generic-label"/>
         </substitute>
       </names>
       <choose>
@@ -459,9 +463,10 @@
   <!-- 3.2. Original publication date (MLA 5.108) -->
   <macro name="supplemental-original-date">
     <choose>
-      <if is-uncertain-date="original-date">
+      <if match="any" variable="original-publisher original-publisher-place"/>
+      <else-if is-uncertain-date="original-date">
         <date form="text" prefix="[" suffix="?]" variable="original-date"/>
-      </if>
+      </else-if>
       <else>
         <date form="text" variable="original-date"/>
       </else>
@@ -614,32 +619,16 @@
             <text term="supplement" text-case="capitalize-first"/>
             <text value="to"/>
           </else-if>
-          <else-if type="periodical">
-            <choose>
-              <if variable="genre">
-                <text text-case="capitalize-first" variable="genre"/>
-              </if>
-              <else-if variable="volume-title">
-                <text term="special-issue" text-case="capitalize-first"/>
-              </else-if>
-              <else-if type="periodical" variable="title">
-                <text term="special-issue" text-case="capitalize-first"/>
-              </else-if>
-            </choose>
+          <else-if type="periodical" variable="volume-title">
+            <text term="special-issue" text-case="capitalize-first"/>
+            <text value="of"/>
+          </else-if>
+          <else-if type="periodical" variable="title">
+            <text term="special-issue" text-case="capitalize-first"/>
             <text value="of"/>
           </else-if>
           <else-if variable="volume-title">
-            <choose>
-              <if variable="genre">
-                <text variable="genre"/>
-              </if>
-              <else-if variable="volume-title">
-                <text term="special-issue"/>
-              </else-if>
-              <else-if type="periodical" variable="title">
-                <text term="special-issue"/>
-              </else-if>
-            </choose>
+            <text term="special-issue"/>
             <text value="of"/>
           </else-if>
         </choose>
@@ -670,36 +659,32 @@
       </names>
       <choose>
         <if variable="container-title">
-          <group delimiter=", ">
-            <names delimiter=", " variable="editor-translator">
-              <label form="verb" suffix=" "/>
-              <name/>
-            </names>
-            <names delimiter=", " variable="editor translator">
-              <label form="verb" suffix=" "/>
-              <name/>
-            </names>
-            <names delimiter=", " variable="director illustrator host series-creator contributor">
-              <label form="verb" suffix=" "/>
-              <name/>
-            </names>
-          </group>
+          <names delimiter=", " variable="editor-translator">
+            <label form="verb" suffix=" "/>
+            <name/>
+          </names>
+          <names delimiter=", " variable="editor translator">
+            <label form="verb" suffix=" "/>
+            <name/>
+          </names>
+          <names delimiter=", " variable="director series-creator illustrator host narrator contributor">
+            <label form="verb" suffix=" "/>
+            <name/>
+          </names>
         </if>
         <else>
-          <group delimiter=", ">
-            <names delimiter=", " variable="editor-translator">
-              <label form="verb" suffix=" " text-case="capitalize-first"/>
-              <name/>
-            </names>
-            <names delimiter=", " variable="editor translator">
-              <label form="verb" suffix=" " text-case="capitalize-first"/>
-              <name/>
-            </names>
-            <names delimiter=", " variable="director illustrator host series-creator contributor">
-              <label form="verb" suffix=" " text-case="capitalize-first"/>
-              <name/>
-            </names>
-          </group>
+          <names delimiter=", " variable="editor-translator">
+            <label form="verb" suffix=" " text-case="capitalize-first"/>
+            <name/>
+          </names>
+          <names delimiter=", " variable="editor translator">
+            <label form="verb" suffix=" " text-case="capitalize-first"/>
+            <name/>
+          </names>
+          <names delimiter=", " variable="director series-creator illustrator host narrator contributor">
+            <label form="verb" suffix=" " text-case="capitalize-first"/>
+            <name/>
+          </names>
         </else>
       </choose>
     </group>
@@ -991,7 +976,11 @@
   <!-- 7.4. Publication history (MLA 5.114) -->
   <macro name="supplemental-publication-history">
     <group delimiter=" ">
-      <text term="original-work-published" text-case="capitalize-first"/>
+      <choose>
+        <if match="any" variable="original-publisher original-publisher-place original-title">
+          <text term="original-work-published" text-case="capitalize-first"/>
+        </if>
+      </choose>
       <group delimiter=", ">
         <choose>
           <if variable="original-title">
@@ -999,16 +988,42 @@
               <text value="as"/>
               <choose>
                 <if match="any" type="article-journal article-magazine article-newspaper periodical post-weblog review review-book">
-                  <text variable="original-title"/>
+                  <text quotes="true" text-case="title" variable="original-title"/>
                 </if>
                 <else>
-                  <text font-style="italic" variable="original-title"/>
+                  <text font-style="italic" text-case="title" variable="original-title"/>
                 </else>
               </choose>
             </group>
           </if>
         </choose>
-        <text variable="original-publisher"/>
+        <choose>
+          <if match="any" variable="original-publisher original-publisher-place">
+            <choose>
+              <if variable="original-publisher">
+                <group delimiter=" ">
+                  <choose>
+                    <if match="none" variable="original-title">
+                      <text term="by"/>
+                    </if>
+                  </choose>
+                  <text variable="original-publisher"/>
+                </group>
+              </if>
+              <else>
+                <text variable="original-publisher-place"/>
+              </else>
+            </choose>
+            <choose>
+              <if is-uncertain-date="original-date">
+                <date date-parts="year" form="text" prefix="[" suffix="?]" variable="original-date"/>
+              </if>
+              <else>
+                <date date-parts="year" form="text" variable="original-date"/>
+              </else>
+            </choose>
+          </if>
+        </choose>
       </group>
     </group>
   </macro>

--- a/modern-language-association.csl
+++ b/modern-language-association.csl
@@ -56,6 +56,7 @@
         <single>n</single>
         <multiple>nn</multiple>
       </term>
+      <term name="original-work-published">originally published</term>
       <term form="short" name="paragraph">
         <single>par.</single>
         <multiple>pars.</multiple>
@@ -229,11 +230,14 @@
       <label form="long" prefix=", "/>
       <substitute>
         <names variable="author"/>
+        <names variable="guest">
+          <name delimiter-precedes-et-al="always" delimiter-precedes-last="always" name-as-sort-order="first"/>
+          <!-- `guest` has no label (see MLA 'Interview by podcast host') -->
+        </names>
         <names variable="editor-translator"/>
         <names variable="editor"/>
         <names variable="translator"/>
         <text macro="title"/>
-        <text macro="supplemental-generic-label"/>
       </substitute>
     </names>
   </macro>
@@ -243,11 +247,11 @@
         <name form="short" initialize-with=". "/>
         <substitute>
           <names variable="author"/>
+          <names variable="guest"/>
           <names variable="editor-translator"/>
           <names variable="editor"/>
           <names variable="translator"/>
           <text macro="title-short"/>
-          <text macro="supplemental-generic-label"/>
         </substitute>
       </names>
       <choose>
@@ -458,9 +462,10 @@
   <!-- 3.2. Original publication date (MLA 5.108) -->
   <macro name="supplemental-original-date">
     <choose>
-      <if is-uncertain-date="original-date">
+      <if match="any" variable="original-publisher original-publisher-place"/>
+      <else-if is-uncertain-date="original-date">
         <date form="text" prefix="[" suffix="?]" variable="original-date"/>
-      </if>
+      </else-if>
       <else>
         <date form="text" variable="original-date"/>
       </else>
@@ -613,32 +618,16 @@
             <text term="supplement" text-case="capitalize-first"/>
             <text value="to"/>
           </else-if>
-          <else-if type="periodical">
-            <choose>
-              <if variable="genre">
-                <text text-case="capitalize-first" variable="genre"/>
-              </if>
-              <else-if variable="volume-title">
-                <text term="special-issue" text-case="capitalize-first"/>
-              </else-if>
-              <else-if type="periodical" variable="title">
-                <text term="special-issue" text-case="capitalize-first"/>
-              </else-if>
-            </choose>
+          <else-if type="periodical" variable="volume-title">
+            <text term="special-issue" text-case="capitalize-first"/>
+            <text value="of"/>
+          </else-if>
+          <else-if type="periodical" variable="title">
+            <text term="special-issue" text-case="capitalize-first"/>
             <text value="of"/>
           </else-if>
           <else-if variable="volume-title">
-            <choose>
-              <if variable="genre">
-                <text variable="genre"/>
-              </if>
-              <else-if variable="volume-title">
-                <text term="special-issue"/>
-              </else-if>
-              <else-if type="periodical" variable="title">
-                <text term="special-issue"/>
-              </else-if>
-            </choose>
+            <text term="special-issue"/>
             <text value="of"/>
           </else-if>
         </choose>
@@ -669,36 +658,32 @@
       </names>
       <choose>
         <if variable="container-title">
-          <group delimiter=", ">
-            <names delimiter=", " variable="editor-translator">
-              <label form="verb" suffix=" "/>
-              <name/>
-            </names>
-            <names delimiter=", " variable="editor translator">
-              <label form="verb" suffix=" "/>
-              <name/>
-            </names>
-            <names delimiter=", " variable="director illustrator host series-creator contributor">
-              <label form="verb" suffix=" "/>
-              <name/>
-            </names>
-          </group>
+          <names delimiter=", " variable="editor-translator">
+            <label form="verb" suffix=" "/>
+            <name/>
+          </names>
+          <names delimiter=", " variable="editor translator">
+            <label form="verb" suffix=" "/>
+            <name/>
+          </names>
+          <names delimiter=", " variable="director series-creator illustrator host narrator contributor">
+            <label form="verb" suffix=" "/>
+            <name/>
+          </names>
         </if>
         <else>
-          <group delimiter=", ">
-            <names delimiter=", " variable="editor-translator">
-              <label form="verb" suffix=" " text-case="capitalize-first"/>
-              <name/>
-            </names>
-            <names delimiter=", " variable="editor translator">
-              <label form="verb" suffix=" " text-case="capitalize-first"/>
-              <name/>
-            </names>
-            <names delimiter=", " variable="director illustrator host series-creator contributor">
-              <label form="verb" suffix=" " text-case="capitalize-first"/>
-              <name/>
-            </names>
-          </group>
+          <names delimiter=", " variable="editor-translator">
+            <label form="verb" suffix=" " text-case="capitalize-first"/>
+            <name/>
+          </names>
+          <names delimiter=", " variable="editor translator">
+            <label form="verb" suffix=" " text-case="capitalize-first"/>
+            <name/>
+          </names>
+          <names delimiter=", " variable="director series-creator illustrator host narrator contributor">
+            <label form="verb" suffix=" " text-case="capitalize-first"/>
+            <name/>
+          </names>
         </else>
       </choose>
     </group>
@@ -990,7 +975,11 @@
   <!-- 7.4. Publication history (MLA 5.114) -->
   <macro name="supplemental-publication-history">
     <group delimiter=" ">
-      <text term="original-work-published" text-case="capitalize-first"/>
+      <choose>
+        <if match="any" variable="original-publisher original-publisher-place original-title">
+          <text term="original-work-published" text-case="capitalize-first"/>
+        </if>
+      </choose>
       <group delimiter=", ">
         <choose>
           <if variable="original-title">
@@ -998,16 +987,42 @@
               <text value="as"/>
               <choose>
                 <if match="any" type="article-journal article-magazine article-newspaper periodical post-weblog review review-book">
-                  <text variable="original-title"/>
+                  <text quotes="true" text-case="title" variable="original-title"/>
                 </if>
                 <else>
-                  <text font-style="italic" variable="original-title"/>
+                  <text font-style="italic" text-case="title" variable="original-title"/>
                 </else>
               </choose>
             </group>
           </if>
         </choose>
-        <text variable="original-publisher"/>
+        <choose>
+          <if match="any" variable="original-publisher original-publisher-place">
+            <choose>
+              <if variable="original-publisher">
+                <group delimiter=" ">
+                  <choose>
+                    <if match="none" variable="original-title">
+                      <text term="by"/>
+                    </if>
+                  </choose>
+                  <text variable="original-publisher"/>
+                </group>
+              </if>
+              <else>
+                <text variable="original-publisher-place"/>
+              </else>
+            </choose>
+            <choose>
+              <if is-uncertain-date="original-date">
+                <date date-parts="year" form="text" prefix="[" suffix="?]" variable="original-date"/>
+              </if>
+              <else>
+                <date date-parts="year" form="text" variable="original-date"/>
+              </else>
+            </choose>
+          </if>
+        </choose>
       </group>
     </group>
   </macro>


### PR DESCRIPTION
- Provide supplemental elements (MLA 5.106– 118), including support for reviews, multivolume and multi-part works, and journal special issues
- Add variants without URLs (MLA 5.84)
- Use `<label>` element to label variables to allow plural 'nos.' etc.
- Support uncertain dates
- Use em dashes in the bibliography (MLA 5.127 allows either dashes or hyphens but prefers the former)
- Provide `archive_collection`
- Allow `publisher-place` as fallback where there is no `publisher`
- Label `version` variable
- Sort attributes
- Add comments to reflect MLA container structure