### PR TITLE
    <contributor>       <name>Ivo Rosa</name>     </contributor>

### DIFF
--- a/apa.csl
+++ b/apa.csl
@@ -81,9 +81,10 @@
     </terms>
   </locale>
   <locale xml:lang="nb">
-    <style-options punctuation-in-quote="false" names-delimiter-precedes-last="never"/>
+    
     <terms>
       <term name="et-al">et al.</term>
+      <style-options punctuation-in-quote="false" names-delimiter-precedes-last="never"/>
       <term name="editor" form="short">
         <single>red.</single>
         <multiple>red.</multiple>


### PR DESCRIPTION
### Description

This PR resolves the issue regarding the superfluous comma before the ampersand in Norwegian APA 7th citations.

Fixes https://github.com/citation-style-language/styles/issues/6794


### Checklist
- [x ] Check that you've added a link to the style you used as a template in the `<info>` block at the beginning of the file with `rel="template"`.  
- [ x] Check that you've added a link to the style guidelines with `rel="documentation"`.  
- [ x] Check that you've added yourself as the `<author>` of the style or `<contributor>` for a style update. 
- [ x] Check that you've used the correct terms or labels instead of hardcoding into affixes (e.g., `<text variable="page" prefix="pp. "/>`).
- [ x] Check that you've not used `<text value="...` if not absolutely necessary.
- [ x] Check that you've not changed line 1 of the style.
