### PR TITLE
Update ausonius-editions.csl

### DIFF
--- a/ausonius-editions.csl
+++ b/ausonius-editions.csl
@@ -41,7 +41,7 @@
     <summary>Style CSL "Ausonius éditions" revu et mis à jour en collaboration avec Ausonius Éditions (d'après le guide de l'auteur du 15 juin 2022), à partir du travail réalisé au départ par N. Monteix, S. Thomas, et les contributions postérieures. - CSL style  "Ausonius éditions" updated, with the collaboration of the Ausonius Editions team (according to the "Guide de l'auteur - 15 juin 2022"), and based on the first work realised by N. Monteix, S. Thomas, and the next contributions.</summary>
     <!-- Informations -->
     <published>2023-01-06T05:43:05+00:00</published>
-    <updated>2024-03-02T02:24:11+00:00</updated>
+    <updated>2025-09-28T09:37:19.544</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <!-- PARAMETRAGE LOCALE\TERMS -->
@@ -296,20 +296,7 @@
     <choose>
       <if variable="accessed" match="any">
         <choose>
-          <if variable="DOI URL" match="any">
-            <text term="online" form="short"/>
-            <text term="accessed" prefix=", "/>
-            <date variable="accessed" form="text" prefix=" "/>
-          </if>
-        </choose>
-      </if>
-    </choose>
-  </macro>
-  <macro name="bloc_en-ligne_lien">
-    <choose>
-      <if variable="accessed" match="any">
-        <choose>
-          <if variable="DOI">
+            <if variable="DOI">
             <text variable="DOI" prefix="DOI&#160;: "/>
           </if>
           <else>
@@ -351,9 +338,8 @@
         <text macro="bloc_auteur"/>
         <text macro="bloc_date-publication"/>
         <text macro="bloc_titre-ouvrage-contribution-article" prefix="&#160;: "/>
-        <text macro="bloc_en-ligne" prefix=". "/>
       </group>
-      <text macro="bloc_en-ligne_lien" prefix=" "/>
+      <text macro="bloc_en-ligne" prefix=" "/>
     </layout>
   </bibliography>
 </style>


### PR DESCRIPTION
After discussion with the Publisher, it appears that the publication guidelines require directly including the DOI or URL link for online references, without the [online] mention or the access date information.

In this update:
- We modified the update information for the steel sheets (l. 44).
- We deleted the macro for the [online] and [accessed] mentions, keeping only the DOI/URL information (l. 295).
- We adjusted the corresponding macro call accordingly (l. 342).