### PR TITLE
Chicago: Update `webpage` to use `publisher` variable

### DIFF
--- a/chicago-author-date-17th-edition.csl
+++ b/chicago-author-date-17th-edition.csl
@@ -1510,16 +1510,25 @@
     <group delimiter=" ">
       <choose>
         <if type="chapter" variable="container-title genre">
-          <text form="short" variable="genre"/>
           <!-- untitled introductions: cf. review model, which includes a title (CMOS18 14.101) -->
-          <text macro="source-monographic-preposition-note"/>
-          <text font-style="italic" form="short" text-case="title" variable="container-title"/>
+          <text form="short" variable="genre"/>
+          <choose>
+            <if match="none" position="ibid ibid-with-locator">
+              <!-- CMOS team suggests leaving out title in repeated references -->
+              <text macro="source-monographic-preposition-note"/>
+              <text font-style="italic" form="short" text-case="title" variable="container-title"/>
+            </if>
+          </choose>
         </if>
         <else-if type="article-journal" variable="container-title genre volume-title">
-          <text form="short" variable="genre"/>
           <!-- untitled introduction to a special issue or supplement -->
-          <text macro="source-monographic-preposition-note"/>
-          <text form="short" quotes="true" text-case="title" variable="volume-title"/>
+          <text form="short" variable="genre"/>
+          <choose>
+            <if match="none" position="ibid ibid-with-locator">
+              <text macro="source-monographic-preposition-note"/>
+              <text form="short" quotes="true" text-case="title" variable="volume-title"/>
+            </if>
+          </choose>
         </else-if>
         <else-if variable="genre">
           <text form="short" variable="genre"/>
@@ -1780,10 +1789,17 @@
     </choose>
   </macro>
   <macro name="description-review-short">
-    <group delimiter=" ">
-      <text term="review-of"/>
-      <text macro="description-review-title-short"/>
-    </group>
+    <choose>
+      <if match="any" position="ibid ibid-with-locator">
+        <text term="review"/>
+      </if>
+      <else>
+        <group delimiter=" ">
+          <text term="review-of"/>
+          <text macro="description-review-title-short"/>
+        </group>
+      </else>
+    </choose>
   </macro>
   <macro name="description-review-term-unsigned-bib">
     <!-- Anonymous reviews appear as 'unsigned' (CMOS18 14.102) -->

--- a/chicago-author-date-access-dates.csl
+++ b/chicago-author-date-access-dates.csl
@@ -1504,16 +1504,25 @@
     <group delimiter=" ">
       <choose>
         <if type="chapter" variable="container-title genre">
-          <text form="short" variable="genre"/>
           <!-- untitled introductions: cf. review model, which includes a title (CMOS18 14.101) -->
-          <text macro="source-monographic-preposition-note"/>
-          <text font-style="italic" form="short" text-case="title" variable="container-title"/>
+          <text form="short" variable="genre"/>
+          <choose>
+            <if match="none" position="ibid ibid-with-locator">
+              <!-- CMOS team suggests leaving out title in repeated references -->
+              <text macro="source-monographic-preposition-note"/>
+              <text font-style="italic" form="short" text-case="title" variable="container-title"/>
+            </if>
+          </choose>
         </if>
         <else-if type="article-journal" variable="container-title genre volume-title">
-          <text form="short" variable="genre"/>
           <!-- untitled introduction to a special issue or supplement -->
-          <text macro="source-monographic-preposition-note"/>
-          <text form="short" quotes="true" text-case="title" variable="volume-title"/>
+          <text form="short" variable="genre"/>
+          <choose>
+            <if match="none" position="ibid ibid-with-locator">
+              <text macro="source-monographic-preposition-note"/>
+              <text form="short" quotes="true" text-case="title" variable="volume-title"/>
+            </if>
+          </choose>
         </else-if>
         <else-if variable="genre">
           <text form="short" variable="genre"/>
@@ -1774,10 +1783,17 @@
     </choose>
   </macro>
   <macro name="description-review-short">
-    <group delimiter=" ">
-      <text term="review-of"/>
-      <text macro="description-review-title-short"/>
-    </group>
+    <choose>
+      <if match="any" position="ibid ibid-with-locator">
+        <text term="review"/>
+      </if>
+      <else>
+        <group delimiter=" ">
+          <text term="review-of"/>
+          <text macro="description-review-title-short"/>
+        </group>
+      </else>
+    </choose>
   </macro>
   <macro name="description-review-term-unsigned-bib">
     <!-- Anonymous reviews appear as 'unsigned' (CMOS18 14.102) -->

--- a/chicago-author-date-archive-place-first-no-url.csl
+++ b/chicago-author-date-archive-place-first-no-url.csl
@@ -1504,16 +1504,25 @@
     <group delimiter=" ">
       <choose>
         <if type="chapter" variable="container-title genre">
-          <text form="short" variable="genre"/>
           <!-- untitled introductions: cf. review model, which includes a title (CMOS18 14.101) -->
-          <text macro="source-monographic-preposition-note"/>
-          <text font-style="italic" form="short" text-case="title" variable="container-title"/>
+          <text form="short" variable="genre"/>
+          <choose>
+            <if match="none" position="ibid ibid-with-locator">
+              <!-- CMOS team suggests leaving out title in repeated references -->
+              <text macro="source-monographic-preposition-note"/>
+              <text font-style="italic" form="short" text-case="title" variable="container-title"/>
+            </if>
+          </choose>
         </if>
         <else-if type="article-journal" variable="container-title genre volume-title">
-          <text form="short" variable="genre"/>
           <!-- untitled introduction to a special issue or supplement -->
-          <text macro="source-monographic-preposition-note"/>
-          <text form="short" quotes="true" text-case="title" variable="volume-title"/>
+          <text form="short" variable="genre"/>
+          <choose>
+            <if match="none" position="ibid ibid-with-locator">
+              <text macro="source-monographic-preposition-note"/>
+              <text form="short" quotes="true" text-case="title" variable="volume-title"/>
+            </if>
+          </choose>
         </else-if>
         <else-if variable="genre">
           <text form="short" variable="genre"/>
@@ -1774,10 +1783,17 @@
     </choose>
   </macro>
   <macro name="description-review-short">
-    <group delimiter=" ">
-      <text term="review-of"/>
-      <text macro="description-review-title-short"/>
-    </group>
+    <choose>
+      <if match="any" position="ibid ibid-with-locator">
+        <text term="review"/>
+      </if>
+      <else>
+        <group delimiter=" ">
+          <text term="review-of"/>
+          <text macro="description-review-title-short"/>
+        </group>
+      </else>
+    </choose>
   </macro>
   <macro name="description-review-term-unsigned-bib">
     <!-- Anonymous reviews appear as 'unsigned' (CMOS18 14.102) -->

--- a/chicago-author-date-archive-place-first.csl
+++ b/chicago-author-date-archive-place-first.csl
@@ -1504,16 +1504,25 @@
     <group delimiter=" ">
       <choose>
         <if type="chapter" variable="container-title genre">
-          <text form="short" variable="genre"/>
           <!-- untitled introductions: cf. review model, which includes a title (CMOS18 14.101) -->
-          <text macro="source-monographic-preposition-note"/>
-          <text font-style="italic" form="short" text-case="title" variable="container-title"/>
+          <text form="short" variable="genre"/>
+          <choose>
+            <if match="none" position="ibid ibid-with-locator">
+              <!-- CMOS team suggests leaving out title in repeated references -->
+              <text macro="source-monographic-preposition-note"/>
+              <text font-style="italic" form="short" text-case="title" variable="container-title"/>
+            </if>
+          </choose>
         </if>
         <else-if type="article-journal" variable="container-title genre volume-title">
-          <text form="short" variable="genre"/>
           <!-- untitled introduction to a special issue or supplement -->
-          <text macro="source-monographic-preposition-note"/>
-          <text form="short" quotes="true" text-case="title" variable="volume-title"/>
+          <text form="short" variable="genre"/>
+          <choose>
+            <if match="none" position="ibid ibid-with-locator">
+              <text macro="source-monographic-preposition-note"/>
+              <text form="short" quotes="true" text-case="title" variable="volume-title"/>
+            </if>
+          </choose>
         </else-if>
         <else-if variable="genre">
           <text form="short" variable="genre"/>
@@ -1774,10 +1783,17 @@
     </choose>
   </macro>
   <macro name="description-review-short">
-    <group delimiter=" ">
-      <text term="review-of"/>
-      <text macro="description-review-title-short"/>
-    </group>
+    <choose>
+      <if match="any" position="ibid ibid-with-locator">
+        <text term="review"/>
+      </if>
+      <else>
+        <group delimiter=" ">
+          <text term="review-of"/>
+          <text macro="description-review-title-short"/>
+        </group>
+      </else>
+    </choose>
   </macro>
   <macro name="description-review-term-unsigned-bib">
     <!-- Anonymous reviews appear as 'unsigned' (CMOS18 14.102) -->

--- a/chicago-author-date-classic-no-url.csl
+++ b/chicago-author-date-classic-no-url.csl
@@ -1504,16 +1504,25 @@
     <group delimiter=" ">
       <choose>
         <if type="chapter" variable="container-title genre">
-          <text form="short" variable="genre"/>
           <!-- untitled introductions: cf. review model, which includes a title (CMOS18 14.101) -->
-          <text macro="source-monographic-preposition-note"/>
-          <text font-style="italic" form="short" text-case="title" variable="container-title"/>
+          <text form="short" variable="genre"/>
+          <choose>
+            <if match="none" position="ibid ibid-with-locator">
+              <!-- CMOS team suggests leaving out title in repeated references -->
+              <text macro="source-monographic-preposition-note"/>
+              <text font-style="italic" form="short" text-case="title" variable="container-title"/>
+            </if>
+          </choose>
         </if>
         <else-if type="article-journal" variable="container-title genre volume-title">
-          <text form="short" variable="genre"/>
           <!-- untitled introduction to a special issue or supplement -->
-          <text macro="source-monographic-preposition-note"/>
-          <text form="short" quotes="true" text-case="title" variable="volume-title"/>
+          <text form="short" variable="genre"/>
+          <choose>
+            <if match="none" position="ibid ibid-with-locator">
+              <text macro="source-monographic-preposition-note"/>
+              <text form="short" quotes="true" text-case="title" variable="volume-title"/>
+            </if>
+          </choose>
         </else-if>
         <else-if variable="genre">
           <text form="short" variable="genre"/>
@@ -1774,10 +1783,17 @@
     </choose>
   </macro>
   <macro name="description-review-short">
-    <group delimiter=" ">
-      <text term="review-of"/>
-      <text macro="description-review-title-short"/>
-    </group>
+    <choose>
+      <if match="any" position="ibid ibid-with-locator">
+        <text term="review"/>
+      </if>
+      <else>
+        <group delimiter=" ">
+          <text term="review-of"/>
+          <text macro="description-review-title-short"/>
+        </group>
+      </else>
+    </choose>
   </macro>
   <macro name="description-review-term-unsigned-bib">
     <!-- Anonymous reviews appear as 'unsigned' (CMOS18 14.102) -->

--- a/chicago-author-date-classic.csl
+++ b/chicago-author-date-classic.csl
@@ -1504,16 +1504,25 @@
     <group delimiter=" ">
       <choose>
         <if type="chapter" variable="container-title genre">
-          <text form="short" variable="genre"/>
           <!-- untitled introductions: cf. review model, which includes a title (CMOS18 14.101) -->
-          <text macro="source-monographic-preposition-note"/>
-          <text font-style="italic" form="short" text-case="title" variable="container-title"/>
+          <text form="short" variable="genre"/>
+          <choose>
+            <if match="none" position="ibid ibid-with-locator">
+              <!-- CMOS team suggests leaving out title in repeated references -->
+              <text macro="source-monographic-preposition-note"/>
+              <text font-style="italic" form="short" text-case="title" variable="container-title"/>
+            </if>
+          </choose>
         </if>
         <else-if type="article-journal" variable="container-title genre volume-title">
-          <text form="short" variable="genre"/>
           <!-- untitled introduction to a special issue or supplement -->
-          <text macro="source-monographic-preposition-note"/>
-          <text form="short" quotes="true" text-case="title" variable="volume-title"/>
+          <text form="short" variable="genre"/>
+          <choose>
+            <if match="none" position="ibid ibid-with-locator">
+              <text macro="source-monographic-preposition-note"/>
+              <text form="short" quotes="true" text-case="title" variable="volume-title"/>
+            </if>
+          </choose>
         </else-if>
         <else-if variable="genre">
           <text form="short" variable="genre"/>
@@ -1774,10 +1783,17 @@
     </choose>
   </macro>
   <macro name="description-review-short">
-    <group delimiter=" ">
-      <text term="review-of"/>
-      <text macro="description-review-title-short"/>
-    </group>
+    <choose>
+      <if match="any" position="ibid ibid-with-locator">
+        <text term="review"/>
+      </if>
+      <else>
+        <group delimiter=" ">
+          <text term="review-of"/>
+          <text macro="description-review-title-short"/>
+        </group>
+      </else>
+    </choose>
   </macro>
   <macro name="description-review-term-unsigned-bib">
     <!-- Anonymous reviews appear as 'unsigned' (CMOS18 14.102) -->

--- a/chicago-author-date-no-url.csl
+++ b/chicago-author-date-no-url.csl
@@ -1504,16 +1504,25 @@
     <group delimiter=" ">
       <choose>
         <if type="chapter" variable="container-title genre">
-          <text form="short" variable="genre"/>
           <!-- untitled introductions: cf. review model, which includes a title (CMOS18 14.101) -->
-          <text macro="source-monographic-preposition-note"/>
-          <text font-style="italic" form="short" text-case="title" variable="container-title"/>
+          <text form="short" variable="genre"/>
+          <choose>
+            <if match="none" position="ibid ibid-with-locator">
+              <!-- CMOS team suggests leaving out title in repeated references -->
+              <text macro="source-monographic-preposition-note"/>
+              <text font-style="italic" form="short" text-case="title" variable="container-title"/>
+            </if>
+          </choose>
         </if>
         <else-if type="article-journal" variable="container-title genre volume-title">
-          <text form="short" variable="genre"/>
           <!-- untitled introduction to a special issue or supplement -->
-          <text macro="source-monographic-preposition-note"/>
-          <text form="short" quotes="true" text-case="title" variable="volume-title"/>
+          <text form="short" variable="genre"/>
+          <choose>
+            <if match="none" position="ibid ibid-with-locator">
+              <text macro="source-monographic-preposition-note"/>
+              <text form="short" quotes="true" text-case="title" variable="volume-title"/>
+            </if>
+          </choose>
         </else-if>
         <else-if variable="genre">
           <text form="short" variable="genre"/>
@@ -1774,10 +1783,17 @@
     </choose>
   </macro>
   <macro name="description-review-short">
-    <group delimiter=" ">
-      <text term="review-of"/>
-      <text macro="description-review-title-short"/>
-    </group>
+    <choose>
+      <if match="any" position="ibid ibid-with-locator">
+        <text term="review"/>
+      </if>
+      <else>
+        <group delimiter=" ">
+          <text term="review-of"/>
+          <text macro="description-review-title-short"/>
+        </group>
+      </else>
+    </choose>
   </macro>
   <macro name="description-review-term-unsigned-bib">
     <!-- Anonymous reviews appear as 'unsigned' (CMOS18 14.102) -->

--- a/chicago-author-date.csl
+++ b/chicago-author-date.csl
@@ -1504,16 +1504,25 @@
     <group delimiter=" ">
       <choose>
         <if type="chapter" variable="container-title genre">
-          <text form="short" variable="genre"/>
           <!-- untitled introductions: cf. review model, which includes a title (CMOS18 14.101) -->
-          <text macro="source-monographic-preposition-note"/>
-          <text font-style="italic" form="short" text-case="title" variable="container-title"/>
+          <text form="short" variable="genre"/>
+          <choose>
+            <if match="none" position="ibid ibid-with-locator">
+              <!-- CMOS team suggests leaving out title in repeated references -->
+              <text macro="source-monographic-preposition-note"/>
+              <text font-style="italic" form="short" text-case="title" variable="container-title"/>
+            </if>
+          </choose>
         </if>
         <else-if type="article-journal" variable="container-title genre volume-title">
-          <text form="short" variable="genre"/>
           <!-- untitled introduction to a special issue or supplement -->
-          <text macro="source-monographic-preposition-note"/>
-          <text form="short" quotes="true" text-case="title" variable="volume-title"/>
+          <text form="short" variable="genre"/>
+          <choose>
+            <if match="none" position="ibid ibid-with-locator">
+              <text macro="source-monographic-preposition-note"/>
+              <text form="short" quotes="true" text-case="title" variable="volume-title"/>
+            </if>
+          </choose>
         </else-if>
         <else-if variable="genre">
           <text form="short" variable="genre"/>
@@ -1774,10 +1783,17 @@
     </choose>
   </macro>
   <macro name="description-review-short">
-    <group delimiter=" ">
-      <text term="review-of"/>
-      <text macro="description-review-title-short"/>
-    </group>
+    <choose>
+      <if match="any" position="ibid ibid-with-locator">
+        <text term="review"/>
+      </if>
+      <else>
+        <group delimiter=" ">
+          <text term="review-of"/>
+          <text macro="description-review-title-short"/>
+        </group>
+      </else>
+    </choose>
   </macro>
   <macro name="description-review-term-unsigned-bib">
     <!-- Anonymous reviews appear as 'unsigned' (CMOS18 14.102) -->

--- a/chicago-in-text-full-no-url.csl
+++ b/chicago-in-text-full-no-url.csl
@@ -1788,16 +1788,25 @@
     <group delimiter=" ">
       <choose>
         <if type="chapter" variable="container-title genre">
-          <text form="short" variable="genre"/>
           <!-- untitled introductions: cf. review model, which includes a title (CMOS18 14.101) -->
-          <text macro="source-monographic-preposition-note"/>
-          <text font-style="italic" form="short" text-case="title" variable="container-title"/>
+          <text form="short" variable="genre"/>
+          <choose>
+            <if match="none" position="ibid ibid-with-locator">
+              <!-- CMOS team suggests leaving out title in repeated references -->
+              <text macro="source-monographic-preposition-note"/>
+              <text font-style="italic" form="short" text-case="title" variable="container-title"/>
+            </if>
+          </choose>
         </if>
         <else-if type="article-journal" variable="container-title genre volume-title">
-          <text form="short" variable="genre"/>
           <!-- untitled introduction to a special issue or supplement -->
-          <text macro="source-monographic-preposition-note"/>
-          <text form="short" quotes="true" text-case="title" variable="volume-title"/>
+          <text form="short" variable="genre"/>
+          <choose>
+            <if match="none" position="ibid ibid-with-locator">
+              <text macro="source-monographic-preposition-note"/>
+              <text form="short" quotes="true" text-case="title" variable="volume-title"/>
+            </if>
+          </choose>
         </else-if>
         <else-if variable="genre">
           <text form="short" variable="genre"/>
@@ -2166,10 +2175,17 @@
     </choose>
   </macro>
   <macro name="description-review-short">
-    <group delimiter=" ">
-      <text term="review-of"/>
-      <text macro="description-review-title-short"/>
-    </group>
+    <choose>
+      <if match="any" position="ibid ibid-with-locator">
+        <text term="review"/>
+      </if>
+      <else>
+        <group delimiter=" ">
+          <text term="review-of"/>
+          <text macro="description-review-title-short"/>
+        </group>
+      </else>
+    </choose>
   </macro>
   <macro name="description-review-term-unsigned-bib">
     <!-- Anonymous reviews appear as 'unsigned' (CMOS18 14.102) -->

--- a/chicago-in-text-full.csl
+++ b/chicago-in-text-full.csl
@@ -1788,16 +1788,25 @@
     <group delimiter=" ">
       <choose>
         <if type="chapter" variable="container-title genre">
-          <text form="short" variable="genre"/>
           <!-- untitled introductions: cf. review model, which includes a title (CMOS18 14.101) -->
-          <text macro="source-monographic-preposition-note"/>
-          <text font-style="italic" form="short" text-case="title" variable="container-title"/>
+          <text form="short" variable="genre"/>
+          <choose>
+            <if match="none" position="ibid ibid-with-locator">
+              <!-- CMOS team suggests leaving out title in repeated references -->
+              <text macro="source-monographic-preposition-note"/>
+              <text font-style="italic" form="short" text-case="title" variable="container-title"/>
+            </if>
+          </choose>
         </if>
         <else-if type="article-journal" variable="container-title genre volume-title">
-          <text form="short" variable="genre"/>
           <!-- untitled introduction to a special issue or supplement -->
