### PR TITLE
Update university-of-hull-harvard.csl (2026)

### DIFF
--- a/university-of-hull-harvard.csl
+++ b/university-of-hull-harvard.csl
@@ -14,7 +14,7 @@
     </contributor>
     <category citation-format="author-date"/>
     <summary>University of Hull Harvard</summary>
-    <updated>2026-02-09T15:59:50+00:00</updated>
+    <updated>2026-02-11T14:15:52+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale xml:lang="en">
@@ -84,7 +84,7 @@
       <if variable="DOI" type="article-journal paper-conference">
         <text variable="DOI" strip-periods="false" prefix="https://doi.org/"/>
       </if>
-      <else-if variable="URL" type="webpage">
+      <else-if type="webpage post post-weblog" match="any">
         <group delimiter=" ">
           <text variable="URL"/>
           <group delimiter=" " prefix="[" suffix="].">
@@ -121,6 +121,12 @@
           <text macro="edition"/>
         </group>
       </if>
+      <else-if type="post-weblog" match="any">
+        <group delimiter=" " suffix=".">
+          <text variable="title"/>
+          <text variable="genre" prefix="[" suffix="]"/>
+        </group>
+      </else-if>
       <else>
         <text variable="title" text-case="capitalize-first" strip-periods="false" quotes="false" suffix="."/>
       </else>


### PR DESCRIPTION
Revisions to University of Hull Harvard (2026)

### Description
Update to University of Hull Harvard to accommodate changes made in 2025/2026.
