### PR TITLE
Update ucl-university-college-harvard.csl

### DIFF
--- a/ucl-university-college-harvard.csl
+++ b/ucl-university-college-harvard.csl
@@ -246,6 +246,9 @@ Also assumes that books with an url provided is an e-book, and outputs "[e-bog]"
           <else-if type="book">
             <text value="e-bog" text-case="capitalize-first"/>
           </else-if>
+          <else-if type="chapter">
+            <text value="e-bog" text-case="capitalize-first"/>
+          </else-if>
           <else>
             <text term="online" text-case="capitalize-first"/>
           </else>


### PR DESCRIPTION
Added a change similar to books with and URL, so when it is a chapter in a book with an URL it correctly states "E-bog" and not "Online".
