### PR TITLE
Change et-al-use-first attribute value in BSSA CSL file

### DIFF
--- a/bulletin-of-the-seismological-society-of-america.csl
+++ b/bulletin-of-the-seismological-society-of-america.csl
@@ -17,12 +17,13 @@
     <category field="geology"/>
     <issn>0037-1106</issn>
     <eissn>1943-3573</eissn>
-    <updated>2018-08-14T15:15:20+00:00</updated>
+    <updated>2026-01-20T22:15:20+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <macro name="author">
     <names variable="author">
       <name name-as-sort-order="first" and="text" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
+      <et-al font-style="italic"/>
       <label form="short" prefix=" (" suffix=")"/>
       <substitute>
         <names variable="editor"/>


### PR DESCRIPTION
After pushback from journal review to increase number of authors, also see https://www.seismosoc.org/publications/bssa-submission-guidelines-2/#data for journal example of 10 use-first authors.

### Description
Increase et-al-use-first for biblio. from 1 to 10.

### Checklist
- [x] Check that you've added a link to the style you used as a template in the `<info>` block at the beginning of the file with `rel="template"`.  
- [x] Check that you've added a link to the style guidelines with `rel="documentation"`.  
- [x] Check that you've added yourself as the `<author>` of the style or `<contributor>` for a style update. 
- [x] Check that you've used the correct terms or labels instead of hardcoding into affixes (e.g., `<text variable="page" prefix="pp. "/>`).
- [x] Check that you've not used `<text value="...` if not absolutely necessary.
- [x] Check that you've not changed line 1 of the style.
