### PR TITLE
Update uniwersytet-gdanski-kulturoznawstwo.csl

### DIFF
--- a/uniwersytet-gdanski-kulturoznawstwo-autor-rok.csl
+++ b/uniwersytet-gdanski-kulturoznawstwo-autor-rok.csl
@@ -272,7 +272,7 @@
               <name delimiter-precedes-last="always" initialize="false" initialize-with=". " name-as-sort-order="all" sort-separator=" "/>
               <et-al font-style="normal"/>
             </names>
-            <names variable="producer" prefix="prod. ">
+            <names variable="producer">
               <name delimiter-precedes-last="always" initialize="false" initialize-with=". " name-as-sort-order="all" sort-separator=" "/>
               <et-al font-style="normal"/>
             </names>

--- a/uniwersytet-gdanski-kulturoznawstwo-autor-rok.csl
+++ b/uniwersytet-gdanski-kulturoznawstwo-autor-rok.csl
@@ -22,14 +22,6 @@
   <locale xml:lang="pl">
     <terms>
       <term name="et-al">i in.</term>
-      <term name="number" form="short"> <!-- The default-locale term is currently broken -->
-        <single>nr</single>
-        <multiple>nr.</multiple>
-      </term>
-      <term name="collection-number" form="short"> <!-- The default-locale term is currently broken -->
-        <single>nr</single>
-        <multiple>nr.</multiple>
-      </term>
     </terms>
   </locale>
   <macro name="title">

--- a/uniwersytet-gdanski-kulturoznawstwo-autor-rok.csl
+++ b/uniwersytet-gdanski-kulturoznawstwo-autor-rok.csl
@@ -16,13 +16,17 @@
     <category field="sociology"/>
     <category field="anthropology"/>
     <summary>A Polish in-text citation style based on Uni. of Gdansk Cultural Studies Department guidelines. Wide use range for cultural studies, digital humanities</summary>
-    <updated>2025-09-27T15:52:20+00:00</updated>
+    <updated>2025-09-27T16:51:48+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale xml:lang="pl">
     <terms>
       <term name="et-al">i in.</term>
       <term name="number" form="short"> <!-- The default-locale term is currently broken -->
+        <single>nr</single>
+        <multiple>nr.</multiple>
+      </term>
+      <term name="collection-number" form="short"> <!-- The default-locale term is currently broken -->
         <single>nr</single>
         <multiple>nr.</multiple>
       </term>
@@ -63,8 +67,12 @@
           <if match="any" variable="collection-title">
             <group delimiter=" ">
               <text variable="collection-title"/>
-              <text term="number" form="short"/>
-              <text variable="collection-number"/>
+              <choose>
+                <if match="any" variable="collection-number">
+                  <label variable="collection-number" form="short"/>
+                  <text variable="collection-number"/>
+                </if>
+              </choose>
             </group>
           </if>
         </choose>
@@ -197,8 +205,12 @@
               <if match="any" variable="collection-title">
                 <group delimiter=" ">
                   <text variable="collection-title"/>
-                  <text term="number" form="short"/>
-                  <text variable="collection-number"/>
+                  <choose>
+                    <if match="any" variable="collection-number">
+                      <label variable="collection-number" form="short"/>
+                      <text variable="collection-number"/>
+                    </if>
+                  </choose>
                 </group>
               </if>
             </choose>
@@ -226,7 +238,7 @@
             <choose>
               <if match="any" variable="number">
                 <group delimiter=" ">
-                  <text term="number" form="short"/>
+                  <label variable="number" form="short"/>
                   <text variable="number"/>
                 </group>
               </if>
@@ -329,8 +341,12 @@
               <if match="any" variable="collection-title">
                 <group delimiter=" ">
                   <text variable="collection-title"/>
-                  <text term="number" form="short"/>
-                  <text variable="collection-number"/>
+                  <choose>
+                    <if match="any" variable="collection-number">
+                      <label variable="collection-number" form="short"/>
+                      <text variable="collection-number"/>
+                    </if>
+                  </choose>
                 </group>
               </if>
             </choose>

--- a/uniwersytet-gdanski-kulturoznawstwo-autor-rok.csl
+++ b/uniwersytet-gdanski-kulturoznawstwo-autor-rok.csl
@@ -16,19 +16,20 @@
     <category field="sociology"/>
     <category field="anthropology"/>
     <summary>A Polish in-text citation style based on Uni. of Gdansk Cultural Studies Department guidelines. Wide use range for cultural studies, digital humanities</summary>
-    <updated>2025-09-27T18:39:48+00:00</updated>
+    <updated>2025-10-05T15:08:38+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale xml:lang="pl">
     <terms>
       <term name="et-al">i in.</term>
+      <term name="entry">hasło</term>
     </terms>
   </locale>
   <macro name="title">
     <text variable="title" text-case="capitalize-first" quotes="false" font-style="italic"/>
   </macro>
   <macro name="title-short">
-    <text variable="title" form="short" text-case="capitalize-first" font-style="normal" prefix="„" suffix="”"/>
+    <text variable="title" form="short" text-case="capitalize-first" quotes="false"/>
   </macro>
   <macro name="author">
     <names variable="author">
@@ -37,13 +38,13 @@
   </macro>
   <macro name="author-bibliography">
     <names variable="author">
-      <name delimiter-precedes-last="always" initialize="false" initialize-with=". " name-as-sort-order="all" sort-separator=" "/>
+      <name delimiter-precedes-last="always" initialize="false" name-as-sort-order="all" sort-separator=" "/>
     </names>
   </macro>
   <macro name="editor-translator-bibliography">
     <names variable="editor translator" delimiter=", ">
       <label form="short" suffix=" "/>
-      <name delimiter-precedes-last="always" initialize="false" initialize-with=". " name-as-sort-order="all" sort-separator=" "/>
+      <name delimiter-precedes-last="always" initialize="false" name-as-sort-order="all" sort-separator=" "/>
     </names>
   </macro>
   <macro name="container-bibliography">
@@ -55,40 +56,21 @@
         <text macro="edition"/>
         <text macro="volume"/>
         <text macro="publisher-place-date"/>
-        <choose>
-          <if match="any" variable="collection-title">
-            <group delimiter=" ">
-              <text variable="collection-title"/>
-              <choose>
-                <if match="any" variable="collection-number">
-                  <label variable="collection-number" form="short"/>
-                  <text variable="collection-number"/>
-                </if>
-              </choose>
-            </group>
-          </if>
-        </choose>
+        <text macro="collection"/>
       </group>
     </group>
   </macro>
   <macro name="journal">
-    <group>
-      <text variable="container-title" quotes="true" font-style="normal"/>
-      <choose>
-        <if match="any" variable="issue">
-          <date date-parts="year" form="numeric" variable="issued" prefix=" "/>
-        </if>
-        <else>
-          <date form="numeric" variable="issued" prefix=", "/>
-        </else>
-      </choose>
-      <text macro="volume" prefix=", "/>
-      <choose>
-        <if match="any" variable="issue">
-          <text term="issue" form="short" text-case="lowercase" prefix=", " suffix=" "/>
-          <text variable="issue"/>
-        </if>
-      </choose>
+    <group delimiter=", ">
+      <group delimiter=" ">
+        <text variable="container-title" quotes="true"/>
+        <date form="numeric" variable="issued"/>
+      </group>
+      <text macro="volume"/>
+      <group delimiter=" ">
+        <label variable="issue" form="short"/>
+        <text variable="issue"/>
+      </group>
     </group>
   </macro>
   <macro name="publisher-place-date">
@@ -101,24 +83,25 @@
     </group>
   </macro>
   <macro name="volume">
-    <choose>
-      <if match="any" variable="volume">
-        <group delimiter=" ">
-          <text term="volume" form="short" text-case="lowercase"/>
-          <text variable="volume"/>
-        </group>
-      </if>
-    </choose>
+    <group delimiter=" ">
+      <label variable="volume" form="short"/>
+      <text variable="volume"/>
+    </group>
   </macro>
   <macro name="edition">
-    <choose>
-      <if match="any" variable="edition">
-        <group delimiter=" ">
-          <text term="edition" form="short"/>
-          <text variable="edition"/>
-        </group>
-      </if>
-    </choose>
+    <group delimiter=" ">
+      <label variable="edition" form="short"/>
+      <text variable="edition"/>
+    </group>
+  </macro>
+  <macro name="collection">
+    <group delimiter=" ">
+      <text variable="collection-title"/>
+      <group delimiter=" ">
+        <label variable="collection-number" form="short"/>
+        <text variable="collection-number"/>
+      </group>
+    </group>
   </macro>
   <macro name="url-accessed">
     <group delimiter=" ">
@@ -193,19 +176,7 @@
             <text macro="volume"/>
             <text macro="edition"/>
             <text macro="publisher-place-date"/>
-            <choose>
-              <if match="any" variable="collection-title">
-                <group delimiter=" ">
-                  <text variable="collection-title"/>
-                  <choose>
-                    <if match="any" variable="collection-number">
-                      <label variable="collection-number" form="short"/>
-                      <text variable="collection-number"/>
-                    </if>
-                  </choose>
-                </group>
-              </if>
-            </choose>
+            <text macro="collection"/>
           </group>
         </if>
         <else-if type="chapter">
@@ -227,14 +198,10 @@
             <text macro="author-bibliography"/>
             <text macro="title"/>
             <text variable="genre"/>
-            <choose>
-              <if match="any" variable="number">
-                <group delimiter=" ">
-                  <label variable="number" form="short"/>
-                  <text variable="number"/>
-                </group>
-              </if>
-            </choose>
+            <group delimiter=" ">
+              <label variable="number" form="short"/>
+              <text variable="number"/>
+            </group>
             <text macro="publisher-place-date"/>
           </group>
         </else-if>
@@ -271,10 +238,10 @@
             <text macro="title"/>
             <text variable="volume"/>
             <names variable="director">
-              <name delimiter-precedes-last="always" initialize="false" initialize-with=". " name-as-sort-order="all" sort-separator=" "/>
+              <name delimiter-precedes-last="always" initialize="false" name-as-sort-order="all" sort-separator=" "/>
             </names>
             <names variable="producer">
-              <name delimiter-precedes-last="always" initialize="false" initialize-with=". " name-as-sort-order="all" sort-separator=" "/>
+              <name delimiter-precedes-last="always" initialize="false" name-as-sort-order="all" sort-separator=" "/>
             </names>
             <text macro="publisher-place-date"/>
             <text macro="url-accessed"/>
@@ -290,7 +257,7 @@
                   <text term="in" prefix="[" suffix=":]"/>
                   <group delimiter=", ">
                     <names variable="composer">
-                      <name delimiter-precedes-last="always" initialize="false" initialize-with=". " name-as-sort-order="all" sort-separator=" "/>
+                      <name delimiter-precedes-last="always" initialize="false" name-as-sort-order="all" sort-separator=" "/>
                     </names>
                     <text variable="collection-title" font-style="italic"/>
                   </group>
@@ -329,19 +296,7 @@
             <text macro="edition"/>
             <text macro="volume"/>
             <text macro="publisher-place-date"/>
