### PR TITLE
MLA: Improve `number` and event

### DIFF
--- a/modern-language-association-annotated-bibliography.csl
+++ b/modern-language-association-annotated-bibliography.csl
@@ -901,14 +901,16 @@
   <macro name="container2-title">
     <group delimiter=", ">
       <choose>
-        <if type="paper-conference">
+        <if type="personal_communication"/>
+        <!-- `event-date` supplies date of composition for letters, handled in `supplemental-original-date` -->
+        <else-if type="paper-conference">
           <choose>
             <if match="none" variable="collection-editor compiler editor editorial-director issue page volume">
               <!-- Don't print event info for conference papers published in a proceedings -->
               <text macro="event"/>
             </if>
           </choose>
-        </if>
+        </else-if>
         <else>
           <!-- For other item types, print event info even if published (e.g. collection catalogs, performance programs). -->
           <text macro="event"/>

--- a/modern-language-association-annotated-bibliography.csl
+++ b/modern-language-association-annotated-bibliography.csl
@@ -490,7 +490,11 @@
   <!-- 3.2. Original publication date (MLA 5.108) -->
   <macro name="supplemental-original-date">
     <choose>
-      <if match="any" variable="original-publisher original-publisher-place"/>
+      <if type="personal_communication">
+        <!-- date and place of composition for letters -->
+        <text macro="event"/>
+      </if>
+      <else-if match="any" variable="original-publisher original-publisher-place"/>
       <else-if is-uncertain-date="original-date">
         <date form="text" prefix="[" suffix="?]" variable="original-date"/>
       </else-if>
@@ -897,32 +901,48 @@
   <macro name="container2-title">
     <group delimiter=", ">
       <choose>
-        <if match="any" variable="event event-date event-title">
+        <if type="paper-conference">
           <choose>
-            <!-- TODO: We expect `event-title` to be used, but processors and applications may not be updated yet. This macro ensures that either `event` or `event-title` can be accepted. Remove if processor logic and application adoption can handle this. -->
-            <if variable="event-title">
-              <text text-case="capitalize-first" variable="event-title"/>
+            <if match="none" variable="collection-editor compiler editor editorial-director issue page volume">
+              <!-- Don't print event info for conference papers published in a proceedings -->
+              <text macro="event"/>
             </if>
-            <else>
-              <text text-case="capitalize-first" variable="event"/>
-            </else>
           </choose>
-          <choose>
-            <if is-uncertain-date="issued">
-              <date form="text" prefix="[" suffix="?]" variable="event-date"/>
-            </if>
-            <else>
-              <date form="text" variable="event-date"/>
-            </else>
-          </choose>
-          <text variable="event-place"/>
         </if>
+        <else>
+          <!-- For other item types, print event info even if published (e.g. collection catalogs, performance programs). -->
+          <text macro="event"/>
+        </else>
       </choose>
       <text variable="archive"/>
       <text variable="archive-place"/>
       <text variable="archive_collection"/>
       <text variable="archive_location"/>
     </group>
+  </macro>
+  <macro name="event">
+    <choose>
+      <if match="any" variable="event event-date event-title">
+        <choose>
+          <!-- TODO: We expect `event-title` to be used, but processors and applications may not be updated yet. This macro ensures that either `event` or `event-title` can be accepted. Remove if processor logic and application adoption can handle this. -->
+          <if variable="event-title">
+            <text text-case="capitalize-first" variable="event-title"/>
+          </if>
+          <else>
+            <text text-case="capitalize-first" variable="event"/>
+          </else>
+        </choose>
+        <choose>
+          <if is-uncertain-date="issued">
+            <date form="text" prefix="[" suffix="?]" variable="event-date"/>
+          </if>
+          <else>
+            <date form="text" variable="event-date"/>
+          </else>
+        </choose>
+        <text variable="event-place"/>
+      </if>
+    </choose>
   </macro>
   <!-- 6.2. Location (MLA 5.84-99) -->
   <macro name="container2-location">

--- a/modern-language-association-annotated-bibliography.csl
+++ b/modern-language-association-annotated-bibliography.csl
@@ -143,6 +143,17 @@
       <text variable="locator"/>
     </group>
   </macro>
