### PR TITLE
Update journal-of-strength-and-conditioning-research.csl

### DIFF
--- a/journal-of-strength-and-conditioning-research.csl
+++ b/journal-of-strength-and-conditioning-research.csl
@@ -18,12 +18,12 @@
     <issn>1064-8011</issn>
     <eissn>1533-4287</eissn>
     <summary>Alphabetic Vancouver variant for JSCR</summary>
-    <updated>2024-01-15T22:06:38+00:00</updated>
+    <updated>2025-09-02T18:35:24+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <macro name="author">
     <names variable="author" suffix=". ">
-      <name sort-separator=", " initialize-with="" name-as-sort-order="all" delimiter=", " and="text"/>
+      <name initialize-with="" name-as-sort-order="all"/>
       <label form="short" prefix=" (" suffix=")"/>
       <substitute>
         <names variable="editor"/>


### PR DESCRIPTION
Remove "and" in bibliography.
Via https://forums.zotero.org/discussion/126471/journal-of-strength-and-conditioning-research-formatting-of-authors-field#latest