### PR TITLE
Chicago: Cite magazines by date only

### DIFF
--- a/chicago-author-date-17th-edition.csl
+++ b/chicago-author-date-17th-edition.csl
@@ -702,14 +702,6 @@
         <!-- Publication name also substituted for unsigned reviews (CMOS18 14.102) -->
         <text macro="source-serial-name"/>
       </else-if>
-      <else-if match="any" type="interview paper-conference">
-        <choose>
-          <if match="none" variable="collection-editor compiler editor editorial-director">
-            <!-- serial usage -->
-            <text macro="source-serial-name"/>
-          </if>
-        </choose>
-      </else-if>
       <else-if match="any" type="entry entry-dictionary entry-encyclopedia">
         <!-- Anonymous entries in reference works (CMOS18 14.130) -->
         <text font-style="italic" text-case="title" variable="container-title"/>
@@ -734,14 +726,6 @@
       <else-if match="any" type="review review-book" variable="reviewed-author reviewed-genre reviewed-title">
         <!-- Publication name also substituted for unsigned reviews (CMOS18 14.102) -->
         <text font-style="italic" text-case="title" variable="container-title"/>
-      </else-if>
-      <else-if match="any" type="interview paper-conference">
-        <choose>
-          <if match="none" variable="collection-editor compiler editor editorial-director">
-            <!-- serial usage -->
-            <text font-style="italic" text-case="title" variable="container-title"/>
-          </if>
-        </choose>
       </else-if>
       <else-if match="any" type="entry entry-dictionary entry-encyclopedia">
         <!-- Anonymous entries in reference works (CMOS18 14.130) -->
@@ -2241,7 +2225,8 @@
     <group delimiter=". ">
       <text macro="source-serial-title-volume-bib"/>
       <choose>
-        <if type="article-newspaper">
+        <if match="any" type="article-magazine article-newspaper">
+          <!-- magazines and newspapers provide the full date in place of volume/issue numbers (CMOS18 14.87, 14.89) -->
           <group delimiter=", ">
             <text macro="source-serial-title-bib"/>
             <text macro="source-serial-identifier-bib"/>
@@ -2349,15 +2334,15 @@
   <macro name="source-serial-identifier-volume-author-date">
     <group delimiter=", ">
       <choose>
-        <if type="article-newspaper">
-          <!-- newspapers provide the full date in place of volume/issue numbers (CMOS18 14.89) -->
+        <if match="any" type="article-magazine article-newspaper">
+          <!-- magazines and newspapers provide the full date in place of volume/issue numbers (CMOS18 14.87, 14.89) -->
           <text variable="collection-title"/>
           <text macro="source-serial-volume-status-bib"/>
         </if>
         <else-if match="any" variable="issue supplement-number volume">
           <choose>
-            <if match="any" type="article-magazine review review-book" variable="reviewed-author reviewed-genre reviewed-title">
-              <!-- date appears first if the magazine or review `container-title` has been substituted for a missing author (CMOS18 14.87, 14.102) -->
+            <if match="any" type="review review-book" variable="reviewed-author reviewed-genre reviewed-title">
+              <!-- date appears first if the review `container-title` has been substituted for a missing author (CMOS18 14.87, 14.102) -->
               <choose>
                 <if match="none" variable="author chair collection-editor compiler composer curator director editor editor-translator editorial-director executive-producer guest host illustrator organizer producer series-creator translator">
                   <choose>
@@ -2383,8 +2368,8 @@
                   <if variable="collection-title">
                     <text macro="label-volume"/>
                   </if>
-                  <else-if match="any" type="article-magazine review review-book" variable="reviewed-author reviewed-genre reviewed-title">
-                    <!-- provide label if a magazine or review `container-title` has been substituted for a missing author (CMOS18 14.87, 14.102) -->
+                  <else-if match="any" type="review review-book" variable="reviewed-author reviewed-genre reviewed-title">
+                    <!-- provide label if a review `container-title` has been substituted for a missing author (CMOS18 14.87, 14.102) -->
                     <choose>
                       <if match="any" variable="author chair collection-editor compiler composer curator director editor editor-translator editorial-director executive-producer guest host illustrator organizer producer series-creator translator">
                         <text variable="volume"/>
@@ -2405,8 +2390,8 @@
                       <text variable="issue"/>
                       <text macro="label-supplement-number"/>
                     </if>
-                    <else-if match="any" type="article-magazine review review-book" variable="reviewed-author reviewed-genre reviewed-title">
-                      <!-- date for anonymous magazine and review articles only appears here if it did not earlier (CMOS18 14.87, 14.102) -->
+                    <else-if match="any" type="review review-book" variable="reviewed-author reviewed-genre reviewed-title">
+                      <!-- date for unsigned reviews only appears here if it did not earlier (CMOS18 14.102) -->
                       <choose>
                         <if match="any" variable="author chair collection-editor compiler composer curator director editor editor-translator editorial-director executive-producer guest host illustrator organizer producer series-creator translator">
                           <text macro="source-date-issued-month-day"/>
@@ -3184,7 +3169,8 @@
   <!-- Date elements -->
   <macro name="source-date-issued-full-serial">
     <choose>
-      <if type="article-newspaper">
+      <if match="any" type="article-magazine article-newspaper">
+        <!-- magazines and newspapers provide the full date in place of volume/issue numbers (CMOS18 14.87, 14.89) -->
         <text macro="date-issued-full"/>
       </if>
       <else-if variable="issue volume">
@@ -3236,8 +3222,8 @@
   </macro>
   <macro name="source-date-issued-month-day-serial">
     <choose>
-      <if type="article-newspaper">
-        <!-- newspapers provide the full date in place of volume/issue numbers (CMOS18 14.89) -->
+      <if match="any" type="article-magazine article-newspaper">
+        <!-- magazines and newspapers provide the full date in place of volume/issue numbers (CMOS18 14.87, 14.89) -->
         <text macro="date-issued-month-day"/>
       </if>
       <else-if match="any" variable="issue supplement-number volume">

--- a/chicago-author-date-archive-place-first-no-url.csl
+++ b/chicago-author-date-archive-place-first-no-url.csl
@@ -705,14 +705,6 @@
         <!-- Publication name also substituted for unsigned reviews (CMOS18 14.102) -->
         <text macro="source-serial-name"/>
       </else-if>
-      <else-if match="any" type="interview paper-conference">
-        <choose>
-          <if match="none" variable="collection-editor compiler editor editorial-director">
-            <!-- serial usage -->
-            <text macro="source-serial-name"/>
-          </if>
-        </choose>
-      </else-if>
       <else-if match="any" type="entry entry-dictionary entry-encyclopedia">
         <!-- Anonymous entries in reference works (CMOS18 14.130) -->
         <text font-style="italic" text-case="title" variable="container-title"/>
@@ -737,14 +729,6 @@
       <else-if match="any" type="review review-book" variable="reviewed-author reviewed-genre reviewed-title">
         <!-- Publication name also substituted for unsigned reviews (CMOS18 14.102) -->
         <text font-style="italic" text-case="title" variable="container-title"/>
-      </else-if>
-      <else-if match="any" type="interview paper-conference">
-        <choose>
-          <if match="none" variable="collection-editor compiler editor editorial-director">
-            <!-- serial usage -->
-            <text font-style="italic" text-case="title" variable="container-title"/>
-          </if>
-        </choose>
       </else-if>
       <else-if match="any" type="entry entry-dictionary entry-encyclopedia">
         <!-- Anonymous entries in reference works (CMOS18 14.130) -->
@@ -2224,7 +2208,8 @@
     <group delimiter=". ">
       <text macro="source-serial-title-volume-bib"/>
       <choose>
-        <if type="article-newspaper">
+        <if match="any" type="article-magazine article-newspaper">
+          <!-- magazines and newspapers provide the full date in place of volume/issue numbers (CMOS18 14.87, 14.89) -->
           <group delimiter=", ">
             <text macro="source-serial-title-bib"/>
             <text macro="source-serial-identifier-bib"/>
@@ -2332,15 +2317,15 @@
   <macro name="source-serial-identifier-volume-author-date">
     <group delimiter=", ">
       <choose>
-        <if type="article-newspaper">
-          <!-- newspapers provide the full date in place of volume/issue numbers (CMOS18 14.89) -->
+        <if match="any" type="article-magazine article-newspaper">
+          <!-- magazines and newspapers provide the full date in place of volume/issue numbers (CMOS18 14.87, 14.89) -->
           <text variable="collection-title"/>
           <text macro="source-serial-volume-status-bib"/>
         </if>
         <else-if match="any" variable="issue supplement-number volume">
           <choose>
-            <if match="any" type="article-magazine review review-book" variable="reviewed-author reviewed-genre reviewed-title">
-              <!-- date appears first if the magazine or review `container-title` has been substituted for a missing author (CMOS18 14.87, 14.102) -->
+            <if match="any" type="review review-book" variable="reviewed-author reviewed-genre reviewed-title">
+              <!-- date appears first if the review `container-title` has been substituted for a missing author (CMOS18 14.87, 14.102) -->
               <choose>
                 <if match="none" variable="author chair collection-editor compiler composer curator director editor editor-translator editorial-director executive-producer guest host illustrator organizer producer series-creator translator">
                   <choose>
@@ -2368,8 +2353,8 @@
                   <if variable="collection-title">
                     <text macro="label-volume"/>
                   </if>
-                  <else-if match="any" type="article-magazine review review-book" variable="reviewed-author reviewed-genre reviewed-title">
-                    <!-- provide label if a magazine or review `container-title` has been substituted for a missing author (CMOS18 14.87, 14.102) -->
+                  <else-if match="any" type="review review-book" variable="reviewed-author reviewed-genre reviewed-title">
+                    <!-- provide label if a review `container-title` has been substituted for a missing author (CMOS18 14.87, 14.102) -->
                     <choose>
                       <if match="any" variable="author chair collection-editor compiler composer curator director editor editor-translator editorial-director executive-producer guest host illustrator organizer producer series-creator translator">
                         <text variable="volume"/>
@@ -2390,8 +2375,8 @@
                       <text variable="issue"/>
                       <text macro="label-supplement-number"/>
                     </if>
-                    <else-if match="any" type="article-magazine review review-book" variable="reviewed-author reviewed-genre reviewed-title">
-                      <!-- date for anonymous magazine and review articles only appears here if it did not earlier (CMOS18 14.87, 14.102) -->
+                    <else-if match="any" type="review review-book" variable="reviewed-author reviewed-genre reviewed-title">
+                      <!-- date for unsigned reviews only appears here if it did not earlier (CMOS18 14.102) -->
                       <choose>
                         <if match="any" variable="author chair collection-editor compiler composer curator director editor editor-translator editorial-director executive-producer guest host illustrator organizer producer series-creator translator">
                           <text macro="source-date-bib"/>
@@ -3216,8 +3201,8 @@
   </macro>
   <macro name="source-date-issued-month-day-serial">
     <choose>
-      <if type="article-newspaper">
-        <!-- newspapers provide the full date in place of volume/issue numbers (CMOS18 14.89) -->
+      <if match="any" type="article-magazine article-newspaper">
+        <!-- magazines and newspapers provide the full date in place of volume/issue numbers (CMOS18 14.87, 14.89) -->
         <text macro="date-issued-month-day"/>
       </if>
       <else-if match="any" variable="issue supplement-number volume">

--- a/chicago-author-date-archive-place-first.csl
+++ b/chicago-author-date-archive-place-first.csl
@@ -705,14 +705,6 @@
         <!-- Publication name also substituted for unsigned reviews (CMOS18 14.102) -->
         <text macro="source-serial-name"/>
       </else-if>
-      <else-if match="any" type="interview paper-conference">
-        <choose>
-          <if match="none" variable="collection-editor compiler editor editorial-director">
-            <!-- serial usage -->
-            <text macro="source-serial-name"/>
-          </if>
-        </choose>
-      </else-if>
       <else-if match="any" type="entry entry-dictionary entry-encyclopedia">
         <!-- Anonymous entries in reference works (CMOS18 14.130) -->
         <text font-style="italic" text-case="title" variable="container-title"/>
@@ -737,14 +729,6 @@
       <else-if match="any" type="review review-book" variable="reviewed-author reviewed-genre reviewed-title">
         <!-- Publication name also substituted for unsigned reviews (CMOS18 14.102) -->
         <text font-style="italic" text-case="title" variable="container-title"/>
-      </else-if>
-      <else-if match="any" type="interview paper-conference">
-        <choose>
-          <if match="none" variable="collection-editor compiler editor editorial-director">
-            <!-- serial usage -->
-            <text font-style="italic" text-case="title" variable="container-title"/>
-          </if>
-        </choose>
       </else-if>
       <else-if match="any" type="entry entry-dictionary entry-encyclopedia">
         <!-- Anonymous entries in reference works (CMOS18 14.130) -->
@@ -2224,7 +2208,8 @@
     <group delimiter=". ">
       <text macro="source-serial-title-volume-bib"/>
       <choose>
-        <if type="article-newspaper">
+        <if match="any" type="article-magazine article-newspaper">
+          <!-- magazines and newspapers provide the full date in place of volume/issue numbers (CMOS18 14.87, 14.89) -->
           <group delimiter=", ">
             <text macro="source-serial-title-bib"/>
             <text macro="source-serial-identifier-bib"/>
@@ -2332,15 +2317,15 @@
   <macro name="source-serial-identifier-volume-author-date">
     <group delimiter=", ">
       <choose>
-        <if type="article-newspaper">
-          <!-- newspapers provide the full date in place of volume/issue numbers (CMOS18 14.89) -->
+        <if match="any" type="article-magazine article-newspaper">
+          <!-- magazines and newspapers provide the full date in place of volume/issue numbers (CMOS18 14.87, 14.89) -->
           <text variable="collection-title"/>
           <text macro="source-serial-volume-status-bib"/>
         </if>
         <else-if match="any" variable="issue supplement-number volume">
           <choose>
-            <if match="any" type="article-magazine review review-book" variable="reviewed-author reviewed-genre reviewed-title">
-              <!-- date appears first if the magazine or review `container-title` has been substituted for a missing author (CMOS18 14.87, 14.102) -->
+            <if match="any" type="review review-book" variable="reviewed-author reviewed-genre reviewed-title">
+              <!-- date appears first if the review `container-title` has been substituted for a missing author (CMOS18 14.87, 14.102) -->
               <choose>
                 <if match="none" variable="author chair collection-editor compiler composer curator director editor editor-translator editorial-director executive-producer guest host illustrator organizer producer series-creator translator">
                   <choose>
@@ -2368,8 +2353,8 @@
                   <if variable="collection-title">
                     <text macro="label-volume"/>
                   </if>
-                  <else-if match="any" type="article-magazine review review-book" variable="reviewed-author reviewed-genre reviewed-title">
-                    <!-- provide label if a magazine or review `container-title` has been substituted for a missing author (CMOS18 14.87, 14.102) -->
+                  <else-if match="any" type="review review-book" variable="reviewed-author reviewed-genre reviewed-title">
+                    <!-- provide label if a review `container-title` has been substituted for a missing author (CMOS18 14.87, 14.102) -->
                     <choose>
                       <if match="any" variable="author chair collection-editor compiler composer curator director editor editor-translator editorial-director executive-producer guest host illustrator organizer producer series-creator translator">
                         <text variable="volume"/>
@@ -2390,8 +2375,8 @@
                       <text variable="issue"/>
                       <text macro="label-supplement-number"/>
                     </if>
-                    <else-if match="any" type="article-magazine review review-book" variable="reviewed-author reviewed-genre reviewed-title">
-                      <!-- date for anonymous magazine and review articles only appears here if it did not earlier (CMOS18 14.87, 14.102) -->
+                    <else-if match="any" type="review review-book" variable="reviewed-author reviewed-genre reviewed-title">
+                      <!-- date for unsigned reviews only appears here if it did not earlier (CMOS18 14.102) -->
                       <choose>
                         <if match="any" variable="author chair collection-editor compiler composer curator director editor editor-translator editorial-director executive-producer guest host illustrator organizer producer series-creator translator">
                           <text macro="source-date-bib"/>
@@ -3216,8 +3201,8 @@
   </macro>
   <macro name="source-date-issued-month-day-serial">
     <choose>
-      <if type="article-newspaper">
-        <!-- newspapers provide the full date in place of volume/issue numbers (CMOS18 14.89) -->
+      <if match="any" type="article-magazine article-newspaper">
+        <!-- magazines and newspapers provide the full date in place of volume/issue numbers (CMOS18 14.87, 14.89) -->
         <text macro="date-issued-month-day"/>
       </if>
       <else-if match="any" variable="issue supplement-number volume">

--- a/chicago-author-date-classic-no-url.csl
+++ b/chicago-author-date-classic-no-url.csl
@@ -705,14 +705,6 @@
         <!-- Publication name also substituted for unsigned reviews (CMOS18 14.102) -->
         <text macro="source-serial-name"/>
       </else-if>
-      <else-if match="any" type="interview paper-conference">
-        <choose>
-          <if match="none" variable="collection-editor compiler editor editorial-director">
-            <!-- serial usage -->
-            <text macro="source-serial-name"/>
-          </if>
-        </choose>
-      </else-if>
       <else-if match="any" type="entry entry-dictionary entry-encyclopedia">
         <!-- Anonymous entries in reference works (CMOS18 14.130) -->
         <text font-style="italic" text-case="title" variable="container-title"/>
@@ -737,14 +729,6 @@
       <else-if match="any" type="review review-book" variable="reviewed-author reviewed-genre reviewed-title">
         <!-- Publication name also substituted for unsigned reviews (CMOS18 14.102) -->
         <text font-style="italic" text-case="title" variable="container-title"/>
-      </else-if>
-      <else-if match="any" type="interview paper-conference">
-        <choose>
-          <if match="none" variable="collection-editor compiler editor editorial-director">
-            <!-- serial usage -->
-            <text font-style="italic" text-case="title" variable="container-title"/>
-          </if>
-        </choose>
       </else-if>
       <else-if match="any" type="entry entry-dictionary entry-encyclopedia">
         <!-- Anonymous entries in reference works (CMOS18 14.130) -->
@@ -2224,7 +2208,8 @@
     <group delimiter=". ">
       <text macro="source-serial-title-volume-bib"/>
       <choose>
-        <if type="article-newspaper">
+        <if match="any" type="article-magazine article-newspaper">
+          <!-- magazines and newspapers provide the full date in place of volume/issue numbers (CMOS18 14.87, 14.89) -->
           <group delimiter=", ">
             <text macro="source-serial-title-bib"/>
             <text macro="source-serial-identifier-bib"/>
@@ -2332,15 +2317,15 @@
   <macro name="source-serial-identifier-volume-author-date">
     <group delimiter=", ">
       <choose>
-        <if type="article-newspaper">
-          <!-- newspapers provide the full date in place of volume/issue numbers (CMOS18 14.89) -->
+        <if match="any" type="article-magazine article-newspaper">
+          <!-- magazines and newspapers provide the full date in place of volume/issue numbers (CMOS18 14.87, 14.89) -->
           <text variable="collection-title"/>
           <text macro="source-serial-volume-status-bib"/>
         </if>
         <else-if match="any" variable="issue supplement-number volume">
           <choose>
-            <if match="any" type="article-magazine review review-book" variable="reviewed-author reviewed-genre reviewed-title">
-              <!-- date appears first if the magazine or review `container-title` has been substituted for a missing author (CMOS18 14.87, 14.102) -->
+            <if match="any" type="review review-book" variable="reviewed-author reviewed-genre reviewed-title">
+              <!-- date appears first if the review `container-title` has been substituted for a missing author (CMOS18 14.87, 14.102) -->
               <choose>
                 <if match="none" variable="author chair collection-editor compiler composer curator director editor editor-translator editorial-director executive-producer guest host illustrator organizer producer series-creator translator">
                   <choose>
@@ -2368,8 +2353,8 @@
                   <if variable="collection-title">
                     <text macro="label-volume"/>
                   </if>
-                  <else-if match="any" type="article-magazine review review-book" variable="reviewed-author reviewed-genre reviewed-title">
-                    <!-- provide label if a magazine or review `container-title` has been substituted for a missing author (CMOS18 14.87, 14.102) -->
+                  <else-if match="any" type="review review-book" variable="reviewed-author reviewed-genre reviewed-title">
+                    <!-- provide label if a review `container-title` has been substituted for a missing author (CMOS18 14.87, 14.102) -->
                     <choose>
                       <if match="any" variable="author chair collection-editor compiler composer curator director editor editor-translator editorial-director executive-producer guest host illustrator organizer producer series-creator translator">
                         <text variable="volume"/>
@@ -2390,8 +2375,8 @@
                       <text variable="issue"/>
                       <text macro="label-supplement-number"/>
                     </if>
-                    <else-if match="any" type="article-magazine review review-book" variable="reviewed-author reviewed-genre reviewed-title">
-                      <!-- date for anonymous magazine and review articles only appears here if it did not earlier (CMOS18 14.87, 14.102) -->
+                    <else-if match="any" type="review review-book" variable="reviewed-author reviewed-genre reviewed-title">
+                      <!-- date for unsigned reviews only appears here if it did not earlier (CMOS18 14.102) -->
                       <choose>
                         <if match="any" variable="author chair collection-editor compiler composer curator director editor editor-translator editorial-director executive-producer guest host illustrator organizer producer series-creator translator">
                           <text macro="source-date-bib"/>
@@ -3210,8 +3195,8 @@
   </macro>
   <macro name="source-date-issued-month-day-serial">
     <choose>
-      <if type="article-newspaper">
-        <!-- newspapers provide the full date in place of volume/issue numbers (CMOS18 14.89) -->
+      <if match="any" type="article-magazine article-newspaper">
+        <!-- magazines and newspapers provide the full date in place of volume/issue numbers (CMOS18 14.87, 14.89) -->
         <text macro="date-issued-month-day"/>
       </if>
       <else-if match="any" variable="issue supplement-number volume">

--- a/chicago-author-date-classic.csl
+++ b/chicago-author-date-classic.csl
@@ -705,14 +705,6 @@
         <!-- Publication name also substituted for unsigned reviews (CMOS18 14.102) -->
         <text macro="source-serial-name"/>
       </else-if>
-      <else-if match="any" type="interview paper-conference">
-        <choose>
-          <if match="none" variable="collection-editor compiler editor editorial-director">
-            <!-- serial usage -->
-            <text macro="source-serial-name"/>
-          </if>
-        </choose>
-      </else-if>
       <else-if match="any" type="entry entry-dictionary entry-encyclopedia">
         <!-- Anonymous entries in reference works (CMOS18 14.130) -->
         <text font-style="italic" text-case="title" variable="container-title"/>
@@ -737,14 +729,6 @@
       <else-if match="any" type="review review-book" variable="reviewed-author reviewed-genre reviewed-title">
         <!-- Publication name also substituted for unsigned reviews (CMOS18 14.102) -->
         <text font-style="italic" text-case="title" variable="container-title"/>
-      </else-if>
-      <else-if match="any" type="interview paper-conference">
-        <choose>
-          <if match="none" variable="collection-editor compiler editor editorial-director">
-            <!-- serial usage -->
-            <text font-style="italic" text-case="title" variable="container-title"/>
-          </if>
-        </choose>
       </else-if>
       <else-if match="any" type="entry entry-dictionary entry-encyclopedia">
         <!-- Anonymous entries in reference works (CMOS18 14.130) -->
@@ -2224,7 +2208,8 @@
     <group delimiter=". ">
       <text macro="source-serial-title-volume-bib"/>
       <choose>
-        <if type="article-newspaper">
+        <if match="any" type="article-magazine article-newspaper">
+          <!-- magazines and newspapers provide the full date in place of volume/issue numbers (CMOS18 14.87, 14.89) -->
           <group delimiter=", ">
             <text macro="source-serial-title-bib"/>
             <text macro="source-serial-identifier-bib"/>
@@ -2332,15 +2317,15 @@
   <macro name="source-serial-identifier-volume-author-date">
     <group delimiter=", ">
       <choose>
-        <if type="article-newspaper">
-          <!-- newspapers provide the full date in place of volume/issue numbers (CMOS18 14.89) -->
+        <if match="any" type="article-magazine article-newspaper">
+          <!-- magazines and newspapers provide the full date in place of volume/issue numbers (CMOS18 14.87, 14.89) -->
           <text variable="collection-title"/>
           <text macro="source-serial-volume-status-bib"/>
         </if>
         <else-if match="any" variable="issue supplement-number volume">
           <choose>
-            <if match="any" type="article-magazine review review-book" variable="reviewed-author reviewed-genre reviewed-title">
-              <!-- date appears first if the magazine or review `container-title` has been substituted for a missing author (CMOS18 14.87, 14.102) -->
+            <if match="any" type="review review-book" variable="reviewed-author reviewed-genre reviewed-title">
+              <!-- date appears first if the review `container-title` has been substituted for a missing author (CMOS18 14.87, 14.102) -->
               <choose>
                 <if match="none" variable="author chair collection-editor compiler composer curator director editor editor-translator editorial-director executive-producer guest host illustrator organizer producer series-creator translator">
                   <choose>
@@ -2368,8 +2353,8 @@
                   <if variable="collection-title">
                     <text macro="label-volume"/>
                   </if>
-                  <else-if match="any" type="article-magazine review review-book" variable="reviewed-author reviewed-genre reviewed-title">
-                    <!-- provide label if a magazine or review `container-title` has been substituted for a missing author (CMOS18 14.87, 14.102) -->
+                  <else-if match="any" type="review review-book" variable="reviewed-author reviewed-genre reviewed-title">
+                    <!-- provide label if a review `container-title` has been substituted for a missing author (CMOS18 14.87, 14.102) -->
                     <choose>
                       <if match="any" variable="author chair collection-editor compiler composer curator director editor editor-translator editorial-director executive-producer guest host illustrator organizer producer series-creator translator">
                         <text variable="volume"/>
@@ -2390,8 +2375,8 @@
                       <text variable="issue"/>
                       <text macro="label-supplement-number"/>
                     </if>
-                    <else-if match="any" type="article-magazine review review-book" variable="reviewed-author reviewed-genre reviewed-title">
-                      <!-- date for anonymous magazine and review articles only appears here if it did not earlier (CMOS18 14.87, 14.102) -->
+                    <else-if match="any" type="review review-book" variable="reviewed-author reviewed-genre reviewed-title">
+                      <!-- date for unsigned reviews only appears here if it did not earlier (CMOS18 14.102) -->
                       <choose>
                         <if match="any" variable="author chair collection-editor compiler composer curator director editor editor-translator editorial-director executive-producer guest host illustrator organizer producer series-creator translator">
                           <text macro="source-date-bib"/>
@@ -3210,8 +3195,8 @@
   </macro>
   <macro name="source-date-issued-month-day-serial">
     <choose>
-      <if type="article-newspaper">
-        <!-- newspapers provide the full date in place of volume/issue numbers (CMOS18 14.89) -->
+      <if match="any" type="article-magazine article-newspaper">
+        <!-- magazines and newspapers provide the full date in place of volume/issue numbers (CMOS18 14.87, 14.89) -->
         <text macro="date-issued-month-day"/>
       </if>
       <else-if match="any" variable="issue supplement-number volume">

--- a/chicago-author-date-no-url.csl
+++ b/chicago-author-date-no-url.csl
@@ -705,14 +705,6 @@
         <!-- Publication name also substituted for unsigned reviews (CMOS18 14.102) -->
         <text macro="source-serial-name"/>
       </else-if>
-      <else-if match="any" type="interview paper-conference">
-        <choose>
-          <if match="none" variable="collection-editor compiler editor editorial-director">
-            <!-- serial usage -->
-            <text macro="source-serial-name"/>
-          </if>
-        </choose>
-      </else-if>
       <else-if match="any" type="entry entry-dictionary entry-encyclopedia">
         <!-- Anonymous entries in reference works (CMOS18 14.130) -->
         <text font-style="italic" text-case="title" variable="container-title"/>
@@ -737,14 +729,6 @@
       <else-if match="any" type="review review-book" variable="reviewed-author reviewed-genre reviewed-title">
         <!-- Publication name also substituted for unsigned reviews (CMOS18 14.102) -->
         <text font-style="italic" text-case="title" variable="container-title"/>
-      </else-if>
-      <else-if match="any" type="interview paper-conference">
-        <choose>
-          <if match="none" variable="collection-editor compiler editor editorial-director">
-            <!-- serial usage -->
-            <text font-style="italic" text-case="title" variable="container-title"/>
-          </if>
-        </choose>
       </else-if>
       <else-if match="any" type="entry entry-dictionary entry-encyclopedia">
         <!-- Anonymous entries in reference works (CMOS18 14.130) -->
@@ -2224,7 +2208,8 @@
     <group delimiter=". ">
       <text macro="source-serial-title-volume-bib"/>
       <choose>
-        <if type="article-newspaper">
+        <if match="any" type="article-magazine article-newspaper">
+          <!-- magazines and newspapers provide the full date in place of volume/issue numbers (CMOS18 14.87, 14.89) -->
           <group delimiter=", ">
             <text macro="source-serial-title-bib"/>
             <text macro="source-serial-identifier-bib"/>
@@ -2332,15 +2317,15 @@
   <macro name="source-serial-identifier-volume-author-date">
     <group delimiter=", ">
       <choose>
-        <if type="article-newspaper">
-          <!-- newspapers provide the full date in place of volume/issue numbers (CMOS18 14.89) -->
+        <if match="any" type="article-magazine article-newspaper">
+          <!-- magazines and newspapers provide the full date in place of volume/issue numbers (CMOS18 14.87, 14.89) -->
           <text variable="collection-title"/>
           <text macro="source-serial-volume-status-bib"/>
         </if>
         <else-if match="any" variable="issue supplement-number volume">
           <choose>
-            <if match="any" type="article-magazine review review-book" variable="reviewed-author reviewed-genre reviewed-title">
-              <!-- date appears first if the magazine or review `container-title` has been substituted for a missing author (CMOS18 14.87, 14.102) -->
+            <if match="any" type="review review-book" variable="reviewed-author reviewed-genre reviewed-title">
+              <!-- date appears first if the review `container-title` has been substituted for a missing author (CMOS18 14.87, 14.102) -->
               <choose>
                 <if match="none" variable="author chair collection-editor compiler composer curator director editor editor-translator editorial-director executive-producer guest host illustrator organizer producer series-creator translator">
                   <choose>
@@ -2368,8 +2353,8 @@
                   <if variable="collection-title">
                     <text macro="label-volume"/>
                   </if>
-                  <else-if match="any" type="article-magazine review review-book" variable="reviewed-author reviewed-genre reviewed-title">
-                    <!-- provide label if a magazine or review `container-title` has been substituted for a missing author (CMOS18 14.87, 14.102) -->
+                  <else-if match="any" type="review review-book" variable="reviewed-author reviewed-genre reviewed-title">
+                    <!-- provide label if a review `container-title` has been substituted for a missing author (CMOS18 14.87, 14.102) -->
                     <choose>
                       <if match="any" variable="author chair collection-editor compiler composer curator director editor editor-translator editorial-director executive-producer guest host illustrator organizer producer series-creator translator">
                         <text variable="volume"/>
@@ -2390,8 +2375,8 @@
                       <text variable="issue"/>
                       <text macro="label-supplement-number"/>
                     </if>
-                    <else-if match="any" type="article-magazine review review-book" variable="reviewed-author reviewed-genre reviewed-title">
-                      <!-- date for anonymous magazine and review articles only appears here if it did not earlier (CMOS18 14.87, 14.102) -->
+                    <else-if match="any" type="review review-book" variable="reviewed-author reviewed-genre reviewed-title">
+                      <!-- date for unsigned reviews only appears here if it did not earlier (CMOS18 14.102) -->
                       <choose>
                         <if match="any" variable="author chair collection-editor compiler composer curator director editor editor-translator editorial-director executive-producer guest host illustrator organizer producer series-creator translator">
                           <text macro="source-date-bib"/>
@@ -3216,8 +3201,8 @@
   </macro>
   <macro name="source-date-issued-month-day-serial">
     <choose>
-      <if type="article-newspaper">
-        <!-- newspapers provide the full date in place of volume/issue numbers (CMOS18 14.89) -->
+      <if match="any" type="article-magazine article-newspaper">
+        <!-- magazines and newspapers provide the full date in place of volume/issue numbers (CMOS18 14.87, 14.89) -->
         <text macro="date-issued-month-day"/>
       </if>
       <else-if match="any" variable="issue supplement-number volume">

--- a/chicago-author-date.csl
+++ b/chicago-author-date.csl
@@ -705,14 +705,6 @@
         <!-- Publication name also substituted for unsigned reviews (CMOS18 14.102) -->
         <text macro="source-serial-name"/>
       </else-if>
-      <else-if match="any" type="interview paper-conference">
-        <choose>
-          <if match="none" variable="collection-editor compiler editor editorial-director">
-            <!-- serial usage -->
-            <text macro="source-serial-name"/>
-          </if>
-        </choose>
-      </else-if>
       <else-if match="any" type="entry entry-dictionary entry-encyclopedia">
         <!-- Anonymous entries in reference works (CMOS18 14.130) -->
         <text font-style="italic" text-case="title" variable="container-title"/>
@@ -737,14 +729,6 @@
       <else-if match="any" type="review review-book" variable="reviewed-author reviewed-genre reviewed-title">
         <!-- Publication name also substituted for unsigned reviews (CMOS18 14.102) -->
         <text font-style="italic" text-case="title" variable="container-title"/>
-      </else-if>
-      <else-if match="any" type="interview paper-conference">
-        <choose>
-          <if match="none" variable="collection-editor compiler editor editorial-director">
-            <!-- serial usage -->
-            <text font-style="italic" text-case="title" variable="container-title"/>
-          </if>
-        </choose>
       </else-if>
       <else-if match="any" type="entry entry-dictionary entry-encyclopedia">
         <!-- Anonymous entries in reference works (CMOS18 14.130) -->
@@ -2224,7 +2208,8 @@
     <group delimiter=". ">
       <text macro="source-serial-title-volume-bib"/>
       <choose>
-        <if type="article-newspaper">
+        <if match="any" type="article-magazine article-newspaper">
+          <!-- magazines and newspapers provide the full date in place of volume/issue numbers (CMOS18 14.87, 14.89) -->
           <group delimiter=", ">
             <text macro="source-serial-title-bib"/>
             <text macro="source-serial-identifier-bib"/>
@@ -2332,15 +2317,15 @@
   <macro name="source-serial-identifier-volume-author-date">
     <group delimiter=", ">
       <choose>
-        <if type="article-newspaper">
-          <!-- newspapers provide the full date in place of volume/issue numbers (CMOS18 14.89) -->
+        <if match="any" type="article-magazine article-newspaper">
+          <!-- magazines and newspapers provide the full date in place of volume/issue numbers (CMOS18 14.87, 14.89) -->
           <text variable="collection-title"/>
           <text macro="source-serial-volume-status-bib"/>
         </if>
         <else-if match="any" variable="issue supplement-number volume">
           <choose>
-            <if match="any" type="article-magazine review review-book" variable="reviewed-author reviewed-genre reviewed-title">
-              <!-- date appears first if the magazine or review `container-title` has been substituted for a missing author (CMOS18 14.87, 14.102) -->
+            <if match="any" type="review review-book" variable="reviewed-author reviewed-genre reviewed-title">
+              <!-- date appears first if the review `container-title` has been substituted for a missing author (CMOS18 14.87, 14.102) -->
               <choose>
                 <if match="none" variable="author chair collection-editor compiler composer curator director editor editor-translator editorial-director executive-producer guest host illustrator organizer producer series-creator translator">
                   <choose>
@@ -2368,8 +2353,8 @@
                   <if variable="collection-title">
                     <text macro="label-volume"/>
                   </if>
-                  <else-if match="any" type="article-magazine review review-book" variable="reviewed-author reviewed-genre reviewed-title">
-                    <!-- provide label if a magazine or review `container-title` has been substituted for a missing author (CMOS18 14.87, 14.102) -->
+                  <else-if match="any" type="review review-book" variable="reviewed-author reviewed-genre reviewed-title">
+                    <!-- provide label if a review `container-title` has been substituted for a missing author (CMOS18 14.87, 14.102) -->
                     <choose>
                       <if match="any" variable="author chair collection-editor compiler composer curator director editor editor-translator editorial-director executive-producer guest host illustrator organizer producer series-creator translator">
                         <text variable="volume"/>
@@ -2390,8 +2375,8 @@
                       <text variable="issue"/>
                       <text macro="label-supplement-number"/>
                     </if>
-                    <else-if match="any" type="article-magazine review review-book" variable="reviewed-author reviewed-genre reviewed-title">
-                      <!-- date for anonymous magazine and review articles only appears here if it did not earlier (CMOS18 14.87, 14.102) -->
+                    <else-if match="any" type="review review-book" variable="reviewed-author reviewed-genre reviewed-title">
+                      <!-- date for unsigned reviews only appears here if it did not earlier (CMOS18 14.102) -->
                       <choose>
                         <if match="any" variable="author chair collection-editor compiler composer curator director editor editor-translator editorial-director executive-producer guest host illustrator organizer producer series-creator translator">
                           <text macro="source-date-bib"/>
@@ -3216,8 +3201,8 @@
   </macro>
   <macro name="source-date-issued-month-day-serial">
     <choose>
-      <if type="article-newspaper">
-        <!-- newspapers provide the full date in place of volume/issue numbers (CMOS18 14.89) -->
+      <if match="any" type="article-magazine article-newspaper">
+        <!-- magazines and newspapers provide the full date in place of volume/issue numbers (CMOS18 14.87, 14.89) -->
         <text macro="date-issued-month-day"/>
       </if>
       <else-if match="any" variable="issue supplement-number volume">

--- a/chicago-in-text-full-no-url.csl
+++ b/chicago-in-text-full-no-url.csl
@@ -867,14 +867,6 @@
         <!-- Publication name also substituted for unsigned reviews (CMOS18 14.102) -->
         <text macro="source-serial-name"/>
       </else-if>
-      <else-if match="any" type="interview paper-conference">
-        <choose>
-          <if match="none" variable="collection-editor compiler editor editorial-director">
-            <!-- serial usage -->
-            <text macro="source-serial-name"/>
-          </if>
-        </choose>
-      </else-if>
       <else-if match="any" type="entry entry-dictionary entry-encyclopedia">
         <!-- Anonymous entries in reference works (CMOS18 14.130) -->
         <text font-style="italic" text-case="title" variable="container-title"/>
@@ -899,14 +891,6 @@
       <else-if match="any" type="review review-book" variable="reviewed-author reviewed-genre reviewed-title">
         <!-- Publication name also substituted for unsigned reviews (CMOS18 14.102) -->
         <text font-style="italic" text-case="title" variable="container-title"/>
-      </else-if>
-      <else-if match="any" type="interview paper-conference">
-        <choose>
-          <if match="none" variable="collection-editor compiler editor editorial-director">
-            <!-- serial usage -->
-            <text font-style="italic" text-case="title" variable="container-title"/>
-          </if>
-        </choose>
       </else-if>
       <else-if match="any" type="entry entry-dictionary entry-encyclopedia">
         <!-- Anonymous entries in reference works (CMOS18 14.130) -->
@@ -3178,7 +3162,8 @@
     <group delimiter=". ">
       <text macro="source-serial-title-volume-bib"/>
       <choose>
-        <if type="article-newspaper">
+        <if match="any" type="article-magazine article-newspaper">
+          <!-- magazines and newspapers provide the full date in place of volume/issue numbers (CMOS18 14.87, 14.89) -->
           <group delimiter=", ">
             <text macro="source-serial-title-bib"/>
             <text macro="source-serial-identifier-bib"/>
@@ -3209,7 +3194,8 @@
     <group delimiter=", ">
       <text macro="source-serial-title-volume-note"/>
       <choose>
-        <if type="article-newspaper">
+        <if match="any" type="article-magazine article-newspaper">
+          <!-- magazines and newspapers provide the full date in place of volume/issue numbers (CMOS18 14.87, 14.89) -->
           <group delimiter=", ">
             <text macro="source-serial-title-note"/>
             <text macro="source-serial-identifier-note"/>
@@ -3381,15 +3367,15 @@
   <macro name="source-serial-identifier-volume-bib">
     <group delimiter=", ">
       <choose>
-        <if type="article-newspaper">
-          <!-- newspapers provide the full date in place of volume/issue numbers (CMOS18 14.89) -->
+        <if match="any" type="article-magazine article-newspaper">
+          <!-- magazines and newspapers provide the full date in place of volume/issue numbers (CMOS18 14.87, 14.89) -->
           <text variable="collection-title"/>
           <text macro="source-serial-volume-status-bib"/>
         </if>
         <else-if match="any" variable="issue supplement-number volume">
           <choose>
-            <if match="any" type="article-magazine review review-book" variable="reviewed-author reviewed-genre reviewed-title">
-              <!-- date appears first if the magazine or review `container-title` has been substituted for a missing author (CMOS18 14.87, 14.102) -->
+            <if match="any" type="review review-book" variable="reviewed-author reviewed-genre reviewed-title">
+              <!-- date appears first if the review `container-title` has been substituted for a missing author (CMOS18 14.87, 14.102) -->
               <choose>
                 <if match="none" variable="author chair collection-editor compiler composer curator director editor editor-translator editorial-director executive-producer guest host illustrator organizer producer series-creator translator">
                   <text macro="source-date-bib"/>
@@ -3407,8 +3393,8 @@
                 <if variable="collection-title volume">
                   <text macro="label-volume"/>
                 </if>
-                <else-if match="any" type="article-magazine review review-book" variable="reviewed-author reviewed-genre reviewed-title">
-                  <!-- date appears first if a magazine or review `container-title` has been substituted for a missing author (CMOS18 14.87, 14.102) -->
+                <else-if match="any" type="review review-book" variable="reviewed-author reviewed-genre reviewed-title">
+                  <!-- date appears first if a review `container-title` has been substituted for a missing author (CMOS18 14.87, 14.102) -->
                   <choose>
                     <if match="any" variable="author chair collection-editor compiler composer curator director editor editor-translator editorial-director executive-producer guest host illustrator organizer producer series-creator translator">
                       <text variable="volume"/>
@@ -3426,8 +3412,8 @@
               <text macro="label-supplement-number"/>
             </group>
             <choose>
-              <if match="any" type="article-magazine review review-book" variable="reviewed-author reviewed-genre reviewed-title">
-                <!-- date for anonymous magazine and review articles only appears here if it did not earlier (CMOS18 14.87, 14.102) -->
+              <if match="any" type="review review-book" variable="reviewed-author reviewed-genre reviewed-title">
+                <!-- date for unsigned reviews only appears here if it did not earlier (CMOS18 14.102) -->
                 <choose>
                   <if match="any" variable="author chair collection-editor compiler composer curator director editor editor-translator editorial-director executive-producer guest host illustrator organizer producer series-creator translator">
                     <text macro="source-date-bib" prefix="(" suffix=")"/>
@@ -3452,16 +3438,16 @@
   <macro name="source-serial-identifier-volume-note">
     <group delimiter=", ">
       <choose>
-        <if type="article-newspaper">
-          <!-- newspapers provide the full date in place of volume/issue numbers (CMOS18 14.89) -->
+        <if match="any" type="article-magazine article-newspaper">
+          <!-- magazines and newspapers provide the full date in place of volume/issue numbers (CMOS18 14.87, 14.89) -->
           <text variable="collection-title"/>
           <text macro="source-serial-volume-status-note"/>
         </if>
         <else-if match="any" variable="issue supplement-number volume">
           <choose>
-            <if match="any" type="article-magazine review review-book" variable="reviewed-author reviewed-genre reviewed-title">
+            <if match="any" type="review review-book" variable="reviewed-author reviewed-genre reviewed-title">
               <choose>
-                <!-- date appears first if a magazine or review `container-title` has been substituted for a missing author (CMOS18 14.89) -->
+                <!-- date appears first if a review `container-title` has been substituted for a missing author (CMOS18 14.89) -->
                 <!-- the conditions below mirror substitution in `author-note` -->
                 <if match="any" variable="author chair collection-editor compiler composer curator director editor editor-translator editorial-director executive-producer guest host illustrator organizer producer series-creator translator"/>
                 <else-if match="any" variable="reviewed-genre reviewed-title title"/>
@@ -3484,8 +3470,8 @@
                 </if>
                 <else-if variable="volume">
                   <choose>
-                    <if match="any" type="article-magazine review review-book" variable="reviewed-author reviewed-genre reviewed-title">
-                      <!-- date appears first if a magazine or review `container-title` has been substituted for a missing author (CMOS18 14.89) -->
+                    <if match="any" type="review review-book" variable="reviewed-author reviewed-genre reviewed-title">
+                      <!-- date appears first if a review `container-title` has been substituted for a missing author (CMOS18 14.89) -->
                       <choose>
                         <if match="any" variable="author chair collection-editor compiler composer curator director editor editor-translator editorial-director executive-producer guest host illustrator organizer producer series-creator translator">
                           <text variable="volume"/>
@@ -3511,8 +3497,8 @@
               <text macro="label-supplement-number"/>
             </group>
             <choose>
-              <if match="any" type="article-magazine review review-book" variable="reviewed-author reviewed-genre reviewed-title">
-                <!-- date appears first if a magazine or review `container-title` has been substituted for a missing author (CMOS18 14.89) -->
+              <if match="any" type="review review-book" variable="reviewed-author reviewed-genre reviewed-title">
+                <!-- date appears first if a review `container-title` has been substituted for a missing author (CMOS18 14.89) -->
                 <choose>
                   <if match="any" variable="author chair collection-editor compiler composer curator director editor editor-translator editorial-director executive-producer guest host illustrator organizer producer series-creator translator">
                     <text macro="source-date-issued-or-status" prefix="[" suffix="]"/>
@@ -5047,7 +5033,8 @@
   </macro>
   <macro name="source-date-issued-full-serial">
     <choose>
-      <if type="article-newspaper">
+      <if match="any" type="article-magazine article-newspaper">
+        <!-- magazines and newspapers provide the full date in place of volume/issue numbers (CMOS18 14.87, 14.89) -->
         <text macro="date-issued-full"/>
       </if>
       <else-if variable="issue volume">

--- a/chicago-in-text-full.csl
+++ b/chicago-in-text-full.csl
@@ -867,14 +867,6 @@
         <!-- Publication name also substituted for unsigned reviews (CMOS18 14.102) -->
         <text macro="source-serial-name"/>
       </else-if>
-      <else-if match="any" type="interview paper-conference">
-        <choose>
-          <if match="none" variable="collection-editor compiler editor editorial-director">
-            <!-- serial usage -->
-            <text macro="source-serial-name"/>
-          </if>
-        </choose>
-      </else-if>
       <else-if match="any" type="entry entry-dictionary entry-encyclopedia">
         <!-- Anonymous entries in reference works (CMOS18 14.130) -->
         <text font-style="italic" text-case="title" variable="container-title"/>
@@ -899,14 +891,6 @@
       <else-if match="any" type="review review-book" variable="reviewed-author reviewed-genre reviewed-title">
         <!-- Publication name also substituted for unsigned reviews (CMOS18 14.102) -->
         <text font-style="italic" text-case="title" variable="container-title"/>
-      </else-if>
-      <else-if match="any" type="interview paper-conference">
-        <choose>
-          <if match="none" variable="collection-editor compiler editor editorial-director">
-            <!-- serial usage -->
-            <text font-style="italic" text-case="title" variable="container-title"/>
-          </if>
-        </choose>
       </else-if>
       <else-if match="any" type="entry entry-dictionary entry-encyclopedia">
         <!-- Anonymous entries in reference works (CMOS18 14.130) -->
@@ -3178,7 +3162,8 @@
     <group delimiter=". ">
       <text macro="source-serial-title-volume-bib"/>
       <choose>
-        <if type="article-newspaper">
+        <if match="any" type="article-magazine article-newspaper">
+          <!-- magazines and newspapers provide the full date in place of volume/issue numbers (CMOS18 14.87, 14.89) -->
           <group delimiter=", ">
             <text macro="source-serial-title-bib"/>
             <text macro="source-serial-identifier-bib"/>
@@ -3209,7 +3194,8 @@
     <group delimiter=", ">
       <text macro="source-serial-title-volume-note"/>
       <choose>
-        <if type="article-newspaper">
+        <if match="any" type="article-magazine article-newspaper">
+          <!-- magazines and newspapers provide the full date in place of volume/issue numbers (CMOS18 14.87, 14.89) -->
           <group delimiter=", ">
             <text macro="source-serial-title-note"/>
             <text macro="source-serial-identifier-note"/>
@@ -3381,15 +3367,15 @@
   <macro name="source-serial-identifier-volume-bib">
     <group delimiter=", ">
       <choose>
-        <if type="article-newspaper">
-          <!-- newspapers provide the full date in place of volume/issue numbers (CMOS18 14.89) -->
+        <if match="any" type="article-magazine article-newspaper">
+          <!-- magazines and newspapers provide the full date in place of volume/issue numbers (CMOS18 14.87, 14.89) -->
           <text variable="collection-title"/>
           <text macro="source-serial-volume-status-bib"/>
         </if>
         <else-if match="any" variable="issue supplement-number volume">
           <choose>
-            <if match="any" type="article-magazine review review-book" variable="reviewed-author reviewed-genre reviewed-title">
-              <!-- date appears first if the magazine or review `container-title` has been substituted for a missing author (CMOS18 14.87, 14.102) -->
+            <if match="any" type="review review-book" variable="reviewed-author reviewed-genre reviewed-title">
+              <!-- date appears first if the review `container-title` has been substituted for a missing author (CMOS18 14.87, 14.102) -->
               <choose>
                 <if match="none" variable="author chair collection-editor compiler composer curator director editor editor-translator editorial-director executive-producer guest host illustrator organizer producer series-creator translator">
                   <text macro="source-date-bib"/>
@@ -3407,8 +3393,8 @@
                 <if variable="collection-title volume">
                   <text macro="label-volume"/>
                 </if>
-                <else-if match="any" type="article-magazine review review-book" variable="reviewed-author reviewed-genre reviewed-title">
-                  <!-- date appears first if a magazine or review `container-title` has been substituted for a missing author (CMOS18 14.87, 14.102) -->
+                <else-if match="any" type="review review-book" variable="reviewed-author reviewed-genre reviewed-title">
+                  <!-- date appears first if a review `container-title` has been substituted for a missing author (CMOS18 14.87, 14.102) -->
                   <choose>
                     <if match="any" variable="author chair collection-editor compiler composer curator director editor editor-translator editorial-director executive-producer guest host illustrator organizer producer series-creator translator">
                       <text variable="volume"/>
@@ -3426,8 +3412,8 @@
               <text macro="label-supplement-number"/>
             </group>
             <choose>
-              <if match="any" type="article-magazine review review-book" variable="reviewed-author reviewed-genre reviewed-title">
-                <!-- date for anonymous magazine and review articles only appears here if it did not earlier (CMOS18 14.87, 14.102) -->
+              <if match="any" type="review review-book" variable="reviewed-author reviewed-genre reviewed-title">
+                <!-- date for unsigned reviews only appears here if it did not earlier (CMOS18 14.102) -->
                 <choose>
                   <if match="any" variable="author chair collection-editor compiler composer curator director editor editor-translator editorial-director executive-producer guest host illustrator organizer producer series-creator translator">
                     <text macro="source-date-bib" prefix="(" suffix=")"/>
@@ -3452,16 +3438,16 @@
   <macro name="source-serial-identifier-volume-note">
     <group delimiter=", ">
       <choose>
-        <if type="article-newspaper">
-          <!-- newspapers provide the full date in place of volume/issue numbers (CMOS18 14.89) -->
+        <if match="any" type="article-magazine article-newspaper">
+          <!-- magazines and newspapers provide the full date in place of volume/issue numbers (CMOS18 14.87, 14.89) -->
           <text variable="collection-title"/>
           <text macro="source-serial-volume-status-note"/>
         </if>
         <else-if match="any" variable="issue supplement-number volume">
           <choose>
-            <if match="any" type="article-magazine review review-book" variable="reviewed-author reviewed-genre reviewed-title">
+            <if match="any" type="review review-book" variable="reviewed-author reviewed-genre reviewed-title">
               <choose>
-                <!-- date appears first if a magazine or review `container-title` has been substituted for a missing author (CMOS18 14.89) -->
+                <!-- date appears first if a review `container-title` has been substituted for a missing author (CMOS18 14.89) -->
                 <!-- the conditions below mirror substitution in `author-note` -->
                 <if match="any" variable="author chair collection-editor compiler composer curator director editor editor-translator editorial-director executive-producer guest host illustrator organizer producer series-creator translator"/>
                 <else-if match="any" variable="reviewed-genre reviewed-title title"/>
@@ -3484,8 +3470,8 @@
                 </if>
                 <else-if variable="volume">
                   <choose>
-                    <if match="any" type="article-magazine review review-book" variable="reviewed-author reviewed-genre reviewed-title">
-                      <!-- date appears first if a magazine or review `container-title` has been substituted for a missing author (CMOS18 14.89) -->
+                    <if match="any" type="review review-book" variable="reviewed-author reviewed-genre reviewed-title">
+                      <!-- date appears first if a review `container-title` has been substituted for a missing author (CMOS18 14.89) -->
                       <choose>
                         <if match="any" variable="author chair collection-editor compiler composer curator director editor editor-translator editorial-director executive-producer guest host illustrator organizer producer series-creator translator">
                           <text variable="volume"/>
@@ -3511,8 +3497,8 @@
               <text macro="label-supplement-number"/>
             </group>
             <choose>
-              <if match="any" type="article-magazine review review-book" variable="reviewed-author reviewed-genre reviewed-title">
-                <!-- date appears first if a magazine or review `container-title` has been substituted for a missing author (CMOS18 14.89) -->
+              <if match="any" type="review review-book" variable="reviewed-author reviewed-genre reviewed-title">
+                <!-- date appears first if a review `container-title` has been substituted for a missing author (CMOS18 14.89) -->
                 <choose>
                   <if match="any" variable="author chair collection-editor compiler composer curator director editor editor-translator editorial-director executive-producer guest host illustrator organizer producer series-creator translator">
                     <text macro="source-date-issued-or-status" prefix="[" suffix="]"/>
@@ -5047,7 +5033,8 @@
   </macro>
   <macro name="source-date-issued-full-serial">
     <choose>
-      <if type="article-newspaper">
+      <if match="any" type="article-magazine article-newspaper">
+        <!-- magazines and newspapers provide the full date in place of volume/issue numbers (CMOS18 14.87, 14.89) -->
         <text macro="date-issued-full"/>
       </if>
       <else-if variable="issue volume">

--- a/chicago-in-text-shortened-author-no-url.csl
+++ b/chicago-in-text-shortened-author-no-url.csl
@@ -704,14 +704,6 @@
         <!-- Publication name also substituted for unsigned reviews (CMOS18 14.102) -->
         <text macro="source-serial-name"/>
       </else-if>
-      <else-if match="any" type="interview paper-conference">
-        <choose>
-          <if match="none" variable="collection-editor compiler editor editorial-director">
-            <!-- serial usage -->
-            <text macro="source-serial-name"/>
-          </if>
-        </choose>
-      </else-if>
       <else-if match="any" type="entry entry-dictionary entry-encyclopedia">
         <!-- Anonymous entries in reference works (CMOS18 14.130) -->
         <text font-style="italic" text-case="title" variable="container-title"/>
@@ -736,14 +728,6 @@
       <else-if match="any" type="review review-book" variable="reviewed-author reviewed-genre reviewed-title">
         <!-- Publication name also substituted for unsigned reviews (CMOS18 14.102) -->
         <text font-style="italic" text-case="title" variable="container-title"/>
-      </else-if>
-      <else-if match="any" type="interview paper-conference">
-        <choose>
-          <if match="none" variable="collection-editor compiler editor editorial-director">
-            <!-- serial usage -->
-            <text font-style="italic" text-case="title" variable="container-title"/>
-          </if>
-        </choose>
       </else-if>
       <else-if match="any" type="entry entry-dictionary entry-encyclopedia">
         <!-- Anonymous entries in reference works (CMOS18 14.130) -->
@@ -2085,7 +2069,8 @@
     <group delimiter=". ">
       <text macro="source-serial-title-volume-bib"/>
       <choose>
-        <if type="article-newspaper">
+        <if match="any" type="article-magazine article-newspaper">
+          <!-- magazines and newspapers provide the full date in place of volume/issue numbers (CMOS18 14.87, 14.89) -->
           <group delimiter=", ">
             <text macro="source-serial-title-bib"/>
             <text macro="source-serial-identifier-bib"/>
@@ -2193,15 +2178,15 @@
   <macro name="source-serial-identifier-volume-bib">
     <group delimiter=", ">
       <choose>
-        <if type="article-newspaper">
-          <!-- newspapers provide the full date in place of volume/issue numbers (CMOS18 14.89) -->
+        <if match="any" type="article-magazine article-newspaper">
+          <!-- magazines and newspapers provide the full date in place of volume/issue numbers (CMOS18 14.87, 14.89) -->
           <text variable="collection-title"/>
           <text macro="source-serial-volume-status-bib"/>
         </if>
         <else-if match="any" variable="issue supplement-number volume">
           <choose>
-            <if match="any" type="article-magazine review review-book" variable="reviewed-author reviewed-genre reviewed-title">
-              <!-- date appears first if the magazine or review `container-title` has been substituted for a missing author (CMOS18 14.87, 14.102) -->
+            <if match="any" type="review review-book" variable="reviewed-author reviewed-genre reviewed-title">
+              <!-- date appears first if the review `container-title` has been substituted for a missing author (CMOS18 14.87, 14.102) -->
               <choose>
                 <if match="none" variable="author chair collection-editor compiler composer curator director editor editor-translator editorial-director executive-producer guest host illustrator organizer producer series-creator translator">
                   <text macro="source-date-bib"/>
@@ -2219,8 +2204,8 @@
                 <if variable="collection-title volume">
                   <text macro="label-volume"/>
                 </if>
-                <else-if match="any" type="article-magazine review review-book" variable="reviewed-author reviewed-genre reviewed-title">
-                  <!-- date appears first if a magazine or review `container-title` has been substituted for a missing author (CMOS18 14.87, 14.102) -->
+                <else-if match="any" type="review review-book" variable="reviewed-author reviewed-genre reviewed-title">
+                  <!-- date appears first if a review `container-title` has been substituted for a missing author (CMOS18 14.87, 14.102) -->
                   <choose>
                     <if match="any" variable="author chair collection-editor compiler composer curator director editor editor-translator editorial-director executive-producer guest host illustrator organizer producer series-creator translator">
                       <text variable="volume"/>
@@ -2238,8 +2223,8 @@
               <text macro="label-supplement-number"/>
             </group>
             <choose>
-              <if match="any" type="article-magazine review review-book" variable="reviewed-author reviewed-genre reviewed-title">
-                <!-- date for anonymous magazine and review articles only appears here if it did not earlier (CMOS18 14.87, 14.102) -->
+              <if match="any" type="review review-book" variable="reviewed-author reviewed-genre reviewed-title">
+                <!-- date for unsigned reviews only appears here if it did not earlier (CMOS18 14.102) -->
                 <choose>
                   <if match="any" variable="author chair collection-editor compiler composer curator director editor editor-translator editorial-director executive-producer guest host illustrator organizer producer series-creator translator">
                     <text macro="source-date-bib" prefix="(" suffix=")"/>
@@ -3056,7 +3041,8 @@
   </macro>
   <macro name="source-date-issued-full-serial">
     <choose>
-      <if type="article-newspaper">
+      <if match="any" type="article-magazine article-newspaper">
+        <!-- magazines and newspapers provide the full date in place of volume/issue numbers (CMOS18 14.87, 14.89) -->
         <text macro="date-issued-full"/>
       </if>
       <else-if variable="issue volume">

--- a/chicago-in-text-shortened-author-title-no-url.csl
+++ b/chicago-in-text-shortened-author-title-no-url.csl
@@ -704,14 +704,6 @@
         <!-- Publication name also substituted for unsigned reviews (CMOS18 14.102) -->
         <text macro="source-serial-name"/>
       </else-if>
-      <else-if match="any" type="interview paper-conference">
-        <choose>
-          <if match="none" variable="collection-editor compiler editor editorial-director">
-            <!-- serial usage -->
-            <text macro="source-serial-name"/>
-          </if>
-        </choose>
-      </else-if>
       <else-if match="any" type="entry entry-dictionary entry-encyclopedia">
         <!-- Anonymous entries in reference works (CMOS18 14.130) -->
         <text font-style="italic" text-case="title" variable="container-title"/>
@@ -736,14 +728,6 @@
       <else-if match="any" type="review review-book" variable="reviewed-author reviewed-genre reviewed-title">
         <!-- Publication name also substituted for unsigned reviews (CMOS18 14.102) -->
         <text font-style="italic" text-case="title" variable="container-title"/>
-      </else-if>
-      <else-if match="any" type="interview paper-conference">
-        <choose>
-          <if match="none" variable="collection-editor compiler editor editorial-director">
-            <!-- serial usage -->
-            <text font-style="italic" text-case="title" variable="container-title"/>
-          </if>
-        </choose>
       </else-if>
       <else-if match="any" type="entry entry-dictionary entry-encyclopedia">
         <!-- Anonymous entries in reference works (CMOS18 14.130) -->
@@ -2158,7 +2142,8 @@
     <group delimiter=". ">
       <text macro="source-serial-title-volume-bib"/>
       <choose>
-        <if type="article-newspaper">
+        <if match="any" type="article-magazine article-newspaper">
+          <!-- magazines and newspapers provide the full date in place of volume/issue numbers (CMOS18 14.87, 14.89) -->
           <group delimiter=", ">
             <text macro="source-serial-title-bib"/>
             <text macro="source-serial-identifier-bib"/>
@@ -2266,15 +2251,15 @@
   <macro name="source-serial-identifier-volume-bib">
     <group delimiter=", ">
       <choose>
-        <if type="article-newspaper">
-          <!-- newspapers provide the full date in place of volume/issue numbers (CMOS18 14.89) -->
+        <if match="any" type="article-magazine article-newspaper">
+          <!-- magazines and newspapers provide the full date in place of volume/issue numbers (CMOS18 14.87, 14.89) -->
           <text variable="collection-title"/>
           <text macro="source-serial-volume-status-bib"/>
         </if>
         <else-if match="any" variable="issue supplement-number volume">
           <choose>
-            <if match="any" type="article-magazine review review-book" variable="reviewed-author reviewed-genre reviewed-title">
-              <!-- date appears first if the magazine or review `container-title` has been substituted for a missing author (CMOS18 14.87, 14.102) -->
+            <if match="any" type="review review-book" variable="reviewed-author reviewed-genre reviewed-title">
+              <!-- date appears first if the review `container-title` has been substituted for a missing author (CMOS18 14.87, 14.102) -->
               <choose>
                 <if match="none" variable="author chair collection-editor compiler composer curator director editor editor-translator editorial-director executive-producer guest host illustrator organizer producer series-creator translator">
                   <text macro="source-date-bib"/>
@@ -2292,8 +2277,8 @@
                 <if variable="collection-title volume">
                   <text macro="label-volume"/>
                 </if>
-                <else-if match="any" type="article-magazine review review-book" variable="reviewed-author reviewed-genre reviewed-title">
-                  <!-- date appears first if a magazine or review `container-title` has been substituted for a missing author (CMOS18 14.87, 14.102) -->
+                <else-if match="any" type="review review-book" variable="reviewed-author reviewed-genre reviewed-title">
+                  <!-- date appears first if a review `container-title` has been substituted for a missing author (CMOS18 14.87, 14.102) -->
                   <choose>
                     <if match="any" variable="author chair collection-editor compiler composer curator director editor editor-translator editorial-director executive-producer guest host illustrator organizer producer series-creator translator">
                       <text variable="volume"/>
@@ -2311,8 +2296,8 @@
               <text macro="label-supplement-number"/>
             </group>
             <choose>
-              <if match="any" type="article-magazine review review-book" variable="reviewed-author reviewed-genre reviewed-title">
-                <!-- date for anonymous magazine and review articles only appears here if it did not earlier (CMOS18 14.87, 14.102) -->
+              <if match="any" type="review review-book" variable="reviewed-author reviewed-genre reviewed-title">
+                <!-- date for unsigned reviews only appears here if it did not earlier (CMOS18 14.102) -->
                 <choose>
                   <if match="any" variable="author chair collection-editor compiler composer curator director editor editor-translator editorial-director executive-producer guest host illustrator organizer producer series-creator translator">
                     <text macro="source-date-bib" prefix="(" suffix=")"/>
@@ -3260,7 +3245,8 @@
   </macro>
   <macro name="source-date-issued-full-serial">
     <choose>
-      <if type="article-newspaper">
+      <if match="any" type="article-magazine article-newspaper">
+        <!-- magazines and newspapers provide the full date in place of volume/issue numbers (CMOS18 14.87, 14.89) -->
         <text macro="date-issued-full"/>
       </if>
       <else-if variable="issue volume">

--- a/chicago-in-text-shortened-author-title.csl
+++ b/chicago-in-text-shortened-author-title.csl
@@ -704,14 +704,6 @@
         <!-- Publication name also substituted for unsigned reviews (CMOS18 14.102) -->
         <text macro="source-serial-name"/>
       </else-if>
-      <else-if match="any" type="interview paper-conference">
-        <choose>
-          <if match="none" variable="collection-editor compiler editor editorial-director">
-            <!-- serial usage -->
-            <text macro="source-serial-name"/>
-          </if>
-        </choose>
-      </else-if>
       <else-if match="any" type="entry entry-dictionary entry-encyclopedia">
         <!-- Anonymous entries in reference works (CMOS18 14.130) -->
         <text font-style="italic" text-case="title" variable="container-title"/>
@@ -736,14 +728,6 @@
       <else-if match="any" type="review review-book" variable="reviewed-author reviewed-genre reviewed-title">
         <!-- Publication name also substituted for unsigned reviews (CMOS18 14.102) -->
         <text font-style="italic" text-case="title" variable="container-title"/>
-      </else-if>
-      <else-if match="any" type="interview paper-conference">
-        <choose>
-          <if match="none" variable="collection-editor compiler editor editorial-director">
-            <!-- serial usage -->
-            <text font-style="italic" text-case="title" variable="container-title"/>
-          </if>
-        </choose>
       </else-if>
       <else-if match="any" type="entry entry-dictionary entry-encyclopedia">
         <!-- Anonymous entries in reference works (CMOS18 14.130) -->
@@ -2158,7 +2142,8 @@
     <group delimiter=". ">
       <text macro="source-serial-title-volume-bib"/>
       <choose>
-        <if type="article-newspaper">
+        <if match="any" type="article-magazine article-newspaper">
+          <!-- magazines and newspapers provide the full date in place of volume/issue numbers (CMOS18 14.87, 14.89) -->
           <group delimiter=", ">
             <text macro="source-serial-title-bib"/>
             <text macro="source-serial-identifier-bib"/>
@@ -2266,15 +2251,15 @@
   <macro name="source-serial-identifier-volume-bib">
     <group delimiter=", ">
       <choose>
-        <if type="article-newspaper">
-          <!-- newspapers provide the full date in place of volume/issue numbers (CMOS18 14.89) -->
+        <if match="any" type="article-magazine article-newspaper">
+          <!-- magazines and newspapers provide the full date in place of volume/issue numbers (CMOS18 14.87, 14.89) -->
           <text variable="collection-title"/>
           <text macro="source-serial-volume-status-bib"/>
         </if>
         <else-if match="any" variable="issue supplement-number volume">
           <choose>
-            <if match="any" type="article-magazine review review-book" variable="reviewed-author reviewed-genre reviewed-title">
-              <!-- date appears first if the magazine or review `container-title` has been substituted for a missing author (CMOS18 14.87, 14.102) -->
+            <if match="any" type="review review-book" variable="reviewed-author reviewed-genre reviewed-title">
+              <!-- date appears first if the review `container-title` has been substituted for a missing author (CMOS18 14.87, 14.102) -->
               <choose>
                 <if match="none" variable="author chair collection-editor compiler composer curator director editor editor-translator editorial-director executive-producer guest host illustrator organizer producer series-creator translator">
                   <text macro="source-date-bib"/>
@@ -2292,8 +2277,8 @@
                 <if variable="collection-title volume">
                   <text macro="label-volume"/>
                 </if>
-                <else-if match="any" type="article-magazine review review-book" variable="reviewed-author reviewed-genre reviewed-title">
-                  <!-- date appears first if a magazine or review `container-title` has been substituted for a missing author (CMOS18 14.87, 14.102) -->
+                <else-if match="any" type="review review-book" variable="reviewed-author reviewed-genre reviewed-title">
+                  <!-- date appears first if a review `container-title` has been substituted for a missing author (CMOS18 14.87, 14.102) -->
                   <choose>
                     <if match="any" variable="author chair collection-editor compiler composer curator director editor editor-translator editorial-director executive-producer guest host illustrator organizer producer series-creator translator">
                       <text variable="volume"/>
@@ -2311,8 +2296,8 @@
               <text macro="label-supplement-number"/>
             </group>
             <choose>
-              <if match="any" type="article-magazine review review-book" variable="reviewed-author reviewed-genre reviewed-title">
-                <!-- date for anonymous magazine and review articles only appears here if it did not earlier (CMOS18 14.87, 14.102) -->
+              <if match="any" type="review review-book" variable="reviewed-author reviewed-genre reviewed-title">
+                <!-- date for unsigned reviews only appears here if it did not earlier (CMOS18 14.102) -->
                 <choose>
                   <if match="any" variable="author chair collection-editor compiler composer curator director editor editor-translator editorial-director executive-producer guest host illustrator organizer producer series-creator translator">
                     <text macro="source-date-bib" prefix="(" suffix=")"/>
@@ -3260,7 +3245,8 @@
   </macro>
   <macro name="source-date-issued-full-serial">
     <choose>
-      <if type="article-newspaper">
+      <if match="any" type="article-magazine article-newspaper">
+        <!-- magazines and newspapers provide the full date in place of volume/issue numbers (CMOS18 14.87, 14.89) -->
         <text macro="date-issued-full"/>
       </if>
       <else-if variable="issue volume">

--- a/chicago-in-text-shortened-author.csl
+++ b/chicago-in-text-shortened-author.csl
@@ -704,14 +704,6 @@
         <!-- Publication name also substituted for unsigned reviews (CMOS18 14.102) -->
         <text macro="source-serial-name"/>
       </else-if>
-      <else-if match="any" type="interview paper-conference">
-        <choose>
-          <if match="none" variable="collection-editor compiler editor editorial-director">
-            <!-- serial usage -->
-            <text macro="source-serial-name"/>
-          </if>
-        </choose>
-      </else-if>
       <else-if match="any" type="entry entry-dictionary entry-encyclopedia">
         <!-- Anonymous entries in reference works (CMOS18 14.130) -->
         <text font-style="italic" text-case="title" variable="container-title"/>
@@ -736,14 +728,6 @@
       <else-if match="any" type="review review-book" variable="reviewed-author reviewed-genre reviewed-title">
         <!-- Publication name also substituted for unsigned reviews (CMOS18 14.102) -->
         <text font-style="italic" text-case="title" variable="container-title"/>
-      </else-if>
-      <else-if match="any" type="interview paper-conference">
-        <choose>
-          <if match="none" variable="collection-editor compiler editor editorial-director">
-            <!-- serial usage -->
-            <text font-style="italic" text-case="title" variable="container-title"/>
-          </if>
-        </choose>
       </else-if>
       <else-if match="any" type="entry entry-dictionary entry-encyclopedia">
         <!-- Anonymous entries in reference works (CMOS18 14.130) -->
@@ -2085,7 +2069,8 @@
     <group delimiter=". ">
       <text macro="source-serial-title-volume-bib"/>
       <choose>
-        <if type="article-newspaper">
+        <if match="any" type="article-magazine article-newspaper">
+          <!-- magazines and newspapers provide the full date in place of volume/issue numbers (CMOS18 14.87, 14.89) -->
           <group delimiter=", ">
             <text macro="source-serial-title-bib"/>
             <text macro="source-serial-identifier-bib"/>
@@ -2193,15 +2178,15 @@
   <macro name="source-serial-identifier-volume-bib">
     <group delimiter=", ">
       <choose>
-        <if type="article-newspaper">
-          <!-- newspapers provide the full date in place of volume/issue numbers (CMOS18 14.89) -->
+        <if match="any" type="article-magazine article-newspaper">
+          <!-- magazines and newspapers provide the full date in place of volume/issue numbers (CMOS18 14.87, 14.89) -->
           <text variable="collection-title"/>
           <text macro="source-serial-volume-status-bib"/>
         </if>
         <else-if match="any" variable="issue supplement-number volume">
           <choose>
-            <if match="any" type="article-magazine review review-book" variable="reviewed-author reviewed-genre reviewed-title">
-              <!-- date appears first if the magazine or review `container-title` has been substituted for a missing author (CMOS18 14.87, 14.102) -->
+            <if match="any" type="review review-book" variable="reviewed-author reviewed-genre reviewed-title">
+              <!-- date appears first if the review `container-title` has been substituted for a missing author (CMOS18 14.87, 14.102) -->
               <choose>
                 <if match="none" variable="author chair collection-editor compiler composer curator director editor editor-translator editorial-director executive-producer guest host illustrator organizer producer series-creator translator">
                   <text macro="source-date-bib"/>
@@ -2219,8 +2204,8 @@
                 <if variable="collection-title volume">
                   <text macro="label-volume"/>
                 </if>
-                <else-if match="any" type="article-magazine review review-book" variable="reviewed-author reviewed-genre reviewed-title">
-                  <!-- date appears first if a magazine or review `container-title` has been substituted for a missing author (CMOS18 14.87, 14.102) -->
+                <else-if match="any" type="review review-book" variable="reviewed-author reviewed-genre reviewed-title">
+                  <!-- date appears first if a review `container-title` has been substituted for a missing author (CMOS18 14.87, 14.102) -->
                   <choose>
                     <if match="any" variable="author chair collection-editor compiler composer curator director editor editor-translator editorial-director executive-producer guest host illustrator organizer producer series-creator translator">
                       <text variable="volume"/>
@@ -2238,8 +2223,8 @@
               <text macro="label-supplement-number"/>
             </group>
             <choose>
-              <if match="any" type="article-magazine review review-book" variable="reviewed-author reviewed-genre reviewed-title">
-                <!-- date for anonymous magazine and review articles only appears here if it did not earlier (CMOS18 14.87, 14.102) -->
+              <if match="any" type="review review-book" variable="reviewed-author reviewed-genre reviewed-title">
+                <!-- date for unsigned reviews only appears here if it did not earlier (CMOS18 14.102) -->
                 <choose>
                   <if match="any" variable="author chair collection-editor compiler composer curator director editor editor-translator editorial-director executive-producer guest host illustrator organizer producer series-creator translator">
                     <text macro="source-date-bib" prefix="(" suffix=")"/>
@@ -3056,7 +3041,8 @@
   </macro>
   <macro name="source-date-issued-full-serial">
     <choose>
-      <if type="article-newspaper">
+      <if match="any" type="article-magazine article-newspaper">
+        <!-- magazines and newspapers provide the full date in place of volume/issue numbers (CMOS18 14.87, 14.89) -->
         <text macro="date-issued-full"/>
       </if>
       <else-if variable="issue volume">

--- a/chicago-notes-archive-place-first-no-url.csl
+++ b/chicago-notes-archive-place-first-no-url.csl
@@ -736,14 +736,6 @@
         <!-- Publication name also substituted for unsigned reviews (CMOS18 14.102) -->
         <text macro="source-serial-name"/>
       </else-if>
-      <else-if match="any" type="interview paper-conference">
-        <choose>
-          <if match="none" variable="collection-editor compiler editor editorial-director">
-            <!-- serial usage -->
-            <text macro="source-serial-name"/>
-          </if>
-        </choose>
-      </else-if>
       <else-if match="any" type="entry entry-dictionary entry-encyclopedia">
         <!-- Anonymous entries in reference works (CMOS18 14.130) -->
         <text font-style="italic" text-case="title" variable="container-title"/>
@@ -768,14 +760,6 @@
       <else-if match="any" type="review review-book" variable="reviewed-author reviewed-genre reviewed-title">
         <!-- Publication name also substituted for unsigned reviews (CMOS18 14.102) -->
         <text font-style="italic" text-case="title" variable="container-title"/>
-      </else-if>
-      <else-if match="any" type="interview paper-conference">
-        <choose>
-          <if match="none" variable="collection-editor compiler editor editorial-director">
-            <!-- serial usage -->
-            <text font-style="italic" text-case="title" variable="container-title"/>
-          </if>
-        </choose>
       </else-if>
       <else-if match="any" type="entry entry-dictionary entry-encyclopedia">
         <!-- Anonymous entries in reference works (CMOS18 14.130) -->
@@ -2966,7 +2950,8 @@
     <group delimiter=", ">
       <text macro="source-serial-title-volume-note"/>
       <choose>
-        <if type="article-newspaper">
+        <if match="any" type="article-magazine article-newspaper">
+          <!-- magazines and newspapers provide the full date in place of volume/issue numbers (CMOS18 14.87, 14.89) -->
           <group delimiter=", ">
             <text macro="source-serial-title-note"/>
             <text macro="source-serial-identifier-note"/>
@@ -3073,16 +3058,16 @@
   <macro name="source-serial-identifier-volume-note">
     <group delimiter=", ">
       <choose>
-        <if type="article-newspaper">
-          <!-- newspapers provide the full date in place of volume/issue numbers (CMOS18 14.89) -->
+        <if match="any" type="article-magazine article-newspaper">
+          <!-- magazines and newspapers provide the full date in place of volume/issue numbers (CMOS18 14.87, 14.89) -->
           <text variable="collection-title"/>
           <text macro="source-serial-volume-status-note"/>
         </if>
         <else-if match="any" variable="issue supplement-number volume">
           <choose>
-            <if match="any" type="article-magazine review review-book" variable="reviewed-author reviewed-genre reviewed-title">
+            <if match="any" type="review review-book" variable="reviewed-author reviewed-genre reviewed-title">
               <choose>
-                <!-- date appears first if a magazine or review `container-title` has been substituted for a missing author (CMOS18 14.89) -->
+                <!-- date appears first if a review `container-title` has been substituted for a missing author (CMOS18 14.89) -->
                 <!-- the conditions below mirror substitution in `author-note` -->
                 <if match="any" variable="author chair collection-editor compiler composer curator director editor editor-translator editorial-director executive-producer guest host illustrator organizer producer series-creator translator"/>
                 <else-if match="any" variable="reviewed-genre reviewed-title title"/>
@@ -3105,8 +3090,8 @@
                 </if>
                 <else-if variable="volume">
                   <choose>
-                    <if match="any" type="article-magazine review review-book" variable="reviewed-author reviewed-genre reviewed-title">
-                      <!-- date appears first if a magazine or review `container-title` has been substituted for a missing author (CMOS18 14.89) -->
+                    <if match="any" type="review review-book" variable="reviewed-author reviewed-genre reviewed-title">
+                      <!-- date appears first if a review `container-title` has been substituted for a missing author (CMOS18 14.89) -->
                       <choose>
                         <if match="any" variable="author chair collection-editor compiler composer curator director editor editor-translator editorial-director executive-producer guest host illustrator organizer producer series-creator translator">
                           <text variable="volume"/>
@@ -3132,8 +3117,8 @@
               <text macro="label-supplement-number"/>
             </group>
             <choose>
-              <if match="any" type="article-magazine review review-book" variable="reviewed-author reviewed-genre reviewed-title">
-                <!-- date appears first if a magazine or review `container-title` has been substituted for a missing author (CMOS18 14.89) -->
+              <if match="any" type="review review-book" variable="reviewed-author reviewed-genre reviewed-title">
+                <!-- date appears first if a review `container-title` has been substituted for a missing author (CMOS18 14.89) -->
                 <choose>
                   <if match="any" variable="author chair collection-editor compiler composer curator director editor editor-translator editorial-director executive-producer guest host illustrator organizer producer series-creator translator">
                     <text macro="source-date-issued-or-status" prefix="(" suffix=")"/>
@@ -4128,7 +4113,8 @@
   </macro>
   <macro name="source-date-issued-full-serial">
     <choose>
-      <if type="article-newspaper">
+      <if match="any" type="article-magazine article-newspaper">
+        <!-- magazines and newspapers provide the full date in place of volume/issue numbers (CMOS18 14.87, 14.89) -->
         <text macro="date-issued-full"/>
       </if>
       <else-if variable="issue volume">

--- a/chicago-notes-archive-place-first.csl
+++ b/chicago-notes-archive-place-first.csl
@@ -736,14 +736,6 @@
         <!-- Publication name also substituted for unsigned reviews (CMOS18 14.102) -->
         <text macro="source-serial-name"/>
       </else-if>
-      <else-if match="any" type="interview paper-conference">
-        <choose>
-          <if match="none" variable="collection-editor compiler editor editorial-director">
-            <!-- serial usage -->
-            <text macro="source-serial-name"/>
-          </if>
-        </choose>
-      </else-if>
       <else-if match="any" type="entry entry-dictionary entry-encyclopedia">
         <!-- Anonymous entries in reference works (CMOS18 14.130) -->
         <text font-style="italic" text-case="title" variable="container-title"/>
@@ -768,14 +760,6 @@
       <else-if match="any" type="review review-book" variable="reviewed-author reviewed-genre reviewed-title">
         <!-- Publication name also substituted for unsigned reviews (CMOS18 14.102) -->
         <text font-style="italic" text-case="title" variable="container-title"/>
-      </else-if>
-      <else-if match="any" type="interview paper-conference">
-        <choose>
-          <if match="none" variable="collection-editor compiler editor editorial-director">
-            <!-- serial usage -->
-            <text font-style="italic" text-case="title" variable="container-title"/>
-          </if>
-        </choose>
       </else-if>
       <else-if match="any" type="entry entry-dictionary entry-encyclopedia">
         <!-- Anonymous entries in reference works (CMOS18 14.130) -->
@@ -2966,7 +2950,8 @@
     <group delimiter=", ">
       <text macro="source-serial-title-volume-note"/>
       <choose>
-        <if type="article-newspaper">
+        <if match="any" type="article-magazine article-newspaper">
+          <!-- magazines and newspapers provide the full date in place of volume/issue numbers (CMOS18 14.87, 14.89) -->
           <group delimiter=", ">
             <text macro="source-serial-title-note"/>
             <text macro="source-serial-identifier-note"/>
@@ -3073,16 +3058,16 @@
   <macro name="source-serial-identifier-volume-note">
     <group delimiter=", ">
       <choose>
-        <if type="article-newspaper">
-          <!-- newspapers provide the full date in place of volume/issue numbers (CMOS18 14.89) -->
+        <if match="any" type="article-magazine article-newspaper">
+          <!-- magazines and newspapers provide the full date in place of volume/issue numbers (CMOS18 14.87, 14.89) -->
           <text variable="collection-title"/>
           <text macro="source-serial-volume-status-note"/>
         </if>
         <else-if match="any" variable="issue supplement-number volume">
           <choose>
-            <if match="any" type="article-magazine review review-book" variable="reviewed-author reviewed-genre reviewed-title">
+            <if match="any" type="review review-book" variable="reviewed-author reviewed-genre reviewed-title">
               <choose>
-                <!-- date appears first if a magazine or review `container-title` has been substituted for a missing author (CMOS18 14.89) -->
+                <!-- date appears first if a review `container-title` has been substituted for a missing author (CMOS18 14.89) -->
                 <!-- the conditions below mirror substitution in `author-note` -->
                 <if match="any" variable="author chair collection-editor compiler composer curator director editor editor-translator editorial-director executive-producer guest host illustrator organizer producer series-creator translator"/>
                 <else-if match="any" variable="reviewed-genre reviewed-title title"/>
@@ -3105,8 +3090,8 @@
                 </if>
                 <else-if variable="volume">
                   <choose>
-                    <if match="any" type="article-magazine review review-book" variable="reviewed-author reviewed-genre reviewed-title">
-                      <!-- date appears first if a magazine or review `container-title` has been substituted for a missing author (CMOS18 14.89) -->
+                    <if match="any" type="review review-book" variable="reviewed-author reviewed-genre reviewed-title">
+                      <!-- date appears first if a review `container-title` has been substituted for a missing author (CMOS18 14.89) -->
                       <choose>
                         <if match="any" variable="author chair collection-editor compiler composer curator director editor editor-translator editorial-director executive-producer guest host illustrator organizer producer series-creator translator">
                           <text variable="volume"/>
@@ -3132,8 +3117,8 @@
               <text macro="label-supplement-number"/>
             </group>
             <choose>
-              <if match="any" type="article-magazine review review-book" variable="reviewed-author reviewed-genre reviewed-title">
-                <!-- date appears first if a magazine or review `container-title` has been substituted for a missing author (CMOS18 14.89) -->
+              <if match="any" type="review review-book" variable="reviewed-author reviewed-genre reviewed-title">
+                <!-- date appears first if a review `container-title` has been substituted for a missing author (CMOS18 14.89) -->
                 <choose>
                   <if match="any" variable="author chair collection-editor compiler composer curator director editor editor-translator editorial-director executive-producer guest host illustrator organizer producer series-creator translator">
                     <text macro="source-date-issued-or-status" prefix="(" suffix=")"/>
@@ -4128,7 +4113,8 @@
   </macro>
   <macro name="source-date-issued-full-serial">
     <choose>
-      <if type="article-newspaper">
+      <if match="any" type="article-magazine article-newspaper">
+        <!-- magazines and newspapers provide the full date in place of volume/issue numbers (CMOS18 14.87, 14.89) -->
         <text macro="date-issued-full"/>
       </if>
       <else-if variable="issue volume">

--- a/chicago-notes-bibliography-17th-edition.csl
+++ b/chicago-notes-bibliography-17th-edition.csl
@@ -865,14 +865,6 @@
         <!-- Publication name also substituted for unsigned reviews (CMOS18 14.102) -->
         <text macro="source-serial-name"/>
       </else-if>
-      <else-if match="any" type="interview paper-conference">
-        <choose>
-          <if match="none" variable="collection-editor compiler editor editorial-director">
-            <!-- serial usage -->
-            <text macro="source-serial-name"/>
-          </if>
-        </choose>
-      </else-if>
       <else-if match="any" type="entry entry-dictionary entry-encyclopedia">
         <!-- Anonymous entries in reference works (CMOS18 14.130) -->
         <text font-style="italic" text-case="title" variable="container-title"/>
@@ -897,14 +889,6 @@
       <else-if match="any" type="review review-book" variable="reviewed-author reviewed-genre reviewed-title">
         <!-- Publication name also substituted for unsigned reviews (CMOS18 14.102) -->
         <text font-style="italic" text-case="title" variable="container-title"/>
-      </else-if>
-      <else-if match="any" type="interview paper-conference">
-        <choose>
-          <if match="none" variable="collection-editor compiler editor editorial-director">
-            <!-- serial usage -->
-            <text font-style="italic" text-case="title" variable="container-title"/>
-          </if>
-        </choose>
       </else-if>
       <else-if match="any" type="entry entry-dictionary entry-encyclopedia">
         <!-- Anonymous entries in reference works (CMOS18 14.130) -->
@@ -3172,7 +3156,8 @@
     <group delimiter=". ">
       <text macro="source-serial-title-volume-bib"/>
       <choose>
-        <if type="article-newspaper">
+        <if match="any" type="article-magazine article-newspaper">
+          <!-- magazines and newspapers provide the full date in place of volume/issue numbers (CMOS18 14.87, 14.89) -->
           <group delimiter=", ">
             <text macro="source-serial-title-bib"/>
             <text macro="source-serial-identifier-bib"/>
@@ -3203,7 +3188,8 @@
     <group delimiter=", ">
       <text macro="source-serial-title-volume-note"/>
       <choose>
-        <if type="article-newspaper">
+        <if match="any" type="article-magazine article-newspaper">
+          <!-- magazines and newspapers provide the full date in place of volume/issue numbers (CMOS18 14.87, 14.89) -->
           <group delimiter=", ">
             <text macro="source-serial-title-note"/>
             <text macro="source-serial-identifier-note"/>
@@ -3375,15 +3361,15 @@
   <macro name="source-serial-identifier-volume-bib">
     <group delimiter=", ">
       <choose>
-        <if type="article-newspaper">
-          <!-- newspapers provide the full date in place of volume/issue numbers (CMOS18 14.89) -->
+        <if match="any" type="article-magazine article-newspaper">
+          <!-- magazines and newspapers provide the full date in place of volume/issue numbers (CMOS18 14.87, 14.89) -->
           <text variable="collection-title"/>
           <text macro="source-serial-volume-status-bib"/>
         </if>
         <else-if match="any" variable="issue supplement-number volume">
           <choose>
-            <if match="any" type="article-magazine review review-book" variable="reviewed-author reviewed-genre reviewed-title">
-              <!-- date appears first if the magazine or review `container-title` has been substituted for a missing author (CMOS18 14.87, 14.102) -->
+            <if match="any" type="review review-book" variable="reviewed-author reviewed-genre reviewed-title">
+              <!-- date appears first if the review `container-title` has been substituted for a missing author (CMOS18 14.87, 14.102) -->
               <choose>
                 <if match="none" variable="author chair collection-editor compiler composer curator director editor editor-translator editorial-director executive-producer guest host illustrator organizer producer series-creator translator">
                   <text macro="source-date-bib"/>
@@ -3401,8 +3387,8 @@
                 <if variable="collection-title volume">
                   <text macro="label-volume"/>
                 </if>
-                <else-if match="any" type="article-magazine review review-book" variable="reviewed-author reviewed-genre reviewed-title">
-                  <!-- date appears first if a magazine or review `container-title` has been substituted for a missing author (CMOS18 14.87, 14.102) -->
+                <else-if match="any" type="review review-book" variable="reviewed-author reviewed-genre reviewed-title">
+                  <!-- date appears first if a review `container-title` has been substituted for a missing author (CMOS18 14.87, 14.102) -->
                   <choose>
                     <if match="any" variable="author chair collection-editor compiler composer curator director editor editor-translator editorial-director executive-producer guest host illustrator organizer producer series-creator translator">
                       <text variable="volume"/>
@@ -3420,8 +3406,8 @@
               <text macro="label-supplement-number"/>
             </group>
             <choose>
-              <if match="any" type="article-magazine review review-book" variable="reviewed-author reviewed-genre reviewed-title">
-                <!-- date for anonymous magazine and review articles only appears here if it did not earlier (CMOS18 14.87, 14.102) -->
+              <if match="any" type="review review-book" variable="reviewed-author reviewed-genre reviewed-title">
+                <!-- date for unsigned reviews only appears here if it did not earlier (CMOS18 14.102) -->
                 <choose>
                   <if match="any" variable="author chair collection-editor compiler composer curator director editor editor-translator editorial-director executive-producer guest host illustrator organizer producer series-creator translator">
                     <text macro="source-date-bib" prefix="(" suffix=")"/>
@@ -3446,16 +3432,16 @@
   <macro name="source-serial-identifier-volume-note">
     <group delimiter=", ">
       <choose>
-        <if type="article-newspaper">
-          <!-- newspapers provide the full date in place of volume/issue numbers (CMOS18 14.89) -->
+        <if match="any" type="article-magazine article-newspaper">
+          <!-- magazines and newspapers provide the full date in place of volume/issue numbers (CMOS18 14.87, 14.89) -->
           <text variable="collection-title"/>
           <text macro="source-serial-volume-status-note"/>
         </if>
         <else-if match="any" variable="issue supplement-number volume">
           <choose>
-            <if match="any" type="article-magazine review review-book" variable="reviewed-author reviewed-genre reviewed-title">
+            <if match="any" type="review review-book" variable="reviewed-author reviewed-genre reviewed-title">
               <choose>
-                <!-- date appears first if a magazine or review `container-title` has been substituted for a missing author (CMOS18 14.89) -->
+                <!-- date appears first if a review `container-title` has been substituted for a missing author (CMOS18 14.89) -->
                 <!-- the conditions below mirror substitution in `author-note` -->
                 <if match="any" variable="author chair collection-editor compiler composer curator director editor editor-translator editorial-director executive-producer guest host illustrator organizer producer series-creator translator"/>
                 <else-if match="any" variable="reviewed-genre reviewed-title title"/>
@@ -3478,8 +3464,8 @@
                 </if>
                 <else-if variable="volume">
                   <choose>
-                    <if match="any" type="article-magazine review review-book" variable="reviewed-author reviewed-genre reviewed-title">
-                      <!-- date appears first if a magazine or review `container-title` has been substituted for a missing author (CMOS18 14.89) -->
+                    <if match="any" type="review review-book" variable="reviewed-author reviewed-genre reviewed-title">
+                      <!-- date appears first if a review `container-title` has been substituted for a missing author (CMOS18 14.89) -->
                       <choose>
                         <if match="any" variable="author chair collection-editor compiler composer curator director editor editor-translator editorial-director executive-producer guest host illustrator organizer producer series-creator translator">
                           <text variable="volume"/>
@@ -3505,8 +3491,8 @@
               <text macro="label-supplement-number"/>
             </group>
             <choose>
-              <if match="any" type="article-magazine review review-book" variable="reviewed-author reviewed-genre reviewed-title">
-                <!-- date appears first if a magazine or review `container-title` has been substituted for a missing author (CMOS18 14.89) -->
+              <if match="any" type="review review-book" variable="reviewed-author reviewed-genre reviewed-title">
+                <!-- date appears first if a review `container-title` has been substituted for a missing author (CMOS18 14.89) -->
                 <choose>
                   <if match="any" variable="author chair collection-editor compiler composer curator director editor editor-translator editorial-director executive-producer guest host illustrator organizer producer series-creator translator">
                     <text macro="source-date-issued-or-status" prefix="(" suffix=")"/>
@@ -5035,7 +5021,8 @@
   </macro>
   <macro name="source-date-issued-full-serial">
     <choose>
-      <if type="article-newspaper">
+      <if match="any" type="article-magazine article-newspaper">
+        <!-- magazines and newspapers provide the full date in place of volume/issue numbers (CMOS18 14.87, 14.89) -->
         <text macro="date-issued-full"/>
       </if>
       <else-if variable="issue volume">

--- a/chicago-notes-bibliography-annotated-abstract.csl
+++ b/chicago-notes-bibliography-annotated-abstract.csl
@@ -868,14 +868,6 @@
         <!-- Publication name also substituted for unsigned reviews (CMOS18 14.102) -->
         <text macro="source-serial-name"/>
       </else-if>
-      <else-if match="any" type="interview paper-conference">
-        <choose>
-          <if match="none" variable="collection-editor compiler editor editorial-director">
-            <!-- serial usage -->
-            <text macro="source-serial-name"/>
-          </if>
-        </choose>
-      </else-if>
       <else-if match="any" type="entry entry-dictionary entry-encyclopedia">
         <!-- Anonymous entries in reference works (CMOS18 14.130) -->
         <text font-style="italic" text-case="title" variable="container-title"/>
@@ -900,14 +892,6 @@
       <else-if match="any" type="review review-book" variable="reviewed-author reviewed-genre reviewed-title">
         <!-- Publication name also substituted for unsigned reviews (CMOS18 14.102) -->
         <text font-style="italic" text-case="title" variable="container-title"/>
-      </else-if>
-      <else-if match="any" type="interview paper-conference">
-        <choose>
-          <if match="none" variable="collection-editor compiler editor editorial-director">
-            <!-- serial usage -->
-            <text font-style="italic" text-case="title" variable="container-title"/>
-          </if>
-        </choose>
       </else-if>
       <else-if match="any" type="entry entry-dictionary entry-encyclopedia">
         <!-- Anonymous entries in reference works (CMOS18 14.130) -->
@@ -3179,7 +3163,8 @@
     <group delimiter=". ">
       <text macro="source-serial-title-volume-bib"/>
       <choose>
-        <if type="article-newspaper">
+        <if match="any" type="article-magazine article-newspaper">
+          <!-- magazines and newspapers provide the full date in place of volume/issue numbers (CMOS18 14.87, 14.89) -->
           <group delimiter=", ">
             <text macro="source-serial-title-bib"/>
             <text macro="source-serial-identifier-bib"/>
@@ -3210,7 +3195,8 @@
     <group delimiter=", ">
       <text macro="source-serial-title-volume-note"/>
       <choose>
-        <if type="article-newspaper">
+        <if match="any" type="article-magazine article-newspaper">
+          <!-- magazines and newspapers provide the full date in place of volume/issue numbers (CMOS18 14.87, 14.89) -->
           <group delimiter=", ">
             <text macro="source-serial-title-note"/>
             <text macro="source-serial-identifier-note"/>
@@ -3382,15 +3368,15 @@
   <macro name="source-serial-identifier-volume-bib">
     <group delimiter=", ">
       <choose>
-        <if type="article-newspaper">
-          <!-- newspapers provide the full date in place of volume/issue numbers (CMOS18 14.89) -->
+        <if match="any" type="article-magazine article-newspaper">
+          <!-- magazines and newspapers provide the full date in place of volume/issue numbers (CMOS18 14.87, 14.89) -->
           <text variable="collection-title"/>
           <text macro="source-serial-volume-status-bib"/>
         </if>
         <else-if match="any" variable="issue supplement-number volume">
           <choose>
-            <if match="any" type="article-magazine review review-book" variable="reviewed-author reviewed-genre reviewed-title">
-              <!-- date appears first if the magazine or review `container-title` has been substituted for a missing author (CMOS18 14.87, 14.102) -->
+            <if match="any" type="review review-book" variable="reviewed-author reviewed-genre reviewed-title">
+              <!-- date appears first if the review `container-title` has been substituted for a missing author (CMOS18 14.87, 14.102) -->
               <choose>
                 <if match="none" variable="author chair collection-editor compiler composer curator director editor editor-translator editorial-director executive-producer guest host illustrator organizer producer series-creator translator">
                   <text macro="source-date-bib"/>
@@ -3408,8 +3394,8 @@
                 <if variable="collection-title volume">
                   <text macro="label-volume"/>
                 </if>
-                <else-if match="any" type="article-magazine review review-book" variable="reviewed-author reviewed-genre reviewed-title">
-                  <!-- date appears first if a magazine or review `container-title` has been substituted for a missing author (CMOS18 14.87, 14.102) -->
+                <else-if match="any" type="review review-book" variable="reviewed-author reviewed-genre reviewed-title">
+                  <!-- date appears first if a review `container-title` has been substituted for a missing author (CMOS18 14.87, 14.102) -->
                   <choose>
                     <if match="any" variable="author chair collection-editor compiler composer curator director editor editor-translator editorial-director executive-producer guest host illustrator organizer producer series-creator translator">
                       <text variable="volume"/>
@@ -3427,8 +3413,8 @@
               <text macro="label-supplement-number"/>
             </group>
             <choose>
-              <if match="any" type="article-magazine review review-book" variable="reviewed-author reviewed-genre reviewed-title">
-                <!-- date for anonymous magazine and review articles only appears here if it did not earlier (CMOS18 14.87, 14.102) -->
+              <if match="any" type="review review-book" variable="reviewed-author reviewed-genre reviewed-title">
+                <!-- date for unsigned reviews only appears here if it did not earlier (CMOS18 14.102) -->
                 <choose>
                   <if match="any" variable="author chair collection-editor compiler composer curator director editor editor-translator editorial-director executive-producer guest host illustrator organizer producer series-creator translator">
                     <text macro="source-date-bib" prefix="(" suffix=")"/>
@@ -3453,16 +3439,16 @@
   <macro name="source-serial-identifier-volume-note">
     <group delimiter=", ">
       <choose>
-        <if type="article-newspaper">
-          <!-- newspapers provide the full date in place of volume/issue numbers (CMOS18 14.89) -->
+        <if match="any" type="article-magazine article-newspaper">
+          <!-- magazines and newspapers provide the full date in place of volume/issue numbers (CMOS18 14.87, 14.89) -->
           <text variable="collection-title"/>
           <text macro="source-serial-volume-status-note"/>
         </if>
         <else-if match="any" variable="issue supplement-number volume">
           <choose>
-            <if match="any" type="article-magazine review review-book" variable="reviewed-author reviewed-genre reviewed-title">
+            <if match="any" type="review review-book" variable="reviewed-author reviewed-genre reviewed-title">
               <choose>
-                <!-- date appears first if a magazine or review `container-title` has been substituted for a missing author (CMOS18 14.89) -->
+                <!-- date appears first if a review `container-title` has been substituted for a missing author (CMOS18 14.89) -->
                 <!-- the conditions below mirror substitution in `author-note` -->
                 <if match="any" variable="author chair collection-editor compiler composer curator director editor editor-translator editorial-director executive-producer guest host illustrator organizer producer series-creator translator"/>
                 <else-if match="any" variable="reviewed-genre reviewed-title title"/>
@@ -3485,8 +3471,8 @@
                 </if>
                 <else-if variable="volume">
                   <choose>
-                    <if match="any" type="article-magazine review review-book" variable="reviewed-author reviewed-genre reviewed-title">
-                      <!-- date appears first if a magazine or review `container-title` has been substituted for a missing author (CMOS18 14.89) -->
+                    <if match="any" type="review review-book" variable="reviewed-author reviewed-genre reviewed-title">
+                      <!-- date appears first if a review `container-title` has been substituted for a missing author (CMOS18 14.89) -->
                       <choose>
                         <if match="any" variable="author chair collection-editor compiler composer curator director editor editor-translator editorial-director executive-producer guest host illustrator organizer producer series-creator translator">
                           <text variable="volume"/>
@@ -3512,8 +3498,8 @@
               <text macro="label-supplement-number"/>
             </group>
             <choose>
-              <if match="any" type="article-magazine review review-book" variable="reviewed-author reviewed-genre reviewed-title">
-                <!-- date appears first if a magazine or review `container-title` has been substituted for a missing author (CMOS18 14.89) -->
+              <if match="any" type="review review-book" variable="reviewed-author reviewed-genre reviewed-title">
+                <!-- date appears first if a review `container-title` has been substituted for a missing author (CMOS18 14.89) -->
                 <choose>
                   <if match="any" variable="author chair collection-editor compiler composer curator director editor editor-translator editorial-director executive-producer guest host illustrator organizer producer series-creator translator">
                     <text macro="source-date-issued-or-status" prefix="(" suffix=")"/>
@@ -5048,7 +5034,8 @@
   </macro>
   <macro name="source-date-issued-full-serial">
     <choose>
-      <if type="article-newspaper">
+      <if match="any" type="article-magazine article-newspaper">
+        <!-- magazines and newspapers provide the full date in place of volume/issue numbers (CMOS18 14.87, 14.89) -->
         <text macro="date-issued-full"/>
       </if>
       <else-if variable="issue volume">

--- a/chicago-notes-bibliography-annotated.csl
+++ b/chicago-notes-bibliography-annotated.csl
@@ -868,14 +868,6 @@
         <!-- Publication name also substituted for unsigned reviews (CMOS18 14.102) -->
         <text macro="source-serial-name"/>
       </else-if>
-      <else-if match="any" type="interview paper-conference">
-        <choose>
-          <if match="none" variable="collection-editor compiler editor editorial-director">
-            <!-- serial usage -->
-            <text macro="source-serial-name"/>
-          </if>
-        </choose>
-      </else-if>
       <else-if match="any" type="entry entry-dictionary entry-encyclopedia">
         <!-- Anonymous entries in reference works (CMOS18 14.130) -->
         <text font-style="italic" text-case="title" variable="container-title"/>
@@ -900,14 +892,6 @@
       <else-if match="any" type="review review-book" variable="reviewed-author reviewed-genre reviewed-title">
         <!-- Publication name also substituted for unsigned reviews (CMOS18 14.102) -->
         <text font-style="italic" text-case="title" variable="container-title"/>
-      </else-if>
-      <else-if match="any" type="interview paper-conference">
-        <choose>
-          <if match="none" variable="collection-editor compiler editor editorial-director">
-            <!-- serial usage -->
-            <text font-style="italic" text-case="title" variable="container-title"/>
-          </if>
-        </choose>
       </else-if>
       <else-if match="any" type="entry entry-dictionary entry-encyclopedia">
         <!-- Anonymous entries in reference works (CMOS18 14.130) -->
@@ -3179,7 +3163,8 @@
     <group delimiter=". ">
       <text macro="source-serial-title-volume-bib"/>
       <choose>
-        <if type="article-newspaper">
+        <if match="any" type="article-magazine article-newspaper">
+          <!-- magazines and newspapers provide the full date in place of volume/issue numbers (CMOS18 14.87, 14.89) -->
           <group delimiter=", ">
             <text macro="source-serial-title-bib"/>
             <text macro="source-serial-identifier-bib"/>
@@ -3210,7 +3195,8 @@
     <group delimiter=", ">
       <text macro="source-serial-title-volume-note"/>
       <choose>
-        <if type="article-newspaper">
+        <if match="any" type="article-magazine article-newspaper">
+          <!-- magazines and newspapers provide the full date in place of volume/issue numbers (CMOS18 14.87, 14.89) -->
           <group delimiter=", ">
             <text macro="source-serial-title-note"/>
             <text macro="source-serial-identifier-note"/>
@@ -3382,15 +3368,15 @@
   <macro name="source-serial-identifier-volume-bib">
     <group delimiter=", ">
       <choose>
-        <if type="article-newspaper">
-          <!-- newspapers provide the full date in place of volume/issue numbers (CMOS18 14.89) -->
+        <if match="any" type="article-magazine article-newspaper">
+          <!-- magazines and newspapers provide the full date in place of volume/issue numbers (CMOS18 14.87, 14.89) -->
           <text variable="collection-title"/>
           <text macro="source-serial-volume-status-bib"/>
         </if>
         <else-if match="any" variable="issue supplement-number volume">
           <choose>
-            <if match="any" type="article-magazine review review-book" variable="reviewed-author reviewed-genre reviewed-title">
-              <!-- date appears first if the magazine or review `container-title` has been substituted for a missing author (CMOS18 14.87, 14.102) -->
+            <if match="any" type="review review-book" variable="reviewed-author reviewed-genre reviewed-title">
+              <!-- date appears first if the review `container-title` has been substituted for a missing author (CMOS18 14.87, 14.102) -->
               <choose>
                 <if match="none" variable="author chair collection-editor compiler composer curator director editor editor-translator editorial-director executive-producer guest host illustrator organizer producer series-creator translator">
                   <text macro="source-date-bib"/>
@@ -3408,8 +3394,8 @@
                 <if variable="collection-title volume">
                   <text macro="label-volume"/>
                 </if>
-                <else-if match="any" type="article-magazine review review-book" variable="reviewed-author reviewed-genre reviewed-title">
-                  <!-- date appears first if a magazine or review `container-title` has been substituted for a missing author (CMOS18 14.87, 14.102) -->
+                <else-if match="any" type="review review-book" variable="reviewed-author reviewed-genre reviewed-title">
+                  <!-- date appears first if a review `container-title` has been substituted for a missing author (CMOS18 14.87, 14.102) -->
                   <choose>
                     <if match="any" variable="author chair collection-editor compiler composer curator director editor editor-translator editorial-director executive-producer guest host illustrator organizer producer series-creator translator">
                       <text variable="volume"/>
@@ -3427,8 +3413,8 @@
               <text macro="label-supplement-number"/>
             </group>
             <choose>
-              <if match="any" type="article-magazine review review-book" variable="reviewed-author reviewed-genre reviewed-title">
-                <!-- date for anonymous magazine and review articles only appears here if it did not earlier (CMOS18 14.87, 14.102) -->
+              <if match="any" type="review review-book" variable="reviewed-author reviewed-genre reviewed-title">
+                <!-- date for unsigned reviews only appears here if it did not earlier (CMOS18 14.102) -->
                 <choose>
                   <if match="any" variable="author chair collection-editor compiler composer curator director editor editor-translator editorial-director executive-producer guest host illustrator organizer producer series-creator translator">
                     <text macro="source-date-bib" prefix="(" suffix=")"/>
@@ -3453,16 +3439,16 @@
   <macro name="source-serial-identifier-volume-note">
     <group delimiter=", ">
       <choose>
-        <if type="article-newspaper">
-          <!-- newspapers provide the full date in place of volume/issue numbers (CMOS18 14.89) -->
+        <if match="any" type="article-magazine article-newspaper">
+          <!-- magazines and newspapers provide the full date in place of volume/issue numbers (CMOS18 14.87, 14.89) -->
           <text variable="collection-title"/>
           <text macro="source-serial-volume-status-note"/>
         </if>
         <else-if match="any" variable="issue supplement-number volume">
           <choose>
-            <if match="any" type="article-magazine review review-book" variable="reviewed-author reviewed-genre reviewed-title">
+            <if match="any" type="review review-book" variable="reviewed-author reviewed-genre reviewed-title">
               <choose>
-                <!-- date appears first if a magazine or review `container-title` has been substituted for a missing author (CMOS18 14.89) -->
+                <!-- date appears first if a review `container-title` has been substituted for a missing author (CMOS18 14.89) -->
                 <!-- the conditions below mirror substitution in `author-note` -->
                 <if match="any" variable="author chair collection-editor compiler composer curator director editor editor-translator editorial-director executive-producer guest host illustrator organizer producer series-creator translator"/>
                 <else-if match="any" variable="reviewed-genre reviewed-title title"/>
@@ -3485,8 +3471,8 @@
                 </if>
                 <else-if variable="volume">
                   <choose>
-                    <if match="any" type="article-magazine review review-book" variable="reviewed-author reviewed-genre reviewed-title">
-                      <!-- date appears first if a magazine or review `container-title` has been substituted for a missing author (CMOS18 14.89) -->
+                    <if match="any" type="review review-book" variable="reviewed-author reviewed-genre reviewed-title">
+                      <!-- date appears first if a review `container-title` has been substituted for a missing author (CMOS18 14.89) -->
                       <choose>
                         <if match="any" variable="author chair collection-editor compiler composer curator director editor editor-translator editorial-director executive-producer guest host illustrator organizer producer series-creator translator">
                           <text variable="volume"/>
@@ -3512,8 +3498,8 @@
               <text macro="label-supplement-number"/>
             </group>
             <choose>
-              <if match="any" type="article-magazine review review-book" variable="reviewed-author reviewed-genre reviewed-title">
-                <!-- date appears first if a magazine or review `container-title` has been substituted for a missing author (CMOS18 14.89) -->
+              <if match="any" type="review review-book" variable="reviewed-author reviewed-genre reviewed-title">
+                <!-- date appears first if a review `container-title` has been substituted for a missing author (CMOS18 14.89) -->
                 <choose>
                   <if match="any" variable="author chair collection-editor compiler composer curator director editor editor-translator editorial-director executive-producer guest host illustrator organizer producer series-creator translator">
                     <text macro="source-date-issued-or-status" prefix="(" suffix=")"/>
@@ -5048,7 +5034,8 @@
   </macro>
   <macro name="source-date-issued-full-serial">
     <choose>
-      <if type="article-newspaper">
+      <if match="any" type="article-magazine article-newspaper">
+        <!-- magazines and newspapers provide the full date in place of volume/issue numbers (CMOS18 14.87, 14.89) -->
         <text macro="date-issued-full"/>
       </if>
       <else-if variable="issue volume">

--- a/chicago-notes-bibliography-archive-place-first-no-url.csl
+++ b/chicago-notes-bibliography-archive-place-first-no-url.csl
@@ -867,14 +867,6 @@
         <!-- Publication name also substituted for unsigned reviews (CMOS18 14.102) -->
         <text macro="source-serial-name"/>
       </else-if>
-      <else-if match="any" type="interview paper-conference">
-        <choose>
-          <if match="none" variable="collection-editor compiler editor editorial-director">
-            <!-- serial usage -->
-            <text macro="source-serial-name"/>
-          </if>
-        </choose>
-      </else-if>
       <else-if match="any" type="entry entry-dictionary entry-encyclopedia">
         <!-- Anonymous entries in reference works (CMOS18 14.130) -->
         <text font-style="italic" text-case="title" variable="container-title"/>
@@ -899,14 +891,6 @@
       <else-if match="any" type="review review-book" variable="reviewed-author reviewed-genre reviewed-title">
         <!-- Publication name also substituted for unsigned reviews (CMOS18 14.102) -->
         <text font-style="italic" text-case="title" variable="container-title"/>
-      </else-if>
-      <else-if match="any" type="interview paper-conference">
-        <choose>
-          <if match="none" variable="collection-editor compiler editor editorial-director">
-            <!-- serial usage -->
-            <text font-style="italic" text-case="title" variable="container-title"/>
-          </if>
-        </choose>
       </else-if>
       <else-if match="any" type="entry entry-dictionary entry-encyclopedia">
         <!-- Anonymous entries in reference works (CMOS18 14.130) -->
@@ -3178,7 +3162,8 @@
     <group delimiter=". ">
       <text macro="source-serial-title-volume-bib"/>
       <choose>
-        <if type="article-newspaper">
+        <if match="any" type="article-magazine article-newspaper">
+          <!-- magazines and newspapers provide the full date in place of volume/issue numbers (CMOS18 14.87, 14.89) -->
           <group delimiter=", ">
             <text macro="source-serial-title-bib"/>
             <text macro="source-serial-identifier-bib"/>
@@ -3209,7 +3194,8 @@
     <group delimiter=", ">
       <text macro="source-serial-title-volume-note"/>
       <choose>
-        <if type="article-newspaper">
+        <if match="any" type="article-magazine article-newspaper">
+          <!-- magazines and newspapers provide the full date in place of volume/issue numbers (CMOS18 14.87, 14.89) -->
           <group delimiter=", ">
             <text macro="source-serial-title-note"/>
             <text macro="source-serial-identifier-note"/>
@@ -3381,15 +3367,15 @@
   <macro name="source-serial-identifier-volume-bib">
     <group delimiter=", ">
       <choose>
-        <if type="article-newspaper">
-          <!-- newspapers provide the full date in place of volume/issue numbers (CMOS18 14.89) -->
+        <if match="any" type="article-magazine article-newspaper">
+          <!-- magazines and newspapers provide the full date in place of volume/issue numbers (CMOS18 14.87, 14.89) -->
           <text variable="collection-title"/>
           <text macro="source-serial-volume-status-bib"/>
         </if>
         <else-if match="any" variable="issue supplement-number volume">
           <choose>
-            <if match="any" type="article-magazine review review-book" variable="reviewed-author reviewed-genre reviewed-title">
-              <!-- date appears first if the magazine or review `container-title` has been substituted for a missing author (CMOS18 14.87, 14.102) -->
+            <if match="any" type="review review-book" variable="reviewed-author reviewed-genre reviewed-title">
+              <!-- date appears first if the review `container-title` has been substituted for a missing author (CMOS18 14.87, 14.102) -->
               <choose>
                 <if match="none" variable="author chair collection-editor compiler composer curator director editor editor-translator editorial-director executive-producer guest host illustrator organizer producer series-creator translator">
                   <text macro="source-date-bib"/>
@@ -3407,8 +3393,8 @@
                 <if variable="collection-title volume">
                   <text macro="label-volume"/>
                 </if>
-                <else-if match="any" type="article-magazine review review-book" variable="reviewed-author reviewed-genre reviewed-title">
-                  <!-- date appears first if a magazine or review `container-title` has been substituted for a missing author (CMOS18 14.87, 14.102) -->
+                <else-if match="any" type="review review-book" variable="reviewed-author reviewed-genre reviewed-title">
+                  <!-- date appears first if a review `container-title` has been substituted for a missing author (CMOS18 14.87, 14.102) -->
                   <choose>
                     <if match="any" variable="author chair collection-editor compiler composer curator director editor editor-translator editorial-director executive-producer guest host illustrator organizer producer series-creator translator">
                       <text variable="volume"/>
@@ -3426,8 +3412,8 @@
               <text macro="label-supplement-number"/>
             </group>
             <choose>
-              <if match="any" type="article-magazine review review-book" variable="reviewed-author reviewed-genre reviewed-title">
-                <!-- date for anonymous magazine and review articles only appears here if it did not earlier (CMOS18 14.87, 14.102) -->
+              <if match="any" type="review review-book" variable="reviewed-author reviewed-genre reviewed-title">
+                <!-- date for unsigned reviews only appears here if it did not earlier (CMOS18 14.102) -->
                 <choose>
                   <if match="any" variable="author chair collection-editor compiler composer curator director editor editor-translator editorial-director executive-producer guest host illustrator organizer producer series-creator translator">
                     <text macro="source-date-bib" prefix="(" suffix=")"/>
@@ -3452,16 +3438,16 @@
   <macro name="source-serial-identifier-volume-note">
     <group delimiter=", ">
       <choose>
-        <if type="article-newspaper">
-          <!-- newspapers provide the full date in place of volume/issue numbers (CMOS18 14.89) -->
+        <if match="any" type="article-magazine article-newspaper">
+          <!-- magazines and newspapers provide the full date in place of volume/issue numbers (CMOS18 14.87, 14.89) -->
           <text variable="collection-title"/>
           <text macro="source-serial-volume-status-note"/>
         </if>
         <else-if match="any" variable="issue supplement-number volume">
           <choose>
-            <if match="any" type="article-magazine review review-book" variable="reviewed-author reviewed-genre reviewed-title">
+            <if match="any" type="review review-book" variable="reviewed-author reviewed-genre reviewed-title">
               <choose>
-                <!-- date appears first if a magazine or review `container-title` has been substituted for a missing author (CMOS18 14.89) -->
+                <!-- date appears first if a review `container-title` has been substituted for a missing author (CMOS18 14.89) -->
                 <!-- the conditions below mirror substitution in `author-note` -->
                 <if match="any" variable="author chair collection-editor compiler composer curator director editor editor-translator editorial-director executive-producer guest host illustrator organizer producer series-creator translator"/>
                 <else-if match="any" variable="reviewed-genre reviewed-title title"/>
@@ -3484,8 +3470,8 @@
                 </if>
                 <else-if variable="volume">
                   <choose>
-                    <if match="any" type="article-magazine review review-book" variable="reviewed-author reviewed-genre reviewed-title">
-                      <!-- date appears first if a magazine or review `container-title` has been substituted for a missing author (CMOS18 14.89) -->
+                    <if match="any" type="review review-book" variable="reviewed-author reviewed-genre reviewed-title">
+                      <!-- date appears first if a review `container-title` has been substituted for a missing author (CMOS18 14.89) -->
                       <choose>
                         <if match="any" variable="author chair collection-editor compiler composer curator director editor editor-translator editorial-director executive-producer guest host illustrator organizer producer series-creator translator">
                           <text variable="volume"/>
@@ -3511,8 +3497,8 @@
               <text macro="label-supplement-number"/>
             </group>
             <choose>
-              <if match="any" type="article-magazine review review-book" variable="reviewed-author reviewed-genre reviewed-title">
-                <!-- date appears first if a magazine or review `container-title` has been substituted for a missing author (CMOS18 14.89) -->
+              <if match="any" type="review review-book" variable="reviewed-author reviewed-genre reviewed-title">
+                <!-- date appears first if a review `container-title` has been substituted for a missing author (CMOS18 14.89) -->
                 <choose>
                   <if match="any" variable="author chair collection-editor compiler composer curator director editor editor-translator editorial-director executive-producer guest host illustrator organizer producer series-creator translator">
                     <text macro="source-date-issued-or-status" prefix="(" suffix=")"/>
@@ -5047,7 +5033,8 @@
   </macro>
   <macro name="source-date-issued-full-serial">
     <choose>
-      <if type="article-newspaper">
+      <if match="any" type="article-magazine article-newspaper">
+        <!-- magazines and newspapers provide the full date in place of volume/issue numbers (CMOS18 14.87, 14.89) -->
         <text macro="date-issued-full"/>
       </if>
       <else-if variable="issue volume">

--- a/chicago-notes-bibliography-archive-place-first.csl
+++ b/chicago-notes-bibliography-archive-place-first.csl
@@ -867,14 +867,6 @@
         <!-- Publication name also substituted for unsigned reviews (CMOS18 14.102) -->
         <text macro="source-serial-name"/>
       </else-if>
-      <else-if match="any" type="interview paper-conference">
-        <choose>
-          <if match="none" variable="collection-editor compiler editor editorial-director">
-            <!-- serial usage -->
-            <text macro="source-serial-name"/>
-          </if>
-        </choose>
-      </else-if>
       <else-if match="any" type="entry entry-dictionary entry-encyclopedia">
         <!-- Anonymous entries in reference works (CMOS18 14.130) -->
         <text font-style="italic" text-case="title" variable="container-title"/>
@@ -899,14 +891,6 @@
       <else-if match="any" type="review review-book" variable="reviewed-author reviewed-genre reviewed-title">
         <!-- Publication name also substituted for unsigned reviews (CMOS18 14.102) -->
         <text font-style="italic" text-case="title" variable="container-title"/>
-      </else-if>
-      <else-if match="any" type="interview paper-conference">
-        <choose>
-          <if match="none" variable="collection-editor compiler editor editorial-director">
-            <!-- serial usage -->
-            <text font-style="italic" text-case="title" variable="container-title"/>
-          </if>
-        </choose>
       </else-if>
       <else-if match="any" type="entry entry-dictionary entry-encyclopedia">
         <!-- Anonymous entries in reference works (CMOS18 14.130) -->
@@ -3178,7 +3162,8 @@
     <group delimiter=". ">
       <text macro="source-serial-title-volume-bib"/>
       <choose>
-        <if type="article-newspaper">
+        <if match="any" type="article-magazine article-newspaper">
+          <!-- magazines and newspapers provide the full date in place of volume/issue numbers (CMOS18 14.87, 14.89) -->
           <group delimiter=", ">
             <text macro="source-serial-title-bib"/>
             <text macro="source-serial-identifier-bib"/>
@@ -3209,7 +3194,8 @@
     <group delimiter=", ">
       <text macro="source-serial-title-volume-note"/>
       <choose>
-        <if type="article-newspaper">
+        <if match="any" type="article-magazine article-newspaper">
+          <!-- magazines and newspapers provide the full date in place of volume/issue numbers (CMOS18 14.87, 14.89) -->
           <group delimiter=", ">
             <text macro="source-serial-title-note"/>
             <text macro="source-serial-identifier-note"/>
@@ -3381,15 +3367,15 @@
   <macro name="source-serial-identifier-volume-bib">
     <group delimiter=", ">
       <choose>
-        <if type="article-newspaper">
-          <!-- newspapers provide the full date in place of volume/issue numbers (CMOS18 14.89) -->
+        <if match="any" type="article-magazine article-newspaper">
+          <!-- magazines and newspapers provide the full date in place of volume/issue numbers (CMOS18 14.87, 14.89) -->
           <text variable="collection-title"/>
           <text macro="source-serial-volume-status-bib"/>
         </if>
         <else-if match="any" variable="issue supplement-number volume">
           <choose>
-            <if match="any" type="article-magazine review review-book" variable="reviewed-author reviewed-genre reviewed-title">
-              <!-- date appears first if the magazine or review `container-title` has been substituted for a missing author (CMOS18 14.87, 14.102) -->
+            <if match="any" type="review review-book" variable="reviewed-author reviewed-genre reviewed-title">
+              <!-- date appears first if the review `container-title` has been substituted for a missing author (CMOS18 14.87, 14.102) -->
               <choose>
                 <if match="none" variable="author chair collection-editor compiler composer curator director editor editor-translator editorial-director executive-producer guest host illustrator organizer producer series-creator translator">
                   <text macro="source-date-bib"/>
@@ -3407,8 +3393,8 @@
                 <if variable="collection-title volume">
                   <text macro="label-volume"/>
                 </if>
-                <else-if match="any" type="article-magazine review review-book" variable="reviewed-author reviewed-genre reviewed-title">
-                  <!-- date appears first if a magazine or review `container-title` has been substituted for a missing author (CMOS18 14.87, 14.102) -->
+                <else-if match="any" type="review review-book" variable="reviewed-author reviewed-genre reviewed-title">
+                  <!-- date appears first if a review `container-title` has been substituted for a missing author (CMOS18 14.87, 14.102) -->
                   <choose>
                     <if match="any" variable="author chair collection-editor compiler composer curator director editor editor-translator editorial-director executive-producer guest host illustrator organizer producer series-creator translator">
                       <text variable="volume"/>
@@ -3426,8 +3412,8 @@
               <text macro="label-supplement-number"/>
             </group>
             <choose>
-              <if match="any" type="article-magazine review review-book" variable="reviewed-author reviewed-genre reviewed-title">
-                <!-- date for anonymous magazine and review articles only appears here if it did not earlier (CMOS18 14.87, 14.102) -->
+              <if match="any" type="review review-book" variable="reviewed-author reviewed-genre reviewed-title">
+                <!-- date for unsigned reviews only appears here if it did not earlier (CMOS18 14.102) -->
                 <choose>
                   <if match="any" variable="author chair collection-editor compiler composer curator director editor editor-translator editorial-director executive-producer guest host illustrator organizer producer series-creator translator">
                     <text macro="source-date-bib" prefix="(" suffix=")"/>
@@ -3452,16 +3438,16 @@
   <macro name="source-serial-identifier-volume-note">
     <group delimiter=", ">
       <choose>
-        <if type="article-newspaper">
-          <!-- newspapers provide the full date in place of volume/issue numbers (CMOS18 14.89) -->
+        <if match="any" type="article-magazine article-newspaper">
+          <!-- magazines and newspapers provide the full date in place of volume/issue numbers (CMOS18 14.87, 14.89) -->
           <text variable="collection-title"/>
           <text macro="source-serial-volume-status-note"/>
         </if>
         <else-if match="any" variable="issue supplement-number volume">
           <choose>
-            <if match="any" type="article-magazine review review-book" variable="reviewed-author reviewed-genre reviewed-title">
+            <if match="any" type="review review-book" variable="reviewed-author reviewed-genre reviewed-title">
               <choose>
-                <!-- date appears first if a magazine or review `container-title` has been substituted for a missing author (CMOS18 14.89) -->
+                <!-- date appears first if a review `container-title` has been substituted for a missing author (CMOS18 14.89) -->
                 <!-- the conditions below mirror substitution in `author-note` -->
                 <if match="any" variable="author chair collection-editor compiler composer curator director editor editor-translator editorial-director executive-producer guest host illustrator organizer producer series-creator translator"/>
                 <else-if match="any" variable="reviewed-genre reviewed-title title"/>
@@ -3484,8 +3470,8 @@
                 </if>
                 <else-if variable="volume">
                   <choose>
-                    <if match="any" type="article-magazine review review-book" variable="reviewed-author reviewed-genre reviewed-title">
-                      <!-- date appears first if a magazine or review `container-title` has been substituted for a missing author (CMOS18 14.89) -->
+                    <if match="any" type="review review-book" variable="reviewed-author reviewed-genre reviewed-title">
+                      <!-- date appears first if a review `container-title` has been substituted for a missing author (CMOS18 14.89) -->
                       <choose>
                         <if match="any" variable="author chair collection-editor compiler composer curator director editor editor-translator editorial-director executive-producer guest host illustrator organizer producer series-creator translator">
                           <text variable="volume"/>
@@ -3511,8 +3497,8 @@
               <text macro="label-supplement-number"/>
             </group>
             <choose>
-              <if match="any" type="article-magazine review review-book" variable="reviewed-author reviewed-genre reviewed-title">
-                <!-- date appears first if a magazine or review `container-title` has been substituted for a missing author (CMOS18 14.89) -->
+              <if match="any" type="review review-book" variable="reviewed-author reviewed-genre reviewed-title">
+                <!-- date appears first if a review `container-title` has been substituted for a missing author (CMOS18 14.89) -->
                 <choose>
                   <if match="any" variable="author chair collection-editor compiler composer curator director editor editor-translator editorial-director executive-producer guest host illustrator organizer producer series-creator translator">
                     <text macro="source-date-issued-or-status" prefix="(" suffix=")"/>
@@ -5047,7 +5033,8 @@
   </macro>
   <macro name="source-date-issued-full-serial">
     <choose>
-      <if type="article-newspaper">
+      <if match="any" type="article-magazine article-newspaper">
+        <!-- magazines and newspapers provide the full date in place of volume/issue numbers (CMOS18 14.87, 14.89) -->
         <text macro="date-issued-full"/>
       </if>
       <else-if variable="issue volume">

--- a/chicago-notes-bibliography-classic-archive-place-first-no-url.csl
+++ b/chicago-notes-bibliography-classic-archive-place-first-no-url.csl
@@ -868,14 +868,6 @@
         <!-- Publication name also substituted for unsigned reviews (CMOS18 14.102) -->
         <text macro="source-serial-name"/>
       </else-if>
-      <else-if match="any" type="interview paper-conference">
-        <choose>
-          <if match="none" variable="collection-editor compiler editor editorial-director">
-            <!-- serial usage -->
-            <text macro="source-serial-name"/>
-          </if>
-        </choose>
-      </else-if>
       <else-if match="any" type="entry entry-dictionary entry-encyclopedia">
         <!-- Anonymous entries in reference works (CMOS18 14.130) -->
         <text font-style="italic" text-case="title" variable="container-title"/>
@@ -900,14 +892,6 @@
       <else-if match="any" type="review review-book" variable="reviewed-author reviewed-genre reviewed-title">
         <!-- Publication name also substituted for unsigned reviews (CMOS18 14.102) -->
         <text font-style="italic" text-case="title" variable="container-title"/>
-      </else-if>
-      <else-if match="any" type="interview paper-conference">
-        <choose>
-          <if match="none" variable="collection-editor compiler editor editorial-director">
-            <!-- serial usage -->
-            <text font-style="italic" text-case="title" variable="container-title"/>
-          </if>
-        </choose>
       </else-if>
       <else-if match="any" type="entry entry-dictionary entry-encyclopedia">
         <!-- Anonymous entries in reference works (CMOS18 14.130) -->
@@ -3175,7 +3159,8 @@
     <group delimiter=". ">
       <text macro="source-serial-title-volume-bib"/>
       <choose>
-        <if type="article-newspaper">
+        <if match="any" type="article-magazine article-newspaper">
+          <!-- magazines and newspapers provide the full date in place of volume/issue numbers (CMOS18 14.87, 14.89) -->
           <group delimiter=", ">
             <text macro="source-serial-title-bib"/>
             <text macro="source-serial-identifier-bib"/>
@@ -3206,7 +3191,8 @@
     <group delimiter=", ">
       <text macro="source-serial-title-volume-note"/>
       <choose>
-        <if type="article-newspaper">
+        <if match="any" type="article-magazine article-newspaper">
+          <!-- magazines and newspapers provide the full date in place of volume/issue numbers (CMOS18 14.87, 14.89) -->
           <group delimiter=", ">
             <text macro="source-serial-title-note"/>
             <text macro="source-serial-identifier-note"/>
@@ -3378,15 +3364,15 @@
   <macro name="source-serial-identifier-volume-bib">
     <group delimiter=", ">
       <choose>
-        <if type="article-newspaper">
-          <!-- newspapers provide the full date in place of volume/issue numbers (CMOS18 14.89) -->
+        <if match="any" type="article-magazine article-newspaper">
+          <!-- magazines and newspapers provide the full date in place of volume/issue numbers (CMOS18 14.87, 14.89) -->
           <text variable="collection-title"/>
           <text macro="source-serial-volume-status-bib"/>
         </if>
         <else-if match="any" variable="issue supplement-number volume">
           <choose>
-            <if match="any" type="article-magazine review review-book" variable="reviewed-author reviewed-genre reviewed-title">
-              <!-- date appears first if the magazine or review `container-title` has been substituted for a missing author (CMOS18 14.87, 14.102) -->
+            <if match="any" type="review review-book" variable="reviewed-author reviewed-genre reviewed-title">
+              <!-- date appears first if the review `container-title` has been substituted for a missing author (CMOS18 14.87, 14.102) -->
               <choose>
                 <if match="none" variable="author chair collection-editor compiler composer curator director editor editor-translator editorial-director executive-producer guest host illustrator organizer producer series-creator translator">
                   <text macro="source-date-bib"/>
@@ -3404,8 +3390,8 @@
                 <if variable="collection-title volume">
                   <text macro="label-volume"/>
                 </if>
-                <else-if match="any" type="article-magazine review review-book" variable="reviewed-author reviewed-genre reviewed-title">
-                  <!-- date appears first if a magazine or review `container-title` has been substituted for a missing author (CMOS18 14.87, 14.102) -->
+                <else-if match="any" type="review review-book" variable="reviewed-author reviewed-genre reviewed-title">
+                  <!-- date appears first if a review `container-title` has been substituted for a missing author (CMOS18 14.87, 14.102) -->
                   <choose>
                     <if match="any" variable="author chair collection-editor compiler composer curator director editor editor-translator editorial-director executive-producer guest host illustrator organizer producer series-creator translator">
                       <text variable="volume"/>
@@ -3423,8 +3409,8 @@
               <text macro="label-supplement-number"/>
             </group>
             <choose>
-              <if match="any" type="article-magazine review review-book" variable="reviewed-author reviewed-genre reviewed-title">
-                <!-- date for anonymous magazine and review articles only appears here if it did not earlier (CMOS18 14.87, 14.102) -->
+              <if match="any" type="review review-book" variable="reviewed-author reviewed-genre reviewed-title">
+                <!-- date for unsigned reviews only appears here if it did not earlier (CMOS18 14.102) -->
                 <choose>
                   <if match="any" variable="author chair collection-editor compiler composer curator director editor editor-translator editorial-director executive-producer guest host illustrator organizer producer series-creator translator">
                     <text macro="source-date-bib" prefix="(" suffix=")"/>
@@ -3449,16 +3435,16 @@
   <macro name="source-serial-identifier-volume-note">
     <group delimiter=", ">
       <choose>
-        <if type="article-newspaper">
-          <!-- newspapers provide the full date in place of volume/issue numbers (CMOS18 14.89) -->
+        <if match="any" type="article-magazine article-newspaper">
+          <!-- magazines and newspapers provide the full date in place of volume/issue numbers (CMOS18 14.87, 14.89) -->
           <text variable="collection-title"/>
           <text macro="source-serial-volume-status-note"/>
         </if>
         <else-if match="any" variable="issue supplement-number volume">
           <choose>
-            <if match="any" type="article-magazine review review-book" variable="reviewed-author reviewed-genre reviewed-title">
+            <if match="any" type="review review-book" variable="reviewed-author reviewed-genre reviewed-title">
               <choose>
-                <!-- date appears first if a magazine or review `container-title` has been substituted for a missing author (CMOS18 14.89) -->
+                <!-- date appears first if a review `container-title` has been substituted for a missing author (CMOS18 14.89) -->
                 <!-- the conditions below mirror substitution in `author-note` -->
                 <if match="any" variable="author chair collection-editor compiler composer curator director editor editor-translator editorial-director executive-producer guest host illustrator organizer producer series-creator translator"/>
                 <else-if match="any" variable="reviewed-genre reviewed-title title"/>
@@ -3481,8 +3467,8 @@
                 </if>
                 <else-if variable="volume">
                   <choose>
-                    <if match="any" type="article-magazine review review-book" variable="reviewed-author reviewed-genre reviewed-title">
-                      <!-- date appears first if a magazine or review `container-title` has been substituted for a missing author (CMOS18 14.89) -->
+                    <if match="any" type="review review-book" variable="reviewed-author reviewed-genre reviewed-title">
+                      <!-- date appears first if a review `container-title` has been substituted for a missing author (CMOS18 14.89) -->
                       <choose>
                         <if match="any" variable="author chair collection-editor compiler composer curator director editor editor-translator editorial-director executive-producer guest host illustrator organizer producer series-creator translator">
                           <text variable="volume"/>
@@ -3508,8 +3494,8 @@
               <text macro="label-supplement-number"/>
             </group>
             <choose>
-              <if match="any" type="article-magazine review review-book" variable="reviewed-author reviewed-genre reviewed-title">
-                <!-- date appears first if a magazine or review `container-title` has been substituted for a missing author (CMOS18 14.89) -->
+              <if match="any" type="review review-book" variable="reviewed-author reviewed-genre reviewed-title">
+                <!-- date appears first if a review `container-title` has been substituted for a missing author (CMOS18 14.89) -->
                 <choose>
                   <if match="any" variable="author chair collection-editor compiler composer curator director editor editor-translator editorial-director executive-producer guest host illustrator organizer producer series-creator translator">
                     <text macro="source-date-issued-or-status" prefix="(" suffix=")"/>
@@ -5038,7 +5024,8 @@
   </macro>
   <macro name="source-date-issued-full-serial">
     <choose>
-      <if type="article-newspaper">
+      <if match="any" type="article-magazine article-newspaper">
+        <!-- magazines and newspapers provide the full date in place of volume/issue numbers (CMOS18 14.87, 14.89) -->
         <text macro="date-issued-full"/>
       </if>
       <else-if variable="issue volume">

--- a/chicago-notes-bibliography-classic-archive-place-first.csl
+++ b/chicago-notes-bibliography-classic-archive-place-first.csl
@@ -868,14 +868,6 @@
         <!-- Publication name also substituted for unsigned reviews (CMOS18 14.102) -->
         <text macro="source-serial-name"/>
       </else-if>
-      <else-if match="any" type="interview paper-conference">
-        <choose>
-          <if match="none" variable="collection-editor compiler editor editorial-director">
-            <!-- serial usage -->
-            <text macro="source-serial-name"/>
-          </if>
-        </choose>
-      </else-if>
       <else-if match="any" type="entry entry-dictionary entry-encyclopedia">
         <!-- Anonymous entries in reference works (CMOS18 14.130) -->
         <text font-style="italic" text-case="title" variable="container-title"/>
@@ -900,14 +892,6 @@
       <else-if match="any" type="review review-book" variable="reviewed-author reviewed-genre reviewed-title">
         <!-- Publication name also substituted for unsigned reviews (CMOS18 14.102) -->
         <text font-style="italic" text-case="title" variable="container-title"/>
-      </else-if>
-      <else-if match="any" type="interview paper-conference">
-        <choose>
-          <if match="none" variable="collection-editor compiler editor editorial-director">
-            <!-- serial usage -->
-            <text font-style="italic" text-case="title" variable="container-title"/>
-          </if>
-        </choose>
       </else-if>
       <else-if match="any" type="entry entry-dictionary entry-encyclopedia">
         <!-- Anonymous entries in reference works (CMOS18 14.130) -->
@@ -3175,7 +3159,8 @@
     <group delimiter=". ">
       <text macro="source-serial-title-volume-bib"/>
       <choose>
-        <if type="article-newspaper">
+        <if match="any" type="article-magazine article-newspaper">
+          <!-- magazines and newspapers provide the full date in place of volume/issue numbers (CMOS18 14.87, 14.89) -->
           <group delimiter=", ">
             <text macro="source-serial-title-bib"/>
             <text macro="source-serial-identifier-bib"/>
@@ -3206,7 +3191,8 @@
     <group delimiter=", ">
       <text macro="source-serial-title-volume-note"/>
       <choose>
-        <if type="article-newspaper">
+        <if match="any" type="article-magazine article-newspaper">
+          <!-- magazines and newspapers provide the full date in place of volume/issue numbers (CMOS18 14.87, 14.89) -->
           <group delimiter=", ">
             <text macro="source-serial-title-note"/>
             <text macro="source-serial-identifier-note"/>
@@ -3378,15 +3364,15 @@
   <macro name="source-serial-identifier-volume-bib">
     <group delimiter=", ">
       <choose>
-        <if type="article-newspaper">
-          <!-- newspapers provide the full date in place of volume/issue numbers (CMOS18 14.89) -->
+        <if match="any" type="article-magazine article-newspaper">
+          <!-- magazines and newspapers provide the full date in place of volume/issue numbers (CMOS18 14.87, 14.89) -->
           <text variable="collection-title"/>
           <text macro="source-serial-volume-status-bib"/>
         </if>
         <else-if match="any" variable="issue supplement-number volume">
           <choose>
-            <if match="any" type="article-magazine review review-book" variable="reviewed-author reviewed-genre reviewed-title">
-              <!-- date appears first if the magazine or review `container-title` has been substituted for a missing author (CMOS18 14.87, 14.102) -->
+            <if match="any" type="review review-book" variable="reviewed-author reviewed-genre reviewed-title">
+              <!-- date appears first if the review `container-title` has been substituted for a missing author (CMOS18 14.87, 14.102) -->
               <choose>
                 <if match="none" variable="author chair collection-editor compiler composer curator director editor editor-translator editorial-director executive-producer guest host illustrator organizer producer series-creator translator">
                   <text macro="source-date-bib"/>
@@ -3404,8 +3390,8 @@
                 <if variable="collection-title volume">
                   <text macro="label-volume"/>
                 </if>
-                <else-if match="any" type="article-magazine review review-book" variable="reviewed-author reviewed-genre reviewed-title">
-                  <!-- date appears first if a magazine or review `container-title` has been substituted for a missing author (CMOS18 14.87, 14.102) -->
+                <else-if match="any" type="review review-book" variable="reviewed-author reviewed-genre reviewed-title">
+                  <!-- date appears first if a review `container-title` has been substituted for a missing author (CMOS18 14.87, 14.102) -->
                   <choose>
                     <if match="any" variable="author chair collection-editor compiler composer curator director editor editor-translator editorial-director executive-producer guest host illustrator organizer producer series-creator translator">
                       <text variable="volume"/>
@@ -3423,8 +3409,8 @@
               <text macro="label-supplement-number"/>
             </group>
             <choose>
-              <if match="any" type="article-magazine review review-book" variable="reviewed-author reviewed-genre reviewed-title">
-                <!-- date for anonymous magazine and review articles only appears here if it did not earlier (CMOS18 14.87, 14.102) -->
+              <if match="any" type="review review-book" variable="reviewed-author reviewed-genre reviewed-title">
+                <!-- date for unsigned reviews only appears here if it did not earlier (CMOS18 14.102) -->
                 <choose>
                   <if match="any" variable="author chair collection-editor compiler composer curator director editor editor-translator editorial-director executive-producer guest host illustrator organizer producer series-creator translator">
                     <text macro="source-date-bib" prefix="(" suffix=")"/>
@@ -3449,16 +3435,16 @@
   <macro name="source-serial-identifier-volume-note">
     <group delimiter=", ">
       <choose>
-        <if type="article-newspaper">
-          <!-- newspapers provide the full date in place of volume/issue numbers (CMOS18 14.89) -->
+        <if match="any" type="article-magazine article-newspaper">
+          <!-- magazines and newspapers provide the full date in place of volume/issue numbers (CMOS18 14.87, 14.89) -->
           <text variable="collection-title"/>
           <text macro="source-serial-volume-status-note"/>
         </if>
         <else-if match="any" variable="issue supplement-number volume">
           <choose>
-            <if match="any" type="article-magazine review review-book" variable="reviewed-author reviewed-genre reviewed-title">
+            <if match="any" type="review review-book" variable="reviewed-author reviewed-genre reviewed-title">
               <choose>
-                <!-- date appears first if a magazine or review `container-title` has been substituted for a missing author (CMOS18 14.89) -->
+                <!-- date appears first if a review `container-title` has been substituted for a missing author (CMOS18 14.89) -->
                 <!-- the conditions below mirror substitution in `author-note` -->
                 <if match="any" variable="author chair collection-editor compiler composer curator director editor editor-translator editorial-director executive-producer guest host illustrator organizer producer series-creator translator"/>
                 <else-if match="any" variable="reviewed-genre reviewed-title title"/>
@@ -3481,8 +3467,8 @@
                 </if>
                 <else-if variable="volume">
                   <choose>
-                    <if match="any" type="article-magazine review review-book" variable="reviewed-author reviewed-genre reviewed-title">
-                      <!-- date appears first if a magazine or review `container-title` has been substituted for a missing author (CMOS18 14.89) -->
+                    <if match="any" type="review review-book" variable="reviewed-author reviewed-genre reviewed-title">
+                      <!-- date appears first if a review `container-title` has been substituted for a missing author (CMOS18 14.89) -->
                       <choose>
                         <if match="any" variable="author chair collection-editor compiler composer curator director editor editor-translator editorial-director executive-producer guest host illustrator organizer producer series-creator translator">
                           <text variable="volume"/>
@@ -3508,8 +3494,8 @@
               <text macro="label-supplement-number"/>
             </group>
             <choose>
-              <if match="any" type="article-magazine review review-book" variable="reviewed-author reviewed-genre reviewed-title">
-                <!-- date appears first if a magazine or review `container-title` has been substituted for a missing author (CMOS18 14.89) -->
+              <if match="any" type="review review-book" variable="reviewed-author reviewed-genre reviewed-title">
+                <!-- date appears first if a review `container-title` has been substituted for a missing author (CMOS18 14.89) -->
                 <choose>
                   <if match="any" variable="author chair collection-editor compiler composer curator director editor editor-translator editorial-director executive-producer guest host illustrator organizer producer series-creator translator">
                     <text macro="source-date-issued-or-status" prefix="(" suffix=")"/>
@@ -5038,7 +5024,8 @@
   </macro>
   <macro name="source-date-issued-full-serial">
     <choose>
-      <if type="article-newspaper">
+      <if match="any" type="article-magazine article-newspaper">
+        <!-- magazines and newspapers provide the full date in place of volume/issue numbers (CMOS18 14.87, 14.89) -->
         <text macro="date-issued-full"/>
       </if>
       <else-if variable="issue volume">

--- a/chicago-notes-bibliography-classic-no-url.csl
+++ b/chicago-notes-bibliography-classic-no-url.csl
@@ -868,14 +868,6 @@
         <!-- Publication name also substituted for unsigned reviews (CMOS18 14.102) -->
         <text macro="source-serial-name"/>
       </else-if>
-      <else-if match="any" type="interview paper-conference">
-        <choose>
-          <if match="none" variable="collection-editor compiler editor editorial-director">
-            <!-- serial usage -->
-            <text macro="source-serial-name"/>
-          </if>
-        </choose>
-      </else-if>
       <else-if match="any" type="entry entry-dictionary entry-encyclopedia">
         <!-- Anonymous entries in reference works (CMOS18 14.130) -->
         <text font-style="italic" text-case="title" variable="container-title"/>
@@ -900,14 +892,6 @@
       <else-if match="any" type="review review-book" variable="reviewed-author reviewed-genre reviewed-title">
         <!-- Publication name also substituted for unsigned reviews (CMOS18 14.102) -->
         <text font-style="italic" text-case="title" variable="container-title"/>
-      </else-if>
-      <else-if match="any" type="interview paper-conference">
-        <choose>
-          <if match="none" variable="collection-editor compiler editor editorial-director">
-            <!-- serial usage -->
-            <text font-style="italic" text-case="title" variable="container-title"/>
-          </if>
-        </choose>
       </else-if>
       <else-if match="any" type="entry entry-dictionary entry-encyclopedia">
         <!-- Anonymous entries in reference works (CMOS18 14.130) -->
@@ -3175,7 +3159,8 @@
     <group delimiter=". ">
       <text macro="source-serial-title-volume-bib"/>
       <choose>
-        <if type="article-newspaper">
+        <if match="any" type="article-magazine article-newspaper">
+          <!-- magazines and newspapers provide the full date in place of volume/issue numbers (CMOS18 14.87, 14.89) -->
           <group delimiter=", ">
             <text macro="source-serial-title-bib"/>
             <text macro="source-serial-identifier-bib"/>
@@ -3206,7 +3191,8 @@
     <group delimiter=", ">
       <text macro="source-serial-title-volume-note"/>
       <choose>
-        <if type="article-newspaper">
+        <if match="any" type="article-magazine article-newspaper">
+          <!-- magazines and newspapers provide the full date in place of volume/issue numbers (CMOS18 14.87, 14.89) -->
           <group delimiter=", ">
             <text macro="source-serial-title-note"/>
             <text macro="source-serial-identifier-note"/>
@@ -3378,15 +3364,15 @@
   <macro name="source-serial-identifier-volume-bib">
     <group delimiter=", ">
       <choose>
-        <if type="article-newspaper">
-          <!-- newspapers provide the full date in place of volume/issue numbers (CMOS18 14.89) -->
+        <if match="any" type="article-magazine article-newspaper">
+          <!-- magazines and newspapers provide the full date in place of volume/issue numbers (CMOS18 14.87, 14.89) -->
           <text variable="collection-title"/>
           <text macro="source-serial-volume-status-bib"/>
         </if>
         <else-if match="any" variable="issue supplement-number volume">
           <choose>
-            <if match="any" type="article-magazine review review-book" variable="reviewed-author reviewed-genre reviewed-title">
-              <!-- date appears first if the magazine or review `container-title` has been substituted for a missing author (CMOS18 14.87, 14.102) -->
+            <if match="any" type="review review-book" variable="reviewed-author reviewed-genre reviewed-title">
+              <!-- date appears first if the review `container-title` has been substituted for a missing author (CMOS18 14.87, 14.102) -->
               <choose>
                 <if match="none" variable="author chair collection-editor compiler composer curator director editor editor-translator editorial-director executive-producer guest host illustrator organizer producer series-creator translator">
                   <text macro="source-date-bib"/>
@@ -3404,8 +3390,8 @@
                 <if variable="collection-title volume">
                   <text macro="label-volume"/>
                 </if>
-                <else-if match="any" type="article-magazine review review-book" variable="reviewed-author reviewed-genre reviewed-title">
-                  <!-- date appears first if a magazine or review `container-title` has been substituted for a missing author (CMOS18 14.87, 14.102) -->
+                <else-if match="any" type="review review-book" variable="reviewed-author reviewed-genre reviewed-title">
+                  <!-- date appears first if a review `container-title` has been substituted for a missing author (CMOS18 14.87, 14.102) -->
                   <choose>
                     <if match="any" variable="author chair collection-editor compiler composer curator director editor editor-translator editorial-director executive-producer guest host illustrator organizer producer series-creator translator">
                       <text variable="volume"/>
@@ -3423,8 +3409,8 @@
               <text macro="label-supplement-number"/>
             </group>
             <choose>
-              <if match="any" type="article-magazine review review-book" variable="reviewed-author reviewed-genre reviewed-title">
-                <!-- date for anonymous magazine and review articles only appears here if it did not earlier (CMOS18 14.87, 14.102) -->
+              <if match="any" type="review review-book" variable="reviewed-author reviewed-genre reviewed-title">
+                <!-- date for unsigned reviews only appears here if it did not earlier (CMOS18 14.102) -->
                 <choose>
                   <if match="any" variable="author chair collection-editor compiler composer curator director editor editor-translator editorial-director executive-producer guest host illustrator organizer producer series-creator translator">
                     <text macro="source-date-bib" prefix="(" suffix=")"/>
@@ -3449,16 +3435,16 @@
   <macro name="source-serial-identifier-volume-note">
     <group delimiter=", ">
       <choose>
-        <if type="article-newspaper">
-          <!-- newspapers provide the full date in place of volume/issue numbers (CMOS18 14.89) -->
+        <if match="any" type="article-magazine article-newspaper">
+          <!-- magazines and newspapers provide the full date in place of volume/issue numbers (CMOS18 14.87, 14.89) -->
           <text variable="collection-title"/>
           <text macro="source-serial-volume-status-note"/>
         </if>
         <else-if match="any" variable="issue supplement-number volume">
           <choose>
-            <if match="any" type="article-magazine review review-book" variable="reviewed-author reviewed-genre reviewed-title">
+            <if match="any" type="review review-book" variable="reviewed-author reviewed-genre reviewed-title">
               <choose>
-                <!-- date appears first if a magazine or review `container-title` has been substituted for a missing author (CMOS18 14.89) -->
+                <!-- date appears first if a review `container-title` has been substituted for a missing author (CMOS18 14.89) -->
                 <!-- the conditions below mirror substitution in `author-note` -->
                 <if match="any" variable="author chair collection-editor compiler composer curator director editor editor-translator editorial-director executive-producer guest host illustrator organizer producer series-creator translator"/>
                 <else-if match="any" variable="reviewed-genre reviewed-title title"/>
@@ -3481,8 +3467,8 @@
                 </if>
                 <else-if variable="volume">
                   <choose>
-                    <if match="any" type="article-magazine review review-book" variable="reviewed-author reviewed-genre reviewed-title">
-                      <!-- date appears first if a magazine or review `container-title` has been substituted for a missing author (CMOS18 14.89) -->
+                    <if match="any" type="review review-book" variable="reviewed-author reviewed-genre reviewed-title">
+                      <!-- date appears first if a review `container-title` has been substituted for a missing author (CMOS18 14.89) -->
                       <choose>
                         <if match="any" variable="author chair collection-editor compiler composer curator director editor editor-translator editorial-director executive-producer guest host illustrator organizer producer series-creator translator">
                           <text variable="volume"/>
@@ -3508,8 +3494,8 @@
               <text macro="label-supplement-number"/>
             </group>
             <choose>
-              <if match="any" type="article-magazine review review-book" variable="reviewed-author reviewed-genre reviewed-title">
-                <!-- date appears first if a magazine or review `container-title` has been substituted for a missing author (CMOS18 14.89) -->
+              <if match="any" type="review review-book" variable="reviewed-author reviewed-genre reviewed-title">
+                <!-- date appears first if a review `container-title` has been substituted for a missing author (CMOS18 14.89) -->
                 <choose>
                   <if match="any" variable="author chair collection-editor compiler composer curator director editor editor-translator editorial-director executive-producer guest host illustrator organizer producer series-creator translator">
                     <text macro="source-date-issued-or-status" prefix="(" suffix=")"/>
@@ -5038,7 +5024,8 @@
   </macro>
   <macro name="source-date-issued-full-serial">
     <choose>
-      <if type="article-newspaper">
+      <if match="any" type="article-magazine article-newspaper">
+        <!-- magazines and newspapers provide the full date in place of volume/issue numbers (CMOS18 14.87, 14.89) -->
         <text macro="date-issued-full"/>
       </if>
       <else-if variable="issue volume">

--- a/chicago-notes-bibliography-classic.csl
+++ b/chicago-notes-bibliography-classic.csl
@@ -868,14 +868,6 @@
         <!-- Publication name also substituted for unsigned reviews (CMOS18 14.102) -->
         <text macro="source-serial-name"/>
       </else-if>
-      <else-if match="any" type="interview paper-conference">
-        <choose>
-          <if match="none" variable="collection-editor compiler editor editorial-director">
-            <!-- serial usage -->
-            <text macro="source-serial-name"/>
-          </if>
-        </choose>
-      </else-if>
       <else-if match="any" type="entry entry-dictionary entry-encyclopedia">
         <!-- Anonymous entries in reference works (CMOS18 14.130) -->
         <text font-style="italic" text-case="title" variable="container-title"/>
@@ -900,14 +892,6 @@
       <else-if match="any" type="review review-book" variable="reviewed-author reviewed-genre reviewed-title">
         <!-- Publication name also substituted for unsigned reviews (CMOS18 14.102) -->
         <text font-style="italic" text-case="title" variable="container-title"/>
-      </else-if>
-      <else-if match="any" type="interview paper-conference">
-        <choose>
-          <if match="none" variable="collection-editor compiler editor editorial-director">
-            <!-- serial usage -->
-            <text font-style="italic" text-case="title" variable="container-title"/>
-          </if>
-        </choose>
       </else-if>
       <else-if match="any" type="entry entry-dictionary entry-encyclopedia">
         <!-- Anonymous entries in reference works (CMOS18 14.130) -->
@@ -3175,7 +3159,8 @@
     <group delimiter=". ">
       <text macro="source-serial-title-volume-bib"/>
       <choose>
-        <if type="article-newspaper">
+        <if match="any" type="article-magazine article-newspaper">
+          <!-- magazines and newspapers provide the full date in place of volume/issue numbers (CMOS18 14.87, 14.89) -->
           <group delimiter=", ">
             <text macro="source-serial-title-bib"/>
             <text macro="source-serial-identifier-bib"/>
@@ -3206,7 +3191,8 @@
     <group delimiter=", ">
       <text macro="source-serial-title-volume-note"/>
       <choose>
-        <if type="article-newspaper">
+        <if match="any" type="article-magazine article-newspaper">
+          <!-- magazines and newspapers provide the full date in place of volume/issue numbers (CMOS18 14.87, 14.89) -->
           <group delimiter=", ">
             <text macro="source-serial-title-note"/>
             <text macro="source-serial-identifier-note"/>
@@ -3378,15 +3364,15 @@
   <macro name="source-serial-identifier-volume-bib">
     <group delimiter=", ">
       <choose>
-        <if type="article-newspaper">
-          <!-- newspapers provide the full date in place of volume/issue numbers (CMOS18 14.89) -->
+        <if match="any" type="article-magazine article-newspaper">
+          <!-- magazines and newspapers provide the full date in place of volume/issue numbers (CMOS18 14.87, 14.89) -->
           <text variable="collection-title"/>
           <text macro="source-serial-volume-status-bib"/>
         </if>
         <else-if match="any" variable="issue supplement-number volume">
           <choose>
-            <if match="any" type="article-magazine review review-book" variable="reviewed-author reviewed-genre reviewed-title">
-              <!-- date appears first if the magazine or review `container-title` has been substituted for a missing author (CMOS18 14.87, 14.102) -->
+            <if match="any" type="review review-book" variable="reviewed-author reviewed-genre reviewed-title">
+              <!-- date appears first if the review `container-title` has been substituted for a missing author (CMOS18 14.87, 14.102) -->
               <choose>
                 <if match="none" variable="author chair collection-editor compiler composer curator director editor editor-translator editorial-director executive-producer guest host illustrator organizer producer series-creator translator">
                   <text macro="source-date-bib"/>
@@ -3404,8 +3390,8 @@
                 <if variable="collection-title volume">
                   <text macro="label-volume"/>
                 </if>
-                <else-if match="any" type="article-magazine review review-book" variable="reviewed-author reviewed-genre reviewed-title">
-                  <!-- date appears first if a magazine or review `container-title` has been substituted for a missing author (CMOS18 14.87, 14.102) -->
+                <else-if match="any" type="review review-book" variable="reviewed-author reviewed-genre reviewed-title">
+                  <!-- date appears first if a review `container-title` has been substituted for a missing author (CMOS18 14.87, 14.102) -->
                   <choose>
                     <if match="any" variable="author chair collection-editor compiler composer curator director editor editor-translator editorial-director executive-producer guest host illustrator organizer producer series-creator translator">
                       <text variable="volume"/>
@@ -3423,8 +3409,8 @@
               <text macro="label-supplement-number"/>
             </group>
             <choose>
-              <if match="any" type="article-magazine review review-book" variable="reviewed-author reviewed-genre reviewed-title">
-                <!-- date for anonymous magazine and review articles only appears here if it did not earlier (CMOS18 14.87, 14.102) -->
+              <if match="any" type="review review-book" variable="reviewed-author reviewed-genre reviewed-title">
+                <!-- date for unsigned reviews only appears here if it did not earlier (CMOS18 14.102) -->
                 <choose>
                   <if match="any" variable="author chair collection-editor compiler composer curator director editor editor-translator editorial-director executive-producer guest host illustrator organizer producer series-creator translator">
                     <text macro="source-date-bib" prefix="(" suffix=")"/>
@@ -3449,16 +3435,16 @@
   <macro name="source-serial-identifier-volume-note">
     <group delimiter=", ">
       <choose>
-        <if type="article-newspaper">
-          <!-- newspapers provide the full date in place of volume/issue numbers (CMOS18 14.89) -->
+        <if match="any" type="article-magazine article-newspaper">
+          <!-- magazines and newspapers provide the full date in place of volume/issue numbers (CMOS18 14.87, 14.89) -->
           <text variable="collection-title"/>
           <text macro="source-serial-volume-status-note"/>
         </if>
         <else-if match="any" variable="issue supplement-number volume">
           <choose>
-            <if match="any" type="article-magazine review review-book" variable="reviewed-author reviewed-genre reviewed-title">
+            <if match="any" type="review review-book" variable="reviewed-author reviewed-genre reviewed-title">
               <choose>
-                <!-- date appears first if a magazine or review `container-title` has been substituted for a missing author (CMOS18 14.89) -->
+                <!-- date appears first if a review `container-title` has been substituted for a missing author (CMOS18 14.89) -->
                 <!-- the conditions below mirror substitution in `author-note` -->
                 <if match="any" variable="author chair collection-editor compiler composer curator director editor editor-translator editorial-director executive-producer guest host illustrator organizer producer series-creator translator"/>
                 <else-if match="any" variable="reviewed-genre reviewed-title title"/>
@@ -3481,8 +3467,8 @@
                 </if>
                 <else-if variable="volume">
                   <choose>
-                    <if match="any" type="article-magazine review review-book" variable="reviewed-author reviewed-genre reviewed-title">
-                      <!-- date appears first if a magazine or review `container-title` has been substituted for a missing author (CMOS18 14.89) -->
+                    <if match="any" type="review review-book" variable="reviewed-author reviewed-genre reviewed-title">
+                      <!-- date appears first if a review `container-title` has been substituted for a missing author (CMOS18 14.89) -->
                       <choose>
                         <if match="any" variable="author chair collection-editor compiler composer curator director editor editor-translator editorial-director executive-producer guest host illustrator organizer producer series-creator translator">
                           <text variable="volume"/>
@@ -3508,8 +3494,8 @@
               <text macro="label-supplement-number"/>
             </group>
             <choose>
-              <if match="any" type="article-magazine review review-book" variable="reviewed-author reviewed-genre reviewed-title">
-                <!-- date appears first if a magazine or review `container-title` has been substituted for a missing author (CMOS18 14.89) -->
+              <if match="any" type="review review-book" variable="reviewed-author reviewed-genre reviewed-title">
+                <!-- date appears first if a review `container-title` has been substituted for a missing author (CMOS18 14.89) -->
                 <choose>
                   <if match="any" variable="author chair collection-editor compiler composer curator director editor editor-translator editorial-director executive-producer guest host illustrator organizer producer series-creator translator">
                     <text macro="source-date-issued-or-status" prefix="(" suffix=")"/>
@@ -5038,7 +5024,8 @@
   </macro>
   <macro name="source-date-issued-full-serial">
     <choose>
-      <if type="article-newspaper">
+      <if match="any" type="article-magazine article-newspaper">
+        <!-- magazines and newspapers provide the full date in place of volume/issue numbers (CMOS18 14.87, 14.89) -->
         <text macro="date-issued-full"/>
       </if>
       <else-if variable="issue volume">

--- a/chicago-notes-bibliography-no-url.csl
+++ b/chicago-notes-bibliography-no-url.csl
@@ -867,14 +867,6 @@
         <!-- Publication name also substituted for unsigned reviews (CMOS18 14.102) -->
         <text macro="source-serial-name"/>
       </else-if>
-      <else-if match="any" type="interview paper-conference">
-        <choose>
-          <if match="none" variable="collection-editor compiler editor editorial-director">
-            <!-- serial usage -->
-            <text macro="source-serial-name"/>
-          </if>
-        </choose>
-      </else-if>
       <else-if match="any" type="entry entry-dictionary entry-encyclopedia">
         <!-- Anonymous entries in reference works (CMOS18 14.130) -->
         <text font-style="italic" text-case="title" variable="container-title"/>
@@ -899,14 +891,6 @@
       <else-if match="any" type="review review-book" variable="reviewed-author reviewed-genre reviewed-title">
         <!-- Publication name also substituted for unsigned reviews (CMOS18 14.102) -->
         <text font-style="italic" text-case="title" variable="container-title"/>
-      </else-if>
-      <else-if match="any" type="interview paper-conference">
-        <choose>
-          <if match="none" variable="collection-editor compiler editor editorial-director">
-            <!-- serial usage -->
-            <text font-style="italic" text-case="title" variable="container-title"/>
-          </if>
-        </choose>
       </else-if>
       <else-if match="any" type="entry entry-dictionary entry-encyclopedia">
         <!-- Anonymous entries in reference works (CMOS18 14.130) -->
@@ -3178,7 +3162,8 @@
     <group delimiter=". ">
       <text macro="source-serial-title-volume-bib"/>
       <choose>
-        <if type="article-newspaper">
+        <if match="any" type="article-magazine article-newspaper">
+          <!-- magazines and newspapers provide the full date in place of volume/issue numbers (CMOS18 14.87, 14.89) -->
           <group delimiter=", ">
             <text macro="source-serial-title-bib"/>
             <text macro="source-serial-identifier-bib"/>
@@ -3209,7 +3194,8 @@
     <group delimiter=", ">
       <text macro="source-serial-title-volume-note"/>
       <choose>
-        <if type="article-newspaper">
+        <if match="any" type="article-magazine article-newspaper">
+          <!-- magazines and newspapers provide the full date in place of volume/issue numbers (CMOS18 14.87, 14.89) -->
           <group delimiter=", ">
             <text macro="source-serial-title-note"/>
             <text macro="source-serial-identifier-note"/>
@@ -3381,15 +3367,15 @@
   <macro name="source-serial-identifier-volume-bib">
     <group delimiter=", ">
       <choose>
-        <if type="article-newspaper">
-          <!-- newspapers provide the full date in place of volume/issue numbers (CMOS18 14.89) -->
+        <if match="any" type="article-magazine article-newspaper">
+          <!-- magazines and newspapers provide the full date in place of volume/issue numbers (CMOS18 14.87, 14.89) -->
           <text variable="collection-title"/>
           <text macro="source-serial-volume-status-bib"/>
         </if>
         <else-if match="any" variable="issue supplement-number volume">
           <choose>
-            <if match="any" type="article-magazine review review-book" variable="reviewed-author reviewed-genre reviewed-title">
-              <!-- date appears first if the magazine or review `container-title` has been substituted for a missing author (CMOS18 14.87, 14.102) -->
+            <if match="any" type="review review-book" variable="reviewed-author reviewed-genre reviewed-title">
+              <!-- date appears first if the review `container-title` has been substituted for a missing author (CMOS18 14.87, 14.102) -->
               <choose>
                 <if match="none" variable="author chair collection-editor compiler composer curator director editor editor-translator editorial-director executive-producer guest host illustrator organizer producer series-creator translator">
                   <text macro="source-date-bib"/>
@@ -3407,8 +3393,8 @@
                 <if variable="collection-title volume">
                   <text macro="label-volume"/>
                 </if>
-                <else-if match="any" type="article-magazine review review-book" variable="reviewed-author reviewed-genre reviewed-title">
-                  <!-- date appears first if a magazine or review `container-title` has been substituted for a missing author (CMOS18 14.87, 14.102) -->
+                <else-if match="any" type="review review-book" variable="reviewed-author reviewed-genre reviewed-title">
+                  <!-- date appears first if a review `container-title` has been substituted for a missing author (CMOS18 14.87, 14.102) -->
                   <choose>
                     <if match="any" variable="author chair collection-editor compiler composer curator director editor editor-translator editorial-director executive-producer guest host illustrator organizer producer series-creator translator">
                       <text variable="volume"/>
@@ -3426,8 +3412,8 @@
               <text macro="label-supplement-number"/>
             </group>
             <choose>
-              <if match="any" type="article-magazine review review-book" variable="reviewed-author reviewed-genre reviewed-title">
-                <!-- date for anonymous magazine and review articles only appears here if it did not earlier (CMOS18 14.87, 14.102) -->
+              <if match="any" type="review review-book" variable="reviewed-author reviewed-genre reviewed-title">
+                <!-- date for unsigned reviews only appears here if it did not earlier (CMOS18 14.102) -->
                 <choose>
                   <if match="any" variable="author chair collection-editor compiler composer curator director editor editor-translator editorial-director executive-producer guest host illustrator organizer producer series-creator translator">
                     <text macro="source-date-bib" prefix="(" suffix=")"/>
@@ -3452,16 +3438,16 @@
   <macro name="source-serial-identifier-volume-note">
     <group delimiter=", ">
       <choose>
-        <if type="article-newspaper">
-          <!-- newspapers provide the full date in place of volume/issue numbers (CMOS18 14.89) -->
+        <if match="any" type="article-magazine article-newspaper">
+          <!-- magazines and newspapers provide the full date in place of volume/issue numbers (CMOS18 14.87, 14.89) -->
           <text variable="collection-title"/>
           <text macro="source-serial-volume-status-note"/>
         </if>
         <else-if match="any" variable="issue supplement-number volume">
           <choose>
-            <if match="any" type="article-magazine review review-book" variable="reviewed-author reviewed-genre reviewed-title">
+            <if match="any" type="review review-book" variable="reviewed-author reviewed-genre reviewed-title">
               <choose>
-                <!-- date appears first if a magazine or review `container-title` has been substituted for a missing author (CMOS18 14.89) -->
+                <!-- date appears first if a review `container-title` has been substituted for a missing author (CMOS18 14.89) -->
                 <!-- the conditions below mirror substitution in `author-note` -->
                 <if match="any" variable="author chair collection-editor compiler composer curator director editor editor-translator editorial-director executive-producer guest host illustrator organizer producer series-creator translator"/>
                 <else-if match="any" variable="reviewed-genre reviewed-title title"/>
@@ -3484,8 +3470,8 @@
                 </if>
                 <else-if variable="volume">
                   <choose>
-                    <if match="any" type="article-magazine review review-book" variable="reviewed-author reviewed-genre reviewed-title">
-                      <!-- date appears first if a magazine or review `container-title` has been substituted for a missing author (CMOS18 14.89) -->
+                    <if match="any" type="review review-book" variable="reviewed-author reviewed-genre reviewed-title">
+                      <!-- date appears first if a review `container-title` has been substituted for a missing author (CMOS18 14.89) -->
                       <choose>
                         <if match="any" variable="author chair collection-editor compiler composer curator director editor editor-translator editorial-director executive-producer guest host illustrator organizer producer series-creator translator">
                           <text variable="volume"/>
@@ -3511,8 +3497,8 @@
               <text macro="label-supplement-number"/>
             </group>
             <choose>
-              <if match="any" type="article-magazine review review-book" variable="reviewed-author reviewed-genre reviewed-title">
-                <!-- date appears first if a magazine or review `container-title` has been substituted for a missing author (CMOS18 14.89) -->
+              <if match="any" type="review review-book" variable="reviewed-author reviewed-genre reviewed-title">
+                <!-- date appears first if a review `container-title` has been substituted for a missing author (CMOS18 14.89) -->
                 <choose>
                   <if match="any" variable="author chair collection-editor compiler composer curator director editor editor-translator editorial-director executive-producer guest host illustrator organizer producer series-creator translator">
                     <text macro="source-date-issued-or-status" prefix="(" suffix=")"/>
@@ -5047,7 +5033,8 @@
   </macro>
   <macro name="source-date-issued-full-serial">
     <choose>
-      <if type="article-newspaper">
+      <if match="any" type="article-magazine article-newspaper">
+        <!-- magazines and newspapers provide the full date in place of volume/issue numbers (CMOS18 14.87, 14.89) -->
         <text macro="date-issued-full"/>
       </if>
       <else-if variable="issue volume">

--- a/chicago-notes-bibliography-subsequent-author-classic-no-url.csl
+++ b/chicago-notes-bibliography-subsequent-author-classic-no-url.csl
@@ -868,14 +868,6 @@
         <!-- Publication name also substituted for unsigned reviews (CMOS18 14.102) -->
         <text macro="source-serial-name"/>
       </else-if>
-      <else-if match="any" type="interview paper-conference">
-        <choose>
-          <if match="none" variable="collection-editor compiler editor editorial-director">
-            <!-- serial usage -->
-            <text macro="source-serial-name"/>
-          </if>
-        </choose>
-      </else-if>
       <else-if match="any" type="entry entry-dictionary entry-encyclopedia">
         <!-- Anonymous entries in reference works (CMOS18 14.130) -->
         <text font-style="italic" text-case="title" variable="container-title"/>
@@ -900,14 +892,6 @@
       <else-if match="any" type="review review-book" variable="reviewed-author reviewed-genre reviewed-title">
         <!-- Publication name also substituted for unsigned reviews (CMOS18 14.102) -->
         <text font-style="italic" text-case="title" variable="container-title"/>
-      </else-if>
-      <else-if match="any" type="interview paper-conference">
-        <choose>
-          <if match="none" variable="collection-editor compiler editor editorial-director">
-            <!-- serial usage -->
-            <text font-style="italic" text-case="title" variable="container-title"/>
-          </if>
-        </choose>
       </else-if>
       <else-if match="any" type="entry entry-dictionary entry-encyclopedia">
         <!-- Anonymous entries in reference works (CMOS18 14.130) -->
@@ -3175,7 +3159,8 @@
     <group delimiter=". ">
       <text macro="source-serial-title-volume-bib"/>
       <choose>
-        <if type="article-newspaper">
+        <if match="any" type="article-magazine article-newspaper">
+          <!-- magazines and newspapers provide the full date in place of volume/issue numbers (CMOS18 14.87, 14.89) -->
           <group delimiter=", ">
             <text macro="source-serial-title-bib"/>
             <text macro="source-serial-identifier-bib"/>
@@ -3206,7 +3191,8 @@
     <group delimiter=", ">
       <text macro="source-serial-title-volume-note"/>
       <choose>
-        <if type="article-newspaper">
+        <if match="any" type="article-magazine article-newspaper">
+          <!-- magazines and newspapers provide the full date in place of volume/issue numbers (CMOS18 14.87, 14.89) -->
           <group delimiter=", ">
             <text macro="source-serial-title-note"/>
             <text macro="source-serial-identifier-note"/>
@@ -3378,15 +3364,15 @@
   <macro name="source-serial-identifier-volume-bib">
     <group delimiter=", ">
       <choose>
-        <if type="article-newspaper">
-          <!-- newspapers provide the full date in place of volume/issue numbers (CMOS18 14.89) -->
+        <if match="any" type="article-magazine article-newspaper">
+          <!-- magazines and newspapers provide the full date in place of volume/issue numbers (CMOS18 14.87, 14.89) -->
           <text variable="collection-title"/>
           <text macro="source-serial-volume-status-bib"/>
         </if>
         <else-if match="any" variable="issue supplement-number volume">
           <choose>
-            <if match="any" type="article-magazine review review-book" variable="reviewed-author reviewed-genre reviewed-title">
-              <!-- date appears first if the magazine or review `container-title` has been substituted for a missing author (CMOS18 14.87, 14.102) -->
+            <if match="any" type="review review-book" variable="reviewed-author reviewed-genre reviewed-title">
+              <!-- date appears first if the review `container-title` has been substituted for a missing author (CMOS18 14.87, 14.102) -->
               <choose>
                 <if match="none" variable="author chair collection-editor compiler composer curator director editor editor-translator editorial-director executive-producer guest host illustrator organizer producer series-creator translator">
                   <text macro="source-date-bib"/>
@@ -3404,8 +3390,8 @@
                 <if variable="collection-title volume">
                   <text macro="label-volume"/>
                 </if>
-                <else-if match="any" type="article-magazine review review-book" variable="reviewed-author reviewed-genre reviewed-title">
-                  <!-- date appears first if a magazine or review `container-title` has been substituted for a missing author (CMOS18 14.87, 14.102) -->
+                <else-if match="any" type="review review-book" variable="reviewed-author reviewed-genre reviewed-title">
+                  <!-- date appears first if a review `container-title` has been substituted for a missing author (CMOS18 14.87, 14.102) -->
                   <choose>
                     <if match="any" variable="author chair collection-editor compiler composer curator director editor editor-translator editorial-director executive-producer guest host illustrator organizer producer series-creator translator">
                       <text variable="volume"/>
@@ -3423,8 +3409,8 @@
               <text macro="label-supplement-number"/>
             </group>
             <choose>
-              <if match="any" type="article-magazine review review-book" variable="reviewed-author reviewed-genre reviewed-title">
-                <!-- date for anonymous magazine and review articles only appears here if it did not earlier (CMOS18 14.87, 14.102) -->
+              <if match="any" type="review review-book" variable="reviewed-author reviewed-genre reviewed-title">
+                <!-- date for unsigned reviews only appears here if it did not earlier (CMOS18 14.102) -->
                 <choose>
                   <if match="any" variable="author chair collection-editor compiler composer curator director editor editor-translator editorial-director executive-producer guest host illustrator organizer producer series-creator translator">
                     <text macro="source-date-bib" prefix="(" suffix=")"/>
@@ -3449,16 +3435,16 @@
   <macro name="source-serial-identifier-volume-note">
     <group delimiter=", ">
       <choose>
-        <if type="article-newspaper">
-          <!-- newspapers provide the full date in place of volume/issue numbers (CMOS18 14.89) -->
+        <if match="any" type="article-magazine article-newspaper">
+          <!-- magazines and newspapers provide the full date in place of volume/issue numbers (CMOS18 14.87, 14.89) -->
           <text variable="collection-title"/>
           <text macro="source-serial-volume-status-note"/>
         </if>
         <else-if match="any" variable="issue supplement-number volume">
           <choose>
-            <if match="any" type="article-magazine review review-book" variable="reviewed-author reviewed-genre reviewed-title">
+            <if match="any" type="review review-book" variable="reviewed-author reviewed-genre reviewed-title">
               <choose>
-                <!-- date appears first if a magazine or review `container-title` has been substituted for a missing author (CMOS18 14.89) -->
+                <!-- date appears first if a review `container-title` has been substituted for a missing author (CMOS18 14.89) -->
                 <!-- the conditions below mirror substitution in `author-note` -->
                 <if match="any" variable="author chair collection-editor compiler composer curator director editor editor-translator editorial-director executive-producer guest host illustrator organizer producer series-creator translator"/>
                 <else-if match="any" variable="reviewed-genre reviewed-title title"/>
@@ -3481,8 +3467,8 @@
                 </if>
                 <else-if variable="volume">
                   <choose>
-                    <if match="any" type="article-magazine review review-book" variable="reviewed-author reviewed-genre reviewed-title">
-                      <!-- date appears first if a magazine or review `container-title` has been substituted for a missing author (CMOS18 14.89) -->
+                    <if match="any" type="review review-book" variable="reviewed-author reviewed-genre reviewed-title">
+                      <!-- date appears first if a review `container-title` has been substituted for a missing author (CMOS18 14.89) -->
                       <choose>
                         <if match="any" variable="author chair collection-editor compiler composer curator director editor editor-translator editorial-director executive-producer guest host illustrator organizer producer series-creator translator">
                           <text variable="volume"/>
@@ -3508,8 +3494,8 @@
               <text macro="label-supplement-number"/>
             </group>
             <choose>
-              <if match="any" type="article-magazine review review-book" variable="reviewed-author reviewed-genre reviewed-title">
-                <!-- date appears first if a magazine or review `container-title` has been substituted for a missing author (CMOS18 14.89) -->
+              <if match="any" type="review review-book" variable="reviewed-author reviewed-genre reviewed-title">
+                <!-- date appears first if a review `container-title` has been substituted for a missing author (CMOS18 14.89) -->
                 <choose>
                   <if match="any" variable="author chair collection-editor compiler composer curator director editor editor-translator editorial-director executive-producer guest host illustrator organizer producer series-creator translator">
                     <text macro="source-date-issued-or-status" prefix="(" suffix=")"/>
@@ -5038,7 +5024,8 @@
   </macro>
   <macro name="source-date-issued-full-serial">
     <choose>
-      <if type="article-newspaper">
+      <if match="any" type="article-magazine article-newspaper">
+        <!-- magazines and newspapers provide the full date in place of volume/issue numbers (CMOS18 14.87, 14.89) -->
         <text macro="date-issued-full"/>
       </if>
       <else-if variable="issue volume">

--- a/chicago-notes-bibliography-subsequent-author-classic.csl
+++ b/chicago-notes-bibliography-subsequent-author-classic.csl
@@ -868,14 +868,6 @@
         <!-- Publication name also substituted for unsigned reviews (CMOS18 14.102) -->
         <text macro="source-serial-name"/>
       </else-if>
-      <else-if match="any" type="interview paper-conference">
-        <choose>
-          <if match="none" variable="collection-editor compiler editor editorial-director">
-            <!-- serial usage -->
-            <text macro="source-serial-name"/>
-          </if>
-        </choose>
-      </else-if>
       <else-if match="any" type="entry entry-dictionary entry-encyclopedia">
         <!-- Anonymous entries in reference works (CMOS18 14.130) -->
         <text font-style="italic" text-case="title" variable="container-title"/>
@@ -900,14 +892,6 @@
       <else-if match="any" type="review review-book" variable="reviewed-author reviewed-genre reviewed-title">
         <!-- Publication name also substituted for unsigned reviews (CMOS18 14.102) -->
         <text font-style="italic" text-case="title" variable="container-title"/>
-      </else-if>
-      <else-if match="any" type="interview paper-conference">
-        <choose>
-          <if match="none" variable="collection-editor compiler editor editorial-director">
-            <!-- serial usage -->
-            <text font-style="italic" text-case="title" variable="container-title"/>
-          </if>
-        </choose>
       </else-if>
       <else-if match="any" type="entry entry-dictionary entry-encyclopedia">
         <!-- Anonymous entries in reference works (CMOS18 14.130) -->
@@ -3175,7 +3159,8 @@
     <group delimiter=". ">
       <text macro="source-serial-title-volume-bib"/>
       <choose>
-        <if type="article-newspaper">
+        <if match="any" type="article-magazine article-newspaper">
+          <!-- magazines and newspapers provide the full date in place of volume/issue numbers (CMOS18 14.87, 14.89) -->
           <group delimiter=", ">
             <text macro="source-serial-title-bib"/>
             <text macro="source-serial-identifier-bib"/>
@@ -3206,7 +3191,8 @@
     <group delimiter=", ">
       <text macro="source-serial-title-volume-note"/>
       <choose>
-        <if type="article-newspaper">
+        <if match="any" type="article-magazine article-newspaper">
+          <!-- magazines and newspapers provide the full date in place of volume/issue numbers (CMOS18 14.87, 14.89) -->
           <group delimiter=", ">
             <text macro="source-serial-title-note"/>
             <text macro="source-serial-identifier-note"/>
@@ -3378,15 +3364,15 @@
   <macro name="source-serial-identifier-volume-bib">
     <group delimiter=", ">
       <choose>
-        <if type="article-newspaper">
-          <!-- newspapers provide the full date in place of volume/issue numbers (CMOS18 14.89) -->
+        <if match="any" type="article-magazine article-newspaper">
+          <!-- magazines and newspapers provide the full date in place of volume/issue numbers (CMOS18 14.87, 14.89) -->
           <text variable="collection-title"/>
           <text macro="source-serial-volume-status-bib"/>
         </if>
         <else-if match="any" variable="issue supplement-number volume">
           <choose>
-            <if match="any" type="article-magazine review review-book" variable="reviewed-author reviewed-genre reviewed-title">
-              <!-- date appears first if the magazine or review `container-title` has been substituted for a missing author (CMOS18 14.87, 14.102) -->
+            <if match="any" type="review review-book" variable="reviewed-author reviewed-genre reviewed-title">
+              <!-- date appears first if the review `container-title` has been substituted for a missing author (CMOS18 14.87, 14.102) -->
               <choose>
                 <if match="none" variable="author chair collection-editor compiler composer curator director editor editor-translator editorial-director executive-producer guest host illustrator organizer producer series-creator translator">
                   <text macro="source-date-bib"/>
@@ -3404,8 +3390,8 @@
                 <if variable="collection-title volume">
                   <text macro="label-volume"/>
                 </if>
-                <else-if match="any" type="article-magazine review review-book" variable="reviewed-author reviewed-genre reviewed-title">
-                  <!-- date appears first if a magazine or review `container-title` has been substituted for a missing author (CMOS18 14.87, 14.102) -->
+                <else-if match="any" type="review review-book" variable="reviewed-author reviewed-genre reviewed-title">
+                  <!-- date appears first if a review `container-title` has been substituted for a missing author (CMOS18 14.87, 14.102) -->
                   <choose>
                     <if match="any" variable="author chair collection-editor compiler composer curator director editor editor-translator editorial-director executive-producer guest host illustrator organizer producer series-creator translator">
                       <text variable="volume"/>
@@ -3423,8 +3409,8 @@
               <text macro="label-supplement-number"/>
             </group>
             <choose>
-              <if match="any" type="article-magazine review review-book" variable="reviewed-author reviewed-genre reviewed-title">
-                <!-- date for anonymous magazine and review articles only appears here if it did not earlier (CMOS18 14.87, 14.102) -->
+              <if match="any" type="review review-book" variable="reviewed-author reviewed-genre reviewed-title">
+                <!-- date for unsigned reviews only appears here if it did not earlier (CMOS18 14.102) -->
                 <choose>
                   <if match="any" variable="author chair collection-editor compiler composer curator director editor editor-translator editorial-director executive-producer guest host illustrator organizer producer series-creator translator">
                     <text macro="source-date-bib" prefix="(" suffix=")"/>
@@ -3449,16 +3435,16 @@
   <macro name="source-serial-identifier-volume-note">
     <group delimiter=", ">
       <choose>
-        <if type="article-newspaper">
-          <!-- newspapers provide the full date in place of volume/issue numbers (CMOS18 14.89) -->
+        <if match="any" type="article-magazine article-newspaper">
+          <!-- magazines and newspapers provide the full date in place of volume/issue numbers (CMOS18 14.87, 14.89) -->
           <text variable="collection-title"/>
           <text macro="source-serial-volume-status-note"/>
         </if>
         <else-if match="any" variable="issue supplement-number volume">
           <choose>
-            <if match="any" type="article-magazine review review-book" variable="reviewed-author reviewed-genre reviewed-title">
+            <if match="any" type="review review-book" variable="reviewed-author reviewed-genre reviewed-title">
               <choose>
-                <!-- date appears first if a magazine or review `container-title` has been substituted for a missing author (CMOS18 14.89) -->
+                <!-- date appears first if a review `container-title` has been substituted for a missing author (CMOS18 14.89) -->
                 <!-- the conditions below mirror substitution in `author-note` -->
                 <if match="any" variable="author chair collection-editor compiler composer curator director editor editor-translator editorial-director executive-producer guest host illustrator organizer producer series-creator translator"/>
                 <else-if match="any" variable="reviewed-genre reviewed-title title"/>
@@ -3481,8 +3467,8 @@
                 </if>
                 <else-if variable="volume">
                   <choose>
-                    <if match="any" type="article-magazine review review-book" variable="reviewed-author reviewed-genre reviewed-title">
-                      <!-- date appears first if a magazine or review `container-title` has been substituted for a missing author (CMOS18 14.89) -->
+                    <if match="any" type="review review-book" variable="reviewed-author reviewed-genre reviewed-title">
+                      <!-- date appears first if a review `container-title` has been substituted for a missing author (CMOS18 14.89) -->
                       <choose>
                         <if match="any" variable="author chair collection-editor compiler composer curator director editor editor-translator editorial-director executive-producer guest host illustrator organizer producer series-creator translator">
                           <text variable="volume"/>
@@ -3508,8 +3494,8 @@
               <text macro="label-supplement-number"/>
             </group>
             <choose>
-              <if match="any" type="article-magazine review review-book" variable="reviewed-author reviewed-genre reviewed-title">
-                <!-- date appears first if a magazine or review `container-title` has been substituted for a missing author (CMOS18 14.89) -->
+              <if match="any" type="review review-book" variable="reviewed-author reviewed-genre reviewed-title">
+                <!-- date appears first if a review `container-title` has been substituted for a missing author (CMOS18 14.89) -->
                 <choose>
                   <if match="any" variable="author chair collection-editor compiler composer curator director editor editor-translator editorial-director executive-producer guest host illustrator organizer producer series-creator translator">
                     <text macro="source-date-issued-or-status" prefix="(" suffix=")"/>
@@ -5038,7 +5024,8 @@
   </macro>
   <macro name="source-date-issued-full-serial">
     <choose>
-      <if type="article-newspaper">
+      <if match="any" type="article-magazine article-newspaper">
+        <!-- magazines and newspapers provide the full date in place of volume/issue numbers (CMOS18 14.87, 14.89) -->
         <text macro="date-issued-full"/>
       </if>
       <else-if variable="issue volume">

--- a/chicago-notes-bibliography-subsequent-author-title-17th-edition.csl
+++ b/chicago-notes-bibliography-subsequent-author-title-17th-edition.csl
@@ -865,14 +865,6 @@
         <!-- Publication name also substituted for unsigned reviews (CMOS18 14.102) -->
         <text macro="source-serial-name"/>
       </else-if>
-      <else-if match="any" type="interview paper-conference">
-        <choose>
-          <if match="none" variable="collection-editor compiler editor editorial-director">
-            <!-- serial usage -->
-            <text macro="source-serial-name"/>
-          </if>
-        </choose>
-      </else-if>
       <else-if match="any" type="entry entry-dictionary entry-encyclopedia">
         <!-- Anonymous entries in reference works (CMOS18 14.130) -->
         <text font-style="italic" text-case="title" variable="container-title"/>
@@ -897,14 +889,6 @@
       <else-if match="any" type="review review-book" variable="reviewed-author reviewed-genre reviewed-title">
         <!-- Publication name also substituted for unsigned reviews (CMOS18 14.102) -->
         <text font-style="italic" text-case="title" variable="container-title"/>
-      </else-if>
-      <else-if match="any" type="interview paper-conference">
-        <choose>
-          <if match="none" variable="collection-editor compiler editor editorial-director">
-            <!-- serial usage -->
-            <text font-style="italic" text-case="title" variable="container-title"/>
-          </if>
-        </choose>
       </else-if>
       <else-if match="any" type="entry entry-dictionary entry-encyclopedia">
         <!-- Anonymous entries in reference works (CMOS18 14.130) -->
@@ -3172,7 +3156,8 @@
     <group delimiter=". ">
       <text macro="source-serial-title-volume-bib"/>
       <choose>
-        <if type="article-newspaper">
+        <if match="any" type="article-magazine article-newspaper">
+          <!-- magazines and newspapers provide the full date in place of volume/issue numbers (CMOS18 14.87, 14.89) -->
           <group delimiter=", ">
             <text macro="source-serial-title-bib"/>
             <text macro="source-serial-identifier-bib"/>
@@ -3203,7 +3188,8 @@
     <group delimiter=", ">
       <text macro="source-serial-title-volume-note"/>
       <choose>
-        <if type="article-newspaper">
+        <if match="any" type="article-magazine article-newspaper">
+          <!-- magazines and newspapers provide the full date in place of volume/issue numbers (CMOS18 14.87, 14.89) -->
           <group delimiter=", ">
             <text macro="source-serial-title-note"/>
             <text macro="source-serial-identifier-note"/>
@@ -3375,15 +3361,15 @@
   <macro name="source-serial-identifier-volume-bib">
     <group delimiter=", ">
       <choose>
-        <if type="article-newspaper">
-          <!-- newspapers provide the full date in place of volume/issue numbers (CMOS18 14.89) -->
+        <if match="any" type="article-magazine article-newspaper">
+          <!-- magazines and newspapers provide the full date in place of volume/issue numbers (CMOS18 14.87, 14.89) -->
           <text variable="collection-title"/>
           <text macro="source-serial-volume-status-bib"/>
         </if>
         <else-if match="any" variable="issue supplement-number volume">
           <choose>
-            <if match="any" type="article-magazine review review-book" variable="reviewed-author reviewed-genre reviewed-title">
-              <!-- date appears first if the magazine or review `container-title` has been substituted for a missing author (CMOS18 14.87, 14.102) -->
+            <if match="any" type="review review-book" variable="reviewed-author reviewed-genre reviewed-title">
+              <!-- date appears first if the review `container-title` has been substituted for a missing author (CMOS18 14.87, 14.102) -->
               <choose>
                 <if match="none" variable="author chair collection-editor compiler composer curator director editor editor-translator editorial-director executive-producer guest host illustrator organizer producer series-creator translator">
                   <text macro="source-date-bib"/>
@@ -3401,8 +3387,8 @@
                 <if variable="collection-title volume">
                   <text macro="label-volume"/>
                 </if>
-                <else-if match="any" type="article-magazine review review-book" variable="reviewed-author reviewed-genre reviewed-title">
-                  <!-- date appears first if a magazine or review `container-title` has been substituted for a missing author (CMOS18 14.87, 14.102) -->
+                <else-if match="any" type="review review-book" variable="reviewed-author reviewed-genre reviewed-title">
+                  <!-- date appears first if a review `container-title` has been substituted for a missing author (CMOS18 14.87, 14.102) -->
                   <choose>
                     <if match="any" variable="author chair collection-editor compiler composer curator director editor editor-translator editorial-director executive-producer guest host illustrator organizer producer series-creator translator">
                       <text variable="volume"/>
@@ -3420,8 +3406,8 @@
               <text macro="label-supplement-number"/>
             </group>
             <choose>
-              <if match="any" type="article-magazine review review-book" variable="reviewed-author reviewed-genre reviewed-title">
-                <!-- date for anonymous magazine and review articles only appears here if it did not earlier (CMOS18 14.87, 14.102) -->
+              <if match="any" type="review review-book" variable="reviewed-author reviewed-genre reviewed-title">
+                <!-- date for unsigned reviews only appears here if it did not earlier (CMOS18 14.102) -->
                 <choose>
                   <if match="any" variable="author chair collection-editor compiler composer curator director editor editor-translator editorial-director executive-producer guest host illustrator organizer producer series-creator translator">
                     <text macro="source-date-bib" prefix="(" suffix=")"/>
@@ -3446,16 +3432,16 @@
   <macro name="source-serial-identifier-volume-note">
     <group delimiter=", ">
       <choose>
-        <if type="article-newspaper">
-          <!-- newspapers provide the full date in place of volume/issue numbers (CMOS18 14.89) -->
+        <if match="any" type="article-magazine article-newspaper">
+          <!-- magazines and newspapers provide the full date in place of volume/issue numbers (CMOS18 14.87, 14.89) -->
           <text variable="collection-title"/>
           <text macro="source-serial-volume-status-note"/>
         </if>
         <else-if match="any" variable="issue supplement-number volume">
           <choose>
-            <if match="any" type="article-magazine review review-book" variable="reviewed-author reviewed-genre reviewed-title">
+            <if match="any" type="review review-book" variable="reviewed-author reviewed-genre reviewed-title">
               <choose>
-                <!-- date appears first if a magazine or review `container-title` has been substituted for a missing author (CMOS18 14.89) -->
+                <!-- date appears first if a review `container-title` has been substituted for a missing author (CMOS18 14.89) -->
                 <!-- the conditions below mirror substitution in `author-note` -->
                 <if match="any" variable="author chair collection-editor compiler composer curator director editor editor-translator editorial-director executive-producer guest host illustrator organizer producer series-creator translator"/>
                 <else-if match="any" variable="reviewed-genre reviewed-title title"/>
@@ -3478,8 +3464,8 @@
                 </if>
                 <else-if variable="volume">
                   <choose>
-                    <if match="any" type="article-magazine review review-book" variable="reviewed-author reviewed-genre reviewed-title">
-                      <!-- date appears first if a magazine or review `container-title` has been substituted for a missing author (CMOS18 14.89) -->
+                    <if match="any" type="review review-book" variable="reviewed-author reviewed-genre reviewed-title">
+                      <!-- date appears first if a review `container-title` has been substituted for a missing author (CMOS18 14.89) -->
                       <choose>
                         <if match="any" variable="author chair collection-editor compiler composer curator director editor editor-translator editorial-director executive-producer guest host illustrator organizer producer series-creator translator">
                           <text variable="volume"/>
@@ -3505,8 +3491,8 @@
               <text macro="label-supplement-number"/>
             </group>
             <choose>
-              <if match="any" type="article-magazine review review-book" variable="reviewed-author reviewed-genre reviewed-title">
-                <!-- date appears first if a magazine or review `container-title` has been substituted for a missing author (CMOS18 14.89) -->
+              <if match="any" type="review review-book" variable="reviewed-author reviewed-genre reviewed-title">
+                <!-- date appears first if a review `container-title` has been substituted for a missing author (CMOS18 14.89) -->
                 <choose>
                   <if match="any" variable="author chair collection-editor compiler composer curator director editor editor-translator editorial-director executive-producer guest host illustrator organizer producer series-creator translator">
                     <text macro="source-date-issued-or-status" prefix="(" suffix=")"/>
@@ -5035,7 +5021,8 @@
   </macro>
   <macro name="source-date-issued-full-serial">
     <choose>
-      <if type="article-newspaper">
+      <if match="any" type="article-magazine article-newspaper">
+        <!-- magazines and newspapers provide the full date in place of volume/issue numbers (CMOS18 14.87, 14.89) -->
         <text macro="date-issued-full"/>
       </if>
       <else-if variable="issue volume">

--- a/chicago-notes-bibliography-subsequent-author.csl
+++ b/chicago-notes-bibliography-subsequent-author.csl
@@ -867,14 +867,6 @@
         <!-- Publication name also substituted for unsigned reviews (CMOS18 14.102) -->
         <text macro="source-serial-name"/>
       </else-if>
-      <else-if match="any" type="interview paper-conference">
-        <choose>
-          <if match="none" variable="collection-editor compiler editor editorial-director">
-            <!-- serial usage -->
-            <text macro="source-serial-name"/>
-          </if>
-        </choose>
-      </else-if>
       <else-if match="any" type="entry entry-dictionary entry-encyclopedia">
         <!-- Anonymous entries in reference works (CMOS18 14.130) -->
         <text font-style="italic" text-case="title" variable="container-title"/>
@@ -899,14 +891,6 @@
       <else-if match="any" type="review review-book" variable="reviewed-author reviewed-genre reviewed-title">
         <!-- Publication name also substituted for unsigned reviews (CMOS18 14.102) -->
         <text font-style="italic" text-case="title" variable="container-title"/>
-      </else-if>
-      <else-if match="any" type="interview paper-conference">
-        <choose>
-          <if match="none" variable="collection-editor compiler editor editorial-director">
-            <!-- serial usage -->
-            <text font-style="italic" text-case="title" variable="container-title"/>
-          </if>
-        </choose>
       </else-if>
       <else-if match="any" type="entry entry-dictionary entry-encyclopedia">
         <!-- Anonymous entries in reference works (CMOS18 14.130) -->
@@ -3178,7 +3162,8 @@
     <group delimiter=". ">
       <text macro="source-serial-title-volume-bib"/>
       <choose>
-        <if type="article-newspaper">
+        <if match="any" type="article-magazine article-newspaper">
+          <!-- magazines and newspapers provide the full date in place of volume/issue numbers (CMOS18 14.87, 14.89) -->
           <group delimiter=", ">
             <text macro="source-serial-title-bib"/>
             <text macro="source-serial-identifier-bib"/>
@@ -3209,7 +3194,8 @@
     <group delimiter=", ">
       <text macro="source-serial-title-volume-note"/>
       <choose>
-        <if type="article-newspaper">
+        <if match="any" type="article-magazine article-newspaper">
+          <!-- magazines and newspapers provide the full date in place of volume/issue numbers (CMOS18 14.87, 14.89) -->
           <group delimiter=", ">
             <text macro="source-serial-title-note"/>
             <text macro="source-serial-identifier-note"/>
@@ -3381,15 +3367,15 @@
   <macro name="source-serial-identifier-volume-bib">
     <group delimiter=", ">
       <choose>
-        <if type="article-newspaper">
-          <!-- newspapers provide the full date in place of volume/issue numbers (CMOS18 14.89) -->
+        <if match="any" type="article-magazine article-newspaper">
+          <!-- magazines and newspapers provide the full date in place of volume/issue numbers (CMOS18 14.87, 14.89) -->
           <text variable="collection-title"/>
           <text macro="source-serial-volume-status-bib"/>
         </if>
         <else-if match="any" variable="issue supplement-number volume">
           <choose>
-            <if match="any" type="article-magazine review review-book" variable="reviewed-author reviewed-genre reviewed-title">
-              <!-- date appears first if the magazine or review `container-title` has been substituted for a missing author (CMOS18 14.87, 14.102) -->
+            <if match="any" type="review review-book" variable="reviewed-author reviewed-genre reviewed-title">
+              <!-- date appears first if the review `container-title` has been substituted for a missing author (CMOS18 14.87, 14.102) -->
               <choose>
                 <if match="none" variable="author chair collection-editor compiler composer curator director editor editor-translator editorial-director executive-producer guest host illustrator organizer producer series-creator translator">
                   <text macro="source-date-bib"/>
@@ -3407,8 +3393,8 @@
                 <if variable="collection-title volume">
                   <text macro="label-volume"/>
                 </if>
-                <else-if match="any" type="article-magazine review review-book" variable="reviewed-author reviewed-genre reviewed-title">
-                  <!-- date appears first if a magazine or review `container-title` has been substituted for a missing author (CMOS18 14.87, 14.102) -->
+                <else-if match="any" type="review review-book" variable="reviewed-author reviewed-genre reviewed-title">
+                  <!-- date appears first if a review `container-title` has been substituted for a missing author (CMOS18 14.87, 14.102) -->
                   <choose>
                     <if match="any" variable="author chair collection-editor compiler composer curator director editor editor-translator editorial-director executive-producer guest host illustrator organizer producer series-creator translator">
                       <text variable="volume"/>
@@ -3426,8 +3412,8 @@
               <text macro="label-supplement-number"/>
             </group>
             <choose>
-              <if match="any" type="article-magazine review review-book" variable="reviewed-author reviewed-genre reviewed-title">
-                <!-- date for anonymous magazine and review articles only appears here if it did not earlier (CMOS18 14.87, 14.102) -->
+              <if match="any" type="review review-book" variable="reviewed-author reviewed-genre reviewed-title">
+                <!-- date for unsigned reviews only appears here if it did not earlier (CMOS18 14.102) -->
                 <choose>
                   <if match="any" variable="author chair collection-editor compiler composer curator director editor editor-translator editorial-director executive-producer guest host illustrator organizer producer series-creator translator">
                     <text macro="source-date-bib" prefix="(" suffix=")"/>
@@ -3452,16 +3438,16 @@
   <macro name="source-serial-identifier-volume-note">
     <group delimiter=", ">
       <choose>
-        <if type="article-newspaper">
-          <!-- newspapers provide the full date in place of volume/issue numbers (CMOS18 14.89) -->
+        <if match="any" type="article-magazine article-newspaper">
+          <!-- magazines and newspapers provide the full date in place of volume/issue numbers (CMOS18 14.87, 14.89) -->
           <text variable="collection-title"/>
           <text macro="source-serial-volume-status-note"/>
         </if>
         <else-if match="any" variable="issue supplement-number volume">
           <choose>
-            <if match="any" type="article-magazine review review-book" variable="reviewed-author reviewed-genre reviewed-title">
+            <if match="any" type="review review-book" variable="reviewed-author reviewed-genre reviewed-title">
               <choose>
-                <!-- date appears first if a magazine or review `container-title` has been substituted for a missing author (CMOS18 14.89) -->
+                <!-- date appears first if a review `container-title` has been substituted for a missing author (CMOS18 14.89) -->
                 <!-- the conditions below mirror substitution in `author-note` -->
                 <if match="any" variable="author chair collection-editor compiler composer curator director editor editor-translator editorial-director executive-producer guest host illustrator organizer producer series-creator translator"/>
                 <else-if match="any" variable="reviewed-genre reviewed-title title"/>
@@ -3484,8 +3470,8 @@
                 </if>
                 <else-if variable="volume">
                   <choose>
-                    <if match="any" type="article-magazine review review-book" variable="reviewed-author reviewed-genre reviewed-title">
-                      <!-- date appears first if a magazine or review `container-title` has been substituted for a missing author (CMOS18 14.89) -->
+                    <if match="any" type="review review-book" variable="reviewed-author reviewed-genre reviewed-title">
+                      <!-- date appears first if a review `container-title` has been substituted for a missing author (CMOS18 14.89) -->
                       <choose>
                         <if match="any" variable="author chair collection-editor compiler composer curator director editor editor-translator editorial-director executive-producer guest host illustrator organizer producer series-creator translator">
                           <text variable="volume"/>
@@ -3511,8 +3497,8 @@
               <text macro="label-supplement-number"/>
             </group>
             <choose>
-              <if match="any" type="article-magazine review review-book" variable="reviewed-author reviewed-genre reviewed-title">
-                <!-- date appears first if a magazine or review `container-title` has been substituted for a missing author (CMOS18 14.89) -->
+              <if match="any" type="review review-book" variable="reviewed-author reviewed-genre reviewed-title">
+                <!-- date appears first if a review `container-title` has been substituted for a missing author (CMOS18 14.89) -->
                 <choose>
                   <if match="any" variable="author chair collection-editor compiler composer curator director editor editor-translator editorial-director executive-producer guest host illustrator organizer producer series-creator translator">
                     <text macro="source-date-issued-or-status" prefix="(" suffix=")"/>
@@ -5047,7 +5033,8 @@
   </macro>
   <macro name="source-date-issued-full-serial">
     <choose>
-      <if type="article-newspaper">
+      <if match="any" type="article-magazine article-newspaper">
+        <!-- magazines and newspapers provide the full date in place of volume/issue numbers (CMOS18 14.87, 14.89) -->
         <text macro="date-issued-full"/>
       </if>
       <else-if variable="issue volume">

--- a/chicago-notes-bibliography-subsequent-ibid-17th-edition.csl
+++ b/chicago-notes-bibliography-subsequent-ibid-17th-edition.csl
@@ -865,14 +865,6 @@
         <!-- Publication name also substituted for unsigned reviews (CMOS18 14.102) -->
         <text macro="source-serial-name"/>
       </else-if>
-      <else-if match="any" type="interview paper-conference">
-        <choose>
-          <if match="none" variable="collection-editor compiler editor editorial-director">
-            <!-- serial usage -->
-            <text macro="source-serial-name"/>
-          </if>
-        </choose>
-      </else-if>
       <else-if match="any" type="entry entry-dictionary entry-encyclopedia">
         <!-- Anonymous entries in reference works (CMOS18 14.130) -->
         <text font-style="italic" text-case="title" variable="container-title"/>
@@ -897,14 +889,6 @@
       <else-if match="any" type="review review-book" variable="reviewed-author reviewed-genre reviewed-title">
         <!-- Publication name also substituted for unsigned reviews (CMOS18 14.102) -->
         <text font-style="italic" text-case="title" variable="container-title"/>
-      </else-if>
-      <else-if match="any" type="interview paper-conference">
-        <choose>
-          <if match="none" variable="collection-editor compiler editor editorial-director">
-            <!-- serial usage -->
-            <text font-style="italic" text-case="title" variable="container-title"/>
-          </if>
-        </choose>
       </else-if>
       <else-if match="any" type="entry entry-dictionary entry-encyclopedia">
         <!-- Anonymous entries in reference works (CMOS18 14.130) -->
@@ -3172,7 +3156,8 @@
     <group delimiter=". ">
       <text macro="source-serial-title-volume-bib"/>
       <choose>
-        <if type="article-newspaper">
+        <if match="any" type="article-magazine article-newspaper">
+          <!-- magazines and newspapers provide the full date in place of volume/issue numbers (CMOS18 14.87, 14.89) -->
           <group delimiter=", ">
             <text macro="source-serial-title-bib"/>
             <text macro="source-serial-identifier-bib"/>
@@ -3203,7 +3188,8 @@
     <group delimiter=", ">
       <text macro="source-serial-title-volume-note"/>
       <choose>
-        <if type="article-newspaper">
+        <if match="any" type="article-magazine article-newspaper">
+          <!-- magazines and newspapers provide the full date in place of volume/issue numbers (CMOS18 14.87, 14.89) -->
           <group delimiter=", ">
             <text macro="source-serial-title-note"/>
             <text macro="source-serial-identifier-note"/>
@@ -3375,15 +3361,15 @@
   <macro name="source-serial-identifier-volume-bib">
     <group delimiter=", ">
       <choose>
-        <if type="article-newspaper">
-          <!-- newspapers provide the full date in place of volume/issue numbers (CMOS18 14.89) -->
+        <if match="any" type="article-magazine article-newspaper">
+          <!-- magazines and newspapers provide the full date in place of volume/issue numbers (CMOS18 14.87, 14.89) -->
           <text variable="collection-title"/>
           <text macro="source-serial-volume-status-bib"/>
         </if>
         <else-if match="any" variable="issue supplement-number volume">
           <choose>
-            <if match="any" type="article-magazine review review-book" variable="reviewed-author reviewed-genre reviewed-title">
-              <!-- date appears first if the magazine or review `container-title` has been substituted for a missing author (CMOS18 14.87, 14.102) -->
+            <if match="any" type="review review-book" variable="reviewed-author reviewed-genre reviewed-title">
+              <!-- date appears first if the review `container-title` has been substituted for a missing author (CMOS18 14.87, 14.102) -->
               <choose>
                 <if match="none" variable="author chair collection-editor compiler composer curator director editor editor-translator editorial-director executive-producer guest host illustrator organizer producer series-creator translator">
                   <text macro="source-date-bib"/>
@@ -3401,8 +3387,8 @@
                 <if variable="collection-title volume">
                   <text macro="label-volume"/>
                 </if>
-                <else-if match="any" type="article-magazine review review-book" variable="reviewed-author reviewed-genre reviewed-title">
-                  <!-- date appears first if a magazine or review `container-title` has been substituted for a missing author (CMOS18 14.87, 14.102) -->
+                <else-if match="any" type="review review-book" variable="reviewed-author reviewed-genre reviewed-title">
+                  <!-- date appears first if a review `container-title` has been substituted for a missing author (CMOS18 14.87, 14.102) -->
                   <choose>
                     <if match="any" variable="author chair collection-editor compiler composer curator director editor editor-translator editorial-director executive-producer guest host illustrator organizer producer series-creator translator">
                       <text variable="volume"/>
@@ -3420,8 +3406,8 @@
               <text macro="label-supplement-number"/>
             </group>
             <choose>
-              <if match="any" type="article-magazine review review-book" variable="reviewed-author reviewed-genre reviewed-title">
-                <!-- date for anonymous magazine and review articles only appears here if it did not earlier (CMOS18 14.87, 14.102) -->
+              <if match="any" type="review review-book" variable="reviewed-author reviewed-genre reviewed-title">
+                <!-- date for unsigned reviews only appears here if it did not earlier (CMOS18 14.102) -->
                 <choose>
                   <if match="any" variable="author chair collection-editor compiler composer curator director editor editor-translator editorial-director executive-producer guest host illustrator organizer producer series-creator translator">
                     <text macro="source-date-bib" prefix="(" suffix=")"/>
@@ -3446,16 +3432,16 @@
   <macro name="source-serial-identifier-volume-note">
     <group delimiter=", ">
       <choose>
-        <if type="article-newspaper">
-          <!-- newspapers provide the full date in place of volume/issue numbers (CMOS18 14.89) -->
+        <if match="any" type="article-magazine article-newspaper">
+          <!-- magazines and newspapers provide the full date in place of volume/issue numbers (CMOS18 14.87, 14.89) -->
           <text variable="collection-title"/>
           <text macro="source-serial-volume-status-note"/>
         </if>
         <else-if match="any" variable="issue supplement-number volume">
           <choose>
-            <if match="any" type="article-magazine review review-book" variable="reviewed-author reviewed-genre reviewed-title">
+            <if match="any" type="review review-book" variable="reviewed-author reviewed-genre reviewed-title">
               <choose>
-                <!-- date appears first if a magazine or review `container-title` has been substituted for a missing author (CMOS18 14.89) -->
+                <!-- date appears first if a review `container-title` has been substituted for a missing author (CMOS18 14.89) -->
                 <!-- the conditions below mirror substitution in `author-note` -->
                 <if match="any" variable="author chair collection-editor compiler composer curator director editor editor-translator editorial-director executive-producer guest host illustrator organizer producer series-creator translator"/>
                 <else-if match="any" variable="reviewed-genre reviewed-title title"/>
@@ -3478,8 +3464,8 @@
                 </if>
                 <else-if variable="volume">
                   <choose>
-                    <if match="any" type="article-magazine review review-book" variable="reviewed-author reviewed-genre reviewed-title">
-                      <!-- date appears first if a magazine or review `container-title` has been substituted for a missing author (CMOS18 14.89) -->
+                    <if match="any" type="review review-book" variable="reviewed-author reviewed-genre reviewed-title">
+                      <!-- date appears first if a review `container-title` has been substituted for a missing author (CMOS18 14.89) -->
                       <choose>
                         <if match="any" variable="author chair collection-editor compiler composer curator director editor editor-translator editorial-director executive-producer guest host illustrator organizer producer series-creator translator">
                           <text variable="volume"/>
@@ -3505,8 +3491,8 @@
               <text macro="label-supplement-number"/>
             </group>
             <choose>
-              <if match="any" type="article-magazine review review-book" variable="reviewed-author reviewed-genre reviewed-title">
-                <!-- date appears first if a magazine or review `container-title` has been substituted for a missing author (CMOS18 14.89) -->
+              <if match="any" type="review review-book" variable="reviewed-author reviewed-genre reviewed-title">
+                <!-- date appears first if a review `container-title` has been substituted for a missing author (CMOS18 14.89) -->
                 <choose>
                   <if match="any" variable="author chair collection-editor compiler composer curator director editor editor-translator editorial-director executive-producer guest host illustrator organizer producer series-creator translator">
                     <text macro="source-date-issued-or-status" prefix="(" suffix=")"/>
@@ -5035,7 +5021,8 @@
   </macro>
   <macro name="source-date-issued-full-serial">
     <choose>
-      <if type="article-newspaper">
+      <if match="any" type="article-magazine article-newspaper">
+        <!-- magazines and newspapers provide the full date in place of volume/issue numbers (CMOS18 14.87, 14.89) -->
         <text macro="date-issued-full"/>
       </if>
       <else-if variable="issue volume">

--- a/chicago-notes-bibliography-subsequent-ibid-classic-no-url.csl
+++ b/chicago-notes-bibliography-subsequent-ibid-classic-no-url.csl
@@ -868,14 +868,6 @@
         <!-- Publication name also substituted for unsigned reviews (CMOS18 14.102) -->
         <text macro="source-serial-name"/>
       </else-if>
-      <else-if match="any" type="interview paper-conference">
-        <choose>
-          <if match="none" variable="collection-editor compiler editor editorial-director">
-            <!-- serial usage -->
-            <text macro="source-serial-name"/>
-          </if>
-        </choose>
-      </else-if>
       <else-if match="any" type="entry entry-dictionary entry-encyclopedia">
         <!-- Anonymous entries in reference works (CMOS18 14.130) -->
         <text font-style="italic" text-case="title" variable="container-title"/>
@@ -900,14 +892,6 @@
       <else-if match="any" type="review review-book" variable="reviewed-author reviewed-genre reviewed-title">
         <!-- Publication name also substituted for unsigned reviews (CMOS18 14.102) -->
         <text font-style="italic" text-case="title" variable="container-title"/>
-      </else-if>
-      <else-if match="any" type="interview paper-conference">
-        <choose>
-          <if match="none" variable="collection-editor compiler editor editorial-director">
-            <!-- serial usage -->
-            <text font-style="italic" text-case="title" variable="container-title"/>
-          </if>
-        </choose>
       </else-if>
       <else-if match="any" type="entry entry-dictionary entry-encyclopedia">
         <!-- Anonymous entries in reference works (CMOS18 14.130) -->
@@ -3175,7 +3159,8 @@
     <group delimiter=". ">
       <text macro="source-serial-title-volume-bib"/>
       <choose>
-        <if type="article-newspaper">
+        <if match="any" type="article-magazine article-newspaper">
+          <!-- magazines and newspapers provide the full date in place of volume/issue numbers (CMOS18 14.87, 14.89) -->
           <group delimiter=", ">
             <text macro="source-serial-title-bib"/>
             <text macro="source-serial-identifier-bib"/>
@@ -3206,7 +3191,8 @@
     <group delimiter=", ">
       <text macro="source-serial-title-volume-note"/>
       <choose>
-        <if type="article-newspaper">
+        <if match="any" type="article-magazine article-newspaper">
+          <!-- magazines and newspapers provide the full date in place of volume/issue numbers (CMOS18 14.87, 14.89) -->
           <group delimiter=", ">
             <text macro="source-serial-title-note"/>
             <text macro="source-serial-identifier-note"/>
@@ -3378,15 +3364,15 @@
   <macro name="source-serial-identifier-volume-bib">
     <group delimiter=", ">
       <choose>
-        <if type="article-newspaper">
-          <!-- newspapers provide the full date in place of volume/issue numbers (CMOS18 14.89) -->
+        <if match="any" type="article-magazine article-newspaper">
+          <!-- magazines and newspapers provide the full date in place of volume/issue numbers (CMOS18 14.87, 14.89) -->
           <text variable="collection-title"/>
           <text macro="source-serial-volume-status-bib"/>
         </if>
         <else-if match="any" variable="issue supplement-number volume">
           <choose>
-            <if match="any" type="article-magazine review review-book" variable="reviewed-author reviewed-genre reviewed-title">
-              <!-- date appears first if the magazine or review `container-title` has been substituted for a missing author (CMOS18 14.87, 14.102) -->
+            <if match="any" type="review review-book" variable="reviewed-author reviewed-genre reviewed-title">
+              <!-- date appears first if the review `container-title` has been substituted for a missing author (CMOS18 14.87, 14.102) -->
               <choose>
                 <if match="none" variable="author chair collection-editor compiler composer curator director editor editor-translator editorial-director executive-producer guest host illustrator organizer producer series-creator translator">
                   <text macro="source-date-bib"/>
@@ -3404,8 +3390,8 @@
                 <if variable="collection-title volume">
                   <text macro="label-volume"/>
                 </if>
-                <else-if match="any" type="article-magazine review review-book" variable="reviewed-author reviewed-genre reviewed-title">
-                  <!-- date appears first if a magazine or review `container-title` has been substituted for a missing author (CMOS18 14.87, 14.102) -->
+                <else-if match="any" type="review review-book" variable="reviewed-author reviewed-genre reviewed-title">
+                  <!-- date appears first if a review `container-title` has been substituted for a missing author (CMOS18 14.87, 14.102) -->
                   <choose>
                     <if match="any" variable="author chair collection-editor compiler composer curator director editor editor-translator editorial-director executive-producer guest host illustrator organizer producer series-creator translator">
                       <text variable="volume"/>
@@ -3423,8 +3409,8 @@
               <text macro="label-supplement-number"/>
             </group>
             <choose>
-              <if match="any" type="article-magazine review review-book" variable="reviewed-author reviewed-genre reviewed-title">
-                <!-- date for anonymous magazine and review articles only appears here if it did not earlier (CMOS18 14.87, 14.102) -->
+              <if match="any" type="review review-book" variable="reviewed-author reviewed-genre reviewed-title">
+                <!-- date for unsigned reviews only appears here if it did not earlier (CMOS18 14.102) -->
                 <choose>
                   <if match="any" variable="author chair collection-editor compiler composer curator director editor editor-translator editorial-director executive-producer guest host illustrator organizer producer series-creator translator">
                     <text macro="source-date-bib" prefix="(" suffix=")"/>
@@ -3449,16 +3435,16 @@
   <macro name="source-serial-identifier-volume-note">
     <group delimiter=", ">
       <choose>
-        <if type="article-newspaper">
-          <!-- newspapers provide the full date in place of volume/issue numbers (CMOS18 14.89) -->
+        <if match="any" type="article-magazine article-newspaper">
+          <!-- magazines and newspapers provide the full date in place of volume/issue numbers (CMOS18 14.87, 14.89) -->
           <text variable="collection-title"/>
           <text macro="source-serial-volume-status-note"/>
         </if>
         <else-if match="any" variable="issue supplement-number volume">
           <choose>
-            <if match="any" type="article-magazine review review-book" variable="reviewed-author reviewed-genre reviewed-title">
+            <if match="any" type="review review-book" variable="reviewed-author reviewed-genre reviewed-title">
               <choose>
-                <!-- date appears first if a magazine or review `container-title` has been substituted for a missing author (CMOS18 14.89) -->
+                <!-- date appears first if a review `container-title` has been substituted for a missing author (CMOS18 14.89) -->
                 <!-- the conditions below mirror substitution in `author-note` -->
                 <if match="any" variable="author chair collection-editor compiler composer curator director editor editor-translator editorial-director executive-producer guest host illustrator organizer producer series-creator translator"/>
                 <else-if match="any" variable="reviewed-genre reviewed-title title"/>
@@ -3481,8 +3467,8 @@
                 </if>
                 <else-if variable="volume">
                   <choose>
-                    <if match="any" type="article-magazine review review-book" variable="reviewed-author reviewed-genre reviewed-title">
-                      <!-- date appears first if a magazine or review `container-title` has been substituted for a missing author (CMOS18 14.89) -->
+                    <if match="any" type="review review-book" variable="reviewed-author reviewed-genre reviewed-title">
+                      <!-- date appears first if a review `container-title` has been substituted for a missing author (CMOS18 14.89) -->
                       <choose>
                         <if match="any" variable="author chair collection-editor compiler composer curator director editor editor-translator editorial-director executive-producer guest host illustrator organizer producer series-creator translator">
                           <text variable="volume"/>
@@ -3508,8 +3494,8 @@
               <text macro="label-supplement-number"/>
             </group>
             <choose>
-              <if match="any" type="article-magazine review review-book" variable="reviewed-author reviewed-genre reviewed-title">
-                <!-- date appears first if a magazine or review `container-title` has been substituted for a missing author (CMOS18 14.89) -->
+              <if match="any" type="review review-book" variable="reviewed-author reviewed-genre reviewed-title">
+                <!-- date appears first if a review `container-title` has been substituted for a missing author (CMOS18 14.89) -->
                 <choose>
                   <if match="any" variable="author chair collection-editor compiler composer curator director editor editor-translator editorial-director executive-producer guest host illustrator organizer producer series-creator translator">
                     <text macro="source-date-issued-or-status" prefix="(" suffix=")"/>
@@ -5038,7 +5024,8 @@
   </macro>
   <macro name="source-date-issued-full-serial">
     <choose>
-      <if type="article-newspaper">
+      <if match="any" type="article-magazine article-newspaper">
+        <!-- magazines and newspapers provide the full date in place of volume/issue numbers (CMOS18 14.87, 14.89) -->
         <text macro="date-issued-full"/>
       </if>
       <else-if variable="issue volume">

--- a/chicago-notes-bibliography-subsequent-ibid-classic.csl
+++ b/chicago-notes-bibliography-subsequent-ibid-classic.csl
@@ -868,14 +868,6 @@
         <!-- Publication name also substituted for unsigned reviews (CMOS18 14.102) -->
         <text macro="source-serial-name"/>
       </else-if>
-      <else-if match="any" type="interview paper-conference">
-        <choose>
-          <if match="none" variable="collection-editor compiler editor editorial-director">
-            <!-- serial usage -->
-            <text macro="source-serial-name"/>
-          </if>
-        </choose>
-      </else-if>
       <else-if match="any" type="entry entry-dictionary entry-encyclopedia">
         <!-- Anonymous entries in reference works (CMOS18 14.130) -->
         <text font-style="italic" text-case="title" variable="container-title"/>
@@ -900,14 +892,6 @@
       <else-if match="any" type="review review-book" variable="reviewed-author reviewed-genre reviewed-title">
         <!-- Publication name also substituted for unsigned reviews (CMOS18 14.102) -->
         <text font-style="italic" text-case="title" variable="container-title"/>
-      </else-if>
-      <else-if match="any" type="interview paper-conference">
-        <choose>
-          <if match="none" variable="collection-editor compiler editor editorial-director">
-            <!-- serial usage -->
-            <text font-style="italic" text-case="title" variable="container-title"/>
-          </if>
-        </choose>
       </else-if>
       <else-if match="any" type="entry entry-dictionary entry-encyclopedia">
         <!-- Anonymous entries in reference works (CMOS18 14.130) -->
@@ -3175,7 +3159,8 @@
     <group delimiter=". ">
       <text macro="source-serial-title-volume-bib"/>
       <choose>
-        <if type="article-newspaper">
+        <if match="any" type="article-magazine article-newspaper">
+          <!-- magazines and newspapers provide the full date in place of volume/issue numbers (CMOS18 14.87, 14.89) -->
           <group delimiter=", ">
             <text macro="source-serial-title-bib"/>
             <text macro="source-serial-identifier-bib"/>
@@ -3206,7 +3191,8 @@
     <group delimiter=", ">
       <text macro="source-serial-title-volume-note"/>
       <choose>
-        <if type="article-newspaper">
+        <if match="any" type="article-magazine article-newspaper">
+          <!-- magazines and newspapers provide the full date in place of volume/issue numbers (CMOS18 14.87, 14.89) -->
           <group delimiter=", ">
             <text macro="source-serial-title-note"/>
             <text macro="source-serial-identifier-note"/>
@@ -3378,15 +3364,15 @@
   <macro name="source-serial-identifier-volume-bib">
     <group delimiter=", ">
       <choose>
-        <if type="article-newspaper">
-          <!-- newspapers provide the full date in place of volume/issue numbers (CMOS18 14.89) -->
+        <if match="any" type="article-magazine article-newspaper">
+          <!-- magazines and newspapers provide the full date in place of volume/issue numbers (CMOS18 14.87, 14.89) -->
           <text variable="collection-title"/>
           <text macro="source-serial-volume-status-bib"/>
         </if>
         <else-if match="any" variable="issue supplement-number volume">
           <choose>
-            <if match="any" type="article-magazine review review-book" variable="reviewed-author reviewed-genre reviewed-title">
-              <!-- date appears first if the magazine or review `container-title` has been substituted for a missing author (CMOS18 14.87, 14.102) -->
+            <if match="any" type="review review-book" variable="reviewed-author reviewed-genre reviewed-title">
+              <!-- date appears first if the review `container-title` has been substituted for a missing author (CMOS18 14.87, 14.102) -->
               <choose>
                 <if match="none" variable="author chair collection-editor compiler composer curator director editor editor-translator editorial-director executive-producer guest host illustrator organizer producer series-creator translator">
                   <text macro="source-date-bib"/>
@@ -3404,8 +3390,8 @@
                 <if variable="collection-title volume">
                   <text macro="label-volume"/>
                 </if>
-                <else-if match="any" type="article-magazine review review-book" variable="reviewed-author reviewed-genre reviewed-title">
-                  <!-- date appears first if a magazine or review `container-title` has been substituted for a missing author (CMOS18 14.87, 14.102) -->
+                <else-if match="any" type="review review-book" variable="reviewed-author reviewed-genre reviewed-title">
+                  <!-- date appears first if a review `container-title` has been substituted for a missing author (CMOS18 14.87, 14.102) -->
                   <choose>
                     <if match="any" variable="author chair collection-editor compiler composer curator director editor editor-translator editorial-director executive-producer guest host illustrator organizer producer series-creator translator">
                       <text variable="volume"/>
@@ -3423,8 +3409,8 @@
               <text macro="label-supplement-number"/>
             </group>
             <choose>
-              <if match="any" type="article-magazine review review-book" variable="reviewed-author reviewed-genre reviewed-title">
-                <!-- date for anonymous magazine and review articles only appears here if it did not earlier (CMOS18 14.87, 14.102) -->
+              <if match="any" type="review review-book" variable="reviewed-author reviewed-genre reviewed-title">
+                <!-- date for unsigned reviews only appears here if it did not earlier (CMOS18 14.102) -->
                 <choose>
                   <if match="any" variable="author chair collection-editor compiler composer curator director editor editor-translator editorial-director executive-producer guest host illustrator organizer producer series-creator translator">
                     <text macro="source-date-bib" prefix="(" suffix=")"/>
@@ -3449,16 +3435,16 @@
   <macro name="source-serial-identifier-volume-note">
     <group delimiter=", ">
       <choose>
-        <if type="article-newspaper">
-          <!-- newspapers provide the full date in place of volume/issue numbers (CMOS18 14.89) -->
+        <if match="any" type="article-magazine article-newspaper">
+          <!-- magazines and newspapers provide the full date in place of volume/issue numbers (CMOS18 14.87, 14.89) -->
           <text variable="collection-title"/>
           <text macro="source-serial-volume-status-note"/>
         </if>
         <else-if match="any" variable="issue supplement-number volume">
           <choose>
-            <if match="any" type="article-magazine review review-book" variable="reviewed-author reviewed-genre reviewed-title">
+            <if match="any" type="review review-book" variable="reviewed-author reviewed-genre reviewed-title">
               <choose>
-                <!-- date appears first if a magazine or review `container-title` has been substituted for a missing author (CMOS18 14.89) -->
+                <!-- date appears first if a review `container-title` has been substituted for a missing author (CMOS18 14.89) -->
                 <!-- the conditions below mirror substitution in `author-note` -->
                 <if match="any" variable="author chair collection-editor compiler composer curator director editor editor-translator editorial-director executive-producer guest host illustrator organizer producer series-creator translator"/>
                 <else-if match="any" variable="reviewed-genre reviewed-title title"/>
@@ -3481,8 +3467,8 @@
                 </if>
                 <else-if variable="volume">
                   <choose>
-                    <if match="any" type="article-magazine review review-book" variable="reviewed-author reviewed-genre reviewed-title">
-                      <!-- date appears first if a magazine or review `container-title` has been substituted for a missing author (CMOS18 14.89) -->
+                    <if match="any" type="review review-book" variable="reviewed-author reviewed-genre reviewed-title">
+                      <!-- date appears first if a review `container-title` has been substituted for a missing author (CMOS18 14.89) -->
                       <choose>
                         <if match="any" variable="author chair collection-editor compiler composer curator director editor editor-translator editorial-director executive-producer guest host illustrator organizer producer series-creator translator">
                           <text variable="volume"/>
@@ -3508,8 +3494,8 @@
               <text macro="label-supplement-number"/>
             </group>
             <choose>
-              <if match="any" type="article-magazine review review-book" variable="reviewed-author reviewed-genre reviewed-title">
-                <!-- date appears first if a magazine or review `container-title` has been substituted for a missing author (CMOS18 14.89) -->
+              <if match="any" type="review review-book" variable="reviewed-author reviewed-genre reviewed-title">
+                <!-- date appears first if a review `container-title` has been substituted for a missing author (CMOS18 14.89) -->
                 <choose>
                   <if match="any" variable="author chair collection-editor compiler composer curator director editor editor-translator editorial-director executive-producer guest host illustrator organizer producer series-creator translator">
                     <text macro="source-date-issued-or-status" prefix="(" suffix=")"/>
@@ -5038,7 +5024,8 @@
   </macro>
   <macro name="source-date-issued-full-serial">
     <choose>
-      <if type="article-newspaper">
+      <if match="any" type="article-magazine article-newspaper">
+        <!-- magazines and newspapers provide the full date in place of volume/issue numbers (CMOS18 14.87, 14.89) -->
         <text macro="date-issued-full"/>
       </if>
       <else-if variable="issue volume">

--- a/chicago-notes-bibliography-subsequent-ibid.csl
+++ b/chicago-notes-bibliography-subsequent-ibid.csl
@@ -867,14 +867,6 @@
         <!-- Publication name also substituted for unsigned reviews (CMOS18 14.102) -->
         <text macro="source-serial-name"/>
       </else-if>
-      <else-if match="any" type="interview paper-conference">
-        <choose>
-          <if match="none" variable="collection-editor compiler editor editorial-director">
-            <!-- serial usage -->
-            <text macro="source-serial-name"/>
-          </if>
-        </choose>
-      </else-if>
       <else-if match="any" type="entry entry-dictionary entry-encyclopedia">
         <!-- Anonymous entries in reference works (CMOS18 14.130) -->
         <text font-style="italic" text-case="title" variable="container-title"/>
@@ -899,14 +891,6 @@
       <else-if match="any" type="review review-book" variable="reviewed-author reviewed-genre reviewed-title">
         <!-- Publication name also substituted for unsigned reviews (CMOS18 14.102) -->
         <text font-style="italic" text-case="title" variable="container-title"/>
-      </else-if>
-      <else-if match="any" type="interview paper-conference">
-        <choose>
-          <if match="none" variable="collection-editor compiler editor editorial-director">
-            <!-- serial usage -->
-            <text font-style="italic" text-case="title" variable="container-title"/>
-          </if>
-        </choose>
       </else-if>
       <else-if match="any" type="entry entry-dictionary entry-encyclopedia">
         <!-- Anonymous entries in reference works (CMOS18 14.130) -->
@@ -3178,7 +3162,8 @@
     <group delimiter=". ">
       <text macro="source-serial-title-volume-bib"/>
       <choose>
-        <if type="article-newspaper">
+        <if match="any" type="article-magazine article-newspaper">
+          <!-- magazines and newspapers provide the full date in place of volume/issue numbers (CMOS18 14.87, 14.89) -->
           <group delimiter=", ">
             <text macro="source-serial-title-bib"/>
             <text macro="source-serial-identifier-bib"/>
@@ -3209,7 +3194,8 @@
     <group delimiter=", ">
       <text macro="source-serial-title-volume-note"/>
       <choose>
-        <if type="article-newspaper">
+        <if match="any" type="article-magazine article-newspaper">
+          <!-- magazines and newspapers provide the full date in place of volume/issue numbers (CMOS18 14.87, 14.89) -->
           <group delimiter=", ">
             <text macro="source-serial-title-note"/>
             <text macro="source-serial-identifier-note"/>
@@ -3381,15 +3367,15 @@
   <macro name="source-serial-identifier-volume-bib">
     <group delimiter=", ">
       <choose>
-        <if type="article-newspaper">
-          <!-- newspapers provide the full date in place of volume/issue numbers (CMOS18 14.89) -->
+        <if match="any" type="article-magazine article-newspaper">
+          <!-- magazines and newspapers provide the full date in place of volume/issue numbers (CMOS18 14.87, 14.89) -->
           <text variable="collection-title"/>
           <text macro="source-serial-volume-status-bib"/>
         </if>
         <else-if match="any" variable="issue supplement-number volume">
           <choose>
-            <if match="any" type="article-magazine review review-book" variable="reviewed-author reviewed-genre reviewed-title">
-              <!-- date appears first if the magazine or review `container-title` has been substituted for a missing author (CMOS18 14.87, 14.102) -->
+            <if match="any" type="review review-book" variable="reviewed-author reviewed-genre reviewed-title">
+              <!-- date appears first if the review `container-title` has been substituted for a missing author (CMOS18 14.87, 14.102) -->
               <choose>
                 <if match="none" variable="author chair collection-editor compiler composer curator director editor editor-translator editorial-director executive-producer guest host illustrator organizer producer series-creator translator">
                   <text macro="source-date-bib"/>
@@ -3407,8 +3393,8 @@
                 <if variable="collection-title volume">
                   <text macro="label-volume"/>
                 </if>
-                <else-if match="any" type="article-magazine review review-book" variable="reviewed-author reviewed-genre reviewed-title">
-                  <!-- date appears first if a magazine or review `container-title` has been substituted for a missing author (CMOS18 14.87, 14.102) -->
+                <else-if match="any" type="review review-book" variable="reviewed-author reviewed-genre reviewed-title">
+                  <!-- date appears first if a review `container-title` has been substituted for a missing author (CMOS18 14.87, 14.102) -->
                   <choose>
                     <if match="any" variable="author chair collection-editor compiler composer curator director editor editor-translator editorial-director executive-producer guest host illustrator organizer producer series-creator translator">
                       <text variable="volume"/>
@@ -3426,8 +3412,8 @@
               <text macro="label-supplement-number"/>
             </group>
             <choose>
-              <if match="any" type="article-magazine review review-book" variable="reviewed-author reviewed-genre reviewed-title">
-                <!-- date for anonymous magazine and review articles only appears here if it did not earlier (CMOS18 14.87, 14.102) -->
+              <if match="any" type="review review-book" variable="reviewed-author reviewed-genre reviewed-title">
+                <!-- date for unsigned reviews only appears here if it did not earlier (CMOS18 14.102) -->
                 <choose>
                   <if match="any" variable="author chair collection-editor compiler composer curator director editor editor-translator editorial-director executive-producer guest host illustrator organizer producer series-creator translator">
                     <text macro="source-date-bib" prefix="(" suffix=")"/>
@@ -3452,16 +3438,16 @@
   <macro name="source-serial-identifier-volume-note">
     <group delimiter=", ">
       <choose>
-        <if type="article-newspaper">
-          <!-- newspapers provide the full date in place of volume/issue numbers (CMOS18 14.89) -->
+        <if match="any" type="article-magazine article-newspaper">
+          <!-- magazines and newspapers provide the full date in place of volume/issue numbers (CMOS18 14.87, 14.89) -->
           <text variable="collection-title"/>
           <text macro="source-serial-volume-status-note"/>
         </if>
         <else-if match="any" variable="issue supplement-number volume">
           <choose>
-            <if match="any" type="article-magazine review review-book" variable="reviewed-author reviewed-genre reviewed-title">
+            <if match="any" type="review review-book" variable="reviewed-author reviewed-genre reviewed-title">
               <choose>
-                <!-- date appears first if a magazine or review `container-title` has been substituted for a missing author (CMOS18 14.89) -->
+                <!-- date appears first if a review `container-title` has been substituted for a missing author (CMOS18 14.89) -->
                 <!-- the conditions below mirror substitution in `author-note` -->
                 <if match="any" variable="author chair collection-editor compiler composer curator director editor editor-translator editorial-director executive-producer guest host illustrator organizer producer series-creator translator"/>
                 <else-if match="any" variable="reviewed-genre reviewed-title title"/>
@@ -3484,8 +3470,8 @@
                 </if>
                 <else-if variable="volume">
                   <choose>
-                    <if match="any" type="article-magazine review review-book" variable="reviewed-author reviewed-genre reviewed-title">
-                      <!-- date appears first if a magazine or review `container-title` has been substituted for a missing author (CMOS18 14.89) -->
+                    <if match="any" type="review review-book" variable="reviewed-author reviewed-genre reviewed-title">
+                      <!-- date appears first if a review `container-title` has been substituted for a missing author (CMOS18 14.89) -->
                       <choose>
                         <if match="any" variable="author chair collection-editor compiler composer curator director editor editor-translator editorial-director executive-producer guest host illustrator organizer producer series-creator translator">
                           <text variable="volume"/>
@@ -3511,8 +3497,8 @@
               <text macro="label-supplement-number"/>
             </group>
             <choose>
-              <if match="any" type="article-magazine review review-book" variable="reviewed-author reviewed-genre reviewed-title">
-                <!-- date appears first if a magazine or review `container-title` has been substituted for a missing author (CMOS18 14.89) -->
+              <if match="any" type="review review-book" variable="reviewed-author reviewed-genre reviewed-title">
+                <!-- date appears first if a review `container-title` has been substituted for a missing author (CMOS18 14.89) -->
                 <choose>
                   <if match="any" variable="author chair collection-editor compiler composer curator director editor editor-translator editorial-director executive-producer guest host illustrator organizer producer series-creator translator">
                     <text macro="source-date-issued-or-status" prefix="(" suffix=")"/>
@@ -5047,7 +5033,8 @@
   </macro>
   <macro name="source-date-issued-full-serial">
     <choose>
-      <if type="article-newspaper">
+      <if match="any" type="article-magazine article-newspaper">
+        <!-- magazines and newspapers provide the full date in place of volume/issue numbers (CMOS18 14.87, 14.89) -->
         <text macro="date-issued-full"/>
       </if>
       <else-if variable="issue volume">

--- a/chicago-notes-bibliography-subsequent-title.csl
+++ b/chicago-notes-bibliography-subsequent-title.csl
@@ -867,14 +867,6 @@
         <!-- Publication name also substituted for unsigned reviews (CMOS18 14.102) -->
         <text macro="source-serial-name"/>
       </else-if>
-      <else-if match="any" type="interview paper-conference">
-        <choose>
-          <if match="none" variable="collection-editor compiler editor editorial-director">
-            <!-- serial usage -->
-            <text macro="source-serial-name"/>
-          </if>
-        </choose>
-      </else-if>
       <else-if match="any" type="entry entry-dictionary entry-encyclopedia">
         <!-- Anonymous entries in reference works (CMOS18 14.130) -->
         <text font-style="italic" text-case="title" variable="container-title"/>
@@ -899,14 +891,6 @@
       <else-if match="any" type="review review-book" variable="reviewed-author reviewed-genre reviewed-title">
         <!-- Publication name also substituted for unsigned reviews (CMOS18 14.102) -->
         <text font-style="italic" text-case="title" variable="container-title"/>
-      </else-if>
-      <else-if match="any" type="interview paper-conference">
-        <choose>
-          <if match="none" variable="collection-editor compiler editor editorial-director">
-            <!-- serial usage -->
-            <text font-style="italic" text-case="title" variable="container-title"/>
-          </if>
-        </choose>
       </else-if>
       <else-if match="any" type="entry entry-dictionary entry-encyclopedia">
         <!-- Anonymous entries in reference works (CMOS18 14.130) -->
@@ -3178,7 +3162,8 @@
     <group delimiter=". ">
       <text macro="source-serial-title-volume-bib"/>
       <choose>
-        <if type="article-newspaper">
+        <if match="any" type="article-magazine article-newspaper">
+          <!-- magazines and newspapers provide the full date in place of volume/issue numbers (CMOS18 14.87, 14.89) -->
           <group delimiter=", ">
             <text macro="source-serial-title-bib"/>
             <text macro="source-serial-identifier-bib"/>
@@ -3209,7 +3194,8 @@
     <group delimiter=", ">
       <text macro="source-serial-title-volume-note"/>
       <choose>
-        <if type="article-newspaper">
+        <if match="any" type="article-magazine article-newspaper">
+          <!-- magazines and newspapers provide the full date in place of volume/issue numbers (CMOS18 14.87, 14.89) -->
           <group delimiter=", ">
             <text macro="source-serial-title-note"/>
             <text macro="source-serial-identifier-note"/>
@@ -3381,15 +3367,15 @@
   <macro name="source-serial-identifier-volume-bib">
     <group delimiter=", ">
       <choose>
-        <if type="article-newspaper">
-          <!-- newspapers provide the full date in place of volume/issue numbers (CMOS18 14.89) -->
+        <if match="any" type="article-magazine article-newspaper">
+          <!-- magazines and newspapers provide the full date in place of volume/issue numbers (CMOS18 14.87, 14.89) -->
           <text variable="collection-title"/>
           <text macro="source-serial-volume-status-bib"/>
         </if>
         <else-if match="any" variable="issue supplement-number volume">
           <choose>
-            <if match="any" type="article-magazine review review-book" variable="reviewed-author reviewed-genre reviewed-title">
-              <!-- date appears first if the magazine or review `container-title` has been substituted for a missing author (CMOS18 14.87, 14.102) -->
+            <if match="any" type="review review-book" variable="reviewed-author reviewed-genre reviewed-title">
+              <!-- date appears first if the review `container-title` has been substituted for a missing author (CMOS18 14.87, 14.102) -->
               <choose>
                 <if match="none" variable="author chair collection-editor compiler composer curator director editor editor-translator editorial-director executive-producer guest host illustrator organizer producer series-creator translator">
                   <text macro="source-date-bib"/>
@@ -3407,8 +3393,8 @@
                 <if variable="collection-title volume">
                   <text macro="label-volume"/>
                 </if>
-                <else-if match="any" type="article-magazine review review-book" variable="reviewed-author reviewed-genre reviewed-title">
-                  <!-- date appears first if a magazine or review `container-title` has been substituted for a missing author (CMOS18 14.87, 14.102) -->
+                <else-if match="any" type="review review-book" variable="reviewed-author reviewed-genre reviewed-title">
+                  <!-- date appears first if a review `container-title` has been substituted for a missing author (CMOS18 14.87, 14.102) -->
                   <choose>
                     <if match="any" variable="author chair collection-editor compiler composer curator director editor editor-translator editorial-director executive-producer guest host illustrator organizer producer series-creator translator">
                       <text variable="volume"/>
@@ -3426,8 +3412,8 @@
               <text macro="label-supplement-number"/>
             </group>
             <choose>
-              <if match="any" type="article-magazine review review-book" variable="reviewed-author reviewed-genre reviewed-title">
-                <!-- date for anonymous magazine and review articles only appears here if it did not earlier (CMOS18 14.87, 14.102) -->
+              <if match="any" type="review review-book" variable="reviewed-author reviewed-genre reviewed-title">
+                <!-- date for unsigned reviews only appears here if it did not earlier (CMOS18 14.102) -->
                 <choose>
                   <if match="any" variable="author chair collection-editor compiler composer curator director editor editor-translator editorial-director executive-producer guest host illustrator organizer producer series-creator translator">
                     <text macro="source-date-bib" prefix="(" suffix=")"/>
@@ -3452,16 +3438,16 @@
   <macro name="source-serial-identifier-volume-note">
     <group delimiter=", ">
       <choose>
-        <if type="article-newspaper">
-          <!-- newspapers provide the full date in place of volume/issue numbers (CMOS18 14.89) -->
+        <if match="any" type="article-magazine article-newspaper">
+          <!-- magazines and newspapers provide the full date in place of volume/issue numbers (CMOS18 14.87, 14.89) -->
           <text variable="collection-title"/>
           <text macro="source-serial-volume-status-note"/>
         </if>
         <else-if match="any" variable="issue supplement-number volume">
           <choose>
-            <if match="any" type="article-magazine review review-book" variable="reviewed-author reviewed-genre reviewed-title">
+            <if match="any" type="review review-book" variable="reviewed-author reviewed-genre reviewed-title">
               <choose>
-                <!-- date appears first if a magazine or review `container-title` has been substituted for a missing author (CMOS18 14.89) -->
+                <!-- date appears first if a review `container-title` has been substituted for a missing author (CMOS18 14.89) -->
                 <!-- the conditions below mirror substitution in `author-note` -->
                 <if match="any" variable="author chair collection-editor compiler composer curator director editor editor-translator editorial-director executive-producer guest host illustrator organizer producer series-creator translator"/>
                 <else-if match="any" variable="reviewed-genre reviewed-title title"/>
@@ -3484,8 +3470,8 @@
                 </if>
                 <else-if variable="volume">
                   <choose>
-                    <if match="any" type="article-magazine review review-book" variable="reviewed-author reviewed-genre reviewed-title">
-                      <!-- date appears first if a magazine or review `container-title` has been substituted for a missing author (CMOS18 14.89) -->
+                    <if match="any" type="review review-book" variable="reviewed-author reviewed-genre reviewed-title">
+                      <!-- date appears first if a review `container-title` has been substituted for a missing author (CMOS18 14.89) -->
                       <choose>
                         <if match="any" variable="author chair collection-editor compiler composer curator director editor editor-translator editorial-director executive-producer guest host illustrator organizer producer series-creator translator">
                           <text variable="volume"/>
@@ -3511,8 +3497,8 @@
               <text macro="label-supplement-number"/>
             </group>
             <choose>
-              <if match="any" type="article-magazine review review-book" variable="reviewed-author reviewed-genre reviewed-title">
-                <!-- date appears first if a magazine or review `container-title` has been substituted for a missing author (CMOS18 14.89) -->
+              <if match="any" type="review review-book" variable="reviewed-author reviewed-genre reviewed-title">
+                <!-- date appears first if a review `container-title` has been substituted for a missing author (CMOS18 14.89) -->
                 <choose>
                   <if match="any" variable="author chair collection-editor compiler composer curator director editor editor-translator editorial-director executive-producer guest host illustrator organizer producer series-creator translator">
                     <text macro="source-date-issued-or-status" prefix="(" suffix=")"/>
@@ -5047,7 +5033,8 @@
   </macro>
   <macro name="source-date-issued-full-serial">
     <choose>
-      <if type="article-newspaper">
+      <if match="any" type="article-magazine article-newspaper">
+        <!-- magazines and newspapers provide the full date in place of volume/issue numbers (CMOS18 14.87, 14.89) -->
         <text macro="date-issued-full"/>
       </if>
       <else-if variable="issue volume">

--- a/chicago-notes-bibliography.csl
+++ b/chicago-notes-bibliography.csl
@@ -867,14 +867,6 @@
         <!-- Publication name also substituted for unsigned reviews (CMOS18 14.102) -->
         <text macro="source-serial-name"/>
       </else-if>
-      <else-if match="any" type="interview paper-conference">
-        <choose>
-          <if match="none" variable="collection-editor compiler editor editorial-director">
-            <!-- serial usage -->
-            <text macro="source-serial-name"/>
-          </if>
-        </choose>
-      </else-if>
       <else-if match="any" type="entry entry-dictionary entry-encyclopedia">
         <!-- Anonymous entries in reference works (CMOS18 14.130) -->
         <text font-style="italic" text-case="title" variable="container-title"/>
@@ -899,14 +891,6 @@
       <else-if match="any" type="review review-book" variable="reviewed-author reviewed-genre reviewed-title">
         <!-- Publication name also substituted for unsigned reviews (CMOS18 14.102) -->
         <text font-style="italic" text-case="title" variable="container-title"/>
-      </else-if>
-      <else-if match="any" type="interview paper-conference">
-        <choose>
-          <if match="none" variable="collection-editor compiler editor editorial-director">
-            <!-- serial usage -->
-            <text font-style="italic" text-case="title" variable="container-title"/>
-          </if>
-        </choose>
       </else-if>
       <else-if match="any" type="entry entry-dictionary entry-encyclopedia">
         <!-- Anonymous entries in reference works (CMOS18 14.130) -->
@@ -3178,7 +3162,8 @@
     <group delimiter=". ">
       <text macro="source-serial-title-volume-bib"/>
       <choose>
-        <if type="article-newspaper">
+        <if match="any" type="article-magazine article-newspaper">
+          <!-- magazines and newspapers provide the full date in place of volume/issue numbers (CMOS18 14.87, 14.89) -->
           <group delimiter=", ">
             <text macro="source-serial-title-bib"/>
             <text macro="source-serial-identifier-bib"/>
@@ -3209,7 +3194,8 @@
     <group delimiter=", ">
       <text macro="source-serial-title-volume-note"/>
       <choose>
-        <if type="article-newspaper">
+        <if match="any" type="article-magazine article-newspaper">
+          <!-- magazines and newspapers provide the full date in place of volume/issue numbers (CMOS18 14.87, 14.89) -->
           <group delimiter=", ">
             <text macro="source-serial-title-note"/>
             <text macro="source-serial-identifier-note"/>
@@ -3381,15 +3367,15 @@
   <macro name="source-serial-identifier-volume-bib">
     <group delimiter=", ">
       <choose>
-        <if type="article-newspaper">
-          <!-- newspapers provide the full date in place of volume/issue numbers (CMOS18 14.89) -->
+        <if match="any" type="article-magazine article-newspaper">
+          <!-- magazines and newspapers provide the full date in place of volume/issue numbers (CMOS18 14.87, 14.89) -->
           <text variable="collection-title"/>
           <text macro="source-serial-volume-status-bib"/>
         </if>
         <else-if match="any" variable="issue supplement-number volume">
           <choose>
-            <if match="any" type="article-magazine review review-book" variable="reviewed-author reviewed-genre reviewed-title">
-              <!-- date appears first if the magazine or review `container-title` has been substituted for a missing author (CMOS18 14.87, 14.102) -->
+            <if match="any" type="review review-book" variable="reviewed-author reviewed-genre reviewed-title">
+              <!-- date appears first if the review `container-title` has been substituted for a missing author (CMOS18 14.87, 14.102) -->
               <choose>
                 <if match="none" variable="author chair collection-editor compiler composer curator director editor editor-translator editorial-director executive-producer guest host illustrator organizer producer series-creator translator">
                   <text macro="source-date-bib"/>
@@ -3407,8 +3393,8 @@
                 <if variable="collection-title volume">
                   <text macro="label-volume"/>
                 </if>
-                <else-if match="any" type="article-magazine review review-book" variable="reviewed-author reviewed-genre reviewed-title">
-                  <!-- date appears first if a magazine or review `container-title` has been substituted for a missing author (CMOS18 14.87, 14.102) -->
+                <else-if match="any" type="review review-book" variable="reviewed-author reviewed-genre reviewed-title">
+                  <!-- date appears first if a review `container-title` has been substituted for a missing author (CMOS18 14.87, 14.102) -->
                   <choose>
                     <if match="any" variable="author chair collection-editor compiler composer curator director editor editor-translator editorial-director executive-producer guest host illustrator organizer producer series-creator translator">
                       <text variable="volume"/>
@@ -3426,8 +3412,8 @@
               <text macro="label-supplement-number"/>
             </group>
             <choose>
-              <if match="any" type="article-magazine review review-book" variable="reviewed-author reviewed-genre reviewed-title">
-                <!-- date for anonymous magazine and review articles only appears here if it did not earlier (CMOS18 14.87, 14.102) -->
+              <if match="any" type="review review-book" variable="reviewed-author reviewed-genre reviewed-title">
+                <!-- date for unsigned reviews only appears here if it did not earlier (CMOS18 14.102) -->
                 <choose>
                   <if match="any" variable="author chair collection-editor compiler composer curator director editor editor-translator editorial-director executive-producer guest host illustrator organizer producer series-creator translator">
                     <text macro="source-date-bib" prefix="(" suffix=")"/>
@@ -3452,16 +3438,16 @@
   <macro name="source-serial-identifier-volume-note">
     <group delimiter=", ">
       <choose>
-        <if type="article-newspaper">
-          <!-- newspapers provide the full date in place of volume/issue numbers (CMOS18 14.89) -->
+        <if match="any" type="article-magazine article-newspaper">
+          <!-- magazines and newspapers provide the full date in place of volume/issue numbers (CMOS18 14.87, 14.89) -->
           <text variable="collection-title"/>
           <text macro="source-serial-volume-status-note"/>
         </if>
         <else-if match="any" variable="issue supplement-number volume">
           <choose>
-            <if match="any" type="article-magazine review review-book" variable="reviewed-author reviewed-genre reviewed-title">
+            <if match="any" type="review review-book" variable="reviewed-author reviewed-genre reviewed-title">
               <choose>
-                <!-- date appears first if a magazine or review `container-title` has been substituted for a missing author (CMOS18 14.89) -->
+                <!-- date appears first if a review `container-title` has been substituted for a missing author (CMOS18 14.89) -->
                 <!-- the conditions below mirror substitution in `author-note` -->
                 <if match="any" variable="author chair collection-editor compiler composer curator director editor editor-translator editorial-director executive-producer guest host illustrator organizer producer series-creator translator"/>
                 <else-if match="any" variable="reviewed-genre reviewed-title title"/>
@@ -3484,8 +3470,8 @@
                 </if>
                 <else-if variable="volume">
                   <choose>
-                    <if match="any" type="article-magazine review review-book" variable="reviewed-author reviewed-genre reviewed-title">
-                      <!-- date appears first if a magazine or review `container-title` has been substituted for a missing author (CMOS18 14.89) -->
+                    <if match="any" type="review review-book" variable="reviewed-author reviewed-genre reviewed-title">
+                      <!-- date appears first if a review `container-title` has been substituted for a missing author (CMOS18 14.89) -->
                       <choose>
                         <if match="any" variable="author chair collection-editor compiler composer curator director editor editor-translator editorial-director executive-producer guest host illustrator organizer producer series-creator translator">
                           <text variable="volume"/>
@@ -3511,8 +3497,8 @@
               <text macro="label-supplement-number"/>
             </group>
             <choose>
-              <if match="any" type="article-magazine review review-book" variable="reviewed-author reviewed-genre reviewed-title">
-                <!-- date appears first if a magazine or review `container-title` has been substituted for a missing author (CMOS18 14.89) -->
+              <if match="any" type="review review-book" variable="reviewed-author reviewed-genre reviewed-title">
+                <!-- date appears first if a review `container-title` has been substituted for a missing author (CMOS18 14.89) -->
                 <choose>
                   <if match="any" variable="author chair collection-editor compiler composer curator director editor editor-translator editorial-director executive-producer guest host illustrator organizer producer series-creator translator">
                     <text macro="source-date-issued-or-status" prefix="(" suffix=")"/>
@@ -5047,7 +5033,8 @@
   </macro>
   <macro name="source-date-issued-full-serial">
     <choose>
-      <if type="article-newspaper">
+      <if match="any" type="article-magazine article-newspaper">
+        <!-- magazines and newspapers provide the full date in place of volume/issue numbers (CMOS18 14.87, 14.89) -->
         <text macro="date-issued-full"/>
       </if>
       <else-if variable="issue volume">

--- a/chicago-notes-classic-no-url.csl
+++ b/chicago-notes-classic-no-url.csl
@@ -736,14 +736,6 @@
         <!-- Publication name also substituted for unsigned reviews (CMOS18 14.102) -->
         <text macro="source-serial-name"/>
       </else-if>
-      <else-if match="any" type="interview paper-conference">
-        <choose>
-          <if match="none" variable="collection-editor compiler editor editorial-director">
-            <!-- serial usage -->
-            <text macro="source-serial-name"/>
-          </if>
-        </choose>
-      </else-if>
       <else-if match="any" type="entry entry-dictionary entry-encyclopedia">
         <!-- Anonymous entries in reference works (CMOS18 14.130) -->
         <text font-style="italic" text-case="title" variable="container-title"/>
@@ -768,14 +760,6 @@
       <else-if match="any" type="review review-book" variable="reviewed-author reviewed-genre reviewed-title">
         <!-- Publication name also substituted for unsigned reviews (CMOS18 14.102) -->
         <text font-style="italic" text-case="title" variable="container-title"/>
-      </else-if>
-      <else-if match="any" type="interview paper-conference">
-        <choose>
-          <if match="none" variable="collection-editor compiler editor editorial-director">
-            <!-- serial usage -->
-            <text font-style="italic" text-case="title" variable="container-title"/>
-          </if>
-        </choose>
       </else-if>
       <else-if match="any" type="entry entry-dictionary entry-encyclopedia">
         <!-- Anonymous entries in reference works (CMOS18 14.130) -->
@@ -2962,7 +2946,8 @@
     <group delimiter=", ">
       <text macro="source-serial-title-volume-note"/>
       <choose>
-        <if type="article-newspaper">
+        <if match="any" type="article-magazine article-newspaper">
+          <!-- magazines and newspapers provide the full date in place of volume/issue numbers (CMOS18 14.87, 14.89) -->
           <group delimiter=", ">
             <text macro="source-serial-title-note"/>
             <text macro="source-serial-identifier-note"/>
@@ -3069,16 +3054,16 @@
   <macro name="source-serial-identifier-volume-note">
     <group delimiter=", ">
       <choose>
-        <if type="article-newspaper">
-          <!-- newspapers provide the full date in place of volume/issue numbers (CMOS18 14.89) -->
+        <if match="any" type="article-magazine article-newspaper">
+          <!-- magazines and newspapers provide the full date in place of volume/issue numbers (CMOS18 14.87, 14.89) -->
           <text variable="collection-title"/>
           <text macro="source-serial-volume-status-note"/>
         </if>
         <else-if match="any" variable="issue supplement-number volume">
           <choose>
-            <if match="any" type="article-magazine review review-book" variable="reviewed-author reviewed-genre reviewed-title">
+            <if match="any" type="review review-book" variable="reviewed-author reviewed-genre reviewed-title">
               <choose>
-                <!-- date appears first if a magazine or review `container-title` has been substituted for a missing author (CMOS18 14.89) -->
+                <!-- date appears first if a review `container-title` has been substituted for a missing author (CMOS18 14.89) -->
                 <!-- the conditions below mirror substitution in `author-note` -->
                 <if match="any" variable="author chair collection-editor compiler composer curator director editor editor-translator editorial-director executive-producer guest host illustrator organizer producer series-creator translator"/>
                 <else-if match="any" variable="reviewed-genre reviewed-title title"/>
@@ -3101,8 +3086,8 @@
                 </if>
                 <else-if variable="volume">
                   <choose>
-                    <if match="any" type="article-magazine review review-book" variable="reviewed-author reviewed-genre reviewed-title">
-                      <!-- date appears first if a magazine or review `container-title` has been substituted for a missing author (CMOS18 14.89) -->
+                    <if match="any" type="review review-book" variable="reviewed-author reviewed-genre reviewed-title">
+                      <!-- date appears first if a review `container-title` has been substituted for a missing author (CMOS18 14.89) -->
                       <choose>
                         <if match="any" variable="author chair collection-editor compiler composer curator director editor editor-translator editorial-director executive-producer guest host illustrator organizer producer series-creator translator">
                           <text variable="volume"/>
@@ -3128,8 +3113,8 @@
               <text macro="label-supplement-number"/>
             </group>
             <choose>
-              <if match="any" type="article-magazine review review-book" variable="reviewed-author reviewed-genre reviewed-title">
-                <!-- date appears first if a magazine or review `container-title` has been substituted for a missing author (CMOS18 14.89) -->
+              <if match="any" type="review review-book" variable="reviewed-author reviewed-genre reviewed-title">
+                <!-- date appears first if a review `container-title` has been substituted for a missing author (CMOS18 14.89) -->
                 <choose>
                   <if match="any" variable="author chair collection-editor compiler composer curator director editor editor-translator editorial-director executive-producer guest host illustrator organizer producer series-creator translator">
                     <text macro="source-date-issued-or-status" prefix="(" suffix=")"/>
@@ -4122,7 +4107,8 @@
   </macro>
   <macro name="source-date-issued-full-serial">
     <choose>
-      <if type="article-newspaper">
+      <if match="any" type="article-magazine article-newspaper">
+        <!-- magazines and newspapers provide the full date in place of volume/issue numbers (CMOS18 14.87, 14.89) -->
         <text macro="date-issued-full"/>
       </if>
       <else-if variable="issue volume">

--- a/chicago-notes-classic.csl
+++ b/chicago-notes-classic.csl
@@ -736,14 +736,6 @@
         <!-- Publication name also substituted for unsigned reviews (CMOS18 14.102) -->
         <text macro="source-serial-name"/>
       </else-if>
-      <else-if match="any" type="interview paper-conference">
-        <choose>
-          <if match="none" variable="collection-editor compiler editor editorial-director">
-            <!-- serial usage -->
-            <text macro="source-serial-name"/>
-          </if>
-        </choose>
-      </else-if>
       <else-if match="any" type="entry entry-dictionary entry-encyclopedia">
         <!-- Anonymous entries in reference works (CMOS18 14.130) -->
         <text font-style="italic" text-case="title" variable="container-title"/>
@@ -768,14 +760,6 @@
       <else-if match="any" type="review review-book" variable="reviewed-author reviewed-genre reviewed-title">
         <!-- Publication name also substituted for unsigned reviews (CMOS18 14.102) -->
         <text font-style="italic" text-case="title" variable="container-title"/>
-      </else-if>
-      <else-if match="any" type="interview paper-conference">
-        <choose>
-          <if match="none" variable="collection-editor compiler editor editorial-director">
-            <!-- serial usage -->
-            <text font-style="italic" text-case="title" variable="container-title"/>
-          </if>
-        </choose>
       </else-if>
       <else-if match="any" type="entry entry-dictionary entry-encyclopedia">
         <!-- Anonymous entries in reference works (CMOS18 14.130) -->
@@ -2962,7 +2946,8 @@
     <group delimiter=", ">
       <text macro="source-serial-title-volume-note"/>
       <choose>
-        <if type="article-newspaper">
+        <if match="any" type="article-magazine article-newspaper">
+          <!-- magazines and newspapers provide the full date in place of volume/issue numbers (CMOS18 14.87, 14.89) -->
           <group delimiter=", ">
             <text macro="source-serial-title-note"/>
             <text macro="source-serial-identifier-note"/>
@@ -3069,16 +3054,16 @@
   <macro name="source-serial-identifier-volume-note">
     <group delimiter=", ">
       <choose>
-        <if type="article-newspaper">
-          <!-- newspapers provide the full date in place of volume/issue numbers (CMOS18 14.89) -->
+        <if match="any" type="article-magazine article-newspaper">
+          <!-- magazines and newspapers provide the full date in place of volume/issue numbers (CMOS18 14.87, 14.89) -->
           <text variable="collection-title"/>
           <text macro="source-serial-volume-status-note"/>
         </if>
         <else-if match="any" variable="issue supplement-number volume">
           <choose>
-            <if match="any" type="article-magazine review review-book" variable="reviewed-author reviewed-genre reviewed-title">
+            <if match="any" type="review review-book" variable="reviewed-author reviewed-genre reviewed-title">
               <choose>
-                <!-- date appears first if a magazine or review `container-title` has been substituted for a missing author (CMOS18 14.89) -->
+                <!-- date appears first if a review `container-title` has been substituted for a missing author (CMOS18 14.89) -->
                 <!-- the conditions below mirror substitution in `author-note` -->
                 <if match="any" variable="author chair collection-editor compiler composer curator director editor editor-translator editorial-director executive-producer guest host illustrator organizer producer series-creator translator"/>
                 <else-if match="any" variable="reviewed-genre reviewed-title title"/>
@@ -3101,8 +3086,8 @@
                 </if>
                 <else-if variable="volume">
                   <choose>
-                    <if match="any" type="article-magazine review review-book" variable="reviewed-author reviewed-genre reviewed-title">
-                      <!-- date appears first if a magazine or review `container-title` has been substituted for a missing author (CMOS18 14.89) -->
+                    <if match="any" type="review review-book" variable="reviewed-author reviewed-genre reviewed-title">
+                      <!-- date appears first if a review `container-title` has been substituted for a missing author (CMOS18 14.89) -->
                       <choose>
                         <if match="any" variable="author chair collection-editor compiler composer curator director editor editor-translator editorial-director executive-producer guest host illustrator organizer producer series-creator translator">
                           <text variable="volume"/>
@@ -3128,8 +3113,8 @@
               <text macro="label-supplement-number"/>
             </group>
             <choose>
-              <if match="any" type="article-magazine review review-book" variable="reviewed-author reviewed-genre reviewed-title">
-                <!-- date appears first if a magazine or review `container-title` has been substituted for a missing author (CMOS18 14.89) -->
+              <if match="any" type="review review-book" variable="reviewed-author reviewed-genre reviewed-title">
+                <!-- date appears first if a review `container-title` has been substituted for a missing author (CMOS18 14.89) -->
                 <choose>
                   <if match="any" variable="author chair collection-editor compiler composer curator director editor editor-translator editorial-director executive-producer guest host illustrator organizer producer series-creator translator">
                     <text macro="source-date-issued-or-status" prefix="(" suffix=")"/>
@@ -4122,7 +4107,8 @@
   </macro>
   <macro name="source-date-issued-full-serial">
     <choose>
-      <if type="article-newspaper">
+      <if match="any" type="article-magazine article-newspaper">
+        <!-- magazines and newspapers provide the full date in place of volume/issue numbers (CMOS18 14.87, 14.89) -->
         <text macro="date-issued-full"/>
       </if>
       <else-if variable="issue volume">

--- a/chicago-notes-no-url.csl
+++ b/chicago-notes-no-url.csl
@@ -736,14 +736,6 @@
         <!-- Publication name also substituted for unsigned reviews (CMOS18 14.102) -->
         <text macro="source-serial-name"/>
       </else-if>
-      <else-if match="any" type="interview paper-conference">
-        <choose>
-          <if match="none" variable="collection-editor compiler editor editorial-director">
-            <!-- serial usage -->
-            <text macro="source-serial-name"/>
-          </if>
-        </choose>
-      </else-if>
       <else-if match="any" type="entry entry-dictionary entry-encyclopedia">
         <!-- Anonymous entries in reference works (CMOS18 14.130) -->
         <text font-style="italic" text-case="title" variable="container-title"/>
@@ -768,14 +760,6 @@
       <else-if match="any" type="review review-book" variable="reviewed-author reviewed-genre reviewed-title">
         <!-- Publication name also substituted for unsigned reviews (CMOS18 14.102) -->
         <text font-style="italic" text-case="title" variable="container-title"/>
-      </else-if>
-      <else-if match="any" type="interview paper-conference">
-        <choose>
-          <if match="none" variable="collection-editor compiler editor editorial-director">
-            <!-- serial usage -->
-            <text font-style="italic" text-case="title" variable="container-title"/>
-          </if>
-        </choose>
       </else-if>
       <else-if match="any" type="entry entry-dictionary entry-encyclopedia">
         <!-- Anonymous entries in reference works (CMOS18 14.130) -->
@@ -2966,7 +2950,8 @@
     <group delimiter=", ">
       <text macro="source-serial-title-volume-note"/>
       <choose>
-        <if type="article-newspaper">
+        <if match="any" type="article-magazine article-newspaper">
+          <!-- magazines and newspapers provide the full date in place of volume/issue numbers (CMOS18 14.87, 14.89) -->
           <group delimiter=", ">
             <text macro="source-serial-title-note"/>
             <text macro="source-serial-identifier-note"/>
@@ -3073,16 +3058,16 @@
   <macro name="source-serial-identifier-volume-note">
     <group delimiter=", ">
       <choose>
-        <if type="article-newspaper">
-          <!-- newspapers provide the full date in place of volume/issue numbers (CMOS18 14.89) -->
+        <if match="any" type="article-magazine article-newspaper">
+          <!-- magazines and newspapers provide the full date in place of volume/issue numbers (CMOS18 14.87, 14.89) -->
           <text variable="collection-title"/>
           <text macro="source-serial-volume-status-note"/>
         </if>
         <else-if match="any" variable="issue supplement-number volume">
           <choose>
-            <if match="any" type="article-magazine review review-book" variable="reviewed-author reviewed-genre reviewed-title">
+            <if match="any" type="review review-book" variable="reviewed-author reviewed-genre reviewed-title">
               <choose>
-                <!-- date appears first if a magazine or review `container-title` has been substituted for a missing author (CMOS18 14.89) -->
+                <!-- date appears first if a review `container-title` has been substituted for a missing author (CMOS18 14.89) -->
                 <!-- the conditions below mirror substitution in `author-note` -->
                 <if match="any" variable="author chair collection-editor compiler composer curator director editor editor-translator editorial-director executive-producer guest host illustrator organizer producer series-creator translator"/>
                 <else-if match="any" variable="reviewed-genre reviewed-title title"/>
@@ -3105,8 +3090,8 @@
                 </if>
                 <else-if variable="volume">
                   <choose>
-                    <if match="any" type="article-magazine review review-book" variable="reviewed-author reviewed-genre reviewed-title">
-                      <!-- date appears first if a magazine or review `container-title` has been substituted for a missing author (CMOS18 14.89) -->
+                    <if match="any" type="review review-book" variable="reviewed-author reviewed-genre reviewed-title">
+                      <!-- date appears first if a review `container-title` has been substituted for a missing author (CMOS18 14.89) -->
                       <choose>
                         <if match="any" variable="author chair collection-editor compiler composer curator director editor editor-translator editorial-director executive-producer guest host illustrator organizer producer series-creator translator">
                           <text variable="volume"/>
@@ -3132,8 +3117,8 @@
               <text macro="label-supplement-number"/>
             </group>
             <choose>
-              <if match="any" type="article-magazine review review-book" variable="reviewed-author reviewed-genre reviewed-title">
-                <!-- date appears first if a magazine or review `container-title` has been substituted for a missing author (CMOS18 14.89) -->
+              <if match="any" type="review review-book" variable="reviewed-author reviewed-genre reviewed-title">
+                <!-- date appears first if a review `container-title` has been substituted for a missing author (CMOS18 14.89) -->
                 <choose>
                   <if match="any" variable="author chair collection-editor compiler composer curator director editor editor-translator editorial-director executive-producer guest host illustrator organizer producer series-creator translator">
                     <text macro="source-date-issued-or-status" prefix="(" suffix=")"/>
@@ -4128,7 +4113,8 @@
   </macro>
   <macro name="source-date-issued-full-serial">
     <choose>
-      <if type="article-newspaper">
+      <if match="any" type="article-magazine article-newspaper">
+        <!-- magazines and newspapers provide the full date in place of volume/issue numbers (CMOS18 14.87, 14.89) -->
         <text macro="date-issued-full"/>
       </if>
       <else-if variable="issue volume">

--- a/chicago-notes-publisher-place-archive-place-first-no-url.csl
+++ b/chicago-notes-publisher-place-archive-place-first-no-url.csl
@@ -736,14 +736,6 @@
         <!-- Publication name also substituted for unsigned reviews (CMOS18 14.102) -->
         <text macro="source-serial-name"/>
       </else-if>
-      <else-if match="any" type="interview paper-conference">
-        <choose>
-          <if match="none" variable="collection-editor compiler editor editorial-director">
-            <!-- serial usage -->
-            <text macro="source-serial-name"/>
-          </if>
-        </choose>
-      </else-if>
       <else-if match="any" type="entry entry-dictionary entry-encyclopedia">
         <!-- Anonymous entries in reference works (CMOS18 14.130) -->
         <text font-style="italic" text-case="title" variable="container-title"/>
@@ -768,14 +760,6 @@
       <else-if match="any" type="review review-book" variable="reviewed-author reviewed-genre reviewed-title">
         <!-- Publication name also substituted for unsigned reviews (CMOS18 14.102) -->
         <text font-style="italic" text-case="title" variable="container-title"/>
-      </else-if>
-      <else-if match="any" type="interview paper-conference">
-        <choose>
-          <if match="none" variable="collection-editor compiler editor editorial-director">
-            <!-- serial usage -->
-            <text font-style="italic" text-case="title" variable="container-title"/>
-          </if>
-        </choose>
       </else-if>
       <else-if match="any" type="entry entry-dictionary entry-encyclopedia">
         <!-- Anonymous entries in reference works (CMOS18 14.130) -->
@@ -2966,7 +2950,8 @@
     <group delimiter=", ">
       <text macro="source-serial-title-volume-note"/>
       <choose>
-        <if type="article-newspaper">
+        <if match="any" type="article-magazine article-newspaper">
+          <!-- magazines and newspapers provide the full date in place of volume/issue numbers (CMOS18 14.87, 14.89) -->
           <group delimiter=", ">
             <text macro="source-serial-title-note"/>
             <text macro="source-serial-identifier-note"/>
@@ -3073,16 +3058,16 @@
   <macro name="source-serial-identifier-volume-note">
     <group delimiter=", ">
       <choose>
-        <if type="article-newspaper">
-          <!-- newspapers provide the full date in place of volume/issue numbers (CMOS18 14.89) -->
+        <if match="any" type="article-magazine article-newspaper">
+          <!-- magazines and newspapers provide the full date in place of volume/issue numbers (CMOS18 14.87, 14.89) -->
           <text variable="collection-title"/>
           <text macro="source-serial-volume-status-note"/>
         </if>
         <else-if match="any" variable="issue supplement-number volume">
           <choose>
-            <if match="any" type="article-magazine review review-book" variable="reviewed-author reviewed-genre reviewed-title">
+            <if match="any" type="review review-book" variable="reviewed-author reviewed-genre reviewed-title">
               <choose>
-                <!-- date appears first if a magazine or review `container-title` has been substituted for a missing author (CMOS18 14.89) -->
+                <!-- date appears first if a review `container-title` has been substituted for a missing author (CMOS18 14.89) -->
                 <!-- the conditions below mirror substitution in `author-note` -->
                 <if match="any" variable="author chair collection-editor compiler composer curator director editor editor-translator editorial-director executive-producer guest host illustrator organizer producer series-creator translator"/>
                 <else-if match="any" variable="reviewed-genre reviewed-title title"/>
@@ -3105,8 +3090,8 @@
                 </if>
                 <else-if variable="volume">
                   <choose>
-                    <if match="any" type="article-magazine review review-book" variable="reviewed-author reviewed-genre reviewed-title">
-                      <!-- date appears first if a magazine or review `container-title` has been substituted for a missing author (CMOS18 14.89) -->
+                    <if match="any" type="review review-book" variable="reviewed-author reviewed-genre reviewed-title">
+                      <!-- date appears first if a review `container-title` has been substituted for a missing author (CMOS18 14.89) -->
                       <choose>
                         <if match="any" variable="author chair collection-editor compiler composer curator director editor editor-translator editorial-director executive-producer guest host illustrator organizer producer series-creator translator">
                           <text variable="volume"/>
@@ -3132,8 +3117,8 @@
               <text macro="label-supplement-number"/>
             </group>
             <choose>
-              <if match="any" type="article-magazine review review-book" variable="reviewed-author reviewed-genre reviewed-title">
-                <!-- date appears first if a magazine or review `container-title` has been substituted for a missing author (CMOS18 14.89) -->
+              <if match="any" type="review review-book" variable="reviewed-author reviewed-genre reviewed-title">
+                <!-- date appears first if a review `container-title` has been substituted for a missing author (CMOS18 14.89) -->
                 <choose>
                   <if match="any" variable="author chair collection-editor compiler composer curator director editor editor-translator editorial-director executive-producer guest host illustrator organizer producer series-creator translator">
                     <text macro="source-date-issued-or-status" prefix="(" suffix=")"/>
@@ -4128,7 +4113,8 @@
   </macro>
   <macro name="source-date-issued-full-serial">
     <choose>
-      <if type="article-newspaper">
+      <if match="any" type="article-magazine article-newspaper">
+        <!-- magazines and newspapers provide the full date in place of volume/issue numbers (CMOS18 14.87, 14.89) -->
         <text macro="date-issued-full"/>
       </if>
       <else-if variable="issue volume">

--- a/chicago-notes-publisher-place-archive-place-first.csl
+++ b/chicago-notes-publisher-place-archive-place-first.csl
@@ -736,14 +736,6 @@
         <!-- Publication name also substituted for unsigned reviews (CMOS18 14.102) -->
         <text macro="source-serial-name"/>
       </else-if>
-      <else-if match="any" type="interview paper-conference">
-        <choose>
-          <if match="none" variable="collection-editor compiler editor editorial-director">
-            <!-- serial usage -->
-            <text macro="source-serial-name"/>
-          </if>
-        </choose>
-      </else-if>
       <else-if match="any" type="entry entry-dictionary entry-encyclopedia">
         <!-- Anonymous entries in reference works (CMOS18 14.130) -->
         <text font-style="italic" text-case="title" variable="container-title"/>
@@ -768,14 +760,6 @@
       <else-if match="any" type="review review-book" variable="reviewed-author reviewed-genre reviewed-title">
         <!-- Publication name also substituted for unsigned reviews (CMOS18 14.102) -->
         <text font-style="italic" text-case="title" variable="container-title"/>
-      </else-if>
-      <else-if match="any" type="interview paper-conference">
-        <choose>
-          <if match="none" variable="collection-editor compiler editor editorial-director">
-            <!-- serial usage -->
-            <text font-style="italic" text-case="title" variable="container-title"/>
-          </if>
-        </choose>
       </else-if>
       <else-if match="any" type="entry entry-dictionary entry-encyclopedia">
         <!-- Anonymous entries in reference works (CMOS18 14.130) -->
@@ -2966,7 +2950,8 @@
     <group delimiter=", ">
       <text macro="source-serial-title-volume-note"/>
       <choose>
-        <if type="article-newspaper">
+        <if match="any" type="article-magazine article-newspaper">
+          <!-- magazines and newspapers provide the full date in place of volume/issue numbers (CMOS18 14.87, 14.89) -->
           <group delimiter=", ">
             <text macro="source-serial-title-note"/>
             <text macro="source-serial-identifier-note"/>
@@ -3073,16 +3058,16 @@
   <macro name="source-serial-identifier-volume-note">
     <group delimiter=", ">
       <choose>
-        <if type="article-newspaper">
-          <!-- newspapers provide the full date in place of volume/issue numbers (CMOS18 14.89) -->
+        <if match="any" type="article-magazine article-newspaper">
+          <!-- magazines and newspapers provide the full date in place of volume/issue numbers (CMOS18 14.87, 14.89) -->
           <text variable="collection-title"/>
           <text macro="source-serial-volume-status-note"/>
         </if>
         <else-if match="any" variable="issue supplement-number volume">
           <choose>
-            <if match="any" type="article-magazine review review-book" variable="reviewed-author reviewed-genre reviewed-title">
+            <if match="any" type="review review-book" variable="reviewed-author reviewed-genre reviewed-title">
               <choose>
-                <!-- date appears first if a magazine or review `container-title` has been substituted for a missing author (CMOS18 14.89) -->
+                <!-- date appears first if a review `container-title` has been substituted for a missing author (CMOS18 14.89) -->
                 <!-- the conditions below mirror substitution in `author-note` -->
                 <if match="any" variable="author chair collection-editor compiler composer curator director editor editor-translator editorial-director executive-producer guest host illustrator organizer producer series-creator translator"/>
                 <else-if match="any" variable="reviewed-genre reviewed-title title"/>
@@ -3105,8 +3090,8 @@
                 </if>
                 <else-if variable="volume">
                   <choose>
-                    <if match="any" type="article-magazine review review-book" variable="reviewed-author reviewed-genre reviewed-title">
-                      <!-- date appears first if a magazine or review `container-title` has been substituted for a missing author (CMOS18 14.89) -->
+                    <if match="any" type="review review-book" variable="reviewed-author reviewed-genre reviewed-title">
+                      <!-- date appears first if a review `container-title` has been substituted for a missing author (CMOS18 14.89) -->
                       <choose>
                         <if match="any" variable="author chair collection-editor compiler composer curator director editor editor-translator editorial-director executive-producer guest host illustrator organizer producer series-creator translator">
                           <text variable="volume"/>
@@ -3132,8 +3117,8 @@
               <text macro="label-supplement-number"/>
             </group>
             <choose>
-              <if match="any" type="article-magazine review review-book" variable="reviewed-author reviewed-genre reviewed-title">
-                <!-- date appears first if a magazine or review `container-title` has been substituted for a missing author (CMOS18 14.89) -->
+              <if match="any" type="review review-book" variable="reviewed-author reviewed-genre reviewed-title">
+                <!-- date appears first if a review `container-title` has been substituted for a missing author (CMOS18 14.89) -->
                 <choose>
                   <if match="any" variable="author chair collection-editor compiler composer curator director editor editor-translator editorial-director executive-producer guest host illustrator organizer producer series-creator translator">
                     <text macro="source-date-issued-or-status" prefix="(" suffix=")"/>
@@ -4128,7 +4113,8 @@
   </macro>
   <macro name="source-date-issued-full-serial">
     <choose>
-      <if type="article-newspaper">
+      <if match="any" type="article-magazine article-newspaper">
+        <!-- magazines and newspapers provide the full date in place of volume/issue numbers (CMOS18 14.87, 14.89) -->
         <text macro="date-issued-full"/>
       </if>
       <else-if variable="issue volume">

--- a/chicago-notes.csl
+++ b/chicago-notes.csl
@@ -736,14 +736,6 @@
         <!-- Publication name also substituted for unsigned reviews (CMOS18 14.102) -->
         <text macro="source-serial-name"/>
       </else-if>
-      <else-if match="any" type="interview paper-conference">
-        <choose>
-          <if match="none" variable="collection-editor compiler editor editorial-director">
-            <!-- serial usage -->
-            <text macro="source-serial-name"/>
-          </if>
-        </choose>
-      </else-if>
       <else-if match="any" type="entry entry-dictionary entry-encyclopedia">
         <!-- Anonymous entries in reference works (CMOS18 14.130) -->
         <text font-style="italic" text-case="title" variable="container-title"/>
@@ -768,14 +760,6 @@
       <else-if match="any" type="review review-book" variable="reviewed-author reviewed-genre reviewed-title">
         <!-- Publication name also substituted for unsigned reviews (CMOS18 14.102) -->
         <text font-style="italic" text-case="title" variable="container-title"/>
-      </else-if>
-      <else-if match="any" type="interview paper-conference">
-        <choose>
-          <if match="none" variable="collection-editor compiler editor editorial-director">
-            <!-- serial usage -->
-            <text font-style="italic" text-case="title" variable="container-title"/>
-          </if>
-        </choose>
       </else-if>
       <else-if match="any" type="entry entry-dictionary entry-encyclopedia">
         <!-- Anonymous entries in reference works (CMOS18 14.130) -->
@@ -2966,7 +2950,8 @@
     <group delimiter=", ">
       <text macro="source-serial-title-volume-note"/>
       <choose>
-        <if type="article-newspaper">
+        <if match="any" type="article-magazine article-newspaper">
+          <!-- magazines and newspapers provide the full date in place of volume/issue numbers (CMOS18 14.87, 14.89) -->
           <group delimiter=", ">
             <text macro="source-serial-title-note"/>
             <text macro="source-serial-identifier-note"/>
@@ -3073,16 +3058,16 @@
   <macro name="source-serial-identifier-volume-note">
     <group delimiter=", ">
       <choose>
-        <if type="article-newspaper">
-          <!-- newspapers provide the full date in place of volume/issue numbers (CMOS18 14.89) -->
+        <if match="any" type="article-magazine article-newspaper">
+          <!-- magazines and newspapers provide the full date in place of volume/issue numbers (CMOS18 14.87, 14.89) -->
           <text variable="collection-title"/>
           <text macro="source-serial-volume-status-note"/>
         </if>
         <else-if match="any" variable="issue supplement-number volume">
           <choose>
-            <if match="any" type="article-magazine review review-book" variable="reviewed-author reviewed-genre reviewed-title">
+            <if match="any" type="review review-book" variable="reviewed-author reviewed-genre reviewed-title">
               <choose>
-                <!-- date appears first if a magazine or review `container-title` has been substituted for a missing author (CMOS18 14.89) -->
+                <!-- date appears first if a review `container-title` has been substituted for a missing author (CMOS18 14.89) -->
                 <!-- the conditions below mirror substitution in `author-note` -->
                 <if match="any" variable="author chair collection-editor compiler composer curator director editor editor-translator editorial-director executive-producer guest host illustrator organizer producer series-creator translator"/>
                 <else-if match="any" variable="reviewed-genre reviewed-title title"/>
@@ -3105,8 +3090,8 @@
                 </if>
                 <else-if variable="volume">
                   <choose>
-                    <if match="any" type="article-magazine review review-book" variable="reviewed-author reviewed-genre reviewed-title">
-                      <!-- date appears first if a magazine or review `container-title` has been substituted for a missing author (CMOS18 14.89) -->
+                    <if match="any" type="review review-book" variable="reviewed-author reviewed-genre reviewed-title">
+                      <!-- date appears first if a review `container-title` has been substituted for a missing author (CMOS18 14.89) -->
                       <choose>
                         <if match="any" variable="author chair collection-editor compiler composer curator director editor editor-translator editorial-director executive-producer guest host illustrator organizer producer series-creator translator">
                           <text variable="volume"/>
@@ -3132,8 +3117,8 @@
               <text macro="label-supplement-number"/>
             </group>
             <choose>
-              <if match="any" type="article-magazine review review-book" variable="reviewed-author reviewed-genre reviewed-title">
-                <!-- date appears first if a magazine or review `container-title` has been substituted for a missing author (CMOS18 14.89) -->
+              <if match="any" type="review review-book" variable="reviewed-author reviewed-genre reviewed-title">
+                <!-- date appears first if a review `container-title` has been substituted for a missing author (CMOS18 14.89) -->
                 <choose>
                   <if match="any" variable="author chair collection-editor compiler composer curator director editor editor-translator editorial-director executive-producer guest host illustrator organizer producer series-creator translator">
                     <text macro="source-date-issued-or-status" prefix="(" suffix=")"/>
@@ -4128,7 +4113,8 @@
   </macro>
   <macro name="source-date-issued-full-serial">
     <choose>
-      <if type="article-newspaper">
+      <if match="any" type="article-magazine article-newspaper">
+        <!-- magazines and newspapers provide the full date in place of volume/issue numbers (CMOS18 14.87, 14.89) -->
         <text macro="date-issued-full"/>
       </if>
       <else-if variable="issue volume">

--- a/chicago-shortened-notes-bibliography-17th-edition.csl
+++ b/chicago-shortened-notes-bibliography-17th-edition.csl
@@ -701,14 +701,6 @@
         <!-- Publication name also substituted for unsigned reviews (CMOS18 14.102) -->
         <text macro="source-serial-name"/>
       </else-if>
-      <else-if match="any" type="interview paper-conference">
-        <choose>
-          <if match="none" variable="collection-editor compiler editor editorial-director">
-            <!-- serial usage -->
-            <text macro="source-serial-name"/>
-          </if>
-        </choose>
-      </else-if>
       <else-if match="any" type="entry entry-dictionary entry-encyclopedia">
         <!-- Anonymous entries in reference works (CMOS18 14.130) -->
         <text font-style="italic" text-case="title" variable="container-title"/>
@@ -733,14 +725,6 @@
       <else-if match="any" type="review review-book" variable="reviewed-author reviewed-genre reviewed-title">
         <!-- Publication name also substituted for unsigned reviews (CMOS18 14.102) -->
         <text font-style="italic" text-case="title" variable="container-title"/>
-      </else-if>
-      <else-if match="any" type="interview paper-conference">
-        <choose>
-          <if match="none" variable="collection-editor compiler editor editorial-director">
-            <!-- serial usage -->
-            <text font-style="italic" text-case="title" variable="container-title"/>
-          </if>
-        </choose>
       </else-if>
       <else-if match="any" type="entry entry-dictionary entry-encyclopedia">
         <!-- Anonymous entries in reference works (CMOS18 14.130) -->
@@ -2155,7 +2139,8 @@
     <group delimiter=". ">
       <text macro="source-serial-title-volume-bib"/>
       <choose>
-        <if type="article-newspaper">
+        <if match="any" type="article-magazine article-newspaper">
+          <!-- magazines and newspapers provide the full date in place of volume/issue numbers (CMOS18 14.87, 14.89) -->
           <group delimiter=", ">
             <text macro="source-serial-title-bib"/>
             <text macro="source-serial-identifier-bib"/>
@@ -2263,15 +2248,15 @@
   <macro name="source-serial-identifier-volume-bib">
     <group delimiter=", ">
       <choose>
-        <if type="article-newspaper">
-          <!-- newspapers provide the full date in place of volume/issue numbers (CMOS18 14.89) -->
+        <if match="any" type="article-magazine article-newspaper">
+          <!-- magazines and newspapers provide the full date in place of volume/issue numbers (CMOS18 14.87, 14.89) -->
           <text variable="collection-title"/>
           <text macro="source-serial-volume-status-bib"/>
         </if>
         <else-if match="any" variable="issue supplement-number volume">
           <choose>
-            <if match="any" type="article-magazine review review-book" variable="reviewed-author reviewed-genre reviewed-title">
-              <!-- date appears first if the magazine or review `container-title` has been substituted for a missing author (CMOS18 14.87, 14.102) -->
+            <if match="any" type="review review-book" variable="reviewed-author reviewed-genre reviewed-title">
+              <!-- date appears first if the review `container-title` has been substituted for a missing author (CMOS18 14.87, 14.102) -->
               <choose>
                 <if match="none" variable="author chair collection-editor compiler composer curator director editor editor-translator editorial-director executive-producer guest host illustrator organizer producer series-creator translator">
                   <text macro="source-date-bib"/>
@@ -2289,8 +2274,8 @@
                 <if variable="collection-title volume">
                   <text macro="label-volume"/>
                 </if>
-                <else-if match="any" type="article-magazine review review-book" variable="reviewed-author reviewed-genre reviewed-title">
-                  <!-- date appears first if a magazine or review `container-title` has been substituted for a missing author (CMOS18 14.87, 14.102) -->
+                <else-if match="any" type="review review-book" variable="reviewed-author reviewed-genre reviewed-title">
+                  <!-- date appears first if a review `container-title` has been substituted for a missing author (CMOS18 14.87, 14.102) -->
                   <choose>
                     <if match="any" variable="author chair collection-editor compiler composer curator director editor editor-translator editorial-director executive-producer guest host illustrator organizer producer series-creator translator">
                       <text variable="volume"/>
@@ -2308,8 +2293,8 @@
               <text macro="label-supplement-number"/>
             </group>
             <choose>
-              <if match="any" type="article-magazine review review-book" variable="reviewed-author reviewed-genre reviewed-title">
-                <!-- date for anonymous magazine and review articles only appears here if it did not earlier (CMOS18 14.87, 14.102) -->
+              <if match="any" type="review review-book" variable="reviewed-author reviewed-genre reviewed-title">
+                <!-- date for unsigned reviews only appears here if it did not earlier (CMOS18 14.102) -->
                 <choose>
                   <if match="any" variable="author chair collection-editor compiler composer curator director editor editor-translator editorial-director executive-producer guest host illustrator organizer producer series-creator translator">
                     <text macro="source-date-bib" prefix="(" suffix=")"/>
@@ -3251,7 +3236,8 @@
   </macro>
   <macro name="source-date-issued-full-serial">
     <choose>
-      <if type="article-newspaper">
+      <if match="any" type="article-magazine article-newspaper">
+        <!-- magazines and newspapers provide the full date in place of volume/issue numbers (CMOS18 14.87, 14.89) -->
         <text macro="date-issued-full"/>
       </if>
       <else-if variable="issue volume">

--- a/chicago-shortened-notes-bibliography-archive-place-first-no-url.csl
+++ b/chicago-shortened-notes-bibliography-archive-place-first-no-url.csl
@@ -704,14 +704,6 @@
         <!-- Publication name also substituted for unsigned reviews (CMOS18 14.102) -->
         <text macro="source-serial-name"/>
       </else-if>
-      <else-if match="any" type="interview paper-conference">
-        <choose>
-          <if match="none" variable="collection-editor compiler editor editorial-director">
-            <!-- serial usage -->
-            <text macro="source-serial-name"/>
-          </if>
-        </choose>
-      </else-if>
       <else-if match="any" type="entry entry-dictionary entry-encyclopedia">
         <!-- Anonymous entries in reference works (CMOS18 14.130) -->
         <text font-style="italic" text-case="title" variable="container-title"/>
@@ -736,14 +728,6 @@
       <else-if match="any" type="review review-book" variable="reviewed-author reviewed-genre reviewed-title">
         <!-- Publication name also substituted for unsigned reviews (CMOS18 14.102) -->
         <text font-style="italic" text-case="title" variable="container-title"/>
-      </else-if>
-      <else-if match="any" type="interview paper-conference">
-        <choose>
-          <if match="none" variable="collection-editor compiler editor editorial-director">
-            <!-- serial usage -->
-            <text font-style="italic" text-case="title" variable="container-title"/>
-          </if>
-        </choose>
       </else-if>
       <else-if match="any" type="entry entry-dictionary entry-encyclopedia">
         <!-- Anonymous entries in reference works (CMOS18 14.130) -->
@@ -2158,7 +2142,8 @@
     <group delimiter=". ">
       <text macro="source-serial-title-volume-bib"/>
       <choose>
-        <if type="article-newspaper">
+        <if match="any" type="article-magazine article-newspaper">
+          <!-- magazines and newspapers provide the full date in place of volume/issue numbers (CMOS18 14.87, 14.89) -->
           <group delimiter=", ">
             <text macro="source-serial-title-bib"/>
             <text macro="source-serial-identifier-bib"/>
@@ -2266,15 +2251,15 @@
   <macro name="source-serial-identifier-volume-bib">
     <group delimiter=", ">
       <choose>
-        <if type="article-newspaper">
-          <!-- newspapers provide the full date in place of volume/issue numbers (CMOS18 14.89) -->
+        <if match="any" type="article-magazine article-newspaper">
+          <!-- magazines and newspapers provide the full date in place of volume/issue numbers (CMOS18 14.87, 14.89) -->
           <text variable="collection-title"/>
           <text macro="source-serial-volume-status-bib"/>
         </if>
         <else-if match="any" variable="issue supplement-number volume">
           <choose>
-            <if match="any" type="article-magazine review review-book" variable="reviewed-author reviewed-genre reviewed-title">
-              <!-- date appears first if the magazine or review `container-title` has been substituted for a missing author (CMOS18 14.87, 14.102) -->
+            <if match="any" type="review review-book" variable="reviewed-author reviewed-genre reviewed-title">
+              <!-- date appears first if the review `container-title` has been substituted for a missing author (CMOS18 14.87, 14.102) -->
               <choose>
                 <if match="none" variable="author chair collection-editor compiler composer curator director editor editor-translator editorial-director executive-producer guest host illustrator organizer producer series-creator translator">
                   <text macro="source-date-bib"/>
@@ -2292,8 +2277,8 @@
                 <if variable="collection-title volume">
                   <text macro="label-volume"/>
                 </if>
-                <else-if match="any" type="article-magazine review review-book" variable="reviewed-author reviewed-genre reviewed-title">
-                  <!-- date appears first if a magazine or review `container-title` has been substituted for a missing author (CMOS18 14.87, 14.102) -->
+                <else-if match="any" type="review review-book" variable="reviewed-author reviewed-genre reviewed-title">
+                  <!-- date appears first if a review `container-title` has been substituted for a missing author (CMOS18 14.87, 14.102) -->
                   <choose>
                     <if match="any" variable="author chair collection-editor compiler composer curator director editor editor-translator editorial-director executive-producer guest host illustrator organizer producer series-creator translator">
                       <text variable="volume"/>
@@ -2311,8 +2296,8 @@
               <text macro="label-supplement-number"/>
             </group>
             <choose>
-              <if match="any" type="article-magazine review review-book" variable="reviewed-author reviewed-genre reviewed-title">
-                <!-- date for anonymous magazine and review articles only appears here if it did not earlier (CMOS18 14.87, 14.102) -->
+              <if match="any" type="review review-book" variable="reviewed-author reviewed-genre reviewed-title">
+                <!-- date for unsigned reviews only appears here if it did not earlier (CMOS18 14.102) -->
                 <choose>
                   <if match="any" variable="author chair collection-editor compiler composer curator director editor editor-translator editorial-director executive-producer guest host illustrator organizer producer series-creator translator">
                     <text macro="source-date-bib" prefix="(" suffix=")"/>
@@ -3260,7 +3245,8 @@
   </macro>
   <macro name="source-date-issued-full-serial">
     <choose>
-      <if type="article-newspaper">
+      <if match="any" type="article-magazine article-newspaper">
+        <!-- magazines and newspapers provide the full date in place of volume/issue numbers (CMOS18 14.87, 14.89) -->
         <text macro="date-issued-full"/>
       </if>
       <else-if variable="issue volume">

--- a/chicago-shortened-notes-bibliography-archive-place-first.csl
+++ b/chicago-shortened-notes-bibliography-archive-place-first.csl
@@ -704,14 +704,6 @@
         <!-- Publication name also substituted for unsigned reviews (CMOS18 14.102) -->
         <text macro="source-serial-name"/>
       </else-if>
-      <else-if match="any" type="interview paper-conference">
-        <choose>
-          <if match="none" variable="collection-editor compiler editor editorial-director">
-            <!-- serial usage -->
-            <text macro="source-serial-name"/>
-          </if>
-        </choose>
-      </else-if>
       <else-if match="any" type="entry entry-dictionary entry-encyclopedia">
         <!-- Anonymous entries in reference works (CMOS18 14.130) -->
         <text font-style="italic" text-case="title" variable="container-title"/>
@@ -736,14 +728,6 @@
       <else-if match="any" type="review review-book" variable="reviewed-author reviewed-genre reviewed-title">
         <!-- Publication name also substituted for unsigned reviews (CMOS18 14.102) -->
         <text font-style="italic" text-case="title" variable="container-title"/>
-      </else-if>
-      <else-if match="any" type="interview paper-conference">
-        <choose>
-          <if match="none" variable="collection-editor compiler editor editorial-director">
-            <!-- serial usage -->
-            <text font-style="italic" text-case="title" variable="container-title"/>
-          </if>
-        </choose>
       </else-if>
       <else-if match="any" type="entry entry-dictionary entry-encyclopedia">
         <!-- Anonymous entries in reference works (CMOS18 14.130) -->
@@ -2158,7 +2142,8 @@
     <group delimiter=". ">
       <text macro="source-serial-title-volume-bib"/>
       <choose>
-        <if type="article-newspaper">
+        <if match="any" type="article-magazine article-newspaper">
+          <!-- magazines and newspapers provide the full date in place of volume/issue numbers (CMOS18 14.87, 14.89) -->
           <group delimiter=", ">
             <text macro="source-serial-title-bib"/>
             <text macro="source-serial-identifier-bib"/>
@@ -2266,15 +2251,15 @@
   <macro name="source-serial-identifier-volume-bib">
     <group delimiter=", ">
       <choose>
-        <if type="article-newspaper">
-          <!-- newspapers provide the full date in place of volume/issue numbers (CMOS18 14.89) -->
+        <if match="any" type="article-magazine article-newspaper">
+          <!-- magazines and newspapers provide the full date in place of volume/issue numbers (CMOS18 14.87, 14.89) -->
           <text variable="collection-title"/>
           <text macro="source-serial-volume-status-bib"/>
         </if>
         <else-if match="any" variable="issue supplement-number volume">
           <choose>
-            <if match="any" type="article-magazine review review-book" variable="reviewed-author reviewed-genre reviewed-title">
-              <!-- date appears first if the magazine or review `container-title` has been substituted for a missing author (CMOS18 14.87, 14.102) -->
+            <if match="any" type="review review-book" variable="reviewed-author reviewed-genre reviewed-title">
+              <!-- date appears first if the review `container-title` has been substituted for a missing author (CMOS18 14.87, 14.102) -->
               <choose>
                 <if match="none" variable="author chair collection-editor compiler composer curator director editor editor-translator editorial-director executive-producer guest host illustrator organizer producer series-creator translator">
                   <text macro="source-date-bib"/>
@@ -2292,8 +2277,8 @@
                 <if variable="collection-title volume">
                   <text macro="label-volume"/>
                 </if>
-                <else-if match="any" type="article-magazine review review-book" variable="reviewed-author reviewed-genre reviewed-title">
-                  <!-- date appears first if a magazine or review `container-title` has been substituted for a missing author (CMOS18 14.87, 14.102) -->
+                <else-if match="any" type="review review-book" variable="reviewed-author reviewed-genre reviewed-title">
+                  <!-- date appears first if a review `container-title` has been substituted for a missing author (CMOS18 14.87, 14.102) -->
                   <choose>
                     <if match="any" variable="author chair collection-editor compiler composer curator director editor editor-translator editorial-director executive-producer guest host illustrator organizer producer series-creator translator">
                       <text variable="volume"/>
@@ -2311,8 +2296,8 @@
               <text macro="label-supplement-number"/>
             </group>
             <choose>
-              <if match="any" type="article-magazine review review-book" variable="reviewed-author reviewed-genre reviewed-title">
-                <!-- date for anonymous magazine and review articles only appears here if it did not earlier (CMOS18 14.87, 14.102) -->
+              <if match="any" type="review review-book" variable="reviewed-author reviewed-genre reviewed-title">
+                <!-- date for unsigned reviews only appears here if it did not earlier (CMOS18 14.102) -->
                 <choose>
                   <if match="any" variable="author chair collection-editor compiler composer curator director editor editor-translator editorial-director executive-producer guest host illustrator organizer producer series-creator translator">
                     <text macro="source-date-bib" prefix="(" suffix=")"/>
@@ -3260,7 +3245,8 @@
   </macro>
   <macro name="source-date-issued-full-serial">
     <choose>
-      <if type="article-newspaper">
+      <if match="any" type="article-magazine article-newspaper">
+        <!-- magazines and newspapers provide the full date in place of volume/issue numbers (CMOS18 14.87, 14.89) -->
         <text macro="date-issued-full"/>
       </if>
       <else-if variable="issue volume">

--- a/chicago-shortened-notes-bibliography-classic-no-url.csl
+++ b/chicago-shortened-notes-bibliography-classic-no-url.csl
@@ -704,14 +704,6 @@
         <!-- Publication name also substituted for unsigned reviews (CMOS18 14.102) -->
         <text macro="source-serial-name"/>
       </else-if>
-      <else-if match="any" type="interview paper-conference">
-        <choose>
-          <if match="none" variable="collection-editor compiler editor editorial-director">
-            <!-- serial usage -->
-            <text macro="source-serial-name"/>
-          </if>
-        </choose>
-      </else-if>
       <else-if match="any" type="entry entry-dictionary entry-encyclopedia">
         <!-- Anonymous entries in reference works (CMOS18 14.130) -->
         <text font-style="italic" text-case="title" variable="container-title"/>
@@ -736,14 +728,6 @@
       <else-if match="any" type="review review-book" variable="reviewed-author reviewed-genre reviewed-title">
         <!-- Publication name also substituted for unsigned reviews (CMOS18 14.102) -->
         <text font-style="italic" text-case="title" variable="container-title"/>
-      </else-if>
-      <else-if match="any" type="interview paper-conference">
-        <choose>
-          <if match="none" variable="collection-editor compiler editor editorial-director">
-            <!-- serial usage -->
-            <text font-style="italic" text-case="title" variable="container-title"/>
-          </if>
-        </choose>
       </else-if>
       <else-if match="any" type="entry entry-dictionary entry-encyclopedia">
         <!-- Anonymous entries in reference works (CMOS18 14.130) -->
@@ -2158,7 +2142,8 @@
     <group delimiter=". ">
       <text macro="source-serial-title-volume-bib"/>
       <choose>
-        <if type="article-newspaper">
+        <if match="any" type="article-magazine article-newspaper">
+          <!-- magazines and newspapers provide the full date in place of volume/issue numbers (CMOS18 14.87, 14.89) -->
           <group delimiter=", ">
             <text macro="source-serial-title-bib"/>
             <text macro="source-serial-identifier-bib"/>
@@ -2266,15 +2251,15 @@
   <macro name="source-serial-identifier-volume-bib">
     <group delimiter=", ">
       <choose>
-        <if type="article-newspaper">
-          <!-- newspapers provide the full date in place of volume/issue numbers (CMOS18 14.89) -->
+        <if match="any" type="article-magazine article-newspaper">
+          <!-- magazines and newspapers provide the full date in place of volume/issue numbers (CMOS18 14.87, 14.89) -->
           <text variable="collection-title"/>
           <text macro="source-serial-volume-status-bib"/>
         </if>
         <else-if match="any" variable="issue supplement-number volume">
           <choose>
-            <if match="any" type="article-magazine review review-book" variable="reviewed-author reviewed-genre reviewed-title">
-              <!-- date appears first if the magazine or review `container-title` has been substituted for a missing author (CMOS18 14.87, 14.102) -->
+            <if match="any" type="review review-book" variable="reviewed-author reviewed-genre reviewed-title">
+              <!-- date appears first if the review `container-title` has been substituted for a missing author (CMOS18 14.87, 14.102) -->
               <choose>
                 <if match="none" variable="author chair collection-editor compiler composer curator director editor editor-translator editorial-director executive-producer guest host illustrator organizer producer series-creator translator">
                   <text macro="source-date-bib"/>
@@ -2292,8 +2277,8 @@
                 <if variable="collection-title volume">
                   <text macro="label-volume"/>
                 </if>
-                <else-if match="any" type="article-magazine review review-book" variable="reviewed-author reviewed-genre reviewed-title">
-                  <!-- date appears first if a magazine or review `container-title` has been substituted for a missing author (CMOS18 14.87, 14.102) -->
+                <else-if match="any" type="review review-book" variable="reviewed-author reviewed-genre reviewed-title">
+                  <!-- date appears first if a review `container-title` has been substituted for a missing author (CMOS18 14.87, 14.102) -->
                   <choose>
                     <if match="any" variable="author chair collection-editor compiler composer curator director editor editor-translator editorial-director executive-producer guest host illustrator organizer producer series-creator translator">
                       <text variable="volume"/>
@@ -2311,8 +2296,8 @@
               <text macro="label-supplement-number"/>
             </group>
             <choose>
-              <if match="any" type="article-magazine review review-book" variable="reviewed-author reviewed-genre reviewed-title">
-                <!-- date for anonymous magazine and review articles only appears here if it did not earlier (CMOS18 14.87, 14.102) -->
+              <if match="any" type="review review-book" variable="reviewed-author reviewed-genre reviewed-title">
+                <!-- date for unsigned reviews only appears here if it did not earlier (CMOS18 14.102) -->
                 <choose>
                   <if match="any" variable="author chair collection-editor compiler composer curator director editor editor-translator editorial-director executive-producer guest host illustrator organizer producer series-creator translator">
                     <text macro="source-date-bib" prefix="(" suffix=")"/>
@@ -3254,7 +3239,8 @@
   </macro>
   <macro name="source-date-issued-full-serial">
     <choose>
-      <if type="article-newspaper">
+      <if match="any" type="article-magazine article-newspaper">
+        <!-- magazines and newspapers provide the full date in place of volume/issue numbers (CMOS18 14.87, 14.89) -->
         <text macro="date-issued-full"/>
       </if>
       <else-if variable="issue volume">

--- a/chicago-shortened-notes-bibliography-classic.csl
+++ b/chicago-shortened-notes-bibliography-classic.csl
@@ -704,14 +704,6 @@
         <!-- Publication name also substituted for unsigned reviews (CMOS18 14.102) -->
         <text macro="source-serial-name"/>
       </else-if>
-      <else-if match="any" type="interview paper-conference">
-        <choose>
-          <if match="none" variable="collection-editor compiler editor editorial-director">
-            <!-- serial usage -->
-            <text macro="source-serial-name"/>
-          </if>
-        </choose>
-      </else-if>
       <else-if match="any" type="entry entry-dictionary entry-encyclopedia">
         <!-- Anonymous entries in reference works (CMOS18 14.130) -->
         <text font-style="italic" text-case="title" variable="container-title"/>
@@ -736,14 +728,6 @@
       <else-if match="any" type="review review-book" variable="reviewed-author reviewed-genre reviewed-title">
         <!-- Publication name also substituted for unsigned reviews (CMOS18 14.102) -->
         <text font-style="italic" text-case="title" variable="container-title"/>
-      </else-if>
-      <else-if match="any" type="interview paper-conference">
-        <choose>
-          <if match="none" variable="collection-editor compiler editor editorial-director">
-            <!-- serial usage -->
-            <text font-style="italic" text-case="title" variable="container-title"/>
-          </if>
-        </choose>
       </else-if>
       <else-if match="any" type="entry entry-dictionary entry-encyclopedia">
         <!-- Anonymous entries in reference works (CMOS18 14.130) -->
@@ -2158,7 +2142,8 @@
     <group delimiter=". ">
       <text macro="source-serial-title-volume-bib"/>
       <choose>
-        <if type="article-newspaper">
+        <if match="any" type="article-magazine article-newspaper">
+          <!-- magazines and newspapers provide the full date in place of volume/issue numbers (CMOS18 14.87, 14.89) -->
           <group delimiter=", ">
             <text macro="source-serial-title-bib"/>
             <text macro="source-serial-identifier-bib"/>
@@ -2266,15 +2251,15 @@
   <macro name="source-serial-identifier-volume-bib">
     <group delimiter=", ">
       <choose>
-        <if type="article-newspaper">
-          <!-- newspapers provide the full date in place of volume/issue numbers (CMOS18 14.89) -->
+        <if match="any" type="article-magazine article-newspaper">
+          <!-- magazines and newspapers provide the full date in place of volume/issue numbers (CMOS18 14.87, 14.89) -->
           <text variable="collection-title"/>
           <text macro="source-serial-volume-status-bib"/>
         </if>
         <else-if match="any" variable="issue supplement-number volume">
           <choose>
-            <if match="any" type="article-magazine review review-book" variable="reviewed-author reviewed-genre reviewed-title">
-              <!-- date appears first if the magazine or review `container-title` has been substituted for a missing author (CMOS18 14.87, 14.102) -->
+            <if match="any" type="review review-book" variable="reviewed-author reviewed-genre reviewed-title">
+              <!-- date appears first if the review `container-title` has been substituted for a missing author (CMOS18 14.87, 14.102) -->
               <choose>
                 <if match="none" variable="author chair collection-editor compiler composer curator director editor editor-translator editorial-director executive-producer guest host illustrator organizer producer series-creator translator">
                   <text macro="source-date-bib"/>
@@ -2292,8 +2277,8 @@
                 <if variable="collection-title volume">
                   <text macro="label-volume"/>
                 </if>
-                <else-if match="any" type="article-magazine review review-book" variable="reviewed-author reviewed-genre reviewed-title">
-                  <!-- date appears first if a magazine or review `container-title` has been substituted for a missing author (CMOS18 14.87, 14.102) -->
+                <else-if match="any" type="review review-book" variable="reviewed-author reviewed-genre reviewed-title">
+                  <!-- date appears first if a review `container-title` has been substituted for a missing author (CMOS18 14.87, 14.102) -->
                   <choose>
                     <if match="any" variable="author chair collection-editor compiler composer curator director editor editor-translator editorial-director executive-producer guest host illustrator organizer producer series-creator translator">
                       <text variable="volume"/>
@@ -2311,8 +2296,8 @@
               <text macro="label-supplement-number"/>
             </group>
             <choose>
-              <if match="any" type="article-magazine review review-book" variable="reviewed-author reviewed-genre reviewed-title">
-                <!-- date for anonymous magazine and review articles only appears here if it did not earlier (CMOS18 14.87, 14.102) -->
+              <if match="any" type="review review-book" variable="reviewed-author reviewed-genre reviewed-title">
+                <!-- date for unsigned reviews only appears here if it did not earlier (CMOS18 14.102) -->
                 <choose>
                   <if match="any" variable="author chair collection-editor compiler composer curator director editor editor-translator editorial-director executive-producer guest host illustrator organizer producer series-creator translator">
                     <text macro="source-date-bib" prefix="(" suffix=")"/>
@@ -3254,7 +3239,8 @@
   </macro>
   <macro name="source-date-issued-full-serial">
     <choose>
-      <if type="article-newspaper">
+      <if match="any" type="article-magazine article-newspaper">
+        <!-- magazines and newspapers provide the full date in place of volume/issue numbers (CMOS18 14.87, 14.89) -->
         <text macro="date-issued-full"/>
       </if>
       <else-if variable="issue volume">

--- a/chicago-shortened-notes-bibliography-no-url.csl
+++ b/chicago-shortened-notes-bibliography-no-url.csl
@@ -704,14 +704,6 @@
         <!-- Publication name also substituted for unsigned reviews (CMOS18 14.102) -->
         <text macro="source-serial-name"/>
       </else-if>
-      <else-if match="any" type="interview paper-conference">
-        <choose>
-          <if match="none" variable="collection-editor compiler editor editorial-director">
-            <!-- serial usage -->
-            <text macro="source-serial-name"/>
-          </if>
-        </choose>
-      </else-if>
       <else-if match="any" type="entry entry-dictionary entry-encyclopedia">
         <!-- Anonymous entries in reference works (CMOS18 14.130) -->
         <text font-style="italic" text-case="title" variable="container-title"/>
@@ -736,14 +728,6 @@
       <else-if match="any" type="review review-book" variable="reviewed-author reviewed-genre reviewed-title">
         <!-- Publication name also substituted for unsigned reviews (CMOS18 14.102) -->
         <text font-style="italic" text-case="title" variable="container-title"/>
-      </else-if>
-      <else-if match="any" type="interview paper-conference">
-        <choose>
-          <if match="none" variable="collection-editor compiler editor editorial-director">
-            <!-- serial usage -->
-            <text font-style="italic" text-case="title" variable="container-title"/>
-          </if>
-        </choose>
       </else-if>
       <else-if match="any" type="entry entry-dictionary entry-encyclopedia">
         <!-- Anonymous entries in reference works (CMOS18 14.130) -->
@@ -2158,7 +2142,8 @@
     <group delimiter=". ">
       <text macro="source-serial-title-volume-bib"/>
       <choose>
-        <if type="article-newspaper">
+        <if match="any" type="article-magazine article-newspaper">
+          <!-- magazines and newspapers provide the full date in place of volume/issue numbers (CMOS18 14.87, 14.89) -->
           <group delimiter=", ">
             <text macro="source-serial-title-bib"/>
             <text macro="source-serial-identifier-bib"/>
@@ -2266,15 +2251,15 @@
   <macro name="source-serial-identifier-volume-bib">
     <group delimiter=", ">
       <choose>
-        <if type="article-newspaper">
-          <!-- newspapers provide the full date in place of volume/issue numbers (CMOS18 14.89) -->
+        <if match="any" type="article-magazine article-newspaper">
+          <!-- magazines and newspapers provide the full date in place of volume/issue numbers (CMOS18 14.87, 14.89) -->
           <text variable="collection-title"/>
           <text macro="source-serial-volume-status-bib"/>
         </if>
         <else-if match="any" variable="issue supplement-number volume">
           <choose>
-            <if match="any" type="article-magazine review review-book" variable="reviewed-author reviewed-genre reviewed-title">
-              <!-- date appears first if the magazine or review `container-title` has been substituted for a missing author (CMOS18 14.87, 14.102) -->
+            <if match="any" type="review review-book" variable="reviewed-author reviewed-genre reviewed-title">
+              <!-- date appears first if the review `container-title` has been substituted for a missing author (CMOS18 14.87, 14.102) -->
               <choose>
                 <if match="none" variable="author chair collection-editor compiler composer curator director editor editor-translator editorial-director executive-producer guest host illustrator organizer producer series-creator translator">
                   <text macro="source-date-bib"/>
@@ -2292,8 +2277,8 @@
                 <if variable="collection-title volume">
                   <text macro="label-volume"/>
                 </if>
-                <else-if match="any" type="article-magazine review review-book" variable="reviewed-author reviewed-genre reviewed-title">
-                  <!-- date appears first if a magazine or review `container-title` has been substituted for a missing author (CMOS18 14.87, 14.102) -->
+                <else-if match="any" type="review review-book" variable="reviewed-author reviewed-genre reviewed-title">
+                  <!-- date appears first if a review `container-title` has been substituted for a missing author (CMOS18 14.87, 14.102) -->
                   <choose>
                     <if match="any" variable="author chair collection-editor compiler composer curator director editor editor-translator editorial-director executive-producer guest host illustrator organizer producer series-creator translator">
                       <text variable="volume"/>
@@ -2311,8 +2296,8 @@
               <text macro="label-supplement-number"/>
             </group>
             <choose>
-              <if match="any" type="article-magazine review review-book" variable="reviewed-author reviewed-genre reviewed-title">
-                <!-- date for anonymous magazine and review articles only appears here if it did not earlier (CMOS18 14.87, 14.102) -->
+              <if match="any" type="review review-book" variable="reviewed-author reviewed-genre reviewed-title">
+                <!-- date for unsigned reviews only appears here if it did not earlier (CMOS18 14.102) -->
                 <choose>
                   <if match="any" variable="author chair collection-editor compiler composer curator director editor editor-translator editorial-director executive-producer guest host illustrator organizer producer series-creator translator">
                     <text macro="source-date-bib" prefix="(" suffix=")"/>
@@ -3260,7 +3245,8 @@
   </macro>
   <macro name="source-date-issued-full-serial">
     <choose>
-      <if type="article-newspaper">
+      <if match="any" type="article-magazine article-newspaper">
+        <!-- magazines and newspapers provide the full date in place of volume/issue numbers (CMOS18 14.87, 14.89) -->
         <text macro="date-issued-full"/>
       </if>
       <else-if variable="issue volume">

--- a/chicago-shortened-notes-bibliography-subsequent-author-classic-no-url.csl
+++ b/chicago-shortened-notes-bibliography-subsequent-author-classic-no-url.csl
@@ -704,14 +704,6 @@
         <!-- Publication name also substituted for unsigned reviews (CMOS18 14.102) -->
         <text macro="source-serial-name"/>
       </else-if>
-      <else-if match="any" type="interview paper-conference">
-        <choose>
-          <if match="none" variable="collection-editor compiler editor editorial-director">
-            <!-- serial usage -->
-            <text macro="source-serial-name"/>
-          </if>
-        </choose>
-      </else-if>
       <else-if match="any" type="entry entry-dictionary entry-encyclopedia">
         <!-- Anonymous entries in reference works (CMOS18 14.130) -->
         <text font-style="italic" text-case="title" variable="container-title"/>
@@ -736,14 +728,6 @@
       <else-if match="any" type="review review-book" variable="reviewed-author reviewed-genre reviewed-title">
         <!-- Publication name also substituted for unsigned reviews (CMOS18 14.102) -->
         <text font-style="italic" text-case="title" variable="container-title"/>
-      </else-if>
-      <else-if match="any" type="interview paper-conference">
-        <choose>
-          <if match="none" variable="collection-editor compiler editor editorial-director">
-            <!-- serial usage -->
-            <text font-style="italic" text-case="title" variable="container-title"/>
-          </if>
-        </choose>
       </else-if>
       <else-if match="any" type="entry entry-dictionary entry-encyclopedia">
         <!-- Anonymous entries in reference works (CMOS18 14.130) -->
@@ -2158,7 +2142,8 @@
     <group delimiter=". ">
       <text macro="source-serial-title-volume-bib"/>
       <choose>
-        <if type="article-newspaper">
+        <if match="any" type="article-magazine article-newspaper">
+          <!-- magazines and newspapers provide the full date in place of volume/issue numbers (CMOS18 14.87, 14.89) -->
           <group delimiter=", ">
             <text macro="source-serial-title-bib"/>
             <text macro="source-serial-identifier-bib"/>
@@ -2266,15 +2251,15 @@
   <macro name="source-serial-identifier-volume-bib">
     <group delimiter=", ">
       <choose>
-        <if type="article-newspaper">
-          <!-- newspapers provide the full date in place of volume/issue numbers (CMOS18 14.89) -->
+        <if match="any" type="article-magazine article-newspaper">
+          <!-- magazines and newspapers provide the full date in place of volume/issue numbers (CMOS18 14.87, 14.89) -->
           <text variable="collection-title"/>
           <text macro="source-serial-volume-status-bib"/>
         </if>
         <else-if match="any" variable="issue supplement-number volume">
           <choose>
-            <if match="any" type="article-magazine review review-book" variable="reviewed-author reviewed-genre reviewed-title">
-              <!-- date appears first if the magazine or review `container-title` has been substituted for a missing author (CMOS18 14.87, 14.102) -->
+            <if match="any" type="review review-book" variable="reviewed-author reviewed-genre reviewed-title">
+              <!-- date appears first if the review `container-title` has been substituted for a missing author (CMOS18 14.87, 14.102) -->
               <choose>
                 <if match="none" variable="author chair collection-editor compiler composer curator director editor editor-translator editorial-director executive-producer guest host illustrator organizer producer series-creator translator">
                   <text macro="source-date-bib"/>
@@ -2292,8 +2277,8 @@
                 <if variable="collection-title volume">
                   <text macro="label-volume"/>
                 </if>
-                <else-if match="any" type="article-magazine review review-book" variable="reviewed-author reviewed-genre reviewed-title">
-                  <!-- date appears first if a magazine or review `container-title` has been substituted for a missing author (CMOS18 14.87, 14.102) -->
+                <else-if match="any" type="review review-book" variable="reviewed-author reviewed-genre reviewed-title">
+                  <!-- date appears first if a review `container-title` has been substituted for a missing author (CMOS18 14.87, 14.102) -->
                   <choose>
                     <if match="any" variable="author chair collection-editor compiler composer curator director editor editor-translator editorial-director executive-producer guest host illustrator organizer producer series-creator translator">
                       <text variable="volume"/>
@@ -2311,8 +2296,8 @@
               <text macro="label-supplement-number"/>
             </group>
             <choose>
-              <if match="any" type="article-magazine review review-book" variable="reviewed-author reviewed-genre reviewed-title">
-                <!-- date for anonymous magazine and review articles only appears here if it did not earlier (CMOS18 14.87, 14.102) -->
+              <if match="any" type="review review-book" variable="reviewed-author reviewed-genre reviewed-title">
+                <!-- date for unsigned reviews only appears here if it did not earlier (CMOS18 14.102) -->
                 <choose>
                   <if match="any" variable="author chair collection-editor compiler composer curator director editor editor-translator editorial-director executive-producer guest host illustrator organizer producer series-creator translator">
                     <text macro="source-date-bib" prefix="(" suffix=")"/>
@@ -3254,7 +3239,8 @@
   </macro>
   <macro name="source-date-issued-full-serial">
     <choose>
-      <if type="article-newspaper">
+      <if match="any" type="article-magazine article-newspaper">
+        <!-- magazines and newspapers provide the full date in place of volume/issue numbers (CMOS18 14.87, 14.89) -->
         <text macro="date-issued-full"/>
       </if>
       <else-if variable="issue volume">

--- a/chicago-shortened-notes-bibliography-subsequent-author-classic.csl
+++ b/chicago-shortened-notes-bibliography-subsequent-author-classic.csl
@@ -704,14 +704,6 @@
         <!-- Publication name also substituted for unsigned reviews (CMOS18 14.102) -->
         <text macro="source-serial-name"/>
       </else-if>
-      <else-if match="any" type="interview paper-conference">
-        <choose>
-          <if match="none" variable="collection-editor compiler editor editorial-director">
-            <!-- serial usage -->
-            <text macro="source-serial-name"/>
-          </if>
-        </choose>
-      </else-if>
       <else-if match="any" type="entry entry-dictionary entry-encyclopedia">
         <!-- Anonymous entries in reference works (CMOS18 14.130) -->
         <text font-style="italic" text-case="title" variable="container-title"/>
@@ -736,14 +728,6 @@
       <else-if match="any" type="review review-book" variable="reviewed-author reviewed-genre reviewed-title">
         <!-- Publication name also substituted for unsigned reviews (CMOS18 14.102) -->
         <text font-style="italic" text-case="title" variable="container-title"/>
-      </else-if>
-      <else-if match="any" type="interview paper-conference">
-        <choose>
-          <if match="none" variable="collection-editor compiler editor editorial-director">
-            <!-- serial usage -->
-            <text font-style="italic" text-case="title" variable="container-title"/>
-          </if>
-        </choose>
       </else-if>
       <else-if match="any" type="entry entry-dictionary entry-encyclopedia">
         <!-- Anonymous entries in reference works (CMOS18 14.130) -->
@@ -2158,7 +2142,8 @@
     <group delimiter=". ">
       <text macro="source-serial-title-volume-bib"/>
       <choose>
-        <if type="article-newspaper">
+        <if match="any" type="article-magazine article-newspaper">
+          <!-- magazines and newspapers provide the full date in place of volume/issue numbers (CMOS18 14.87, 14.89) -->
           <group delimiter=", ">
             <text macro="source-serial-title-bib"/>
             <text macro="source-serial-identifier-bib"/>
@@ -2266,15 +2251,15 @@
   <macro name="source-serial-identifier-volume-bib">
     <group delimiter=", ">
       <choose>
-        <if type="article-newspaper">
-          <!-- newspapers provide the full date in place of volume/issue numbers (CMOS18 14.89) -->
+        <if match="any" type="article-magazine article-newspaper">
+          <!-- magazines and newspapers provide the full date in place of volume/issue numbers (CMOS18 14.87, 14.89) -->
           <text variable="collection-title"/>
           <text macro="source-serial-volume-status-bib"/>
         </if>
         <else-if match="any" variable="issue supplement-number volume">
           <choose>
-            <if match="any" type="article-magazine review review-book" variable="reviewed-author reviewed-genre reviewed-title">
-              <!-- date appears first if the magazine or review `container-title` has been substituted for a missing author (CMOS18 14.87, 14.102) -->
+            <if match="any" type="review review-book" variable="reviewed-author reviewed-genre reviewed-title">
+              <!-- date appears first if the review `container-title` has been substituted for a missing author (CMOS18 14.87, 14.102) -->
               <choose>
                 <if match="none" variable="author chair collection-editor compiler composer curator director editor editor-translator editorial-director executive-producer guest host illustrator organizer producer series-creator translator">
                   <text macro="source-date-bib"/>
@@ -2292,8 +2277,8 @@
                 <if variable="collection-title volume">
                   <text macro="label-volume"/>
                 </if>
-                <else-if match="any" type="article-magazine review review-book" variable="reviewed-author reviewed-genre reviewed-title">
-                  <!-- date appears first if a magazine or review `container-title` has been substituted for a missing author (CMOS18 14.87, 14.102) -->
+                <else-if match="any" type="review review-book" variable="reviewed-author reviewed-genre reviewed-title">
+                  <!-- date appears first if a review `container-title` has been substituted for a missing author (CMOS18 14.87, 14.102) -->
                   <choose>
                     <if match="any" variable="author chair collection-editor compiler composer curator director editor editor-translator editorial-director executive-producer guest host illustrator organizer producer series-creator translator">
                       <text variable="volume"/>
@@ -2311,8 +2296,8 @@
               <text macro="label-supplement-number"/>
             </group>
             <choose>
-              <if match="any" type="article-magazine review review-book" variable="reviewed-author reviewed-genre reviewed-title">
-                <!-- date for anonymous magazine and review articles only appears here if it did not earlier (CMOS18 14.87, 14.102) -->
+              <if match="any" type="review review-book" variable="reviewed-author reviewed-genre reviewed-title">
+                <!-- date for unsigned reviews only appears here if it did not earlier (CMOS18 14.102) -->
                 <choose>
                   <if match="any" variable="author chair collection-editor compiler composer curator director editor editor-translator editorial-director executive-producer guest host illustrator organizer producer series-creator translator">
                     <text macro="source-date-bib" prefix="(" suffix=")"/>
@@ -3254,7 +3239,8 @@
   </macro>
   <macro name="source-date-issued-full-serial">
     <choose>
-      <if type="article-newspaper">
+      <if match="any" type="article-magazine article-newspaper">
+        <!-- magazines and newspapers provide the full date in place of volume/issue numbers (CMOS18 14.87, 14.89) -->
         <text macro="date-issued-full"/>
       </if>
       <else-if variable="issue volume">

--- a/chicago-shortened-notes-bibliography-subsequent-author.csl
+++ b/chicago-shortened-notes-bibliography-subsequent-author.csl
@@ -704,14 +704,6 @@
         <!-- Publication name also substituted for unsigned reviews (CMOS18 14.102) -->
         <text macro="source-serial-name"/>
       </else-if>
-      <else-if match="any" type="interview paper-conference">
-        <choose>
-          <if match="none" variable="collection-editor compiler editor editorial-director">
-            <!-- serial usage -->
-            <text macro="source-serial-name"/>
-          </if>
-        </choose>
-      </else-if>
       <else-if match="any" type="entry entry-dictionary entry-encyclopedia">
         <!-- Anonymous entries in reference works (CMOS18 14.130) -->
         <text font-style="italic" text-case="title" variable="container-title"/>
@@ -736,14 +728,6 @@
       <else-if match="any" type="review review-book" variable="reviewed-author reviewed-genre reviewed-title">
         <!-- Publication name also substituted for unsigned reviews (CMOS18 14.102) -->
         <text font-style="italic" text-case="title" variable="container-title"/>
-      </else-if>
-      <else-if match="any" type="interview paper-conference">
-        <choose>
-          <if match="none" variable="collection-editor compiler editor editorial-director">
-            <!-- serial usage -->
-            <text font-style="italic" text-case="title" variable="container-title"/>
-          </if>
-        </choose>
       </else-if>
       <else-if match="any" type="entry entry-dictionary entry-encyclopedia">
         <!-- Anonymous entries in reference works (CMOS18 14.130) -->
@@ -2158,7 +2142,8 @@
     <group delimiter=". ">
       <text macro="source-serial-title-volume-bib"/>
       <choose>
-        <if type="article-newspaper">
+        <if match="any" type="article-magazine article-newspaper">
+          <!-- magazines and newspapers provide the full date in place of volume/issue numbers (CMOS18 14.87, 14.89) -->
           <group delimiter=", ">
             <text macro="source-serial-title-bib"/>
             <text macro="source-serial-identifier-bib"/>
@@ -2266,15 +2251,15 @@
   <macro name="source-serial-identifier-volume-bib">
     <group delimiter=", ">
       <choose>
-        <if type="article-newspaper">
-          <!-- newspapers provide the full date in place of volume/issue numbers (CMOS18 14.89) -->
+        <if match="any" type="article-magazine article-newspaper">
+          <!-- magazines and newspapers provide the full date in place of volume/issue numbers (CMOS18 14.87, 14.89) -->
           <text variable="collection-title"/>
           <text macro="source-serial-volume-status-bib"/>
         </if>
         <else-if match="any" variable="issue supplement-number volume">
           <choose>
-            <if match="any" type="article-magazine review review-book" variable="reviewed-author reviewed-genre reviewed-title">
-              <!-- date appears first if the magazine or review `container-title` has been substituted for a missing author (CMOS18 14.87, 14.102) -->
+            <if match="any" type="review review-book" variable="reviewed-author reviewed-genre reviewed-title">
+              <!-- date appears first if the review `container-title` has been substituted for a missing author (CMOS18 14.87, 14.102) -->
               <choose>
                 <if match="none" variable="author chair collection-editor compiler composer curator director editor editor-translator editorial-director executive-producer guest host illustrator organizer producer series-creator translator">
                   <text macro="source-date-bib"/>
@@ -2292,8 +2277,8 @@
                 <if variable="collection-title volume">
                   <text macro="label-volume"/>
                 </if>
-                <else-if match="any" type="article-magazine review review-book" variable="reviewed-author reviewed-genre reviewed-title">
-                  <!-- date appears first if a magazine or review `container-title` has been substituted for a missing author (CMOS18 14.87, 14.102) -->
+                <else-if match="any" type="review review-book" variable="reviewed-author reviewed-genre reviewed-title">
+                  <!-- date appears first if a review `container-title` has been substituted for a missing author (CMOS18 14.87, 14.102) -->
                   <choose>
                     <if match="any" variable="author chair collection-editor compiler composer curator director editor editor-translator editorial-director executive-producer guest host illustrator organizer producer series-creator translator">
                       <text variable="volume"/>
@@ -2311,8 +2296,8 @@
               <text macro="label-supplement-number"/>
             </group>
             <choose>
-              <if match="any" type="article-magazine review review-book" variable="reviewed-author reviewed-genre reviewed-title">
-                <!-- date for anonymous magazine and review articles only appears here if it did not earlier (CMOS18 14.87, 14.102) -->
+              <if match="any" type="review review-book" variable="reviewed-author reviewed-genre reviewed-title">
+                <!-- date for unsigned reviews only appears here if it did not earlier (CMOS18 14.102) -->
                 <choose>
                   <if match="any" variable="author chair collection-editor compiler composer curator director editor editor-translator editorial-director executive-producer guest host illustrator organizer producer series-creator translator">
                     <text macro="source-date-bib" prefix="(" suffix=")"/>
@@ -3260,7 +3245,8 @@
   </macro>
   <macro name="source-date-issued-full-serial">
     <choose>
-      <if type="article-newspaper">
+      <if match="any" type="article-magazine article-newspaper">
+        <!-- magazines and newspapers provide the full date in place of volume/issue numbers (CMOS18 14.87, 14.89) -->
         <text macro="date-issued-full"/>
       </if>
       <else-if variable="issue volume">

--- a/chicago-shortened-notes-bibliography-subsequent-ibid-classic-no-url.csl
+++ b/chicago-shortened-notes-bibliography-subsequent-ibid-classic-no-url.csl
@@ -704,14 +704,6 @@
         <!-- Publication name also substituted for unsigned reviews (CMOS18 14.102) -->
         <text macro="source-serial-name"/>
       </else-if>
-      <else-if match="any" type="interview paper-conference">
-        <choose>
-          <if match="none" variable="collection-editor compiler editor editorial-director">
-            <!-- serial usage -->
-            <text macro="source-serial-name"/>
-          </if>
-        </choose>
-      </else-if>
       <else-if match="any" type="entry entry-dictionary entry-encyclopedia">
         <!-- Anonymous entries in reference works (CMOS18 14.130) -->
         <text font-style="italic" text-case="title" variable="container-title"/>
@@ -736,14 +728,6 @@
       <else-if match="any" type="review review-book" variable="reviewed-author reviewed-genre reviewed-title">
         <!-- Publication name also substituted for unsigned reviews (CMOS18 14.102) -->
         <text font-style="italic" text-case="title" variable="container-title"/>
-      </else-if>
-      <else-if match="any" type="interview paper-conference">
-        <choose>
-          <if match="none" variable="collection-editor compiler editor editorial-director">
-            <!-- serial usage -->
-            <text font-style="italic" text-case="title" variable="container-title"/>
-          </if>
-        </choose>
       </else-if>
       <else-if match="any" type="entry entry-dictionary entry-encyclopedia">
         <!-- Anonymous entries in reference works (CMOS18 14.130) -->
@@ -2158,7 +2142,8 @@
     <group delimiter=". ">
       <text macro="source-serial-title-volume-bib"/>
       <choose>
-        <if type="article-newspaper">
+        <if match="any" type="article-magazine article-newspaper">
+          <!-- magazines and newspapers provide the full date in place of volume/issue numbers (CMOS18 14.87, 14.89) -->
           <group delimiter=", ">
             <text macro="source-serial-title-bib"/>
             <text macro="source-serial-identifier-bib"/>
@@ -2266,15 +2251,15 @@
   <macro name="source-serial-identifier-volume-bib">
     <group delimiter=", ">
       <choose>
-        <if type="article-newspaper">
-          <!-- newspapers provide the full date in place of volume/issue numbers (CMOS18 14.89) -->
+        <if match="any" type="article-magazine article-newspaper">
+          <!-- magazines and newspapers provide the full date in place of volume/issue numbers (CMOS18 14.87, 14.89) -->
           <text variable="collection-title"/>
           <text macro="source-serial-volume-status-bib"/>
         </if>
         <else-if match="any" variable="issue supplement-number volume">
           <choose>
-            <if match="any" type="article-magazine review review-book" variable="reviewed-author reviewed-genre reviewed-title">
-              <!-- date appears first if the magazine or review `container-title` has been substituted for a missing author (CMOS18 14.87, 14.102) -->
+            <if match="any" type="review review-book" variable="reviewed-author reviewed-genre reviewed-title">
+              <!-- date appears first if the review `container-title` has been substituted for a missing author (CMOS18 14.87, 14.102) -->
               <choose>
                 <if match="none" variable="author chair collection-editor compiler composer curator director editor editor-translator editorial-director executive-producer guest host illustrator organizer producer series-creator translator">
                   <text macro="source-date-bib"/>
@@ -2292,8 +2277,8 @@
                 <if variable="collection-title volume">
                   <text macro="label-volume"/>
                 </if>
-                <else-if match="any" type="article-magazine review review-book" variable="reviewed-author reviewed-genre reviewed-title">
-                  <!-- date appears first if a magazine or review `container-title` has been substituted for a missing author (CMOS18 14.87, 14.102) -->
+                <else-if match="any" type="review review-book" variable="reviewed-author reviewed-genre reviewed-title">
+                  <!-- date appears first if a review `container-title` has been substituted for a missing author (CMOS18 14.87, 14.102) -->
                   <choose>
                     <if match="any" variable="author chair collection-editor compiler composer curator director editor editor-translator editorial-director executive-producer guest host illustrator organizer producer series-creator translator">
                       <text variable="volume"/>
@@ -2311,8 +2296,8 @@
               <text macro="label-supplement-number"/>
             </group>
             <choose>
-              <if match="any" type="article-magazine review review-book" variable="reviewed-author reviewed-genre reviewed-title">
-                <!-- date for anonymous magazine and review articles only appears here if it did not earlier (CMOS18 14.87, 14.102) -->
+              <if match="any" type="review review-book" variable="reviewed-author reviewed-genre reviewed-title">
+                <!-- date for unsigned reviews only appears here if it did not earlier (CMOS18 14.102) -->
                 <choose>
                   <if match="any" variable="author chair collection-editor compiler composer curator director editor editor-translator editorial-director executive-producer guest host illustrator organizer producer series-creator translator">
                     <text macro="source-date-bib" prefix="(" suffix=")"/>
@@ -3254,7 +3239,8 @@
   </macro>
   <macro name="source-date-issued-full-serial">
     <choose>
-      <if type="article-newspaper">
+      <if match="any" type="article-magazine article-newspaper">
+        <!-- magazines and newspapers provide the full date in place of volume/issue numbers (CMOS18 14.87, 14.89) -->
         <text macro="date-issued-full"/>
       </if>
       <else-if variable="issue volume">

--- a/chicago-shortened-notes-bibliography-subsequent-ibid-classic.csl
+++ b/chicago-shortened-notes-bibliography-subsequent-ibid-classic.csl
@@ -704,14 +704,6 @@
         <!-- Publication name also substituted for unsigned reviews (CMOS18 14.102) -->
         <text macro="source-serial-name"/>
       </else-if>
-      <else-if match="any" type="interview paper-conference">
-        <choose>
-          <if match="none" variable="collection-editor compiler editor editorial-director">
-            <!-- serial usage -->
-            <text macro="source-serial-name"/>
-          </if>
-        </choose>
-      </else-if>
       <else-if match="any" type="entry entry-dictionary entry-encyclopedia">
         <!-- Anonymous entries in reference works (CMOS18 14.130) -->
         <text font-style="italic" text-case="title" variable="container-title"/>
@@ -736,14 +728,6 @@
       <else-if match="any" type="review review-book" variable="reviewed-author reviewed-genre reviewed-title">
         <!-- Publication name also substituted for unsigned reviews (CMOS18 14.102) -->
         <text font-style="italic" text-case="title" variable="container-title"/>
-      </else-if>
-      <else-if match="any" type="interview paper-conference">
-        <choose>
-          <if match="none" variable="collection-editor compiler editor editorial-director">
-            <!-- serial usage -->
-            <text font-style="italic" text-case="title" variable="container-title"/>
-          </if>
-        </choose>
       </else-if>
       <else-if match="any" type="entry entry-dictionary entry-encyclopedia">
         <!-- Anonymous entries in reference works (CMOS18 14.130) -->
@@ -2158,7 +2142,8 @@
     <group delimiter=". ">
       <text macro="source-serial-title-volume-bib"/>
       <choose>
-        <if type="article-newspaper">
+        <if match="any" type="article-magazine article-newspaper">
+          <!-- magazines and newspapers provide the full date in place of volume/issue numbers (CMOS18 14.87, 14.89) -->
           <group delimiter=", ">
             <text macro="source-serial-title-bib"/>
             <text macro="source-serial-identifier-bib"/>
@@ -2266,15 +2251,15 @@
   <macro name="source-serial-identifier-volume-bib">
     <group delimiter=", ">
       <choose>
-        <if type="article-newspaper">
-          <!-- newspapers provide the full date in place of volume/issue numbers (CMOS18 14.89) -->
+        <if match="any" type="article-magazine article-newspaper">
+          <!-- magazines and newspapers provide the full date in place of volume/issue numbers (CMOS18 14.87, 14.89) -->
           <text variable="collection-title"/>
           <text macro="source-serial-volume-status-bib"/>
         </if>
         <else-if match="any" variable="issue supplement-number volume">
           <choose>
-            <if match="any" type="article-magazine review review-book" variable="reviewed-author reviewed-genre reviewed-title">
-              <!-- date appears first if the magazine or review `container-title` has been substituted for a missing author (CMOS18 14.87, 14.102) -->
+            <if match="any" type="review review-book" variable="reviewed-author reviewed-genre reviewed-title">
+              <!-- date appears first if the review `container-title` has been substituted for a missing author (CMOS18 14.87, 14.102) -->
               <choose>
                 <if match="none" variable="author chair collection-editor compiler composer curator director editor editor-translator editorial-director executive-producer guest host illustrator organizer producer series-creator translator">
                   <text macro="source-date-bib"/>
@@ -2292,8 +2277,8 @@
                 <if variable="collection-title volume">
                   <text macro="label-volume"/>
                 </if>
-                <else-if match="any" type="article-magazine review review-book" variable="reviewed-author reviewed-genre reviewed-title">
-                  <!-- date appears first if a magazine or review `container-title` has been substituted for a missing author (CMOS18 14.87, 14.102) -->
+                <else-if match="any" type="review review-book" variable="reviewed-author reviewed-genre reviewed-title">
+                  <!-- date appears first if a review `container-title` has been substituted for a missing author (CMOS18 14.87, 14.102) -->
                   <choose>
                     <if match="any" variable="author chair collection-editor compiler composer curator director editor editor-translator editorial-director executive-producer guest host illustrator organizer producer series-creator translator">
                       <text variable="volume"/>
@@ -2311,8 +2296,8 @@
               <text macro="label-supplement-number"/>
             </group>
             <choose>
-              <if match="any" type="article-magazine review review-book" variable="reviewed-author reviewed-genre reviewed-title">
-                <!-- date for anonymous magazine and review articles only appears here if it did not earlier (CMOS18 14.87, 14.102) -->
+              <if match="any" type="review review-book" variable="reviewed-author reviewed-genre reviewed-title">
+                <!-- date for unsigned reviews only appears here if it did not earlier (CMOS18 14.102) -->
                 <choose>
                   <if match="any" variable="author chair collection-editor compiler composer curator director editor editor-translator editorial-director executive-producer guest host illustrator organizer producer series-creator translator">
                     <text macro="source-date-bib" prefix="(" suffix=")"/>
@@ -3254,7 +3239,8 @@
   </macro>
   <macro name="source-date-issued-full-serial">
     <choose>
-      <if type="article-newspaper">
+      <if match="any" type="article-magazine article-newspaper">
+        <!-- magazines and newspapers provide the full date in place of volume/issue numbers (CMOS18 14.87, 14.89) -->
         <text macro="date-issued-full"/>
       </if>
       <else-if variable="issue volume">

--- a/chicago-shortened-notes-bibliography-subsequent-ibid.csl
+++ b/chicago-shortened-notes-bibliography-subsequent-ibid.csl
@@ -704,14 +704,6 @@
         <!-- Publication name also substituted for unsigned reviews (CMOS18 14.102) -->
         <text macro="source-serial-name"/>
       </else-if>
-      <else-if match="any" type="interview paper-conference">
-        <choose>
-          <if match="none" variable="collection-editor compiler editor editorial-director">
-            <!-- serial usage -->
-            <text macro="source-serial-name"/>
-          </if>
-        </choose>
-      </else-if>
       <else-if match="any" type="entry entry-dictionary entry-encyclopedia">
         <!-- Anonymous entries in reference works (CMOS18 14.130) -->
         <text font-style="italic" text-case="title" variable="container-title"/>
@@ -736,14 +728,6 @@
       <else-if match="any" type="review review-book" variable="reviewed-author reviewed-genre reviewed-title">
         <!-- Publication name also substituted for unsigned reviews (CMOS18 14.102) -->
         <text font-style="italic" text-case="title" variable="container-title"/>
-      </else-if>
-      <else-if match="any" type="interview paper-conference">
-        <choose>
-          <if match="none" variable="collection-editor compiler editor editorial-director">
-            <!-- serial usage -->
-            <text font-style="italic" text-case="title" variable="container-title"/>
-          </if>
-        </choose>
       </else-if>
       <else-if match="any" type="entry entry-dictionary entry-encyclopedia">
         <!-- Anonymous entries in reference works (CMOS18 14.130) -->
@@ -2158,7 +2142,8 @@
     <group delimiter=". ">
       <text macro="source-serial-title-volume-bib"/>
       <choose>
-        <if type="article-newspaper">
+        <if match="any" type="article-magazine article-newspaper">
+          <!-- magazines and newspapers provide the full date in place of volume/issue numbers (CMOS18 14.87, 14.89) -->
           <group delimiter=", ">
             <text macro="source-serial-title-bib"/>
             <text macro="source-serial-identifier-bib"/>
@@ -2266,15 +2251,15 @@
   <macro name="source-serial-identifier-volume-bib">
     <group delimiter=", ">
       <choose>
-        <if type="article-newspaper">
-          <!-- newspapers provide the full date in place of volume/issue numbers (CMOS18 14.89) -->
+        <if match="any" type="article-magazine article-newspaper">
+          <!-- magazines and newspapers provide the full date in place of volume/issue numbers (CMOS18 14.87, 14.89) -->
           <text variable="collection-title"/>
           <text macro="source-serial-volume-status-bib"/>
         </if>
         <else-if match="any" variable="issue supplement-number volume">
           <choose>
-            <if match="any" type="article-magazine review review-book" variable="reviewed-author reviewed-genre reviewed-title">
-              <!-- date appears first if the magazine or review `container-title` has been substituted for a missing author (CMOS18 14.87, 14.102) -->
+            <if match="any" type="review review-book" variable="reviewed-author reviewed-genre reviewed-title">
+              <!-- date appears first if the review `container-title` has been substituted for a missing author (CMOS18 14.87, 14.102) -->
               <choose>
                 <if match="none" variable="author chair collection-editor compiler composer curator director editor editor-translator editorial-director executive-producer guest host illustrator organizer producer series-creator translator">
                   <text macro="source-date-bib"/>
@@ -2292,8 +2277,8 @@
                 <if variable="collection-title volume">
                   <text macro="label-volume"/>
                 </if>
-                <else-if match="any" type="article-magazine review review-book" variable="reviewed-author reviewed-genre reviewed-title">
-                  <!-- date appears first if a magazine or review `container-title` has been substituted for a missing author (CMOS18 14.87, 14.102) -->
+                <else-if match="any" type="review review-book" variable="reviewed-author reviewed-genre reviewed-title">
+                  <!-- date appears first if a review `container-title` has been substituted for a missing author (CMOS18 14.87, 14.102) -->
                   <choose>
                     <if match="any" variable="author chair collection-editor compiler composer curator director editor editor-translator editorial-director executive-producer guest host illustrator organizer producer series-creator translator">
                       <text variable="volume"/>
@@ -2311,8 +2296,8 @@
               <text macro="label-supplement-number"/>
             </group>
             <choose>
-              <if match="any" type="article-magazine review review-book" variable="reviewed-author reviewed-genre reviewed-title">
-                <!-- date for anonymous magazine and review articles only appears here if it did not earlier (CMOS18 14.87, 14.102) -->
+              <if match="any" type="review review-book" variable="reviewed-author reviewed-genre reviewed-title">
+                <!-- date for unsigned reviews only appears here if it did not earlier (CMOS18 14.102) -->
                 <choose>
                   <if match="any" variable="author chair collection-editor compiler composer curator director editor editor-translator editorial-director executive-producer guest host illustrator organizer producer series-creator translator">
                     <text macro="source-date-bib" prefix="(" suffix=")"/>
@@ -3260,7 +3245,8 @@
   </macro>
   <macro name="source-date-issued-full-serial">
     <choose>
-      <if type="article-newspaper">
+      <if match="any" type="article-magazine article-newspaper">
+        <!-- magazines and newspapers provide the full date in place of volume/issue numbers (CMOS18 14.87, 14.89) -->
         <text macro="date-issued-full"/>
       </if>
       <else-if variable="issue volume">

--- a/chicago-shortened-notes-bibliography-subsequent-title.csl
+++ b/chicago-shortened-notes-bibliography-subsequent-title.csl
@@ -704,14 +704,6 @@
         <!-- Publication name also substituted for unsigned reviews (CMOS18 14.102) -->
         <text macro="source-serial-name"/>
       </else-if>
-      <else-if match="any" type="interview paper-conference">
-        <choose>
-          <if match="none" variable="collection-editor compiler editor editorial-director">
-            <!-- serial usage -->
-            <text macro="source-serial-name"/>
-          </if>
-        </choose>
-      </else-if>
       <else-if match="any" type="entry entry-dictionary entry-encyclopedia">
         <!-- Anonymous entries in reference works (CMOS18 14.130) -->
         <text font-style="italic" text-case="title" variable="container-title"/>
@@ -736,14 +728,6 @@
       <else-if match="any" type="review review-book" variable="reviewed-author reviewed-genre reviewed-title">
         <!-- Publication name also substituted for unsigned reviews (CMOS18 14.102) -->
         <text font-style="italic" text-case="title" variable="container-title"/>
-      </else-if>
-      <else-if match="any" type="interview paper-conference">
-        <choose>
-          <if match="none" variable="collection-editor compiler editor editorial-director">
-            <!-- serial usage -->
-            <text font-style="italic" text-case="title" variable="container-title"/>
-          </if>
-        </choose>
       </else-if>
       <else-if match="any" type="entry entry-dictionary entry-encyclopedia">
         <!-- Anonymous entries in reference works (CMOS18 14.130) -->
@@ -2158,7 +2142,8 @@
     <group delimiter=". ">
       <text macro="source-serial-title-volume-bib"/>
       <choose>
-        <if type="article-newspaper">
+        <if match="any" type="article-magazine article-newspaper">
+          <!-- magazines and newspapers provide the full date in place of volume/issue numbers (CMOS18 14.87, 14.89) -->
           <group delimiter=", ">
             <text macro="source-serial-title-bib"/>
             <text macro="source-serial-identifier-bib"/>
@@ -2266,15 +2251,15 @@
   <macro name="source-serial-identifier-volume-bib">
     <group delimiter=", ">
       <choose>
-        <if type="article-newspaper">
-          <!-- newspapers provide the full date in place of volume/issue numbers (CMOS18 14.89) -->
+        <if match="any" type="article-magazine article-newspaper">
+          <!-- magazines and newspapers provide the full date in place of volume/issue numbers (CMOS18 14.87, 14.89) -->
           <text variable="collection-title"/>
           <text macro="source-serial-volume-status-bib"/>
         </if>
         <else-if match="any" variable="issue supplement-number volume">
           <choose>
-            <if match="any" type="article-magazine review review-book" variable="reviewed-author reviewed-genre reviewed-title">
-              <!-- date appears first if the magazine or review `container-title` has been substituted for a missing author (CMOS18 14.87, 14.102) -->
+            <if match="any" type="review review-book" variable="reviewed-author reviewed-genre reviewed-title">
+              <!-- date appears first if the review `container-title` has been substituted for a missing author (CMOS18 14.87, 14.102) -->
               <choose>
                 <if match="none" variable="author chair collection-editor compiler composer curator director editor editor-translator editorial-director executive-producer guest host illustrator organizer producer series-creator translator">
                   <text macro="source-date-bib"/>
@@ -2292,8 +2277,8 @@
                 <if variable="collection-title volume">
                   <text macro="label-volume"/>
                 </if>
-                <else-if match="any" type="article-magazine review review-book" variable="reviewed-author reviewed-genre reviewed-title">
-                  <!-- date appears first if a magazine or review `container-title` has been substituted for a missing author (CMOS18 14.87, 14.102) -->
+                <else-if match="any" type="review review-book" variable="reviewed-author reviewed-genre reviewed-title">
+                  <!-- date appears first if a review `container-title` has been substituted for a missing author (CMOS18 14.87, 14.102) -->
                   <choose>
                     <if match="any" variable="author chair collection-editor compiler composer curator director editor editor-translator editorial-director executive-producer guest host illustrator organizer producer series-creator translator">
                       <text variable="volume"/>
@@ -2311,8 +2296,8 @@
               <text macro="label-supplement-number"/>
             </group>
             <choose>
-              <if match="any" type="article-magazine review review-book" variable="reviewed-author reviewed-genre reviewed-title">
-                <!-- date for anonymous magazine and review articles only appears here if it did not earlier (CMOS18 14.87, 14.102) -->
+              <if match="any" type="review review-book" variable="reviewed-author reviewed-genre reviewed-title">
+                <!-- date for unsigned reviews only appears here if it did not earlier (CMOS18 14.102) -->
                 <choose>
                   <if match="any" variable="author chair collection-editor compiler composer curator director editor editor-translator editorial-director executive-producer guest host illustrator organizer producer series-creator translator">
                     <text macro="source-date-bib" prefix="(" suffix=")"/>
@@ -3260,7 +3245,8 @@
   </macro>
   <macro name="source-date-issued-full-serial">
     <choose>
-      <if type="article-newspaper">
+      <if match="any" type="article-magazine article-newspaper">
+        <!-- magazines and newspapers provide the full date in place of volume/issue numbers (CMOS18 14.87, 14.89) -->
         <text macro="date-issued-full"/>
       </if>
       <else-if variable="issue volume">

--- a/chicago-shortened-notes-bibliography.csl
+++ b/chicago-shortened-notes-bibliography.csl
@@ -704,14 +704,6 @@
         <!-- Publication name also substituted for unsigned reviews (CMOS18 14.102) -->
         <text macro="source-serial-name"/>
       </else-if>
-      <else-if match="any" type="interview paper-conference">
-        <choose>
-          <if match="none" variable="collection-editor compiler editor editorial-director">
-            <!-- serial usage -->
-            <text macro="source-serial-name"/>
-          </if>
-        </choose>
-      </else-if>
       <else-if match="any" type="entry entry-dictionary entry-encyclopedia">
         <!-- Anonymous entries in reference works (CMOS18 14.130) -->
         <text font-style="italic" text-case="title" variable="container-title"/>
@@ -736,14 +728,6 @@
       <else-if match="any" type="review review-book" variable="reviewed-author reviewed-genre reviewed-title">
         <!-- Publication name also substituted for unsigned reviews (CMOS18 14.102) -->
         <text font-style="italic" text-case="title" variable="container-title"/>
-      </else-if>
-      <else-if match="any" type="interview paper-conference">
-        <choose>
-          <if match="none" variable="collection-editor compiler editor editorial-director">
-            <!-- serial usage -->
-            <text font-style="italic" text-case="title" variable="container-title"/>
-          </if>
-        </choose>
       </else-if>
       <else-if match="any" type="entry entry-dictionary entry-encyclopedia">
         <!-- Anonymous entries in reference works (CMOS18 14.130) -->
@@ -2158,7 +2142,8 @@
     <group delimiter=". ">
       <text macro="source-serial-title-volume-bib"/>
       <choose>
-        <if type="article-newspaper">
+        <if match="any" type="article-magazine article-newspaper">
+          <!-- magazines and newspapers provide the full date in place of volume/issue numbers (CMOS18 14.87, 14.89) -->
           <group delimiter=", ">
             <text macro="source-serial-title-bib"/>
             <text macro="source-serial-identifier-bib"/>
@@ -2266,15 +2251,15 @@
   <macro name="source-serial-identifier-volume-bib">
     <group delimiter=", ">
       <choose>
-        <if type="article-newspaper">
-          <!-- newspapers provide the full date in place of volume/issue numbers (CMOS18 14.89) -->
+        <if match="any" type="article-magazine article-newspaper">
+          <!-- magazines and newspapers provide the full date in place of volume/issue numbers (CMOS18 14.87, 14.89) -->
           <text variable="collection-title"/>
           <text macro="source-serial-volume-status-bib"/>
         </if>
         <else-if match="any" variable="issue supplement-number volume">
           <choose>
-            <if match="any" type="article-magazine review review-book" variable="reviewed-author reviewed-genre reviewed-title">
-              <!-- date appears first if the magazine or review `container-title` has been substituted for a missing author (CMOS18 14.87, 14.102) -->
+            <if match="any" type="review review-book" variable="reviewed-author reviewed-genre reviewed-title">
+              <!-- date appears first if the review `container-title` has been substituted for a missing author (CMOS18 14.87, 14.102) -->
               <choose>
                 <if match="none" variable="author chair collection-editor compiler composer curator director editor editor-translator editorial-director executive-producer guest host illustrator organizer producer series-creator translator">
                   <text macro="source-date-bib"/>
@@ -2292,8 +2277,8 @@
                 <if variable="collection-title volume">
                   <text macro="label-volume"/>
                 </if>
-                <else-if match="any" type="article-magazine review review-book" variable="reviewed-author reviewed-genre reviewed-title">
-                  <!-- date appears first if a magazine or review `container-title` has been substituted for a missing author (CMOS18 14.87, 14.102) -->
+                <else-if match="any" type="review review-book" variable="reviewed-author reviewed-genre reviewed-title">
+                  <!-- date appears first if a review `container-title` has been substituted for a missing author (CMOS18 14.87, 14.102) -->
                   <choose>
                     <if match="any" variable="author chair collection-editor compiler composer curator director editor editor-translator editorial-director executive-producer guest host illustrator organizer producer series-creator translator">
                       <text variable="volume"/>
@@ -2311,8 +2296,8 @@
               <text macro="label-supplement-number"/>
             </group>
             <choose>
-              <if match="any" type="article-magazine review review-book" variable="reviewed-author reviewed-genre reviewed-title">
-                <!-- date for anonymous magazine and review articles only appears here if it did not earlier (CMOS18 14.87, 14.102) -->
+              <if match="any" type="review review-book" variable="reviewed-author reviewed-genre reviewed-title">
+                <!-- date for unsigned reviews only appears here if it did not earlier (CMOS18 14.102) -->
                 <choose>
                   <if match="any" variable="author chair collection-editor compiler composer curator director editor editor-translator editorial-director executive-producer guest host illustrator organizer producer series-creator translator">
                     <text macro="source-date-bib" prefix="(" suffix=")"/>
@@ -3260,7 +3245,8 @@
   </macro>
   <macro name="source-date-issued-full-serial">
     <choose>
-      <if type="article-newspaper">
+      <if match="any" type="article-magazine article-newspaper">
+        <!-- magazines and newspapers provide the full date in place of volume/issue numbers (CMOS18 14.87, 14.89) -->
         <text macro="date-issued-full"/>
       </if>
       <else-if variable="issue volume">

--- a/taylor-and-francis-chicago-author-date.csl
+++ b/taylor-and-francis-chicago-author-date.csl
@@ -687,14 +687,6 @@
         <!-- Publication name also substituted for unsigned reviews (CMOS18 14.102) -->
         <text macro="source-serial-name"/>
       </else-if>
-      <else-if match="any" type="interview paper-conference">
-        <choose>
-          <if match="none" variable="collection-editor compiler editor editorial-director">
-            <!-- serial usage -->
-            <text macro="source-serial-name"/>
-          </if>
-        </choose>
-      </else-if>
       <else-if match="any" type="entry entry-dictionary entry-encyclopedia">
         <!-- Anonymous entries in reference works (CMOS18 14.130) -->
         <text font-style="italic" text-case="title" variable="container-title"/>
@@ -719,14 +711,6 @@
       <else-if match="any" type="review review-book" variable="reviewed-author reviewed-genre reviewed-title">
         <!-- Publication name also substituted for unsigned reviews (CMOS18 14.102) -->
         <text font-style="italic" text-case="title" variable="container-title"/>
-      </else-if>
-      <else-if match="any" type="interview paper-conference">
-        <choose>
-          <if match="none" variable="collection-editor compiler editor editorial-director">
-            <!-- serial usage -->
-            <text font-style="italic" text-case="title" variable="container-title"/>
-          </if>
-        </choose>
       </else-if>
       <else-if match="any" type="entry entry-dictionary entry-encyclopedia">
         <!-- Anonymous entries in reference works (CMOS18 14.130) -->
@@ -2226,7 +2210,8 @@
     <group delimiter=". ">
       <text macro="source-serial-title-volume-bib"/>
       <choose>
-        <if type="article-newspaper">
+        <if match="any" type="article-magazine article-newspaper">
+          <!-- magazines and newspapers provide the full date in place of volume/issue numbers (CMOS18 14.87, 14.89) -->
           <group delimiter=", ">
             <text macro="source-serial-title-bib"/>
             <text macro="source-serial-identifier-bib"/>
@@ -2334,15 +2319,15 @@
   <macro name="source-serial-identifier-volume-author-date">
     <group delimiter=", ">
       <choose>
-        <if type="article-newspaper">
-          <!-- newspapers provide the full date in place of volume/issue numbers (CMOS18 14.89) -->
+        <if match="any" type="article-magazine article-newspaper">
+          <!-- magazines and newspapers provide the full date in place of volume/issue numbers (CMOS18 14.87, 14.89) -->
           <text variable="collection-title"/>
           <text macro="source-serial-volume-status-bib"/>
         </if>
         <else-if match="any" variable="issue supplement-number volume">
           <choose>
-            <if match="any" type="article-magazine review review-book" variable="reviewed-author reviewed-genre reviewed-title">
-              <!-- date appears first if the magazine or review `container-title` has been substituted for a missing author (CMOS18 14.87, 14.102) -->
+            <if match="any" type="review review-book" variable="reviewed-author reviewed-genre reviewed-title">
+              <!-- date appears first if the review `container-title` has been substituted for a missing author (CMOS18 14.87, 14.102) -->
               <choose>
                 <if match="none" variable="author chair collection-editor compiler composer curator director editor editor-translator editorial-director executive-producer guest host illustrator organizer producer series-creator translator">
                   <choose>
@@ -2368,8 +2353,8 @@
                   <if variable="collection-title">
                     <text macro="label-volume"/>
                   </if>
-                  <else-if match="any" type="article-magazine review review-book" variable="reviewed-author reviewed-genre reviewed-title">
-                    <!-- provide label if a magazine or review `container-title` has been substituted for a missing author (CMOS18 14.87, 14.102) -->
+                  <else-if match="any" type="review review-book" variable="reviewed-author reviewed-genre reviewed-title">
+                    <!-- provide label if a review `container-title` has been substituted for a missing author (CMOS18 14.87, 14.102) -->
                     <choose>
                       <if match="any" variable="author chair collection-editor compiler composer curator director editor editor-translator editorial-director executive-producer guest host illustrator organizer producer series-creator translator">
                         <text variable="volume"/>
@@ -2390,8 +2375,8 @@
                       <text variable="issue"/>
                       <text macro="label-supplement-number"/>
                     </if>
-                    <else-if match="any" type="article-magazine review review-book" variable="reviewed-author reviewed-genre reviewed-title">
-                      <!-- date for anonymous magazine and review articles only appears here if it did not earlier (CMOS18 14.87, 14.102) -->
+                    <else-if match="any" type="review review-book" variable="reviewed-author reviewed-genre reviewed-title">
+                      <!-- date for unsigned reviews only appears here if it did not earlier (CMOS18 14.102) -->
                       <choose>
                         <if match="any" variable="author chair collection-editor compiler composer curator director editor editor-translator editorial-director executive-producer guest host illustrator organizer producer series-creator translator">
                           <text macro="source-date-issued-month-day"/>
@@ -3169,7 +3154,8 @@
   <!-- Date elements -->
   <macro name="source-date-issued-full-serial">
     <choose>
-      <if type="article-newspaper">
+      <if match="any" type="article-magazine article-newspaper">
+        <!-- magazines and newspapers provide the full date in place of volume/issue numbers (CMOS18 14.87, 14.89) -->
         <text macro="date-issued-full"/>
       </if>
       <else-if variable="issue volume">
@@ -3221,8 +3207,8 @@
   </macro>
   <macro name="source-date-issued-month-day-serial">
     <choose>
-      <if type="article-newspaper">
-        <!-- newspapers provide the full date in place of volume/issue numbers (CMOS18 14.89) -->
+      <if match="any" type="article-magazine article-newspaper">
+        <!-- magazines and newspapers provide the full date in place of volume/issue numbers (CMOS18 14.87, 14.89) -->
         <text macro="date-issued-month-day"/>
       </if>
       <else-if match="any" variable="issue supplement-number volume">


### PR DESCRIPTION
Cite magazines by their full date only, using the same formatting as newspapers (but with the option of page ranges). See _CMOS_ 14.87: 'Weekly or monthly (or bimonthly) magazines, even if numbered by volume and issue, are usually cited by date only.' Previously, the styles interpreted 'usually' as meaning that volume or issue numbers could be printed if available. _CMOS_ staff have clarified that the example of a magazine cited with a volume number in 14.100 is a holdover from the 15th edition that has been overlooked in subsequent revisions. In 14.65, there is the option of applying 'journal form' to magazines, but _CMOS_ staff recommend that this should only be applied to items that the author feels is best presented as part of a journal, such as a periodical with articles that give formal citations; an item treated as a magazine should always be cited by full date only.