-          <text macro="source-monographic-preposition-note"/>
-          <text form="short" quotes="true" text-case="title" variable="volume-title"/>
+          <text form="short" variable="genre"/>
+          <choose>
+            <if match="none" position="ibid ibid-with-locator">
+              <text macro="source-monographic-preposition-note"/>
+              <text form="short" quotes="true" text-case="title" variable="volume-title"/>
+            </if>
+          </choose>
         </else-if>
         <else-if variable="genre">
           <text form="short" variable="genre"/>
@@ -2166,10 +2175,17 @@
     </choose>
   </macro>
   <macro name="description-review-short">
-    <group delimiter=" ">
-      <text term="review-of"/>
-      <text macro="description-review-title-short"/>
-    </group>
+    <choose>
+      <if match="any" position="ibid ibid-with-locator">
+        <text term="review"/>
+      </if>
+      <else>
+        <group delimiter=" ">
+          <text term="review-of"/>
+          <text macro="description-review-title-short"/>
+        </group>
+      </else>
+    </choose>
   </macro>
   <macro name="description-review-term-unsigned-bib">
     <!-- Anonymous reviews appear as 'unsigned' (CMOS18 14.102) -->

--- a/chicago-in-text-shortened-author-no-url.csl
+++ b/chicago-in-text-shortened-author-no-url.csl
@@ -1378,16 +1378,25 @@
     <group delimiter=" ">
       <choose>
         <if type="chapter" variable="container-title genre">
-          <text form="short" variable="genre"/>
           <!-- untitled introductions: cf. review model, which includes a title (CMOS18 14.101) -->
-          <text macro="source-monographic-preposition-note"/>
-          <text font-style="italic" form="short" text-case="title" variable="container-title"/>
+          <text form="short" variable="genre"/>
+          <choose>
+            <if match="none" position="ibid ibid-with-locator">
+              <!-- CMOS team suggests leaving out title in repeated references -->
+              <text macro="source-monographic-preposition-note"/>
+              <text font-style="italic" form="short" text-case="title" variable="container-title"/>
+            </if>
+          </choose>
         </if>
         <else-if type="article-journal" variable="container-title genre volume-title">
-          <text form="short" variable="genre"/>
           <!-- untitled introduction to a special issue or supplement -->
-          <text macro="source-monographic-preposition-note"/>
-          <text form="short" quotes="true" text-case="title" variable="volume-title"/>
+          <text form="short" variable="genre"/>
+          <choose>
+            <if match="none" position="ibid ibid-with-locator">
+              <text macro="source-monographic-preposition-note"/>
+              <text form="short" quotes="true" text-case="title" variable="volume-title"/>
+            </if>
+          </choose>
         </else-if>
         <else-if variable="genre">
           <text form="short" variable="genre"/>
@@ -1648,10 +1657,17 @@
     </choose>
   </macro>
   <macro name="description-review-short">
-    <group delimiter=" ">
-      <text term="review-of"/>
-      <text macro="description-review-title-short"/>
-    </group>
+    <choose>
+      <if match="any" position="ibid ibid-with-locator">
+        <text term="review"/>
+      </if>
+      <else>
+        <group delimiter=" ">
+          <text term="review-of"/>
+          <text macro="description-review-title-short"/>
+        </group>
+      </else>
+    </choose>
   </macro>
   <macro name="description-review-term-unsigned-bib">
     <!-- Anonymous reviews appear as 'unsigned' (CMOS18 14.102) -->

--- a/chicago-in-text-shortened-author-title-no-url.csl
+++ b/chicago-in-text-shortened-author-title-no-url.csl
@@ -1449,16 +1449,25 @@
     <group delimiter=" ">
       <choose>
         <if type="chapter" variable="container-title genre">
-          <text form="short" variable="genre"/>
           <!-- untitled introductions: cf. review model, which includes a title (CMOS18 14.101) -->
-          <text macro="source-monographic-preposition-note"/>
-          <text font-style="italic" form="short" text-case="title" variable="container-title"/>
+          <text form="short" variable="genre"/>
+          <choose>
+            <if match="none" position="ibid ibid-with-locator">
+              <!-- CMOS team suggests leaving out title in repeated references -->
+              <text macro="source-monographic-preposition-note"/>
+              <text font-style="italic" form="short" text-case="title" variable="container-title"/>
+            </if>
+          </choose>
         </if>
         <else-if type="article-journal" variable="container-title genre volume-title">
-          <text form="short" variable="genre"/>
           <!-- untitled introduction to a special issue or supplement -->
-          <text macro="source-monographic-preposition-note"/>
-          <text form="short" quotes="true" text-case="title" variable="volume-title"/>
+          <text form="short" variable="genre"/>
+          <choose>
+            <if match="none" position="ibid ibid-with-locator">
+              <text macro="source-monographic-preposition-note"/>
+              <text form="short" quotes="true" text-case="title" variable="volume-title"/>
+            </if>
+          </choose>
         </else-if>
         <else-if variable="genre">
           <text form="short" variable="genre"/>
@@ -1719,10 +1728,17 @@
     </choose>
   </macro>
   <macro name="description-review-short">
-    <group delimiter=" ">
-      <text term="review-of"/>
-      <text macro="description-review-title-short"/>
-    </group>
+    <choose>
+      <if match="any" position="ibid ibid-with-locator">
+        <text term="review"/>
+      </if>
+      <else>
+        <group delimiter=" ">
+          <text term="review-of"/>
+          <text macro="description-review-title-short"/>
+        </group>
+      </else>
+    </choose>
   </macro>
   <macro name="description-review-term-unsigned-bib">
     <!-- Anonymous reviews appear as 'unsigned' (CMOS18 14.102) -->

--- a/chicago-in-text-shortened-author-title.csl
+++ b/chicago-in-text-shortened-author-title.csl
@@ -1449,16 +1449,25 @@
     <group delimiter=" ">
       <choose>
         <if type="chapter" variable="container-title genre">
-          <text form="short" variable="genre"/>
           <!-- untitled introductions: cf. review model, which includes a title (CMOS18 14.101) -->
-          <text macro="source-monographic-preposition-note"/>
-          <text font-style="italic" form="short" text-case="title" variable="container-title"/>
+          <text form="short" variable="genre"/>
+          <choose>
+            <if match="none" position="ibid ibid-with-locator">
+              <!-- CMOS team suggests leaving out title in repeated references -->
+              <text macro="source-monographic-preposition-note"/>
+              <text font-style="italic" form="short" text-case="title" variable="container-title"/>
+            </if>
+          </choose>
         </if>
         <else-if type="article-journal" variable="container-title genre volume-title">
-          <text form="short" variable="genre"/>
           <!-- untitled introduction to a special issue or supplement -->
-          <text macro="source-monographic-preposition-note"/>
-          <text form="short" quotes="true" text-case="title" variable="volume-title"/>
+          <text form="short" variable="genre"/>
+          <choose>
+            <if match="none" position="ibid ibid-with-locator">
+              <text macro="source-monographic-preposition-note"/>
+              <text form="short" quotes="true" text-case="title" variable="volume-title"/>
+            </if>
+          </choose>
         </else-if>
         <else-if variable="genre">
           <text form="short" variable="genre"/>
@@ -1719,10 +1728,17 @@
     </choose>
   </macro>
   <macro name="description-review-short">
-    <group delimiter=" ">
-      <text term="review-of"/>
-      <text macro="description-review-title-short"/>
-    </group>
+    <choose>
+      <if match="any" position="ibid ibid-with-locator">
+        <text term="review"/>
+      </if>
+      <else>
+        <group delimiter=" ">
+          <text term="review-of"/>
+          <text macro="description-review-title-short"/>
+        </group>
+      </else>
+    </choose>
   </macro>
   <macro name="description-review-term-unsigned-bib">
     <!-- Anonymous reviews appear as 'unsigned' (CMOS18 14.102) -->

--- a/chicago-in-text-shortened-author.csl
+++ b/chicago-in-text-shortened-author.csl
@@ -1378,16 +1378,25 @@
     <group delimiter=" ">
       <choose>
         <if type="chapter" variable="container-title genre">
-          <text form="short" variable="genre"/>
           <!-- untitled introductions: cf. review model, which includes a title (CMOS18 14.101) -->
-          <text macro="source-monographic-preposition-note"/>
-          <text font-style="italic" form="short" text-case="title" variable="container-title"/>
+          <text form="short" variable="genre"/>
+          <choose>
+            <if match="none" position="ibid ibid-with-locator">
+              <!-- CMOS team suggests leaving out title in repeated references -->
+              <text macro="source-monographic-preposition-note"/>
+              <text font-style="italic" form="short" text-case="title" variable="container-title"/>
+            </if>
+          </choose>
         </if>
         <else-if type="article-journal" variable="container-title genre volume-title">
-          <text form="short" variable="genre"/>
           <!-- untitled introduction to a special issue or supplement -->
-          <text macro="source-monographic-preposition-note"/>
-          <text form="short" quotes="true" text-case="title" variable="volume-title"/>
+          <text form="short" variable="genre"/>
+          <choose>
+            <if match="none" position="ibid ibid-with-locator">
+              <text macro="source-monographic-preposition-note"/>
+              <text form="short" quotes="true" text-case="title" variable="volume-title"/>
+            </if>
+          </choose>
         </else-if>
         <else-if variable="genre">
           <text form="short" variable="genre"/>
@@ -1648,10 +1657,17 @@
     </choose>
   </macro>
   <macro name="description-review-short">
-    <group delimiter=" ">
-      <text term="review-of"/>
-      <text macro="description-review-title-short"/>
-    </group>
+    <choose>
+      <if match="any" position="ibid ibid-with-locator">
+        <text term="review"/>
+      </if>
+      <else>
+        <group delimiter=" ">
+          <text term="review-of"/>
+          <text macro="description-review-title-short"/>
+        </group>
+      </else>
+    </choose>
   </macro>
   <macro name="description-review-term-unsigned-bib">
     <!-- Anonymous reviews appear as 'unsigned' (CMOS18 14.102) -->

--- a/chicago-notes-archive-place-first-no-url.csl
+++ b/chicago-notes-archive-place-first-no-url.csl
@@ -1588,16 +1588,25 @@
     <group delimiter=" ">
       <choose>
         <if type="chapter" variable="container-title genre">
-          <text form="short" variable="genre"/>
           <!-- untitled introductions: cf. review model, which includes a title (CMOS18 14.101) -->
-          <text macro="source-monographic-preposition-note"/>
-          <text font-style="italic" form="short" text-case="title" variable="container-title"/>
+          <text form="short" variable="genre"/>
+          <choose>
+            <if match="none" position="ibid ibid-with-locator">
+              <!-- CMOS team suggests leaving out title in repeated references -->
+              <text macro="source-monographic-preposition-note"/>
+              <text font-style="italic" form="short" text-case="title" variable="container-title"/>
+            </if>
+          </choose>
         </if>
         <else-if type="article-journal" variable="container-title genre volume-title">
-          <text form="short" variable="genre"/>
           <!-- untitled introduction to a special issue or supplement -->
-          <text macro="source-monographic-preposition-note"/>
-          <text form="short" quotes="true" text-case="title" variable="volume-title"/>
+          <text form="short" variable="genre"/>
+          <choose>
+            <if match="none" position="ibid ibid-with-locator">
+              <text macro="source-monographic-preposition-note"/>
+              <text form="short" quotes="true" text-case="title" variable="volume-title"/>
+            </if>
+          </choose>
         </else-if>
         <else-if variable="genre">
           <text form="short" variable="genre"/>
@@ -1966,10 +1975,17 @@
     </choose>
   </macro>
   <macro name="description-review-short">
-    <group delimiter=" ">
-      <text term="review-of"/>
-      <text macro="description-review-title-short"/>
-    </group>
+    <choose>
+      <if match="any" position="ibid ibid-with-locator">
+        <text term="review"/>
+      </if>
+      <else>
+        <group delimiter=" ">
+          <text term="review-of"/>
+          <text macro="description-review-title-short"/>
+        </group>
+      </else>
+    </choose>
   </macro>
   <macro name="description-review-term-unsigned-bib">
     <!-- Anonymous reviews appear as 'unsigned' (CMOS18 14.102) -->

--- a/chicago-notes-archive-place-first.csl
+++ b/chicago-notes-archive-place-first.csl
@@ -1588,16 +1588,25 @@
     <group delimiter=" ">
       <choose>
         <if type="chapter" variable="container-title genre">
-          <text form="short" variable="genre"/>
           <!-- untitled introductions: cf. review model, which includes a title (CMOS18 14.101) -->
-          <text macro="source-monographic-preposition-note"/>
-          <text font-style="italic" form="short" text-case="title" variable="container-title"/>
+          <text form="short" variable="genre"/>
+          <choose>
+            <if match="none" position="ibid ibid-with-locator">
+              <!-- CMOS team suggests leaving out title in repeated references -->
+              <text macro="source-monographic-preposition-note"/>
+              <text font-style="italic" form="short" text-case="title" variable="container-title"/>
+            </if>
+          </choose>
         </if>
         <else-if type="article-journal" variable="container-title genre volume-title">
-          <text form="short" variable="genre"/>
           <!-- untitled introduction to a special issue or supplement -->
-          <text macro="source-monographic-preposition-note"/>
-          <text form="short" quotes="true" text-case="title" variable="volume-title"/>
+          <text form="short" variable="genre"/>
+          <choose>
+            <if match="none" position="ibid ibid-with-locator">
+              <text macro="source-monographic-preposition-note"/>
+              <text form="short" quotes="true" text-case="title" variable="volume-title"/>
+            </if>
+          </choose>
         </else-if>
         <else-if variable="genre">
           <text form="short" variable="genre"/>
@@ -1966,10 +1975,17 @@
     </choose>
   </macro>
   <macro name="description-review-short">
-    <group delimiter=" ">
-      <text term="review-of"/>
-      <text macro="description-review-title-short"/>
-    </group>
+    <choose>
+      <if match="any" position="ibid ibid-with-locator">
+        <text term="review"/>
+      </if>
+      <else>
+        <group delimiter=" ">
+          <text term="review-of"/>
+          <text macro="description-review-title-short"/>
+        </group>
+      </else>
+    </choose>
   </macro>
   <macro name="description-review-term-unsigned-bib">
     <!-- Anonymous reviews appear as 'unsigned' (CMOS18 14.102) -->

--- a/chicago-notes-bibliography-17th-edition.csl
+++ b/chicago-notes-bibliography-17th-edition.csl
@@ -1786,16 +1786,25 @@
     <group delimiter=" ">
       <choose>
         <if type="chapter" variable="container-title genre">
-          <text form="short" variable="genre"/>
           <!-- untitled introductions: cf. review model, which includes a title (CMOS18 14.101) -->
-          <text macro="source-monographic-preposition-note"/>
-          <text font-style="italic" form="short" text-case="title" variable="container-title"/>
+          <text form="short" variable="genre"/>
+          <choose>
+            <if match="none" position="ibid ibid-with-locator">
+              <!-- CMOS team suggests leaving out title in repeated references -->
+              <text macro="source-monographic-preposition-note"/>
+              <text font-style="italic" form="short" text-case="title" variable="container-title"/>
+            </if>
+          </choose>
         </if>
         <else-if type="article-journal" variable="container-title genre volume-title">
-          <text form="short" variable="genre"/>
           <!-- untitled introduction to a special issue or supplement -->
-          <text macro="source-monographic-preposition-note"/>
-          <text form="short" quotes="true" text-case="title" variable="volume-title"/>
+          <text form="short" variable="genre"/>
+          <choose>
+            <if match="none" position="ibid ibid-with-locator">
+              <text macro="source-monographic-preposition-note"/>
+              <text form="short" quotes="true" text-case="title" variable="volume-title"/>
+            </if>
+          </choose>
         </else-if>
         <else-if variable="genre">
           <text form="short" variable="genre"/>
@@ -2164,10 +2173,17 @@
     </choose>
   </macro>
   <macro name="description-review-short">
-    <group delimiter=" ">
-      <text term="review-of"/>
-      <text macro="description-review-title-short"/>
-    </group>
+    <choose>
+      <if match="any" position="ibid ibid-with-locator">
+        <text term="review"/>
+      </if>
+      <else>
+        <group delimiter=" ">
+          <text term="review-of"/>
+          <text macro="description-review-title-short"/>
+        </group>
+      </else>
+    </choose>
   </macro>
   <macro name="description-review-term-unsigned-bib">
     <!-- Anonymous reviews appear as 'unsigned' (CMOS18 14.102) -->

--- a/chicago-notes-bibliography-access-dates.csl
+++ b/chicago-notes-bibliography-access-dates.csl
@@ -1789,16 +1789,25 @@
     <group delimiter=" ">
       <choose>
         <if type="chapter" variable="container-title genre">
-          <text form="short" variable="genre"/>
           <!-- untitled introductions: cf. review model, which includes a title (CMOS18 14.101) -->
-          <text macro="source-monographic-preposition-note"/>
-          <text font-style="italic" form="short" text-case="title" variable="container-title"/>
+          <text form="short" variable="genre"/>
+          <choose>
+            <if match="none" position="ibid ibid-with-locator">
+              <!-- CMOS team suggests leaving out title in repeated references -->
+              <text macro="source-monographic-preposition-note"/>
+              <text font-style="italic" form="short" text-case="title" variable="container-title"/>
+            </if>
+          </choose>
         </if>
         <else-if type="article-journal" variable="container-title genre volume-title">
-          <text form="short" variable="genre"/>
           <!-- untitled introduction to a special issue or supplement -->
-          <text macro="source-monographic-preposition-note"/>
-          <text form="short" quotes="true" text-case="title" variable="volume-title"/>
+          <text form="short" variable="genre"/>
+          <choose>
+            <if match="none" position="ibid ibid-with-locator">
+              <text macro="source-monographic-preposition-note"/>
+              <text form="short" quotes="true" text-case="title" variable="volume-title"/>
+            </if>
+          </choose>
         </else-if>
         <else-if variable="genre">
           <text form="short" variable="genre"/>
@@ -2167,10 +2176,17 @@
     </choose>
   </macro>
   <macro name="description-review-short">
-    <group delimiter=" ">
-      <text term="review-of"/>
-      <text macro="description-review-title-short"/>
-    </group>
+    <choose>
+      <if match="any" position="ibid ibid-with-locator">
+        <text term="review"/>
+      </if>
+      <else>
+        <group delimiter=" ">
+          <text term="review-of"/>
+          <text macro="description-review-title-short"/>
+        </group>
+      </else>
+    </choose>
   </macro>
   <macro name="description-review-term-unsigned-bib">
     <!-- Anonymous reviews appear as 'unsigned' (CMOS18 14.102) -->

--- a/chicago-notes-bibliography-annotated-abstract.csl
+++ b/chicago-notes-bibliography-annotated-abstract.csl
@@ -1789,16 +1789,25 @@
     <group delimiter=" ">
       <choose>
         <if type="chapter" variable="container-title genre">
-          <text form="short" variable="genre"/>
           <!-- untitled introductions: cf. review model, which includes a title (CMOS18 14.101) -->
-          <text macro="source-monographic-preposition-note"/>
-          <text font-style="italic" form="short" text-case="title" variable="container-title"/>
+          <text form="short" variable="genre"/>
+          <choose>
+            <if match="none" position="ibid ibid-with-locator">
+              <!-- CMOS team suggests leaving out title in repeated references -->
+              <text macro="source-monographic-preposition-note"/>
+              <text font-style="italic" form="short" text-case="title" variable="container-title"/>
+            </if>
+          </choose>
         </if>
         <else-if type="article-journal" variable="container-title genre volume-title">
-          <text form="short" variable="genre"/>
           <!-- untitled introduction to a special issue or supplement -->
-          <text macro="source-monographic-preposition-note"/>
-          <text form="short" quotes="true" text-case="title" variable="volume-title"/>
+          <text form="short" variable="genre"/>
+          <choose>
+            <if match="none" position="ibid ibid-with-locator">
+              <text macro="source-monographic-preposition-note"/>
+              <text form="short" quotes="true" text-case="title" variable="volume-title"/>
+            </if>
+          </choose>
         </else-if>
         <else-if variable="genre">
           <text form="short" variable="genre"/>
@@ -2167,10 +2176,17 @@
     </choose>
   </macro>
   <macro name="description-review-short">
-    <group delimiter=" ">
-      <text term="review-of"/>
-      <text macro="description-review-title-short"/>
-    </group>
+    <choose>
+      <if match="any" position="ibid ibid-with-locator">
+        <text term="review"/>
+      </if>
+      <else>
+        <group delimiter=" ">
+          <text term="review-of"/>
+          <text macro="description-review-title-short"/>
+        </group>
+      </else>
+    </choose>
   </macro>
   <macro name="description-review-term-unsigned-bib">
     <!-- Anonymous reviews appear as 'unsigned' (CMOS18 14.102) -->

--- a/chicago-notes-bibliography-annotated.csl
+++ b/chicago-notes-bibliography-annotated.csl
@@ -1789,16 +1789,25 @@
     <group delimiter=" ">
       <choose>
         <if type="chapter" variable="container-title genre">
