### PR TITLE
Update iso690-numeric-en.csl

### DIFF
--- a/iso690-numeric-en.csl
+++ b/iso690-numeric-en.csl
@@ -201,7 +201,7 @@
     <text variable="edition" form="long"/>
   </macro>
   <macro name="publisher-group">
-    <group delimiter=" : ">
+    <group delimiter="&#160;: ">
       <text variable="publisher-place"/>
       <text variable="publisher"/>
     </group>
@@ -239,9 +239,9 @@
         <group prefix=" [" suffix="]">
           <text term="accessed" text-case="capitalize-first"/>
           <date variable="accessed">
-            <date-part name="day" prefix=" "/>
-            <date-part name="month" prefix=" "/>
-            <date-part name="year" prefix=" "/>
+            <date-part name="day" prefix="&#160;"/>
+            <date-part name="month" prefix="&#160;"/>
+            <date-part name="year" prefix="&#160;"/>
           </date>
         </group>
       </if>
@@ -273,10 +273,10 @@
     </choose>
   </macro>
   <macro name="isbn">
-    <text variable="ISBN" prefix="ISBN "/>
+    <text variable="ISBN" prefix="ISBN&#160;"/>
   </macro>
   <macro name="doi">
-    <text variable="DOI" prefix="DOI "/>
+    <text variable="DOI" prefix="DOI&#160;"/>
   </macro>
   <macro name="url">
     <choose>
@@ -294,7 +294,7 @@
     </choose>
   </macro>
   <macro name="archive">
-    <group delimiter=": ">
+    <group delimiter=":&#160;">
       <text variable="archive"/>
       <text macro="archive_location"/>
     </group>
@@ -323,7 +323,7 @@
       <group delimiter=", ">
         <text variable="citation-number"/>
         <group>
-          <label variable="locator" suffix=". " form="short" strip-periods="true"/>
+          <label variable="locator" suffix=".&#160;" form="short" strip-periods="true"/>
           <text variable="locator"/>
         </group>
       </group>


### PR DESCRIPTION
via https://forums.zotero.org/discussion/128164/error-in-citation-style-iso-690-numeric-english#latest

1. remove 1mio suffixes
2. Remove abstract+note from bibliography


As mentioned in the thread, I'm not sure the note/abstract is by design or not. I see not all of our ISO690 styles have it. We can either accept this PR and remove it, or make a no-abstract version. As you prefer.