### PR TITLE
ASA: Use official name in `<title>`

### DIFF
--- a/american-sociological-association.csl
+++ b/american-sociological-association.csl
@@ -6,6 +6,7 @@
     <id>http://www.zotero.org/styles/american-sociological-association</id>
     <link href="http://www.zotero.org/styles/american-sociological-association" rel="self"/>
     <link href="https://www.asanet.org/publications/journals/asa-style-guide/" rel="documentation"/>
+    <link href="https://owl.purdue.edu/owl/research_and_citation/asa_style/index.html" rel="documentation"/>
     <author>
       <name>Julian Onions</name>
       <email>julian.onions@gmail.com</email>


### PR DESCRIPTION
The official website at <https://www.asanet.org/publications/journals/asa-style-guide/> refers to this as the *ASA Style Guide*.