### PR TITLE
Add OSCOLA variant with journal abbreviations

### DIFF
--- a/eu-interinstitutional-style-1st-edition.csl
+++ b/eu-interinstitutional-style-1st-edition.csl
@@ -1,4 +1,5 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+﻿
+<?xml version="1.0" encoding="utf-8"?>
 <style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" and="text" delimiter-precedes-et-al="never" delimiter-precedes-last="never" initialize-with=". " page-range-format="expanded" demote-non-dropping-particle="never" default-locale="en-GB">
   <!-- This style was edited with the Visual CSL Editor (https://editor.citationstyles.org/visualEditor/) -->
   <info>

--- a/eu-interinstitutional-style-1st-edition.csl
+++ b/eu-interinstitutional-style-1st-edition.csl
@@ -1,5 +1,4 @@
-﻿
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" and="text" delimiter-precedes-et-al="never" delimiter-precedes-last="never" initialize-with=". " page-range-format="expanded" demote-non-dropping-particle="never" default-locale="en-GB">
   <!-- This style was edited with the Visual CSL Editor (https://editor.citationstyles.org/visualEditor/) -->
   <info>

--- a/oscola-journal-abbreviations.csl
+++ b/oscola-journal-abbreviations.csl
@@ -1,19 +1,25 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <style xmlns="http://purl.org/net/xbiblio/csl" class="note" version="1.0" demote-non-dropping-particle="never" default-locale="en-GB">
   <info>
-    <title>OSCOLA (Oxford University Standard for Citation of Legal Authorities)</title>
-    <title-short>OSCOLA</title-short>
-    <id>http://www.zotero.org/styles/oscola</id>
-    <link href="http://www.zotero.org/styles/oscola" rel="self"/>
-    <link href="http://www.zotero.org/styles/australian-guide-to-legal-citation" rel="template"/>
+    <title>OSCOLA (Oxford University Standard for Citation of Legal Authorities, with journal abbreviations)</title>
+    <title-short>OSCOLA (with journal abbreviations)</title-short>
+    <id>http://www.zotero.org/styles/oscola-journal-abbreviations</id>
+    <link href="http://www.zotero.org/styles/oscola-journal-abbreviations" rel="self"/>
+    <link href="http://www.zotero.org/styles/oscola" rel="template"/>
     <link href="http://www.law.ox.ac.uk/publications/oscola.php" rel="documentation"/>
     <author>
       <name>Sebastian Karcher</name>
     </author>
+    <contributor>
+      <name>Aaron Timoshanko</name>
+    </contributor>
+    <contributor>
+      <name>Brenton M. Wiernik</name>
+    </contributor>
     <category citation-format="note"/>
     <category field="law"/>
-    <summary>The OSCOLA Standards. For a Zotero Group showing data-entry in Zotero see: https://www.zotero.org/groups/oscola_samples/items/order/itemType</summary>
-    <updated>2013-11-15T01:56:32+00:00</updated>
+    <summary>The OSCOLA Standards, with journal abbreviations. For a Zotero Group showing data-entry in Zotero see: https://www.zotero.org/groups/oscola_samples/items/order/itemType</summary>
+    <updated>2025-02-23T10:56:32+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale>
@@ -418,6 +424,16 @@
                   </if>
                 </choose>
               </if>
+              <else-if type="article-journal" match="any">
+                <choose>
+                  <if match="any" variable="container-title-short">
+                    <text variable="container-title-short" form="short" strip-periods="true"/>
+                  </if>
+                  <else>
+                    <text variable="container-title" strip-periods="true"/>
+                  </else>
+                </choose>
+              </else-if>
               <else-if type="article-magazine article-newspaper" match="any">
                 <text variable="container-title" font-style="italic"/>
               </else-if>

--- a/oscola-journal-abbreviations.csl
+++ b/oscola-journal-abbreviations.csl
@@ -1,4 +1,5 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+﻿
+<?xml version="1.0" encoding="utf-8"?>
 <style xmlns="http://purl.org/net/xbiblio/csl" class="note" version="1.0" demote-non-dropping-particle="never" default-locale="en-GB">
   <info>
     <title>OSCOLA (Oxford University Standard for Citation of Legal Authorities, with journal abbreviations)</title>

--- a/oscola-no-ibid.csl
+++ b/oscola-no-ibid.csl
@@ -10,13 +10,10 @@
     <author>
       <name>Sebastian Karcher</name>
     </author>
-    <contributor>
-      <name>Brenton M. Wiernik</name>
-    </contributor>
     <category citation-format="note"/>
     <category field="law"/>
     <summary>The OSCOLA Standards with no ibid. For a Zotero Group showing data-entry in Zotero see: https://www.zotero.org/groups/oscola_samples/items/order/itemType</summary>
-    <updated>2025-08-26T01:14:57+00:00</updated>
+    <updated>2013-11-15T01:14:57+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale>
@@ -417,16 +414,6 @@
                   </if>
                 </choose>
               </if>
-              <else-if type="article-journal" match="any">
-                <choose>
-                  <if match="any" variable="container-title-short">
-                    <text variable="container-title-short" form="short" strip-periods="true"/>
-                  </if>
-                  <else>
-                    <text variable="container-title" strip-periods="true"/>
-                  </else>
-                </choose>
-              </else-if>
               <else-if type="article-magazine article-newspaper" match="any">
                 <text variable="container-title" font-style="italic"/>
               </else-if>

--- a/oscola.csl
+++ b/oscola.csl
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <style xmlns="http://purl.org/net/xbiblio/csl" class="note" version="1.0" demote-non-dropping-particle="never" default-locale="en-GB">
-  <!-- This style was edited with the Visual CSL Editor (https://editor.citationstyles.org/visualEditor/) -->
   <info>
     <title>OSCOLA (Oxford University Standard for Citation of Legal Authorities)</title>
     <title-short>OSCOLA</title-short>
@@ -42,7 +41,9 @@
       <term name="et-al">and others</term>
     </terms>
   </locale>
+  <!--Authors and Persons-->
   <macro name="author-note">
+    <!--for bills & hearing this should start with jurisdiction once available-->
     <choose>
       <if type="interview">
         <group delimiter=", ">
@@ -125,6 +126,7 @@
     </choose>
   </macro>
   <macro name="author">
+    <!--for bills & hearing this should start with jurisdiction once available-->
     <choose>
       <if type="interview">
         <group delimiter=", ">
@@ -185,6 +187,7 @@
       </names>
     </group>
   </macro>
+  <!-- Titles -->
   <macro name="title">
     <choose>
       <if type="book motion_picture treaty" match="any">
@@ -224,6 +227,7 @@
       </else>
     </choose>
   </macro>
+  <!--Dates-->
   <macro name="issued-year">
     <date variable="issued" form="text" date-parts="year"/>
   </macro>
@@ -241,6 +245,7 @@
             <text macro="issued-year" prefix="(" suffix=")"/>
           </else-if>
           <else-if variable="container-title volume number" match="any">
+            <!--no year in square brackets for unreported case w/o medium neutral citation-->
             <text macro="issued-year" prefix="[" suffix="]"/>
           </else-if>
         </choose>
@@ -250,6 +255,7 @@
       </else-if>
     </choose>
   </macro>
+  <!--publication info -->
   <macro name="publisher">
     <choose>
       <if type="book chapter broadcast personal_communication manuscript paper-conference article-newspaper report legislation motion_picture speech interview thesis entry-encyclopedia webpage post-weblog article" match="any">
@@ -264,6 +270,7 @@
                 <date variable="issued" form="text"/>
               </else-if>
               <else-if type="legislation bill" match="any">
+                <!--this should be jurisdiction we use code instead-->
                 <text variable="container-title" strip-periods="true"/>
               </else-if>
               <else>
@@ -274,6 +281,7 @@
                 </names>
                 <text macro="editor"/>
                 <choose>
+                  <!--if none of these, this we don't want edition either. Might be Loose-Leaf-->
                   <if variable="publisher issued genre container-title" match="any">
                     <text macro="edition"/>
                   </if>
@@ -394,6 +402,7 @@
     <choose>
       <if type="article-journal article-magazine article-newspaper legal_case" match="any">
         <group delimiter=", ">
+          <!--Assume that only cases with a Medium Neutral Citation have a docket number -->
           <choose>
             <if variable="authority number" match="all">
               <group delimiter=" ">
@@ -523,6 +532,7 @@
       </else-if>
     </choose>
   </macro>
+  <!--Others -->
   <macro name="treaty-catchall">
     <choose>
       <if type="treaty">
@@ -556,6 +566,7 @@
     </names>
   </macro>
   <macro name="sort-type">
+    <!--This should just sort secondary sources first. I'm leaving the rest from AGLC for simplicity-->
     <choose>
       <if type="book chapter paper-conference article-magazine article-newspaper article-journal manuscript report speech entry-encyclopedia" match="any">
         <text value="1"/>
@@ -595,6 +606,7 @@
         <else-if position="subsequent">
           <choose>
             <if type="legal_case bill legislation treaty" match="any">
+              <!--don't use short form and above note for legal citations -->
               <group delimiter=" ">
                 <text macro="author-note"/>
                 <text macro="title-short"/>

--- a/oscola.csl
+++ b/oscola.csl
@@ -1,6 +1,7 @@
 ﻿
 <?xml version="1.0" encoding="utf-8"?>
 <style xmlns="http://purl.org/net/xbiblio/csl" class="note" version="1.0" demote-non-dropping-particle="never" default-locale="en-GB">
+  <!-- This style was edited with the Visual CSL Editor (https://editor.citationstyles.org/visualEditor/) -->
   <info>
     <title>OSCOLA (Oxford University Standard for Citation of Legal Authorities)</title>
     <title-short>OSCOLA</title-short>
@@ -42,9 +43,7 @@
       <term name="et-al">and others</term>
     </terms>
   </locale>
-  <!--Authors and Persons-->
   <macro name="author-note">
-    <!--for bills & hearing this should start with jurisdiction once available-->
     <choose>
       <if type="interview">
         <group delimiter=", ">
@@ -127,7 +126,6 @@
     </choose>
   </macro>
   <macro name="author">
-    <!--for bills & hearing this should start with jurisdiction once available-->
     <choose>
       <if type="interview">
         <group delimiter=", ">
@@ -188,7 +186,6 @@
       </names>
     </group>
   </macro>
-  <!-- Titles -->
   <macro name="title">
     <choose>
       <if type="book motion_picture treaty" match="any">
@@ -228,7 +225,6 @@
       </else>
     </choose>
   </macro>
-  <!--Dates-->
   <macro name="issued-year">
     <date variable="issued" form="text" date-parts="year"/>
   </macro>
@@ -246,7 +242,6 @@
             <text macro="issued-year" prefix="(" suffix=")"/>
           </else-if>
           <else-if variable="container-title volume number" match="any">
-            <!--no year in square brackets for unreported case w/o medium neutral citation-->
             <text macro="issued-year" prefix="[" suffix="]"/>
           </else-if>
         </choose>
@@ -256,7 +251,6 @@
       </else-if>
     </choose>
   </macro>
-  <!--publication info -->
   <macro name="publisher">
     <choose>
       <if type="book chapter broadcast personal_communication manuscript paper-conference article-newspaper report legislation motion_picture speech interview thesis entry-encyclopedia webpage post-weblog article" match="any">
@@ -271,7 +265,6 @@
                 <date variable="issued" form="text"/>
               </else-if>
               <else-if type="legislation bill" match="any">
-                <!--this should be jurisdiction we use code instead-->
                 <text variable="container-title" strip-periods="true"/>
               </else-if>
               <else>
@@ -282,7 +275,6 @@
                 </names>
                 <text macro="editor"/>
                 <choose>
-                  <!--if none of these, this we don't want edition either. Might be Loose-Leaf-->
                   <if variable="publisher issued genre container-title" match="any">
                     <text macro="edition"/>
                   </if>
@@ -403,7 +395,6 @@
     <choose>
       <if type="article-journal article-magazine article-newspaper legal_case" match="any">
         <group delimiter=", ">
-          <!--Assume that only cases with a Medium Neutral Citation have a docket number -->
           <choose>
             <if variable="authority number" match="all">
               <group delimiter=" ">
@@ -533,7 +524,6 @@
       </else-if>
     </choose>
   </macro>
-  <!--Others -->
   <macro name="treaty-catchall">
     <choose>
       <if type="treaty">
@@ -567,7 +557,6 @@
     </names>
   </macro>
   <macro name="sort-type">
-    <!--This should just sort secondary sources first. I'm leaving the rest from AGLC for simplicity-->
     <choose>
       <if type="book chapter paper-conference article-magazine article-newspaper article-journal manuscript report speech entry-encyclopedia" match="any">
         <text value="1"/>
@@ -607,7 +596,6 @@
         <else-if position="subsequent">
           <choose>
             <if type="legal_case bill legislation treaty" match="any">
-              <!--don't use short form and above note for legal citations -->
               <group delimiter=" ">
                 <text macro="author-note"/>
                 <text macro="title-short"/>
@@ -674,7 +662,7 @@
       </choose>
     </layout>
   </citation>
-  <bibliography et-al-min="4" et-al-use-first="1" subsequent-author-substitute="&#8212;&#8212;">
+  <bibliography et-al-min="4" et-al-use-first="1" subsequent-author-substitute="——">
     <sort>
       <key macro="sort-type"/>
       <key macro="author" names-min="1" names-use-first="1"/>

--- a/oscola.csl
+++ b/oscola.csl
@@ -1,4 +1,3 @@
-﻿
 <?xml version="1.0" encoding="utf-8"?>
 <style xmlns="http://purl.org/net/xbiblio/csl" class="note" version="1.0" demote-non-dropping-particle="never" default-locale="en-GB">
   <!-- This style was edited with the Visual CSL Editor (https://editor.citationstyles.org/visualEditor/) -->

--- a/oscola.csl
+++ b/oscola.csl
@@ -661,7 +661,7 @@
       </choose>
     </layout>
   </citation>
-  <bibliography et-al-min="4" et-al-use-first="1" subsequent-author-substitute="——">
+  <bibliography et-al-min="4" et-al-use-first="1" subsequent-author-substitute="&#8212;&#8212;">
     <sort>
       <key macro="sort-type"/>
       <key macro="author" names-min="1" names-use-first="1"/>


### PR DESCRIPTION
As @adam3smith has said, including journal abbreviations by default is problematic for Zotero, as automatic MEDLINE abbreviations are incorrect. Adding a separate variant for users who manually enter abbreviations or use a custom abbreviations file. cc @adunning 