### PR TITLE
Add medical-education-and-clinical-practice.csl

### DIFF
--- a/medical-education-and-clinical-practice.csl
+++ b/medical-education-and-clinical-practice.csl
@@ -232,21 +232,23 @@
         </group>
       </else-if>
       <else-if type="report">
-        <date variable="issued" delimiter=" ">
-          <date-part name="year"/>
-          <date-part name="month" form="short" strip-periods="true"/>
-        </date>
-        <text macro="accessed-date" prefix=" "/>
+        <group delimiter=" ">
+          <date variable="issued" delimiter=" ">
+            <date-part name="year"/>
+            <date-part name="month" form="short" strip-periods="true"/>
+          </date>
+          <text macro="accessed-date"/>
+        </group>
       </else-if>
       <else-if type="patent">
-        <group suffix=".">
+        <group suffix=". ">
           <group delimiter=", ">
             <text variable="number"/>
             <date variable="issued">
               <date-part name="year"/>
             </date>
           </group>
-          <text macro="accessed-date" prefix=" "/>
+          <text macro="accessed-date"/>
         </group>
       </else-if>
       <else-if type="speech">
@@ -280,7 +282,7 @@
       <else-if type="book" match="any">
         <group delimiter=" ">
           <text variable="number-of-pages" prefix=" "/>
-          <label variable="number-of-pages" form="short" prefix=" " plural="never"/>
+          <label variable="number-of-pages" form="short" plural="never"/>
         </group>
       </else-if>
       <else>
@@ -343,28 +345,30 @@
   <bibliography et-al-min="7" et-al-use-first="6" second-field-align="flush">
     <layout>
       <text variable="citation-number" suffix=". "/>
-      <group delimiter=". " suffix=". ">
-        <text macro="author"/>
-        <text macro="title"/>
-      </group>
-      <group delimiter=" " suffix=". ">
-        <group delimiter=": ">
-          <text macro="chapter-marker"/>
-          <group delimiter=" ">
-            <text macro="editor"/>
-            <text macro="container-title"/>
+      <group delimiter=". ">
+        <group delimiter=". ">
+          <text macro="author"/>
+          <text macro="title"/>
+        </group>
+        <group delimiter=" " suffix=". ">
+          <group delimiter=": ">
+            <text macro="chapter-marker"/>
+            <group delimiter=" ">
+              <text macro="editor"/>
+              <text macro="container-title"/>
+            </group>
+          </group>
+          <text macro="publisher"/>
+          <group>
+            <text macro="date"/>
+            <text macro="journal-location"/>
+            <text macro="pages"/>
           </group>
         </group>
-        <text macro="publisher"/>
-        <group>
-          <text macro="date"/>
-          <text macro="journal-location"/>
-          <text macro="pages"/>
-        </group>
+        <text macro="collection-details"/>
+        <text macro="report-details"/>
+        <text macro="access"/>
       </group>
-      <text macro="collection-details" suffix=". "/>
-      <text macro="report-details" suffix=". "/>
-      <text macro="access"/>
     </layout>
   </bibliography>
 </style>


### PR DESCRIPTION
This pull request adds a new citation style file for a medical education journal that follows Vancouver-style formatting, adapted for Spanish-language publications:

Medical Education & Clinical Practice
Filename: medical-education-and-clinical-practice.csl
Citation style follows Vancouver numeric format with superscript citations in brackets [1,2,3] and Vancouver standard bibliography for biomedical journals according to ICMJE guidelines.
ISSN: 3084-8008
Template: Based on Vancouver style (vancouver template).
Documentation link to the journal's official instructions for authors is included.
Citations are placed before punctuation marks, with consecutive references separated by commas [1,2] and ranges by hyphens [1-3].
References with more than six authors display first six followed by "et al."
Includes automatic DOI formatting when available.
