### PR TITLE
Update gost-r-7-0-5-2008-numeric.csl

### DIFF
--- a/gost-r-7-0-5-2008-numeric.csl
+++ b/gost-r-7-0-5-2008-numeric.csl
@@ -57,12 +57,12 @@
   <macro name="editor-translator">
     <names variable="editor translator" delimiter="; ">
       <label form="verb-short" suffix=" "/>
-      <name name-as-sort-order="all" sort-separator=" " initialize-with="." delimiter=", " delimiter-precedes-last="always"/>
+      <name name-as-sort-order="all" sort-separator=" " initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
     </names>
   </macro>
   <macro name="author">
     <names variable="author">
-      <name name-as-sort-order="all" sort-separator=" " initialize-with="." delimiter=", " delimiter-precedes-last="always"/>
+      <name name-as-sort-order="all" sort-separator=" " initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
     </names>
   </macro>
   <macro name="title">


### PR DESCRIPTION
### Description

Add space between first and last name. This is consistent with the standard and the other 2 GOST styles (regular and alphabetical).

### Checklist
- [ ] Check that you've added a link to the style you used as a template in the `<info>` block at the beginning of the file with `rel="template"`.
- [ ] Check that you've added a link to the style guidelines with `rel="documentation"`.
- [ ] Check that you've added yourself as the `<author>` of the style or `<contributor>` for a style update.
- [ ] Check that you've used the correct terms or labels instead of hardcoding into affixes (e.g., `<text variable="page" prefix="pp. "/>`).
- [x] Check that you've not used `<text value="...` if not absolutely necessary.
- [x] Check that you've not changed line 1 of the style.
