### PR TITLE
New Hart's Rules: Show all access dates with URLs

### DIFF
--- a/new-harts-rules-author-date-publisher.csl
+++ b/new-harts-rules-author-date-publisher.csl
@@ -2972,9 +2972,9 @@
   <!-- 4.10. DOI or URL -->
   <macro name="source-date-accessed-DOI-URL">
     <group delimiter=", ">
+      <text macro="source-DOI-URL"/>
       <choose>
         <if variable="DOI"/>
-        <else-if match="any" variable="available-date event-date issued status"/>
         <else-if variable="URL">
           <group delimiter=" ">
             <text term="accessed"/>
@@ -2982,7 +2982,6 @@
           </group>
         </else-if>
       </choose>
-      <text macro="source-DOI-URL"/>
     </group>
   </macro>
   <macro name="source-DOI-URL">

--- a/new-harts-rules-author-date-space-publisher.csl
+++ b/new-harts-rules-author-date-space-publisher.csl
@@ -2972,9 +2972,9 @@
   <!-- 4.10. DOI or URL -->
   <macro name="source-date-accessed-DOI-URL">
     <group delimiter=", ">
+      <text macro="source-DOI-URL"/>
       <choose>
         <if variable="DOI"/>
-        <else-if match="any" variable="available-date event-date issued status"/>
         <else-if variable="URL">
           <group delimiter=" ">
             <text term="accessed"/>
@@ -2982,7 +2982,6 @@
           </group>
         </else-if>
       </choose>
-      <text macro="source-DOI-URL"/>
     </group>
   </macro>
   <macro name="source-DOI-URL">

--- a/new-harts-rules-author-date.csl
+++ b/new-harts-rules-author-date.csl
@@ -2972,9 +2972,9 @@
   <!-- 4.10. DOI or URL -->
   <macro name="source-date-accessed-DOI-URL">
     <group delimiter=", ">
+      <text macro="source-DOI-URL"/>
       <choose>
         <if variable="DOI"/>
-        <else-if match="any" variable="available-date event-date issued status"/>
         <else-if variable="URL">
           <group delimiter=" ">
             <text term="accessed"/>
@@ -2982,7 +2982,6 @@
           </group>
         </else-if>
       </choose>
-      <text macro="source-DOI-URL"/>
     </group>
   </macro>
   <macro name="source-DOI-URL">

--- a/new-harts-rules-notes-initials-bracket-role-page-range-no-url.csl
+++ b/new-harts-rules-notes-initials-bracket-role-page-range-no-url.csl
@@ -948,7 +948,7 @@
         <text macro="source-medium" prefix="[" suffix="]"/>
       </group>
       <text macro="source-archive"/>
-      <text macro="source-date-accessed-DOI-URL"/>
+      <text macro="source-date-accessed"/>
     </group>
   </macro>
   <!-- 3.1. Title -->
@@ -3191,7 +3191,8 @@
     </group>
   </macro>
   <!-- 4.10. DOI or URL -->
-  <macro name="source-date-accessed-DOI-URL">
+  <macro name="source-date-accessed">
+    <!-- provide accessed date if none other available, when no URL is printed -->
     <group delimiter=", ">
       <choose>
         <if variable="DOI"/>
@@ -3203,7 +3204,6 @@
           </group>
         </else-if>
       </choose>
-      <!-- <text macro="source-DOI-URL"/> -->
     </group>
   </macro>
   <!-- Citation -->

--- a/new-harts-rules-notes-initials-bracket-role-page-range.csl
+++ b/new-harts-rules-notes-initials-bracket-role-page-range.csl
@@ -3193,9 +3193,9 @@
   <!-- 4.10. DOI or URL -->
   <macro name="source-date-accessed-DOI-URL">
     <group delimiter=", ">
+      <text macro="source-DOI-URL"/>
       <choose>
         <if variable="DOI"/>
-        <else-if match="any" variable="available-date event-date issued status"/>
         <else-if variable="URL">
           <group delimiter=" ">
             <text term="accessed"/>
@@ -3203,7 +3203,6 @@
           </group>
         </else-if>
       </choose>
-      <text macro="source-DOI-URL"/>
     </group>
   </macro>
   <macro name="source-DOI-URL">

--- a/new-harts-rules-notes-initials-label-page-no-url.csl
+++ b/new-harts-rules-notes-initials-label-page-no-url.csl
@@ -959,7 +959,7 @@
         <text macro="source-medium" prefix="[" suffix="]"/>
       </group>
       <text macro="source-archive"/>
