### PR TITLE
OSCOLA: Fix subsequent `legal_case` locator

### DIFF
--- a/oscola-journal-abbreviations.csl
+++ b/oscola-journal-abbreviations.csl
@@ -489,16 +489,19 @@
         </choose>
       </if>
       <else>
-        <group delimiter=" ">
-          <choose>
-            <if locator="page" match="none">
-              <label variable="locator" form="short" strip-periods="true"/>
-            </if>
-          </choose>
-          <text variable="locator"/>
-        </group>
+        <text macro="locator-subsequent"/>
       </else>
     </choose>
+  </macro>
+  <macro name="locator-subsequent">
+    <group delimiter=" ">
+      <choose>
+        <if locator="page" match="none">
+          <label variable="locator" form="short" strip-periods="true"/>
+        </if>
+      </choose>
+      <text variable="locator"/>
+    </group>
   </macro>
   <macro name="locator-space">
     <choose>
@@ -633,7 +636,7 @@
                     </group>
                   </if>
                 </choose>
-                <text macro="locator-basic"/>
+                <text macro="locator-subsequent"/>
               </group>
             </if>
             <else>

--- a/oscola-no-ibid.csl
+++ b/oscola-no-ibid.csl
@@ -473,16 +473,19 @@
         </choose>
       </if>
       <else>
-        <group delimiter=" ">
-          <choose>
-            <if locator="page" match="none">
-              <label variable="locator" form="short" strip-periods="true"/>
-            </if>
-          </choose>
-          <text variable="locator"/>
-        </group>
+        <text macro="locator-subsequent"/>
       </else>
     </choose>
+  </macro>
+  <macro name="locator-subsequent">
+    <group delimiter=" ">
+      <choose>
+        <if locator="page" match="none">
+          <label variable="locator" form="short" strip-periods="true"/>
+        </if>
+      </choose>
+      <text variable="locator"/>
+    </group>
   </macro>
   <macro name="locator-space">
     <choose>
@@ -608,7 +611,7 @@
                     </group>
                   </if>
                 </choose>
-                <text macro="locator-basic"/>
+                <text macro="locator-subsequent"/>
               </group>
             </if>
             <else>

--- a/oscola.csl
+++ b/oscola.csl
@@ -472,16 +472,19 @@
         </choose>
       </if>
       <else>
-        <group delimiter=" ">
-          <choose>
-            <if locator="page" match="none">
-              <label variable="locator" form="short" strip-periods="true"/>
-            </if>
-          </choose>
-          <text variable="locator"/>
-        </group>
+        <text macro="locator-subsequent"/>
       </else>
     </choose>
+  </macro>
+  <macro name="locator-subsequent">
+    <group delimiter=" ">
+      <choose>
+        <if locator="page" match="none">
+          <label variable="locator" form="short" strip-periods="true"/>
+        </if>
+      </choose>
+      <text variable="locator"/>
+    </group>
   </macro>
   <macro name="locator-space">
     <choose>
@@ -616,7 +619,7 @@
                     </group>
                   </if>
                 </choose>
-                <text macro="locator-basic"/>
+                <text macro="locator-subsequent"/>
               </group>
             </if>
             <else>


### PR DESCRIPTION
Create a separate macro for subsequent locators to compensate for the change in <https://github.com/citation-style-language/styles/commit/670bca4ff8f7a92657f4f4571b0d3ef271e9600e>, which caused a `legal_case` locator to disappear in the `subsequent` position. Reported at <https://forums.zotero.org/discussion/126960>.

### Checklist
- [X] Check that you've added a link to the style you used as a template in the `<info>` block at the beginning of the file with `rel="template"`.  
- [X] Check that you've added a link to the style guidelines with `rel="documentation"`.  
- [X] Check that you've added yourself as the `<author>` of the style or `<contributor>` for a style update. 
- [X] Check that you've used the correct terms or labels instead of hardcoding into affixes (e.g., `<text variable="page" prefix="pp. "/>`).
- [X] Check that you've not used `<text value="...` if not absolutely necessary.
- [X] Check that you've not changed line 1 of the style.
