### PR TITLE
Update associacao-brasileira-de-normas-tecnicas-ufrgs.csl

### DIFF
--- a/associacao-brasileira-de-normas-tecnicas-ufrgs.csl
+++ b/associacao-brasileira-de-normas-tecnicas-ufrgs.csl
@@ -254,7 +254,8 @@
         </names>
       </else-if>
       <else-if type="hearing" match="any">
-        <names variable="contributor"> <!-- utiliza contribuidor como autor para audiências -->
+        <names variable="contributor">
+          <!-- utiliza contribuidor como autor para audiências -->
           <!-- para outros tipos de documentos mantém a posição original -->
           <name delimiter="; " delimiter-precedes-et-al="never" delimiter-precedes-last="always" name-as-sort-order="all">
             <name-part name="family" text-case="uppercase"/>
@@ -403,7 +404,7 @@
       </if>
       <else-if type="legal_case">
         <text variable="container-title" font-weight="normal"/>
-	    </else-if>
+      </else-if>
       <else-if type="chapter entry-dictionary entry-encyclopedia" match="any">
         <choose>
           <if variable="container-author editor collection-editor" match="any">

--- a/associacao-brasileira-de-normas-tecnicas-ufrgs.csl
+++ b/associacao-brasileira-de-normas-tecnicas-ufrgs.csl
@@ -54,6 +54,11 @@
       <name>Patrick O'Brien</name>
       <uri>https://citationstyler.com/</uri>
     </contributor>
+    <contributor>
+      <name>Adriano Damasceno da Silva Júnior</name>
+      <email>adamascenosj@gmail.com</email>
+      <uri>https://www.zotero.org/dr1jr</uri>
+    </contributor>
     <category citation-format="author-date"/>
     <category field="generic-base"/>
     <summary>The Brazilian Standard Style in accordance with ABNT-NBR 10520.2023 and ABNT-NBR 6023.2018</summary>

--- a/associacao-brasileira-de-normas-tecnicas-ufrgs.csl
+++ b/associacao-brasileira-de-normas-tecnicas-ufrgs.csl
@@ -64,11 +64,11 @@
     <terms>
       <term name="accessed">acesso</term>
       <term name="available at">disponível em</term>
-      <term name="composer">compositor</term>
-      <term name="recipient">destinatário</term>
-      <term name="interviewer">entrevistador</term>
-      <term name="director">direção</term>
-      <term name="translator">tradução</term>
+      <term name="composer">Compositor</term>
+      <term name="recipient">Destinatário</term>
+      <term name="interviewer">Entrevistador</term>
+      <term name="director">Direção</term>
+      <term name="translator">Tradução</term>
       <term name="in">in</term>
       <term name="elocation" form="short">local.</term>
       <term name="no-place" form="short">s. l.</term>
@@ -113,7 +113,7 @@
       <if type="broadcast" match="any">
         <!-- para transmissões é apresentador -->
         <text value="Apresentado por "/>
-        <names variable="author">
+        <names variable="host">
           <name and="text">
             <name-part name="given"/>
             <name-part name="family"/>
@@ -123,7 +123,7 @@
       <else-if type="motion_picture" match="any">
         <!-- para filmes é o diretor -->
         <text term="director" suffix=": "/>
-        <names variable="author">
+        <names variable="director">
           <name and="text">
             <name-part name="given"/>
             <name-part name="family"/>
@@ -156,7 +156,7 @@
         </names>
       </else-if>
       <else-if type="hearing" match="any">
-        <names variable="contributor"> <!-- utiliza contribuidor como autor para audiências -->
+        <names variable="contributor">
           <!-- para outros tipos de documentos mantém a posição original -->
           <name delimiter="; " delimiter-precedes-et-al="never" delimiter-precedes-last="always" name-as-sort-order="all">
             <name-part name="family" text-case="uppercase"/>
@@ -321,7 +321,7 @@
       <if type="article-journal article-magazine article-newspaper chapter paper-conference " match="any">
         <text variable="title" font-weight="normal" suffix=". "/>
       </if>
-      <else-if type="bill legal_case legislation post-weblog" match="any">
+      <else-if type="bill legislation post-weblog" match="any">
         <text variable="title" font-weight="normal"/>
       </else-if>
       <else-if type="entry-dictionary entry-encyclopedia">
