### PR TITLE
barbara-budrich.csl: fix DOI format, add chapter page numbers

### DIFF
--- a/barbara-budrich.csl
+++ b/barbara-budrich.csl
@@ -13,11 +13,15 @@
     <contributor>
       <name>Katarina Willems</name>
     </contributor>
+    <contributor>
+      <name>Keridoo</name>
+      <uri>https://github.com/Keridoo</uri>
+    </contributor>
     <category citation-format="author-date"/>
     <category field="social_science"/>
     <category field="humanities"/>
-    <summary>This citation style for books and edited volumes of the publisher Barbar Budrich is based on the 'Style Sheet' for authors and editors from 2024 which is unfortunately not available from the publisher's website.</summary>
-    <updated>2025-11-06T15:41:13+00:00</updated>
+    <summary>This citation style for books and edited volumes of the publisher Barbara Budrich is based on the 'Style Sheet' for authors and editors from 2024 which is unfortunately not available from the publisher's website.</summary>
+    <updated>2026-02-28T00:00:00+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale xml:lang="de">
@@ -74,7 +78,14 @@
     </group>
   </macro>
   <macro name="doi">
-    <text variable="DOI" prefix="DOI:"/>
+    <choose>
+      <if type="article-journal article-magazine article-newspaper" match="any">
+        <text variable="DOI" prefix="https://doi.org/"/>
+      </if>
+      <else>
+        <text variable="DOI" prefix="DOI: https://doi.org/"/>
+      </else>
+    </choose>
   </macro>
   <macro name="edition">
     <choose>
@@ -182,7 +193,11 @@
               <text variable="container-title"/>
             </group>
             <text macro="edition"/>
-            <text macro="publication-place-publisher"/>
+            <group delimiter=", ">
+              <text macro="publication-place-publisher"/>
+              <text macro="page-range"/>
+            </group>
+            <text macro="collection-title-number"/>
             <text macro="doi"/>
           </else-if>
           <else-if type="thesis">
@@ -202,7 +217,6 @@
             <text macro="page-range"/>
             <text macro="collection-title-number"/>
             <text macro="online-url"/>
-            <text macro="page-range"/>
             <text macro="doi"/>
           </else>
         </choose>


### PR DESCRIPTION
## Summary

Fixes three bugs in `barbara-budrich.csl` against the publisher's Style Sheet (Stand 05.06.2024):

### 1. DOI format — bare DOI instead of full URL

**Current output:**
```
DOI:10.3224/84742602
```

**Style Sheet requires (books/chapters, sections 5.1–5.3):**
```
DOI: https://doi.org/10.3224/84742602.
```

**Style Sheet requires (journals, section 5.5):**
```
https://doi.org/10.3224/gender.v15i1.03.
```

Issues: missing space after `DOI:`, missing `https://doi.org/` URL prefix, and journals should omit the `DOI:` label entirely.

### 2. Missing page numbers for chapter/paper-conference types

**Current output** (no page range):
```
Kampshoff, Marita/Kleiner, Bettina/Langer, Antje (2023): Trans* und Inter*Geschlechtlichkeit
  in Erziehung und Bildung – Einleitung. In: Kampshoff, Marita/Kleiner, Bettina/Langer, Antje
  (Hrsg.): Trans- und Intergeschlechtlichkeit in Erziehung und Bildung. Opladen/Berlin/Toronto:
  Verlag Barbara Budrich. DOI:10.3224/84742703.01.
```

**Style Sheet requires (section 5.2):**
```
… Opladen/Berlin/Toronto: Verlag Barbara Budrich, S. 9-22. DOI: https://doi.org/10.3224/84742703.01.
```

Template from Style Sheet 5.2:
> Familienname, Vorname (Jahr): Titel. In: Familienname, Vorname (Hrsg.): Titel. Verlagsort: Verlag, x. Aufl. S. xx-xxx. DOI.

### 3. Duplicate `page-range` in fallback `else` block

The `<else>` block contained `<text macro="page-range"/>` twice (copy-paste error). Removed the duplicate.

## Before/After

| Type | Field | Before | After |
|------|-------|--------|-------|
| Book | DOI | `DOI:10.3224/84742602` | `DOI: https://doi.org/10.3224/84742602` |
| Journal | DOI | `DOI:10.1080/13540602.2021.1986694` | `https://doi.org/10.1080/13540602.2021.1986694` |
| Chapter | DOI | `DOI:10.3224/84742703.01` | `DOI: https://doi.org/10.3224/84742703.01` |
| Chapter | Pages | *(missing)* | `S. 9-22` |

## Style Sheet reference

https://budrich.de/wiki/doku.php?id=formatierung:stylesheet (linked from the CSL metadata)

**Note on DOI inconsistency in the Style Sheet:** Sections 5.1–5.3 (books, chapters, series) use `DOI: https://doi.org/...` while section 5.5 (journals) uses `https://doi.org/...` without the `DOI:` label. This fix matches that distinction. If the publisher later standardizes the format, only the `doi` macro needs updating.