-      <text macro="source-date-accessed-DOI-URL"/>
+      <text macro="source-date-accessed"/>
     </group>
   </macro>
   <!-- 3.1. Title -->
@@ -3185,7 +3185,8 @@
     </group>
   </macro>
   <!-- 4.10. DOI or URL -->
-  <macro name="source-date-accessed-DOI-URL">
+  <macro name="source-date-accessed">
+    <!-- provide accessed date if none other available, when no URL is printed -->
     <group delimiter=", ">
       <choose>
         <if variable="DOI"/>
@@ -3197,7 +3198,6 @@
           </group>
         </else-if>
       </choose>
-      <!-- <text macro="source-DOI-URL"/> -->
     </group>
   </macro>
   <!-- Citation -->

--- a/new-harts-rules-notes-initials-label-page.csl
+++ b/new-harts-rules-notes-initials-label-page.csl
@@ -3187,9 +3187,9 @@
   <!-- 4.10. DOI or URL -->
   <macro name="source-date-accessed-DOI-URL">
     <group delimiter=", ">
+      <text macro="source-DOI-URL"/>
       <choose>
         <if variable="DOI"/>
-        <else-if match="any" variable="available-date event-date issued status"/>
         <else-if variable="URL">
           <group delimiter=" ">
             <text term="accessed"/>
@@ -3197,7 +3197,6 @@
           </group>
         </else-if>
       </choose>
-      <text macro="source-DOI-URL"/>
     </group>
   </macro>
   <macro name="source-DOI-URL">

--- a/new-harts-rules-notes-initials-no-url.csl
+++ b/new-harts-rules-notes-initials-no-url.csl
@@ -960,7 +960,7 @@
         <text macro="source-medium" prefix="[" suffix="]"/>
       </group>
       <text macro="source-archive"/>
-      <text macro="source-date-accessed-DOI-URL"/>
+      <text macro="source-date-accessed"/>
     </group>
   </macro>
   <!-- 3.1. Title -->
@@ -3183,7 +3183,8 @@
     </group>
   </macro>
   <!-- 4.10. DOI or URL -->
-  <macro name="source-date-accessed-DOI-URL">
+  <macro name="source-date-accessed">
+    <!-- provide accessed date if none other available, when no URL is printed -->
     <group delimiter=", ">
       <choose>
         <if variable="DOI"/>
@@ -3195,7 +3196,6 @@
           </group>
         </else-if>
       </choose>
-      <!-- <text macro="source-DOI-URL"/> -->
     </group>
   </macro>
   <!-- Citation -->

--- a/new-harts-rules-notes-initials-publisher-no-url.csl
+++ b/new-harts-rules-notes-initials-publisher-no-url.csl
@@ -960,7 +960,7 @@
         <text macro="source-medium" prefix="[" suffix="]"/>
       </group>
       <text macro="source-archive"/>
-      <text macro="source-date-accessed-DOI-URL"/>
+      <text macro="source-date-accessed"/>
     </group>
   </macro>
   <!-- 3.1. Title -->
@@ -3183,7 +3183,8 @@
     </group>
   </macro>
   <!-- 4.10. DOI or URL -->
-  <macro name="source-date-accessed-DOI-URL">
+  <macro name="source-date-accessed">
+    <!-- provide accessed date if none other available, when no URL is printed -->
     <group delimiter=", ">
       <choose>
         <if variable="DOI"/>
@@ -3195,7 +3196,6 @@
           </group>
         </else-if>
       </choose>
-      <!-- <text macro="source-DOI-URL"/> -->
     </group>
   </macro>
   <!-- Citation -->

--- a/new-harts-rules-notes-initials-publisher.csl
+++ b/new-harts-rules-notes-initials-publisher.csl
@@ -3185,9 +3185,9 @@
   <!-- 4.10. DOI or URL -->
   <macro name="source-date-accessed-DOI-URL">
     <group delimiter=", ">
+      <text macro="source-DOI-URL"/>
       <choose>
         <if variable="DOI"/>
-        <else-if match="any" variable="available-date event-date issued status"/>
         <else-if variable="URL">
           <group delimiter=" ">
             <text term="accessed"/>
@@ -3195,7 +3195,6 @@
           </group>
         </else-if>
       </choose>
