### PR TITLE
Fix: Conformidade NBR 10520:2023 (caixa baixa) e lógica [S. l.].

### DIFF
--- a/pontificia-universidade-catolica-do-parana-abnt.csl
+++ b/pontificia-universidade-catolica-do-parana-abnt.csl
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<style xmlns="http://purl.org/net/xbiblio/csl" version="1.0" class="in-text" default-locale="pt-BR">
+<style xmlns="http://purl.org/net/xbiblio/csl" version="1.0" class="in-text" demote-non-dropping-particle="never" default-locale="pt-BR">
   <info>
     <title>Pontificia Universidade Catolica do Parana - ABNT (Portuguese - Brazil)</title>
     <title-short>PUC-PR-ABNT</title-short>


### PR DESCRIPTION
Olá,

Este Pull Request é uma correção  e ajustes de conformidade no estilo CSL pontificia-universidade-catolica-do-parana-abnt, que foi recentemente mesclado.

As alterações implementadas corrigem dois pontos importantes:

Conformidade com NBR 10520:2023 (Sobrenome em Citação):

Alteração na macro citation-author para que o sobrenome do autor na citação entre parênteses (Sobrenome, ano) apareça em apenas a primeira letra em maiúsculo (text-case="capitalize-first"), conforme a atualização da NBR 10520. Antes estava em caixa alta.

Lógica para Local de Publicação Omitido ([S. l.]):

Restauração e garantia da inclusão do campo Local/Editora (que insere [S. l.] se o local for omitido) nas referências de report, thesis e motion_picture.

Estas são correções pontuais para garantir a plena conformidade do estilo.