+  <macro name="label-number">
+    <group delimiter=" ">
+      <choose>
+        <if type="standard"/>
+        <else-if is-numeric="number">
+          <label form="short" variable="number"/>
+        </else-if>
+      </choose>
+      <text variable="number"/>
+    </group>
+  </macro>
   <macro name="label-number-of-volumes">
     <group delimiter=" ">
       <text variable="number-of-volumes"/>
@@ -238,6 +249,14 @@
         <names variable="editor-translator"/>
         <names variable="editor"/>
         <names variable="translator"/>
+        <choose>
+          <if type="software">
+            <text variable="publisher"/>
+          </if>
+          <else-if type="standard">
+            <text variable="authority"/>
+          </else-if>
+        </choose>
         <text macro="title"/>
       </substitute>
     </names>
@@ -252,6 +271,14 @@
           <names variable="editor-translator"/>
           <names variable="editor"/>
           <names variable="translator"/>
+          <choose>
+            <if type="software">
+              <text variable="publisher"/>
+            </if>
+            <else-if type="standard">
+              <text variable="authority"/>
+            </else-if>
+          </choose>
           <text macro="title-short"/>
         </substitute>
       </names>
@@ -757,12 +784,22 @@
       </choose>
       <text macro="label-issue"/>
       <text macro="label-supplement-number"/>
-      <choose>
-        <if type="report">
-          <text variable="genre"/>
-        </if>
-      </choose>
-      <text variable="number"/>
+      <group delimiter=" ">
+        <choose>
+          <if is-numeric="number" type="broadcast" variable="genre">
+            <text variable="genre"/>
+            <text variable="number"/>
+          </if>
+          <else-if is-numeric="number" type="broadcast">
+            <text value="episode"/>
+            <text variable="number"/>
+          </else-if>
+          <else-if variable="number">
+            <text variable="genre"/>
+            <text macro="label-number"/>
+          </else-if>
+        </choose>
+      </group>
     </group>
   </macro>
   <!-- 4.5. Publisher (MLA 5.54-67) -->
@@ -860,8 +897,16 @@
   <macro name="container2-title">
     <group delimiter=", ">
       <choose>
-        <if type="speech">
-          <text variable="event"/>
+        <if match="any" variable="event event-date event-title">
+          <choose>
+            <!-- TODO: We expect `event-title` to be used, but processors and applications may not be updated yet. This macro ensures that either `event` or `event-title` can be accepted. Remove if processor logic and application adoption can handle this. -->
+            <if variable="event-title">
+              <text text-case="capitalize-first" variable="event-title"/>
+            </if>
+            <else>
+              <text text-case="capitalize-first" variable="event"/>
+            </else>
+          </choose>
           <choose>
             <if is-uncertain-date="issued">
               <date form="text" prefix="[" suffix="?]" variable="event-date"/>

--- a/modern-language-association-no-url.csl
+++ b/modern-language-association-no-url.csl
@@ -895,14 +895,16 @@
   <macro name="container2-title">
     <group delimiter=", ">
       <choose>
-        <if type="paper-conference">
+        <if type="personal_communication"/>
+        <!-- `event-date` supplies date of composition for letters, handled in `supplemental-original-date` -->
+        <else-if type="paper-conference">
           <choose>
             <if match="none" variable="collection-editor compiler editor editorial-director issue page volume">
               <!-- Don't print event info for conference papers published in a proceedings -->
               <text macro="event"/>
             </if>
           </choose>
-        </if>
+        </else-if>
         <else>
           <!-- For other item types, print event info even if published (e.g. collection catalogs, performance programs). -->
           <text macro="event"/>

--- a/modern-language-association-no-url.csl
+++ b/modern-language-association-no-url.csl
@@ -143,6 +143,17 @@
       <text variable="locator"/>
     </group>
   </macro>
+  <macro name="label-number">
+    <group delimiter=" ">
+      <choose>
+        <if type="standard"/>
+        <else-if is-numeric="number">
+          <label form="short" variable="number"/>
+        </else-if>
+      </choose>
+      <text variable="number"/>
+    </group>
+  </macro>
   <macro name="label-number-of-volumes">
     <group delimiter=" ">
       <text variable="number-of-volumes"/>
@@ -238,6 +249,14 @@
         <names variable="editor-translator"/>
         <names variable="editor"/>
         <names variable="translator"/>
+        <choose>
+          <if type="software">
+            <text variable="publisher"/>
+          </if>
+          <else-if type="standard">
+            <text variable="authority"/>
+          </else-if>
+        </choose>
         <text macro="title"/>
       </substitute>
     </names>
