### PR TITLE
infoclio.ch: add support for periodicals

### DIFF
--- a/infoclio-de-kurzbelege.csl
+++ b/infoclio-de-kurzbelege.csl
@@ -472,13 +472,6 @@
       <if type="webpage post post-weblog dataset" match="any">
         <text macro="url-or-doi"/>
       </if>
-      <else-if type="periodical">
-        <choose>
-          <if variable="note">
-            <text macro="url-or-doi"/>
-          </if>
-        </choose>
-      </else-if>
       <else-if type="article-journal">
         <choose>
           <if variable="page" match="none">
@@ -490,20 +483,13 @@
   </macro>
   <macro name="url-non-web-documents">
     <choose>
-      <if type="periodical">
-        <choose>
-          <if variable="note" match="none">
-            <text macro="url-or-doi-with-online-term"/>
-          </if>
-        </choose>
-      </if>
-      <else-if type="article-journal">
+      <if type="article-journal">
         <choose>
           <if variable="page">
             <text macro="url-or-doi-with-online-term"/>
           </if>
         </choose>
-      </else-if>
+      </if>
       <else-if type="webpage post post-weblog dataset" match="none">
         <text macro="url-or-doi-with-online-term"/>
       </else-if>

--- a/infoclio-de-kurzbelege.csl
+++ b/infoclio-de-kurzbelege.csl
@@ -25,7 +25,7 @@
     <category citation-format="note"/>
     <category field="history"/>
     <category field="social_science"/>
-    <updated>2024-09-04T12:30:00+02:00</updated>
+    <updated>2025-09-10T14:15:00+02:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale xml:lang="de">
@@ -73,6 +73,7 @@
       <group delimiter=", ">
         <group delimiter=": ">
           <text macro="creator"/>
+          <text macro="periodical-info"/>
           <group delimiter=", ">
             <text macro="title"/>
             <text macro="scientific-editor"/>
@@ -117,22 +118,26 @@
   </macro>
   <macro name="creator">
     <choose>
-      <if variable="director">
-        <!-- special rule to avoid printing the label for directors -->
-        <names variable="director">
-          <name sort-separator=", " name-as-sort-order="all" et-al-min="4" et-al-use-first="3"/>
-        </names>
+      <if type="periodical" match="none">
+        <choose>
+          <if variable="director">
+            <!-- special rule to avoid printing the label for directors -->
+            <names variable="director">
+              <name sort-separator=", " name-as-sort-order="all" et-al-min="4" et-al-use-first="3"/>
+            </names>
+          </if>
+          <else>
+            <names variable="author">
+              <name sort-separator=", " name-as-sort-order="all" et-al-min="4" et-al-use-first="3"/>
+              <label form="short" prefix="&#160;(" suffix=")"/>
+              <substitute>
+                <names variable="editor"/>
+                <names variable="composer"/>
+              </substitute>
+            </names>
+          </else>
+        </choose>
       </if>
-      <else>
-        <names variable="author">
-          <name sort-separator=", " name-as-sort-order="all" et-al-min="4" et-al-use-first="3"/>
-          <label form="short" prefix="&#160;(" suffix=")"/>
-          <substitute>
-            <names variable="editor"/>
-            <names variable="composer"/>
-          </substitute>
-        </names>
-      </else>
     </choose>
   </macro>
   <macro name="creator-for-short-references">
@@ -145,6 +150,19 @@
         <names variable="director"/>
       </substitute>
     </names>
+  </macro>
+  <macro name="periodical-info">
+    <choose>
+      <if type="periodical">
+        <group delimiter=" ">
+          <text variable="container-title"/>
+          <group delimiter="&#160;">
+            <number variable="volume"/>
+            <number variable="issue" prefix="(" suffix=")"/>
+          </group>
+        </group>
+      </if>
+    </choose>
   </macro>
   <macro name="title">
     <group delimiter=" ">
@@ -362,6 +380,16 @@
           </if>
         </choose>
       </if>
+      <else-if type="periodical">
+        <choose>
+          <if variable="volume issue" match="none">
+            <date variable="issued" form="numeric" date-parts="year" prefix="Jg.&#160;"/>
+          </if>
+          <else>
+            <date variable="issued" form="numeric" date-parts="year"/>
+          </else>
+        </choose>
+      </else-if>
       <else>
         <date variable="issued" form="numeric" date-parts="year-month-day"/>
       </else>
