### PR TITLE
Add new CSL style: Linguistics Vanguard

### DIFF
--- a/linguistics-vanguard.csl
+++ b/linguistics-vanguard.csl
@@ -7,28 +7,31 @@
     <link href="http://www.zotero.org/styles/linguistics-vanguard" rel="self"/>
     <link href="http://www.zotero.org/styles/journal-of-historical-linguistics" rel="template"/>
     <link href="https://www.degruyterbrill.com/journal/key/lingvan/html#submit" rel="documentation"/>
+    <link href="file:///D:/Installs/LINGVAN_LINGVAN_Mouton_journal_stylesheet-1.pdf" rel="documentation"/>
     <author>
       <name>Tsy Yih</name>
       <email>yihtsy@outlook.com</email>
     </author>
+    <contributor>
+      <name>Patrick O'Brien</name>
+    </contributor>
     <category citation-format="author-date"/>
     <category field="linguistics"/>
     <eissn>2199-174X</eissn>
-    <updated>2025-09-17T12:00:00+00:00</updated>
+    <updated>2025-10-10T09:05:28+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <macro name="editor-translator">
-    <names variable="editor translator" prefix="(" suffix=")" delimiter=", ">
+    <names variable="editor translator" delimiter=", " prefix="(" suffix=")">
       <name and="text" initialize-with="" delimiter=", "/>
-      <et-al font-style="normal"/>
+      <et-al font-style="italic"/>
       <label form="short" prefix=", " text-case="capitalize-first"/>
     </names>
   </macro>
   <macro name="author">
     <names variable="author">
       <name delimiter-precedes-last="never" initialize="false" initialize-with="." name-as-sort-order="first" and="symbol"/>
-      <et-al font-style="normal"/>
-      <label form="short" prefix=" (" suffix=")" text-case="capitalize-first"/>
+      <label form="short" prefix=" (" suffix=")"/>
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
@@ -39,7 +42,6 @@
   <macro name="author-short">
     <names variable="author">
       <name form="short"/>
-      <et-al font-style="normal"/>
       <substitute>
         <names variable="editor"/>
         <names variable="translator"/>
@@ -54,10 +56,27 @@
       </substitute>
     </names>
   </macro>
+  <macro name="edition">
+    <choose>
+      <if is-numeric="edition">
+        <group delimiter=" ">
+          <number variable="edition" form="ordinal"/>
+          <label variable="edition" form="short"/>
+        </group>
+      </if>
+      <else>
+        <text variable="edition"/>
+      </else>
+    </choose>
+  </macro>
   <macro name="title">
     <choose>
       <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
-        <text variable="title" font-style="italic"/>
+        <group delimiter=" ">
+          <text variable="title" font-style="italic"/>
+          <text macro="editor-translator"/>
+          <text variable="original-title" prefix="[" suffix="]"/>
+        </group>
       </if>
       <else>
         <text variable="title"/>
@@ -67,7 +86,36 @@
   <macro name="publisher">
     <group delimiter=": ">
       <text variable="publisher-place"/>
-      <text variable="publisher"/>
+      <group delimiter=" ">
+        <text variable="publisher"/>
+        <choose>
+          <if type="thesis" match="any">
+            <text variable="genre"/>
+          </if>
+        </choose>
+      </group>
+    </group>
+  </macro>
+  <macro name="year-date">
+    <date variable="issued" text-case="uppercase">
+      <date-part name="year"/>
+    </date>
+    <date date-parts="year" form="text" variable="original-date" prefix=" [" suffix="]"/>
+  </macro>
+  <macro name="access">
+    <group delimiter=" ">
+      <choose>
+        <if match="any" variable="DOI">
+          <text variable="DOI" prefix="https://doi.org/"/>
+        </if>
+        <else>
+          <text variable="URL"/>
+        </else>
+      </choose>
+      <group delimiter=" " prefix="(" suffix=")">
+        <text term="accessed"/>
+        <date form="text" variable="accessed"/>
+      </group>
     </group>
   </macro>
   <citation collapse="year-suffix" and="text" et-al-min="3" et-al-use-first="1" et-al-subsequent-min="3" et-al-subsequent-use-first="1" disambiguate-add-year-suffix="true" year-suffix-delimiter=",">
@@ -76,12 +124,17 @@
       <key variable="author"/>
     </sort>
     <layout delimiter=", " prefix="(" suffix=")">