@@ -396,6 +396,9 @@
           </else>
         </choose>
       </if>
+      <else-if type="legal_case">
+        <text variable="container-title" font-weight="normal"/>
+	    </else-if>
       <else-if type="chapter entry-dictionary entry-encyclopedia" match="any">
         <choose>
           <if variable="container-author editor collection-editor" match="any">
@@ -419,6 +422,10 @@
           <if variable="publisher-place">
             <text variable="publisher-place"/>
           </if>
+          <else-if variable="event-place">
+            <!-- Utiliza o local do evento como local de publicação. Especialmente em Gravação de vídeo -->
+            <text variable="event-place"/>
+          </else-if>
           <else>
             <text term="no-place" form="short" text-case="capitalize-first" font-style="italic" prefix="[" suffix="]"/>
           </else>
@@ -634,6 +641,9 @@
       <if variable="publisher-place" match="any">
         <text variable="publisher-place" suffix=", "/>
       </if>
+      <else-if type="graphic">
+        <!-- Obras de arte não precisam mostrar o local -->
+      </else-if>
       <else>
         <choose>
           <if type="graphic post webpage" match="any">

--- a/associacao-brasileira-de-normas-tecnicas-ufrgs.csl
+++ b/associacao-brasileira-de-normas-tecnicas-ufrgs.csl
@@ -155,6 +155,20 @@
           </substitute>
         </names>
       </else-if>
+      <else-if type="hearing" match="any">
+        <names variable="contributor"> <!-- utiliza contribuidor como autor para audiências -->
+          <!-- para outros tipos de documentos mantém a posição original -->
+          <name delimiter="; " delimiter-precedes-et-al="never" delimiter-precedes-last="always" name-as-sort-order="all">
+            <name-part name="family" text-case="uppercase"/>
+            <name-part name="given"/>
+          </name>
+          <et-al font-style="italic"/>
+          <substitute>
+            <!-- na ausência de um autor, utiliza organizador, editor, tradutor ou título  -->
+            <text variable="title" text-case="uppercase"/>
+          </substitute>
+        </names>
+      </else-if>
       <else>
         <names variable="author">
           <!-- para outros tipos de documentos mantém a posição original -->
@@ -232,6 +246,20 @@
             <name-part name="family"/>
             <name-part name="given"/>
           </name>
+        </names>
+      </else-if>
+      <else-if type="hearing" match="any">
+        <names variable="contributor"> <!-- utiliza contribuidor como autor para audiências -->
+          <!-- para outros tipos de documentos mantém a posição original -->
+          <name delimiter="; " delimiter-precedes-et-al="never" delimiter-precedes-last="always" name-as-sort-order="all">
+            <name-part name="family" text-case="uppercase"/>
+            <name-part name="given"/>
+          </name>
+          <et-al font-style="italic"/>
+          <substitute>
+            <!-- na ausência de um autor, utiliza organizador, editor, tradutor ou título  -->
+            <text variable="title" text-case="uppercase"/>
+          </substitute>
         </names>
       </else-if>
       <else>


### PR DESCRIPTION
# Adequações nas referências de audiência, áudio, filme, gravação de vídeo, jurisprudência, obra de arte e transmissão de televisão.


