### PR TITLE
APSA: Use official name in `<title>`

### DIFF
--- a/american-political-science-association.csl
+++ b/american-political-science-association.csl
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" page-range-format="chicago" demote-non-dropping-particle="sort-only">
   <info>
-    <title>American Political Science Association</title>
-    <title-short>APSA</title-short>
+    <title>APSA Style Manual revised 2018 edition</title>
+    <title-short>American Political Science Association</title-short>
     <id>http://www.zotero.org/styles/american-political-science-association</id>
     <link href="http://www.zotero.org/styles/american-political-science-association" rel="self"/>
-    <link href="https://connect.apsanet.org/stylemanual/wp-content/uploads/sites/43/2023/12/Style-Manual-for-Political-Science-December-2023-Revision.pdf" rel="documentation"/>
+    <link href="https://connect.apsanet.org/stylemanual/" rel="documentation"/>
     <author>
       <name>Julian Onions</name>
       <email>julian.onions@gmail.com</email>


### PR DESCRIPTION
The official website refers to this work as the 'APSA Style Manual', so presumably that is how the field refers to it, though its published title is the 'Style Manual for Political Science'.