### PR TITLE
Update canadian-journal-of-remote-sensing.csl

### DIFF
--- a/canadian-journal-of-remote-sensing.csl
+++ b/canadian-journal-of-remote-sensing.csl
@@ -209,7 +209,7 @@
       </group>
     </layout>
   </citation>
-  <bibliography hanging-indent="true" entry-spacing="0" line-spacing="1">
+  <bibliography hanging-indent="false" entry-spacing="0" line-spacing="1">
     <sort>
       <key macro="author"/>
       <key macro="issued" sort="descending"/>


### PR DESCRIPTION
This PR updates the CJRS style by disabling hanging indent in the bibliography.
This matches journal formatting guidelines, which require references to be flush left.