-      <text macro="source-DOI-URL"/>
     </group>
   </macro>
   <macro name="source-DOI-URL">

--- a/new-harts-rules-notes-initials.csl
+++ b/new-harts-rules-notes-initials.csl
@@ -3185,9 +3185,9 @@
   <!-- 4.10. DOI or URL -->
   <macro name="source-date-accessed-DOI-URL">
     <group delimiter=", ">
+      <text macro="source-DOI-URL"/>
       <choose>
         <if variable="DOI"/>
-        <else-if match="any" variable="available-date event-date issued status"/>
         <else-if variable="URL">
           <group delimiter=" ">
             <text term="accessed"/>
@@ -3195,7 +3195,6 @@
           </group>
         </else-if>
       </choose>
-      <text macro="source-DOI-URL"/>
     </group>
   </macro>
   <macro name="source-DOI-URL">

--- a/new-harts-rules-notes-label-page-no-url.csl
+++ b/new-harts-rules-notes-label-page-no-url.csl
@@ -958,7 +958,7 @@
         <text macro="source-medium" prefix="[" suffix="]"/>
       </group>
       <text macro="source-archive"/>
-      <text macro="source-date-accessed-DOI-URL"/>
+      <text macro="source-date-accessed"/>
     </group>
   </macro>
   <!-- 3.1. Title -->
@@ -3184,7 +3184,8 @@
     </group>
   </macro>
   <!-- 4.10. DOI or URL -->
-  <macro name="source-date-accessed-DOI-URL">
+  <macro name="source-date-accessed">
+    <!-- provide accessed date if none other available, when no URL is printed -->
     <group delimiter=", ">
       <choose>
         <if variable="DOI"/>
@@ -3196,7 +3197,6 @@
           </group>
         </else-if>
       </choose>
-      <!-- <text macro="source-DOI-URL"/> -->
     </group>
   </macro>
   <!-- Citation -->

--- a/new-harts-rules-notes-label-page.csl
+++ b/new-harts-rules-notes-label-page.csl
@@ -3186,9 +3186,9 @@
   <!-- 4.10. DOI or URL -->
   <macro name="source-date-accessed-DOI-URL">
     <group delimiter=", ">
+      <text macro="source-DOI-URL"/>
       <choose>
         <if variable="DOI"/>
-        <else-if match="any" variable="available-date event-date issued status"/>
         <else-if variable="URL">
           <group delimiter=" ">
             <text term="accessed"/>
@@ -3196,7 +3196,6 @@
           </group>
         </else-if>
       </choose>
-      <text macro="source-DOI-URL"/>
     </group>
   </macro>
   <macro name="source-DOI-URL">

--- a/new-harts-rules-notes-no-url.csl
+++ b/new-harts-rules-notes-no-url.csl
@@ -960,7 +960,7 @@
         <text macro="source-medium" prefix="[" suffix="]"/>
       </group>
       <text macro="source-archive"/>
-      <text macro="source-date-accessed-DOI-URL"/>
+      <text macro="source-date-accessed"/>
     </group>
   </macro>
   <!-- 3.1. Title -->
@@ -3183,7 +3183,8 @@
     </group>
   </macro>
   <!-- 4.10. DOI or URL -->
-  <macro name="source-date-accessed-DOI-URL">
+  <macro name="source-date-accessed">
+    <!-- provide accessed date if none other available, when no URL is printed -->
     <group delimiter=", ">
       <choose>
         <if variable="DOI"/>
@@ -3195,7 +3196,6 @@
           </group>
         </else-if>
       </choose>
-      <!-- <text macro="source-DOI-URL"/> -->
     </group>
   </macro>
   <!-- Citation -->

--- a/new-harts-rules-notes-publisher-no-url.csl
+++ b/new-harts-rules-notes-publisher-no-url.csl
@@ -960,7 +960,7 @@
         <text macro="source-medium" prefix="[" suffix="]"/>
       </group>
       <text macro="source-archive"/>
-      <text macro="source-date-accessed-DOI-URL"/>
+      <text macro="source-date-accessed"/>
     </group>
   </macro>
   <!-- 3.1. Title -->
@@ -3183,7 +3183,8 @@
     </group>
   </macro>
   <!-- 4.10. DOI or URL -->
-  <macro name="source-date-accessed-DOI-URL">
+  <macro name="source-date-accessed">
+    <!-- provide accessed date if none other available, when no URL is printed -->
     <group delimiter=", ">
       <choose>
         <if variable="DOI"/>
