### PR TITLE
Update sociologie.csl with contributor and DOI changes

### DIFF
--- a/sociologie.csl
+++ b/sociologie.csl
@@ -229,8 +229,8 @@
               <choose>
                 <if type="article-journal bill book chapter graphic legal_case legislation motion_picture paper-conference report song thesis" match="none">
                   <date variable="issued">
-                    <date-part prefix=", " name="month"/>
-                    <date-part prefix=" " name="day"/>
+                    <date-part prefix=", " name="day"/>
+                    <date-part prefix=" " name="month"/>
                   </date>
                 </if>
               </choose>


### PR DESCRIPTION
### Description
The list of corrections made is as follows:

- Repair of the display of DOIs and URLs for references, in accordance with the instructions to authors and what appears to be the practice in the bibliographies of certain articles in the journal. 
- Addition of a non-breaking space before the semicolon in in-text citations. 
- Addition of a “Speech” type, which was missing, to correctly format references to oral presentations at scientific events.

