### PR TITLE
New style: American Psychological Association 7th edition (Polish)

### DIFF
--- a/apa-pl.csl
+++ b/apa-pl.csl
@@ -11,7 +11,7 @@
       <name>cs_pinkie</name>
     </author>
     <contributor>
-      <name></name>
+      <name/>
     </contributor>
     <category citation-format="author-date"/>
     <category field="psychology"/>
@@ -74,7 +74,7 @@
       <term name="retrieved">pobrane</term>
       <term name="from">z</term>
       <term name="article-locator">artykuł</term>
-      <term name="in">W</term> 
+      <term name="in">W</term>
       <term name="chair" form="long">przew.</term>
     </terms>
   </locale>
@@ -165,7 +165,7 @@
             <label form="long" prefix=" (" suffix=")" text-case="title"/>
           </names>
           <names variable="collection-editor">
-            <name name-as-sort-order="all"  sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
+            <name name-as-sort-order="all" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
             <label form="short" prefix=" (" suffix=")" text-case="title"/>
           </names>
           <choose>
@@ -1230,7 +1230,8 @@
         <group delimiter="; ">
           <choose>
             <if variable="number" match="none">
-              <text variable="genre" text-case="lowercase"/> <!-- Lowercase genre in brackets -->
+              <text variable="genre" text-case="lowercase"/>
+              <!-- Lowercase genre in brackets -->
             </if>
           </choose>
           <text variable="medium" text-case="capitalize-first"/>


### PR DESCRIPTION
### Description
This pull request adds a Polish localization of the APA 7th edition style. While based on the standard APA 7th edition, this version incorporates specific Polish linguistic requirements and academic conventions.

Locale: pl-PL

Documentation source: Guidelines provided by [liberilibri.pl](https://apa7.liberilibri.pl/), which is a widely recognized standard for APA 7 in Poland based on recent publications and differs quite a bit from the typical english APA7 due to inherent differences in how the Polish language works.

Key changes: 
-Localized terms for "editor" (red.), "edition" (wyd.), "page" (s.), and "no date" (b.d.).
-Adjusted "et al." to the Polish equivalent (i in.).
-Corrected punctuation and delimiters for Polish citations (e.g., using "i" instead of "&" where appropriate for the locale) which are the main difference as well as problem and not able to be implemented in parallel to other languages in one file.


### Checklist
- [x] Check that you've added a link to the style you used as a template in the `<info>` block at the beginning of the file with `rel="template"`.  
- [x] Check that you've added a link to the style guidelines with `rel="documentation"`.  
- [x] Check that you've added yourself as the `<author>` of the style or `<contributor>` for a style update. 
- [x] Check that you've used the correct terms or labels instead of hardcoding into affixes (e.g., `<text variable="page" prefix="pp. "/>`).
- [x] Check that you've not used `<text value="...` if not absolutely necessary.
- [x] Check that you've not changed line 1 of the style.
