### PR TITLE
Chicago: Improve URL handling

### DIFF
--- a/chicago-author-date-17th-edition.csl
+++ b/chicago-author-date-17th-edition.csl
@@ -1093,7 +1093,7 @@
       </group>
       <text macro="source-medium-bib"/>
       <text macro="source-archive-bib"/>
-      <text macro="source-DOI-URL-bib"/>
+      <text macro="source-date-accessed-DOI-URL-bib"/>
     </group>
   </macro>
   <!-- 3.1. Title -->
@@ -3475,35 +3475,33 @@
     </group>
   </macro>
   <!-- 4.10. URL or persistent identifier -->
-  <macro name="source-DOI-URL-bib">
+  <macro name="source-date-accessed-DOI-URL-bib">
+    <group delimiter=", ">
+      <choose>
+        <if variable="DOI"/>
+        <else-if match="any" variable="available-date event-date issued status"/>
+        <else-if variable="accessed URL">
+          <group delimiter=" ">
+            <text term="accessed" text-case="capitalize-first"/>
+            <date form="text" variable="accessed"/>
+          </group>
+        </else-if>
+      </choose>
+      <text macro="source-DOI-URL"/>
+    </group>
+  </macro>
+  <macro name="source-DOI-URL">
     <choose>
       <if variable="DOI">
         <text prefix="https://doi.org/" variable="DOI"/>
       </if>
       <else-if variable="URL">
-        <group delimiter=". ">
-          <choose>
-            <if match="none" variable="available-date event-date issued status">
-              <group delimiter=" ">
-                <text term="accessed" text-case="capitalize-first"/>
-                <date form="text" variable="accessed"/>
-              </group>
-            </if>
-          </choose>
-          <text variable="URL"/>
-        </group>
+        <text variable="URL"/>
       </else-if>
     </choose>
   </macro>
-  <macro name="source-DOI-URL">
-    <!-- Alias to avoid modifying legal references block shared with APA -->
-    <text macro="source-DOI-URL-bib"/>
-  </macro>
   <!-- 5. Notes -->
-  <macro name="notes">
-    <!-- Notes on source element: original publication, reprint info, retraction info -->
-    <text variable="references"/>
-  </macro>
+  <!-- TODO: add variables for distributor and exhibitions if available in CSL -->
   <!-- 6. Legal references: Bluebook style (shared with APA) -->
   <!-- Where APA or Chicago diverge from Bluebook, the official manual is followed -->
   <macro name="legal-reference">
@@ -3527,42 +3525,38 @@
          `treaty`
          : treaties
     -->
-    <group delimiter=" ">
-      <group delimiter=", " suffix=".">
-        <choose>
-          <if type="treaty">
-            <text macro="legal-title"/>
-            <names variable="author">
-              <!-- Treaty parties should be included at least for bilateral treaties (Bluebook 21.4.2) -->
-              <name delimiter="-" et-al-min="100" et-al-use-first="99" form="short"/>
-            </names>
-            <text macro="legal-date"/>
-            <!-- treaty source/report in addition to URL (Bluebook 21.4.5) -->
-            <text macro="legal-source"/>
-          </if>
-          <else>
-            <group delimiter=" ">
-              <group delimiter=", ">
-                <text macro="legal-title"/>
-                <text macro="legal-source"/>
-              </group>
-              <text macro="legal-date"/>
-              <text macro="legal-identifier"/>
+    <group delimiter=", ">
+      <choose>
+        <if type="treaty">
+          <text macro="legal-title"/>
+          <names variable="author">
+            <!-- Treaty parties should be included at least for bilateral treaties (Bluebook 21.4.2) -->
+            <name delimiter="-" et-al-min="100" et-al-use-first="99" form="short"/>
+          </names>
+          <text macro="legal-date"/>
+          <!-- treaty source/report in addition to URL (Bluebook 21.4.5) -->
+          <text macro="legal-source"/>
+        </if>
+        <else>
+          <group delimiter=" ">
+            <group delimiter=", ">
+              <text macro="legal-title"/>
+              <text macro="legal-source"/>
             </group>
-          </else>
+            <text macro="legal-date"/>
+            <text macro="legal-identifier"/>
+          </group>
+        </else>
+      </choose>
+      <group delimiter=" ">
+        <!-- locator for use in notes -->
+        <choose>
+          <if locator="page" variable="page">
+            <text term="at"/>
+          </if>
         </choose>
-        <group delimiter=" ">
-          <!-- locator for use in notes -->
-          <choose>
-            <if locator="page" variable="page">
-              <text term="at"/>
-            </if>
-          </choose>
-          <text macro="label-locator"/>
-        </group>
+        <text macro="label-locator"/>
       </group>
-      <text variable="references"/>
-      <text macro="source-DOI-URL"/>
     </group>
   </macro>
   <!-- 6.1. Legal date -->
@@ -3904,20 +3898,22 @@
   </citation>
   <!-- Bibliography -->
   <macro name="bibliography-author-date">
-    <choose>
-      <if match="any" type="bill hearing legal_case legislation regulation treaty">
-        <!-- Legal items have different orders and delimiters -->
-        <text macro="legal-reference"/>
-      </if>
-      <else>
-        <group delimiter=". ">
+    <group delimiter=". ">
+      <choose>
+        <if match="any" type="bill hearing legal_case legislation regulation treaty">
+          <!-- Legal items have different orders and delimiters -->
+          <text macro="legal-reference"/>
+          <text macro="source-date-accessed-DOI-URL-bib"/>
+          <text variable="references"/>
+        </if>
+        <else>
           <text macro="author-bib"/>
           <text macro="date"/>
           <text macro="title-and-source-bib"/>
-          <text macro="notes"/>
-        </group>
-      </else>
-    </choose>
+          <text variable="references"/>
+        </else>
+      </choose>
+    </group>
   </macro>
   <bibliography et-al-min="11" et-al-use-first="7" hanging-indent="true" subsequent-author-substitute="&#8212;&#8212;&#8212;">
     <sort>

--- a/chicago-author-date-archive-place-first-no-url.csl
+++ b/chicago-author-date-archive-place-first-no-url.csl
@@ -1076,7 +1076,7 @@
       </group>
       <text macro="source-medium-bib"/>
       <text macro="source-archive-bib"/>
-      <!-- <text macro="source-DOI-URL-bib"/> -->
+      <text macro="source-date-accessed-DOI-URL-bib"/>
     </group>
   </macro>
   <!-- 3.1. Title -->
@@ -3422,11 +3422,23 @@
     </group>
   </macro>
   <!-- 4.10. URL or persistent identifier -->
-  <!-- 5. Notes -->
-  <macro name="notes">
-    <!-- Notes on source element: original publication, reprint info, retraction info -->
-    <text variable="references"/>
+  <macro name="source-date-accessed-DOI-URL-bib">
+    <group delimiter=", ">
+      <choose>
+        <if variable="DOI"/>
+        <else-if match="any" variable="available-date event-date issued status"/>
+        <else-if variable="accessed URL">
+          <group delimiter=" ">
+            <text term="accessed" text-case="capitalize-first"/>
+            <date form="text" variable="accessed"/>
+          </group>
+        </else-if>
+      </choose>
+      <!-- <text macro="source-DOI-URL"/> -->
+    </group>
   </macro>
+  <!-- 5. Notes -->
+  <!-- TODO: add variables for distributor and exhibitions if available in CSL -->
   <!-- 6. Legal references: Bluebook style (shared with APA) -->
   <!-- Where APA or Chicago diverge from Bluebook, the official manual is followed -->
   <macro name="legal-reference">
@@ -3450,42 +3462,38 @@
          `treaty`
          : treaties
     -->
-    <group delimiter=" ">
-      <group delimiter=", " suffix=".">
-        <choose>
-          <if type="treaty">
-            <text macro="legal-title"/>
-            <names variable="author">
-              <!-- Treaty parties should be included at least for bilateral treaties (Bluebook 21.4.2) -->
-              <name delimiter="-" et-al-min="100" et-al-use-first="99" form="short"/>
-            </names>
-            <text macro="legal-date"/>
-            <!-- treaty source/report in addition to URL (Bluebook 21.4.5) -->
-            <text macro="legal-source"/>
-          </if>
-          <else>
-            <group delimiter=" ">
-              <group delimiter=", ">
-                <text macro="legal-title"/>
-                <text macro="legal-source"/>
-              </group>
-              <text macro="legal-date"/>
-              <text macro="legal-identifier"/>
+    <group delimiter=", ">
+      <choose>
+        <if type="treaty">
+          <text macro="legal-title"/>
+          <names variable="author">
+            <!-- Treaty parties should be included at least for bilateral treaties (Bluebook 21.4.2) -->
+            <name delimiter="-" et-al-min="100" et-al-use-first="99" form="short"/>
+          </names>
+          <text macro="legal-date"/>
+          <!-- treaty source/report in addition to URL (Bluebook 21.4.5) -->
+          <text macro="legal-source"/>
+        </if>
+        <else>
+          <group delimiter=" ">
+            <group delimiter=", ">
+              <text macro="legal-title"/>
+              <text macro="legal-source"/>
             </group>
-          </else>
+            <text macro="legal-date"/>
+            <text macro="legal-identifier"/>
+          </group>
+        </else>
+      </choose>
+      <group delimiter=" ">
+        <!-- locator for use in notes -->
+        <choose>
+          <if locator="page" variable="page">
+            <text term="at"/>
+          </if>
         </choose>
-        <group delimiter=" ">
-          <!-- locator for use in notes -->
-          <choose>
-            <if locator="page" variable="page">
-              <text term="at"/>
-            </if>
-          </choose>
-          <text macro="label-locator"/>
-        </group>
+        <text macro="label-locator"/>
       </group>
-      <text variable="references"/>
-      <!-- <text macro="source-DOI-URL"/> -->
     </group>
   </macro>
   <!-- 6.1. Legal date -->
@@ -3827,20 +3835,22 @@
   </citation>
   <!-- Bibliography -->
   <macro name="bibliography-author-date">
-    <choose>
-      <if match="any" type="bill hearing legal_case legislation regulation treaty">
-        <!-- Legal items have different orders and delimiters -->
-        <text macro="legal-reference"/>
-      </if>
-      <else>
-        <group delimiter=". ">
+    <group delimiter=". ">
+      <choose>
+        <if match="any" type="bill hearing legal_case legislation regulation treaty">
+          <!-- Legal items have different orders and delimiters -->
+          <text macro="legal-reference"/>
+          <text macro="source-date-accessed-DOI-URL-bib"/>
+          <text variable="references"/>
+        </if>
+        <else>
           <text macro="author-bib"/>
           <text macro="date"/>
           <text macro="title-and-source-bib"/>
-          <text macro="notes"/>
-        </group>
-      </else>
-    </choose>
+          <text variable="references"/>
+        </else>
+      </choose>
+    </group>
   </macro>
   <bibliography et-al-min="7" et-al-use-first="3" hanging-indent="true">
     <sort>

--- a/chicago-author-date-archive-place-first.csl
+++ b/chicago-author-date-archive-place-first.csl
@@ -1076,7 +1076,7 @@
       </group>
       <text macro="source-medium-bib"/>
       <text macro="source-archive-bib"/>
-      <text macro="source-DOI-URL-bib"/>
+      <text macro="source-date-accessed-DOI-URL-bib"/>
     </group>
   </macro>
   <!-- 3.1. Title -->
@@ -3422,35 +3422,33 @@
     </group>
   </macro>
   <!-- 4.10. URL or persistent identifier -->
-  <macro name="source-DOI-URL-bib">
+  <macro name="source-date-accessed-DOI-URL-bib">
+    <group delimiter=", ">
+      <choose>
+        <if variable="DOI"/>
+        <else-if match="any" variable="available-date event-date issued status"/>
+        <else-if variable="accessed URL">
+          <group delimiter=" ">
+            <text term="accessed" text-case="capitalize-first"/>
+            <date form="text" variable="accessed"/>
+          </group>
+        </else-if>
+      </choose>
+      <text macro="source-DOI-URL"/>
+    </group>
+  </macro>
+  <macro name="source-DOI-URL">
     <choose>
       <if variable="DOI">
         <text prefix="https://doi.org/" variable="DOI"/>
       </if>
       <else-if variable="URL">
-        <group delimiter=". ">
-          <choose>
-            <if match="none" variable="available-date event-date issued status">
-              <group delimiter=" ">
-                <text term="accessed" text-case="capitalize-first"/>
-                <date form="text" variable="accessed"/>
-              </group>
-            </if>
-          </choose>
-          <text variable="URL"/>
-        </group>
+        <text variable="URL"/>
       </else-if>
     </choose>
   </macro>
-  <macro name="source-DOI-URL">
-    <!-- Alias to avoid modifying legal references block shared with APA -->
-    <text macro="source-DOI-URL-bib"/>
-  </macro>
   <!-- 5. Notes -->
-  <macro name="notes">
-    <!-- Notes on source element: original publication, reprint info, retraction info -->
-    <text variable="references"/>
-  </macro>
+  <!-- TODO: add variables for distributor and exhibitions if available in CSL -->
   <!-- 6. Legal references: Bluebook style (shared with APA) -->
   <!-- Where APA or Chicago diverge from Bluebook, the official manual is followed -->
   <macro name="legal-reference">
@@ -3474,42 +3472,38 @@
          `treaty`
          : treaties
     -->
-    <group delimiter=" ">
-      <group delimiter=", " suffix=".">
-        <choose>
-          <if type="treaty">
-            <text macro="legal-title"/>
-            <names variable="author">
-              <!-- Treaty parties should be included at least for bilateral treaties (Bluebook 21.4.2) -->
-              <name delimiter="-" et-al-min="100" et-al-use-first="99" form="short"/>
-            </names>
-            <text macro="legal-date"/>
-            <!-- treaty source/report in addition to URL (Bluebook 21.4.5) -->
-            <text macro="legal-source"/>
-          </if>
-          <else>
-            <group delimiter=" ">
-              <group delimiter=", ">
-                <text macro="legal-title"/>
-                <text macro="legal-source"/>
-              </group>
-              <text macro="legal-date"/>
-              <text macro="legal-identifier"/>
+    <group delimiter=", ">
+      <choose>
+        <if type="treaty">
+          <text macro="legal-title"/>
+          <names variable="author">
+            <!-- Treaty parties should be included at least for bilateral treaties (Bluebook 21.4.2) -->
+            <name delimiter="-" et-al-min="100" et-al-use-first="99" form="short"/>
+          </names>
+          <text macro="legal-date"/>
+          <!-- treaty source/report in addition to URL (Bluebook 21.4.5) -->
+          <text macro="legal-source"/>
+        </if>
+        <else>
+          <group delimiter=" ">
+            <group delimiter=", ">
+              <text macro="legal-title"/>
+              <text macro="legal-source"/>
             </group>
-          </else>
+            <text macro="legal-date"/>
+            <text macro="legal-identifier"/>
+          </group>
+        </else>
+      </choose>
+      <group delimiter=" ">
+        <!-- locator for use in notes -->
+        <choose>
+          <if locator="page" variable="page">
+            <text term="at"/>
+          </if>
         </choose>
-        <group delimiter=" ">
-          <!-- locator for use in notes -->
-          <choose>
-            <if locator="page" variable="page">
-              <text term="at"/>
-            </if>
-          </choose>
-          <text macro="label-locator"/>
-        </group>
+        <text macro="label-locator"/>
       </group>
-      <text variable="references"/>
-      <text macro="source-DOI-URL"/>
     </group>
   </macro>
   <!-- 6.1. Legal date -->
@@ -3851,20 +3845,22 @@
   </citation>
   <!-- Bibliography -->
   <macro name="bibliography-author-date">
-    <choose>
-      <if match="any" type="bill hearing legal_case legislation regulation treaty">
-        <!-- Legal items have different orders and delimiters -->
-        <text macro="legal-reference"/>
-      </if>
-      <else>
-        <group delimiter=". ">
+    <group delimiter=". ">
+      <choose>
+        <if match="any" type="bill hearing legal_case legislation regulation treaty">
+          <!-- Legal items have different orders and delimiters -->
+          <text macro="legal-reference"/>
+          <text macro="source-date-accessed-DOI-URL-bib"/>
+          <text variable="references"/>
+        </if>
+        <else>
           <text macro="author-bib"/>
           <text macro="date"/>
           <text macro="title-and-source-bib"/>
-          <text macro="notes"/>
-        </group>
-      </else>
-    </choose>
+          <text variable="references"/>
+        </else>
+      </choose>
+    </group>
   </macro>
   <bibliography et-al-min="7" et-al-use-first="3" hanging-indent="true">
     <sort>

--- a/chicago-author-date-classic-no-url.csl
+++ b/chicago-author-date-classic-no-url.csl
@@ -1076,7 +1076,7 @@
       </group>
       <text macro="source-medium-bib"/>
       <text macro="source-archive-bib"/>
-      <!-- <text macro="source-DOI-URL-bib"/> -->
+      <text macro="source-date-accessed-DOI-URL-bib"/>
     </group>
   </macro>
   <!-- 3.1. Title -->
@@ -3435,11 +3435,23 @@
     </group>
   </macro>
   <!-- 4.10. URL or persistent identifier -->
-  <!-- 5. Notes -->
-  <macro name="notes">
-    <!-- Notes on source element: original publication, reprint info, retraction info -->
-    <text variable="references"/>
+  <macro name="source-date-accessed-DOI-URL-bib">
+    <group delimiter=", ">
+      <choose>
+        <if variable="DOI"/>
+        <else-if match="any" variable="available-date event-date issued status"/>
+        <else-if variable="accessed URL">
+          <group delimiter=" ">
+            <text term="accessed" text-case="capitalize-first"/>
+            <date form="text" variable="accessed"/>
+          </group>
+        </else-if>
+      </choose>
+      <!-- <text macro="source-DOI-URL"/> -->
+    </group>
   </macro>
+  <!-- 5. Notes -->
+  <!-- TODO: add variables for distributor and exhibitions if available in CSL -->
   <!-- 6. Legal references: Bluebook style (shared with APA) -->
   <!-- Where APA or Chicago diverge from Bluebook, the official manual is followed -->
   <macro name="legal-reference">
@@ -3463,42 +3475,38 @@
          `treaty`
          : treaties
     -->
-    <group delimiter=" ">
-      <group delimiter=", " suffix=".">
-        <choose>
-          <if type="treaty">
-            <text macro="legal-title"/>
-            <names variable="author">
-              <!-- Treaty parties should be included at least for bilateral treaties (Bluebook 21.4.2) -->
-              <name delimiter="-" et-al-min="100" et-al-use-first="99" form="short"/>
-            </names>
-            <text macro="legal-date"/>
-            <!-- treaty source/report in addition to URL (Bluebook 21.4.5) -->
-            <text macro="legal-source"/>
-          </if>
-          <else>
-            <group delimiter=" ">
-              <group delimiter=", ">
-                <text macro="legal-title"/>
-                <text macro="legal-source"/>
-              </group>
-              <text macro="legal-date"/>
-              <text macro="legal-identifier"/>
+    <group delimiter=", ">
+      <choose>
+        <if type="treaty">
+          <text macro="legal-title"/>
+          <names variable="author">
+            <!-- Treaty parties should be included at least for bilateral treaties (Bluebook 21.4.2) -->
+            <name delimiter="-" et-al-min="100" et-al-use-first="99" form="short"/>
+          </names>
+          <text macro="legal-date"/>
+          <!-- treaty source/report in addition to URL (Bluebook 21.4.5) -->
+          <text macro="legal-source"/>
+        </if>
+        <else>
+          <group delimiter=" ">
+            <group delimiter=", ">
+              <text macro="legal-title"/>
+              <text macro="legal-source"/>
             </group>
-          </else>
+            <text macro="legal-date"/>
+            <text macro="legal-identifier"/>
+          </group>
+        </else>
+      </choose>
+      <group delimiter=" ">
+        <!-- locator for use in notes -->
+        <choose>
+          <if locator="page" variable="page">
+            <text term="at"/>
+          </if>
         </choose>
-        <group delimiter=" ">
-          <!-- locator for use in notes -->
-          <choose>
-            <if locator="page" variable="page">
-              <text term="at"/>
-            </if>
-          </choose>
-          <text macro="label-locator"/>
-        </group>
+        <text macro="label-locator"/>
       </group>
-      <text variable="references"/>
-      <!-- <text macro="source-DOI-URL"/> -->
     </group>
   </macro>
   <!-- 6.1. Legal date -->
@@ -3840,20 +3848,22 @@
   </citation>
   <!-- Bibliography -->
   <macro name="bibliography-author-date">
-    <choose>
-      <if match="any" type="bill hearing legal_case legislation regulation treaty">
-        <!-- Legal items have different orders and delimiters -->
-        <text macro="legal-reference"/>
-      </if>
-      <else>
-        <group delimiter=". ">
+    <group delimiter=". ">
+      <choose>
+        <if match="any" type="bill hearing legal_case legislation regulation treaty">
+          <!-- Legal items have different orders and delimiters -->
+          <text macro="legal-reference"/>
+          <text macro="source-date-accessed-DOI-URL-bib"/>
+          <text variable="references"/>
+        </if>
+        <else>
           <text macro="author-bib"/>
           <text macro="date"/>
           <text macro="title-and-source-bib"/>
-          <text macro="notes"/>
-        </group>
-      </else>
-    </choose>
+          <text variable="references"/>
+        </else>
+      </choose>
+    </group>
   </macro>
   <bibliography et-al-min="7" et-al-use-first="3" hanging-indent="true" subsequent-author-substitute="&#8212;&#8212;&#8212;">
     <sort>

--- a/chicago-author-date-classic.csl
+++ b/chicago-author-date-classic.csl
@@ -1076,7 +1076,7 @@
       </group>
       <text macro="source-medium-bib"/>
       <text macro="source-archive-bib"/>
-      <text macro="source-DOI-URL-bib"/>
+      <text macro="source-date-accessed-DOI-URL-bib"/>
     </group>
   </macro>
   <!-- 3.1. Title -->
@@ -3435,35 +3435,33 @@
     </group>
   </macro>
   <!-- 4.10. URL or persistent identifier -->
-  <macro name="source-DOI-URL-bib">
+  <macro name="source-date-accessed-DOI-URL-bib">
+    <group delimiter=", ">
+      <choose>
+        <if variable="DOI"/>
+        <else-if match="any" variable="available-date event-date issued status"/>
+        <else-if variable="accessed URL">
+          <group delimiter=" ">
+            <text term="accessed" text-case="capitalize-first"/>
+            <date form="text" variable="accessed"/>
+          </group>
+        </else-if>
+      </choose>
+      <text macro="source-DOI-URL"/>
+    </group>
+  </macro>
+  <macro name="source-DOI-URL">
     <choose>
       <if variable="DOI">
         <text prefix="https://doi.org/" variable="DOI"/>
       </if>
       <else-if variable="URL">
-        <group delimiter=". ">
-          <choose>
-            <if match="none" variable="available-date event-date issued status">
-              <group delimiter=" ">
-                <text term="accessed" text-case="capitalize-first"/>
-                <date form="text" variable="accessed"/>
-              </group>
-            </if>
-          </choose>
-          <text variable="URL"/>
-        </group>
+        <text variable="URL"/>
       </else-if>
     </choose>
   </macro>
-  <macro name="source-DOI-URL">
-    <!-- Alias to avoid modifying legal references block shared with APA -->
-    <text macro="source-DOI-URL-bib"/>
-  </macro>
   <!-- 5. Notes -->
-  <macro name="notes">
-    <!-- Notes on source element: original publication, reprint info, retraction info -->
-    <text variable="references"/>
-  </macro>
+  <!-- TODO: add variables for distributor and exhibitions if available in CSL -->
   <!-- 6. Legal references: Bluebook style (shared with APA) -->
   <!-- Where APA or Chicago diverge from Bluebook, the official manual is followed -->
   <macro name="legal-reference">
@@ -3487,42 +3485,38 @@
          `treaty`
          : treaties
     -->
-    <group delimiter=" ">
-      <group delimiter=", " suffix=".">
-        <choose>
-          <if type="treaty">
-            <text macro="legal-title"/>
-            <names variable="author">
-              <!-- Treaty parties should be included at least for bilateral treaties (Bluebook 21.4.2) -->
-              <name delimiter="-" et-al-min="100" et-al-use-first="99" form="short"/>
-            </names>
-            <text macro="legal-date"/>
-            <!-- treaty source/report in addition to URL (Bluebook 21.4.5) -->
-            <text macro="legal-source"/>
-          </if>
-          <else>
-            <group delimiter=" ">
-              <group delimiter=", ">
-                <text macro="legal-title"/>
-                <text macro="legal-source"/>
-              </group>
-              <text macro="legal-date"/>
-              <text macro="legal-identifier"/>
+    <group delimiter=", ">
+      <choose>
+        <if type="treaty">
+          <text macro="legal-title"/>
+          <names variable="author">
+            <!-- Treaty parties should be included at least for bilateral treaties (Bluebook 21.4.2) -->
+            <name delimiter="-" et-al-min="100" et-al-use-first="99" form="short"/>
+          </names>
+          <text macro="legal-date"/>
+          <!-- treaty source/report in addition to URL (Bluebook 21.4.5) -->
+          <text macro="legal-source"/>
+        </if>
+        <else>
+          <group delimiter=" ">
+            <group delimiter=", ">
+              <text macro="legal-title"/>
+              <text macro="legal-source"/>
             </group>
-          </else>
+            <text macro="legal-date"/>
+            <text macro="legal-identifier"/>
+          </group>
+        </else>
+      </choose>
+      <group delimiter=" ">
+        <!-- locator for use in notes -->
+        <choose>
+          <if locator="page" variable="page">
+            <text term="at"/>
+          </if>
         </choose>
-        <group delimiter=" ">
-          <!-- locator for use in notes -->
-          <choose>
-            <if locator="page" variable="page">
-              <text term="at"/>
-            </if>
-          </choose>
-          <text macro="label-locator"/>
-        </group>
+        <text macro="label-locator"/>
       </group>
-      <text variable="references"/>
-      <text macro="source-DOI-URL"/>
     </group>
   </macro>
   <!-- 6.1. Legal date -->
@@ -3864,20 +3858,22 @@
   </citation>
   <!-- Bibliography -->
   <macro name="bibliography-author-date">
-    <choose>
-      <if match="any" type="bill hearing legal_case legislation regulation treaty">
-        <!-- Legal items have different orders and delimiters -->
-        <text macro="legal-reference"/>
-      </if>
-      <else>
-        <group delimiter=". ">
+    <group delimiter=". ">
+      <choose>
+        <if match="any" type="bill hearing legal_case legislation regulation treaty">
+          <!-- Legal items have different orders and delimiters -->
+          <text macro="legal-reference"/>
+          <text macro="source-date-accessed-DOI-URL-bib"/>
+          <text variable="references"/>
+        </if>
+        <else>
           <text macro="author-bib"/>
           <text macro="date"/>
           <text macro="title-and-source-bib"/>
-          <text macro="notes"/>
-        </group>
-      </else>
-    </choose>
+          <text variable="references"/>
+        </else>
+      </choose>
+    </group>
   </macro>
   <bibliography et-al-min="7" et-al-use-first="3" hanging-indent="true" subsequent-author-substitute="&#8212;&#8212;&#8212;">
     <sort>

--- a/chicago-author-date-no-url.csl
+++ b/chicago-author-date-no-url.csl
@@ -1076,7 +1076,7 @@
       </group>
       <text macro="source-medium-bib"/>
       <text macro="source-archive-bib"/>
-      <!-- <text macro="source-DOI-URL-bib"/> -->
+      <text macro="source-date-accessed-DOI-URL-bib"/>
     </group>
   </macro>
   <!-- 3.1. Title -->
@@ -3441,11 +3441,23 @@
     </group>
   </macro>
   <!-- 4.10. URL or persistent identifier -->
-  <!-- 5. Notes -->
-  <macro name="notes">
-    <!-- Notes on source element: original publication, reprint info, retraction info -->
-    <text variable="references"/>
+  <macro name="source-date-accessed-DOI-URL-bib">
+    <group delimiter=", ">
+      <choose>
+        <if variable="DOI"/>
+        <else-if match="any" variable="available-date event-date issued status"/>
+        <else-if variable="accessed URL">
+          <group delimiter=" ">
+            <text term="accessed" text-case="capitalize-first"/>
+            <date form="text" variable="accessed"/>
+          </group>
+        </else-if>
+      </choose>
+      <!-- <text macro="source-DOI-URL"/> -->
+    </group>
   </macro>
+  <!-- 5. Notes -->
+  <!-- TODO: add variables for distributor and exhibitions if available in CSL -->
   <!-- 6. Legal references: Bluebook style (shared with APA) -->
   <!-- Where APA or Chicago diverge from Bluebook, the official manual is followed -->
   <macro name="legal-reference">
@@ -3469,42 +3481,38 @@
          `treaty`
          : treaties
     -->
-    <group delimiter=" ">
-      <group delimiter=", " suffix=".">
-        <choose>
-          <if type="treaty">
-            <text macro="legal-title"/>
-            <names variable="author">
-              <!-- Treaty parties should be included at least for bilateral treaties (Bluebook 21.4.2) -->
-              <name delimiter="-" et-al-min="100" et-al-use-first="99" form="short"/>
-            </names>
-            <text macro="legal-date"/>
-            <!-- treaty source/report in addition to URL (Bluebook 21.4.5) -->
-            <text macro="legal-source"/>
-          </if>
-          <else>
-            <group delimiter=" ">
-              <group delimiter=", ">
-                <text macro="legal-title"/>
-                <text macro="legal-source"/>
-              </group>
-              <text macro="legal-date"/>
-              <text macro="legal-identifier"/>
+    <group delimiter=", ">
+      <choose>
+        <if type="treaty">
+          <text macro="legal-title"/>
+          <names variable="author">
+            <!-- Treaty parties should be included at least for bilateral treaties (Bluebook 21.4.2) -->
+            <name delimiter="-" et-al-min="100" et-al-use-first="99" form="short"/>
+          </names>
+          <text macro="legal-date"/>
+          <!-- treaty source/report in addition to URL (Bluebook 21.4.5) -->
+          <text macro="legal-source"/>
+        </if>
+        <else>
+          <group delimiter=" ">
+            <group delimiter=", ">
+              <text macro="legal-title"/>
+              <text macro="legal-source"/>
             </group>
-          </else>
+            <text macro="legal-date"/>
+            <text macro="legal-identifier"/>
+          </group>
+        </else>
+      </choose>
+      <group delimiter=" ">
+        <!-- locator for use in notes -->
+        <choose>
+          <if locator="page" variable="page">
+            <text term="at"/>
+          </if>
         </choose>
-        <group delimiter=" ">
-          <!-- locator for use in notes -->
-          <choose>
-            <if locator="page" variable="page">
-              <text term="at"/>
-            </if>
-          </choose>
-          <text macro="label-locator"/>
-        </group>
+        <text macro="label-locator"/>
       </group>
-      <text variable="references"/>
-      <!-- <text macro="source-DOI-URL"/> -->
     </group>
   </macro>
   <!-- 6.1. Legal date -->
@@ -3846,20 +3854,22 @@
   </citation>
   <!-- Bibliography -->
   <macro name="bibliography-author-date">
-    <choose>
-      <if match="any" type="bill hearing legal_case legislation regulation treaty">
-        <!-- Legal items have different orders and delimiters -->
-        <text macro="legal-reference"/>
-      </if>
-      <else>
-        <group delimiter=". ">
+    <group delimiter=". ">
+      <choose>
+        <if match="any" type="bill hearing legal_case legislation regulation treaty">
+          <!-- Legal items have different orders and delimiters -->
+          <text macro="legal-reference"/>
+          <text macro="source-date-accessed-DOI-URL-bib"/>
+          <text variable="references"/>
+        </if>
+        <else>
           <text macro="author-bib"/>
           <text macro="date"/>
           <text macro="title-and-source-bib"/>
-          <text macro="notes"/>
-        </group>
-      </else>
-    </choose>
+          <text variable="references"/>
+        </else>
+      </choose>
+    </group>
   </macro>
   <bibliography et-al-min="7" et-al-use-first="3" hanging-indent="true">
     <sort>

--- a/chicago-author-date.csl
+++ b/chicago-author-date.csl
@@ -1076,7 +1076,7 @@
       </group>
       <text macro="source-medium-bib"/>
       <text macro="source-archive-bib"/>
-      <text macro="source-DOI-URL-bib"/>
+      <text macro="source-date-accessed-DOI-URL-bib"/>
     </group>
   </macro>
   <!-- 3.1. Title -->
@@ -3441,35 +3441,33 @@
     </group>
   </macro>
   <!-- 4.10. URL or persistent identifier -->
-  <macro name="source-DOI-URL-bib">
+  <macro name="source-date-accessed-DOI-URL-bib">
+    <group delimiter=", ">
+      <choose>
+        <if variable="DOI"/>
+        <else-if match="any" variable="available-date event-date issued status"/>
+        <else-if variable="accessed URL">
+          <group delimiter=" ">
+            <text term="accessed" text-case="capitalize-first"/>
+            <date form="text" variable="accessed"/>
+          </group>
+        </else-if>
+      </choose>
+      <text macro="source-DOI-URL"/>
+    </group>
+  </macro>
+  <macro name="source-DOI-URL">
     <choose>
       <if variable="DOI">
         <text prefix="https://doi.org/" variable="DOI"/>
       </if>
       <else-if variable="URL">
-        <group delimiter=". ">
-          <choose>
-            <if match="none" variable="available-date event-date issued status">
-              <group delimiter=" ">
-                <text term="accessed" text-case="capitalize-first"/>
-                <date form="text" variable="accessed"/>
-              </group>
-            </if>
-          </choose>
-          <text variable="URL"/>
-        </group>
+        <text variable="URL"/>
       </else-if>
     </choose>
   </macro>
-  <macro name="source-DOI-URL">
-    <!-- Alias to avoid modifying legal references block shared with APA -->
-    <text macro="source-DOI-URL-bib"/>
-  </macro>
   <!-- 5. Notes -->
-  <macro name="notes">
-    <!-- Notes on source element: original publication, reprint info, retraction info -->
-    <text variable="references"/>
-  </macro>
+  <!-- TODO: add variables for distributor and exhibitions if available in CSL -->
   <!-- 6. Legal references: Bluebook style (shared with APA) -->
   <!-- Where APA or Chicago diverge from Bluebook, the official manual is followed -->
   <macro name="legal-reference">
@@ -3493,42 +3491,38 @@
          `treaty`
          : treaties
     -->
-    <group delimiter=" ">
-      <group delimiter=", " suffix=".">
-        <choose>
-          <if type="treaty">
-            <text macro="legal-title"/>
-            <names variable="author">
-              <!-- Treaty parties should be included at least for bilateral treaties (Bluebook 21.4.2) -->
-              <name delimiter="-" et-al-min="100" et-al-use-first="99" form="short"/>
-            </names>
-            <text macro="legal-date"/>
-            <!-- treaty source/report in addition to URL (Bluebook 21.4.5) -->
-            <text macro="legal-source"/>
-          </if>
-          <else>
-            <group delimiter=" ">
-              <group delimiter=", ">
-                <text macro="legal-title"/>
-                <text macro="legal-source"/>
-              </group>
-              <text macro="legal-date"/>
-              <text macro="legal-identifier"/>
+    <group delimiter=", ">
+      <choose>
+        <if type="treaty">
+          <text macro="legal-title"/>
+          <names variable="author">
+            <!-- Treaty parties should be included at least for bilateral treaties (Bluebook 21.4.2) -->
+            <name delimiter="-" et-al-min="100" et-al-use-first="99" form="short"/>
+          </names>
+          <text macro="legal-date"/>
+          <!-- treaty source/report in addition to URL (Bluebook 21.4.5) -->
+          <text macro="legal-source"/>
+        </if>
+        <else>
+          <group delimiter=" ">
+            <group delimiter=", ">
+              <text macro="legal-title"/>
+              <text macro="legal-source"/>
             </group>
-          </else>
+            <text macro="legal-date"/>
+            <text macro="legal-identifier"/>
+          </group>
+        </else>
+      </choose>
+      <group delimiter=" ">
+        <!-- locator for use in notes -->
+        <choose>
+          <if locator="page" variable="page">
+            <text term="at"/>
+          </if>
         </choose>
-        <group delimiter=" ">
-          <!-- locator for use in notes -->
-          <choose>
-            <if locator="page" variable="page">
-              <text term="at"/>
-            </if>
-          </choose>
-          <text macro="label-locator"/>
-        </group>
+        <text macro="label-locator"/>
       </group>
-      <text variable="references"/>
-      <text macro="source-DOI-URL"/>
     </group>
   </macro>
   <!-- 6.1. Legal date -->
@@ -3870,20 +3864,22 @@
   </citation>
   <!-- Bibliography -->
   <macro name="bibliography-author-date">
-    <choose>
-      <if match="any" type="bill hearing legal_case legislation regulation treaty">
-        <!-- Legal items have different orders and delimiters -->
-        <text macro="legal-reference"/>
-      </if>
-      <else>
-        <group delimiter=". ">
+    <group delimiter=". ">
+      <choose>
+        <if match="any" type="bill hearing legal_case legislation regulation treaty">
+          <!-- Legal items have different orders and delimiters -->
+          <text macro="legal-reference"/>
+          <text macro="source-date-accessed-DOI-URL-bib"/>
+          <text variable="references"/>
+        </if>
+        <else>
           <text macro="author-bib"/>
           <text macro="date"/>
           <text macro="title-and-source-bib"/>
-          <text macro="notes"/>
-        </group>
-      </else>
-    </choose>
+          <text variable="references"/>
+        </else>
+      </choose>
+    </group>
   </macro>
   <bibliography et-al-min="7" et-al-use-first="3" hanging-indent="true">
     <sort>

--- a/chicago-in-text-full-no-url.csl
+++ b/chicago-in-text-full-no-url.csl
@@ -1221,7 +1221,7 @@
       </group>
       <text macro="source-medium-bib"/>
       <text macro="source-archive-bib"/>
-      <!-- <text macro="source-DOI-URL-bib"/> -->
+      <text macro="source-date-accessed-DOI-URL-bib"/>
     </group>
   </macro>
   <macro name="title-and-source-note">
@@ -1274,7 +1274,7 @@
       </choose>
       <text macro="source-medium-note"/>
       <text macro="source-archive-note"/>
-      <!-- <text macro="source-DOI-URL-note"/> -->
+      <text macro="source-date-accessed-DOI-URL-note"/>
     </group>
   </macro>
   <!-- 3.1. Title -->
@@ -5396,11 +5396,38 @@
     </group>
   </macro>
   <!-- 4.10. URL or persistent identifier -->
-  <!-- 5. Notes -->
-  <macro name="notes">
-    <!-- Notes on source element: original publication, reprint info, retraction info -->
-    <text variable="references"/>
+  <macro name="source-date-accessed-DOI-URL-bib">
+    <group delimiter=", ">
+      <choose>
+        <if variable="DOI"/>
+        <else-if match="any" variable="available-date event-date issued status"/>
+        <else-if variable="accessed URL">
+          <group delimiter=" ">
+            <text term="accessed" text-case="capitalize-first"/>
+            <date form="text" variable="accessed"/>
+          </group>
+        </else-if>
+      </choose>
+      <!-- <text macro="source-DOI-URL"/> -->
+    </group>
   </macro>
+  <macro name="source-date-accessed-DOI-URL-note">
+    <group delimiter=", ">
+      <choose>
+        <if variable="DOI"/>
+        <else-if match="any" variable="available-date event-date issued status"/>
+        <else-if variable="URL">
+          <group delimiter=" ">
+            <text term="accessed"/>
+            <date form="text" variable="accessed"/>
+          </group>
+        </else-if>
+      </choose>
+      <!-- <text macro="source-DOI-URL"/> -->
+    </group>
+  </macro>
+  <!-- 5. Notes -->
+  <!-- TODO: add variables for distributor and exhibitions if available in CSL -->
   <!-- 6. Legal references: Bluebook style (shared with APA) -->
   <!-- Where APA or Chicago diverge from Bluebook, the official manual is followed -->
   <macro name="legal-reference">
@@ -5424,42 +5451,38 @@
          `treaty`
          : treaties
     -->
-    <group delimiter=" ">
-      <group delimiter=", " suffix=".">
-        <choose>
-          <if type="treaty">
-            <text macro="legal-title"/>
-            <names variable="author">
-              <!-- Treaty parties should be included at least for bilateral treaties (Bluebook 21.4.2) -->
-              <name delimiter="-" et-al-min="100" et-al-use-first="99" form="short"/>
-            </names>
-            <text macro="legal-date"/>
-            <!-- treaty source/report in addition to URL (Bluebook 21.4.5) -->
-            <text macro="legal-source"/>
-          </if>
-          <else>
-            <group delimiter=" ">
-              <group delimiter=", ">
-                <text macro="legal-title"/>
-                <text macro="legal-source"/>
-              </group>
-              <text macro="legal-date"/>
-              <text macro="legal-identifier"/>
+    <group delimiter=", ">
+      <choose>
+        <if type="treaty">
+          <text macro="legal-title"/>
+          <names variable="author">
+            <!-- Treaty parties should be included at least for bilateral treaties (Bluebook 21.4.2) -->
+            <name delimiter="-" et-al-min="100" et-al-use-first="99" form="short"/>
+          </names>
+          <text macro="legal-date"/>
+          <!-- treaty source/report in addition to URL (Bluebook 21.4.5) -->
+          <text macro="legal-source"/>
+        </if>
+        <else>
+          <group delimiter=" ">
+            <group delimiter=", ">
+              <text macro="legal-title"/>
+              <text macro="legal-source"/>
             </group>
-          </else>
+            <text macro="legal-date"/>
+            <text macro="legal-identifier"/>
+          </group>
+        </else>
+      </choose>
+      <group delimiter=" ">
+        <!-- locator for use in notes -->
+        <choose>
+          <if locator="page" variable="page">
+            <text term="at"/>
+          </if>
         </choose>
-        <group delimiter=" ">
-          <!-- locator for use in notes -->
-          <choose>
-            <if locator="page" variable="page">
-              <text term="at"/>
-            </if>
-          </choose>
-          <text macro="label-locator"/>
-        </group>
+        <text macro="label-locator"/>
       </group>
-      <text variable="references"/>
-      <!-- <text macro="source-DOI-URL"/> -->
     </group>
   </macro>
   <!-- 6.1. Legal date -->
@@ -5710,30 +5733,29 @@
   </macro>
   <!-- Citation -->
   <macro name="citation-notes-full">
-    <choose>
-      <if match="any" type="bill hearing legal_case legislation regulation treaty">
-        <!-- Legal items have different orders and delimiters -->
-        <text macro="legal-reference"/>
-      </if>
-      <else-if type="personal_communication" variable="genre">
-        <group delimiter=", ">
+    <group delimiter=", ">
+      <choose>
+        <if match="any" type="bill hearing legal_case legislation regulation treaty">
+          <!-- Legal items have different orders and delimiters -->
+          <text macro="legal-reference"/>
+          <text macro="source-date-accessed-DOI-URL-note"/>
+        </if>
+        <else-if type="personal_communication" variable="genre">
           <text macro="author-note"/>
           <text macro="title-and-source-note"/>
-        </group>
-      </else-if>
-      <else-if type="personal_communication" variable="author recipient">
-        <group delimiter=" ">
+        </else-if>
+        <else-if type="personal_communication" variable="author recipient">
+          <group delimiter=" ">
+            <text macro="author-note"/>
+            <text macro="title-and-source-note"/>
+          </group>
+        </else-if>
+        <else>
           <text macro="author-note"/>
           <text macro="title-and-source-note"/>
-        </group>
-      </else-if>
-      <else>
-        <group delimiter=", ">
-          <text macro="author-note"/>
-          <text macro="title-and-source-note"/>
-        </group>
-      </else>
-    </choose>
+        </else>
+      </choose>
+    </group>
   </macro>
   <macro name="citation-notes-shortened-author-only">
     <choose>
@@ -5902,19 +5924,21 @@
   </citation>
   <!-- Bibliography -->
   <macro name="bibliography-notes">
-    <choose>
-      <if match="any" type="bill hearing legal_case legislation regulation treaty">
-        <!-- Legal items have different orders and delimiters -->
-        <text macro="legal-reference"/>
-      </if>
-      <else>
-        <group delimiter=". ">
+    <group delimiter=". ">
+      <choose>
+        <if match="any" type="bill hearing legal_case legislation regulation treaty">
+          <!-- Legal items have different orders and delimiters -->
+          <text macro="legal-reference"/>
+          <text macro="source-date-accessed-DOI-URL-bib"/>
+          <text variable="references"/>
+        </if>
+        <else>
           <text macro="author-bib"/>
           <text macro="title-and-source-bib"/>
-          <text macro="notes"/>
-        </group>
-      </else>
-    </choose>
+          <text variable="references"/>
+        </else>
+      </choose>
+    </group>
   </macro>
   <bibliography et-al-min="7" et-al-use-first="3" hanging-indent="true">
     <sort>

--- a/chicago-in-text-full.csl
+++ b/chicago-in-text-full.csl
@@ -1221,7 +1221,7 @@
       </group>
       <text macro="source-medium-bib"/>
       <text macro="source-archive-bib"/>
-      <text macro="source-DOI-URL-bib"/>
+      <text macro="source-date-accessed-DOI-URL-bib"/>
     </group>
   </macro>
   <macro name="title-and-source-note">
@@ -1274,7 +1274,7 @@
       </choose>
       <text macro="source-medium-note"/>
       <text macro="source-archive-note"/>
-      <text macro="source-DOI-URL-note"/>
+      <text macro="source-date-accessed-DOI-URL-note"/>
     </group>
   </macro>
   <!-- 3.1. Title -->
@@ -5396,55 +5396,48 @@
     </group>
   </macro>
   <!-- 4.10. URL or persistent identifier -->
-  <macro name="source-DOI-URL-bib">
-    <choose>
-      <if variable="DOI">
-        <text prefix="https://doi.org/" variable="DOI"/>
-      </if>
-      <else-if variable="URL">
-        <group delimiter=". ">
-          <choose>
-            <if match="none" variable="available-date event-date issued status">
-              <group delimiter=" ">
-                <text term="accessed" text-case="capitalize-first"/>
-                <date form="text" variable="accessed"/>
-              </group>
-            </if>
-          </choose>
-          <text variable="URL"/>
-        </group>
-      </else-if>
-    </choose>
+  <macro name="source-date-accessed-DOI-URL-bib">
+    <group delimiter=", ">
+      <choose>
+        <if variable="DOI"/>
+        <else-if match="any" variable="available-date event-date issued status"/>
+        <else-if variable="accessed URL">
+          <group delimiter=" ">
+            <text term="accessed" text-case="capitalize-first"/>
+            <date form="text" variable="accessed"/>
+          </group>
+        </else-if>
+      </choose>
+      <text macro="source-DOI-URL"/>
+    </group>
   </macro>
-  <macro name="source-DOI-URL-note">
-    <choose>
-      <if variable="DOI">
-        <text prefix="https://doi.org/" variable="DOI"/>
-      </if>
-      <else-if variable="URL">
-        <group delimiter=", ">
-          <choose>
-            <if match="none" variable="available-date event-date issued status">
-              <group delimiter=" ">
-                <text term="accessed"/>
-                <date form="text" variable="accessed"/>
-              </group>
-            </if>
-          </choose>
-          <text variable="URL"/>
-        </group>
-      </else-if>
-    </choose>
+  <macro name="source-date-accessed-DOI-URL-note">
+    <group delimiter=", ">
+      <choose>
+        <if variable="DOI"/>
+        <else-if match="any" variable="available-date event-date issued status"/>
+        <else-if variable="URL">
+          <group delimiter=" ">
+            <text term="accessed"/>
+            <date form="text" variable="accessed"/>
+          </group>
+        </else-if>
+      </choose>
+      <text macro="source-DOI-URL"/>
+    </group>
   </macro>
   <macro name="source-DOI-URL">
-    <!-- Alias to avoid modifying legal references block shared with APA -->
-    <text macro="source-DOI-URL-bib"/>
+    <choose>
+      <if variable="DOI">
+        <text prefix="https://doi.org/" variable="DOI"/>
+      </if>
+      <else-if variable="URL">
+        <text variable="URL"/>
+      </else-if>
+    </choose>
   </macro>
   <!-- 5. Notes -->
-  <macro name="notes">
-    <!-- Notes on source element: original publication, reprint info, retraction info -->
-    <text variable="references"/>
-  </macro>
+  <!-- TODO: add variables for distributor and exhibitions if available in CSL -->
   <!-- 6. Legal references: Bluebook style (shared with APA) -->
   <!-- Where APA or Chicago diverge from Bluebook, the official manual is followed -->
   <macro name="legal-reference">
@@ -5468,42 +5461,38 @@
          `treaty`
          : treaties
     -->
-    <group delimiter=" ">
-      <group delimiter=", " suffix=".">
-        <choose>
-          <if type="treaty">
-            <text macro="legal-title"/>
-            <names variable="author">
-              <!-- Treaty parties should be included at least for bilateral treaties (Bluebook 21.4.2) -->
-              <name delimiter="-" et-al-min="100" et-al-use-first="99" form="short"/>
-            </names>
-            <text macro="legal-date"/>
-            <!-- treaty source/report in addition to URL (Bluebook 21.4.5) -->
-            <text macro="legal-source"/>
-          </if>
-          <else>
-            <group delimiter=" ">
-              <group delimiter=", ">
-                <text macro="legal-title"/>
-                <text macro="legal-source"/>
-              </group>
-              <text macro="legal-date"/>
-              <text macro="legal-identifier"/>
+    <group delimiter=", ">
+      <choose>
+        <if type="treaty">
+          <text macro="legal-title"/>
+          <names variable="author">
+            <!-- Treaty parties should be included at least for bilateral treaties (Bluebook 21.4.2) -->
+            <name delimiter="-" et-al-min="100" et-al-use-first="99" form="short"/>
+          </names>
+          <text macro="legal-date"/>
+          <!-- treaty source/report in addition to URL (Bluebook 21.4.5) -->
+          <text macro="legal-source"/>
+        </if>
+        <else>
+          <group delimiter=" ">
+            <group delimiter=", ">
+              <text macro="legal-title"/>
+              <text macro="legal-source"/>
             </group>
-          </else>
+            <text macro="legal-date"/>
+            <text macro="legal-identifier"/>
+          </group>
+        </else>
+      </choose>
+      <group delimiter=" ">
+        <!-- locator for use in notes -->
+        <choose>
+          <if locator="page" variable="page">
+            <text term="at"/>
+          </if>
         </choose>
-        <group delimiter=" ">
-          <!-- locator for use in notes -->
-          <choose>
-            <if locator="page" variable="page">
-              <text term="at"/>
-            </if>
-          </choose>
-          <text macro="label-locator"/>
-        </group>
+        <text macro="label-locator"/>
       </group>
-      <text variable="references"/>
-      <text macro="source-DOI-URL"/>
     </group>
   </macro>
   <!-- 6.1. Legal date -->
@@ -5754,30 +5743,29 @@
   </macro>
   <!-- Citation -->
   <macro name="citation-notes-full">
-    <choose>
-      <if match="any" type="bill hearing legal_case legislation regulation treaty">
-        <!-- Legal items have different orders and delimiters -->
-        <text macro="legal-reference"/>
-      </if>
-      <else-if type="personal_communication" variable="genre">
-        <group delimiter=", ">
+    <group delimiter=", ">
+      <choose>
+        <if match="any" type="bill hearing legal_case legislation regulation treaty">
+          <!-- Legal items have different orders and delimiters -->
+          <text macro="legal-reference"/>
+          <text macro="source-date-accessed-DOI-URL-note"/>
+        </if>
+        <else-if type="personal_communication" variable="genre">
           <text macro="author-note"/>
           <text macro="title-and-source-note"/>
-        </group>
-      </else-if>
-      <else-if type="personal_communication" variable="author recipient">
-        <group delimiter=" ">
+        </else-if>
+        <else-if type="personal_communication" variable="author recipient">
+          <group delimiter=" ">
+            <text macro="author-note"/>
+            <text macro="title-and-source-note"/>
+          </group>
+        </else-if>
+        <else>
           <text macro="author-note"/>
           <text macro="title-and-source-note"/>
-        </group>
-      </else-if>
-      <else>
-        <group delimiter=", ">
-          <text macro="author-note"/>
-          <text macro="title-and-source-note"/>
-        </group>
-      </else>
-    </choose>
+        </else>
+      </choose>
+    </group>
   </macro>
   <macro name="citation-notes-shortened-author-only">
     <choose>
@@ -5946,19 +5934,21 @@
   </citation>
   <!-- Bibliography -->
   <macro name="bibliography-notes">
-    <choose>
-      <if match="any" type="bill hearing legal_case legislation regulation treaty">
-        <!-- Legal items have different orders and delimiters -->
-        <text macro="legal-reference"/>
-      </if>
-      <else>
-        <group delimiter=". ">
+    <group delimiter=". ">
+      <choose>
+        <if match="any" type="bill hearing legal_case legislation regulation treaty">
+          <!-- Legal items have different orders and delimiters -->
+          <text macro="legal-reference"/>
+          <text macro="source-date-accessed-DOI-URL-bib"/>
+          <text variable="references"/>
+        </if>
+        <else>
           <text macro="author-bib"/>
           <text macro="title-and-source-bib"/>
-          <text macro="notes"/>
-        </group>
-      </else>
-    </choose>
+          <text variable="references"/>
+        </else>
+      </choose>
+    </group>
   </macro>
   <bibliography et-al-min="7" et-al-use-first="3" hanging-indent="true">
     <sort>

--- a/chicago-in-text-shortened-author-no-url.csl
+++ b/chicago-in-text-shortened-author-no-url.csl
@@ -937,7 +937,7 @@
       </group>
       <text macro="source-medium-bib"/>
       <text macro="source-archive-bib"/>
-      <!-- <text macro="source-DOI-URL-bib"/> -->
+      <text macro="source-date-accessed-DOI-URL-bib"/>
     </group>
   </macro>
   <!-- 3.1. Title -->
@@ -3378,11 +3378,23 @@
     </group>
   </macro>
   <!-- 4.10. URL or persistent identifier -->
-  <!-- 5. Notes -->
-  <macro name="notes">
-    <!-- Notes on source element: original publication, reprint info, retraction info -->
-    <text variable="references"/>
+  <macro name="source-date-accessed-DOI-URL-bib">
+    <group delimiter=", ">
+      <choose>
+        <if variable="DOI"/>
+        <else-if match="any" variable="available-date event-date issued status"/>
+        <else-if variable="accessed URL">
+          <group delimiter=" ">
+            <text term="accessed" text-case="capitalize-first"/>
+            <date form="text" variable="accessed"/>
+          </group>
+        </else-if>
+      </choose>
+      <!-- <text macro="source-DOI-URL"/> -->
+    </group>
   </macro>
+  <!-- 5. Notes -->
+  <!-- TODO: add variables for distributor and exhibitions if available in CSL -->
   <!-- 6. Legal references: Bluebook style (shared with APA) -->
   <!-- Where APA or Chicago diverge from Bluebook, the official manual is followed -->
   <macro name="legal-reference">
@@ -3406,42 +3418,38 @@
          `treaty`
          : treaties
     -->
-    <group delimiter=" ">
-      <group delimiter=", " suffix=".">
-        <choose>
-          <if type="treaty">
-            <text macro="legal-title"/>
-            <names variable="author">
-              <!-- Treaty parties should be included at least for bilateral treaties (Bluebook 21.4.2) -->
-              <name delimiter="-" et-al-min="100" et-al-use-first="99" form="short"/>
-            </names>
-            <text macro="legal-date"/>
-            <!-- treaty source/report in addition to URL (Bluebook 21.4.5) -->
-            <text macro="legal-source"/>
-          </if>
-          <else>
-            <group delimiter=" ">
-              <group delimiter=", ">
-                <text macro="legal-title"/>
-                <text macro="legal-source"/>
-              </group>
-              <text macro="legal-date"/>
-              <text macro="legal-identifier"/>
+    <group delimiter=", ">
+      <choose>
+        <if type="treaty">
+          <text macro="legal-title"/>
+          <names variable="author">
+            <!-- Treaty parties should be included at least for bilateral treaties (Bluebook 21.4.2) -->
+            <name delimiter="-" et-al-min="100" et-al-use-first="99" form="short"/>
+          </names>
+          <text macro="legal-date"/>
+          <!-- treaty source/report in addition to URL (Bluebook 21.4.5) -->
+          <text macro="legal-source"/>
+        </if>
+        <else>
+          <group delimiter=" ">
+            <group delimiter=", ">
+              <text macro="legal-title"/>
+              <text macro="legal-source"/>
             </group>
-          </else>
+            <text macro="legal-date"/>
+            <text macro="legal-identifier"/>
+          </group>
+        </else>
+      </choose>
+      <group delimiter=" ">
+        <!-- locator for use in notes -->
+        <choose>
+          <if locator="page" variable="page">
+            <text term="at"/>
+          </if>
         </choose>
-        <group delimiter=" ">
-          <!-- locator for use in notes -->
-          <choose>
-            <if locator="page" variable="page">
-              <text term="at"/>
-            </if>
-          </choose>
-          <text macro="label-locator"/>
-        </group>
+        <text macro="label-locator"/>
       </group>
-      <text variable="references"/>
-      <!-- <text macro="source-DOI-URL"/> -->
     </group>
   </macro>
   <!-- 6.1. Legal date -->
@@ -3762,19 +3770,21 @@
   </citation>
   <!-- Bibliography -->
   <macro name="bibliography-notes">
-    <choose>
-      <if match="any" type="bill hearing legal_case legislation regulation treaty">
-        <!-- Legal items have different orders and delimiters -->
-        <text macro="legal-reference"/>
-      </if>
-      <else>
-        <group delimiter=". ">
+    <group delimiter=". ">
+      <choose>
+        <if match="any" type="bill hearing legal_case legislation regulation treaty">
+          <!-- Legal items have different orders and delimiters -->
+          <text macro="legal-reference"/>
+          <text macro="source-date-accessed-DOI-URL-bib"/>
+          <text variable="references"/>
+        </if>
+        <else>
           <text macro="author-bib"/>
           <text macro="title-and-source-bib"/>
-          <text macro="notes"/>
-        </group>
-      </else>
-    </choose>
+          <text variable="references"/>
+        </else>
+      </choose>
+    </group>
   </macro>
   <bibliography et-al-min="7" et-al-use-first="3" hanging-indent="true">
     <sort>

--- a/chicago-in-text-shortened-author-title-no-url.csl
+++ b/chicago-in-text-shortened-author-title-no-url.csl
@@ -1010,7 +1010,7 @@
       </group>
       <text macro="source-medium-bib"/>
       <text macro="source-archive-bib"/>
-      <!-- <text macro="source-DOI-URL-bib"/> -->
+      <text macro="source-date-accessed-DOI-URL-bib"/>
     </group>
   </macro>
   <!-- 3.1. Title -->
@@ -3582,11 +3582,23 @@
     </group>
   </macro>
   <!-- 4.10. URL or persistent identifier -->
-  <!-- 5. Notes -->
-  <macro name="notes">
-    <!-- Notes on source element: original publication, reprint info, retraction info -->
-    <text variable="references"/>
+  <macro name="source-date-accessed-DOI-URL-bib">
+    <group delimiter=", ">
+      <choose>
+        <if variable="DOI"/>
+        <else-if match="any" variable="available-date event-date issued status"/>
+        <else-if variable="accessed URL">
+          <group delimiter=" ">
+            <text term="accessed" text-case="capitalize-first"/>
+            <date form="text" variable="accessed"/>
+          </group>
+        </else-if>
+      </choose>
+      <!-- <text macro="source-DOI-URL"/> -->
+    </group>
   </macro>
+  <!-- 5. Notes -->
+  <!-- TODO: add variables for distributor and exhibitions if available in CSL -->
   <!-- 6. Legal references: Bluebook style (shared with APA) -->
   <!-- Where APA or Chicago diverge from Bluebook, the official manual is followed -->
   <macro name="legal-reference">
@@ -3610,42 +3622,38 @@
          `treaty`
          : treaties
     -->
-    <group delimiter=" ">
-      <group delimiter=", " suffix=".">
-        <choose>
-          <if type="treaty">
-            <text macro="legal-title"/>
-            <names variable="author">
-              <!-- Treaty parties should be included at least for bilateral treaties (Bluebook 21.4.2) -->
-              <name delimiter="-" et-al-min="100" et-al-use-first="99" form="short"/>
-            </names>
-            <text macro="legal-date"/>
-            <!-- treaty source/report in addition to URL (Bluebook 21.4.5) -->
-            <text macro="legal-source"/>
-          </if>
-          <else>
-            <group delimiter=" ">
-              <group delimiter=", ">
-                <text macro="legal-title"/>
-                <text macro="legal-source"/>
-              </group>
-              <text macro="legal-date"/>
-              <text macro="legal-identifier"/>
+    <group delimiter=", ">
+      <choose>
+        <if type="treaty">
+          <text macro="legal-title"/>
+          <names variable="author">
+            <!-- Treaty parties should be included at least for bilateral treaties (Bluebook 21.4.2) -->
+            <name delimiter="-" et-al-min="100" et-al-use-first="99" form="short"/>
+          </names>
+          <text macro="legal-date"/>
+          <!-- treaty source/report in addition to URL (Bluebook 21.4.5) -->
+          <text macro="legal-source"/>
+        </if>
+        <else>
+          <group delimiter=" ">
+            <group delimiter=", ">
+              <text macro="legal-title"/>
+              <text macro="legal-source"/>
             </group>
-          </else>
+            <text macro="legal-date"/>
+            <text macro="legal-identifier"/>
+          </group>
+        </else>
+      </choose>
+      <group delimiter=" ">
+        <!-- locator for use in notes -->
+        <choose>
+          <if locator="page" variable="page">
+            <text term="at"/>
+          </if>
         </choose>
-        <group delimiter=" ">
-          <!-- locator for use in notes -->
-          <choose>
-            <if locator="page" variable="page">
-              <text term="at"/>
-            </if>
-          </choose>
-          <text macro="label-locator"/>
-        </group>
+        <text macro="label-locator"/>
       </group>
-      <text variable="references"/>
-      <!-- <text macro="source-DOI-URL"/> -->
     </group>
   </macro>
   <!-- 6.1. Legal date -->
@@ -3982,19 +3990,21 @@
   </citation>
   <!-- Bibliography -->
   <macro name="bibliography-notes">
-    <choose>
-      <if match="any" type="bill hearing legal_case legislation regulation treaty">
-        <!-- Legal items have different orders and delimiters -->
-        <text macro="legal-reference"/>
-      </if>
-      <else>
-        <group delimiter=". ">
+    <group delimiter=". ">
+      <choose>
+        <if match="any" type="bill hearing legal_case legislation regulation treaty">
+          <!-- Legal items have different orders and delimiters -->
+          <text macro="legal-reference"/>
+          <text macro="source-date-accessed-DOI-URL-bib"/>
+          <text variable="references"/>
+        </if>
+        <else>
           <text macro="author-bib"/>
           <text macro="title-and-source-bib"/>
-          <text macro="notes"/>
-        </group>
-      </else>
-    </choose>
+          <text variable="references"/>
+        </else>
+      </choose>
+    </group>
   </macro>
   <bibliography et-al-min="7" et-al-use-first="3" hanging-indent="true">
     <sort>

--- a/chicago-in-text-shortened-author-title.csl
+++ b/chicago-in-text-shortened-author-title.csl
@@ -1010,7 +1010,7 @@
       </group>
       <text macro="source-medium-bib"/>
       <text macro="source-archive-bib"/>
-      <text macro="source-DOI-URL-bib"/>
+      <text macro="source-date-accessed-DOI-URL-bib"/>
     </group>
   </macro>
   <!-- 3.1. Title -->
@@ -3582,35 +3582,33 @@
     </group>
   </macro>
   <!-- 4.10. URL or persistent identifier -->
-  <macro name="source-DOI-URL-bib">
+  <macro name="source-date-accessed-DOI-URL-bib">
+    <group delimiter=", ">
+      <choose>
+        <if variable="DOI"/>
+        <else-if match="any" variable="available-date event-date issued status"/>
+        <else-if variable="accessed URL">
+          <group delimiter=" ">
+            <text term="accessed" text-case="capitalize-first"/>
+            <date form="text" variable="accessed"/>
+          </group>
+        </else-if>
+      </choose>
+      <text macro="source-DOI-URL"/>
+    </group>
+  </macro>
+  <macro name="source-DOI-URL">
     <choose>
       <if variable="DOI">
         <text prefix="https://doi.org/" variable="DOI"/>
       </if>
       <else-if variable="URL">
-        <group delimiter=". ">
-          <choose>
-            <if match="none" variable="available-date event-date issued status">
-              <group delimiter=" ">
-                <text term="accessed" text-case="capitalize-first"/>
-                <date form="text" variable="accessed"/>
-              </group>
-            </if>
-          </choose>
-          <text variable="URL"/>
-        </group>
+        <text variable="URL"/>
       </else-if>
     </choose>
   </macro>
-  <macro name="source-DOI-URL">
-    <!-- Alias to avoid modifying legal references block shared with APA -->
-    <text macro="source-DOI-URL-bib"/>
-  </macro>
   <!-- 5. Notes -->
-  <macro name="notes">
-    <!-- Notes on source element: original publication, reprint info, retraction info -->
-    <text variable="references"/>
-  </macro>
+  <!-- TODO: add variables for distributor and exhibitions if available in CSL -->
   <!-- 6. Legal references: Bluebook style (shared with APA) -->
   <!-- Where APA or Chicago diverge from Bluebook, the official manual is followed -->
   <macro name="legal-reference">
@@ -3634,42 +3632,38 @@
          `treaty`
          : treaties
     -->
-    <group delimiter=" ">
-      <group delimiter=", " suffix=".">
-        <choose>
-          <if type="treaty">
-            <text macro="legal-title"/>
-            <names variable="author">
-              <!-- Treaty parties should be included at least for bilateral treaties (Bluebook 21.4.2) -->
-              <name delimiter="-" et-al-min="100" et-al-use-first="99" form="short"/>
-            </names>
-            <text macro="legal-date"/>
-            <!-- treaty source/report in addition to URL (Bluebook 21.4.5) -->
-            <text macro="legal-source"/>
-          </if>
-          <else>
-            <group delimiter=" ">
-              <group delimiter=", ">
-                <text macro="legal-title"/>
-                <text macro="legal-source"/>
-              </group>
-              <text macro="legal-date"/>
-              <text macro="legal-identifier"/>
+    <group delimiter=", ">
+      <choose>
+        <if type="treaty">
+          <text macro="legal-title"/>
+          <names variable="author">
+            <!-- Treaty parties should be included at least for bilateral treaties (Bluebook 21.4.2) -->
+            <name delimiter="-" et-al-min="100" et-al-use-first="99" form="short"/>
+          </names>
+          <text macro="legal-date"/>
+          <!-- treaty source/report in addition to URL (Bluebook 21.4.5) -->
+          <text macro="legal-source"/>
+        </if>
+        <else>
+          <group delimiter=" ">
+            <group delimiter=", ">
+              <text macro="legal-title"/>
+              <text macro="legal-source"/>
             </group>
-          </else>
+            <text macro="legal-date"/>
+            <text macro="legal-identifier"/>
+          </group>
+        </else>
+      </choose>
+      <group delimiter=" ">
+        <!-- locator for use in notes -->
+        <choose>
+          <if locator="page" variable="page">
+            <text term="at"/>
+          </if>
         </choose>
-        <group delimiter=" ">
-          <!-- locator for use in notes -->
-          <choose>
-            <if locator="page" variable="page">
-              <text term="at"/>
-            </if>
-          </choose>
-          <text macro="label-locator"/>
-        </group>
+        <text macro="label-locator"/>
       </group>
-      <text variable="references"/>
-      <text macro="source-DOI-URL"/>
     </group>
   </macro>
   <!-- 6.1. Legal date -->
@@ -4006,19 +4000,21 @@
   </citation>
   <!-- Bibliography -->
   <macro name="bibliography-notes">
-    <choose>
-      <if match="any" type="bill hearing legal_case legislation regulation treaty">
-        <!-- Legal items have different orders and delimiters -->
-        <text macro="legal-reference"/>
-      </if>
-      <else>
-        <group delimiter=". ">
+    <group delimiter=". ">
+      <choose>
+        <if match="any" type="bill hearing legal_case legislation regulation treaty">
+          <!-- Legal items have different orders and delimiters -->
+          <text macro="legal-reference"/>
+          <text macro="source-date-accessed-DOI-URL-bib"/>
+          <text variable="references"/>
+        </if>
+        <else>
           <text macro="author-bib"/>
           <text macro="title-and-source-bib"/>
-          <text macro="notes"/>
-        </group>
-      </else>
-    </choose>
+          <text variable="references"/>
+        </else>
+      </choose>
+    </group>
   </macro>
   <bibliography et-al-min="7" et-al-use-first="3" hanging-indent="true">
     <sort>

--- a/chicago-in-text-shortened-author.csl
+++ b/chicago-in-text-shortened-author.csl
@@ -937,7 +937,7 @@
       </group>
       <text macro="source-medium-bib"/>
       <text macro="source-archive-bib"/>
-      <text macro="source-DOI-URL-bib"/>
+      <text macro="source-date-accessed-DOI-URL-bib"/>
     </group>
   </macro>
   <!-- 3.1. Title -->
@@ -3378,35 +3378,33 @@
     </group>
   </macro>
   <!-- 4.10. URL or persistent identifier -->
-  <macro name="source-DOI-URL-bib">
+  <macro name="source-date-accessed-DOI-URL-bib">
+    <group delimiter=", ">
+      <choose>
+        <if variable="DOI"/>
+        <else-if match="any" variable="available-date event-date issued status"/>
+        <else-if variable="accessed URL">
+          <group delimiter=" ">
+            <text term="accessed" text-case="capitalize-first"/>
+            <date form="text" variable="accessed"/>
+          </group>
+        </else-if>
+      </choose>
+      <text macro="source-DOI-URL"/>
+    </group>
+  </macro>
+  <macro name="source-DOI-URL">
     <choose>
       <if variable="DOI">
         <text prefix="https://doi.org/" variable="DOI"/>
       </if>
       <else-if variable="URL">
-        <group delimiter=". ">
-          <choose>
-            <if match="none" variable="available-date event-date issued status">
-              <group delimiter=" ">
-                <text term="accessed" text-case="capitalize-first"/>
-                <date form="text" variable="accessed"/>
-              </group>
-            </if>
-          </choose>
-          <text variable="URL"/>
-        </group>
+        <text variable="URL"/>
       </else-if>
     </choose>
   </macro>
-  <macro name="source-DOI-URL">
-    <!-- Alias to avoid modifying legal references block shared with APA -->
-    <text macro="source-DOI-URL-bib"/>
-  </macro>
   <!-- 5. Notes -->
-  <macro name="notes">
-    <!-- Notes on source element: original publication, reprint info, retraction info -->
-    <text variable="references"/>
-  </macro>
+  <!-- TODO: add variables for distributor and exhibitions if available in CSL -->
   <!-- 6. Legal references: Bluebook style (shared with APA) -->
   <!-- Where APA or Chicago diverge from Bluebook, the official manual is followed -->
   <macro name="legal-reference">
@@ -3430,42 +3428,38 @@
          `treaty`
          : treaties
     -->
-    <group delimiter=" ">
-      <group delimiter=", " suffix=".">
-        <choose>
-          <if type="treaty">
-            <text macro="legal-title"/>
-            <names variable="author">
-              <!-- Treaty parties should be included at least for bilateral treaties (Bluebook 21.4.2) -->
-              <name delimiter="-" et-al-min="100" et-al-use-first="99" form="short"/>
-            </names>
-            <text macro="legal-date"/>
-            <!-- treaty source/report in addition to URL (Bluebook 21.4.5) -->
-            <text macro="legal-source"/>
-          </if>
-          <else>
-            <group delimiter=" ">
-              <group delimiter=", ">
-                <text macro="legal-title"/>
-                <text macro="legal-source"/>
-              </group>
-              <text macro="legal-date"/>
-              <text macro="legal-identifier"/>
+    <group delimiter=", ">
+      <choose>
+        <if type="treaty">
+          <text macro="legal-title"/>
+          <names variable="author">
+            <!-- Treaty parties should be included at least for bilateral treaties (Bluebook 21.4.2) -->
+            <name delimiter="-" et-al-min="100" et-al-use-first="99" form="short"/>
+          </names>
+          <text macro="legal-date"/>
+          <!-- treaty source/report in addition to URL (Bluebook 21.4.5) -->
+          <text macro="legal-source"/>
+        </if>
+        <else>
+          <group delimiter=" ">
+            <group delimiter=", ">
+              <text macro="legal-title"/>
+              <text macro="legal-source"/>
             </group>
-          </else>
+            <text macro="legal-date"/>
+            <text macro="legal-identifier"/>
+          </group>
+        </else>
+      </choose>
+      <group delimiter=" ">
+        <!-- locator for use in notes -->
+        <choose>
+          <if locator="page" variable="page">
+            <text term="at"/>
+          </if>
         </choose>
-        <group delimiter=" ">
-          <!-- locator for use in notes -->
-          <choose>
-            <if locator="page" variable="page">
-              <text term="at"/>
-            </if>
-          </choose>
-          <text macro="label-locator"/>
-        </group>
+        <text macro="label-locator"/>
       </group>
-      <text variable="references"/>
-      <text macro="source-DOI-URL"/>
     </group>
   </macro>
   <!-- 6.1. Legal date -->
@@ -3786,19 +3780,21 @@
   </citation>
   <!-- Bibliography -->
   <macro name="bibliography-notes">
-    <choose>
-      <if match="any" type="bill hearing legal_case legislation regulation treaty">
-        <!-- Legal items have different orders and delimiters -->
-        <text macro="legal-reference"/>
-      </if>
-      <else>
-        <group delimiter=". ">
+    <group delimiter=". ">
+      <choose>
+        <if match="any" type="bill hearing legal_case legislation regulation treaty">
+          <!-- Legal items have different orders and delimiters -->
+          <text macro="legal-reference"/>
+          <text macro="source-date-accessed-DOI-URL-bib"/>
+          <text variable="references"/>
+        </if>
+        <else>
           <text macro="author-bib"/>
           <text macro="title-and-source-bib"/>
-          <text macro="notes"/>
-        </group>
-      </else>
-    </choose>
+          <text variable="references"/>
+        </else>
+      </choose>
+    </group>
   </macro>
   <bibliography et-al-min="7" et-al-use-first="3" hanging-indent="true">
     <sort>

--- a/chicago-notes-archive-place-first-no-url.csl
+++ b/chicago-notes-archive-place-first-no-url.csl
@@ -1086,7 +1086,7 @@
       </choose>
       <text macro="source-medium-note"/>
       <text macro="source-archive-note"/>
-      <!-- <text macro="source-DOI-URL-note"/> -->
+      <text macro="source-date-accessed-DOI-URL-note"/>
     </group>
   </macro>
   <!-- 3.1. Title -->
@@ -4394,7 +4394,23 @@
     </group>
   </macro>
   <!-- 4.10. URL or persistent identifier -->
+  <macro name="source-date-accessed-DOI-URL-note">
+    <group delimiter=", ">
+      <choose>
+        <if variable="DOI"/>
+        <else-if match="any" variable="available-date event-date issued status"/>
+        <else-if variable="URL">
+          <group delimiter=" ">
+            <text term="accessed"/>
+            <date form="text" variable="accessed"/>
+          </group>
+        </else-if>
+      </choose>
+      <!-- <text macro="source-DOI-URL"/> -->
+    </group>
+  </macro>
   <!-- 5. Notes -->
+  <!-- TODO: add variables for distributor and exhibitions if available in CSL -->
   <!-- 6. Legal references: Bluebook style (shared with APA) -->
   <!-- Where APA or Chicago diverge from Bluebook, the official manual is followed -->
   <macro name="legal-reference">
@@ -4418,42 +4434,38 @@
          `treaty`
          : treaties
     -->
-    <group delimiter=" ">
-      <group delimiter=", " suffix=".">
-        <choose>
-          <if type="treaty">
-            <text macro="legal-title"/>
-            <names variable="author">
-              <!-- Treaty parties should be included at least for bilateral treaties (Bluebook 21.4.2) -->
-              <name delimiter="-" et-al-min="100" et-al-use-first="99" form="short"/>
-            </names>
-            <text macro="legal-date"/>
-            <!-- treaty source/report in addition to URL (Bluebook 21.4.5) -->
-            <text macro="legal-source"/>
-          </if>
-          <else>
-            <group delimiter=" ">
-              <group delimiter=", ">
-                <text macro="legal-title"/>
-                <text macro="legal-source"/>
-              </group>
-              <text macro="legal-date"/>
-              <text macro="legal-identifier"/>
+    <group delimiter=", ">
+      <choose>
+        <if type="treaty">
+          <text macro="legal-title"/>
+          <names variable="author">
+            <!-- Treaty parties should be included at least for bilateral treaties (Bluebook 21.4.2) -->
+            <name delimiter="-" et-al-min="100" et-al-use-first="99" form="short"/>
+          </names>
+          <text macro="legal-date"/>
+          <!-- treaty source/report in addition to URL (Bluebook 21.4.5) -->
+          <text macro="legal-source"/>
+        </if>
+        <else>
+          <group delimiter=" ">
+            <group delimiter=", ">
+              <text macro="legal-title"/>
+              <text macro="legal-source"/>
             </group>
-          </else>
+            <text macro="legal-date"/>
+            <text macro="legal-identifier"/>
+          </group>
+        </else>
+      </choose>
+      <group delimiter=" ">
+        <!-- locator for use in notes -->
+        <choose>
+          <if locator="page" variable="page">
+            <text term="at"/>
+          </if>
         </choose>
-        <group delimiter=" ">
-          <!-- locator for use in notes -->
-          <choose>
-            <if locator="page" variable="page">
-              <text term="at"/>
-            </if>
-          </choose>
-          <text macro="label-locator"/>
-        </group>
+        <text macro="label-locator"/>
       </group>
-      <text variable="references"/>
-      <!-- <text macro="source-DOI-URL"/> -->
     </group>
   </macro>
   <!-- 6.1. Legal date -->
@@ -4704,30 +4716,29 @@
   </macro>
   <!-- Citation -->
   <macro name="citation-notes-full">
-    <choose>
-      <if match="any" type="bill hearing legal_case legislation regulation treaty">
-        <!-- Legal items have different orders and delimiters -->
-        <text macro="legal-reference"/>
-      </if>
-      <else-if type="personal_communication" variable="genre">
-        <group delimiter=", ">
+    <group delimiter=", ">
+      <choose>
+        <if match="any" type="bill hearing legal_case legislation regulation treaty">
+          <!-- Legal items have different orders and delimiters -->
+          <text macro="legal-reference"/>
+          <text macro="source-date-accessed-DOI-URL-note"/>
+        </if>
+        <else-if type="personal_communication" variable="genre">
           <text macro="author-note"/>
           <text macro="title-and-source-note"/>
-        </group>
-      </else-if>
-      <else-if type="personal_communication" variable="author recipient">
-        <group delimiter=" ">
+        </else-if>
+        <else-if type="personal_communication" variable="author recipient">
+          <group delimiter=" ">
+            <text macro="author-note"/>
+            <text macro="title-and-source-note"/>
+          </group>
+        </else-if>
+        <else>
           <text macro="author-note"/>
           <text macro="title-and-source-note"/>
-        </group>
-      </else-if>
-      <else>
-        <group delimiter=", ">
-          <text macro="author-note"/>
-          <text macro="title-and-source-note"/>
-        </group>
-      </else>
-    </choose>
+        </else>
+      </choose>
+    </group>
   </macro>
   <macro name="citation-notes-shortened-author-title">
     <!-- Shortened note styles mirror the filtering approach of author-date -->

--- a/chicago-notes-archive-place-first.csl
+++ b/chicago-notes-archive-place-first.csl
@@ -1086,7 +1086,7 @@
       </choose>
       <text macro="source-medium-note"/>
       <text macro="source-archive-note"/>
-      <text macro="source-DOI-URL-note"/>
+      <text macro="source-date-accessed-DOI-URL-note"/>
     </group>
   </macro>
   <!-- 3.1. Title -->
@@ -4394,51 +4394,33 @@
     </group>
   </macro>
   <!-- 4.10. URL or persistent identifier -->
-  <macro name="source-DOI-URL-bib">
-    <choose>
-      <if variable="DOI">
-        <text prefix="https://doi.org/" variable="DOI"/>
-      </if>
-      <else-if variable="URL">
-        <group delimiter=". ">
-          <choose>
-            <if match="none" variable="available-date event-date issued status">
-              <group delimiter=" ">
-                <text term="accessed" text-case="capitalize-first"/>
-                <date form="text" variable="accessed"/>
-              </group>
-            </if>
-          </choose>
-          <text variable="URL"/>
-        </group>
-      </else-if>
-    </choose>
-  </macro>
-  <macro name="source-DOI-URL-note">
-    <choose>
-      <if variable="DOI">
-        <text prefix="https://doi.org/" variable="DOI"/>
-      </if>
-      <else-if variable="URL">
-        <group delimiter=", ">
-          <choose>
-            <if match="none" variable="available-date event-date issued status">
-              <group delimiter=" ">
-                <text term="accessed"/>
-                <date form="text" variable="accessed"/>
-              </group>
-            </if>
-          </choose>
-          <text variable="URL"/>
-        </group>
-      </else-if>
-    </choose>
+  <macro name="source-date-accessed-DOI-URL-note">
+    <group delimiter=", ">
+      <choose>
+        <if variable="DOI"/>
+        <else-if match="any" variable="available-date event-date issued status"/>
+        <else-if variable="URL">
+          <group delimiter=" ">
+            <text term="accessed"/>
+            <date form="text" variable="accessed"/>
+          </group>
+        </else-if>
+      </choose>
+      <text macro="source-DOI-URL"/>
+    </group>
   </macro>
   <macro name="source-DOI-URL">
-    <!-- Alias to avoid modifying legal references block shared with APA -->
-    <text macro="source-DOI-URL-bib"/>
+    <choose>
+      <if variable="DOI">
+        <text prefix="https://doi.org/" variable="DOI"/>
+      </if>
+      <else-if variable="URL">
+        <text variable="URL"/>
+      </else-if>
+    </choose>
   </macro>
   <!-- 5. Notes -->
+  <!-- TODO: add variables for distributor and exhibitions if available in CSL -->
   <!-- 6. Legal references: Bluebook style (shared with APA) -->
   <!-- Where APA or Chicago diverge from Bluebook, the official manual is followed -->
   <macro name="legal-reference">
@@ -4462,42 +4444,38 @@
          `treaty`
          : treaties
     -->
-    <group delimiter=" ">
-      <group delimiter=", " suffix=".">
-        <choose>
-          <if type="treaty">
-            <text macro="legal-title"/>
-            <names variable="author">
-              <!-- Treaty parties should be included at least for bilateral treaties (Bluebook 21.4.2) -->
-              <name delimiter="-" et-al-min="100" et-al-use-first="99" form="short"/>
-            </names>
-            <text macro="legal-date"/>
-            <!-- treaty source/report in addition to URL (Bluebook 21.4.5) -->
-            <text macro="legal-source"/>
-          </if>
-          <else>
-            <group delimiter=" ">
-              <group delimiter=", ">
-                <text macro="legal-title"/>
-                <text macro="legal-source"/>
-              </group>
-              <text macro="legal-date"/>
-              <text macro="legal-identifier"/>
+    <group delimiter=", ">
+      <choose>
+        <if type="treaty">
+          <text macro="legal-title"/>
+          <names variable="author">
+            <!-- Treaty parties should be included at least for bilateral treaties (Bluebook 21.4.2) -->
+            <name delimiter="-" et-al-min="100" et-al-use-first="99" form="short"/>
+          </names>
+          <text macro="legal-date"/>
+          <!-- treaty source/report in addition to URL (Bluebook 21.4.5) -->
+          <text macro="legal-source"/>
+        </if>
+        <else>
+          <group delimiter=" ">
+            <group delimiter=", ">
+              <text macro="legal-title"/>
+              <text macro="legal-source"/>
             </group>
-          </else>
+            <text macro="legal-date"/>
+            <text macro="legal-identifier"/>
+          </group>
+        </else>
+      </choose>
+      <group delimiter=" ">
+        <!-- locator for use in notes -->
+        <choose>
+          <if locator="page" variable="page">
+            <text term="at"/>
+          </if>
         </choose>
-        <group delimiter=" ">
-          <!-- locator for use in notes -->
-          <choose>
-            <if locator="page" variable="page">
-              <text term="at"/>
-            </if>
-          </choose>
-          <text macro="label-locator"/>
-        </group>
+        <text macro="label-locator"/>
       </group>
-      <text variable="references"/>
-      <text macro="source-DOI-URL"/>
     </group>
   </macro>
   <!-- 6.1. Legal date -->
@@ -4748,30 +4726,29 @@
   </macro>
   <!-- Citation -->
   <macro name="citation-notes-full">
-    <choose>
-      <if match="any" type="bill hearing legal_case legislation regulation treaty">
-        <!-- Legal items have different orders and delimiters -->
-        <text macro="legal-reference"/>
-      </if>
-      <else-if type="personal_communication" variable="genre">
-        <group delimiter=", ">
+    <group delimiter=", ">
+      <choose>
+        <if match="any" type="bill hearing legal_case legislation regulation treaty">
+          <!-- Legal items have different orders and delimiters -->
+          <text macro="legal-reference"/>
+          <text macro="source-date-accessed-DOI-URL-note"/>
+        </if>
+        <else-if type="personal_communication" variable="genre">
           <text macro="author-note"/>
           <text macro="title-and-source-note"/>
-        </group>
-      </else-if>
-      <else-if type="personal_communication" variable="author recipient">
-        <group delimiter=" ">
+        </else-if>
+        <else-if type="personal_communication" variable="author recipient">
+          <group delimiter=" ">
+            <text macro="author-note"/>
+            <text macro="title-and-source-note"/>
+          </group>
+        </else-if>
+        <else>
           <text macro="author-note"/>
           <text macro="title-and-source-note"/>
-        </group>
-      </else-if>
-      <else>
-        <group delimiter=", ">
-          <text macro="author-note"/>
-          <text macro="title-and-source-note"/>
-        </group>
-      </else>
-    </choose>
+        </else>
+      </choose>
+    </group>
   </macro>
   <macro name="citation-notes-shortened-author-title">
     <!-- Shortened note styles mirror the filtering approach of author-date -->

--- a/chicago-notes-bibliography-17th-edition.csl
+++ b/chicago-notes-bibliography-17th-edition.csl
@@ -1219,7 +1219,7 @@
       </group>
       <text macro="source-medium-bib"/>
       <text macro="source-archive-bib"/>
-      <text macro="source-DOI-URL-bib"/>
+      <text macro="source-date-accessed-DOI-URL-bib"/>
     </group>
   </macro>
   <macro name="title-and-source-note">
@@ -1272,7 +1272,7 @@
       </choose>
       <text macro="source-medium-note"/>
       <text macro="source-archive-note"/>
-      <text macro="source-DOI-URL-note"/>
+      <text macro="source-date-accessed-DOI-URL-note"/>
     </group>
   </macro>
   <!-- 3.1. Title -->
@@ -5376,55 +5376,48 @@
     </group>
   </macro>
   <!-- 4.10. URL or persistent identifier -->
-  <macro name="source-DOI-URL-bib">
-    <choose>
-      <if variable="DOI">
-        <text prefix="https://doi.org/" variable="DOI"/>
-      </if>
-      <else-if variable="URL">
-        <group delimiter=". ">
-          <choose>
-            <if match="none" variable="available-date event-date issued status">
-              <group delimiter=" ">
-                <text term="accessed" text-case="capitalize-first"/>
-                <date form="text" variable="accessed"/>
-              </group>
-            </if>
-          </choose>
-          <text variable="URL"/>
-        </group>
-      </else-if>
-    </choose>
+  <macro name="source-date-accessed-DOI-URL-bib">
+    <group delimiter=", ">
+      <choose>
+        <if variable="DOI"/>
+        <else-if match="any" variable="available-date event-date issued status"/>
+        <else-if variable="accessed URL">
+          <group delimiter=" ">
+            <text term="accessed" text-case="capitalize-first"/>
+            <date form="text" variable="accessed"/>
+          </group>
+        </else-if>
+      </choose>
+      <text macro="source-DOI-URL"/>
+    </group>
   </macro>
-  <macro name="source-DOI-URL-note">
-    <choose>
-      <if variable="DOI">
-        <text prefix="https://doi.org/" variable="DOI"/>
-      </if>
-      <else-if variable="URL">
-        <group delimiter=", ">
-          <choose>
-            <if match="none" variable="available-date event-date issued status">
-              <group delimiter=" ">
-                <text term="accessed"/>
-                <date form="text" variable="accessed"/>
-              </group>
-            </if>
-          </choose>
-          <text variable="URL"/>
-        </group>
-      </else-if>
-    </choose>
+  <macro name="source-date-accessed-DOI-URL-note">
+    <group delimiter=", ">
+      <choose>
+        <if variable="DOI"/>
+        <else-if match="any" variable="available-date event-date issued status"/>
+        <else-if variable="URL">
+          <group delimiter=" ">
+            <text term="accessed"/>
+            <date form="text" variable="accessed"/>
+          </group>
+        </else-if>
+      </choose>
+      <text macro="source-DOI-URL"/>
+    </group>
   </macro>
   <macro name="source-DOI-URL">
-    <!-- Alias to avoid modifying legal references block shared with APA -->
-    <text macro="source-DOI-URL-bib"/>
+    <choose>
+      <if variable="DOI">
+        <text prefix="https://doi.org/" variable="DOI"/>
+      </if>
+      <else-if variable="URL">
+        <text variable="URL"/>
+      </else-if>
+    </choose>
   </macro>
   <!-- 5. Notes -->
-  <macro name="notes">
-    <!-- Notes on source element: original publication, reprint info, retraction info -->
-    <text variable="references"/>
-  </macro>
+  <!-- TODO: add variables for distributor and exhibitions if available in CSL -->
   <!-- 6. Legal references: Bluebook style (shared with APA) -->
   <!-- Where APA or Chicago diverge from Bluebook, the official manual is followed -->
   <macro name="legal-reference">
@@ -5448,42 +5441,38 @@
          `treaty`
          : treaties
     -->
-    <group delimiter=" ">
-      <group delimiter=", " suffix=".">
-        <choose>
-          <if type="treaty">
-            <text macro="legal-title"/>
-            <names variable="author">
-              <!-- Treaty parties should be included at least for bilateral treaties (Bluebook 21.4.2) -->
-              <name delimiter="-" et-al-min="100" et-al-use-first="99" form="short"/>
-            </names>
-            <text macro="legal-date"/>
-            <!-- treaty source/report in addition to URL (Bluebook 21.4.5) -->
-            <text macro="legal-source"/>
-          </if>
-          <else>
-            <group delimiter=" ">
-              <group delimiter=", ">
-                <text macro="legal-title"/>
-                <text macro="legal-source"/>
-              </group>
-              <text macro="legal-date"/>
-              <text macro="legal-identifier"/>
+    <group delimiter=", ">
+      <choose>
+        <if type="treaty">
+          <text macro="legal-title"/>
+          <names variable="author">
+            <!-- Treaty parties should be included at least for bilateral treaties (Bluebook 21.4.2) -->
+            <name delimiter="-" et-al-min="100" et-al-use-first="99" form="short"/>
+          </names>
+          <text macro="legal-date"/>
+          <!-- treaty source/report in addition to URL (Bluebook 21.4.5) -->
+          <text macro="legal-source"/>
+        </if>
+        <else>
+          <group delimiter=" ">
+            <group delimiter=", ">
+              <text macro="legal-title"/>
+              <text macro="legal-source"/>
             </group>
-          </else>
+            <text macro="legal-date"/>
+            <text macro="legal-identifier"/>
+          </group>
+        </else>
+      </choose>
+      <group delimiter=" ">
+        <!-- locator for use in notes -->
+        <choose>
+          <if locator="page" variable="page">
+            <text term="at"/>
+          </if>
         </choose>
-        <group delimiter=" ">
-          <!-- locator for use in notes -->
-          <choose>
-            <if locator="page" variable="page">
-              <text term="at"/>
-            </if>
-          </choose>
-          <text macro="label-locator"/>
-        </group>
+        <text macro="label-locator"/>
       </group>
-      <text variable="references"/>
-      <text macro="source-DOI-URL"/>
     </group>
   </macro>
   <!-- 6.1. Legal date -->
@@ -5734,30 +5723,29 @@
   </macro>
   <!-- Citation -->
   <macro name="citation-notes-full">
-    <choose>
-      <if match="any" type="bill hearing legal_case legislation regulation treaty">
-        <!-- Legal items have different orders and delimiters -->
-        <text macro="legal-reference"/>
-      </if>
-      <else-if type="personal_communication" variable="genre">
-        <group delimiter=", ">
+    <group delimiter=", ">
+      <choose>
+        <if match="any" type="bill hearing legal_case legislation regulation treaty">
+          <!-- Legal items have different orders and delimiters -->
+          <text macro="legal-reference"/>
+          <text macro="source-date-accessed-DOI-URL-note"/>
+        </if>
+        <else-if type="personal_communication" variable="genre">
           <text macro="author-note"/>
           <text macro="title-and-source-note"/>
-        </group>
-      </else-if>
-      <else-if type="personal_communication" variable="author recipient">
-        <group delimiter=" ">
+        </else-if>
+        <else-if type="personal_communication" variable="author recipient">
+          <group delimiter=" ">
+            <text macro="author-note"/>
+            <text macro="title-and-source-note"/>
+          </group>
+        </else-if>
+        <else>
           <text macro="author-note"/>
           <text macro="title-and-source-note"/>
-        </group>
-      </else-if>
-      <else>
-        <group delimiter=", ">
-          <text macro="author-note"/>
-          <text macro="title-and-source-note"/>
-        </group>
-      </else>
-    </choose>
+        </else>
+      </choose>
+    </group>
   </macro>
   <macro name="citation-notes-shortened-author-only">
     <choose>
@@ -5926,19 +5914,21 @@
   </citation>
   <!-- Bibliography -->
   <macro name="bibliography-notes">
-    <choose>
-      <if match="any" type="bill hearing legal_case legislation regulation treaty">
-        <!-- Legal items have different orders and delimiters -->
-        <text macro="legal-reference"/>
-      </if>
-      <else>
-        <group delimiter=". ">
+    <group delimiter=". ">
+      <choose>
+        <if match="any" type="bill hearing legal_case legislation regulation treaty">
+          <!-- Legal items have different orders and delimiters -->
+          <text macro="legal-reference"/>
+          <text macro="source-date-accessed-DOI-URL-bib"/>
+          <text variable="references"/>
+        </if>
+        <else>
           <text macro="author-bib"/>
           <text macro="title-and-source-bib"/>
-          <text macro="notes"/>
-        </group>
-      </else>
-    </choose>
+          <text variable="references"/>
+        </else>
+      </choose>
+    </group>
   </macro>
   <bibliography et-al-min="11" et-al-use-first="7" hanging-indent="true" subsequent-author-substitute="&#8212;&#8212;&#8212;">
     <sort>

--- a/chicago-notes-bibliography-annotated-abstract.csl
+++ b/chicago-notes-bibliography-annotated-abstract.csl
@@ -1222,7 +1222,7 @@
       </group>
       <text macro="source-medium-bib"/>
       <text macro="source-archive-bib"/>
-      <text macro="source-DOI-URL-bib"/>
+      <text macro="source-date-accessed-DOI-URL-bib"/>
     </group>
   </macro>
   <macro name="title-and-source-note">
@@ -1275,7 +1275,7 @@
       </choose>
       <text macro="source-medium-note"/>
       <text macro="source-archive-note"/>
-      <text macro="source-DOI-URL-note"/>
+      <text macro="source-date-accessed-DOI-URL-note"/>
     </group>
   </macro>
   <!-- 3.1. Title -->
@@ -5397,55 +5397,48 @@
     </group>
   </macro>
   <!-- 4.10. URL or persistent identifier -->
-  <macro name="source-DOI-URL-bib">
-    <choose>
-      <if variable="DOI">
-        <text prefix="https://doi.org/" variable="DOI"/>
-      </if>
-      <else-if variable="URL">
-        <group delimiter=". ">
-          <choose>
-            <if match="none" variable="available-date event-date issued status">
-              <group delimiter=" ">
-                <text term="accessed" text-case="capitalize-first"/>
-                <date form="text" variable="accessed"/>
-              </group>
-            </if>
-          </choose>
-          <text variable="URL"/>
-        </group>
-      </else-if>
-    </choose>
+  <macro name="source-date-accessed-DOI-URL-bib">
+    <group delimiter=", ">
+      <choose>
+        <if variable="DOI"/>
+        <else-if match="any" variable="available-date event-date issued status"/>
+        <else-if variable="accessed URL">
+          <group delimiter=" ">
+            <text term="accessed" text-case="capitalize-first"/>
+            <date form="text" variable="accessed"/>
+          </group>
+        </else-if>
+      </choose>
+      <text macro="source-DOI-URL"/>
+    </group>
   </macro>
-  <macro name="source-DOI-URL-note">
-    <choose>
-      <if variable="DOI">
-        <text prefix="https://doi.org/" variable="DOI"/>
-      </if>
-      <else-if variable="URL">
-        <group delimiter=", ">
-          <choose>
-            <if match="none" variable="available-date event-date issued status">
-              <group delimiter=" ">
-                <text term="accessed"/>
-                <date form="text" variable="accessed"/>
-              </group>
-            </if>
-          </choose>
-          <text variable="URL"/>
-        </group>
-      </else-if>
-    </choose>
+  <macro name="source-date-accessed-DOI-URL-note">
+    <group delimiter=", ">
+      <choose>
+        <if variable="DOI"/>
+        <else-if match="any" variable="available-date event-date issued status"/>
+        <else-if variable="URL">
+          <group delimiter=" ">
+            <text term="accessed"/>
+            <date form="text" variable="accessed"/>
+          </group>
+        </else-if>
+      </choose>
+      <text macro="source-DOI-URL"/>
+    </group>
   </macro>
   <macro name="source-DOI-URL">
-    <!-- Alias to avoid modifying legal references block shared with APA -->
-    <text macro="source-DOI-URL-bib"/>
+    <choose>
+      <if variable="DOI">
+        <text prefix="https://doi.org/" variable="DOI"/>
+      </if>
+      <else-if variable="URL">
+        <text variable="URL"/>
+      </else-if>
+    </choose>
   </macro>
   <!-- 5. Notes -->
-  <macro name="notes">
-    <!-- Notes on source element: original publication, reprint info, retraction info -->
-    <text variable="references"/>
-  </macro>
+  <!-- TODO: add variables for distributor and exhibitions if available in CSL -->
   <!-- 6. Legal references: Bluebook style (shared with APA) -->
   <!-- Where APA or Chicago diverge from Bluebook, the official manual is followed -->
   <macro name="legal-reference">
@@ -5469,42 +5462,38 @@
          `treaty`
          : treaties
     -->
-    <group delimiter=" ">
-      <group delimiter=", " suffix=".">
-        <choose>
-          <if type="treaty">
-            <text macro="legal-title"/>
-            <names variable="author">
-              <!-- Treaty parties should be included at least for bilateral treaties (Bluebook 21.4.2) -->
-              <name delimiter="-" et-al-min="100" et-al-use-first="99" form="short"/>
-            </names>
-            <text macro="legal-date"/>
-            <!-- treaty source/report in addition to URL (Bluebook 21.4.5) -->
-            <text macro="legal-source"/>
-          </if>
-          <else>
-            <group delimiter=" ">
-              <group delimiter=", ">
-                <text macro="legal-title"/>
-                <text macro="legal-source"/>
-              </group>
-              <text macro="legal-date"/>
-              <text macro="legal-identifier"/>
+    <group delimiter=", ">
+      <choose>
+        <if type="treaty">
+          <text macro="legal-title"/>
+          <names variable="author">
+            <!-- Treaty parties should be included at least for bilateral treaties (Bluebook 21.4.2) -->
+            <name delimiter="-" et-al-min="100" et-al-use-first="99" form="short"/>
+          </names>
+          <text macro="legal-date"/>
+          <!-- treaty source/report in addition to URL (Bluebook 21.4.5) -->
+          <text macro="legal-source"/>
+        </if>
+        <else>
+          <group delimiter=" ">
+            <group delimiter=", ">
+              <text macro="legal-title"/>
+              <text macro="legal-source"/>
             </group>
-          </else>
+            <text macro="legal-date"/>
+            <text macro="legal-identifier"/>
+          </group>
+        </else>
+      </choose>
+      <group delimiter=" ">
+        <!-- locator for use in notes -->
+        <choose>
+          <if locator="page" variable="page">
+            <text term="at"/>
+          </if>
         </choose>
-        <group delimiter=" ">
-          <!-- locator for use in notes -->
-          <choose>
-            <if locator="page" variable="page">
-              <text term="at"/>
-            </if>
-          </choose>
-          <text macro="label-locator"/>
-        </group>
+        <text macro="label-locator"/>
       </group>
-      <text variable="references"/>
-      <text macro="source-DOI-URL"/>
     </group>
   </macro>
   <!-- 6.1. Legal date -->
@@ -5755,30 +5744,29 @@
   </macro>
   <!-- Citation -->
   <macro name="citation-notes-full">
-    <choose>
-      <if match="any" type="bill hearing legal_case legislation regulation treaty">
-        <!-- Legal items have different orders and delimiters -->
-        <text macro="legal-reference"/>
-      </if>
-      <else-if type="personal_communication" variable="genre">
-        <group delimiter=", ">
+    <group delimiter=", ">
+      <choose>
+        <if match="any" type="bill hearing legal_case legislation regulation treaty">
+          <!-- Legal items have different orders and delimiters -->
+          <text macro="legal-reference"/>
+          <text macro="source-date-accessed-DOI-URL-note"/>
+        </if>
+        <else-if type="personal_communication" variable="genre">
           <text macro="author-note"/>
           <text macro="title-and-source-note"/>
-        </group>
-      </else-if>
-      <else-if type="personal_communication" variable="author recipient">
-        <group delimiter=" ">
+        </else-if>
+        <else-if type="personal_communication" variable="author recipient">
+          <group delimiter=" ">
+            <text macro="author-note"/>
+            <text macro="title-and-source-note"/>
+          </group>
+        </else-if>
+        <else>
           <text macro="author-note"/>
           <text macro="title-and-source-note"/>
-        </group>
-      </else-if>
-      <else>
-        <group delimiter=", ">
-          <text macro="author-note"/>
-          <text macro="title-and-source-note"/>
-        </group>
-      </else>
-    </choose>
+        </else>
+      </choose>
+    </group>
   </macro>
   <macro name="citation-notes-shortened-author-title">
     <!-- Shortened note styles mirror the filtering approach of author-date -->
@@ -5877,20 +5865,21 @@
   </citation>
   <!-- Bibliography -->
   <macro name="bibliography-notes">
-    <choose>
-      <if match="any" type="bill hearing legal_case legislation regulation treaty">
-        <!-- Legal items have different orders and delimiters -->
-        <text macro="legal-reference"/>
-      </if>
-      <else>
-        <group delimiter=". ">
+    <group delimiter=". ">
+      <choose>
+        <if match="any" type="bill hearing legal_case legislation regulation treaty">
+          <!-- Legal items have different orders and delimiters -->
+          <text macro="legal-reference"/>
+          <text macro="source-date-accessed-DOI-URL-bib"/>
+          <text variable="references"/>
+        </if>
+        <else>
           <text macro="author-bib"/>
           <text macro="title-and-source-bib"/>
-          <text macro="notes"/>
-        </group>
-        <text display="block" variable="abstract"/>
-      </else>
-    </choose>
+          <text variable="references"/>
+        </else>
+      </choose>
+    </group>
   </macro>
   <bibliography et-al-min="7" et-al-use-first="3" hanging-indent="true">
     <sort>

--- a/chicago-notes-bibliography-annotated.csl
+++ b/chicago-notes-bibliography-annotated.csl
@@ -1222,7 +1222,7 @@
       </group>
       <text macro="source-medium-bib"/>
       <text macro="source-archive-bib"/>
-      <text macro="source-DOI-URL-bib"/>
+      <text macro="source-date-accessed-DOI-URL-bib"/>
     </group>
   </macro>
   <macro name="title-and-source-note">
@@ -1275,7 +1275,7 @@
       </choose>
       <text macro="source-medium-note"/>
       <text macro="source-archive-note"/>
-      <text macro="source-DOI-URL-note"/>
+      <text macro="source-date-accessed-DOI-URL-note"/>
     </group>
   </macro>
   <!-- 3.1. Title -->
@@ -5397,55 +5397,48 @@
     </group>
   </macro>
   <!-- 4.10. URL or persistent identifier -->
-  <macro name="source-DOI-URL-bib">
-    <choose>
-      <if variable="DOI">
-        <text prefix="https://doi.org/" variable="DOI"/>
-      </if>
-      <else-if variable="URL">
-        <group delimiter=". ">
-          <choose>
-            <if match="none" variable="available-date event-date issued status">
-              <group delimiter=" ">
-                <text term="accessed" text-case="capitalize-first"/>
-                <date form="text" variable="accessed"/>
-              </group>
-            </if>
-          </choose>
-          <text variable="URL"/>
-        </group>
-      </else-if>
-    </choose>
+  <macro name="source-date-accessed-DOI-URL-bib">
+    <group delimiter=", ">
+      <choose>
+        <if variable="DOI"/>
+        <else-if match="any" variable="available-date event-date issued status"/>
+        <else-if variable="accessed URL">
+          <group delimiter=" ">
+            <text term="accessed" text-case="capitalize-first"/>
+            <date form="text" variable="accessed"/>
+          </group>
+        </else-if>
+      </choose>
+      <text macro="source-DOI-URL"/>
+    </group>
   </macro>
-  <macro name="source-DOI-URL-note">
-    <choose>
-      <if variable="DOI">
-        <text prefix="https://doi.org/" variable="DOI"/>
-      </if>
-      <else-if variable="URL">
-        <group delimiter=", ">
-          <choose>
-            <if match="none" variable="available-date event-date issued status">
-              <group delimiter=" ">
-                <text term="accessed"/>
-                <date form="text" variable="accessed"/>
-              </group>
-            </if>
-          </choose>
-          <text variable="URL"/>
-        </group>
-      </else-if>
-    </choose>
+  <macro name="source-date-accessed-DOI-URL-note">
+    <group delimiter=", ">
+      <choose>
+        <if variable="DOI"/>
+        <else-if match="any" variable="available-date event-date issued status"/>
+        <else-if variable="URL">
+          <group delimiter=" ">
+            <text term="accessed"/>
+            <date form="text" variable="accessed"/>
+          </group>
+        </else-if>
+      </choose>
+      <text macro="source-DOI-URL"/>
+    </group>
   </macro>
   <macro name="source-DOI-URL">
-    <!-- Alias to avoid modifying legal references block shared with APA -->
-    <text macro="source-DOI-URL-bib"/>
+    <choose>
+      <if variable="DOI">
+        <text prefix="https://doi.org/" variable="DOI"/>
+      </if>
+      <else-if variable="URL">
+        <text variable="URL"/>
+      </else-if>
+    </choose>
   </macro>
   <!-- 5. Notes -->
-  <macro name="notes">
-    <!-- Notes on source element: original publication, reprint info, retraction info -->
-    <text variable="references"/>
-  </macro>
+  <!-- TODO: add variables for distributor and exhibitions if available in CSL -->
   <!-- 6. Legal references: Bluebook style (shared with APA) -->
   <!-- Where APA or Chicago diverge from Bluebook, the official manual is followed -->
   <macro name="legal-reference">
@@ -5469,42 +5462,38 @@
          `treaty`
          : treaties
     -->
-    <group delimiter=" ">
-      <group delimiter=", " suffix=".">
-        <choose>
-          <if type="treaty">
-            <text macro="legal-title"/>
-            <names variable="author">
-              <!-- Treaty parties should be included at least for bilateral treaties (Bluebook 21.4.2) -->
-              <name delimiter="-" et-al-min="100" et-al-use-first="99" form="short"/>
-            </names>
-            <text macro="legal-date"/>
-            <!-- treaty source/report in addition to URL (Bluebook 21.4.5) -->
-            <text macro="legal-source"/>
-          </if>
-          <else>
-            <group delimiter=" ">
-              <group delimiter=", ">
-                <text macro="legal-title"/>
-                <text macro="legal-source"/>
-              </group>
-              <text macro="legal-date"/>
-              <text macro="legal-identifier"/>
+    <group delimiter=", ">
+      <choose>
+        <if type="treaty">
+          <text macro="legal-title"/>
+          <names variable="author">
+            <!-- Treaty parties should be included at least for bilateral treaties (Bluebook 21.4.2) -->
+            <name delimiter="-" et-al-min="100" et-al-use-first="99" form="short"/>
+          </names>
+          <text macro="legal-date"/>
+          <!-- treaty source/report in addition to URL (Bluebook 21.4.5) -->
+          <text macro="legal-source"/>
+        </if>
+        <else>
+          <group delimiter=" ">
+            <group delimiter=", ">
+              <text macro="legal-title"/>
+              <text macro="legal-source"/>
             </group>
-          </else>
+            <text macro="legal-date"/>
+            <text macro="legal-identifier"/>
+          </group>
+        </else>
+      </choose>
+      <group delimiter=" ">
+        <!-- locator for use in notes -->
+        <choose>
+          <if locator="page" variable="page">
+            <text term="at"/>
+          </if>
         </choose>
-        <group delimiter=" ">
-          <!-- locator for use in notes -->
-          <choose>
-            <if locator="page" variable="page">
-              <text term="at"/>
-            </if>
-          </choose>
-          <text macro="label-locator"/>
-        </group>
+        <text macro="label-locator"/>
       </group>
-      <text variable="references"/>
-      <text macro="source-DOI-URL"/>
     </group>
   </macro>
   <!-- 6.1. Legal date -->
@@ -5755,30 +5744,29 @@
   </macro>
   <!-- Citation -->
   <macro name="citation-notes-full">
-    <choose>
-      <if match="any" type="bill hearing legal_case legislation regulation treaty">
-        <!-- Legal items have different orders and delimiters -->
-        <text macro="legal-reference"/>
-      </if>
-      <else-if type="personal_communication" variable="genre">
-        <group delimiter=", ">
+    <group delimiter=", ">
+      <choose>
+        <if match="any" type="bill hearing legal_case legislation regulation treaty">
+          <!-- Legal items have different orders and delimiters -->
+          <text macro="legal-reference"/>
+          <text macro="source-date-accessed-DOI-URL-note"/>
+        </if>
+        <else-if type="personal_communication" variable="genre">
           <text macro="author-note"/>
           <text macro="title-and-source-note"/>
-        </group>
-      </else-if>
-      <else-if type="personal_communication" variable="author recipient">
-        <group delimiter=" ">
+        </else-if>
+        <else-if type="personal_communication" variable="author recipient">
+          <group delimiter=" ">
+            <text macro="author-note"/>
+            <text macro="title-and-source-note"/>
+          </group>
+        </else-if>
+        <else>
           <text macro="author-note"/>
           <text macro="title-and-source-note"/>
-        </group>
-      </else-if>
-      <else>
-        <group delimiter=", ">
-          <text macro="author-note"/>
-          <text macro="title-and-source-note"/>
-        </group>
-      </else>
-    </choose>
+        </else>
+      </choose>
+    </group>
   </macro>
   <macro name="citation-notes-shortened-author-title">
     <!-- Shortened note styles mirror the filtering approach of author-date -->
@@ -5877,20 +5865,21 @@
   </citation>
   <!-- Bibliography -->
   <macro name="bibliography-notes">
-    <choose>
-      <if match="any" type="bill hearing legal_case legislation regulation treaty">
-        <!-- Legal items have different orders and delimiters -->
-        <text macro="legal-reference"/>
-      </if>
-      <else>
-        <group delimiter=". ">
+    <group delimiter=". ">
+      <choose>
+        <if match="any" type="bill hearing legal_case legislation regulation treaty">
+          <!-- Legal items have different orders and delimiters -->
+          <text macro="legal-reference"/>
+          <text macro="source-date-accessed-DOI-URL-bib"/>
+          <text variable="references"/>
+        </if>
+        <else>
           <text macro="author-bib"/>
           <text macro="title-and-source-bib"/>
-          <text macro="notes"/>
-        </group>
-        <text display="block" variable="note"/>
-      </else>
-    </choose>
+          <text variable="references"/>
+        </else>
+      </choose>
+    </group>
   </macro>
   <bibliography et-al-min="7" et-al-use-first="3" hanging-indent="true">
     <sort>

--- a/chicago-notes-bibliography-archive-place-first-no-url.csl
+++ b/chicago-notes-bibliography-archive-place-first-no-url.csl
@@ -1221,7 +1221,7 @@
       </group>
       <text macro="source-medium-bib"/>
       <text macro="source-archive-bib"/>
-      <!-- <text macro="source-DOI-URL-bib"/> -->
+      <text macro="source-date-accessed-DOI-URL-bib"/>
     </group>
   </macro>
   <macro name="title-and-source-note">
@@ -1274,7 +1274,7 @@
       </choose>
       <text macro="source-medium-note"/>
       <text macro="source-archive-note"/>
-      <!-- <text macro="source-DOI-URL-note"/> -->
+      <text macro="source-date-accessed-DOI-URL-note"/>
     </group>
   </macro>
   <!-- 3.1. Title -->
@@ -5377,11 +5377,38 @@
     </group>
   </macro>
   <!-- 4.10. URL or persistent identifier -->
-  <!-- 5. Notes -->
-  <macro name="notes">
-    <!-- Notes on source element: original publication, reprint info, retraction info -->
-    <text variable="references"/>
+  <macro name="source-date-accessed-DOI-URL-bib">
+    <group delimiter=", ">
+      <choose>
+        <if variable="DOI"/>
+        <else-if match="any" variable="available-date event-date issued status"/>
+        <else-if variable="accessed URL">
+          <group delimiter=" ">
+            <text term="accessed" text-case="capitalize-first"/>
+            <date form="text" variable="accessed"/>
+          </group>
+        </else-if>
+      </choose>
+      <!-- <text macro="source-DOI-URL"/> -->
+    </group>
   </macro>
+  <macro name="source-date-accessed-DOI-URL-note">
+    <group delimiter=", ">
+      <choose>
+        <if variable="DOI"/>
+        <else-if match="any" variable="available-date event-date issued status"/>
+        <else-if variable="URL">
+          <group delimiter=" ">
+            <text term="accessed"/>
+            <date form="text" variable="accessed"/>
+          </group>
+        </else-if>
+      </choose>
+      <!-- <text macro="source-DOI-URL"/> -->
+    </group>
+  </macro>
+  <!-- 5. Notes -->
+  <!-- TODO: add variables for distributor and exhibitions if available in CSL -->
   <!-- 6. Legal references: Bluebook style (shared with APA) -->
   <!-- Where APA or Chicago diverge from Bluebook, the official manual is followed -->
   <macro name="legal-reference">
@@ -5405,42 +5432,38 @@
          `treaty`
          : treaties
     -->
-    <group delimiter=" ">
-      <group delimiter=", " suffix=".">
-        <choose>
-          <if type="treaty">
-            <text macro="legal-title"/>
-            <names variable="author">
-              <!-- Treaty parties should be included at least for bilateral treaties (Bluebook 21.4.2) -->
-              <name delimiter="-" et-al-min="100" et-al-use-first="99" form="short"/>
-            </names>
-            <text macro="legal-date"/>
-            <!-- treaty source/report in addition to URL (Bluebook 21.4.5) -->
-            <text macro="legal-source"/>
-          </if>
-          <else>
-            <group delimiter=" ">
-              <group delimiter=", ">
-                <text macro="legal-title"/>
-                <text macro="legal-source"/>
-              </group>
-              <text macro="legal-date"/>
-              <text macro="legal-identifier"/>
+    <group delimiter=", ">
+      <choose>
+        <if type="treaty">
+          <text macro="legal-title"/>
+          <names variable="author">
+            <!-- Treaty parties should be included at least for bilateral treaties (Bluebook 21.4.2) -->
+            <name delimiter="-" et-al-min="100" et-al-use-first="99" form="short"/>
+          </names>
+          <text macro="legal-date"/>
+          <!-- treaty source/report in addition to URL (Bluebook 21.4.5) -->
+          <text macro="legal-source"/>
+        </if>
+        <else>
+          <group delimiter=" ">
+            <group delimiter=", ">
+              <text macro="legal-title"/>
+              <text macro="legal-source"/>
             </group>
-          </else>
+            <text macro="legal-date"/>
+            <text macro="legal-identifier"/>
+          </group>
+        </else>
+      </choose>
+      <group delimiter=" ">
+        <!-- locator for use in notes -->
+        <choose>
+          <if locator="page" variable="page">
+            <text term="at"/>
+          </if>
         </choose>
-        <group delimiter=" ">
-          <!-- locator for use in notes -->
-          <choose>
-            <if locator="page" variable="page">
-              <text term="at"/>
-            </if>
-          </choose>
-          <text macro="label-locator"/>
-        </group>
+        <text macro="label-locator"/>
       </group>
-      <text variable="references"/>
-      <!-- <text macro="source-DOI-URL"/> -->
     </group>
   </macro>
   <!-- 6.1. Legal date -->
@@ -5691,30 +5714,29 @@
   </macro>
   <!-- Citation -->
   <macro name="citation-notes-full">
-    <choose>
-      <if match="any" type="bill hearing legal_case legislation regulation treaty">
-        <!-- Legal items have different orders and delimiters -->
-        <text macro="legal-reference"/>
-      </if>
-      <else-if type="personal_communication" variable="genre">
-        <group delimiter=", ">
+    <group delimiter=", ">
+      <choose>
+        <if match="any" type="bill hearing legal_case legislation regulation treaty">
+          <!-- Legal items have different orders and delimiters -->
+          <text macro="legal-reference"/>
+          <text macro="source-date-accessed-DOI-URL-note"/>
+        </if>
+        <else-if type="personal_communication" variable="genre">
           <text macro="author-note"/>
           <text macro="title-and-source-note"/>
-        </group>
-      </else-if>
-      <else-if type="personal_communication" variable="author recipient">
-        <group delimiter=" ">
+        </else-if>
+        <else-if type="personal_communication" variable="author recipient">
+          <group delimiter=" ">
+            <text macro="author-note"/>
+            <text macro="title-and-source-note"/>
+          </group>
+        </else-if>
+        <else>
           <text macro="author-note"/>
           <text macro="title-and-source-note"/>
-        </group>
-      </else-if>
-      <else>
-        <group delimiter=", ">
-          <text macro="author-note"/>
-          <text macro="title-and-source-note"/>
-        </group>
-      </else>
-    </choose>
+        </else>
+      </choose>
+    </group>
   </macro>
   <macro name="citation-notes-shortened-author-title">
     <!-- Shortened note styles mirror the filtering approach of author-date -->
@@ -5813,19 +5835,21 @@
   </citation>
   <!-- Bibliography -->
   <macro name="bibliography-notes">
-    <choose>
-      <if match="any" type="bill hearing legal_case legislation regulation treaty">
-        <!-- Legal items have different orders and delimiters -->
-        <text macro="legal-reference"/>
-      </if>
-      <else>
-        <group delimiter=". ">
+    <group delimiter=". ">
+      <choose>
+        <if match="any" type="bill hearing legal_case legislation regulation treaty">
+          <!-- Legal items have different orders and delimiters -->
+          <text macro="legal-reference"/>
+          <text macro="source-date-accessed-DOI-URL-bib"/>
+          <text variable="references"/>
+        </if>
+        <else>
           <text macro="author-bib"/>
           <text macro="title-and-source-bib"/>
-          <text macro="notes"/>
-        </group>
-      </else>
-    </choose>
+          <text variable="references"/>
+        </else>
+      </choose>
+    </group>
   </macro>
   <bibliography et-al-min="7" et-al-use-first="3" hanging-indent="true">
     <sort>

--- a/chicago-notes-bibliography-archive-place-first.csl
+++ b/chicago-notes-bibliography-archive-place-first.csl
@@ -1221,7 +1221,7 @@
       </group>
       <text macro="source-medium-bib"/>
       <text macro="source-archive-bib"/>
-      <text macro="source-DOI-URL-bib"/>
+      <text macro="source-date-accessed-DOI-URL-bib"/>
     </group>
   </macro>
   <macro name="title-and-source-note">
@@ -1274,7 +1274,7 @@
       </choose>
       <text macro="source-medium-note"/>
       <text macro="source-archive-note"/>
-      <text macro="source-DOI-URL-note"/>
+      <text macro="source-date-accessed-DOI-URL-note"/>
     </group>
   </macro>
   <!-- 3.1. Title -->
@@ -5377,55 +5377,48 @@
     </group>
   </macro>
   <!-- 4.10. URL or persistent identifier -->
-  <macro name="source-DOI-URL-bib">
-    <choose>
-      <if variable="DOI">
-        <text prefix="https://doi.org/" variable="DOI"/>
-      </if>
-      <else-if variable="URL">
-        <group delimiter=". ">
-          <choose>
-            <if match="none" variable="available-date event-date issued status">
-              <group delimiter=" ">
-                <text term="accessed" text-case="capitalize-first"/>
-                <date form="text" variable="accessed"/>
-              </group>
-            </if>
-          </choose>
-          <text variable="URL"/>
-        </group>
-      </else-if>
-    </choose>
+  <macro name="source-date-accessed-DOI-URL-bib">
+    <group delimiter=", ">
+      <choose>
+        <if variable="DOI"/>
+        <else-if match="any" variable="available-date event-date issued status"/>
+        <else-if variable="accessed URL">
+          <group delimiter=" ">
+            <text term="accessed" text-case="capitalize-first"/>
+            <date form="text" variable="accessed"/>
+          </group>
+        </else-if>
+      </choose>
+      <text macro="source-DOI-URL"/>
+    </group>
   </macro>
-  <macro name="source-DOI-URL-note">
-    <choose>
-      <if variable="DOI">
-        <text prefix="https://doi.org/" variable="DOI"/>
-      </if>
-      <else-if variable="URL">
-        <group delimiter=", ">
-          <choose>
-            <if match="none" variable="available-date event-date issued status">
-              <group delimiter=" ">
-                <text term="accessed"/>
-                <date form="text" variable="accessed"/>
-              </group>
-            </if>
-          </choose>
-          <text variable="URL"/>
-        </group>
-      </else-if>
-    </choose>
+  <macro name="source-date-accessed-DOI-URL-note">
+    <group delimiter=", ">
+      <choose>
+        <if variable="DOI"/>
+        <else-if match="any" variable="available-date event-date issued status"/>
+        <else-if variable="URL">
+          <group delimiter=" ">
+            <text term="accessed"/>
+            <date form="text" variable="accessed"/>
+          </group>
+        </else-if>
+      </choose>
+      <text macro="source-DOI-URL"/>
+    </group>
   </macro>
   <macro name="source-DOI-URL">
-    <!-- Alias to avoid modifying legal references block shared with APA -->
-    <text macro="source-DOI-URL-bib"/>
+    <choose>
+      <if variable="DOI">
+        <text prefix="https://doi.org/" variable="DOI"/>
+      </if>
+      <else-if variable="URL">
+        <text variable="URL"/>
+      </else-if>
+    </choose>
   </macro>
   <!-- 5. Notes -->
-  <macro name="notes">
-    <!-- Notes on source element: original publication, reprint info, retraction info -->
-    <text variable="references"/>
-  </macro>
+  <!-- TODO: add variables for distributor and exhibitions if available in CSL -->
   <!-- 6. Legal references: Bluebook style (shared with APA) -->
   <!-- Where APA or Chicago diverge from Bluebook, the official manual is followed -->
   <macro name="legal-reference">
@@ -5449,42 +5442,38 @@
          `treaty`
          : treaties
     -->
-    <group delimiter=" ">
-      <group delimiter=", " suffix=".">
-        <choose>
-          <if type="treaty">
-            <text macro="legal-title"/>
-            <names variable="author">
-              <!-- Treaty parties should be included at least for bilateral treaties (Bluebook 21.4.2) -->
-              <name delimiter="-" et-al-min="100" et-al-use-first="99" form="short"/>
-            </names>
-            <text macro="legal-date"/>
-            <!-- treaty source/report in addition to URL (Bluebook 21.4.5) -->
-            <text macro="legal-source"/>
-          </if>
-          <else>
-            <group delimiter=" ">
-              <group delimiter=", ">
-                <text macro="legal-title"/>
-                <text macro="legal-source"/>
-              </group>
-              <text macro="legal-date"/>
-              <text macro="legal-identifier"/>
+    <group delimiter=", ">
+      <choose>
+        <if type="treaty">
+          <text macro="legal-title"/>
+          <names variable="author">
+            <!-- Treaty parties should be included at least for bilateral treaties (Bluebook 21.4.2) -->
+            <name delimiter="-" et-al-min="100" et-al-use-first="99" form="short"/>
+          </names>
+          <text macro="legal-date"/>
+          <!-- treaty source/report in addition to URL (Bluebook 21.4.5) -->
+          <text macro="legal-source"/>
+        </if>
+        <else>
+          <group delimiter=" ">
+            <group delimiter=", ">
+              <text macro="legal-title"/>
+              <text macro="legal-source"/>
             </group>
-          </else>
+            <text macro="legal-date"/>
+            <text macro="legal-identifier"/>
+          </group>
+        </else>
+      </choose>
+      <group delimiter=" ">
+        <!-- locator for use in notes -->
+        <choose>
+          <if locator="page" variable="page">
+            <text term="at"/>
+          </if>
         </choose>
-        <group delimiter=" ">
-          <!-- locator for use in notes -->
-          <choose>
-            <if locator="page" variable="page">
-              <text term="at"/>
-            </if>
-          </choose>
-          <text macro="label-locator"/>
-        </group>
+        <text macro="label-locator"/>
       </group>
-      <text variable="references"/>
-      <text macro="source-DOI-URL"/>
     </group>
   </macro>
   <!-- 6.1. Legal date -->
@@ -5735,30 +5724,29 @@
   </macro>
   <!-- Citation -->
   <macro name="citation-notes-full">
-    <choose>
-      <if match="any" type="bill hearing legal_case legislation regulation treaty">
-        <!-- Legal items have different orders and delimiters -->
-        <text macro="legal-reference"/>
-      </if>
-      <else-if type="personal_communication" variable="genre">
-        <group delimiter=", ">
+    <group delimiter=", ">
+      <choose>
+        <if match="any" type="bill hearing legal_case legislation regulation treaty">
+          <!-- Legal items have different orders and delimiters -->
+          <text macro="legal-reference"/>
+          <text macro="source-date-accessed-DOI-URL-note"/>
+        </if>
+        <else-if type="personal_communication" variable="genre">
           <text macro="author-note"/>
           <text macro="title-and-source-note"/>
-        </group>
-      </else-if>
-      <else-if type="personal_communication" variable="author recipient">
-        <group delimiter=" ">
+        </else-if>
+        <else-if type="personal_communication" variable="author recipient">
+          <group delimiter=" ">
+            <text macro="author-note"/>
+            <text macro="title-and-source-note"/>
+          </group>
+        </else-if>
+        <else>
           <text macro="author-note"/>
           <text macro="title-and-source-note"/>
-        </group>
-      </else-if>
-      <else>
-        <group delimiter=", ">
-          <text macro="author-note"/>
-          <text macro="title-and-source-note"/>
-        </group>
-      </else>
-    </choose>
+        </else>
+      </choose>
+    </group>
   </macro>
   <macro name="citation-notes-shortened-author-title">
     <!-- Shortened note styles mirror the filtering approach of author-date -->
@@ -5857,19 +5845,21 @@
   </citation>
   <!-- Bibliography -->
   <macro name="bibliography-notes">
-    <choose>
-      <if match="any" type="bill hearing legal_case legislation regulation treaty">
-        <!-- Legal items have different orders and delimiters -->
-        <text macro="legal-reference"/>
-      </if>
-      <else>
-        <group delimiter=". ">
+    <group delimiter=". ">
+      <choose>
+        <if match="any" type="bill hearing legal_case legislation regulation treaty">
+          <!-- Legal items have different orders and delimiters -->
+          <text macro="legal-reference"/>
+          <text macro="source-date-accessed-DOI-URL-bib"/>
+          <text variable="references"/>
+        </if>
+        <else>
           <text macro="author-bib"/>
           <text macro="title-and-source-bib"/>
-          <text macro="notes"/>
-        </group>
-      </else>
-    </choose>
+          <text variable="references"/>
+        </else>
+      </choose>
+    </group>
   </macro>
   <bibliography et-al-min="7" et-al-use-first="3" hanging-indent="true">
     <sort>

--- a/chicago-notes-bibliography-classic-archive-place-first-no-url.csl
+++ b/chicago-notes-bibliography-classic-archive-place-first-no-url.csl
@@ -1222,7 +1222,7 @@
       </group>
       <text macro="source-medium-bib"/>
       <text macro="source-archive-bib"/>
-      <!-- <text macro="source-DOI-URL-bib"/> -->
+      <text macro="source-date-accessed-DOI-URL-bib"/>
     </group>
   </macro>
   <macro name="title-and-source-note">
@@ -1275,7 +1275,7 @@
       </choose>
       <text macro="source-medium-note"/>
       <text macro="source-archive-note"/>
-      <!-- <text macro="source-DOI-URL-note"/> -->
+      <text macro="source-date-accessed-DOI-URL-note"/>
     </group>
   </macro>
   <!-- 3.1. Title -->
@@ -5368,11 +5368,38 @@
     </group>
   </macro>
   <!-- 4.10. URL or persistent identifier -->
-  <!-- 5. Notes -->
-  <macro name="notes">
-    <!-- Notes on source element: original publication, reprint info, retraction info -->
-    <text variable="references"/>
+  <macro name="source-date-accessed-DOI-URL-bib">
+    <group delimiter=", ">
+      <choose>
+        <if variable="DOI"/>
+        <else-if match="any" variable="available-date event-date issued status"/>
+        <else-if variable="accessed URL">
+          <group delimiter=" ">
+            <text term="accessed" text-case="capitalize-first"/>
+            <date form="text" variable="accessed"/>
+          </group>
+        </else-if>
+      </choose>
+      <!-- <text macro="source-DOI-URL"/> -->
+    </group>
   </macro>
+  <macro name="source-date-accessed-DOI-URL-note">
+    <group delimiter=", ">
+      <choose>
+        <if variable="DOI"/>
+        <else-if match="any" variable="available-date event-date issued status"/>
+        <else-if variable="URL">
+          <group delimiter=" ">
+            <text term="accessed"/>
+            <date form="text" variable="accessed"/>
+          </group>
+        </else-if>
+      </choose>
+      <!-- <text macro="source-DOI-URL"/> -->
+    </group>
+  </macro>
+  <!-- 5. Notes -->
+  <!-- TODO: add variables for distributor and exhibitions if available in CSL -->
   <!-- 6. Legal references: Bluebook style (shared with APA) -->
   <!-- Where APA or Chicago diverge from Bluebook, the official manual is followed -->
   <macro name="legal-reference">
@@ -5396,42 +5423,38 @@
          `treaty`
          : treaties
     -->
-    <group delimiter=" ">
-      <group delimiter=", " suffix=".">
-        <choose>
-          <if type="treaty">
-            <text macro="legal-title"/>
-            <names variable="author">
-              <!-- Treaty parties should be included at least for bilateral treaties (Bluebook 21.4.2) -->
-              <name delimiter="-" et-al-min="100" et-al-use-first="99" form="short"/>
-            </names>
-            <text macro="legal-date"/>
-            <!-- treaty source/report in addition to URL (Bluebook 21.4.5) -->
-            <text macro="legal-source"/>
-          </if>
-          <else>
-            <group delimiter=" ">
-              <group delimiter=", ">
-                <text macro="legal-title"/>
-                <text macro="legal-source"/>
-              </group>
-              <text macro="legal-date"/>
-              <text macro="legal-identifier"/>
+    <group delimiter=", ">
+      <choose>
+        <if type="treaty">
+          <text macro="legal-title"/>
+          <names variable="author">
+            <!-- Treaty parties should be included at least for bilateral treaties (Bluebook 21.4.2) -->
+            <name delimiter="-" et-al-min="100" et-al-use-first="99" form="short"/>
+          </names>
+          <text macro="legal-date"/>
+          <!-- treaty source/report in addition to URL (Bluebook 21.4.5) -->
+          <text macro="legal-source"/>
+        </if>
+        <else>
+          <group delimiter=" ">
+            <group delimiter=", ">
+              <text macro="legal-title"/>
+              <text macro="legal-source"/>
             </group>
-          </else>
+            <text macro="legal-date"/>
+            <text macro="legal-identifier"/>
+          </group>
+        </else>
+      </choose>
+      <group delimiter=" ">
+        <!-- locator for use in notes -->
+        <choose>
+          <if locator="page" variable="page">
+            <text term="at"/>
+          </if>
         </choose>
-        <group delimiter=" ">
-          <!-- locator for use in notes -->
-          <choose>
-            <if locator="page" variable="page">
-              <text term="at"/>
-            </if>
-          </choose>
-          <text macro="label-locator"/>
-        </group>
+        <text macro="label-locator"/>
       </group>
-      <text variable="references"/>
-      <!-- <text macro="source-DOI-URL"/> -->
     </group>
   </macro>
   <!-- 6.1. Legal date -->
@@ -5682,30 +5705,29 @@
   </macro>
   <!-- Citation -->
   <macro name="citation-notes-full">
-    <choose>
-      <if match="any" type="bill hearing legal_case legislation regulation treaty">
-        <!-- Legal items have different orders and delimiters -->
-        <text macro="legal-reference"/>
-      </if>
-      <else-if type="personal_communication" variable="genre">
-        <group delimiter=", ">
+    <group delimiter=", ">
+      <choose>
+        <if match="any" type="bill hearing legal_case legislation regulation treaty">
+          <!-- Legal items have different orders and delimiters -->
+          <text macro="legal-reference"/>
+          <text macro="source-date-accessed-DOI-URL-note"/>
+        </if>
+        <else-if type="personal_communication" variable="genre">
           <text macro="author-note"/>
           <text macro="title-and-source-note"/>
-        </group>
-      </else-if>
-      <else-if type="personal_communication" variable="author recipient">
-        <group delimiter=" ">
+        </else-if>
+        <else-if type="personal_communication" variable="author recipient">
+          <group delimiter=" ">
+            <text macro="author-note"/>
+            <text macro="title-and-source-note"/>
+          </group>
+        </else-if>
+        <else>
           <text macro="author-note"/>
           <text macro="title-and-source-note"/>
-        </group>
-      </else-if>
-      <else>
-        <group delimiter=", ">
-          <text macro="author-note"/>
-          <text macro="title-and-source-note"/>
-        </group>
-      </else>
-    </choose>
+        </else>
+      </choose>
+    </group>
   </macro>
   <macro name="citation-notes-shortened-author-title">
     <!-- Shortened note styles mirror the filtering approach of author-date -->
@@ -5804,19 +5826,21 @@
   </citation>
   <!-- Bibliography -->
   <macro name="bibliography-notes">
-    <choose>
-      <if match="any" type="bill hearing legal_case legislation regulation treaty">
-        <!-- Legal items have different orders and delimiters -->
-        <text macro="legal-reference"/>
-      </if>
-      <else>
-        <group delimiter=". ">
+    <group delimiter=". ">
+      <choose>
+        <if match="any" type="bill hearing legal_case legislation regulation treaty">
+          <!-- Legal items have different orders and delimiters -->
+          <text macro="legal-reference"/>
+          <text macro="source-date-accessed-DOI-URL-bib"/>
+          <text variable="references"/>
+        </if>
+        <else>
           <text macro="author-bib"/>
           <text macro="title-and-source-bib"/>
-          <text macro="notes"/>
-        </group>
-      </else>
-    </choose>
+          <text variable="references"/>
+        </else>
+      </choose>
+    </group>
   </macro>
   <bibliography et-al-min="7" et-al-use-first="3" hanging-indent="true" subsequent-author-substitute="&#8212;&#8212;&#8212;">
     <sort>

--- a/chicago-notes-bibliography-classic-archive-place-first.csl
+++ b/chicago-notes-bibliography-classic-archive-place-first.csl
@@ -1222,7 +1222,7 @@
       </group>
       <text macro="source-medium-bib"/>
       <text macro="source-archive-bib"/>
-      <text macro="source-DOI-URL-bib"/>
+      <text macro="source-date-accessed-DOI-URL-bib"/>
     </group>
   </macro>
   <macro name="title-and-source-note">
@@ -1275,7 +1275,7 @@
       </choose>
       <text macro="source-medium-note"/>
       <text macro="source-archive-note"/>
-      <text macro="source-DOI-URL-note"/>
+      <text macro="source-date-accessed-DOI-URL-note"/>
     </group>
   </macro>
   <!-- 3.1. Title -->
@@ -5368,55 +5368,48 @@
     </group>
   </macro>
   <!-- 4.10. URL or persistent identifier -->
-  <macro name="source-DOI-URL-bib">
-    <choose>
-      <if variable="DOI">
-        <text prefix="https://doi.org/" variable="DOI"/>
-      </if>
-      <else-if variable="URL">
-        <group delimiter=". ">
-          <choose>
-            <if match="none" variable="available-date event-date issued status">
-              <group delimiter=" ">
-                <text term="accessed" text-case="capitalize-first"/>
-                <date form="text" variable="accessed"/>
-              </group>
-            </if>
-          </choose>
-          <text variable="URL"/>
-        </group>
-      </else-if>
-    </choose>
+  <macro name="source-date-accessed-DOI-URL-bib">
+    <group delimiter=", ">
+      <choose>
+        <if variable="DOI"/>
+        <else-if match="any" variable="available-date event-date issued status"/>
+        <else-if variable="accessed URL">
+          <group delimiter=" ">
+            <text term="accessed" text-case="capitalize-first"/>
+            <date form="text" variable="accessed"/>
+          </group>
+        </else-if>
+      </choose>
+      <text macro="source-DOI-URL"/>
+    </group>
   </macro>
-  <macro name="source-DOI-URL-note">
-    <choose>
-      <if variable="DOI">
-        <text prefix="https://doi.org/" variable="DOI"/>
-      </if>
-      <else-if variable="URL">
-        <group delimiter=", ">
-          <choose>
-            <if match="none" variable="available-date event-date issued status">
-              <group delimiter=" ">
-                <text term="accessed"/>
-                <date form="text" variable="accessed"/>
-              </group>
-            </if>
-          </choose>
-          <text variable="URL"/>
-        </group>
-      </else-if>
-    </choose>
+  <macro name="source-date-accessed-DOI-URL-note">
+    <group delimiter=", ">
+      <choose>
+        <if variable="DOI"/>
+        <else-if match="any" variable="available-date event-date issued status"/>
+        <else-if variable="URL">
+          <group delimiter=" ">
+            <text term="accessed"/>
+            <date form="text" variable="accessed"/>
+          </group>
+        </else-if>
+      </choose>
+      <text macro="source-DOI-URL"/>
+    </group>
   </macro>
   <macro name="source-DOI-URL">
-    <!-- Alias to avoid modifying legal references block shared with APA -->
-    <text macro="source-DOI-URL-bib"/>
+    <choose>
+      <if variable="DOI">
+        <text prefix="https://doi.org/" variable="DOI"/>
+      </if>
+      <else-if variable="URL">
+        <text variable="URL"/>
+      </else-if>
+    </choose>
   </macro>
   <!-- 5. Notes -->
-  <macro name="notes">
-    <!-- Notes on source element: original publication, reprint info, retraction info -->
-    <text variable="references"/>
-  </macro>
+  <!-- TODO: add variables for distributor and exhibitions if available in CSL -->
   <!-- 6. Legal references: Bluebook style (shared with APA) -->
   <!-- Where APA or Chicago diverge from Bluebook, the official manual is followed -->
   <macro name="legal-reference">
@@ -5440,42 +5433,38 @@
          `treaty`
          : treaties
     -->
-    <group delimiter=" ">
-      <group delimiter=", " suffix=".">
-        <choose>
-          <if type="treaty">
-            <text macro="legal-title"/>
-            <names variable="author">
-              <!-- Treaty parties should be included at least for bilateral treaties (Bluebook 21.4.2) -->
-              <name delimiter="-" et-al-min="100" et-al-use-first="99" form="short"/>
-            </names>
-            <text macro="legal-date"/>
-            <!-- treaty source/report in addition to URL (Bluebook 21.4.5) -->
-            <text macro="legal-source"/>
-          </if>
-          <else>
-            <group delimiter=" ">
-              <group delimiter=", ">
-                <text macro="legal-title"/>
-                <text macro="legal-source"/>
-              </group>
-              <text macro="legal-date"/>
-              <text macro="legal-identifier"/>
+    <group delimiter=", ">
+      <choose>
+        <if type="treaty">
+          <text macro="legal-title"/>
+          <names variable="author">
+            <!-- Treaty parties should be included at least for bilateral treaties (Bluebook 21.4.2) -->
+            <name delimiter="-" et-al-min="100" et-al-use-first="99" form="short"/>
+          </names>
+          <text macro="legal-date"/>
+          <!-- treaty source/report in addition to URL (Bluebook 21.4.5) -->
+          <text macro="legal-source"/>
+        </if>
+        <else>
+          <group delimiter=" ">
+            <group delimiter=", ">
+              <text macro="legal-title"/>
+              <text macro="legal-source"/>
             </group>
-          </else>
+            <text macro="legal-date"/>
+            <text macro="legal-identifier"/>
+          </group>
+        </else>
+      </choose>
+      <group delimiter=" ">
+        <!-- locator for use in notes -->
+        <choose>
+          <if locator="page" variable="page">
+            <text term="at"/>
+          </if>
         </choose>
-        <group delimiter=" ">
-          <!-- locator for use in notes -->
-          <choose>
-            <if locator="page" variable="page">
-              <text term="at"/>
-            </if>
-          </choose>
-          <text macro="label-locator"/>
-        </group>
+        <text macro="label-locator"/>
       </group>
-      <text variable="references"/>
-      <text macro="source-DOI-URL"/>
     </group>
   </macro>
   <!-- 6.1. Legal date -->
@@ -5726,30 +5715,29 @@
   </macro>
   <!-- Citation -->
   <macro name="citation-notes-full">
-    <choose>
-      <if match="any" type="bill hearing legal_case legislation regulation treaty">
-        <!-- Legal items have different orders and delimiters -->
-        <text macro="legal-reference"/>
-      </if>
-      <else-if type="personal_communication" variable="genre">
-        <group delimiter=", ">
+    <group delimiter=", ">
+      <choose>
+        <if match="any" type="bill hearing legal_case legislation regulation treaty">
+          <!-- Legal items have different orders and delimiters -->
+          <text macro="legal-reference"/>
+          <text macro="source-date-accessed-DOI-URL-note"/>
+        </if>
+        <else-if type="personal_communication" variable="genre">
           <text macro="author-note"/>
           <text macro="title-and-source-note"/>
-        </group>
-      </else-if>
-      <else-if type="personal_communication" variable="author recipient">
-        <group delimiter=" ">
+        </else-if>
+        <else-if type="personal_communication" variable="author recipient">
+          <group delimiter=" ">
+            <text macro="author-note"/>
+            <text macro="title-and-source-note"/>
+          </group>
+        </else-if>
+        <else>
           <text macro="author-note"/>
           <text macro="title-and-source-note"/>
-        </group>
-      </else-if>
-      <else>
-        <group delimiter=", ">
-          <text macro="author-note"/>
-          <text macro="title-and-source-note"/>
-        </group>
-      </else>
-    </choose>
+        </else>
+      </choose>
+    </group>
   </macro>
   <macro name="citation-notes-shortened-author-title">
     <!-- Shortened note styles mirror the filtering approach of author-date -->
@@ -5848,19 +5836,21 @@
   </citation>
   <!-- Bibliography -->
   <macro name="bibliography-notes">
-    <choose>
-      <if match="any" type="bill hearing legal_case legislation regulation treaty">
-        <!-- Legal items have different orders and delimiters -->
-        <text macro="legal-reference"/>
-      </if>
-      <else>
-        <group delimiter=". ">
+    <group delimiter=". ">
+      <choose>
+        <if match="any" type="bill hearing legal_case legislation regulation treaty">
+          <!-- Legal items have different orders and delimiters -->
+          <text macro="legal-reference"/>
+          <text macro="source-date-accessed-DOI-URL-bib"/>
+          <text variable="references"/>
+        </if>
+        <else>
           <text macro="author-bib"/>
           <text macro="title-and-source-bib"/>
-          <text macro="notes"/>
-        </group>
-      </else>
-    </choose>
+          <text variable="references"/>
+        </else>
+      </choose>
+    </group>
   </macro>
   <bibliography et-al-min="7" et-al-use-first="3" hanging-indent="true" subsequent-author-substitute="&#8212;&#8212;&#8212;">
     <sort>

--- a/chicago-notes-bibliography-classic-no-url.csl
+++ b/chicago-notes-bibliography-classic-no-url.csl
@@ -1222,7 +1222,7 @@
       </group>
       <text macro="source-medium-bib"/>
       <text macro="source-archive-bib"/>
-      <!-- <text macro="source-DOI-URL-bib"/> -->
+      <text macro="source-date-accessed-DOI-URL-bib"/>
     </group>
   </macro>
   <macro name="title-and-source-note">
@@ -1275,7 +1275,7 @@
       </choose>
       <text macro="source-medium-note"/>
       <text macro="source-archive-note"/>
-      <!-- <text macro="source-DOI-URL-note"/> -->
+      <text macro="source-date-accessed-DOI-URL-note"/>
     </group>
   </macro>
   <!-- 3.1. Title -->
@@ -5387,11 +5387,38 @@
     </group>
   </macro>
   <!-- 4.10. URL or persistent identifier -->
-  <!-- 5. Notes -->
-  <macro name="notes">
-    <!-- Notes on source element: original publication, reprint info, retraction info -->
-    <text variable="references"/>
+  <macro name="source-date-accessed-DOI-URL-bib">
+    <group delimiter=", ">
+      <choose>
+        <if variable="DOI"/>
+        <else-if match="any" variable="available-date event-date issued status"/>
+        <else-if variable="accessed URL">
+          <group delimiter=" ">
+            <text term="accessed" text-case="capitalize-first"/>
+            <date form="text" variable="accessed"/>
+          </group>
+        </else-if>
+      </choose>
+      <!-- <text macro="source-DOI-URL"/> -->
+    </group>
   </macro>
+  <macro name="source-date-accessed-DOI-URL-note">
+    <group delimiter=", ">
+      <choose>
+        <if variable="DOI"/>
+        <else-if match="any" variable="available-date event-date issued status"/>
+        <else-if variable="URL">
+          <group delimiter=" ">
+            <text term="accessed"/>
+            <date form="text" variable="accessed"/>
+          </group>
+        </else-if>
+      </choose>
+      <!-- <text macro="source-DOI-URL"/> -->
+    </group>
+  </macro>
+  <!-- 5. Notes -->
+  <!-- TODO: add variables for distributor and exhibitions if available in CSL -->
   <!-- 6. Legal references: Bluebook style (shared with APA) -->
   <!-- Where APA or Chicago diverge from Bluebook, the official manual is followed -->
   <macro name="legal-reference">
@@ -5415,42 +5442,38 @@
          `treaty`
          : treaties
     -->
-    <group delimiter=" ">
-      <group delimiter=", " suffix=".">
-        <choose>
-          <if type="treaty">
-            <text macro="legal-title"/>
-            <names variable="author">
-              <!-- Treaty parties should be included at least for bilateral treaties (Bluebook 21.4.2) -->
-              <name delimiter="-" et-al-min="100" et-al-use-first="99" form="short"/>
-            </names>
-            <text macro="legal-date"/>
-            <!-- treaty source/report in addition to URL (Bluebook 21.4.5) -->
-            <text macro="legal-source"/>
-          </if>
-          <else>
-            <group delimiter=" ">
-              <group delimiter=", ">
-                <text macro="legal-title"/>
-                <text macro="legal-source"/>
-              </group>
-              <text macro="legal-date"/>
-              <text macro="legal-identifier"/>
+    <group delimiter=", ">
+      <choose>
+        <if type="treaty">
+          <text macro="legal-title"/>
+          <names variable="author">
+            <!-- Treaty parties should be included at least for bilateral treaties (Bluebook 21.4.2) -->
+            <name delimiter="-" et-al-min="100" et-al-use-first="99" form="short"/>
+          </names>
+          <text macro="legal-date"/>
+          <!-- treaty source/report in addition to URL (Bluebook 21.4.5) -->
+          <text macro="legal-source"/>
+        </if>
+        <else>
+          <group delimiter=" ">
+            <group delimiter=", ">
+              <text macro="legal-title"/>
+              <text macro="legal-source"/>
             </group>
-          </else>
+            <text macro="legal-date"/>
+            <text macro="legal-identifier"/>
+          </group>
+        </else>
+      </choose>
+      <group delimiter=" ">
+        <!-- locator for use in notes -->
+        <choose>
+          <if locator="page" variable="page">
+            <text term="at"/>
+          </if>
         </choose>
-        <group delimiter=" ">
-          <!-- locator for use in notes -->
-          <choose>
-            <if locator="page" variable="page">
-              <text term="at"/>
-            </if>
-          </choose>
-          <text macro="label-locator"/>
-        </group>
+        <text macro="label-locator"/>
       </group>
-      <text variable="references"/>
-      <!-- <text macro="source-DOI-URL"/> -->
     </group>
   </macro>
   <!-- 6.1. Legal date -->
@@ -5701,30 +5724,29 @@
   </macro>
   <!-- Citation -->
   <macro name="citation-notes-full">
-    <choose>
-      <if match="any" type="bill hearing legal_case legislation regulation treaty">
-        <!-- Legal items have different orders and delimiters -->
-        <text macro="legal-reference"/>
-      </if>
-      <else-if type="personal_communication" variable="genre">
-        <group delimiter=", ">
+    <group delimiter=", ">
+      <choose>
+        <if match="any" type="bill hearing legal_case legislation regulation treaty">
+          <!-- Legal items have different orders and delimiters -->
+          <text macro="legal-reference"/>
+          <text macro="source-date-accessed-DOI-URL-note"/>
+        </if>
+        <else-if type="personal_communication" variable="genre">
           <text macro="author-note"/>
           <text macro="title-and-source-note"/>
-        </group>
-      </else-if>
-      <else-if type="personal_communication" variable="author recipient">
-        <group delimiter=" ">
+        </else-if>
+        <else-if type="personal_communication" variable="author recipient">
+          <group delimiter=" ">
+            <text macro="author-note"/>
+            <text macro="title-and-source-note"/>
+          </group>
+        </else-if>
+        <else>
           <text macro="author-note"/>
           <text macro="title-and-source-note"/>
-        </group>
-      </else-if>
-      <else>
-        <group delimiter=", ">
-          <text macro="author-note"/>
-          <text macro="title-and-source-note"/>
-        </group>
-      </else>
-    </choose>
+        </else>
+      </choose>
+    </group>
   </macro>
   <macro name="citation-notes-shortened-author-title">
     <!-- Shortened note styles mirror the filtering approach of author-date -->
@@ -5823,19 +5845,21 @@
   </citation>
   <!-- Bibliography -->
   <macro name="bibliography-notes">
-    <choose>
-      <if match="any" type="bill hearing legal_case legislation regulation treaty">
-        <!-- Legal items have different orders and delimiters -->
-        <text macro="legal-reference"/>
-      </if>
-      <else>
-        <group delimiter=". ">
+    <group delimiter=". ">
+      <choose>
+        <if match="any" type="bill hearing legal_case legislation regulation treaty">
+          <!-- Legal items have different orders and delimiters -->
+          <text macro="legal-reference"/>
+          <text macro="source-date-accessed-DOI-URL-bib"/>
+          <text variable="references"/>
+        </if>
+        <else>
           <text macro="author-bib"/>
           <text macro="title-and-source-bib"/>
-          <text macro="notes"/>
-        </group>
-      </else>
-    </choose>
+          <text variable="references"/>
+        </else>
+      </choose>
+    </group>
   </macro>
   <bibliography et-al-min="7" et-al-use-first="3" hanging-indent="true" subsequent-author-substitute="&#8212;&#8212;&#8212;">
     <sort>

--- a/chicago-notes-bibliography-classic.csl
+++ b/chicago-notes-bibliography-classic.csl
@@ -1222,7 +1222,7 @@
       </group>
       <text macro="source-medium-bib"/>
       <text macro="source-archive-bib"/>
-      <text macro="source-DOI-URL-bib"/>
+      <text macro="source-date-accessed-DOI-URL-bib"/>
     </group>
   </macro>
   <macro name="title-and-source-note">
@@ -1275,7 +1275,7 @@
       </choose>
       <text macro="source-medium-note"/>
       <text macro="source-archive-note"/>
-      <text macro="source-DOI-URL-note"/>
+      <text macro="source-date-accessed-DOI-URL-note"/>
     </group>
   </macro>
   <!-- 3.1. Title -->
@@ -5387,55 +5387,48 @@
     </group>
   </macro>
   <!-- 4.10. URL or persistent identifier -->
-  <macro name="source-DOI-URL-bib">
-    <choose>
-      <if variable="DOI">
-        <text prefix="https://doi.org/" variable="DOI"/>
-      </if>
-      <else-if variable="URL">
-        <group delimiter=". ">
-          <choose>
-            <if match="none" variable="available-date event-date issued status">
-              <group delimiter=" ">
-                <text term="accessed" text-case="capitalize-first"/>
-                <date form="text" variable="accessed"/>
-              </group>
-            </if>
-          </choose>
-          <text variable="URL"/>
-        </group>
-      </else-if>
-    </choose>
+  <macro name="source-date-accessed-DOI-URL-bib">
+    <group delimiter=", ">
+      <choose>
+        <if variable="DOI"/>
+        <else-if match="any" variable="available-date event-date issued status"/>
+        <else-if variable="accessed URL">
+          <group delimiter=" ">
+            <text term="accessed" text-case="capitalize-first"/>
+            <date form="text" variable="accessed"/>
+          </group>
+        </else-if>
+      </choose>
+      <text macro="source-DOI-URL"/>
+    </group>
   </macro>
-  <macro name="source-DOI-URL-note">
-    <choose>
-      <if variable="DOI">
-        <text prefix="https://doi.org/" variable="DOI"/>
-      </if>
-      <else-if variable="URL">
-        <group delimiter=", ">
-          <choose>
-            <if match="none" variable="available-date event-date issued status">
-              <group delimiter=" ">
-                <text term="accessed"/>
-                <date form="text" variable="accessed"/>
-              </group>
-            </if>
-          </choose>
-          <text variable="URL"/>
-        </group>
-      </else-if>
-    </choose>
+  <macro name="source-date-accessed-DOI-URL-note">
+    <group delimiter=", ">
+      <choose>
+        <if variable="DOI"/>
+        <else-if match="any" variable="available-date event-date issued status"/>
+        <else-if variable="URL">
+          <group delimiter=" ">
+            <text term="accessed"/>
+            <date form="text" variable="accessed"/>
+          </group>
+        </else-if>
+      </choose>
+      <text macro="source-DOI-URL"/>
+    </group>
   </macro>
   <macro name="source-DOI-URL">
-    <!-- Alias to avoid modifying legal references block shared with APA -->
-    <text macro="source-DOI-URL-bib"/>
+    <choose>
+      <if variable="DOI">
+        <text prefix="https://doi.org/" variable="DOI"/>
+      </if>
+      <else-if variable="URL">
+        <text variable="URL"/>
+      </else-if>
+    </choose>
   </macro>
   <!-- 5. Notes -->
-  <macro name="notes">
-    <!-- Notes on source element: original publication, reprint info, retraction info -->
-    <text variable="references"/>
-  </macro>
+  <!-- TODO: add variables for distributor and exhibitions if available in CSL -->
   <!-- 6. Legal references: Bluebook style (shared with APA) -->
   <!-- Where APA or Chicago diverge from Bluebook, the official manual is followed -->
   <macro name="legal-reference">
@@ -5459,42 +5452,38 @@
          `treaty`
          : treaties
     -->
-    <group delimiter=" ">
-      <group delimiter=", " suffix=".">
-        <choose>
-          <if type="treaty">
-            <text macro="legal-title"/>
-            <names variable="author">
-              <!-- Treaty parties should be included at least for bilateral treaties (Bluebook 21.4.2) -->
-              <name delimiter="-" et-al-min="100" et-al-use-first="99" form="short"/>
-            </names>
-            <text macro="legal-date"/>
-            <!-- treaty source/report in addition to URL (Bluebook 21.4.5) -->
-            <text macro="legal-source"/>
-          </if>
-          <else>
-            <group delimiter=" ">
-              <group delimiter=", ">
-                <text macro="legal-title"/>
-                <text macro="legal-source"/>
-              </group>
-              <text macro="legal-date"/>
-              <text macro="legal-identifier"/>
+    <group delimiter=", ">
+      <choose>
+        <if type="treaty">
+          <text macro="legal-title"/>
+          <names variable="author">
+            <!-- Treaty parties should be included at least for bilateral treaties (Bluebook 21.4.2) -->
+            <name delimiter="-" et-al-min="100" et-al-use-first="99" form="short"/>
+          </names>
+          <text macro="legal-date"/>
+          <!-- treaty source/report in addition to URL (Bluebook 21.4.5) -->
+          <text macro="legal-source"/>
+        </if>
+        <else>
+          <group delimiter=" ">
+            <group delimiter=", ">
+              <text macro="legal-title"/>
+              <text macro="legal-source"/>
             </group>
-          </else>
+            <text macro="legal-date"/>
+            <text macro="legal-identifier"/>
+          </group>
+        </else>
+      </choose>
+      <group delimiter=" ">
+        <!-- locator for use in notes -->
+        <choose>
+          <if locator="page" variable="page">
+            <text term="at"/>
+          </if>
         </choose>
-        <group delimiter=" ">
-          <!-- locator for use in notes -->
-          <choose>
-            <if locator="page" variable="page">
-              <text term="at"/>
-            </if>
-          </choose>
-          <text macro="label-locator"/>
-        </group>
+        <text macro="label-locator"/>
       </group>
-      <text variable="references"/>
-      <text macro="source-DOI-URL"/>
     </group>
   </macro>
   <!-- 6.1. Legal date -->
@@ -5745,30 +5734,29 @@
   </macro>
   <!-- Citation -->
   <macro name="citation-notes-full">
-    <choose>
-      <if match="any" type="bill hearing legal_case legislation regulation treaty">
-        <!-- Legal items have different orders and delimiters -->
-        <text macro="legal-reference"/>
-      </if>
-      <else-if type="personal_communication" variable="genre">
-        <group delimiter=", ">
+    <group delimiter=", ">
+      <choose>
+        <if match="any" type="bill hearing legal_case legislation regulation treaty">
+          <!-- Legal items have different orders and delimiters -->
+          <text macro="legal-reference"/>
+          <text macro="source-date-accessed-DOI-URL-note"/>
+        </if>
+        <else-if type="personal_communication" variable="genre">
           <text macro="author-note"/>
           <text macro="title-and-source-note"/>
-        </group>
-      </else-if>
-      <else-if type="personal_communication" variable="author recipient">
-        <group delimiter=" ">
+        </else-if>
+        <else-if type="personal_communication" variable="author recipient">
+          <group delimiter=" ">
+            <text macro="author-note"/>
+            <text macro="title-and-source-note"/>
+          </group>
+        </else-if>
+        <else>
           <text macro="author-note"/>
           <text macro="title-and-source-note"/>
-        </group>
-      </else-if>
-      <else>
-        <group delimiter=", ">
-          <text macro="author-note"/>
-          <text macro="title-and-source-note"/>
-        </group>
-      </else>
-    </choose>
+        </else>
+      </choose>
+    </group>
   </macro>
   <macro name="citation-notes-shortened-author-title">
     <!-- Shortened note styles mirror the filtering approach of author-date -->
@@ -5867,19 +5855,21 @@
   </citation>
   <!-- Bibliography -->
   <macro name="bibliography-notes">
-    <choose>
-      <if match="any" type="bill hearing legal_case legislation regulation treaty">
-        <!-- Legal items have different orders and delimiters -->
-        <text macro="legal-reference"/>
-      </if>
-      <else>
-        <group delimiter=". ">
+    <group delimiter=". ">
+      <choose>
+        <if match="any" type="bill hearing legal_case legislation regulation treaty">
+          <!-- Legal items have different orders and delimiters -->
+          <text macro="legal-reference"/>
+          <text macro="source-date-accessed-DOI-URL-bib"/>
+          <text variable="references"/>
+        </if>
+        <else>
           <text macro="author-bib"/>
           <text macro="title-and-source-bib"/>
-          <text macro="notes"/>
-        </group>
-      </else>
-    </choose>
+          <text variable="references"/>
+        </else>
+      </choose>
+    </group>
   </macro>
   <bibliography et-al-min="7" et-al-use-first="3" hanging-indent="true" subsequent-author-substitute="&#8212;&#8212;&#8212;">
     <sort>

--- a/chicago-notes-bibliography-no-url.csl
+++ b/chicago-notes-bibliography-no-url.csl
@@ -1221,7 +1221,7 @@
       </group>
       <text macro="source-medium-bib"/>
       <text macro="source-archive-bib"/>
-      <!-- <text macro="source-DOI-URL-bib"/> -->
+      <text macro="source-date-accessed-DOI-URL-bib"/>
     </group>
   </macro>
   <macro name="title-and-source-note">
@@ -1274,7 +1274,7 @@
       </choose>
       <text macro="source-medium-note"/>
       <text macro="source-archive-note"/>
-      <!-- <text macro="source-DOI-URL-note"/> -->
+      <text macro="source-date-accessed-DOI-URL-note"/>
     </group>
   </macro>
   <!-- 3.1. Title -->
@@ -5396,11 +5396,38 @@
     </group>
   </macro>
   <!-- 4.10. URL or persistent identifier -->
-  <!-- 5. Notes -->
-  <macro name="notes">
-    <!-- Notes on source element: original publication, reprint info, retraction info -->
-    <text variable="references"/>
+  <macro name="source-date-accessed-DOI-URL-bib">
+    <group delimiter=", ">
+      <choose>
+        <if variable="DOI"/>
+        <else-if match="any" variable="available-date event-date issued status"/>
+        <else-if variable="accessed URL">
+          <group delimiter=" ">
+            <text term="accessed" text-case="capitalize-first"/>
+            <date form="text" variable="accessed"/>
+          </group>
+        </else-if>
+      </choose>
+      <!-- <text macro="source-DOI-URL"/> -->
+    </group>
   </macro>
+  <macro name="source-date-accessed-DOI-URL-note">
+    <group delimiter=", ">
+      <choose>
+        <if variable="DOI"/>
+        <else-if match="any" variable="available-date event-date issued status"/>
+        <else-if variable="URL">
+          <group delimiter=" ">
+            <text term="accessed"/>
+            <date form="text" variable="accessed"/>
+          </group>
+        </else-if>
+      </choose>
+      <!-- <text macro="source-DOI-URL"/> -->
+    </group>
+  </macro>
+  <!-- 5. Notes -->
+  <!-- TODO: add variables for distributor and exhibitions if available in CSL -->
   <!-- 6. Legal references: Bluebook style (shared with APA) -->
   <!-- Where APA or Chicago diverge from Bluebook, the official manual is followed -->
   <macro name="legal-reference">
@@ -5424,42 +5451,38 @@
          `treaty`
          : treaties
     -->
-    <group delimiter=" ">
-      <group delimiter=", " suffix=".">
-        <choose>
-          <if type="treaty">
-            <text macro="legal-title"/>
-            <names variable="author">
-              <!-- Treaty parties should be included at least for bilateral treaties (Bluebook 21.4.2) -->
-              <name delimiter="-" et-al-min="100" et-al-use-first="99" form="short"/>
-            </names>
-            <text macro="legal-date"/>
-            <!-- treaty source/report in addition to URL (Bluebook 21.4.5) -->
-            <text macro="legal-source"/>
-          </if>
-          <else>
-            <group delimiter=" ">
-              <group delimiter=", ">
-                <text macro="legal-title"/>
-                <text macro="legal-source"/>
-              </group>
-              <text macro="legal-date"/>
-              <text macro="legal-identifier"/>
+    <group delimiter=", ">
+      <choose>
+        <if type="treaty">
+          <text macro="legal-title"/>
+          <names variable="author">
+            <!-- Treaty parties should be included at least for bilateral treaties (Bluebook 21.4.2) -->
+            <name delimiter="-" et-al-min="100" et-al-use-first="99" form="short"/>
+          </names>
+          <text macro="legal-date"/>
+          <!-- treaty source/report in addition to URL (Bluebook 21.4.5) -->
+          <text macro="legal-source"/>
+        </if>
+        <else>
+          <group delimiter=" ">
+            <group delimiter=", ">
+              <text macro="legal-title"/>
+              <text macro="legal-source"/>
             </group>
-          </else>
+            <text macro="legal-date"/>
+            <text macro="legal-identifier"/>
+          </group>
+        </else>
+      </choose>
+      <group delimiter=" ">
+        <!-- locator for use in notes -->
+        <choose>
+          <if locator="page" variable="page">
+            <text term="at"/>
+          </if>
         </choose>
-        <group delimiter=" ">
-          <!-- locator for use in notes -->
-          <choose>
-            <if locator="page" variable="page">
-              <text term="at"/>
-            </if>
-          </choose>
-          <text macro="label-locator"/>
-        </group>
+        <text macro="label-locator"/>
       </group>
-      <text variable="references"/>
-      <!-- <text macro="source-DOI-URL"/> -->
     </group>
   </macro>
   <!-- 6.1. Legal date -->
@@ -5710,30 +5733,29 @@
   </macro>
   <!-- Citation -->
   <macro name="citation-notes-full">
-    <choose>
-      <if match="any" type="bill hearing legal_case legislation regulation treaty">
-        <!-- Legal items have different orders and delimiters -->
-        <text macro="legal-reference"/>
-      </if>
-      <else-if type="personal_communication" variable="genre">
-        <group delimiter=", ">
+    <group delimiter=", ">
+      <choose>
+        <if match="any" type="bill hearing legal_case legislation regulation treaty">
+          <!-- Legal items have different orders and delimiters -->
+          <text macro="legal-reference"/>
+          <text macro="source-date-accessed-DOI-URL-note"/>
+        </if>
+        <else-if type="personal_communication" variable="genre">
           <text macro="author-note"/>
           <text macro="title-and-source-note"/>
-        </group>
-      </else-if>
-      <else-if type="personal_communication" variable="author recipient">
-        <group delimiter=" ">
+        </else-if>
+        <else-if type="personal_communication" variable="author recipient">
+          <group delimiter=" ">
+            <text macro="author-note"/>
+            <text macro="title-and-source-note"/>
+          </group>
+        </else-if>
+        <else>
           <text macro="author-note"/>
           <text macro="title-and-source-note"/>
-        </group>
-      </else-if>
-      <else>
-        <group delimiter=", ">
-          <text macro="author-note"/>
-          <text macro="title-and-source-note"/>
-        </group>
-      </else>
-    </choose>
+        </else>
+      </choose>
+    </group>
   </macro>
   <macro name="citation-notes-shortened-author-title">
     <!-- Shortened note styles mirror the filtering approach of author-date -->
@@ -5832,19 +5854,21 @@
   </citation>
   <!-- Bibliography -->
   <macro name="bibliography-notes">
-    <choose>
-      <if match="any" type="bill hearing legal_case legislation regulation treaty">
-        <!-- Legal items have different orders and delimiters -->
-        <text macro="legal-reference"/>
-      </if>
-      <else>
-        <group delimiter=". ">
+    <group delimiter=". ">
+      <choose>
+        <if match="any" type="bill hearing legal_case legislation regulation treaty">
+          <!-- Legal items have different orders and delimiters -->
+          <text macro="legal-reference"/>
+          <text macro="source-date-accessed-DOI-URL-bib"/>
+          <text variable="references"/>
+        </if>
+        <else>
           <text macro="author-bib"/>
           <text macro="title-and-source-bib"/>
-          <text macro="notes"/>
-        </group>
-      </else>
-    </choose>
+          <text variable="references"/>
+        </else>
+      </choose>
+    </group>
   </macro>
   <bibliography et-al-min="7" et-al-use-first="3" hanging-indent="true">
     <sort>

--- a/chicago-notes-bibliography-subsequent-author-classic-no-url.csl
+++ b/chicago-notes-bibliography-subsequent-author-classic-no-url.csl
@@ -1222,7 +1222,7 @@
       </group>
       <text macro="source-medium-bib"/>
       <text macro="source-archive-bib"/>
-      <!-- <text macro="source-DOI-URL-bib"/> -->
+      <text macro="source-date-accessed-DOI-URL-bib"/>
     </group>
   </macro>
   <macro name="title-and-source-note">
@@ -1275,7 +1275,7 @@
       </choose>
       <text macro="source-medium-note"/>
       <text macro="source-archive-note"/>
-      <!-- <text macro="source-DOI-URL-note"/> -->
+      <text macro="source-date-accessed-DOI-URL-note"/>
     </group>
   </macro>
   <!-- 3.1. Title -->
@@ -5387,11 +5387,38 @@
     </group>
   </macro>
   <!-- 4.10. URL or persistent identifier -->
-  <!-- 5. Notes -->
-  <macro name="notes">
-    <!-- Notes on source element: original publication, reprint info, retraction info -->
-    <text variable="references"/>
+  <macro name="source-date-accessed-DOI-URL-bib">
+    <group delimiter=", ">
+      <choose>
+        <if variable="DOI"/>
+        <else-if match="any" variable="available-date event-date issued status"/>
+        <else-if variable="accessed URL">
+          <group delimiter=" ">
+            <text term="accessed" text-case="capitalize-first"/>
+            <date form="text" variable="accessed"/>
+          </group>
+        </else-if>
+      </choose>
+      <!-- <text macro="source-DOI-URL"/> -->
+    </group>
   </macro>
+  <macro name="source-date-accessed-DOI-URL-note">
+    <group delimiter=", ">
+      <choose>
+        <if variable="DOI"/>
+        <else-if match="any" variable="available-date event-date issued status"/>
+        <else-if variable="URL">
+          <group delimiter=" ">
+            <text term="accessed"/>
+            <date form="text" variable="accessed"/>
+          </group>
+        </else-if>
+      </choose>
+      <!-- <text macro="source-DOI-URL"/> -->
+    </group>
+  </macro>
+  <!-- 5. Notes -->
+  <!-- TODO: add variables for distributor and exhibitions if available in CSL -->
   <!-- 6. Legal references: Bluebook style (shared with APA) -->
   <!-- Where APA or Chicago diverge from Bluebook, the official manual is followed -->
   <macro name="legal-reference">
@@ -5415,42 +5442,38 @@
          `treaty`
          : treaties
     -->
-    <group delimiter=" ">
-      <group delimiter=", " suffix=".">
-        <choose>
-          <if type="treaty">
-            <text macro="legal-title"/>
-            <names variable="author">
-              <!-- Treaty parties should be included at least for bilateral treaties (Bluebook 21.4.2) -->
-              <name delimiter="-" et-al-min="100" et-al-use-first="99" form="short"/>
-            </names>
-            <text macro="legal-date"/>
-            <!-- treaty source/report in addition to URL (Bluebook 21.4.5) -->
-            <text macro="legal-source"/>
-          </if>
-          <else>
-            <group delimiter=" ">
-              <group delimiter=", ">
-                <text macro="legal-title"/>
-                <text macro="legal-source"/>
-              </group>
-              <text macro="legal-date"/>
-              <text macro="legal-identifier"/>
+    <group delimiter=", ">
+      <choose>
+        <if type="treaty">
+          <text macro="legal-title"/>
+          <names variable="author">
+            <!-- Treaty parties should be included at least for bilateral treaties (Bluebook 21.4.2) -->
+            <name delimiter="-" et-al-min="100" et-al-use-first="99" form="short"/>
+          </names>
+          <text macro="legal-date"/>
+          <!-- treaty source/report in addition to URL (Bluebook 21.4.5) -->
+          <text macro="legal-source"/>
+        </if>
+        <else>
+          <group delimiter=" ">
+            <group delimiter=", ">
+              <text macro="legal-title"/>
+              <text macro="legal-source"/>
             </group>
-          </else>
+            <text macro="legal-date"/>
+            <text macro="legal-identifier"/>
+          </group>
+        </else>
+      </choose>
+      <group delimiter=" ">
+        <!-- locator for use in notes -->
+        <choose>
+          <if locator="page" variable="page">
+            <text term="at"/>
+          </if>
         </choose>
-        <group delimiter=" ">
-          <!-- locator for use in notes -->
-          <choose>
-            <if locator="page" variable="page">
-              <text term="at"/>
-            </if>
-          </choose>
-          <text macro="label-locator"/>
-        </group>
+        <text macro="label-locator"/>
       </group>
-      <text variable="references"/>
-      <!-- <text macro="source-DOI-URL"/> -->
     </group>
   </macro>
   <!-- 6.1. Legal date -->
@@ -5701,30 +5724,29 @@
   </macro>
   <!-- Citation -->
   <macro name="citation-notes-full">
-    <choose>
-      <if match="any" type="bill hearing legal_case legislation regulation treaty">
-        <!-- Legal items have different orders and delimiters -->
-        <text macro="legal-reference"/>
-      </if>
-      <else-if type="personal_communication" variable="genre">
-        <group delimiter=", ">
+    <group delimiter=", ">
+      <choose>
+        <if match="any" type="bill hearing legal_case legislation regulation treaty">
+          <!-- Legal items have different orders and delimiters -->
+          <text macro="legal-reference"/>
+          <text macro="source-date-accessed-DOI-URL-note"/>
+        </if>
+        <else-if type="personal_communication" variable="genre">
           <text macro="author-note"/>
           <text macro="title-and-source-note"/>
-        </group>
-      </else-if>
-      <else-if type="personal_communication" variable="author recipient">
-        <group delimiter=" ">
+        </else-if>
+        <else-if type="personal_communication" variable="author recipient">
+          <group delimiter=" ">
+            <text macro="author-note"/>
+            <text macro="title-and-source-note"/>
+          </group>
+        </else-if>
+        <else>
           <text macro="author-note"/>
           <text macro="title-and-source-note"/>
-        </group>
-      </else-if>
-      <else>
-        <group delimiter=", ">
-          <text macro="author-note"/>
-          <text macro="title-and-source-note"/>
-        </group>
-      </else>
-    </choose>
+        </else>
+      </choose>
+    </group>
   </macro>
   <macro name="citation-notes-shortened-author-only">
     <choose>
@@ -5893,19 +5915,21 @@
   </citation>
   <!-- Bibliography -->
   <macro name="bibliography-notes">
-    <choose>
-      <if match="any" type="bill hearing legal_case legislation regulation treaty">
-        <!-- Legal items have different orders and delimiters -->
-        <text macro="legal-reference"/>
-      </if>
-      <else>
-        <group delimiter=". ">
+    <group delimiter=". ">
+      <choose>
+        <if match="any" type="bill hearing legal_case legislation regulation treaty">
+          <!-- Legal items have different orders and delimiters -->
+          <text macro="legal-reference"/>
+          <text macro="source-date-accessed-DOI-URL-bib"/>
+          <text variable="references"/>
+        </if>
+        <else>
           <text macro="author-bib"/>
           <text macro="title-and-source-bib"/>
-          <text macro="notes"/>
-        </group>
-      </else>
-    </choose>
+          <text variable="references"/>
+        </else>
+      </choose>
+    </group>
   </macro>
   <bibliography et-al-min="7" et-al-use-first="3" hanging-indent="true" subsequent-author-substitute="&#8212;&#8212;&#8212;">
     <sort>

--- a/chicago-notes-bibliography-subsequent-author-classic.csl
+++ b/chicago-notes-bibliography-subsequent-author-classic.csl
@@ -1222,7 +1222,7 @@
       </group>
       <text macro="source-medium-bib"/>
       <text macro="source-archive-bib"/>
-      <text macro="source-DOI-URL-bib"/>
+      <text macro="source-date-accessed-DOI-URL-bib"/>
     </group>
   </macro>
   <macro name="title-and-source-note">
@@ -1275,7 +1275,7 @@
       </choose>
       <text macro="source-medium-note"/>
       <text macro="source-archive-note"/>
-      <text macro="source-DOI-URL-note"/>
+      <text macro="source-date-accessed-DOI-URL-note"/>
     </group>
   </macro>
   <!-- 3.1. Title -->
@@ -5387,55 +5387,48 @@
     </group>
   </macro>
   <!-- 4.10. URL or persistent identifier -->
-  <macro name="source-DOI-URL-bib">
-    <choose>
-      <if variable="DOI">
-        <text prefix="https://doi.org/" variable="DOI"/>
-      </if>
-      <else-if variable="URL">
-        <group delimiter=". ">
-          <choose>
-            <if match="none" variable="available-date event-date issued status">
-              <group delimiter=" ">
-                <text term="accessed" text-case="capitalize-first"/>
-                <date form="text" variable="accessed"/>
-              </group>
-            </if>
-          </choose>
-          <text variable="URL"/>
-        </group>
-      </else-if>
-    </choose>
+  <macro name="source-date-accessed-DOI-URL-bib">
+    <group delimiter=", ">
+      <choose>
+        <if variable="DOI"/>
+        <else-if match="any" variable="available-date event-date issued status"/>
+        <else-if variable="accessed URL">
+          <group delimiter=" ">
+            <text term="accessed" text-case="capitalize-first"/>
+            <date form="text" variable="accessed"/>
+          </group>
+        </else-if>
+      </choose>
+      <text macro="source-DOI-URL"/>
+    </group>
   </macro>
-  <macro name="source-DOI-URL-note">
-    <choose>
-      <if variable="DOI">
-        <text prefix="https://doi.org/" variable="DOI"/>
-      </if>
-      <else-if variable="URL">
-        <group delimiter=", ">
-          <choose>
-            <if match="none" variable="available-date event-date issued status">
-              <group delimiter=" ">
-                <text term="accessed"/>
-                <date form="text" variable="accessed"/>
-              </group>
-            </if>
-          </choose>
-          <text variable="URL"/>
-        </group>
-      </else-if>
-    </choose>
+  <macro name="source-date-accessed-DOI-URL-note">
+    <group delimiter=", ">
+      <choose>
+        <if variable="DOI"/>
+        <else-if match="any" variable="available-date event-date issued status"/>
+        <else-if variable="URL">
+          <group delimiter=" ">
+            <text term="accessed"/>
+            <date form="text" variable="accessed"/>
+          </group>
+        </else-if>
+      </choose>
+      <text macro="source-DOI-URL"/>
+    </group>
   </macro>
   <macro name="source-DOI-URL">
-    <!-- Alias to avoid modifying legal references block shared with APA -->
-    <text macro="source-DOI-URL-bib"/>
+    <choose>
+      <if variable="DOI">
+        <text prefix="https://doi.org/" variable="DOI"/>
+      </if>
+      <else-if variable="URL">
+        <text variable="URL"/>
+      </else-if>
+    </choose>
   </macro>
   <!-- 5. Notes -->
-  <macro name="notes">
-    <!-- Notes on source element: original publication, reprint info, retraction info -->
-    <text variable="references"/>
-  </macro>
+  <!-- TODO: add variables for distributor and exhibitions if available in CSL -->
   <!-- 6. Legal references: Bluebook style (shared with APA) -->
   <!-- Where APA or Chicago diverge from Bluebook, the official manual is followed -->
   <macro name="legal-reference">
@@ -5459,42 +5452,38 @@
          `treaty`
          : treaties
     -->
-    <group delimiter=" ">
-      <group delimiter=", " suffix=".">
-        <choose>
-          <if type="treaty">
-            <text macro="legal-title"/>
-            <names variable="author">
-              <!-- Treaty parties should be included at least for bilateral treaties (Bluebook 21.4.2) -->
-              <name delimiter="-" et-al-min="100" et-al-use-first="99" form="short"/>
-            </names>
-            <text macro="legal-date"/>
-            <!-- treaty source/report in addition to URL (Bluebook 21.4.5) -->
-            <text macro="legal-source"/>
-          </if>
-          <else>
-            <group delimiter=" ">
-              <group delimiter=", ">
-                <text macro="legal-title"/>
-                <text macro="legal-source"/>
-              </group>
-              <text macro="legal-date"/>
-              <text macro="legal-identifier"/>
+    <group delimiter=", ">
+      <choose>
+        <if type="treaty">
+          <text macro="legal-title"/>
+          <names variable="author">
+            <!-- Treaty parties should be included at least for bilateral treaties (Bluebook 21.4.2) -->
+            <name delimiter="-" et-al-min="100" et-al-use-first="99" form="short"/>
+          </names>
+          <text macro="legal-date"/>
+          <!-- treaty source/report in addition to URL (Bluebook 21.4.5) -->
+          <text macro="legal-source"/>
+        </if>
+        <else>
+          <group delimiter=" ">
+            <group delimiter=", ">
+              <text macro="legal-title"/>
+              <text macro="legal-source"/>
             </group>
-          </else>
+            <text macro="legal-date"/>
+            <text macro="legal-identifier"/>
+          </group>
+        </else>
+      </choose>
+      <group delimiter=" ">
+        <!-- locator for use in notes -->
+        <choose>
+          <if locator="page" variable="page">
+            <text term="at"/>
+          </if>
         </choose>
-        <group delimiter=" ">
-          <!-- locator for use in notes -->
-          <choose>
-            <if locator="page" variable="page">
-              <text term="at"/>
-            </if>
-          </choose>
-          <text macro="label-locator"/>
-        </group>
+        <text macro="label-locator"/>
       </group>
-      <text variable="references"/>
-      <text macro="source-DOI-URL"/>
     </group>
   </macro>
   <!-- 6.1. Legal date -->
@@ -5745,30 +5734,29 @@
   </macro>
   <!-- Citation -->
   <macro name="citation-notes-full">
-    <choose>
-      <if match="any" type="bill hearing legal_case legislation regulation treaty">
-        <!-- Legal items have different orders and delimiters -->
-        <text macro="legal-reference"/>
-      </if>
-      <else-if type="personal_communication" variable="genre">
-        <group delimiter=", ">
+    <group delimiter=", ">
+      <choose>
+        <if match="any" type="bill hearing legal_case legislation regulation treaty">
+          <!-- Legal items have different orders and delimiters -->
+          <text macro="legal-reference"/>
+          <text macro="source-date-accessed-DOI-URL-note"/>
+        </if>
+        <else-if type="personal_communication" variable="genre">
           <text macro="author-note"/>
           <text macro="title-and-source-note"/>
-        </group>
-      </else-if>
-      <else-if type="personal_communication" variable="author recipient">
-        <group delimiter=" ">
+        </else-if>
+        <else-if type="personal_communication" variable="author recipient">
+          <group delimiter=" ">
+            <text macro="author-note"/>
+            <text macro="title-and-source-note"/>
+          </group>
+        </else-if>
+        <else>
           <text macro="author-note"/>
           <text macro="title-and-source-note"/>
-        </group>
-      </else-if>
-      <else>
-        <group delimiter=", ">
-          <text macro="author-note"/>
-          <text macro="title-and-source-note"/>
-        </group>
-      </else>
-    </choose>
+        </else>
+      </choose>
+    </group>
   </macro>
   <macro name="citation-notes-shortened-author-only">
     <choose>
@@ -5937,19 +5925,21 @@
   </citation>
   <!-- Bibliography -->
   <macro name="bibliography-notes">
-    <choose>
-      <if match="any" type="bill hearing legal_case legislation regulation treaty">
-        <!-- Legal items have different orders and delimiters -->
-        <text macro="legal-reference"/>
-      </if>
-      <else>
-        <group delimiter=". ">
+    <group delimiter=". ">
+      <choose>
+        <if match="any" type="bill hearing legal_case legislation regulation treaty">
+          <!-- Legal items have different orders and delimiters -->
+          <text macro="legal-reference"/>
+          <text macro="source-date-accessed-DOI-URL-bib"/>
+          <text variable="references"/>
+        </if>
+        <else>
           <text macro="author-bib"/>
           <text macro="title-and-source-bib"/>
-          <text macro="notes"/>
-        </group>
-      </else>
-    </choose>
+          <text variable="references"/>
+        </else>
+      </choose>
+    </group>
   </macro>
   <bibliography et-al-min="7" et-al-use-first="3" hanging-indent="true" subsequent-author-substitute="&#8212;&#8212;&#8212;">
     <sort>

--- a/chicago-notes-bibliography-subsequent-author-title-17th-edition.csl
+++ b/chicago-notes-bibliography-subsequent-author-title-17th-edition.csl
@@ -1219,7 +1219,7 @@
       </group>
       <text macro="source-medium-bib"/>
       <text macro="source-archive-bib"/>
-      <text macro="source-DOI-URL-bib"/>
+      <text macro="source-date-accessed-DOI-URL-bib"/>
     </group>
   </macro>
   <macro name="title-and-source-note">
@@ -1272,7 +1272,7 @@
       </choose>
       <text macro="source-medium-note"/>
       <text macro="source-archive-note"/>
-      <text macro="source-DOI-URL-note"/>
+      <text macro="source-date-accessed-DOI-URL-note"/>
     </group>
   </macro>
   <!-- 3.1. Title -->
@@ -5376,55 +5376,48 @@
     </group>
   </macro>
   <!-- 4.10. URL or persistent identifier -->
-  <macro name="source-DOI-URL-bib">
-    <choose>
-      <if variable="DOI">
-        <text prefix="https://doi.org/" variable="DOI"/>
-      </if>
-      <else-if variable="URL">
-        <group delimiter=". ">
-          <choose>
-            <if match="none" variable="available-date event-date issued status">
-              <group delimiter=" ">
-                <text term="accessed" text-case="capitalize-first"/>
-                <date form="text" variable="accessed"/>
-              </group>
-            </if>
-          </choose>
-          <text variable="URL"/>
-        </group>
-      </else-if>
-    </choose>
+  <macro name="source-date-accessed-DOI-URL-bib">
+    <group delimiter=", ">
+      <choose>
+        <if variable="DOI"/>
+        <else-if match="any" variable="available-date event-date issued status"/>
+        <else-if variable="accessed URL">
+          <group delimiter=" ">
+            <text term="accessed" text-case="capitalize-first"/>
+            <date form="text" variable="accessed"/>
+          </group>
+        </else-if>
+      </choose>
+      <text macro="source-DOI-URL"/>
+    </group>
   </macro>
-  <macro name="source-DOI-URL-note">
-    <choose>
-      <if variable="DOI">
-        <text prefix="https://doi.org/" variable="DOI"/>
-      </if>
-      <else-if variable="URL">
-        <group delimiter=", ">
-          <choose>
-            <if match="none" variable="available-date event-date issued status">
-              <group delimiter=" ">
-                <text term="accessed"/>
-                <date form="text" variable="accessed"/>
-              </group>
-            </if>
-          </choose>
-          <text variable="URL"/>
-        </group>
-      </else-if>
-    </choose>
+  <macro name="source-date-accessed-DOI-URL-note">
+    <group delimiter=", ">
+      <choose>
+        <if variable="DOI"/>
+        <else-if match="any" variable="available-date event-date issued status"/>
+        <else-if variable="URL">
+          <group delimiter=" ">
+            <text term="accessed"/>
+            <date form="text" variable="accessed"/>
+          </group>
+        </else-if>
+      </choose>
+      <text macro="source-DOI-URL"/>
+    </group>
   </macro>
   <macro name="source-DOI-URL">
-    <!-- Alias to avoid modifying legal references block shared with APA -->
-    <text macro="source-DOI-URL-bib"/>
+    <choose>
+      <if variable="DOI">
+        <text prefix="https://doi.org/" variable="DOI"/>
+      </if>
+      <else-if variable="URL">
+        <text variable="URL"/>
+      </else-if>
+    </choose>
   </macro>
   <!-- 5. Notes -->
-  <macro name="notes">
-    <!-- Notes on source element: original publication, reprint info, retraction info -->
-    <text variable="references"/>
-  </macro>
+  <!-- TODO: add variables for distributor and exhibitions if available in CSL -->
   <!-- 6. Legal references: Bluebook style (shared with APA) -->
   <!-- Where APA or Chicago diverge from Bluebook, the official manual is followed -->
   <macro name="legal-reference">
@@ -5448,42 +5441,38 @@
          `treaty`
          : treaties
     -->
-    <group delimiter=" ">
-      <group delimiter=", " suffix=".">
-        <choose>
-          <if type="treaty">
-            <text macro="legal-title"/>
-            <names variable="author">
-              <!-- Treaty parties should be included at least for bilateral treaties (Bluebook 21.4.2) -->
-              <name delimiter="-" et-al-min="100" et-al-use-first="99" form="short"/>
-            </names>
-            <text macro="legal-date"/>
-            <!-- treaty source/report in addition to URL (Bluebook 21.4.5) -->
-            <text macro="legal-source"/>
-          </if>
-          <else>
-            <group delimiter=" ">
-              <group delimiter=", ">
-                <text macro="legal-title"/>
-                <text macro="legal-source"/>
-              </group>
-              <text macro="legal-date"/>
-              <text macro="legal-identifier"/>
+    <group delimiter=", ">
+      <choose>
+        <if type="treaty">
+          <text macro="legal-title"/>
+          <names variable="author">
+            <!-- Treaty parties should be included at least for bilateral treaties (Bluebook 21.4.2) -->
+            <name delimiter="-" et-al-min="100" et-al-use-first="99" form="short"/>
+          </names>
+          <text macro="legal-date"/>
+          <!-- treaty source/report in addition to URL (Bluebook 21.4.5) -->
+          <text macro="legal-source"/>
+        </if>
+        <else>
+          <group delimiter=" ">
+            <group delimiter=", ">
+              <text macro="legal-title"/>
+              <text macro="legal-source"/>
             </group>
-          </else>
+            <text macro="legal-date"/>
+            <text macro="legal-identifier"/>
+          </group>
+        </else>
+      </choose>
+      <group delimiter=" ">
+        <!-- locator for use in notes -->
+        <choose>
+          <if locator="page" variable="page">
+            <text term="at"/>
+          </if>
         </choose>
-        <group delimiter=" ">
-          <!-- locator for use in notes -->
-          <choose>
-            <if locator="page" variable="page">
-              <text term="at"/>
-            </if>
-          </choose>
-          <text macro="label-locator"/>
-        </group>
+        <text macro="label-locator"/>
       </group>
-      <text variable="references"/>
-      <text macro="source-DOI-URL"/>
     </group>
   </macro>
   <!-- 6.1. Legal date -->
@@ -5734,30 +5723,29 @@
   </macro>
   <!-- Citation -->
   <macro name="citation-notes-full">
-    <choose>
-      <if match="any" type="bill hearing legal_case legislation regulation treaty">
-        <!-- Legal items have different orders and delimiters -->
-        <text macro="legal-reference"/>
-      </if>
-      <else-if type="personal_communication" variable="genre">
-        <group delimiter=", ">
+    <group delimiter=", ">
+      <choose>
+        <if match="any" type="bill hearing legal_case legislation regulation treaty">
+          <!-- Legal items have different orders and delimiters -->
+          <text macro="legal-reference"/>
+          <text macro="source-date-accessed-DOI-URL-note"/>
+        </if>
+        <else-if type="personal_communication" variable="genre">
           <text macro="author-note"/>
           <text macro="title-and-source-note"/>
-        </group>
-      </else-if>
-      <else-if type="personal_communication" variable="author recipient">
-        <group delimiter=" ">
+        </else-if>
+        <else-if type="personal_communication" variable="author recipient">
+          <group delimiter=" ">
+            <text macro="author-note"/>
+            <text macro="title-and-source-note"/>
+          </group>
+        </else-if>
+        <else>
           <text macro="author-note"/>
           <text macro="title-and-source-note"/>
-        </group>
-      </else-if>
-      <else>
-        <group delimiter=", ">
-          <text macro="author-note"/>
-          <text macro="title-and-source-note"/>
-        </group>
-      </else>
-    </choose>
+        </else>
+      </choose>
+    </group>
   </macro>
   <macro name="citation-notes-shortened-author-title">
     <!-- Shortened note styles mirror the filtering approach of author-date -->
@@ -5856,19 +5844,21 @@
   </citation>
   <!-- Bibliography -->
   <macro name="bibliography-notes">
-    <choose>
-      <if match="any" type="bill hearing legal_case legislation regulation treaty">
-        <!-- Legal items have different orders and delimiters -->
-        <text macro="legal-reference"/>
-      </if>
-      <else>
-        <group delimiter=". ">
+    <group delimiter=". ">
+      <choose>
+        <if match="any" type="bill hearing legal_case legislation regulation treaty">
+          <!-- Legal items have different orders and delimiters -->
+          <text macro="legal-reference"/>
+          <text macro="source-date-accessed-DOI-URL-bib"/>
+          <text variable="references"/>
+        </if>
+        <else>
           <text macro="author-bib"/>
           <text macro="title-and-source-bib"/>
-          <text macro="notes"/>
-        </group>
-      </else>
-    </choose>
+          <text variable="references"/>
+        </else>
+      </choose>
+    </group>
   </macro>
   <bibliography et-al-min="11" et-al-use-first="7" hanging-indent="true" subsequent-author-substitute="&#8212;&#8212;&#8212;">
     <sort>

--- a/chicago-notes-bibliography-subsequent-author.csl
+++ b/chicago-notes-bibliography-subsequent-author.csl
@@ -1221,7 +1221,7 @@
       </group>
       <text macro="source-medium-bib"/>
       <text macro="source-archive-bib"/>
-      <text macro="source-DOI-URL-bib"/>
+      <text macro="source-date-accessed-DOI-URL-bib"/>
     </group>
   </macro>
   <macro name="title-and-source-note">
@@ -1274,7 +1274,7 @@
       </choose>
       <text macro="source-medium-note"/>
       <text macro="source-archive-note"/>
-      <text macro="source-DOI-URL-note"/>
+      <text macro="source-date-accessed-DOI-URL-note"/>
     </group>
   </macro>
   <!-- 3.1. Title -->
@@ -5396,55 +5396,48 @@
     </group>
   </macro>
   <!-- 4.10. URL or persistent identifier -->
-  <macro name="source-DOI-URL-bib">
-    <choose>
-      <if variable="DOI">
-        <text prefix="https://doi.org/" variable="DOI"/>
-      </if>
-      <else-if variable="URL">
-        <group delimiter=". ">
-          <choose>
-            <if match="none" variable="available-date event-date issued status">
-              <group delimiter=" ">
-                <text term="accessed" text-case="capitalize-first"/>
-                <date form="text" variable="accessed"/>
-              </group>
-            </if>
-          </choose>
-          <text variable="URL"/>
-        </group>
-      </else-if>
-    </choose>
+  <macro name="source-date-accessed-DOI-URL-bib">
+    <group delimiter=", ">
+      <choose>
+        <if variable="DOI"/>
+        <else-if match="any" variable="available-date event-date issued status"/>
+        <else-if variable="accessed URL">
+          <group delimiter=" ">
+            <text term="accessed" text-case="capitalize-first"/>
+            <date form="text" variable="accessed"/>
+          </group>
+        </else-if>
+      </choose>
+      <text macro="source-DOI-URL"/>
+    </group>
   </macro>
-  <macro name="source-DOI-URL-note">
-    <choose>
-      <if variable="DOI">
-        <text prefix="https://doi.org/" variable="DOI"/>
-      </if>
-      <else-if variable="URL">
-        <group delimiter=", ">
-          <choose>
-            <if match="none" variable="available-date event-date issued status">
-              <group delimiter=" ">
-                <text term="accessed"/>
-                <date form="text" variable="accessed"/>
-              </group>
-            </if>
-          </choose>
-          <text variable="URL"/>
-        </group>
-      </else-if>
-    </choose>
+  <macro name="source-date-accessed-DOI-URL-note">
+    <group delimiter=", ">
+      <choose>
+        <if variable="DOI"/>
+        <else-if match="any" variable="available-date event-date issued status"/>
+        <else-if variable="URL">
+          <group delimiter=" ">
+            <text term="accessed"/>
+            <date form="text" variable="accessed"/>
+          </group>
+        </else-if>
+      </choose>
+      <text macro="source-DOI-URL"/>
+    </group>
   </macro>
   <macro name="source-DOI-URL">
-    <!-- Alias to avoid modifying legal references block shared with APA -->
-    <text macro="source-DOI-URL-bib"/>
+    <choose>
+      <if variable="DOI">
+        <text prefix="https://doi.org/" variable="DOI"/>
+      </if>
+      <else-if variable="URL">
+        <text variable="URL"/>
+      </else-if>
+    </choose>
   </macro>
   <!-- 5. Notes -->
-  <macro name="notes">
-    <!-- Notes on source element: original publication, reprint info, retraction info -->
-    <text variable="references"/>
-  </macro>
+  <!-- TODO: add variables for distributor and exhibitions if available in CSL -->
   <!-- 6. Legal references: Bluebook style (shared with APA) -->
   <!-- Where APA or Chicago diverge from Bluebook, the official manual is followed -->
   <macro name="legal-reference">
@@ -5468,42 +5461,38 @@
          `treaty`
          : treaties
     -->
-    <group delimiter=" ">
-      <group delimiter=", " suffix=".">
-        <choose>
-          <if type="treaty">
-            <text macro="legal-title"/>
-            <names variable="author">
-              <!-- Treaty parties should be included at least for bilateral treaties (Bluebook 21.4.2) -->
-              <name delimiter="-" et-al-min="100" et-al-use-first="99" form="short"/>
-            </names>
-            <text macro="legal-date"/>
-            <!-- treaty source/report in addition to URL (Bluebook 21.4.5) -->
-            <text macro="legal-source"/>
-          </if>
-          <else>
-            <group delimiter=" ">
-              <group delimiter=", ">
-                <text macro="legal-title"/>
-                <text macro="legal-source"/>
-              </group>
-              <text macro="legal-date"/>
-              <text macro="legal-identifier"/>
+    <group delimiter=", ">
+      <choose>
+        <if type="treaty">
+          <text macro="legal-title"/>
+          <names variable="author">
+            <!-- Treaty parties should be included at least for bilateral treaties (Bluebook 21.4.2) -->
+            <name delimiter="-" et-al-min="100" et-al-use-first="99" form="short"/>
+          </names>
+          <text macro="legal-date"/>
+          <!-- treaty source/report in addition to URL (Bluebook 21.4.5) -->
+          <text macro="legal-source"/>
+        </if>
+        <else>
+          <group delimiter=" ">
+            <group delimiter=", ">
+              <text macro="legal-title"/>
+              <text macro="legal-source"/>
             </group>
-          </else>
+            <text macro="legal-date"/>
+            <text macro="legal-identifier"/>
+          </group>
+        </else>
+      </choose>
+      <group delimiter=" ">
+        <!-- locator for use in notes -->
+        <choose>
+          <if locator="page" variable="page">
+            <text term="at"/>
+          </if>
         </choose>
-        <group delimiter=" ">
-          <!-- locator for use in notes -->
-          <choose>
-            <if locator="page" variable="page">
-              <text term="at"/>
-            </if>
-          </choose>
-          <text macro="label-locator"/>
-        </group>
+        <text macro="label-locator"/>
       </group>
-      <text variable="references"/>
-      <text macro="source-DOI-URL"/>
     </group>
   </macro>
   <!-- 6.1. Legal date -->
@@ -5754,30 +5743,29 @@
   </macro>
   <!-- Citation -->
   <macro name="citation-notes-full">
-    <choose>
-      <if match="any" type="bill hearing legal_case legislation regulation treaty">
-        <!-- Legal items have different orders and delimiters -->
-        <text macro="legal-reference"/>
-      </if>
-      <else-if type="personal_communication" variable="genre">
-        <group delimiter=", ">
+    <group delimiter=", ">
+      <choose>
+        <if match="any" type="bill hearing legal_case legislation regulation treaty">
+          <!-- Legal items have different orders and delimiters -->
+          <text macro="legal-reference"/>
+          <text macro="source-date-accessed-DOI-URL-note"/>
+        </if>
+        <else-if type="personal_communication" variable="genre">
           <text macro="author-note"/>
           <text macro="title-and-source-note"/>
-        </group>
-      </else-if>
-      <else-if type="personal_communication" variable="author recipient">
-        <group delimiter=" ">
+        </else-if>
+        <else-if type="personal_communication" variable="author recipient">
+          <group delimiter=" ">
+            <text macro="author-note"/>
+            <text macro="title-and-source-note"/>
+          </group>
+        </else-if>
+        <else>
           <text macro="author-note"/>
           <text macro="title-and-source-note"/>
-        </group>
-      </else-if>
-      <else>
-        <group delimiter=", ">
-          <text macro="author-note"/>
-          <text macro="title-and-source-note"/>
-        </group>
-      </else>
-    </choose>
+        </else>
+      </choose>
+    </group>
   </macro>
   <macro name="citation-notes-shortened-author-only">
     <choose>
@@ -5946,19 +5934,21 @@
   </citation>
   <!-- Bibliography -->
   <macro name="bibliography-notes">
-    <choose>
-      <if match="any" type="bill hearing legal_case legislation regulation treaty">
-        <!-- Legal items have different orders and delimiters -->
-        <text macro="legal-reference"/>
-      </if>
-      <else>
-        <group delimiter=". ">
+    <group delimiter=". ">
+      <choose>
+        <if match="any" type="bill hearing legal_case legislation regulation treaty">
+          <!-- Legal items have different orders and delimiters -->
+          <text macro="legal-reference"/>
+          <text macro="source-date-accessed-DOI-URL-bib"/>
+          <text variable="references"/>
+        </if>
+        <else>
           <text macro="author-bib"/>
           <text macro="title-and-source-bib"/>
-          <text macro="notes"/>
-        </group>
-      </else>
-    </choose>
+          <text variable="references"/>
+        </else>
+      </choose>
+    </group>
   </macro>
   <bibliography et-al-min="7" et-al-use-first="3" hanging-indent="true">
     <sort>

--- a/chicago-notes-bibliography-subsequent-ibid-17th-edition.csl
+++ b/chicago-notes-bibliography-subsequent-ibid-17th-edition.csl
@@ -1219,7 +1219,7 @@
       </group>
       <text macro="source-medium-bib"/>
       <text macro="source-archive-bib"/>
-      <text macro="source-DOI-URL-bib"/>
+      <text macro="source-date-accessed-DOI-URL-bib"/>
     </group>
   </macro>
   <macro name="title-and-source-note">
@@ -1272,7 +1272,7 @@
       </choose>
       <text macro="source-medium-note"/>
       <text macro="source-archive-note"/>
-      <text macro="source-DOI-URL-note"/>
+      <text macro="source-date-accessed-DOI-URL-note"/>
     </group>
   </macro>
   <!-- 3.1. Title -->
@@ -5376,55 +5376,48 @@
     </group>
   </macro>
   <!-- 4.10. URL or persistent identifier -->
-  <macro name="source-DOI-URL-bib">
-    <choose>
-      <if variable="DOI">
-        <text prefix="https://doi.org/" variable="DOI"/>
-      </if>
-      <else-if variable="URL">
-        <group delimiter=". ">
-          <choose>
-            <if match="none" variable="available-date event-date issued status">
-              <group delimiter=" ">
-                <text term="accessed" text-case="capitalize-first"/>
-                <date form="text" variable="accessed"/>
-              </group>
-            </if>
-          </choose>
-          <text variable="URL"/>
-        </group>
-      </else-if>
-    </choose>
+  <macro name="source-date-accessed-DOI-URL-bib">
+    <group delimiter=", ">
+      <choose>
+        <if variable="DOI"/>
+        <else-if match="any" variable="available-date event-date issued status"/>
+        <else-if variable="accessed URL">
+          <group delimiter=" ">
+            <text term="accessed" text-case="capitalize-first"/>
+            <date form="text" variable="accessed"/>
+          </group>
+        </else-if>
+      </choose>
+      <text macro="source-DOI-URL"/>
+    </group>
   </macro>
-  <macro name="source-DOI-URL-note">
-    <choose>
-      <if variable="DOI">
-        <text prefix="https://doi.org/" variable="DOI"/>
-      </if>
-      <else-if variable="URL">
-        <group delimiter=", ">
-          <choose>
-            <if match="none" variable="available-date event-date issued status">
-              <group delimiter=" ">
-                <text term="accessed"/>
-                <date form="text" variable="accessed"/>
-              </group>
-            </if>
-          </choose>
-          <text variable="URL"/>
-        </group>
-      </else-if>
-    </choose>
+  <macro name="source-date-accessed-DOI-URL-note">
+    <group delimiter=", ">
+      <choose>
+        <if variable="DOI"/>
+        <else-if match="any" variable="available-date event-date issued status"/>
+        <else-if variable="URL">
+          <group delimiter=" ">
+            <text term="accessed"/>
+            <date form="text" variable="accessed"/>
+          </group>
+        </else-if>
+      </choose>
+      <text macro="source-DOI-URL"/>
+    </group>
   </macro>
   <macro name="source-DOI-URL">
-    <!-- Alias to avoid modifying legal references block shared with APA -->
-    <text macro="source-DOI-URL-bib"/>
+    <choose>
+      <if variable="DOI">
+        <text prefix="https://doi.org/" variable="DOI"/>
+      </if>
+      <else-if variable="URL">
+        <text variable="URL"/>
+      </else-if>
+    </choose>
   </macro>
   <!-- 5. Notes -->
-  <macro name="notes">
-    <!-- Notes on source element: original publication, reprint info, retraction info -->
-    <text variable="references"/>
-  </macro>
+  <!-- TODO: add variables for distributor and exhibitions if available in CSL -->
   <!-- 6. Legal references: Bluebook style (shared with APA) -->
   <!-- Where APA or Chicago diverge from Bluebook, the official manual is followed -->
   <macro name="legal-reference">
@@ -5448,42 +5441,38 @@
          `treaty`
          : treaties
     -->
-    <group delimiter=" ">
-      <group delimiter=", " suffix=".">
-        <choose>
-          <if type="treaty">
-            <text macro="legal-title"/>
-            <names variable="author">
-              <!-- Treaty parties should be included at least for bilateral treaties (Bluebook 21.4.2) -->
-              <name delimiter="-" et-al-min="100" et-al-use-first="99" form="short"/>
-            </names>
-            <text macro="legal-date"/>
-            <!-- treaty source/report in addition to URL (Bluebook 21.4.5) -->
-            <text macro="legal-source"/>
-          </if>
-          <else>
-            <group delimiter=" ">
-              <group delimiter=", ">
-                <text macro="legal-title"/>
-                <text macro="legal-source"/>
-              </group>
-              <text macro="legal-date"/>
-              <text macro="legal-identifier"/>
+    <group delimiter=", ">
+      <choose>
+        <if type="treaty">
+          <text macro="legal-title"/>
+          <names variable="author">
+            <!-- Treaty parties should be included at least for bilateral treaties (Bluebook 21.4.2) -->
+            <name delimiter="-" et-al-min="100" et-al-use-first="99" form="short"/>
+          </names>
+          <text macro="legal-date"/>
+          <!-- treaty source/report in addition to URL (Bluebook 21.4.5) -->
+          <text macro="legal-source"/>
+        </if>
+        <else>
+          <group delimiter=" ">
+            <group delimiter=", ">
+              <text macro="legal-title"/>
+              <text macro="legal-source"/>
             </group>
-          </else>
+            <text macro="legal-date"/>
+            <text macro="legal-identifier"/>
+          </group>
+        </else>
+      </choose>
+      <group delimiter=" ">
+        <!-- locator for use in notes -->
+        <choose>
+          <if locator="page" variable="page">
+            <text term="at"/>
+          </if>
         </choose>
-        <group delimiter=" ">
-          <!-- locator for use in notes -->
-          <choose>
-            <if locator="page" variable="page">
-              <text term="at"/>
-            </if>
-          </choose>
-          <text macro="label-locator"/>
-        </group>
+        <text macro="label-locator"/>
       </group>
-      <text variable="references"/>
-      <text macro="source-DOI-URL"/>
     </group>
   </macro>
   <!-- 6.1. Legal date -->
@@ -5734,30 +5723,29 @@
   </macro>
   <!-- Citation -->
   <macro name="citation-notes-full">
-    <choose>
-      <if match="any" type="bill hearing legal_case legislation regulation treaty">
-        <!-- Legal items have different orders and delimiters -->
-        <text macro="legal-reference"/>
-      </if>
-      <else-if type="personal_communication" variable="genre">
-        <group delimiter=", ">
+    <group delimiter=", ">
+      <choose>
+        <if match="any" type="bill hearing legal_case legislation regulation treaty">
+          <!-- Legal items have different orders and delimiters -->
+          <text macro="legal-reference"/>
+          <text macro="source-date-accessed-DOI-URL-note"/>
+        </if>
+        <else-if type="personal_communication" variable="genre">
           <text macro="author-note"/>
           <text macro="title-and-source-note"/>
-        </group>
-      </else-if>
-      <else-if type="personal_communication" variable="author recipient">
-        <group delimiter=" ">
+        </else-if>
+        <else-if type="personal_communication" variable="author recipient">
+          <group delimiter=" ">
+            <text macro="author-note"/>
+            <text macro="title-and-source-note"/>
+          </group>
+        </else-if>
+        <else>
           <text macro="author-note"/>
           <text macro="title-and-source-note"/>
-        </group>
-      </else-if>
-      <else>
-        <group delimiter=", ">
-          <text macro="author-note"/>
-          <text macro="title-and-source-note"/>
-        </group>
-      </else>
-    </choose>
+        </else>
+      </choose>
+    </group>
   </macro>
   <macro name="citation-notes-shortened-author-title">
     <!-- Shortened note styles mirror the filtering approach of author-date -->
@@ -5868,19 +5856,21 @@
   </citation>
   <!-- Bibliography -->
   <macro name="bibliography-notes">
-    <choose>
-      <if match="any" type="bill hearing legal_case legislation regulation treaty">
-        <!-- Legal items have different orders and delimiters -->
-        <text macro="legal-reference"/>
-      </if>
-      <else>
-        <group delimiter=". ">
+    <group delimiter=". ">
+      <choose>
+        <if match="any" type="bill hearing legal_case legislation regulation treaty">
+          <!-- Legal items have different orders and delimiters -->
+          <text macro="legal-reference"/>
+          <text macro="source-date-accessed-DOI-URL-bib"/>
+          <text variable="references"/>
+        </if>
+        <else>
           <text macro="author-bib"/>
           <text macro="title-and-source-bib"/>
-          <text macro="notes"/>
-        </group>
-      </else>
-    </choose>
+          <text variable="references"/>
+        </else>
+      </choose>
+    </group>
   </macro>
   <bibliography et-al-min="11" et-al-use-first="7" hanging-indent="true" subsequent-author-substitute="&#8212;&#8212;&#8212;">
     <sort>

--- a/chicago-notes-bibliography-subsequent-ibid-classic-no-url.csl
+++ b/chicago-notes-bibliography-subsequent-ibid-classic-no-url.csl
@@ -1222,7 +1222,7 @@
       </group>
       <text macro="source-medium-bib"/>
       <text macro="source-archive-bib"/>
-      <!-- <text macro="source-DOI-URL-bib"/> -->
+      <text macro="source-date-accessed-DOI-URL-bib"/>
     </group>
   </macro>
   <macro name="title-and-source-note">
@@ -1275,7 +1275,7 @@
       </choose>
       <text macro="source-medium-note"/>
       <text macro="source-archive-note"/>
-      <!-- <text macro="source-DOI-URL-note"/> -->
+      <text macro="source-date-accessed-DOI-URL-note"/>
     </group>
   </macro>
   <!-- 3.1. Title -->
@@ -5387,11 +5387,38 @@
     </group>
   </macro>
   <!-- 4.10. URL or persistent identifier -->
-  <!-- 5. Notes -->
-  <macro name="notes">
-    <!-- Notes on source element: original publication, reprint info, retraction info -->
-    <text variable="references"/>
+  <macro name="source-date-accessed-DOI-URL-bib">
+    <group delimiter=", ">
+      <choose>
+        <if variable="DOI"/>
+        <else-if match="any" variable="available-date event-date issued status"/>
+        <else-if variable="accessed URL">
+          <group delimiter=" ">
+            <text term="accessed" text-case="capitalize-first"/>
+            <date form="text" variable="accessed"/>
+          </group>
+        </else-if>
+      </choose>
+      <!-- <text macro="source-DOI-URL"/> -->
+    </group>
   </macro>
+  <macro name="source-date-accessed-DOI-URL-note">
+    <group delimiter=", ">
+      <choose>
+        <if variable="DOI"/>
+        <else-if match="any" variable="available-date event-date issued status"/>
+        <else-if variable="URL">
+          <group delimiter=" ">
+            <text term="accessed"/>
+            <date form="text" variable="accessed"/>
+          </group>
+        </else-if>
+      </choose>
+      <!-- <text macro="source-DOI-URL"/> -->
+    </group>
+  </macro>
+  <!-- 5. Notes -->
+  <!-- TODO: add variables for distributor and exhibitions if available in CSL -->
   <!-- 6. Legal references: Bluebook style (shared with APA) -->
   <!-- Where APA or Chicago diverge from Bluebook, the official manual is followed -->
   <macro name="legal-reference">
@@ -5415,42 +5442,38 @@
          `treaty`
          : treaties
     -->
-    <group delimiter=" ">
-      <group delimiter=", " suffix=".">
-        <choose>
-          <if type="treaty">
-            <text macro="legal-title"/>
-            <names variable="author">
-              <!-- Treaty parties should be included at least for bilateral treaties (Bluebook 21.4.2) -->
-              <name delimiter="-" et-al-min="100" et-al-use-first="99" form="short"/>
-            </names>
-            <text macro="legal-date"/>
-            <!-- treaty source/report in addition to URL (Bluebook 21.4.5) -->
-            <text macro="legal-source"/>
-          </if>
-          <else>
-            <group delimiter=" ">
-              <group delimiter=", ">
-                <text macro="legal-title"/>
-                <text macro="legal-source"/>
-              </group>
-              <text macro="legal-date"/>
-              <text macro="legal-identifier"/>
+    <group delimiter=", ">
+      <choose>
+        <if type="treaty">
+          <text macro="legal-title"/>
+          <names variable="author">
+            <!-- Treaty parties should be included at least for bilateral treaties (Bluebook 21.4.2) -->
+            <name delimiter="-" et-al-min="100" et-al-use-first="99" form="short"/>
+          </names>
+          <text macro="legal-date"/>
+          <!-- treaty source/report in addition to URL (Bluebook 21.4.5) -->
+          <text macro="legal-source"/>
+        </if>
+        <else>
+          <group delimiter=" ">
+            <group delimiter=", ">
+              <text macro="legal-title"/>
+              <text macro="legal-source"/>
             </group>
-          </else>
+            <text macro="legal-date"/>
+            <text macro="legal-identifier"/>
+          </group>
+        </else>
+      </choose>
+      <group delimiter=" ">
+        <!-- locator for use in notes -->
+        <choose>
+          <if locator="page" variable="page">
+            <text term="at"/>
+          </if>
         </choose>
-        <group delimiter=" ">
-          <!-- locator for use in notes -->
-          <choose>
-            <if locator="page" variable="page">
-              <text term="at"/>
-            </if>
-          </choose>
-          <text macro="label-locator"/>
-        </group>
+        <text macro="label-locator"/>
       </group>
-      <text variable="references"/>
-      <!-- <text macro="source-DOI-URL"/> -->
     </group>
   </macro>
   <!-- 6.1. Legal date -->
@@ -5701,30 +5724,29 @@
   </macro>
   <!-- Citation -->
   <macro name="citation-notes-full">
-    <choose>
-      <if match="any" type="bill hearing legal_case legislation regulation treaty">
-        <!-- Legal items have different orders and delimiters -->
-        <text macro="legal-reference"/>
-      </if>
-      <else-if type="personal_communication" variable="genre">
-        <group delimiter=", ">
+    <group delimiter=", ">
+      <choose>
+        <if match="any" type="bill hearing legal_case legislation regulation treaty">
+          <!-- Legal items have different orders and delimiters -->
+          <text macro="legal-reference"/>
+          <text macro="source-date-accessed-DOI-URL-note"/>
+        </if>
+        <else-if type="personal_communication" variable="genre">
           <text macro="author-note"/>
           <text macro="title-and-source-note"/>
-        </group>
-      </else-if>
-      <else-if type="personal_communication" variable="author recipient">
-        <group delimiter=" ">
+        </else-if>
+        <else-if type="personal_communication" variable="author recipient">
+          <group delimiter=" ">
+            <text macro="author-note"/>
+            <text macro="title-and-source-note"/>
+          </group>
+        </else-if>
+        <else>
           <text macro="author-note"/>
           <text macro="title-and-source-note"/>
-        </group>
-      </else-if>
-      <else>
-        <group delimiter=", ">
-          <text macro="author-note"/>
-          <text macro="title-and-source-note"/>
-        </group>
-      </else>
-    </choose>
+        </else>
+      </choose>
+    </group>
   </macro>
   <macro name="citation-notes-shortened-author-title">
     <!-- Shortened note styles mirror the filtering approach of author-date -->
@@ -5835,19 +5857,21 @@
   </citation>
   <!-- Bibliography -->
   <macro name="bibliography-notes">
-    <choose>
-      <if match="any" type="bill hearing legal_case legislation regulation treaty">
-        <!-- Legal items have different orders and delimiters -->
-        <text macro="legal-reference"/>
-      </if>
-      <else>
-        <group delimiter=". ">
+    <group delimiter=". ">
+      <choose>
+        <if match="any" type="bill hearing legal_case legislation regulation treaty">
+          <!-- Legal items have different orders and delimiters -->
+          <text macro="legal-reference"/>
+          <text macro="source-date-accessed-DOI-URL-bib"/>
+          <text variable="references"/>
+        </if>
+        <else>
           <text macro="author-bib"/>
           <text macro="title-and-source-bib"/>
-          <text macro="notes"/>
-        </group>
-      </else>
-    </choose>
+          <text variable="references"/>
+        </else>
+      </choose>
+    </group>
   </macro>
   <bibliography et-al-min="7" et-al-use-first="3" hanging-indent="true" subsequent-author-substitute="&#8212;&#8212;&#8212;">
     <sort>

--- a/chicago-notes-bibliography-subsequent-ibid-classic.csl
+++ b/chicago-notes-bibliography-subsequent-ibid-classic.csl
@@ -1222,7 +1222,7 @@
       </group>
       <text macro="source-medium-bib"/>
       <text macro="source-archive-bib"/>
-      <text macro="source-DOI-URL-bib"/>
+      <text macro="source-date-accessed-DOI-URL-bib"/>
     </group>
   </macro>
   <macro name="title-and-source-note">
@@ -1275,7 +1275,7 @@
       </choose>
       <text macro="source-medium-note"/>
       <text macro="source-archive-note"/>
-      <text macro="source-DOI-URL-note"/>
+      <text macro="source-date-accessed-DOI-URL-note"/>
     </group>
   </macro>
   <!-- 3.1. Title -->
@@ -5387,55 +5387,48 @@
     </group>
   </macro>
   <!-- 4.10. URL or persistent identifier -->
-  <macro name="source-DOI-URL-bib">
-    <choose>
-      <if variable="DOI">
-        <text prefix="https://doi.org/" variable="DOI"/>
-      </if>
-      <else-if variable="URL">
-        <group delimiter=". ">
-          <choose>
-            <if match="none" variable="available-date event-date issued status">
-              <group delimiter=" ">
-                <text term="accessed" text-case="capitalize-first"/>
-                <date form="text" variable="accessed"/>
-              </group>
-            </if>
-          </choose>
-          <text variable="URL"/>
-        </group>
-      </else-if>
-    </choose>
+  <macro name="source-date-accessed-DOI-URL-bib">
+    <group delimiter=", ">
+      <choose>
+        <if variable="DOI"/>
+        <else-if match="any" variable="available-date event-date issued status"/>
+        <else-if variable="accessed URL">
+          <group delimiter=" ">
+            <text term="accessed" text-case="capitalize-first"/>
+            <date form="text" variable="accessed"/>
+          </group>
+        </else-if>
+      </choose>
+      <text macro="source-DOI-URL"/>
+    </group>
   </macro>
-  <macro name="source-DOI-URL-note">
-    <choose>
-      <if variable="DOI">
-        <text prefix="https://doi.org/" variable="DOI"/>
-      </if>
-      <else-if variable="URL">
-        <group delimiter=", ">
-          <choose>
-            <if match="none" variable="available-date event-date issued status">
-              <group delimiter=" ">
-                <text term="accessed"/>
-                <date form="text" variable="accessed"/>
-              </group>
-            </if>
-          </choose>
-          <text variable="URL"/>
-        </group>
-      </else-if>
-    </choose>
+  <macro name="source-date-accessed-DOI-URL-note">
+    <group delimiter=", ">
+      <choose>
+        <if variable="DOI"/>
+        <else-if match="any" variable="available-date event-date issued status"/>
+        <else-if variable="URL">
+          <group delimiter=" ">
+            <text term="accessed"/>
+            <date form="text" variable="accessed"/>
+          </group>
+        </else-if>
+      </choose>
+      <text macro="source-DOI-URL"/>
+    </group>
   </macro>
   <macro name="source-DOI-URL">
-    <!-- Alias to avoid modifying legal references block shared with APA -->
-    <text macro="source-DOI-URL-bib"/>
+    <choose>
+      <if variable="DOI">
+        <text prefix="https://doi.org/" variable="DOI"/>
+      </if>
+      <else-if variable="URL">
+        <text variable="URL"/>
+      </else-if>
+    </choose>
   </macro>
   <!-- 5. Notes -->
-  <macro name="notes">
-    <!-- Notes on source element: original publication, reprint info, retraction info -->
-    <text variable="references"/>
-  </macro>
+  <!-- TODO: add variables for distributor and exhibitions if available in CSL -->
   <!-- 6. Legal references: Bluebook style (shared with APA) -->
   <!-- Where APA or Chicago diverge from Bluebook, the official manual is followed -->
   <macro name="legal-reference">
@@ -5459,42 +5452,38 @@
          `treaty`
          : treaties
     -->
-    <group delimiter=" ">
-      <group delimiter=", " suffix=".">
-        <choose>
-          <if type="treaty">
-            <text macro="legal-title"/>
-            <names variable="author">
-              <!-- Treaty parties should be included at least for bilateral treaties (Bluebook 21.4.2) -->
-              <name delimiter="-" et-al-min="100" et-al-use-first="99" form="short"/>
-            </names>
-            <text macro="legal-date"/>
-            <!-- treaty source/report in addition to URL (Bluebook 21.4.5) -->
-            <text macro="legal-source"/>
-          </if>
-          <else>
-            <group delimiter=" ">
-              <group delimiter=", ">
-                <text macro="legal-title"/>
-                <text macro="legal-source"/>
-              </group>
-              <text macro="legal-date"/>
-              <text macro="legal-identifier"/>
+    <group delimiter=", ">
+      <choose>
+        <if type="treaty">
+          <text macro="legal-title"/>
+          <names variable="author">
+            <!-- Treaty parties should be included at least for bilateral treaties (Bluebook 21.4.2) -->
+            <name delimiter="-" et-al-min="100" et-al-use-first="99" form="short"/>
+          </names>
+          <text macro="legal-date"/>
+          <!-- treaty source/report in addition to URL (Bluebook 21.4.5) -->
+          <text macro="legal-source"/>
+        </if>
+        <else>
+          <group delimiter=" ">
+            <group delimiter=", ">
+              <text macro="legal-title"/>
+              <text macro="legal-source"/>
             </group>
-          </else>
+            <text macro="legal-date"/>
+            <text macro="legal-identifier"/>
+          </group>
+        </else>
+      </choose>
+      <group delimiter=" ">
+        <!-- locator for use in notes -->
+        <choose>
+          <if locator="page" variable="page">
+            <text term="at"/>
+          </if>
         </choose>
-        <group delimiter=" ">
-          <!-- locator for use in notes -->
-          <choose>
-            <if locator="page" variable="page">
-              <text term="at"/>
-            </if>
-          </choose>
-          <text macro="label-locator"/>
-        </group>
+        <text macro="label-locator"/>
       </group>
-      <text variable="references"/>
-      <text macro="source-DOI-URL"/>
     </group>
   </macro>
   <!-- 6.1. Legal date -->
@@ -5745,30 +5734,29 @@
   </macro>
   <!-- Citation -->
   <macro name="citation-notes-full">
-    <choose>
-      <if match="any" type="bill hearing legal_case legislation regulation treaty">
-        <!-- Legal items have different orders and delimiters -->
-        <text macro="legal-reference"/>
-      </if>
-      <else-if type="personal_communication" variable="genre">
-        <group delimiter=", ">
+    <group delimiter=", ">
+      <choose>
+        <if match="any" type="bill hearing legal_case legislation regulation treaty">
+          <!-- Legal items have different orders and delimiters -->
+          <text macro="legal-reference"/>
+          <text macro="source-date-accessed-DOI-URL-note"/>
+        </if>
+        <else-if type="personal_communication" variable="genre">
           <text macro="author-note"/>
           <text macro="title-and-source-note"/>
-        </group>
-      </else-if>
-      <else-if type="personal_communication" variable="author recipient">
-        <group delimiter=" ">
+        </else-if>
+        <else-if type="personal_communication" variable="author recipient">
+          <group delimiter=" ">
+            <text macro="author-note"/>
+            <text macro="title-and-source-note"/>
+          </group>
+        </else-if>
+        <else>
           <text macro="author-note"/>
           <text macro="title-and-source-note"/>
-        </group>
-      </else-if>
-      <else>
-        <group delimiter=", ">
-          <text macro="author-note"/>
-          <text macro="title-and-source-note"/>
-        </group>
-      </else>
-    </choose>
+        </else>
+      </choose>
+    </group>
   </macro>
   <macro name="citation-notes-shortened-author-title">
     <!-- Shortened note styles mirror the filtering approach of author-date -->
@@ -5879,19 +5867,21 @@
   </citation>
   <!-- Bibliography -->
   <macro name="bibliography-notes">
-    <choose>
-      <if match="any" type="bill hearing legal_case legislation regulation treaty">
-        <!-- Legal items have different orders and delimiters -->
-        <text macro="legal-reference"/>
-      </if>
-      <else>
-        <group delimiter=". ">
+    <group delimiter=". ">
+      <choose>
+        <if match="any" type="bill hearing legal_case legislation regulation treaty">
+          <!-- Legal items have different orders and delimiters -->
+          <text macro="legal-reference"/>
+          <text macro="source-date-accessed-DOI-URL-bib"/>
+          <text variable="references"/>
+        </if>
+        <else>
           <text macro="author-bib"/>
           <text macro="title-and-source-bib"/>
-          <text macro="notes"/>
-        </group>
-      </else>
-    </choose>
+          <text variable="references"/>
+        </else>
+      </choose>
+    </group>
   </macro>
   <bibliography et-al-min="7" et-al-use-first="3" hanging-indent="true" subsequent-author-substitute="&#8212;&#8212;&#8212;">
     <sort>

--- a/chicago-notes-bibliography-subsequent-ibid.csl
+++ b/chicago-notes-bibliography-subsequent-ibid.csl
@@ -1221,7 +1221,7 @@
       </group>
       <text macro="source-medium-bib"/>
       <text macro="source-archive-bib"/>
-      <text macro="source-DOI-URL-bib"/>
+      <text macro="source-date-accessed-DOI-URL-bib"/>
     </group>
   </macro>
   <macro name="title-and-source-note">
@@ -1274,7 +1274,7 @@
       </choose>
       <text macro="source-medium-note"/>
       <text macro="source-archive-note"/>
-      <text macro="source-DOI-URL-note"/>
+      <text macro="source-date-accessed-DOI-URL-note"/>
     </group>
   </macro>
   <!-- 3.1. Title -->
@@ -5396,55 +5396,48 @@
     </group>
   </macro>
   <!-- 4.10. URL or persistent identifier -->
-  <macro name="source-DOI-URL-bib">
-    <choose>
-      <if variable="DOI">
-        <text prefix="https://doi.org/" variable="DOI"/>
-      </if>
-      <else-if variable="URL">
-        <group delimiter=". ">
-          <choose>
-            <if match="none" variable="available-date event-date issued status">
-              <group delimiter=" ">
-                <text term="accessed" text-case="capitalize-first"/>
-                <date form="text" variable="accessed"/>
-              </group>
-            </if>
-          </choose>
-          <text variable="URL"/>
-        </group>
-      </else-if>
-    </choose>
+  <macro name="source-date-accessed-DOI-URL-bib">
+    <group delimiter=", ">
+      <choose>
+        <if variable="DOI"/>
+        <else-if match="any" variable="available-date event-date issued status"/>
+        <else-if variable="accessed URL">
+          <group delimiter=" ">
+            <text term="accessed" text-case="capitalize-first"/>
+            <date form="text" variable="accessed"/>
+          </group>
+        </else-if>
+      </choose>
+      <text macro="source-DOI-URL"/>
+    </group>
   </macro>
-  <macro name="source-DOI-URL-note">
-    <choose>
-      <if variable="DOI">
-        <text prefix="https://doi.org/" variable="DOI"/>
-      </if>
-      <else-if variable="URL">
-        <group delimiter=", ">
-          <choose>
-            <if match="none" variable="available-date event-date issued status">
-              <group delimiter=" ">
-                <text term="accessed"/>
-                <date form="text" variable="accessed"/>
-              </group>
-            </if>
-          </choose>
-          <text variable="URL"/>
-        </group>
-      </else-if>
-    </choose>
+  <macro name="source-date-accessed-DOI-URL-note">
+    <group delimiter=", ">
+      <choose>
+        <if variable="DOI"/>
+        <else-if match="any" variable="available-date event-date issued status"/>
+        <else-if variable="URL">
+          <group delimiter=" ">
+            <text term="accessed"/>
+            <date form="text" variable="accessed"/>
+          </group>
+        </else-if>
+      </choose>
+      <text macro="source-DOI-URL"/>
+    </group>
   </macro>
   <macro name="source-DOI-URL">
-    <!-- Alias to avoid modifying legal references block shared with APA -->
-    <text macro="source-DOI-URL-bib"/>
+    <choose>
+      <if variable="DOI">
+        <text prefix="https://doi.org/" variable="DOI"/>
+      </if>
+      <else-if variable="URL">
+        <text variable="URL"/>
+      </else-if>
+    </choose>
   </macro>
   <!-- 5. Notes -->
-  <macro name="notes">
-    <!-- Notes on source element: original publication, reprint info, retraction info -->
-    <text variable="references"/>
-  </macro>
+  <!-- TODO: add variables for distributor and exhibitions if available in CSL -->
   <!-- 6. Legal references: Bluebook style (shared with APA) -->
   <!-- Where APA or Chicago diverge from Bluebook, the official manual is followed -->
   <macro name="legal-reference">
@@ -5468,42 +5461,38 @@
          `treaty`
          : treaties
     -->
-    <group delimiter=" ">
-      <group delimiter=", " suffix=".">
-        <choose>
-          <if type="treaty">
-            <text macro="legal-title"/>
-            <names variable="author">
-              <!-- Treaty parties should be included at least for bilateral treaties (Bluebook 21.4.2) -->
-              <name delimiter="-" et-al-min="100" et-al-use-first="99" form="short"/>
-            </names>
-            <text macro="legal-date"/>
-            <!-- treaty source/report in addition to URL (Bluebook 21.4.5) -->
-            <text macro="legal-source"/>
-          </if>
-          <else>
-            <group delimiter=" ">
-              <group delimiter=", ">
-                <text macro="legal-title"/>
-                <text macro="legal-source"/>
-              </group>
-              <text macro="legal-date"/>
-              <text macro="legal-identifier"/>
+    <group delimiter=", ">
+      <choose>
+        <if type="treaty">
+          <text macro="legal-title"/>
+          <names variable="author">
+            <!-- Treaty parties should be included at least for bilateral treaties (Bluebook 21.4.2) -->
+            <name delimiter="-" et-al-min="100" et-al-use-first="99" form="short"/>
+          </names>
+          <text macro="legal-date"/>
+          <!-- treaty source/report in addition to URL (Bluebook 21.4.5) -->
+          <text macro="legal-source"/>
+        </if>
+        <else>
+          <group delimiter=" ">
+            <group delimiter=", ">
+              <text macro="legal-title"/>
+              <text macro="legal-source"/>
             </group>
-          </else>
+            <text macro="legal-date"/>
+            <text macro="legal-identifier"/>
+          </group>
+        </else>
+      </choose>
+      <group delimiter=" ">
+        <!-- locator for use in notes -->
+        <choose>
+          <if locator="page" variable="page">
+            <text term="at"/>
+          </if>
         </choose>
-        <group delimiter=" ">
-          <!-- locator for use in notes -->
-          <choose>
-            <if locator="page" variable="page">
-              <text term="at"/>
-            </if>
-          </choose>
-          <text macro="label-locator"/>
-        </group>
+        <text macro="label-locator"/>
       </group>
-      <text variable="references"/>
-      <text macro="source-DOI-URL"/>
     </group>
   </macro>
   <!-- 6.1. Legal date -->
@@ -5754,30 +5743,29 @@
   </macro>
   <!-- Citation -->
   <macro name="citation-notes-full">
-    <choose>
-      <if match="any" type="bill hearing legal_case legislation regulation treaty">
-        <!-- Legal items have different orders and delimiters -->
-        <text macro="legal-reference"/>
-      </if>
-      <else-if type="personal_communication" variable="genre">
-        <group delimiter=", ">
+    <group delimiter=", ">
+      <choose>
+        <if match="any" type="bill hearing legal_case legislation regulation treaty">
+          <!-- Legal items have different orders and delimiters -->
+          <text macro="legal-reference"/>
+          <text macro="source-date-accessed-DOI-URL-note"/>
+        </if>
+        <else-if type="personal_communication" variable="genre">
           <text macro="author-note"/>
           <text macro="title-and-source-note"/>
-        </group>
-      </else-if>
-      <else-if type="personal_communication" variable="author recipient">
-        <group delimiter=" ">
+        </else-if>
+        <else-if type="personal_communication" variable="author recipient">
+          <group delimiter=" ">
+            <text macro="author-note"/>
+            <text macro="title-and-source-note"/>
+          </group>
+        </else-if>
+        <else>
           <text macro="author-note"/>
           <text macro="title-and-source-note"/>
-        </group>
-      </else-if>
-      <else>
-        <group delimiter=", ">
-          <text macro="author-note"/>
-          <text macro="title-and-source-note"/>
-        </group>
-      </else>
-    </choose>
+        </else>
+      </choose>
+    </group>
   </macro>
   <macro name="citation-notes-shortened-author-title">
     <!-- Shortened note styles mirror the filtering approach of author-date -->
@@ -5888,19 +5876,21 @@
   </citation>
   <!-- Bibliography -->
   <macro name="bibliography-notes">
-    <choose>
-      <if match="any" type="bill hearing legal_case legislation regulation treaty">
-        <!-- Legal items have different orders and delimiters -->
-        <text macro="legal-reference"/>
-      </if>
-      <else>
-        <group delimiter=". ">
+    <group delimiter=". ">
+      <choose>
+        <if match="any" type="bill hearing legal_case legislation regulation treaty">
+          <!-- Legal items have different orders and delimiters -->
+          <text macro="legal-reference"/>
+          <text macro="source-date-accessed-DOI-URL-bib"/>
+          <text variable="references"/>
+        </if>
+        <else>
           <text macro="author-bib"/>
           <text macro="title-and-source-bib"/>
-          <text macro="notes"/>
-        </group>
-      </else>
-    </choose>
+          <text variable="references"/>
+        </else>
+      </choose>
+    </group>
   </macro>
   <bibliography et-al-min="7" et-al-use-first="3" hanging-indent="true">
     <sort>

--- a/chicago-notes-bibliography-subsequent-title.csl
+++ b/chicago-notes-bibliography-subsequent-title.csl
@@ -1221,7 +1221,7 @@
       </group>
       <text macro="source-medium-bib"/>
       <text macro="source-archive-bib"/>
-      <text macro="source-DOI-URL-bib"/>
+      <text macro="source-date-accessed-DOI-URL-bib"/>
     </group>
   </macro>
   <macro name="title-and-source-note">
@@ -1274,7 +1274,7 @@
       </choose>
       <text macro="source-medium-note"/>
       <text macro="source-archive-note"/>
-      <text macro="source-DOI-URL-note"/>
+      <text macro="source-date-accessed-DOI-URL-note"/>
     </group>
   </macro>
   <!-- 3.1. Title -->
@@ -5396,55 +5396,48 @@
     </group>
   </macro>
   <!-- 4.10. URL or persistent identifier -->
-  <macro name="source-DOI-URL-bib">
-    <choose>
-      <if variable="DOI">
-        <text prefix="https://doi.org/" variable="DOI"/>
-      </if>
-      <else-if variable="URL">
-        <group delimiter=". ">
-          <choose>
-            <if match="none" variable="available-date event-date issued status">
-              <group delimiter=" ">
-                <text term="accessed" text-case="capitalize-first"/>
-                <date form="text" variable="accessed"/>
-              </group>
-            </if>
-          </choose>
-          <text variable="URL"/>
-        </group>
-      </else-if>
-    </choose>
+  <macro name="source-date-accessed-DOI-URL-bib">
+    <group delimiter=", ">
+      <choose>
+        <if variable="DOI"/>
+        <else-if match="any" variable="available-date event-date issued status"/>
+        <else-if variable="accessed URL">
+          <group delimiter=" ">
+            <text term="accessed" text-case="capitalize-first"/>
+            <date form="text" variable="accessed"/>
+          </group>
+        </else-if>
+      </choose>
+      <text macro="source-DOI-URL"/>
+    </group>
   </macro>
-  <macro name="source-DOI-URL-note">
-    <choose>
-      <if variable="DOI">
-        <text prefix="https://doi.org/" variable="DOI"/>
-      </if>
-      <else-if variable="URL">
-        <group delimiter=", ">
-          <choose>
-            <if match="none" variable="available-date event-date issued status">
-              <group delimiter=" ">
-                <text term="accessed"/>
-                <date form="text" variable="accessed"/>
-              </group>
-            </if>
-          </choose>
-          <text variable="URL"/>
-        </group>
-      </else-if>
-    </choose>
+  <macro name="source-date-accessed-DOI-URL-note">
+    <group delimiter=", ">
+      <choose>
+        <if variable="DOI"/>
+        <else-if match="any" variable="available-date event-date issued status"/>
+        <else-if variable="URL">
+          <group delimiter=" ">
+            <text term="accessed"/>
+            <date form="text" variable="accessed"/>
+          </group>
+        </else-if>
+      </choose>
+      <text macro="source-DOI-URL"/>
+    </group>
   </macro>
   <macro name="source-DOI-URL">
-    <!-- Alias to avoid modifying legal references block shared with APA -->
-    <text macro="source-DOI-URL-bib"/>
+    <choose>
+      <if variable="DOI">
+        <text prefix="https://doi.org/" variable="DOI"/>
+      </if>
+      <else-if variable="URL">
+        <text variable="URL"/>
+      </else-if>
+    </choose>
   </macro>
   <!-- 5. Notes -->
-  <macro name="notes">
-    <!-- Notes on source element: original publication, reprint info, retraction info -->
-    <text variable="references"/>
-  </macro>
+  <!-- TODO: add variables for distributor and exhibitions if available in CSL -->
   <!-- 6. Legal references: Bluebook style (shared with APA) -->
   <!-- Where APA or Chicago diverge from Bluebook, the official manual is followed -->
   <macro name="legal-reference">
@@ -5468,42 +5461,38 @@
          `treaty`
          : treaties
     -->
-    <group delimiter=" ">
-      <group delimiter=", " suffix=".">
-        <choose>
-          <if type="treaty">
-            <text macro="legal-title"/>
-            <names variable="author">
-              <!-- Treaty parties should be included at least for bilateral treaties (Bluebook 21.4.2) -->
-              <name delimiter="-" et-al-min="100" et-al-use-first="99" form="short"/>
-            </names>
-            <text macro="legal-date"/>
-            <!-- treaty source/report in addition to URL (Bluebook 21.4.5) -->
-            <text macro="legal-source"/>
-          </if>
-          <else>
-            <group delimiter=" ">
-              <group delimiter=", ">
-                <text macro="legal-title"/>
-                <text macro="legal-source"/>
-              </group>
-              <text macro="legal-date"/>
-              <text macro="legal-identifier"/>
+    <group delimiter=", ">
+      <choose>
+        <if type="treaty">
+          <text macro="legal-title"/>
+          <names variable="author">
+            <!-- Treaty parties should be included at least for bilateral treaties (Bluebook 21.4.2) -->
+            <name delimiter="-" et-al-min="100" et-al-use-first="99" form="short"/>
+          </names>
+          <text macro="legal-date"/>
+          <!-- treaty source/report in addition to URL (Bluebook 21.4.5) -->
+          <text macro="legal-source"/>
+        </if>
+        <else>
+          <group delimiter=" ">
+            <group delimiter=", ">
+              <text macro="legal-title"/>
+              <text macro="legal-source"/>
             </group>
-          </else>
+            <text macro="legal-date"/>
+            <text macro="legal-identifier"/>
+          </group>
+        </else>
+      </choose>
+      <group delimiter=" ">
+        <!-- locator for use in notes -->
+        <choose>
+          <if locator="page" variable="page">
+            <text term="at"/>
+          </if>
         </choose>
-        <group delimiter=" ">
-          <!-- locator for use in notes -->
-          <choose>
-            <if locator="page" variable="page">
-              <text term="at"/>
-            </if>
-          </choose>
-          <text macro="label-locator"/>
-        </group>
+        <text macro="label-locator"/>
       </group>
-      <text variable="references"/>
-      <text macro="source-DOI-URL"/>
     </group>
   </macro>
   <!-- 6.1. Legal date -->
@@ -5754,30 +5743,29 @@
   </macro>
   <!-- Citation -->
   <macro name="citation-notes-full">
-    <choose>
-      <if match="any" type="bill hearing legal_case legislation regulation treaty">
-        <!-- Legal items have different orders and delimiters -->
-        <text macro="legal-reference"/>
-      </if>
-      <else-if type="personal_communication" variable="genre">
-        <group delimiter=", ">
+    <group delimiter=", ">
+      <choose>
+        <if match="any" type="bill hearing legal_case legislation regulation treaty">
+          <!-- Legal items have different orders and delimiters -->
+          <text macro="legal-reference"/>
+          <text macro="source-date-accessed-DOI-URL-note"/>
+        </if>
+        <else-if type="personal_communication" variable="genre">
           <text macro="author-note"/>
           <text macro="title-and-source-note"/>
-        </group>
-      </else-if>
-      <else-if type="personal_communication" variable="author recipient">
-        <group delimiter=" ">
+        </else-if>
+        <else-if type="personal_communication" variable="author recipient">
+          <group delimiter=" ">
+            <text macro="author-note"/>
+            <text macro="title-and-source-note"/>
+          </group>
+        </else-if>
+        <else>
           <text macro="author-note"/>
           <text macro="title-and-source-note"/>
-        </group>
-      </else-if>
-      <else>
-        <group delimiter=", ">
-          <text macro="author-note"/>
-          <text macro="title-and-source-note"/>
-        </group>
-      </else>
-    </choose>
+        </else>
+      </choose>
+    </group>
   </macro>
   <macro name="citation-notes-shortened-author-title">
     <!-- Shortened note styles mirror the filtering approach of author-date -->
@@ -5908,19 +5896,21 @@
   </citation>
   <!-- Bibliography -->
   <macro name="bibliography-notes">
-    <choose>
-      <if match="any" type="bill hearing legal_case legislation regulation treaty">
-        <!-- Legal items have different orders and delimiters -->
-        <text macro="legal-reference"/>
-      </if>
-      <else>
-        <group delimiter=". ">
+    <group delimiter=". ">
+      <choose>
+        <if match="any" type="bill hearing legal_case legislation regulation treaty">
+          <!-- Legal items have different orders and delimiters -->
+          <text macro="legal-reference"/>
+          <text macro="source-date-accessed-DOI-URL-bib"/>
+          <text variable="references"/>
+        </if>
+        <else>
           <text macro="author-bib"/>
           <text macro="title-and-source-bib"/>
-          <text macro="notes"/>
-        </group>
-      </else>
-    </choose>
+          <text variable="references"/>
+        </else>
+      </choose>
+    </group>
   </macro>
   <bibliography et-al-min="7" et-al-use-first="3" hanging-indent="true">
     <sort>

--- a/chicago-notes-bibliography.csl
+++ b/chicago-notes-bibliography.csl
@@ -1221,7 +1221,7 @@
       </group>
       <text macro="source-medium-bib"/>
       <text macro="source-archive-bib"/>
-      <text macro="source-DOI-URL-bib"/>
+      <text macro="source-date-accessed-DOI-URL-bib"/>
     </group>
   </macro>
   <macro name="title-and-source-note">
@@ -1274,7 +1274,7 @@
       </choose>
       <text macro="source-medium-note"/>
       <text macro="source-archive-note"/>
-      <text macro="source-DOI-URL-note"/>
+      <text macro="source-date-accessed-DOI-URL-note"/>
     </group>
   </macro>
   <!-- 3.1. Title -->
@@ -5396,55 +5396,48 @@
     </group>
   </macro>
   <!-- 4.10. URL or persistent identifier -->
-  <macro name="source-DOI-URL-bib">
-    <choose>
-      <if variable="DOI">
-        <text prefix="https://doi.org/" variable="DOI"/>
-      </if>
-      <else-if variable="URL">
-        <group delimiter=". ">
-          <choose>
-            <if match="none" variable="available-date event-date issued status">
-              <group delimiter=" ">
-                <text term="accessed" text-case="capitalize-first"/>
-                <date form="text" variable="accessed"/>
-              </group>
-            </if>
-          </choose>
-          <text variable="URL"/>
-        </group>
-      </else-if>
-    </choose>
+  <macro name="source-date-accessed-DOI-URL-bib">
+    <group delimiter=", ">
+      <choose>
+        <if variable="DOI"/>
+        <else-if match="any" variable="available-date event-date issued status"/>
+        <else-if variable="accessed URL">
+          <group delimiter=" ">
+            <text term="accessed" text-case="capitalize-first"/>
+            <date form="text" variable="accessed"/>
+          </group>
+        </else-if>
+      </choose>
+      <text macro="source-DOI-URL"/>
+    </group>
   </macro>
-  <macro name="source-DOI-URL-note">
-    <choose>
-      <if variable="DOI">
-        <text prefix="https://doi.org/" variable="DOI"/>
-      </if>
-      <else-if variable="URL">
-        <group delimiter=", ">
-          <choose>
-            <if match="none" variable="available-date event-date issued status">
-              <group delimiter=" ">
-                <text term="accessed"/>
-                <date form="text" variable="accessed"/>
-              </group>
-            </if>
-          </choose>
-          <text variable="URL"/>
-        </group>
-      </else-if>
-    </choose>
+  <macro name="source-date-accessed-DOI-URL-note">
+    <group delimiter=", ">
+      <choose>
+        <if variable="DOI"/>
+        <else-if match="any" variable="available-date event-date issued status"/>
+        <else-if variable="URL">
+          <group delimiter=" ">
+            <text term="accessed"/>
+            <date form="text" variable="accessed"/>
+          </group>
+        </else-if>
+      </choose>
+      <text macro="source-DOI-URL"/>
+    </group>
   </macro>
   <macro name="source-DOI-URL">
-    <!-- Alias to avoid modifying legal references block shared with APA -->
-    <text macro="source-DOI-URL-bib"/>
+    <choose>
+      <if variable="DOI">
+        <text prefix="https://doi.org/" variable="DOI"/>
+      </if>
+      <else-if variable="URL">
+        <text variable="URL"/>
+      </else-if>
+    </choose>
   </macro>
   <!-- 5. Notes -->
-  <macro name="notes">
-    <!-- Notes on source element: original publication, reprint info, retraction info -->
-    <text variable="references"/>
-  </macro>
+  <!-- TODO: add variables for distributor and exhibitions if available in CSL -->
   <!-- 6. Legal references: Bluebook style (shared with APA) -->
   <!-- Where APA or Chicago diverge from Bluebook, the official manual is followed -->
   <macro name="legal-reference">
@@ -5468,42 +5461,38 @@
          `treaty`
          : treaties
     -->
-    <group delimiter=" ">
-      <group delimiter=", " suffix=".">
-        <choose>
-          <if type="treaty">
-            <text macro="legal-title"/>
-            <names variable="author">
-              <!-- Treaty parties should be included at least for bilateral treaties (Bluebook 21.4.2) -->
-              <name delimiter="-" et-al-min="100" et-al-use-first="99" form="short"/>
-            </names>
-            <text macro="legal-date"/>
-            <!-- treaty source/report in addition to URL (Bluebook 21.4.5) -->
-            <text macro="legal-source"/>
-          </if>
-          <else>
-            <group delimiter=" ">
-              <group delimiter=", ">
-                <text macro="legal-title"/>
-                <text macro="legal-source"/>
-              </group>
-              <text macro="legal-date"/>
-              <text macro="legal-identifier"/>
+    <group delimiter=", ">
+      <choose>
+        <if type="treaty">
+          <text macro="legal-title"/>
+          <names variable="author">
+            <!-- Treaty parties should be included at least for bilateral treaties (Bluebook 21.4.2) -->
+            <name delimiter="-" et-al-min="100" et-al-use-first="99" form="short"/>
+          </names>
+          <text macro="legal-date"/>
+          <!-- treaty source/report in addition to URL (Bluebook 21.4.5) -->
+          <text macro="legal-source"/>
+        </if>
+        <else>
+          <group delimiter=" ">
+            <group delimiter=", ">
+              <text macro="legal-title"/>
+              <text macro="legal-source"/>
             </group>
-          </else>
+            <text macro="legal-date"/>
+            <text macro="legal-identifier"/>
+          </group>
+        </else>
+      </choose>
+      <group delimiter=" ">
+        <!-- locator for use in notes -->
+        <choose>
+          <if locator="page" variable="page">
+            <text term="at"/>
+          </if>
         </choose>
-        <group delimiter=" ">
-          <!-- locator for use in notes -->
-          <choose>
-            <if locator="page" variable="page">
-              <text term="at"/>
-            </if>
-          </choose>
-          <text macro="label-locator"/>
-        </group>
+        <text macro="label-locator"/>
       </group>
-      <text variable="references"/>
-      <text macro="source-DOI-URL"/>
     </group>
   </macro>
   <!-- 6.1. Legal date -->
@@ -5754,30 +5743,29 @@
   </macro>
   <!-- Citation -->
   <macro name="citation-notes-full">
-    <choose>
-      <if match="any" type="bill hearing legal_case legislation regulation treaty">
-        <!-- Legal items have different orders and delimiters -->
-        <text macro="legal-reference"/>
-      </if>
-      <else-if type="personal_communication" variable="genre">
-        <group delimiter=", ">
+    <group delimiter=", ">
+      <choose>
+        <if match="any" type="bill hearing legal_case legislation regulation treaty">
+          <!-- Legal items have different orders and delimiters -->
+          <text macro="legal-reference"/>
+          <text macro="source-date-accessed-DOI-URL-note"/>
+        </if>
+        <else-if type="personal_communication" variable="genre">
           <text macro="author-note"/>
           <text macro="title-and-source-note"/>
-        </group>
-      </else-if>
-      <else-if type="personal_communication" variable="author recipient">
-        <group delimiter=" ">
+        </else-if>
+        <else-if type="personal_communication" variable="author recipient">
+          <group delimiter=" ">
+            <text macro="author-note"/>
+            <text macro="title-and-source-note"/>
+          </group>
+        </else-if>
+        <else>
           <text macro="author-note"/>
           <text macro="title-and-source-note"/>
-        </group>
-      </else-if>
-      <else>
-        <group delimiter=", ">
-          <text macro="author-note"/>
-          <text macro="title-and-source-note"/>
-        </group>
-      </else>
-    </choose>
+        </else>
+      </choose>
+    </group>
   </macro>
   <macro name="citation-notes-shortened-author-title">
     <!-- Shortened note styles mirror the filtering approach of author-date -->
@@ -5876,19 +5864,21 @@
   </citation>
   <!-- Bibliography -->
   <macro name="bibliography-notes">
-    <choose>
-      <if match="any" type="bill hearing legal_case legislation regulation treaty">
-        <!-- Legal items have different orders and delimiters -->
-        <text macro="legal-reference"/>
-      </if>
-      <else>
-        <group delimiter=". ">
+    <group delimiter=". ">
+      <choose>
+        <if match="any" type="bill hearing legal_case legislation regulation treaty">
+          <!-- Legal items have different orders and delimiters -->
+          <text macro="legal-reference"/>
+          <text macro="source-date-accessed-DOI-URL-bib"/>
+          <text variable="references"/>
+        </if>
+        <else>
           <text macro="author-bib"/>
           <text macro="title-and-source-bib"/>
-          <text macro="notes"/>
-        </group>
-      </else>
-    </choose>
+          <text variable="references"/>
+        </else>
+      </choose>
+    </group>
   </macro>
   <bibliography et-al-min="7" et-al-use-first="3" hanging-indent="true">
     <sort>

--- a/chicago-notes-classic-no-url.csl
+++ b/chicago-notes-classic-no-url.csl
@@ -1086,7 +1086,7 @@
       </choose>
       <text macro="source-medium-note"/>
       <text macro="source-archive-note"/>
-      <!-- <text macro="source-DOI-URL-note"/> -->
+      <text macro="source-date-accessed-DOI-URL-note"/>
     </group>
   </macro>
   <!-- 3.1. Title -->
@@ -4393,7 +4393,23 @@
     </group>
   </macro>
   <!-- 4.10. URL or persistent identifier -->
+  <macro name="source-date-accessed-DOI-URL-note">
+    <group delimiter=", ">
+      <choose>
+        <if variable="DOI"/>
+        <else-if match="any" variable="available-date event-date issued status"/>
+        <else-if variable="URL">
+          <group delimiter=" ">
+            <text term="accessed"/>
+            <date form="text" variable="accessed"/>
+          </group>
+        </else-if>
+      </choose>
+      <!-- <text macro="source-DOI-URL"/> -->
+    </group>
+  </macro>
   <!-- 5. Notes -->
+  <!-- TODO: add variables for distributor and exhibitions if available in CSL -->
   <!-- 6. Legal references: Bluebook style (shared with APA) -->
   <!-- Where APA or Chicago diverge from Bluebook, the official manual is followed -->
   <macro name="legal-reference">
@@ -4417,42 +4433,38 @@
          `treaty`
          : treaties
     -->
-    <group delimiter=" ">
-      <group delimiter=", " suffix=".">
-        <choose>
-          <if type="treaty">
-            <text macro="legal-title"/>
-            <names variable="author">
-              <!-- Treaty parties should be included at least for bilateral treaties (Bluebook 21.4.2) -->
-              <name delimiter="-" et-al-min="100" et-al-use-first="99" form="short"/>
-            </names>
-            <text macro="legal-date"/>
-            <!-- treaty source/report in addition to URL (Bluebook 21.4.5) -->
-            <text macro="legal-source"/>
-          </if>
-          <else>
-            <group delimiter=" ">
-              <group delimiter=", ">
-                <text macro="legal-title"/>
-                <text macro="legal-source"/>
-              </group>
-              <text macro="legal-date"/>
-              <text macro="legal-identifier"/>
+    <group delimiter=", ">
+      <choose>
+        <if type="treaty">
+          <text macro="legal-title"/>
+          <names variable="author">
+            <!-- Treaty parties should be included at least for bilateral treaties (Bluebook 21.4.2) -->
+            <name delimiter="-" et-al-min="100" et-al-use-first="99" form="short"/>
+          </names>
+          <text macro="legal-date"/>
+          <!-- treaty source/report in addition to URL (Bluebook 21.4.5) -->
+          <text macro="legal-source"/>
+        </if>
+        <else>
+          <group delimiter=" ">
+            <group delimiter=", ">
+              <text macro="legal-title"/>
+              <text macro="legal-source"/>
             </group>
-          </else>
+            <text macro="legal-date"/>
+            <text macro="legal-identifier"/>
+          </group>
+        </else>
+      </choose>
+      <group delimiter=" ">
+        <!-- locator for use in notes -->
+        <choose>
+          <if locator="page" variable="page">
+            <text term="at"/>
+          </if>
         </choose>
-        <group delimiter=" ">
-          <!-- locator for use in notes -->
-          <choose>
-            <if locator="page" variable="page">
-              <text term="at"/>
-            </if>
-          </choose>
-          <text macro="label-locator"/>
-        </group>
+        <text macro="label-locator"/>
       </group>
-      <text variable="references"/>
-      <!-- <text macro="source-DOI-URL"/> -->
     </group>
   </macro>
   <!-- 6.1. Legal date -->
@@ -4703,30 +4715,29 @@
   </macro>
   <!-- Citation -->
   <macro name="citation-notes-full">
-    <choose>
-      <if match="any" type="bill hearing legal_case legislation regulation treaty">
-        <!-- Legal items have different orders and delimiters -->
-        <text macro="legal-reference"/>
-      </if>
-      <else-if type="personal_communication" variable="genre">
-        <group delimiter=", ">
+    <group delimiter=", ">
+      <choose>
+        <if match="any" type="bill hearing legal_case legislation regulation treaty">
+          <!-- Legal items have different orders and delimiters -->
+          <text macro="legal-reference"/>
+          <text macro="source-date-accessed-DOI-URL-note"/>
+        </if>
+        <else-if type="personal_communication" variable="genre">
           <text macro="author-note"/>
           <text macro="title-and-source-note"/>
-        </group>
-      </else-if>
-      <else-if type="personal_communication" variable="author recipient">
-        <group delimiter=" ">
+        </else-if>
+        <else-if type="personal_communication" variable="author recipient">
+          <group delimiter=" ">
+            <text macro="author-note"/>
+            <text macro="title-and-source-note"/>
+          </group>
+        </else-if>
+        <else>
           <text macro="author-note"/>
           <text macro="title-and-source-note"/>
-        </group>
-      </else-if>
-      <else>
-        <group delimiter=", ">
-          <text macro="author-note"/>
-          <text macro="title-and-source-note"/>
-        </group>
-      </else>
-    </choose>
+        </else>
+      </choose>
+    </group>
   </macro>
   <macro name="citation-notes-shortened-author-title">
     <!-- Shortened note styles mirror the filtering approach of author-date -->

--- a/chicago-notes-classic.csl
+++ b/chicago-notes-classic.csl
@@ -1086,7 +1086,7 @@
       </choose>
       <text macro="source-medium-note"/>
       <text macro="source-archive-note"/>
-      <text macro="source-DOI-URL-note"/>
+      <text macro="source-date-accessed-DOI-URL-note"/>
     </group>
   </macro>
   <!-- 3.1. Title -->
@@ -4393,51 +4393,33 @@
     </group>
   </macro>
   <!-- 4.10. URL or persistent identifier -->
-  <macro name="source-DOI-URL-bib">
-    <choose>
-      <if variable="DOI">
-        <text prefix="https://doi.org/" variable="DOI"/>
-      </if>
-      <else-if variable="URL">
-        <group delimiter=". ">
-          <choose>
-            <if match="none" variable="available-date event-date issued status">
-              <group delimiter=" ">
-                <text term="accessed" text-case="capitalize-first"/>
-                <date form="text" variable="accessed"/>
-              </group>
-            </if>
-          </choose>
-          <text variable="URL"/>
-        </group>
-      </else-if>
-    </choose>
-  </macro>
-  <macro name="source-DOI-URL-note">
-    <choose>
-      <if variable="DOI">
-        <text prefix="https://doi.org/" variable="DOI"/>
-      </if>
-      <else-if variable="URL">
-        <group delimiter=", ">
-          <choose>
-            <if match="none" variable="available-date event-date issued status">
-              <group delimiter=" ">
-                <text term="accessed"/>
-                <date form="text" variable="accessed"/>
-              </group>
-            </if>
-          </choose>
-          <text variable="URL"/>
-        </group>
-      </else-if>
-    </choose>
+  <macro name="source-date-accessed-DOI-URL-note">
+    <group delimiter=", ">
+      <choose>
+        <if variable="DOI"/>
+        <else-if match="any" variable="available-date event-date issued status"/>
+        <else-if variable="URL">
+          <group delimiter=" ">
+            <text term="accessed"/>
+            <date form="text" variable="accessed"/>
+          </group>
+        </else-if>
+      </choose>
+      <text macro="source-DOI-URL"/>
+    </group>
   </macro>
   <macro name="source-DOI-URL">
-    <!-- Alias to avoid modifying legal references block shared with APA -->
-    <text macro="source-DOI-URL-bib"/>
+    <choose>
+      <if variable="DOI">
+        <text prefix="https://doi.org/" variable="DOI"/>
+      </if>
+      <else-if variable="URL">
+        <text variable="URL"/>
+      </else-if>
+    </choose>
   </macro>
   <!-- 5. Notes -->
+  <!-- TODO: add variables for distributor and exhibitions if available in CSL -->
   <!-- 6. Legal references: Bluebook style (shared with APA) -->
   <!-- Where APA or Chicago diverge from Bluebook, the official manual is followed -->
   <macro name="legal-reference">
@@ -4461,42 +4443,38 @@
          `treaty`
          : treaties
     -->
-    <group delimiter=" ">
-      <group delimiter=", " suffix=".">
-        <choose>
-          <if type="treaty">
-            <text macro="legal-title"/>
-            <names variable="author">
-              <!-- Treaty parties should be included at least for bilateral treaties (Bluebook 21.4.2) -->
-              <name delimiter="-" et-al-min="100" et-al-use-first="99" form="short"/>
-            </names>
-            <text macro="legal-date"/>
-            <!-- treaty source/report in addition to URL (Bluebook 21.4.5) -->
-            <text macro="legal-source"/>
-          </if>
-          <else>
-            <group delimiter=" ">
-              <group delimiter=", ">
-                <text macro="legal-title"/>
-                <text macro="legal-source"/>
-              </group>
-              <text macro="legal-date"/>
-              <text macro="legal-identifier"/>
+    <group delimiter=", ">
+      <choose>
+        <if type="treaty">
+          <text macro="legal-title"/>
+          <names variable="author">
+            <!-- Treaty parties should be included at least for bilateral treaties (Bluebook 21.4.2) -->
+            <name delimiter="-" et-al-min="100" et-al-use-first="99" form="short"/>
+          </names>
+          <text macro="legal-date"/>
+          <!-- treaty source/report in addition to URL (Bluebook 21.4.5) -->
+          <text macro="legal-source"/>
+        </if>
+        <else>
+          <group delimiter=" ">
+            <group delimiter=", ">
+              <text macro="legal-title"/>
+              <text macro="legal-source"/>
             </group>
-          </else>
+            <text macro="legal-date"/>
+            <text macro="legal-identifier"/>
+          </group>
+        </else>
+      </choose>
+      <group delimiter=" ">
+        <!-- locator for use in notes -->
+        <choose>
+          <if locator="page" variable="page">
+            <text term="at"/>
+          </if>
         </choose>
-        <group delimiter=" ">
-          <!-- locator for use in notes -->
-          <choose>
-            <if locator="page" variable="page">
-              <text term="at"/>
-            </if>
-          </choose>
-          <text macro="label-locator"/>
-        </group>
+        <text macro="label-locator"/>
       </group>
-      <text variable="references"/>
-      <text macro="source-DOI-URL"/>
     </group>
   </macro>
   <!-- 6.1. Legal date -->
@@ -4747,30 +4725,29 @@
   </macro>
   <!-- Citation -->
   <macro name="citation-notes-full">
-    <choose>
-      <if match="any" type="bill hearing legal_case legislation regulation treaty">
-        <!-- Legal items have different orders and delimiters -->
-        <text macro="legal-reference"/>
-      </if>
-      <else-if type="personal_communication" variable="genre">
-        <group delimiter=", ">
+    <group delimiter=", ">
+      <choose>
+        <if match="any" type="bill hearing legal_case legislation regulation treaty">
+          <!-- Legal items have different orders and delimiters -->
+          <text macro="legal-reference"/>
+          <text macro="source-date-accessed-DOI-URL-note"/>
+        </if>
+        <else-if type="personal_communication" variable="genre">
           <text macro="author-note"/>
           <text macro="title-and-source-note"/>
-        </group>
-      </else-if>
-      <else-if type="personal_communication" variable="author recipient">
-        <group delimiter=" ">
+        </else-if>
+        <else-if type="personal_communication" variable="author recipient">
+          <group delimiter=" ">
+            <text macro="author-note"/>
+            <text macro="title-and-source-note"/>
+          </group>
+        </else-if>
+        <else>
           <text macro="author-note"/>
           <text macro="title-and-source-note"/>
-        </group>
-      </else-if>
-      <else>
-        <group delimiter=", ">
-          <text macro="author-note"/>
-          <text macro="title-and-source-note"/>
-        </group>
-      </else>
-    </choose>
+        </else>
+      </choose>
+    </group>
   </macro>
   <macro name="citation-notes-shortened-author-title">
     <!-- Shortened note styles mirror the filtering approach of author-date -->

--- a/chicago-notes-no-url.csl
+++ b/chicago-notes-no-url.csl
@@ -1086,7 +1086,7 @@
       </choose>
       <text macro="source-medium-note"/>
       <text macro="source-archive-note"/>
-      <!-- <text macro="source-DOI-URL-note"/> -->
+      <text macro="source-date-accessed-DOI-URL-note"/>
     </group>
   </macro>
   <!-- 3.1. Title -->
@@ -4399,7 +4399,23 @@
     </group>
   </macro>
   <!-- 4.10. URL or persistent identifier -->
+  <macro name="source-date-accessed-DOI-URL-note">
+    <group delimiter=", ">
+      <choose>
+        <if variable="DOI"/>
+        <else-if match="any" variable="available-date event-date issued status"/>
+        <else-if variable="URL">
+          <group delimiter=" ">
+            <text term="accessed"/>
+            <date form="text" variable="accessed"/>
+          </group>
+        </else-if>
+      </choose>
+      <!-- <text macro="source-DOI-URL"/> -->
+    </group>
+  </macro>
   <!-- 5. Notes -->
+  <!-- TODO: add variables for distributor and exhibitions if available in CSL -->
   <!-- 6. Legal references: Bluebook style (shared with APA) -->
   <!-- Where APA or Chicago diverge from Bluebook, the official manual is followed -->
   <macro name="legal-reference">
@@ -4423,42 +4439,38 @@
          `treaty`
          : treaties
     -->
-    <group delimiter=" ">
-      <group delimiter=", " suffix=".">
-        <choose>
-          <if type="treaty">
-            <text macro="legal-title"/>
-            <names variable="author">
-              <!-- Treaty parties should be included at least for bilateral treaties (Bluebook 21.4.2) -->
-              <name delimiter="-" et-al-min="100" et-al-use-first="99" form="short"/>
-            </names>
-            <text macro="legal-date"/>
-            <!-- treaty source/report in addition to URL (Bluebook 21.4.5) -->
-            <text macro="legal-source"/>
-          </if>
-          <else>
-            <group delimiter=" ">
-              <group delimiter=", ">
-                <text macro="legal-title"/>
-                <text macro="legal-source"/>
-              </group>
-              <text macro="legal-date"/>
-              <text macro="legal-identifier"/>
+    <group delimiter=", ">
+      <choose>
+        <if type="treaty">
+          <text macro="legal-title"/>
+          <names variable="author">
+            <!-- Treaty parties should be included at least for bilateral treaties (Bluebook 21.4.2) -->
+            <name delimiter="-" et-al-min="100" et-al-use-first="99" form="short"/>
+          </names>
+          <text macro="legal-date"/>
+          <!-- treaty source/report in addition to URL (Bluebook 21.4.5) -->
+          <text macro="legal-source"/>
+        </if>
+        <else>
+          <group delimiter=" ">
+            <group delimiter=", ">
+              <text macro="legal-title"/>
+              <text macro="legal-source"/>
             </group>
-          </else>
+            <text macro="legal-date"/>
+            <text macro="legal-identifier"/>
+          </group>
+        </else>
+      </choose>
+      <group delimiter=" ">
+        <!-- locator for use in notes -->
+        <choose>
+          <if locator="page" variable="page">
+            <text term="at"/>
+          </if>
         </choose>
-        <group delimiter=" ">
-          <!-- locator for use in notes -->
-          <choose>
-            <if locator="page" variable="page">
-              <text term="at"/>
-            </if>
-          </choose>
-          <text macro="label-locator"/>
-        </group>
+        <text macro="label-locator"/>
       </group>
-      <text variable="references"/>
-      <!-- <text macro="source-DOI-URL"/> -->
     </group>
   </macro>
   <!-- 6.1. Legal date -->
@@ -4709,30 +4721,29 @@
   </macro>
   <!-- Citation -->
   <macro name="citation-notes-full">
-    <choose>
-      <if match="any" type="bill hearing legal_case legislation regulation treaty">
-        <!-- Legal items have different orders and delimiters -->
-        <text macro="legal-reference"/>
-      </if>
-      <else-if type="personal_communication" variable="genre">
-        <group delimiter=", ">
+    <group delimiter=", ">
+      <choose>
+        <if match="any" type="bill hearing legal_case legislation regulation treaty">
+          <!-- Legal items have different orders and delimiters -->
+          <text macro="legal-reference"/>
+          <text macro="source-date-accessed-DOI-URL-note"/>
+        </if>
+        <else-if type="personal_communication" variable="genre">
           <text macro="author-note"/>
           <text macro="title-and-source-note"/>
-        </group>
-      </else-if>
-      <else-if type="personal_communication" variable="author recipient">
-        <group delimiter=" ">
+        </else-if>
+        <else-if type="personal_communication" variable="author recipient">
+          <group delimiter=" ">
+            <text macro="author-note"/>
+            <text macro="title-and-source-note"/>
+          </group>
+        </else-if>
+        <else>
           <text macro="author-note"/>
           <text macro="title-and-source-note"/>
-        </group>
-      </else-if>
-      <else>
-        <group delimiter=", ">
-          <text macro="author-note"/>
-          <text macro="title-and-source-note"/>
-        </group>
-      </else>
-    </choose>
+        </else>
+      </choose>
+    </group>
   </macro>
   <macro name="citation-notes-shortened-author-title">
     <!-- Shortened note styles mirror the filtering approach of author-date -->

--- a/chicago-notes-publisher-place-archive-place-first-no-url.csl
+++ b/chicago-notes-publisher-place-archive-place-first-no-url.csl
@@ -1086,7 +1086,7 @@
       </choose>
       <text macro="source-medium-note"/>
       <text macro="source-archive-note"/>
-      <!-- <text macro="source-DOI-URL-note"/> -->
+      <text macro="source-date-accessed-DOI-URL-note"/>
     </group>
   </macro>
   <!-- 3.1. Title -->
@@ -4394,7 +4394,23 @@
     </group>
   </macro>
   <!-- 4.10. URL or persistent identifier -->
+  <macro name="source-date-accessed-DOI-URL-note">
+    <group delimiter=", ">
+      <choose>
+        <if variable="DOI"/>
+        <else-if match="any" variable="available-date event-date issued status"/>
+        <else-if variable="URL">
+          <group delimiter=" ">
+            <text term="accessed"/>
+            <date form="text" variable="accessed"/>
+          </group>
+        </else-if>
+      </choose>
+      <!-- <text macro="source-DOI-URL"/> -->
+    </group>
+  </macro>
   <!-- 5. Notes -->
+  <!-- TODO: add variables for distributor and exhibitions if available in CSL -->
   <!-- 6. Legal references: Bluebook style (shared with APA) -->
   <!-- Where APA or Chicago diverge from Bluebook, the official manual is followed -->
   <macro name="legal-reference">
@@ -4418,42 +4434,38 @@
          `treaty`
          : treaties
     -->
-    <group delimiter=" ">
-      <group delimiter=", " suffix=".">
-        <choose>
-          <if type="treaty">
-            <text macro="legal-title"/>
-            <names variable="author">
-              <!-- Treaty parties should be included at least for bilateral treaties (Bluebook 21.4.2) -->
-              <name delimiter="-" et-al-min="100" et-al-use-first="99" form="short"/>
-            </names>
-            <text macro="legal-date"/>
-            <!-- treaty source/report in addition to URL (Bluebook 21.4.5) -->
-            <text macro="legal-source"/>
-          </if>
-          <else>
-            <group delimiter=" ">
-              <group delimiter=", ">
-                <text macro="legal-title"/>
-                <text macro="legal-source"/>
-              </group>
-              <text macro="legal-date"/>
-              <text macro="legal-identifier"/>
+    <group delimiter=", ">
+      <choose>
+        <if type="treaty">
+          <text macro="legal-title"/>
+          <names variable="author">
+            <!-- Treaty parties should be included at least for bilateral treaties (Bluebook 21.4.2) -->
+            <name delimiter="-" et-al-min="100" et-al-use-first="99" form="short"/>
+          </names>
+          <text macro="legal-date"/>
+          <!-- treaty source/report in addition to URL (Bluebook 21.4.5) -->
+          <text macro="legal-source"/>
+        </if>
+        <else>
+          <group delimiter=" ">
+            <group delimiter=", ">
+              <text macro="legal-title"/>
+              <text macro="legal-source"/>
             </group>
-          </else>
+            <text macro="legal-date"/>
+            <text macro="legal-identifier"/>
+          </group>
+        </else>
+      </choose>
+      <group delimiter=" ">
+        <!-- locator for use in notes -->
+        <choose>
+          <if locator="page" variable="page">
+            <text term="at"/>
+          </if>
         </choose>
-        <group delimiter=" ">
-          <!-- locator for use in notes -->
-          <choose>
-            <if locator="page" variable="page">
-              <text term="at"/>
-            </if>
-          </choose>
-          <text macro="label-locator"/>
-        </group>
+        <text macro="label-locator"/>
       </group>
-      <text variable="references"/>
-      <!-- <text macro="source-DOI-URL"/> -->
     </group>
   </macro>
   <!-- 6.1. Legal date -->
@@ -4704,30 +4716,29 @@
   </macro>
   <!-- Citation -->
   <macro name="citation-notes-full">
-    <choose>
-      <if match="any" type="bill hearing legal_case legislation regulation treaty">
-        <!-- Legal items have different orders and delimiters -->
-        <text macro="legal-reference"/>
-      </if>
-      <else-if type="personal_communication" variable="genre">
-        <group delimiter=", ">
+    <group delimiter=", ">
+      <choose>
+        <if match="any" type="bill hearing legal_case legislation regulation treaty">
+          <!-- Legal items have different orders and delimiters -->
+          <text macro="legal-reference"/>
+          <text macro="source-date-accessed-DOI-URL-note"/>
+        </if>
+        <else-if type="personal_communication" variable="genre">
           <text macro="author-note"/>
           <text macro="title-and-source-note"/>
-        </group>
-      </else-if>
-      <else-if type="personal_communication" variable="author recipient">
-        <group delimiter=" ">
+        </else-if>
+        <else-if type="personal_communication" variable="author recipient">
+          <group delimiter=" ">
+            <text macro="author-note"/>
+            <text macro="title-and-source-note"/>
+          </group>
+        </else-if>
+        <else>
           <text macro="author-note"/>
           <text macro="title-and-source-note"/>
-        </group>
-      </else-if>
-      <else>
-        <group delimiter=", ">
-          <text macro="author-note"/>
-          <text macro="title-and-source-note"/>
-        </group>
-      </else>
-    </choose>
+        </else>
+      </choose>
+    </group>
   </macro>
   <macro name="citation-notes-shortened-author-title">
     <!-- Shortened note styles mirror the filtering approach of author-date -->

--- a/chicago-notes-publisher-place-archive-place-first.csl
+++ b/chicago-notes-publisher-place-archive-place-first.csl
@@ -1086,7 +1086,7 @@
       </choose>
       <text macro="source-medium-note"/>
       <text macro="source-archive-note"/>
-      <text macro="source-DOI-URL-note"/>
+      <text macro="source-date-accessed-DOI-URL-note"/>
     </group>
   </macro>
   <!-- 3.1. Title -->
@@ -4394,51 +4394,33 @@
     </group>
   </macro>
   <!-- 4.10. URL or persistent identifier -->
-  <macro name="source-DOI-URL-bib">
-    <choose>
-      <if variable="DOI">
-        <text prefix="https://doi.org/" variable="DOI"/>
-      </if>
-      <else-if variable="URL">
-        <group delimiter=". ">
-          <choose>
-            <if match="none" variable="available-date event-date issued status">
-              <group delimiter=" ">
-                <text term="accessed" text-case="capitalize-first"/>
-                <date form="text" variable="accessed"/>
-              </group>
-            </if>
-          </choose>
-          <text variable="URL"/>
-        </group>
-      </else-if>
-    </choose>
-  </macro>
-  <macro name="source-DOI-URL-note">
-    <choose>
-      <if variable="DOI">
-        <text prefix="https://doi.org/" variable="DOI"/>
-      </if>
-      <else-if variable="URL">
-        <group delimiter=", ">
-          <choose>
-            <if match="none" variable="available-date event-date issued status">
-              <group delimiter=" ">
-                <text term="accessed"/>
-                <date form="text" variable="accessed"/>
-              </group>
-            </if>
-          </choose>
-          <text variable="URL"/>
-        </group>
-      </else-if>
-    </choose>
+  <macro name="source-date-accessed-DOI-URL-note">
+    <group delimiter=", ">
+      <choose>
+        <if variable="DOI"/>
+        <else-if match="any" variable="available-date event-date issued status"/>
+        <else-if variable="URL">
+          <group delimiter=" ">
+            <text term="accessed"/>
+            <date form="text" variable="accessed"/>
+          </group>
+        </else-if>
+      </choose>
+      <text macro="source-DOI-URL"/>
+    </group>
   </macro>
   <macro name="source-DOI-URL">
-    <!-- Alias to avoid modifying legal references block shared with APA -->
-    <text macro="source-DOI-URL-bib"/>
+    <choose>
+      <if variable="DOI">
+        <text prefix="https://doi.org/" variable="DOI"/>
+      </if>
+      <else-if variable="URL">
+        <text variable="URL"/>
+      </else-if>
+    </choose>
   </macro>
   <!-- 5. Notes -->
+  <!-- TODO: add variables for distributor and exhibitions if available in CSL -->
   <!-- 6. Legal references: Bluebook style (shared with APA) -->
   <!-- Where APA or Chicago diverge from Bluebook, the official manual is followed -->
   <macro name="legal-reference">
@@ -4462,42 +4444,38 @@
          `treaty`
          : treaties
     -->
-    <group delimiter=" ">
-      <group delimiter=", " suffix=".">
-        <choose>
-          <if type="treaty">
-            <text macro="legal-title"/>
-            <names variable="author">
-              <!-- Treaty parties should be included at least for bilateral treaties (Bluebook 21.4.2) -->
-              <name delimiter="-" et-al-min="100" et-al-use-first="99" form="short"/>
-            </names>
-            <text macro="legal-date"/>
-            <!-- treaty source/report in addition to URL (Bluebook 21.4.5) -->
-            <text macro="legal-source"/>
-          </if>
-          <else>
-            <group delimiter=" ">
-              <group delimiter=", ">
-                <text macro="legal-title"/>
-                <text macro="legal-source"/>
-              </group>
-              <text macro="legal-date"/>
-              <text macro="legal-identifier"/>
+    <group delimiter=", ">
+      <choose>
+        <if type="treaty">
+          <text macro="legal-title"/>
+          <names variable="author">
+            <!-- Treaty parties should be included at least for bilateral treaties (Bluebook 21.4.2) -->
+            <name delimiter="-" et-al-min="100" et-al-use-first="99" form="short"/>
+          </names>
+          <text macro="legal-date"/>
+          <!-- treaty source/report in addition to URL (Bluebook 21.4.5) -->
+          <text macro="legal-source"/>
+        </if>
+        <else>
+          <group delimiter=" ">
+            <group delimiter=", ">
+              <text macro="legal-title"/>
+              <text macro="legal-source"/>
             </group>
-          </else>
+            <text macro="legal-date"/>
+            <text macro="legal-identifier"/>
+          </group>
+        </else>
+      </choose>
+      <group delimiter=" ">
+        <!-- locator for use in notes -->
+        <choose>
+          <if locator="page" variable="page">
+            <text term="at"/>
+          </if>
         </choose>
-        <group delimiter=" ">
-          <!-- locator for use in notes -->
-          <choose>
-            <if locator="page" variable="page">
-              <text term="at"/>
-            </if>
-          </choose>
-          <text macro="label-locator"/>
-        </group>
+        <text macro="label-locator"/>
       </group>
-      <text variable="references"/>
-      <text macro="source-DOI-URL"/>
     </group>
   </macro>
   <!-- 6.1. Legal date -->
@@ -4748,30 +4726,29 @@
   </macro>
   <!-- Citation -->
   <macro name="citation-notes-full">
-    <choose>
-      <if match="any" type="bill hearing legal_case legislation regulation treaty">
-        <!-- Legal items have different orders and delimiters -->
-        <text macro="legal-reference"/>
-      </if>
-      <else-if type="personal_communication" variable="genre">
-        <group delimiter=", ">
+    <group delimiter=", ">
+      <choose>
+        <if match="any" type="bill hearing legal_case legislation regulation treaty">
+          <!-- Legal items have different orders and delimiters -->
+          <text macro="legal-reference"/>
+          <text macro="source-date-accessed-DOI-URL-note"/>
+        </if>
+        <else-if type="personal_communication" variable="genre">
           <text macro="author-note"/>
           <text macro="title-and-source-note"/>
-        </group>
-      </else-if>
-      <else-if type="personal_communication" variable="author recipient">
-        <group delimiter=" ">
+        </else-if>
+        <else-if type="personal_communication" variable="author recipient">
+          <group delimiter=" ">
+            <text macro="author-note"/>
+            <text macro="title-and-source-note"/>
+          </group>
+        </else-if>
+        <else>
           <text macro="author-note"/>
           <text macro="title-and-source-note"/>
-        </group>
-      </else-if>
-      <else>
-        <group delimiter=", ">
-          <text macro="author-note"/>
-          <text macro="title-and-source-note"/>
-        </group>
-      </else>
-    </choose>
+        </else>
+      </choose>
+    </group>
   </macro>
   <macro name="citation-notes-shortened-author-title">
     <!-- Shortened note styles mirror the filtering approach of author-date -->

--- a/chicago-notes.csl
+++ b/chicago-notes.csl
@@ -1086,7 +1086,7 @@
       </choose>
       <text macro="source-medium-note"/>
       <text macro="source-archive-note"/>
-      <text macro="source-DOI-URL-note"/>
+      <text macro="source-date-accessed-DOI-URL-note"/>
     </group>
   </macro>
   <!-- 3.1. Title -->
@@ -4399,51 +4399,33 @@
     </group>
   </macro>
   <!-- 4.10. URL or persistent identifier -->
-  <macro name="source-DOI-URL-bib">
-    <choose>
-      <if variable="DOI">
-        <text prefix="https://doi.org/" variable="DOI"/>
-      </if>
-      <else-if variable="URL">
-        <group delimiter=". ">
-          <choose>
-            <if match="none" variable="available-date event-date issued status">
-              <group delimiter=" ">
-                <text term="accessed" text-case="capitalize-first"/>
-                <date form="text" variable="accessed"/>
-              </group>
-            </if>
-          </choose>
-          <text variable="URL"/>
-        </group>
-      </else-if>
-    </choose>
-  </macro>
-  <macro name="source-DOI-URL-note">
-    <choose>
-      <if variable="DOI">
-        <text prefix="https://doi.org/" variable="DOI"/>
-      </if>
-      <else-if variable="URL">
-        <group delimiter=", ">
-          <choose>
-            <if match="none" variable="available-date event-date issued status">
-              <group delimiter=" ">
-                <text term="accessed"/>
-                <date form="text" variable="accessed"/>
-              </group>
-            </if>
-          </choose>
-          <text variable="URL"/>
-        </group>
-      </else-if>
-    </choose>
+  <macro name="source-date-accessed-DOI-URL-note">
+    <group delimiter=", ">
+      <choose>
+        <if variable="DOI"/>
+        <else-if match="any" variable="available-date event-date issued status"/>
+        <else-if variable="URL">
+          <group delimiter=" ">
+            <text term="accessed"/>
+            <date form="text" variable="accessed"/>
+          </group>
+        </else-if>
+      </choose>
+      <text macro="source-DOI-URL"/>
+    </group>
   </macro>
   <macro name="source-DOI-URL">
-    <!-- Alias to avoid modifying legal references block shared with APA -->
-    <text macro="source-DOI-URL-bib"/>
+    <choose>
+      <if variable="DOI">
+        <text prefix="https://doi.org/" variable="DOI"/>
+      </if>
+      <else-if variable="URL">
+        <text variable="URL"/>
+      </else-if>
+    </choose>
   </macro>
   <!-- 5. Notes -->
+  <!-- TODO: add variables for distributor and exhibitions if available in CSL -->
   <!-- 6. Legal references: Bluebook style (shared with APA) -->
   <!-- Where APA or Chicago diverge from Bluebook, the official manual is followed -->
   <macro name="legal-reference">
@@ -4467,42 +4449,38 @@
          `treaty`
          : treaties
     -->
-    <group delimiter=" ">
-      <group delimiter=", " suffix=".">
-        <choose>
-          <if type="treaty">
-            <text macro="legal-title"/>
-            <names variable="author">
-              <!-- Treaty parties should be included at least for bilateral treaties (Bluebook 21.4.2) -->
-              <name delimiter="-" et-al-min="100" et-al-use-first="99" form="short"/>
-            </names>
-            <text macro="legal-date"/>
-            <!-- treaty source/report in addition to URL (Bluebook 21.4.5) -->
-            <text macro="legal-source"/>
-          </if>
-          <else>
-            <group delimiter=" ">
-              <group delimiter=", ">
-                <text macro="legal-title"/>
-                <text macro="legal-source"/>
-              </group>
-              <text macro="legal-date"/>
-              <text macro="legal-identifier"/>
+    <group delimiter=", ">
+      <choose>
+        <if type="treaty">
+          <text macro="legal-title"/>
+          <names variable="author">
+            <!-- Treaty parties should be included at least for bilateral treaties (Bluebook 21.4.2) -->
+            <name delimiter="-" et-al-min="100" et-al-use-first="99" form="short"/>
+          </names>
+          <text macro="legal-date"/>
+          <!-- treaty source/report in addition to URL (Bluebook 21.4.5) -->
+          <text macro="legal-source"/>
+        </if>
+        <else>
+          <group delimiter=" ">
+            <group delimiter=", ">
+              <text macro="legal-title"/>
+              <text macro="legal-source"/>
             </group>
-          </else>
+            <text macro="legal-date"/>
+            <text macro="legal-identifier"/>
+          </group>
+        </else>
+      </choose>
+      <group delimiter=" ">
+        <!-- locator for use in notes -->
+        <choose>
+          <if locator="page" variable="page">
+            <text term="at"/>
+          </if>
         </choose>
-        <group delimiter=" ">
-          <!-- locator for use in notes -->
-          <choose>
-            <if locator="page" variable="page">
-              <text term="at"/>
-            </if>
-          </choose>
-          <text macro="label-locator"/>
-        </group>
+        <text macro="label-locator"/>
       </group>
-      <text variable="references"/>
-      <text macro="source-DOI-URL"/>
     </group>
   </macro>
   <!-- 6.1. Legal date -->
@@ -4753,30 +4731,29 @@
   </macro>
   <!-- Citation -->
   <macro name="citation-notes-full">
-    <choose>
-      <if match="any" type="bill hearing legal_case legislation regulation treaty">
-        <!-- Legal items have different orders and delimiters -->
-        <text macro="legal-reference"/>
-      </if>
-      <else-if type="personal_communication" variable="genre">
-        <group delimiter=", ">
+    <group delimiter=", ">
+      <choose>
+        <if match="any" type="bill hearing legal_case legislation regulation treaty">
+          <!-- Legal items have different orders and delimiters -->
+          <text macro="legal-reference"/>
+          <text macro="source-date-accessed-DOI-URL-note"/>
+        </if>
+        <else-if type="personal_communication" variable="genre">
           <text macro="author-note"/>
           <text macro="title-and-source-note"/>
-        </group>
-      </else-if>
-      <else-if type="personal_communication" variable="author recipient">
-        <group delimiter=" ">
+        </else-if>
+        <else-if type="personal_communication" variable="author recipient">
+          <group delimiter=" ">
+            <text macro="author-note"/>
+            <text macro="title-and-source-note"/>
+          </group>
+        </else-if>
+        <else>
           <text macro="author-note"/>
           <text macro="title-and-source-note"/>
-        </group>
-      </else-if>
-      <else>
-        <group delimiter=", ">
-          <text macro="author-note"/>
-          <text macro="title-and-source-note"/>
-        </group>
-      </else>
-    </choose>
+        </else>
+      </choose>
+    </group>
   </macro>
   <macro name="citation-notes-shortened-author-title">
     <!-- Shortened note styles mirror the filtering approach of author-date -->

--- a/chicago-shortened-notes-bibliography-17th-edition.csl
+++ b/chicago-shortened-notes-bibliography-17th-edition.csl
@@ -1007,7 +1007,7 @@
       </group>
       <text macro="source-medium-bib"/>
       <text macro="source-archive-bib"/>
-      <text macro="source-DOI-URL-bib"/>
+      <text macro="source-date-accessed-DOI-URL-bib"/>
     </group>
   </macro>
   <!-- 3.1. Title -->
@@ -3565,35 +3565,33 @@
     </group>
   </macro>
   <!-- 4.10. URL or persistent identifier -->
-  <macro name="source-DOI-URL-bib">
+  <macro name="source-date-accessed-DOI-URL-bib">
+    <group delimiter=", ">
+      <choose>
+        <if variable="DOI"/>
+        <else-if match="any" variable="available-date event-date issued status"/>
+        <else-if variable="accessed URL">
+          <group delimiter=" ">
+            <text term="accessed" text-case="capitalize-first"/>
+            <date form="text" variable="accessed"/>
+          </group>
+        </else-if>
+      </choose>
+      <text macro="source-DOI-URL"/>
+    </group>
+  </macro>
+  <macro name="source-DOI-URL">
     <choose>
       <if variable="DOI">
         <text prefix="https://doi.org/" variable="DOI"/>
       </if>
       <else-if variable="URL">
-        <group delimiter=". ">
-          <choose>
-            <if match="none" variable="available-date event-date issued status">
-              <group delimiter=" ">
-                <text term="accessed" text-case="capitalize-first"/>
-                <date form="text" variable="accessed"/>
-              </group>
-            </if>
-          </choose>
-          <text variable="URL"/>
-        </group>
+        <text variable="URL"/>
       </else-if>
     </choose>
   </macro>
-  <macro name="source-DOI-URL">
-    <!-- Alias to avoid modifying legal references block shared with APA -->
-    <text macro="source-DOI-URL-bib"/>
-  </macro>
   <!-- 5. Notes -->
-  <macro name="notes">
-    <!-- Notes on source element: original publication, reprint info, retraction info -->
-    <text variable="references"/>
-  </macro>
+  <!-- TODO: add variables for distributor and exhibitions if available in CSL -->
   <!-- 6. Legal references: Bluebook style (shared with APA) -->
   <!-- Where APA or Chicago diverge from Bluebook, the official manual is followed -->
   <macro name="legal-reference">
@@ -3617,42 +3615,38 @@
          `treaty`
          : treaties
     -->
-    <group delimiter=" ">
-      <group delimiter=", " suffix=".">
-        <choose>
-          <if type="treaty">
-            <text macro="legal-title"/>
-            <names variable="author">
-              <!-- Treaty parties should be included at least for bilateral treaties (Bluebook 21.4.2) -->
-              <name delimiter="-" et-al-min="100" et-al-use-first="99" form="short"/>
-            </names>
-            <text macro="legal-date"/>
-            <!-- treaty source/report in addition to URL (Bluebook 21.4.5) -->
-            <text macro="legal-source"/>
-          </if>
-          <else>
-            <group delimiter=" ">
-              <group delimiter=", ">
-                <text macro="legal-title"/>
-                <text macro="legal-source"/>
-              </group>
-              <text macro="legal-date"/>
-              <text macro="legal-identifier"/>
+    <group delimiter=", ">
+      <choose>
+        <if type="treaty">
+          <text macro="legal-title"/>
+          <names variable="author">
+            <!-- Treaty parties should be included at least for bilateral treaties (Bluebook 21.4.2) -->
+            <name delimiter="-" et-al-min="100" et-al-use-first="99" form="short"/>
+          </names>
+          <text macro="legal-date"/>
+          <!-- treaty source/report in addition to URL (Bluebook 21.4.5) -->
+          <text macro="legal-source"/>
+        </if>
+        <else>
+          <group delimiter=" ">
+            <group delimiter=", ">
+              <text macro="legal-title"/>
+              <text macro="legal-source"/>
             </group>
-          </else>
+            <text macro="legal-date"/>
+            <text macro="legal-identifier"/>
+          </group>
+        </else>
+      </choose>
+      <group delimiter=" ">
+        <!-- locator for use in notes -->
+        <choose>
+          <if locator="page" variable="page">
+            <text term="at"/>
+          </if>
         </choose>
-        <group delimiter=" ">
-          <!-- locator for use in notes -->
-          <choose>
-            <if locator="page" variable="page">
-              <text term="at"/>
-            </if>
-          </choose>
-          <text macro="label-locator"/>
-        </group>
+        <text macro="label-locator"/>
       </group>
-      <text variable="references"/>
-      <text macro="source-DOI-URL"/>
     </group>
   </macro>
   <!-- 6.1. Legal date -->
@@ -4066,19 +4060,21 @@
   </citation>
   <!-- Bibliography -->
   <macro name="bibliography-notes">
-    <choose>
-      <if match="any" type="bill hearing legal_case legislation regulation treaty">
-        <!-- Legal items have different orders and delimiters -->
-        <text macro="legal-reference"/>
-      </if>
-      <else>
-        <group delimiter=". ">
+    <group delimiter=". ">
+      <choose>
+        <if match="any" type="bill hearing legal_case legislation regulation treaty">
+          <!-- Legal items have different orders and delimiters -->
+          <text macro="legal-reference"/>
+          <text macro="source-date-accessed-DOI-URL-bib"/>
+          <text variable="references"/>
+        </if>
+        <else>
           <text macro="author-bib"/>
           <text macro="title-and-source-bib"/>
-          <text macro="notes"/>
-        </group>
-      </else>
-    </choose>
+          <text variable="references"/>
+        </else>
+      </choose>
+    </group>
   </macro>
   <bibliography et-al-min="11" et-al-use-first="7" hanging-indent="true" subsequent-author-substitute="&#8212;&#8212;&#8212;">
     <sort>

--- a/chicago-shortened-notes-bibliography-archive-place-first-no-url.csl
+++ b/chicago-shortened-notes-bibliography-archive-place-first-no-url.csl
@@ -1010,7 +1010,7 @@
       </group>
       <text macro="source-medium-bib"/>
       <text macro="source-archive-bib"/>
-      <!-- <text macro="source-DOI-URL-bib"/> -->
+      <text macro="source-date-accessed-DOI-URL-bib"/>
     </group>
   </macro>
   <!-- 3.1. Title -->
@@ -3563,11 +3563,23 @@
     </group>
   </macro>
   <!-- 4.10. URL or persistent identifier -->
-  <!-- 5. Notes -->
-  <macro name="notes">
-    <!-- Notes on source element: original publication, reprint info, retraction info -->
-    <text variable="references"/>
+  <macro name="source-date-accessed-DOI-URL-bib">
+    <group delimiter=", ">
+      <choose>
+        <if variable="DOI"/>
+        <else-if match="any" variable="available-date event-date issued status"/>
+        <else-if variable="accessed URL">
+          <group delimiter=" ">
+            <text term="accessed" text-case="capitalize-first"/>
+            <date form="text" variable="accessed"/>
+          </group>
+        </else-if>
+      </choose>
+      <!-- <text macro="source-DOI-URL"/> -->
+    </group>
   </macro>
+  <!-- 5. Notes -->
+  <!-- TODO: add variables for distributor and exhibitions if available in CSL -->
   <!-- 6. Legal references: Bluebook style (shared with APA) -->
   <!-- Where APA or Chicago diverge from Bluebook, the official manual is followed -->
   <macro name="legal-reference">
@@ -3591,42 +3603,38 @@
          `treaty`
          : treaties
     -->
-    <group delimiter=" ">
-      <group delimiter=", " suffix=".">
-        <choose>
-          <if type="treaty">
-            <text macro="legal-title"/>
-            <names variable="author">
-              <!-- Treaty parties should be included at least for bilateral treaties (Bluebook 21.4.2) -->
-              <name delimiter="-" et-al-min="100" et-al-use-first="99" form="short"/>
-            </names>
-            <text macro="legal-date"/>
-            <!-- treaty source/report in addition to URL (Bluebook 21.4.5) -->
-            <text macro="legal-source"/>
-          </if>
-          <else>
-            <group delimiter=" ">
-              <group delimiter=", ">
-                <text macro="legal-title"/>
-                <text macro="legal-source"/>
-              </group>
-              <text macro="legal-date"/>
-              <text macro="legal-identifier"/>
+    <group delimiter=", ">
+      <choose>
+        <if type="treaty">
+          <text macro="legal-title"/>
+          <names variable="author">
+            <!-- Treaty parties should be included at least for bilateral treaties (Bluebook 21.4.2) -->
+            <name delimiter="-" et-al-min="100" et-al-use-first="99" form="short"/>
+          </names>
+          <text macro="legal-date"/>
+          <!-- treaty source/report in addition to URL (Bluebook 21.4.5) -->
+          <text macro="legal-source"/>
+        </if>
+        <else>
+          <group delimiter=" ">
+            <group delimiter=", ">
+              <text macro="legal-title"/>
+              <text macro="legal-source"/>
             </group>
-          </else>
+            <text macro="legal-date"/>
+            <text macro="legal-identifier"/>
+          </group>
+        </else>
+      </choose>
+      <group delimiter=" ">
+        <!-- locator for use in notes -->
+        <choose>
+          <if locator="page" variable="page">
+            <text term="at"/>
+          </if>
         </choose>
-        <group delimiter=" ">
-          <!-- locator for use in notes -->
-          <choose>
-            <if locator="page" variable="page">
-              <text term="at"/>
-            </if>
-          </choose>
-          <text macro="label-locator"/>
-        </group>
+        <text macro="label-locator"/>
       </group>
-      <text variable="references"/>
-      <!-- <text macro="source-DOI-URL"/> -->
     </group>
   </macro>
   <!-- 6.1. Legal date -->
@@ -3963,19 +3971,21 @@
   </citation>
   <!-- Bibliography -->
   <macro name="bibliography-notes">
-    <choose>
-      <if match="any" type="bill hearing legal_case legislation regulation treaty">
-        <!-- Legal items have different orders and delimiters -->
-        <text macro="legal-reference"/>
-      </if>
-      <else>
-        <group delimiter=". ">
+    <group delimiter=". ">
+      <choose>
+        <if match="any" type="bill hearing legal_case legislation regulation treaty">
+          <!-- Legal items have different orders and delimiters -->
+          <text macro="legal-reference"/>
+          <text macro="source-date-accessed-DOI-URL-bib"/>
+          <text variable="references"/>
+        </if>
+        <else>
           <text macro="author-bib"/>
           <text macro="title-and-source-bib"/>
-          <text macro="notes"/>
-        </group>
-      </else>
-    </choose>
+          <text variable="references"/>
+        </else>
+      </choose>
+    </group>
   </macro>
   <bibliography et-al-min="7" et-al-use-first="3" hanging-indent="true">
     <sort>

--- a/chicago-shortened-notes-bibliography-archive-place-first.csl
+++ b/chicago-shortened-notes-bibliography-archive-place-first.csl
@@ -1010,7 +1010,7 @@
       </group>
       <text macro="source-medium-bib"/>
       <text macro="source-archive-bib"/>
-      <text macro="source-DOI-URL-bib"/>
+      <text macro="source-date-accessed-DOI-URL-bib"/>
     </group>
   </macro>
   <!-- 3.1. Title -->
@@ -3563,35 +3563,33 @@
     </group>
   </macro>
   <!-- 4.10. URL or persistent identifier -->
-  <macro name="source-DOI-URL-bib">
+  <macro name="source-date-accessed-DOI-URL-bib">
+    <group delimiter=", ">
+      <choose>
+        <if variable="DOI"/>
+        <else-if match="any" variable="available-date event-date issued status"/>
+        <else-if variable="accessed URL">
+          <group delimiter=" ">
+            <text term="accessed" text-case="capitalize-first"/>
+            <date form="text" variable="accessed"/>
+          </group>
+        </else-if>
+      </choose>
+      <text macro="source-DOI-URL"/>
+    </group>
+  </macro>
+  <macro name="source-DOI-URL">
     <choose>
       <if variable="DOI">
         <text prefix="https://doi.org/" variable="DOI"/>
       </if>
       <else-if variable="URL">
-        <group delimiter=". ">
-          <choose>
-            <if match="none" variable="available-date event-date issued status">
-              <group delimiter=" ">
-                <text term="accessed" text-case="capitalize-first"/>
-                <date form="text" variable="accessed"/>
-              </group>
-            </if>
-          </choose>
-          <text variable="URL"/>
-        </group>
+        <text variable="URL"/>
       </else-if>
     </choose>
   </macro>
-  <macro name="source-DOI-URL">
-    <!-- Alias to avoid modifying legal references block shared with APA -->
-    <text macro="source-DOI-URL-bib"/>
-  </macro>
   <!-- 5. Notes -->
-  <macro name="notes">
-    <!-- Notes on source element: original publication, reprint info, retraction info -->
-    <text variable="references"/>
-  </macro>
+  <!-- TODO: add variables for distributor and exhibitions if available in CSL -->
   <!-- 6. Legal references: Bluebook style (shared with APA) -->
   <!-- Where APA or Chicago diverge from Bluebook, the official manual is followed -->
   <macro name="legal-reference">
@@ -3615,42 +3613,38 @@
          `treaty`
          : treaties
     -->
-    <group delimiter=" ">
-      <group delimiter=", " suffix=".">
-        <choose>
-          <if type="treaty">
-            <text macro="legal-title"/>
-            <names variable="author">
-              <!-- Treaty parties should be included at least for bilateral treaties (Bluebook 21.4.2) -->
-              <name delimiter="-" et-al-min="100" et-al-use-first="99" form="short"/>
-            </names>
-            <text macro="legal-date"/>
-            <!-- treaty source/report in addition to URL (Bluebook 21.4.5) -->
-            <text macro="legal-source"/>
-          </if>
-          <else>
-            <group delimiter=" ">
-              <group delimiter=", ">
-                <text macro="legal-title"/>
-                <text macro="legal-source"/>
-              </group>
-              <text macro="legal-date"/>
-              <text macro="legal-identifier"/>
+    <group delimiter=", ">
+      <choose>
+        <if type="treaty">
+          <text macro="legal-title"/>
+          <names variable="author">
+            <!-- Treaty parties should be included at least for bilateral treaties (Bluebook 21.4.2) -->
+            <name delimiter="-" et-al-min="100" et-al-use-first="99" form="short"/>
+          </names>
+          <text macro="legal-date"/>
+          <!-- treaty source/report in addition to URL (Bluebook 21.4.5) -->
+          <text macro="legal-source"/>
+        </if>
+        <else>
+          <group delimiter=" ">
+            <group delimiter=", ">
+              <text macro="legal-title"/>
+              <text macro="legal-source"/>
             </group>
-          </else>
+            <text macro="legal-date"/>
+            <text macro="legal-identifier"/>
+          </group>
+        </else>
+      </choose>
+      <group delimiter=" ">
+        <!-- locator for use in notes -->
+        <choose>
+          <if locator="page" variable="page">
+            <text term="at"/>
+          </if>
         </choose>
-        <group delimiter=" ">
-          <!-- locator for use in notes -->
-          <choose>
-            <if locator="page" variable="page">
-              <text term="at"/>
-            </if>
-          </choose>
-          <text macro="label-locator"/>
-        </group>
+        <text macro="label-locator"/>
       </group>
-      <text variable="references"/>
-      <text macro="source-DOI-URL"/>
     </group>
   </macro>
   <!-- 6.1. Legal date -->
@@ -3987,19 +3981,21 @@
   </citation>
   <!-- Bibliography -->
   <macro name="bibliography-notes">
-    <choose>
-      <if match="any" type="bill hearing legal_case legislation regulation treaty">
-        <!-- Legal items have different orders and delimiters -->
-        <text macro="legal-reference"/>
-      </if>
-      <else>
-        <group delimiter=". ">
+    <group delimiter=". ">
+      <choose>
+        <if match="any" type="bill hearing legal_case legislation regulation treaty">
+          <!-- Legal items have different orders and delimiters -->
+          <text macro="legal-reference"/>
+          <text macro="source-date-accessed-DOI-URL-bib"/>
+          <text variable="references"/>
+        </if>
+        <else>
           <text macro="author-bib"/>
           <text macro="title-and-source-bib"/>
-          <text macro="notes"/>
-        </group>
-      </else>
-    </choose>
+          <text variable="references"/>
+        </else>
+      </choose>
+    </group>
   </macro>
   <bibliography et-al-min="7" et-al-use-first="3" hanging-indent="true">
     <sort>

--- a/chicago-shortened-notes-bibliography-classic-no-url.csl
+++ b/chicago-shortened-notes-bibliography-classic-no-url.csl
@@ -1010,7 +1010,7 @@
       </group>
       <text macro="source-medium-bib"/>
       <text macro="source-archive-bib"/>
-      <!-- <text macro="source-DOI-URL-bib"/> -->
+      <text macro="source-date-accessed-DOI-URL-bib"/>
     </group>
   </macro>
   <!-- 3.1. Title -->
@@ -3576,11 +3576,23 @@
     </group>
   </macro>
   <!-- 4.10. URL or persistent identifier -->
-  <!-- 5. Notes -->
-  <macro name="notes">
-    <!-- Notes on source element: original publication, reprint info, retraction info -->
-    <text variable="references"/>
+  <macro name="source-date-accessed-DOI-URL-bib">
+    <group delimiter=", ">
+      <choose>
+        <if variable="DOI"/>
+        <else-if match="any" variable="available-date event-date issued status"/>
+        <else-if variable="accessed URL">
+          <group delimiter=" ">
+            <text term="accessed" text-case="capitalize-first"/>
+            <date form="text" variable="accessed"/>
+          </group>
+        </else-if>
+      </choose>
+      <!-- <text macro="source-DOI-URL"/> -->
+    </group>
   </macro>
+  <!-- 5. Notes -->
+  <!-- TODO: add variables for distributor and exhibitions if available in CSL -->
   <!-- 6. Legal references: Bluebook style (shared with APA) -->
   <!-- Where APA or Chicago diverge from Bluebook, the official manual is followed -->
   <macro name="legal-reference">
@@ -3604,42 +3616,38 @@
          `treaty`
          : treaties
     -->
-    <group delimiter=" ">
-      <group delimiter=", " suffix=".">
-        <choose>
-          <if type="treaty">
-            <text macro="legal-title"/>
-            <names variable="author">
-              <!-- Treaty parties should be included at least for bilateral treaties (Bluebook 21.4.2) -->
-              <name delimiter="-" et-al-min="100" et-al-use-first="99" form="short"/>
-            </names>
-            <text macro="legal-date"/>
-            <!-- treaty source/report in addition to URL (Bluebook 21.4.5) -->
-            <text macro="legal-source"/>
-          </if>
-          <else>
-            <group delimiter=" ">
-              <group delimiter=", ">
-                <text macro="legal-title"/>
-                <text macro="legal-source"/>
-              </group>
-              <text macro="legal-date"/>
-              <text macro="legal-identifier"/>
+    <group delimiter=", ">
+      <choose>
+        <if type="treaty">
+          <text macro="legal-title"/>
+          <names variable="author">
+            <!-- Treaty parties should be included at least for bilateral treaties (Bluebook 21.4.2) -->
+            <name delimiter="-" et-al-min="100" et-al-use-first="99" form="short"/>
+          </names>
+          <text macro="legal-date"/>
+          <!-- treaty source/report in addition to URL (Bluebook 21.4.5) -->
+          <text macro="legal-source"/>
+        </if>
+        <else>
+          <group delimiter=" ">
+            <group delimiter=", ">
+              <text macro="legal-title"/>
+              <text macro="legal-source"/>
             </group>
-          </else>
+            <text macro="legal-date"/>
+            <text macro="legal-identifier"/>
+          </group>
+        </else>
+      </choose>
+      <group delimiter=" ">
+        <!-- locator for use in notes -->
+        <choose>
+          <if locator="page" variable="page">
+            <text term="at"/>
+          </if>
         </choose>
-        <group delimiter=" ">
-          <!-- locator for use in notes -->
-          <choose>
-            <if locator="page" variable="page">
-              <text term="at"/>
-            </if>
-          </choose>
-          <text macro="label-locator"/>
-        </group>
+        <text macro="label-locator"/>
       </group>
-      <text variable="references"/>
-      <!-- <text macro="source-DOI-URL"/> -->
     </group>
   </macro>
   <!-- 6.1. Legal date -->
@@ -3976,19 +3984,21 @@
   </citation>
   <!-- Bibliography -->
   <macro name="bibliography-notes">
-    <choose>
-      <if match="any" type="bill hearing legal_case legislation regulation treaty">
-        <!-- Legal items have different orders and delimiters -->
-        <text macro="legal-reference"/>
-      </if>
-      <else>
-        <group delimiter=". ">
+    <group delimiter=". ">
+      <choose>
+        <if match="any" type="bill hearing legal_case legislation regulation treaty">
+          <!-- Legal items have different orders and delimiters -->
+          <text macro="legal-reference"/>
+          <text macro="source-date-accessed-DOI-URL-bib"/>
+          <text variable="references"/>
+        </if>
+        <else>
           <text macro="author-bib"/>
           <text macro="title-and-source-bib"/>
-          <text macro="notes"/>
-        </group>
-      </else>
-    </choose>
+          <text variable="references"/>
+        </else>
+      </choose>
+    </group>
   </macro>
   <bibliography et-al-min="7" et-al-use-first="3" hanging-indent="true" subsequent-author-substitute="&#8212;&#8212;&#8212;">
     <sort>

--- a/chicago-shortened-notes-bibliography-classic.csl
+++ b/chicago-shortened-notes-bibliography-classic.csl
@@ -1010,7 +1010,7 @@
       </group>
       <text macro="source-medium-bib"/>
       <text macro="source-archive-bib"/>
-      <text macro="source-DOI-URL-bib"/>
+      <text macro="source-date-accessed-DOI-URL-bib"/>
     </group>
   </macro>
   <!-- 3.1. Title -->
@@ -3576,35 +3576,33 @@
     </group>
   </macro>
   <!-- 4.10. URL or persistent identifier -->
-  <macro name="source-DOI-URL-bib">
+  <macro name="source-date-accessed-DOI-URL-bib">
+    <group delimiter=", ">
+      <choose>
+        <if variable="DOI"/>
+        <else-if match="any" variable="available-date event-date issued status"/>
+        <else-if variable="accessed URL">
+          <group delimiter=" ">
+            <text term="accessed" text-case="capitalize-first"/>
+            <date form="text" variable="accessed"/>
+          </group>
+        </else-if>
+      </choose>
+      <text macro="source-DOI-URL"/>
+    </group>
+  </macro>
+  <macro name="source-DOI-URL">
     <choose>
       <if variable="DOI">
         <text prefix="https://doi.org/" variable="DOI"/>
       </if>
       <else-if variable="URL">
-        <group delimiter=". ">
-          <choose>
-            <if match="none" variable="available-date event-date issued status">
-              <group delimiter=" ">
-                <text term="accessed" text-case="capitalize-first"/>
-                <date form="text" variable="accessed"/>
-              </group>
-            </if>
-          </choose>
-          <text variable="URL"/>
-        </group>
+        <text variable="URL"/>
       </else-if>
     </choose>
   </macro>
-  <macro name="source-DOI-URL">
-    <!-- Alias to avoid modifying legal references block shared with APA -->
-    <text macro="source-DOI-URL-bib"/>
-  </macro>
   <!-- 5. Notes -->
-  <macro name="notes">
-    <!-- Notes on source element: original publication, reprint info, retraction info -->
-    <text variable="references"/>
-  </macro>
+  <!-- TODO: add variables for distributor and exhibitions if available in CSL -->
   <!-- 6. Legal references: Bluebook style (shared with APA) -->
   <!-- Where APA or Chicago diverge from Bluebook, the official manual is followed -->
   <macro name="legal-reference">
@@ -3628,42 +3626,38 @@
          `treaty`
          : treaties
     -->
-    <group delimiter=" ">
-      <group delimiter=", " suffix=".">
-        <choose>
-          <if type="treaty">
-            <text macro="legal-title"/>
-            <names variable="author">
-              <!-- Treaty parties should be included at least for bilateral treaties (Bluebook 21.4.2) -->
-              <name delimiter="-" et-al-min="100" et-al-use-first="99" form="short"/>
-            </names>
-            <text macro="legal-date"/>
-            <!-- treaty source/report in addition to URL (Bluebook 21.4.5) -->
-            <text macro="legal-source"/>
-          </if>
-          <else>
-            <group delimiter=" ">
-              <group delimiter=", ">
-                <text macro="legal-title"/>
-                <text macro="legal-source"/>
-              </group>
-              <text macro="legal-date"/>
-              <text macro="legal-identifier"/>
+    <group delimiter=", ">
+      <choose>
+        <if type="treaty">
+          <text macro="legal-title"/>
+          <names variable="author">
+            <!-- Treaty parties should be included at least for bilateral treaties (Bluebook 21.4.2) -->
+            <name delimiter="-" et-al-min="100" et-al-use-first="99" form="short"/>
+          </names>
+          <text macro="legal-date"/>
+          <!-- treaty source/report in addition to URL (Bluebook 21.4.5) -->
+          <text macro="legal-source"/>
+        </if>
+        <else>
+          <group delimiter=" ">
+            <group delimiter=", ">
+              <text macro="legal-title"/>
+              <text macro="legal-source"/>
             </group>
-          </else>
+            <text macro="legal-date"/>
+            <text macro="legal-identifier"/>
+          </group>
+        </else>
+      </choose>
+      <group delimiter=" ">
+        <!-- locator for use in notes -->
+        <choose>
+          <if locator="page" variable="page">
+            <text term="at"/>
+          </if>
         </choose>
-        <group delimiter=" ">
-          <!-- locator for use in notes -->
-          <choose>
-            <if locator="page" variable="page">
-              <text term="at"/>
-            </if>
-          </choose>
-          <text macro="label-locator"/>
-        </group>
+        <text macro="label-locator"/>
       </group>
-      <text variable="references"/>
-      <text macro="source-DOI-URL"/>
     </group>
   </macro>
   <!-- 6.1. Legal date -->
@@ -4000,19 +3994,21 @@
   </citation>
   <!-- Bibliography -->
   <macro name="bibliography-notes">
-    <choose>
-      <if match="any" type="bill hearing legal_case legislation regulation treaty">
-        <!-- Legal items have different orders and delimiters -->
-        <text macro="legal-reference"/>
-      </if>
-      <else>
-        <group delimiter=". ">
+    <group delimiter=". ">
+      <choose>
+        <if match="any" type="bill hearing legal_case legislation regulation treaty">
+          <!-- Legal items have different orders and delimiters -->
+          <text macro="legal-reference"/>
+          <text macro="source-date-accessed-DOI-URL-bib"/>
+          <text variable="references"/>
+        </if>
+        <else>
           <text macro="author-bib"/>
           <text macro="title-and-source-bib"/>
-          <text macro="notes"/>
-        </group>
-      </else>
-    </choose>
+          <text variable="references"/>
+        </else>
+      </choose>
+    </group>
   </macro>
   <bibliography et-al-min="7" et-al-use-first="3" hanging-indent="true" subsequent-author-substitute="&#8212;&#8212;&#8212;">
     <sort>

--- a/chicago-shortened-notes-bibliography-no-url.csl
+++ b/chicago-shortened-notes-bibliography-no-url.csl
@@ -1010,7 +1010,7 @@
       </group>
       <text macro="source-medium-bib"/>
       <text macro="source-archive-bib"/>
-      <!-- <text macro="source-DOI-URL-bib"/> -->
+      <text macro="source-date-accessed-DOI-URL-bib"/>
     </group>
   </macro>
   <!-- 3.1. Title -->
@@ -3582,11 +3582,23 @@
     </group>
   </macro>
   <!-- 4.10. URL or persistent identifier -->
-  <!-- 5. Notes -->
-  <macro name="notes">
-    <!-- Notes on source element: original publication, reprint info, retraction info -->
-    <text variable="references"/>
+  <macro name="source-date-accessed-DOI-URL-bib">
+    <group delimiter=", ">
+      <choose>
+        <if variable="DOI"/>
+        <else-if match="any" variable="available-date event-date issued status"/>
+        <else-if variable="accessed URL">
+          <group delimiter=" ">
+            <text term="accessed" text-case="capitalize-first"/>
+            <date form="text" variable="accessed"/>
+          </group>
+        </else-if>
+      </choose>
+      <!-- <text macro="source-DOI-URL"/> -->
+    </group>
   </macro>
+  <!-- 5. Notes -->
+  <!-- TODO: add variables for distributor and exhibitions if available in CSL -->
   <!-- 6. Legal references: Bluebook style (shared with APA) -->
   <!-- Where APA or Chicago diverge from Bluebook, the official manual is followed -->
   <macro name="legal-reference">
@@ -3610,42 +3622,38 @@
          `treaty`
          : treaties
     -->
-    <group delimiter=" ">
-      <group delimiter=", " suffix=".">
-        <choose>
-          <if type="treaty">
-            <text macro="legal-title"/>
-            <names variable="author">
-              <!-- Treaty parties should be included at least for bilateral treaties (Bluebook 21.4.2) -->
-              <name delimiter="-" et-al-min="100" et-al-use-first="99" form="short"/>
-            </names>
-            <text macro="legal-date"/>
-            <!-- treaty source/report in addition to URL (Bluebook 21.4.5) -->
-            <text macro="legal-source"/>
-          </if>
-          <else>
-            <group delimiter=" ">
-              <group delimiter=", ">
-                <text macro="legal-title"/>
-                <text macro="legal-source"/>
-              </group>
-              <text macro="legal-date"/>
-              <text macro="legal-identifier"/>
+    <group delimiter=", ">
+      <choose>
+        <if type="treaty">
+          <text macro="legal-title"/>
+          <names variable="author">
+            <!-- Treaty parties should be included at least for bilateral treaties (Bluebook 21.4.2) -->
+            <name delimiter="-" et-al-min="100" et-al-use-first="99" form="short"/>
+          </names>
+          <text macro="legal-date"/>
+          <!-- treaty source/report in addition to URL (Bluebook 21.4.5) -->
+          <text macro="legal-source"/>
+        </if>
+        <else>
+          <group delimiter=" ">
+            <group delimiter=", ">
+              <text macro="legal-title"/>
+              <text macro="legal-source"/>
             </group>
-          </else>
+            <text macro="legal-date"/>
+            <text macro="legal-identifier"/>
+          </group>
+        </else>
+      </choose>
+      <group delimiter=" ">
+        <!-- locator for use in notes -->
+        <choose>
+          <if locator="page" variable="page">
+            <text term="at"/>
+          </if>
         </choose>
-        <group delimiter=" ">
-          <!-- locator for use in notes -->
-          <choose>
-            <if locator="page" variable="page">
-              <text term="at"/>
-            </if>
-          </choose>
-          <text macro="label-locator"/>
-        </group>
+        <text macro="label-locator"/>
       </group>
-      <text variable="references"/>
-      <!-- <text macro="source-DOI-URL"/> -->
     </group>
   </macro>
   <!-- 6.1. Legal date -->
@@ -3982,19 +3990,21 @@
   </citation>
   <!-- Bibliography -->
   <macro name="bibliography-notes">
-    <choose>
-      <if match="any" type="bill hearing legal_case legislation regulation treaty">
-        <!-- Legal items have different orders and delimiters -->
-        <text macro="legal-reference"/>
-      </if>
-      <else>
-        <group delimiter=". ">
+    <group delimiter=". ">
+      <choose>
+        <if match="any" type="bill hearing legal_case legislation regulation treaty">
+          <!-- Legal items have different orders and delimiters -->
+          <text macro="legal-reference"/>
+          <text macro="source-date-accessed-DOI-URL-bib"/>
+          <text variable="references"/>
+        </if>
+        <else>
           <text macro="author-bib"/>
           <text macro="title-and-source-bib"/>
-          <text macro="notes"/>
-        </group>
-      </else>
-    </choose>
+          <text variable="references"/>
+        </else>
+      </choose>
+    </group>
   </macro>
   <bibliography et-al-min="7" et-al-use-first="3" hanging-indent="true">
     <sort>

--- a/chicago-shortened-notes-bibliography-subsequent-author-classic-no-url.csl
+++ b/chicago-shortened-notes-bibliography-subsequent-author-classic-no-url.csl
@@ -1010,7 +1010,7 @@
       </group>
       <text macro="source-medium-bib"/>
       <text macro="source-archive-bib"/>
-      <!-- <text macro="source-DOI-URL-bib"/> -->
+      <text macro="source-date-accessed-DOI-URL-bib"/>
     </group>
   </macro>
   <!-- 3.1. Title -->
@@ -3576,11 +3576,23 @@
     </group>
   </macro>
   <!-- 4.10. URL or persistent identifier -->
-  <!-- 5. Notes -->
-  <macro name="notes">
-    <!-- Notes on source element: original publication, reprint info, retraction info -->
-    <text variable="references"/>
+  <macro name="source-date-accessed-DOI-URL-bib">
+    <group delimiter=", ">
+      <choose>
+        <if variable="DOI"/>
+        <else-if match="any" variable="available-date event-date issued status"/>
+        <else-if variable="accessed URL">
+          <group delimiter=" ">
+            <text term="accessed" text-case="capitalize-first"/>
+            <date form="text" variable="accessed"/>
+          </group>
+        </else-if>
+      </choose>
+      <!-- <text macro="source-DOI-URL"/> -->
+    </group>
   </macro>
+  <!-- 5. Notes -->
+  <!-- TODO: add variables for distributor and exhibitions if available in CSL -->
   <!-- 6. Legal references: Bluebook style (shared with APA) -->
   <!-- Where APA or Chicago diverge from Bluebook, the official manual is followed -->
   <macro name="legal-reference">
@@ -3604,42 +3616,38 @@
          `treaty`
          : treaties
     -->
-    <group delimiter=" ">
-      <group delimiter=", " suffix=".">
-        <choose>
-          <if type="treaty">
-            <text macro="legal-title"/>
-            <names variable="author">
-              <!-- Treaty parties should be included at least for bilateral treaties (Bluebook 21.4.2) -->
-              <name delimiter="-" et-al-min="100" et-al-use-first="99" form="short"/>
-            </names>
-            <text macro="legal-date"/>
-            <!-- treaty source/report in addition to URL (Bluebook 21.4.5) -->
-            <text macro="legal-source"/>
-          </if>
-          <else>
-            <group delimiter=" ">
-              <group delimiter=", ">
-                <text macro="legal-title"/>
-                <text macro="legal-source"/>
-              </group>
-              <text macro="legal-date"/>
-              <text macro="legal-identifier"/>
+    <group delimiter=", ">
+      <choose>
+        <if type="treaty">
+          <text macro="legal-title"/>
+          <names variable="author">
+            <!-- Treaty parties should be included at least for bilateral treaties (Bluebook 21.4.2) -->
+            <name delimiter="-" et-al-min="100" et-al-use-first="99" form="short"/>
+          </names>
+          <text macro="legal-date"/>
+          <!-- treaty source/report in addition to URL (Bluebook 21.4.5) -->
+          <text macro="legal-source"/>
+        </if>
+        <else>
+          <group delimiter=" ">
+            <group delimiter=", ">
+              <text macro="legal-title"/>
+              <text macro="legal-source"/>
             </group>
-          </else>
+            <text macro="legal-date"/>
+            <text macro="legal-identifier"/>
+          </group>
+        </else>
+      </choose>
+      <group delimiter=" ">
+        <!-- locator for use in notes -->
+        <choose>
+          <if locator="page" variable="page">
+            <text term="at"/>
+          </if>
         </choose>
-        <group delimiter=" ">
-          <!-- locator for use in notes -->
-          <choose>
-            <if locator="page" variable="page">
-              <text term="at"/>
-            </if>
-          </choose>
-          <text macro="label-locator"/>
-        </group>
+        <text macro="label-locator"/>
       </group>
-      <text variable="references"/>
-      <!-- <text macro="source-DOI-URL"/> -->
     </group>
   </macro>
   <!-- 6.1. Legal date -->
@@ -4053,19 +4061,21 @@
   </citation>
   <!-- Bibliography -->
   <macro name="bibliography-notes">
-    <choose>
-      <if match="any" type="bill hearing legal_case legislation regulation treaty">
-        <!-- Legal items have different orders and delimiters -->
-        <text macro="legal-reference"/>
-      </if>
-      <else>
-        <group delimiter=". ">
+    <group delimiter=". ">
+      <choose>
+        <if match="any" type="bill hearing legal_case legislation regulation treaty">
+          <!-- Legal items have different orders and delimiters -->
+          <text macro="legal-reference"/>
+          <text macro="source-date-accessed-DOI-URL-bib"/>
+          <text variable="references"/>
+        </if>
+        <else>
           <text macro="author-bib"/>
           <text macro="title-and-source-bib"/>
-          <text macro="notes"/>
-        </group>
-      </else>
-    </choose>
+          <text variable="references"/>
+        </else>
+      </choose>
+    </group>
   </macro>
   <bibliography et-al-min="7" et-al-use-first="3" hanging-indent="true" subsequent-author-substitute="&#8212;&#8212;&#8212;">
     <sort>

--- a/chicago-shortened-notes-bibliography-subsequent-author-classic.csl
+++ b/chicago-shortened-notes-bibliography-subsequent-author-classic.csl
@@ -1010,7 +1010,7 @@
       </group>
       <text macro="source-medium-bib"/>
       <text macro="source-archive-bib"/>
-      <text macro="source-DOI-URL-bib"/>
+      <text macro="source-date-accessed-DOI-URL-bib"/>
     </group>
   </macro>
   <!-- 3.1. Title -->
@@ -3576,35 +3576,33 @@
     </group>
   </macro>
   <!-- 4.10. URL or persistent identifier -->
-  <macro name="source-DOI-URL-bib">
+  <macro name="source-date-accessed-DOI-URL-bib">
+    <group delimiter=", ">
+      <choose>
+        <if variable="DOI"/>
+        <else-if match="any" variable="available-date event-date issued status"/>
+        <else-if variable="accessed URL">
+          <group delimiter=" ">
+            <text term="accessed" text-case="capitalize-first"/>
+            <date form="text" variable="accessed"/>
+          </group>
+        </else-if>
+      </choose>
+      <text macro="source-DOI-URL"/>
+    </group>
+  </macro>
+  <macro name="source-DOI-URL">
     <choose>
       <if variable="DOI">
         <text prefix="https://doi.org/" variable="DOI"/>
       </if>
       <else-if variable="URL">
-        <group delimiter=". ">
-          <choose>
-            <if match="none" variable="available-date event-date issued status">
-              <group delimiter=" ">
-                <text term="accessed" text-case="capitalize-first"/>
-                <date form="text" variable="accessed"/>
-              </group>
-            </if>
-          </choose>
-          <text variable="URL"/>
-        </group>
+        <text variable="URL"/>
       </else-if>
     </choose>
   </macro>
-  <macro name="source-DOI-URL">
-    <!-- Alias to avoid modifying legal references block shared with APA -->
-    <text macro="source-DOI-URL-bib"/>
-  </macro>
   <!-- 5. Notes -->
-  <macro name="notes">
-    <!-- Notes on source element: original publication, reprint info, retraction info -->
-    <text variable="references"/>
-  </macro>
+  <!-- TODO: add variables for distributor and exhibitions if available in CSL -->
   <!-- 6. Legal references: Bluebook style (shared with APA) -->
   <!-- Where APA or Chicago diverge from Bluebook, the official manual is followed -->
   <macro name="legal-reference">
@@ -3628,42 +3626,38 @@
          `treaty`
          : treaties
     -->
-    <group delimiter=" ">
-      <group delimiter=", " suffix=".">
-        <choose>
-          <if type="treaty">
-            <text macro="legal-title"/>
-            <names variable="author">
-              <!-- Treaty parties should be included at least for bilateral treaties (Bluebook 21.4.2) -->
-              <name delimiter="-" et-al-min="100" et-al-use-first="99" form="short"/>
-            </names>
-            <text macro="legal-date"/>
-            <!-- treaty source/report in addition to URL (Bluebook 21.4.5) -->
-            <text macro="legal-source"/>
-          </if>
-          <else>
-            <group delimiter=" ">
-              <group delimiter=", ">
-                <text macro="legal-title"/>
-                <text macro="legal-source"/>
-              </group>
-              <text macro="legal-date"/>
-              <text macro="legal-identifier"/>
+    <group delimiter=", ">
+      <choose>
+        <if type="treaty">
+          <text macro="legal-title"/>
+          <names variable="author">
+            <!-- Treaty parties should be included at least for bilateral treaties (Bluebook 21.4.2) -->
+            <name delimiter="-" et-al-min="100" et-al-use-first="99" form="short"/>
+          </names>
+          <text macro="legal-date"/>
+          <!-- treaty source/report in addition to URL (Bluebook 21.4.5) -->
+          <text macro="legal-source"/>
+        </if>
+        <else>
+          <group delimiter=" ">
+            <group delimiter=", ">
+              <text macro="legal-title"/>
+              <text macro="legal-source"/>
             </group>
-          </else>
+            <text macro="legal-date"/>
+            <text macro="legal-identifier"/>
+          </group>
+        </else>
+      </choose>
+      <group delimiter=" ">
+        <!-- locator for use in notes -->
+        <choose>
+          <if locator="page" variable="page">
+            <text term="at"/>
+          </if>
         </choose>
-        <group delimiter=" ">
-          <!-- locator for use in notes -->
-          <choose>
-            <if locator="page" variable="page">
-              <text term="at"/>
-            </if>
-          </choose>
-          <text macro="label-locator"/>
-        </group>
+        <text macro="label-locator"/>
       </group>
-      <text variable="references"/>
-      <text macro="source-DOI-URL"/>
     </group>
   </macro>
   <!-- 6.1. Legal date -->
@@ -4077,19 +4071,21 @@
   </citation>
   <!-- Bibliography -->
   <macro name="bibliography-notes">
-    <choose>
-      <if match="any" type="bill hearing legal_case legislation regulation treaty">
-        <!-- Legal items have different orders and delimiters -->
-        <text macro="legal-reference"/>
-      </if>
-      <else>
-        <group delimiter=". ">
+    <group delimiter=". ">
+      <choose>
+        <if match="any" type="bill hearing legal_case legislation regulation treaty">
+          <!-- Legal items have different orders and delimiters -->
+          <text macro="legal-reference"/>
+          <text macro="source-date-accessed-DOI-URL-bib"/>
+          <text variable="references"/>
+        </if>
+        <else>
           <text macro="author-bib"/>
           <text macro="title-and-source-bib"/>
-          <text macro="notes"/>
-        </group>
-      </else>
-    </choose>
+          <text variable="references"/>
+        </else>
+      </choose>
+    </group>
   </macro>
   <bibliography et-al-min="7" et-al-use-first="3" hanging-indent="true" subsequent-author-substitute="&#8212;&#8212;&#8212;">
     <sort>

--- a/chicago-shortened-notes-bibliography-subsequent-author.csl
+++ b/chicago-shortened-notes-bibliography-subsequent-author.csl
@@ -1010,7 +1010,7 @@
       </group>
       <text macro="source-medium-bib"/>
       <text macro="source-archive-bib"/>
-      <text macro="source-DOI-URL-bib"/>
+      <text macro="source-date-accessed-DOI-URL-bib"/>
     </group>
   </macro>
   <!-- 3.1. Title -->
@@ -3582,35 +3582,33 @@
     </group>
   </macro>
   <!-- 4.10. URL or persistent identifier -->
-  <macro name="source-DOI-URL-bib">
+  <macro name="source-date-accessed-DOI-URL-bib">
+    <group delimiter=", ">
+      <choose>
+        <if variable="DOI"/>
+        <else-if match="any" variable="available-date event-date issued status"/>
+        <else-if variable="accessed URL">
+          <group delimiter=" ">
+            <text term="accessed" text-case="capitalize-first"/>
+            <date form="text" variable="accessed"/>
+          </group>
+        </else-if>
+      </choose>
+      <text macro="source-DOI-URL"/>
+    </group>
+  </macro>
+  <macro name="source-DOI-URL">
     <choose>
       <if variable="DOI">
         <text prefix="https://doi.org/" variable="DOI"/>
       </if>
       <else-if variable="URL">
-        <group delimiter=". ">
-          <choose>
-            <if match="none" variable="available-date event-date issued status">
-              <group delimiter=" ">
-                <text term="accessed" text-case="capitalize-first"/>
-                <date form="text" variable="accessed"/>
-              </group>
-            </if>
-          </choose>
-          <text variable="URL"/>
-        </group>
+        <text variable="URL"/>
       </else-if>
     </choose>
   </macro>
-  <macro name="source-DOI-URL">
-    <!-- Alias to avoid modifying legal references block shared with APA -->
-    <text macro="source-DOI-URL-bib"/>
-  </macro>
   <!-- 5. Notes -->
-  <macro name="notes">
-    <!-- Notes on source element: original publication, reprint info, retraction info -->
-    <text variable="references"/>
-  </macro>
+  <!-- TODO: add variables for distributor and exhibitions if available in CSL -->
   <!-- 6. Legal references: Bluebook style (shared with APA) -->
   <!-- Where APA or Chicago diverge from Bluebook, the official manual is followed -->
   <macro name="legal-reference">
@@ -3634,42 +3632,38 @@
          `treaty`
          : treaties
     -->
-    <group delimiter=" ">
-      <group delimiter=", " suffix=".">
-        <choose>
-          <if type="treaty">
-            <text macro="legal-title"/>
-            <names variable="author">
-              <!-- Treaty parties should be included at least for bilateral treaties (Bluebook 21.4.2) -->
-              <name delimiter="-" et-al-min="100" et-al-use-first="99" form="short"/>
-            </names>
-            <text macro="legal-date"/>
-            <!-- treaty source/report in addition to URL (Bluebook 21.4.5) -->
-            <text macro="legal-source"/>
-          </if>
-          <else>
-            <group delimiter=" ">
-              <group delimiter=", ">
-                <text macro="legal-title"/>
-                <text macro="legal-source"/>
-              </group>
-              <text macro="legal-date"/>
-              <text macro="legal-identifier"/>
+    <group delimiter=", ">
+      <choose>
+        <if type="treaty">
+          <text macro="legal-title"/>
+          <names variable="author">
+            <!-- Treaty parties should be included at least for bilateral treaties (Bluebook 21.4.2) -->
+            <name delimiter="-" et-al-min="100" et-al-use-first="99" form="short"/>
+          </names>
+          <text macro="legal-date"/>
+          <!-- treaty source/report in addition to URL (Bluebook 21.4.5) -->
+          <text macro="legal-source"/>
+        </if>
+        <else>
+          <group delimiter=" ">
+            <group delimiter=", ">
+              <text macro="legal-title"/>
+              <text macro="legal-source"/>
             </group>
-          </else>
+            <text macro="legal-date"/>
+            <text macro="legal-identifier"/>
+          </group>
+        </else>
+      </choose>
+      <group delimiter=" ">
+        <!-- locator for use in notes -->
+        <choose>
+          <if locator="page" variable="page">
+            <text term="at"/>
+          </if>
         </choose>
-        <group delimiter=" ">
-          <!-- locator for use in notes -->
-          <choose>
-            <if locator="page" variable="page">
-              <text term="at"/>
-            </if>
-          </choose>
-          <text macro="label-locator"/>
-        </group>
+        <text macro="label-locator"/>
       </group>
-      <text variable="references"/>
-      <text macro="source-DOI-URL"/>
     </group>
   </macro>
   <!-- 6.1. Legal date -->
@@ -4083,19 +4077,21 @@
   </citation>
   <!-- Bibliography -->
   <macro name="bibliography-notes">
-    <choose>
-      <if match="any" type="bill hearing legal_case legislation regulation treaty">
-        <!-- Legal items have different orders and delimiters -->
-        <text macro="legal-reference"/>
-      </if>
-      <else>
-        <group delimiter=". ">
+    <group delimiter=". ">
+      <choose>
+        <if match="any" type="bill hearing legal_case legislation regulation treaty">
+          <!-- Legal items have different orders and delimiters -->
+          <text macro="legal-reference"/>
+          <text macro="source-date-accessed-DOI-URL-bib"/>
+          <text variable="references"/>
+        </if>
+        <else>
           <text macro="author-bib"/>
           <text macro="title-and-source-bib"/>
-          <text macro="notes"/>
-        </group>
-      </else>
-    </choose>
+          <text variable="references"/>
+        </else>
+      </choose>
+    </group>
   </macro>
   <bibliography et-al-min="7" et-al-use-first="3" hanging-indent="true">
     <sort>

--- a/chicago-shortened-notes-bibliography-subsequent-ibid-classic-no-url.csl
+++ b/chicago-shortened-notes-bibliography-subsequent-ibid-classic-no-url.csl
@@ -1010,7 +1010,7 @@
       </group>
       <text macro="source-medium-bib"/>
       <text macro="source-archive-bib"/>
-      <!-- <text macro="source-DOI-URL-bib"/> -->
+      <text macro="source-date-accessed-DOI-URL-bib"/>
     </group>
   </macro>
   <!-- 3.1. Title -->
@@ -3576,11 +3576,23 @@
     </group>
   </macro>
   <!-- 4.10. URL or persistent identifier -->
-  <!-- 5. Notes -->
-  <macro name="notes">
-    <!-- Notes on source element: original publication, reprint info, retraction info -->
-    <text variable="references"/>
+  <macro name="source-date-accessed-DOI-URL-bib">
+    <group delimiter=", ">
+      <choose>
+        <if variable="DOI"/>
+        <else-if match="any" variable="available-date event-date issued status"/>
+        <else-if variable="accessed URL">
+          <group delimiter=" ">
+            <text term="accessed" text-case="capitalize-first"/>
+            <date form="text" variable="accessed"/>
+          </group>
+        </else-if>
+      </choose>
+      <!-- <text macro="source-DOI-URL"/> -->
+    </group>
   </macro>
+  <!-- 5. Notes -->
+  <!-- TODO: add variables for distributor and exhibitions if available in CSL -->
   <!-- 6. Legal references: Bluebook style (shared with APA) -->
   <!-- Where APA or Chicago diverge from Bluebook, the official manual is followed -->
   <macro name="legal-reference">
@@ -3604,42 +3616,38 @@
          `treaty`
          : treaties
     -->
-    <group delimiter=" ">
-      <group delimiter=", " suffix=".">
-        <choose>
-          <if type="treaty">
-            <text macro="legal-title"/>
-            <names variable="author">
-              <!-- Treaty parties should be included at least for bilateral treaties (Bluebook 21.4.2) -->
-              <name delimiter="-" et-al-min="100" et-al-use-first="99" form="short"/>
-            </names>
-            <text macro="legal-date"/>
-            <!-- treaty source/report in addition to URL (Bluebook 21.4.5) -->
-            <text macro="legal-source"/>
-          </if>
-          <else>
-            <group delimiter=" ">
-              <group delimiter=", ">
-                <text macro="legal-title"/>
-                <text macro="legal-source"/>
-              </group>
-              <text macro="legal-date"/>
-              <text macro="legal-identifier"/>
+    <group delimiter=", ">
+      <choose>
+        <if type="treaty">
+          <text macro="legal-title"/>
+          <names variable="author">
+            <!-- Treaty parties should be included at least for bilateral treaties (Bluebook 21.4.2) -->
+            <name delimiter="-" et-al-min="100" et-al-use-first="99" form="short"/>
+          </names>
+          <text macro="legal-date"/>
+          <!-- treaty source/report in addition to URL (Bluebook 21.4.5) -->
+          <text macro="legal-source"/>
+        </if>
+        <else>
+          <group delimiter=" ">
+            <group delimiter=", ">
+              <text macro="legal-title"/>
+              <text macro="legal-source"/>
             </group>
-          </else>
+            <text macro="legal-date"/>
+            <text macro="legal-identifier"/>
+          </group>
+        </else>
+      </choose>
+      <group delimiter=" ">
+        <!-- locator for use in notes -->
+        <choose>
+          <if locator="page" variable="page">
+            <text term="at"/>
+          </if>
         </choose>
-        <group delimiter=" ">
-          <!-- locator for use in notes -->
-          <choose>
-            <if locator="page" variable="page">
-              <text term="at"/>
-            </if>
-          </choose>
-          <text macro="label-locator"/>
-        </group>
+        <text macro="label-locator"/>
       </group>
-      <text variable="references"/>
-      <!-- <text macro="source-DOI-URL"/> -->
     </group>
   </macro>
   <!-- 6.1. Legal date -->
@@ -3995,19 +4003,21 @@
   </citation>
   <!-- Bibliography -->
   <macro name="bibliography-notes">
-    <choose>
-      <if match="any" type="bill hearing legal_case legislation regulation treaty">
-        <!-- Legal items have different orders and delimiters -->
-        <text macro="legal-reference"/>
-      </if>
-      <else>
-        <group delimiter=". ">
+    <group delimiter=". ">
+      <choose>
+        <if match="any" type="bill hearing legal_case legislation regulation treaty">
+          <!-- Legal items have different orders and delimiters -->
+          <text macro="legal-reference"/>
+          <text macro="source-date-accessed-DOI-URL-bib"/>
+          <text variable="references"/>
+        </if>
+        <else>
           <text macro="author-bib"/>
           <text macro="title-and-source-bib"/>
-          <text macro="notes"/>
-        </group>
-      </else>
-    </choose>
+          <text variable="references"/>
+        </else>
+      </choose>
+    </group>
   </macro>
   <bibliography et-al-min="7" et-al-use-first="3" hanging-indent="true" subsequent-author-substitute="&#8212;&#8212;&#8212;">
     <sort>

--- a/chicago-shortened-notes-bibliography-subsequent-ibid-classic.csl
+++ b/chicago-shortened-notes-bibliography-subsequent-ibid-classic.csl
@@ -1010,7 +1010,7 @@
       </group>
       <text macro="source-medium-bib"/>
       <text macro="source-archive-bib"/>
-      <text macro="source-DOI-URL-bib"/>
+      <text macro="source-date-accessed-DOI-URL-bib"/>
     </group>
   </macro>
   <!-- 3.1. Title -->
@@ -3576,35 +3576,33 @@
     </group>
   </macro>
   <!-- 4.10. URL or persistent identifier -->
-  <macro name="source-DOI-URL-bib">
+  <macro name="source-date-accessed-DOI-URL-bib">
+    <group delimiter=", ">
+      <choose>
+        <if variable="DOI"/>
+        <else-if match="any" variable="available-date event-date issued status"/>
+        <else-if variable="accessed URL">
+          <group delimiter=" ">
+            <text term="accessed" text-case="capitalize-first"/>
+            <date form="text" variable="accessed"/>
+          </group>
+        </else-if>
+      </choose>
+      <text macro="source-DOI-URL"/>
+    </group>
+  </macro>
+  <macro name="source-DOI-URL">
     <choose>
       <if variable="DOI">
         <text prefix="https://doi.org/" variable="DOI"/>
       </if>
       <else-if variable="URL">
-        <group delimiter=". ">
-          <choose>
-            <if match="none" variable="available-date event-date issued status">
-              <group delimiter=" ">
-                <text term="accessed" text-case="capitalize-first"/>
-                <date form="text" variable="accessed"/>
-              </group>
-            </if>
-          </choose>
-          <text variable="URL"/>
-        </group>
+        <text variable="URL"/>
       </else-if>
     </choose>
   </macro>
-  <macro name="source-DOI-URL">
-    <!-- Alias to avoid modifying legal references block shared with APA -->
-    <text macro="source-DOI-URL-bib"/>
-  </macro>
   <!-- 5. Notes -->
-  <macro name="notes">
-    <!-- Notes on source element: original publication, reprint info, retraction info -->
-    <text variable="references"/>
-  </macro>
+  <!-- TODO: add variables for distributor and exhibitions if available in CSL -->
   <!-- 6. Legal references: Bluebook style (shared with APA) -->
   <!-- Where APA or Chicago diverge from Bluebook, the official manual is followed -->
   <macro name="legal-reference">
@@ -3628,42 +3626,38 @@
          `treaty`
          : treaties
     -->
-    <group delimiter=" ">
-      <group delimiter=", " suffix=".">
-        <choose>
-          <if type="treaty">
-            <text macro="legal-title"/>
-            <names variable="author">
-              <!-- Treaty parties should be included at least for bilateral treaties (Bluebook 21.4.2) -->
-              <name delimiter="-" et-al-min="100" et-al-use-first="99" form="short"/>
-            </names>
-            <text macro="legal-date"/>
-            <!-- treaty source/report in addition to URL (Bluebook 21.4.5) -->
-            <text macro="legal-source"/>
-          </if>
-          <else>
-            <group delimiter=" ">
-              <group delimiter=", ">
-                <text macro="legal-title"/>
-                <text macro="legal-source"/>
-              </group>
-              <text macro="legal-date"/>
-              <text macro="legal-identifier"/>
+    <group delimiter=", ">
+      <choose>
+        <if type="treaty">
+          <text macro="legal-title"/>
+          <names variable="author">
+            <!-- Treaty parties should be included at least for bilateral treaties (Bluebook 21.4.2) -->
+            <name delimiter="-" et-al-min="100" et-al-use-first="99" form="short"/>
+          </names>
+          <text macro="legal-date"/>
+          <!-- treaty source/report in addition to URL (Bluebook 21.4.5) -->
+          <text macro="legal-source"/>
+        </if>
+        <else>
+          <group delimiter=" ">
+            <group delimiter=", ">
+              <text macro="legal-title"/>
+              <text macro="legal-source"/>
             </group>
-          </else>
+            <text macro="legal-date"/>
+            <text macro="legal-identifier"/>
+          </group>
+        </else>
+      </choose>
+      <group delimiter=" ">
+        <!-- locator for use in notes -->
+        <choose>
+          <if locator="page" variable="page">
+            <text term="at"/>
+          </if>
         </choose>
-        <group delimiter=" ">
-          <!-- locator for use in notes -->
-          <choose>
-            <if locator="page" variable="page">
-              <text term="at"/>
-            </if>
-          </choose>
-          <text macro="label-locator"/>
-        </group>
+        <text macro="label-locator"/>
       </group>
-      <text variable="references"/>
-      <text macro="source-DOI-URL"/>
     </group>
   </macro>
   <!-- 6.1. Legal date -->
@@ -4019,19 +4013,21 @@
   </citation>
   <!-- Bibliography -->
   <macro name="bibliography-notes">
-    <choose>
-      <if match="any" type="bill hearing legal_case legislation regulation treaty">
-        <!-- Legal items have different orders and delimiters -->
-        <text macro="legal-reference"/>
-      </if>
-      <else>
-        <group delimiter=". ">
+    <group delimiter=". ">
+      <choose>
+        <if match="any" type="bill hearing legal_case legislation regulation treaty">
+          <!-- Legal items have different orders and delimiters -->
+          <text macro="legal-reference"/>
+          <text macro="source-date-accessed-DOI-URL-bib"/>
+          <text variable="references"/>
+        </if>
+        <else>
           <text macro="author-bib"/>
           <text macro="title-and-source-bib"/>
-          <text macro="notes"/>
-        </group>
-      </else>
-    </choose>
+          <text variable="references"/>
+        </else>
+      </choose>
+    </group>
   </macro>
   <bibliography et-al-min="7" et-al-use-first="3" hanging-indent="true" subsequent-author-substitute="&#8212;&#8212;&#8212;">
     <sort>

--- a/chicago-shortened-notes-bibliography-subsequent-ibid.csl
+++ b/chicago-shortened-notes-bibliography-subsequent-ibid.csl
@@ -1010,7 +1010,7 @@
       </group>
       <text macro="source-medium-bib"/>
       <text macro="source-archive-bib"/>
-      <text macro="source-DOI-URL-bib"/>
+      <text macro="source-date-accessed-DOI-URL-bib"/>
     </group>
   </macro>
   <!-- 3.1. Title -->
@@ -3582,35 +3582,33 @@
     </group>
   </macro>
   <!-- 4.10. URL or persistent identifier -->
-  <macro name="source-DOI-URL-bib">
+  <macro name="source-date-accessed-DOI-URL-bib">
+    <group delimiter=", ">
+      <choose>
+        <if variable="DOI"/>
+        <else-if match="any" variable="available-date event-date issued status"/>
+        <else-if variable="accessed URL">
+          <group delimiter=" ">
+            <text term="accessed" text-case="capitalize-first"/>
+            <date form="text" variable="accessed"/>
+          </group>
+        </else-if>
+      </choose>
+      <text macro="source-DOI-URL"/>
+    </group>
+  </macro>
+  <macro name="source-DOI-URL">
     <choose>
       <if variable="DOI">
         <text prefix="https://doi.org/" variable="DOI"/>
       </if>
       <else-if variable="URL">
-        <group delimiter=". ">
-          <choose>
-            <if match="none" variable="available-date event-date issued status">
-              <group delimiter=" ">
-                <text term="accessed" text-case="capitalize-first"/>
-                <date form="text" variable="accessed"/>
-              </group>
-            </if>
-          </choose>
-          <text variable="URL"/>
-        </group>
+        <text variable="URL"/>
       </else-if>
     </choose>
   </macro>
-  <macro name="source-DOI-URL">
-    <!-- Alias to avoid modifying legal references block shared with APA -->
-    <text macro="source-DOI-URL-bib"/>
-  </macro>
   <!-- 5. Notes -->
-  <macro name="notes">
-    <!-- Notes on source element: original publication, reprint info, retraction info -->
-    <text variable="references"/>
-  </macro>
+  <!-- TODO: add variables for distributor and exhibitions if available in CSL -->
   <!-- 6. Legal references: Bluebook style (shared with APA) -->
   <!-- Where APA or Chicago diverge from Bluebook, the official manual is followed -->
   <macro name="legal-reference">
@@ -3634,42 +3632,38 @@
          `treaty`
          : treaties
     -->
-    <group delimiter=" ">
-      <group delimiter=", " suffix=".">
-        <choose>
-          <if type="treaty">
-            <text macro="legal-title"/>
-            <names variable="author">
-              <!-- Treaty parties should be included at least for bilateral treaties (Bluebook 21.4.2) -->
-              <name delimiter="-" et-al-min="100" et-al-use-first="99" form="short"/>
-            </names>
-            <text macro="legal-date"/>
-            <!-- treaty source/report in addition to URL (Bluebook 21.4.5) -->
-            <text macro="legal-source"/>
-          </if>
-          <else>
-            <group delimiter=" ">
-              <group delimiter=", ">
-                <text macro="legal-title"/>
-                <text macro="legal-source"/>
-              </group>
-              <text macro="legal-date"/>
-              <text macro="legal-identifier"/>
+    <group delimiter=", ">
+      <choose>
+        <if type="treaty">
+          <text macro="legal-title"/>
+          <names variable="author">
+            <!-- Treaty parties should be included at least for bilateral treaties (Bluebook 21.4.2) -->
+            <name delimiter="-" et-al-min="100" et-al-use-first="99" form="short"/>
+          </names>
+          <text macro="legal-date"/>
+          <!-- treaty source/report in addition to URL (Bluebook 21.4.5) -->
+          <text macro="legal-source"/>
+        </if>
+        <else>
+          <group delimiter=" ">
+            <group delimiter=", ">
+              <text macro="legal-title"/>
+              <text macro="legal-source"/>
             </group>
-          </else>
+            <text macro="legal-date"/>
+            <text macro="legal-identifier"/>
+          </group>
+        </else>
+      </choose>
+      <group delimiter=" ">
+        <!-- locator for use in notes -->
+        <choose>
+          <if locator="page" variable="page">
+            <text term="at"/>
+          </if>
         </choose>
-        <group delimiter=" ">
-          <!-- locator for use in notes -->
-          <choose>
-            <if locator="page" variable="page">
-              <text term="at"/>
-            </if>
-          </choose>
-          <text macro="label-locator"/>
-        </group>
+        <text macro="label-locator"/>
       </group>
-      <text variable="references"/>
-      <text macro="source-DOI-URL"/>
     </group>
   </macro>
   <!-- 6.1. Legal date -->
@@ -4025,19 +4019,21 @@
   </citation>
   <!-- Bibliography -->
   <macro name="bibliography-notes">
-    <choose>
-      <if match="any" type="bill hearing legal_case legislation regulation treaty">
-        <!-- Legal items have different orders and delimiters -->
-        <text macro="legal-reference"/>
-      </if>
-      <else>
-        <group delimiter=". ">
+    <group delimiter=". ">
+      <choose>
+        <if match="any" type="bill hearing legal_case legislation regulation treaty">
+          <!-- Legal items have different orders and delimiters -->
+          <text macro="legal-reference"/>
+          <text macro="source-date-accessed-DOI-URL-bib"/>
+          <text variable="references"/>
+        </if>
+        <else>
           <text macro="author-bib"/>
           <text macro="title-and-source-bib"/>
-          <text macro="notes"/>
-        </group>
-      </else>
-    </choose>
+          <text variable="references"/>
+        </else>
+      </choose>
+    </group>
   </macro>
   <bibliography et-al-min="7" et-al-use-first="3" hanging-indent="true">
     <sort>

--- a/chicago-shortened-notes-bibliography-subsequent-title.csl
+++ b/chicago-shortened-notes-bibliography-subsequent-title.csl
@@ -1010,7 +1010,7 @@
       </group>
       <text macro="source-medium-bib"/>
       <text macro="source-archive-bib"/>
-      <text macro="source-DOI-URL-bib"/>
+      <text macro="source-date-accessed-DOI-URL-bib"/>
     </group>
   </macro>
   <!-- 3.1. Title -->
@@ -3582,35 +3582,33 @@
     </group>
   </macro>
   <!-- 4.10. URL or persistent identifier -->
-  <macro name="source-DOI-URL-bib">
+  <macro name="source-date-accessed-DOI-URL-bib">
+    <group delimiter=", ">
+      <choose>
+        <if variable="DOI"/>
+        <else-if match="any" variable="available-date event-date issued status"/>
+        <else-if variable="accessed URL">
+          <group delimiter=" ">
+            <text term="accessed" text-case="capitalize-first"/>
+            <date form="text" variable="accessed"/>
+          </group>
+        </else-if>
+      </choose>
+      <text macro="source-DOI-URL"/>
+    </group>
+  </macro>
+  <macro name="source-DOI-URL">
     <choose>
       <if variable="DOI">
         <text prefix="https://doi.org/" variable="DOI"/>
       </if>
       <else-if variable="URL">
-        <group delimiter=". ">
-          <choose>
-            <if match="none" variable="available-date event-date issued status">
-              <group delimiter=" ">
-                <text term="accessed" text-case="capitalize-first"/>
-                <date form="text" variable="accessed"/>
-              </group>
-            </if>
-          </choose>
-          <text variable="URL"/>
-        </group>
+        <text variable="URL"/>
       </else-if>
     </choose>
   </macro>
-  <macro name="source-DOI-URL">
-    <!-- Alias to avoid modifying legal references block shared with APA -->
-    <text macro="source-DOI-URL-bib"/>
-  </macro>
   <!-- 5. Notes -->
-  <macro name="notes">
-    <!-- Notes on source element: original publication, reprint info, retraction info -->
-    <text variable="references"/>
-  </macro>
+  <!-- TODO: add variables for distributor and exhibitions if available in CSL -->
   <!-- 6. Legal references: Bluebook style (shared with APA) -->
   <!-- Where APA or Chicago diverge from Bluebook, the official manual is followed -->
   <macro name="legal-reference">
@@ -3634,42 +3632,38 @@
          `treaty`
          : treaties
     -->
-    <group delimiter=" ">
-      <group delimiter=", " suffix=".">
-        <choose>
-          <if type="treaty">
-            <text macro="legal-title"/>
-            <names variable="author">
-              <!-- Treaty parties should be included at least for bilateral treaties (Bluebook 21.4.2) -->
-              <name delimiter="-" et-al-min="100" et-al-use-first="99" form="short"/>
-            </names>
-            <text macro="legal-date"/>
-            <!-- treaty source/report in addition to URL (Bluebook 21.4.5) -->
-            <text macro="legal-source"/>
-          </if>
-          <else>
-            <group delimiter=" ">
-              <group delimiter=", ">
-                <text macro="legal-title"/>
-                <text macro="legal-source"/>
-              </group>
-              <text macro="legal-date"/>
-              <text macro="legal-identifier"/>
+    <group delimiter=", ">
+      <choose>
+        <if type="treaty">
+          <text macro="legal-title"/>
+          <names variable="author">
+            <!-- Treaty parties should be included at least for bilateral treaties (Bluebook 21.4.2) -->
+            <name delimiter="-" et-al-min="100" et-al-use-first="99" form="short"/>
+          </names>
+          <text macro="legal-date"/>
+          <!-- treaty source/report in addition to URL (Bluebook 21.4.5) -->
+          <text macro="legal-source"/>
+        </if>
+        <else>
+          <group delimiter=" ">
+            <group delimiter=", ">
+              <text macro="legal-title"/>
+              <text macro="legal-source"/>
             </group>
-          </else>
+            <text macro="legal-date"/>
+            <text macro="legal-identifier"/>
+          </group>
+        </else>
+      </choose>
+      <group delimiter=" ">
+        <!-- locator for use in notes -->
+        <choose>
+          <if locator="page" variable="page">
+            <text term="at"/>
+          </if>
         </choose>
-        <group delimiter=" ">
-          <!-- locator for use in notes -->
-          <choose>
-            <if locator="page" variable="page">
-              <text term="at"/>
-            </if>
-          </choose>
-          <text macro="label-locator"/>
-        </group>
+        <text macro="label-locator"/>
       </group>
-      <text variable="references"/>
-      <text macro="source-DOI-URL"/>
     </group>
   </macro>
   <!-- 6.1. Legal date -->
@@ -4045,19 +4039,21 @@
   </citation>
   <!-- Bibliography -->
   <macro name="bibliography-notes">
-    <choose>
-      <if match="any" type="bill hearing legal_case legislation regulation treaty">
-        <!-- Legal items have different orders and delimiters -->
-        <text macro="legal-reference"/>
-      </if>
-      <else>
-        <group delimiter=". ">
+    <group delimiter=". ">
+      <choose>
+        <if match="any" type="bill hearing legal_case legislation regulation treaty">
+          <!-- Legal items have different orders and delimiters -->
+          <text macro="legal-reference"/>
+          <text macro="source-date-accessed-DOI-URL-bib"/>
+          <text variable="references"/>
+        </if>
+        <else>
           <text macro="author-bib"/>
           <text macro="title-and-source-bib"/>
-          <text macro="notes"/>
-        </group>
-      </else>
-    </choose>
+          <text variable="references"/>
+        </else>
+      </choose>
+    </group>
   </macro>
   <bibliography et-al-min="7" et-al-use-first="3" hanging-indent="true">
     <sort>

--- a/chicago-shortened-notes-bibliography.csl
+++ b/chicago-shortened-notes-bibliography.csl
@@ -1010,7 +1010,7 @@
       </group>
       <text macro="source-medium-bib"/>
       <text macro="source-archive-bib"/>
-      <text macro="source-DOI-URL-bib"/>
+      <text macro="source-date-accessed-DOI-URL-bib"/>
     </group>
   </macro>
   <!-- 3.1. Title -->
@@ -3582,35 +3582,33 @@
     </group>
   </macro>
   <!-- 4.10. URL or persistent identifier -->
-  <macro name="source-DOI-URL-bib">
+  <macro name="source-date-accessed-DOI-URL-bib">
+    <group delimiter=", ">
+      <choose>
+        <if variable="DOI"/>
+        <else-if match="any" variable="available-date event-date issued status"/>
+        <else-if variable="accessed URL">
+          <group delimiter=" ">
+            <text term="accessed" text-case="capitalize-first"/>
+            <date form="text" variable="accessed"/>
+          </group>
+        </else-if>
+      </choose>
+      <text macro="source-DOI-URL"/>
+    </group>
+  </macro>
+  <macro name="source-DOI-URL">
     <choose>
       <if variable="DOI">
         <text prefix="https://doi.org/" variable="DOI"/>
       </if>
       <else-if variable="URL">
-        <group delimiter=". ">
-          <choose>
-            <if match="none" variable="available-date event-date issued status">
-              <group delimiter=" ">
-                <text term="accessed" text-case="capitalize-first"/>
-                <date form="text" variable="accessed"/>
-              </group>
-            </if>
-          </choose>
-          <text variable="URL"/>
-        </group>
+        <text variable="URL"/>
       </else-if>
     </choose>
   </macro>
-  <macro name="source-DOI-URL">
-    <!-- Alias to avoid modifying legal references block shared with APA -->
-    <text macro="source-DOI-URL-bib"/>
-  </macro>
   <!-- 5. Notes -->
-  <macro name="notes">
-    <!-- Notes on source element: original publication, reprint info, retraction info -->
-    <text variable="references"/>
-  </macro>
+  <!-- TODO: add variables for distributor and exhibitions if available in CSL -->
   <!-- 6. Legal references: Bluebook style (shared with APA) -->
   <!-- Where APA or Chicago diverge from Bluebook, the official manual is followed -->
   <macro name="legal-reference">
@@ -3634,42 +3632,38 @@
          `treaty`
          : treaties
     -->
-    <group delimiter=" ">
-      <group delimiter=", " suffix=".">
-        <choose>
-          <if type="treaty">
-            <text macro="legal-title"/>
-            <names variable="author">
-              <!-- Treaty parties should be included at least for bilateral treaties (Bluebook 21.4.2) -->
-              <name delimiter="-" et-al-min="100" et-al-use-first="99" form="short"/>
-            </names>
-            <text macro="legal-date"/>
-            <!-- treaty source/report in addition to URL (Bluebook 21.4.5) -->
-            <text macro="legal-source"/>
-          </if>
-          <else>
-            <group delimiter=" ">
-              <group delimiter=", ">
-                <text macro="legal-title"/>
-                <text macro="legal-source"/>
-              </group>
-              <text macro="legal-date"/>
-              <text macro="legal-identifier"/>
+    <group delimiter=", ">
+      <choose>
+        <if type="treaty">
+          <text macro="legal-title"/>
+          <names variable="author">
+            <!-- Treaty parties should be included at least for bilateral treaties (Bluebook 21.4.2) -->
+            <name delimiter="-" et-al-min="100" et-al-use-first="99" form="short"/>
+          </names>
+          <text macro="legal-date"/>
+          <!-- treaty source/report in addition to URL (Bluebook 21.4.5) -->
+          <text macro="legal-source"/>
+        </if>
+        <else>
+          <group delimiter=" ">
+            <group delimiter=", ">
+              <text macro="legal-title"/>
+              <text macro="legal-source"/>
             </group>
-          </else>
+            <text macro="legal-date"/>
+            <text macro="legal-identifier"/>
+          </group>
+        </else>
+      </choose>
+      <group delimiter=" ">
+        <!-- locator for use in notes -->
+        <choose>
+          <if locator="page" variable="page">
+            <text term="at"/>
+          </if>
         </choose>
-        <group delimiter=" ">
-          <!-- locator for use in notes -->
-          <choose>
-            <if locator="page" variable="page">
-              <text term="at"/>
-            </if>
-          </choose>
-          <text macro="label-locator"/>
-        </group>
+        <text macro="label-locator"/>
       </group>
-      <text variable="references"/>
-      <text macro="source-DOI-URL"/>
     </group>
   </macro>
   <!-- 6.1. Legal date -->
@@ -4006,19 +4000,21 @@
   </citation>
   <!-- Bibliography -->
   <macro name="bibliography-notes">
-    <choose>
-      <if match="any" type="bill hearing legal_case legislation regulation treaty">
-        <!-- Legal items have different orders and delimiters -->
-        <text macro="legal-reference"/>
-      </if>
-      <else>
-        <group delimiter=". ">
+    <group delimiter=". ">
+      <choose>
+        <if match="any" type="bill hearing legal_case legislation regulation treaty">
+          <!-- Legal items have different orders and delimiters -->
+          <text macro="legal-reference"/>
+          <text macro="source-date-accessed-DOI-URL-bib"/>
+          <text variable="references"/>
+        </if>
+        <else>
           <text macro="author-bib"/>
           <text macro="title-and-source-bib"/>
-          <text macro="notes"/>
-        </group>
-      </else>
-    </choose>
+          <text variable="references"/>
+        </else>
+      </choose>
+    </group>
   </macro>
   <bibliography et-al-min="7" et-al-use-first="3" hanging-indent="true">
     <sort>

--- a/taylor-and-francis-chicago-author-date.csl
+++ b/taylor-and-francis-chicago-author-date.csl
@@ -1078,7 +1078,7 @@
       </group>
       <text macro="source-medium-bib"/>
       <text macro="source-archive-bib"/>
-      <text macro="source-DOI-URL-bib"/>
+      <text macro="source-date-accessed-DOI-URL-bib"/>
     </group>
   </macro>
   <!-- 3.1. Title -->
@@ -3460,35 +3460,33 @@
     </group>
   </macro>
   <!-- 4.10. URL or persistent identifier -->
-  <macro name="source-DOI-URL-bib">
+  <macro name="source-date-accessed-DOI-URL-bib">
+    <group delimiter=", ">
+      <choose>
+        <if variable="DOI"/>
+        <else-if match="any" variable="available-date event-date issued status"/>
+        <else-if variable="accessed URL">
+          <group delimiter=" ">
+            <text term="accessed" text-case="capitalize-first"/>
+            <date form="text" variable="accessed"/>
+          </group>
+        </else-if>
+      </choose>
+      <text macro="source-DOI-URL"/>
+    </group>
+  </macro>
+  <macro name="source-DOI-URL">
     <choose>
       <if variable="DOI">
         <text prefix="https://doi.org/" variable="DOI"/>
       </if>
       <else-if variable="URL">
-        <group delimiter=". ">
-          <choose>
-            <if match="none" variable="available-date event-date issued status">
-              <group delimiter=" ">
-                <text term="accessed" text-case="capitalize-first"/>
-                <date form="text" variable="accessed"/>
-              </group>
-            </if>
-          </choose>
-          <text variable="URL"/>
-        </group>
+        <text variable="URL"/>
       </else-if>
     </choose>
   </macro>
-  <macro name="source-DOI-URL">
-    <!-- Alias to avoid modifying legal references block shared with APA -->
-    <text macro="source-DOI-URL-bib"/>
-  </macro>
   <!-- 5. Notes -->
-  <macro name="notes">
-    <!-- Notes on source element: original publication, reprint info, retraction info -->
-    <text variable="references"/>
-  </macro>
+  <!-- TODO: add variables for distributor and exhibitions if available in CSL -->
   <!-- 6. Legal references: Bluebook style (shared with APA) -->
   <!-- Where APA or Chicago diverge from Bluebook, the official manual is followed -->
   <macro name="legal-reference">
@@ -3512,42 +3510,38 @@
          `treaty`
          : treaties
     -->
-    <group delimiter=" ">
-      <group delimiter=", " suffix=".">
-        <choose>
-          <if type="treaty">
-            <text macro="legal-title"/>
-            <names variable="author">
-              <!-- Treaty parties should be included at least for bilateral treaties (Bluebook 21.4.2) -->
-              <name delimiter="-" et-al-min="100" et-al-use-first="99" form="short"/>
-            </names>
-            <text macro="legal-date"/>
-            <!-- treaty source/report in addition to URL (Bluebook 21.4.5) -->
-            <text macro="legal-source"/>
-          </if>
-          <else>
-            <group delimiter=" ">
-              <group delimiter=", ">
-                <text macro="legal-title"/>
-                <text macro="legal-source"/>
-              </group>
-              <text macro="legal-date"/>
-              <text macro="legal-identifier"/>
+    <group delimiter=", ">
+      <choose>
+        <if type="treaty">
+          <text macro="legal-title"/>
+          <names variable="author">
+            <!-- Treaty parties should be included at least for bilateral treaties (Bluebook 21.4.2) -->
+            <name delimiter="-" et-al-min="100" et-al-use-first="99" form="short"/>
+          </names>
+          <text macro="legal-date"/>
+          <!-- treaty source/report in addition to URL (Bluebook 21.4.5) -->
+          <text macro="legal-source"/>
+        </if>
+        <else>
+          <group delimiter=" ">
+            <group delimiter=", ">
+              <text macro="legal-title"/>
+              <text macro="legal-source"/>
             </group>
-          </else>
+            <text macro="legal-date"/>
+            <text macro="legal-identifier"/>
+          </group>
+        </else>
+      </choose>
+      <group delimiter=" ">
+        <!-- locator for use in notes -->
+        <choose>
+          <if locator="page" variable="page">
+            <text term="at"/>
+          </if>
         </choose>
-        <group delimiter=" ">
-          <!-- locator for use in notes -->
-          <choose>
-            <if locator="page" variable="page">
-              <text term="at"/>
-            </if>
-          </choose>
-          <text macro="label-locator"/>
-        </group>
+        <text macro="label-locator"/>
       </group>
-      <text variable="references"/>
-      <text macro="source-DOI-URL"/>
     </group>
   </macro>
   <!-- 6.1. Legal date -->
@@ -3889,20 +3883,22 @@
   </citation>
   <!-- Bibliography -->
   <macro name="bibliography-author-date">
-    <choose>
-      <if match="any" type="bill hearing legal_case legislation regulation treaty">
-        <!-- Legal items have different orders and delimiters -->
-        <text macro="legal-reference"/>
-      </if>
-      <else>
-        <group delimiter=". ">
+    <group delimiter=". ">
+      <choose>
+        <if match="any" type="bill hearing legal_case legislation regulation treaty">
+          <!-- Legal items have different orders and delimiters -->
+          <text macro="legal-reference"/>
+          <text macro="source-date-accessed-DOI-URL-bib"/>
+          <text variable="references"/>
+        </if>
+        <else>
           <text macro="author-bib"/>
           <text macro="date"/>
           <text macro="title-and-source-bib"/>
-          <text macro="notes"/>
-        </group>
-      </else>
-    </choose>
+          <text variable="references"/>
+        </else>
+      </choose>
+    </group>
   </macro>
   <bibliography et-al-min="11" et-al-use-first="7" hanging-indent="true">
     <sort>


### PR DESCRIPTION
Retain access dates in variants that do not print URLs. Fix punctuation with legal references including URLs.