### PR TITLE
Update norsk-henvisningsstandard-for-rettsvitenskapelige-tekster.csl: macro refactoring and some improvements for "treaty"

### DIFF
--- a/norsk-henvisningsstandard-for-rettsvitenskapelige-tekster.csl
+++ b/norsk-henvisningsstandard-for-rettsvitenskapelige-tekster.csl
@@ -203,10 +203,10 @@
       <else>
         <choose>
           <if locator="paragraph article-locator" match="any">
-              <group delimiter=" ">
-                <label variable="locator" form="long"/>
-                <text variable="locator"/>
-              </group>
+            <group delimiter=" ">
+              <label variable="locator" form="long"/>
+              <text variable="locator"/>
+            </group>
           </if>
           <else-if locator="page">
             <group delimiter="&#160;">


### PR DESCRIPTION
### Description
- refactored title macro and nor-legislation macro to make code more logical/less obscure.
- add hard spaces for relevant locators
- reordered locator conditionals and removed unneccesary conditional
- improve treaty citation (add options for other citation formats using the "Public Law Number"/"number" field)
- add support for "article" locator, including forcing long-form where appropriate (though this will only work in Zotero after this fix is pulled into zotero/zotero: https://github.com/Juris-M/citeproc-js/pull/263)

### Checklist
- [x] Check that you've added a link to the style you used as a template in the `<info>` block at the beginning of the file with `rel="template"`.  
- [x] Check that you've added a link to the style guidelines with `rel="documentation"`.  
- [x] Check that you've added yourself as the `<author>` of the style or `<contributor>` for a style update. 
- [x] Check that you've used the correct terms or labels instead of hardcoding into affixes (e.g., `<text variable="page" prefix="pp. "/>`).
- [x] Check that you've not used `<text value="...` if not absolutely necessary.
- [x] Check that you've not changed line 1 of the style.
