### PR TITLE
Fix UTF-8 encoding of oscola-journal-abbreviations

### DIFF
--- a/oscola-journal-abbreviations.csl
+++ b/oscola-journal-abbreviations.csl
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <style xmlns="http://purl.org/net/xbiblio/csl" class="note" version="1.0" demote-non-dropping-particle="never" default-locale="en-GB">
   <info>
     <title>OSCOLA (Oxford University Standard for Citation of Legal Authorities, with journal abbreviations)</title>


### PR DESCRIPTION
`.csl` styles in this repository are stored as UTF-8. `oscola-journal-abbreviations.csl` was saved with encoding "UTF-8 with BOM". Some XML parsers do not handle the leading BOM well. Change the encoding to UTF-8.

This is the same issue as recently fixed in #7712 for `literatura.csl`.