@@ -444,19 +472,50 @@
       <if type="webpage post post-weblog dataset" match="any">
         <text macro="url-or-doi"/>
       </if>
+      <else-if type="periodical">
+        <choose>
+          <if variable="note">
+            <text macro="url-or-doi"/>
+          </if>
+        </choose>
+      </else-if>
+      <else-if type="article-journal">
+        <choose>
+          <if variable="page" match="none">
+            <text macro="url-or-doi"/>
+          </if>
+        </choose>
+      </else-if>
     </choose>
   </macro>
   <macro name="url-non-web-documents">
     <choose>
-      <if type="webpage post post-weblog dataset" match="none">
+      <if type="periodical">
         <choose>
-          <if variable="DOI URL" match="any">
-            <group delimiter=": ">
-              <text term="online" text-case="capitalize-first"/>
-              <text macro="url-or-doi"/>
-            </group>
+          <if variable="note" match="none">
+            <text macro="url-or-doi-with-online-term"/>
           </if>
         </choose>
+      </if>
+      <else-if type="article-journal">
+        <choose>
+          <if variable="page">
+            <text macro="url-or-doi-with-online-term"/>
+          </if>
+        </choose>
+      </else-if>
+      <else-if type="webpage post post-weblog dataset" match="none">
+        <text macro="url-or-doi-with-online-term"/>
+      </else-if>
+    </choose>
+  </macro>
+  <macro name="url-or-doi-with-online-term">
+    <choose>
+      <if variable="DOI URL" match="any">
+        <group delimiter=": ">
+          <text term="online" text-case="capitalize-first"/>
+          <text macro="url-or-doi"/>
+        </group>
       </if>
     </choose>
   </macro>
@@ -464,11 +523,7 @@
     <choose>
       <if variable="DOI">
         <group delimiter=", ">
-          <group delimiter="">
-            <text value="&lt;"/>
-            <text variable="DOI" prefix="https://doi.org/"/>
-            <text value="&gt;"/>
-          </group>
+          <text variable="DOI" prefix="&lt;https://doi.org/" suffix="&gt;"/>
           <text macro="accessed"/>
         </group>
       </if>

--- a/infoclio-de.csl
+++ b/infoclio-de.csl
@@ -477,7 +477,7 @@
       </if>
       <else-if type="periodical">
         <choose>
-          <if variable="note">
+          <if variable="medium">
             <text macro="url-or-doi"/>
           </if>
         </choose>
@@ -495,7 +495,7 @@
     <choose>
       <if type="periodical">
         <choose>
-          <if variable="note" match="none">
+          <if variable="medium" match="none">
             <text macro="url-or-doi-with-online-term"/>
           </if>
         </choose>

--- a/infoclio-de.csl
+++ b/infoclio-de.csl
@@ -475,13 +475,6 @@
       <if type="webpage post post-weblog dataset" match="any">
         <text macro="url-or-doi"/>
       </if>
-      <else-if type="periodical">
-        <choose>
-          <if variable="medium">
-            <text macro="url-or-doi"/>
-          </if>
-        </choose>
-      </else-if>
       <else-if type="article-journal">
         <choose>
           <if variable="page" match="none">
@@ -493,20 +486,13 @@
   </macro>
   <macro name="url-non-web-documents">
     <choose>
-      <if type="periodical">
-        <choose>
-          <if variable="medium" match="none">
-            <text macro="url-or-doi-with-online-term"/>
-          </if>
-        </choose>
-      </if>
-      <else-if type="article-journal">
+      <if type="article-journal">
         <choose>
           <if variable="page">
             <text macro="url-or-doi-with-online-term"/>
           </if>
         </choose>
-      </else-if>
+      </if>
       <else-if type="webpage post post-weblog dataset" match="none">
         <text macro="url-or-doi-with-online-term"/>
       </else-if>

--- a/infoclio-de.csl
+++ b/infoclio-de.csl
@@ -25,7 +25,7 @@
     <category citation-format="note"/>
     <category field="history"/>
     <category field="social_science"/>
