### PR TITLE
Update et-al-min value in citation macro

### DIFF
--- a/university-of-south-wales-harvard.csl
+++ b/university-of-south-wales-harvard.csl
@@ -164,7 +164,7 @@
   <macro name="patent">
     <text variable="number" suffix=" [Patent]."/>
   </macro>
-  <citation et-al-min="3" et-al-use-first="1" disambiguate-add-year-suffix="true">
+  <citation et-al-min="4" et-al-use-first="1" disambiguate-add-year-suffix="true">
     <sort>
       <key macro="year-date"/>
       <key variable="author"/>


### PR DESCRIPTION
USW Harvard doesn't want 'et al' in in-text citations until four or more authors

## CSL Styles Pull Request Template
You're about to create a pull request to the CSL **styles** repository.  
If you haven't done so already, see <https://github.com/citation-style-language/styles/blob/master/CONTRIBUTING.md> for instructions on how to contribute, and <https://github.com/citation-style-language/styles/blob/master/STYLE_REQUIREMENTS.md> for the requirements a style must meet before acceptance.  
In addition, please fill out the pull request template below.


### Description
(Briefly describe the style or changes you're proposing.)
Edited the line: <citation et-al-min="3" et-al-use-first="1" disambiguate-add-year-suffix="true"> and changed the "3" to "4"


### Checklist
- [ ] Check that you've added a link to the style you used as a template in the `<info>` block at the beginning of the file with `rel="template"`.  
- [ ] Check that you've added a link to the style guidelines with `rel="documentation"`.  
- [ ] Check that you've added yourself as the `<author>` of the style or `<contributor>` for a style update. 
- [ ] Check that you've used the correct terms or labels instead of hardcoding into affixes (e.g., `<text variable="page" prefix="pp. "/>`).
- [ ] Check that you've not used `<text value="...` if not absolutely necessary.
- [ ] Check that you've not changed line 1 of the style.
