### PR TITLE
Update harvard-institut-fur-praxisforschung-de.csl

### DIFF
--- a/harvard-institut-fur-praxisforschung-de.csl
+++ b/harvard-institut-fur-praxisforschung-de.csl
@@ -20,7 +20,7 @@
     <category field="political_science"/>
     <category field="social_science"/>
     <summary>A Harvard author-date style variant as used for Political Science and others, mostly German. The in-text citation style is changed to [author year: page], avoiding the abbreviation for pages (S.) and changing the delimiters.</summary>
-    <updated>2025-05-18T00:55:38+00:00</updated>
+    <updated>2026-01-05T00:55:38+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale xml:lang="de">


### PR DESCRIPTION
Update 2026, I added the variable original-date, which now will be displayed in square brackets after the current year of the publication.

Stand 2026 – Aktualisierung durch Saskia Mestern & Copilot
    Änderung: Originalerscheinungsjahr wird nach dem Ausgabejahr in eckigen Klammern ausgegeben (z. B. 2024 [1968]).
    Hinweis: Bitte in Zotero das Feld "Original Date" verwenden (nicht mehr über "Extra").

## CSL Styles Pull Request Template
You're about to create a pull request to the CSL **styles** repository.  
If you haven't done so already, see <https://github.com/citation-style-language/styles/blob/master/CONTRIBUTING.md> for instructions on how to contribute, and <https://github.com/citation-style-language/styles/blob/master/STYLE_REQUIREMENTS.md> for the requirements a style must meet before acceptance.  
In addition, please fill out the pull request template below.


### Description
(Briefly describe the style or changes you're proposing.)


### Checklist
- [x] Check that you've added a link to the style you used as a template in the `<info>` block at the beginning of the file with `rel="template"`.  
- [x] Check that you've added a link to the style guidelines with `rel="documentation"`.  
- [x] Check that you've added yourself as the `<author>` of the style or `<contributor>` for a style update. 
- [x] Check that you've used the correct terms or labels instead of hardcoding into affixes (e.g., `<text variable="page" prefix="pp. "/>`).
- [x] Check that you've not used `<text value="...` if not absolutely necessary.
- [x] Check that you've not changed line 1 of the style.
