### PR TITLE
Update bluebook-law-review.csl

### DIFF
--- a/bluebook-law-review.csl
+++ b/bluebook-law-review.csl
@@ -23,10 +23,14 @@
       <name>Shay Elbaum</name>
       <email>selbaum@law.harvard.edu</email>
     </contributor>
+    <contributor>
+      <name>James Tierney</name>
+      <email>jtierney1@illinoistech.edu</email>
+    </contributor>
     <category citation-format="note"/>
     <category field="law"/>
     <summary>The Bluebook legal citation style for law reviews.</summary>
-    <updated>2025-05-06T00:00:00+00:00</updated>
+    <updated>2026-03-14T00:00:00+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale>
@@ -42,17 +46,22 @@
       <label form="short" prefix=" "/>
     </names>
   </macro>
+  <macro name="consec-periodical-issuance">
+    <date variable="issued">
+      <date-part name="year"/>
+    </date>
+  </macro>
+  <macro name="periodical-issuance">
+    <date variable="issued">
+      <date-part name="month" form="short" suffix=" "/>
+      <date-part name="day" suffix=", "/>
+      <date-part name="year"/>
+    </date>
+  </macro>
   <macro name="author-short">
     <choose>
       <if type="legal_case">
-        <choose>
-          <if variable="title-short">
-            <text macro="name-short-macro" font-style="italic"/>
-          </if>
-          <else>
-            <text macro="name-short-macro"/>
-          </else>
-        </choose>
+        <text macro="name-short-macro" font-style="italic"/>
       </if>
       <else-if type="bill legislation" match="any">
         <text macro="name-macro"/>
@@ -75,17 +84,12 @@
   </macro>
   <macro name="author">
     <choose>
-      <if type="legal_case legislation" match="any">
-        <!-- legal cases do not display the author at the beginning of the line -->
-      </if>
-      <else-if type="bill" match="any">
-        <text macro="name-macro"/>
-      </else-if>
+      <if type="bill legal_case legislation" match="any"/>
       <else-if type="book graphic motion_picture report song" match="any">
-        <text macro="name-macro" font-variant="small-caps"/>
+        <text macro="name-macro" font-variant="small-caps" suffix=", "/>
       </else-if>
       <else>
-        <text macro="name-macro"/>
+        <text macro="name-macro" suffix=", "/>
       </else>
     </choose>
   </macro>
@@ -97,24 +101,18 @@
   </macro>
   <macro name="access">
     <choose>
-      <if type="legal_case legislation" match="any">
-        <!-- legal case citations generally do not use URL's -->
-      </if>
+      <if type="legal_case bill legislation article-journal" match="any"/>
       <else-if variable="URL">
-        <group delimiter=" ">
+        <group prefix=", " delimiter=" ">
           <text variable="URL"/>
-          <choose>
-            <if variable="issued" match="none">
-              <group delimiter=" " prefix="(" suffix=")">
-                <text value="last visited"/>
-                <date variable="accessed">
-                  <date-part name="month" form="short" suffix=" "/>
-                  <date-part name="day" suffix=", "/>
-                  <date-part name="year"/>
-                </date>
-              </group>
-            </if>
-          </choose>
+          <group delimiter=" " prefix="(" suffix=")">
+            <text value="last visited"/>
+            <date variable="accessed">
+              <date-part name="month" form="short" suffix=" " strip-periods="true"/>
+              <date-part name="day" suffix=", "/>
+              <date-part name="year"/>
+            </date>
+          </group>
         </group>
       </else-if>
     </choose>
@@ -130,11 +128,59 @@
               <text macro="container"/>
               <text variable="page-first"/>
             </group>
-            <text variable="locator"/>
+            <choose>
+              <if variable="locator">
+                <text variable="locator"/>
+              </if>
+            </choose>
           </group>