@@ -252,6 +271,14 @@
           <names variable="editor-translator"/>
           <names variable="editor"/>
           <names variable="translator"/>
+          <choose>
+            <if type="software">
+              <text variable="publisher"/>
+            </if>
+            <else-if type="standard">
+              <text variable="authority"/>
+            </else-if>
+          </choose>
           <text macro="title-short"/>
         </substitute>
       </names>
@@ -757,12 +784,22 @@
       </choose>
       <text macro="label-issue"/>
       <text macro="label-supplement-number"/>
-      <choose>
-        <if type="report">
-          <text variable="genre"/>
-        </if>
-      </choose>
-      <text variable="number"/>
+      <group delimiter=" ">
+        <choose>
+          <if is-numeric="number" type="broadcast" variable="genre">
+            <text variable="genre"/>
+            <text variable="number"/>
+          </if>
+          <else-if is-numeric="number" type="broadcast">
+            <text value="episode"/>
+            <text variable="number"/>
+          </else-if>
+          <else-if variable="number">
+            <text variable="genre"/>
+            <text macro="label-number"/>
+          </else-if>
+        </choose>
+      </group>
     </group>
   </macro>
   <!-- 4.5. Publisher (MLA 5.54-67) -->
@@ -854,8 +891,16 @@
   <macro name="container2-title">
     <group delimiter=", ">
       <choose>
-        <if type="speech">
-          <text variable="event"/>
+        <if match="any" variable="event event-date event-title">
+          <choose>
+            <!-- TODO: We expect `event-title` to be used, but processors and applications may not be updated yet. This macro ensures that either `event` or `event-title` can be accepted. Remove if processor logic and application adoption can handle this. -->
+            <if variable="event-title">
+              <text text-case="capitalize-first" variable="event-title"/>
+            </if>
+            <else>
+              <text text-case="capitalize-first" variable="event"/>
+            </else>
+          </choose>
           <choose>
             <if is-uncertain-date="issued">
               <date form="text" prefix="[" suffix="?]" variable="event-date"/>

--- a/modern-language-association-no-url.csl
+++ b/modern-language-association-no-url.csl
@@ -490,7 +490,11 @@
   <!-- 3.2. Original publication date (MLA 5.108) -->
   <macro name="supplemental-original-date">
     <choose>
-      <if match="any" variable="original-publisher original-publisher-place"/>
+      <if type="personal_communication">
+        <!-- date and place of composition for letters -->
+        <text macro="event"/>
+      </if>
+      <else-if match="any" variable="original-publisher original-publisher-place"/>
       <else-if is-uncertain-date="original-date">
         <date form="text" prefix="[" suffix="?]" variable="original-date"/>
       </else-if>
@@ -891,32 +895,48 @@
   <macro name="container2-title">
     <group delimiter=", ">
       <choose>
-        <if match="any" variable="event event-date event-title">
+        <if type="paper-conference">
           <choose>
-            <!-- TODO: We expect `event-title` to be used, but processors and applications may not be updated yet. This macro ensures that either `event` or `event-title` can be accepted. Remove if processor logic and application adoption can handle this. -->
-            <if variable="event-title">
-              <text text-case="capitalize-first" variable="event-title"/>
+            <if match="none" variable="collection-editor compiler editor editorial-director issue page volume">
+              <!-- Don't print event info for conference papers published in a proceedings -->
+              <text macro="event"/>
             </if>
-            <else>
-              <text text-case="capitalize-first" variable="event"/>
-            </else>
           </choose>
-          <choose>
-            <if is-uncertain-date="issued">
-              <date form="text" prefix="[" suffix="?]" variable="event-date"/>
-            </if>
-            <else>
-              <date form="text" variable="event-date"/>
-            </else>
-          </choose>
-          <text variable="event-place"/>
         </if>
+        <else>
+          <!-- For other item types, print event info even if published (e.g. collection catalogs, performance programs). -->
+          <text macro="event"/>
+        </else>
       </choose>
       <text variable="archive"/>
       <text variable="archive-place"/>
       <text variable="archive_collection"/>
       <text variable="archive_location"/>
     </group>
