### PR TITLE
Add style: Polish Engineering — Numeric citations, Alphabetical bibliography

### DIFF
--- a/polish-engineering-numeric-alphabetical.csl.txt
+++ b/polish-engineering-numeric-alphabetical.csl.txt
@@ -1,0 +1,89 @@
+<?xml version="1.0" encoding="utf-8"?>
+<style xmlns="http://purl.org/net/xbiblio/csl" version="1.0"
+  class="in-text"
+  default-locale="en-US"
+  demote-non-dropping-particle="sort-only"
+  page-range-format="expanded">
+  <info>
+    <title>Polish Engineering — Numeric citations, Alphabetical bibliography</title>
+    <title-short>Polish Eng. Numeric-Alpha</title-short>
+    <id>http://www.zotero.org/styles/polish-engineering-numeric-alphabetical</id>
+    <link href="http://www.zotero.org/styles/polish-engineering-numeric-alphabetical" rel="self"/>
+    <link href="https://citationstyles.org/" rel="documentation"/>
+    <author>
+      <name>Your Name</name>
+      <email>you@example.com</email>
+    </author>
+    <category citation-format="numeric"/>
+    <category field="engineering"/>
+    <summary>
+      Numeric in-text citations ([1], [2–4]); bibliography sorted alphabetically by author (then by year).
+      Format: Authors, Year. Title. Journal (italic), Volume, Pages/Article number.
+    </summary>
+    <updated>2025-09-17T00:00:00+00:00</updated>
+    <rights license="http://creativecommons.org/licenses/by-sa/3.0/">
+      This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License
+    </rights>
+  </info>
+
+  <!-- ========= MACROS ========= -->
+  <macro name="authors">
+    <names variable="author">
+      <name name-as-sort-order="all" sort-separator=" " initialize-with=". " delimiter=", "/>
+      <et-al term="et-al"/>
+    </names>
+  </macro>
+
+  <macro name="year">
+    <date variable="issued">
+      <date-part name="year"/>
+    </date>
+  </macro>
+
+  <macro name="title">
+    <text variable="title"/>
+  </macro>
+
+  <macro name="container">
+    <group delimiter=", ">
+      <text variable="container-title" font-style="italic"/>
+      <text variable="volume"/>
+      <choose>
+        <if variable="page">
+          <text variable="page"/>
+        </if>
+        <else-if variable="number">
+          <text variable="number"/>
+        </else-if>
+      </choose>
+    </group>
+  </macro>
+
+  <!-- ========= CITATIONS ========= -->
+  <citation collapse="citation-number">
+    <sort>
+      <key variable="citation-number"/>
+    </sort>
+    <layout prefix="[" suffix="]" delimiter=", ">
+      <text variable="citation-number"/>
+    </layout>
+  </citation>
+
+  <!-- ========= BIBLIOGRAPHY ========= -->
+  <bibliography entry-spacing="0" line-spacing="1" et-al-min="7" et-al-use-first="6">
+    <sort>
+      <key variable="author"/>
+      <key variable="issued"/>
+      <key variable="title"/>
+    </sort>
+    <layout suffix=".">
+      <group delimiter=", ">
+        <text macro="authors"/>
+        <text macro="year"/>
+      </group>
+      <text value=" "/>
+      <text macro="title" suffix=". "/>
+      <text macro="container"/>
+    </layout>
+  </bibliography>
+</style>


### PR DESCRIPTION
This pull request adds a new citation style:

**Name:** Polish Engineering — Numeric citations, Alphabetical bibliography  
**Citation format:** Numeric ([1], [2–4])  
**Bibliography order:** Alphabetical by author (then by year, then by title)  
**Reference format example:**
Szewczykowski P., Sykutera D., Czyżewski P., Cieszko M., Szczepański Z., Nowinka B., 2023.
Structure Analysis and Its Correlation with Mechanical Properties of Microcellular Polyamide Composites Reinforced with Glass Fibers.
*Materials*, 16, 23.

**Motivation / Use case:**
Required citation style for doctoral dissertations at Polish technical universities (engineering faculties).
Not available in the current CSL repository.