-          <text macro="issuance" prefix="(" suffix=")"/>
+          <choose>
+            <if variable="status">
+              <group prefix="(" suffix=")" delimiter=" ">
+                <text variable="status" text-case="lowercase"/>
+                <date variable="issued">
+                  <date-part name="year"/>
+                </date>
+              </group>
+            </if>
+            <else>
+              <text macro="consec-periodical-issuance" prefix="(" suffix=")"/>
+            </else>
+          </choose>
         </group>
       </if>
+      <else-if type="legislation" match="any">
+        <text macro="statute-citation"/>
+      </else-if>
+      <else-if type="bill">
+        <group delimiter=", ">
+          <text variable="title"/>
+          <group delimiter=" ">
+            <text value="Pub. L. No."/>
+            <text variable="number"/>
+          </group>
+          <group prefix="§ ">
+            <text variable="section"/>
+          </group>
+          <group delimiter=" ">
+            <text variable="volume"/>
+            <text macro="container"/>
+            <group delimiter=", ">
+              <text variable="page-first"/>
+              <text variable="locator"/>
+            </group>
+          </group>
+        </group>
+        <text macro="consec-periodical-issuance" prefix=" (" suffix=")"/>
+      </else-if>
+      <else-if type="book">
+        <text variable="title" text-case="title" font-variant="small-caps"/>
+        <text variable="locator" prefix=" "/>
+        <text macro="issuance" prefix=" (" suffix=")"/>
+      </else-if>
+      <else-if type="manuscript">
+        <text macro="rules"/>
+      </else-if>
       <else-if type="legal_case">
         <group delimiter=" ">
           <group delimiter=", ">
@@ -144,58 +190,30 @@
           <text macro="container"/>
           <group delimiter=", ">
             <text variable="page-first"/>
-            <text variable="locator"/>
+            <choose>
+              <if variable="locator">
+                <text variable="locator"/>
+              </if>
+            </choose>
           </group>
-          <text macro="issuance" prefix="(" suffix=")"/>
+          <text macro="legal-case-issuance"/>
         </group>
       </else-if>
-      <else-if type="legislation">
-        <group delimiter=" ">
-          <group delimiter=", ">
-            <group>
-              <text variable="title" text-case="title"/>
-              <text macro="issuance" prefix=" of "/>
-            </group>
-            <text variable="number"/>
-            <group delimiter=" ">
-              <text variable="volume"/>
-              <text macro="container"/>
-              <group delimiter=" ">
-                <text value="§"/>
-                <text variable="section"/>
-              </group>
-            </group>
-          </group>
-        </group>
-      </else-if>
-      <else-if type="article-newspaper article-magazine" match="any">
+      <else-if type="article-newspaper article-magazine thesis" match="any">
         <group delimiter=", ">
           <text variable="title" text-case="title" font-style="italic"/>
-          <group delimiter=" ">
-            <text variable="volume"/>
-            <text macro="container"/>
-          </group>
-          <text macro="issuance"/>
+          <text macro="container"/>
+          <text macro="periodical-issuance"/>
           <group delimiter=" ">
             <text value="at"/>
             <text variable="page-first"/>
           </group>
+          <choose>
+            <if variable="locator">
+              <text variable="locator"/>
+            </if>
+          </choose>
         </group>
-      </else-if>
-      <else-if type="article thesis" match="any">
-        <group delimiter=", ">
-          <text variable="title" text-case="title"/>
-          <text macro="container"/>
-        </group>
-        <text macro="issuance" prefix=" (" suffix=")"/>
-        <choose>
-          <if type="thesis">
-            <group delimiter=", " prefix=" (" suffix=")">
-              <text variable="genre" suffix=" dissertation"/>
-              <text variable="publisher"/>
-            </group>
-          </if>
-        </choose>
       </else-if>
       <else-if type="chapter paper-conference" match="any">
         <text variable="title" text-case="title" font-style="italic"/>
