### PR TITLE
Add Eduvos - Harvard citation style definition

### DIFF
--- a/eduvos-harvard.csl
+++ b/eduvos-harvard.csl
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
-<style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" demote-non-dropping-particle="sort-only" >
+<style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" demote-non-dropping-particle="sort-only">
   <info>
     <title>Eduvos - Harvard</title>
     <id>http://www.zotero.org/styles/eduvos-harvard</id>
-        <link href="http://www.zotero.org/styles/eduvos-harvard" rel="self"/>
+    <link href="http://www.zotero.org/styles/eduvos-harvard" rel="self"/>
     <link href="http://www.zotero.org/styles/harvard-cite-them-right-11th-edition" rel="template"/>
     <link href="http://www.citethemrightonline.com/" rel="documentation"/>
     <author>
@@ -18,19 +18,19 @@
   <!-- Global options -->
   <locale xml:lang="en-GB">
     <terms>
-      <term name="page" form="short"></term>
+      <term name="page" form="short"/>
       <term name="chapter" form="short">Chapter</term>
       <term name="section" form="short">Section</term>
-      <term name="page-range-delimiter">–</term>
+      <term name="page-range-delimiter">&#8211;</term>
       <term name="and">and</term>
-        <term name="edition" form="short">ed.</term>
-         <term name="editor" form="short">
+      <term name="edition" form="short">ed.</term>
+      <term name="editor" form="short">
         <single>ed.</single>
         <multiple>eds</multiple>
       </term>
       <term name="available at">Available at:</term>
       <term name="accessed" form="short">Accessed:</term>
-        <term name="accessed" form="long">Downloaded:</term>
+      <term name="accessed" form="long">Downloaded:</term>
       <term name="online">Online</term>
     </terms>
     <date form="text">
@@ -125,34 +125,33 @@
           </date>
         </group>
       </if>
-       <else-if variable="edition">
- <choose>
-      <if is-numeric="edition">
-    <text term="available at" suffix=": " text-case="capitalize-first"/>
-        <text variable="URL"/>
-        <group prefix=" [" delimiter=": " suffix="]">
-          <text term="accessed" form="short" text-case="capitalize-first"/>
-          <date form="text" variable="accessed">
-            <date-part name="day"/>
-            <date-part name="month"/>
-            <date-part name="year"/>
-          </date>
-        </group>
+      <else-if variable="edition">
+        <choose>
+          <if is-numeric="edition">
+            <text term="available at" suffix=": " text-case="capitalize-first"/>
+            <text variable="URL"/>
+            <group prefix=" [" delimiter=": " suffix="]">
+              <text term="accessed" form="short" text-case="capitalize-first"/>
+              <date form="text" variable="accessed">
+                <date-part name="day"/>
+                <date-part name="month"/>
+                <date-part name="year"/>
+              </date>
+            </group>
           </if>
-      <else>
-        <text term="available at" suffix=": " text-case="capitalize-first"/>
-        <text variable="URL"/>
-        <group prefix=" [" delimiter=": " suffix="]">
-          <text term="accessed" form="long" text-case="capitalize-first"/>
-          <date form="text" variable="accessed">
-            <date-part name="day"/>
-            <date-part name="month"/>
-            <date-part name="year"/>
-          </date>
-        </group>
-      </else>
-    </choose>
-
+          <else>
+            <text term="available at" suffix=": " text-case="capitalize-first"/>
+            <text variable="URL"/>
+            <group prefix=" [" delimiter=": " suffix="]">
+              <text term="accessed" form="long" text-case="capitalize-first"/>
+              <date form="text" variable="accessed">
+                <date-part name="day"/>
+                <date-part name="month"/>
+                <date-part name="year"/>
+              </date>
+            </group>
+          </else>
+        </choose>
       </else-if>
       <else-if variable="URL">
         <text term="available at" suffix=": " text-case="capitalize-first"/>