-          <text form="short" variable="genre"/>
           <!-- untitled introductions: cf. review model, which includes a title (CMOS18 14.101) -->
-          <text macro="source-monographic-preposition-note"/>
-          <text font-style="italic" form="short" text-case="title" variable="container-title"/>
+          <text form="short" variable="genre"/>
+          <choose>
+            <if match="none" position="ibid ibid-with-locator">
+              <!-- CMOS team suggests leaving out title in repeated references -->
+              <text macro="source-monographic-preposition-note"/>
+              <text font-style="italic" form="short" text-case="title" variable="container-title"/>
+            </if>
+          </choose>
         </if>
         <else-if type="article-journal" variable="container-title genre volume-title">
-          <text form="short" variable="genre"/>
           <!-- untitled introduction to a special issue or supplement -->
-          <text macro="source-monographic-preposition-note"/>
-          <text form="short" quotes="true" text-case="title" variable="volume-title"/>
+          <text form="short" variable="genre"/>
+          <choose>
+            <if match="none" position="ibid ibid-with-locator">
+              <text macro="source-monographic-preposition-note"/>
+              <text form="short" quotes="true" text-case="title" variable="volume-title"/>
+            </if>
+          </choose>
         </else-if>
         <else-if variable="genre">
           <text form="short" variable="genre"/>
@@ -2167,10 +2176,17 @@
     </choose>
   </macro>
   <macro name="description-review-short">
-    <group delimiter=" ">
-      <text term="review-of"/>
-      <text macro="description-review-title-short"/>
-    </group>
+    <choose>
+      <if match="any" position="ibid ibid-with-locator">
+        <text term="review"/>
+      </if>
+      <else>
+        <group delimiter=" ">
+          <text term="review-of"/>
+          <text macro="description-review-title-short"/>
+        </group>
+      </else>
+    </choose>
   </macro>
   <macro name="description-review-term-unsigned-bib">
     <!-- Anonymous reviews appear as 'unsigned' (CMOS18 14.102) -->

--- a/chicago-notes-bibliography-archive-place-first-no-url.csl
+++ b/chicago-notes-bibliography-archive-place-first-no-url.csl
@@ -1788,16 +1788,25 @@
     <group delimiter=" ">
       <choose>
         <if type="chapter" variable="container-title genre">
-          <text form="short" variable="genre"/>
           <!-- untitled introductions: cf. review model, which includes a title (CMOS18 14.101) -->
-          <text macro="source-monographic-preposition-note"/>
-          <text font-style="italic" form="short" text-case="title" variable="container-title"/>
+          <text form="short" variable="genre"/>
+          <choose>
+            <if match="none" position="ibid ibid-with-locator">
+              <!-- CMOS team suggests leaving out title in repeated references -->
+              <text macro="source-monographic-preposition-note"/>
+              <text font-style="italic" form="short" text-case="title" variable="container-title"/>
+            </if>
+          </choose>
         </if>
         <else-if type="article-journal" variable="container-title genre volume-title">
-          <text form="short" variable="genre"/>
           <!-- untitled introduction to a special issue or supplement -->
-          <text macro="source-monographic-preposition-note"/>
-          <text form="short" quotes="true" text-case="title" variable="volume-title"/>
+          <text form="short" variable="genre"/>
+          <choose>
+            <if match="none" position="ibid ibid-with-locator">
+              <text macro="source-monographic-preposition-note"/>
+              <text form="short" quotes="true" text-case="title" variable="volume-title"/>
+            </if>
+          </choose>
         </else-if>
         <else-if variable="genre">
           <text form="short" variable="genre"/>
@@ -2166,10 +2175,17 @@
     </choose>
   </macro>
   <macro name="description-review-short">
-    <group delimiter=" ">
-      <text term="review-of"/>
-      <text macro="description-review-title-short"/>
-    </group>
+    <choose>
+      <if match="any" position="ibid ibid-with-locator">
+        <text term="review"/>
+      </if>
+      <else>
+        <group delimiter=" ">
+          <text term="review-of"/>
+          <text macro="description-review-title-short"/>
+        </group>
+      </else>
+    </choose>
   </macro>
   <macro name="description-review-term-unsigned-bib">
     <!-- Anonymous reviews appear as 'unsigned' (CMOS18 14.102) -->

--- a/chicago-notes-bibliography-archive-place-first.csl
+++ b/chicago-notes-bibliography-archive-place-first.csl
@@ -1788,16 +1788,25 @@
     <group delimiter=" ">
       <choose>
         <if type="chapter" variable="container-title genre">
-          <text form="short" variable="genre"/>
           <!-- untitled introductions: cf. review model, which includes a title (CMOS18 14.101) -->
-          <text macro="source-monographic-preposition-note"/>
-          <text font-style="italic" form="short" text-case="title" variable="container-title"/>
+          <text form="short" variable="genre"/>
+          <choose>
+            <if match="none" position="ibid ibid-with-locator">
+              <!-- CMOS team suggests leaving out title in repeated references -->
+              <text macro="source-monographic-preposition-note"/>
+              <text font-style="italic" form="short" text-case="title" variable="container-title"/>
+            </if>
+          </choose>
         </if>
         <else-if type="article-journal" variable="container-title genre volume-title">
-          <text form="short" variable="genre"/>
           <!-- untitled introduction to a special issue or supplement -->
-          <text macro="source-monographic-preposition-note"/>
-          <text form="short" quotes="true" text-case="title" variable="volume-title"/>
+          <text form="short" variable="genre"/>
+          <choose>
+            <if match="none" position="ibid ibid-with-locator">
+              <text macro="source-monographic-preposition-note"/>
+              <text form="short" quotes="true" text-case="title" variable="volume-title"/>
+            </if>
+          </choose>
         </else-if>
         <else-if variable="genre">
           <text form="short" variable="genre"/>
@@ -2166,10 +2175,17 @@
     </choose>
   </macro>
   <macro name="description-review-short">
-    <group delimiter=" ">
-      <text term="review-of"/>
-      <text macro="description-review-title-short"/>
-    </group>
+    <choose>
+      <if match="any" position="ibid ibid-with-locator">
+        <text term="review"/>
+      </if>
+      <else>
+        <group delimiter=" ">
+          <text term="review-of"/>
+          <text macro="description-review-title-short"/>
+        </group>
+      </else>
+    </choose>
   </macro>
   <macro name="description-review-term-unsigned-bib">
     <!-- Anonymous reviews appear as 'unsigned' (CMOS18 14.102) -->

--- a/chicago-notes-bibliography-classic-archive-place-first-no-url.csl
+++ b/chicago-notes-bibliography-classic-archive-place-first-no-url.csl
@@ -1789,16 +1789,25 @@
     <group delimiter=" ">
       <choose>
         <if type="chapter" variable="container-title genre">
-          <text form="short" variable="genre"/>
           <!-- untitled introductions: cf. review model, which includes a title (CMOS18 14.101) -->
-          <text macro="source-monographic-preposition-note"/>
-          <text font-style="italic" form="short" text-case="title" variable="container-title"/>
+          <text form="short" variable="genre"/>
+          <choose>
+            <if match="none" position="ibid ibid-with-locator">
+              <!-- CMOS team suggests leaving out title in repeated references -->
+              <text macro="source-monographic-preposition-note"/>
+              <text font-style="italic" form="short" text-case="title" variable="container-title"/>
+            </if>
+          </choose>
         </if>
         <else-if type="article-journal" variable="container-title genre volume-title">
-          <text form="short" variable="genre"/>
           <!-- untitled introduction to a special issue or supplement -->
-          <text macro="source-monographic-preposition-note"/>
-          <text form="short" quotes="true" text-case="title" variable="volume-title"/>
+          <text form="short" variable="genre"/>
+          <choose>
+            <if match="none" position="ibid ibid-with-locator">
+              <text macro="source-monographic-preposition-note"/>
+              <text form="short" quotes="true" text-case="title" variable="volume-title"/>
+            </if>
+          </choose>
         </else-if>
         <else-if variable="genre">
           <text form="short" variable="genre"/>
@@ -2167,10 +2176,17 @@
     </choose>
   </macro>
   <macro name="description-review-short">
-    <group delimiter=" ">
-      <text term="review-of"/>
-      <text macro="description-review-title-short"/>
-    </group>
+    <choose>
+      <if match="any" position="ibid ibid-with-locator">
+        <text term="review"/>
+      </if>
+      <else>
+        <group delimiter=" ">
+          <text term="review-of"/>
+          <text macro="description-review-title-short"/>
+        </group>
+      </else>
+    </choose>
   </macro>
   <macro name="description-review-term-unsigned-bib">
     <!-- Anonymous reviews appear as 'unsigned' (CMOS18 14.102) -->

--- a/chicago-notes-bibliography-classic-archive-place-first.csl
+++ b/chicago-notes-bibliography-classic-archive-place-first.csl
@@ -1789,16 +1789,25 @@
     <group delimiter=" ">
       <choose>
         <if type="chapter" variable="container-title genre">
-          <text form="short" variable="genre"/>
           <!-- untitled introductions: cf. review model, which includes a title (CMOS18 14.101) -->
-          <text macro="source-monographic-preposition-note"/>
-          <text font-style="italic" form="short" text-case="title" variable="container-title"/>
+          <text form="short" variable="genre"/>
+          <choose>
+            <if match="none" position="ibid ibid-with-locator">
+              <!-- CMOS team suggests leaving out title in repeated references -->
+              <text macro="source-monographic-preposition-note"/>
+              <text font-style="italic" form="short" text-case="title" variable="container-title"/>
+            </if>
+          </choose>
         </if>
         <else-if type="article-journal" variable="container-title genre volume-title">
-          <text form="short" variable="genre"/>
           <!-- untitled introduction to a special issue or supplement -->
-          <text macro="source-monographic-preposition-note"/>
-          <text form="short" quotes="true" text-case="title" variable="volume-title"/>
+          <text form="short" variable="genre"/>
+          <choose>
+            <if match="none" position="ibid ibid-with-locator">
+              <text macro="source-monographic-preposition-note"/>
+              <text form="short" quotes="true" text-case="title" variable="volume-title"/>
+            </if>
+          </choose>
         </else-if>
         <else-if variable="genre">
           <text form="short" variable="genre"/>
@@ -2167,10 +2176,17 @@
     </choose>
   </macro>
   <macro name="description-review-short">
-    <group delimiter=" ">
-      <text term="review-of"/>
-      <text macro="description-review-title-short"/>
-    </group>
+    <choose>
+      <if match="any" position="ibid ibid-with-locator">
+        <text term="review"/>
+      </if>
+      <else>
+        <group delimiter=" ">
+          <text term="review-of"/>
+          <text macro="description-review-title-short"/>
+        </group>
+      </else>
+    </choose>
   </macro>
   <macro name="description-review-term-unsigned-bib">
     <!-- Anonymous reviews appear as 'unsigned' (CMOS18 14.102) -->

--- a/chicago-notes-bibliography-classic-no-url.csl
+++ b/chicago-notes-bibliography-classic-no-url.csl
@@ -1789,16 +1789,25 @@
     <group delimiter=" ">
       <choose>
         <if type="chapter" variable="container-title genre">
-          <text form="short" variable="genre"/>
           <!-- untitled introductions: cf. review model, which includes a title (CMOS18 14.101) -->
-          <text macro="source-monographic-preposition-note"/>
-          <text font-style="italic" form="short" text-case="title" variable="container-title"/>
+          <text form="short" variable="genre"/>
+          <choose>
+            <if match="none" position="ibid ibid-with-locator">
+              <!-- CMOS team suggests leaving out title in repeated references -->
+              <text macro="source-monographic-preposition-note"/>
+              <text font-style="italic" form="short" text-case="title" variable="container-title"/>
+            </if>
+          </choose>
         </if>
         <else-if type="article-journal" variable="container-title genre volume-title">
-          <text form="short" variable="genre"/>
           <!-- untitled introduction to a special issue or supplement -->
-          <text macro="source-monographic-preposition-note"/>
-          <text form="short" quotes="true" text-case="title" variable="volume-title"/>
+          <text form="short" variable="genre"/>
+          <choose>
+            <if match="none" position="ibid ibid-with-locator">
+              <text macro="source-monographic-preposition-note"/>
+              <text form="short" quotes="true" text-case="title" variable="volume-title"/>
+            </if>
+          </choose>
         </else-if>
         <else-if variable="genre">
           <text form="short" variable="genre"/>
@@ -2167,10 +2176,17 @@
     </choose>
   </macro>
   <macro name="description-review-short">
-    <group delimiter=" ">
-      <text term="review-of"/>
-      <text macro="description-review-title-short"/>
-    </group>
+    <choose>
+      <if match="any" position="ibid ibid-with-locator">
+        <text term="review"/>
+      </if>
+      <else>
+        <group delimiter=" ">
+          <text term="review-of"/>
+          <text macro="description-review-title-short"/>
+        </group>
+      </else>
+    </choose>
   </macro>
   <macro name="description-review-term-unsigned-bib">
     <!-- Anonymous reviews appear as 'unsigned' (CMOS18 14.102) -->

--- a/chicago-notes-bibliography-classic.csl
+++ b/chicago-notes-bibliography-classic.csl
@@ -1789,16 +1789,25 @@
     <group delimiter=" ">
       <choose>
         <if type="chapter" variable="container-title genre">
-          <text form="short" variable="genre"/>
           <!-- untitled introductions: cf. review model, which includes a title (CMOS18 14.101) -->
-          <text macro="source-monographic-preposition-note"/>
-          <text font-style="italic" form="short" text-case="title" variable="container-title"/>
+          <text form="short" variable="genre"/>
+          <choose>
+            <if match="none" position="ibid ibid-with-locator">
+              <!-- CMOS team suggests leaving out title in repeated references -->
+              <text macro="source-monographic-preposition-note"/>
+              <text font-style="italic" form="short" text-case="title" variable="container-title"/>
+            </if>
+          </choose>
         </if>
         <else-if type="article-journal" variable="container-title genre volume-title">
-          <text form="short" variable="genre"/>
           <!-- untitled introduction to a special issue or supplement -->
-          <text macro="source-monographic-preposition-note"/>
-          <text form="short" quotes="true" text-case="title" variable="volume-title"/>
+          <text form="short" variable="genre"/>
+          <choose>
+            <if match="none" position="ibid ibid-with-locator">
+              <text macro="source-monographic-preposition-note"/>
+              <text form="short" quotes="true" text-case="title" variable="volume-title"/>
+            </if>
+          </choose>
         </else-if>
         <else-if variable="genre">
           <text form="short" variable="genre"/>
@@ -2167,10 +2176,17 @@
     </choose>
   </macro>
   <macro name="description-review-short">
-    <group delimiter=" ">
-      <text term="review-of"/>
-      <text macro="description-review-title-short"/>
-    </group>
+    <choose>
+      <if match="any" position="ibid ibid-with-locator">
+        <text term="review"/>
+      </if>
+      <else>
+        <group delimiter=" ">
+          <text term="review-of"/>
+          <text macro="description-review-title-short"/>
+        </group>
+      </else>
+    </choose>
   </macro>
   <macro name="description-review-term-unsigned-bib">
     <!-- Anonymous reviews appear as 'unsigned' (CMOS18 14.102) -->

--- a/chicago-notes-bibliography-no-url.csl
+++ b/chicago-notes-bibliography-no-url.csl
@@ -1788,16 +1788,25 @@
     <group delimiter=" ">
       <choose>
         <if type="chapter" variable="container-title genre">
-          <text form="short" variable="genre"/>
           <!-- untitled introductions: cf. review model, which includes a title (CMOS18 14.101) -->
-          <text macro="source-monographic-preposition-note"/>
-          <text font-style="italic" form="short" text-case="title" variable="container-title"/>
+          <text form="short" variable="genre"/>
+          <choose>
+            <if match="none" position="ibid ibid-with-locator">
+              <!-- CMOS team suggests leaving out title in repeated references -->
+              <text macro="source-monographic-preposition-note"/>
+              <text font-style="italic" form="short" text-case="title" variable="container-title"/>
+            </if>
+          </choose>
         </if>
         <else-if type="article-journal" variable="container-title genre volume-title">
-          <text form="short" variable="genre"/>
           <!-- untitled introduction to a special issue or supplement -->
-          <text macro="source-monographic-preposition-note"/>
-          <text form="short" quotes="true" text-case="title" variable="volume-title"/>
+          <text form="short" variable="genre"/>
+          <choose>
+            <if match="none" position="ibid ibid-with-locator">
+              <text macro="source-monographic-preposition-note"/>
+              <text form="short" quotes="true" text-case="title" variable="volume-title"/>
+            </if>
+          </choose>
         </else-if>
         <else-if variable="genre">
           <text form="short" variable="genre"/>
@@ -2166,10 +2175,17 @@
     </choose>
   </macro>
   <macro name="description-review-short">
-    <group delimiter=" ">
-      <text term="review-of"/>
-      <text macro="description-review-title-short"/>
-    </group>
+    <choose>
+      <if match="any" position="ibid ibid-with-locator">
+        <text term="review"/>
+      </if>
+      <else>
+        <group delimiter=" ">
+          <text term="review-of"/>
+          <text macro="description-review-title-short"/>
+        </group>
+      </else>
+    </choose>
   </macro>
   <macro name="description-review-term-unsigned-bib">
     <!-- Anonymous reviews appear as 'unsigned' (CMOS18 14.102) -->

--- a/chicago-notes-bibliography-subsequent-author-classic-no-url.csl
+++ b/chicago-notes-bibliography-subsequent-author-classic-no-url.csl
@@ -1789,16 +1789,25 @@
     <group delimiter=" ">
       <choose>
         <if type="chapter" variable="container-title genre">
-          <text form="short" variable="genre"/>
           <!-- untitled introductions: cf. review model, which includes a title (CMOS18 14.101) -->
-          <text macro="source-monographic-preposition-note"/>
-          <text font-style="italic" form="short" text-case="title" variable="container-title"/>
+          <text form="short" variable="genre"/>
+          <choose>
+            <if match="none" position="ibid ibid-with-locator">
+              <!-- CMOS team suggests leaving out title in repeated references -->
+              <text macro="source-monographic-preposition-note"/>
+              <text font-style="italic" form="short" text-case="title" variable="container-title"/>
+            </if>
+          </choose>
         </if>
         <else-if type="article-journal" variable="container-title genre volume-title">
-          <text form="short" variable="genre"/>
           <!-- untitled introduction to a special issue or supplement -->
-          <text macro="source-monographic-preposition-note"/>
-          <text form="short" quotes="true" text-case="title" variable="volume-title"/>
+          <text form="short" variable="genre"/>
+          <choose>
+            <if match="none" position="ibid ibid-with-locator">
+              <text macro="source-monographic-preposition-note"/>
+              <text form="short" quotes="true" text-case="title" variable="volume-title"/>
+            </if>
+          </choose>
         </else-if>
         <else-if variable="genre">
           <text form="short" variable="genre"/>
@@ -2167,10 +2176,17 @@
     </choose>
   </macro>
   <macro name="description-review-short">
-    <group delimiter=" ">
-      <text term="review-of"/>
-      <text macro="description-review-title-short"/>
-    </group>
+    <choose>
+      <if match="any" position="ibid ibid-with-locator">
+        <text term="review"/>
+      </if>
+      <else>
+        <group delimiter=" ">
+          <text term="review-of"/>
+          <text macro="description-review-title-short"/>
+        </group>
+      </else>
+    </choose>
   </macro>
   <macro name="description-review-term-unsigned-bib">
     <!-- Anonymous reviews appear as 'unsigned' (CMOS18 14.102) -->

--- a/chicago-notes-bibliography-subsequent-author-classic.csl
+++ b/chicago-notes-bibliography-subsequent-author-classic.csl
@@ -1789,16 +1789,25 @@
     <group delimiter=" ">
       <choose>
         <if type="chapter" variable="container-title genre">
-          <text form="short" variable="genre"/>
           <!-- untitled introductions: cf. review model, which includes a title (CMOS18 14.101) -->
-          <text macro="source-monographic-preposition-note"/>
-          <text font-style="italic" form="short" text-case="title" variable="container-title"/>
+          <text form="short" variable="genre"/>
+          <choose>
+            <if match="none" position="ibid ibid-with-locator">
+              <!-- CMOS team suggests leaving out title in repeated references -->
+              <text macro="source-monographic-preposition-note"/>
+              <text font-style="italic" form="short" text-case="title" variable="container-title"/>
+            </if>
+          </choose>
         </if>
         <else-if type="article-journal" variable="container-title genre volume-title">
-          <text form="short" variable="genre"/>
           <!-- untitled introduction to a special issue or supplement -->
