### PR TITLE
  Add TÜHAS - Turkish Legal Citation Style (Türkçe)

### DIFF
--- a/tuhas.csl
+++ b/tuhas.csl
@@ -15,7 +15,6 @@
     <updated>2025-07-07T12:00:00+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
-
   <!-- LOCALE ITEMS -->
   <locale xml:lang="tr">
     <terms>
@@ -36,7 +35,6 @@
       <term name="cited">op. cit.</term>
     </terms>
   </locale>
-  
   <!-- MACROS -->
   <!-- Dipnot için yazar: Ad Soyad -->
   <macro name="author-note">
@@ -50,7 +48,6 @@
       </substitute>
     </names>
   </macro>
-  
   <!-- Kaynakça için yazar: İlk yazar Soyad, Ad - diğerleri Ad Soyad -->
   <macro name="author">
     <names variable="author">
@@ -63,7 +60,6 @@
       </substitute>
     </names>
   </macro>
-  
   <!-- Kısa atıflar için yazar -->
   <macro name="author-short">
     <names variable="author">
@@ -75,7 +71,6 @@
       </substitute>
     </names>
   </macro>
-  
   <macro name="title">
     <choose>
       <if type="book thesis" match="any">
@@ -89,7 +84,6 @@
       </else>
     </choose>
   </macro>
-  
   <macro name="title-short">
     <choose>
       <if type="book thesis" match="any">
@@ -100,7 +94,6 @@
       </else>
     </choose>
   </macro>
-  
   <macro name="container-title">
     <choose>
       <if type="chapter paper-conference" match="any">
@@ -120,7 +113,6 @@
       </else-if>
     </choose>
   </macro>
-
   <macro name="publisher">
     <choose>
       <if type="book thesis chapter paper-conference" match="any">
@@ -143,14 +135,12 @@
       </if>
     </choose>
   </macro>
-  
   <macro name="translators">
     <names variable="translator">
       <label form="verb-short" text-case="capitalize-first" suffix=" "/>
       <name delimiter=" ve "/>
     </names>
   </macro>
-  
   <!-- Dergi bilgileri: Cilt X, Sayı Y, Tarih -->
   <macro name="journal-details">
     <choose>
@@ -169,7 +159,6 @@
       </if>
     </choose>
   </macro>
-  
   <!-- Dipnot için sayfa -->
   <macro name="pages-citation">
     <choose>
@@ -189,7 +178,6 @@
       </else-if>
     </choose>
   </macro>
-  
   <!-- Kaynakça için sayfa aralığı -->
   <macro name="pages-bibliography">
     <choose>
@@ -201,7 +189,6 @@
       </if>
     </choose>
   </macro>
-
   <macro name="access">
     <choose>
       <if type="webpage post post-weblog" match="any">
@@ -223,7 +210,6 @@
       </if>
     </choose>
   </macro>
-
   <!-- CITATION -->
   <citation et-al-min="4" et-al-use-first="1" disambiguate-add-names="true" disambiguate-add-givenname="true">
     <layout suffix="." delimiter="; ">
@@ -281,9 +267,8 @@
       </choose>
     </layout>
   </citation>
-  
   <!-- BIBLIOGRAPHY -->
-  <bibliography hanging-indent="true" et-al-min="4" et-al-use-first="1" subsequent-author-substitute="———" entry-spacing="0">
+  <bibliography hanging-indent="true" et-al-min="4" et-al-use-first="1" subsequent-author-substitute="&#8212;&#8212;&#8212;" entry-spacing="0">
     <sort>
       <key macro="author"/>
       <key variable="issued"/>


### PR DESCRIPTION
 ### Description
  TÜHAS (Türk Hukuk Atıf Sistemi) is the first Turkish legal citation style for Zotero.

  It is based on Kemal Gözler's comprehensive style guide "Türk Hukuk Atıf Sistemi" (Turkish Legal Citation System), which is the standard citation format used in Turkish legal academia.

  **Features:**
  - Footnote-based citation format (note style)
  - Turkish locale with proper terms (Çev., Ed., Cilt, Sayı, s., ve)
  - Support for books, journal articles, chapters, conference papers, theses, webpages
  - Ibid. and op. cit. for subsequent citations
  - Bibliography with hanging indent and author name substitution (———)

  **Documentation:** https://tuhas.com.tr

  ### Checklist
  - [x] Check that you've added a link to the style you used as a template in the `<info>` block at the beginning of the file with `rel="template"`. *(N/A - written from scratch)*
  - [x] Check that you've added a link to the style guidelines with `rel="documentation"`.
  - [x] Check that you've added yourself as the `<author>` of the style or `<contributor>` for a style update.
  - [x] Check that you've used the correct terms or labels instead of hardcoding into affixes.
  - [x] Check that you've not used `<text value="...` if not absolutely necessary.
  - [x] Check that you've not changed line 1 of the style.