-      <group>
-        <text macro="author-short" text-case="capitalize-first" suffix=" "/>
-        <date variable="issued">
-          <date-part name="year"/>
-        </date>
-        <group prefix=": ">
+      <group delimiter=": ">
+        <group delimiter=" ">
+          <text macro="author-short" text-case="capitalize-first"/>
+          <text macro="year-date"/>
+        </group>
+        <group delimiter=" ">
+          <choose>
+            <if match="none" locator="page">
+              <label variable="locator" form="short"/>
+            </if>
+          </choose>
           <text variable="locator" prefix=" "/>
         </group>
       </group>
@@ -93,52 +146,49 @@
       <key variable="issued"/>
     </sort>
     <layout suffix=".">
-      <text macro="author" text-case="capitalize-first" suffix="."/>
-      <date variable="issued" text-case="uppercase" prefix=" " suffix=".">
-        <date-part name="year"/>
-      </date>
-      <choose>
-        <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
-          <group suffix=".">
-            <text macro="title" prefix=" "/>
-            <text macro="editor-translator" prefix=" "/>
-          </group>
-          <text prefix=" " suffix="." macro="publisher"/>
-        </if>
-        <else-if type="chapter paper-conference" match="any">
+      <group delimiter=". ">
+        <text macro="author" text-case="capitalize-first"/>
+        <text macro="year-date"/>
+        <group delimiter=", ">
           <text macro="title" prefix=" " suffix="."/>
-          <group prefix=" In " suffix=".">
-            <names variable="editor">
-              <name initialize="false" and="symbol" delimiter=", " delimiter-precedes-last="never"/>
-              <label form="short" prefix=" (" suffix=")"/>
-            </names>
-            <text variable="container-title" font-style="italic" prefix=", "/>
-            <text variable="page" prefix=", "/>
-            <text macro="publisher" prefix=". "/>
-          </group>
-        </else-if>
-        <else-if type="thesis" match="any">
-          <group suffix=".">
-            <text macro="title" prefix=" "/>
-            <text macro="editor-translator" prefix=" "/>
-          </group>
-          <text prefix=" Unpublished thesis, " suffix="." variable="publisher"/>
-        </else-if>
-        <else>
-          <group suffix=".">
-            <text macro="title" prefix=" "/>
-            <text macro="editor-translator" prefix=" "/>
-          </group>
-          <group prefix=" " suffix=".">
-            <text variable="container-title" font-style="italic"/>
-            <group delimiter="" prefix=" " suffix=".">
-              <text variable="volume"/>
-              <text variable="issue" prefix="(" suffix=")"/>
+          <text macro="edition"/>
+        </group>
+        <choose>
+          <if type="bill book graphic legal_case legislation motion_picture report song" match="any">
+            <text macro="publisher"/>
+          </if>
+          <else-if type="chapter paper-conference" match="any">
+            <group delimiter=", ">
+              <group delimiter=" ">
+                <text term="in" text-case="capitalize-first"/>
+                <names variable="editor">
+                  <name initialize="false" and="symbol" delimiter=", " delimiter-precedes-last="never"/>
+                  <label form="short" prefix=" (" suffix=")"/>
+                </names>
+              </group>
+              <text variable="container-title" font-style="italic"/>
+              <text variable="page"/>
             </group>
-            <text variable="page" prefix=" "/>
-          </group>
-        </else>
-      </choose>
+            <text macro="publisher"/>
+          </else-if>
+          <else-if type="thesis" match="any">
+            <text macro="editor-translator" prefix=" "/>
+            <text macro="publisher"/>
+          </else-if>
+          <else>
+            <text macro="editor-translator" prefix=" "/>
+            <group delimiter=" ">
+              <text variable="container-title" font-style="italic"/>
+              <group prefix=" ">
+                <text variable="volume"/>
+                <text variable="issue" prefix="(" suffix=")"/>
+              </group>
+            </group>
+            <text variable="page"/>
+          </else>
+        </choose>
+        <text macro="access"/>
+      </group>
     </layout>
   </bibliography>
 </style>


### PR DESCRIPTION
This commit adds a new CSL style for the journal *Linguistics Vanguard*.

- Based on the *Journal of Historical Linguistics* template.  
- Adapted according to the official author guidelines of the journal.  
- Validated using the CSL validator (https://validator.citationstyles.org/).  

Please let me know if any further adjustments are needed.
