### PR TITLE
AMA: Correct bracketed locator group

### DIFF
--- a/american-medical-association-alphabetical.csl
+++ b/american-medical-association-alphabetical.csl
@@ -8,6 +8,7 @@
     <link href="http://www.zotero.org/styles/american-medical-association-alphabetical" rel="self"/>
     <link href="http://www.zotero.org/styles/american-medical-association" rel="template"/>
     <link href="https://doi.org/10.1093/jama/9780190246556.003.0003" rel="documentation"/>
+    <link href="https://zotero.org/groups/2205533/collections/QW4JGG9G" rel="documentation"/>
     <author>
       <name>Julian Onions</name>
       <uri>https://orcid.org/0000-0001-5192-6856</uri>

--- a/american-medical-association-brackets.csl
+++ b/american-medical-association-brackets.csl
@@ -8,6 +8,7 @@
     <link href="http://www.zotero.org/styles/american-medical-association-brackets" rel="self"/>
     <link href="http://www.zotero.org/styles/american-medical-association" rel="template"/>
     <link href="https://doi.org/10.1093/jama/9780190246556.003.0003" rel="documentation"/>
+    <link href="https://zotero.org/groups/2205533/collections/QW4JGG9G" rel="documentation"/>
     <author>
       <name>Julian Onions</name>
       <uri>https://orcid.org/0000-0001-5192-6856</uri>

--- a/american-medical-association-no-et-al.csl
+++ b/american-medical-association-no-et-al.csl
@@ -8,6 +8,7 @@
     <link href="http://www.zotero.org/styles/american-medical-association-no-et-al" rel="self"/>
     <link href="http://www.zotero.org/styles/american-medical-association" rel="template"/>
     <link href="https://doi.org/10.1093/jama/9780190246556.003.0003" rel="documentation"/>
+    <link href="https://zotero.org/groups/2205533/collections/QW4JGG9G" rel="documentation"/>
     <author>
       <name>Julian Onions</name>
       <uri>https://orcid.org/0000-0001-5192-6856</uri>

--- a/american-medical-association-no-url-alphabetical.csl
+++ b/american-medical-association-no-url-alphabetical.csl
@@ -8,6 +8,7 @@
     <link href="http://www.zotero.org/styles/american-medical-association-no-url-alphabetical" rel="self"/>
     <link href="http://www.zotero.org/styles/american-medical-association-no-url" rel="template"/>
     <link href="https://doi.org/10.1093/jama/9780190246556.003.0003" rel="documentation"/>
+    <link href="https://zotero.org/groups/2205533/collections/QW4JGG9G" rel="documentation"/>
     <author>
       <name>Julian Onions</name>
       <uri>https://orcid.org/0000-0001-5192-6856</uri>

--- a/american-medical-association-no-url.csl
+++ b/american-medical-association-no-url.csl
@@ -8,6 +8,7 @@
     <link href="http://www.zotero.org/styles/american-medical-association-no-url" rel="self"/>
     <link href="http://www.zotero.org/styles/american-medical-association" rel="template"/>
     <link href="https://doi.org/10.1093/jama/9780190246556.003.0003" rel="documentation"/>
+    <link href="https://zotero.org/groups/2205533/collections/QW4JGG9G" rel="documentation"/>
     <author>
       <name>Julian Onions</name>
       <uri>https://orcid.org/0000-0001-5192-6856</uri>

--- a/american-medical-association-parentheses.csl
+++ b/american-medical-association-parentheses.csl
@@ -8,6 +8,7 @@
     <link href="http://www.zotero.org/styles/american-medical-association-parentheses" rel="self"/>
     <link href="http://www.zotero.org/styles/american-medical-association-brackets" rel="template"/>
     <link href="https://doi.org/10.1093/jama/9780190246556.003.0003" rel="documentation"/>
+    <link href="https://zotero.org/groups/2205533/collections/QW4JGG9G" rel="documentation"/>
     <author>
       <name>Julian Onions</name>
       <uri>https://orcid.org/0000-0001-5192-6856</uri>

--- a/american-medical-association.csl
+++ b/american-medical-association.csl
@@ -8,6 +8,7 @@
     <link href="http://www.zotero.org/styles/american-medical-association" rel="self"/>
     <link href="http://www.zotero.org/styles/american-medical-association-10th-edition" rel="template"/>
     <link href="https://doi.org/10.1093/jama/9780190246556.003.0003" rel="documentation"/>
+    <link href="https://zotero.org/groups/2205533/collections/QW4JGG9G" rel="documentation"/>
     <author>
       <name>Julian Onions</name>
       <uri>https://orcid.org/0000-0001-5192-6856</uri>


### PR DESCRIPTION
Correct a prefix to a delimiter in the locator for bracketed variants. Update documentation link.

### Checklist
- [X] Check that you've added a link to the style you used as a template in the `<info>` block at the beginning of the file with `rel="template"`.  
- [X] Check that you've added a link to the style guidelines with `rel="documentation"`.  
- [X] Check that you've added yourself as the `<author>` of the style or `<contributor>` for a style update. 
- [X] Check that you've used the correct terms or labels instead of hardcoding into affixes (e.g., `<text variable="page" prefix="pp. "/>`).
- [X] Check that you've not used `<text value="...` if not absolutely necessary.
- [X] Check that you've not changed line 1 of the style.