-            <choose>
-              <if match="any" variable="collection-title">
-                <group delimiter=" ">
-                  <text variable="collection-title"/>
-                  <choose>
-                    <if match="any" variable="collection-number">
-                      <label variable="collection-number" form="short"/>
-                      <text variable="collection-number"/>
-                    </if>
-                  </choose>
-                </group>
-              </if>
-            </choose>
+            <text macro="collection"/>
           </group>
         </else>
       </choose>

--- a/uniwersytet-gdanski-kulturoznawstwo-autor-rok.csl
+++ b/uniwersytet-gdanski-kulturoznawstwo-autor-rok.csl
@@ -16,12 +16,12 @@
     <category field="sociology"/>
     <category field="anthropology"/>
     <summary>A Polish in-text citation style based on Uni. of Gdansk Cultural Studies Department guidelines. Wide use range for cultural studies, digital humanities</summary>
-    <updated>2025-09-24T15:17:52+00:00</updated>
+    <updated>2025-09-27T13:06:45+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale xml:lang="pl">
     <terms>
-      <term name="et-al">et al.</term>
+      <term name="et-al">i in.</term>
     </terms>
   </locale>
   <macro name="title">
@@ -33,30 +33,27 @@
   <macro name="author">
     <names variable="author">
       <name form="short" delimiter-precedes-last="always" initialize-with=". "/>
-      <et-al font-style="italic"/>
+      <et-al font-style="normal"/>
     </names>
   </macro>
   <macro name="author-bibliography">
     <names variable="author">
       <name delimiter-precedes-last="always" initialize="false" initialize-with=". " name-as-sort-order="all" sort-separator=" "/>
-      <et-al font-style="italic"/>
+      <et-al font-style="normal"/>
     </names>
   </macro>
   <macro name="editor-translator-bibliography">
     <names variable="editor translator" delimiter=", ">
       <label form="short" suffix=" "/>
       <name delimiter-precedes-last="always" initialize="false" initialize-with=". " name-as-sort-order="all" sort-separator=" "/>
+      <et-al/>
     </names>
   </macro>
   <macro name="container-bibliography">
-    <text term="in" prefix=" [" suffix=":] "/>
+    <text term="in" prefix="[" suffix=":] "/>
     <group delimiter=", ">
       <text variable="container-title" font-style="italic"/>
-      <choose>
-        <if match="any" variable="editor translator">
-          <text macro="editor-translator-bibliography"/>
-        </if>
-      </choose>
+      <text macro="editor-translator-bibliography"/>
       <choose>
         <if match="any" variable="edition">
           <text macro="edition"/>
@@ -104,10 +101,12 @@
     </group>
   </macro>
   <macro name="publisher-place-date">
-    <group delimiter=" ">
-      <text variable="publisher" suffix=","/>
-      <text variable="publisher-place"/>
-      <date date-parts="year" form="numeric" variable="issued"/>
+    <group delimiter=", ">
+      <text variable="publisher"/>
+      <group delimiter=" ">
+        <text variable="publisher-place"/>
+        <date date-parts="year" form="numeric" variable="issued"/>
+      </group>
     </group>
   </macro>
   <macro name="volume">
@@ -158,11 +157,7 @@
                 </else>
               </choose>
             </group>
-            <choose>
-              <if match="any" variable="locator">
-                <text macro="locator"/>
-              </if>
-            </choose>
+            <text macro="locator"/>
           </group>
         </if>
         <else>
@@ -178,11 +173,7 @@
                 </else>
               </choose>
             </group>
-            <choose>
-              <if match="any" variable="locator">
-                <text macro="locator"/>
-              </if>
-            </choose>
+            <text macro="locator"/>
           </group>
         </else>
       </choose>
@@ -197,17 +188,9 @@
       <choose>
         <if type="book">
           <group delimiter=", ">
-            <choose>
-              <if match="any" variable="author">
-                <text macro="author-bibliography"/>
-              </if>
-            </choose>
+            <text macro="author-bibliography"/>
             <text macro="title"/>
-            <choose>
-              <if match="any" variable="editor translator">
-                <text macro="editor-translator-bibliography"/>
-              </if>
-            </choose>
+            <text macro="editor-translator-bibliography"/>
             <choose>
               <if match="any" variable="volume">
                 <text macro="volume"/>
@@ -233,18 +216,15 @@
         <else-if type="chapter">
           <group delimiter=", ">
             <text macro="author-bibliography"/>
-            <text macro="title" suffix=","/>
+            <text macro="title"/>
+            <text macro="container-bibliography"/>
           </group>
-          <text macro="container-bibliography"/>
         </else-if>
         <else-if type="article article-journal article-newspaper article-magazine" match="any">
           <group delimiter=", ">
             <text macro="author-bibliography"/>
-            <group delimiter=" ">
-              <text macro="title" suffix=","/>
-              <text macro="journal"/>
-            </group>
-            <text macro="locator"/>
+            <text macro="title"/>
+            <text macro="journal"/>
           </group>
         </else-if>
         <else-if type="report" match="any">
@@ -261,29 +241,17 @@
             <text macro="author-bibliography"/>
             <text macro="title"/>
             <text variable="event-title"/>
-            <choose>
-              <if match="any" variable="container-title">
-                <text variable="container-title"/>
-              </if>
-            </choose>
+            <text variable="container-title"/>
             <text macro="publisher-place-date"/>
           </group>
         </else-if>
         <else-if type="webpage post-weblog post" match="any">
           <group delimiter=", ">
-            <choose>
-              <if match="any" variable="author">
-                <text macro="author-bibliography"/>
-              </if>
-            </choose>
+            <text macro="author-bibliography"/>
             <text macro="title"/>
             <text variable="genre"/>
             <text variable="container-title"/>
-            <choose>
-              <if match="any" variable="issued">
-                <date date-parts="year" form="numeric" variable="issued"/>
-              </if>
-            </choose>
+            <date date-parts="year" form="numeric" variable="issued"/>
             <text macro="url-accessed"/>
           </group>
         </else-if>
@@ -293,76 +261,60 @@
             <text macro="title"/>
             <text macro="publisher-place-date"/>
             <text variable="medium"/>
-            <choose>
-              <if match="any" variable="version">
-                <text variable="version"/>
-              </if>
-            </choose>
+            <text variable="version"/>
           </group>
         </else-if>
         <else-if type="motion_picture" match="any">
           <group delimiter=", ">
             <text macro="title"/>
-            <choose>
-              <if match="any" variable="volume">
-                <text variable="volume"/>
-              </if>
-            </choose>
-            <choose>
-              <if match="any" variable="director">
-                <names variable="director">
-                  <name delimiter-precedes-last="always" initialize="false" initialize-with=". " name-as-sort-order="all" sort-separator=" "/>
-                  <et-al font-style="italic"/>
-                </names>
-              </if>
-            </choose>
-            <choose>
-              <if match="any" variable="producer">
-                <names variable="producer" prefix="prod. ">
-                  <name delimiter-precedes-last="always" initialize="false" initialize-with=". " name-as-sort-order="all" sort-separator=" "/>
-                  <et-al font-style="italic"/>
-                </names>
-              </if>
-            </choose>
+            <text variable="volume"/>
+            <names variable="director">
+              <name delimiter-precedes-last="always" initialize="false" initialize-with=". " name-as-sort-order="all" sort-separator=" "/>
+              <et-al font-style="normal"/>
+            </names>
+            <names variable="producer" prefix="prod. ">
+              <name delimiter-precedes-last="always" initialize="false" initialize-with=". " name-as-sort-order="all" sort-separator=" "/>
+              <et-al font-style="normal"/>
+            </names>
             <text macro="publisher-place-date"/>
-            <choose>
-              <if match="any" variable="URL">
-                <text macro="url-accessed"/>
-              </if>
-            </choose>
+            <text macro="url-accessed"/>
           </group>
         </else-if>
         <else-if type="song" match="any">
-          <group>
-            <text macro="author-bibliography" suffix=", "/>
-            <text macro="title" suffix=", "/>
-            <text term="in" prefix="[" suffix=":] "/>
+          <group delimiter=", ">
+            <text macro="author-bibliography"/>
+            <text macro="title"/>
             <choose>
-              <if match="any" variable="composer">
-                <names variable="composer" suffix=", ">
-                  <name delimiter-precedes-last="always" initialize="false" initialize-with=". " name-as-sort-order="all" sort-separator=" "/>
-                  <et-al font-style="italic"/>
-                </names>
+              <if match="any" variable="collection-title">
+                <group>
+                  <text term="in" prefix="[" suffix=":] "/>
+                  <group delimiter=", ">
+                    <names variable="composer">
+                      <name delimiter-precedes-last="always" initialize="false" initialize-with=". " name-as-sort-order="all" sort-separator=" "/>
+                      <et-al font-style="normal"/>
+                    </names>
+                    <text variable="collection-title" font-style="italic"/>
+                  </group>
+                </group>
               </if>
             </choose>
-            <text variable="collection-title" font-style="italic" suffix=", "/>
             <text macro="publisher-place-date"/>
           </group>
         </else-if>
         <else-if type="entry-dictionary entry-encyclopedia" match="any">
           <choose>
             <if match="any" variable="editor">
-              <group>
-                <text variable="container-title" suffix=", "/>
-                <text macro="editor-translator-bibliography" suffix=", "/>
+              <group delimiter=", ">
+                <text variable="container-title"/>
+                <text macro="editor-translator-bibliography"/>
                 <choose>
                   <if match="any" variable="volume">
-                    <text macro="volume" suffix=", "/>
+                    <text macro="volume"/>
                   </if>
                 </choose>
                 <choose>
                   <if match="any" variable="edition">
-                    <text macro="edition" suffix=", "/>
+                    <text macro="edition"/>
                   </if>
                 </choose>
                 <text macro="publisher-place-date"/>
@@ -381,16 +333,8 @@
           <group delimiter=", ">
             <text macro="author-bibliography"/>
             <text macro="title"/>
-            <choose>
-              <if match="any" variable="genre">
-                <text variable="genre"/>
-              </if>
-            </choose>
-            <choose>
-              <if match="any" variable="editor translator">
-                <text macro="editor-translator-bibliography"/>
-              </if>
-            </choose>
+            <text variable="genre"/>
+            <text macro="editor-translator-bibliography"/>
             <choose>
               <if match="any" variable="edition">
                 <text macro="edition"/>

--- a/uniwersytet-gdanski-kulturoznawstwo-autor-rok.csl
+++ b/uniwersytet-gdanski-kulturoznawstwo-autor-rok.csl
@@ -16,12 +16,16 @@
     <category field="sociology"/>
     <category field="anthropology"/>
     <summary>A Polish in-text citation style based on Uni. of Gdansk Cultural Studies Department guidelines. Wide use range for cultural studies, digital humanities</summary>
-    <updated>2025-09-27T13:06:45+00:00</updated>
+    <updated>2025-09-27T15:52:20+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale xml:lang="pl">
     <terms>
       <term name="et-al">i in.</term>
+      <term name="number" form="short"> <!-- The default-locale term is currently broken -->
+        <single>nr</single>
+        <multiple>nr.</multiple>
+      </term>
     </terms>
   </locale>
   <macro name="title">
