### PR TITLE
OSCOLA: Support DOI and use more global options

### DIFF
--- a/oscola-journal-abbreviations.csl
+++ b/oscola-journal-abbreviations.csl
@@ -198,7 +198,7 @@
             <text term="interview" text-case="capitalize-first"/>
             <text form="verb" term="contributor"/>
             <names variable="author">
-              <name/>
+              <name initialize="false"/>
             </names>
           </group>
         </group>
@@ -213,7 +213,7 @@
           </group>
           <names variable="recipient">
             <label form="verb" suffix=" "/>
-            <name/>
+            <name initialize="false"/>
           </names>
         </group>
       </else-if>

--- a/oscola-no-ibid.csl
+++ b/oscola-no-ibid.csl
@@ -192,7 +192,7 @@
             <text term="interview" text-case="capitalize-first"/>
             <text form="verb" term="contributor"/>
             <names variable="author">
-              <name/>
+              <name initialize="false"/>
             </names>
           </group>
         </group>
@@ -207,7 +207,7 @@
           </group>
           <names variable="recipient">
             <label form="verb" suffix=" "/>
-            <name/>
+            <name initialize="false"/>
           </names>
         </group>
       </else-if>

--- a/oscola.csl
+++ b/oscola.csl
@@ -191,7 +191,7 @@
             <text term="interview" text-case="capitalize-first"/>
             <text form="verb" term="contributor"/>
             <names variable="author">
-              <name/>
+              <name initialize="false"/>
             </names>
           </group>
         </group>
@@ -206,7 +206,7 @@
           </group>
           <names variable="recipient">
             <label form="verb" suffix=" "/>
-            <name/>
+            <name initialize="false"/>
           </names>
         </group>
       </else-if>


### PR DESCRIPTION
Use a DOI if available; although the OSCOLA guide never refers to them, they give a more reliable permalink than the `URL` variable, and it is implied at <https://www.law.ox.ac.uk/research-subject-groups/publications/oscola-faqs> that they may be used in this way.

Set repeated name options globally to simplify code.

### Checklist
- [X] Check that you've added a link to the style you used as a template in the `<info>` block at the beginning of the file with `rel="template"`.  
- [X] Check that you've added a link to the style guidelines with `rel="documentation"`.  
- [X] Check that you've added yourself as the `<author>` of the style or `<contributor>` for a style update. 
- [X] Check that you've used the correct terms or labels instead of hardcoding into affixes (e.g., `<text variable="page" prefix="pp. "/>`).
- [X] Check that you've not used `<text value="...` if not absolutely necessary.
- [X] Check that you've not changed line 1 of the style.