As seguintes referências foram corrigidas de seu formato atual para estarem de acordo com o modelo disponibilizado pela UFRGS (cf. [https://www.ufrgs.br/bibliotecas/ferramentas/campos-basicos-abnt-zotero/](https://www.ufrgs.br/bibliotecas/ferramentas/campos-basicos-abnt-zotero/)). 

Em **exemplo** vocês podem conferir como deve ser (e também como será se minha mudança no código for aceita) e em **Zotero** como está hoje.

- **Audiência.** daptou-se para que o "contribuidor" seja utilizado na autoria.
**Exemplo**: COMISSÃO MISTA DA MEDIDA PROVISÓRIA N° 908, DE 2019. **Auxílio emergencial a pescadores afetados por manchas de óleo (MP 908/2019)**. Debater a MEDIDA PROVISÓRIA No 908, de 2019. Brasília: Senado Federal, 28 fev. 2020. Disponível em: https://www12.senado.leg.br/ecidadania/visualizacaoaudiencia?id=17967. Acesso em: 5 mar. 2020.
**Zotero:** AUXÍLIO EMERGENCIAL A PESCADORES AFETADOS POR MANCHAS DE ÓLEO (MP 908/2019). Debater a MEDIDA PROVISÓRIA No 908, de 2019. Brasília: Senado Federal, 28 fev. 2020. Disponível em: https://www12.senado.leg.br/ecidadania/visualizacaoaudiencia?id=17967. Acesso em: 5 mar. 2020.

- **Áudio**. Corrigiu-se o termo "compositor"
**Exemplo:** AS ROSAS NÃO FALAM. Intérprete: Beth Carvalho. Compositor: Agenor De Oliveira. São Paulo: Philips, 1976. 1 arquivo (5min).
**Zotero:** AS ROSAS NÃO FALAM. Intérprete: Beth Carvalho. compositor: Agenor de Oliveira. São Paulo: Philips, 1976. 1 CD, faixa 7 ou 1 arquivo MP3 (5 min).

- **Filme**. Inserção de "Direção: xxx".
 **Exemplo:** E O VENTO LEVOU. Direção: Victor Fleming. Estados Unidos: Selznick International Pictures, 1940. 1 vídeo (3h12min).
**Zotero** E O VENTO LEVOU. Estados Unidos: Selznick International Pictures, 1940. 1 vídeo (3h12min). 

- **Gravação de Vídeo**. Adaptação para que _event-place_ possa ser o local, quando não houver _publisher-place_
 **Exemplo:** LIVRARIA SOLIDÁRIA – ACONTECE NA UFRGS. Direção: Gabriela Scott, Vinicius Dutra. Porto Alegre: UFRGS TV, 2019. 1 vídeo (6:37). Disponível em: https://www.youtube.com/watch?v=jJh0EKRb8Sk. Acesso em: 6 jan. 2020.
**Zotero:** LIVRARIA SOLIDÁRIA – ACONTECE NA UFRGS. Direção: Gabriela Scott. [S. l.]: UFRGS TV, 2019. 1 vídeo (6 min 37 seg). Disponível em: https://www.youtube.com/watch?v=jJh0EKRb8Sk. Acesso em: 20 dez. 2019.

- **Jurisprudência**. Correção do uso de negrito.
 **Exemplo:** BRASIL. SUPREMO TRIBUNAL FEDERAL. **Súmula n° 333**. Cabe mandado de segurança contra  ato praticado em licitação promovida por sociedade de economia mista ou empresa pública. Relator: Min. Ellen, 1 out. 1998. Disponível em: http://www.stf.jus.br/portal/jurisprudencia/menuSumarioSumulas.asp?sumula=3304. Acesso em: 22 nov. 2019.
**Zotero:** BRASIL. SUPREMO TRIBUNAL FEDERAL. STF. Súmula n° 333. Cabe mandado de segurança contra ato praticado em licitação promovida por sociedade de economia mista ou empresa pública. **Min. Ellen**, 10 jan. 1998. Disponível em: http://www.stf.jus.br/portal/jurisprudencia/menuSumarioSumulas.asp?sumula=3304. Acesso em: 22 nov. 2019.

- **Obra de arte**. Obras de arte não precisam informar o local ou sua ausência.
 **Exemplo:** VINCI, Leonardo Da. Monalisa. 1503. Pintura, óleo sobre tela, 50x100cm. Museu do Louvre.
**Zotero:** VINCI, Leonardo da. Monalisa. [S. l.], 1503. Pintura, óleo sobre tela, 50 x 60 cm. Museu do Louvre.

- **Transmissão de Televisão**. O Zotero não tem o campo _author_ para programa de televisão. Para o apresentador podemos usar o campo _host_.
 **Exemplo:** CARA A CARA. Apresentado por Marília Gabriela. São Paulo: Rede Bandeirantes de Televisão, 1991. Programa de Televisão (60min).
**Zotero:** CARA A CARA. São Paulo: Rede Bandeirantes de Televisão, 1991. Programa de televisão (60 min). 

_Obs.: é a primeira vez que sugiro uma mudança em um código aberto aqui no GitHub. Sugestões de como fazer isso melhor no futuro são bem-vindas. Espero ter sido claro o suficiente em tudo."