+  </macro>
+  <macro name="event">
+    <choose>
+      <if match="any" variable="event event-date event-title">
+        <choose>
+          <!-- TODO: We expect `event-title` to be used, but processors and applications may not be updated yet. This macro ensures that either `event` or `event-title` can be accepted. Remove if processor logic and application adoption can handle this. -->
+          <if variable="event-title">
+            <text text-case="capitalize-first" variable="event-title"/>
+          </if>
+          <else>
+            <text text-case="capitalize-first" variable="event"/>
+          </else>
+        </choose>
+        <choose>
+          <if is-uncertain-date="issued">
+            <date form="text" prefix="[" suffix="?]" variable="event-date"/>
+          </if>
+          <else>
+            <date form="text" variable="event-date"/>
+          </else>
+        </choose>
+        <text variable="event-place"/>
+      </if>
+    </choose>
   </macro>
   <!-- 6.2. Location (MLA 5.84-99) -->
   <!-- 7. Supplemental Element at End of Entry (MLA 5.110-118) -->

--- a/modern-language-association-notes-no-url.csl
+++ b/modern-language-association-notes-no-url.csl
@@ -895,14 +895,16 @@
   <macro name="container2-title">
     <group delimiter=", ">
       <choose>
-        <if type="paper-conference">
+        <if type="personal_communication"/>
+        <!-- `event-date` supplies date of composition for letters, handled in `supplemental-original-date` -->
+        <else-if type="paper-conference">
           <choose>
             <if match="none" variable="collection-editor compiler editor editorial-director issue page volume">
               <!-- Don't print event info for conference papers published in a proceedings -->
               <text macro="event"/>
             </if>
           </choose>
-        </if>
+        </else-if>
         <else>
           <!-- For other item types, print event info even if published (e.g. collection catalogs, performance programs). -->
           <text macro="event"/>

--- a/modern-language-association-notes-no-url.csl
+++ b/modern-language-association-notes-no-url.csl
@@ -143,6 +143,17 @@
       <text variable="locator"/>
     </group>
   </macro>
+  <macro name="label-number">
+    <group delimiter=" ">
+      <choose>
+        <if type="standard"/>
+        <else-if is-numeric="number">
+          <label form="short" variable="number"/>
+        </else-if>
+      </choose>
+      <text variable="number"/>
+    </group>
+  </macro>
   <macro name="label-number-of-volumes">
     <group delimiter=" ">
       <text variable="number-of-volumes"/>
@@ -238,6 +249,14 @@
         <names variable="editor-translator"/>
         <names variable="editor"/>
         <names variable="translator"/>
+        <choose>
+          <if type="software">
+            <text variable="publisher"/>
+          </if>
+          <else-if type="standard">
+            <text variable="authority"/>
+          </else-if>
+        </choose>
         <text macro="title"/>
       </substitute>
     </names>
@@ -252,6 +271,14 @@
           <names variable="editor-translator"/>
           <names variable="editor"/>
           <names variable="translator"/>
+          <choose>
+            <if type="software">
+              <text variable="publisher"/>
+            </if>
+            <else-if type="standard">
+              <text variable="authority"/>
+            </else-if>
+          </choose>
           <text macro="title-short"/>
         </substitute>
       </names>
@@ -757,12 +784,22 @@
       </choose>
       <text macro="label-issue"/>
       <text macro="label-supplement-number"/>
-      <choose>
-        <if type="report">
-          <text variable="genre"/>
-        </if>
-      </choose>
-      <text variable="number"/>
+      <group delimiter=" ">
+        <choose>
+          <if is-numeric="number" type="broadcast" variable="genre">
+            <text variable="genre"/>
+            <text variable="number"/>
+          </if>
+          <else-if is-numeric="number" type="broadcast">
+            <text value="episode"/>
+            <text variable="number"/>
+          </else-if>
+          <else-if variable="number">
+            <text variable="genre"/>
+            <text macro="label-number"/>
+          </else-if>
+        </choose>
+      </group>
     </group>
   </macro>
   <!-- 4.5. Publisher (MLA 5.54-67) -->
@@ -854,8 +891,16 @@
   <macro name="container2-title">
     <group delimiter=", ">
       <choose>
