### PR TITLE
Fix: Corrected [S. l.] to required lowercase [s. l.] in publisher macro.

### DIFF
--- a/pontificia-universidade-catolica-do-parana-abnt.csl
+++ b/pontificia-universidade-catolica-do-parana-abnt.csl
@@ -342,8 +342,8 @@
           </else-if>
           <else-if type="webpage post post-weblog" match="any">
             <group delimiter=": ">
-                <text term="in" font-weight="bold" text-case="capitalize-first"/>
-                <text variable="container-title" font-weight="bold"/>
+              <text term="in" font-weight="bold" text-case="capitalize-first"/>
+              <text variable="container-title" font-weight="bold"/>
             </group>
             <text macro="issued"/>
             <text macro="access"/>


### PR DESCRIPTION
Olá!

Este é um PR de correção final para o estilo Pontifícia Universidade Católica do Paraná - ABNT.

O PR anterior (#7896) foi mesclado com sucesso, mas testes finais no Zotero identificaram um detalhe na formatação das abreviaturas de "sem local" e "sem nome" na macro publisher.

Correção feita:

A abreviatura para "sem local" estava sendo renderizada como [S. l.] (inicial maiúscula) devido ao termo text-case="capitalize-first".

A correção altera o código para que o formato seja estritamente o exigido pela ABNT: todo em minúsculo e em itálico ([s. l.] e [s. n.]).

Peço desculpas por este ajuste de última hora. Agradeço imensamente a paciência e a atenção para que o estilo fique 100% conforme as normas.

Atenciosamente,
Adriano
