### PR TITLE
NLM: fix report number labelling

### DIFF
--- a/nlm-citation-name.csl
+++ b/nlm-citation-name.csl
@@ -99,6 +99,17 @@
       </choose>
     </group>
   </macro>
+  <macro name="label-number">
+    <group delimiter=": ">
+      <choose>
+        <if type="standard"/>
+        <else-if is-numeric="number" match="any" type="legislation patent regulation">
+          <label form="short" variable="number"/>
+        </else-if>
+      </choose>
+      <text variable="number"/>
+    </group>
+  </macro>
   <macro name="label-number-of-pages">
     <group delimiter=" ">
       <text variable="number-of-pages"/>
@@ -405,13 +416,17 @@
   </macro>
   <macro name="report-number">
     <choose>
-      <if type="report">
-        <group delimiter=": ">
-          <group delimiter=" ">
-            <text term="report" text-case="capitalize-first"/>
-            <label form="short" text-case="capitalize-first" variable="number"/>
-          </group>
-          <text variable="number"/>
+      <if type="report" variable="number">
+        <group delimiter=" ">
+          <choose>
+            <if variable="genre">
+              <text text-case="capitalize-first" variable="genre"/>
+            </if>
+            <else>
+              <text term="report" text-case="capitalize-first"/>
+            </else>
+          </choose>
+          <text macro="label-number"/>
         </group>
       </if>
     </choose>

--- a/nlm-citation-sequence-brackets-no-et-al.csl
+++ b/nlm-citation-sequence-brackets-no-et-al.csl
@@ -99,6 +99,17 @@
       </choose>
     </group>
   </macro>
+  <macro name="label-number">
+    <group delimiter=": ">
+      <choose>
+        <if type="standard"/>
+        <else-if is-numeric="number" match="any" type="legislation patent regulation">
+          <label form="short" variable="number"/>
+        </else-if>
+      </choose>
+      <text variable="number"/>
+    </group>
+  </macro>
   <macro name="label-number-of-pages">
     <group delimiter=" ">
       <text variable="number-of-pages"/>
@@ -405,13 +416,17 @@
   </macro>
   <macro name="report-number">
     <choose>
-      <if type="report">
-        <group delimiter=": ">
-          <group delimiter=" ">
-            <text term="report" text-case="capitalize-first"/>
-            <label form="short" text-case="capitalize-first" variable="number"/>
-          </group>
-          <text variable="number"/>
+      <if type="report" variable="number">
+        <group delimiter=" ">
+          <choose>
+            <if variable="genre">
+              <text text-case="capitalize-first" variable="genre"/>
+            </if>
+            <else>
+              <text term="report" text-case="capitalize-first"/>
+            </else>
+          </choose>
+          <text macro="label-number"/>
         </group>
       </if>
     </choose>

--- a/nlm-citation-sequence-brackets-year-only-no-issue.csl
+++ b/nlm-citation-sequence-brackets-year-only-no-issue.csl
@@ -99,6 +99,17 @@
       </choose>
     </group>
   </macro>
+  <macro name="label-number">
+    <group delimiter=": ">
+      <choose>
+        <if type="standard"/>
+        <else-if is-numeric="number" match="any" type="legislation patent regulation">
+          <label form="short" variable="number"/>
+        </else-if>
+      </choose>
+      <text variable="number"/>
+    </group>
+  </macro>
   <macro name="label-number-of-pages">
     <group delimiter=" ">
       <text variable="number-of-pages"/>
@@ -405,13 +416,17 @@
   </macro>
   <macro name="report-number">
     <choose>
-      <if type="report">
-        <group delimiter=": ">
-          <group delimiter=" ">
-            <text term="report" text-case="capitalize-first"/>
-            <label form="short" text-case="capitalize-first" variable="number"/>
-          </group>
-          <text variable="number"/>
+      <if type="report" variable="number">
+        <group delimiter=" ">
+          <choose>
+            <if variable="genre">
+              <text text-case="capitalize-first" variable="genre"/>
+            </if>
+            <else>
+              <text term="report" text-case="capitalize-first"/>
+            </else>
+          </choose>
+          <text macro="label-number"/>
         </group>
       </if>
     </choose>

--- a/nlm-citation-sequence-brackets.csl
+++ b/nlm-citation-sequence-brackets.csl
@@ -99,6 +99,17 @@
       </choose>
     </group>
   </macro>
