### PR TITLE
Fix UTF-8 encoding of literatura.csl

### DIFF
--- a/literatura.csl
+++ b/literatura.csl
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" demote-non-dropping-particle="sort-only">
   <!-- Polyglot; journal publishes in English, French, Italian, German, Lithuanian and Russian. -->
   <info>


### PR DESCRIPTION
`.csl` styles in this repository are stored as UTF-8. `literatura.csl` was saved with encoding "UTF-8 with BOM". Some XML parsers do not handle the leading BOM well. Change the encoding to UTF-8.