### PR TITLE
"Programme Sorgho CNRA_JPS" citation style

### DIFF
--- a/Programme Sorgho CNRA_JPS
+++ b/Programme Sorgho CNRA_JPS
@@ -1,0 +1,147 @@
+<?xml version="1.0" encoding="utf-8"?>
+<style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" default-locale="en-US" demote-non-dropping-particle="sort-only">
+  <info>
+    <title>Programme Sorgho CNRA_JPS</title>
+    <id>http://www.zotero.org/styles/style_jps_cnra</id>
+    <link href="http://onlinelibrary.wiley.com/journal/10.1111/%28ISSN%291365-294X/homepage/ForAuthors.html" rel="documentation"/>
+    <author>
+      <name>Joseph Pascal SENE</name>
+      <email>joseph15.sene@gmail.com</email>
+    </author>
+    <category citation-format="author-date"/>
+    <category field="biology"/>
+    <issn>0962-1083</issn>
+    <eissn>1365-294X</eissn>
+    <updated>2025-01-22T22:19:51+00:00</updated>
+    <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
+  </info>
+  <macro name="editor-translator">
+    <names variable="editor translator" prefix=" (" delimiter=", " suffix=")">
+      <name initialize-with="" delimiter=", "/>
+      <label form="short" prefix=", " text-case="capitalize-first" suffix="," strip-periods="true"/>
+    </names>
+  </macro>
+  <macro name="author">
+    <names variable="author">
+      <name name-as-sort-order="all" sort-separator=" " initialize-with="." delimiter=", " delimiter-precedes-et-al="never"/>
+      <label form="short" prefix=" (" suffix=")" text-case="capitalize-first"/>
+      <et-al font-style="italic"/>
+      <substitute>
+        <names variable="editor"/>
+        <names variable="translator"/>
+        <text macro="title"/>
+      </substitute>
+    </names>
+  </macro>
+  <macro name="author-short">
+    <names variable="author">
+      <name form="short" and="symbol" delimiter=", " initialize-with=". "/>
+      <et-al font-style="italic"/>
+      <substitute>
+        <names variable="editor"/>
+        <names variable="translator"/>
+        <choose>
+          <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
+            <text variable="title" form="short" font-style="italic"/>
+          </if>
+          <else>
+            <text variable="title" form="short" quotes="true"/>
+          </else>
+        </choose>
+      </substitute>
+    </names>
+  </macro>
+  <macro name="title">
+    <choose>
+      <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
+        <text variable="title" font-style="italic"/>
+      </if>
+      <else>
+        <text variable="title"/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="publisher">
+    <group delimiter=", ">
+      <text variable="publisher"/>
+      <text variable="publisher-place"/>
+    </group>
+  </macro>
+  <citation collapse="year-suffix" et-al-min="3" et-al-use-first="1" disambiguate-add-year-suffix="true">
+    <sort>
+      <key variable="issued"/>
+      <key variable="author"/>
+    </sort>
+    <layout prefix="(" suffix=")" delimiter="; ">
+      <group delimiter=", ">
+        <text macro="author-short"/>
+        <date variable="issued">
+          <date-part name="year"/>
+        </date>
+        <group>
+          <label variable="locator" form="short"/>
+          <text variable="locator" prefix=" "/>
+        </group>
+      </group>
+    </layout>
+  </citation>
+  <bibliography hanging-indent="true" et-al-min="1" et-al-use-first="3" entry-spacing="0" line-spacing="2">
+    <sort>
+      <key macro="author-short"/>
+      <key variable="issued"/>
+    </sort>
+    <layout>
+      <text macro="author" suffix=" "/>
+      <date variable="issued" prefix="(" suffix=") –">
+        <date-part name="year"/>
+      </date>
+      <choose>
+        <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
+          <group suffix=".">
+            <text macro="title" prefix=" "/>
+            <text macro="editor-translator" prefix=" "/>
+          </group>
+          <text prefix=" " suffix="." macro="publisher"/>
+        </if>
+        <else-if type="thesis" match="any">
+          <group suffix=".">
+            <text macro="title" prefix=" " suffix="."/>
+            <text variable="genre" prefix=" " suffix=" Thesis."/>
+            <text prefix=" " macro="publisher"/>
+          </group>
+        </else-if>
+        <else-if type="chapter paper-conference" match="any">
+          <text macro="title" prefix=" "/>
+          <group prefix=".">
+            <group prefix=" In:">
+              <text variable="container-title" font-style="italic" prefix=" "/>
+              <text variable="collection-title" prefix=" " suffix="."/>
+              <names variable="editor translator" prefix=" (" delimiter=", " suffix=")">
+                <label form="short" suffix=" " strip-periods="true"/>
+                <name name-as-sort-order="all" sort-separator=" " initialize-with="" delimiter=", " delimiter-precedes-last="never"/>
+              </names>
+              <group suffix=".">
+                <label variable="page" form="short" prefix=", " suffix=" "/>
+                <text variable="page"/>
+                <text macro="publisher" prefix=". " suffix="."/>
+              </group>
+            </group>
+          </group>
+        </else-if>
+        <else>
+          <group suffix=".">
+            <text macro="title" prefix=" "/>
+            <text macro="editor-translator" prefix=" "/>
+          </group>
+          <group prefix=" " suffix=".">
+            <text variable="container-title" font-style="italic"/>
+            <group prefix=", ">
+              <text variable="volume" font-weight="bold"/>
+            </group>
+            <text variable="page" prefix=", "/>
+          </group>
+        </else>
+      </choose>
+    </layout>
+  </bibliography>
+</style>


### PR DESCRIPTION
This CSL citation style is for the "Programme Sorgho CNRA_JPS" references.

- Style Name: Programme Sorgho CNRA_JPS
- Target Journal: CNRA Sorghum Research Program
- Citation Format: Author-Date
- Notes: Custom style for internal sorghum research citations. Handles journal articles, theses, book chapters, and conference papers.
- Author: Joseph Pascal SENE (joseph15.sene@gmail.com)
- Version: 1.0
- Tested on: Mendeley Reference Manager and Zotero
- License: Creative Commons Attribution-ShareAlike 3.0