### PR TITLE
Update norsk-henvisningsstandard-for-rettsvitenskapelige-tekster.csl (et-al-min adjustment for short form citations)

### DIFF
--- a/norsk-henvisningsstandard-for-rettsvitenskapelige-tekster.csl
+++ b/norsk-henvisningsstandard-for-rettsvitenskapelige-tekster.csl
@@ -19,7 +19,7 @@
     <category citation-format="note"/>
     <category field="law"/>
     <summary>Norwegian legal citation style based on "Veiledning for henvisninger i juridiske tekster" (February 2019).</summary>
-    <updated>2026-01-16T13:18:00+00:00</updated>
+    <updated>2026-01-20T12:38:00+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale xml:lang="nb">
@@ -267,7 +267,7 @@
       </else>
     </choose>
   </macro>
-  <citation disambiguate-add-givenname="true" givenname-disambiguation-rule="primary-name" disambiguate-add-year-suffix="true" et-al-min="2" et-al-use-first="1">
+  <citation disambiguate-add-givenname="true" givenname-disambiguation-rule="primary-name" disambiguate-add-year-suffix="true" et-al-min="4" et-al-use-first="1">
     <sort>
       <key macro="author-short"/>
       <key macro="title-short"/>


### PR DESCRIPTION
Aligned the et al. style for short form citations with the style guide (only et al. if there are more than three authors, even in short form).

A sidenote: the overhaul of other parts of the style this month seems to have caused a regression here, as I don't think the line in question has been touched this year, and the output was as expected at least in September 2025.