### PR TITLE
Update norsk-henvisningsstandard-for-rettsvitenskapelige-tekster.csl

### DIFF
--- a/norsk-henvisningsstandard-for-rettsvitenskapelige-tekster.csl
+++ b/norsk-henvisningsstandard-for-rettsvitenskapelige-tekster.csl
@@ -454,16 +454,16 @@
             </group>
             <group prefix="(" delimiter=", " suffix=")">
               <group delimiter=" ">
-                <text term="henceforth"/>
                 <!-- Hack (see <locale> for details) -->
+                <text term="henceforth"/>
                 <names variable="author">
                   <name delimiter-precedes-last="never" name-as-sort-order="first" et-al-min="99" and="text"/>
                   <et-al term="and others"/>
                 </names>
               </group>
               <group delimiter=" ">
-                <text term="in press"/>
                 <!-- Hack (see <locale> for details) -->
+                <text term="in press"/>
                 <!-- "issued" is mapped to "Date Enacted" in Zotero, but nevertheless used for the "in force" date in this style due to the above-mentioned mention of treaty in the CSL specification for "available-date". -->
                 <text macro="issued-full-date"/>
               </group>


### PR DESCRIPTION
Added support for the "treaty" item type (via Zotero Extra fields for the time being)

The hardcoded terms on line 444 and 446 are terms that I could not find in the locale file, which are rather specific for citing treaties. They are, respectively, the Norwegian equivalents of "treaty between" (444) and "in force" (446).

PS: can terms that do not exist in the locale file at all be defined in the style-specific terms section? E.g. like this (see the last two term name lines):
```
  <locale xml:lang="nb">
    <terms>
      <term name="and others">et al.</term>
      <term name="accessed">lest</term>
      <term name="treaty between">traktat mellom</term>
      <term name="in force">i kraft</term>
    </terms>
  </locale>
```
If so, I would like to amend the CSL to set the terms like this before the pull request is merged.