@@ -207,17 +225,36 @@
         <text variable="locator" prefix=", "/>
         <text macro="issuance" prefix=" (" suffix=")"/>
       </else-if>
-      <else-if type="book report" match="any">
-        <text variable="title" text-case="title" font-variant="small-caps"/>
-        <text variable="locator" prefix=" "/>
-        <text macro="issuance" prefix=" (" suffix=")"/>
+      <else-if type="webpage post-weblog" match="any">
+        <group delimiter=", ">
+          <text variable="title" text-case="title" font-style="italic"/>
+          <text variable="container-title"/>
+          <text macro="periodical-issuance"/>
+        </group>
+      </else-if>
+      <else-if type="report">
+        <group delimiter=" ">
+          <text variable="title" text-case="title" font-variant="small-caps"/>
+          <group prefix="§ " delimiter=" ">
+            <text variable="number"/>
+            <text variable="locator"/>
+          </group>
+          <group prefix="(" suffix=")" delimiter=" ">
+            <text variable="publisher"/>
+            <date variable="issued">
+              <date-part name="year"/>
+            </date>
+          </group>
+        </group>
       </else-if>
       <else>
-        <group delimiter=", ">
+        <group delimiter=" ">
           <text variable="title" text-case="title" font-style="italic"/>
           <group delimiter=" ">
             <text variable="volume"/>
-            <text macro="container"/>
+            <group delimiter=" ">
+              <text macro="container"/>
+            </group>
             <text variable="page-first"/>
             <text variable="locator"/>
             <text macro="issuance" prefix="(" suffix=")"/>
@@ -225,6 +262,21 @@
         </group>
       </else>
     </choose>
+  </macro>
+  <macro name="statute-citation">
+    <group delimiter=" ">
+      <text variable="title"/>
+      <group delimiter=" " prefix="§ ">
+        <text variable="section"/>
+        <text variable="locator"/>
+      </group>
+      <group delimiter=" " prefix="(" suffix=")">
+        <text variable="publisher"/>
+        <date variable="issued">
+          <date-part name="year"/>
+        </date>
+      </group>
+    </group>
   </macro>
   <macro name="issuance">
     <choose>
@@ -238,14 +290,14 @@
       </if>
       <else>
         <choose>
-          <if type="article article-journal article-magazine article-newspaper broadcast interview manuscript map patent personal_communication song speech thesis webpage post-weblog" match="any">
+          <if type="article-journal article-magazine article-newspaper broadcast interview manuscript map patent personal_communication song speech thesis webpage post-weblog" match="any">
             <group>
               <choose>
-                <if type="article article-newspaper thesis webpage post-weblog" match="any">
-                  <group>
+                <if type="article-newspaper thesis post-weblog" match="any">
+                  <group suffix=", ">
                     <date variable="issued">
-                      <date-part name="month" form="short" suffix=" "/>
-                      <date-part name="day" prefix=" " suffix=", "/>
+                      <date-part name="month" form="short"/>
+                      <date-part name="day" prefix=" "/>
                     </date>
                   </group>
                 </if>
@@ -261,12 +313,7 @@
             </group>
           </if>
           <else-if type="legal_case">
-            <group delimiter=" ">
-              <text variable="authority"/>
-              <date variable="issued">
-                <date-part name="year"/>
-              </date>
-            </group>
+            <text macro="legal-case-issuance"/>
           </else-if>
           <else>
             <group delimiter=", ">
@@ -276,15 +323,30 @@
                   <text variable="edition"/>
                   <label variable="edition" form="short"/>
                 </group>
-                <date variable="issued">
-                  <date-part name="year"/>
-                </date>
+                <choose>
+                  <if match="any" variable="authority">
+                    <group>
+                      <text variable="authority"/>
+                    </group>
+                  </if>
+                  <else>
+                    <date form="text" variable="issued">
+                      <date-part name="year"/>
+                    </date>
+                  </else>
+                </choose>
               </group>
             </group>
           </else>
         </choose>
       </else>
     </choose>