-    <updated>2024-09-04T12:30:00+02:00</updated>
+    <updated>2025-09-10T14:15:00+02:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale xml:lang="de">
@@ -76,6 +76,7 @@
       <group delimiter=", ">
         <group delimiter=": ">
           <text macro="creator"/>
+          <text macro="periodical-info"/>
           <group delimiter=", ">
             <text macro="title"/>
             <text macro="scientific-editor"/>
@@ -120,22 +121,26 @@
   </macro>
   <macro name="creator">
     <choose>
-      <if variable="director">
-        <!-- special rule to avoid printing the label for directors -->
-        <names variable="director">
-          <name sort-separator=", " name-as-sort-order="all" et-al-min="4" et-al-use-first="3"/>
-        </names>
+      <if type="periodical" match="none">
+        <choose>
+          <if variable="director">
+            <!-- special rule to avoid printing the label for directors -->
+            <names variable="director">
+              <name sort-separator=", " name-as-sort-order="all" et-al-min="4" et-al-use-first="3"/>
+            </names>
+          </if>
+          <else>
+            <names variable="author">
+              <name sort-separator=", " name-as-sort-order="all" et-al-min="4" et-al-use-first="3"/>
+              <label form="short" prefix="&#160;(" suffix=")"/>
+              <substitute>
+                <names variable="editor"/>
+                <names variable="composer"/>
+              </substitute>
+            </names>
+          </else>
+        </choose>
       </if>
-      <else>
-        <names variable="author">
-          <name sort-separator=", " name-as-sort-order="all" et-al-min="4" et-al-use-first="3"/>
-          <label form="short" prefix="&#160;(" suffix=")"/>
-          <substitute>
-            <names variable="editor"/>
-            <names variable="composer"/>
-          </substitute>
-        </names>
-      </else>
     </choose>
   </macro>
   <macro name="creator-for-subsequent">
@@ -148,6 +153,19 @@
         <names variable="director"/>
       </substitute>
     </names>
+  </macro>
+  <macro name="periodical-info">
+    <choose>
+      <if type="periodical">
+        <group delimiter=" ">
+          <text variable="container-title"/>
+          <group delimiter="&#160;">
+            <number variable="volume"/>
+            <number variable="issue" prefix="(" suffix=")"/>
+          </group>
+        </group>
+      </if>
+    </choose>
   </macro>
   <macro name="title">
     <group delimiter=" ">
@@ -365,6 +383,16 @@
           </if>
         </choose>
       </if>
+      <else-if type="periodical">
+        <choose>
+          <if variable="volume issue" match="none">
+            <date variable="issued" form="numeric" date-parts="year" prefix="Jg.&#160;"/>
+          </if>
+          <else>
+            <date variable="issued" form="numeric" date-parts="year"/>
+          </else>
+        </choose>
+      </else-if>
       <else>
         <date variable="issued" form="numeric" date-parts="year-month-day"/>
       </else>
@@ -447,19 +475,50 @@
       <if type="webpage post post-weblog dataset" match="any">
         <text macro="url-or-doi"/>
       </if>
+      <else-if type="periodical">
+        <choose>
+          <if variable="note">
+            <text macro="url-or-doi"/>
+          </if>
+        </choose>
+      </else-if>
+      <else-if type="article-journal">
+        <choose>
+          <if variable="page" match="none">
+            <text macro="url-or-doi"/>
+          </if>
+        </choose>
+      </else-if>
     </choose>
   </macro>
   <macro name="url-non-web-documents">
     <choose>
-      <if type="webpage post post-weblog dataset" match="none">
+      <if type="periodical">
         <choose>
-          <if variable="DOI URL" match="any">
-            <group delimiter=": ">
-              <text term="online" text-case="capitalize-first"/>
-              <text macro="url-or-doi"/>
-            </group>
+          <if variable="note" match="none">
+            <text macro="url-or-doi-with-online-term"/>
           </if>
         </choose>
+      </if>
+      <else-if type="article-journal">
+        <choose>
+          <if variable="page">
+            <text macro="url-or-doi-with-online-term"/>
+          </if>
+        </choose>
+      </else-if>
+      <else-if type="webpage post post-weblog dataset" match="none">
+        <text macro="url-or-doi-with-online-term"/>
+      </else-if>
+    </choose>
+  </macro>
+  <macro name="url-or-doi-with-online-term">
+    <choose>
+      <if variable="DOI URL" match="any">
+        <group delimiter=": ">
+          <text term="online" text-case="capitalize-first"/>
+          <text macro="url-or-doi"/>
+        </group>
       </if>
     </choose>
   </macro>