@@ -33,47 +37,38 @@
   <macro name="author">
     <names variable="author">
       <name form="short" delimiter-precedes-last="always" initialize-with=". "/>
-      <et-al font-style="normal"/>
     </names>
   </macro>
   <macro name="author-bibliography">
     <names variable="author">
       <name delimiter-precedes-last="always" initialize="false" initialize-with=". " name-as-sort-order="all" sort-separator=" "/>
-      <et-al font-style="normal"/>
     </names>
   </macro>
   <macro name="editor-translator-bibliography">
     <names variable="editor translator" delimiter=", ">
       <label form="short" suffix=" "/>
       <name delimiter-precedes-last="always" initialize="false" initialize-with=". " name-as-sort-order="all" sort-separator=" "/>
-      <et-al/>
     </names>
   </macro>
   <macro name="container-bibliography">
-    <text term="in" prefix="[" suffix=":] "/>
-    <group delimiter=", ">
-      <text variable="container-title" font-style="italic"/>
-      <text macro="editor-translator-bibliography"/>
-      <choose>
-        <if match="any" variable="edition">
-          <text macro="edition"/>
-        </if>
-      </choose>
-      <choose>
-        <if match="any" variable="volume">
-          <text macro="volume"/>
-        </if>
-      </choose>
-      <text macro="publisher-place-date"/>
-      <choose>
-        <if match="any" variable="collection-title">
-          <group delimiter=" ">
-            <text variable="collection-title"/>
-            <text term="number" form="short"/>
-            <text variable="collection-number"/>
-          </group>
-        </if>
-      </choose>
+    <group delimiter=" ">
+      <text term="in" prefix="[" suffix=":]"/>
+      <group delimiter=", ">
+        <text variable="container-title" font-style="italic"/>
+        <text macro="editor-translator-bibliography"/>
+        <text macro="edition"/>
+        <text macro="volume"/>
+        <text macro="publisher-place-date"/>
+        <choose>
+          <if match="any" variable="collection-title">
+            <group delimiter=" ">
+              <text variable="collection-title"/>
+              <text term="number" form="short"/>
+              <text variable="collection-number"/>
+            </group>
+          </if>
+        </choose>
+      </group>
     </group>
   </macro>
   <macro name="journal">
@@ -87,11 +82,7 @@
           <date form="numeric" variable="issued" prefix=", "/>
         </else>
       </choose>
-      <choose>
-        <if match="any" variable="volume">
-          <text macro="volume" prefix=", "/>
-        </if>
-      </choose>
+      <text macro="volume" prefix=", "/>
       <choose>
         <if match="any" variable="issue">
           <text term="issue" form="short" text-case="lowercase" prefix=", " suffix=" "/>
@@ -110,16 +101,24 @@
     </group>
   </macro>
   <macro name="volume">
-    <group delimiter=" ">
-      <text term="volume" form="short" text-case="lowercase"/>
-      <text variable="volume"/>
-    </group>
+    <choose>
+      <if match="any" variable="volume">
+        <group delimiter=" ">
+          <text term="volume" form="short" text-case="lowercase"/>
+          <text variable="volume"/>
+        </group>
+      </if>
+    </choose>
   </macro>
   <macro name="edition">
-    <group delimiter=" ">
-      <text term="edition" form="short"/>
-      <text variable="edition"/>
-    </group>
+    <choose>
+      <if match="any" variable="edition">
+        <group delimiter=" ">
+          <text term="edition" form="short"/>
+          <text variable="edition"/>
+        </group>
+      </if>
+    </choose>
   </macro>
   <macro name="url-accessed">
     <group delimiter=" ">
@@ -191,16 +190,8 @@
             <text macro="author-bibliography"/>
             <text macro="title"/>
             <text macro="editor-translator-bibliography"/>
-            <choose>
-              <if match="any" variable="volume">
-                <text macro="volume"/>
-              </if>
-            </choose>
-            <choose>
-              <if match="any" variable="edition">
-                <text macro="edition"/>
-              </if>
-            </choose>
+            <text macro="volume"/>
+            <text macro="edition"/>
             <text macro="publisher-place-date"/>
             <choose>
               <if match="any" variable="collection-title">
@@ -232,7 +223,14 @@
             <text macro="author-bibliography"/>
             <text macro="title"/>
             <text variable="genre"/>
-            <text variable="number" prefix="nr "/>
+            <choose>
+              <if match="any" variable="number">
+                <group delimiter=" ">
+                  <text term="number" form="short"/>
+                  <text variable="number"/>
+                </group>
+              </if>
+            </choose>
             <text macro="publisher-place-date"/>
           </group>
         </else-if>
@@ -270,11 +268,9 @@
             <text variable="volume"/>
             <names variable="director">
               <name delimiter-precedes-last="always" initialize="false" initialize-with=". " name-as-sort-order="all" sort-separator=" "/>
-              <et-al font-style="normal"/>
             </names>
             <names variable="producer">
               <name delimiter-precedes-last="always" initialize="false" initialize-with=". " name-as-sort-order="all" sort-separator=" "/>
-              <et-al font-style="normal"/>
             </names>
             <text macro="publisher-place-date"/>
             <text macro="url-accessed"/>
@@ -286,12 +282,11 @@
             <text macro="title"/>
             <choose>
               <if match="any" variable="collection-title">
-                <group>
-                  <text term="in" prefix="[" suffix=":] "/>
+                <group delimiter=" ">
+                  <text term="in" prefix="[" suffix=":]"/>
                   <group delimiter=", ">
                     <names variable="composer">
                       <name delimiter-precedes-last="always" initialize="false" initialize-with=". " name-as-sort-order="all" sort-separator=" "/>
-                      <et-al font-style="normal"/>
                     </names>
                     <text variable="collection-title" font-style="italic"/>
                   </group>
@@ -307,16 +302,8 @@
               <group delimiter=", ">
                 <text variable="container-title"/>
                 <text macro="editor-translator-bibliography"/>
-                <choose>
-                  <if match="any" variable="volume">
-                    <text macro="volume"/>
-                  </if>
-                </choose>
-                <choose>
-                  <if match="any" variable="edition">
-                    <text macro="edition"/>
-                  </if>
-                </choose>
+                <text macro="volume"/>
+                <text macro="edition"/>
                 <text macro="publisher-place-date"/>
               </group>
             </if>
@@ -335,16 +322,8 @@
             <text macro="title"/>
             <text variable="genre"/>
             <text macro="editor-translator-bibliography"/>
-            <choose>
-              <if match="any" variable="edition">
-                <text macro="edition"/>
-              </if>
-            </choose>
-            <choose>
-              <if match="any" variable="volume">
-                <text macro="volume"/>
-              </if>
-            </choose>
+            <text macro="edition"/>
+            <text macro="volume"/>
             <text macro="publisher-place-date"/>
             <choose>
               <if match="any" variable="collection-title">

--- a/uniwersytet-gdanski-kulturoznawstwo-autor-rok.csl
+++ b/uniwersytet-gdanski-kulturoznawstwo-autor-rok.csl
@@ -15,8 +15,8 @@
     <category field="humanities"/>
     <category field="sociology"/>
     <category field="anthropology"/>
-    <summary>A Polish in-text citation style with wide use range for cultural studies, digital humanities. Based on Uni. of Gdansk guildelines</summary>
-    <updated>2025-08-10T17:26:29+00:00</updated>
+    <summary>A Polish in-text citation style based on Uni. of Gdansk Cultural Studies Department guidelines. Wide use range for cultural studies, digital humanities</summary>
+    <updated>2025-09-24T15:17:52+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale xml:lang="pl">
@@ -289,6 +289,7 @@
         </else-if>
         <else-if type="software" match="any">
           <group delimiter=", ">
+            <text macro="author-bibliography"/>
             <text macro="title"/>
             <text macro="publisher-place-date"/>
             <text variable="medium"/>

--- a/uniwersytet-gdanski-kulturoznawstwo-autor-rok.csl
+++ b/uniwersytet-gdanski-kulturoznawstwo-autor-rok.csl
@@ -16,7 +16,7 @@
     <category field="sociology"/>
     <category field="anthropology"/>
     <summary>A Polish in-text citation style based on Uni. of Gdansk Cultural Studies Department guidelines. Wide use range for cultural studies, digital humanities</summary>
-    <updated>2025-09-27T16:51:48+00:00</updated>
+    <updated>2025-09-27T18:39:48+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale xml:lang="pl">

--- a/uniwersytet-gdanski-kulturoznawstwo-przypis.csl
+++ b/uniwersytet-gdanski-kulturoznawstwo-przypis.csl
@@ -96,8 +96,8 @@
       </choose>
       <text macro="volume"/>
       <group delimiter=" ">
-          <text term="issue" form="short" text-case="lowercase" suffix=" "/>
-          <text variable="issue"/>
+        <text term="issue" form="short" text-case="lowercase" suffix=" "/>
+        <text variable="issue"/>
       </group>
     </group>
   </macro>
@@ -111,16 +111,16 @@
     </group>
   </macro>
   <macro name="volume">
-        <group delimiter=" ">
-          <text term="volume" form="short" text-case="lowercase"/>
-          <text variable="volume"/>
-        </group>
+    <group delimiter=" ">
+      <text term="volume" form="short" text-case="lowercase"/>
+      <text variable="volume"/>
+    </group>
   </macro>
   <macro name="edition">
-        <group delimiter=" ">
-          <text term="edition" form="short"/>
-          <text variable="edition"/>
-        </group>
+    <group delimiter=" ">
+      <text term="edition" form="short"/>
+      <text variable="edition"/>
+    </group>
   </macro>
   <macro name="url-accessed">
     <group delimiter=" ">
@@ -140,7 +140,7 @@
       <group delimiter=" ">
         <label variable="collection-number" form="short"/>
         <text variable="collection-number"/>
-      </group>      
+      </group>
     </group>
   </macro>
   <citation et-al-min="3" et-al-use-first="1" initialize-with=". " sort-separator=" " disambiguate-add-names="true">

--- a/uniwersytet-gdanski-kulturoznawstwo-przypis.csl
+++ b/uniwersytet-gdanski-kulturoznawstwo-przypis.csl
@@ -16,7 +16,7 @@
     <category field="sociology"/>
     <category field="anthropology"/>
     <summary>A Polish note citation style based on Uni. of Gdansk Cultural Studies Department guidelines. Wide use range for cultural studies, digital humanities</summary>
-    <updated>2025-09-27T13:05:58+00:00</updated>
+    <updated>2025-09-27T15:42:50+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale xml:lang="pl">
@@ -24,6 +24,10 @@
       <term name="ibid">tamże</term>
       <term name="et-al">i in.</term>
       <term name="op-cit">dz. cyt.</term>
+      <term name="number" form="short"> <!-- The default-locale term is currently broken -->
+        <single>nr</single>
+        <multiple>nr.</multiple>
+      </term>
     </terms>
   </locale>
   <macro name="title">
@@ -36,81 +40,65 @@
   <macro name="author">
     <names variable="author">
       <name delimiter-precedes-last="always" initialize-with=". "/>