@@ -3195,7 +3196,6 @@
           </group>
         </else-if>
       </choose>
-      <!-- <text macro="source-DOI-URL"/> -->
     </group>
   </macro>
   <!-- Citation -->

--- a/new-harts-rules-notes-publisher.csl
+++ b/new-harts-rules-notes-publisher.csl
@@ -3185,9 +3185,9 @@
   <!-- 4.10. DOI or URL -->
   <macro name="source-date-accessed-DOI-URL">
     <group delimiter=", ">
+      <text macro="source-DOI-URL"/>
       <choose>
         <if variable="DOI"/>
-        <else-if match="any" variable="available-date event-date issued status"/>
         <else-if variable="URL">
           <group delimiter=" ">
             <text term="accessed"/>
@@ -3195,7 +3195,6 @@
           </group>
         </else-if>
       </choose>
-      <text macro="source-DOI-URL"/>
     </group>
   </macro>
   <macro name="source-DOI-URL">

--- a/new-harts-rules-notes.csl
+++ b/new-harts-rules-notes.csl
@@ -3184,9 +3184,9 @@
   <!-- 4.10. DOI or URL -->
   <macro name="source-date-accessed-DOI-URL">
     <group delimiter=", ">
+      <text macro="source-DOI-URL"/>
       <choose>
         <if variable="DOI"/>
-        <else-if match="any" variable="available-date event-date issued status"/>
         <else-if variable="URL">
           <group delimiter=" ">
             <text term="accessed"/>
@@ -3194,7 +3194,6 @@
           </group>
         </else-if>
       </choose>
-      <text macro="source-DOI-URL"/>
     </group>
   </macro>
   <macro name="source-DOI-URL">

--- a/new-harts-rules-numbered.csl
+++ b/new-harts-rules-numbered.csl
@@ -2496,9 +2496,9 @@
   <!-- 4.10. DOI or URL -->
   <macro name="source-date-accessed-DOI-URL">
     <group delimiter=", ">
+      <text macro="source-DOI-URL"/>
       <choose>
         <if variable="DOI"/>
-        <else-if match="any" variable="available-date event-date issued status"/>
         <else-if variable="URL">
           <group delimiter=" ">
             <text term="accessed"/>
@@ -2506,7 +2506,6 @@
           </group>
         </else-if>
       </choose>
-      <text macro="source-DOI-URL"/>
     </group>
   </macro>
   <macro name="source-DOI-URL">

--- a/new-harts-rules-short-notes-no-url.csl
+++ b/new-harts-rules-short-notes-no-url.csl
@@ -884,7 +884,7 @@
         <text macro="source-medium" prefix="[" suffix="]"/>
       </group>
       <text macro="source-archive"/>
-      <text macro="source-date-accessed-DOI-URL"/>
+      <text macro="source-date-accessed"/>
     </group>
   </macro>
   <!-- 3.1. Title -->
@@ -3107,7 +3107,8 @@
     </group>
   </macro>
   <!-- 4.10. DOI or URL -->
-  <macro name="source-date-accessed-DOI-URL">
+  <macro name="source-date-accessed">
+    <!-- provide accessed date if none other available, when no URL is printed -->
     <group delimiter=", ">
       <choose>
         <if variable="DOI"/>
@@ -3119,7 +3120,6 @@
           </group>
         </else-if>
       </choose>
-      <!-- <text macro="source-DOI-URL"/> -->
     </group>
   </macro>
   <!-- Citation -->

--- a/new-harts-rules-short-notes.csl
+++ b/new-harts-rules-short-notes.csl
@@ -3109,9 +3109,9 @@
   <!-- 4.10. DOI or URL -->
   <macro name="source-date-accessed-DOI-URL">
     <group delimiter=", ">
+      <text macro="source-DOI-URL"/>
       <choose>
         <if variable="DOI"/>
-        <else-if match="any" variable="available-date event-date issued status"/>
         <else-if variable="URL">
           <group delimiter=" ">
             <text term="accessed"/>
@@ -3119,7 +3119,6 @@
           </group>
         </else-if>
       </choose>
-      <text macro="source-DOI-URL"/>
     </group>
   </macro>
   <macro name="source-DOI-URL">

