### PR TITLE
APA and friends: Use `givenname-disambiguation-rule`

### DIFF
--- a/apa-annotated-bibliography.csl
+++ b/apa-annotated-bibliography.csl
@@ -2206,7 +2206,7 @@
     </group>
   </macro>
   <!-- Citation -->
-  <citation collapse="year" disambiguate-add-givenname="true" disambiguate-add-names="true" disambiguate-add-year-suffix="true" et-al-min="3" et-al-use-first="1">
+  <citation collapse="year" disambiguate-add-givenname="true" disambiguate-add-names="true" disambiguate-add-year-suffix="true" et-al-min="3" et-al-use-first="1" givenname-disambiguation-rule="primary-name-with-initials">
     <sort>
       <key macro="author-sort" names-min="3" names-use-first="1"/>
       <key macro="date-sort-group"/>

--- a/apa-no-ampersand.csl
+++ b/apa-no-ampersand.csl
@@ -2214,7 +2214,7 @@
     </group>
   </macro>
   <!-- Citation -->
-  <citation collapse="year" disambiguate-add-givenname="true" disambiguate-add-names="true" disambiguate-add-year-suffix="true" et-al-min="3" et-al-use-first="1">
+  <citation collapse="year" disambiguate-add-givenname="true" disambiguate-add-names="true" disambiguate-add-year-suffix="true" et-al-min="3" et-al-use-first="1" givenname-disambiguation-rule="primary-name-with-initials">
     <sort>
       <key macro="author-sort" names-min="3" names-use-first="1"/>
       <key macro="date-sort-group"/>

--- a/apa-no-initials.csl
+++ b/apa-no-initials.csl
@@ -2206,7 +2206,7 @@
     </group>
   </macro>
   <!-- Citation -->
-  <citation collapse="year" disambiguate-add-givenname="true" disambiguate-add-names="true" disambiguate-add-year-suffix="true" et-al-min="3" et-al-use-first="1">
+  <citation collapse="year" disambiguate-add-givenname="true" disambiguate-add-names="true" disambiguate-add-year-suffix="true" et-al-min="3" et-al-use-first="1" givenname-disambiguation-rule="primary-name-with-initials">
     <sort>
       <key macro="author-sort" names-min="3" names-use-first="1"/>
       <key macro="date-sort-group"/>

--- a/apa-single-spaced.csl
+++ b/apa-single-spaced.csl
@@ -2206,7 +2206,7 @@
     </group>
   </macro>
   <!-- Citation -->
-  <citation collapse="year" disambiguate-add-givenname="true" disambiguate-add-names="true" disambiguate-add-year-suffix="true" et-al-min="3" et-al-use-first="1">
+  <citation collapse="year" disambiguate-add-givenname="true" disambiguate-add-names="true" disambiguate-add-year-suffix="true" et-al-min="3" et-al-use-first="1" givenname-disambiguation-rule="primary-name-with-initials">
     <sort>
       <key macro="author-sort" names-min="3" names-use-first="1"/>
       <key macro="date-sort-group"/>

--- a/apa-with-abstract.csl
+++ b/apa-with-abstract.csl
@@ -2206,7 +2206,7 @@
     </group>
   </macro>
   <!-- Citation -->
-  <citation collapse="year" disambiguate-add-givenname="true" disambiguate-add-names="true" disambiguate-add-year-suffix="true" et-al-min="3" et-al-use-first="1">
+  <citation collapse="year" disambiguate-add-givenname="true" disambiguate-add-names="true" disambiguate-add-year-suffix="true" et-al-min="3" et-al-use-first="1" givenname-disambiguation-rule="primary-name-with-initials">
     <sort>
       <key macro="author-sort" names-min="3" names-use-first="1"/>
       <key macro="date-sort-group"/>

--- a/apa.csl
+++ b/apa.csl
@@ -2206,7 +2206,7 @@
     </group>
   </macro>
   <!-- Citation -->
-  <citation collapse="year" disambiguate-add-givenname="true" disambiguate-add-names="true" disambiguate-add-year-suffix="true" et-al-min="3" et-al-use-first="1">
+  <citation collapse="year" disambiguate-add-givenname="true" disambiguate-add-names="true" disambiguate-add-year-suffix="true" et-al-min="3" et-al-use-first="1" givenname-disambiguation-rule="primary-name-with-initials">
     <sort>
       <key macro="author-sort" names-min="3" names-use-first="1"/>
       <key macro="date-sort-group"/>

