### PR TITLE
Add CSL for Journal of Vacuum Science & Technology A

### DIFF
--- a/journal-of-vacuum-science-and-technology-a.csl
+++ b/journal-of-vacuum-science-and-technology-a.csl
@@ -14,10 +14,8 @@
     <category citation-format="numeric"/>
     <category field="physics"/>
     <category field="chemistry"/>
-    <issn>0734-2101</issn>
-    <eissn>1520-8559</eissn>
     <summary>AIP-based style for Journal of Vacuum Science &amp; Technology A: numeric superscript in-text citations; journal article titles and issue numbers omitted from the bibliography.</summary>
-    <updated>2026-02-19T20:00:00+00:00</updated>
+    <updated>2026-02-19T20:30:00+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <macro name="author">


### PR DESCRIPTION
## Description
Adds a new independent CSL style for Journal of Vacuum Science & Technology A, derived from the AIP style, with JVST A-specific bibliography behavior (omits journal article titles and issue numbers).

### Checklist
- [x] Added a template link in `<info>` with `rel="template"`.
- [x] Added documentation link(s) with `rel="documentation"`.
- [x] Added myself as `<author>`.
- [x] Used CSL labels/terms instead of hardcoded affixes where applicable.
- [x] Did not use `<text value="...">` unnecessarily.
- [x] Did not change line 1 of the style.