### PR TITLE
Add Labour/Le Travail

### DIFF
--- a/dependent/labour-le-travail.csl
+++ b/dependent/labour-le-travail.csl
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<style xmlns="http://purl.org/net/xbiblio/csl" version="1.0" default-locale="en-US">
+  <info>
+    <title>Labour/Le Travail: Journal of Canadian Labour Studies</title>
+    <title-short>L/LT</title-short>
+    <id>http://www.zotero.org/styles/labour-le-travail</id>
+    <link href="http://www.zotero.org/styles/labour-le-travail" rel="self"/>
+    <link href="http://www.zotero.org/styles/chicago-notes-classic" rel="independent-parent"/>
+    <link href="https://lltjournal.ca/index.php/llt/about/submissions" rel="documentation"/>
+    <category citation-format="note"/>
+    <category field="humanities"/>
+    <category field="social_science"/>
+    <issn>0700-3862</issn>
+    <eissn>1911-4842</eissn>
+    <updated>2026-01-04T00:00:00+00:00</updated>
+    <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
+  </info>
+</style>


### PR DESCRIPTION
Dependent style for _Labour/Le Travail_, requested in <https://forums.zotero.org/discussion/128621/>.


### Checklist
- [X] Check that you've added a link to the style you used as a template in the `<info>` block at the beginning of the file with `red="template"`.  
- [X] Check that you've added a link to the style guidelines with `rel="documentation"`.  
- [X] Check that you've used the correct terms or labels instead of hardcoding into affixes (e.g., `<text variable="page" prefix="pp. "/>`).
- [X] Check that you've not used `<text value="...` if not absolutely necessary.
- [X] Check that you've not changed line 1 of the style.
