### PR TITLE
Update council-of-science-editors-author-date.csl (sort alphabetically)

### DIFF
--- a/council-of-science-editors-author-date.csl
+++ b/council-of-science-editors-author-date.csl
@@ -12,7 +12,7 @@
     </author>
     <category citation-format="author-date"/>
     <category field="science"/>
-    <summary>The Council of Science Editors style 9th edition, Citation-Sequence system: numbers in text, sorted by order of appearance in text.</summary>
+    <summary>The Council of Science Editors style 9th edition, Citation-Sequence system: author-date in text, sorted alphabetically.</summary>
     <updated>2025-09-12T07:37:16+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>


### PR DESCRIPTION
via https://forums.zotero.org/discussion/126699/style-error-cse-name-year-9th-edition/p1

[Guidelines](https://www.csemanual.org/Tools/CSE-Citation-Quick-Guide.html): "**Name–Year**
The following examples illustrate the name–year system. In this system, in-text references consist of the surname of the author or authors and the year of publication of the document. **End references are unnumbered and appear in alphabetical order by author and year of publication**, with multiple works by the same author listed in chronological order."