-        <if type="speech">
-          <text variable="event"/>
+        <if match="any" variable="event event-date event-title">
+          <choose>
+            <!-- TODO: We expect `event-title` to be used, but processors and applications may not be updated yet. This macro ensures that either `event` or `event-title` can be accepted. Remove if processor logic and application adoption can handle this. -->
+            <if variable="event-title">
+              <text text-case="capitalize-first" variable="event-title"/>
+            </if>
+            <else>
+              <text text-case="capitalize-first" variable="event"/>
+            </else>
+          </choose>
           <choose>
             <if is-uncertain-date="issued">
               <date form="text" prefix="[" suffix="?]" variable="event-date"/>

--- a/modern-language-association-notes-no-url.csl
+++ b/modern-language-association-notes-no-url.csl
@@ -490,7 +490,11 @@
   <!-- 3.2. Original publication date (MLA 5.108) -->
   <macro name="supplemental-original-date">
     <choose>
-      <if match="any" variable="original-publisher original-publisher-place"/>
+      <if type="personal_communication">
+        <!-- date and place of composition for letters -->
+        <text macro="event"/>
+      </if>
+      <else-if match="any" variable="original-publisher original-publisher-place"/>
       <else-if is-uncertain-date="original-date">
         <date form="text" prefix="[" suffix="?]" variable="original-date"/>
       </else-if>
@@ -891,32 +895,48 @@
   <macro name="container2-title">
     <group delimiter=", ">
       <choose>
-        <if match="any" variable="event event-date event-title">
+        <if type="paper-conference">
           <choose>
-            <!-- TODO: We expect `event-title` to be used, but processors and applications may not be updated yet. This macro ensures that either `event` or `event-title` can be accepted. Remove if processor logic and application adoption can handle this. -->
-            <if variable="event-title">
-              <text text-case="capitalize-first" variable="event-title"/>
+            <if match="none" variable="collection-editor compiler editor editorial-director issue page volume">
+              <!-- Don't print event info for conference papers published in a proceedings -->
+              <text macro="event"/>
             </if>
-            <else>
-              <text text-case="capitalize-first" variable="event"/>
-            </else>
           </choose>
-          <choose>
-            <if is-uncertain-date="issued">
-              <date form="text" prefix="[" suffix="?]" variable="event-date"/>
-            </if>
-            <else>
-              <date form="text" variable="event-date"/>
-            </else>
-          </choose>
-          <text variable="event-place"/>
         </if>
+        <else>
+          <!-- For other item types, print event info even if published (e.g. collection catalogs, performance programs). -->
+          <text macro="event"/>
+        </else>
       </choose>
       <text variable="archive"/>
       <text variable="archive-place"/>
       <text variable="archive_collection"/>
       <text variable="archive_location"/>
     </group>
+  </macro>
+  <macro name="event">
+    <choose>
+      <if match="any" variable="event event-date event-title">
+        <choose>
+          <!-- TODO: We expect `event-title` to be used, but processors and applications may not be updated yet. This macro ensures that either `event` or `event-title` can be accepted. Remove if processor logic and application adoption can handle this. -->
+          <if variable="event-title">
+            <text text-case="capitalize-first" variable="event-title"/>
+          </if>
+          <else>
+            <text text-case="capitalize-first" variable="event"/>
+          </else>
+        </choose>
+        <choose>
+          <if is-uncertain-date="issued">
+            <date form="text" prefix="[" suffix="?]" variable="event-date"/>
+          </if>
+          <else>
+            <date form="text" variable="event-date"/>
+          </else>
+        </choose>
+        <text variable="event-place"/>
+      </if>
+    </choose>
   </macro>
   <!-- 6.2. Location (MLA 5.84-99) -->
   <!-- 7. Supplemental Element at End of Entry (MLA 5.110-118) -->

--- a/modern-language-association-notes.csl
+++ b/modern-language-association-notes.csl
@@ -901,14 +901,16 @@
   <macro name="container2-title">
     <group delimiter=", ">
       <choose>
-        <if type="paper-conference">
+        <if type="personal_communication"/>
+        <!-- `event-date` supplies date of composition for letters, handled in `supplemental-original-date` -->
+        <else-if type="paper-conference">
           <choose>
             <if match="none" variable="collection-editor compiler editor editorial-director issue page volume">
               <!-- Don't print event info for conference papers published in a proceedings -->
               <text macro="event"/>
             </if>
           </choose>
-        </if>
+        </else-if>
         <else>
           <!-- For other item types, print event info even if published (e.g. collection catalogs, performance programs). -->
           <text macro="event"/>