--- a/oxford-guide-to-style-notes-initials-article-sentence-case-roman-volume-label-page.csl
+++ b/oxford-guide-to-style-notes-initials-article-sentence-case-roman-volume-label-page.csl
@@ -3225,9 +3225,9 @@
   <!-- 4.10. DOI or URL -->
   <macro name="source-date-accessed-DOI-URL">
     <group delimiter=", ">
+      <text macro="source-DOI-URL"/>
       <choose>
         <if variable="DOI"/>
-        <else-if match="any" variable="available-date event-date issued status"/>
         <else-if variable="URL">
           <group delimiter=" ">
             <text term="accessed"/>
@@ -3235,7 +3235,6 @@
           </group>
         </else-if>
       </choose>
-      <text macro="source-DOI-URL"/>
     </group>
   </macro>
   <macro name="source-DOI-URL">

--- a/oxford-guide-to-style-notes-initials-label-page-no-url.csl
+++ b/oxford-guide-to-style-notes-initials-label-page-no-url.csl
@@ -1001,7 +1001,7 @@
         <text macro="source-medium" prefix="[" suffix="]"/>
       </group>
       <text macro="source-archive"/>
-      <text macro="source-date-accessed-DOI-URL"/>
+      <text macro="source-date-accessed"/>
     </group>
   </macro>
   <!-- 3.1. Title -->
@@ -3229,7 +3229,8 @@
     </group>
   </macro>
   <!-- 4.10. DOI or URL -->
-  <macro name="source-date-accessed-DOI-URL">
+  <macro name="source-date-accessed">
+    <!-- provide accessed date if none other available, when no URL is printed -->
     <group delimiter=", ">
       <choose>
         <if variable="DOI"/>
@@ -3241,7 +3242,6 @@
           </group>
         </else-if>
       </choose>
-      <!-- <text macro="source-DOI-URL"/> -->
     </group>
   </macro>
   <!-- Citation -->

--- a/oxford-guide-to-style-notes-initials-label-page.csl
+++ b/oxford-guide-to-style-notes-initials-label-page.csl
@@ -3231,9 +3231,9 @@
   <!-- 4.10. DOI or URL -->
   <macro name="source-date-accessed-DOI-URL">
     <group delimiter=", ">
+      <text macro="source-DOI-URL"/>
       <choose>
         <if variable="DOI"/>
-        <else-if match="any" variable="available-date event-date issued status"/>
         <else-if variable="URL">
           <group delimiter=" ">
             <text term="accessed"/>
@@ -3241,7 +3241,6 @@
           </group>
         </else-if>
       </choose>
-      <text macro="source-DOI-URL"/>
     </group>
   </macro>
   <macro name="source-DOI-URL">

--- a/oxford-guide-to-style-notes-initials.csl
+++ b/oxford-guide-to-style-notes-initials.csl
@@ -3232,9 +3232,9 @@
   <!-- 4.10. DOI or URL -->
   <macro name="source-date-accessed-DOI-URL">
     <group delimiter=", ">
+      <text macro="source-DOI-URL"/>
       <choose>
         <if variable="DOI"/>
-        <else-if match="any" variable="available-date event-date issued status"/>
         <else-if variable="URL">
           <group delimiter=" ">
             <text term="accessed"/>
@@ -3242,7 +3242,6 @@
           </group>
         </else-if>
       </choose>
-      <text macro="source-DOI-URL"/>
     </group>
   </macro>
   <macro name="source-DOI-URL">

--- a/oxford-guide-to-style-notes-no-url.csl
+++ b/oxford-guide-to-style-notes-no-url.csl
@@ -1002,7 +1002,7 @@
         <text macro="source-medium" prefix="[" suffix="]"/>
       </group>
       <text macro="source-archive"/>
-      <text macro="source-date-accessed-DOI-URL"/>
+      <text macro="source-date-accessed"/>
     </group>
   </macro>
   <!-- 3.1. Title -->
@@ -3230,7 +3230,8 @@
     </group>
   </macro>
   <!-- 4.10. DOI or URL -->
-  <macro name="source-date-accessed-DOI-URL">
+  <macro name="source-date-accessed">
+    <!-- provide accessed date if none other available, when no URL is printed -->
     <group delimiter=", ">
       <choose>
         <if variable="DOI"/>
@@ -3242,7 +3243,6 @@
           </group>
         </else-if>
       </choose>
-      <!-- <text macro="source-DOI-URL"/> -->
     </group>
   </macro>
   <!-- Citation -->