+  <macro name="label-number">
+    <group delimiter=": ">
+      <choose>
+        <if type="standard"/>
+        <else-if is-numeric="number" match="any" type="legislation patent regulation">
+          <label form="short" variable="number"/>
+        </else-if>
+      </choose>
+      <text variable="number"/>
+    </group>
+  </macro>
   <macro name="label-number-of-pages">
     <group delimiter=" ">
       <text variable="number-of-pages"/>
@@ -405,13 +416,17 @@
   </macro>
   <macro name="report-number">
     <choose>
-      <if type="report">
-        <group delimiter=": ">
-          <group delimiter=" ">
-            <text term="report" text-case="capitalize-first"/>
-            <label form="short" text-case="capitalize-first" variable="number"/>
-          </group>
-          <text variable="number"/>
+      <if type="report" variable="number">
+        <group delimiter=" ">
+          <choose>
+            <if variable="genre">
+              <text text-case="capitalize-first" variable="genre"/>
+            </if>
+            <else>
+              <text term="report" text-case="capitalize-first"/>
+            </else>
+          </choose>
+          <text macro="label-number"/>
         </group>
       </if>
     </choose>

--- a/nlm-citation-sequence-superscript-brackets-year-only.csl
+++ b/nlm-citation-sequence-superscript-brackets-year-only.csl
@@ -99,6 +99,17 @@
       </choose>
     </group>
   </macro>
+  <macro name="label-number">
+    <group delimiter=": ">
+      <choose>
+        <if type="standard"/>
+        <else-if is-numeric="number" match="any" type="legislation patent regulation">
+          <label form="short" variable="number"/>
+        </else-if>
+      </choose>
+      <text variable="number"/>
+    </group>
+  </macro>
   <macro name="label-number-of-pages">
     <group delimiter=" ">
       <text variable="number-of-pages"/>
@@ -405,13 +416,17 @@
   </macro>
   <macro name="report-number">
     <choose>
-      <if type="report">
-        <group delimiter=": ">
-          <group delimiter=" ">
-            <text term="report" text-case="capitalize-first"/>
-            <label form="short" text-case="capitalize-first" variable="number"/>
-          </group>
-          <text variable="number"/>
+      <if type="report" variable="number">
+        <group delimiter=" ">
+          <choose>
+            <if variable="genre">
+              <text text-case="capitalize-first" variable="genre"/>
+            </if>
+            <else>
+              <text term="report" text-case="capitalize-first"/>
+            </else>
+          </choose>
+          <text macro="label-number"/>
         </group>
       </if>
     </choose>

--- a/nlm-citation-sequence-superscript-year-only-no-issue.csl
+++ b/nlm-citation-sequence-superscript-year-only-no-issue.csl
@@ -99,6 +99,17 @@
       </choose>
     </group>
   </macro>
+  <macro name="label-number">
+    <group delimiter=": ">
+      <choose>
+        <if type="standard"/>
+        <else-if is-numeric="number" match="any" type="legislation patent regulation">
+          <label form="short" variable="number"/>
+        </else-if>
+      </choose>
+      <text variable="number"/>
+    </group>
+  </macro>
   <macro name="label-number-of-pages">
     <group delimiter=" ">
       <text variable="number-of-pages"/>
@@ -405,13 +416,17 @@
   </macro>
   <macro name="report-number">
     <choose>
-      <if type="report">
-        <group delimiter=": ">
-          <group delimiter=" ">
-            <text term="report" text-case="capitalize-first"/>
-            <label form="short" text-case="capitalize-first" variable="number"/>
-          </group>
-          <text variable="number"/>
+      <if type="report" variable="number">
+        <group delimiter=" ">
+          <choose>
+            <if variable="genre">
+              <text text-case="capitalize-first" variable="genre"/>
+            </if>
+            <else>
+              <text term="report" text-case="capitalize-first"/>
+            </else>
+          </choose>
+          <text macro="label-number"/>
         </group>
       </if>
     </choose>

--- a/nlm-citation-sequence-superscript.csl
+++ b/nlm-citation-sequence-superscript.csl
@@ -99,6 +99,17 @@
       </choose>
     </group>
   </macro>