+  </macro>
+  <macro name="rules">
+    <group delimiter=" ">
+      <text variable="title"/>
+      <text variable="locator"/>
+    </group>
   </macro>
   <macro name="at_page">
     <group delimiter=" ">
@@ -303,7 +365,7 @@
       <else-if type="legal_case">
         <text variable="container-title" form="short" prefix=" "/>
       </else-if>
-      <else-if type="legislation">
+      <else-if type="legislation bill" match="any">
         <text variable="container-title"/>
       </else-if>
       <else-if type="article-journal">
@@ -314,8 +376,16 @@
       </else>
     </choose>
   </macro>
-  <citation et-al-min="4" et-al-use-first="1">
-    <layout suffix="." delimiter="; ">
+  <macro name="legal-case-issuance">
+    <group delimiter=" " prefix="(" suffix=")">
+      <text variable="authority"/>
+      <date variable="issued">
+        <date-part name="year"/>
+      </date>
+    </group>
+  </macro>
+  <citation et-al-min="3" et-al-use-first="1">
+    <layout delimiter="; " suffix=".">
       <choose>
         <if position="ibid-with-locator">
           <group delimiter=" ">
@@ -328,24 +398,44 @@
         </else-if>
         <else-if position="subsequent">
           <choose>
-            <!-- subsequent legal citations do not use supra -->
-            <if type="legal_case">
+            <if type="article-journal article-newspaper article-magazine thesis" match="any">
               <group delimiter=", ">
-                <text variable="title" form="short" font-style="italic"/>
-                <group delimiter=" ">
-                  <text variable="volume"/>
-                  <text variable="container-title" form="short"/>
-                  <text macro="at_page"/>
+                <text macro="author-short"/>
+                <group>
+                  <text value="supra" font-style="italic" suffix=" "/>
+                  <text value="note" suffix=" "/>
+                  <text variable="first-reference-note-number"/>
+                  <group>
+                    <choose>
+                      <if match="any" variable="locator">
+                        <text variable="locator" prefix=" at "/>
+                      </if>
+                    </choose>
+                  </group>
                 </group>
               </group>
             </if>
-            <else-if type="legislation">
+            <else-if type="bill legislation" match="any">
               <group delimiter=" ">
-                <text variable="volume"/>
-                <text variable="container-title" form="short"/>
-                <group delimiter=" ">
-                  <text value="§"/>
+                <text variable="title"/>
+                <group prefix="§ " delimiter=" ">
                   <text variable="section"/>
+                  <text variable="locator"/>
+                </group>
+              </group>
+            </else-if>
+            <else-if type="manuscript" match="any">
+              <group delimiter=" ">
+                <text variable="title"/>
+                <text variable="locator"/>
+              </group>
+            </else-if>
+            <else-if type="report" match="any">
+              <group delimiter=" ">
+                <text macro="author-short"/>
+                <group prefix="§ " delimiter=" ">
+                  <text variable="number"/>
+                  <text variable="locator"/>
                 </group>
               </group>
             </else-if>
@@ -360,17 +450,38 @@
                   <text macro="author-short"/>
                 </group>
                 <group delimiter=" ">
-                  <text value="supra" font-style="italic"/>
-                  <text value="note"/>
-                  <text variable="first-reference-note-number"/>
-                  <text macro="at_page"/>
+                  <choose>
+                    <if type="legal_case" match="any">
+                      <group>
+                        <text variable="volume" suffix=" "/>
+                        <text variable="container-title"/>
+                        <group>
+                          <text value="at" prefix=" " suffix=" "/>
+                          <choose>
+                            <if match="any" variable="locator">
+                              <text variable="locator"/>
+                            </if>
+                            <else>
+                              <text variable="page" form="short"/>
+                            </else>
+                          </choose>
+                        </group>
+                      </group>
+                    </if>
+                    <else>
+                      <text value="supra" font-style="italic"/>
+                      <text value="note"/>
+                      <text variable="first-reference-note-number"/>
+                      <text macro="at_page"/>
+                    </else>
+                  </choose>
                 </group>
               </group>
             </else>
           </choose>
         </else-if>
         <else>
