### PR TITLE
Create thai-endodontic-journal.csl

### DIFF
--- a/thai-endodontic-journal.csl
+++ b/thai-endodontic-journal.csl
@@ -212,11 +212,9 @@
   <macro name="date">
     <choose>
       <if type="article-journal article-magazine article-newspaper review review-book" match="any">
-
-          <date variable="issued" suffix=";">
-            <date-part name="year"/>
-          </date>
-
+        <date variable="issued" suffix=";">
+          <date-part name="year"/>
+        </date>
       </if>
       <else-if type="bill legislation" match="any">
         <group delimiter=", ">


### PR DESCRIPTION
Journal: Thai Endodontic Journal (TEJ)

Key formatting: bold journal abbreviations incl. trailing dot; year-only for journal items; volume only; minimal page ranges; 3-letter months for non-journal types.

Validated at validator.citationstyles.org (no errors).