### PR TITLE
Update DOI formatting on CSE Author Date 8th Edition

### DIFF
--- a/council-of-science-editors-author-date-8th-edition.csl
+++ b/council-of-science-editors-author-date-8th-edition.csl
@@ -6,6 +6,7 @@
     <id>http://www.zotero.org/styles/council-of-science-editors-author-date-8th-edition</id>
     <link href="http://www.zotero.org/styles/council-of-science-editors-author-date-8th-edition" rel="self"/>
     <link href="https://cdn.dal.ca/content/dam/dalhousie/pdf/library/Style_Guides/cse_style8.pdf" rel="documentation"/>
+    <link href="https://www.csemanual.org/Tools/CSE-Citation-Quick-Guide.html" rel="documentation"/>
     <author>
       <name>Julian Onions</name>
       <email>julian.onions@gmail.com</email>


### PR DESCRIPTION
### Description
Hello!

I come from Zotero, and I noticed that the CSE Name-Year citation, when including DOIs in the references section, formatted them as "doi:10.1175/JPO-D-23-0038.1", rather than the accepted "https://doi.org/10.1175/JPO-D-23-0038.1".

The other change I made was updating the documentation source. The link of the previous one was no longer found (e.g. error 404), so considering that the previous one was hosted by a university, I added the guide from my university's library. I also followed/updated the necessary items in the checklist (I hope).

If there are any issues/formatting/other technical-related items that I missed, I'd love to learn how to fix them. (I saw on the Zotero documentation/maybe this one about updating the links in the `<id></id>` tags, but I'm not fully sure).

:)


### Checklist
- [x] Check that you've added a link to the style you used as a template in the `<info>` block at the beginning of the file with `rel="template"`.  
- [x] Check that you've added a link to the style guidelines with `rel="documentation"`.  
- [x] Check that you've added yourself as the `<author>` of the style or `<contributor>` for a style update. 
- [x] Check that you've used the correct terms or labels instead of hardcoding into affixes (e.g., `<text variable="page" prefix="pp. "/>`).
- [x] Check that you've not used `<text value="...` if not absolutely necessary.
- [x] Check that you've not changed line 1 of the style.
