### PR TITLE
Update associacao-brasileira-de-normas-tecnicas-ufrgs.csl (refactor)

### DIFF
--- a/associacao-brasileira-de-normas-tecnicas-ufrgs.csl
+++ b/associacao-brasileira-de-normas-tecnicas-ufrgs.csl
@@ -820,7 +820,7 @@
                 <text variable="publisher" suffix=", "/>
                 <text macro="volume" suffix=", "/>
                 <text macro="number" suffix=", "/>
-                <text macro="page" suffix=", "/>
+                <text macro="pages" suffix=", "/>
                 <text macro="issued-legislation" suffix=". "/>
                 <text variable="genre" suffix=". "/>
                 <text macro="access"/>

--- a/associacao-brasileira-de-normas-tecnicas-ufrgs.csl
+++ b/associacao-brasileira-de-normas-tecnicas-ufrgs.csl
@@ -381,33 +381,27 @@
   </macro>
   <macro name="publisher">
     <!-- Macro responsável por mostrar os responsáveis pela publicação. No caso de ausência deles, incluir expressões para sem local ou sem editor -->
-    <choose>
-      <if variable="publisher-place publisher" match="any">
+    <group delimiter=", ">
+      <group delimiter=": " suffix=",">
         <choose>
           <if variable="publisher-place">
             <text variable="publisher-place"/>
           </if>
           <else>
-            <text value="s. l." font-style="italic" prefix="[" suffix="]" text-case="capitalize-first"/>
+            <text term="no-place" form="short" text-case="capitalize-first" font-style="italic" prefix="[" suffix="]"/>
           </else>
         </choose>
-        <group prefix=": " suffix=",">
-          <choose>
-            <if variable="publisher">
-              <text variable="publisher"/>
-            </if>
-            <else>
-              <text value="s. n." font-style="italic" prefix="[" suffix="]"/>
-            </else>
-          </choose>
-        </group>
-        <text macro="issued" prefix=" "/>
-      </if>
-      <else>
-        <text value="s. l.: s. n." font-style="italic" prefix="[" suffix="]" text-case="capitalize-first"/>
-        <text macro="issued" prefix=", "/>
-      </else>
-    </choose>
+        <choose>
+          <if variable="publisher">
+            <text variable="publisher"/>
+          </if>
+          <else>
+            <text term="no date" form="short" font-style="italic" prefix="[" suffix="]"/>
+          </else>
+        </choose>
+      </group>
+      <text macro="issued" prefix=" "/>
+    </group>
   </macro>
   <macro name="issued">
     <!-- Macro responsável por mostrar a data completa de um documento -->

--- a/associacao-brasileira-de-normas-tecnicas-ufrgs.csl
+++ b/associacao-brasileira-de-normas-tecnicas-ufrgs.csl
@@ -54,7 +54,7 @@
       <name>Patrick O'Brien</name>
       <uri>https://citationstyler.com/</uri>
     </contributor>
-   <category citation-format="author-date"/>
+    <category citation-format="author-date"/>
     <category field="generic-base"/>
     <summary>The Brazilian Standard Style in accordance with ABNT-NBR 10520.2023 and ABNT-NBR 6023.2018</summary>
     <updated>2025-09-23T02:00:08+00:00</updated>
@@ -414,9 +414,10 @@
         <if is-uncertain-date="issued">
           <group delimiter=" " prefix="[" suffix="]">
             <text term="circa" form="short"/>
-          <date variable="issued">
-            <date-part name="year" />
-          </date></group>
+            <date variable="issued">
+              <date-part name="year"/>
+            </date>
+          </group>
         </if>
         <else-if variable="issued" match="any">
           <choose>
@@ -623,13 +624,13 @@
       <text variable="page"/>
     </group>
   </macro>
-    <macro name="number">
+  <macro name="number">
     <group delimiter=" ">
       <label variable="number" form="short"/>
       <text variable="number"/>
     </group>
   </macro>
-      <macro name="volume">
+  <macro name="volume">
     <group delimiter=" ">
       <label variable="number" form="short"/>
       <text variable="number"/>

--- a/associacao-brasileira-de-normas-tecnicas-ufrgs.csl
+++ b/associacao-brasileira-de-normas-tecnicas-ufrgs.csl
@@ -57,7 +57,7 @@
     <category citation-format="author-date"/>
     <category field="generic-base"/>
     <summary>The Brazilian Standard Style in accordance with ABNT-NBR 10520.2023 and ABNT-NBR 6023.2018</summary>
-    <updated>2025-09-23T02:00:08+00:00</updated>
+    <updated>2025-09-25T02:00:08+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale xml:lang="pt-BR">

--- a/associacao-brasileira-de-normas-tecnicas-ufrgs.csl
+++ b/associacao-brasileira-de-normas-tecnicas-ufrgs.csl
@@ -50,10 +50,14 @@
       <name>Leticia Strehl</name>
       <uri>http://www.mendeley.com/profiles/leticia-strehl/</uri>
     </contributor>
-    <category citation-format="author-date"/>
+    <contributor>
+      <name>Patrick O'Brien</name>
+      <uri>https://citationstyler.com/</uri>
+    </contributor>
+   <category citation-format="author-date"/>
     <category field="generic-base"/>
     <summary>The Brazilian Standard Style in accordance with ABNT-NBR 10520.2023 and ABNT-NBR 6023.2018</summary>
-    <updated>2023-11-27T02:00:08+00:00</updated>
+    <updated>2025-09-23T02:00:08+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale xml:lang="pt-BR">


### PR DESCRIPTION
I noticed this style was used as a template for other ABNT variants and I was requesting the same changes. This PR fixes issues with this style, so we don't see them in the future when it is used as a template.

Main issues:
- Use of `value` instead of term/label
- Lack of use of groups
- repetition of elements that could be done via a macro

(nota bene, I've added a bunch of macros that are not shown as changes, oddly enough)