### PR TITLE
Fix: Remove serial comma for Norwegian locales (nb, nn)

### DIFF
--- a/apa.csl
+++ b/apa.csl
@@ -11,6 +11,9 @@
       <name>Brenton M. Wiernik</name>
       <email>zotero@wiernik.org</email>
     </author>
+    <contributor>
+      <name>Ivo Rosa</name>
+    </contributor>
     <category citation-format="author-date"/>
     <category field="psychology"/>
     <category field="generic-base"/>


### PR DESCRIPTION
Description:

This PR resolves the issue regarding the superfluous comma before the ampersand in Norwegian APA 7th citations.

Fixes #6794

Changes:

Added names-delimiter-precedes-last="never" to nb and nn locales.

Updated name macros to delimiter-precedes-last="contextual" to honor locale-specific rules.