-          <text macro="source-monographic-preposition-note"/>
-          <text form="short" quotes="true" text-case="title" variable="volume-title"/>
+          <text form="short" variable="genre"/>
+          <choose>
+            <if match="none" position="ibid ibid-with-locator">
+              <text macro="source-monographic-preposition-note"/>
+              <text form="short" quotes="true" text-case="title" variable="volume-title"/>
+            </if>
+          </choose>
         </else-if>
         <else-if variable="genre">
           <text form="short" variable="genre"/>
@@ -2167,10 +2176,17 @@
     </choose>
   </macro>
   <macro name="description-review-short">
-    <group delimiter=" ">
-      <text term="review-of"/>
-      <text macro="description-review-title-short"/>
-    </group>
+    <choose>
+      <if match="any" position="ibid ibid-with-locator">
+        <text term="review"/>
+      </if>
+      <else>
+        <group delimiter=" ">
+          <text term="review-of"/>
+          <text macro="description-review-title-short"/>
+        </group>
+      </else>
+    </choose>
   </macro>
   <macro name="description-review-term-unsigned-bib">
     <!-- Anonymous reviews appear as 'unsigned' (CMOS18 14.102) -->

--- a/chicago-notes-bibliography-subsequent-author-no-url.csl
+++ b/chicago-notes-bibliography-subsequent-author-no-url.csl
@@ -1788,16 +1788,25 @@
     <group delimiter=" ">
       <choose>
         <if type="chapter" variable="container-title genre">
-          <text form="short" variable="genre"/>
           <!-- untitled introductions: cf. review model, which includes a title (CMOS18 14.101) -->
-          <text macro="source-monographic-preposition-note"/>
-          <text font-style="italic" form="short" text-case="title" variable="container-title"/>
+          <text form="short" variable="genre"/>
+          <choose>
+            <if match="none" position="ibid ibid-with-locator">
+              <!-- CMOS team suggests leaving out title in repeated references -->
+              <text macro="source-monographic-preposition-note"/>
+              <text font-style="italic" form="short" text-case="title" variable="container-title"/>
+            </if>
+          </choose>
         </if>
         <else-if type="article-journal" variable="container-title genre volume-title">
-          <text form="short" variable="genre"/>
           <!-- untitled introduction to a special issue or supplement -->
-          <text macro="source-monographic-preposition-note"/>
-          <text form="short" quotes="true" text-case="title" variable="volume-title"/>
+          <text form="short" variable="genre"/>
+          <choose>
+            <if match="none" position="ibid ibid-with-locator">
+              <text macro="source-monographic-preposition-note"/>
+              <text form="short" quotes="true" text-case="title" variable="volume-title"/>
+            </if>
+          </choose>
         </else-if>
         <else-if variable="genre">
           <text form="short" variable="genre"/>
@@ -2166,10 +2175,17 @@
     </choose>
   </macro>
   <macro name="description-review-short">
-    <group delimiter=" ">
-      <text term="review-of"/>
-      <text macro="description-review-title-short"/>
-    </group>
+    <choose>
+      <if match="any" position="ibid ibid-with-locator">
+        <text term="review"/>
+      </if>
+      <else>
+        <group delimiter=" ">
+          <text term="review-of"/>
+          <text macro="description-review-title-short"/>
+        </group>
+      </else>
+    </choose>
   </macro>
   <macro name="description-review-term-unsigned-bib">
     <!-- Anonymous reviews appear as 'unsigned' (CMOS18 14.102) -->

--- a/chicago-notes-bibliography-subsequent-author-title-17th-edition.csl
+++ b/chicago-notes-bibliography-subsequent-author-title-17th-edition.csl
@@ -1786,16 +1786,25 @@
     <group delimiter=" ">
       <choose>
         <if type="chapter" variable="container-title genre">
-          <text form="short" variable="genre"/>
           <!-- untitled introductions: cf. review model, which includes a title (CMOS18 14.101) -->
-          <text macro="source-monographic-preposition-note"/>
-          <text font-style="italic" form="short" text-case="title" variable="container-title"/>
+          <text form="short" variable="genre"/>
+          <choose>
+            <if match="none" position="ibid ibid-with-locator">
+              <!-- CMOS team suggests leaving out title in repeated references -->
+              <text macro="source-monographic-preposition-note"/>
+              <text font-style="italic" form="short" text-case="title" variable="container-title"/>
+            </if>
+          </choose>
         </if>
         <else-if type="article-journal" variable="container-title genre volume-title">
-          <text form="short" variable="genre"/>
           <!-- untitled introduction to a special issue or supplement -->
-          <text macro="source-monographic-preposition-note"/>
-          <text form="short" quotes="true" text-case="title" variable="volume-title"/>
+          <text form="short" variable="genre"/>
+          <choose>
+            <if match="none" position="ibid ibid-with-locator">
+              <text macro="source-monographic-preposition-note"/>
+              <text form="short" quotes="true" text-case="title" variable="volume-title"/>
+            </if>
+          </choose>
         </else-if>
         <else-if variable="genre">
           <text form="short" variable="genre"/>
@@ -2164,10 +2173,17 @@
     </choose>
   </macro>
   <macro name="description-review-short">
-    <group delimiter=" ">
-      <text term="review-of"/>
-      <text macro="description-review-title-short"/>
-    </group>
+    <choose>
+      <if match="any" position="ibid ibid-with-locator">
+        <text term="review"/>
+      </if>
+      <else>
+        <group delimiter=" ">
+          <text term="review-of"/>
+          <text macro="description-review-title-short"/>
+        </group>
+      </else>
+    </choose>
   </macro>
   <macro name="description-review-term-unsigned-bib">
     <!-- Anonymous reviews appear as 'unsigned' (CMOS18 14.102) -->

--- a/chicago-notes-bibliography-subsequent-author.csl
+++ b/chicago-notes-bibliography-subsequent-author.csl
@@ -1788,16 +1788,25 @@
     <group delimiter=" ">
       <choose>
         <if type="chapter" variable="container-title genre">
-          <text form="short" variable="genre"/>
           <!-- untitled introductions: cf. review model, which includes a title (CMOS18 14.101) -->
-          <text macro="source-monographic-preposition-note"/>
-          <text font-style="italic" form="short" text-case="title" variable="container-title"/>
+          <text form="short" variable="genre"/>
+          <choose>
+            <if match="none" position="ibid ibid-with-locator">
+              <!-- CMOS team suggests leaving out title in repeated references -->
+              <text macro="source-monographic-preposition-note"/>
+              <text font-style="italic" form="short" text-case="title" variable="container-title"/>
+            </if>
+          </choose>
         </if>
         <else-if type="article-journal" variable="container-title genre volume-title">
-          <text form="short" variable="genre"/>
           <!-- untitled introduction to a special issue or supplement -->
-          <text macro="source-monographic-preposition-note"/>
-          <text form="short" quotes="true" text-case="title" variable="volume-title"/>
+          <text form="short" variable="genre"/>
+          <choose>
+            <if match="none" position="ibid ibid-with-locator">
+              <text macro="source-monographic-preposition-note"/>
+              <text form="short" quotes="true" text-case="title" variable="volume-title"/>
+            </if>
+          </choose>
         </else-if>
         <else-if variable="genre">
           <text form="short" variable="genre"/>
@@ -2166,10 +2175,17 @@
     </choose>
   </macro>
   <macro name="description-review-short">
-    <group delimiter=" ">
-      <text term="review-of"/>
-      <text macro="description-review-title-short"/>
-    </group>
+    <choose>
+      <if match="any" position="ibid ibid-with-locator">
+        <text term="review"/>
+      </if>
+      <else>
+        <group delimiter=" ">
+          <text term="review-of"/>
+          <text macro="description-review-title-short"/>
+        </group>
+      </else>
+    </choose>
   </macro>
   <macro name="description-review-term-unsigned-bib">
     <!-- Anonymous reviews appear as 'unsigned' (CMOS18 14.102) -->

--- a/chicago-notes-bibliography-subsequent-ibid-17th-edition.csl
+++ b/chicago-notes-bibliography-subsequent-ibid-17th-edition.csl
@@ -1786,16 +1786,25 @@
     <group delimiter=" ">
       <choose>
         <if type="chapter" variable="container-title genre">
-          <text form="short" variable="genre"/>
           <!-- untitled introductions: cf. review model, which includes a title (CMOS18 14.101) -->
-          <text macro="source-monographic-preposition-note"/>
-          <text font-style="italic" form="short" text-case="title" variable="container-title"/>
+          <text form="short" variable="genre"/>
+          <choose>
+            <if match="none" position="ibid ibid-with-locator">
+              <!-- CMOS team suggests leaving out title in repeated references -->
+              <text macro="source-monographic-preposition-note"/>
+              <text font-style="italic" form="short" text-case="title" variable="container-title"/>
+            </if>
+          </choose>
         </if>
         <else-if type="article-journal" variable="container-title genre volume-title">
-          <text form="short" variable="genre"/>
           <!-- untitled introduction to a special issue or supplement -->
-          <text macro="source-monographic-preposition-note"/>
-          <text form="short" quotes="true" text-case="title" variable="volume-title"/>
+          <text form="short" variable="genre"/>
+          <choose>
+            <if match="none" position="ibid ibid-with-locator">
+              <text macro="source-monographic-preposition-note"/>
+              <text form="short" quotes="true" text-case="title" variable="volume-title"/>
+            </if>
+          </choose>
         </else-if>
         <else-if variable="genre">
           <text form="short" variable="genre"/>
@@ -2164,10 +2173,17 @@
     </choose>
   </macro>
   <macro name="description-review-short">
-    <group delimiter=" ">
-      <text term="review-of"/>
-      <text macro="description-review-title-short"/>
-    </group>
+    <choose>
+      <if match="any" position="ibid ibid-with-locator">
+        <text term="review"/>
+      </if>
+      <else>
+        <group delimiter=" ">
+          <text term="review-of"/>
+          <text macro="description-review-title-short"/>
+        </group>
+      </else>
+    </choose>
   </macro>
   <macro name="description-review-term-unsigned-bib">
     <!-- Anonymous reviews appear as 'unsigned' (CMOS18 14.102) -->

--- a/chicago-notes-bibliography-subsequent-ibid-classic-no-url.csl
+++ b/chicago-notes-bibliography-subsequent-ibid-classic-no-url.csl
@@ -1789,16 +1789,25 @@
     <group delimiter=" ">
       <choose>
         <if type="chapter" variable="container-title genre">
-          <text form="short" variable="genre"/>
           <!-- untitled introductions: cf. review model, which includes a title (CMOS18 14.101) -->
-          <text macro="source-monographic-preposition-note"/>
-          <text font-style="italic" form="short" text-case="title" variable="container-title"/>
+          <text form="short" variable="genre"/>
+          <choose>
+            <if match="none" position="ibid ibid-with-locator">
+              <!-- CMOS team suggests leaving out title in repeated references -->
+              <text macro="source-monographic-preposition-note"/>
+              <text font-style="italic" form="short" text-case="title" variable="container-title"/>
+            </if>
+          </choose>
         </if>
         <else-if type="article-journal" variable="container-title genre volume-title">
-          <text form="short" variable="genre"/>
           <!-- untitled introduction to a special issue or supplement -->
-          <text macro="source-monographic-preposition-note"/>
-          <text form="short" quotes="true" text-case="title" variable="volume-title"/>
+          <text form="short" variable="genre"/>
+          <choose>
+            <if match="none" position="ibid ibid-with-locator">
+              <text macro="source-monographic-preposition-note"/>
+              <text form="short" quotes="true" text-case="title" variable="volume-title"/>
+            </if>
+          </choose>
         </else-if>
         <else-if variable="genre">
           <text form="short" variable="genre"/>
@@ -2167,10 +2176,17 @@
     </choose>
   </macro>
   <macro name="description-review-short">
-    <group delimiter=" ">
-      <text term="review-of"/>
-      <text macro="description-review-title-short"/>
-    </group>
+    <choose>
+      <if match="any" position="ibid ibid-with-locator">
+        <text term="review"/>
+      </if>
+      <else>
+        <group delimiter=" ">
+          <text term="review-of"/>
+          <text macro="description-review-title-short"/>
+        </group>
+      </else>
+    </choose>
   </macro>
   <macro name="description-review-term-unsigned-bib">
     <!-- Anonymous reviews appear as 'unsigned' (CMOS18 14.102) -->

--- a/chicago-notes-bibliography-subsequent-ibid-classic.csl
+++ b/chicago-notes-bibliography-subsequent-ibid-classic.csl
@@ -1789,16 +1789,25 @@
     <group delimiter=" ">
       <choose>
         <if type="chapter" variable="container-title genre">
-          <text form="short" variable="genre"/>
           <!-- untitled introductions: cf. review model, which includes a title (CMOS18 14.101) -->
-          <text macro="source-monographic-preposition-note"/>
-          <text font-style="italic" form="short" text-case="title" variable="container-title"/>
+          <text form="short" variable="genre"/>
+          <choose>
+            <if match="none" position="ibid ibid-with-locator">
+              <!-- CMOS team suggests leaving out title in repeated references -->
+              <text macro="source-monographic-preposition-note"/>
+              <text font-style="italic" form="short" text-case="title" variable="container-title"/>
+            </if>
+          </choose>
         </if>
         <else-if type="article-journal" variable="container-title genre volume-title">
-          <text form="short" variable="genre"/>
           <!-- untitled introduction to a special issue or supplement -->
-          <text macro="source-monographic-preposition-note"/>
-          <text form="short" quotes="true" text-case="title" variable="volume-title"/>
+          <text form="short" variable="genre"/>
+          <choose>
+            <if match="none" position="ibid ibid-with-locator">
+              <text macro="source-monographic-preposition-note"/>
+              <text form="short" quotes="true" text-case="title" variable="volume-title"/>
+            </if>
+          </choose>
         </else-if>
         <else-if variable="genre">
           <text form="short" variable="genre"/>
@@ -2167,10 +2176,17 @@
     </choose>
   </macro>
   <macro name="description-review-short">
-    <group delimiter=" ">
-      <text term="review-of"/>
-      <text macro="description-review-title-short"/>
-    </group>
+    <choose>
+      <if match="any" position="ibid ibid-with-locator">
+        <text term="review"/>
+      </if>
+      <else>
+        <group delimiter=" ">
+          <text term="review-of"/>
+          <text macro="description-review-title-short"/>
+        </group>
+      </else>
+    </choose>
   </macro>
   <macro name="description-review-term-unsigned-bib">
     <!-- Anonymous reviews appear as 'unsigned' (CMOS18 14.102) -->

--- a/chicago-notes-bibliography-subsequent-ibid-no-url.csl
+++ b/chicago-notes-bibliography-subsequent-ibid-no-url.csl
@@ -1788,16 +1788,25 @@
     <group delimiter=" ">
       <choose>
         <if type="chapter" variable="container-title genre">
-          <text form="short" variable="genre"/>
           <!-- untitled introductions: cf. review model, which includes a title (CMOS18 14.101) -->
-          <text macro="source-monographic-preposition-note"/>
-          <text font-style="italic" form="short" text-case="title" variable="container-title"/>
+          <text form="short" variable="genre"/>
+          <choose>
+            <if match="none" position="ibid ibid-with-locator">
+              <!-- CMOS team suggests leaving out title in repeated references -->
+              <text macro="source-monographic-preposition-note"/>
+              <text font-style="italic" form="short" text-case="title" variable="container-title"/>
+            </if>
+          </choose>
         </if>
         <else-if type="article-journal" variable="container-title genre volume-title">
-          <text form="short" variable="genre"/>
           <!-- untitled introduction to a special issue or supplement -->
-          <text macro="source-monographic-preposition-note"/>
-          <text form="short" quotes="true" text-case="title" variable="volume-title"/>
+          <text form="short" variable="genre"/>
+          <choose>
+            <if match="none" position="ibid ibid-with-locator">
+              <text macro="source-monographic-preposition-note"/>
+              <text form="short" quotes="true" text-case="title" variable="volume-title"/>
+            </if>
+          </choose>
         </else-if>
         <else-if variable="genre">
           <text form="short" variable="genre"/>
@@ -2166,10 +2175,17 @@
     </choose>
   </macro>
   <macro name="description-review-short">
-    <group delimiter=" ">
-      <text term="review-of"/>
-      <text macro="description-review-title-short"/>
-    </group>
+    <choose>
+      <if match="any" position="ibid ibid-with-locator">
+        <text term="review"/>
+      </if>
+      <else>
+        <group delimiter=" ">
+          <text term="review-of"/>
+          <text macro="description-review-title-short"/>
+        </group>
+      </else>
+    </choose>
   </macro>
   <macro name="description-review-term-unsigned-bib">
     <!-- Anonymous reviews appear as 'unsigned' (CMOS18 14.102) -->

--- a/chicago-notes-bibliography-subsequent-ibid.csl
+++ b/chicago-notes-bibliography-subsequent-ibid.csl
@@ -1788,16 +1788,25 @@
     <group delimiter=" ">
       <choose>
         <if type="chapter" variable="container-title genre">
-          <text form="short" variable="genre"/>
           <!-- untitled introductions: cf. review model, which includes a title (CMOS18 14.101) -->
-          <text macro="source-monographic-preposition-note"/>
-          <text font-style="italic" form="short" text-case="title" variable="container-title"/>
+          <text form="short" variable="genre"/>
+          <choose>
+            <if match="none" position="ibid ibid-with-locator">
+              <!-- CMOS team suggests leaving out title in repeated references -->
+              <text macro="source-monographic-preposition-note"/>
+              <text font-style="italic" form="short" text-case="title" variable="container-title"/>
+            </if>
+          </choose>
         </if>
         <else-if type="article-journal" variable="container-title genre volume-title">
-          <text form="short" variable="genre"/>
           <!-- untitled introduction to a special issue or supplement -->
-          <text macro="source-monographic-preposition-note"/>
-          <text form="short" quotes="true" text-case="title" variable="volume-title"/>
+          <text form="short" variable="genre"/>
+          <choose>
+            <if match="none" position="ibid ibid-with-locator">
+              <text macro="source-monographic-preposition-note"/>
+              <text form="short" quotes="true" text-case="title" variable="volume-title"/>
+            </if>
+          </choose>
         </else-if>
         <else-if variable="genre">
           <text form="short" variable="genre"/>
@@ -2166,10 +2175,17 @@
     </choose>
   </macro>
   <macro name="description-review-short">
-    <group delimiter=" ">
-      <text term="review-of"/>
-      <text macro="description-review-title-short"/>
-    </group>
+    <choose>
+      <if match="any" position="ibid ibid-with-locator">
+        <text term="review"/>
+      </if>
+      <else>
+        <group delimiter=" ">
+          <text term="review-of"/>
+          <text macro="description-review-title-short"/>
+        </group>
+      </else>
+    </choose>
   </macro>
   <macro name="description-review-term-unsigned-bib">
     <!-- Anonymous reviews appear as 'unsigned' (CMOS18 14.102) -->

--- a/chicago-notes-bibliography-subsequent-title-no-url.csl
+++ b/chicago-notes-bibliography-subsequent-title-no-url.csl
@@ -1788,16 +1788,25 @@
     <group delimiter=" ">
       <choose>
         <if type="chapter" variable="container-title genre">
-          <text form="short" variable="genre"/>
           <!-- untitled introductions: cf. review model, which includes a title (CMOS18 14.101) -->
-          <text macro="source-monographic-preposition-note"/>
-          <text font-style="italic" form="short" text-case="title" variable="container-title"/>
+          <text form="short" variable="genre"/>
+          <choose>
+            <if match="none" position="ibid ibid-with-locator">
+              <!-- CMOS team suggests leaving out title in repeated references -->
+              <text macro="source-monographic-preposition-note"/>
+              <text font-style="italic" form="short" text-case="title" variable="container-title"/>
+            </if>
+          </choose>
         </if>
         <else-if type="article-journal" variable="container-title genre volume-title">
-          <text form="short" variable="genre"/>
           <!-- untitled introduction to a special issue or supplement -->
-          <text macro="source-monographic-preposition-note"/>
-          <text form="short" quotes="true" text-case="title" variable="volume-title"/>
+          <text form="short" variable="genre"/>
+          <choose>
+            <if match="none" position="ibid ibid-with-locator">
+              <text macro="source-monographic-preposition-note"/>
+              <text form="short" quotes="true" text-case="title" variable="volume-title"/>
+            </if>
+          </choose>
         </else-if>
         <else-if variable="genre">
           <text form="short" variable="genre"/>
@@ -2166,10 +2175,17 @@
     </choose>
   </macro>
   <macro name="description-review-short">
-    <group delimiter=" ">
-      <text term="review-of"/>
-      <text macro="description-review-title-short"/>
-    </group>
+    <choose>
+      <if match="any" position="ibid ibid-with-locator">
+        <text term="review"/>
+      </if>
+      <else>
+        <group delimiter=" ">
+          <text term="review-of"/>
+          <text macro="description-review-title-short"/>
+        </group>
+      </else>
+    </choose>
   </macro>
   <macro name="description-review-term-unsigned-bib">
     <!-- Anonymous reviews appear as 'unsigned' (CMOS18 14.102) -->

