### PR TITLE
Update eu-interinstitutional-style-2nd-edition.csl

### DIFF
--- a/eu-interinstitutional-style-1st-edition.csl
+++ b/eu-interinstitutional-style-1st-edition.csl
@@ -1,20 +1,19 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" and="text" delimiter-precedes-et-al="never" delimiter-precedes-last="never" initialize-with=". " page-range-format="expanded" demote-non-dropping-particle="never" default-locale="en-GB">
-  <!-- This style was edited with the Visual CSL Editor (https://editor.citationstyles.org/visualEditor/) -->
   <info>
-    <title>EU Interinstitutional Style 1st edition (English, author-date)</title>
-    <title-short>EU style author-date En 1st Ed.</title-short>
-    <id>http://www.zotero.org/styles/eu-interinstitutional-style-1st-edition</id>
-    <link xml:lang="en-GB" href="http://www.zotero.org/styles/eu-interinstitutional-style-1st-edition" rel="self"/>
-    <link href="https://style-guide.europa.eu/en/home" xml:lang="en-GB" rel="documentation"/>
+    <title>EU Interinstitutional Style 2nd Ed. author-date, Eng. (rev20250611)</title>
+    <title-short>EU style author-data Eng</title-short>
+    <id>http://www.zotero.org/styles/eu-interinstitutional-style-2nd-ed-author-date-eng</id>
+    <link rel="self" xml:lang="en-GB" href="http://www.zotero.org/styles/eu-interinstitutional-style-2nd-ed-author-date-eng"/>
+    <link href="https://style-guide.europa.eu/en/home" rel="documentation" xml:lang="en-GB"/>
     <author>
       <name>Luis Machado</name>
       <email>luis.oliveira-machado@ec.europa.eu</email>
     </author>
     <category citation-format="author-date"/>
     <category field="generic-base"/>
-    <summary>European Union Interinstitutional style in author-date format (English), 1st Edition (revision 18e-2024.11.21).</summary>
-    <updated>2024-11-21T08:48:51+00:00</updated>
+    <summary>European Union Interinstitutional style in author-data format, Eng 2nd Edition</summary>
+    <updated>2025-09-30T14:11:02+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale xml:lang="en-GB">
@@ -23,50 +22,63 @@
         <single>ed.</single>
         <multiple>eds</multiple>
       </term>
-      <term name="webpage">website</term>
-      <term name="issue">issue</term>
+      <term name="translator" form="short">
+        <single>trans.</single>
+        <multiple>trans</multiple>
+      </term>
+      <term name="collection-editor" form="short">
+        <single>ser. ed</single>
+        <multiple>ser. eds</multiple>
+      </term>
     </terms>
   </locale>
+  <macro name="editor">
+    <group>
+      <names variable="container-author">
+        <name delimiter-precedes-et-al="never" delimiter-precedes-last="never" initialize-with=". "/>
+        <label form="short" text-case="lowercase" prefix=" (" suffix=")"/>
+        <substitute>
+          <names variable="editor"/>
+          <names variable="collection-editor"/>
+        </substitute>
+      </names>
+    </group>
+  </macro>
   <macro name="anon-in-text">
     <choose>
       <if type="book motion_picture musical_score" match="any">
-        <text variable="title" form="short" strip-periods="false" font-style="italic"/>
+        <text variable="title" form="short" font-style="italic"/>
       </if>
-      <else-if type="legislation" match="all" variable="container-title">
-        <text variable="container-title" form="short"/>
-      </else-if>
-      <else-if type="legislation" match="any">
-        <text variable="title" form="short"/>
-      </else-if>
       <else>
         <text variable="title" form="short" strip-periods="false" quotes="true" font-style="normal"/>
       </else>
     </choose>
   </macro>
   <macro name="author">
-    <names variable="host">
-      <name and="text" delimiter-precedes-et-al="never" delimiter-precedes-last="never" initialize-with=". "/>
-      <label form="short" text-case="lowercase" prefix=" (" suffix=")"/>
-      <et-al font-style="normal"/>
-      <substitute>
-        <names variable="author"/>
-        <names variable="editor director performer"/>
-        <names variable="translator recipient"/>
-        <names variable="contributor"/>
-        <text macro="anon"/>
-      </substitute>
-    </names>
+    <choose>
+      <if type="legislation" match="any">
+        <text variable="title" suffix=","/>
+      </if>
+      <else>
+        <names variable="host">
+          <name and="text" delimiter-precedes-et-al="never" delimiter-precedes-last="never" initialize-with=". "/>
+          <label form="short" text-case="lowercase" prefix=" (" suffix=")"/>
+          <et-al font-style="normal"/>
+          <substitute>
+            <names variable="author"/>
+            <names variable="container-author"/>
+            <names variable="editor director performer" delimiter=", "/>
+            <names variable="translator recipient" delimiter=", "/>
+            <names variable="collection-editor"/>
+            <names variable="contributor"/>
+            <text macro="anon"/>
+          </substitute>
+        </names>
+      </else>
+    </choose>
   </macro>
   <macro name="anon">
     <group>
-      <choose>
-        <if type="legislation" match="all" variable="container-title">
-          <text variable="container-title"/>
-        </if>
-        <else-if type="legislation" match="any">
-          <text variable="title"/>
-        </else-if>
-      </choose>
       <choose>
         <if type="book motion_picture musical_score" match="any">
           <text variable="title" font-style="italic"/>
@@ -78,29 +90,34 @@
     </group>
   </macro>
   <macro name="author-in-text">
-    <names variable="host">
-      <name form="short" and="text" delimiter-precedes-et-al="never" delimiter-precedes-last="never" initialize-with=". "/>
-      <et-al font-style="normal"/>
-      <substitute>
-        <names variable="author"/>
-        <names variable="editor director performer"/>
-        <names variable="translator recipient"/>
-        <names variable="contributor"/>
-        <text macro="anon-in-text"/>
-      </substitute>
-    </names>
+    <choose>
+      <if type="legislation" match="all">
+        <text variable="title" form="short"/>
+      </if>
+      <else>
+        <names variable="host">
+          <name form="short" and="text" delimiter-precedes-et-al="never" delimiter-precedes-last="never" initialize-with=". "/>
+          <et-al font-style="normal"/>
+          <substitute>
+            <names variable="author"/>
+            <names variable="editor director performer" delimiter=", "/>
+            <names variable="translator recipient" delimiter=", "/>
+            <names variable="collection-editor"/>
+            <names variable="contributor"/>
+            <text macro="anon-in-text"/>
+          </substitute>
+        </names>
+      </else>
+    </choose>
   </macro>
   <macro name="title">
     <choose>
       <if type="book motion_picture musical_score" match="any">
         <text variable="title" strip-periods="false" quotes="false" font-style="italic"/>
       </if>
-      <else-if type="legislation" match="any">
-        <text variable="title"/>
+      <else-if type="legislation" match="none">
+        <text variable="title" quotes="true"/>
       </else-if>
-      <else>
-        <text variable="title" strip-periods="false" quotes="true" font-variant="normal" vertical-align="baseline"/>
-      </else>
     </choose>
   </macro>
   <macro name="publisher">
@@ -109,7 +126,7 @@
       <text variable="publisher-place" form="short"/>
     </group>
   </macro>
-  <macro name="year-date">
+  <macro name="year-date_in-text">
     <choose>
       <if variable="issued">
         <date variable="issued">
@@ -121,26 +138,24 @@
       </else>
     </choose>
   </macro>
-  <macro name="locators-journal">
+  <macro name="locators-article">
     <choose>
-      <if type="article-journal article-magazine article" match="any">
-        <group delimiter=", ">
-          <group delimiter=" ">
-            <label variable="volume" text-case="capitalize-first" form="short"/>
-            <text variable="volume" strip-periods="false"/>
-          </group>
-          <group delimiter=" ">
-            <label variable="issue" text-case="capitalize-first"/>
-            <text variable="issue"/>
-          </group>
-        </group>
+      <if match="none" variable="collection-title">
+        <choose>
+          <if type="article-journal article-magazine article" match="any">
+            <group delimiter=", ">
+              <text variable="volume" strip-periods="false" prefix="Vol. "/>
+              <text variable="issue" prefix="Issue "/>
+            </group>
+          </if>
+          <else-if type="article-newspaper">
+            <date variable="issued" delimiter=" ">
+              <date-part name="day"/>
+              <date-part name="month"/>
+            </date>
+          </else-if>
+        </choose>
       </if>
-      <else-if type="article-newspaper">
-        <date variable="issued" delimiter=" ">
-          <date-part name="day"/>
-          <date-part name="month"/>
-        </date>
-      </else-if>
     </choose>
   </macro>
   <macro name="pages">
@@ -221,22 +236,18 @@
   <macro name="version">
     <choose>
       <if match="any" variable="version">
-        <group delimiter=" ">
-          <label variable="version" text-case="capitalize-first"/>
-          <text variable="version"/>
-        </group>
+        <text variable="version" form="short" prefix="Version "/>
       </if>
-      <else-if type="webpage" match="all" variable="number">
-        <group delimiter=" ">
-          <text term="version" text-case="capitalize-first"/>
-          <text variable="number"/>
-        </group>
-      </else-if>
+    </choose>
+    <choose>
+      <if type="webpage" match="all" variable="number">
+        <text variable="number" prefix="Version "/>
+      </if>
     </choose>
   </macro>
   <macro name="citation-locater">
-    <group delimiter=" ">
-      <label text-case="lowercase" variable="locator" form="short"/>
+    <group>
+      <label text-case="lowercase" suffix=" " variable="locator" form="short"/>
       <text variable="locator"/>
     </group>
   </macro>
@@ -246,8 +257,7 @@
         <group delimiter=", ">
           <group delimiter=" ">
             <text variable="genre"/>
-            <label variable="number" form="short" strip-periods="true"/>
-            <text variable="number"/>
+            <text variable="number" prefix="No "/>
           </group>
           <date delimiter=" " variable="issued">
             <date-part name="day"/>
@@ -260,7 +270,7 @@
           <text variable="genre"/>
           <text variable="number"/>
           <date delimiter=" " variable="issued">
-            <date-part name="day"/>
+            <date-part name="day" suffix=" "/>
             <date-part name="month"/>
           </date>
         </group>
@@ -277,50 +287,65 @@
       </if>
     </choose>
   </macro>
-  <macro name="serial">
+  <macro name="series_title">
     <choose>
-      <if type="book chapter" match="any">
+      <if match="any" variable="collection-title">
         <choose>
-          <if match="any" variable="collection-title collection-number">
+          <if type="book chapter report" match="any">
             <group delimiter=", ">
-              <text variable="collection-title" strip-periods="false" font-style="italic"/>
-              <group delimiter=" ">
-                <label variable="number" form="short" strip-periods="true" text-case="capitalize-first"/>
-                <text variable="collection-number"/>
-              </group>
+              <text variable="collection-title" strip-periods="false" font-style="normal"/>
+              <text variable="collection-number" prefix="No "/>
+            </group>
+          </if>
+          <else-if type="article-journal article article-magazine" match="any">
+            <group delimiter=", ">
+              <text variable="collection-title"/>
+              <text variable="issue" prefix="No "/>
               <date delimiter=" " variable="issued">
                 <date-part name="month"/>
               </date>
             </group>
-          </if>
+          </else-if>
+          <else-if type="paper-conference" match="any">
+            <group delimiter=", ">
+              <text variable="collection-title"/>
+              <text variable="volume" prefix="No "/>
+            </group>
+          </else-if>
         </choose>
       </if>
     </choose>
   </macro>
-  <macro name="creation-date">
+  <macro name="creation-dataset">
     <choose>
-      <if type="dataset webpage" match="any">
-        <choose>
-          <if match="all" variable="original-date">
-            <date form="text" variable="original-date" prefix="(created " suffix=")">
-              <date-part name="day"/>
-              <date-part name="month"/>
-              <date-part name="year"/>
-            </date>
-          </if>
-        </choose>
+      <if type="dataset" match="all" variable="original-date">
+        <date form="text" variable="original-date" prefix="(created " suffix=")">
+          <date-part name="day"/>
+          <date-part name="month"/>
+          <date-part name="year"/>
+        </date>
       </if>
     </choose>
   </macro>
   <macro name="other-creators">
-    <names variable="translator contributor recipient" delimiter=", ">
+    <names variable="translator" delimiter=", ">
       <name delimiter-precedes-et-al="never" delimiter-precedes-last="never" initialize-with=". "/>
       <label form="short" text-case="lowercase" prefix=" (" suffix=")"/>
     </names>
   </macro>
-  <macro name="original-author">
+  <macro name="in">
     <choose>
-      <if type="book chapter post-weblog" match="any">
+      <if type="chapter" match="any">
+        <text term="in" text-case="lowercase" suffix=": "/>
+      </if>
+      <else-if type="paper-conference" match="all" variable="collection-title">
+        <text term="in" text-case="lowercase" suffix=": "/>
+      </else-if>
+    </choose>
+  </macro>
+  <macro name="original-author_webPost">
+    <choose>
+      <if type="post post-weblog" match="any">
         <choose>
           <if match="any" variable="original-author">
             <names variable="original-author" delimiter=", ">
@@ -332,54 +357,124 @@
       </if>
     </choose>
   </macro>
-  <macro name="container">
-    <group delimiter=": ">
-      <text term="in" text-case="lowercase"/>
-      <group delimiter=", ">
-        <names variable="editor" delimiter=", ">
-          <name delimiter-precedes-et-al="never" delimiter-precedes-last="never" initialize-with=". "/>
-          <label form="short" text-case="lowercase" prefix=" (" suffix=")"/>
-        </names>
+  <macro name="container-title">
+    <choose>
+      <if type="webpage" match="any">
+        <text variable="container-title" strip-periods="false" suffix=" website"/>
+      </if>
+      <else-if type="legislation post post-weblog" match="any">
+        <text variable="container-title"/>
+      </else-if>
+      <else-if type="paper-conference" match="all">
         <choose>
-          <if type="webpage" match="any">
-            <group delimiter=" ">
-              <text variable="container-title" strip-periods="false"/>
-              <text term="webpage"/>
+          <if match="none" variable="container-title">
+            <group delimiter=", ">
+              <text variable="event-title" font-style="normal"/>
+              <text macro="event-date"/>
             </group>
           </if>
           <else>
-            <choose>
-              <if type="legislation" match="none">
-                <text variable="container-title" strip-periods="false" font-style="italic"/>
-              </if>
-            </choose>
+            <text variable="container-title" font-style="italic"/>
           </else>
         </choose>
-      </group>
-    </group>
+      </else-if>
+      <else>
+        <text variable="container-title" strip-periods="false" font-style="italic"/>
+      </else>
+    </choose>
   </macro>
-  <macro name="preprint">
+  <macro name="extra-IDnum">
     <choose>
-      <if type="article" match="all" variable="genre">
-        <text variable="genre"/>
+      <if type="webpage" match="none">
+        <choose>
+          <if match="any" variable="call-number">
+            <text variable="call-number"/>
+          </if>
+        </choose>
       </if>
     </choose>
   </macro>
-  <citation delimiter-precedes-et-al="never" delimiter-precedes-last="never" et-al-min="3" et-al-use-first="1" disambiguate-add-names="true" disambiguate-add-givenname="true" disambiguate-add-year-suffix="true" givenname-disambiguation-rule="primary-name-with-initials" collapse="year">
+  <macro name="preprint">
+    <choose>
+      <if type="article" match="all" variable="genre" is-numeric="number">
+        <group delimiter=" ">
+          <text variable="genre"/>
+          <text variable="number" prefix="No "/>
+        </group>
+      </if>
+      <else-if type="article" match="any" variable="genre">
+        <group delimiter=", ">
+          <text variable="genre"/>
+          <text variable="number"/>
+        </group>
+      </else-if>
+    </choose>
+  </macro>
+  <macro name="extra-IDnum-webpage">
+    <choose>
+      <if type="webpage" match="all" variable="call-number">
+        <text variable="call-number"/>
+      </if>
+    </choose>
+  </macro>
+  <macro name="year-date_bib">
+    <choose>
+      <if type="legislation" match="all" variable="issued">
+        <date form="text" variable="issued">
+          <date-part name="day"/>
+          <date-part name="month"/>
+          <date-part name="year"/>
+        </date>
+      </if>
+      <else-if match="any" variable="issued">
+        <date date-parts="year" form="text" variable="issued">
+          <date-part name="year"/>
+        </date>
+      </else-if>
+      <else>
+        <text term="no date" form="short"/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="event-date">
+    <date delimiter=" " variable="event-date">
+      <date-part name="day"/>
+      <date-part name="month"/>
+    </date>
+  </macro>
+  <macro name="book-author">
+    <choose>
+      <if type="chapter" match="all" variable="container-author">
+        <names variable="container-author">
+          <name delimiter-precedes-et-al="never" delimiter-precedes-last="never" initialize-with=". "/>
+          <label form="short" text-case="lowercase" prefix=" )" suffix=")"/>
+        </names>
+      </if>
+    </choose>
+  </macro>
+  <macro name="author-alias">
+    <choose>
+      <if type="post post-weblog" match="any">
+        <text variable="annote" prefix=" (" suffix=")"/>
+      </if>
+    </choose>
+  </macro>
+  <citation delimiter-precedes-et-al="never" delimiter-precedes-last="never" et-al-min="2" et-al-use-first="1" disambiguate-add-names="true" disambiguate-add-givenname="true" disambiguate-add-year-suffix="true" givenname-disambiguation-rule="primary-name-with-initials" collapse="year">
     <sort>
       <key macro="author"/>
+      <key variable="year-suffix"/>
       <key macro="year-date"/>
       <key macro="title"/>
     </sort>
     <layout prefix="(" suffix=")" delimiter="; ">
       <group delimiter=", ">
         <text macro="author-in-text"/>
-        <text macro="year-date"/>
+        <text macro="year-date_in-text"/>
         <text macro="citation-locater"/>
       </group>
     </layout>
   </citation>
-  <bibliography delimiter-precedes-et-al="never" delimiter-precedes-last="never" et-al-min="6" et-al-use-first="5" name-as-sort-order="all">
+  <bibliography delimiter-precedes-et-al="never" delimiter-precedes-last="never" et-al-min="5" et-al-use-first="5" name-as-sort-order="all">
     <sort>
       <key macro="author"/>
       <key macro="year-date"/>
@@ -387,36 +482,51 @@
     </sort>
     <layout suffix=".">
       <group delimiter=", ">
-        <group delimiter=" ">
+        <group>
           <text macro="author"/>
-          <group prefix="(" suffix=")">
-            <text macro="year-date"/>
+          <text macro="author-alias"/>
+          <group prefix=" (" suffix=")">
+            <text macro="year-date_bib"/>
           </group>
         </group>
         <text macro="title"/>
-        <text macro="other-creators"/>
-        <text macro="version"/>
-        <group delimiter=" ">
-          <text macro="original-author"/>
-          <text macro="container"/>
+        <group delimiter=", ">
+          <text macro="version"/>
+          <text macro="extra-IDnum-webpage"/>
         </group>
-        <text macro="locators-journal"/>
+        <group delimiter=", ">
+          <group delimiter=" ">
+            <text macro="in"/>
+            <text macro="editor"/>
+          </group>
+          <group>
+            <text macro="container-title"/>
+          </group>
+          <text macro="other-creators"/>
+        </group>
+        <text macro="locators-article"/>
         <text macro="edition"/>
-        <text macro="report"/>
-        <text macro="serial"/>
+        <group delimiter=", ">
+          <text macro="series_title"/>
+          <text macro="report"/>
+        </group>
         <text macro="preprint"/>
         <text macro="publisher"/>
-        <group delimiter=" ">
-          <text macro="day-month"/>
-          <text macro="creation-date"/>
+        <group delimiter=", ">
+          <group delimiter=" ">
+            <text macro="day-month"/>
+            <text macro="creation-dataset"/>
+          </group>
+          <text macro="original-author_webPost"/>
         </group>
         <group delimiter=", ">
           <text macro="pages"/>
+          <text macro="extra-IDnum"/>
           <text macro="access"/>
-          <text variable="call-number"/>
-          <!-- extra-IDnum -->
         </group>
       </group>
     </layout>
+  </bibliography>
+</style>
   </bibliography>
 </style>


### PR DESCRIPTION
Revisions included in this 2nd edition:

rev22c-20250611 
-Included the bibliographic element original author in the elements to display when present in records from social media post document type (Zotero item types Forum Post and Blog Post) to include the name of the author of the original post in case of a repost reference. 
 
rev22a-20250527 
-Added a specific tag (annote:) to use in the Zotero 'Extra' field for the author social media identification. The added rules allow this identification to be the displayed in the list of the references, but exclude it from in-text citation. 

rev21i-20250526 
-Update rules for report document type to include series title.  -Added rules for additional document types: 
*Conference-paper not in event proceedings.  
 *Conference-paper published in conference proceedings (strictly speaking this type should be included in the 'Part of a work' type, but in Zotero it's preferable to use  the 'Conference Paper' item rather than the 'Book Section' item).  

rev20c-20250414  
-Update the reference and in-text citation for legal documents in a more standard way for legislation. Namely using the short title instead of author's name for in-text citation and include the container-title (the Code) in the reference. 

rev19c-20250326  
-Change the location of the optional internal reference number ('Call Number' Zotero field) to a more standard position before the hyperlink.  -Add the internal reference number ('call number' as an 'Extra' field) to the web page item type after the title, following the ISG example Reference to a web page. 
-Update the rules for documents that are part of a collection ('Series' Zotero field) to include the title of the collection into the reference.