--- a/chicago-author-date-17th-edition.csl
+++ b/chicago-author-date-17th-edition.csl
@@ -4137,7 +4137,7 @@
       </choose>
     </group>
   </macro>
-  <citation collapse="year" disambiguate-add-givenname="true" disambiguate-add-names="true" disambiguate-add-year-suffix="true" et-al-min="4" et-al-use-first="1">
+  <citation collapse="year" disambiguate-add-givenname="true" disambiguate-add-names="true" disambiguate-add-year-suffix="true" et-al-min="4" et-al-use-first="1" givenname-disambiguation-rule="primary-name">
     <layout delimiter="; " prefix="(" suffix=")">
       <group delimiter=", ">
         <choose>

--- a/chicago-author-date-access-dates.csl
+++ b/chicago-author-date-access-dates.csl
@@ -4093,7 +4093,7 @@
       </choose>
     </group>
   </macro>
-  <citation collapse="year" disambiguate-add-givenname="true" disambiguate-add-names="true" disambiguate-add-year-suffix="true" et-al-min="3" et-al-use-first="1">
+  <citation collapse="year" disambiguate-add-givenname="true" disambiguate-add-names="true" disambiguate-add-year-suffix="true" et-al-min="3" et-al-use-first="1" givenname-disambiguation-rule="primary-name">
     <layout delimiter="; " prefix="(" suffix=")">
       <group delimiter=", ">
         <choose>

--- a/chicago-author-date-archive-place-first-no-url.csl
+++ b/chicago-author-date-archive-place-first-no-url.csl
@@ -4070,7 +4070,7 @@
       </choose>
     </group>
   </macro>
-  <citation collapse="year" disambiguate-add-givenname="true" disambiguate-add-names="true" disambiguate-add-year-suffix="true" et-al-min="3" et-al-use-first="1">
+  <citation collapse="year" disambiguate-add-givenname="true" disambiguate-add-names="true" disambiguate-add-year-suffix="true" et-al-min="3" et-al-use-first="1" givenname-disambiguation-rule="primary-name">
     <layout delimiter="; " prefix="(" suffix=")">
       <group delimiter=", ">
         <choose>

--- a/chicago-author-date-archive-place-first.csl
+++ b/chicago-author-date-archive-place-first.csl
@@ -4080,7 +4080,7 @@
       </choose>
     </group>
   </macro>
-  <citation collapse="year" disambiguate-add-givenname="true" disambiguate-add-names="true" disambiguate-add-year-suffix="true" et-al-min="3" et-al-use-first="1">
+  <citation collapse="year" disambiguate-add-givenname="true" disambiguate-add-names="true" disambiguate-add-year-suffix="true" et-al-min="3" et-al-use-first="1" givenname-disambiguation-rule="primary-name">
     <layout delimiter="; " prefix="(" suffix=")">
       <group delimiter=", ">
         <choose>

--- a/chicago-author-date-classic-no-url.csl
+++ b/chicago-author-date-classic-no-url.csl
@@ -4078,7 +4078,7 @@
       </choose>
     </group>
   </macro>
-  <citation collapse="year" disambiguate-add-givenname="true" disambiguate-add-names="true" disambiguate-add-year-suffix="true" et-al-min="3" et-al-use-first="1">
+  <citation collapse="year" disambiguate-add-givenname="true" disambiguate-add-names="true" disambiguate-add-year-suffix="true" et-al-min="3" et-al-use-first="1" givenname-disambiguation-rule="primary-name">
     <layout delimiter="; " prefix="(" suffix=")">
       <group delimiter=", ">
         <choose>

--- a/chicago-author-date-classic.csl
+++ b/chicago-author-date-classic.csl
@@ -4088,7 +4088,7 @@
       </choose>
     </group>
   </macro>