+  <macro name="label-number">
+    <group delimiter=": ">
+      <choose>
+        <if type="standard"/>
+        <else-if is-numeric="number" match="any" type="legislation patent regulation">
+          <label form="short" variable="number"/>
+        </else-if>
+      </choose>
+      <text variable="number"/>
+    </group>
+  </macro>
   <macro name="label-number-of-pages">
     <group delimiter=" ">
       <text variable="number-of-pages"/>
@@ -405,13 +416,17 @@
   </macro>
   <macro name="report-number">
     <choose>
-      <if type="report">
-        <group delimiter=": ">
-          <group delimiter=" ">
-            <text term="report" text-case="capitalize-first"/>
-            <label form="short" text-case="capitalize-first" variable="number"/>
-          </group>
-          <text variable="number"/>
+      <if type="report" variable="number">
+        <group delimiter=" ">
+          <choose>
+            <if variable="genre">
+              <text text-case="capitalize-first" variable="genre"/>
+            </if>
+            <else>
+              <text term="report" text-case="capitalize-first"/>
+            </else>
+          </choose>
+          <text macro="label-number"/>
         </group>
       </if>
     </choose>

--- a/nlm-citation-sequence.csl
+++ b/nlm-citation-sequence.csl
@@ -98,6 +98,17 @@
       </choose>
     </group>
   </macro>
+  <macro name="label-number">
+    <group delimiter=": ">
+      <choose>
+        <if type="standard"/>
+        <else-if is-numeric="number" match="any" type="legislation patent regulation">
+          <label form="short" variable="number"/>
+        </else-if>
+      </choose>
+      <text variable="number"/>
+    </group>
+  </macro>
   <macro name="label-number-of-pages">
     <group delimiter=" ">
       <text variable="number-of-pages"/>
@@ -404,13 +415,17 @@
   </macro>
   <macro name="report-number">
     <choose>
-      <if type="report">
-        <group delimiter=": ">
-          <group delimiter=" ">
-            <text term="report" text-case="capitalize-first"/>
-            <label form="short" text-case="capitalize-first" variable="number"/>
-          </group>
-          <text variable="number"/>
+      <if type="report" variable="number">
+        <group delimiter=" ">
+          <choose>
+            <if variable="genre">
+              <text text-case="capitalize-first" variable="genre"/>
+            </if>
+            <else>
+              <text term="report" text-case="capitalize-first"/>
+            </else>
+          </choose>
+          <text macro="label-number"/>
         </group>
       </if>
     </choose>

--- a/nlm-name-year.csl
+++ b/nlm-name-year.csl
@@ -105,6 +105,17 @@
       <text variable="locator"/>
     </group>
   </macro>
+  <macro name="label-number">
+    <group delimiter=": ">
+      <choose>
+        <if type="standard"/>
+        <else-if is-numeric="number" match="any" type="legislation patent regulation">
+          <label form="short" variable="number"/>
+        </else-if>
+      </choose>
+      <text variable="number"/>
+    </group>
+  </macro>
   <macro name="label-number-of-pages">
     <group delimiter=" ">
       <text variable="number-of-pages"/>
@@ -430,13 +441,17 @@
   </macro>
   <macro name="report-number">
     <choose>
-      <if type="report">
-        <group delimiter=": ">
-          <group delimiter=" ">
-            <text term="report" text-case="capitalize-first"/>
-            <label form="short" text-case="capitalize-first" variable="number"/>
-          </group>
-          <text variable="number"/>
+      <if type="report" variable="number">
+        <group delimiter=" ">
+          <choose>
+            <if variable="genre">
+              <text text-case="capitalize-first" variable="genre"/>
+            </if>
+            <else>
+              <text term="report" text-case="capitalize-first"/>
+            </else>
+          </choose>
+          <text macro="label-number"/>
         </group>
       </if>
     </choose>


### PR DESCRIPTION
Reported at <https://forums.zotero.org/discussion/130598/>.

### Checklist
- [X] Check that you've added a link to the style you used as a template in the `<info>` block at the beginning of the file with `rel="template"`.  
- [X] Check that you've added a link to the style guidelines with `rel="documentation"`.  
- [X] Check that you've added yourself as the `<author>` of the style or `<contributor>` for a style update. 
- [X] Check that you've used the correct terms or labels instead of hardcoding into affixes (e.g., `<text variable="page" prefix="pp. "/>`).
- [X] Check that you've not used `<text value="...` if not absolutely necessary.
- [X] Check that you've not changed line 1 of the style.
