### PR TITLE
norsk-henvisningsstandard-for-rettsvitenskapelige-tekster.csl: support for new types, other improvements and fixes

### DIFF
--- a/norsk-henvisningsstandard-for-rettsvitenskapelige-tekster.csl
+++ b/norsk-henvisningsstandard-for-rettsvitenskapelige-tekster.csl
@@ -113,10 +113,7 @@
       <if type="chapter article-journal article-newspaper article-magazine post-weblog" match="any">
         <text quotes="true" variable="title"/>
       </if>
-      <else-if type="bill">
-        <text variable="title"/>
-      </else-if>
-      <else-if type="treaty">
+      <else-if type="bill treaty" match="any">
         <text variable="title"/>
       </else-if>
       <else>


### PR DESCRIPTION
### Description
- add support for citing Norwegian preparatory works using "bill" item type (European jurisdictions do not know of the concept of a "bill", which is a quite US-centric item type. However, a US bill is a form of preparatory work for legislation, which makes the item type the most closely related).
- add distinction between legislations and regulations, with separate sorting (the citation formats are the same, though)
- various minor improvements and fixes

### Checklist
- [x] Check that you've added a link to the style you used as a template in the `<info>` block at the beginning of the file with `rel="template"`.  
- [x] Check that you've added a link to the style guidelines with `rel="documentation"`.  
- [x] Check that you've added yourself as the `<author>` of the style or `<contributor>` for a style update. 
- [x] Check that you've used the correct terms or labels instead of hardcoding into affixes (e.g., `<text variable="page" prefix="pp. "/>`).
- [x] Check that you've not used `<text value="...` if not absolutely necessary.
- [x] Check that you've not changed line 1 of the style.