--- a/modern-language-association-notes.csl
+++ b/modern-language-association-notes.csl
@@ -490,7 +490,11 @@
   <!-- 3.2. Original publication date (MLA 5.108) -->
   <macro name="supplemental-original-date">
     <choose>
-      <if match="any" variable="original-publisher original-publisher-place"/>
+      <if type="personal_communication">
+        <!-- date and place of composition for letters -->
+        <text macro="event"/>
+      </if>
+      <else-if match="any" variable="original-publisher original-publisher-place"/>
       <else-if is-uncertain-date="original-date">
         <date form="text" prefix="[" suffix="?]" variable="original-date"/>
       </else-if>
@@ -897,32 +901,48 @@
   <macro name="container2-title">
     <group delimiter=", ">
       <choose>
-        <if match="any" variable="event event-date event-title">
+        <if type="paper-conference">
           <choose>
-            <!-- TODO: We expect `event-title` to be used, but processors and applications may not be updated yet. This macro ensures that either `event` or `event-title` can be accepted. Remove if processor logic and application adoption can handle this. -->
-            <if variable="event-title">
-              <text text-case="capitalize-first" variable="event-title"/>
+            <if match="none" variable="collection-editor compiler editor editorial-director issue page volume">
+              <!-- Don't print event info for conference papers published in a proceedings -->
+              <text macro="event"/>
             </if>
-            <else>
-              <text text-case="capitalize-first" variable="event"/>
-            </else>
           </choose>
-          <choose>
-            <if is-uncertain-date="issued">
-              <date form="text" prefix="[" suffix="?]" variable="event-date"/>
-            </if>
-            <else>
-              <date form="text" variable="event-date"/>
-            </else>
-          </choose>
-          <text variable="event-place"/>
         </if>
+        <else>
+          <!-- For other item types, print event info even if published (e.g. collection catalogs, performance programs). -->
+          <text macro="event"/>
+        </else>
       </choose>
       <text variable="archive"/>
       <text variable="archive-place"/>
       <text variable="archive_collection"/>
       <text variable="archive_location"/>
     </group>
+  </macro>
+  <macro name="event">
+    <choose>
+      <if match="any" variable="event event-date event-title">
+        <choose>
+          <!-- TODO: We expect `event-title` to be used, but processors and applications may not be updated yet. This macro ensures that either `event` or `event-title` can be accepted. Remove if processor logic and application adoption can handle this. -->
+          <if variable="event-title">
+            <text text-case="capitalize-first" variable="event-title"/>
+          </if>
+          <else>
+            <text text-case="capitalize-first" variable="event"/>
+          </else>
+        </choose>
+        <choose>
+          <if is-uncertain-date="issued">
+            <date form="text" prefix="[" suffix="?]" variable="event-date"/>
+          </if>
+          <else>
+            <date form="text" variable="event-date"/>
+          </else>
+        </choose>
+        <text variable="event-place"/>
+      </if>
+    </choose>
   </macro>
   <!-- 6.2. Location (MLA 5.84-99) -->
   <macro name="container2-location">

--- a/modern-language-association-notes.csl
+++ b/modern-language-association-notes.csl
@@ -143,6 +143,17 @@
       <text variable="locator"/>
     </group>
   </macro>
+  <macro name="label-number">
+    <group delimiter=" ">
+      <choose>
+        <if type="standard"/>
+        <else-if is-numeric="number">
+          <label form="short" variable="number"/>
+        </else-if>
+      </choose>
+      <text variable="number"/>
+    </group>
+  </macro>
   <macro name="label-number-of-volumes">
     <group delimiter=" ">
       <text variable="number-of-volumes"/>
@@ -238,6 +249,14 @@
         <names variable="editor-translator"/>
         <names variable="editor"/>
         <names variable="translator"/>
+        <choose>
+          <if type="software">
+            <text variable="publisher"/>
+          </if>
+          <else-if type="standard">
+            <text variable="authority"/>
+          </else-if>
+        </choose>
         <text macro="title"/>
       </substitute>
     </names>
@@ -252,6 +271,14 @@
           <names variable="editor-translator"/>
           <names variable="editor"/>
           <names variable="translator"/>
+          <choose>
+            <if type="software">
+              <text variable="publisher"/>
+            </if>
+            <else-if type="standard">
+              <text variable="authority"/>
+            </else-if>
+          </choose>
           <text macro="title-short"/>
         </substitute>
       </names>