@@ -467,11 +526,7 @@
     <choose>
       <if variable="DOI">
         <group delimiter=", ">
-          <group delimiter="">
-            <text value="&lt;"/>
-            <text variable="DOI" prefix="https://doi.org/"/>
-            <text value="&gt;"/>
-          </group>
+          <text variable="DOI" prefix="&lt;https://doi.org/" suffix="&gt;"/>
           <text macro="accessed"/>
         </group>
       </if>

--- a/infoclio-fr-nocaps.csl
+++ b/infoclio-fr-nocaps.csl
@@ -559,13 +559,6 @@
       <if type="webpage post post-weblog dataset" match="any">
         <text macro="url-or-doi"/>
       </if>
-      <else-if type="periodical">
-        <choose>
-          <if variable="medium">
-            <text macro="url-or-doi"/>
-          </if>
-        </choose>
-      </else-if>
       <else-if type="article-journal">
         <choose>
           <if variable="page" match="none">
@@ -577,20 +570,13 @@
   </macro>
   <macro name="url-non-web-documents">
     <choose>
-      <if type="periodical">
-        <choose>
-          <if variable="medium" match="none">
-            <text macro="url-or-doi-with-online-term"/>
-          </if>
-        </choose>
-      </if>
-      <else-if type="article-journal">
+      <if type="article-journal">
         <choose>
           <if variable="page">
             <text macro="url-or-doi-with-online-term"/>
           </if>
         </choose>
-      </else-if>
+      </if>
       <else-if type="webpage post post-weblog dataset" match="none">
         <text macro="url-or-doi-with-online-term"/>
       </else-if>

--- a/infoclio-fr-nocaps.csl
+++ b/infoclio-fr-nocaps.csl
@@ -561,7 +561,7 @@
       </if>
       <else-if type="periodical">
         <choose>
-          <if variable="note">
+          <if variable="medium">
             <text macro="url-or-doi"/>
           </if>
         </choose>
@@ -579,7 +579,7 @@
     <choose>
       <if type="periodical">
         <choose>
-          <if variable="note" match="none">
+          <if variable="medium" match="none">
             <text macro="url-or-doi-with-online-term"/>
           </if>
         </choose>

--- a/infoclio-fr-nocaps.csl
+++ b/infoclio-fr-nocaps.csl
@@ -25,7 +25,7 @@
     <category citation-format="note"/>
     <category field="history"/>
     <category field="social_science"/>
-    <updated>2024-09-04T12:30:00+02:00</updated>
+    <updated>2025-09-10T14:15:00+02:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale xml:lang="fr">
@@ -83,6 +83,7 @@
     <group delimiter=". ">
       <group delimiter=", ">
         <text macro="creator"/>
+        <text macro="periodical-info"/>
         <text macro="title"/>
         <text macro="scientific-editor"/>
         <group delimiter=": ">
@@ -125,22 +126,26 @@
   </macro>
   <macro name="creator">
     <choose>
-      <if variable="director">
-        <!-- special rule to avoid printing the label for directors -->
-        <names variable="director">
-          <name sort-separator=" " name-as-sort-order="all" et-al-min="4" et-al-use-first="3"/>
-        </names>
+      <if type="periodical" match="none">
+        <choose>
+          <if variable="director">
+            <!-- special rule to avoid printing the label for directors -->
+            <names variable="director">
+              <name sort-separator=" " name-as-sort-order="all" et-al-min="4" et-al-use-first="3"/>
+            </names>
+          </if>
+          <else>
+            <names variable="author">
+              <name sort-separator=" " name-as-sort-order="all" et-al-min="4" et-al-use-first="3"/>
+              <label form="short" prefix="&#160;(" suffix=")"/>
+              <substitute>
+                <names variable="editor"/>
+                <names variable="composer"/>
+              </substitute>
+            </names>
+          </else>
+        </choose>
       </if>