--- a/chicago-notes-bibliography-subsequent-title.csl
+++ b/chicago-notes-bibliography-subsequent-title.csl
@@ -1788,16 +1788,25 @@
     <group delimiter=" ">
       <choose>
         <if type="chapter" variable="container-title genre">
-          <text form="short" variable="genre"/>
           <!-- untitled introductions: cf. review model, which includes a title (CMOS18 14.101) -->
-          <text macro="source-monographic-preposition-note"/>
-          <text font-style="italic" form="short" text-case="title" variable="container-title"/>
+          <text form="short" variable="genre"/>
+          <choose>
+            <if match="none" position="ibid ibid-with-locator">
+              <!-- CMOS team suggests leaving out title in repeated references -->
+              <text macro="source-monographic-preposition-note"/>
+              <text font-style="italic" form="short" text-case="title" variable="container-title"/>
+            </if>
+          </choose>
         </if>
         <else-if type="article-journal" variable="container-title genre volume-title">
-          <text form="short" variable="genre"/>
           <!-- untitled introduction to a special issue or supplement -->
-          <text macro="source-monographic-preposition-note"/>
-          <text form="short" quotes="true" text-case="title" variable="volume-title"/>
+          <text form="short" variable="genre"/>
+          <choose>
+            <if match="none" position="ibid ibid-with-locator">
+              <text macro="source-monographic-preposition-note"/>
+              <text form="short" quotes="true" text-case="title" variable="volume-title"/>
+            </if>
+          </choose>
         </else-if>
         <else-if variable="genre">
           <text form="short" variable="genre"/>
@@ -2166,10 +2175,17 @@
     </choose>
   </macro>
   <macro name="description-review-short">
-    <group delimiter=" ">
-      <text term="review-of"/>
-      <text macro="description-review-title-short"/>
-    </group>
+    <choose>
+      <if match="any" position="ibid ibid-with-locator">
+        <text term="review"/>
+      </if>
+      <else>
+        <group delimiter=" ">
+          <text term="review-of"/>
+          <text macro="description-review-title-short"/>
+        </group>
+      </else>
+    </choose>
   </macro>
   <macro name="description-review-term-unsigned-bib">
     <!-- Anonymous reviews appear as 'unsigned' (CMOS18 14.102) -->

--- a/chicago-notes-bibliography.csl
+++ b/chicago-notes-bibliography.csl
@@ -1788,16 +1788,25 @@
     <group delimiter=" ">
       <choose>
         <if type="chapter" variable="container-title genre">
-          <text form="short" variable="genre"/>
           <!-- untitled introductions: cf. review model, which includes a title (CMOS18 14.101) -->
-          <text macro="source-monographic-preposition-note"/>
-          <text font-style="italic" form="short" text-case="title" variable="container-title"/>
+          <text form="short" variable="genre"/>
+          <choose>
+            <if match="none" position="ibid ibid-with-locator">
+              <!-- CMOS team suggests leaving out title in repeated references -->
+              <text macro="source-monographic-preposition-note"/>
+              <text font-style="italic" form="short" text-case="title" variable="container-title"/>
+            </if>
+          </choose>
         </if>
         <else-if type="article-journal" variable="container-title genre volume-title">
-          <text form="short" variable="genre"/>
           <!-- untitled introduction to a special issue or supplement -->
-          <text macro="source-monographic-preposition-note"/>
-          <text form="short" quotes="true" text-case="title" variable="volume-title"/>
+          <text form="short" variable="genre"/>
+          <choose>
+            <if match="none" position="ibid ibid-with-locator">
+              <text macro="source-monographic-preposition-note"/>
+              <text form="short" quotes="true" text-case="title" variable="volume-title"/>
+            </if>
+          </choose>
         </else-if>
         <else-if variable="genre">
           <text form="short" variable="genre"/>
@@ -2166,10 +2175,17 @@
     </choose>
   </macro>
   <macro name="description-review-short">
-    <group delimiter=" ">
-      <text term="review-of"/>
-      <text macro="description-review-title-short"/>
-    </group>
+    <choose>
+      <if match="any" position="ibid ibid-with-locator">
+        <text term="review"/>
+      </if>
+      <else>
+        <group delimiter=" ">
+          <text term="review-of"/>
+          <text macro="description-review-title-short"/>
+        </group>
+      </else>
+    </choose>
   </macro>
   <macro name="description-review-term-unsigned-bib">
     <!-- Anonymous reviews appear as 'unsigned' (CMOS18 14.102) -->

--- a/chicago-notes-classic-archive-place-first-no-url.csl
+++ b/chicago-notes-classic-archive-place-first-no-url.csl
@@ -1593,16 +1593,25 @@
     <group delimiter=" ">
       <choose>
         <if type="chapter" variable="container-title genre">
-          <text form="short" variable="genre"/>
           <!-- untitled introductions: cf. review model, which includes a title (CMOS18 14.101) -->
-          <text macro="source-monographic-preposition-note"/>
-          <text font-style="italic" form="short" text-case="title" variable="container-title"/>
+          <text form="short" variable="genre"/>
+          <choose>
+            <if match="none" position="ibid ibid-with-locator">
+              <!-- CMOS team suggests leaving out title in repeated references -->
+              <text macro="source-monographic-preposition-note"/>
+              <text font-style="italic" form="short" text-case="title" variable="container-title"/>
+            </if>
+          </choose>
         </if>
         <else-if type="article-journal" variable="container-title genre volume-title">
-          <text form="short" variable="genre"/>
           <!-- untitled introduction to a special issue or supplement -->
-          <text macro="source-monographic-preposition-note"/>
-          <text form="short" quotes="true" text-case="title" variable="volume-title"/>
+          <text form="short" variable="genre"/>
+          <choose>
+            <if match="none" position="ibid ibid-with-locator">
+              <text macro="source-monographic-preposition-note"/>
+              <text form="short" quotes="true" text-case="title" variable="volume-title"/>
+            </if>
+          </choose>
         </else-if>
         <else-if variable="genre">
           <text form="short" variable="genre"/>
@@ -1971,10 +1980,17 @@
     </choose>
   </macro>
   <macro name="description-review-short">
-    <group delimiter=" ">
-      <text term="review-of"/>
-      <text macro="description-review-title-short"/>
-    </group>
+    <choose>
+      <if match="any" position="ibid ibid-with-locator">
+        <text term="review"/>
+      </if>
+      <else>
+        <group delimiter=" ">
+          <text term="review-of"/>
+          <text macro="description-review-title-short"/>
+        </group>
+      </else>
+    </choose>
   </macro>
   <macro name="description-review-term-unsigned-bib">
     <!-- Anonymous reviews appear as 'unsigned' (CMOS18 14.102) -->

--- a/chicago-notes-classic-archive-place-first.csl
+++ b/chicago-notes-classic-archive-place-first.csl
@@ -1593,16 +1593,25 @@
     <group delimiter=" ">
       <choose>
         <if type="chapter" variable="container-title genre">
-          <text form="short" variable="genre"/>
           <!-- untitled introductions: cf. review model, which includes a title (CMOS18 14.101) -->
-          <text macro="source-monographic-preposition-note"/>
-          <text font-style="italic" form="short" text-case="title" variable="container-title"/>
+          <text form="short" variable="genre"/>
+          <choose>
+            <if match="none" position="ibid ibid-with-locator">
+              <!-- CMOS team suggests leaving out title in repeated references -->
+              <text macro="source-monographic-preposition-note"/>
+              <text font-style="italic" form="short" text-case="title" variable="container-title"/>
+            </if>
+          </choose>
         </if>
         <else-if type="article-journal" variable="container-title genre volume-title">
-          <text form="short" variable="genre"/>
           <!-- untitled introduction to a special issue or supplement -->
-          <text macro="source-monographic-preposition-note"/>
-          <text form="short" quotes="true" text-case="title" variable="volume-title"/>
+          <text form="short" variable="genre"/>
+          <choose>
+            <if match="none" position="ibid ibid-with-locator">
+              <text macro="source-monographic-preposition-note"/>
+              <text form="short" quotes="true" text-case="title" variable="volume-title"/>
+            </if>
+          </choose>
         </else-if>
         <else-if variable="genre">
           <text form="short" variable="genre"/>
@@ -1971,10 +1980,17 @@
     </choose>
   </macro>
   <macro name="description-review-short">
-    <group delimiter=" ">
-      <text term="review-of"/>
-      <text macro="description-review-title-short"/>
-    </group>
+    <choose>
+      <if match="any" position="ibid ibid-with-locator">
+        <text term="review"/>
+      </if>
+      <else>
+        <group delimiter=" ">
+          <text term="review-of"/>
+          <text macro="description-review-title-short"/>
+        </group>
+      </else>
+    </choose>
   </macro>
   <macro name="description-review-term-unsigned-bib">
     <!-- Anonymous reviews appear as 'unsigned' (CMOS18 14.102) -->

--- a/chicago-notes-classic-no-url.csl
+++ b/chicago-notes-classic-no-url.csl
@@ -1593,16 +1593,25 @@
     <group delimiter=" ">
       <choose>
         <if type="chapter" variable="container-title genre">
-          <text form="short" variable="genre"/>
           <!-- untitled introductions: cf. review model, which includes a title (CMOS18 14.101) -->
-          <text macro="source-monographic-preposition-note"/>
-          <text font-style="italic" form="short" text-case="title" variable="container-title"/>
+          <text form="short" variable="genre"/>
+          <choose>
+            <if match="none" position="ibid ibid-with-locator">
+              <!-- CMOS team suggests leaving out title in repeated references -->
+              <text macro="source-monographic-preposition-note"/>
+              <text font-style="italic" form="short" text-case="title" variable="container-title"/>
+            </if>
+          </choose>
         </if>
         <else-if type="article-journal" variable="container-title genre volume-title">
-          <text form="short" variable="genre"/>
           <!-- untitled introduction to a special issue or supplement -->
-          <text macro="source-monographic-preposition-note"/>
-          <text form="short" quotes="true" text-case="title" variable="volume-title"/>
+          <text form="short" variable="genre"/>
+          <choose>
+            <if match="none" position="ibid ibid-with-locator">
+              <text macro="source-monographic-preposition-note"/>
+              <text form="short" quotes="true" text-case="title" variable="volume-title"/>
+            </if>
+          </choose>
         </else-if>
         <else-if variable="genre">
           <text form="short" variable="genre"/>
@@ -1971,10 +1980,17 @@
     </choose>
   </macro>
   <macro name="description-review-short">
-    <group delimiter=" ">
-      <text term="review-of"/>
-      <text macro="description-review-title-short"/>
-    </group>
+    <choose>
+      <if match="any" position="ibid ibid-with-locator">
+        <text term="review"/>
+      </if>
+      <else>
+        <group delimiter=" ">
+          <text term="review-of"/>
+          <text macro="description-review-title-short"/>
+        </group>
+      </else>
+    </choose>
   </macro>
   <macro name="description-review-term-unsigned-bib">
     <!-- Anonymous reviews appear as 'unsigned' (CMOS18 14.102) -->

--- a/chicago-notes-classic.csl
+++ b/chicago-notes-classic.csl
@@ -1593,16 +1593,25 @@
     <group delimiter=" ">
       <choose>
         <if type="chapter" variable="container-title genre">
-          <text form="short" variable="genre"/>
           <!-- untitled introductions: cf. review model, which includes a title (CMOS18 14.101) -->
-          <text macro="source-monographic-preposition-note"/>
-          <text font-style="italic" form="short" text-case="title" variable="container-title"/>
+          <text form="short" variable="genre"/>
+          <choose>
+            <if match="none" position="ibid ibid-with-locator">
+              <!-- CMOS team suggests leaving out title in repeated references -->
+              <text macro="source-monographic-preposition-note"/>
+              <text font-style="italic" form="short" text-case="title" variable="container-title"/>
+            </if>
+          </choose>
         </if>
         <else-if type="article-journal" variable="container-title genre volume-title">
-          <text form="short" variable="genre"/>
           <!-- untitled introduction to a special issue or supplement -->
-          <text macro="source-monographic-preposition-note"/>
-          <text form="short" quotes="true" text-case="title" variable="volume-title"/>
+          <text form="short" variable="genre"/>
+          <choose>
+            <if match="none" position="ibid ibid-with-locator">
+              <text macro="source-monographic-preposition-note"/>
+              <text form="short" quotes="true" text-case="title" variable="volume-title"/>
+            </if>
+          </choose>
         </else-if>
         <else-if variable="genre">
           <text form="short" variable="genre"/>
@@ -1971,10 +1980,17 @@
     </choose>
   </macro>
   <macro name="description-review-short">
-    <group delimiter=" ">
-      <text term="review-of"/>
-      <text macro="description-review-title-short"/>
-    </group>
+    <choose>
+      <if match="any" position="ibid ibid-with-locator">
+        <text term="review"/>
+      </if>
+      <else>
+        <group delimiter=" ">
+          <text term="review-of"/>
+          <text macro="description-review-title-short"/>
+        </group>
+      </else>
+    </choose>
   </macro>
   <macro name="description-review-term-unsigned-bib">
     <!-- Anonymous reviews appear as 'unsigned' (CMOS18 14.102) -->

--- a/chicago-notes-no-url.csl
+++ b/chicago-notes-no-url.csl
@@ -1593,16 +1593,25 @@
     <group delimiter=" ">
       <choose>
         <if type="chapter" variable="container-title genre">
-          <text form="short" variable="genre"/>
           <!-- untitled introductions: cf. review model, which includes a title (CMOS18 14.101) -->
-          <text macro="source-monographic-preposition-note"/>
-          <text font-style="italic" form="short" text-case="title" variable="container-title"/>
+          <text form="short" variable="genre"/>
+          <choose>
+            <if match="none" position="ibid ibid-with-locator">
+              <!-- CMOS team suggests leaving out title in repeated references -->
+              <text macro="source-monographic-preposition-note"/>
+              <text font-style="italic" form="short" text-case="title" variable="container-title"/>
+            </if>
+          </choose>
         </if>
         <else-if type="article-journal" variable="container-title genre volume-title">
-          <text form="short" variable="genre"/>
           <!-- untitled introduction to a special issue or supplement -->
-          <text macro="source-monographic-preposition-note"/>
-          <text form="short" quotes="true" text-case="title" variable="volume-title"/>
+          <text form="short" variable="genre"/>
+          <choose>
+            <if match="none" position="ibid ibid-with-locator">
+              <text macro="source-monographic-preposition-note"/>
+              <text form="short" quotes="true" text-case="title" variable="volume-title"/>
+            </if>
+          </choose>
         </else-if>
         <else-if variable="genre">
           <text form="short" variable="genre"/>
@@ -1971,10 +1980,17 @@
     </choose>
   </macro>
   <macro name="description-review-short">
-    <group delimiter=" ">
-      <text term="review-of"/>
-      <text macro="description-review-title-short"/>
-    </group>
+    <choose>
+      <if match="any" position="ibid ibid-with-locator">
+        <text term="review"/>
+      </if>
+      <else>
+        <group delimiter=" ">
+          <text term="review-of"/>
+          <text macro="description-review-title-short"/>
+        </group>
+      </else>
+    </choose>
   </macro>
   <macro name="description-review-term-unsigned-bib">
     <!-- Anonymous reviews appear as 'unsigned' (CMOS18 14.102) -->

--- a/chicago-notes-publisher-place-archive-place-first-no-url.csl
+++ b/chicago-notes-publisher-place-archive-place-first-no-url.csl
@@ -1593,16 +1593,25 @@
     <group delimiter=" ">
       <choose>
         <if type="chapter" variable="container-title genre">
-          <text form="short" variable="genre"/>
           <!-- untitled introductions: cf. review model, which includes a title (CMOS18 14.101) -->
-          <text macro="source-monographic-preposition-note"/>
-          <text font-style="italic" form="short" text-case="title" variable="container-title"/>
+          <text form="short" variable="genre"/>
+          <choose>
+            <if match="none" position="ibid ibid-with-locator">
+              <!-- CMOS team suggests leaving out title in repeated references -->
+              <text macro="source-monographic-preposition-note"/>
+              <text font-style="italic" form="short" text-case="title" variable="container-title"/>
+            </if>
+          </choose>
         </if>
         <else-if type="article-journal" variable="container-title genre volume-title">
-          <text form="short" variable="genre"/>
           <!-- untitled introduction to a special issue or supplement -->
-          <text macro="source-monographic-preposition-note"/>
-          <text form="short" quotes="true" text-case="title" variable="volume-title"/>
+          <text form="short" variable="genre"/>
+          <choose>
+            <if match="none" position="ibid ibid-with-locator">
+              <text macro="source-monographic-preposition-note"/>
+              <text form="short" quotes="true" text-case="title" variable="volume-title"/>
+            </if>
+          </choose>
         </else-if>
         <else-if variable="genre">
           <text form="short" variable="genre"/>
@@ -1971,10 +1980,17 @@
     </choose>
   </macro>
   <macro name="description-review-short">
-    <group delimiter=" ">
-      <text term="review-of"/>
-      <text macro="description-review-title-short"/>
-    </group>
+    <choose>
+      <if match="any" position="ibid ibid-with-locator">
+        <text term="review"/>
+      </if>
+      <else>
+        <group delimiter=" ">
+          <text term="review-of"/>
+          <text macro="description-review-title-short"/>
+        </group>
+      </else>
+    </choose>
   </macro>
   <macro name="description-review-term-unsigned-bib">
     <!-- Anonymous reviews appear as 'unsigned' (CMOS18 14.102) -->

--- a/chicago-notes-publisher-place-archive-place-first.csl
+++ b/chicago-notes-publisher-place-archive-place-first.csl
@@ -1593,16 +1593,25 @@
     <group delimiter=" ">
       <choose>
         <if type="chapter" variable="container-title genre">
-          <text form="short" variable="genre"/>
           <!-- untitled introductions: cf. review model, which includes a title (CMOS18 14.101) -->
-          <text macro="source-monographic-preposition-note"/>
-          <text font-style="italic" form="short" text-case="title" variable="container-title"/>
+          <text form="short" variable="genre"/>
+          <choose>
+            <if match="none" position="ibid ibid-with-locator">
+              <!-- CMOS team suggests leaving out title in repeated references -->
+              <text macro="source-monographic-preposition-note"/>
+              <text font-style="italic" form="short" text-case="title" variable="container-title"/>
+            </if>
+          </choose>
         </if>
         <else-if type="article-journal" variable="container-title genre volume-title">
-          <text form="short" variable="genre"/>
           <!-- untitled introduction to a special issue or supplement -->
-          <text macro="source-monographic-preposition-note"/>
-          <text form="short" quotes="true" text-case="title" variable="volume-title"/>
+          <text form="short" variable="genre"/>
+          <choose>
+            <if match="none" position="ibid ibid-with-locator">
+              <text macro="source-monographic-preposition-note"/>
+              <text form="short" quotes="true" text-case="title" variable="volume-title"/>
+            </if>
+          </choose>
         </else-if>
         <else-if variable="genre">
           <text form="short" variable="genre"/>
@@ -1971,10 +1980,17 @@
     </choose>
   </macro>
   <macro name="description-review-short">
-    <group delimiter=" ">
-      <text term="review-of"/>
-      <text macro="description-review-title-short"/>
-    </group>
+    <choose>
+      <if match="any" position="ibid ibid-with-locator">
+        <text term="review"/>
+      </if>
+      <else>
+        <group delimiter=" ">
+          <text term="review-of"/>
+          <text macro="description-review-title-short"/>
+        </group>
+      </else>
+    </choose>
   </macro>
   <macro name="description-review-term-unsigned-bib">
     <!-- Anonymous reviews appear as 'unsigned' (CMOS18 14.102) -->

--- a/chicago-notes-publisher-place-label-page-archive-place-first-no-url.csl
+++ b/chicago-notes-publisher-place-label-page-archive-place-first-no-url.csl
@@ -1592,16 +1592,25 @@
     <group delimiter=" ">
       <choose>
         <if type="chapter" variable="container-title genre">
-          <text form="short" variable="genre"/>
           <!-- untitled introductions: cf. review model, which includes a title (CMOS18 14.101) -->
-          <text macro="source-monographic-preposition-note"/>
-          <text font-style="italic" form="short" text-case="title" variable="container-title"/>
+          <text form="short" variable="genre"/>
+          <choose>
+            <if match="none" position="ibid ibid-with-locator">
+              <!-- CMOS team suggests leaving out title in repeated references -->
+              <text macro="source-monographic-preposition-note"/>
+              <text font-style="italic" form="short" text-case="title" variable="container-title"/>
+            </if>
+          </choose>
         </if>
         <else-if type="article-journal" variable="container-title genre volume-title">
