### PR TITLE
Update springer-vancouver-brackets.csl (incl. DOI)

### DIFF
--- a/springer-vancouver-brackets.csl
+++ b/springer-vancouver-brackets.csl
@@ -18,7 +18,7 @@
     </contributor>
     <category citation-format="numeric"/>
     <category field="generic-base"/>
-    <summary>Based on the document &quot;Key Style Points 2.0 І December 2024&quot;.</summary>
+    <summary>Based on the document "Key Style Points 2.0 І December 2024".</summary>
     <updated>2025-09-14T15:13:05+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>


### PR DESCRIPTION
I noticed this while reviewing the style for another dependent style (see https://github.com/citation-style-language/styles/issues/6513)

I noticed that springer-vancouver.csl and springer-vancouver-brackets.csl are both styled like [1] in-text. Is this an error?