### PR TITLE
Create turabian-fullnote-9th-ibid-opcit-locit.csl

### DIFF
--- a/turabian-fullnote-9th-ibid-opcit-locit.csl
+++ b/turabian-fullnote-9th-ibid-opcit-locit.csl
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <style xmlns="http://purl.org/net/xbiblio/csl" version="1.0" class="note" demote-non-dropping-particle="sort-only" default-locale="en-US">
   <info>
     <title>Turabian Full Note 9th Edition</title>
@@ -14,11 +14,10 @@
     </contributor>
     <category citation-format="note"/>
     <category field="generic-base"/>
+    <summary>The Turabian full note citation system (9th edition)</summary>
     <updated>2024-01-01T00:00:00+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
-    <summary>The Turabian full note citation system (9th edition)</summary>
   </info>
-
   <locale xml:lang="en">
     <terms>
       <term name="editor" form="verb">ed.</term>
@@ -33,7 +32,6 @@
       <term name="page" form="short">p.</term>
     </terms>
   </locale>
-
   <macro name="author-short">
     <names variable="author">
       <name form="short" and="text" delimiter=", " delimiter-precedes-last="never"/>
@@ -44,7 +42,6 @@
       </substitute>
     </names>
   </macro>
-
   <macro name="author-note">
     <names variable="author">
       <name form="long" and="text" delimiter=", " delimiter-precedes-last="never"/>
@@ -54,7 +51,6 @@
       </substitute>
     </names>
   </macro>
-
   <macro name="editor-translator">
     <group delimiter=", ">
       <names variable="editor" delimiter=", ">
@@ -67,7 +63,6 @@
       </names>
     </group>
   </macro>
-
   <macro name="title-short">
     <choose>
       <if type="book">
@@ -81,7 +76,6 @@
       </else>
     </choose>
   </macro>
-
   <macro name="title">
     <choose>
       <if type="book">
@@ -98,14 +92,12 @@
       </else>
     </choose>
   </macro>
-
   <macro name="publisher">
     <group delimiter=": ">
       <text variable="publisher-place"/>
       <text variable="publisher"/>
     </group>
   </macro>
-
   <macro name="edition">
     <choose>
       <if variable="edition">
@@ -113,7 +105,6 @@
       </if>
     </choose>
   </macro>
-
   <macro name="date">
     <choose>
       <if variable="issued">
@@ -126,7 +117,6 @@
       </else>
     </choose>
   </macro>
-
   <macro name="date-full">
     <choose>
       <if variable="issued">
@@ -141,7 +131,6 @@
       </else>
     </choose>
   </macro>
-
   <macro name="pages">
     <choose>
       <if variable="page">
@@ -150,7 +139,6 @@
       </if>
     </choose>
   </macro>
-
   <macro name="point-locators">
     <choose>
       <if variable="locator">
@@ -159,7 +147,6 @@
       </if>
     </choose>
   </macro>
-
   <macro name="point-locators-subsequent">
     <choose>
       <if variable="locator">
@@ -168,7 +155,6 @@
       </if>
     </choose>
   </macro>
-
   <macro name="url">
     <choose>
       <if type="webpage">
@@ -176,7 +162,6 @@
       </if>
     </choose>
   </macro>
-
   <macro name="access-date">
     <choose>
       <if type="webpage">
@@ -191,7 +176,6 @@
       </if>
     </choose>
   </macro>
-
   <macro name="volumes">
     <choose>
       <if variable="volume">
@@ -204,7 +188,6 @@
       </if>
     </choose>
   </macro>
-
   <!-- Citation format -->
   <citation et-al-min="4" et-al-use-first="1" disambiguate-add-names="true" disambiguate-add-givenname="true">
     <!-- ibid logic: if the current item is the same as the previous one -->
@@ -310,7 +293,6 @@
       </choose>
     </layout>
   </citation>
-
   <!-- Bibliography format -->
   <bibliography et-al-min="4" et-al-use-first="1" hanging-indent="true" entry-spacing="0">
     <layout>


### PR DESCRIPTION
Add Turabian full‑note 9th style with ibid/op.cit./loc.cit. (author Khozin Nur)

## CSL Styles Pull Request Template
You're about to create a pull request to the CSL **styles** repository.  
If you haven't done so already, see <https://github.com/citation-style-language/styles/blob/master/CONTRIBUTING.md> for instructions on how to contribute, and <https://github.com/citation-style-language/styles/blob/master/STYLE_REQUIREMENTS.md> for the requirements a style must meet before acceptance.  
In addition, please fill out the pull request template below.


### Description
Add a new CSL style implementing Turabian Full Note (9th edition) with extended citation logic.

Full‑note note‑style layout for books, chapters, journal articles, newspapers and webpages.
Support for ibid. and ibid. with locator when the immediately preceding note is identical.
Subsequent‑citation handling:
op. cit. when citing the same work again (different page/locator).
loc. cit. when citing the same work and the same page/locator as first occurrence.
Metadata updated:
<title>, <title‑short>, <summary> describe the Turabian 9th full‑note system.
<author> set to Khozin Nur (style creator).
<contributor> retains Cite Them Right.
License remains CC‑BY‑SA 3.0.
Filename includes “ibid‑opcit‑locit” to distinguish from base style.


### Checklist
- [ ] Check that you've added a link to the style you used as a template in the `<info>` block at the beginning of the file with `rel="template"`.  
- [ ] Check that you've added a link to the style guidelines with `rel="documentation"`.  
- [ ] Check that you've added yourself as the `<author>` of the style or `<contributor>` for a style update. 
- [ ] Check that you've used the correct terms or labels instead of hardcoding into affixes (e.g., `<text variable="page" prefix="pp. "/>`).
- [ ] Check that you've not used `<text value="...` if not absolutely necessary.
- [ ] Check that you've not changed line 1 of the style.