-          <text form="short" variable="genre"/>
           <!-- untitled introduction to a special issue or supplement -->
-          <text macro="source-monographic-preposition-note"/>
-          <text form="short" quotes="true" text-case="title" variable="volume-title"/>
+          <text form="short" variable="genre"/>
+          <choose>
+            <if match="none" position="ibid ibid-with-locator">
+              <text macro="source-monographic-preposition-note"/>
+              <text form="short" quotes="true" text-case="title" variable="volume-title"/>
+            </if>
+          </choose>
         </else-if>
         <else-if variable="genre">
           <text form="short" variable="genre"/>
@@ -1970,10 +1979,17 @@
     </choose>
   </macro>
   <macro name="description-review-short">
-    <group delimiter=" ">
-      <text term="review-of"/>
-      <text macro="description-review-title-short"/>
-    </group>
+    <choose>
+      <if match="any" position="ibid ibid-with-locator">
+        <text term="review"/>
+      </if>
+      <else>
+        <group delimiter=" ">
+          <text term="review-of"/>
+          <text macro="description-review-title-short"/>
+        </group>
+      </else>
+    </choose>
   </macro>
   <macro name="description-review-term-unsigned-bib">
     <!-- Anonymous reviews appear as 'unsigned' (CMOS18 14.102) -->

--- a/chicago-notes-publisher-place-label-page-archive-place-first.csl
+++ b/chicago-notes-publisher-place-label-page-archive-place-first.csl
@@ -1592,16 +1592,25 @@
     <group delimiter=" ">
       <choose>
         <if type="chapter" variable="container-title genre">
-          <text form="short" variable="genre"/>
           <!-- untitled introductions: cf. review model, which includes a title (CMOS18 14.101) -->
-          <text macro="source-monographic-preposition-note"/>
-          <text font-style="italic" form="short" text-case="title" variable="container-title"/>
+          <text form="short" variable="genre"/>
+          <choose>
+            <if match="none" position="ibid ibid-with-locator">
+              <!-- CMOS team suggests leaving out title in repeated references -->
+              <text macro="source-monographic-preposition-note"/>
+              <text font-style="italic" form="short" text-case="title" variable="container-title"/>
+            </if>
+          </choose>
         </if>
         <else-if type="article-journal" variable="container-title genre volume-title">
-          <text form="short" variable="genre"/>
           <!-- untitled introduction to a special issue or supplement -->
-          <text macro="source-monographic-preposition-note"/>
-          <text form="short" quotes="true" text-case="title" variable="volume-title"/>
+          <text form="short" variable="genre"/>
+          <choose>
+            <if match="none" position="ibid ibid-with-locator">
+              <text macro="source-monographic-preposition-note"/>
+              <text form="short" quotes="true" text-case="title" variable="volume-title"/>
+            </if>
+          </choose>
         </else-if>
         <else-if variable="genre">
           <text form="short" variable="genre"/>
@@ -1970,10 +1979,17 @@
     </choose>
   </macro>
   <macro name="description-review-short">
-    <group delimiter=" ">
-      <text term="review-of"/>
-      <text macro="description-review-title-short"/>
-    </group>
+    <choose>
+      <if match="any" position="ibid ibid-with-locator">
+        <text term="review"/>
+      </if>
+      <else>
+        <group delimiter=" ">
+          <text term="review-of"/>
+          <text macro="description-review-title-short"/>
+        </group>
+      </else>
+    </choose>
   </macro>
   <macro name="description-review-term-unsigned-bib">
     <!-- Anonymous reviews appear as 'unsigned' (CMOS18 14.102) -->

--- a/chicago-notes-publisher-place-no-url.csl
+++ b/chicago-notes-publisher-place-no-url.csl
@@ -1593,16 +1593,25 @@
     <group delimiter=" ">
       <choose>
         <if type="chapter" variable="container-title genre">
-          <text form="short" variable="genre"/>
           <!-- untitled introductions: cf. review model, which includes a title (CMOS18 14.101) -->
-          <text macro="source-monographic-preposition-note"/>
-          <text font-style="italic" form="short" text-case="title" variable="container-title"/>
+          <text form="short" variable="genre"/>
+          <choose>
+            <if match="none" position="ibid ibid-with-locator">
+              <!-- CMOS team suggests leaving out title in repeated references -->
+              <text macro="source-monographic-preposition-note"/>
+              <text font-style="italic" form="short" text-case="title" variable="container-title"/>
+            </if>
+          </choose>
         </if>
         <else-if type="article-journal" variable="container-title genre volume-title">
-          <text form="short" variable="genre"/>
           <!-- untitled introduction to a special issue or supplement -->
-          <text macro="source-monographic-preposition-note"/>
-          <text form="short" quotes="true" text-case="title" variable="volume-title"/>
+          <text form="short" variable="genre"/>
+          <choose>
+            <if match="none" position="ibid ibid-with-locator">
+              <text macro="source-monographic-preposition-note"/>
+              <text form="short" quotes="true" text-case="title" variable="volume-title"/>
+            </if>
+          </choose>
         </else-if>
         <else-if variable="genre">
           <text form="short" variable="genre"/>
@@ -1971,10 +1980,17 @@
     </choose>
   </macro>
   <macro name="description-review-short">
-    <group delimiter=" ">
-      <text term="review-of"/>
-      <text macro="description-review-title-short"/>
-    </group>
+    <choose>
+      <if match="any" position="ibid ibid-with-locator">
+        <text term="review"/>
+      </if>
+      <else>
+        <group delimiter=" ">
+          <text term="review-of"/>
+          <text macro="description-review-title-short"/>
+        </group>
+      </else>
+    </choose>
   </macro>
   <macro name="description-review-term-unsigned-bib">
     <!-- Anonymous reviews appear as 'unsigned' (CMOS18 14.102) -->

--- a/chicago-notes-publisher-place.csl
+++ b/chicago-notes-publisher-place.csl
@@ -1593,16 +1593,25 @@
     <group delimiter=" ">
       <choose>
         <if type="chapter" variable="container-title genre">
-          <text form="short" variable="genre"/>
           <!-- untitled introductions: cf. review model, which includes a title (CMOS18 14.101) -->
-          <text macro="source-monographic-preposition-note"/>
-          <text font-style="italic" form="short" text-case="title" variable="container-title"/>
+          <text form="short" variable="genre"/>
+          <choose>
+            <if match="none" position="ibid ibid-with-locator">
+              <!-- CMOS team suggests leaving out title in repeated references -->
+              <text macro="source-monographic-preposition-note"/>
+              <text font-style="italic" form="short" text-case="title" variable="container-title"/>
+            </if>
+          </choose>
         </if>
         <else-if type="article-journal" variable="container-title genre volume-title">
-          <text form="short" variable="genre"/>
           <!-- untitled introduction to a special issue or supplement -->
-          <text macro="source-monographic-preposition-note"/>
-          <text form="short" quotes="true" text-case="title" variable="volume-title"/>
+          <text form="short" variable="genre"/>
+          <choose>
+            <if match="none" position="ibid ibid-with-locator">
+              <text macro="source-monographic-preposition-note"/>
+              <text form="short" quotes="true" text-case="title" variable="volume-title"/>
+            </if>
+          </choose>
         </else-if>
         <else-if variable="genre">
           <text form="short" variable="genre"/>
@@ -1971,10 +1980,17 @@
     </choose>
   </macro>
   <macro name="description-review-short">
-    <group delimiter=" ">
-      <text term="review-of"/>
-      <text macro="description-review-title-short"/>
-    </group>
+    <choose>
+      <if match="any" position="ibid ibid-with-locator">
+        <text term="review"/>
+      </if>
+      <else>
+        <group delimiter=" ">
+          <text term="review-of"/>
+          <text macro="description-review-title-short"/>
+        </group>
+      </else>
+    </choose>
   </macro>
   <macro name="description-review-term-unsigned-bib">
     <!-- Anonymous reviews appear as 'unsigned' (CMOS18 14.102) -->

--- a/chicago-notes.csl
+++ b/chicago-notes.csl
@@ -1593,16 +1593,25 @@
     <group delimiter=" ">
       <choose>
         <if type="chapter" variable="container-title genre">
-          <text form="short" variable="genre"/>
           <!-- untitled introductions: cf. review model, which includes a title (CMOS18 14.101) -->
-          <text macro="source-monographic-preposition-note"/>
-          <text font-style="italic" form="short" text-case="title" variable="container-title"/>
+          <text form="short" variable="genre"/>
+          <choose>
+            <if match="none" position="ibid ibid-with-locator">
+              <!-- CMOS team suggests leaving out title in repeated references -->
+              <text macro="source-monographic-preposition-note"/>
+              <text font-style="italic" form="short" text-case="title" variable="container-title"/>
+            </if>
+          </choose>
         </if>
         <else-if type="article-journal" variable="container-title genre volume-title">
-          <text form="short" variable="genre"/>
           <!-- untitled introduction to a special issue or supplement -->
-          <text macro="source-monographic-preposition-note"/>
-          <text form="short" quotes="true" text-case="title" variable="volume-title"/>
+          <text form="short" variable="genre"/>
+          <choose>
+            <if match="none" position="ibid ibid-with-locator">
+              <text macro="source-monographic-preposition-note"/>
+              <text form="short" quotes="true" text-case="title" variable="volume-title"/>
+            </if>
+          </choose>
         </else-if>
         <else-if variable="genre">
           <text form="short" variable="genre"/>
@@ -1971,10 +1980,17 @@
     </choose>
   </macro>
   <macro name="description-review-short">
-    <group delimiter=" ">
-      <text term="review-of"/>
-      <text macro="description-review-title-short"/>
-    </group>
+    <choose>
+      <if match="any" position="ibid ibid-with-locator">
+        <text term="review"/>
+      </if>
+      <else>
+        <group delimiter=" ">
+          <text term="review-of"/>
+          <text macro="description-review-title-short"/>
+        </group>
+      </else>
+    </choose>
   </macro>
   <macro name="description-review-term-unsigned-bib">
     <!-- Anonymous reviews appear as 'unsigned' (CMOS18 14.102) -->

--- a/chicago-shortened-notes-bibliography-17th-edition.csl
+++ b/chicago-shortened-notes-bibliography-17th-edition.csl
@@ -1446,16 +1446,25 @@
     <group delimiter=" ">
       <choose>
         <if type="chapter" variable="container-title genre">
-          <text form="short" variable="genre"/>
           <!-- untitled introductions: cf. review model, which includes a title (CMOS18 14.101) -->
-          <text macro="source-monographic-preposition-note"/>
-          <text font-style="italic" form="short" text-case="title" variable="container-title"/>
+          <text form="short" variable="genre"/>
+          <choose>
+            <if match="none" position="ibid ibid-with-locator">
+              <!-- CMOS team suggests leaving out title in repeated references -->
+              <text macro="source-monographic-preposition-note"/>
+              <text font-style="italic" form="short" text-case="title" variable="container-title"/>
+            </if>
+          </choose>
         </if>
         <else-if type="article-journal" variable="container-title genre volume-title">
-          <text form="short" variable="genre"/>
           <!-- untitled introduction to a special issue or supplement -->
-          <text macro="source-monographic-preposition-note"/>
-          <text form="short" quotes="true" text-case="title" variable="volume-title"/>
+          <text form="short" variable="genre"/>
+          <choose>
+            <if match="none" position="ibid ibid-with-locator">
+              <text macro="source-monographic-preposition-note"/>
+              <text form="short" quotes="true" text-case="title" variable="volume-title"/>
+            </if>
+          </choose>
         </else-if>
         <else-if variable="genre">
           <text form="short" variable="genre"/>
@@ -1716,10 +1725,17 @@
     </choose>
   </macro>
   <macro name="description-review-short">
-    <group delimiter=" ">
-      <text term="review-of"/>
-      <text macro="description-review-title-short"/>
-    </group>
+    <choose>
+      <if match="any" position="ibid ibid-with-locator">
+        <text term="review"/>
+      </if>
+      <else>
+        <group delimiter=" ">
+          <text term="review-of"/>
+          <text macro="description-review-title-short"/>
+        </group>
+      </else>
+    </choose>
   </macro>
   <macro name="description-review-term-unsigned-bib">
     <!-- Anonymous reviews appear as 'unsigned' (CMOS18 14.102) -->

--- a/chicago-shortened-notes-bibliography-access-dates.csl
+++ b/chicago-shortened-notes-bibliography-access-dates.csl
@@ -1449,16 +1449,25 @@
     <group delimiter=" ">
       <choose>
         <if type="chapter" variable="container-title genre">
-          <text form="short" variable="genre"/>
           <!-- untitled introductions: cf. review model, which includes a title (CMOS18 14.101) -->
-          <text macro="source-monographic-preposition-note"/>
-          <text font-style="italic" form="short" text-case="title" variable="container-title"/>
+          <text form="short" variable="genre"/>
+          <choose>
+            <if match="none" position="ibid ibid-with-locator">
+              <!-- CMOS team suggests leaving out title in repeated references -->
+              <text macro="source-monographic-preposition-note"/>
+              <text font-style="italic" form="short" text-case="title" variable="container-title"/>
+            </if>
+          </choose>
         </if>
         <else-if type="article-journal" variable="container-title genre volume-title">
-          <text form="short" variable="genre"/>
           <!-- untitled introduction to a special issue or supplement -->
-          <text macro="source-monographic-preposition-note"/>
-          <text form="short" quotes="true" text-case="title" variable="volume-title"/>
+          <text form="short" variable="genre"/>
+          <choose>
+            <if match="none" position="ibid ibid-with-locator">
+              <text macro="source-monographic-preposition-note"/>
+              <text form="short" quotes="true" text-case="title" variable="volume-title"/>
+            </if>
+          </choose>
         </else-if>
         <else-if variable="genre">
           <text form="short" variable="genre"/>
@@ -1719,10 +1728,17 @@
     </choose>
   </macro>
   <macro name="description-review-short">
-    <group delimiter=" ">
-      <text term="review-of"/>
-      <text macro="description-review-title-short"/>
-    </group>
+    <choose>
+      <if match="any" position="ibid ibid-with-locator">
+        <text term="review"/>
+      </if>
+      <else>
+        <group delimiter=" ">
+          <text term="review-of"/>
+          <text macro="description-review-title-short"/>
+        </group>
+      </else>
+    </choose>
   </macro>
   <macro name="description-review-term-unsigned-bib">
     <!-- Anonymous reviews appear as 'unsigned' (CMOS18 14.102) -->

--- a/chicago-shortened-notes-bibliography-archive-place-first-no-url.csl
+++ b/chicago-shortened-notes-bibliography-archive-place-first-no-url.csl
@@ -1449,16 +1449,25 @@
     <group delimiter=" ">
       <choose>
         <if type="chapter" variable="container-title genre">
-          <text form="short" variable="genre"/>
           <!-- untitled introductions: cf. review model, which includes a title (CMOS18 14.101) -->
-          <text macro="source-monographic-preposition-note"/>
-          <text font-style="italic" form="short" text-case="title" variable="container-title"/>
+          <text form="short" variable="genre"/>
+          <choose>
+            <if match="none" position="ibid ibid-with-locator">
+              <!-- CMOS team suggests leaving out title in repeated references -->
+              <text macro="source-monographic-preposition-note"/>
+              <text font-style="italic" form="short" text-case="title" variable="container-title"/>
+            </if>
+          </choose>
         </if>
         <else-if type="article-journal" variable="container-title genre volume-title">
-          <text form="short" variable="genre"/>
           <!-- untitled introduction to a special issue or supplement -->
-          <text macro="source-monographic-preposition-note"/>
-          <text form="short" quotes="true" text-case="title" variable="volume-title"/>
+          <text form="short" variable="genre"/>
+          <choose>
+            <if match="none" position="ibid ibid-with-locator">
+              <text macro="source-monographic-preposition-note"/>
+              <text form="short" quotes="true" text-case="title" variable="volume-title"/>
+            </if>
+          </choose>
         </else-if>
         <else-if variable="genre">
           <text form="short" variable="genre"/>
@@ -1719,10 +1728,17 @@
     </choose>
   </macro>
   <macro name="description-review-short">
-    <group delimiter=" ">
-      <text term="review-of"/>
-      <text macro="description-review-title-short"/>
-    </group>
+    <choose>
+      <if match="any" position="ibid ibid-with-locator">
+        <text term="review"/>
+      </if>
+      <else>
+        <group delimiter=" ">
+          <text term="review-of"/>
+          <text macro="description-review-title-short"/>
+        </group>
+      </else>
+    </choose>
   </macro>
   <macro name="description-review-term-unsigned-bib">
     <!-- Anonymous reviews appear as 'unsigned' (CMOS18 14.102) -->

--- a/chicago-shortened-notes-bibliography-archive-place-first.csl
+++ b/chicago-shortened-notes-bibliography-archive-place-first.csl
@@ -1449,16 +1449,25 @@
     <group delimiter=" ">
       <choose>
         <if type="chapter" variable="container-title genre">
-          <text form="short" variable="genre"/>
           <!-- untitled introductions: cf. review model, which includes a title (CMOS18 14.101) -->
-          <text macro="source-monographic-preposition-note"/>
-          <text font-style="italic" form="short" text-case="title" variable="container-title"/>
+          <text form="short" variable="genre"/>
+          <choose>
+            <if match="none" position="ibid ibid-with-locator">
+              <!-- CMOS team suggests leaving out title in repeated references -->
+              <text macro="source-monographic-preposition-note"/>
+              <text font-style="italic" form="short" text-case="title" variable="container-title"/>
+            </if>
+          </choose>
         </if>
         <else-if type="article-journal" variable="container-title genre volume-title">
-          <text form="short" variable="genre"/>
           <!-- untitled introduction to a special issue or supplement -->
-          <text macro="source-monographic-preposition-note"/>
-          <text form="short" quotes="true" text-case="title" variable="volume-title"/>
+          <text form="short" variable="genre"/>
+          <choose>
+            <if match="none" position="ibid ibid-with-locator">
+              <text macro="source-monographic-preposition-note"/>
+              <text form="short" quotes="true" text-case="title" variable="volume-title"/>
+            </if>
+          </choose>
         </else-if>
         <else-if variable="genre">
           <text form="short" variable="genre"/>
@@ -1719,10 +1728,17 @@
     </choose>
   </macro>
   <macro name="description-review-short">
-    <group delimiter=" ">
-      <text term="review-of"/>
-      <text macro="description-review-title-short"/>
-    </group>
+    <choose>
+      <if match="any" position="ibid ibid-with-locator">
+        <text term="review"/>
+      </if>
+      <else>
+        <group delimiter=" ">
+          <text term="review-of"/>
+          <text macro="description-review-title-short"/>
+        </group>
+      </else>
+    </choose>
   </macro>
   <macro name="description-review-term-unsigned-bib">
     <!-- Anonymous reviews appear as 'unsigned' (CMOS18 14.102) -->

--- a/chicago-shortened-notes-bibliography-classic-archive-place-first-no-url.csl
+++ b/chicago-shortened-notes-bibliography-classic-archive-place-first-no-url.csl
@@ -1449,16 +1449,25 @@
     <group delimiter=" ">
       <choose>
         <if type="chapter" variable="container-title genre">
-          <text form="short" variable="genre"/>
           <!-- untitled introductions: cf. review model, which includes a title (CMOS18 14.101) -->
-          <text macro="source-monographic-preposition-note"/>
-          <text font-style="italic" form="short" text-case="title" variable="container-title"/>
+          <text form="short" variable="genre"/>
+          <choose>
+            <if match="none" position="ibid ibid-with-locator">
+              <!-- CMOS team suggests leaving out title in repeated references -->
+              <text macro="source-monographic-preposition-note"/>
+              <text font-style="italic" form="short" text-case="title" variable="container-title"/>
+            </if>
+          </choose>
         </if>
         <else-if type="article-journal" variable="container-title genre volume-title">
-          <text form="short" variable="genre"/>
           <!-- untitled introduction to a special issue or supplement -->
-          <text macro="source-monographic-preposition-note"/>
-          <text form="short" quotes="true" text-case="title" variable="volume-title"/>
+          <text form="short" variable="genre"/>
+          <choose>
+            <if match="none" position="ibid ibid-with-locator">
+              <text macro="source-monographic-preposition-note"/>
+              <text form="short" quotes="true" text-case="title" variable="volume-title"/>
+            </if>
+          </choose>
         </else-if>
         <else-if variable="genre">
           <text form="short" variable="genre"/>
@@ -1719,10 +1728,17 @@
     </choose>
   </macro>
   <macro name="description-review-short">
