### PR TITLE
Pamukkale Üniversitesi Fen Bilimleri Enstitüsü (Türkçe)

### DIFF
--- a/pau-fbe-tr.csl
+++ b/pau-fbe-tr.csl
@@ -1,0 +1,504 @@
+<?xml version="1.0" encoding="utf-8"?>
+<style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" demote-non-dropping-particle="never" default-locale="tr-TR">
+  <info>
+    <title>Pamukkale Üniversitesi Fen Bilimleri Enstitüsü (Türkçe)</title>
+    <title-short>PAÜ FBE (TR)</title-short>
+    <id>https://raw.githubusercontent.com/rsnbhr/csl-styles/refs/heads/main/pau-fbe-tr.csl</id>
+    <link href="https://raw.githubusercontent.com/rsnbhr/csl-styles/refs/heads/main/pau-fbe-tr.csl" rel="self"/>
+    <link href="http://www.zotero.org/styles/apa-tr" rel="template"/>
+    <link href="https://github.com/citation-style-language/styles/issues/240" rel="documentation"/>
+    <contributor>
+      <name>Ersin Bahar</name>
+      <email>ebahar@pau.edu.tr</email>
+    </contributor>
+    <category citation-format="author-date"/>
+    <category field="engineering"/>
+    <category field="science"/>
+    <category field="generic-base"/>
+    <summary>PAÜ FBE için, "APA 6 (Türkçe)" stilinin hafifçe revize edilmiş sürümü. Başlıca değişiklikler: (i) metin içi atıflarda üç ve daha fazla yazarlı çalışmalarda ilk ve sonraki tüm atıflarda "ve diğerleri" (et al.) kullanımı; (ii) bibliyografyada tüm yazarların listelenmesi (et al. yok). Bu çalışma, "American Psychological Association 6th edition (Türkçe)" stilinden türetilmiş olup orijinal lisans ve atıflar korunmaktadır. Ersin Bahar.</summary>
+    <updated>2025-10-03T11:54:00+03:00</updated>
+    <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
+  </info>
+  <locale xml:lang="tr-TR">
+    <terms>
+      <term name="no date">t.y.</term>
+      <term name="et-al">v.d.</term>
+      <term name="and">ve</term>
+      <term name="in">içinde</term>
+      <term name="retrieved">erişildi</term>
+      <term name="from">adresinden</term>
+      <term name="presented at">sunulmuş bildiri</term>
+      <term name="edition">basım</term>
+      <term name="edition" form="short">bs.</term>
+      <term name="page">
+        <single>page</single>
+        <multiple>pages</multiple>
+      </term>
+      <term name="page" form="short">
+        <single>s.</single>
+        <multiple>ss.</multiple>
+      </term>
+      <term name="volume" form="short">c.</term>
+      <term name="translator" form="short">çev.</term>
+      <term name="editor" form="short">ed.</term>
+      <!-- ORDINALS -->
+      <term name="ordinal-01">.</term>
+      <term name="ordinal-02">.</term>
+      <term name="ordinal-03">.</term>
+      <term name="ordinal-04">.</term>
+      <!-- LONG MONTH FORMS -->
+      <term name="month-01">Ocak</term>
+      <term name="month-02">Şubat</term>
+      <term name="month-03">Mart</term>
+      <term name="month-04">Nisan</term>
+      <term name="month-05">Mayıs</term>
+      <term name="month-06">Haziran</term>
+      <term name="month-07">Temmuz</term>
+      <term name="month-08">Ağustos</term>
+      <term name="month-09">Eylül</term>
+      <term name="month-10">Ekim</term>
+      <term name="month-11">Kasım</term>
+      <term name="month-12">Aralık</term>
+    </terms>
+  </locale>
+  <macro name="container-contributors">
+    <choose>
+      <if type="chapter paper-conference" match="any">
+        <names variable="editor" delimiter=", " suffix=", ">
+          <name and="text" initialize-with=". " delimiter=", " delimiter-precedes-last="never"/>
+          <label form="short" prefix=" (" text-case="capitalize-first" suffix=")"/>
+          <substitute>
+            <names variable="translator"/>
+          </substitute>
+        </names>
+      </if>
+    </choose>
+  </macro>
+  <macro name="secondary-contributors">
+    <choose>
+      <if type="article-journal chapter paper-conference" match="none">
+        <names variable="translator" delimiter=", " prefix=" (" suffix=")">
+          <name and="text" initialize-with=". " delimiter=", " delimiter-precedes-last="never"/>
+          <label form="short" prefix=", " text-case="capitalize-first"/>
+          <substitute>
+            <names variable="editor"/>
+          </substitute>
+        </names>
+      </if>
+    </choose>
+  </macro>
+  <macro name="author">
+    <names variable="author">
+      <name name-as-sort-order="all" and="text" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="never"/>
+      <label form="short" prefix=" (" suffix=")" text-case="capitalize-first"/>
+      <substitute>
+        <names variable="editor"/>
+        <names variable="translator"/>
+        <choose>
+          <if type="report">
+            <text variable="publisher"/>
+            <text macro="title"/>
+          </if>
+          <else>
+            <text macro="title"/>
+          </else>
+        </choose>
+      </substitute>
+    </names>
+  </macro>
+  <macro name="author-short">
+    <names variable="author">
+      <name form="short" and="text" delimiter=", " initialize-with=". " delimiter-precedes-last="never"/>
+      <substitute>
+        <names variable="editor"/>
+        <names variable="translator"/>
+        <choose>
+          <if type="report">
+            <text variable="publisher"/>
+            <text variable="title" form="short" font-style="italic"/>
+          </if>
+          <else-if type="bill book graphic legal_case legislation motion_picture song" match="any">
+            <text variable="title" form="short" font-style="italic"/>
+          </else-if>
+          <else>
+            <text variable="title" form="short" quotes="true"/>
+          </else>
+        </choose>
+      </substitute>
+    </names>
+  </macro>
+  <macro name="access">
+    <choose>
+      <if type="thesis">
+        <choose>
+          <if variable="archive" match="any">
+            <group>
+              <text variable="archive"/>
+              <text variable="archive_location" prefix=" (" suffix=")"/>
+              <text term="retrieved" prefix=" veri tabanından " suffix="."/>
+            </group>
+          </if>
+          <else>
+            <group>
+              <text variable="URL"/>
+              <text term="from" prefix=" "/>
+              <text term="retrieved" prefix=" " suffix="."/>
+            </group>
+          </else>
+        </choose>
+      </if>
+      <else>
+        <choose>
+          <if variable="DOI">
+            <text variable="DOI" prefix="doi:"/>
+          </if>
+          <else>
+            <choose>
+              <if type="webpage">
+                <group delimiter=" " suffix=".">
+                  <group>
+                    <date variable="accessed" suffix=" ">
+                      <date-part name="day" suffix=" "/>
+                      <date-part name="month" suffix=" "/>
+                      <date-part name="year" suffix=" tarihinde "/>
+                    </date>
+                  </group>
+                  <text variable="URL"/>
+                  <text term="from"/>
+                  <text term="retrieved"/>
+                </group>
+              </if>
+              <else>
+                <group delimiter=" " suffix=".">
+                  <text variable="URL"/>
+                  <text term="from"/>
+                  <text term="retrieved"/>
+                </group>
+              </else>
+            </choose>
+          </else>
+        </choose>
+      </else>
+    </choose>
+  </macro>
+  <macro name="title">
+    <choose>
+      <if type="report">
+        <text variable="title" font-style="italic"/>
+        <group prefix=" (" suffix=")">
+          <text variable="genre"/>
+          <text variable="number" prefix=" No: "/>
+        </group>
+      </if>
+      <else-if type="book graphic motion_picture report song manuscript speech thesis" match="any">
+        <text variable="title" font-style="italic"/>
+      </else-if>
+      <else>
+        <text variable="title"/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="publisher">
+    <choose>
+      <if type="report">
+        <group delimiter=": ">
+          <text variable="publisher-place"/>
+          <text variable="publisher"/>
+        </group>
+      </if>
+      <else-if type="thesis">
+        <choose>
+          <if variable="archive URL" match="any">
+            <text variable="genre" text-case="capitalize-first" prefix=" (" suffix=")"/>
+          </if>
+          <else>
+            <text variable="genre" text-case="lowercase" prefix=" (Yayımlanmamış " suffix="). "/>
+            <group delimiter=", ">
+              <text variable="publisher"/>
+              <text variable="publisher-place"/>
+            </group>
+          </else>
+        </choose>
+      </else-if>
+      <else>
+        <group delimiter=", ">
+          <choose>
+            <if variable="event event-title" match="none">
+              <text variable="genre"/>
+            </if>
+          </choose>
+          <choose>
+            <if type="article-journal article-magazine" match="none">
+              <group delimiter=": ">
+                <text variable="publisher-place"/>
+                <text variable="publisher"/>
+              </group>
+            </if>
+          </choose>
+        </group>
+      </else>
+    </choose>
+  </macro>
+  <macro name="event">
+    <choose>
+      <if variable="event event-title" match="any">
+        <choose>
+          <if variable="genre" match="none">
+            <text macro="event-title"/>
+            <text term="presented at" prefix=", "/>
+          </if>
+          <else>
+            <group delimiter=" ">
+              <text macro="event-title"/>
+              <text variable="genre"/>
+            </group>
+          </else>
+        </choose>
+      </if>
+    </choose>
+  </macro>
+  <macro name="event-title">
+    <choose>
+      <!-- TODO: We expect "event-title" to be used,
+           but processors and applications may not be updated yet.
+           This macro ensures that either "event" or "event-title" can be accpeted.
+           Remove if procesor logic and application adoption can handle this. -->
+      <if variable="event-title">
+        <text variable="event-title"/>
+      </if>
+      <else>
+        <text variable="event"/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="issued">
+    <choose>
+      <if type="bill legal_case legislation" match="none">
+        <choose>
+          <if variable="issued">
+            <group prefix=" (" suffix=").">
+              <date variable="issued">
+                <date-part name="year"/>
+              </date>
+              <text variable="year-suffix"/>
+              <choose>
+                <if type="bill book graphic legal_case legislation motion_picture report song article-journal chapter paper-conference" match="none">
+                  <date variable="issued" prefix=",">
+                    <date-part prefix=" " name="day"/>
+                    <date-part prefix=" " name="month"/>
+                  </date>
+                </if>
+              </choose>
+            </group>
+          </if>
+          <else>
+            <group prefix=" (" suffix=").">
+              <text term="no date" form="short"/>
+              <text variable="year-suffix" prefix="-"/>
+            </group>
+          </else>
+        </choose>
+      </if>
+    </choose>
+  </macro>
+  <macro name="issued-sort">
+    <choose>
+      <if type="article-journal bill book chapter graphic legal_case legislation motion_picture paper-conference report song" match="none">
+        <date variable="issued">
+          <date-part name="year"/>
+          <date-part prefix=", " name="day"/>
+          <date-part prefix=" " name="month"/>
+        </date>
+      </if>
+      <else>
+        <date variable="issued">
+          <date-part name="year"/>
+        </date>
+      </else>
+    </choose>
+  </macro>
+  <macro name="issued-year">
+    <choose>
+      <if variable="issued">
+        <date variable="issued">
+          <date-part name="year"/>
+        </date>
+        <text variable="year-suffix"/>
+      </if>
+      <else>
+        <text term="no date" form="short"/>
+        <text variable="year-suffix" prefix="-"/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="edition">
+    <choose>
+      <if is-numeric="edition">
+        <group delimiter=" ">
+          <number variable="edition" form="ordinal"/>
+          <text term="edition" form="short"/>
+        </group>
+      </if>
+      <else>
+        <text variable="edition" suffix="."/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="locators">
+    <choose>
+      <if type="article-journal article-magazine" match="any">
+        <group prefix=", " delimiter=", ">
+          <group>
+            <text variable="volume" font-style="italic"/>
+            <text variable="issue" prefix="(" suffix=")"/>
+          </group>
+          <text variable="page"/>
+        </group>
+      </if>
+      <else-if type="article-newspaper">
+        <group delimiter=" " prefix=", ">
+          <label variable="page" form="short"/>
+          <text variable="page"/>
+        </group>
+      </else-if>
+      <else-if type="book graphic motion_picture report song chapter paper-conference" match="any">
+        <group prefix=" (" suffix=")" delimiter=", ">
+          <text macro="edition"/>
+          <group>
+            <text term="volume" form="short" plural="true" text-case="capitalize-first" suffix=" "/>
+            <number variable="number-of-volumes" form="numeric" prefix="1-"/>
+          </group>
+          <group>
+            <text term="volume" form="short" text-case="capitalize-first" suffix=" "/>
+            <number variable="volume" form="numeric"/>
+          </group>
+          <group>
+            <label variable="page" form="short" suffix=" "/>
+            <text variable="page"/>
+          </group>
+        </group>
+      </else-if>
+      <else-if type="legal_case">
+        <group prefix=" (" suffix=")" delimiter=" ">
+          <text variable="authority"/>
+          <date variable="issued" delimiter=" ">
+            <date-part name="month" form="short"/>
+            <date-part name="day" suffix=","/>
+            <date-part name="year"/>
+          </date>
+        </group>
+      </else-if>
+      <else-if type="bill legislation" match="any">
+        <date variable="issued" prefix=" (" suffix=")">
+          <date-part name="year"/>
+        </date>
+      </else-if>
+    </choose>
+  </macro>
+  <macro name="citation-locator">
+    <group>
+      <label variable="locator" form="short"/>
+      <text variable="locator" prefix=" "/>
+    </group>
+  </macro>
+  <macro name="container">
+    <choose>
+      <if type="bill legal_case legislation" match="none">
+        <text variable="container-title" font-style="italic"/>
+        <choose>
+          <if type="chapter paper-conference" match="any">
+            <text term="in" prefix=" " suffix=" "/>
+          </if>
+        </choose>
+      </if>
+      <else>
+        <group delimiter=" " prefix=" ">
+          <choose>
+            <if variable="container-title">
+              <text variable="volume"/>
+              <text variable="container-title"/>
+              <group delimiter=" ">
+                <!--change to label variable="section" as that becomes available -->
+                <text term="section" form="symbol"/>
+                <text variable="section"/>
+              </group>
+              <text variable="page"/>
+            </if>
+            <else>
+              <choose>
+                <if type="legal_case">
+                  <text variable="number" prefix="No. "/>
+                </if>
+                <else>
+                  <text variable="number" prefix="Pub. L. No. "/>
+                  <group delimiter=" ">
+                    <!--change to label variable="section" as that becomes available -->
+                    <text term="section" form="symbol"/>
+                    <text variable="section"/>
+                  </group>
+                </else>
+              </choose>
+            </else>
+          </choose>
+        </group>
+      </else>
+    </choose>
+  </macro>
+  <citation et-al-min="3" et-al-use-first="1" et-al-subsequent-min="3" et-al-subsequent-use-first="1" disambiguate-add-year-suffix="true" disambiguate-add-names="true" disambiguate-add-givenname="true" collapse="year" givenname-disambiguation-rule="primary-name">
+    <sort>
+      <key macro="author"/>
+      <key macro="issued-sort"/>
+    </sort>
+    <layout prefix="(" suffix=")" delimiter="; ">
+      <group delimiter=", ">
+        <choose>
+          <if type="personal_communication interview" match="any">
+            <names variable="author">
+              <name initialize-with=". "/>
+            </names>
+            <text value="kişisel iletişim"/>
+            <date variable="issued">
+              <date-part prefix=" " name="day"/>
+              <date-part prefix=" " name="month"/>
+              <date-part prefix=" " name="year"/>
+            </date>
+          </if>
+          <else>
+            <text macro="author-short"/>
+            <text macro="issued-year"/>
+          </else>
+        </choose>
+        <text macro="citation-locator"/>
+      </group>
+    </layout>
+  </citation>
+  <bibliography hanging-indent="true" entry-spacing="0" line-spacing="2">
+    <sort>
+      <key macro="author"/>
+      <key macro="issued-sort" sort="ascending"/>
+    </sort>
+    <layout>
+      <group suffix=".">
+        <text macro="author" suffix="."/>
+        <text macro="issued"/>
+        <group delimiter=". ">
+          <text macro="title" prefix=" "/>
+          <group>
+            <text macro="container-contributors"/>
+            <text macro="secondary-contributors"/>
+            <group delimiter=", ">
+              <text macro="container"/>
+              <text variable="collection-title"/>
+            </group>
+          </group>
+        </group>
+        <text macro="locators"/>
+        <group delimiter=", " prefix=". ">
+          <text macro="event"/>
+          <text macro="publisher"/>
+        </group>
+      </group>
+      <text macro="access" prefix=" "/>
+    </layout>
+  </bibliography>
+</style>


### PR DESCRIPTION
This citation style is a revision of the "American Psychological Association 6th edition (Türkçe)" style 
(http://www.zotero.org/styles/apa-tr), adapted for Pamukkale University The Graduate School of Natural and 
Applied Sciences. 

Two main modifications were applied:
1. In-text citations with three or more authors always use "et al." from the very first citation. 
2. In the bibliography, all authors are always listed (no use of "et al.").