### PR TITLE
Fix: et al. em itálico e adição do localizador 'p.' na citação.

### DIFF
--- a/pontificia-universidade-catolica-do-parana-abnt.csl
+++ b/pontificia-universidade-catolica-do-parana-abnt.csl
@@ -157,7 +157,7 @@
           <text variable="publisher-place"/>
         </if>
         <else>
-          <text value="[S. l.]" font-style="italic"/>
+          <text term="no-place" prefix="[" suffix="]" text-case="capitalize-first" font-style="italic"/>
         </else>
       </choose>
       <choose>
@@ -165,7 +165,7 @@
           <text variable="publisher"/>
         </if>
         <else>
-          <text value="[s. n.]" font-style="italic"/>
+          <text term="no-publisher" prefix="[" suffix="]" text-case="capitalize-first" font-style="italic"/>
         </else>
       </choose>
     </group>
@@ -191,7 +191,7 @@
         <date form="numeric" variable="issued" suffix="."/>
       </else-if>
       <else>
-        <text value="[s. d.]" font-style="italic"/>
+        <text term="no date" prefix="[" suffix="]" font-style="italic"/>
       </else>
     </choose>
   </macro>
@@ -208,7 +208,7 @@
         </date>
       </else-if>
       <else>
-        <text value="[s. d.]" font-style="italic"/>
+        <text term="no date" prefix="[" suffix="]" font-style="italic"/>
       </else>
     </choose>
   </macro>


### PR DESCRIPTION

Prezados revisores,

Este Pull Request implementa várias correções de formatação de acordo com os requisitos da ABNT, conforme solicitados pela Pontifícia Universidade Católica do Paraná (PUC-PR).

As correções abordam inconsistências na formatação de citações no corpo do texto e na lista de referências, focando na conformidade com as normas NBR 10520 e NBR 6023. Formatação do Sobrenome na Citação:

Problema anterior: Os sobrenomes nas citações entre parênteses estavam em CAIXA ALTA ((SILVA, 2023)).

Correção: Alterado para exibir apenas a primeira letra em maiúsculo ((Silva, 2023)), conforme a regra do estilo ABNT da instituição.

Formatação do et al.:

Problema anterior: A abreviatura et al. era exibida em formato normal.

Correção: Adicionada a formatação para que o et al. seja exibido em itálico ((Silva *et al.*, 2023)), requisito comum da ABNT.

Inclusão do Localizador de Página (p.) na Citação:

Problema anterior: Ao citar uma página específica, faltava o prefixo p. antes do número ((Silva, 2023, 25)).

Correção: Implementado o p. para que o resultado seja: (Silva, 2023, p. 25).

Inclusão do [S. l.] e [s. n.] (Local e Editora Omitidos):

Problema anterior: Em referências de itens como Teses ou Relatórios, quando os campos de Local e/ou Editora (Publisher) estavam vazios no Zotero, a referência ficava incompleta.

Correção: Implementada a lógica para exibir [S. l.] (Sine loco) e [s. n.] (Sine nomine), conforme exigido pela NBR 6023, quando os respectivos campos estiverem ausentes.

Agradeço a revisão e aprovação.
