### PR TITLE
Add nn support and extra documentation link (user's guide)

### DIFF
--- a/norsk-henvisningsstandard-for-rettsvitenskapelige-tekster.csl
+++ b/norsk-henvisningsstandard-for-rettsvitenskapelige-tekster.csl
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <style xmlns="http://purl.org/net/xbiblio/csl" class="note" version="1.0" demote-non-dropping-particle="sort-only" page-range-format="expanded">
+  <!-- Polyglot; this citation style supports both Norwegian dialects, i.e. bokmål (nb-NO) and nynorsk (nn-NO) -->
   <info>
     <title>Norsk henvisningsstandard for rettsvitenskapelige tekster (Norsk - Bokmål | Norsk - Nynorsk)</title>
     <id>http://www.zotero.org/styles/norsk-henvisningsstandard-for-rettsvitenskapelige-tekster</id>


### PR DESCRIPTION
Added an extra documentation link, that points to a new page with information and guides for users of the style, authored by the current maintainer (me): https://obykanalen.no/zotero/

Added locale info for Norsk - Nynorsk (nn), which is a dialect of Norwegian - Bokmål (nb). Since the removal of hardcoded text in https://github.com/citation-style-language/styles/pull/8003 the style should now support both dialects through the general CSL locale files.
