### PR TITLE
Add AI-enabled Harvard Cite Them Right 13th edition style

### DIFF
--- a/harvard-cite-them-right-13-ai.csl
+++ b/harvard-cite-them-right-13-ai.csl
@@ -15,7 +15,6 @@
     <updated>2025-11-18T13:43:35Z</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
-
   <locale xml:lang="en-GB">
     <terms>
       <term name="editor" form="short">
@@ -26,7 +25,6 @@
       <term name="edition" form="short">edn.</term>
     </terms>
   </locale>
-
   <macro name="editor">
     <choose>
       <if type="chapter paper-conference" match="any">
@@ -44,7 +42,6 @@
       </if>
     </choose>
   </macro>
-
   <macro name="secondary-contributors">
     <choose>
       <if type="chapter paper-conference" match="none">
@@ -61,7 +58,6 @@
       </else-if>
     </choose>
   </macro>
-
   <macro name="author">
     <names variable="author">
       <name and="text" delimiter-precedes-last="never" initialize-with="." name-as-sort-order="all"/>
@@ -81,7 +77,6 @@
       </substitute>
     </names>
   </macro>
-
   <macro name="author-short">
     <names variable="author">
       <name form="short" and="text" delimiter=", " delimiter-precedes-last="never" initialize-with=". "/>
@@ -100,7 +95,6 @@
       </substitute>
     </names>
   </macro>
-
   <macro name="access">
     <choose>
       <if variable="DOI">
@@ -123,7 +117,6 @@
       </else-if>
     </choose>
   </macro>
-
   <macro name="number-volumes">
     <choose>
       <if variable="volume" match="none">
@@ -134,7 +127,6 @@
       </if>
     </choose>
   </macro>
-
   <!-- NEW: AI helpers -->
   <macro name="ai-version">
     <choose>
@@ -143,7 +135,6 @@
       </if>
     </choose>
   </macro>
-
   <macro name="ai-prompt">
     <choose>
       <if variable="original-title">
@@ -155,7 +146,6 @@
       </if>
     </choose>
   </macro>
-
   <macro name="title">
     <choose>
       <if type="bill book legal_case legislation motion_picture report song thesis webpage graphic" match="any">
@@ -184,7 +174,6 @@
       </if>
     </choose>
   </macro>
-
   <!-- UPDATED: remove place for reports; keep event & event-place for conferences -->
   <macro name="publisher">
     <choose>
@@ -194,7 +183,6 @@
           <text variable="publisher"/>
         </group>
       </if>
-
       <!-- CTR 13: reports no longer include place of publication -->
       <else-if type="report">
         <group delimiter=". ">
@@ -205,7 +193,6 @@
           <text variable="publisher"/>
         </group>
       </else-if>
-
       <!-- All other non-journal items -->
       <else-if type="article-journal article-newspaper article-magazine" match="none">
         <group delimiter=" ">
@@ -229,7 +216,6 @@
       </else-if>
     </choose>
   </macro>
-
   <macro name="year-date">
     <choose>
       <if variable="issued">
@@ -244,7 +230,6 @@
       </else>
     </choose>
   </macro>
-
   <macro name="locator">
     <choose>
       <if type="article-journal">
@@ -253,7 +238,6 @@
       </if>
     </choose>
   </macro>
-
   <macro name="published-date">
     <choose>
       <if type="article-newspaper article-magazine post-weblog speech" match="any">
@@ -264,7 +248,6 @@
       </if>
     </choose>
   </macro>
-
   <!-- UPDATED: article numbers for journals without pages -->
   <macro name="pages">
     <choose>
@@ -292,7 +275,6 @@
       </else-if>
     </choose>
   </macro>
-
   <macro name="container-title">
     <choose>
       <if variable="container-title">
@@ -314,7 +296,6 @@
       </if>
     </choose>
   </macro>
-
   <macro name="edition">
     <choose>
       <if is-numeric="edition">
@@ -328,7 +309,6 @@
       </else>
     </choose>
   </macro>
-
   <macro name="container-prefix">
     <choose>
       <if type="chapter paper-conference" match="any">
@@ -336,7 +316,6 @@
       </if>
     </choose>
   </macro>
-
   <citation et-al-min="4" et-al-use-first="1" disambiguate-add-year-suffix="true" disambiguate-add-names="true" disambiguate-add-givenname="true" collapse="year">
     <sort>
       <key macro="year-date"/>
@@ -354,7 +333,6 @@
       </group>
     </layout>
   </citation>
-
   <bibliography and="text" et-al-min="4" et-al-use-first="1">
     <sort>
       <key macro="author"/>


### PR DESCRIPTION
This file implements the AI-enabled version of the Harvard Cite Them Right style, incorporating updates for the 13th edition. Key features include removal of place of publication, support for AI-source prompts, versioning, and adjustments to citation formats for various types of works.

## CSL Styles Pull Request Template
You're about to create a pull request to the CSL **styles** repository.  
If you haven't done so already, see <https://github.com/citation-style-language/styles/blob/master/CONTRIBUTING.md> for instructions on how to contribute, and <https://github.com/citation-style-language/styles/blob/master/STYLE_REQUIREMENTS.md> for the requirements a style must meet before acceptance.  
In addition, please fill out the pull request template below.


### Description
(Briefly describe the style or changes you're proposing.)


### Checklist
- [ ] Check that you've added a link to the style you used as a template in the `<info>` block at the beginning of the file with `rel="template"`.  
- [ ] Check that you've added a link to the style guidelines with `rel="documentation"`.  
- [ ] Check that you've added yourself as the `<author>` of the style or `<contributor>` for a style update. 
- [ ] Check that you've used the correct terms or labels instead of hardcoding into affixes (e.g., `<text variable="page" prefix="pp. "/>`).
- [ ] Check that you've not used `<text value="...` if not absolutely necessary.
- [ ] Check that you've not changed line 1 of the style.
