### PR TITLE
ACS: Use official name in `<title>`

### DIFF
--- a/american-chemical-society.csl
+++ b/american-chemical-society.csl
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" demote-non-dropping-particle="sort-only" page-range-format="expanded" default-locale="en-US">
   <info>
-    <title>ACS Guide 2022</title>
+    <title>ACS Guide 2022 revision</title>
     <title-short>American Chemical Society</title-short>
     <id>http://www.zotero.org/styles/american-chemical-society</id>
     <link href="http://www.zotero.org/styles/american-chemical-society" rel="self"/>


### PR DESCRIPTION
The full title of the source for this style is the *ACS Guide to Scholarly Communication*, but <https://pubs.acs.org/page/acsguide> refers to it as the *ACS Guide*. There are no longer official editions but changes continue to be made, which is why I am suggesting the inclusion of the date in the title. (It is not clear to me whether the revisions in 2025 need CSL changes.)