-          <group delimiter=", ">
+          <group delimiter="">
             <group delimiter=" ">
               <choose>
                 <if type="book" match="any">
@@ -379,8 +490,12 @@
               </choose>
               <text macro="author"/>
             </group>
-            <text macro="source"/>
-            <text macro="access"/>
+            <group delimiter="">
+              <text macro="source"/>
+              <group>
+                <text macro="access"/>
+              </group>
+            </group>
           </group>
         </else>
       </choose>

--- a/bluebook-law-review.csl
+++ b/bluebook-law-review.csl
@@ -30,7 +30,7 @@
     <category citation-format="note"/>
     <category field="law"/>
     <summary>The Bluebook legal citation style for law reviews.</summary>
-    <updated>2026-03-14T00:00:00+00:00</updated>
+    <updated>2026-03-29T00:00:00+00:00</updated>
     <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
   </info>
   <locale>
@@ -128,11 +128,7 @@
               <text macro="container"/>
               <text variable="page-first"/>
             </group>
-            <choose>
-              <if variable="locator">
-                <text variable="locator"/>
-              </if>
-            </choose>
+            <text variable="locator"/>
           </group>
           <choose>
             <if variable="status">
@@ -153,29 +149,46 @@
         <text macro="statute-citation"/>
       </else-if>
       <else-if type="bill">
-        <group delimiter=", ">
-          <text variable="title"/>
-          <group delimiter=" ">
-            <text value="Pub. L. No."/>
-            <text variable="number"/>
-          </group>
-          <group prefix="§ ">
-            <text variable="section"/>
-          </group>
-          <group delimiter=" ">
-            <text variable="volume"/>
-            <text macro="container"/>
+        <choose>
+          <if variable="number">
             <group delimiter=", ">
-              <text variable="page-first"/>
-              <text variable="locator"/>
+              <text variable="title"/>
+              <group delimiter=" ">
+                <text value="Pub. L. No."/>
+                <text variable="number"/>
+              </group>
+              <text variable="section" prefix="§ "/>
+              <group delimiter=" ">
+                <text variable="volume"/>
+                <text macro="container"/>
+                <group delimiter=", ">
+                  <text variable="page-first"/>
+                  <text variable="locator"/>
+                </group>
+              </group>
             </group>
-          </group>
-        </group>
-        <text macro="consec-periodical-issuance" prefix=" (" suffix=")"/>
+            <text macro="consec-periodical-issuance" prefix=" (" suffix=")"/>
+          </if>
+          <else>
+            <text macro="statute-citation"/>
+          </else>
+        </choose>
       </else-if>
       <else-if type="book">
         <text variable="title" text-case="title" font-variant="small-caps"/>
-        <text variable="locator" prefix=" "/>
+        <choose>
+          <if locator="page" match="any">
+            <!-- Page: bare number, no label (Bluebook never uses "p." for books) -->
+            <text variable="locator" prefix=" "/>
+          </if>
+          <else-if variable="locator">
+            <!-- Non-page locator: prefix with appropriate label (§, ch., col., ¶, etc.) -->
+            <group prefix=" ">
+              <label variable="locator" form="short" suffix=" "/>
+              <text variable="locator"/>
+            </group>
+          </else-if>
+        </choose>
         <text macro="issuance" prefix=" (" suffix=")"/>
       </else-if>
       <else-if type="manuscript">
@@ -199,20 +212,32 @@
           <text macro="legal-case-issuance"/>
         </group>
       </else-if>