-      <else>
-        <names variable="author">
-          <name sort-separator=" " name-as-sort-order="all" et-al-min="4" et-al-use-first="3"/>
-          <label form="short" prefix="&#160;(" suffix=")"/>
-          <substitute>
-            <names variable="editor"/>
-            <names variable="composer"/>
-          </substitute>
-        </names>
-      </else>
     </choose>
   </macro>
   <macro name="creator-for-subsequent">
@@ -154,6 +159,19 @@
       </substitute>
     </names>
   </macro>
+  <macro name="periodical-info">
+    <choose>
+      <if type="periodical">
+        <group delimiter=" ">
+          <text variable="container-title" font-style="italic"/>
+          <group delimiter="&#160;">
+            <number variable="volume"/>
+            <number variable="issue" prefix="(" suffix=")"/>
+          </group>
+        </group>
+      </if>
+    </choose>
+  </macro>
   <macro name="title">
     <choose>
       <if type="book thesis graphic" match="any">
@@ -166,6 +184,17 @@
           </choose>
         </group>
       </if>
+      <else-if type="periodical">
+        <choose>
+          <if variable="container-title title" match="all">
+            <!-- when citing a single issue -->
+            <text variable="title" quotes="true"/>
+          </if>
+          <else>
+            <text variable="title" font-style="italic"/>
+          </else>
+        </choose>
+      </else-if>
       <else-if type="article article-magazine article-newspaper article-journal entry entry-dictionary entry-encyclopedia report chapter paper-conference post post-weblog webpage song broadcast dataset" match="any">
         <text variable="title" quotes="true"/>
       </else-if>
@@ -438,6 +467,16 @@
       <if type="book chapter paper-conference thesis" match="any">
         <date variable="issued" form="numeric" date-parts="year"/>
       </if>
+      <else-if type="periodical">
+        <choose>
+          <if variable="volume issue" match="none">
+            <date variable="issued" form="numeric" date-parts="year" prefix="années "/>
+          </if>
+          <else>
+            <date variable="issued" form="numeric" date-parts="year"/>
+          </else>
+        </choose>
+      </else-if>
       <else>
         <date variable="issued" form="numeric" date-parts="year-month-day"/>
       </else>
@@ -520,19 +559,50 @@
       <if type="webpage post post-weblog dataset" match="any">
         <text macro="url-or-doi"/>
       </if>
+      <else-if type="periodical">
+        <choose>
+          <if variable="note">
+            <text macro="url-or-doi"/>
+          </if>
+        </choose>
+      </else-if>
+      <else-if type="article-journal">
+        <choose>
+          <if variable="page" match="none">
+            <text macro="url-or-doi"/>
+          </if>
+        </choose>
+      </else-if>
     </choose>
   </macro>
   <macro name="url-non-web-documents">
     <choose>
-      <if type="webpage post post-weblog dataset" match="none">
+      <if type="periodical">
         <choose>
-          <if variable="DOI URL" match="any">
-            <group delimiter=": ">
-              <text term="online" text-case="capitalize-first"/>
-              <text macro="url-or-doi"/>
-            </group>
+          <if variable="note" match="none">
+            <text macro="url-or-doi-with-online-term"/>
           </if>
         </choose>
+      </if>
+      <else-if type="article-journal">
+        <choose>
+          <if variable="page">
+            <text macro="url-or-doi-with-online-term"/>
+          </if>
+        </choose>
+      </else-if>
+      <else-if type="webpage post post-weblog dataset" match="none">
+        <text macro="url-or-doi-with-online-term"/>
+      </else-if>
+    </choose>
+  </macro>
+  <macro name="url-or-doi-with-online-term">
+    <choose>
+      <if variable="DOI URL" match="any">
+        <group delimiter=": ">
+          <text term="online" text-case="capitalize-first"/>
+          <text macro="url-or-doi"/>
+        </group>
       </if>
     </choose>
   </macro>
@@ -540,11 +610,7 @@
     <choose>
       <if variable="DOI">
         <group delimiter=", ">
-          <group delimiter="">
-            <text value="&lt;"/>
-            <text variable="DOI" prefix="https://doi.org/"/>
-            <text value="&gt;"/>
-          </group>
+          <text variable="DOI" prefix="&lt;https://doi.org/" suffix="&gt;"/>
           <text macro="accessed"/>
         </group>
       </if>

