### PR TITLE
Add archivos-peruanos-de-cardiologia-y-cirugia-cardiovascular.csl

### DIFF
--- a/archivos-peruanos-de-cardiologia-y-cirugia-cardiovascular.csl
+++ b/archivos-peruanos-de-cardiologia-y-cirugia-cardiovascular.csl
@@ -2,7 +2,7 @@
 <style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" page-range-format="minimal" demote-non-dropping-particle="sort-only">
   <!-- Polyglot; journal publishes in English, and Spanish. -->
   <info>
-    <title>Archivos Peruanos de Cardiología y Cirugía Cardiovascular (Spanish)</title>
+    <title>Archivos Peruanos de Cardiología y Cirugía Cardiovascular</title>
     <title-short>APCYCCV</title-short>
     <id>http://www.zotero.org/styles/archivos-peruanos-de-cardiologia-y-cirugia-cardiovascular</id>
     <link href="http://www.zotero.org/styles/archivos-peruanos-de-cardiologia-y-cirugia-cardiovascular" rel="self"/>


### PR DESCRIPTION
This pull request adds two new citation style files for journals that follow Vancouver-style formatting, adapted for Spanish-language publications:

Archivos Peruanos de Cardiología y Cirugía Cardiovascular

Filename: archivos-peruanos-de-cardiologia-y-cirugia-cardiovascular.csl

Citation style follows Vancouver numeric format with superscript citations and Vancouver standard bibliography for biomedical journals.

ISSN: 2708-7212

Template: Based on Vancouver style (vancouver template).

Documentation link to the journal’s official instructions for authors is included.
