### PR TITLE
Improve journal article examples in `items.json`

### DIFF
--- a/spec/sheldon/items.json
+++ b/spec/sheldon/items.json
@@ -1,54 +1,5 @@
 [
   {
-    "id": "hanckeVarietiesCapitalismConflict2007",
-    "abstract": "This edited work critically analyses developments in European Political Economy and their effects on the continental European economies. Leading political economists from Europe and the United States consider how the influential 'Varieties of Capitalism' approach can help us understand these challenges",
-    "accessed": {
-      "date-parts": [
-        [
-          "2025",
-          10,
-          19
-        ]
-      ]
-    },
-    "call-number": "HC240 .B455 2007",
-    "citation-key": "hanckeVarietiesCapitalismConflict2007",
-    "DOI": "10.1093/acprof:oso/9780199206483.001.0001",
-    "editor": [
-      {
-        "family": "Hancké",
-        "given": "Bob"
-      },
-      {
-        "family": "Rhodes",
-        "given": "Martin"
-      },
-      {
-        "family": "Thatcher",
-        "given": "Mark"
-      }
-    ],
-    "event-place": "Oxford",
-    "ISBN": "978-0-19-920648-3 978-0-19-170971-5",
-    "issued": {
-      "date-parts": [
-        [
-          "2007"
-        ]
-      ]
-    },
-    "language": "en",
-    "number-of-pages": "438",
-    "publisher": "Oxford University Press",
-    "publisher-place": "Oxford",
-    "source": "Oxford Academic",
-    "title": "Beyond varieties of capitalism: conflict, contradictions, and complementarities in the European economy",
-    "title-short": "Beyond varieties of capitalism",
-    "type": "book",
-    "URL": "https://academic.oup.com/book/5397",
-    "citation-number": 1
-  },
-  {
     "id": "CSLSearchExample2012",
     "accessed": {
       "date-parts": [
@@ -60,6 +11,7 @@
       ]
     },
     "citation-key": "CSLSearchExample2012",
+    "citation-number": 2,
     "container-title": "Citation style editor",
     "issued": {
       "date-parts": [
@@ -71,63 +23,7 @@
     "language": "en",
     "title": "CSL search by example",
     "type": "webpage",
-    "URL": "https://editor.citationstyles.org/searchByExample/",
-    "citation-number": 2
-  },
-  {
-    "id": "maresFirmsWelfareState2001",
-    "abstract": "When and why have employers supported the development of institutions of social insurance that provide benefits to workers for various employment‐related risks in the areas of unemployment insurance, accident insurance, and early retirement? This paper challenges the dominant explanations of welfare state development premised on the assumption of business opposition to social insurance. It examines the conditions under which firms support the introduction of a new social policy and specifies the most important variables explaining the variation in the social policy preferences of employers. The model is tested in three episodes of social policy development in Germany, relying on a collection of archival sources and policy documents submitted by business associations to bureaucratic and parliamentary commissions.",
-    "accessed": {
-      "date-parts": [
-        [
-          "2026",
-          1,
-          7
-        ]
-      ]
-    },
-    "author": [
-      {
-        "family": "Mares",
-        "given": "Isabela"
-      }
-    ],
-    "call-number": "HB501 .V355 2001",
-    "chapter-number": "5",
-    "citation-key": "maresFirmsWelfareState2001",
-    "container-title": "Varieties of capitalism: the institutional foundations of comparative advantage",
-    "DOI": "10.1093/0199247757.003.0005",
-    "editor": [
-      {
-        "family": "Hall",
-        "given": "Peter A."
-      },
-      {
-        "family": "Soskice",
-        "given": "David"
-      }
-    ],
-    "event-place": "Oxford",
-    "ISBN": "978-0-19-924775-2 978-0-19-159634-6",
-    "issued": {
-      "date-parts": [
-        [
-          "2001",
-          8,
-          30
-        ]
-      ]
-    },
-    "language": "en",
-    "page": "184–212",
-    "publisher": "Oxford University Press",
-    "publisher-place": "Oxford",
-    "source": "Oxford Academic",
-    "title": "Firms and the welfare state: when, why, and how does social policy matter to employers?",
-    "title-short": "Firms and the welfare state",
-    "type": "chapter",
-    "URL": "https://academic.oup.com/book/301/chapter/134896619",
-    "citation-number": 3
+    "URL": "https://editor.citationstyles.org/searchByExample/"
   },
   {
     "id": "fennerDataCitationRoadmap2019",
@@ -188,6 +84,7 @@
       }
     ],
     "citation-key": "fennerDataCitationRoadmap2019",
+    "citation-number": 4,
     "container-title": "Scientific Data",
     "container-title-short": "Sci. Data",
     "DOI": "10.1038/s41597-019-0031-8",
@@ -212,8 +109,7 @@
     "title-short": "Data citation roadmap",
     "type": "article-journal",
     "URL": "https://www.nature.com/articles/s41597-019-0031-8",
-    "volume": "6",
-    "citation-number": 4
+    "volume": "6"
   },
   {
     "id": "galindo-castanedaLocatingMicrobesMaize2025",
@@ -254,6 +150,7 @@
       }
     ],
     "citation-key": "galindo-castanedaLocatingMicrobesMaize2025",