@@ -172,7 +171,7 @@
     <choose>
       <if variable="volume" match="none">
         <group delimiter=" " prefix="(" suffix=")">
-          <text variable="number-of-volumes" />
+          <text variable="number-of-volumes"/>
           <label variable="volume" form="short" strip-periods="true"/>
         </group>
       </if>
@@ -185,9 +184,8 @@
           <group delimiter=" ">
             <group delimiter=" ">
               <text variable="title" font-style="italic"/>
-           
             </group>
-            <text macro="number-volumes" />
+            <text macro="number-volumes"/>
           </group>
           <text macro="edition"/>
         </group>
@@ -244,7 +242,7 @@
         <date variable="issued">
           <date-part name="year"/>
         </date>
-        <text variable="year-suffix" />
+        <text variable="year-suffix"/>
       </if>
       <else>
         <text term="no date"/>
@@ -254,9 +252,9 @@
   </macro>
   <macro name="locator">
     <choose>
-      <if type="article-journal" >
-        <text variable="volume" />
-        <text variable="issue" prefix="(" suffix=")" />
+      <if type="article-journal">
+        <text variable="volume"/>
+        <text variable="issue" prefix="(" suffix=")"/>
       </if>
     </choose>
   </macro>
@@ -335,17 +333,16 @@
           <label variable="locator" form="short" suffix=" "/>
           <text variable="locator"/>
         </group>
-        
       </group>
     </layout>
   </citation>
   <bibliography and="text" et-al-min="101" et-al-use-first="100" hanging-indent="false" line-spacing="2">
     <sort>
       <key macro="author"/>
-      <key macro="year-date" />
+      <key macro="year-date"/>
       <key variable="title"/>
     </sort>
-    <layout suffix="." >
+    <layout suffix=".">
       <group delimiter=". ">
         <group delimiter=" ">
           <text macro="author"/>
@@ -355,19 +352,19 @@
             <group delimiter=" ">
               <text macro="container-prefix"/>
               <text macro="editor"/>
-              <text macro="container-title" />
+              <text macro="container-title"/>
             </group>
           </group>
         </group>
-        <text macro="secondary-contributors" />
-        <text macro="publisher" />
+        <text macro="secondary-contributors"/>
+        <text macro="publisher"/>
       </group>
       <group delimiter=", " prefix=", ">
         <text macro="locator" suffix="."/>
         <text macro="published-date"/>
-        <text macro="pages" />
+        <text macro="pages"/>
       </group>
-         <text variable="medium" prefix=" [" suffix="]"/>
+      <text variable="medium" prefix=" [" suffix="]"/>
       <text macro="access" prefix=" "/>
     </layout>
   </bibliography>


### PR DESCRIPTION
This file defines the Eduvos - Harvard citation style in XML format, including macros for various citation components and layout specifications.

## CSL Styles Pull Request Template
You're about to create a pull request to the CSL **styles** repository.  
If you haven't done so already, see <https://github.com/citation-style-language/styles/blob/master/CONTRIBUTING.md> for instructions on how to contribute, and <https://github.com/citation-style-language/styles/blob/master/STYLE_REQUIREMENTS.md> for the requirements a style must meet before acceptance.  
In addition, please fill out the pull request template below.


### Description
Eduvos removes brackets around date in reference list, they don't use et al in reference list and also prefer : for page numbers. 

#### Checklist
- [x] Check that you've added a link to the style you used as a template in the <info> block at the beginning of the file with rel="template".
- [x] Check that you've added a link to the style guidelines with rel="documentation".
- [x] Check that you've added yourself as the <author> of the style or <contributor> for a style update.
- [x] Check that you've used the correct terms or labels instead of hardcoding into affixes (e.g., <text variable="page" prefix="pp. "/>).
- [x] Check that you've not used <text value="... if not absolutely necessary.
- [x] Check that you've not changed line 1 of the style.