@@ -757,12 +784,22 @@
       </choose>
       <text macro="label-issue"/>
       <text macro="label-supplement-number"/>
-      <choose>
-        <if type="report">
-          <text variable="genre"/>
-        </if>
-      </choose>
-      <text variable="number"/>
+      <group delimiter=" ">
+        <choose>
+          <if is-numeric="number" type="broadcast" variable="genre">
+            <text variable="genre"/>
+            <text variable="number"/>
+          </if>
+          <else-if is-numeric="number" type="broadcast">
+            <text value="episode"/>
+            <text variable="number"/>
+          </else-if>
+          <else-if variable="number">
+            <text variable="genre"/>
+            <text macro="label-number"/>
+          </else-if>
+        </choose>
+      </group>
     </group>
   </macro>
   <!-- 4.5. Publisher (MLA 5.54-67) -->
@@ -860,8 +897,16 @@
   <macro name="container2-title">
     <group delimiter=", ">
       <choose>
-        <if type="speech">
-          <text variable="event"/>
+        <if match="any" variable="event event-date event-title">
+          <choose>
+            <!-- TODO: We expect `event-title` to be used, but processors and applications may not be updated yet. This macro ensures that either `event` or `event-title` can be accepted. Remove if processor logic and application adoption can handle this. -->
+            <if variable="event-title">
+              <text text-case="capitalize-first" variable="event-title"/>
+            </if>
+            <else>
+              <text text-case="capitalize-first" variable="event"/>
+            </else>
+          </choose>
           <choose>
             <if is-uncertain-date="issued">
               <date form="text" prefix="[" suffix="?]" variable="event-date"/>

--- a/modern-language-association.csl
+++ b/modern-language-association.csl
@@ -142,6 +142,17 @@
       <text variable="locator"/>
     </group>
   </macro>
+  <macro name="label-number">
+    <group delimiter=" ">
+      <choose>
+        <if type="standard"/>
+        <else-if is-numeric="number">
+          <label form="short" variable="number"/>
+        </else-if>
+      </choose>
+      <text variable="number"/>
+    </group>
+  </macro>
   <macro name="label-number-of-volumes">
     <group delimiter=" ">
       <text variable="number-of-volumes"/>
@@ -237,6 +248,14 @@
         <names variable="editor-translator"/>
         <names variable="editor"/>
         <names variable="translator"/>
+        <choose>
+          <if type="software">
+            <text variable="publisher"/>
+          </if>
+          <else-if type="standard">
+            <text variable="authority"/>
+          </else-if>
+        </choose>
         <text macro="title"/>
       </substitute>
     </names>
@@ -251,6 +270,14 @@
           <names variable="editor-translator"/>
           <names variable="editor"/>
           <names variable="translator"/>
+          <choose>
+            <if type="software">
+              <text variable="publisher"/>
+            </if>
+            <else-if type="standard">
+              <text variable="authority"/>
+            </else-if>
+          </choose>
           <text macro="title-short"/>
         </substitute>
       </names>
@@ -756,12 +783,22 @@
       </choose>
       <text macro="label-issue"/>
       <text macro="label-supplement-number"/>
-      <choose>
-        <if type="report">
-          <text variable="genre"/>
-        </if>
-      </choose>
-      <text variable="number"/>
+      <group delimiter=" ">
+        <choose>
+          <if is-numeric="number" type="broadcast" variable="genre">
+            <text variable="genre"/>
+            <text variable="number"/>
+          </if>
+          <else-if is-numeric="number" type="broadcast">
+            <text value="episode"/>
+            <text variable="number"/>
+          </else-if>
+          <else-if variable="number">
+            <text variable="genre"/>
+            <text macro="label-number"/>
+          </else-if>
+        </choose>
+      </group>
     </group>
   </macro>
   <!-- 4.5. Publisher (MLA 5.54-67) -->
@@ -859,8 +896,16 @@
   <macro name="container2-title">
     <group delimiter=", ">
       <choose>
