### PR TITLE
Hotfix for uniwersytet-gdanski-kulturoznawstwo-autor-rok.csl

### DIFF
--- a/uniwersytet-gdanski-kulturoznawstwo-autor-rok.csl
+++ b/uniwersytet-gdanski-kulturoznawstwo-autor-rok.csl
@@ -16,7 +16,7 @@
     <category field="sociology"/>
     <category field="anthropology"/>
     <summary>A Polish in-text citation style based on Uni. of Gdansk Cultural Studies Department guidelines. Wide use range for cultural studies, digital humanities</summary>
-    <updated>2025-10-05T15:08:38+00:00</updated>
+    <updated>2025-10-09T17:14:56+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale xml:lang="pl">
@@ -29,7 +29,7 @@
     <text variable="title" text-case="capitalize-first" quotes="false" font-style="italic"/>
   </macro>
   <macro name="title-short">
-    <text variable="title" form="short" text-case="capitalize-first" quotes="false"/>
+    <text variable="title" form="short" text-case="capitalize-first" quotes="true"/>
   </macro>
   <macro name="author">
     <names variable="author">


### PR DESCRIPTION
Fixed lack of quotes in `title-short` macro, which should be there. [See recent overhaul](https://github.com/citation-style-language/styles/commit/7222ca198092660cc7fd568f7a47ff4293bb434e#diff-5253686f908cece21d3b0cf1670c5d73e02e7ce622617bd9e87e6fdd28e0ee30R30-R32), where I made the mistake.
Thanks!