### PR TITLE
OSCOLA: Create label macros and simplify conditionals

### DIFF
--- a/oscola-journal-abbreviations.csl
+++ b/oscola-journal-abbreviations.csl
@@ -503,14 +503,14 @@
         <text variable="locator"/>
       </else-if>
       <else-if type="book" variable="issued">
-        <text macro="locator-basic"/>
+        <text macro="label-locator"/>
       </else-if>
       <else-if type="book" variable="publisher">
-        <text macro="locator-basic"/>
+        <text macro="label-locator"/>
       </else-if>
       <else-if match="any" type="article-journal article-magazine book legislation"/>
       <else>
-        <text macro="locator-basic"/>
+        <text macro="label-locator"/>
       </else>
     </choose>
   </macro>
@@ -525,7 +525,7 @@
         <text variable="locator"/>
       </else-if>
       <else-if match="any" type="article-journal article-magazine legislation">
-        <text macro="locator-basic"/>
+        <text macro="label-locator"/>
       </else-if>
     </choose>
   </macro>

--- a/oscola-no-ibid.csl
+++ b/oscola-no-ibid.csl
@@ -487,14 +487,14 @@
         <text variable="locator"/>
       </else-if>
       <else-if type="book" variable="issued">
-        <text macro="locator-basic"/>
+        <text macro="label-locator"/>
       </else-if>
       <else-if type="book" variable="publisher">
-        <text macro="locator-basic"/>
+        <text macro="label-locator"/>
       </else-if>
       <else-if match="any" type="article-journal article-magazine book legislation"/>
       <else>
-        <text macro="locator-basic"/>
+        <text macro="label-locator"/>
       </else>
     </choose>
   </macro>
@@ -509,7 +509,7 @@
         <text variable="locator"/>
       </else-if>
       <else-if match="any" type="article-journal article-magazine legislation">
-        <text macro="locator-basic"/>
+        <text macro="label-locator"/>
       </else-if>
     </choose>
   </macro>

--- a/oscola.csl
+++ b/oscola.csl
@@ -486,14 +486,14 @@
         <text variable="locator"/>
       </else-if>
       <else-if type="book" variable="issued">
-        <text macro="locator-basic"/>
+        <text macro="label-locator"/>
       </else-if>
       <else-if type="book" variable="publisher">
-        <text macro="locator-basic"/>
+        <text macro="label-locator"/>
       </else-if>
       <else-if match="any" type="article-journal article-magazine book legislation"/>
       <else>
-        <text macro="locator-basic"/>
+        <text macro="label-locator"/>
       </else>
     </choose>
   </macro>
@@ -508,7 +508,7 @@
         <text variable="locator"/>
       </else-if>
       <else-if match="any" type="article-journal article-magazine legislation">
-        <text macro="locator-basic"/>
+        <text macro="label-locator"/>
       </else-if>
     </choose>
   </macro>


### PR DESCRIPTION
Make the code for OSCOLA simpler and more robust in preparation for creating an embedded version for _New Hart's Rules_ and MHRA, as well as a probable fifth edition this year:

- Introduce label macros for `edition`, `volume`, `locator`, and `first-reference-note-number`.
- Simplify the logic for legal case titles, date parentheses, publisher info, and locator formatting for greater consistency and maintainability.
- Sort XML attributes and variables.

### Checklist
- [X] Check that you've added a link to the style you used as a template in the `<info>` block at the beginning of the file with `rel="template"`.  
- [X] Check that you've added a link to the style guidelines with `rel="documentation"`.  
- [X] Check that you've added yourself as the `<author>` of the style or `<contributor>` for a style update. 
- [X] Check that you've used the correct terms or labels instead of hardcoding into affixes (e.g., `<text variable="page" prefix="pp. "/>`).
- [X] Check that you've not used `<text value="...` if not absolutely necessary.
- [X] Check that you've not changed line 1 of the style.