--- a/infoclio-fr-smallcaps.csl
+++ b/infoclio-fr-smallcaps.csl
@@ -568,13 +568,6 @@
       <if type="webpage post post-weblog dataset" match="any">
         <text macro="url-or-doi"/>
       </if>
-      <else-if type="periodical">
-        <choose>
-          <if variable="medium">
-            <text macro="url-or-doi"/>
-          </if>
-        </choose>
-      </else-if>
       <else-if type="article-journal">
         <choose>
           <if variable="page" match="none">
@@ -586,20 +579,13 @@
   </macro>
   <macro name="url-non-web-documents">
     <choose>
-      <if type="periodical">
-        <choose>
-          <if variable="medium" match="none">
-            <text macro="url-or-doi-with-online-term"/>
-          </if>
-        </choose>
-      </if>
-      <else-if type="article-journal">
+      <if type="article-journal">
         <choose>
           <if variable="page">
             <text macro="url-or-doi-with-online-term"/>
           </if>
         </choose>
-      </else-if>
+      </if>
       <else-if type="webpage post post-weblog dataset" match="none">
         <text macro="url-or-doi-with-online-term"/>
       </else-if>

--- a/infoclio-fr-smallcaps.csl
+++ b/infoclio-fr-smallcaps.csl
@@ -570,7 +570,7 @@
       </if>
       <else-if type="periodical">
         <choose>
-          <if variable="note">
+          <if variable="medium">
             <text macro="url-or-doi"/>
           </if>
         </choose>
@@ -588,7 +588,7 @@
     <choose>
       <if type="periodical">
         <choose>
-          <if variable="note" match="none">
+          <if variable="medium" match="none">
             <text macro="url-or-doi-with-online-term"/>
           </if>
         </choose>

--- a/infoclio-fr-smallcaps.csl
+++ b/infoclio-fr-smallcaps.csl
@@ -24,7 +24,7 @@
     <category citation-format="note"/>
     <category field="history"/>
     <category field="social_science"/>
-    <updated>2024-09-04T12:30:00+02:00</updated>
+    <updated>2025-09-10T14:15:00+02:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale xml:lang="fr">
@@ -82,6 +82,7 @@
     <group delimiter=". ">
       <group delimiter=", ">
         <text macro="creator"/>
+        <text macro="periodical-info"/>
         <text macro="title"/>
         <text macro="scientific-editor"/>
         <group delimiter=": ">
@@ -124,26 +125,30 @@
   </macro>
   <macro name="creator">
     <choose>
-      <if variable="director">
-        <!-- special rule to avoid printing the label for directors -->
-        <names variable="director">
-          <name sort-separator=" " name-as-sort-order="all" et-al-min="4" et-al-use-first="3">
-            <name-part name="family" font-variant="small-caps"/>
-          </name>
-        </names>
+      <if type="periodical" match="none">
+        <choose>
+          <if variable="director">
+            <!-- special rule to avoid printing the label for directors -->
+            <names variable="director">
+              <name sort-separator=" " name-as-sort-order="all" et-al-min="4" et-al-use-first="3">
+                <name-part name="family" font-variant="small-caps"/>
+              </name>
+            </names>
+          </if>
+          <else>
+            <names variable="author">
+              <name sort-separator=" " name-as-sort-order="all" et-al-min="4" et-al-use-first="3">
+                <name-part name="family" font-variant="small-caps"/>
+              </name>
+              <label form="short" prefix="&#160;(" suffix=")"/>
+              <substitute>
+                <names variable="editor"/>
+                <names variable="composer"/>
+              </substitute>
+            </names>
+          </else>
+        </choose>
       </if>
-      <else>
-        <names variable="author">
-          <name sort-separator=" " name-as-sort-order="all" et-al-min="4" et-al-use-first="3">
-            <name-part name="family" font-variant="small-caps"/>
-          </name>
-          <label form="short" prefix="&#160;(" suffix=")"/>
-          <substitute>
-            <names variable="editor"/>
-            <names variable="composer"/>
-          </substitute>
-        </names>
-      </else>
     </choose>
   </macro>
   <macro name="creator-for-subsequent">
@@ -159,6 +164,19 @@
       </substitute>
     </names>
   </macro>
