### PR TITLE
IEEE: Use three-letter abbreviations for months

### DIFF
--- a/ieee.csl
+++ b/ieee.csl
@@ -62,11 +62,11 @@
       <term name="chapter-number" form="short">ch.</term>
       <term name="presented at">presented at the</term>
       <term name="available at">available</term>
+      <!-- always use three-letter abbreviations for months -->
+      <term name="month-06" form="short">Jun.</term>
+      <term name="month-07" form="short">Jul.</term>
+      <term name="month-09" form="short">Sep.</term>
     </terms>
-    <!-- always use three-letter abbreviations for months -->
-    <term name="month-06" form="short">Jun.</term>
-    <term name="month-07" form="short">Jul.</term>
-    <term name="month-09" form="short">Sep.</term>
   </locale>
   <!-- Macros -->
   <macro name="status">


### PR DESCRIPTION
Introduced three-letter abbreviations for June, July, and September in the locale terms to ensure consistent month formatting in citations.