-      <et-al font-style="normal"/>
     </names>
   </macro>
   <macro name="author-bibliography">
     <names variable="author">
       <name delimiter-precedes-last="always" initialize="false" initialize-with=". " name-as-sort-order="all" sort-separator=" "/>
-      <et-al font-style="normal"/>
     </names>
   </macro>
   <macro name="editor-translator">
     <names variable="editor translator" delimiter=", ">
       <label form="short" suffix=" "/>
       <name delimiter-precedes-last="always" initialize-with=". "/>
-      <et-al/>
     </names>
   </macro>
   <macro name="editor-translator-bibliography">
     <names variable="editor translator" delimiter=", ">
       <label form="short" suffix=" "/>
       <name delimiter-precedes-last="always" initialize="false" initialize-with=". " name-as-sort-order="all" sort-separator=" "/>
-      <et-al/>
     </names>
   </macro>
   <macro name="container">
-    <text term="in" prefix="[" suffix=":] "/>
-    <group delimiter=", ">
-      <text variable="container-title" quotes="false" font-style="italic"/>
-      <text macro="editor-translator"/>
-      <choose>
-        <if match="any" variable="edition">
-          <text macro="edition"/>
-        </if>
-      </choose>
-      <choose>
-        <if match="any" variable="volume">
-          <text macro="volume"/>
-        </if>
-      </choose>
-      <text macro="publisher-place-date"/>
-      <choose>
-        <if match="any" variable="collection-title">
-          <group delimiter=" ">
-            <text variable="collection-title"/>
-            <text term="number" form="short"/>
-            <text variable="collection-number"/>
-          </group>
-        </if>
-      </choose>
+    <group delimiter=" ">
+      <text term="in" prefix="[" suffix=":]"/>
+      <group delimiter=", ">
+        <text variable="container-title" quotes="false" font-style="italic"/>
+        <text macro="editor-translator"/>
+        <text macro="edition"/>
+        <text macro="volume"/>
+        <text macro="publisher-place-date"/>
+        <choose>
+          <if match="any" variable="collection-title">
+            <group delimiter=" ">
+              <text variable="collection-title"/>
+              <text term="number" form="short"/>
+              <text variable="collection-number"/>
+            </group>
+          </if>
+        </choose>
+      </group>
     </group>
   </macro>
   <macro name="container-bibliography">
-    <text term="in" prefix="[" suffix=":] "/>
-    <group delimiter=", ">
-      <text variable="container-title" font-style="italic"/>
-      <text macro="editor-translator-bibliography"/>
-      <choose>
-        <if match="any" variable="edition">
-          <text macro="edition"/>
-        </if>
-      </choose>
-      <choose>
-        <if match="any" variable="volume">
-          <text macro="volume"/>
-        </if>
-      </choose>
-      <text macro="publisher-place-date"/>
-      <choose>
-        <if match="any" variable="collection-title">
-          <group delimiter=" ">
-            <text variable="collection-title"/>
-            <text term="number" form="short"/>
-            <text variable="collection-number"/>
-          </group>
-        </if>
-      </choose>
+    <group delimiter=" ">
+      <text term="in" prefix="[" suffix=":]"/>
+      <group delimiter=", ">
+        <text variable="container-title" font-style="italic"/>
+        <text macro="editor-translator-bibliography"/>
+        <text macro="edition"/>
+        <text macro="volume"/>
+        <text macro="publisher-place-date"/>
+        <choose>
+          <if match="any" variable="collection-title">
+            <group delimiter=" ">
+              <text variable="collection-title"/>
+              <text term="number" form="short"/>
+              <text variable="collection-number"/>
+            </group>
+          </if>
+        </choose>
+      </group>
     </group>
   </macro>
   <macro name="journal">
@@ -124,11 +112,7 @@
           <date form="numeric" variable="issued" prefix=", "/>
         </else>
       </choose>
-      <choose>
-        <if match="any" variable="volume">
-          <text macro="volume" prefix=", "/>
-        </if>
-      </choose>
+      <text macro="volume" prefix=", "/>
       <choose>
         <if match="any" variable="issue">
           <text term="issue" form="short" text-case="lowercase" prefix=", " suffix=" "/>
@@ -147,16 +131,24 @@
     </group>
   </macro>
   <macro name="volume">
-    <group delimiter=" ">
-      <text term="volume" form="short" text-case="lowercase"/>
-      <text variable="volume"/>
-    </group>
+    <choose>
+      <if match="any" variable="volume">
+        <group delimiter=" ">
+          <text term="volume" form="short" text-case="lowercase"/>
+          <text variable="volume"/>
+        </group>
+      </if>
+    </choose>
   </macro>
   <macro name="edition">
-    <group delimiter=" ">
-      <text term="edition" form="short"/>
-      <text variable="edition"/>
-    </group>
+    <choose>
+      <if match="any" variable="edition">
+        <group delimiter=" ">
+          <text term="edition" form="short"/>
+          <text variable="edition"/>
+        </group>
+      </if>
+    </choose>
   </macro>
   <macro name="url-accessed">
     <group delimiter=" ">
@@ -184,16 +176,8 @@
                 <text macro="author"/>
                 <text macro="title"/>
                 <text macro="editor-translator"/>
-                <choose>
-                  <if match="any" variable="volume">
-                    <text macro="volume"/>
-                  </if>
-                </choose>
-                <choose>
-                  <if match="any" variable="edition">
-                    <text macro="edition"/>
-                  </if>
-                </choose>
+                <text macro="volume"/>
+                <text macro="edition"/>
                 <text macro="publisher-place-date"/>
                 <choose>
                   <if match="any" variable="collection-title">
@@ -228,7 +212,14 @@
                 <text macro="author"/>
                 <text macro="title"/>
                 <text variable="genre"/>
-                <text variable="number" prefix="nr "/>
+                <choose>
+                  <if match="any" variable="number">
+                    <group delimiter=" ">
+                      <text term="number" form="short"/>
+                      <text variable="number"/>
+                    </group>
+                  </if>
+                </choose>
                 <text macro="publisher-place-date"/>
                 <text macro="locator"/>
               </group>
@@ -270,11 +261,9 @@
                 <text variable="volume"/>
                 <names variable="director">
                   <name delimiter-precedes-last="always" initialize-with=". "/>
-                  <et-al font-style="normal"/>
                 </names>
                 <names variable="producer">
                   <name delimiter-precedes-last="always" initialize-with=". "/>
-                  <et-al font-style="normal"/>
                 </names>
                 <text macro="publisher-place-date"/>
                 <text macro="locator"/>
@@ -287,12 +276,11 @@
                 <text macro="title"/>
                 <choose>
                   <if match="any" variable="collection-title">
-                    <group>
-                      <text term="in" prefix="[" suffix=":] "/>
+                    <group delimiter=" ">
+                      <text term="in" prefix="[" suffix=":]"/>
                       <group delimiter=", ">
                         <names variable="composer">
                           <name delimiter-precedes-last="always" initialize-with=". "/>
-                          <et-al font-style="normal"/>
                         </names>
                         <text variable="collection-title" font-style="italic"/>
                       </group>
@@ -300,7 +288,7 @@
                   </if>
                 </choose>
                 <text macro="publisher-place-date"/>
-                <text macro="locator" prefix=", "/>
+                <text macro="locator"/>
               </group>
             </else-if>
             <else-if type="entry-dictionary entry-encyclopedia" match="any">
@@ -311,16 +299,8 @@
                     <text macro="title"/>
                     <text variable="container-title" font-style="italic" prefix="[hasło w:] "/>
                     <text macro="editor-translator"/>
-                    <choose>
-                      <if match="any" variable="volume">
-                        <text macro="volume"/>
-                      </if>
-                    </choose>
-                    <choose>
-                      <if match="any" variable="edition">
-                        <text macro="edition"/>
-                      </if>
-                    </choose>
+                    <text macro="volume"/>
+                    <text macro="edition"/>
                     <text macro="publisher-place-date"/>
                     <text macro="locator"/>
                   </group>
@@ -342,16 +322,8 @@
                 <text macro="title"/>
                 <text variable="genre"/>
                 <text macro="editor-translator"/>
-                <choose>
-                  <if match="any" variable="edition">
-                    <text macro="edition"/>
-                  </if>
-                </choose>
-                <choose>
-                  <if match="any" variable="volume">
-                    <text macro="volume"/>
-                  </if>
-                </choose>
+                <text macro="edition"/>
+                <text macro="volume"/>
                 <text macro="publisher-place-date"/>
                 <choose>
                   <if match="any" variable="collection-title">
@@ -380,11 +352,7 @@
           <group delimiter=", ">
             <text macro="author"/>
             <text macro="title-short" font-style="italic"/>
-            <choose>
-              <if match="any" variable="volume">
-                <text macro="volume"/>
-              </if>
-            </choose>
+            <text macro="volume"/>
             <text macro="locator"/>
           </group>
         </else-if>
@@ -403,16 +371,8 @@
             <text macro="author-bibliography"/>
             <text macro="title"/>
             <text macro="editor-translator-bibliography"/>
-            <choose>
-              <if match="any" variable="volume">
-                <text macro="volume"/>
-              </if>
-            </choose>
-            <choose>
-              <if match="any" variable="edition">
-                <text macro="edition"/>
-              </if>
-            </choose>
+            <text macro="volume"/>
+            <text macro="edition"/>
             <text macro="publisher-place-date"/>
             <choose>
               <if match="any" variable="collection-title">
@@ -444,7 +404,14 @@
             <text macro="author-bibliography"/>
             <text macro="title"/>
             <text variable="genre"/>
-            <text variable="number" prefix="nr "/>
+            <choose>
+              <if match="any" variable="number">
+                <group delimiter=" ">
+                  <text term="number" form="short"/>
+                  <text variable="number"/>
+                </group>
+              </if>
+            </choose>
             <text macro="publisher-place-date"/>
           </group>
         </else-if>
@@ -482,11 +449,9 @@
             <text variable="volume"/>
             <names variable="director">
               <name delimiter-precedes-last="always" initialize="false" initialize-with=". " name-as-sort-order="all" sort-separator=" "/>
-              <et-al font-style="normal"/>
             </names>
             <names variable="producer">
               <name delimiter-precedes-last="always" initialize="false" initialize-with=". " name-as-sort-order="all" sort-separator=" "/>
-              <et-al font-style="normal"/>
             </names>
             <text macro="publisher-place-date"/>
             <text macro="url-accessed"/>
@@ -498,12 +463,11 @@
             <text macro="title"/>
             <choose>
               <if match="any" variable="collection-title">
-                <group>
-                  <text term="in" prefix="[" suffix=":] "/>
+                <group delimiter=" ">
+                  <text term="in" prefix="[" suffix=":]"/>
                   <group delimiter=", ">
                     <names variable="composer">
                       <name delimiter-precedes-last="always" initialize="false" initialize-with=". " name-as-sort-order="all" sort-separator=" "/>
-                      <et-al font-style="normal"/>
                     </names>
                     <text variable="collection-title" font-style="italic"/>
                   </group>
@@ -517,18 +481,10 @@
           <choose>
             <if match="any" variable="editor">
               <group delimiter=", ">
-                <text variable="container-title" suffix=", "/>
+                <text variable="container-title"/>
                 <text macro="editor-translator-bibliography"/>