-    <group delimiter=" ">
-      <text term="review-of"/>
-      <text macro="description-review-title-short"/>
-    </group>
+    <choose>
+      <if match="any" position="ibid ibid-with-locator">
+        <text term="review"/>
+      </if>
+      <else>
+        <group delimiter=" ">
+          <text term="review-of"/>
+          <text macro="description-review-title-short"/>
+        </group>
+      </else>
+    </choose>
   </macro>
   <macro name="description-review-term-unsigned-bib">
     <!-- Anonymous reviews appear as 'unsigned' (CMOS18 14.102) -->

--- a/chicago-shortened-notes-bibliography-classic-archive-place-first.csl
+++ b/chicago-shortened-notes-bibliography-classic-archive-place-first.csl
@@ -1449,16 +1449,25 @@
     <group delimiter=" ">
       <choose>
         <if type="chapter" variable="container-title genre">
-          <text form="short" variable="genre"/>
           <!-- untitled introductions: cf. review model, which includes a title (CMOS18 14.101) -->
-          <text macro="source-monographic-preposition-note"/>
-          <text font-style="italic" form="short" text-case="title" variable="container-title"/>
+          <text form="short" variable="genre"/>
+          <choose>
+            <if match="none" position="ibid ibid-with-locator">
+              <!-- CMOS team suggests leaving out title in repeated references -->
+              <text macro="source-monographic-preposition-note"/>
+              <text font-style="italic" form="short" text-case="title" variable="container-title"/>
+            </if>
+          </choose>
         </if>
         <else-if type="article-journal" variable="container-title genre volume-title">
-          <text form="short" variable="genre"/>
           <!-- untitled introduction to a special issue or supplement -->
-          <text macro="source-monographic-preposition-note"/>
-          <text form="short" quotes="true" text-case="title" variable="volume-title"/>
+          <text form="short" variable="genre"/>
+          <choose>
+            <if match="none" position="ibid ibid-with-locator">
+              <text macro="source-monographic-preposition-note"/>
+              <text form="short" quotes="true" text-case="title" variable="volume-title"/>
+            </if>
+          </choose>
         </else-if>
         <else-if variable="genre">
           <text form="short" variable="genre"/>
@@ -1719,10 +1728,17 @@
     </choose>
   </macro>
   <macro name="description-review-short">
-    <group delimiter=" ">
-      <text term="review-of"/>
-      <text macro="description-review-title-short"/>
-    </group>
+    <choose>
+      <if match="any" position="ibid ibid-with-locator">
+        <text term="review"/>
+      </if>
+      <else>
+        <group delimiter=" ">
+          <text term="review-of"/>
+          <text macro="description-review-title-short"/>
+        </group>
+      </else>
+    </choose>
   </macro>
   <macro name="description-review-term-unsigned-bib">
     <!-- Anonymous reviews appear as 'unsigned' (CMOS18 14.102) -->

--- a/chicago-shortened-notes-bibliography-classic-no-url.csl
+++ b/chicago-shortened-notes-bibliography-classic-no-url.csl
@@ -1449,16 +1449,25 @@
     <group delimiter=" ">
       <choose>
         <if type="chapter" variable="container-title genre">
-          <text form="short" variable="genre"/>
           <!-- untitled introductions: cf. review model, which includes a title (CMOS18 14.101) -->
-          <text macro="source-monographic-preposition-note"/>
-          <text font-style="italic" form="short" text-case="title" variable="container-title"/>
+          <text form="short" variable="genre"/>
+          <choose>
+            <if match="none" position="ibid ibid-with-locator">
+              <!-- CMOS team suggests leaving out title in repeated references -->
+              <text macro="source-monographic-preposition-note"/>
+              <text font-style="italic" form="short" text-case="title" variable="container-title"/>
+            </if>
+          </choose>
         </if>
         <else-if type="article-journal" variable="container-title genre volume-title">
-          <text form="short" variable="genre"/>
           <!-- untitled introduction to a special issue or supplement -->
-          <text macro="source-monographic-preposition-note"/>
-          <text form="short" quotes="true" text-case="title" variable="volume-title"/>
+          <text form="short" variable="genre"/>
+          <choose>
+            <if match="none" position="ibid ibid-with-locator">
+              <text macro="source-monographic-preposition-note"/>
+              <text form="short" quotes="true" text-case="title" variable="volume-title"/>
+            </if>
+          </choose>
         </else-if>
         <else-if variable="genre">
           <text form="short" variable="genre"/>
@@ -1719,10 +1728,17 @@
     </choose>
   </macro>
   <macro name="description-review-short">
-    <group delimiter=" ">
-      <text term="review-of"/>
-      <text macro="description-review-title-short"/>
-    </group>
+    <choose>
+      <if match="any" position="ibid ibid-with-locator">
+        <text term="review"/>
+      </if>
+      <else>
+        <group delimiter=" ">
+          <text term="review-of"/>
+          <text macro="description-review-title-short"/>
+        </group>
+      </else>
+    </choose>
   </macro>
   <macro name="description-review-term-unsigned-bib">
     <!-- Anonymous reviews appear as 'unsigned' (CMOS18 14.102) -->

--- a/chicago-shortened-notes-bibliography-classic.csl
+++ b/chicago-shortened-notes-bibliography-classic.csl
@@ -1449,16 +1449,25 @@
     <group delimiter=" ">
       <choose>
         <if type="chapter" variable="container-title genre">
-          <text form="short" variable="genre"/>
           <!-- untitled introductions: cf. review model, which includes a title (CMOS18 14.101) -->
-          <text macro="source-monographic-preposition-note"/>
-          <text font-style="italic" form="short" text-case="title" variable="container-title"/>
+          <text form="short" variable="genre"/>
+          <choose>
+            <if match="none" position="ibid ibid-with-locator">
+              <!-- CMOS team suggests leaving out title in repeated references -->
+              <text macro="source-monographic-preposition-note"/>
+              <text font-style="italic" form="short" text-case="title" variable="container-title"/>
+            </if>
+          </choose>
         </if>
         <else-if type="article-journal" variable="container-title genre volume-title">
-          <text form="short" variable="genre"/>
           <!-- untitled introduction to a special issue or supplement -->
-          <text macro="source-monographic-preposition-note"/>
-          <text form="short" quotes="true" text-case="title" variable="volume-title"/>
+          <text form="short" variable="genre"/>
+          <choose>
+            <if match="none" position="ibid ibid-with-locator">
+              <text macro="source-monographic-preposition-note"/>
+              <text form="short" quotes="true" text-case="title" variable="volume-title"/>
+            </if>
+          </choose>
         </else-if>
         <else-if variable="genre">
           <text form="short" variable="genre"/>
@@ -1719,10 +1728,17 @@
     </choose>
   </macro>
   <macro name="description-review-short">
-    <group delimiter=" ">
-      <text term="review-of"/>
-      <text macro="description-review-title-short"/>
-    </group>
+    <choose>
+      <if match="any" position="ibid ibid-with-locator">
+        <text term="review"/>
+      </if>
+      <else>
+        <group delimiter=" ">
+          <text term="review-of"/>
+          <text macro="description-review-title-short"/>
+        </group>
+      </else>
+    </choose>
   </macro>
   <macro name="description-review-term-unsigned-bib">
     <!-- Anonymous reviews appear as 'unsigned' (CMOS18 14.102) -->

--- a/chicago-shortened-notes-bibliography-no-url.csl
+++ b/chicago-shortened-notes-bibliography-no-url.csl
@@ -1449,16 +1449,25 @@
     <group delimiter=" ">
       <choose>
         <if type="chapter" variable="container-title genre">
-          <text form="short" variable="genre"/>
           <!-- untitled introductions: cf. review model, which includes a title (CMOS18 14.101) -->
-          <text macro="source-monographic-preposition-note"/>
-          <text font-style="italic" form="short" text-case="title" variable="container-title"/>
+          <text form="short" variable="genre"/>
+          <choose>
+            <if match="none" position="ibid ibid-with-locator">
+              <!-- CMOS team suggests leaving out title in repeated references -->
+              <text macro="source-monographic-preposition-note"/>
+              <text font-style="italic" form="short" text-case="title" variable="container-title"/>
+            </if>
+          </choose>
         </if>
         <else-if type="article-journal" variable="container-title genre volume-title">
-          <text form="short" variable="genre"/>
           <!-- untitled introduction to a special issue or supplement -->
-          <text macro="source-monographic-preposition-note"/>
-          <text form="short" quotes="true" text-case="title" variable="volume-title"/>
+          <text form="short" variable="genre"/>
+          <choose>
+            <if match="none" position="ibid ibid-with-locator">
+              <text macro="source-monographic-preposition-note"/>
+              <text form="short" quotes="true" text-case="title" variable="volume-title"/>
+            </if>
+          </choose>
         </else-if>
         <else-if variable="genre">
           <text form="short" variable="genre"/>
@@ -1719,10 +1728,17 @@
     </choose>
   </macro>
   <macro name="description-review-short">
-    <group delimiter=" ">
-      <text term="review-of"/>
-      <text macro="description-review-title-short"/>
-    </group>
+    <choose>
+      <if match="any" position="ibid ibid-with-locator">
+        <text term="review"/>
+      </if>
+      <else>
+        <group delimiter=" ">
+          <text term="review-of"/>
+          <text macro="description-review-title-short"/>
+        </group>
+      </else>
+    </choose>
   </macro>
   <macro name="description-review-term-unsigned-bib">
     <!-- Anonymous reviews appear as 'unsigned' (CMOS18 14.102) -->

--- a/chicago-shortened-notes-bibliography-subsequent-author-classic-no-url.csl
+++ b/chicago-shortened-notes-bibliography-subsequent-author-classic-no-url.csl
@@ -1449,16 +1449,25 @@
     <group delimiter=" ">
       <choose>
         <if type="chapter" variable="container-title genre">
-          <text form="short" variable="genre"/>
           <!-- untitled introductions: cf. review model, which includes a title (CMOS18 14.101) -->
-          <text macro="source-monographic-preposition-note"/>
-          <text font-style="italic" form="short" text-case="title" variable="container-title"/>
+          <text form="short" variable="genre"/>
+          <choose>
+            <if match="none" position="ibid ibid-with-locator">
+              <!-- CMOS team suggests leaving out title in repeated references -->
+              <text macro="source-monographic-preposition-note"/>
+              <text font-style="italic" form="short" text-case="title" variable="container-title"/>
+            </if>
+          </choose>
         </if>
         <else-if type="article-journal" variable="container-title genre volume-title">
-          <text form="short" variable="genre"/>
           <!-- untitled introduction to a special issue or supplement -->
-          <text macro="source-monographic-preposition-note"/>
-          <text form="short" quotes="true" text-case="title" variable="volume-title"/>
+          <text form="short" variable="genre"/>
+          <choose>
+            <if match="none" position="ibid ibid-with-locator">
+              <text macro="source-monographic-preposition-note"/>
+              <text form="short" quotes="true" text-case="title" variable="volume-title"/>
+            </if>
+          </choose>
         </else-if>
         <else-if variable="genre">
           <text form="short" variable="genre"/>
@@ -1719,10 +1728,17 @@
     </choose>
   </macro>
   <macro name="description-review-short">
-    <group delimiter=" ">
-      <text term="review-of"/>
-      <text macro="description-review-title-short"/>
-    </group>
+    <choose>
+      <if match="any" position="ibid ibid-with-locator">
+        <text term="review"/>
+      </if>
+      <else>
+        <group delimiter=" ">
+          <text term="review-of"/>
+          <text macro="description-review-title-short"/>
+        </group>
+      </else>
+    </choose>
   </macro>
   <macro name="description-review-term-unsigned-bib">
     <!-- Anonymous reviews appear as 'unsigned' (CMOS18 14.102) -->

--- a/chicago-shortened-notes-bibliography-subsequent-author-classic.csl
+++ b/chicago-shortened-notes-bibliography-subsequent-author-classic.csl
@@ -1449,16 +1449,25 @@
     <group delimiter=" ">
       <choose>
         <if type="chapter" variable="container-title genre">
-          <text form="short" variable="genre"/>
           <!-- untitled introductions: cf. review model, which includes a title (CMOS18 14.101) -->
-          <text macro="source-monographic-preposition-note"/>
-          <text font-style="italic" form="short" text-case="title" variable="container-title"/>
+          <text form="short" variable="genre"/>
+          <choose>
+            <if match="none" position="ibid ibid-with-locator">
+              <!-- CMOS team suggests leaving out title in repeated references -->
+              <text macro="source-monographic-preposition-note"/>
+              <text font-style="italic" form="short" text-case="title" variable="container-title"/>
+            </if>
+          </choose>
         </if>
         <else-if type="article-journal" variable="container-title genre volume-title">
-          <text form="short" variable="genre"/>
           <!-- untitled introduction to a special issue or supplement -->
-          <text macro="source-monographic-preposition-note"/>
-          <text form="short" quotes="true" text-case="title" variable="volume-title"/>
+          <text form="short" variable="genre"/>
+          <choose>
+            <if match="none" position="ibid ibid-with-locator">
+              <text macro="source-monographic-preposition-note"/>
+              <text form="short" quotes="true" text-case="title" variable="volume-title"/>
+            </if>
+          </choose>
         </else-if>
         <else-if variable="genre">
           <text form="short" variable="genre"/>
@@ -1719,10 +1728,17 @@
     </choose>
   </macro>
   <macro name="description-review-short">
-    <group delimiter=" ">
-      <text term="review-of"/>
-      <text macro="description-review-title-short"/>
-    </group>
+    <choose>
+      <if match="any" position="ibid ibid-with-locator">
+        <text term="review"/>
+      </if>
+      <else>
+        <group delimiter=" ">
+          <text term="review-of"/>
+          <text macro="description-review-title-short"/>
+        </group>
+      </else>
+    </choose>
   </macro>
   <macro name="description-review-term-unsigned-bib">
     <!-- Anonymous reviews appear as 'unsigned' (CMOS18 14.102) -->

--- a/chicago-shortened-notes-bibliography-subsequent-author-no-url.csl
+++ b/chicago-shortened-notes-bibliography-subsequent-author-no-url.csl
@@ -1449,16 +1449,25 @@
     <group delimiter=" ">
       <choose>
         <if type="chapter" variable="container-title genre">
-          <text form="short" variable="genre"/>
           <!-- untitled introductions: cf. review model, which includes a title (CMOS18 14.101) -->
-          <text macro="source-monographic-preposition-note"/>
-          <text font-style="italic" form="short" text-case="title" variable="container-title"/>
+          <text form="short" variable="genre"/>
+          <choose>
+            <if match="none" position="ibid ibid-with-locator">
+              <!-- CMOS team suggests leaving out title in repeated references -->
+              <text macro="source-monographic-preposition-note"/>
+              <text font-style="italic" form="short" text-case="title" variable="container-title"/>
+            </if>
+          </choose>
         </if>
         <else-if type="article-journal" variable="container-title genre volume-title">
-          <text form="short" variable="genre"/>
           <!-- untitled introduction to a special issue or supplement -->
-          <text macro="source-monographic-preposition-note"/>
-          <text form="short" quotes="true" text-case="title" variable="volume-title"/>
+          <text form="short" variable="genre"/>
+          <choose>
+            <if match="none" position="ibid ibid-with-locator">
+              <text macro="source-monographic-preposition-note"/>
+              <text form="short" quotes="true" text-case="title" variable="volume-title"/>
+            </if>
+          </choose>
         </else-if>
         <else-if variable="genre">
           <text form="short" variable="genre"/>
@@ -1719,10 +1728,17 @@
     </choose>
   </macro>
   <macro name="description-review-short">
-    <group delimiter=" ">
-      <text term="review-of"/>
-      <text macro="description-review-title-short"/>
-    </group>
+    <choose>
+      <if match="any" position="ibid ibid-with-locator">
+        <text term="review"/>
+      </if>
+      <else>
+        <group delimiter=" ">
+          <text term="review-of"/>
+          <text macro="description-review-title-short"/>
+        </group>
+      </else>
+    </choose>
   </macro>
   <macro name="description-review-term-unsigned-bib">
     <!-- Anonymous reviews appear as 'unsigned' (CMOS18 14.102) -->

--- a/chicago-shortened-notes-bibliography-subsequent-author-title-17th-edition.csl
+++ b/chicago-shortened-notes-bibliography-subsequent-author-title-17th-edition.csl
@@ -1446,16 +1446,25 @@
     <group delimiter=" ">
       <choose>
         <if type="chapter" variable="container-title genre">
-          <text form="short" variable="genre"/>
           <!-- untitled introductions: cf. review model, which includes a title (CMOS18 14.101) -->
-          <text macro="source-monographic-preposition-note"/>
-          <text font-style="italic" form="short" text-case="title" variable="container-title"/>
+          <text form="short" variable="genre"/>
+          <choose>
+            <if match="none" position="ibid ibid-with-locator">
+              <!-- CMOS team suggests leaving out title in repeated references -->
+              <text macro="source-monographic-preposition-note"/>
+              <text font-style="italic" form="short" text-case="title" variable="container-title"/>
+            </if>
+          </choose>
         </if>
         <else-if type="article-journal" variable="container-title genre volume-title">
-          <text form="short" variable="genre"/>
           <!-- untitled introduction to a special issue or supplement -->
-          <text macro="source-monographic-preposition-note"/>
-          <text form="short" quotes="true" text-case="title" variable="volume-title"/>
+          <text form="short" variable="genre"/>
+          <choose>
+            <if match="none" position="ibid ibid-with-locator">
+              <text macro="source-monographic-preposition-note"/>
+              <text form="short" quotes="true" text-case="title" variable="volume-title"/>
+            </if>
+          </choose>
         </else-if>
         <else-if variable="genre">
           <text form="short" variable="genre"/>
@@ -1716,10 +1725,17 @@
     </choose>
   </macro>
   <macro name="description-review-short">
-    <group delimiter=" ">
-      <text term="review-of"/>
-      <text macro="description-review-title-short"/>
-    </group>
+    <choose>
+      <if match="any" position="ibid ibid-with-locator">
+        <text term="review"/>
+      </if>
+      <else>
+        <group delimiter=" ">
+          <text term="review-of"/>
+          <text macro="description-review-title-short"/>
+        </group>
+      </else>
+    </choose>
   </macro>
   <macro name="description-review-term-unsigned-bib">
     <!-- Anonymous reviews appear as 'unsigned' (CMOS18 14.102) -->

--- a/chicago-shortened-notes-bibliography-subsequent-author.csl
+++ b/chicago-shortened-notes-bibliography-subsequent-author.csl
@@ -1449,16 +1449,25 @@
     <group delimiter=" ">
       <choose>
         <if type="chapter" variable="container-title genre">
-          <text form="short" variable="genre"/>
           <!-- untitled introductions: cf. review model, which includes a title (CMOS18 14.101) -->
-          <text macro="source-monographic-preposition-note"/>
-          <text font-style="italic" form="short" text-case="title" variable="container-title"/>
+          <text form="short" variable="genre"/>
+          <choose>
+            <if match="none" position="ibid ibid-with-locator">
+              <!-- CMOS team suggests leaving out title in repeated references -->
+              <text macro="source-monographic-preposition-note"/>
+              <text font-style="italic" form="short" text-case="title" variable="container-title"/>
+            </if>
+          </choose>
         </if>
         <else-if type="article-journal" variable="container-title genre volume-title">
-          <text form="short" variable="genre"/>
           <!-- untitled introduction to a special issue or supplement -->
-          <text macro="source-monographic-preposition-note"/>
-          <text form="short" quotes="true" text-case="title" variable="volume-title"/>
+          <text form="short" variable="genre"/>
+          <choose>
+            <if match="none" position="ibid ibid-with-locator">
+              <text macro="source-monographic-preposition-note"/>
+              <text form="short" quotes="true" text-case="title" variable="volume-title"/>
+            </if>
+          </choose>
         </else-if>
         <else-if variable="genre">
           <text form="short" variable="genre"/>
@@ -1719,10 +1728,17 @@
     </choose>
   </macro>
   <macro name="description-review-short">
-    <group delimiter=" ">
-      <text term="review-of"/>
-      <text macro="description-review-title-short"/>
-    </group>
+    <choose>
+      <if match="any" position="ibid ibid-with-locator">
+        <text term="review"/>
+      </if>
+      <else>
+        <group delimiter=" ">
+          <text term="review-of"/>
+          <text macro="description-review-title-short"/>
+        </group>
+      </else>
+    </choose>
   </macro>
   <macro name="description-review-term-unsigned-bib">
     <!-- Anonymous reviews appear as 'unsigned' (CMOS18 14.102) -->

--- a/chicago-shortened-notes-bibliography-subsequent-ibid-17th-edition.csl
+++ b/chicago-shortened-notes-bibliography-subsequent-ibid-17th-edition.csl
@@ -1446,16 +1446,25 @@
     <group delimiter=" ">
       <choose>
         <if type="chapter" variable="container-title genre">
-          <text form="short" variable="genre"/>
           <!-- untitled introductions: cf. review model, which includes a title (CMOS18 14.101) -->
