### PR TITLE
AMA: Use official name in `<title>`

### DIFF
--- a/american-medical-association-10th-edition.csl
+++ b/american-medical-association-10th-edition.csl
@@ -6,6 +6,7 @@
     <id>http://www.zotero.org/styles/american-medical-association-10th-edition</id>
     <link href="http://www.zotero.org/styles/american-medical-association-10th-edition" rel="self"/>
     <link href="https://academic.oup.com/amamanualofstyle" rel="documentation"/>
+    <link href="https://owl.purdue.edu/owl/research_and_citation/ama_style/index.html" rel="documentation"/>
     <author>
       <name>Julian Onions</name>
       <email>julian.onions@gmail.com</email>

--- a/american-medical-association-alphabetical.csl
+++ b/american-medical-association-alphabetical.csl
@@ -7,6 +7,7 @@
     <link href="http://www.zotero.org/styles/american-medical-association-alphabetical" rel="self"/>
     <link href="http://www.zotero.org/styles/american-medical-association" rel="template"/>
     <link href="https://academic.oup.com/amamanualofstyle" rel="documentation"/>
+    <link href="https://owl.purdue.edu/owl/research_and_citation/ama_style/index.html" rel="documentation"/>
     <author>
       <name>Julian Onions</name>
       <email>julian.onions@gmail.com</email>

--- a/american-medical-association-brackets.csl
+++ b/american-medical-association-brackets.csl
@@ -7,6 +7,7 @@
     <link href="http://www.zotero.org/styles/american-medical-association-brackets" rel="self"/>
     <link href="http://www.zotero.org/styles/american-medical-association" rel="template"/>
     <link href="https://academic.oup.com/amamanualofstyle" rel="documentation"/>
+    <link href="https://owl.purdue.edu/owl/research_and_citation/ama_style/index.html" rel="documentation"/>
     <author>
       <name>Julian Onions</name>
       <email>julian.onions@gmail.com</email>

--- a/american-medical-association-no-et-al.csl
+++ b/american-medical-association-no-et-al.csl
@@ -7,6 +7,7 @@
     <link href="http://www.zotero.org/styles/american-medical-association-no-et-al" rel="self"/>
     <link href="http://www.zotero.org/styles/american-medical-association" rel="template"/>
     <link href="https://academic.oup.com/amamanualofstyle" rel="documentation"/>
+    <link href="https://owl.purdue.edu/owl/research_and_citation/ama_style/index.html" rel="documentation"/>
     <author>
       <name>Julian Onions</name>
       <email>julian.onions@gmail.com</email>

--- a/american-medical-association-no-url-alphabetical.csl
+++ b/american-medical-association-no-url-alphabetical.csl
@@ -7,6 +7,7 @@
     <link href="http://www.zotero.org/styles/american-medical-association-no-url-alphabetical" rel="self"/>
     <link href="http://www.zotero.org/styles/american-medical-association-no-url" rel="template"/>
     <link href="https://academic.oup.com/amamanualofstyle" rel="documentation"/>
+    <link href="https://owl.purdue.edu/owl/research_and_citation/ama_style/index.html" rel="documentation"/>
     <author>
       <name>Julian Onions</name>
       <email>julian.onions@gmail.com</email>

--- a/american-medical-association-no-url.csl
+++ b/american-medical-association-no-url.csl
@@ -7,6 +7,7 @@
     <link href="http://www.zotero.org/styles/american-medical-association-no-url" rel="self"/>
     <link href="http://www.zotero.org/styles/american-medical-association" rel="template"/>
     <link href="https://academic.oup.com/amamanualofstyle" rel="documentation"/>
+    <link href="https://owl.purdue.edu/owl/research_and_citation/ama_style/index.html" rel="documentation"/>
     <author>
       <name>Julian Onions</name>
       <email>julian.onions@gmail.com</email>

--- a/american-medical-association-parentheses.csl
+++ b/american-medical-association-parentheses.csl
@@ -7,6 +7,7 @@
     <link href="http://www.zotero.org/styles/american-medical-association-parentheses" rel="self"/>
     <link href="http://www.zotero.org/styles/american-medical-association-brackets" rel="template"/>
     <link href="https://academic.oup.com/amamanualofstyle" rel="documentation"/>
+    <link href="https://owl.purdue.edu/owl/research_and_citation/ama_style/index.html" rel="documentation"/>
     <author>
       <name>Patrick O'Brien</name>
     </author>

--- a/american-medical-association.csl
+++ b/american-medical-association.csl
@@ -7,6 +7,7 @@
     <link href="http://www.zotero.org/styles/american-medical-association" rel="self"/>
     <link href="http://www.zotero.org/styles/american-medical-association-10th-edition" rel="template"/>
     <link href="https://academic.oup.com/amamanualofstyle" rel="documentation"/>
+    <link href="https://owl.purdue.edu/owl/research_and_citation/ama_style/index.html" rel="documentation"/>
     <author>
       <name>Julian Onions</name>
       <email>julian.onions@gmail.com</email>


### PR DESCRIPTION
Use published name of the style source at <https://academic.oup.com/amamanualofstyle> as the primary `<title>`.