-                <choose>
-                  <if match="any" variable="volume">
-                    <text macro="volume"/>
-                  </if>
-                </choose>
-                <choose>
-                  <if match="any" variable="edition">
-                    <text macro="edition"/>
-                  </if>
-                </choose>
+                <text macro="volume"/>
+                <text macro="edition"/>
                 <text macro="publisher-place-date"/>
               </group>
             </if>
@@ -547,16 +503,8 @@
             <text macro="title"/>
             <text variable="genre"/>
             <text macro="editor-translator-bibliography"/>
-            <choose>
-              <if match="any" variable="edition">
-                <text macro="edition"/>
-              </if>
-            </choose>
-            <choose>
-              <if match="any" variable="volume">
-                <text macro="volume"/>
-              </if>
-            </choose>
+            <text macro="edition"/>
+            <text macro="volume"/>
             <text macro="publisher-place-date"/>
             <choose>
               <if match="any" variable="collection-title">

--- a/uniwersytet-gdanski-kulturoznawstwo-przypis.csl
+++ b/uniwersytet-gdanski-kulturoznawstwo-przypis.csl
@@ -16,14 +16,14 @@
     <category field="sociology"/>
     <category field="anthropology"/>
     <summary>A Polish note citation style based on Uni. of Gdansk Cultural Studies Department guidelines. Wide use range for cultural studies, digital humanities</summary>
-    <updated>2025-09-24T15:16:34+00:00</updated>
+    <updated>2025-09-27T13:05:58+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale xml:lang="pl">
     <terms>
-      <term name="ibid">ibid.</term>
-      <term name="et-al">et al.</term>
-      <term name="op-cit">op. cit.</term>
+      <term name="ibid">tamże</term>
+      <term name="et-al">i in.</term>
+      <term name="op-cit">dz. cyt.</term>
     </terms>
   </locale>
   <macro name="title">
@@ -36,36 +36,34 @@
   <macro name="author">
     <names variable="author">
       <name delimiter-precedes-last="always" initialize-with=". "/>
-      <et-al font-style="italic"/>
+      <et-al font-style="normal"/>
     </names>
   </macro>
   <macro name="author-bibliography">
     <names variable="author">
       <name delimiter-precedes-last="always" initialize="false" initialize-with=". " name-as-sort-order="all" sort-separator=" "/>
-      <et-al font-style="italic"/>
+      <et-al font-style="normal"/>
     </names>
   </macro>
   <macro name="editor-translator">
     <names variable="editor translator" delimiter=", ">
       <label form="short" suffix=" "/>
       <name delimiter-precedes-last="always" initialize-with=". "/>
+      <et-al/>
     </names>
   </macro>
   <macro name="editor-translator-bibliography">
     <names variable="editor translator" delimiter=", ">
       <label form="short" suffix=" "/>
       <name delimiter-precedes-last="always" initialize="false" initialize-with=". " name-as-sort-order="all" sort-separator=" "/>
+      <et-al/>
     </names>
   </macro>
   <macro name="container">
-    <text term="in" prefix=" [" suffix=":] "/>
+    <text term="in" prefix="[" suffix=":] "/>
     <group delimiter=", ">
       <text variable="container-title" quotes="false" font-style="italic"/>
-      <choose>
-        <if match="any" variable="editor translator">
-          <text macro="editor-translator"/>
-        </if>
-      </choose>
+      <text macro="editor-translator"/>
       <choose>
         <if match="any" variable="edition">
           <text macro="edition"/>
@@ -89,14 +87,10 @@
     </group>
   </macro>
   <macro name="container-bibliography">
-    <text term="in" prefix=" [" suffix=":] "/>
+    <text term="in" prefix="[" suffix=":] "/>
     <group delimiter=", ">
       <text variable="container-title" font-style="italic"/>
-      <choose>
-        <if match="any" variable="editor translator">
-          <text macro="editor-translator-bibliography"/>
-        </if>
-      </choose>
+      <text macro="editor-translator-bibliography"/>
       <choose>
         <if match="any" variable="edition">
           <text macro="edition"/>
@@ -144,10 +138,12 @@
     </group>
   </macro>
   <macro name="publisher-place-date">
-    <group delimiter=" ">
-      <text variable="publisher" suffix=","/>
-      <text variable="publisher-place"/>
-      <date date-parts="year" form="numeric" variable="issued"/>
+    <group delimiter=", ">
+      <text variable="publisher"/>
+      <group delimiter=" ">
+        <text variable="publisher-place"/>
+        <date date-parts="year" form="numeric" variable="issued"/>
+      </group>
     </group>
   </macro>
   <macro name="volume">
@@ -185,17 +181,9 @@
           <choose>
             <if type="book">
               <group delimiter=", ">
-                <choose>
-                  <if match="any" variable="author">
-                    <text macro="author"/>
-                  </if>
-                </choose>
+                <text macro="author"/>
                 <text macro="title"/>
-                <choose>
-                  <if match="any" variable="editor translator">
-                    <text macro="editor-translator"/>
-                  </if>
-                </choose>
+                <text macro="editor-translator"/>
                 <choose>
                   <if match="any" variable="volume">
                     <text macro="volume"/>
@@ -222,18 +210,16 @@
             <else-if type="chapter">
               <group delimiter=", ">
                 <text macro="author"/>
-                <text macro="title" suffix=","/>
+                <text macro="title"/>
+                <text macro="container"/>
+                <text macro="locator"/>
               </group>
-              <text macro="container"/>
-              <text macro="locator" prefix=", "/>
             </else-if>
             <else-if type="article article-journal article-newspaper article-magazine" match="any">
               <group delimiter=", ">
                 <text macro="author"/>
-                <group delimiter=" ">
-                  <text macro="title" suffix=","/>
-                  <text macro="journal"/>
-                </group>
+                <text macro="title"/>
+                <text macro="journal"/>
                 <text macro="locator"/>
               </group>
             </else-if>
@@ -244,6 +230,7 @@
                 <text variable="genre"/>
                 <text variable="number" prefix="nr "/>
                 <text macro="publisher-place-date"/>
+                <text macro="locator"/>
               </group>
             </else-if>
             <else-if type="paper-conference" match="any">
@@ -251,44 +238,20 @@
                 <text macro="author"/>
                 <text macro="title"/>
                 <text variable="event-title"/>
-                <choose>
-                  <if match="any" variable="container-title">
-                    <text variable="container-title"/>
-                  </if>
-                </choose>
+                <text variable="container-title"/>
                 <text macro="publisher-place-date"/>
                 <text macro="locator"/>
               </group>
             </else-if>
             <else-if type="webpage post-weblog post" match="any">
               <group delimiter=", ">
-                <choose>
-                  <if match="any" variable="author">
-                    <text macro="author"/>
-                  </if>
-                </choose>
+                <text macro="author"/>
                 <text macro="title"/>
-                <choose>
-                  <if match="any" variable="genre">
-                    <text variable="genre"/>
-                  </if>
-                </choose>
+                <text variable="genre"/>
                 <text variable="container-title"/>
-                <choose>
-                  <if match="any" variable="issued">
-                    <date date-parts="year" form="numeric" variable="issued"/>
-                  </if>
-                </choose>
-                <choose>
-                  <if match="any" variable="locator">
-                    <text macro="locator"/>
-                  </if>
-                </choose>
-                <choose>
-                  <if match="any" variable="URL">
-                    <text macro="url-accessed"/>
-                  </if>
-                </choose>
+                <date date-parts="year" form="numeric" variable="issued"/>
+                <text macro="locator"/>
+                <text macro="url-accessed"/>
               </group>
             </else-if>
             <else-if type="software" match="any">
@@ -297,113 +260,77 @@
                 <text macro="title"/>
                 <text macro="publisher-place-date"/>
                 <text variable="medium"/>
-                <choose>
-                  <if match="any" variable="version">
-                    <text variable="version"/>
-                  </if>
-                </choose>
-                <choose>
-                  <if match="any" variable="locator">
-                    <text macro="locator"/>
-                  </if>
-                </choose>
+                <text variable="version"/>
+                <text macro="locator"/>
               </group>
             </else-if>
             <else-if type="motion_picture" match="any">
               <group delimiter=", ">
                 <text macro="title"/>
-                <choose>
-                  <if match="any" variable="volume">
-                    <text variable="volume"/>
-                  </if>
-                </choose>
-                <choose>
-                  <if match="any" variable="director">
-                    <names variable="director">
-                      <name delimiter-precedes-last="always" initialize-with=". "/>
-                      <et-al font-style="italic"/>
-                    </names>
-                  </if>
-                </choose>
-                <choose>
-                  <if match="any" variable="producer">
-                    <names variable="producer" prefix="prod. ">
-                      <name delimiter-precedes-last="always" initialize-with=". "/>
-                      <et-al font-style="italic"/>
-                    </names>
-                  </if>
-                </choose>
+                <text variable="volume"/>
+                <names variable="director">
+                  <name delimiter-precedes-last="always" initialize-with=". "/>
+                  <et-al font-style="normal"/>
+                </names>
+                <names variable="producer" prefix="prod. ">
+                  <name delimiter-precedes-last="always" initialize-with=". "/>
+                  <et-al font-style="normal"/>
+                </names>
                 <text macro="publisher-place-date"/>
-                <choose>
-                  <if match="any" variable="locator">
-                    <text macro="locator"/>
-                  </if>
-                </choose>
-                <choose>
-                  <if match="any" variable="URL">
-                    <text macro="url-accessed"/>
-                  </if>
-                </choose>
+                <text macro="locator"/>
+                <text macro="url-accessed"/>
               </group>
             </else-if>
             <else-if type="song" match="any">
-              <group>
-                <text macro="author" suffix=", "/>
-                <text macro="title" suffix=", "/>
-                <text term="in" prefix="[" suffix=":] "/>
+              <group delimiter=", ">
+                <text macro="author"/>
+                <text macro="title"/>
                 <choose>
-                  <if match="any" variable="composer">
-                    <names variable="composer" suffix=", ">
-                      <name delimiter-precedes-last="always" initialize-with=". "/>
-                      <et-al font-style="italic"/>
-                    </names>
+                  <if match="any" variable="collection-title">
+                    <group>
+                      <text term="in" prefix="[" suffix=":] "/>
+                      <group delimiter=", ">
+                        <names variable="composer">
+                          <name delimiter-precedes-last="always" initialize-with=". "/>
+                          <et-al font-style="normal"/>
+                        </names>
+                        <text variable="collection-title" font-style="italic"/>
+                      </group>
+                    </group>
                   </if>
                 </choose>
-                <text variable="collection-title" font-style="italic" suffix=", "/>
                 <text macro="publisher-place-date"/>
-                <choose>
-                  <if match="any" variable="locator">
-                    <text macro="locator" prefix=", "/>
-                  </if>
-                </choose>
+                <text macro="locator" prefix=", "/>
               </group>
             </else-if>
             <else-if type="entry-dictionary entry-encyclopedia" match="any">
               <choose>
                 <if match="any" variable="editor">