-  <citation collapse="year" disambiguate-add-givenname="true" disambiguate-add-names="true" disambiguate-add-year-suffix="true" et-al-min="3" et-al-use-first="1">
+  <citation collapse="year" disambiguate-add-givenname="true" disambiguate-add-names="true" disambiguate-add-year-suffix="true" et-al-min="3" et-al-use-first="1" givenname-disambiguation-rule="primary-name">
     <layout delimiter="; " prefix="(" suffix=")">
       <group delimiter=", ">
         <choose>

--- a/chicago-author-date-no-url.csl
+++ b/chicago-author-date-no-url.csl
@@ -4084,7 +4084,7 @@
       </choose>
     </group>
   </macro>
-  <citation collapse="year" disambiguate-add-givenname="true" disambiguate-add-names="true" disambiguate-add-year-suffix="true" et-al-min="3" et-al-use-first="1">
+  <citation collapse="year" disambiguate-add-givenname="true" disambiguate-add-names="true" disambiguate-add-year-suffix="true" et-al-min="3" et-al-use-first="1" givenname-disambiguation-rule="primary-name">
     <layout delimiter="; " prefix="(" suffix=")">
       <group delimiter=", ">
         <choose>

--- a/chicago-author-date.csl
+++ b/chicago-author-date.csl
@@ -4094,7 +4094,7 @@
       </choose>
     </group>
   </macro>
-  <citation collapse="year" disambiguate-add-givenname="true" disambiguate-add-names="true" disambiguate-add-year-suffix="true" et-al-min="3" et-al-use-first="1">
+  <citation collapse="year" disambiguate-add-givenname="true" disambiguate-add-names="true" disambiguate-add-year-suffix="true" et-al-min="3" et-al-use-first="1" givenname-disambiguation-rule="primary-name">
     <layout delimiter="; " prefix="(" suffix=")">
       <group delimiter=", ">
         <choose>

--- a/mhra-author-date-no-url.csl
+++ b/mhra-author-date-no-url.csl
@@ -3218,7 +3218,7 @@
     </choose>
   </macro>
   <!-- Citation -->
-  <citation collapse="year" disambiguate-add-givenname="true" disambiguate-add-names="true" disambiguate-add-year-suffix="true">
+  <citation collapse="year" disambiguate-add-givenname="true" disambiguate-add-names="true" disambiguate-add-year-suffix="true" givenname-disambiguation-rule="primary-name">
     <layout delimiter="; " prefix="(" suffix=")">
       <!-- MHRA's approach to author-date (sect. 7.13) is a simplification of the Oxford Guide to Style, sect. 15.19 -->
       <group delimiter=": ">

--- a/mhra-author-date-publisher-place-no-url.csl
+++ b/mhra-author-date-publisher-place-no-url.csl
@@ -3218,7 +3218,7 @@
     </choose>
   </macro>
   <!-- Citation -->
-  <citation collapse="year" disambiguate-add-givenname="true" disambiguate-add-names="true" disambiguate-add-year-suffix="true">
+  <citation collapse="year" disambiguate-add-givenname="true" disambiguate-add-names="true" disambiguate-add-year-suffix="true" givenname-disambiguation-rule="primary-name">
     <layout delimiter="; " prefix="(" suffix=")">
       <!-- MHRA's approach to author-date (sect. 7.13) is a simplification of the Oxford Guide to Style, sect. 15.19 -->
       <group delimiter=": ">

--- a/mhra-author-date-publisher-place.csl
+++ b/mhra-author-date-publisher-place.csl
@@ -3221,7 +3221,7 @@
     </choose>
   </macro>
   <!-- Citation -->
-  <citation collapse="year" disambiguate-add-givenname="true" disambiguate-add-names="true" disambiguate-add-year-suffix="true">
+  <citation collapse="year" disambiguate-add-givenname="true" disambiguate-add-names="true" disambiguate-add-year-suffix="true" givenname-disambiguation-rule="primary-name">
     <layout delimiter="; " prefix="(" suffix=")">
       <!-- MHRA's approach to author-date (sect. 7.13) is a simplification of the Oxford Guide to Style, sect. 15.19 -->
       <group delimiter=": ">

--- a/mhra-author-date.csl
+++ b/mhra-author-date.csl
@@ -3221,7 +3221,7 @@
     </choose>
   </macro>
   <!-- Citation -->