+  <macro name="periodical-info">
+    <choose>
+      <if type="periodical">
+        <group delimiter=" ">
+          <text variable="container-title" font-style="italic"/>
+          <group delimiter="&#160;">
+            <number variable="volume"/>
+            <number variable="issue" prefix="(" suffix=")"/>
+          </group>
+        </group>
+      </if>
+    </choose>
+  </macro>
   <macro name="title">
     <choose>
       <if type="book thesis graphic" match="any">
@@ -171,6 +189,17 @@
           </choose>
         </group>
       </if>
+      <else-if type="periodical">
+        <choose>
+          <if variable="container-title title" match="all">
+            <!-- when citing a single issue -->
+            <text variable="title" quotes="true"/>
+          </if>
+          <else>
+            <text variable="title" font-style="italic"/>
+          </else>
+        </choose>
+      </else-if>
       <else-if type="article article-magazine article-newspaper article-journal entry entry-dictionary entry-encyclopedia report chapter paper-conference post post-weblog webpage song broadcast dataset" match="any">
         <text variable="title" quotes="true"/>
       </else-if>
@@ -447,6 +476,16 @@
       <if type="book chapter paper-conference thesis" match="any">
         <date variable="issued" form="numeric" date-parts="year"/>
       </if>
+      <else-if type="periodical">
+        <choose>
+          <if variable="volume issue" match="none">
+            <date variable="issued" form="numeric" date-parts="year" prefix="années "/>
+          </if>
+          <else>
+            <date variable="issued" form="numeric" date-parts="year"/>
+          </else>
+        </choose>
+      </else-if>
       <else>
         <date variable="issued" form="numeric" date-parts="year-month-day"/>
       </else>
@@ -529,19 +568,50 @@
       <if type="webpage post post-weblog dataset" match="any">
         <text macro="url-or-doi"/>
       </if>
+      <else-if type="periodical">
+        <choose>
+          <if variable="note">
+            <text macro="url-or-doi"/>
+          </if>
+        </choose>
+      </else-if>
+      <else-if type="article-journal">
+        <choose>
+          <if variable="page" match="none">
+            <text macro="url-or-doi"/>
+          </if>
+        </choose>
+      </else-if>
     </choose>
   </macro>
   <macro name="url-non-web-documents">
     <choose>
-      <if type="webpage post post-weblog dataset" match="none">
+      <if type="periodical">
         <choose>
-          <if variable="DOI URL" match="any">
-            <group delimiter=": ">
-              <text term="online" text-case="capitalize-first"/>
-              <text macro="url-or-doi"/>
-            </group>
+          <if variable="note" match="none">
+            <text macro="url-or-doi-with-online-term"/>
           </if>
         </choose>
+      </if>
+      <else-if type="article-journal">
+        <choose>
+          <if variable="page">
+            <text macro="url-or-doi-with-online-term"/>
+          </if>
+        </choose>
+      </else-if>
+      <else-if type="webpage post post-weblog dataset" match="none">
+        <text macro="url-or-doi-with-online-term"/>
+      </else-if>
+    </choose>
+  </macro>
+  <macro name="url-or-doi-with-online-term">
+    <choose>
+      <if variable="DOI URL" match="any">
+        <group delimiter=": ">
+          <text term="online" text-case="capitalize-first"/>
+          <text macro="url-or-doi"/>
+        </group>
       </if>
     </choose>
   </macro>
@@ -549,11 +619,7 @@
     <choose>
       <if variable="DOI">
         <group delimiter=", ">
-          <group delimiter="">
-            <text value="&lt;"/>
-            <text variable="DOI" prefix="https://doi.org/"/>
-            <text value="&gt;"/>
-          </group>
+          <text variable="DOI" prefix="&lt;https://doi.org/" suffix="&gt;"/>
           <text macro="accessed"/>
         </group>
       </if>


### PR DESCRIPTION
A small update to the infoclio.ch styles, for history students (and scholars) - originally submitted in #234 and last updated in #7191.

This update adds support for items of type `periodical`, allowing users to cite specific issues or even a journal as a whole. 

Furthermore, it enables users to respect the style guide more closely, by introducing a difference between articles that exist both in print and online (in which case the standard citation is followed by the keyword "Online:" before the URL), and those that exist only online (in which case the keyword is left out). Articles without indication of pages are assumed to exist only online.

As always, thank you for your continued work on maintaining the CSL styles! :pray: 

cc @janbaumanninfoclio