-                  <group>
-                    <text macro="author" suffix=", "/>
-                    <text macro="title" suffix=", "/>
-                    <text variable="container-title" font-style="italic" prefix="[hasło w:] " suffix=", "/>
-                    <text macro="editor-translator" suffix=", "/>
+                  <group delimiter=", ">
+                    <text macro="author"/>
+                    <text macro="title"/>
+                    <text variable="container-title" font-style="italic" prefix="[hasło w:] "/>
+                    <text macro="editor-translator"/>
                     <choose>
                       <if match="any" variable="volume">
-                        <text macro="volume" suffix=", "/>
+                        <text macro="volume"/>
                       </if>
                     </choose>
                     <choose>
                       <if match="any" variable="edition">
-                        <text variable="edition" prefix="wyd. " suffix=", "/>
+                        <text macro="edition"/>
                       </if>
                     </choose>
                     <text macro="publisher-place-date"/>
-                    <choose>
-                      <if match="any" variable="locator">
-                        <text macro="locator" prefix=", "/>
-                      </if>
-                    </choose>
+                    <text macro="locator"/>
                   </group>
                 </if>
                 <else>
                   <group delimiter=", ">
-                    <text macro="author" suffix=", "/>
-                    <text variable="container-title" font-style="italic" suffix=", "/>
+                    <text macro="author"/>
+                    <text variable="container-title" font-style="italic"/>
                     <text macro="publisher-place-date"/>
-                    <choose>
-                      <if match="any" variable="locator">
-                        <text macro="locator"/>
-                      </if>
-                    </choose>
+                    <text macro="locator"/>
                     <text macro="title" prefix="[hasło: " suffix="]"/>
                   </group>
                 </else>
@@ -413,16 +340,8 @@
               <group delimiter=", ">
                 <text macro="author"/>
                 <text macro="title"/>
-                <choose>
-                  <if match="any" variable="genre">
-                    <text variable="genre"/>
-                  </if>
-                </choose>
-                <choose>
-                  <if match="any" variable="editor translator">
-                    <text macro="editor-translator"/>
-                  </if>
-                </choose>
+                <text variable="genre"/>
+                <text macro="editor-translator"/>
                 <choose>
                   <if match="any" variable="edition">
                     <text macro="edition"/>
@@ -443,11 +362,7 @@
                     </group>
                   </if>
                 </choose>
-                <choose>
-                  <if match="any" variable="locator">
-                    <text macro="locator"/>
-                  </if>
-                </choose>
+                <text macro="locator"/>
               </group>
             </else>
           </choose>
@@ -462,23 +377,16 @@
           <text term="ibid" text-case="capitalize-first" font-style="italic"/>
         </else-if>
         <else-if position="subsequent">
-          <choose>
-            <if type="book">
-              <group delimiter=", ">
-                <text macro="author"/>
-                <text macro="title-short" font-style="italic"/>
+          <group delimiter=", ">
+            <text macro="author"/>
+            <text macro="title-short" font-style="italic"/>
+            <choose>
+              <if match="any" variable="volume">
                 <text macro="volume"/>
-                <text macro="locator"/>
-              </group>
-            </if>
-            <else>
-              <group delimiter=", ">
-                <text macro="author"/>
-                <text macro="title-short"/>
-                <text macro="locator"/>
-              </group>
-            </else>
-          </choose>
+              </if>
+            </choose>
+            <text macro="locator"/>
+          </group>
         </else-if>
       </choose>
     </layout>
@@ -492,17 +400,9 @@
       <choose>
         <if type="book">
           <group delimiter=", ">
-            <choose>
-              <if match="any" variable="author">
-                <text macro="author-bibliography"/>
-              </if>
-            </choose>
+            <text macro="author-bibliography"/>
             <text macro="title"/>
-            <choose>
-              <if match="any" variable="editor translator">
-                <text macro="editor-translator-bibliography"/>
-              </if>
-            </choose>
+            <text macro="editor-translator-bibliography"/>
             <choose>
               <if match="any" variable="volume">
                 <text macro="volume"/>
@@ -528,18 +428,15 @@
         <else-if type="chapter">
           <group delimiter=", ">
             <text macro="author-bibliography"/>
-            <text macro="title" suffix=","/>
+            <text macro="title"/>
+            <text macro="container-bibliography"/>
           </group>
-          <text macro="container-bibliography"/>
         </else-if>
         <else-if type="article article-journal article-newspaper article-magazine" match="any">
           <group delimiter=", ">
             <text macro="author-bibliography"/>
-            <group delimiter=" ">
-              <text macro="title" suffix=","/>
-              <text macro="journal"/>
-            </group>
-            <text macro="locator"/>
+            <text macro="title"/>
+            <text macro="journal"/>
           </group>
         </else-if>
         <else-if type="report" match="any">
@@ -556,38 +453,18 @@
             <text macro="author-bibliography"/>
             <text macro="title"/>
             <text variable="event-title"/>
-            <choose>
-              <if match="any" variable="container-title">
-                <text variable="container-title"/>
-              </if>
-            </choose>
+            <text variable="container-title"/>
             <text macro="publisher-place-date"/>
           </group>
         </else-if>
         <else-if type="webpage post-weblog post" match="any">
           <group delimiter=", ">
-            <choose>
-              <if match="any" variable="author">
-                <text macro="author-bibliography"/>
-              </if>
-            </choose>
+            <text macro="author-bibliography"/>
             <text macro="title"/>
-            <choose>
-              <if match="any" variable="genre">
-                <text variable="genre"/>
-              </if>
-            </choose>
+            <text variable="genre"/>
             <text variable="container-title"/>
-            <choose>
-              <if match="any" variable="issued">
-                <date date-parts="year" form="numeric" variable="issued"/>
-              </if>
-            </choose>
-            <choose>
-              <if match="any" variable="URL">
-                <text macro="url-accessed"/>
-              </if>
-            </choose>
+            <date date-parts="year" form="numeric" variable="issued"/>
+            <text macro="url-accessed"/>
           </group>
         </else-if>
         <else-if type="software" match="any">
@@ -596,76 +473,60 @@
             <text macro="title"/>
             <text macro="publisher-place-date"/>
             <text variable="medium"/>
-            <choose>
-              <if match="any" variable="version">
-                <text variable="version"/>
-              </if>
-            </choose>
+            <text variable="version"/>
           </group>
         </else-if>
         <else-if type="motion_picture" match="any">
           <group delimiter=", ">
             <text macro="title"/>
-            <choose>
-              <if match="any" variable="volume">
-                <text variable="volume"/>
-              </if>
-            </choose>
-            <choose>
-              <if match="any" variable="director">
-                <names variable="director">
-                  <name delimiter-precedes-last="always" initialize="false" initialize-with=". " name-as-sort-order="all" sort-separator=" "/>
-                  <et-al font-style="italic"/>
-                </names>
-              </if>
-            </choose>
-            <choose>
-              <if match="any" variable="producer">
-                <names variable="producer" prefix="prod. ">
-                  <name delimiter-precedes-last="always" initialize="false" initialize-with=". " name-as-sort-order="all" sort-separator=" "/>
-                  <et-al font-style="italic"/>
-                </names>
-              </if>
-            </choose>
+            <text variable="volume"/>
+            <names variable="director">
+              <name delimiter-precedes-last="always" initialize="false" initialize-with=". " name-as-sort-order="all" sort-separator=" "/>
+              <et-al font-style="normal"/>
+            </names>
+            <names variable="producer" prefix="prod. ">
+              <name delimiter-precedes-last="always" initialize="false" initialize-with=". " name-as-sort-order="all" sort-separator=" "/>
+              <et-al font-style="normal"/>
+            </names>
             <text macro="publisher-place-date"/>
-            <choose>
-              <if match="any" variable="URL">
-                <text macro="url-accessed"/>
-              </if>
-            </choose>
+            <text macro="url-accessed"/>
           </group>
         </else-if>
         <else-if type="song" match="any">
-          <group>
-            <text macro="author-bibliography" suffix=", "/>
-            <text macro="title" suffix=", "/>
-            <text term="in" prefix="[" suffix=":] "/>
+          <group delimiter=", ">
+            <text macro="author-bibliography"/>
+            <text macro="title"/>
             <choose>
-              <if match="any" variable="composer">
-                <names variable="composer" suffix=", ">
-                  <name delimiter-precedes-last="always" initialize="false" initialize-with=". " name-as-sort-order="all" sort-separator=" "/>
-                  <et-al font-style="italic"/>
-                </names>
+              <if match="any" variable="collection-title">
+                <group>
+                  <text term="in" prefix="[" suffix=":] "/>
+                  <group delimiter=", ">
+                    <names variable="composer">
+                      <name delimiter-precedes-last="always" initialize="false" initialize-with=". " name-as-sort-order="all" sort-separator=" "/>
+                      <et-al font-style="normal"/>
+                    </names>
+                    <text variable="collection-title" font-style="italic"/>
+                  </group>
+                </group>
               </if>
             </choose>
-            <text variable="collection-title" font-style="italic" suffix=", "/>
             <text macro="publisher-place-date"/>
           </group>
         </else-if>
         <else-if type="entry-dictionary entry-encyclopedia" match="any">
           <choose>
             <if match="any" variable="editor">
-              <group>
+              <group delimiter=", ">
                 <text variable="container-title" suffix=", "/>
-                <text macro="editor-translator-bibliography" suffix=", "/>
+                <text macro="editor-translator-bibliography"/>
                 <choose>
                   <if match="any" variable="volume">
-                    <text macro="volume" suffix=", "/>
+                    <text macro="volume"/>
                   </if>
                 </choose>
                 <choose>
                   <if match="any" variable="edition">
-                    <text variable="edition" suffix=", "/>
+                    <text macro="edition"/>
                   </if>
                 </choose>
                 <text macro="publisher-place-date"/>
@@ -684,16 +545,8 @@
           <group delimiter=", ">
             <text macro="author-bibliography"/>
             <text macro="title"/>
-            <choose>
-              <if match="any" variable="genre">
-                <text variable="genre"/>
-              </if>
-            </choose>
-            <choose>
-              <if match="any" variable="editor translator">
-                <text macro="editor-translator-bibliography"/>
-              </if>
-            </choose>
+            <text variable="genre"/>
+            <text macro="editor-translator-bibliography"/>
             <choose>
               <if match="any" variable="edition">
                 <text macro="edition"/>

--- a/uniwersytet-gdanski-kulturoznawstwo-przypis.csl
+++ b/uniwersytet-gdanski-kulturoznawstwo-przypis.csl
@@ -15,8 +15,8 @@
     <category field="humanities"/>
     <category field="sociology"/>
     <category field="anthropology"/>
-    <summary>A Polish note citation style with wide use range for cultural studies, digital humanities. Based on Uni. of Gdansk guildelines</summary>
-    <updated>2025-08-10T17:26:07+00:00</updated>
+    <summary>A Polish note citation style based on Uni. of Gdansk Cultural Studies Department guidelines. Wide use range for cultural studies, digital humanities</summary>
+    <updated>2025-09-24T15:16:34+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale xml:lang="pl">
@@ -293,6 +293,7 @@
             </else-if>
             <else-if type="software" match="any">
               <group delimiter=", ">
+                <text macro="author"/>
                 <text macro="title"/>
                 <text macro="publisher-place-date"/>
                 <text variable="medium"/>