-      <else-if type="article-newspaper article-magazine thesis" match="any">
+      <else-if type="article-newspaper article-magazine" match="any">
         <group delimiter=", ">
           <text variable="title" text-case="title" font-style="italic"/>
           <text macro="container"/>
           <text macro="periodical-issuance"/>
           <group delimiter=" ">
-            <text value="at"/>
+            <text term="at"/>
             <text variable="page-first"/>
           </group>
-          <choose>
-            <if variable="locator">
-              <text variable="locator"/>
-            </if>
-          </choose>
+          <text variable="locator"/>
+        </group>
+      </else-if>
+      <else-if type="thesis">
+        <!-- Bluebook Rule 17.2.2: Author, Title (year) (Type, Institution). -->
+        <group delimiter=" ">
+          <text variable="title" font-style="italic"/>
+          <text variable="locator" prefix=" "/>
+          <group prefix="(" suffix=")">
+            <date variable="issued">
+              <date-part name="year"/>
+            </date>
+          </group>
+          <group prefix="(" suffix=")" delimiter=", ">
+            <text variable="genre"/>
+            <text variable="publisher"/>
+          </group>
         </group>
       </else-if>
       <else-if type="chapter paper-conference" match="any">
@@ -233,19 +258,39 @@
         </group>
       </else-if>
       <else-if type="report">
-        <group delimiter=" ">
-          <text variable="title" text-case="title" font-variant="small-caps"/>
-          <group prefix="§ " delimiter=" ">
-            <text variable="number"/>
-            <text variable="locator"/>
-          </group>
-          <group prefix="(" suffix=")" delimiter=" ">
-            <text variable="publisher"/>
-            <date variable="issued">
-              <date-part name="year"/>
-            </date>
+        <group delimiter=", ">
+          <text variable="title"/>
+          <group delimiter=" ">
+            <text variable="volume"/>
+            <text macro="container"/>
+            <group delimiter=", ">
+              <text variable="page-first"/>
+              <text variable="locator"/>
+            </group>
           </group>
         </group>
+        <choose>
+          <if variable="status">
+            <group prefix=" (" suffix=")">
+              <text variable="status" suffix=" "/>
+              <date variable="issued">
+                <date-part name="month" form="short" suffix=" "/>
+                <date-part name="day" suffix=", "/>
+                <date-part name="year"/>
+              </date>
+            </group>
+          </if>
+          <else-if variable="issued">
+            <group prefix=" (" suffix=")">
+              <date variable="issued">
+                <date-part name="month" form="short" suffix=" "/>
+                <date-part name="day" suffix=", "/>
+                <date-part name="year"/>
+              </date>
+            </group>
+          </else-if>
+        </choose>
+        <text variable="note" prefix=" (" suffix=")"/>
       </else-if>
       <else>
         <group delimiter=" ">
@@ -350,7 +395,7 @@
   </macro>
   <macro name="at_page">
     <group delimiter=" ">
-      <text value="at"/>
+      <text term="at"/>
       <text variable="locator"/>
     </group>
   </macro>
@@ -403,15 +448,9 @@
                 <text macro="author-short"/>
                 <group>
                   <text value="supra" font-style="italic" suffix=" "/>
-                  <text value="note" suffix=" "/>
+                  <text term="note" suffix=" "/>
                   <text variable="first-reference-note-number"/>
-                  <group>
-                    <choose>
-                      <if match="any" variable="locator">
-                        <text variable="locator" prefix=" at "/>
-                      </if>
-                    </choose>
-                  </group>
+                  <text variable="locator" prefix=" at "/>
                 </group>
               </group>
             </if>
@@ -431,11 +470,24 @@
               </group>
             </else-if>
             <else-if type="report" match="any">
