### PR TITLE
Update harvard-cite-them-right.csl (fix trailing "in")

### DIFF
--- a/harvard-cite-them-right.csl
+++ b/harvard-cite-them-right.csl
@@ -17,7 +17,7 @@
     <category citation-format="author-date"/>
     <category field="generic-base"/>
     <summary>Harvard according to Cite Them Right, 11th edition.</summary>
-    <updated>2026-02-07T20:13:00+00:00</updated>
+    <updated>2026-02-09T07:00:00+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale xml:lang="en-GB">
@@ -268,17 +268,6 @@
       </else>
     </choose>
   </macro>
-  <macro name="container-prefix">
-    <choose>
-      <if type="chapter paper-conference" match="any">
-        <choose>
-          <if variable="container-title">
-            <text term="in"/>
-          </if>
-        </choose>
-      </if>
-    </choose>
-  </macro>
   <citation et-al-min="4" et-al-use-first="1" disambiguate-add-year-suffix="true" disambiguate-add-names="true" disambiguate-add-givenname="true" collapse="year">
     <sort>
       <key macro="year-date"/>
@@ -310,9 +299,8 @@
           <group delimiter=", ">
             <text macro="title"/>
             <group delimiter=" ">
-              <text macro="container-prefix"/>
-              <text macro="editor"/>
-              <text macro="container-title"/>
+              <text term="in"/>
+              <text variable="container-title"/>
             </group>
           </group>
         </group>


### PR DESCRIPTION
## CSL Styles Pull Request Template
You're about to create a pull request to the CSL **styles** repository.  
If you haven't done so already, see <https://github.com/citation-style-language/styles/blob/master/CONTRIBUTING.md> for instructions on how to contribute, and <https://github.com/citation-style-language/styles/blob/master/STYLE_REQUIREMENTS.md> for the requirements a style must meet before acceptance.  
In addition, please fill out the pull request template below.

### Description

This makes a small tweak to the Harvard CTR style.

Whilst using Zotero, I noticed that there is an issue with my own Conference Paper references. If I have no Proceedings Title set inside of Zotero, then it would lead to a trailing "in." after the Title, for example:

```
Decan, A., Mens, T. and Claes, M. (2017) ‘An empirical comparison of dependency issues in OSS packaging ecosystems’, in. 2017 IEEE 24th International Conference on Software Analysis, Evolution and Reengineering (SANER), pp. 2–12. Available at: https://doi.org/10.1109/SANER.2017.7884604.
```

This PR changes it so that this is only included if the Proceedings Title is also included.

```
Decan, A., Mens, T. and Claes, M. (2017) ‘An empirical comparison of dependency issues in OSS packaging ecosystems’. 2017 IEEE 24th International Conference on Software Analysis, Evolution and Reengineering (SANER), pp. 2–12. Available at: https://doi.org/10.1109/SANER.2017.7884604.
```

Apologies if the double-nested if statement is bad practice, I'm not 100% familiar with CSL. If there are appropriate tweaks to be made then please let me know.

### Checklist

- [x] Check that you've added a link to the style you used as a template in the `<info>` block at the beginning of the file with `rel="template"`.  
- [x] Check that you've added a link to the style guidelines with `rel="documentation"`.  
- [x] Check that you've added yourself as the `<author>` of the style or `<contributor>` for a style update. 
- [x] Check that you've used the correct terms or labels instead of hardcoding into affixes (e.g., `<text variable="page" prefix="pp. "/>`).
- [x] Check that you've not used `<text value="...` if not absolutely necessary.
- [x] Check that you've not changed line 1 of the style.