@@ -591,6 +592,7 @@
         </else-if>
         <else-if type="software" match="any">
           <group delimiter=", ">
+            <text macro="author-bibliography"/>
             <text macro="title"/>
             <text macro="publisher-place-date"/>
             <text variable="medium"/>

--- a/uniwersytet-gdanski-kulturoznawstwo-przypis.csl
+++ b/uniwersytet-gdanski-kulturoznawstwo-przypis.csl
@@ -16,7 +16,7 @@
     <category field="sociology"/>
     <category field="anthropology"/>
     <summary>A Polish note citation style based on Uni. of Gdansk Cultural Studies Department guidelines. Wide use range for cultural studies, digital humanities</summary>
-    <updated>2025-09-27T18:40:37+00:00</updated>
+    <updated>2025-10-05T18:40:37+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale xml:lang="pl">
@@ -30,8 +30,10 @@
     <text variable="title" text-case="capitalize-first" quotes="false" font-style="italic"/>
   </macro>
   <macro name="title-short">
-    <text variable="title" form="short" text-case="capitalize-first" font-style="italic" suffix=", "/>
-    <text term="op-cit" font-style="italic"/>
+    <group delimiter=", ">
+      <text variable="title" form="short" text-case="capitalize-first" font-style="italic"/>
+      <text term="op-cit" font-style="italic"/>
+    </group>
   </macro>
   <macro name="author">
     <names variable="author">
@@ -64,19 +66,7 @@
         <text macro="edition"/>
         <text macro="volume"/>
         <text macro="publisher-place-date"/>
-        <choose>
-          <if match="any" variable="collection-title">
-            <group delimiter=" ">
-              <text variable="collection-title"/>
-              <choose>
-                <if match="any" variable="collection-number">
-                  <label variable="collection-number" form="short"/>
-                  <text variable="collection-number"/>
-                </if>
-              </choose>
-            </group>
-          </if>
-        </choose>
+        <text macro="collection"/>
       </group>
     </group>
   </macro>
@@ -89,40 +79,26 @@
         <text macro="edition"/>
         <text macro="volume"/>
         <text macro="publisher-place-date"/>
-        <choose>
-          <if match="any" variable="collection-title">
-            <group delimiter=" ">
-              <text variable="collection-title"/>
-              <choose>
-                <if match="any" variable="collection-number">
-                  <label variable="collection-number" form="short"/>
-                  <text variable="collection-number"/>
-                </if>
-              </choose>
-            </group>
-          </if>
-        </choose>
+        <text macro="collection"/>
       </group>
     </group>
   </macro>
   <macro name="journal">
-    <group>
+    <group delimiter=", ">
       <text variable="container-title" quotes="true" font-style="normal"/>
       <choose>
         <if match="any" variable="issue">
-          <date date-parts="year" form="numeric" variable="issued" prefix=" "/>
+          <date variable="issued" date-parts="year" form="numeric" prefix=" "/>
         </if>
         <else>
-          <date form="numeric" variable="issued" prefix=", "/>
+          <date variable="issued" form="numeric" prefix=", "/>
         </else>
       </choose>
-      <text macro="volume" prefix=", "/>
-      <choose>
-        <if match="any" variable="issue">
-          <text term="issue" form="short" text-case="lowercase" prefix=", " suffix=" "/>
+      <text macro="volume"/>
+      <group delimiter=" ">
+          <text term="issue" form="short" text-case="lowercase" suffix=" "/>
           <text variable="issue"/>
-        </if>
-      </choose>
+      </group>
     </group>
   </macro>
   <macro name="publisher-place-date">
@@ -135,24 +111,16 @@
     </group>
   </macro>
   <macro name="volume">
-    <choose>
-      <if match="any" variable="volume">
         <group delimiter=" ">
           <text term="volume" form="short" text-case="lowercase"/>
           <text variable="volume"/>
         </group>
-      </if>
-    </choose>
   </macro>
   <macro name="edition">
-    <choose>
-      <if match="any" variable="edition">
         <group delimiter=" ">
           <text term="edition" form="short"/>
           <text variable="edition"/>
         </group>
-      </if>
-    </choose>
   </macro>
   <macro name="url-accessed">
     <group delimiter=" ">
@@ -164,6 +132,15 @@
     <group delimiter=" ">
       <label variable="locator" form="short"/>
       <text variable="locator"/>
+    </group>
+  </macro>
+  <macro name="collection">
+    <group delimiter=" ">
+      <text variable="collection-title"/>
+      <group delimiter=" ">
+        <label variable="collection-number" form="short"/>
+        <text variable="collection-number"/>
+      </group>      
     </group>
   </macro>
   <citation et-al-min="3" et-al-use-first="1" initialize-with=". " sort-separator=" " disambiguate-add-names="true">
@@ -183,19 +160,7 @@
                 <text macro="volume"/>
                 <text macro="edition"/>
                 <text macro="publisher-place-date"/>
-                <choose>
-                  <if match="any" variable="collection-title">
-                    <group delimiter=" ">
-                      <text variable="collection-title"/>
-                      <choose>
-                        <if match="any" variable="collection-number">
-                          <label variable="collection-number" form="short"/>
-                          <text variable="collection-number"/>
-                        </if>
-                      </choose>
-                    </group>
-                  </if>
-                </choose>
+                <text macro="collection"/>
                 <text macro="locator"/>
               </group>
             </if>
@@ -220,14 +185,10 @@
                 <text macro="author"/>
                 <text macro="title"/>
                 <text variable="genre"/>
-                <choose>
-                  <if match="any" variable="number">
-                    <group delimiter=" ">
-                      <label variable="number" form="short"/>
-                      <text variable="number"/>
-                    </group>
-                  </if>
-                </choose>
+                <group delimiter=" ">
+                  <label variable="number" form="short"/>
+                  <text variable="number"/>
+                </group>
                 <text macro="publisher-place-date"/>
                 <text macro="locator"/>
               </group>
@@ -333,19 +294,7 @@
                 <text macro="edition"/>
                 <text macro="volume"/>
                 <text macro="publisher-place-date"/>
-                <choose>
-                  <if match="any" variable="collection-title">
-                    <group delimiter=" ">
-                      <text variable="collection-title"/>
-                      <choose>
-                        <if match="any" variable="collection-number">
-                          <label variable="collection-number" form="short"/>
-                          <text variable="collection-number"/>
-                        </if>
-                      </choose>
-                    </group>
-                  </if>
-                </choose>
+                <text macro="collection"/>
                 <text macro="locator"/>
               </group>
             </else>
@@ -386,19 +335,7 @@
             <text macro="volume"/>
             <text macro="edition"/>
             <text macro="publisher-place-date"/>
-            <choose>
-              <if match="any" variable="collection-title">
-                <group delimiter=" ">
-                  <text variable="collection-title"/>
-                  <choose>
-                    <if match="any" variable="collection-number">
-                      <label variable="collection-number" form="short"/>
-                      <text variable="collection-number"/>
-                    </if>
-                  </choose>
-                </group>
-              </if>
-            </choose>
+            <text macro="collection"/>
           </group>
         </if>
         <else-if type="chapter">
@@ -522,19 +459,7 @@
             <text macro="edition"/>
             <text macro="volume"/>
             <text macro="publisher-place-date"/>
-            <choose>
-              <if match="any" variable="collection-title">
-                <group delimiter=" ">
-                  <text variable="collection-title"/>
-                  <choose>
-                    <if match="any" variable="collection-number">
-                      <label variable="collection-number" form="short"/>
-                      <text variable="collection-number"/>
-                    </if>
-                  </choose>
-                </group>
-              </if>
-            </choose>
+            <text macro="collection"/>
           </group>
         </else>
       </choose>

--- a/uniwersytet-gdanski-kulturoznawstwo-przypis.csl
+++ b/uniwersytet-gdanski-kulturoznawstwo-przypis.csl
@@ -16,7 +16,7 @@
     <category field="sociology"/>
     <category field="anthropology"/>
     <summary>A Polish note citation style based on Uni. of Gdansk Cultural Studies Department guidelines. Wide use range for cultural studies, digital humanities</summary>
-    <updated>2025-09-27T16:55:28+00:00</updated>
+    <updated>2025-09-27T18:40:37+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale xml:lang="pl">
@@ -24,14 +24,6 @@
       <term name="ibid">tamże</term>
       <term name="et-al">i in.</term>
       <term name="op-cit">dz. cyt.</term>
-      <term name="number" form="short"> <!-- The default-locale term is currently broken -->
-        <single>nr</single>
-        <multiple>nr.</multiple>
-      </term>
-      <term name="collection-number" form="short"> <!-- The default-locale term is currently broken -->
-        <single>nr</single>
-        <multiple>nr.</multiple>
-      </term>
     </terms>
   </locale>
   <macro name="title">

--- a/uniwersytet-gdanski-kulturoznawstwo-przypis.csl
+++ b/uniwersytet-gdanski-kulturoznawstwo-przypis.csl
@@ -16,7 +16,7 @@
     <category field="sociology"/>
     <category field="anthropology"/>
     <summary>A Polish note citation style based on Uni. of Gdansk Cultural Studies Department guidelines. Wide use range for cultural studies, digital humanities</summary>
-    <updated>2025-10-05T18:40:37+00:00</updated>
+    <updated>2025-10-05T15:09:15+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale xml:lang="pl">
@@ -24,6 +24,7 @@
       <term name="ibid">tamże</term>
       <term name="et-al">i in.</term>
       <term name="op-cit">dz. cyt.</term>
+      <term name="entry">hasło</term>
     </terms>
   </locale>
   <macro name="title">
@@ -32,7 +33,7 @@
   <macro name="title-short">
     <group delimiter=", ">
       <text variable="title" form="short" text-case="capitalize-first" font-style="italic"/>
-      <text term="op-cit" font-style="italic"/>
+      <text term="op-cit"/>
     </group>
   </macro>
   <macro name="author">
@@ -42,7 +43,7 @@
   </macro>
   <macro name="author-bibliography">
     <names variable="author">
-      <name delimiter-precedes-last="always" initialize="false" initialize-with=". " name-as-sort-order="all" sort-separator=" "/>
+      <name delimiter-precedes-last="always" initialize="false" name-as-sort-order="all" sort-separator=" "/>
     </names>
   </macro>
   <macro name="editor-translator">
@@ -54,7 +55,7 @@
   <macro name="editor-translator-bibliography">
     <names variable="editor translator" delimiter=", ">
       <label form="short" suffix=" "/>
-      <name delimiter-precedes-last="always" initialize="false" initialize-with=". " name-as-sort-order="all" sort-separator=" "/>
+      <name delimiter-precedes-last="always" initialize="false" name-as-sort-order="all" sort-separator=" "/>
     </names>
   </macro>
   <macro name="container">
@@ -85,18 +86,13 @@
   </macro>
   <macro name="journal">
     <group delimiter=", ">