+    "citation-number": 5,
     "container-title": "Annals of Botany",
     "container-title-short": "Ann. Bot.",
     "DOI": "10.1093/aob/mcaf185",
@@ -293,7 +190,108 @@
     "type": "article-journal",
     "URL": "https://academic.oup.com/aob/article/136/5-6/1143/8231684",
     "volume": "136",
-    "volume-title": "Stress physiology of root systems",
-    "citation-number": 5
+    "volume-title": "Stress physiology of root systems"
+  },
+  {
+    "id": "hanckeVarietiesCapitalismConflict2007",
+    "abstract": "This edited work critically analyses developments in European Political Economy and their effects on the continental European economies. Leading political economists from Europe and the United States consider how the influential 'Varieties of Capitalism' approach can help us understand these challenges",
+    "accessed": {
+      "date-parts": [
+        [
+          "2025",
+          10,
+          19
+        ]
+      ]
+    },
+    "call-number": "HC240 .B455 2007",
+    "citation-key": "hanckeVarietiesCapitalismConflict2007",
+    "citation-number": 1,
+    "DOI": "10.1093/acprof:oso/9780199206483.001.0001",
+    "editor": [
+      {
+        "family": "Hancké",
+        "given": "Bob"
+      },
+      {
+        "family": "Rhodes",
+        "given": "Martin"
+      },
+      {
+        "family": "Thatcher",
+        "given": "Mark"
+      }
+    ],
+    "ISBN": "978-0-19-920648-3 978-0-19-170971-5",
+    "issued": {
+      "date-parts": [
+        [
+          "2007"
+        ]
+      ]
+    },
+    "language": "en",
+    "number-of-pages": "438",
+    "publisher": "Oxford University Press",
+    "publisher-place": "Oxford",
+    "source": "Oxford Academic",
+    "title": "Beyond varieties of capitalism: conflict, contradictions, and complementarities in the European economy",
+    "title-short": "Beyond varieties of capitalism",
+    "type": "book",
+    "URL": "https://academic.oup.com/book/5397"
+  },
+  {
+    "id": "maresFirmsWelfareState2001",
+    "abstract": "When and why have employers supported the development of institutions of social insurance that provide benefits to workers for various employment‐related risks in the areas of unemployment insurance, accident insurance, and early retirement? This paper challenges the dominant explanations of welfare state development premised on the assumption of business opposition to social insurance. It examines the conditions under which firms support the introduction of a new social policy and specifies the most important variables explaining the variation in the social policy preferences of employers. The model is tested in three episodes of social policy development in Germany, relying on a collection of archival sources and policy documents submitted by business associations to bureaucratic and parliamentary commissions.",
+    "accessed": {
+      "date-parts": [
+        [
+          "2026",
+          1,
+          7
+        ]
+      ]
+    },
+    "author": [
+      {
+        "family": "Mares",
+        "given": "Isabela"
+      }
+    ],
+    "call-number": "HB501 .V355 2001",
+    "chapter-number": "5",
+    "citation-key": "maresFirmsWelfareState2001",
+    "citation-number": 3,
+    "container-title": "Varieties of capitalism: the institutional foundations of comparative advantage",
+    "DOI": "10.1093/0199247757.003.0005",
+    "editor": [
+      {
+        "family": "Hall",
+        "given": "Peter A."
+      },
+      {
+        "family": "Soskice",
+        "given": "David"
+      }
+    ],
+    "ISBN": "978-0-19-924775-2 978-0-19-159634-6",
+    "issued": {
+      "date-parts": [
+        [
+          "2001",
+          8,
+          30
+        ]
+      ]
+    },
+    "language": "en",
+    "page": "184–212",
+    "publisher": "Oxford University Press",
+    "publisher-place": "Oxford",
+    "source": "Oxford Academic",
+    "title": "Firms and the welfare state: when, why, and how does social policy matter to employers?",
+    "title-short": "Firms and the welfare state",
+    "type": "chapter",
+    "URL": "https://academic.oup.com/book/301/chapter/134896619"
   }
 ]


### PR DESCRIPTION
Fix the Fenner example in the sample citations, which has an article number rather than a page reference.