### PR TITLE
Create the-british-journal-of-social-work.csl

### DIFF
--- a/dependent/the-british-journal-of-social-work-author-date.csl
+++ b/dependent/the-british-journal-of-social-work-author-date.csl
@@ -1,4 +1,3 @@
-
 <style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" default-locale="en-GB">
   <info>
     <title>The British Journal of Social Work</title>


### PR DESCRIPTION
referencing format for The British Journal of Social Work (author-date). similar to Harvard but with journal specific changes.   