-              <group delimiter=" ">
-                <text macro="author-short"/>
-                <group prefix="§ " delimiter=" ">
-                  <text variable="number"/>
-                  <text variable="locator"/>
+              <!-- Short cite: Title, vol Container at locator/page -->
+              <!-- e.g., Importation of Fruits and Vegetables, 60 Fed. Reg. at 50381 -->
+              <group delimiter=", ">
+                <text variable="title"/>
+                <group delimiter=" ">
+                  <text variable="volume"/>
+                  <text macro="container"/>
+                  <group>
+                    <text term="at" suffix=" "/>
+                    <choose>
+                      <if variable="locator">
+                        <text variable="locator"/>
+                      </if>
+                      <else>
+                        <text variable="page-first"/>
+                      </else>
+                    </choose>
+                  </group>
                 </group>
               </group>
             </else-if>
@@ -456,7 +508,7 @@
                         <text variable="volume" suffix=" "/>
                         <text variable="container-title"/>
                         <group>
-                          <text value="at" prefix=" " suffix=" "/>
+                          <text term="at" prefix=" " suffix=" "/>
                           <choose>
                             <if match="any" variable="locator">
                               <text variable="locator"/>
@@ -470,7 +522,7 @@
                     </if>
                     <else>
                       <text value="supra" font-style="italic"/>
-                      <text value="note"/>
+                      <text term="note"/>
                       <text variable="first-reference-note-number"/>
                       <text macro="at_page"/>
                     </else>
@@ -492,9 +544,7 @@
             </group>
             <group delimiter="">
               <text macro="source"/>
-              <group>
-                <text macro="access"/>
-              </group>
+              <text macro="access"/>
             </group>
           </group>
         </else>


### PR DESCRIPTION
## CSL Styles Pull Request Template
You're about to create a pull request to the CSL **styles** repository.  
If you haven't done so already, see <https://github.com/citation-style-language/styles/blob/master/CONTRIBUTING.md> for instructions on how to contribute, and <https://github.com/citation-style-language/styles/blob/master/STYLE_REQUIREMENTS.md> for the requirements a style must meet before acceptance.  
In addition, please fill out the pull request template below.


### Description
This revision corrects several formatting errors in prior implementations and extends coverage to additional source types. Specific changes include: italicizing case names in subsequent short-form citations regardless of whether a title-short is stored, but not full first-occurrence citations; fixing the statute-citation macro's erroneous comma-delimited outer group (which produced 42 U.S.C. , § 1983) by switching to a space delimiter; correcting the et-al-min threshold from 4 to 3 per Bluebook R 30.2.3; eliminating a double-space artifact between the author group and source text by setting the outer citation group delimiter to an empty string; adding explicit bill/legislation and manuscript branches in the subsequent-citation block to prevent impermissible supra forms for statutes and procedural rules; adding a dedicated report branch for Restatements and Model Codes (title in small caps, § number from the Report Number field, institutional publisher in parenthetical); adding a webpage/post-weblog source branch with URL and "last visited" access macro; adding status-variable support in the article-journal branch for forthcoming articles; removing the <substitute> element from name-macro to prevent double-title output for authorless items; suppressing author output for legal_case, legislation, and bill types; removing a spurious <label form="verb-short"> from name-short-macro; suppressing URL and "last visited" output for case and statute citations; adding a legislation/bill branch to the container macro; and splitting bill and legislation into separate source branches so that Zotero Bill items render in Statutes at Large session-law format (title, Pub. L. No. number, § section, volume Stat. page (year)) while legislation items continue to use the codified-statute macro. 


### Checklist
- [ ] Check that you've added a link to the style you used as a template in the `<info>` block at the beginning of the file with `rel="template"`.  
- [x] Check that you've added a link to the style guidelines with `rel="documentation"`.  
- [x] Check that you've added yourself as the `<author>` of the style or `<contributor>` for a style update. 
- [ ] Check that you've used the correct terms or labels instead of hardcoding into affixes (e.g., `<text variable="page" prefix="pp. "/>`).
- [ ] Check that you've not used `<text value="...` if not absolutely necessary.
- [x] Check that you've not changed line 1 of the style.