-  <citation collapse="year" disambiguate-add-givenname="true" disambiguate-add-names="true" disambiguate-add-year-suffix="true">
+  <citation collapse="year" disambiguate-add-givenname="true" disambiguate-add-names="true" disambiguate-add-year-suffix="true" givenname-disambiguation-rule="primary-name">
     <layout delimiter="; " prefix="(" suffix=")">
       <!-- MHRA's approach to author-date (sect. 7.13) is a simplification of the Oxford Guide to Style, sect. 15.19 -->
       <group delimiter=": ">

--- a/new-harts-rules-author-date-publisher.csl
+++ b/new-harts-rules-author-date-publisher.csl
@@ -3257,7 +3257,7 @@
     </choose>
   </macro>
   <!-- Citation -->
-  <citation collapse="year" disambiguate-add-givenname="true" disambiguate-add-names="true" disambiguate-add-year-suffix="true">
+  <citation collapse="year" disambiguate-add-givenname="true" disambiguate-add-names="true" disambiguate-add-year-suffix="true" givenname-disambiguation-rule="primary-name">
     <layout delimiter="; " prefix="(" suffix=")">
       <!-- more detail in Oxford Guide to Style, sect. 15.19 -->
       <group delimiter=": ">

--- a/new-harts-rules-author-date-space-publisher.csl
+++ b/new-harts-rules-author-date-space-publisher.csl
@@ -3257,7 +3257,7 @@
     </choose>
   </macro>
   <!-- Citation -->
-  <citation collapse="year" disambiguate-add-givenname="true" disambiguate-add-names="true" disambiguate-add-year-suffix="true">
+  <citation collapse="year" disambiguate-add-givenname="true" disambiguate-add-names="true" disambiguate-add-year-suffix="true" givenname-disambiguation-rule="primary-name">
     <layout delimiter="; " prefix="(" suffix=")">
       <!-- more detail in Oxford Guide to Style, sect. 15.19 -->
       <group delimiter=": ">

--- a/new-harts-rules-author-date.csl
+++ b/new-harts-rules-author-date.csl
@@ -3257,7 +3257,7 @@
     </choose>
   </macro>
   <!-- Citation -->
-  <citation collapse="year" disambiguate-add-givenname="true" disambiguate-add-names="true" disambiguate-add-year-suffix="true">
+  <citation collapse="year" disambiguate-add-givenname="true" disambiguate-add-names="true" disambiguate-add-year-suffix="true" givenname-disambiguation-rule="primary-name">
     <layout delimiter="; " prefix="(" suffix=")">
       <!-- more detail in Oxford Guide to Style, sect. 15.19 -->
       <group delimiter=": ">

--- a/taylor-and-francis-chicago-author-date.csl
+++ b/taylor-and-francis-chicago-author-date.csl
@@ -4121,7 +4121,7 @@
       </choose>
     </group>
   </macro>
-  <citation collapse="year" disambiguate-add-givenname="true" disambiguate-add-names="true" disambiguate-add-year-suffix="true" et-al-min="4" et-al-use-first="1">
+  <citation collapse="year" disambiguate-add-givenname="true" disambiguate-add-names="true" disambiguate-add-year-suffix="true" et-al-min="4" et-al-use-first="1" givenname-disambiguation-rule="primary-name">
     <layout delimiter="; " prefix="(" suffix=")">
       <group delimiter=", ">
         <choose>


### PR DESCRIPTION
APA 8.20 and CMOS 13.116 indicate that an author's initials should be added to an author–date citation wherever there is more than one person with the same surname, even if the dates are different. Reported at <https://forums.zotero.org/discussion/129753/>.

### Checklist
- [X] Check that you've added a link to the style you used as a template in the `<info>` block at the beginning of the file with `rel="template"`.  
- [X] Check that you've added a link to the style guidelines with `rel="documentation"`.  
- [X] Check that you've added yourself as the `<author>` of the style or `<contributor>` for a style update. 
- [X] Check that you've used the correct terms or labels instead of hardcoding into affixes (e.g., `<text variable="page" prefix="pp. "/>`).
- [X] Check that you've not used `<text value="...` if not absolutely necessary.
- [X] Check that you've not changed line 1 of the style.