-      <text variable="container-title" quotes="true" font-style="normal"/>
-      <choose>
-        <if match="any" variable="issue">
-          <date variable="issued" date-parts="year" form="numeric" prefix=" "/>
-        </if>
-        <else>
-          <date variable="issued" form="numeric" prefix=", "/>
-        </else>
-      </choose>
+      <group delimiter=" ">
+        <text variable="container-title" quotes="true"/>
+        <date form="numeric" variable="issued"/>
+      </group>
       <text macro="volume"/>
       <group delimiter=" ">
-        <text term="issue" form="short" text-case="lowercase" suffix=" "/>
+        <label variable="issue" form="short"/>
         <text variable="issue"/>
       </group>
     </group>
@@ -112,14 +108,23 @@
   </macro>
   <macro name="volume">
     <group delimiter=" ">
-      <text term="volume" form="short" text-case="lowercase"/>
+      <label variable="volume" form="short"/>
       <text variable="volume"/>
     </group>
   </macro>
   <macro name="edition">
     <group delimiter=" ">
-      <text term="edition" form="short"/>
+      <label variable="edition" form="short"/>
       <text variable="edition"/>
+    </group>
+  </macro>
+  <macro name="collection">
+    <group delimiter=" ">
+      <text variable="collection-title"/>
+      <group delimiter=" ">
+        <label variable="collection-number" form="short"/>
+        <text variable="collection-number"/>
+      </group>
     </group>
   </macro>
   <macro name="url-accessed">
@@ -132,15 +137,6 @@
     <group delimiter=" ">
       <label variable="locator" form="short"/>
       <text variable="locator"/>
-    </group>
-  </macro>
-  <macro name="collection">
-    <group delimiter=" ">
-      <text variable="collection-title"/>
-      <group delimiter=" ">
-        <label variable="collection-number" form="short"/>
-        <text variable="collection-number"/>
-      </group>
     </group>
   </macro>
   <citation et-al-min="3" et-al-use-first="1" initialize-with=". " sort-separator=" " disambiguate-add-names="true">
@@ -266,7 +262,13 @@
                   <group delimiter=", ">
                     <text macro="author"/>
                     <text macro="title"/>
-                    <text variable="container-title" font-style="italic" prefix="[hasło w:] "/>
+                    <group delimiter=" ">
+                      <group delimiter=" " prefix="[" suffix=":]">
+                        <text term="entry"/>
+                        <text term="in"/>
+                      </group>
+                      <text variable="container-title" font-style="italic"/>
+                    </group>
                     <text macro="editor-translator"/>
                     <text macro="volume"/>
                     <text macro="edition"/>
@@ -280,7 +282,10 @@
                     <text variable="container-title" font-style="italic"/>
                     <text macro="publisher-place-date"/>
                     <text macro="locator"/>
-                    <text macro="title" prefix="[hasło: " suffix="]"/>
+                    <group delimiter=": " prefix="[" suffix="]">
+                      <text term="entry"/>
+                      <text macro="title"/>
+                    </group>
                   </group>
                 </else>
               </choose>
@@ -302,12 +307,12 @@
         </if>
         <else-if position="ibid-with-locator">
           <group delimiter=", ">
-            <text term="ibid" text-case="capitalize-first" font-style="italic" suffix="."/>
+            <text term="ibid" text-case="capitalize-first"/>
             <text macro="locator"/>
           </group>
         </else-if>
         <else-if position="ibid">
-          <text term="ibid" text-case="capitalize-first" font-style="italic"/>
+          <text term="ibid" text-case="capitalize-first"/>
         </else-if>
         <else-if position="subsequent">
           <group delimiter=", ">
@@ -357,14 +362,10 @@
             <text macro="author-bibliography"/>
             <text macro="title"/>
             <text variable="genre"/>
-            <choose>
-              <if match="any" variable="number">
-                <group delimiter=" ">
-                  <label variable="number" form="short"/>
-                  <text variable="number"/>
-                </group>
-              </if>
-            </choose>
+            <group delimiter=" ">
+              <label variable="number" form="short"/>
+              <text variable="number"/>
+            </group>
             <text macro="publisher-place-date"/>
           </group>
         </else-if>
@@ -401,10 +402,10 @@
             <text macro="title"/>
             <text variable="volume"/>
             <names variable="director">
-              <name delimiter-precedes-last="always" initialize="false" initialize-with=". " name-as-sort-order="all" sort-separator=" "/>
+              <name delimiter-precedes-last="always" initialize="false" name-as-sort-order="all" sort-separator=" "/>
             </names>
             <names variable="producer">
-              <name delimiter-precedes-last="always" initialize="false" initialize-with=". " name-as-sort-order="all" sort-separator=" "/>
+              <name delimiter-precedes-last="always" initialize="false" name-as-sort-order="all" sort-separator=" "/>
             </names>
             <text macro="publisher-place-date"/>
             <text macro="url-accessed"/>
@@ -420,7 +421,7 @@
                   <text term="in" prefix="[" suffix=":]"/>
                   <group delimiter=", ">
                     <names variable="composer">
-                      <name delimiter-precedes-last="always" initialize="false" initialize-with=". " name-as-sort-order="all" sort-separator=" "/>
+                      <name delimiter-precedes-last="always" initialize="false" name-as-sort-order="all" sort-separator=" "/>
                     </names>
                     <text variable="collection-title" font-style="italic"/>
                   </group>

--- a/uniwersytet-gdanski-kulturoznawstwo-przypis.csl
+++ b/uniwersytet-gdanski-kulturoznawstwo-przypis.csl
@@ -33,7 +33,6 @@
         <multiple>nr.</multiple>
       </term>
     </terms>
-    </terms>
   </locale>
   <macro name="title">
     <text variable="title" text-case="capitalize-first" quotes="false" font-style="italic"/>

--- a/uniwersytet-gdanski-kulturoznawstwo-przypis.csl
+++ b/uniwersytet-gdanski-kulturoznawstwo-przypis.csl
@@ -272,7 +272,7 @@
                   <name delimiter-precedes-last="always" initialize-with=". "/>
                   <et-al font-style="normal"/>
                 </names>
-                <names variable="producer" prefix="prod. ">
+                <names variable="producer">
                   <name delimiter-precedes-last="always" initialize-with=". "/>
                   <et-al font-style="normal"/>
                 </names>
@@ -484,7 +484,7 @@
               <name delimiter-precedes-last="always" initialize="false" initialize-with=". " name-as-sort-order="all" sort-separator=" "/>
               <et-al font-style="normal"/>
             </names>
-            <names variable="producer" prefix="prod. ">
+            <names variable="producer">
               <name delimiter-precedes-last="always" initialize="false" initialize-with=". " name-as-sort-order="all" sort-separator=" "/>
               <et-al font-style="normal"/>
             </names>

--- a/uniwersytet-gdanski-kulturoznawstwo-przypis.csl
+++ b/uniwersytet-gdanski-kulturoznawstwo-przypis.csl
@@ -16,7 +16,7 @@
     <category field="sociology"/>
     <category field="anthropology"/>
     <summary>A Polish note citation style based on Uni. of Gdansk Cultural Studies Department guidelines. Wide use range for cultural studies, digital humanities</summary>
-    <updated>2025-09-27T15:42:50+00:00</updated>
+    <updated>2025-09-27T16:55:28+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale xml:lang="pl">
@@ -28,6 +28,11 @@
         <single>nr</single>
         <multiple>nr.</multiple>
       </term>
+      <term name="collection-number" form="short"> <!-- The default-locale term is currently broken -->
+        <single>nr</single>
+        <multiple>nr.</multiple>
+      </term>
+    </terms>
     </terms>
   </locale>
   <macro name="title">
@@ -72,8 +77,12 @@
           <if match="any" variable="collection-title">
             <group delimiter=" ">
               <text variable="collection-title"/>
-              <text term="number" form="short"/>
-              <text variable="collection-number"/>
+              <choose>
+                <if match="any" variable="collection-number">
+                  <label variable="collection-number" form="short"/>
+                  <text variable="collection-number"/>
+                </if>
+              </choose>
             </group>
           </if>
         </choose>
@@ -93,8 +102,12 @@
           <if match="any" variable="collection-title">
             <group delimiter=" ">
               <text variable="collection-title"/>
-              <text term="number" form="short"/>
-              <text variable="collection-number"/>
+              <choose>
+                <if match="any" variable="collection-number">
+                  <label variable="collection-number" form="short"/>
+                  <text variable="collection-number"/>
+                </if>
+              </choose>
             </group>
           </if>
         </choose>
@@ -183,8 +196,12 @@
                   <if match="any" variable="collection-title">
                     <group delimiter=" ">
                       <text variable="collection-title"/>
-                      <text term="number" form="short"/>
-                      <text variable="collection-number"/>
+                      <choose>
+                        <if match="any" variable="collection-number">
+                          <label variable="collection-number" form="short"/>
+                          <text variable="collection-number"/>
+                        </if>
+                      </choose>
                     </group>
                   </if>
                 </choose>
@@ -215,7 +232,7 @@
                 <choose>
                   <if match="any" variable="number">
                     <group delimiter=" ">
-                      <text term="number" form="short"/>
+                      <label variable="number" form="short"/>
                       <text variable="number"/>
                     </group>
                   </if>
@@ -329,8 +346,12 @@
                   <if match="any" variable="collection-title">
                     <group delimiter=" ">
                       <text variable="collection-title"/>
-                      <text term="number" form="short"/>
-                      <text variable="collection-number"/>
+                      <choose>
+                        <if match="any" variable="collection-number">
+                          <label variable="collection-number" form="short"/>
+                          <text variable="collection-number"/>
+                        </if>
+                      </choose>
                     </group>
                   </if>
                 </choose>
@@ -378,8 +399,12 @@
               <if match="any" variable="collection-title">
                 <group delimiter=" ">
                   <text variable="collection-title"/>
-                  <text term="number" form="short"/>
-                  <text variable="collection-number"/>
+                  <choose>
+                    <if match="any" variable="collection-number">
+                      <label variable="collection-number" form="short"/>
+                      <text variable="collection-number"/>
+                    </if>
+                  </choose>
                 </group>
               </if>
             </choose>
@@ -407,7 +432,7 @@
             <choose>
               <if match="any" variable="number">
                 <group delimiter=" ">
-                  <text term="number" form="short"/>
+                  <label variable="number" form="short"/>
                   <text variable="number"/>
                 </group>
               </if>
@@ -510,8 +535,12 @@
               <if match="any" variable="collection-title">
                 <group delimiter=" ">
                   <text variable="collection-title"/>
-                  <text term="number" form="short"/>
-                  <text variable="collection-number"/>
+                  <choose>
+                    <if match="any" variable="collection-number">
+                      <label variable="collection-number" form="short"/>
+                      <text variable="collection-number"/>
+                    </if>
+                  </choose>
                 </group>
               </if>
             </choose>


### PR DESCRIPTION
Two changes here:
- Added `author` and `author-bibliography` in corresponding `type="software"` to reflect a situation where the software (or a video game) is authored by a programmer, or a group of programmers, instead of a sofware house/studio, as per internal request I received. In Zotero, a `"Programmer"` field is just `author` in CSL, so this is a fairly simple change, but will be reflected in rendering and sorting (these styles sort by authors and then titles if no author present).
- Slightly rephrased `summary` for clarity.

I'm the original author of the style (#7549, #7547).

Thanks!