-        <if type="speech">
-          <text variable="event"/>
+        <if match="any" variable="event event-date event-title">
+          <choose>
+            <!-- TODO: We expect `event-title` to be used, but processors and applications may not be updated yet. This macro ensures that either `event` or `event-title` can be accepted. Remove if processor logic and application adoption can handle this. -->
+            <if variable="event-title">
+              <text text-case="capitalize-first" variable="event-title"/>
+            </if>
+            <else>
+              <text text-case="capitalize-first" variable="event"/>
+            </else>
+          </choose>
           <choose>
             <if is-uncertain-date="issued">
               <date form="text" prefix="[" suffix="?]" variable="event-date"/>

--- a/modern-language-association.csl
+++ b/modern-language-association.csl
@@ -489,7 +489,11 @@
   <!-- 3.2. Original publication date (MLA 5.108) -->
   <macro name="supplemental-original-date">
     <choose>
-      <if match="any" variable="original-publisher original-publisher-place"/>
+      <if type="personal_communication">
+        <!-- date and place of composition for letters -->
+        <text macro="event"/>
+      </if>
+      <else-if match="any" variable="original-publisher original-publisher-place"/>
       <else-if is-uncertain-date="original-date">
         <date form="text" prefix="[" suffix="?]" variable="original-date"/>
       </else-if>
@@ -896,32 +900,48 @@
   <macro name="container2-title">
     <group delimiter=", ">
       <choose>
-        <if match="any" variable="event event-date event-title">
+        <if type="paper-conference">
           <choose>
-            <!-- TODO: We expect `event-title` to be used, but processors and applications may not be updated yet. This macro ensures that either `event` or `event-title` can be accepted. Remove if processor logic and application adoption can handle this. -->
-            <if variable="event-title">
-              <text text-case="capitalize-first" variable="event-title"/>
+            <if match="none" variable="collection-editor compiler editor editorial-director issue page volume">
+              <!-- Don't print event info for conference papers published in a proceedings -->
+              <text macro="event"/>
             </if>
-            <else>
-              <text text-case="capitalize-first" variable="event"/>
-            </else>
           </choose>
-          <choose>
-            <if is-uncertain-date="issued">
-              <date form="text" prefix="[" suffix="?]" variable="event-date"/>
-            </if>
-            <else>
-              <date form="text" variable="event-date"/>
-            </else>
-          </choose>
-          <text variable="event-place"/>
         </if>
+        <else>
+          <!-- For other item types, print event info even if published (e.g. collection catalogs, performance programs). -->
+          <text macro="event"/>
+        </else>
       </choose>
       <text variable="archive"/>
       <text variable="archive-place"/>
       <text variable="archive_collection"/>
       <text variable="archive_location"/>
     </group>
+  </macro>
+  <macro name="event">
+    <choose>
+      <if match="any" variable="event event-date event-title">
+        <choose>
+          <!-- TODO: We expect `event-title` to be used, but processors and applications may not be updated yet. This macro ensures that either `event` or `event-title` can be accepted. Remove if processor logic and application adoption can handle this. -->
+          <if variable="event-title">
+            <text text-case="capitalize-first" variable="event-title"/>
+          </if>
+          <else>
+            <text text-case="capitalize-first" variable="event"/>
+          </else>
+        </choose>
+        <choose>
+          <if is-uncertain-date="issued">
+            <date form="text" prefix="[" suffix="?]" variable="event-date"/>
+          </if>
+          <else>
+            <date form="text" variable="event-date"/>
+          </else>
+        </choose>
+        <text variable="event-place"/>
+      </if>
+    </choose>
   </macro>
   <!-- 6.2. Location (MLA 5.84-99) -->
   <macro name="container2-location">

--- a/modern-language-association.csl
+++ b/modern-language-association.csl
@@ -900,14 +900,16 @@
   <macro name="container2-title">
     <group delimiter=", ">
       <choose>
-        <if type="paper-conference">
+        <if type="personal_communication"/>
+        <!-- `event-date` supplies date of composition for letters, handled in `supplemental-original-date` -->
+        <else-if type="paper-conference">
           <choose>
             <if match="none" variable="collection-editor compiler editor editorial-director issue page volume">
               <!-- Don't print event info for conference papers published in a proceedings -->
               <text macro="event"/>
             </if>
           </choose>
-        </if>
+        </else-if>
         <else>
           <!-- For other item types, print event info even if published (e.g. collection catalogs, performance programs). -->
           <text macro="event"/>


### PR DESCRIPTION
- Provide `publisher` as a possible author substitute with `software` and `authority` for `standard` (see MLA examples)
- Provide labels for `number`
- Render event information with additional types