### PR TITLE
Fixed casing in unsigned dictionary article titles.

### DIFF
--- a/society-of-biblical-literature-fullnote-bibliography.csl
+++ b/society-of-biblical-literature-fullnote-bibliography.csl
@@ -721,7 +721,7 @@
     <choose>
       <if variable="original-date issued" match="all">
         <choose>
-          <!--Omission of the reprint abbreviation in notes is incorrect. See SBLHS2 §6.2.17–18.-->
+          <!--Omission of the reprint abbreviation in notes is incorrect. See SBLHS2 §6.2.17&#8211;18.-->
           <if variable="original-publisher original-publisher-place" match="any">
             <text value="repr."/>
           </if>


### PR DESCRIPTION
Unsigned dictionary articles should have regular, headline casing, not all caps.