-          <text macro="source-monographic-preposition-note"/>
-          <text font-style="italic" form="short" text-case="title" variable="container-title"/>
+          <text form="short" variable="genre"/>
+          <choose>
+            <if match="none" position="ibid ibid-with-locator">
+              <!-- CMOS team suggests leaving out title in repeated references -->
+              <text macro="source-monographic-preposition-note"/>
+              <text font-style="italic" form="short" text-case="title" variable="container-title"/>
+            </if>
+          </choose>
         </if>
         <else-if type="article-journal" variable="container-title genre volume-title">
-          <text form="short" variable="genre"/>
           <!-- untitled introduction to a special issue or supplement -->
-          <text macro="source-monographic-preposition-note"/>
-          <text form="short" quotes="true" text-case="title" variable="volume-title"/>
+          <text form="short" variable="genre"/>
+          <choose>
+            <if match="none" position="ibid ibid-with-locator">
+              <text macro="source-monographic-preposition-note"/>
+              <text form="short" quotes="true" text-case="title" variable="volume-title"/>
+            </if>
+          </choose>
         </else-if>
         <else-if variable="genre">
           <text form="short" variable="genre"/>
@@ -1716,10 +1725,17 @@
     </choose>
   </macro>
   <macro name="description-review-short">
-    <group delimiter=" ">
-      <text term="review-of"/>
-      <text macro="description-review-title-short"/>
-    </group>
+    <choose>
+      <if match="any" position="ibid ibid-with-locator">
+        <text term="review"/>
+      </if>
+      <else>
+        <group delimiter=" ">
+          <text term="review-of"/>
+          <text macro="description-review-title-short"/>
+        </group>
+      </else>
+    </choose>
   </macro>
   <macro name="description-review-term-unsigned-bib">
     <!-- Anonymous reviews appear as 'unsigned' (CMOS18 14.102) -->

--- a/chicago-shortened-notes-bibliography-subsequent-ibid-classic-no-url.csl
+++ b/chicago-shortened-notes-bibliography-subsequent-ibid-classic-no-url.csl
@@ -1449,16 +1449,25 @@
     <group delimiter=" ">
       <choose>
         <if type="chapter" variable="container-title genre">
-          <text form="short" variable="genre"/>
           <!-- untitled introductions: cf. review model, which includes a title (CMOS18 14.101) -->
-          <text macro="source-monographic-preposition-note"/>
-          <text font-style="italic" form="short" text-case="title" variable="container-title"/>
+          <text form="short" variable="genre"/>
+          <choose>
+            <if match="none" position="ibid ibid-with-locator">
+              <!-- CMOS team suggests leaving out title in repeated references -->
+              <text macro="source-monographic-preposition-note"/>
+              <text font-style="italic" form="short" text-case="title" variable="container-title"/>
+            </if>
+          </choose>
         </if>
         <else-if type="article-journal" variable="container-title genre volume-title">
-          <text form="short" variable="genre"/>
           <!-- untitled introduction to a special issue or supplement -->
-          <text macro="source-monographic-preposition-note"/>
-          <text form="short" quotes="true" text-case="title" variable="volume-title"/>
+          <text form="short" variable="genre"/>
+          <choose>
+            <if match="none" position="ibid ibid-with-locator">
+              <text macro="source-monographic-preposition-note"/>
+              <text form="short" quotes="true" text-case="title" variable="volume-title"/>
+            </if>
+          </choose>
         </else-if>
         <else-if variable="genre">
           <text form="short" variable="genre"/>
@@ -1719,10 +1728,17 @@
     </choose>
   </macro>
   <macro name="description-review-short">
-    <group delimiter=" ">
-      <text term="review-of"/>
-      <text macro="description-review-title-short"/>
-    </group>
+    <choose>
+      <if match="any" position="ibid ibid-with-locator">
+        <text term="review"/>
+      </if>
+      <else>
+        <group delimiter=" ">
+          <text term="review-of"/>
+          <text macro="description-review-title-short"/>
+        </group>
+      </else>
+    </choose>
   </macro>
   <macro name="description-review-term-unsigned-bib">
     <!-- Anonymous reviews appear as 'unsigned' (CMOS18 14.102) -->

--- a/chicago-shortened-notes-bibliography-subsequent-ibid-classic.csl
+++ b/chicago-shortened-notes-bibliography-subsequent-ibid-classic.csl
@@ -1449,16 +1449,25 @@
     <group delimiter=" ">
       <choose>
         <if type="chapter" variable="container-title genre">
-          <text form="short" variable="genre"/>
           <!-- untitled introductions: cf. review model, which includes a title (CMOS18 14.101) -->
-          <text macro="source-monographic-preposition-note"/>
-          <text font-style="italic" form="short" text-case="title" variable="container-title"/>
+          <text form="short" variable="genre"/>
+          <choose>
+            <if match="none" position="ibid ibid-with-locator">
+              <!-- CMOS team suggests leaving out title in repeated references -->
+              <text macro="source-monographic-preposition-note"/>
+              <text font-style="italic" form="short" text-case="title" variable="container-title"/>
+            </if>
+          </choose>
         </if>
         <else-if type="article-journal" variable="container-title genre volume-title">
-          <text form="short" variable="genre"/>
           <!-- untitled introduction to a special issue or supplement -->
-          <text macro="source-monographic-preposition-note"/>
-          <text form="short" quotes="true" text-case="title" variable="volume-title"/>
+          <text form="short" variable="genre"/>
+          <choose>
+            <if match="none" position="ibid ibid-with-locator">
+              <text macro="source-monographic-preposition-note"/>
+              <text form="short" quotes="true" text-case="title" variable="volume-title"/>
+            </if>
+          </choose>
         </else-if>
         <else-if variable="genre">
           <text form="short" variable="genre"/>
@@ -1719,10 +1728,17 @@
     </choose>
   </macro>
   <macro name="description-review-short">
-    <group delimiter=" ">
-      <text term="review-of"/>
-      <text macro="description-review-title-short"/>
-    </group>
+    <choose>
+      <if match="any" position="ibid ibid-with-locator">
+        <text term="review"/>
+      </if>
+      <else>
+        <group delimiter=" ">
+          <text term="review-of"/>
+          <text macro="description-review-title-short"/>
+        </group>
+      </else>
+    </choose>
   </macro>
   <macro name="description-review-term-unsigned-bib">
     <!-- Anonymous reviews appear as 'unsigned' (CMOS18 14.102) -->

--- a/chicago-shortened-notes-bibliography-subsequent-ibid-no-url.csl
+++ b/chicago-shortened-notes-bibliography-subsequent-ibid-no-url.csl
@@ -1449,16 +1449,25 @@
     <group delimiter=" ">
       <choose>
         <if type="chapter" variable="container-title genre">
-          <text form="short" variable="genre"/>
           <!-- untitled introductions: cf. review model, which includes a title (CMOS18 14.101) -->
-          <text macro="source-monographic-preposition-note"/>
-          <text font-style="italic" form="short" text-case="title" variable="container-title"/>
+          <text form="short" variable="genre"/>
+          <choose>
+            <if match="none" position="ibid ibid-with-locator">
+              <!-- CMOS team suggests leaving out title in repeated references -->
+              <text macro="source-monographic-preposition-note"/>
+              <text font-style="italic" form="short" text-case="title" variable="container-title"/>
+            </if>
+          </choose>
         </if>
         <else-if type="article-journal" variable="container-title genre volume-title">
-          <text form="short" variable="genre"/>
           <!-- untitled introduction to a special issue or supplement -->
-          <text macro="source-monographic-preposition-note"/>
-          <text form="short" quotes="true" text-case="title" variable="volume-title"/>
+          <text form="short" variable="genre"/>
+          <choose>
+            <if match="none" position="ibid ibid-with-locator">
+              <text macro="source-monographic-preposition-note"/>
+              <text form="short" quotes="true" text-case="title" variable="volume-title"/>
+            </if>
+          </choose>
         </else-if>
         <else-if variable="genre">
           <text form="short" variable="genre"/>
@@ -1719,10 +1728,17 @@
     </choose>
   </macro>
   <macro name="description-review-short">
-    <group delimiter=" ">
-      <text term="review-of"/>
-      <text macro="description-review-title-short"/>
-    </group>
+    <choose>
+      <if match="any" position="ibid ibid-with-locator">
+        <text term="review"/>
+      </if>
+      <else>
+        <group delimiter=" ">
+          <text term="review-of"/>
+          <text macro="description-review-title-short"/>
+        </group>
+      </else>
+    </choose>
   </macro>
   <macro name="description-review-term-unsigned-bib">
     <!-- Anonymous reviews appear as 'unsigned' (CMOS18 14.102) -->

--- a/chicago-shortened-notes-bibliography-subsequent-ibid.csl
+++ b/chicago-shortened-notes-bibliography-subsequent-ibid.csl
@@ -1449,16 +1449,25 @@
     <group delimiter=" ">
       <choose>
         <if type="chapter" variable="container-title genre">
-          <text form="short" variable="genre"/>
           <!-- untitled introductions: cf. review model, which includes a title (CMOS18 14.101) -->
-          <text macro="source-monographic-preposition-note"/>
-          <text font-style="italic" form="short" text-case="title" variable="container-title"/>
+          <text form="short" variable="genre"/>
+          <choose>
+            <if match="none" position="ibid ibid-with-locator">
+              <!-- CMOS team suggests leaving out title in repeated references -->
+              <text macro="source-monographic-preposition-note"/>
+              <text font-style="italic" form="short" text-case="title" variable="container-title"/>
+            </if>
+          </choose>
         </if>
         <else-if type="article-journal" variable="container-title genre volume-title">
-          <text form="short" variable="genre"/>
           <!-- untitled introduction to a special issue or supplement -->
-          <text macro="source-monographic-preposition-note"/>
-          <text form="short" quotes="true" text-case="title" variable="volume-title"/>
+          <text form="short" variable="genre"/>
+          <choose>
+            <if match="none" position="ibid ibid-with-locator">
+              <text macro="source-monographic-preposition-note"/>
+              <text form="short" quotes="true" text-case="title" variable="volume-title"/>
+            </if>
+          </choose>
         </else-if>
         <else-if variable="genre">
           <text form="short" variable="genre"/>
@@ -1719,10 +1728,17 @@
     </choose>
   </macro>
   <macro name="description-review-short">
-    <group delimiter=" ">
-      <text term="review-of"/>
-      <text macro="description-review-title-short"/>
-    </group>
+    <choose>
+      <if match="any" position="ibid ibid-with-locator">
+        <text term="review"/>
+      </if>
+      <else>
+        <group delimiter=" ">
+          <text term="review-of"/>
+          <text macro="description-review-title-short"/>
+        </group>
+      </else>
+    </choose>
   </macro>
   <macro name="description-review-term-unsigned-bib">
     <!-- Anonymous reviews appear as 'unsigned' (CMOS18 14.102) -->

--- a/chicago-shortened-notes-bibliography-subsequent-title-no-url.csl
+++ b/chicago-shortened-notes-bibliography-subsequent-title-no-url.csl
@@ -1449,16 +1449,25 @@
     <group delimiter=" ">
       <choose>
         <if type="chapter" variable="container-title genre">
-          <text form="short" variable="genre"/>
           <!-- untitled introductions: cf. review model, which includes a title (CMOS18 14.101) -->
-          <text macro="source-monographic-preposition-note"/>
-          <text font-style="italic" form="short" text-case="title" variable="container-title"/>
+          <text form="short" variable="genre"/>
+          <choose>
+            <if match="none" position="ibid ibid-with-locator">
+              <!-- CMOS team suggests leaving out title in repeated references -->
+              <text macro="source-monographic-preposition-note"/>
+              <text font-style="italic" form="short" text-case="title" variable="container-title"/>
+            </if>
+          </choose>
         </if>
         <else-if type="article-journal" variable="container-title genre volume-title">
-          <text form="short" variable="genre"/>
           <!-- untitled introduction to a special issue or supplement -->
-          <text macro="source-monographic-preposition-note"/>
-          <text form="short" quotes="true" text-case="title" variable="volume-title"/>
+          <text form="short" variable="genre"/>
+          <choose>
+            <if match="none" position="ibid ibid-with-locator">
+              <text macro="source-monographic-preposition-note"/>
+              <text form="short" quotes="true" text-case="title" variable="volume-title"/>
+            </if>
+          </choose>
         </else-if>
         <else-if variable="genre">
           <text form="short" variable="genre"/>
@@ -1719,10 +1728,17 @@
     </choose>
   </macro>
   <macro name="description-review-short">
-    <group delimiter=" ">
-      <text term="review-of"/>
-      <text macro="description-review-title-short"/>
-    </group>
+    <choose>
+      <if match="any" position="ibid ibid-with-locator">
+        <text term="review"/>
+      </if>
+      <else>
+        <group delimiter=" ">
+          <text term="review-of"/>
+          <text macro="description-review-title-short"/>
+        </group>
+      </else>
+    </choose>
   </macro>
   <macro name="description-review-term-unsigned-bib">
     <!-- Anonymous reviews appear as 'unsigned' (CMOS18 14.102) -->

--- a/chicago-shortened-notes-bibliography-subsequent-title.csl
+++ b/chicago-shortened-notes-bibliography-subsequent-title.csl
@@ -1449,16 +1449,25 @@
     <group delimiter=" ">
       <choose>
         <if type="chapter" variable="container-title genre">
-          <text form="short" variable="genre"/>
           <!-- untitled introductions: cf. review model, which includes a title (CMOS18 14.101) -->
-          <text macro="source-monographic-preposition-note"/>
-          <text font-style="italic" form="short" text-case="title" variable="container-title"/>
+          <text form="short" variable="genre"/>
+          <choose>
+            <if match="none" position="ibid ibid-with-locator">
+              <!-- CMOS team suggests leaving out title in repeated references -->
+              <text macro="source-monographic-preposition-note"/>
+              <text font-style="italic" form="short" text-case="title" variable="container-title"/>
+            </if>
+          </choose>
         </if>
         <else-if type="article-journal" variable="container-title genre volume-title">
-          <text form="short" variable="genre"/>
           <!-- untitled introduction to a special issue or supplement -->
-          <text macro="source-monographic-preposition-note"/>
-          <text form="short" quotes="true" text-case="title" variable="volume-title"/>
+          <text form="short" variable="genre"/>
+          <choose>
+            <if match="none" position="ibid ibid-with-locator">
+              <text macro="source-monographic-preposition-note"/>
+              <text form="short" quotes="true" text-case="title" variable="volume-title"/>
+            </if>
+          </choose>
         </else-if>
         <else-if variable="genre">
           <text form="short" variable="genre"/>
@@ -1719,10 +1728,17 @@
     </choose>
   </macro>
   <macro name="description-review-short">
-    <group delimiter=" ">
-      <text term="review-of"/>
-      <text macro="description-review-title-short"/>
-    </group>
+    <choose>
+      <if match="any" position="ibid ibid-with-locator">
+        <text term="review"/>
+      </if>
+      <else>
+        <group delimiter=" ">
+          <text term="review-of"/>
+          <text macro="description-review-title-short"/>
+        </group>
+      </else>
+    </choose>
   </macro>
   <macro name="description-review-term-unsigned-bib">
     <!-- Anonymous reviews appear as 'unsigned' (CMOS18 14.102) -->

--- a/chicago-shortened-notes-bibliography.csl
+++ b/chicago-shortened-notes-bibliography.csl
@@ -1449,16 +1449,25 @@
     <group delimiter=" ">
       <choose>
         <if type="chapter" variable="container-title genre">
-          <text form="short" variable="genre"/>
           <!-- untitled introductions: cf. review model, which includes a title (CMOS18 14.101) -->
-          <text macro="source-monographic-preposition-note"/>
-          <text font-style="italic" form="short" text-case="title" variable="container-title"/>
+          <text form="short" variable="genre"/>
+          <choose>
+            <if match="none" position="ibid ibid-with-locator">
+              <!-- CMOS team suggests leaving out title in repeated references -->
+              <text macro="source-monographic-preposition-note"/>
+              <text font-style="italic" form="short" text-case="title" variable="container-title"/>
+            </if>
+          </choose>
         </if>
         <else-if type="article-journal" variable="container-title genre volume-title">
-          <text form="short" variable="genre"/>
           <!-- untitled introduction to a special issue or supplement -->
-          <text macro="source-monographic-preposition-note"/>
-          <text form="short" quotes="true" text-case="title" variable="volume-title"/>
+          <text form="short" variable="genre"/>
+          <choose>
+            <if match="none" position="ibid ibid-with-locator">
+              <text macro="source-monographic-preposition-note"/>
+              <text form="short" quotes="true" text-case="title" variable="volume-title"/>
+            </if>
+          </choose>
         </else-if>
         <else-if variable="genre">
           <text form="short" variable="genre"/>
@@ -1719,10 +1728,17 @@
     </choose>
   </macro>
   <macro name="description-review-short">
-    <group delimiter=" ">
-      <text term="review-of"/>
-      <text macro="description-review-title-short"/>
-    </group>
+    <choose>
+      <if match="any" position="ibid ibid-with-locator">
+        <text term="review"/>
+      </if>
+      <else>
+        <group delimiter=" ">
+          <text term="review-of"/>
+          <text macro="description-review-title-short"/>
+        </group>
+      </else>
+    </choose>
   </macro>
   <macro name="description-review-term-unsigned-bib">
     <!-- Anonymous reviews appear as 'unsigned' (CMOS18 14.102) -->

--- a/taylor-and-francis-chicago-author-date.csl
+++ b/taylor-and-francis-chicago-author-date.csl
@@ -1495,16 +1495,25 @@
     <group delimiter=" ">
       <choose>
         <if type="chapter" variable="container-title genre">
-          <text form="short" variable="genre"/>
           <!-- untitled introductions: cf. review model, which includes a title (CMOS18 14.101) -->
-          <text macro="source-monographic-preposition-note"/>
-          <text font-style="italic" form="short" text-case="title" variable="container-title"/>
+          <text form="short" variable="genre"/>
+          <choose>
+            <if match="none" position="ibid ibid-with-locator">
+              <!-- CMOS team suggests leaving out title in repeated references -->
+              <text macro="source-monographic-preposition-note"/>
+              <text font-style="italic" form="short" text-case="title" variable="container-title"/>
+            </if>
+          </choose>
         </if>
         <else-if type="article-journal" variable="container-title genre volume-title">
-          <text form="short" variable="genre"/>
           <!-- untitled introduction to a special issue or supplement -->
-          <text macro="source-monographic-preposition-note"/>
-          <text form="short" quotes="true" text-case="title" variable="volume-title"/>
+          <text form="short" variable="genre"/>
+          <choose>
+            <if match="none" position="ibid ibid-with-locator">
+              <text macro="source-monographic-preposition-note"/>
+              <text form="short" quotes="true" text-case="title" variable="volume-title"/>
+            </if>
+          </choose>
         </else-if>
         <else-if variable="genre">
           <text form="short" variable="genre"/>
@@ -1765,10 +1774,17 @@
     </choose>
   </macro>
   <macro name="description-review-short">
-    <group delimiter=" ">
-      <text term="review-of"/>
-      <text macro="description-review-title-short"/>
-    </group>
+    <choose>
+      <if match="any" position="ibid ibid-with-locator">
+        <text term="review"/>
+      </if>
+      <else>
+        <group delimiter=" ">
+          <text term="review-of"/>
+          <text macro="description-review-title-short"/>
+        </group>
+      </else>
+    </choose>
   </macro>
   <macro name="description-review-term-unsigned-bib">
     <!-- Anonymous reviews appear as 'unsigned' (CMOS18 14.102) -->


### PR DESCRIPTION
Use the `publisher` variable that Zotero now provides on `webpage` items, which corresponds closely to 'the owner or sponsor of the site' in CMOS 14.104. Creating a distinction between the website title and its publisher allows the style to match the Manual's examples more closely, such as the Google example in the Quick Guide, <https://www.zotero.org/groups/2205533/items/QVWG47MP>; and the AI examples, <https://www.zotero.org/groups/2205533/items/KUTRD58P> and <https://www.zotero.org/groups/2205533/items/DUJY83G4> (CMOS 14.112). Correct the rendering of a `part-title` on a web page.

### Checklist
- [X] Check that you've added a link to the style you used as a template in the `<info>` block at the beginning of the file with `rel="template"`.  
- [X] Check that you've added a link to the style guidelines with `rel="documentation"`.  
- [X] Check that you've added yourself as the `<author>` of the style or `<contributor>` for a style update. 
- [X] Check that you've used the correct terms or labels instead of hardcoding into affixes (e.g., `<text variable="page" prefix="pp. "/>`).
- [X] Check that you've not used `<text value="...` if not absolutely necessary.
- [X] Check that you've not changed line 1 of the style.
