### PR TITLE
Update manchester-university-press.csl (fix delimiter issue)

### DIFF
--- a/manchester-university-press.csl
+++ b/manchester-university-press.csl
@@ -491,7 +491,7 @@
       </choose>
     </layout>
   </citation>
-  <bibliography hanging-indent="true" et-al-min="7" et-al-use-first="6" subsequent-author-substitute="———">
+  <bibliography hanging-indent="true" et-al-min="7" et-al-use-first="6" subsequent-author-substitute="&#8212;&#8212;&#8212;">
     <sort>
       <key macro="author"/>
       <key variable="issued"/>


### PR DESCRIPTION
via https://forums.zotero.org/discussion/128540/double-comma-appearing-in-ibid-notes-only-sometimes#latest