### PR TITLE
Update harvard-university-of-bath.csl

### DIFF
--- a/harvard-university-of-bath.csl
+++ b/harvard-university-of-bath.csl
@@ -20,7 +20,7 @@
     </contributor>
     <category citation-format="author-date"/>
     <summary>Adaptation of Harvard referencing style used at the University of Bath.</summary>
-    <updated>2025-04-01T09:39:05+01:00</updated>
+    <updated>2026-01-26T13:42:00+01:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale xml:lang="en">
@@ -30,6 +30,7 @@
         <single>c.</single>
         <multiple>cc.</multiple>
       </term>
+      <term name="edition" form="short">ed.</term>
       <term name="editor" form="short">
         <single>ed.</single>
         <multiple>eds</multiple>
@@ -109,7 +110,7 @@
   </macro>
   <macro name="author">
     <names variable="author">
-      <name and="text" delimiter-precedes-last="never" initialize-with="." name-as-sort-order="all"/>
+      <name and="text" delimiter-precedes-last="never" delimiter-precedes-et-al="never" initialize-with="." name-as-sort-order="all"/>
       <substitute>
         <choose>
           <if type="entry" variable="title container-title">
@@ -117,7 +118,7 @@
           </if>
           <else-if variable="editor">
             <names variable="editor">
-              <name and="text" delimiter-precedes-last="never" initialize-with="." name-as-sort-order="all"/>
+              <name and="text" delimiter-precedes-last="never" delimiter-precedes-et-al="never" initialize-with="." name-as-sort-order="all"/>
               <label form="short" prefix=", " text-case="lowercase"/>
             </names>
           </else-if>
@@ -130,7 +131,7 @@
   </macro>
   <macro name="author-short">
     <names variable="author">
-      <name form="short" and="text" delimiter-precedes-last="never" initialize-with="."/>
+      <name form="short" and="text" delimiter-precedes-last="never" delimiter-precedes-et-al="never" initialize-with="." name-as-sort-order="all"/>
       <substitute>
         <choose>
           <if type="entry"/>
@@ -789,9 +790,11 @@
         <date variable="issued">
           <date-part name="year"/>
         </date>
+        <text variable="year-suffix"/>
       </if>
       <else>
         <text term="no date" form="short"/>
+        <text variable="year-suffix" prefix=" "/>
       </else>
     </choose>
   </macro>
@@ -807,11 +810,13 @@
                   <date-part name="month" suffix=" "/>
                   <date-part name="year"/>
                 </date>
+                <text variable="year-suffix"/>
               </if>
               <else>
                 <date variable="issued">
                   <date-part name="year"/>
                 </date>
+                <text variable="year-suffix"/>
               </else>
             </choose>
           </if>
@@ -819,15 +824,17 @@
             <date variable="issued">
               <date-part name="year"/>
             </date>
+            <text variable="year-suffix"/>
           </else>
         </choose>
       </if>
       <else>
         <text term="no date" form="short"/>
+        <text variable="year-suffix" prefix=" "/>
       </else>
     </choose>
   </macro>
-  <citation et-al-min="4" et-al-use-first="1" disambiguate-add-names="true" disambiguate-add-givenname="true" disambiguate-add-year-suffix="true" collapse="year">
+  <citation et-al-min="4" et-al-use-first="1" disambiguate-add-givenname="true" givenname-disambiguation-rule="primary-name-with-initials" disambiguate-add-names="true" disambiguate-add-year-suffix="true" collapse="year" cite-group-delimiter="; ">
     <sort>
       <key variable="issued"/>
       <key variable="author"/>


### PR DESCRIPTION
### Description

This PR adds settings for better conformance with the requirements for in-text citations.

- Lead authors are disambiguated with initials following the family name.
- Truncated author lists are disambiguated by including more names.
- Incorrect punctuation has been fixed.
- Handling of the extra label for years has been fixed (should be a space between "n.d." and letter).

It also explicitly sets the abbreviation for "edition".

### Checklist
- [x] Check that you've added a link to the style you used as a template in the `<info>` block at the beginning of the file with `rel="template"`.  
- [x] Check that you've added a link to the style guidelines with `rel="documentation"`.  
- [x] Check that you've added yourself as the `<author>` of the style or `<contributor>` for a style update. 
- [x] Check that you've used the correct terms or labels instead of hardcoding into affixes (e.g., `<text variable="page" prefix="pp. "/>`).
- [x] Check that you've not used `<text value="...` if not absolutely necessary.
- [x] Check that you've not changed line 1 of the style.
