### PR TITLE
Add CSL styles for Archivos Peruanos de Cardiología y Cirugía Cardiovascular

### DIFF
--- a/archivos-peruanos-de-cardiologia-y-cirugia-cardiovascular.csl
+++ b/archivos-peruanos-de-cardiologia-y-cirugia-cardiovascular.csl
@@ -114,7 +114,7 @@
       <if variable="URL">
         <group prefix="[" suffix="]" delimiter=" ">
           <text term="cited" text-case="lowercase"/>
-	  <text value="el"/>
+          <text value="el"/>
           <date variable="accessed" form="text"/>
         </group>
       </if>


### PR DESCRIPTION
This pull request adds two new citation style files for journals that follow Vancouver-style formatting, adapted for Spanish-language publications:

Archivos Peruanos de Cardiología y Cirugía Cardiovascular

Filename: archivos-peruanos-de-cardiologia-y-cirugia-cardiovascular.csl

Citation style follows Vancouver numeric format with superscript citations and Vancouver standard bibliography for biomedical journals.

ISSN: 2708-7212

Template: Based on Vancouver style (vancouver template).

Documentation link to the journal’s official instructions for authors is included.

The style have been validated against the CSL schema and include appropriate <info> metadata, locale elements, and formatting rules for citations and bibliography.