--- a/oxford-guide-to-style-notes-roman-volume-archive-first-no-url.csl
+++ b/oxford-guide-to-style-notes-roman-volume-archive-first-no-url.csl
@@ -1002,7 +1002,7 @@
         <text macro="source-medium" prefix="[" suffix="]"/>
       </group>
       <text macro="source-archive"/>
-      <text macro="source-date-accessed-DOI-URL"/>
+      <text macro="source-date-accessed"/>
     </group>
   </macro>
   <!-- 3.1. Title -->
@@ -3224,7 +3224,8 @@
     </group>
   </macro>
   <!-- 4.10. DOI or URL -->
-  <macro name="source-date-accessed-DOI-URL">
+  <macro name="source-date-accessed">
+    <!-- provide accessed date if none other available, when no URL is printed -->
     <group delimiter=", ">
       <choose>
         <if variable="DOI"/>
@@ -3236,7 +3237,6 @@
           </group>
         </else-if>
       </choose>
-      <!-- <text macro="source-DOI-URL"/> -->
     </group>
   </macro>
   <!-- Citation -->

--- a/oxford-guide-to-style-notes-roman-volume-archive-first.csl
+++ b/oxford-guide-to-style-notes-roman-volume-archive-first.csl
@@ -3226,9 +3226,9 @@
   <!-- 4.10. DOI or URL -->
   <macro name="source-date-accessed-DOI-URL">
     <group delimiter=", ">
+      <text macro="source-DOI-URL"/>
       <choose>
         <if variable="DOI"/>
-        <else-if match="any" variable="available-date event-date issued status"/>
         <else-if variable="URL">
           <group delimiter=" ">
             <text term="accessed"/>
@@ -3236,7 +3236,6 @@
           </group>
         </else-if>
       </choose>
-      <text macro="source-DOI-URL"/>
     </group>
   </macro>
   <macro name="source-DOI-URL">

--- a/oxford-guide-to-style-notes.csl
+++ b/oxford-guide-to-style-notes.csl
@@ -3232,9 +3232,9 @@
   <!-- 4.10. DOI or URL -->
   <macro name="source-date-accessed-DOI-URL">
     <group delimiter=", ">
+      <text macro="source-DOI-URL"/>
       <choose>
         <if variable="DOI"/>
-        <else-if match="any" variable="available-date event-date issued status"/>
         <else-if variable="URL">
           <group delimiter=" ">
             <text term="accessed"/>
@@ -3242,7 +3242,6 @@
           </group>
         </else-if>
       </choose>
-      <text macro="source-DOI-URL"/>
     </group>
   </macro>
   <macro name="source-DOI-URL">

--- a/the-journal-of-ecclesiastical-history.csl
+++ b/the-journal-of-ecclesiastical-history.csl
@@ -941,7 +941,7 @@
         <text macro="source-medium" prefix="[" suffix="]"/>
       </group>
       <text macro="source-archive"/>
-      <text macro="source-date-accessed-DOI-URL"/>
+      <text macro="source-date-accessed"/>
     </group>
   </macro>
   <!-- 3.1. Title -->
@@ -3101,7 +3101,8 @@
     </group>
   </macro>
   <!-- 4.10. DOI or URL -->
-  <macro name="source-date-accessed-DOI-URL">
+  <macro name="source-date-accessed">
+    <!-- provide accessed date if none other available, when no URL is printed -->
     <group delimiter=", ">
       <choose>
         <if variable="DOI"/>
@@ -3113,7 +3114,6 @@
           </group>
         </else-if>
       </choose>
-      <!-- <text macro="source-DOI-URL"/> -->
     </group>
   </macro>
   <!-- Citation -->


### PR DESCRIPTION
_New Hart's Rules_ 18.8.5 always shows the access date when printing a URL. Reported at <https://forums.zotero.org/discussion/128799>.

### Checklist
- [X] Check that you've added a link to the style you used as a template in the `<info>` block at the beginning of the file with `rel="template"`.  
- [X] Check that you've added a link to the style guidelines with `rel="documentation"`.  
- [X] Check that you've added yourself as the `<author>` of the style or `<contributor>` for a style update. 
- [X] Check that you've used the correct terms or labels instead of hardcoding into affixes (e.g., `<text variable="page" prefix="pp. "/>`).
- [X] Check that you've not used `<text value="...` if not absolutely necessary.
- [X] Check that you've not changed line 1 of the style.
